### PR TITLE
07 feat(mastracode): add GitHub signal subscriptions

### DIFF
--- a/.changeset/blue-dryers-do.md
+++ b/.changeset/blue-dryers-do.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved GitHub PR notifications in Mastra Code with clearer status, subscription hints, automatic merged PR cleanup, and more reliable inbox access.

--- a/.changeset/blue-dryers-do.md
+++ b/.changeset/blue-dryers-do.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Added GitHub PR notifications in Mastra Code with subscription management, PR status badges, subscription hints, automatic merged PR cleanup, and inbox access.
+Added GitHub PR notifications in Mastra Code with subscription management, manual sync, PR status badges, subscription hints, automatic merged PR cleanup, and inbox access.

--- a/.changeset/blue-dryers-do.md
+++ b/.changeset/blue-dryers-do.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Improved GitHub PR notifications in Mastra Code with clearer status, subscription hints, automatic merged PR cleanup, and more reliable inbox access.
+Added GitHub PR notifications in Mastra Code with subscription management, PR status badges, subscription hints, automatic merged PR cleanup, and inbox access.

--- a/.changeset/fiery-monkeys-pick.md
+++ b/.changeset/fiery-monkeys-pick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved notification delivery targeting and inbox search so notification records can be found and delivered to the intended thread.

--- a/.changeset/legal-glasses-pick.md
+++ b/.changeset/legal-glasses-pick.md
@@ -1,5 +1,0 @@
----
-'mastracode': patch
----
-
-Added GitHub PR subscription signals for MastraCode local testing.

--- a/.changeset/legal-glasses-pick.md
+++ b/.changeset/legal-glasses-pick.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added GitHub PR subscription signals for MastraCode local testing.

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -528,6 +528,10 @@ describe('createMastraCode', () => {
       ...createMockSettings(),
       signals: { unixSocketPubSub: false, experimentalGithubSignals: true },
     });
+    harnessGetCurrentThreadIdMock.mockReturnValue('thread-1');
+    harnessListThreadsMock.mockResolvedValue([{ id: 'thread-1', resourceId: 'thread-resource', metadata: {} }]);
+    const { GithubSignals } = await import('../github-signals/index.js');
+    const startPollingForThread = vi.spyOn(GithubSignals.prototype, 'startPollingForThread').mockResolvedValue(true);
     const { createMastraCode } = await import('../index.js');
 
     await createMastraCode();
@@ -537,5 +541,9 @@ describe('createMastraCode', () => {
       | { inputProcessors?: Array<{ id?: string }> }
       | undefined;
     expect(agentConfig?.inputProcessors?.map(processor => processor.id)).toContain('github-signals');
+    expect(startPollingForThread).toHaveBeenCalledWith(
+      { threadId: 'thread-1', resourceId: 'thread-resource' },
+      { pollImmediately: true },
+    );
   });
 });

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -521,4 +521,16 @@ describe('createMastraCode', () => {
     expect(agentConfig?.inputProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
     expect(agentConfig?.errorProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
   });
+
+  it('configures GitHubSignals as an input processor for local PR subscriptions', async () => {
+    const { createMastraCode } = await import('../index.js');
+
+    await createMastraCode();
+
+    expect(agentConstructorMock).toHaveBeenCalled();
+    const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
+      | { inputProcessors?: Array<{ id?: string }> }
+      | undefined;
+    expect(agentConfig?.inputProcessors?.map(processor => processor.id)).toContain('github-signals');
+  });
 });

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -92,6 +92,7 @@ function createMockSettings() {
       stagehand: { env: 'LOCAL' },
     },
     observability: { resources: {}, localTracing: false },
+    signals: { unixSocketPubSub: false, experimentalGithubSignals: false },
   };
 }
 
@@ -523,6 +524,10 @@ describe('createMastraCode', () => {
   });
 
   it('configures GitHubSignals as an input processor for local PR subscriptions', async () => {
+    loadSettingsMock.mockReturnValue({
+      ...createMockSettings(),
+      signals: { unixSocketPubSub: false, experimentalGithubSignals: true },
+    });
     const { createMastraCode } = await import('../index.js');
 
     await createMastraCode();

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -171,14 +171,14 @@ describe('GithubSignals', () => {
   it('creates typed subscribe and unsubscribe PR signals', () => {
     expect(GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 })).toEqual(
       expect.objectContaining({
-        type: 'user',
+        type: 'reactive',
         tagName: 'github-subscribe-pr',
         attributes: { owner: 'mastra-ai', repo: 'mastra', number: 123 },
       }),
     );
     expect(GithubSignals.signals.unsubscribeFromPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 })).toEqual(
       expect.objectContaining({
-        type: 'user',
+        type: 'reactive',
         tagName: 'github-unsubscribe-pr',
         attributes: { owner: 'mastra-ai', repo: 'mastra', number: 123 },
       }),
@@ -358,7 +358,7 @@ describe('GithubSignals', () => {
     expect(sendSignal).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        type: 'user',
+        type: 'reactive',
         tagName: 'github-subscribe-pr',
         attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
       }),
@@ -372,7 +372,7 @@ describe('GithubSignals', () => {
     expect(sendSignal).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        type: 'user',
+        type: 'reactive',
         tagName: 'github-unsubscribe-pr',
         attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
       }),

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -1003,6 +1003,17 @@ describe('GithubSignals', () => {
       }),
       expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
     );
+    expect(syncClient.syncPullRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123, includeComments: true }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(syncClient.syncPullRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123, includeComments: false }),
+    );
     processor.stopAllPolling();
   });
 

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -1014,7 +1014,11 @@ describe('GithubSignals', () => {
     await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
 
     expect(sendNotificationSignal).toHaveBeenCalledWith(
-      expect.objectContaining({ source: 'github', kind: 'pull-request-activity' }),
+      expect.objectContaining({
+        source: 'github',
+        kind: 'pull-request-activity',
+        coalesceKey: 'github:mastra-ai/mastra#123:pull-request-activity',
+      }),
       expect.objectContaining({
         resourceId: thread.resourceId,
         threadId: thread.id,

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -4,10 +4,15 @@ import type { IMastraLogger } from '@mastra/core/logger';
 import type { StorageThreadType } from '@mastra/core/memory';
 import { ProcessorRunner } from '@mastra/core/processors';
 import { RequestContext } from '@mastra/core/request-context';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { GithubSignals, GITHUB_SIGNALS_METADATA_KEY, GITHUB_SYNC_STATUS_TAG } from './index.js';
-import type { GithubRepositoryResolver, GithubSignalsSyncClient, GithubSignalsThreadStore } from './index.js';
+import type {
+  GithubPullRequestSnapshot,
+  GithubRepositoryResolver,
+  GithubSignalsSyncClient,
+  GithubSignalsThreadStore,
+} from './index.js';
 
 const mockLogger: IMastraLogger = {
   debug: vi.fn(),
@@ -70,11 +75,22 @@ async function runGithubSignalsProcessor(args: {
 }
 
 describe('GithubSignals', () => {
-  it('creates typed subscribe-to-PR signals', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('creates typed subscribe and unsubscribe PR signals', () => {
     expect(GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 })).toEqual(
       expect.objectContaining({
         type: 'user',
         tagName: 'github-subscribe-pr',
+        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 123 },
+      }),
+    );
+    expect(GithubSignals.signals.unsubscribeFromPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 })).toEqual(
+      expect.objectContaining({
+        type: 'user',
+        tagName: 'github-unsubscribe-pr',
         attributes: { owner: 'mastra-ai', repo: 'mastra', number: 123 },
       }),
     );
@@ -91,10 +107,15 @@ describe('GithubSignals', () => {
     const threadStore = createThreadStore(thread);
     const syncClient: GithubSignalsSyncClient = {
       syncPullRequest: vi.fn(async () => ({ ok: true, stdout: '{"ok":true}' })),
+      getPullRequestSnapshot: vi.fn(async () => ({
+        githubUpdatedAt: '2026-01-01T00:00:00.000Z',
+        contentHash: 'initial-hash',
+      })),
     };
-    const signal = createSignal(
-      GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
-    );
+    const signal = createSignal({
+      ...GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+      type: 'reactive',
+    });
     const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
     messageList.add([signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })], 'input');
     const chunks: unknown[] = [];
@@ -123,6 +144,8 @@ describe('GithubSignals', () => {
                 number: 123,
                 lastSubscribeSignalId: signal.id,
                 lastSyncStatus: 'success',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'initial-hash',
               }),
             ],
           },
@@ -144,6 +167,71 @@ describe('GithubSignals', () => {
         }),
       }),
     );
+  });
+
+  it('emits an initial PR baseline notification on subscribe', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-baseline',
+      resourceId: 'resource-baseline',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const threadStore = createThreadStore(thread);
+    const snapshot: GithubPullRequestSnapshot = {
+      title: 'Add GitHub signals',
+      state: 'open',
+      githubUpdatedAt: '2026-01-01T00:00:00.000Z',
+      contentHash: 'baseline-hash',
+      ciState: 'failure',
+      mergeableState: 'clean',
+      unresolvedReviewThreads: 2,
+      reviewStateHash: 'reviews-2',
+      checks: [{ name: 'Quality assurance', status: 'completed', conclusion: 'failure' }],
+    };
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => snapshot),
+    };
+    const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
+    const processor = new GithubSignals({ threadStore, syncClient, agentId: 'code-agent' });
+    processor.__registerMastra({ getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })) } as any);
+    const signal = createSignal(
+      GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    messageList.add([signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })], 'input');
+
+    await runGithubSignalsProcessor({
+      processor,
+      messageList,
+      requestContext: createRequestContext(thread),
+    });
+
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'github',
+        kind: 'pull-request-baseline',
+        priority: 'high',
+        summary:
+          'mastra-ai/mastra#123 subscribed: Add GitHub signals (state: open; CI: failure; mergeability: clean; 2 unresolved review threads; failing: Quality assurance)',
+        attributes: expect.objectContaining({
+          owner: 'mastra-ai',
+          repo: 'mastra',
+          number: 123,
+          ciState: 'failure',
+          unresolvedReviewThreads: 2,
+        }),
+      }),
+      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
+    );
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscription).toMatchObject({
+      lastObservedCiState: 'failure',
+      lastObservedReviewStateHash: 'reviews-2',
+      lastObservedState: 'open',
+      lastObservedMergeableState: 'clean',
+    });
   });
 
   it('resolves owner and repo from the project when the signal only carries a PR number', async () => {
@@ -213,5 +301,402 @@ describe('GithubSignals', () => {
 
     expect(syncClient.syncPullRequest).not.toHaveBeenCalled();
     expect(threadStore.saveThread).not.toHaveBeenCalled();
+  });
+
+  it('removes a subscription from thread metadata when an unsubscribe signal is processed', async () => {
+    const signal = createSignal(
+      GithubSignals.signals.unsubscribeFromPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    const thread: StorageThreadType = {
+      id: 'thread-4',
+      resourceId: 'resource-4',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    messageList.add([signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })], 'input');
+    const chunks: unknown[] = [];
+
+    await runGithubSignalsProcessor({
+      processor: new GithubSignals({ threadStore, syncOnSubscribe: false }),
+      messageList,
+      requestContext: createRequestContext(thread),
+      chunks,
+    });
+
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([]);
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          tagName: GITHUB_SYNC_STATUS_TAG,
+          attributes: expect.objectContaining({
+            status: 'unsubscribed',
+            owner: 'mastra-ai',
+            repo: 'mastra',
+            number: 123,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('returns processor-owned tools that send subscribe and unsubscribe signals to the current agent', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-5',
+      resourceId: 'resource-5',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    const processor = new GithubSignals({ syncOnSubscribe: false });
+    const sendSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true, runId: 'run-1' }) }));
+    processor.__registerMastra({ getAgentById: vi.fn(() => ({ sendSignal })) } as any);
+
+    const result = await runGithubSignalsProcessor({
+      processor,
+      messageList,
+      requestContext: createRequestContext(thread),
+    });
+
+    const tools = result.tools as Record<string, { execute: (input: any, context: any) => Promise<any> }>;
+    await expect(
+      tools.github_subscribe_pr.execute(
+        { owner: 'mastra-ai', repo: 'mastra', number: 123 },
+        { agent: { agentId: 'code-agent', threadId: thread.id, resourceId: thread.resourceId } },
+      ),
+    ).resolves.toMatchObject({ subscribed: true, number: 123 });
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({ tagName: 'github-subscribe-pr' }),
+      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
+    );
+
+    await expect(
+      tools.github_unsubscribe_pr.execute(
+        { owner: 'mastra-ai', repo: 'mastra', number: 123 },
+        { agent: { agentId: 'code-agent', threadId: thread.id, resourceId: thread.resourceId } },
+      ),
+    ).resolves.toMatchObject({ unsubscribed: true, number: 123 });
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({ tagName: 'github-unsubscribe-pr' }),
+      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
+    );
+  });
+
+  it('polls subscribed PRs on the configured interval and updates thread metadata', async () => {
+    vi.useFakeTimers();
+    const thread: StorageThreadType = {
+      id: 'thread-6',
+      resourceId: 'resource-6',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastSyncError: 'old-error',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'old-hash',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({
+        title: 'Add GitHub signals',
+        state: 'open',
+        htmlUrl: 'https://github.com/mastra-ai/mastra/pull/123',
+        githubUpdatedAt: '2026-01-01T00:05:00.000Z',
+        contentHash: 'new-hash',
+      })),
+    };
+    const processor = new GithubSignals({ threadStore, syncClient, pollIntervalMs: 1_000, agentId: 'code-agent' });
+    const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
+    processor.__registerMastra({ getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })) } as any);
+
+    await expect(processor.startPollingForThread({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(
+      true,
+    );
+    expect(processor.isPollingThread({ threadId: thread.id, resourceId: thread.resourceId })).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(syncClient.syncPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscription).toMatchObject({
+      lastSyncStatus: 'success',
+      lastObservedGithubUpdatedAt: '2026-01-01T00:05:00.000Z',
+      lastObservedContentHash: 'new-hash',
+      lastNotificationKind: 'pull-request-activity',
+      lastNotificationPriority: 'medium',
+      lastNotificationSummary: 'mastra-ai/mastra#123 has new activity: Add GitHub signals',
+    });
+    expect(subscription.lastNotificationAt).toEqual(expect.any(String));
+    expect(subscription.lastSyncError).toBeUndefined();
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'github',
+        kind: 'pull-request-activity',
+        priority: 'medium',
+        summary: 'mastra-ai/mastra#123 has new activity: Add GitHub signals',
+        attributes: expect.objectContaining({
+          owner: 'mastra-ai',
+          repo: 'mastra',
+          number: 123,
+          previousGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+          githubUpdatedAt: '2026-01-01T00:05:00.000Z',
+        }),
+      }),
+      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
+    );
+    processor.stopAllPolling();
+  });
+
+  it('emits a high-priority notification when CI fails between polls', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-ci',
+      resourceId: 'resource-ci',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'ci-pending-hash',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({
+        title: 'Add GitHub signals',
+        state: 'open',
+        githubUpdatedAt: '2026-01-01T00:00:00.000Z',
+        contentHash: 'ci-failed-hash',
+        ciState: 'failure' as const,
+        checks: [
+          {
+            name: 'Quality assurance',
+            status: 'completed',
+            conclusion: 'failure',
+            detailsUrl: 'https://github.com/mastra-ai/mastra/actions/runs/1',
+          },
+        ],
+      })),
+    };
+    const processor = new GithubSignals({ threadStore, syncClient, agentId: 'code-agent' });
+    const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
+    processor.__registerMastra({ getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })) } as any);
+
+    await expect(processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(1);
+
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscription.lastObservedContentHash).toBe('ci-failed-hash');
+    expect(subscription).toMatchObject({
+      lastNotificationKind: 'pull-request-ci-failure',
+      lastNotificationPriority: 'high',
+      lastNotificationSummary: 'mastra-ai/mastra#123 has failing CI: Quality assurance',
+    });
+    expect(subscription.lastNotificationAt).toEqual(expect.any(String));
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'github',
+        kind: 'pull-request-ci-failure',
+        priority: 'high',
+        summary: 'mastra-ai/mastra#123 has failing CI: Quality assurance',
+        attributes: expect.objectContaining({
+          ciState: 'failure',
+          failingChecks: 'Quality assurance',
+        }),
+      }),
+      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
+    );
+  });
+
+  it('classifies CI recovery, review activity, terminal states, and bot-only noise', async () => {
+    const baseThread: StorageThreadType = {
+      id: 'thread-classify',
+      resourceId: 'resource-classify',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const createThreadWithCursor = (cursor: Record<string, unknown>): StorageThreadType => ({
+      ...baseThread,
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'old-hash',
+                ...cursor,
+              },
+            ],
+          },
+        },
+      },
+    });
+    const runPoll = async (thread: StorageThreadType, snapshot: GithubPullRequestSnapshot) => {
+      const threadStore = createThreadStore(thread);
+      const syncClient: GithubSignalsSyncClient = {
+        syncPullRequest: vi.fn(async () => ({ ok: true })),
+        getPullRequestSnapshot: vi.fn(async () => snapshot),
+      };
+      const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
+      const processor = new GithubSignals({ threadStore, syncClient, agentId: 'code-agent' });
+      processor.__registerMastra({
+        getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })),
+      } as any);
+      await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
+      return sendNotificationSignal;
+    };
+
+    const ciRecovered = await runPoll(createThreadWithCursor({ lastObservedCiState: 'failure' }), {
+      title: 'PR',
+      state: 'open',
+      contentHash: 'ci-ok',
+      ciState: 'success',
+    });
+    expect(ciRecovered).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'pull-request-ci-recovered', priority: 'medium' }),
+      expect.anything(),
+    );
+    const reviewActivity = await runPoll(createThreadWithCursor({ lastObservedReviewStateHash: 'reviews-1' }), {
+      title: 'PR',
+      state: 'open',
+      contentHash: 'reviews-2',
+      ciState: 'unknown',
+      unresolvedReviewThreads: 2,
+      reviewStateHash: 'reviews-2',
+    });
+    expect(reviewActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'pull-request-review-activity', priority: 'medium' }),
+      expect.anything(),
+    );
+    const conflictsResolved = await runPoll(createThreadWithCursor({ lastObservedMergeableState: 'dirty' }), {
+      title: 'PR',
+      state: 'open',
+      contentHash: 'clean',
+      ciState: 'success',
+      mergeableState: 'clean',
+    });
+    expect(conflictsResolved).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'pull-request-conflict-resolved', priority: 'medium' }),
+      expect.anything(),
+    );
+    const merged = await runPoll(createThreadWithCursor({ lastObservedState: 'open' }), {
+      title: 'PR',
+      state: 'merged',
+      contentHash: 'merged',
+      ciState: 'success',
+    });
+    expect(merged).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'pull-request-merged', priority: 'high' }),
+      expect.anything(),
+    );
+    const botNoise = await runPoll(createThreadWithCursor({ lastObservedContentHash: 'old-hash' }), {
+      title: 'PR',
+      state: 'open',
+      contentHash: 'bot-hash',
+      ciState: 'unknown',
+      latestCommentAuthor: 'github-actions[bot]',
+      latestCommentIsBot: true,
+    });
+    expect(botNoise).not.toHaveBeenCalled();
+  });
+
+  it('starts polling after subscribe and stops after the last subscription is removed', async () => {
+    const subscribeSignal = createSignal(
+      GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    const thread: StorageThreadType = {
+      id: 'thread-7',
+      resourceId: 'resource-7',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = { syncPullRequest: vi.fn(async () => ({ ok: true })) };
+    const processor = new GithubSignals({ threadStore, syncClient });
+    const subscribeMessageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    subscribeMessageList.add(
+      [subscribeSignal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })],
+      'input',
+    );
+
+    await runGithubSignalsProcessor({
+      processor,
+      messageList: subscribeMessageList,
+      requestContext: createRequestContext(thread),
+    });
+
+    expect(processor.isPollingThread({ threadId: thread.id, resourceId: thread.resourceId })).toBe(true);
+
+    const unsubscribeSignal = createSignal(
+      GithubSignals.signals.unsubscribeFromPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    const unsubscribeMessageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    unsubscribeMessageList.add(
+      [unsubscribeSignal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })],
+      'input',
+    );
+
+    await runGithubSignalsProcessor({
+      processor,
+      messageList: unsubscribeMessageList,
+      requestContext: createRequestContext(thread),
+    });
+
+    expect(processor.isPollingThread({ threadId: thread.id, resourceId: thread.resourceId })).toBe(false);
   });
 });

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -6,7 +6,12 @@ import { ProcessorRunner } from '@mastra/core/processors';
 import { RequestContext } from '@mastra/core/request-context';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { GithubSignals, GITHUB_SIGNALS_METADATA_KEY, GITHUB_SYNC_STATUS_TAG } from './index.js';
+import {
+  GithubSignals,
+  GITHUB_SIGNALS_METADATA_KEY,
+  GITHUB_SYNC_STATUS_TAG,
+  normalizeGithubChecksForSnapshot,
+} from './index.js';
 import type {
   GithubPullRequestSnapshot,
   GithubRepositoryResolver,
@@ -74,6 +79,90 @@ async function runGithubSignalsProcessor(args: {
   });
 }
 
+describe('normalizeGithubChecksForSnapshot', () => {
+  it('drops old failing workflow rows when newer current check rows supersede them', () => {
+    const checks = normalizeGithubChecksForSnapshot({
+      checkRows: [
+        {
+          source: 'check',
+          name: 'Prebuild',
+          status: 'completed',
+          conclusion: 'success',
+          detailsUrl: 'https://github.com/mastra-ai/mastra/actions/runs/current',
+          updatedAt: '2026-06-02T22:00:00.000Z',
+        },
+      ],
+      workflowRows: [
+        {
+          source: 'workflow',
+          name: 'Prebuild',
+          status: 'completed',
+          conclusion: 'failure',
+          detailsUrl: 'https://github.com/mastra-ai/mastra/actions/runs/old',
+          updatedAt: '2026-06-02T21:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(checks).toEqual([expect.objectContaining({ name: 'Prebuild', status: 'completed', conclusion: 'success' })]);
+  });
+
+  it('keeps rerun pending checks when they are the current state', () => {
+    const checks = normalizeGithubChecksForSnapshot({
+      checkRows: [
+        {
+          source: 'check',
+          name: 'E2E Tests / E2E kitchen-sink (1/3)',
+          status: 'queued',
+          conclusion: undefined,
+          detailsUrl: 'https://github.com/mastra-ai/mastra/actions/runs/current',
+          updatedAt: '2026-06-02T22:10:00.000Z',
+        },
+      ],
+      workflowRows: [],
+    });
+
+    expect(checks).toEqual([expect.objectContaining({ name: 'E2E Tests / E2E kitchen-sink (1/3)', status: 'queued' })]);
+  });
+
+  it('collapses duplicate workflow and check rows to the latest current row', () => {
+    const checks = normalizeGithubChecksForSnapshot({
+      checkRows: [
+        {
+          source: 'check',
+          name: 'Changed Test Gate',
+          status: 'completed',
+          conclusion: 'success',
+          detailsUrl: 'https://github.com/mastra-ai/mastra/actions/runs/1',
+          updatedAt: '2026-06-02T22:00:00.000Z',
+        },
+        {
+          source: 'check',
+          name: 'Changed Test Gate',
+          status: 'completed',
+          conclusion: 'failure',
+          detailsUrl: 'https://github.com/mastra-ai/mastra/actions/runs/1',
+          updatedAt: '2026-06-02T21:00:00.000Z',
+        },
+      ],
+      workflowRows: [
+        {
+          source: 'workflow',
+          name: 'Changed Test Gate',
+          status: 'completed',
+          conclusion: 'failure',
+          detailsUrl: 'https://github.com/mastra-ai/mastra/actions/runs/1',
+          updatedAt: '2026-06-02T21:30:00.000Z',
+        },
+      ],
+    });
+
+    expect(checks).toEqual([
+      expect.objectContaining({ name: 'Changed Test Gate', status: 'completed', conclusion: 'success' }),
+    ]);
+  });
+});
+
 describe('GithubSignals', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -94,6 +183,295 @@ describe('GithubSignals', () => {
         attributes: { owner: 'mastra-ai', repo: 'mastra', number: 123 },
       }),
     );
+  });
+
+  it('emits a subscription hint after PR work evidence', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-hint',
+      resourceId: 'resource-hint',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {},
+    };
+    const threadStore = createThreadStore(thread);
+    const sendSignal = vi.fn(async () => ({ id: 'hint-signal' }));
+
+    await new GithubSignals({ threadStore }).processOutputStep({
+      messages: [],
+      messageList: new MessageList({ threadId: thread.id, resourceId: thread.resourceId }),
+      requestContext: createRequestContext(thread),
+      stepNumber: 0,
+      steps: [],
+      text: 'I checked https://github.com/mastra-ai/mastra/pull/17439 and CI is failing.',
+      toolCalls: [],
+      usage: {} as any,
+      systemMessages: [],
+      state: {},
+      sendSignal,
+    } as any);
+
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'reactive',
+        tagName: 'system-reminder',
+        contents: expect.stringContaining('/github subscribe 17439'),
+        attributes: { type: 'github-subscription-hint' },
+      }),
+    );
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptionHintShown).toBe(true);
+  });
+
+  it('does not duplicate subscription hints once shown', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-hint-shown',
+      resourceId: 'resource-hint-shown',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: { mastra: { [GITHUB_SIGNALS_METADATA_KEY]: { subscriptions: [], subscriptionHintShown: true } } },
+    };
+    const threadStore = createThreadStore(thread);
+    const sendSignal = vi.fn();
+
+    await new GithubSignals({ threadStore }).processOutputStep({
+      messages: [],
+      messageList: new MessageList({ threadId: thread.id, resourceId: thread.resourceId }),
+      requestContext: createRequestContext(thread),
+      stepNumber: 0,
+      steps: [],
+      text: 'gh pr checks 17439',
+      toolCalls: [],
+      usage: {} as any,
+      systemMessages: [],
+      state: {},
+      sendSignal,
+    } as any);
+
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(threadStore.saveThread).not.toHaveBeenCalled();
+  });
+
+  it('does not emit subscription hints when the thread is already subscribed', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-hint-subscribed',
+      resourceId: 'resource-hint-subscribed',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 17439,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const sendSignal = vi.fn();
+
+    await new GithubSignals({ threadStore }).processOutputStep({
+      messages: [],
+      messageList: new MessageList({ threadId: thread.id, resourceId: thread.resourceId }),
+      requestContext: createRequestContext(thread),
+      stepNumber: 0,
+      steps: [],
+      text: 'gh pr view 17439',
+      toolCalls: [],
+      usage: {} as any,
+      systemMessages: [],
+      state: {},
+      sendSignal,
+    } as any);
+
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(threadStore.saveThread).not.toHaveBeenCalled();
+  });
+
+  it('returns GitHub subscribe and unsubscribe tools from processInputStep', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-tools',
+      resourceId: 'resource-tools',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {},
+    };
+
+    const result = await runGithubSignalsProcessor({
+      processor: new GithubSignals({ threadStore: createThreadStore(thread) }),
+      messageList: new MessageList({ threadId: thread.id, resourceId: thread.resourceId }),
+      requestContext: createRequestContext(thread),
+    });
+
+    expect(Object.keys(result.tools ?? {})).toEqual(
+      expect.arrayContaining(['github_subscribe_pr', 'github_unsubscribe_pr']),
+    );
+  });
+
+  it('subscribe and unsubscribe tools emit typed GitHub signals through the registered agent', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-tool-signal',
+      resourceId: 'resource-tool-signal',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {},
+    };
+    const processor = new GithubSignals({ threadStore: createThreadStore(thread) });
+    const sendSignal = vi.fn(() => ({ accepted: true, signal: { id: 'tool-signal' } }));
+    processor.addAgent({ sendSignal } as any);
+
+    const result = await runGithubSignalsProcessor({
+      processor,
+      messageList: new MessageList({ threadId: thread.id, resourceId: thread.resourceId }),
+      requestContext: createRequestContext(thread),
+    });
+    const tools = result.tools as Record<string, { execute: (input: unknown, context?: unknown) => Promise<unknown> }>;
+
+    await tools.github_subscribe_pr!.execute(
+      { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
+      {
+        agentId: 'code-agent',
+        threadId: thread.id,
+        resourceId: thread.resourceId,
+        toolCallId: 'tool-call-1',
+        messages: [],
+      },
+    );
+    await tools.github_unsubscribe_pr!.execute(
+      { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
+      {
+        agentId: 'code-agent',
+        threadId: thread.id,
+        resourceId: thread.resourceId,
+        toolCallId: 'tool-call-2',
+        messages: [],
+      },
+    );
+
+    expect(sendSignal).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        type: 'user',
+        tagName: 'github-subscribe-pr',
+        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
+      }),
+      {
+        resourceId: thread.resourceId,
+        threadId: thread.id,
+        ifActive: { behavior: 'deliver' },
+        ifIdle: { behavior: 'wake' },
+      },
+    );
+    expect(sendSignal).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        type: 'user',
+        tagName: 'github-unsubscribe-pr',
+        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
+      }),
+      {
+        resourceId: thread.resourceId,
+        threadId: thread.id,
+        ifActive: { behavior: 'deliver' },
+        ifIdle: { behavior: 'wake' },
+      },
+    );
+  });
+
+  it('subscribe tool falls back to processor thread context when execution context omits agent details', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-tool-context-fallback',
+      resourceId: 'resource-tool-context-fallback',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {},
+    };
+    const processor = new GithubSignals({ threadStore: createThreadStore(thread) });
+    const sendSignal = vi.fn(() => ({ accepted: true, signal: { id: 'tool-signal' } }));
+    processor.addAgent({ sendSignal } as any);
+
+    const result = await runGithubSignalsProcessor({
+      processor,
+      messageList: new MessageList({ threadId: thread.id, resourceId: thread.resourceId }),
+      requestContext: createRequestContext(thread),
+    });
+    const tools = result.tools as Record<string, { execute: (input: unknown, context?: unknown) => Promise<unknown> }>;
+
+    await tools.github_subscribe_pr!.execute({ owner: 'mastra-ai', repo: 'mastra', number: 17439 }, {});
+
+    expect(sendSignal).toHaveBeenCalledWith(expect.objectContaining({ tagName: 'github-subscribe-pr' }), {
+      resourceId: thread.resourceId,
+      threadId: thread.id,
+      ifActive: { behavior: 'deliver' },
+      ifIdle: { behavior: 'wake' },
+    });
+  });
+
+  it('tool-emitted subscribe signals are handled by the same subscription logic', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-tool-shared-path',
+      resourceId: 'resource-tool-shared-path',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {},
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({ githubUpdatedAt: '2026-01-01T00:00:00.000Z', contentHash: 'hash' })),
+    };
+    const signal = createSignal({
+      ...GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 17439 }),
+      type: 'reactive',
+    });
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    messageList.add([signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })], 'input');
+
+    await runGithubSignalsProcessor({
+      processor: new GithubSignals({ threadStore, syncClient }),
+      messageList,
+      requestContext: createRequestContext(thread),
+    });
+
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const subscriptions = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscriptions).toEqual([expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 17439 })]);
+  });
+
+  it('does not emit subscription hints for unrelated tool calls', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-no-hint',
+      resourceId: 'resource-no-hint',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {},
+    };
+    const threadStore = createThreadStore(thread);
+    const sendSignal = vi.fn();
+
+    await new GithubSignals({ threadStore }).processOutputStep({
+      messages: [],
+      messageList: new MessageList({ threadId: thread.id, resourceId: thread.resourceId }),
+      requestContext: createRequestContext(thread),
+      stepNumber: 0,
+      steps: [],
+      text: 'pnpm test -- --bail 1',
+      toolCalls: [{ toolName: 'execute_command', toolCallId: 'tool-1', args: { command: 'pnpm test' } }],
+      usage: {} as any,
+      systemMessages: [],
+      state: {},
+      sendSignal,
+    } as any);
+
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(threadStore.saveThread).not.toHaveBeenCalled();
   });
 
   it('persists a thread-scoped PR subscription and syncs only that PR', async () => {
@@ -483,6 +861,52 @@ describe('GithubSignals', () => {
     processor.stopAllPolling();
   });
 
+  it('uses the configured notification sender with the explicit polling target', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-sender',
+      resourceId: 'resource-sender',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'old-hash',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({
+        title: 'Add GitHub signals',
+        state: 'open',
+        githubUpdatedAt: '2026-01-01T00:05:00.000Z',
+        contentHash: 'new-hash',
+      })),
+    };
+    const notificationSender = vi.fn(async () => ({ accepted: true }));
+    const processor = new GithubSignals({ threadStore: createThreadStore(thread), syncClient });
+    processor.addNotificationSender(notificationSender);
+
+    await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
+
+    expect(notificationSender).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'github', kind: 'pull-request-activity' }),
+      { resourceId: thread.resourceId, threadId: thread.id },
+    );
+  });
+
   it('only keeps one active polling thread at a time', async () => {
     vi.useFakeTimers();
     const firstThread: StorageThreadType = {
@@ -603,23 +1027,17 @@ describe('GithubSignals', () => {
     const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
     processor.__registerMastra({ getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })) } as any);
 
-    await expect(processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(1);
+    await expect(processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(0);
 
     const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
-    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
-    expect(subscription).toMatchObject({
-      lastObservedState: 'merged',
-      lastObservedCiState: 'success',
-      lastNotificationKind: 'pull-request-merged',
-      lastNotificationPriority: 'high',
-      lastNotificationSummary: 'mastra-ai/mastra#123: Fix duplicate reasoning IDs was merged',
-    });
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([]);
     expect(sendNotificationSignal).toHaveBeenCalledWith(
       expect.objectContaining({
         source: 'github',
         kind: 'pull-request-merged',
         priority: 'high',
-        summary: 'mastra-ai/mastra#123: Fix duplicate reasoning IDs was merged',
+        summary:
+          'mastra-ai/mastra#123: Fix duplicate reasoning IDs was merged. This thread has been automatically unsubscribed from this PR. Resubscribe if you still need updates.',
         attributes: expect.objectContaining({
           state: 'merged',
         }),
@@ -627,6 +1045,116 @@ describe('GithubSignals', () => {
           github: expect.objectContaining({ mergedAt: '2026-06-02T18:42:32Z' }),
         }),
       }),
+      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
+    );
+  });
+
+  it('stops polling after a merged PR was the only subscription', async () => {
+    vi.useFakeTimers();
+    const thread: StorageThreadType = {
+      id: 'thread-merged-polling',
+      resourceId: 'resource-merged-polling',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'old-hash',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({
+        title: 'Fix duplicate reasoning IDs',
+        state: 'merged',
+        mergedAt: '2026-06-02T18:42:32Z',
+        githubUpdatedAt: '2026-06-02T18:43:57Z',
+        contentHash: 'merged-hash',
+      })),
+    };
+    const processor = new GithubSignals({ threadStore, syncClient, pollIntervalMs: 1_000, agentId: 'code-agent' });
+    const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
+    processor.__registerMastra({ getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })) } as any);
+
+    await expect(processor.startPollingForThread({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(
+      true,
+    );
+    expect(processor.isPollingThread({ threadId: thread.id, resourceId: thread.resourceId })).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(processor.isPollingThread({ threadId: thread.id, resourceId: thread.resourceId })).toBe(false);
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([]);
+  });
+
+  it('does not unsubscribe after a closed-unmerged PR notification', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-closed',
+      resourceId: 'resource-closed',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'old-hash',
+                lastObservedState: 'open',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({
+        title: 'Close stale PR',
+        state: 'closed',
+        closedAt: '2026-06-02T18:42:32Z',
+        githubUpdatedAt: '2026-06-02T18:43:57Z',
+        contentHash: 'closed-hash',
+      })),
+    };
+    const processor = new GithubSignals({ threadStore, syncClient, agentId: 'code-agent' });
+    const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
+    processor.__registerMastra({ getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })) } as any);
+
+    await expect(processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(1);
+
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const subscriptions = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscriptions).toHaveLength(1);
+    expect(subscriptions[0]).toMatchObject({
+      number: 123,
+      lastObservedState: 'closed',
+      lastNotificationKind: 'pull-request-closed',
+    });
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'pull-request-closed' }),
       expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
     );
   });

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -903,12 +903,22 @@ describe('GithubSignals', () => {
         contentHash: 'sync-now-hash',
       })),
     };
+    const sendNotificationSignal = vi.fn(async () => ({ accepted: true }));
     const processor = new GithubSignals({ threadStore, syncClient });
+    processor.addAgent({ sendSignal: vi.fn(), sendNotificationSignal });
 
     await expect(processor.syncThreadNow({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(1);
 
     expect(syncClient.syncPullRequest).toHaveBeenCalledWith(
       expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'github',
+        kind: 'pull-request-activity',
+        summary: 'mastra-ai/mastra#123 has new activity: Add GitHub signals',
+      }),
+      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
     );
     const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
     expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions[0]).toMatchObject({

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -1,0 +1,217 @@
+import { createSignal } from '@mastra/core/agent';
+import { MessageList } from '@mastra/core/agent/message-list';
+import type { IMastraLogger } from '@mastra/core/logger';
+import type { StorageThreadType } from '@mastra/core/memory';
+import { ProcessorRunner } from '@mastra/core/processors';
+import { RequestContext } from '@mastra/core/request-context';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GithubSignals, GITHUB_SIGNALS_METADATA_KEY, GITHUB_SYNC_STATUS_TAG } from './index.js';
+import type { GithubRepositoryResolver, GithubSignalsSyncClient, GithubSignalsThreadStore } from './index.js';
+
+const mockLogger: IMastraLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trackException: vi.fn(),
+  getTransports: vi.fn(() => []),
+  listLogs: vi.fn(() => []),
+  listLogsByRunId: vi.fn(() => []),
+} as any;
+
+function createThreadStore(thread: StorageThreadType): GithubSignalsThreadStore {
+  return {
+    getThreadById: vi.fn(async () => thread),
+    saveThread: vi.fn(async ({ thread: nextThread }: { thread: StorageThreadType }) => {
+      thread = nextThread;
+      return nextThread;
+    }),
+  };
+}
+
+function createRequestContext(thread: StorageThreadType) {
+  const requestContext = new RequestContext();
+  requestContext.set('MastraMemory', {
+    thread: { id: thread.id },
+    resourceId: thread.resourceId,
+  });
+  return requestContext;
+}
+
+async function runGithubSignalsProcessor(args: {
+  processor: GithubSignals;
+  messageList: MessageList;
+  requestContext: RequestContext;
+  chunks?: unknown[];
+}) {
+  const runner = new ProcessorRunner({
+    inputProcessors: [args.processor],
+    outputProcessors: [],
+    logger: mockLogger,
+    agentName: 'github-agent',
+  });
+
+  return runner.runProcessInputStep({
+    messageList: args.messageList,
+    stepNumber: 0,
+    steps: [],
+    model: {} as any,
+    tools: {},
+    retryCount: 0,
+    requestContext: args.requestContext,
+    messageId: 'response-1',
+    writer: {
+      custom: vi.fn(async (chunk: unknown) => {
+        args.chunks?.push(chunk);
+      }),
+    },
+  });
+}
+
+describe('GithubSignals', () => {
+  it('creates typed subscribe-to-PR signals', () => {
+    expect(GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 })).toEqual(
+      expect.objectContaining({
+        type: 'user',
+        tagName: 'github-subscribe-pr',
+        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 123 },
+      }),
+    );
+  });
+
+  it('persists a thread-scoped PR subscription and syncs only that PR', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-1',
+      resourceId: 'resource-1',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: { existing: true },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true, stdout: '{"ok":true}' })),
+    };
+    const signal = createSignal(
+      GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    messageList.add([signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })], 'input');
+    const chunks: unknown[] = [];
+
+    await runGithubSignalsProcessor({
+      processor: new GithubSignals({ threadStore, syncClient }),
+      messageList,
+      requestContext: createRequestContext(thread),
+      chunks,
+    });
+
+    expect(syncClient.syncPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    expect(threadStore.saveThread).toHaveBeenCalledTimes(1);
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    expect(savedThread.metadata).toEqual(
+      expect.objectContaining({
+        existing: true,
+        mastra: expect.objectContaining({
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              expect.objectContaining({
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                lastSubscribeSignalId: signal.id,
+                lastSyncStatus: 'success',
+              }),
+            ],
+          },
+        }),
+      }),
+    );
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'data-signal',
+        data: expect.objectContaining({
+          type: 'reactive',
+          tagName: GITHUB_SYNC_STATUS_TAG,
+          attributes: expect.objectContaining({
+            status: 'subscribed',
+            owner: 'mastra-ai',
+            repo: 'mastra',
+            number: 123,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('resolves owner and repo from the project when the signal only carries a PR number', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-2',
+      resourceId: 'resource-2',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = { syncPullRequest: vi.fn(async () => ({ ok: true })) };
+    const repositoryResolver: GithubRepositoryResolver = {
+      resolveRepository: vi.fn(async () => ({ owner: 'mastra-ai', repo: 'mastra' })),
+    };
+    const signal = createSignal(GithubSignals.signals.subscribeToPR(456));
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    messageList.add([signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })], 'input');
+
+    await runGithubSignalsProcessor({
+      processor: new GithubSignals({ cwd: '/repo', threadStore, syncClient, repositoryResolver }),
+      messageList,
+      requestContext: createRequestContext(thread),
+    });
+
+    expect(repositoryResolver.resolveRepository).toHaveBeenCalledWith(expect.objectContaining({ cwd: '/repo' }));
+    expect(syncClient.syncPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 456, cwd: '/repo' }),
+    );
+  });
+
+  it('does not reprocess the same subscribe signal twice', async () => {
+    const signal = createSignal(
+      GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    const thread: StorageThreadType = {
+      id: 'thread-3',
+      resourceId: 'resource-3',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: signal.id,
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = { syncPullRequest: vi.fn(async () => ({ ok: true })) };
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    messageList.add([signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })], 'input');
+
+    await runGithubSignalsProcessor({
+      processor: new GithubSignals({ threadStore, syncClient }),
+      messageList,
+      requestContext: createRequestContext(thread),
+    });
+
+    expect(syncClient.syncPullRequest).not.toHaveBeenCalled();
+    expect(threadStore.saveThread).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -575,6 +575,59 @@ describe('GithubSignals', () => {
     );
   });
 
+  it('preserves one-time hint state and granular cursors when resubscribing', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-resubscribe',
+      resourceId: 'resource-resubscribe',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptionHintShown: true,
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'aggregate-hash',
+                lastObservedThreadContentHash: 'thread-hash',
+                lastObservedHeadSha: 'head-sha',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const signal = createSignal(
+      GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    messageList.add([signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })], 'input');
+
+    await runGithubSignalsProcessor({
+      processor: new GithubSignals({ threadStore, syncOnSubscribe: false }),
+      messageList,
+      requestContext: createRequestContext(thread),
+    });
+
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const savedGithubMetadata = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY];
+    expect(savedGithubMetadata.subscriptionHintShown).toBe(true);
+    expect(savedGithubMetadata.subscriptions[0]).toMatchObject({
+      lastSubscribeSignalId: signal.id,
+      lastObservedContentHash: 'aggregate-hash',
+      lastObservedThreadContentHash: 'thread-hash',
+      lastObservedHeadSha: 'head-sha',
+      lastSyncStatus: 'skipped',
+    });
+  });
+
   it('emits an initial PR baseline notification on subscribe', async () => {
     const thread: StorageThreadType = {
       id: 'thread-baseline',
@@ -827,6 +880,7 @@ describe('GithubSignals', () => {
       metadata: {
         mastra: {
           [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptionHintShown: true,
             subscriptions: [
               {
                 owner: 'mastra-ai',
@@ -872,7 +926,9 @@ describe('GithubSignals', () => {
       expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
     );
     const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
-    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    const savedGithubMetadata = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY];
+    expect(savedGithubMetadata.subscriptionHintShown).toBe(true);
+    const [subscription] = savedGithubMetadata.subscriptions;
     expect(subscription).toMatchObject({
       lastSyncStatus: 'success',
       lastObservedGithubUpdatedAt: '2026-01-01T00:05:00.000Z',

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -315,7 +315,7 @@ describe('GithubSignals', () => {
     );
   });
 
-  it('subscribe and unsubscribe tools emit typed GitHub signals through the registered agent', async () => {
+  it('subscribe and unsubscribe tools mutate the current thread subscription directly', async () => {
     const thread: StorageThreadType = {
       id: 'thread-tool-signal',
       resourceId: 'resource-tool-signal',
@@ -323,9 +323,12 @@ describe('GithubSignals', () => {
       updatedAt: new Date('2026-01-01T00:00:00.000Z'),
       metadata: {},
     };
-    const processor = new GithubSignals({ threadStore: createThreadStore(thread) });
-    const sendSignal = vi.fn(() => ({ accepted: true, signal: { id: 'tool-signal' } }));
-    processor.addAgent({ sendSignal } as any);
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({ githubUpdatedAt: '2026-01-01T00:00:00.000Z', contentHash: 'hash' })),
+    };
+    const processor = new GithubSignals({ threadStore, syncClient });
 
     const result = await runGithubSignalsProcessor({
       processor,
@@ -334,55 +337,38 @@ describe('GithubSignals', () => {
     });
     const tools = result.tools as Record<string, { execute: (input: unknown, context?: unknown) => Promise<unknown> }>;
 
-    await tools.github_subscribe_pr!.execute(
-      { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
-      {
-        agentId: 'code-agent',
-        threadId: thread.id,
-        resourceId: thread.resourceId,
-        toolCallId: 'tool-call-1',
-        messages: [],
-      },
-    );
-    await tools.github_unsubscribe_pr!.execute(
-      { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
-      {
-        agentId: 'code-agent',
-        threadId: thread.id,
-        resourceId: thread.resourceId,
-        toolCallId: 'tool-call-2',
-        messages: [],
-      },
-    );
+    await expect(
+      tools.github_subscribe_pr!.execute(
+        { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
+        {
+          agentId: 'code-agent',
+          threadId: thread.id,
+          resourceId: thread.resourceId,
+          toolCallId: 'tool-call-1',
+          messages: [],
+        },
+      ),
+    ).resolves.toMatchObject({ subscribed: true, owner: 'mastra-ai', repo: 'mastra', number: 17439 });
+    let savedThread = vi.mocked(threadStore.saveThread).mock.calls.at(-1)![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 17439 }),
+    ]);
 
-    expect(sendSignal).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        type: 'reactive',
-        tagName: 'github-subscribe-pr',
-        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
-      }),
-      {
-        resourceId: thread.resourceId,
-        threadId: thread.id,
-        ifActive: { behavior: 'deliver' },
-        ifIdle: { behavior: 'wake' },
-      },
-    );
-    expect(sendSignal).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        type: 'reactive',
-        tagName: 'github-unsubscribe-pr',
-        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
-      }),
-      {
-        resourceId: thread.resourceId,
-        threadId: thread.id,
-        ifActive: { behavior: 'deliver' },
-        ifIdle: { behavior: 'wake' },
-      },
-    );
+    await expect(
+      tools.github_unsubscribe_pr!.execute(
+        { owner: 'mastra-ai', repo: 'mastra', number: 17439 },
+        {
+          agentId: 'code-agent',
+          threadId: thread.id,
+          resourceId: thread.resourceId,
+          toolCallId: 'tool-call-2',
+          messages: [],
+        },
+      ),
+    ).resolves.toMatchObject({ unsubscribed: true, owner: 'mastra-ai', repo: 'mastra', number: 17439 });
+    savedThread = vi.mocked(threadStore.saveThread).mock.calls.at(-1)![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([]);
+    processor.stopAllPolling();
   });
 
   it('subscribe tool falls back to processor thread context when execution context omits agent details', async () => {
@@ -393,9 +379,8 @@ describe('GithubSignals', () => {
       updatedAt: new Date('2026-01-01T00:00:00.000Z'),
       metadata: {},
     };
-    const processor = new GithubSignals({ threadStore: createThreadStore(thread) });
-    const sendSignal = vi.fn(() => ({ accepted: true, signal: { id: 'tool-signal' } }));
-    processor.addAgent({ sendSignal } as any);
+    const threadStore = createThreadStore(thread);
+    const processor = new GithubSignals({ threadStore, syncOnSubscribe: false });
 
     const result = await runGithubSignalsProcessor({
       processor,
@@ -406,12 +391,11 @@ describe('GithubSignals', () => {
 
     await tools.github_subscribe_pr!.execute({ owner: 'mastra-ai', repo: 'mastra', number: 17439 }, {});
 
-    expect(sendSignal).toHaveBeenCalledWith(expect.objectContaining({ tagName: 'github-subscribe-pr' }), {
-      resourceId: thread.resourceId,
-      threadId: thread.id,
-      ifActive: { behavior: 'deliver' },
-      ifIdle: { behavior: 'wake' },
-    });
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls.at(-1)![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 17439, lastSyncStatus: 'skipped' }),
+    ]);
+    processor.stopAllPolling();
   });
 
   it('tool-emitted subscribe signals are handled by the same subscription logic', async () => {
@@ -780,17 +764,17 @@ describe('GithubSignals', () => {
     );
   });
 
-  it('returns processor-owned tools that send subscribe and unsubscribe signals to the current agent', async () => {
+  it('returns processor-owned tools that persist subscribe and unsubscribe operations immediately', async () => {
     const thread: StorageThreadType = {
       id: 'thread-5',
       resourceId: 'resource-5',
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
       updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {},
     };
+    const threadStore = createThreadStore(thread);
     const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
-    const processor = new GithubSignals({ syncOnSubscribe: false });
-    const sendSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true, runId: 'run-1' }) }));
-    processor.__registerMastra({ getAgentById: vi.fn(() => ({ sendSignal })) } as any);
+    const processor = new GithubSignals({ threadStore, syncOnSubscribe: false });
 
     const result = await runGithubSignalsProcessor({
       processor,
@@ -804,22 +788,21 @@ describe('GithubSignals', () => {
         { owner: 'mastra-ai', repo: 'mastra', number: 123 },
         { agent: { agentId: 'code-agent', threadId: thread.id, resourceId: thread.resourceId } },
       ),
-    ).resolves.toMatchObject({ subscribed: true, number: 123 });
-    expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({ tagName: 'github-subscribe-pr' }),
-      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
-    );
+    ).resolves.toMatchObject({ subscribed: true, owner: 'mastra-ai', repo: 'mastra', number: 123 });
+    let savedThread = vi.mocked(threadStore.saveThread).mock.calls.at(-1)![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123, lastSyncStatus: 'skipped' }),
+    ]);
 
     await expect(
       tools.github_unsubscribe_pr.execute(
         { owner: 'mastra-ai', repo: 'mastra', number: 123 },
         { agent: { agentId: 'code-agent', threadId: thread.id, resourceId: thread.resourceId } },
       ),
-    ).resolves.toMatchObject({ unsubscribed: true, number: 123 });
-    expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({ tagName: 'github-unsubscribe-pr' }),
-      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
-    );
+    ).resolves.toMatchObject({ unsubscribed: true, owner: 'mastra-ai', repo: 'mastra', number: 123 });
+    savedThread = vi.mocked(threadStore.saveThread).mock.calls.at(-1)![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([]);
+    processor.stopAllPolling();
   });
 
   it('polls subscribed PRs on the configured interval and updates thread metadata', async () => {

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -905,7 +905,7 @@ describe('GithubSignals', () => {
     processor.stopAllPolling();
   });
 
-  it('uses the configured notification sender with the explicit polling target', async () => {
+  it('sends GitHub notifications through the registered agent with polling target stream options', async () => {
     const thread: StorageThreadType = {
       id: 'thread-sender',
       resourceId: 'resource-sender',
@@ -939,15 +939,26 @@ describe('GithubSignals', () => {
         contentHash: 'new-hash',
       })),
     };
-    const notificationSender = vi.fn(async () => ({ accepted: true }));
+    const sendNotificationSignal = vi.fn(async () => ({ accepted: true }));
     const processor = new GithubSignals({ threadStore: createThreadStore(thread), syncClient });
-    processor.addNotificationSender(notificationSender);
+    processor.addAgent(
+      { sendSignal: vi.fn(), sendNotificationSignal },
+      {
+        getNotificationStreamOptions: async target => ({
+          memory: { resource: target.resourceId, thread: target.threadId },
+        }),
+      },
+    );
 
     await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
 
-    expect(notificationSender).toHaveBeenCalledWith(
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
       expect.objectContaining({ source: 'github', kind: 'pull-request-activity' }),
-      { resourceId: thread.resourceId, threadId: thread.id },
+      expect.objectContaining({
+        resourceId: thread.resourceId,
+        threadId: thread.id,
+        ifIdle: { streamOptions: { memory: { resource: thread.resourceId, thread: thread.id } } },
+      }),
     );
   });
 

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -445,6 +445,50 @@ describe('GithubSignals', () => {
     expect(subscriptions).toEqual([expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 17439 })]);
   });
 
+  it('does not replay historical subscribe signals when they are not the latest message', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-historical-subscribe',
+      resourceId: 'resource-historical-subscribe',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {},
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({ githubUpdatedAt: '2026-01-01T00:00:00.000Z', contentHash: 'hash' })),
+    };
+    const signal = createSignal({
+      ...GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 17449 }),
+      type: 'reactive',
+    });
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    messageList.add(
+      [
+        signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId }),
+        {
+          id: 'assistant-after-merge',
+          role: 'assistant',
+          type: 'text',
+          thread_id: thread.id,
+          resourceId: thread.resourceId,
+          content: { format: 2, parts: [{ type: 'text', text: 'PR merged and auto-unsubscribed.' }] },
+          createdAt: new Date(),
+        } as any,
+      ],
+      'input',
+    );
+
+    await runGithubSignalsProcessor({
+      processor: new GithubSignals({ threadStore, syncClient }),
+      messageList,
+      requestContext: createRequestContext(thread),
+    });
+
+    expect(syncClient.syncPullRequest).not.toHaveBeenCalled();
+    expect(threadStore.saveThread).not.toHaveBeenCalled();
+  });
+
   it('does not emit subscription hints for unrelated tool calls', async () => {
     const thread: StorageThreadType = {
       id: 'thread-no-hint',

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -838,6 +838,7 @@ describe('GithubSignals', () => {
                 lastSyncError: 'old-error',
                 lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
                 lastObservedContentHash: 'old-hash',
+                lastObservedThreadContentHash: 'old-thread-hash',
               },
             ],
           },
@@ -853,6 +854,7 @@ describe('GithubSignals', () => {
         htmlUrl: 'https://github.com/mastra-ai/mastra/pull/123',
         githubUpdatedAt: '2026-01-01T00:05:00.000Z',
         contentHash: 'new-hash',
+        threadContentHash: 'new-thread-hash',
       })),
     };
     const processor = new GithubSignals({ threadStore, syncClient, pollIntervalMs: 1_000, agentId: 'code-agent' });
@@ -875,6 +877,7 @@ describe('GithubSignals', () => {
       lastSyncStatus: 'success',
       lastObservedGithubUpdatedAt: '2026-01-01T00:05:00.000Z',
       lastObservedContentHash: 'new-hash',
+      lastObservedThreadContentHash: 'new-thread-hash',
       lastNotificationKind: 'pull-request-activity',
       lastNotificationPriority: 'medium',
       lastNotificationSummary: 'mastra-ai/mastra#123 has new activity: Add GitHub signals',
@@ -962,6 +965,74 @@ describe('GithubSignals', () => {
       lastObservedMergeableState: 'unstable',
       lastObservedCiState: 'pending',
       lastObservedReviewStateHash: 'reviews-0',
+    });
+    expect(subscription.lastNotificationKind).toBeUndefined();
+  });
+
+  it('updates the GitHub cursor without notifying when only pending check details change', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-check-churn',
+      resourceId: 'resource-check-churn',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 17447,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastObservedGithubUpdatedAt: '2026-06-03T05:06:31.000Z',
+                lastObservedContentHash: 'old-check-hash',
+                lastObservedState: 'open',
+                lastObservedMergeableState: 'unstable',
+                lastObservedCiState: 'pending',
+                lastObservedReviewStateHash: 'reviews-0',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(
+        async () =>
+          ({
+            title: '07 feat(mastracode): add GitHub signal subscriptions',
+            state: 'open',
+            githubUpdatedAt: '2026-06-03T05:11:30.000Z',
+            contentHash: 'new-check-hash',
+            threadContentHash: 'same-thread-hash',
+            headSha: 'same-head-sha',
+            ciState: 'pending',
+            mergeableState: 'unstable',
+            unresolvedReviewThreads: 0,
+            reviewStateHash: 'reviews-0',
+            checks: [{ name: 'changed-tests', status: 'queued', conclusion: undefined }],
+          }) satisfies GithubPullRequestSnapshot,
+      ),
+    };
+    const sendNotificationSignal = vi.fn(async () => ({ accepted: true }));
+    const processor = new GithubSignals({ threadStore, syncClient });
+    processor.addAgent({ sendSignal: vi.fn(), sendNotificationSignal });
+
+    await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
+
+    expect(sendNotificationSignal).not.toHaveBeenCalled();
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscription).toMatchObject({
+      lastObservedGithubUpdatedAt: '2026-06-03T05:11:30.000Z',
+      lastObservedContentHash: 'new-check-hash',
+      lastObservedThreadContentHash: 'same-thread-hash',
+      lastObservedHeadSha: 'same-head-sha',
+      lastObservedCiState: 'pending',
     });
     expect(subscription.lastNotificationKind).toBeUndefined();
   });

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -870,6 +870,53 @@ describe('GithubSignals', () => {
     processor.stopAllPolling();
   });
 
+  it('syncs subscribed PRs immediately on request', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-sync-now',
+      resourceId: 'resource-sync-now',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({
+        title: 'Add GitHub signals',
+        state: 'open',
+        githubUpdatedAt: '2026-01-01T00:05:00.000Z',
+        contentHash: 'sync-now-hash',
+      })),
+    };
+    const processor = new GithubSignals({ threadStore, syncClient });
+
+    await expect(processor.syncThreadNow({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(1);
+
+    expect(syncClient.syncPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+    );
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions[0]).toMatchObject({
+      lastSyncStatus: 'success',
+      lastObservedContentHash: 'sync-now-hash',
+    });
+  });
+
   it('polls subscribed PRs on the configured interval and updates thread metadata', async () => {
     vi.useFakeTimers();
     const thread: StorageThreadType = {

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -775,6 +775,8 @@ describe('GithubSignals', () => {
     const threadStore = createThreadStore(thread);
     const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
     const processor = new GithubSignals({ threadStore, syncOnSubscribe: false });
+    const onSubscriptionsChanged = vi.fn();
+    processor.onSubscriptionsChanged(onSubscriptionsChanged);
 
     const result = await runGithubSignalsProcessor({
       processor,
@@ -793,6 +795,11 @@ describe('GithubSignals', () => {
     expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([
       expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123, lastSyncStatus: 'skipped' }),
     ]);
+    expect(onSubscriptionsChanged).toHaveBeenLastCalledWith({
+      threadId: thread.id,
+      resourceId: thread.resourceId,
+      subscriptions: [expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 123 })],
+    });
 
     await expect(
       tools.github_unsubscribe_pr.execute(
@@ -802,6 +809,11 @@ describe('GithubSignals', () => {
     ).resolves.toMatchObject({ unsubscribed: true, owner: 'mastra-ai', repo: 'mastra', number: 123 });
     savedThread = vi.mocked(threadStore.saveThread).mock.calls.at(-1)![0].thread;
     expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([]);
+    expect(onSubscriptionsChanged).toHaveBeenLastCalledWith({
+      threadId: thread.id,
+      resourceId: thread.resourceId,
+      subscriptions: [],
+    });
     processor.stopAllPolling();
   });
 

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -888,6 +888,72 @@ describe('GithubSignals', () => {
     processor.stopAllPolling();
   });
 
+  it('updates the GitHub cursor without notifying when only githubUpdatedAt changes', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-timestamp-only',
+      resourceId: 'resource-timestamp-only',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 17447,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastObservedGithubUpdatedAt: '2026-06-03T03:51:10.000Z',
+                lastObservedContentHash: 'same-semantic-hash',
+                lastObservedState: 'open',
+                lastObservedMergeableState: 'unstable',
+                lastObservedCiState: 'pending',
+                lastObservedReviewStateHash: 'reviews-0',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(
+        async () =>
+          ({
+            title: '07 feat(mastracode): add GitHub signal subscriptions',
+            state: 'open',
+            githubUpdatedAt: '2026-06-03T04:02:44.000Z',
+            contentHash: 'same-semantic-hash',
+            ciState: 'pending',
+            mergeableState: 'unstable',
+            unresolvedReviewThreads: 0,
+            reviewStateHash: 'reviews-0',
+            checks: [{ name: 'changed-tests', status: 'queued', conclusion: undefined }],
+          }) satisfies GithubPullRequestSnapshot,
+      ),
+    };
+    const sendNotificationSignal = vi.fn(async () => ({ accepted: true }));
+    const processor = new GithubSignals({ threadStore, syncClient });
+    processor.addAgent({ sendSignal: vi.fn(), sendNotificationSignal });
+
+    await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
+
+    expect(sendNotificationSignal).not.toHaveBeenCalled();
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscription).toMatchObject({
+      lastObservedGithubUpdatedAt: '2026-06-03T04:02:44.000Z',
+      lastObservedContentHash: 'same-semantic-hash',
+      lastObservedMergeableState: 'unstable',
+      lastObservedCiState: 'pending',
+      lastObservedReviewStateHash: 'reviews-0',
+    });
+    expect(subscription.lastNotificationKind).toBeUndefined();
+  });
+
   it('sends GitHub notifications through the registered agent with polling target stream options', async () => {
     const thread: StorageThreadType = {
       id: 'thread-sender',

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -1421,6 +1421,21 @@ describe('GithubSignals', () => {
       expect.objectContaining({ kind: 'pull-request-conflict', priority: 'high' }),
       expect.anything(),
     );
+    const dirtySuppressesCiPending = await runPoll(
+      createThreadWithCursor({ lastObservedCiState: 'success', lastObservedMergeableState: 'dirty' }),
+      {
+        title: 'PR',
+        state: 'open',
+        contentHash: 'dirty-ci-pending',
+        ciState: 'pending',
+        mergeableState: 'dirty',
+        checks: [
+          { name: 'PR Triage', status: 'queued', conclusion: undefined },
+          { name: 'summarize', status: 'queued', conclusion: undefined },
+        ],
+      },
+    );
+    expect(dirtySuppressesCiPending).not.toHaveBeenCalled();
     const reviewActivity = await runPoll(createThreadWithCursor({ lastObservedReviewStateHash: 'reviews-1' }), {
       title: 'PR',
       state: 'open',

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -855,11 +855,27 @@ describe('GithubSignals', () => {
     });
 
     await expect(
-      tools.github_unsubscribe_pr.execute(
-        { owner: 'mastra-ai', repo: 'mastra', number: 123 },
+      tools.github_subscribe_pr.execute(
+        { owner: 'mastra-ai', repo: 'mastra', number: 456 },
         { agent: { agentId: 'code-agent', threadId: thread.id, resourceId: thread.resourceId } },
       ),
-    ).resolves.toMatchObject({ unsubscribed: true, owner: 'mastra-ai', repo: 'mastra', number: 123 });
+    ).resolves.toMatchObject({ subscribed: true, owner: 'mastra-ai', repo: 'mastra', number: 456 });
+    savedThread = vi.mocked(threadStore.saveThread).mock.calls.at(-1)![0].thread;
+    expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([
+      expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 456, lastSyncStatus: 'skipped' }),
+    ]);
+    expect(onSubscriptionsChanged).toHaveBeenLastCalledWith({
+      threadId: thread.id,
+      resourceId: thread.resourceId,
+      subscriptions: [expect.objectContaining({ owner: 'mastra-ai', repo: 'mastra', number: 456 })],
+    });
+
+    await expect(
+      tools.github_unsubscribe_pr.execute(
+        { owner: 'mastra-ai', repo: 'mastra', number: 456 },
+        { agent: { agentId: 'code-agent', threadId: thread.id, resourceId: thread.resourceId } },
+      ),
+    ).resolves.toMatchObject({ unsubscribed: true, owner: 'mastra-ai', repo: 'mastra', number: 456 });
     savedThread = vi.mocked(threadStore.saveThread).mock.calls.at(-1)![0].thread;
     expect((savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions).toEqual([]);
     expect(onSubscriptionsChanged).toHaveBeenLastCalledWith({

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -483,6 +483,154 @@ describe('GithubSignals', () => {
     processor.stopAllPolling();
   });
 
+  it('only keeps one active polling thread at a time', async () => {
+    vi.useFakeTimers();
+    const firstThread: StorageThreadType = {
+      id: 'thread-one',
+      resourceId: 'resource-1',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 1,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const secondThread: StorageThreadType = {
+      id: 'thread-two',
+      resourceId: 'resource-1',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 2,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-2',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threads = new Map([
+      [firstThread.id, firstThread],
+      [secondThread.id, secondThread],
+    ]);
+    const threadStore: GithubSignalsThreadStore = {
+      getThreadById: vi.fn(async ({ threadId }: { threadId: string }) => threads.get(threadId) ?? null),
+      saveThread: vi.fn(async ({ thread }: { thread: StorageThreadType }) => thread),
+    };
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({ githubUpdatedAt: '2026-01-01T00:00:00.000Z' })),
+    };
+    const processor = new GithubSignals({ threadStore, syncClient, pollIntervalMs: 1_000 });
+
+    await expect(
+      processor.startPollingForThread({ threadId: firstThread.id, resourceId: firstThread.resourceId }),
+    ).resolves.toBe(true);
+    expect(processor.isPollingThread({ threadId: firstThread.id, resourceId: firstThread.resourceId })).toBe(true);
+
+    await expect(
+      processor.startPollingForThread({ threadId: secondThread.id, resourceId: secondThread.resourceId }),
+    ).resolves.toBe(true);
+
+    expect(processor.isPollingThread({ threadId: firstThread.id, resourceId: firstThread.resourceId })).toBe(false);
+    expect(processor.isPollingThread({ threadId: secondThread.id, resourceId: secondThread.resourceId })).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(syncClient.syncPullRequest).toHaveBeenCalledTimes(1);
+    expect(syncClient.syncPullRequest).toHaveBeenCalledWith(expect.objectContaining({ number: 2 }));
+    processor.stopAllPolling();
+  });
+
+  it('emits a high-priority notification when a legacy subscribed PR is first observed as merged', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-merged',
+      resourceId: 'resource-merged',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'old-hash',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({
+        title: 'Fix duplicate reasoning IDs',
+        state: 'merged',
+        mergedAt: '2026-06-02T18:42:32Z',
+        githubUpdatedAt: '2026-06-02T18:43:57Z',
+        contentHash: 'merged-hash',
+        ciState: 'success' as const,
+      })),
+    };
+    const processor = new GithubSignals({ threadStore, syncClient, agentId: 'code-agent' });
+    const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
+    processor.__registerMastra({ getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })) } as any);
+
+    await expect(processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(1);
+
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscription).toMatchObject({
+      lastObservedState: 'merged',
+      lastObservedCiState: 'success',
+      lastNotificationKind: 'pull-request-merged',
+      lastNotificationPriority: 'high',
+      lastNotificationSummary: 'mastra-ai/mastra#123: Fix duplicate reasoning IDs was merged',
+    });
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'github',
+        kind: 'pull-request-merged',
+        priority: 'high',
+        summary: 'mastra-ai/mastra#123: Fix duplicate reasoning IDs was merged',
+        attributes: expect.objectContaining({
+          state: 'merged',
+        }),
+        metadata: expect.objectContaining({
+          github: expect.objectContaining({ mergedAt: '2026-06-02T18:42:32Z' }),
+        }),
+      }),
+      expect.objectContaining({ resourceId: thread.resourceId, threadId: thread.id }),
+    );
+  });
+
   it('emits a high-priority notification when CI fails between polls', async () => {
     const thread: StorageThreadType = {
       id: 'thread-ci',

--- a/mastracode/src/github-signals/index.test.ts
+++ b/mastracode/src/github-signals/index.test.ts
@@ -1407,6 +1407,20 @@ describe('GithubSignals', () => {
       expect.objectContaining({ kind: 'pull-request-ci-recovered', priority: 'medium' }),
       expect.anything(),
     );
+    const conflictBeatsRecovery = await runPoll(
+      createThreadWithCursor({ lastObservedCiState: 'pending', lastObservedMergeableState: 'unknown' }),
+      {
+        title: 'PR',
+        state: 'open',
+        contentHash: 'dirty-ci-ok',
+        ciState: 'success',
+        mergeableState: 'dirty',
+      },
+    );
+    expect(conflictBeatsRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'pull-request-conflict', priority: 'high' }),
+      expect.anything(),
+    );
     const reviewActivity = await runPoll(createThreadWithCursor({ lastObservedReviewStateHash: 'reviews-1' }), {
       title: 'PR',
       state: 'open',

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -1493,24 +1493,27 @@ export class GithubSignals implements Processor<'github-signals'> {
   }
 
   #findLatestGithubSignal(messages: MastraDBMessage[]): (GithubPRSignal & { tagName: string }) | undefined {
-    for (const message of [...messages].reverse()) {
-      const signal = getSignalMetadata(message);
-      if (!signal || (signal.tagName !== GITHUB_SUBSCRIBE_PR_TAG && signal.tagName !== GITHUB_UNSUBSCRIBE_PR_TAG))
-        continue;
-      const attributes = isPlainObject(signal.attributes) ? signal.attributes : {};
-      const metadata = isPlainObject(signal.metadata) ? signal.metadata : {};
-      const github = isPlainObject(metadata.github) ? metadata.github : {};
-      const number = readNumber(attributes.number) ?? readNumber(github.number);
-      if (!number) continue;
-      return {
-        tagName: String(signal.tagName),
-        id: readString(signal.id) ?? message.id,
-        owner: readString(attributes.owner) ?? readString(github.owner),
-        repo: readString(attributes.repo) ?? readString(github.repo),
-        number,
-      };
+    const message = messages.at(-1);
+    if (!message) return undefined;
+
+    const signal = getSignalMetadata(message);
+    if (!signal || (signal.tagName !== GITHUB_SUBSCRIBE_PR_TAG && signal.tagName !== GITHUB_UNSUBSCRIBE_PR_TAG)) {
+      return undefined;
     }
-    return undefined;
+
+    const attributes = isPlainObject(signal.attributes) ? signal.attributes : {};
+    const metadata = isPlainObject(signal.metadata) ? signal.metadata : {};
+    const github = isPlainObject(metadata.github) ? metadata.github : {};
+    const number = readNumber(attributes.number) ?? readNumber(github.number);
+    if (!number) return undefined;
+
+    return {
+      tagName: String(signal.tagName),
+      id: readString(signal.id) ?? message.id,
+      owner: readString(attributes.owner) ?? readString(github.owner),
+      repo: readString(attributes.repo) ?? readString(github.repo),
+      number,
+    };
   }
 
   async #sendStatus(

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -514,6 +514,7 @@ function classifyGithubActivityNotification(input: {
       summary: `${pr} merge conflicts were resolved`,
     };
   }
+  if (input.snapshot.mergeableState === 'dirty') return undefined;
   if (
     input.snapshot.ciState === 'success' &&
     input.subscription.lastObservedCiState &&

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -906,6 +906,10 @@ export class GithubSignals implements Processor<'github-signals'> {
     this.mastra = mastra as unknown as GithubSignalsMastra;
   }
 
+  async syncThreadNow(input: GithubPollingThread): Promise<number> {
+    return this.#pollThread(input);
+  }
+
   async startPollingForThread(
     input: GithubPollingThread,
     options: { pollImmediately?: boolean } = {},

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -1047,19 +1047,25 @@ export class GithubSignals implements Processor<'github-signals'> {
           owner: z.string().optional(),
           repo: z.string().optional(),
         }),
-        execute: async (input, context) => {
-          await this.#sendToolSignal({
-            signal: GithubSignals.signals.subscribeToPR(input),
-            agentId: context?.agent?.agentId,
-            threadId: context?.agent?.threadId ?? threadContext.threadId,
-            resourceId: context?.agent?.resourceId ?? threadContext.resourceId,
-          });
-          return {
-            subscribed: true,
+        execute: async input => {
+          const result = await this.#subscribe({
+            id: `github-tool-subscribe-${randomUUID()}`,
             owner: input.owner,
             repo: input.repo,
             number: input.number,
-            message: `GitHub PR #${input.number} subscription signal sent.`,
+            threadId: threadContext.threadId,
+            resourceId: threadContext.resourceId,
+          });
+          return {
+            subscribed: true,
+            owner: result.owner,
+            repo: result.repo,
+            number: result.number,
+            syncStatus: result.syncResult?.ok === false ? 'error' : result.syncResult ? 'success' : undefined,
+            message:
+              result.syncResult?.ok === false
+                ? `Subscribed to ${result.owner}/${result.repo}#${result.number}, but gitcrawl sync failed: ${result.syncResult.error}`
+                : `Subscribed to ${result.owner}/${result.repo}#${result.number}.`,
           };
         },
       }),
@@ -1071,45 +1077,28 @@ export class GithubSignals implements Processor<'github-signals'> {
           owner: z.string().optional(),
           repo: z.string().optional(),
         }),
-        execute: async (input, context) => {
-          await this.#sendToolSignal({
-            signal: GithubSignals.signals.unsubscribeFromPR(input),
-            agentId: context?.agent?.agentId,
-            threadId: context?.agent?.threadId ?? threadContext.threadId,
-            resourceId: context?.agent?.resourceId ?? threadContext.resourceId,
-          });
-          return {
-            unsubscribed: true,
+        execute: async input => {
+          const result = await this.#unsubscribe({
+            id: `github-tool-unsubscribe-${randomUUID()}`,
             owner: input.owner,
             repo: input.repo,
             number: input.number,
-            message: `GitHub PR #${input.number} unsubscribe signal sent.`,
+            threadId: threadContext.threadId,
+            resourceId: threadContext.resourceId,
+          });
+          return {
+            unsubscribed: result.removed ?? false,
+            owner: result.owner,
+            repo: result.repo,
+            number: result.number,
+            remainingSubscriptions: result.remainingSubscriptions,
+            message: result.removed
+              ? `Unsubscribed from ${result.owner}/${result.repo}#${result.number}.`
+              : `No GitHub subscription found for ${result.owner}/${result.repo}#${result.number}.`,
           };
         },
       }),
     };
-  }
-
-  async #sendToolSignal(input: {
-    signal: AgentSignalInput;
-    agentId?: string;
-    threadId?: string;
-    resourceId?: string;
-  }): Promise<void> {
-    if (!input.threadId || !input.resourceId) {
-      throw new Error('GitHub tools require threadId and resourceId.');
-    }
-    const agent = this.#getNotificationAgent({ agentId: input.agentId });
-    if (!agent?.sendSignal) {
-      throw new Error('Could not find an agent for GitHub tool signal delivery.');
-    }
-    const result = agent.sendSignal(input.signal, {
-      resourceId: input.resourceId,
-      threadId: input.threadId,
-      ifActive: { behavior: 'deliver' },
-      ifIdle: { behavior: 'wake' },
-    });
-    if (result.accepted instanceof Promise) await result.accepted;
   }
 
   async #resolveRepository(input: GithubPRSignal & { abortSignal?: AbortSignal }): Promise<GithubRepository> {

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -136,9 +136,11 @@ type GithubPRSignal = {
 };
 
 type GithubSignalAgent = {
-  sendSignal(signal: AgentSignalInput, target: unknown): { accepted: Promise<unknown> };
-  sendNotificationSignal?(notification: unknown, target: unknown): { accepted: Promise<unknown> } | Promise<unknown>;
+  sendSignal(signal: AgentSignalInput, target: unknown): { accepted: unknown };
+  sendNotificationSignal?(notification: unknown, target: unknown): { accepted?: unknown } | Promise<unknown>;
 };
+
+type GithubNotificationSender = (notification: unknown) => Promise<unknown>;
 
 type GithubSignalsMastra = {
   getStorage?: () => { getStore?: (name: 'memory') => Promise<unknown> } | undefined;
@@ -355,12 +357,12 @@ function classifyGithubActivityNotification(input: {
 }): { kind: string; priority: 'medium' | 'high'; summary: string } | undefined {
   const pr = `${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}`;
   const label = getPrLabel(input.subscription, input.snapshot);
-  if (input.subscription.lastObservedState && input.subscription.lastObservedState !== input.snapshot.state) {
+  if (input.snapshot.state && input.subscription.lastObservedState !== input.snapshot.state) {
     if (input.snapshot.state === 'merged')
       return { kind: 'pull-request-merged', priority: 'high', summary: `${label} was merged` };
     if (input.snapshot.state === 'closed')
       return { kind: 'pull-request-closed', priority: 'high', summary: `${label} was closed` };
-    if (input.snapshot.state === 'open')
+    if (input.subscription.lastObservedState && input.snapshot.state === 'open')
       return { kind: 'pull-request-reopened', priority: 'medium', summary: `${label} was reopened` };
   }
 
@@ -560,13 +562,16 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
         head_sha?: string;
         head_ref?: string;
         mergeable_state?: string;
-      }>(`select d.head_sha, d.head_ref, d.mergeable_state
+        merged_at?: string;
+      }>(`select d.head_sha, d.head_ref, d.mergeable_state,
+                 json_extract(d.raw_json, '$.merged_at') as merged_at
           from pull_request_details d
           join threads t on t.id=d.thread_id
           join repositories r on r.id=t.repo_id
          where r.owner=${owner} and r.name=${repo} and t.number=${number}
          limit 1`);
 
+      const headSha = readString(details?.head_sha);
       const checkRows = await queryGitcrawlDb<{
         name?: string;
         status?: string;
@@ -574,12 +579,12 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
         workflow_name?: string;
         details_url?: string;
         updated_at?: string;
-      }>(`select name, status, conclusion, workflow_name, details_url,
-                 coalesce(completed_at, started_at, fetched_at) as updated_at
+      }>(`select c.name, c.status, c.conclusion, c.workflow_name, c.details_url,
+                 coalesce(c.completed_at, c.started_at, c.fetched_at) as updated_at
             from pull_request_checks c
             join threads t on t.id=c.thread_id
             join repositories r on r.id=t.repo_id
-           where r.owner=${owner} and r.name=${repo} and t.number=${number}`);
+           where r.owner=${owner} and r.name=${repo} and t.number=${number}${headSha ? ` and json_extract(c.raw_json, '$.head_sha')=${sqlString(headSha)}` : ''}`);
 
       const workflowRows = details?.head_sha
         ? await queryGitcrawlDb<{
@@ -662,13 +667,14 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
       });
       return {
         title: readString(thread.title),
-        state: readString(threadDetails?.merged_at_gh)
-          ? 'merged'
-          : (readString(threadDetails?.state) ?? readString(thread.state)),
+        state:
+          readString(details?.merged_at) || readString(threadDetails?.merged_at_gh)
+            ? 'merged'
+            : (readString(threadDetails?.state) ?? readString(thread.state)),
         htmlUrl: readString(thread.html_url),
         githubUpdatedAt: readString(thread.updated_at_gh),
         closedAt: readString(threadDetails?.closed_at_gh),
-        mergedAt: readString(threadDetails?.merged_at_gh),
+        mergedAt: readString(details?.merged_at) ?? readString(threadDetails?.merged_at_gh),
         threadContentHash,
         contentHash,
         headSha: readString(details?.head_sha),
@@ -739,6 +745,8 @@ export class GithubSignals implements Processor<'github-signals'> {
   readonly #syncClient: GithubSignalsSyncClient;
   readonly #repositoryResolver: GithubRepositoryResolver;
   readonly #polling = new Map<string, GithubPollingState>();
+  #agent?: GithubSignalAgent;
+  #notificationSender?: GithubNotificationSender;
 
   constructor(options: GithubSignalsOptions = {}) {
     this.#options = options;
@@ -746,11 +754,22 @@ export class GithubSignals implements Processor<'github-signals'> {
     this.#repositoryResolver = options.repositoryResolver ?? new GitRemoteRepositoryResolver();
   }
 
+  addAgent(agent: GithubSignalAgent): void {
+    this.#agent = agent;
+  }
+
+  addNotificationSender(sender: GithubNotificationSender): void {
+    this.#notificationSender = sender;
+  }
+
   __registerMastra(mastra: Mastra<any, any, any, any, any, any, any, any, any, any>): void {
     this.mastra = mastra as unknown as GithubSignalsMastra;
   }
 
-  async startPollingForThread(input: GithubPollingThread): Promise<boolean> {
+  async startPollingForThread(
+    input: GithubPollingThread,
+    options: { pollImmediately?: boolean } = {},
+  ): Promise<boolean> {
     const subscriptions = await this.#getThreadSubscriptions(input);
     if (subscriptions.length === 0) {
       this.stopPollingForThread(input);
@@ -758,11 +777,21 @@ export class GithubSignals implements Processor<'github-signals'> {
     }
 
     const key = this.#pollingKey(input);
+    for (const [pollingKey, state] of this.#polling.entries()) {
+      if (pollingKey === key) continue;
+      clearInterval(state.timer);
+      this.#polling.delete(pollingKey);
+    }
+
     if (this.#polling.has(key)) return true;
 
-    const timer = setInterval(() => {
-      void this.#pollThread(input);
-    }, this.#options.pollIntervalMs ?? 60_000);
+    const runPoll = () => {
+      void this.#pollThread(input).catch(error => {
+        console.warn('GitHub PR polling failed:', error);
+      });
+    };
+    const timer = setInterval(runPoll, this.#options.pollIntervalMs ?? 60_000);
+    if (options.pollImmediately) runPoll();
     timer.unref?.();
     this.#polling.set(key, { ...input, timer, running: false });
     return true;
@@ -911,7 +940,7 @@ export class GithubSignals implements Processor<'github-signals'> {
       ifActive: { behavior: 'deliver' },
       ifIdle: { behavior: 'wake' },
     });
-    await result.accepted;
+    if (result.accepted instanceof Promise) await result.accepted;
   }
 
   async #resolveRepository(input: GithubPRSignal & { abortSignal?: AbortSignal }): Promise<GithubRepository> {
@@ -949,8 +978,9 @@ export class GithubSignals implements Processor<'github-signals'> {
     return `${input.resourceId}:${input.threadId}`;
   }
 
-  #getNotificationAgent(input: { agentId?: string }): GithubSignalAgent | undefined {
-    const agentId = input.agentId ?? this.#options.agentId;
+  #getNotificationAgent(_input?: { agentId?: string }): GithubSignalAgent | undefined {
+    if (this.#agent) return this.#agent;
+    const agentId = _input?.agentId ?? this.#options.agentId;
     return agentId ? this.mastra?.getAgentById?.(agentId) : undefined;
   }
 
@@ -962,7 +992,9 @@ export class GithubSignals implements Processor<'github-signals'> {
   async #pollThread(input: GithubPollingThread): Promise<number> {
     const key = this.#pollingKey(input);
     const state = this.#polling.get(key);
-    if (state?.running) return 0;
+    if (state?.running) {
+      return 0;
+    }
     if (state) state.running = true;
 
     try {
@@ -997,23 +1029,28 @@ export class GithubSignals implements Processor<'github-signals'> {
         const previousContentHash = subscription.lastObservedContentHash;
         if (snapshot) applySnapshotCursor(nextSubscription, snapshot);
 
+        // First observation (no previous cursor) always counts as changed so we
+        // emit a baseline notification with the PR's current state.
+        const isFirstObservation = syncResult.ok && snapshot && !previousGithubUpdatedAt && !previousContentHash;
+
         const changed =
-          syncResult.ok &&
-          snapshot &&
-          ((previousGithubUpdatedAt &&
-            snapshot.githubUpdatedAt &&
-            previousGithubUpdatedAt !== snapshot.githubUpdatedAt) ||
-            (previousContentHash && snapshot.contentHash && previousContentHash !== snapshot.contentHash) ||
-            (subscription.lastObservedState && snapshot.state && subscription.lastObservedState !== snapshot.state) ||
-            (subscription.lastObservedMergeableState &&
-              snapshot.mergeableState &&
-              subscription.lastObservedMergeableState !== snapshot.mergeableState) ||
-            (subscription.lastObservedCiState &&
-              snapshot.ciState &&
-              subscription.lastObservedCiState !== snapshot.ciState) ||
-            (subscription.lastObservedReviewStateHash &&
-              snapshot.reviewStateHash &&
-              subscription.lastObservedReviewStateHash !== snapshot.reviewStateHash));
+          isFirstObservation ||
+          (syncResult.ok &&
+            snapshot &&
+            ((previousGithubUpdatedAt &&
+              snapshot.githubUpdatedAt &&
+              previousGithubUpdatedAt !== snapshot.githubUpdatedAt) ||
+              (previousContentHash && snapshot.contentHash && previousContentHash !== snapshot.contentHash) ||
+              (subscription.lastObservedState && snapshot.state && subscription.lastObservedState !== snapshot.state) ||
+              (subscription.lastObservedMergeableState &&
+                snapshot.mergeableState &&
+                subscription.lastObservedMergeableState !== snapshot.mergeableState) ||
+              (subscription.lastObservedCiState &&
+                snapshot.ciState &&
+                subscription.lastObservedCiState !== snapshot.ciState) ||
+              (subscription.lastObservedReviewStateHash &&
+                snapshot.reviewStateHash &&
+                subscription.lastObservedReviewStateHash !== snapshot.reviewStateHash)));
         if (changed) {
           const notification = await this.#sendActivityNotification({
             polling: input,
@@ -1044,6 +1081,8 @@ export class GithubSignals implements Processor<'github-signals'> {
         },
       });
       return subscriptions.length;
+    } catch (error) {
+      throw error;
     } finally {
       const latestState = this.#polling.get(key);
       if (latestState) latestState.running = false;
@@ -1051,7 +1090,7 @@ export class GithubSignals implements Processor<'github-signals'> {
   }
 
   async #sendGithubNotification(input: {
-    agent: GithubSignalAgent;
+    agent?: GithubSignalAgent;
     subscription: GithubPRSubscription;
     snapshot: GithubPullRequestSnapshot;
     notification: { kind: string; priority: 'medium' | 'high'; summary: string };
@@ -1062,64 +1101,62 @@ export class GithubSignals implements Processor<'github-signals'> {
   }): Promise<void> {
     const failingChecks = getFailingChecks(input.snapshot);
     const pendingChecks = getPendingChecks(input.snapshot);
-    const result = await input.agent.sendNotificationSignal?.(
-      {
-        source: 'github',
-        kind: input.notification.kind,
-        priority: input.notification.priority,
-        summary: input.notification.summary,
-        dedupeKey: `github:${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}:${input.dedupeSuffix}`,
-        coalesceKey: `github:${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}`,
-        attributes: {
+    const notificationInput = {
+      source: 'github',
+      kind: input.notification.kind,
+      priority: input.notification.priority,
+      summary: input.notification.summary,
+      dedupeKey: `github:${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}:${input.dedupeSuffix}`,
+      coalesceKey: `github:${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}`,
+      attributes: {
+        owner: input.subscription.owner,
+        repo: input.subscription.repo,
+        number: input.subscription.number,
+        ...(input.snapshot.title ? { title: input.snapshot.title } : {}),
+        ...(input.snapshot.state ? { state: input.snapshot.state } : {}),
+        ...(input.snapshot.htmlUrl ? { url: input.snapshot.htmlUrl } : {}),
+        ...(input.snapshot.githubUpdatedAt ? { githubUpdatedAt: input.snapshot.githubUpdatedAt } : {}),
+        ...(input.previousGithubUpdatedAt ? { previousGithubUpdatedAt: input.previousGithubUpdatedAt } : {}),
+        ...(input.snapshot.mergeableState ? { mergeableState: input.snapshot.mergeableState } : {}),
+        ...(input.snapshot.ciState ? { ciState: input.snapshot.ciState } : {}),
+        ...(input.snapshot.unresolvedReviewThreads !== undefined
+          ? { unresolvedReviewThreads: input.snapshot.unresolvedReviewThreads }
+          : {}),
+        ...(failingChecks.length > 0 ? { failingChecks: failingChecks.map(check => check.name).join(', ') } : {}),
+        ...(pendingChecks.length > 0 ? { pendingChecks: pendingChecks.map(check => check.name).join(', ') } : {}),
+      },
+      metadata: {
+        github: {
           owner: input.subscription.owner,
           repo: input.subscription.repo,
           number: input.subscription.number,
-          ...(input.snapshot.title ? { title: input.snapshot.title } : {}),
-          ...(input.snapshot.state ? { state: input.snapshot.state } : {}),
-          ...(input.snapshot.htmlUrl ? { url: input.snapshot.htmlUrl } : {}),
-          ...(input.snapshot.githubUpdatedAt ? { githubUpdatedAt: input.snapshot.githubUpdatedAt } : {}),
-          ...(input.previousGithubUpdatedAt ? { previousGithubUpdatedAt: input.previousGithubUpdatedAt } : {}),
-          ...(input.snapshot.mergeableState ? { mergeableState: input.snapshot.mergeableState } : {}),
-          ...(input.snapshot.ciState ? { ciState: input.snapshot.ciState } : {}),
-          ...(input.snapshot.unresolvedReviewThreads !== undefined
-            ? { unresolvedReviewThreads: input.snapshot.unresolvedReviewThreads }
-            : {}),
-          ...(failingChecks.length > 0 ? { failingChecks: failingChecks.map(check => check.name).join(', ') } : {}),
-          ...(pendingChecks.length > 0 ? { pendingChecks: pendingChecks.map(check => check.name).join(', ') } : {}),
-        },
-        metadata: {
-          github: {
-            owner: input.subscription.owner,
-            repo: input.subscription.repo,
-            number: input.subscription.number,
-            title: input.snapshot.title,
-            state: input.snapshot.state,
-            htmlUrl: input.snapshot.htmlUrl,
-            githubUpdatedAt: input.snapshot.githubUpdatedAt,
-            previousGithubUpdatedAt: input.previousGithubUpdatedAt,
-            contentHash: input.snapshot.contentHash,
-            previousContentHash: input.previousContentHash,
-            threadContentHash: input.snapshot.threadContentHash,
-            headSha: input.snapshot.headSha,
-            headRef: input.snapshot.headRef,
-            mergeableState: input.snapshot.mergeableState,
-            ciState: input.snapshot.ciState,
-            closedAt: input.snapshot.closedAt,
-            mergedAt: input.snapshot.mergedAt,
-            unresolvedReviewThreads: input.snapshot.unresolvedReviewThreads,
-            reviewStateHash: input.snapshot.reviewStateHash,
-            latestReviewThreadAt: input.snapshot.latestReviewThreadAt,
-            latestCommentAuthor: input.snapshot.latestCommentAuthor,
-            latestCommentAuthorType: input.snapshot.latestCommentAuthorType,
-            latestCommentIsBot: input.snapshot.latestCommentIsBot,
-            failingChecks,
-            pendingChecks,
-          },
+          title: input.snapshot.title,
+          state: input.snapshot.state,
+          htmlUrl: input.snapshot.htmlUrl,
+          githubUpdatedAt: input.snapshot.githubUpdatedAt,
+          previousGithubUpdatedAt: input.previousGithubUpdatedAt,
+          contentHash: input.snapshot.contentHash,
+          previousContentHash: input.previousContentHash,
+          threadContentHash: input.snapshot.threadContentHash,
+          headSha: input.snapshot.headSha,
+          headRef: input.snapshot.headRef,
+          mergeableState: input.snapshot.mergeableState,
+          ciState: input.snapshot.ciState,
+          closedAt: input.snapshot.closedAt,
+          mergedAt: input.snapshot.mergedAt,
+          unresolvedReviewThreads: input.snapshot.unresolvedReviewThreads,
+          reviewStateHash: input.snapshot.reviewStateHash,
+          latestReviewThreadAt: input.snapshot.latestReviewThreadAt,
+          latestCommentAuthor: input.snapshot.latestCommentAuthor,
+          latestCommentAuthorType: input.snapshot.latestCommentAuthorType,
+          latestCommentIsBot: input.snapshot.latestCommentIsBot,
+          failingChecks,
+          pendingChecks,
         },
       },
-      input.target,
-    );
-    if (isPlainObject(result) && result.accepted instanceof Promise) await result.accepted;
+    };
+    if (this.#notificationSender) await this.#notificationSender(notificationInput);
+    else await input.agent?.sendNotificationSignal?.(notificationInput, input.target);
   }
 
   async #sendBaselineNotification(input: {
@@ -1129,7 +1166,7 @@ export class GithubSignals implements Processor<'github-signals'> {
     snapshot: GithubPullRequestSnapshot;
   }): Promise<void> {
     const agent = this.#getNotificationAgent({});
-    if (!agent?.sendNotificationSignal) return;
+    if (!this.#notificationSender && !agent?.sendNotificationSignal) return;
     await this.#sendGithubNotification({
       agent,
       subscription: input.subscription,
@@ -1148,7 +1185,7 @@ export class GithubSignals implements Processor<'github-signals'> {
     previousContentHash?: string;
   }): Promise<{ kind: string; priority: 'medium' | 'high'; summary: string } | undefined> {
     const agent = this.#getNotificationAgent(input.polling);
-    if (!agent?.sendNotificationSignal) return undefined;
+    if (!this.#notificationSender && !agent?.sendNotificationSignal) return undefined;
     const notification = classifyGithubActivityNotification({
       subscription: input.subscription,
       snapshot: input.snapshot,

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -816,7 +816,7 @@ export class GithubSignals implements Processor<'github-signals'> {
     subscribeToPR(input: GithubSubscribePRSignalInput): AgentSignalInput {
       const normalized = typeof input === 'number' ? { number: input } : input;
       return {
-        type: 'user',
+        type: 'reactive',
         tagName: GITHUB_SUBSCRIBE_PR_TAG,
         contents: `Subscribe to GitHub PR #${normalized.number}`,
         attributes: {
@@ -835,7 +835,7 @@ export class GithubSignals implements Processor<'github-signals'> {
     unsubscribeFromPR(input: GithubUnsubscribePRSignalInput): AgentSignalInput {
       const normalized = typeof input === 'number' ? { number: input } : input;
       return {
-        type: 'user',
+        type: 'reactive',
         tagName: GITHUB_UNSUBSCRIBE_PR_TAG,
         contents: `Unsubscribe from GitHub PR #${normalized.number}`,
         attributes: {

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -496,13 +496,6 @@ function classifyGithubActivityNotification(input: {
       summary: `${pr} has failing CI${names ? `: ${names}` : ''}`,
     };
   }
-  if (
-    input.snapshot.ciState === 'success' &&
-    input.subscription.lastObservedCiState &&
-    input.subscription.lastObservedCiState !== 'success'
-  ) {
-    return { kind: 'pull-request-ci-recovered', priority: 'medium', summary: `${pr} CI recovered` };
-  }
   if (input.snapshot.mergeableState === 'dirty' && input.subscription.lastObservedMergeableState !== 'dirty') {
     return {
       kind: 'pull-request-conflict',
@@ -520,6 +513,13 @@ function classifyGithubActivityNotification(input: {
       priority: 'medium',
       summary: `${pr} merge conflicts were resolved`,
     };
+  }
+  if (
+    input.snapshot.ciState === 'success' &&
+    input.subscription.lastObservedCiState &&
+    input.subscription.lastObservedCiState !== 'success'
+  ) {
+    return { kind: 'pull-request-ci-recovered', priority: 'medium', summary: `${pr} CI recovered` };
   }
   if (
     input.snapshot.reviewStateHash &&

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -898,7 +898,7 @@ export class GithubSignals implements Processor<'github-signals'> {
         console.warn('GitHub PR polling failed:', error);
       });
     };
-    const timer = setInterval(runPoll, this.#options.pollIntervalMs ?? 60_000);
+    const timer = setInterval(runPoll, this.#options.pollIntervalMs ?? 300_000);
     if (options.pollImmediately) runPoll();
     timer.unref?.();
     this.#polling.set(key, { ...input, timer, running: false });
@@ -918,7 +918,7 @@ export class GithubSignals implements Processor<'github-signals'> {
   }
 
   getPollIntervalMs(): number {
-    return this.#options.pollIntervalMs ?? 60_000;
+    return this.#options.pollIntervalMs ?? 300_000;
   }
 
   stopAllPolling(): void {

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -138,6 +138,14 @@ export type GithubSignalsOptions = {
   threadStore?: GithubSignalsThreadStore;
 };
 
+export type GithubSubscriptionsChangedEvent = {
+  threadId: string;
+  resourceId: string;
+  subscriptions: GithubPRSubscription[];
+};
+
+type GithubSubscriptionsChangedHandler = (event: GithubSubscriptionsChangedEvent) => void;
+
 type GithubPRSignal = {
   id: string;
   owner?: string;
@@ -859,6 +867,7 @@ export class GithubSignals implements Processor<'github-signals'> {
   readonly #polling = new Map<string, GithubPollingState>();
   #agent?: GithubSignalAgent;
   #agentOptions: GithubSignalAgentOptions = {};
+  #subscriptionsChangedHandler?: GithubSubscriptionsChangedHandler;
 
   constructor(options: GithubSignalsOptions = {}) {
     this.#options = options;
@@ -869,6 +878,10 @@ export class GithubSignals implements Processor<'github-signals'> {
   addAgent(agent: GithubSignalAgent, options: GithubSignalAgentOptions = {}): void {
     this.#agent = agent;
     this.#agentOptions = options;
+  }
+
+  onSubscriptionsChanged(handler: GithubSubscriptionsChangedHandler): void {
+    this.#subscriptionsChangedHandler = handler;
   }
 
   __registerMastra(mastra: Mastra<any, any, any, any, any, any, any, any, any, any>): void {
@@ -1147,6 +1160,10 @@ export class GithubSignals implements Processor<'github-signals'> {
     return getGithubMetadata(loadedThread.metadata).subscriptions;
   }
 
+  #notifySubscriptionsChanged(input: GithubSubscriptionsChangedEvent): void {
+    this.#subscriptionsChangedHandler?.(input);
+  }
+
   async #pollThread(input: GithubPollingThread): Promise<number> {
     const key = this.#pollingKey(input);
     const state = this.#polling.get(key);
@@ -1237,6 +1254,7 @@ export class GithubSignals implements Processor<'github-signals'> {
           metadata: setGithubMetadata(loadedThread.metadata, { subscriptions }),
         },
       });
+      this.#notifySubscriptionsChanged({ threadId: input.threadId, resourceId: input.resourceId, subscriptions });
       if (subscriptions.length === 0) this.stopPollingForThread(input);
       return subscriptions.length;
     } catch (error) {
@@ -1441,6 +1459,7 @@ export class GithubSignals implements Processor<'github-signals'> {
         metadata: setGithubMetadata(loadedThread.metadata, { subscriptions }),
       },
     });
+    this.#notifySubscriptionsChanged({ threadId: input.threadId!, resourceId: input.resourceId!, subscriptions });
     if (baselineSnapshot) {
       await this.#sendBaselineNotification({
         threadId: input.threadId!,
@@ -1476,6 +1495,7 @@ export class GithubSignals implements Processor<'github-signals'> {
           metadata: setGithubMetadata(loadedThread.metadata, { subscriptions }),
         },
       });
+      this.#notifySubscriptionsChanged({ threadId: input.threadId!, resourceId: input.resourceId!, subscriptions });
       if (subscriptions.length === 0)
         this.stopPollingForThread({ threadId: input.threadId!, resourceId: input.resourceId! });
     }

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -1,0 +1,438 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { AgentSignalInput } from '@mastra/core/agent';
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import type { Mastra } from '@mastra/core/mastra';
+import type { StorageThreadType } from '@mastra/core/memory';
+import type { Processor, ProcessInputStepArgs } from '@mastra/core/processors';
+
+const execFileAsync = promisify(execFile);
+
+export const GITHUB_SUBSCRIBE_PR_TAG = 'github-subscribe-pr';
+export const GITHUB_SYNC_STATUS_TAG = 'github-sync-status';
+export const GITHUB_SIGNALS_METADATA_KEY = 'githubSignals';
+
+export type GithubPRSubscription = {
+  owner: string;
+  repo: string;
+  number: number;
+  subscribedAt: string;
+  updatedAt: string;
+  lastSubscribeSignalId: string;
+  lastSyncAt?: string;
+  lastSyncStatus?: 'success' | 'error' | 'skipped';
+  lastSyncError?: string;
+};
+
+export type GithubSignalsThreadMetadata = {
+  subscriptions: GithubPRSubscription[];
+};
+
+export type GithubSubscribePRSignalInput = number | { owner?: string; repo?: string; number: number };
+
+export type GithubSignalsSyncInput = {
+  owner: string;
+  repo: string;
+  number: number;
+  cwd?: string;
+  abortSignal?: AbortSignal;
+};
+
+export type GithubSignalsSyncResult = {
+  ok: boolean;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+};
+
+export type GithubSignalsSyncClient = {
+  syncPullRequest(input: GithubSignalsSyncInput): Promise<GithubSignalsSyncResult>;
+};
+
+export type GithubRepository = {
+  owner: string;
+  repo: string;
+};
+
+export type GithubRepositoryResolver = {
+  resolveRepository(input: { cwd?: string; abortSignal?: AbortSignal }): Promise<GithubRepository | undefined>;
+};
+
+export type GithubSignalsThreadStore = {
+  getThreadById(input: { threadId: string; resourceId?: string }): Promise<StorageThreadType | null>;
+  saveThread(input: { thread: StorageThreadType }): Promise<StorageThreadType>;
+};
+
+export type GithubSignalsOptions = {
+  owner?: string;
+  repo?: string;
+  cwd?: string;
+  syncOnSubscribe?: boolean;
+  gitcrawlCommand?: string;
+  syncClient?: GithubSignalsSyncClient;
+  repositoryResolver?: GithubRepositoryResolver;
+  threadStore?: GithubSignalsThreadStore;
+};
+
+type GithubSubscribeSignal = {
+  id: string;
+  owner?: string;
+  repo?: string;
+  number: number;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) return Number(value);
+  return undefined;
+}
+
+function getSignalMetadata(message: MastraDBMessage): Record<string, unknown> | undefined {
+  if (message.role !== 'signal') return undefined;
+  const signal = message.content.metadata?.signal;
+  return isPlainObject(signal) ? signal : undefined;
+}
+
+function getGithubMetadata(threadMetadata: Record<string, unknown> | undefined): GithubSignalsThreadMetadata {
+  const mastra = isPlainObject(threadMetadata?.mastra) ? threadMetadata.mastra : {};
+  const githubSignals = isPlainObject(mastra[GITHUB_SIGNALS_METADATA_KEY]) ? mastra[GITHUB_SIGNALS_METADATA_KEY] : {};
+  const rawSubscriptions = Array.isArray(githubSignals.subscriptions) ? githubSignals.subscriptions : [];
+  const subscriptions: GithubPRSubscription[] = [];
+
+  for (const rawSubscription of rawSubscriptions) {
+    if (!isPlainObject(rawSubscription)) continue;
+    const owner = readString(rawSubscription.owner);
+    const repo = readString(rawSubscription.repo);
+    const number = readNumber(rawSubscription.number);
+    const subscribedAt = readString(rawSubscription.subscribedAt);
+    const updatedAt = readString(rawSubscription.updatedAt);
+    const lastSubscribeSignalId = readString(rawSubscription.lastSubscribeSignalId);
+    if (!owner || !repo || !number || !subscribedAt || !updatedAt || !lastSubscribeSignalId) continue;
+    subscriptions.push({
+      owner,
+      repo,
+      number,
+      subscribedAt,
+      updatedAt,
+      lastSubscribeSignalId,
+      ...(readString(rawSubscription.lastSyncAt) ? { lastSyncAt: readString(rawSubscription.lastSyncAt)! } : {}),
+      ...(rawSubscription.lastSyncStatus === 'success' ||
+      rawSubscription.lastSyncStatus === 'error' ||
+      rawSubscription.lastSyncStatus === 'skipped'
+        ? { lastSyncStatus: rawSubscription.lastSyncStatus }
+        : {}),
+      ...(readString(rawSubscription.lastSyncError)
+        ? { lastSyncError: readString(rawSubscription.lastSyncError)! }
+        : {}),
+    });
+  }
+
+  return { subscriptions };
+}
+
+function setGithubMetadata(
+  threadMetadata: Record<string, unknown> | undefined,
+  githubSignals: GithubSignalsThreadMetadata,
+): Record<string, unknown> {
+  const existing = threadMetadata ?? {};
+  const mastra = isPlainObject(existing.mastra) ? existing.mastra : {};
+
+  return {
+    ...existing,
+    mastra: {
+      ...mastra,
+      [GITHUB_SIGNALS_METADATA_KEY]: githubSignals,
+    },
+  };
+}
+
+function parseGitHubRemoteUrl(remoteUrl: string): GithubRepository | undefined {
+  const trimmed = remoteUrl.trim().replace(/\.git$/, '');
+  const httpsMatch = /^https:\/\/github\.com\/([^/]+)\/([^/]+)$/.exec(trimmed);
+  if (httpsMatch?.[1] && httpsMatch[2]) return { owner: httpsMatch[1], repo: httpsMatch[2] };
+  const sshMatch = /^git@github\.com:([^/]+)\/([^/]+)$/.exec(trimmed);
+  if (sshMatch?.[1] && sshMatch[2]) return { owner: sshMatch[1], repo: sshMatch[2] };
+  return undefined;
+}
+
+export class GitRemoteRepositoryResolver implements GithubRepositoryResolver {
+  async resolveRepository(input: { cwd?: string; abortSignal?: AbortSignal }): Promise<GithubRepository | undefined> {
+    try {
+      const { stdout } = await execFileAsync('git', ['remote', 'get-url', 'origin'], {
+        cwd: input.cwd,
+        signal: input.abortSignal,
+      });
+      return parseGitHubRemoteUrl(stdout);
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+export class GitcrawlSyncClient implements GithubSignalsSyncClient {
+  readonly #command: string;
+
+  constructor(options: { command?: string } = {}) {
+    this.#command = options.command ?? 'gitcrawl';
+  }
+
+  async syncPullRequest(input: GithubSignalsSyncInput): Promise<GithubSignalsSyncResult> {
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        this.#command,
+        [
+          'sync',
+          `${input.owner}/${input.repo}`,
+          '--numbers',
+          String(input.number),
+          '--include-comments',
+          '--with',
+          'pr-details',
+          '--json',
+        ],
+        {
+          cwd: input.cwd,
+          signal: input.abortSignal,
+          maxBuffer: 10 * 1024 * 1024,
+        },
+      );
+      return { ok: true, stdout, stderr };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+}
+
+export class GithubSignals implements Processor<'github-signals'> {
+  readonly id = 'github-signals' as const;
+  readonly name = 'GitHub Signals';
+  protected mastra?: Mastra<any, any, any, any, any, any, any, any, any, any>;
+
+  static signals = {
+    subscribeToPR(input: GithubSubscribePRSignalInput): AgentSignalInput {
+      const normalized = typeof input === 'number' ? { number: input } : input;
+      return {
+        type: 'user',
+        tagName: GITHUB_SUBSCRIBE_PR_TAG,
+        contents: `Subscribe to GitHub PR #${normalized.number}`,
+        attributes: {
+          ...(normalized.owner ? { owner: normalized.owner } : {}),
+          ...(normalized.repo ? { repo: normalized.repo } : {}),
+          number: normalized.number,
+        },
+        metadata: {
+          github: {
+            action: 'subscribeToPR',
+            ...normalized,
+          },
+        },
+      };
+    },
+  };
+
+  readonly #options: GithubSignalsOptions;
+  readonly #syncClient: GithubSignalsSyncClient;
+  readonly #repositoryResolver: GithubRepositoryResolver;
+
+  constructor(options: GithubSignalsOptions = {}) {
+    this.#options = options;
+    this.#syncClient = options.syncClient ?? new GitcrawlSyncClient({ command: options.gitcrawlCommand });
+    this.#repositoryResolver = options.repositoryResolver ?? new GitRemoteRepositoryResolver();
+  }
+
+  __registerMastra(mastra: Mastra<any, any, any, any, any, any, any, any, any, any>): void {
+    this.mastra = mastra;
+  }
+
+  async processInputStep(args: ProcessInputStepArgs) {
+    if (args.stepNumber !== 0) return;
+
+    const subscribeSignal = this.#findLatestSubscribeSignal(args.messages);
+    if (!subscribeSignal) return;
+
+    const resolvedRepository =
+      subscribeSignal.owner && subscribeSignal.repo
+        ? { owner: subscribeSignal.owner, repo: subscribeSignal.repo }
+        : this.#options.owner && this.#options.repo
+          ? { owner: this.#options.owner, repo: this.#options.repo }
+          : await this.#repositoryResolver.resolveRepository({ cwd: this.#options.cwd, abortSignal: args.abortSignal });
+    const owner = resolvedRepository?.owner;
+    const repo = resolvedRepository?.repo;
+    if (!owner || !repo) {
+      await this.#sendStatus(args, subscribeSignal, {
+        status: 'error',
+        message: 'GitHub PR subscription requires owner and repo.',
+      });
+      return;
+    }
+
+    const threadStore = await this.#resolveThreadStore();
+    if (!threadStore) {
+      await this.#sendStatus(
+        args,
+        { ...subscribeSignal, owner, repo },
+        {
+          status: 'error',
+          message: 'GitHub PR subscription requires memory-backed thread storage.',
+        },
+      );
+      return;
+    }
+
+    const memoryContext = args.requestContext?.get('MastraMemory') as
+      | { thread?: { id?: string }; resourceId?: string }
+      | undefined;
+    const threadId = memoryContext?.thread?.id;
+    const resourceId = memoryContext?.resourceId;
+    if (!threadId || !resourceId) {
+      await this.#sendStatus(
+        args,
+        { ...subscribeSignal, owner, repo },
+        {
+          status: 'error',
+          message: 'GitHub PR subscription requires threadId and resourceId.',
+        },
+      );
+      return;
+    }
+
+    const loadedThread = (await threadStore.getThreadById({ threadId, resourceId })) ?? undefined;
+    if (!loadedThread) {
+      await this.#sendStatus(
+        args,
+        { ...subscribeSignal, owner, repo },
+        {
+          status: 'error',
+          message: `Could not load thread ${threadId}.`,
+        },
+      );
+      return;
+    }
+
+    const githubMetadata = getGithubMetadata(loadedThread.metadata);
+    const existingIndex = githubMetadata.subscriptions.findIndex(
+      subscription =>
+        subscription.owner === owner && subscription.repo === repo && subscription.number === subscribeSignal.number,
+    );
+    const existing = existingIndex >= 0 ? githubMetadata.subscriptions[existingIndex] : undefined;
+    if (existing?.lastSubscribeSignalId === subscribeSignal.id) return;
+
+    const now = new Date().toISOString();
+    const subscription: GithubPRSubscription = {
+      owner,
+      repo,
+      number: subscribeSignal.number,
+      subscribedAt: existing?.subscribedAt ?? now,
+      updatedAt: now,
+      lastSubscribeSignalId: subscribeSignal.id,
+      ...(existing?.lastSyncAt ? { lastSyncAt: existing.lastSyncAt } : {}),
+      ...(existing?.lastSyncStatus ? { lastSyncStatus: existing.lastSyncStatus } : {}),
+      ...(existing?.lastSyncError ? { lastSyncError: existing.lastSyncError } : {}),
+    };
+
+    let syncResult: GithubSignalsSyncResult | undefined;
+    if (this.#options.syncOnSubscribe !== false) {
+      syncResult = await this.#syncClient.syncPullRequest({
+        owner,
+        repo,
+        number: subscribeSignal.number,
+        cwd: this.#options.cwd,
+        abortSignal: args.abortSignal,
+      });
+      subscription.lastSyncAt = new Date().toISOString();
+      subscription.lastSyncStatus = syncResult.ok ? 'success' : 'error';
+      if (syncResult.error) subscription.lastSyncError = syncResult.error;
+      else delete subscription.lastSyncError;
+    } else {
+      subscription.lastSyncStatus = 'skipped';
+    }
+
+    const subscriptions = [...githubMetadata.subscriptions];
+    if (existingIndex >= 0) subscriptions[existingIndex] = subscription;
+    else subscriptions.push(subscription);
+
+    await threadStore.saveThread({
+      thread: {
+        ...loadedThread,
+        id: threadId,
+        resourceId,
+        createdAt: loadedThread.createdAt ?? new Date(),
+        updatedAt: new Date(),
+        metadata: setGithubMetadata(loadedThread.metadata, { subscriptions }),
+      },
+    });
+
+    await this.#sendStatus(
+      args,
+      { ...subscribeSignal, owner, repo },
+      {
+        status: syncResult?.ok === false ? 'sync_error' : 'subscribed',
+        message:
+          syncResult?.ok === false
+            ? `Subscribed to ${owner}/${repo}#${subscribeSignal.number}, but gitcrawl sync failed: ${syncResult.error}`
+            : `Subscribed to ${owner}/${repo}#${subscribeSignal.number}.`,
+      },
+    );
+  }
+
+  async #resolveThreadStore(): Promise<GithubSignalsThreadStore | undefined> {
+    if (this.#options.threadStore) return this.#options.threadStore;
+    const memoryStore = await this.mastra?.getStorage()?.getStore('memory');
+    return memoryStore as GithubSignalsThreadStore | undefined;
+  }
+
+  #findLatestSubscribeSignal(messages: MastraDBMessage[]): GithubSubscribeSignal | undefined {
+    for (const message of [...messages].reverse()) {
+      const signal = getSignalMetadata(message);
+      if (!signal || signal.tagName !== GITHUB_SUBSCRIBE_PR_TAG) continue;
+      const attributes = isPlainObject(signal.attributes) ? signal.attributes : {};
+      const metadata = isPlainObject(signal.metadata) ? signal.metadata : {};
+      const github = isPlainObject(metadata.github) ? metadata.github : {};
+      const number = readNumber(attributes.number) ?? readNumber(github.number);
+      if (!number) continue;
+      return {
+        id: readString(signal.id) ?? message.id,
+        owner: readString(attributes.owner) ?? readString(github.owner),
+        repo: readString(attributes.repo) ?? readString(github.repo),
+        number,
+      };
+    }
+    return undefined;
+  }
+
+  async #sendStatus(
+    args: ProcessInputStepArgs,
+    signal: GithubSubscribeSignal & { owner?: string; repo?: string },
+    status: { status: 'subscribed' | 'sync_error' | 'error'; message: string },
+  ) {
+    await args.sendSignal?.({
+      type: 'reactive',
+      tagName: GITHUB_SYNC_STATUS_TAG,
+      contents: status.message,
+      attributes: {
+        status: status.status,
+        ...(signal.owner ? { owner: signal.owner } : {}),
+        ...(signal.repo ? { repo: signal.repo } : {}),
+        number: signal.number,
+      },
+      metadata: {
+        github: {
+          action: 'subscribeToPR',
+          status: status.status,
+          owner: signal.owner,
+          repo: signal.repo,
+          number: signal.number,
+        },
+      },
+    });
+  }
+}

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -64,6 +64,7 @@ export type GithubSignalsSyncInput = {
   number: number;
   cwd?: string;
   abortSignal?: AbortSignal;
+  includeComments?: boolean;
 };
 
 export type GithubSignalsSyncResult = {
@@ -643,24 +644,21 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
 
   async syncPullRequest(input: GithubSignalsSyncInput): Promise<GithubSignalsSyncResult> {
     try {
-      const { stdout, stderr } = await execFileAsync(
-        this.#command,
-        [
-          'sync',
-          `${input.owner}/${input.repo}`,
-          '--numbers',
-          String(input.number),
-          '--include-comments',
-          '--with',
-          'pr-details',
-          '--json',
-        ],
-        {
-          cwd: input.cwd,
-          signal: input.abortSignal,
-          maxBuffer: 10 * 1024 * 1024,
-        },
-      );
+      const args = [
+        'sync',
+        `${input.owner}/${input.repo}`,
+        '--numbers',
+        String(input.number),
+        ...(input.includeComments === false ? [] : ['--include-comments']),
+        '--with',
+        'pr-details',
+        '--json',
+      ];
+      const { stdout, stderr } = await execFileAsync(this.#command, args, {
+        cwd: input.cwd,
+        signal: input.abortSignal,
+        maxBuffer: 10 * 1024 * 1024,
+      });
       return { ok: true, stdout, stderr };
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) };
@@ -907,7 +905,7 @@ export class GithubSignals implements Processor<'github-signals'> {
   }
 
   async syncThreadNow(input: GithubPollingThread): Promise<number> {
-    return this.#pollThread(input);
+    return this.#pollThread(input, { includeComments: true });
   }
 
   async startPollingForThread(
@@ -929,13 +927,17 @@ export class GithubSignals implements Processor<'github-signals'> {
 
     if (this.#polling.has(key)) return true;
 
-    const runPoll = () => {
-      void this.#pollThread(input).catch(error => {
+    let scheduledPollCount = options.pollImmediately ? 1 : 0;
+    const runPoll = (pollOptions: { includeComments?: boolean } = {}) => {
+      void this.#pollThread(input, pollOptions).catch(error => {
         console.warn('GitHub PR polling failed:', error);
       });
     };
-    const timer = setInterval(runPoll, this.#options.pollIntervalMs ?? 300_000);
-    if (options.pollImmediately) runPoll();
+    const timer = setInterval(() => {
+      scheduledPollCount += 1;
+      runPoll({ includeComments: scheduledPollCount % 2 === 1 });
+    }, this.#options.pollIntervalMs ?? 300_000);
+    if (options.pollImmediately) runPoll({ includeComments: true });
     timer.unref?.();
     this.#polling.set(key, { ...input, timer, running: false });
     return true;
@@ -963,7 +965,7 @@ export class GithubSignals implements Processor<'github-signals'> {
   }
 
   async pollThreadNow(input: GithubPollingThread): Promise<number> {
-    return this.#pollThread(input);
+    return this.#pollThread(input, { includeComments: true });
   }
 
   async processInputStep(args: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
@@ -1186,7 +1188,7 @@ export class GithubSignals implements Processor<'github-signals'> {
     this.#subscriptionsChangedHandler?.(input);
   }
 
-  async #pollThread(input: GithubPollingThread): Promise<number> {
+  async #pollThread(input: GithubPollingThread, options: { includeComments?: boolean } = {}): Promise<number> {
     const key = this.#pollingKey(input);
     const state = this.#polling.get(key);
     if (state?.running) {
@@ -1210,6 +1212,7 @@ export class GithubSignals implements Processor<'github-signals'> {
           repo: subscription.repo,
           number: subscription.number,
           cwd: this.#options.cwd,
+          includeComments: options.includeComments,
         };
         const syncResult = await this.#syncClient.syncPullRequest(syncInput);
         const snapshot = syncResult.ok ? await this.#syncClient.getPullRequestSnapshot?.(syncInput) : undefined;

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -150,10 +150,14 @@ type GithubSignalAgent = {
   sendNotificationSignal?(notification: unknown, target: unknown): { accepted?: unknown } | Promise<unknown>;
 };
 
-type GithubNotificationSender = (
-  notification: unknown,
-  target: { resourceId: string; threadId: string },
-) => Promise<unknown>;
+type GithubNotificationStreamOptions = Record<string, unknown>;
+
+type GithubSignalAgentOptions = {
+  getNotificationStreamOptions?: (target: {
+    resourceId: string;
+    threadId: string;
+  }) => GithubNotificationStreamOptions | Promise<GithubNotificationStreamOptions>;
+};
 
 type GithubSignalsMastra = {
   getStorage?: () => { getStore?: (name: 'memory') => Promise<unknown> } | undefined;
@@ -854,7 +858,7 @@ export class GithubSignals implements Processor<'github-signals'> {
   readonly #repositoryResolver: GithubRepositoryResolver;
   readonly #polling = new Map<string, GithubPollingState>();
   #agent?: GithubSignalAgent;
-  #notificationSender?: GithubNotificationSender;
+  #agentOptions: GithubSignalAgentOptions = {};
 
   constructor(options: GithubSignalsOptions = {}) {
     this.#options = options;
@@ -862,12 +866,9 @@ export class GithubSignals implements Processor<'github-signals'> {
     this.#repositoryResolver = options.repositoryResolver ?? new GitRemoteRepositoryResolver();
   }
 
-  addAgent(agent: GithubSignalAgent): void {
+  addAgent(agent: GithubSignalAgent, options: GithubSignalAgentOptions = {}): void {
     this.#agent = agent;
-  }
-
-  addNotificationSender(sender: GithubNotificationSender): void {
-    this.#notificationSender = sender;
+    this.#agentOptions = options;
   }
 
   __registerMastra(mastra: Mastra<any, any, any, any, any, any, any, any, any, any>): void {
@@ -1326,8 +1327,11 @@ export class GithubSignals implements Processor<'github-signals'> {
         },
       },
     };
-    if (this.#notificationSender) await this.#notificationSender(notificationInput, input.target);
-    else await input.agent?.sendNotificationSignal?.(notificationInput, input.target);
+    const streamOptions = await this.#agentOptions.getNotificationStreamOptions?.(input.target);
+    await input.agent?.sendNotificationSignal?.(
+      notificationInput,
+      streamOptions ? { ...input.target, ifIdle: { streamOptions } } : input.target,
+    );
   }
 
   async #sendBaselineNotification(input: {
@@ -1337,7 +1341,7 @@ export class GithubSignals implements Processor<'github-signals'> {
     snapshot: GithubPullRequestSnapshot;
   }): Promise<void> {
     const agent = this.#getNotificationAgent({});
-    if (!this.#notificationSender && !agent?.sendNotificationSignal) return;
+    if (!agent?.sendNotificationSignal) return;
     await this.#sendGithubNotification({
       agent,
       subscription: input.subscription,
@@ -1356,7 +1360,7 @@ export class GithubSignals implements Processor<'github-signals'> {
     previousContentHash?: string;
   }): Promise<{ kind: string; priority: 'medium' | 'high'; summary: string } | undefined> {
     const agent = this.#getNotificationAgent(input.polling);
-    if (!this.#notificationSender && !agent?.sendNotificationSignal) return undefined;
+    if (!agent?.sendNotificationSignal) return undefined;
     const notification = classifyGithubActivityNotification({
       subscription: input.subscription,
       snapshot: input.snapshot,

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -1195,10 +1195,7 @@ export class GithubSignals implements Processor<'github-signals'> {
           isFirstObservation ||
           (syncResult.ok &&
             snapshot &&
-            ((previousGithubUpdatedAt &&
-              snapshot.githubUpdatedAt &&
-              previousGithubUpdatedAt !== snapshot.githubUpdatedAt) ||
-              (previousContentHash && snapshot.contentHash && previousContentHash !== snapshot.contentHash) ||
+            ((previousContentHash && snapshot.contentHash && previousContentHash !== snapshot.contentHash) ||
               (subscription.lastObservedState && snapshot.state && subscription.lastObservedState !== snapshot.state) ||
               (subscription.lastObservedMergeableState &&
                 snapshot.mergeableState &&

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -908,6 +908,28 @@ export class GithubSignals implements Processor<'github-signals'> {
     return this.#pollThread(input, { includeComments: true });
   }
 
+  async subscribeThreadToPR(input: GithubPollingThread & { pr: GithubPRSignalInput }): Promise<GithubOperationResult> {
+    const pr = typeof input.pr === 'number' ? { number: input.pr } : input.pr;
+    return this.#subscribe({
+      id: `github-command-subscribe-${randomUUID()}`,
+      ...pr,
+      threadId: input.threadId,
+      resourceId: input.resourceId,
+    });
+  }
+
+  async unsubscribeThreadFromPR(
+    input: GithubPollingThread & { pr: GithubPRSignalInput },
+  ): Promise<GithubOperationResult> {
+    const pr = typeof input.pr === 'number' ? { number: input.pr } : input.pr;
+    return this.#unsubscribe({
+      id: `github-command-unsubscribe-${randomUUID()}`,
+      ...pr,
+      threadId: input.threadId,
+      resourceId: input.resourceId,
+    });
+  }
+
   async startPollingForThread(
     input: GithubPollingThread,
     options: { pollImmediately?: boolean } = {},
@@ -1486,9 +1508,7 @@ export class GithubSignals implements Processor<'github-signals'> {
       subscription.lastSyncStatus = 'skipped';
     }
 
-    const subscriptions = [...githubMetadata.subscriptions];
-    if (existingIndex >= 0) subscriptions[existingIndex] = subscription;
-    else subscriptions.push(subscription);
+    const subscriptions = [subscription];
 
     await threadStore.saveThread({
       thread: {

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -1283,7 +1283,7 @@ export class GithubSignals implements Processor<'github-signals'> {
       priority: input.notification.priority,
       summary: input.notification.summary,
       dedupeKey: `github:${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}:${input.dedupeSuffix}`,
-      coalesceKey: `github:${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}`,
+      coalesceKey: `github:${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}:${input.notification.kind}`,
       attributes: {
         owner: input.subscription.owner,
         repo: input.subscription.repo,

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -1,15 +1,22 @@
 import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 
 import type { AgentSignalInput } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import type { Mastra } from '@mastra/core/mastra';
 import type { StorageThreadType } from '@mastra/core/memory';
-import type { Processor, ProcessInputStepArgs } from '@mastra/core/processors';
+import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from '@mastra/core/processors';
+import { createTool } from '@mastra/core/tools';
+import z from 'zod';
 
 const execFileAsync = promisify(execFile);
 
 export const GITHUB_SUBSCRIBE_PR_TAG = 'github-subscribe-pr';
+export const GITHUB_UNSUBSCRIBE_PR_TAG = 'github-unsubscribe-pr';
 export const GITHUB_SYNC_STATUS_TAG = 'github-sync-status';
 export const GITHUB_SIGNALS_METADATA_KEY = 'githubSignals';
 
@@ -23,13 +30,25 @@ export type GithubPRSubscription = {
   lastSyncAt?: string;
   lastSyncStatus?: 'success' | 'error' | 'skipped';
   lastSyncError?: string;
+  lastObservedGithubUpdatedAt?: string;
+  lastObservedContentHash?: string;
+  lastObservedState?: string;
+  lastObservedMergeableState?: string;
+  lastObservedCiState?: string;
+  lastObservedReviewStateHash?: string;
+  lastNotificationAt?: string;
+  lastNotificationKind?: string;
+  lastNotificationPriority?: 'medium' | 'high';
+  lastNotificationSummary?: string;
 };
 
 export type GithubSignalsThreadMetadata = {
   subscriptions: GithubPRSubscription[];
 };
 
-export type GithubSubscribePRSignalInput = number | { owner?: string; repo?: string; number: number };
+export type GithubPRSignalInput = number | { owner?: string; repo?: string; number: number };
+export type GithubSubscribePRSignalInput = GithubPRSignalInput;
+export type GithubUnsubscribePRSignalInput = GithubPRSignalInput;
 
 export type GithubSignalsSyncInput = {
   owner: string;
@@ -46,8 +65,40 @@ export type GithubSignalsSyncResult = {
   error?: string;
 };
 
+export type GithubPullRequestCheckSnapshot = {
+  name: string;
+  status?: string;
+  conclusion?: string;
+  workflowName?: string;
+  detailsUrl?: string;
+  updatedAt?: string;
+};
+
+export type GithubPullRequestSnapshot = {
+  title?: string;
+  state?: string;
+  htmlUrl?: string;
+  githubUpdatedAt?: string;
+  contentHash?: string;
+  threadContentHash?: string;
+  headSha?: string;
+  headRef?: string;
+  mergeableState?: string;
+  closedAt?: string;
+  mergedAt?: string;
+  checks?: GithubPullRequestCheckSnapshot[];
+  ciState?: 'success' | 'failure' | 'pending' | 'unknown';
+  unresolvedReviewThreads?: number;
+  reviewStateHash?: string;
+  latestReviewThreadAt?: string;
+  latestCommentAuthor?: string;
+  latestCommentAuthorType?: string;
+  latestCommentIsBot?: boolean;
+};
+
 export type GithubSignalsSyncClient = {
   syncPullRequest(input: GithubSignalsSyncInput): Promise<GithubSignalsSyncResult>;
+  getPullRequestSnapshot?(input: GithubSignalsSyncInput): Promise<GithubPullRequestSnapshot | undefined>;
 };
 
 export type GithubRepository = {
@@ -69,17 +120,71 @@ export type GithubSignalsOptions = {
   repo?: string;
   cwd?: string;
   syncOnSubscribe?: boolean;
+  pollIntervalMs?: number;
+  agentId?: string;
   gitcrawlCommand?: string;
   syncClient?: GithubSignalsSyncClient;
   repositoryResolver?: GithubRepositoryResolver;
   threadStore?: GithubSignalsThreadStore;
 };
 
-type GithubSubscribeSignal = {
+type GithubPRSignal = {
   id: string;
   owner?: string;
   repo?: string;
   number: number;
+};
+
+type GithubSignalAgent = {
+  sendSignal(signal: AgentSignalInput, target: unknown): { accepted: Promise<unknown> };
+  sendNotificationSignal?(notification: unknown, target: unknown): { accepted: Promise<unknown> } | Promise<unknown>;
+};
+
+type GithubSignalsMastra = {
+  getStorage?: () => { getStore?: (name: 'memory') => Promise<unknown> } | undefined;
+  getAgentById?: (id: string) => GithubSignalAgent;
+};
+
+type GithubToolExecuteContext = {
+  agent?: {
+    agentId?: string;
+    threadId?: string;
+    resourceId?: string;
+  };
+};
+
+type GithubToolFactory = (definition: {
+  id: string;
+  description: string;
+  inputSchema: z.ZodTypeAny;
+  execute: (
+    input: { owner?: string; repo?: string; number: number },
+    context?: GithubToolExecuteContext,
+  ) => Promise<unknown>;
+}) => unknown;
+
+const createGithubTool = createTool as unknown as GithubToolFactory;
+
+type GithubOperationResult = {
+  owner: string;
+  repo: string;
+  number: number;
+  subscription?: GithubPRSubscription;
+  syncResult?: GithubSignalsSyncResult;
+  removed?: boolean;
+  remainingSubscriptions?: number;
+  alreadyProcessed?: boolean;
+};
+
+type GithubPollingThread = {
+  threadId: string;
+  resourceId: string;
+  agentId?: string;
+};
+
+type GithubPollingState = GithubPollingThread & {
+  timer: ReturnType<typeof setInterval>;
+  running: boolean;
 };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -94,6 +199,48 @@ function readNumber(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
   if (typeof value === 'string' && /^\d+$/.test(value)) return Number(value);
   return undefined;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function snapshotHash(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+function resolveHomePath(path: string): string {
+  return path.startsWith('~/') ? join(homedir(), path.slice(2)) : path;
+}
+
+async function getGitcrawlDbPath(): Promise<string> {
+  if (process.env.GITCRAWL_DB_PATH) return resolveHomePath(process.env.GITCRAWL_DB_PATH);
+  const configPath = process.env.GITCRAWL_CONFIG_PATH ?? join(homedir(), '.config', 'gitcrawl', 'config.toml');
+  try {
+    const config = await readFile(resolveHomePath(configPath), 'utf8');
+    const match = /^\s*db_path\s*=\s*['\"]([^'\"]+)['\"]/m.exec(config);
+    if (match?.[1]) return resolveHomePath(match[1]);
+  } catch {
+    // fall back to gitcrawl's default config location
+  }
+  return join(homedir(), '.config', 'gitcrawl', 'gitcrawl.db');
+}
+
+async function queryGitcrawlDb<T>(sql: string): Promise<T[]> {
+  const dbPath = await getGitcrawlDbPath();
+  const { stdout } = await execFileAsync('sqlite3', ['-json', dbPath, sql], { maxBuffer: 10 * 1024 * 1024 });
+  return JSON.parse(stdout || '[]') as T[];
+}
+
+function sqlString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
 }
 
 function getSignalMetadata(message: MastraDBMessage): Record<string, unknown> | undefined {
@@ -133,6 +280,36 @@ function getGithubMetadata(threadMetadata: Record<string, unknown> | undefined):
       ...(readString(rawSubscription.lastSyncError)
         ? { lastSyncError: readString(rawSubscription.lastSyncError)! }
         : {}),
+      ...(readString(rawSubscription.lastObservedGithubUpdatedAt)
+        ? { lastObservedGithubUpdatedAt: readString(rawSubscription.lastObservedGithubUpdatedAt)! }
+        : {}),
+      ...(readString(rawSubscription.lastObservedContentHash)
+        ? { lastObservedContentHash: readString(rawSubscription.lastObservedContentHash)! }
+        : {}),
+      ...(readString(rawSubscription.lastObservedState)
+        ? { lastObservedState: readString(rawSubscription.lastObservedState)! }
+        : {}),
+      ...(readString(rawSubscription.lastObservedMergeableState)
+        ? { lastObservedMergeableState: readString(rawSubscription.lastObservedMergeableState)! }
+        : {}),
+      ...(readString(rawSubscription.lastObservedCiState)
+        ? { lastObservedCiState: readString(rawSubscription.lastObservedCiState)! }
+        : {}),
+      ...(readString(rawSubscription.lastObservedReviewStateHash)
+        ? { lastObservedReviewStateHash: readString(rawSubscription.lastObservedReviewStateHash)! }
+        : {}),
+      ...(readString(rawSubscription.lastNotificationAt)
+        ? { lastNotificationAt: readString(rawSubscription.lastNotificationAt)! }
+        : {}),
+      ...(readString(rawSubscription.lastNotificationKind)
+        ? { lastNotificationKind: readString(rawSubscription.lastNotificationKind)! }
+        : {}),
+      ...(rawSubscription.lastNotificationPriority === 'medium' || rawSubscription.lastNotificationPriority === 'high'
+        ? { lastNotificationPriority: rawSubscription.lastNotificationPriority }
+        : {}),
+      ...(readString(rawSubscription.lastNotificationSummary)
+        ? { lastNotificationSummary: readString(rawSubscription.lastNotificationSummary)! }
+        : {}),
     });
   }
 
@@ -153,6 +330,147 @@ function setGithubMetadata(
       [GITHUB_SIGNALS_METADATA_KEY]: githubSignals,
     },
   };
+}
+
+function getFailingChecks(snapshot: GithubPullRequestSnapshot): GithubPullRequestCheckSnapshot[] {
+  return (snapshot.checks ?? []).filter(check => check.conclusion === 'failure' || check.conclusion === 'timed_out');
+}
+
+function getPendingChecks(snapshot: GithubPullRequestSnapshot): GithubPullRequestCheckSnapshot[] {
+  return (snapshot.checks ?? []).filter(check => check.status && check.status !== 'completed');
+}
+
+function getPrLabel(subscription: GithubPRSubscription, snapshot?: GithubPullRequestSnapshot): string {
+  const pr = `${subscription.owner}/${subscription.repo}#${subscription.number}`;
+  return snapshot?.title ? `${pr}: ${snapshot.title}` : pr;
+}
+
+function isBotOnlyActivity(snapshot: GithubPullRequestSnapshot): boolean {
+  return snapshot.latestCommentIsBot === true && (!snapshot.ciState || snapshot.ciState === 'unknown');
+}
+
+function classifyGithubActivityNotification(input: {
+  subscription: GithubPRSubscription;
+  snapshot: GithubPullRequestSnapshot;
+}): { kind: string; priority: 'medium' | 'high'; summary: string } | undefined {
+  const pr = `${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}`;
+  const label = getPrLabel(input.subscription, input.snapshot);
+  if (input.subscription.lastObservedState && input.subscription.lastObservedState !== input.snapshot.state) {
+    if (input.snapshot.state === 'merged')
+      return { kind: 'pull-request-merged', priority: 'high', summary: `${label} was merged` };
+    if (input.snapshot.state === 'closed')
+      return { kind: 'pull-request-closed', priority: 'high', summary: `${label} was closed` };
+    if (input.snapshot.state === 'open')
+      return { kind: 'pull-request-reopened', priority: 'medium', summary: `${label} was reopened` };
+  }
+
+  const failingChecks = getFailingChecks(input.snapshot);
+  if (input.snapshot.ciState === 'failure' && input.subscription.lastObservedCiState !== 'failure') {
+    const names = failingChecks
+      .slice(0, 3)
+      .map(check => check.name)
+      .join(', ');
+    return {
+      kind: 'pull-request-ci-failure',
+      priority: 'high',
+      summary: `${pr} has failing CI${names ? `: ${names}` : ''}`,
+    };
+  }
+  if (
+    input.snapshot.ciState === 'success' &&
+    input.subscription.lastObservedCiState &&
+    input.subscription.lastObservedCiState !== 'success'
+  ) {
+    return { kind: 'pull-request-ci-recovered', priority: 'medium', summary: `${pr} CI recovered` };
+  }
+  if (input.snapshot.mergeableState === 'dirty' && input.subscription.lastObservedMergeableState !== 'dirty') {
+    return {
+      kind: 'pull-request-conflict',
+      priority: 'high',
+      summary: `${pr} has merge conflicts${input.snapshot.title ? `: ${input.snapshot.title}` : ''}`,
+    };
+  }
+  if (
+    input.snapshot.mergeableState &&
+    input.subscription.lastObservedMergeableState === 'dirty' &&
+    input.snapshot.mergeableState !== 'dirty'
+  ) {
+    return {
+      kind: 'pull-request-conflict-resolved',
+      priority: 'medium',
+      summary: `${pr} merge conflicts were resolved`,
+    };
+  }
+  if (
+    input.snapshot.reviewStateHash &&
+    input.subscription.lastObservedReviewStateHash &&
+    input.snapshot.reviewStateHash !== input.subscription.lastObservedReviewStateHash &&
+    (input.snapshot.unresolvedReviewThreads ?? 0) > 0
+  ) {
+    return {
+      kind: 'pull-request-review-activity',
+      priority: 'medium',
+      summary: `${pr} has ${input.snapshot.unresolvedReviewThreads} unresolved review thread${input.snapshot.unresolvedReviewThreads === 1 ? '' : 's'}`,
+    };
+  }
+  const pendingChecks = getPendingChecks(input.snapshot);
+  if (
+    input.snapshot.ciState === 'pending' &&
+    input.subscription.lastObservedCiState !== 'pending' &&
+    pendingChecks.length > 0
+  ) {
+    const names = pendingChecks
+      .slice(0, 3)
+      .map(check => check.name)
+      .join(', ');
+    return {
+      kind: 'pull-request-ci-pending',
+      priority: 'medium',
+      summary: `${pr} has CI still running${names ? `: ${names}` : ''}`,
+    };
+  }
+  if (isBotOnlyActivity(input.snapshot)) return undefined;
+  return {
+    kind: 'pull-request-activity',
+    priority: 'medium',
+    summary: `${pr} has new activity${input.snapshot.title ? `: ${input.snapshot.title}` : ''}`,
+  };
+}
+
+function classifyGithubBaselineNotification(input: {
+  subscription: GithubPRSubscription;
+  snapshot: GithubPullRequestSnapshot;
+}): { kind: string; priority: 'medium' | 'high'; summary: string } {
+  const pr = `${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}`;
+  const failingChecks = getFailingChecks(input.snapshot);
+  const reviewCount = input.snapshot.unresolvedReviewThreads ?? 0;
+  const high = input.snapshot.ciState === 'failure' || input.snapshot.mergeableState === 'dirty';
+  const details = [
+    input.snapshot.state ? `state: ${input.snapshot.state}` : undefined,
+    input.snapshot.ciState && input.snapshot.ciState !== 'unknown' ? `CI: ${input.snapshot.ciState}` : undefined,
+    input.snapshot.mergeableState ? `mergeability: ${input.snapshot.mergeableState}` : undefined,
+    reviewCount > 0 ? `${reviewCount} unresolved review thread${reviewCount === 1 ? '' : 's'}` : undefined,
+    failingChecks.length > 0
+      ? `failing: ${failingChecks
+          .slice(0, 3)
+          .map(check => check.name)
+          .join(', ')}`
+      : undefined,
+  ].filter(Boolean);
+  return {
+    kind: 'pull-request-baseline',
+    priority: high ? 'high' : 'medium',
+    summary: `${pr} subscribed${input.snapshot.title ? `: ${input.snapshot.title}` : ''}${details.length ? ` (${details.join('; ')})` : ''}`,
+  };
+}
+
+function applySnapshotCursor(subscription: GithubPRSubscription, snapshot: GithubPullRequestSnapshot): void {
+  if (snapshot.githubUpdatedAt) subscription.lastObservedGithubUpdatedAt = snapshot.githubUpdatedAt;
+  if (snapshot.contentHash) subscription.lastObservedContentHash = snapshot.contentHash;
+  if (snapshot.state) subscription.lastObservedState = snapshot.state;
+  if (snapshot.mergeableState) subscription.lastObservedMergeableState = snapshot.mergeableState;
+  if (snapshot.ciState) subscription.lastObservedCiState = snapshot.ciState;
+  if (snapshot.reviewStateHash) subscription.lastObservedReviewStateHash = snapshot.reviewStateHash;
 }
 
 function parseGitHubRemoteUrl(remoteUrl: string): GithubRepository | undefined {
@@ -210,12 +528,171 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
       return { ok: false, error: error instanceof Error ? error.message : String(error) };
     }
   }
+
+  async getPullRequestSnapshot(input: GithubSignalsSyncInput): Promise<GithubPullRequestSnapshot | undefined> {
+    try {
+      const { stdout } = await execFileAsync(
+        this.#command,
+        ['threads', `${input.owner}/${input.repo}`, '--numbers', String(input.number), '--json'],
+        {
+          cwd: input.cwd,
+          signal: input.abortSignal,
+          maxBuffer: 10 * 1024 * 1024,
+        },
+      );
+      const parsed = JSON.parse(stdout) as { threads?: Array<Record<string, unknown>> };
+      const thread = parsed.threads?.find(item => readNumber(item.number) === input.number);
+      if (!thread) return undefined;
+
+      const owner = sqlString(input.owner);
+      const repo = sqlString(input.repo);
+      const number = input.number;
+      const [threadDetails] = await queryGitcrawlDb<{
+        state?: string;
+        closed_at_gh?: string;
+        merged_at_gh?: string;
+      }>(`select t.state, t.closed_at_gh, t.merged_at_gh
+          from threads t
+          join repositories r on r.id=t.repo_id
+         where r.owner=${owner} and r.name=${repo} and t.number=${number}
+         limit 1`);
+      const [details] = await queryGitcrawlDb<{
+        head_sha?: string;
+        head_ref?: string;
+        mergeable_state?: string;
+      }>(`select d.head_sha, d.head_ref, d.mergeable_state
+          from pull_request_details d
+          join threads t on t.id=d.thread_id
+          join repositories r on r.id=t.repo_id
+         where r.owner=${owner} and r.name=${repo} and t.number=${number}
+         limit 1`);
+
+      const checkRows = await queryGitcrawlDb<{
+        name?: string;
+        status?: string;
+        conclusion?: string;
+        workflow_name?: string;
+        details_url?: string;
+        updated_at?: string;
+      }>(`select name, status, conclusion, workflow_name, details_url,
+                 coalesce(completed_at, started_at, fetched_at) as updated_at
+            from pull_request_checks c
+            join threads t on t.id=c.thread_id
+            join repositories r on r.id=t.repo_id
+           where r.owner=${owner} and r.name=${repo} and t.number=${number}`);
+
+      const workflowRows = details?.head_sha
+        ? await queryGitcrawlDb<{
+            workflow_name?: string;
+            status?: string;
+            conclusion?: string;
+            html_url?: string;
+            updated_at_gh?: string;
+          }>(`select workflow_name, status, conclusion, html_url, updated_at_gh
+                from github_workflow_runs w
+                join repositories r on r.id=w.repo_id
+               where r.owner=${owner} and r.name=${repo} and w.head_sha=${sqlString(details.head_sha)}`)
+        : [];
+      const [reviewState] = await queryGitcrawlDb<{
+        unresolved_count?: number;
+        latest_review_thread_at?: string;
+      }>(`select count(*) as unresolved_count,
+                 max(coalesce(first_comment_updated_at, first_comment_created_at, fetched_at)) as latest_review_thread_at
+            from pull_request_review_threads rt
+            join threads t on t.id=rt.thread_id
+            join repositories r on r.id=t.repo_id
+           where r.owner=${owner} and r.name=${repo} and t.number=${number} and rt.is_resolved=0`);
+      const [latestComment] = await queryGitcrawlDb<{
+        author_login?: string;
+        author_type?: string;
+        is_bot?: number;
+      }>(`select c.author_login, c.author_type, c.is_bot
+            from comments c
+            join threads t on t.id=c.thread_id
+            join repositories r on r.id=t.repo_id
+           where r.owner=${owner} and r.name=${repo} and t.number=${number}
+           order by coalesce(c.updated_at_gh, c.created_at_gh) desc
+           limit 1`);
+
+      const checks = [
+        ...checkRows.map(row => ({
+          name: readString(row.name) ?? 'check',
+          status: readString(row.status),
+          conclusion: readString(row.conclusion),
+          workflowName: readString(row.workflow_name),
+          detailsUrl: readString(row.details_url),
+          updatedAt: readString(row.updated_at),
+        })),
+        ...workflowRows.map(row => ({
+          name: readString(row.workflow_name) ?? 'workflow',
+          status: readString(row.status),
+          conclusion: readString(row.conclusion),
+          workflowName: readString(row.workflow_name),
+          detailsUrl: readString(row.html_url),
+          updatedAt: readString(row.updated_at_gh),
+        })),
+      ].sort((a, b) => `${a.name}:${a.detailsUrl ?? ''}`.localeCompare(`${b.name}:${b.detailsUrl ?? ''}`));
+      const ciState = checks.some(check => check.conclusion === 'failure' || check.conclusion === 'timed_out')
+        ? 'failure'
+        : checks.some(check => check.status && check.status !== 'completed')
+          ? 'pending'
+          : checks.length > 0
+            ? 'success'
+            : 'unknown';
+      const threadContentHash = readString(thread.content_hash);
+      const unresolvedReviewThreads = Number(reviewState?.unresolved_count ?? 0);
+      const reviewStateHash = snapshotHash({
+        unresolvedReviewThreads,
+        latestReviewThreadAt: reviewState?.latest_review_thread_at,
+      });
+      const contentHash = snapshotHash({
+        threadContentHash,
+        state: thread.state,
+        headSha: details?.head_sha,
+        mergeableState: details?.mergeable_state,
+        ciState,
+        reviewStateHash,
+        checks: checks.map(check => ({
+          name: check.name,
+          status: check.status,
+          conclusion: check.conclusion,
+          detailsUrl: check.detailsUrl,
+          updatedAt: check.updatedAt,
+        })),
+      });
+      return {
+        title: readString(thread.title),
+        state: readString(threadDetails?.merged_at_gh)
+          ? 'merged'
+          : (readString(threadDetails?.state) ?? readString(thread.state)),
+        htmlUrl: readString(thread.html_url),
+        githubUpdatedAt: readString(thread.updated_at_gh),
+        closedAt: readString(threadDetails?.closed_at_gh),
+        mergedAt: readString(threadDetails?.merged_at_gh),
+        threadContentHash,
+        contentHash,
+        headSha: readString(details?.head_sha),
+        headRef: readString(details?.head_ref),
+        mergeableState: readString(details?.mergeable_state),
+        checks,
+        ciState,
+        unresolvedReviewThreads,
+        reviewStateHash,
+        latestReviewThreadAt: readString(reviewState?.latest_review_thread_at),
+        latestCommentAuthor: readString(latestComment?.author_login),
+        latestCommentAuthorType: readString(latestComment?.author_type),
+        latestCommentIsBot: latestComment?.is_bot === 1,
+      };
+    } catch {
+      return undefined;
+    }
+  }
 }
 
 export class GithubSignals implements Processor<'github-signals'> {
   readonly id = 'github-signals' as const;
   readonly name = 'GitHub Signals';
-  protected mastra?: Mastra<any, any, any, any, any, any, any, any, any, any>;
+  protected mastra?: GithubSignalsMastra;
 
   static signals = {
     subscribeToPR(input: GithubSubscribePRSignalInput): AgentSignalInput {
@@ -237,11 +714,31 @@ export class GithubSignals implements Processor<'github-signals'> {
         },
       };
     },
+    unsubscribeFromPR(input: GithubUnsubscribePRSignalInput): AgentSignalInput {
+      const normalized = typeof input === 'number' ? { number: input } : input;
+      return {
+        type: 'user',
+        tagName: GITHUB_UNSUBSCRIBE_PR_TAG,
+        contents: `Unsubscribe from GitHub PR #${normalized.number}`,
+        attributes: {
+          ...(normalized.owner ? { owner: normalized.owner } : {}),
+          ...(normalized.repo ? { repo: normalized.repo } : {}),
+          number: normalized.number,
+        },
+        metadata: {
+          github: {
+            action: 'unsubscribeFromPR',
+            ...normalized,
+          },
+        },
+      };
+    },
   };
 
   readonly #options: GithubSignalsOptions;
   readonly #syncClient: GithubSignalsSyncClient;
   readonly #repositoryResolver: GithubRepositoryResolver;
+  readonly #polling = new Map<string, GithubPollingState>();
 
   constructor(options: GithubSignalsOptions = {}) {
     this.#options = options;
@@ -250,108 +747,484 @@ export class GithubSignals implements Processor<'github-signals'> {
   }
 
   __registerMastra(mastra: Mastra<any, any, any, any, any, any, any, any, any, any>): void {
-    this.mastra = mastra;
+    this.mastra = mastra as unknown as GithubSignalsMastra;
   }
 
-  async processInputStep(args: ProcessInputStepArgs) {
-    if (args.stepNumber !== 0) return;
+  async startPollingForThread(input: GithubPollingThread): Promise<boolean> {
+    const subscriptions = await this.#getThreadSubscriptions(input);
+    if (subscriptions.length === 0) {
+      this.stopPollingForThread(input);
+      return false;
+    }
 
-    const subscribeSignal = this.#findLatestSubscribeSignal(args.messages);
-    if (!subscribeSignal) return;
+    const key = this.#pollingKey(input);
+    if (this.#polling.has(key)) return true;
 
-    const resolvedRepository =
-      subscribeSignal.owner && subscribeSignal.repo
-        ? { owner: subscribeSignal.owner, repo: subscribeSignal.repo }
-        : this.#options.owner && this.#options.repo
-          ? { owner: this.#options.owner, repo: this.#options.repo }
-          : await this.#repositoryResolver.resolveRepository({ cwd: this.#options.cwd, abortSignal: args.abortSignal });
-    const owner = resolvedRepository?.owner;
-    const repo = resolvedRepository?.repo;
-    if (!owner || !repo) {
-      await this.#sendStatus(args, subscribeSignal, {
-        status: 'error',
-        message: 'GitHub PR subscription requires owner and repo.',
+    const timer = setInterval(() => {
+      void this.#pollThread(input);
+    }, this.#options.pollIntervalMs ?? 60_000);
+    timer.unref?.();
+    this.#polling.set(key, { ...input, timer, running: false });
+    return true;
+  }
+
+  stopPollingForThread(input: GithubPollingThread): void {
+    const key = this.#pollingKey(input);
+    const state = this.#polling.get(key);
+    if (!state) return;
+    clearInterval(state.timer);
+    this.#polling.delete(key);
+  }
+
+  isPollingThread(input: GithubPollingThread): boolean {
+    return this.#polling.has(this.#pollingKey(input));
+  }
+
+  stopAllPolling(): void {
+    for (const state of this.#polling.values()) clearInterval(state.timer);
+    this.#polling.clear();
+  }
+
+  async pollThreadNow(input: GithubPollingThread): Promise<number> {
+    return this.#pollThread(input);
+  }
+
+  async processInputStep(args: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
+    const tools = this.#createTools(args);
+    if (args.stepNumber !== 0) return { tools };
+
+    const signal = this.#findLatestGithubSignal(args.messages);
+    if (!signal) return { tools };
+
+    const threadContext = this.#getThreadContext(args);
+
+    if (signal.tagName === GITHUB_UNSUBSCRIBE_PR_TAG) {
+      const result = await this.#unsubscribe({ ...signal, ...threadContext, abortSignal: args.abortSignal });
+      await this.#sendStatus(args, result, {
+        status: result.removed ? 'unsubscribed' : 'not_subscribed',
+        action: 'unsubscribeFromPR',
+        message: result.removed
+          ? `Unsubscribed from ${result.owner}/${result.repo}#${result.number}.`
+          : `No GitHub subscription found for ${result.owner}/${result.repo}#${result.number}.`,
       });
-      return;
+      return { tools };
     }
 
-    const threadStore = await this.#resolveThreadStore();
-    if (!threadStore) {
-      await this.#sendStatus(
-        args,
-        { ...subscribeSignal, owner, repo },
-        {
-          status: 'error',
-          message: 'GitHub PR subscription requires memory-backed thread storage.',
-        },
-      );
-      return;
-    }
+    const result = await this.#subscribe({ ...signal, ...threadContext, abortSignal: args.abortSignal });
+    if (result.alreadyProcessed) return { tools };
+    await this.#sendStatus(args, result, {
+      status: result.syncResult?.ok === false ? 'sync_error' : 'subscribed',
+      action: 'subscribeToPR',
+      message:
+        result.syncResult?.ok === false
+          ? `Subscribed to ${result.owner}/${result.repo}#${result.number}, but gitcrawl sync failed: ${result.syncResult.error}`
+          : `Subscribed to ${result.owner}/${result.repo}#${result.number}.`,
+    });
+    return { tools };
+  }
 
+  async #resolveThreadStore(): Promise<GithubSignalsThreadStore | undefined> {
+    if (this.#options.threadStore) return this.#options.threadStore;
+    const storage = this.mastra?.getStorage?.();
+    const memoryStore = storage?.getStore ? await storage.getStore('memory') : undefined;
+    return memoryStore as GithubSignalsThreadStore | undefined;
+  }
+
+  #getThreadContext(args: ProcessInputStepArgs): { threadId?: string; resourceId?: string } {
     const memoryContext = args.requestContext?.get('MastraMemory') as
       | { thread?: { id?: string }; resourceId?: string }
       | undefined;
-    const threadId = memoryContext?.thread?.id;
-    const resourceId = memoryContext?.resourceId;
-    if (!threadId || !resourceId) {
-      await this.#sendStatus(
-        args,
-        { ...subscribeSignal, owner, repo },
-        {
-          status: 'error',
-          message: 'GitHub PR subscription requires threadId and resourceId.',
+    return { threadId: memoryContext?.thread?.id, resourceId: memoryContext?.resourceId };
+  }
+
+  #createTools(args: ProcessInputStepArgs): Record<string, unknown> {
+    return {
+      ...args.tools,
+      github_subscribe_pr: createGithubTool({
+        id: 'github_subscribe_pr',
+        description:
+          'Subscribe this thread to a GitHub pull request. Syncs only the requested PR with gitcrawl and stores the subscription on the thread.',
+        inputSchema: z.object({
+          number: z.number().int().positive(),
+          owner: z.string().optional(),
+          repo: z.string().optional(),
+        }),
+        execute: async (input, context) => {
+          await this.#sendToolSignal({
+            signal: GithubSignals.signals.subscribeToPR(input),
+            agentId: context?.agent?.agentId,
+            threadId: context?.agent?.threadId,
+            resourceId: context?.agent?.resourceId,
+          });
+          return {
+            subscribed: true,
+            owner: input.owner,
+            repo: input.repo,
+            number: input.number,
+            message: `GitHub PR #${input.number} subscription signal sent.`,
+          };
         },
+      }),
+      github_unsubscribe_pr: createGithubTool({
+        id: 'github_unsubscribe_pr',
+        description: 'Unsubscribe this thread from a GitHub pull request.',
+        inputSchema: z.object({
+          number: z.number().int().positive(),
+          owner: z.string().optional(),
+          repo: z.string().optional(),
+        }),
+        execute: async (input, context) => {
+          await this.#sendToolSignal({
+            signal: GithubSignals.signals.unsubscribeFromPR(input),
+            agentId: context?.agent?.agentId,
+            threadId: context?.agent?.threadId,
+            resourceId: context?.agent?.resourceId,
+          });
+          return {
+            unsubscribed: true,
+            owner: input.owner,
+            repo: input.repo,
+            number: input.number,
+            message: `GitHub PR #${input.number} unsubscribe signal sent.`,
+          };
+        },
+      }),
+    };
+  }
+
+  async #sendToolSignal(input: {
+    signal: AgentSignalInput;
+    agentId?: string;
+    threadId?: string;
+    resourceId?: string;
+  }): Promise<void> {
+    if (!input.agentId || !input.threadId || !input.resourceId) {
+      throw new Error('GitHub tools require agentId, threadId, and resourceId.');
+    }
+    const agent = this.mastra?.getAgentById?.(input.agentId);
+    if (!agent?.sendSignal) {
+      throw new Error(`Could not find agent ${input.agentId} for GitHub tool signal delivery.`);
+    }
+    const result = agent.sendSignal(input.signal, {
+      resourceId: input.resourceId,
+      threadId: input.threadId,
+      ifActive: { behavior: 'deliver' },
+      ifIdle: { behavior: 'wake' },
+    });
+    await result.accepted;
+  }
+
+  async #resolveRepository(input: GithubPRSignal & { abortSignal?: AbortSignal }): Promise<GithubRepository> {
+    const resolvedRepository =
+      input.owner && input.repo
+        ? { owner: input.owner, repo: input.repo }
+        : this.#options.owner && this.#options.repo
+          ? { owner: this.#options.owner, repo: this.#options.repo }
+          : await this.#repositoryResolver.resolveRepository({
+              cwd: this.#options.cwd,
+              abortSignal: input.abortSignal,
+            });
+
+    if (!resolvedRepository?.owner || !resolvedRepository.repo) {
+      throw new Error(
+        'GitHub PR subscription requires owner and repo. Run inside a GitHub repo or pass owner and repo.',
       );
-      return;
     }
 
-    const loadedThread = (await threadStore.getThreadById({ threadId, resourceId })) ?? undefined;
-    if (!loadedThread) {
-      await this.#sendStatus(
-        args,
-        { ...subscribeSignal, owner, repo },
-        {
-          status: 'error',
-          message: `Could not load thread ${threadId}.`,
-        },
-      );
-      return;
-    }
+    return resolvedRepository;
+  }
 
+  async #loadThread(input: { threadId?: string; resourceId?: string }) {
+    const threadStore = await this.#resolveThreadStore();
+    if (!threadStore) throw new Error('GitHub PR subscription requires memory-backed thread storage.');
+    if (!input.threadId || !input.resourceId)
+      throw new Error('GitHub PR subscription requires threadId and resourceId.');
+    const loadedThread =
+      (await threadStore.getThreadById({ threadId: input.threadId, resourceId: input.resourceId })) ?? undefined;
+    if (!loadedThread) throw new Error(`Could not load thread ${input.threadId}.`);
+    return { threadStore, loadedThread };
+  }
+
+  #pollingKey(input: GithubPollingThread): string {
+    return `${input.resourceId}:${input.threadId}`;
+  }
+
+  #getNotificationAgent(input: { agentId?: string }): GithubSignalAgent | undefined {
+    const agentId = input.agentId ?? this.#options.agentId;
+    return agentId ? this.mastra?.getAgentById?.(agentId) : undefined;
+  }
+
+  async #getThreadSubscriptions(input: GithubPollingThread): Promise<GithubPRSubscription[]> {
+    const { loadedThread } = await this.#loadThread(input);
+    return getGithubMetadata(loadedThread.metadata).subscriptions;
+  }
+
+  async #pollThread(input: GithubPollingThread): Promise<number> {
+    const key = this.#pollingKey(input);
+    const state = this.#polling.get(key);
+    if (state?.running) return 0;
+    if (state) state.running = true;
+
+    try {
+      const { threadStore, loadedThread } = await this.#loadThread(input);
+      const githubMetadata = getGithubMetadata(loadedThread.metadata);
+      if (githubMetadata.subscriptions.length === 0) {
+        this.stopPollingForThread(input);
+        return 0;
+      }
+
+      const now = new Date().toISOString();
+      const subscriptions: GithubPRSubscription[] = [];
+      for (const subscription of githubMetadata.subscriptions) {
+        const syncInput = {
+          owner: subscription.owner,
+          repo: subscription.repo,
+          number: subscription.number,
+          cwd: this.#options.cwd,
+        };
+        const syncResult = await this.#syncClient.syncPullRequest(syncInput);
+        const snapshot = syncResult.ok ? await this.#syncClient.getPullRequestSnapshot?.(syncInput) : undefined;
+        const nextSubscription: GithubPRSubscription = {
+          ...subscription,
+          updatedAt: now,
+          lastSyncAt: now,
+          lastSyncStatus: syncResult.ok ? 'success' : 'error',
+        };
+        if (syncResult.error) nextSubscription.lastSyncError = syncResult.error;
+        else delete nextSubscription.lastSyncError;
+
+        const previousGithubUpdatedAt = subscription.lastObservedGithubUpdatedAt;
+        const previousContentHash = subscription.lastObservedContentHash;
+        if (snapshot) applySnapshotCursor(nextSubscription, snapshot);
+
+        const changed =
+          syncResult.ok &&
+          snapshot &&
+          ((previousGithubUpdatedAt &&
+            snapshot.githubUpdatedAt &&
+            previousGithubUpdatedAt !== snapshot.githubUpdatedAt) ||
+            (previousContentHash && snapshot.contentHash && previousContentHash !== snapshot.contentHash) ||
+            (subscription.lastObservedState && snapshot.state && subscription.lastObservedState !== snapshot.state) ||
+            (subscription.lastObservedMergeableState &&
+              snapshot.mergeableState &&
+              subscription.lastObservedMergeableState !== snapshot.mergeableState) ||
+            (subscription.lastObservedCiState &&
+              snapshot.ciState &&
+              subscription.lastObservedCiState !== snapshot.ciState) ||
+            (subscription.lastObservedReviewStateHash &&
+              snapshot.reviewStateHash &&
+              subscription.lastObservedReviewStateHash !== snapshot.reviewStateHash));
+        if (changed) {
+          const notification = await this.#sendActivityNotification({
+            polling: input,
+            subscription,
+            snapshot,
+            previousGithubUpdatedAt,
+            previousContentHash,
+          });
+          if (notification) {
+            nextSubscription.lastNotificationAt = now;
+            nextSubscription.lastNotificationKind = notification.kind;
+            nextSubscription.lastNotificationPriority = notification.priority;
+            nextSubscription.lastNotificationSummary = notification.summary;
+          }
+        }
+
+        subscriptions.push(nextSubscription);
+      }
+
+      await threadStore.saveThread({
+        thread: {
+          ...loadedThread,
+          id: input.threadId,
+          resourceId: input.resourceId,
+          createdAt: loadedThread.createdAt ?? new Date(),
+          updatedAt: new Date(),
+          metadata: setGithubMetadata(loadedThread.metadata, { subscriptions }),
+        },
+      });
+      return subscriptions.length;
+    } finally {
+      const latestState = this.#polling.get(key);
+      if (latestState) latestState.running = false;
+    }
+  }
+
+  async #sendGithubNotification(input: {
+    agent: GithubSignalAgent;
+    subscription: GithubPRSubscription;
+    snapshot: GithubPullRequestSnapshot;
+    notification: { kind: string; priority: 'medium' | 'high'; summary: string };
+    target: { resourceId: string; threadId: string };
+    dedupeSuffix: string;
+    previousGithubUpdatedAt?: string;
+    previousContentHash?: string;
+  }): Promise<void> {
+    const failingChecks = getFailingChecks(input.snapshot);
+    const pendingChecks = getPendingChecks(input.snapshot);
+    const result = await input.agent.sendNotificationSignal?.(
+      {
+        source: 'github',
+        kind: input.notification.kind,
+        priority: input.notification.priority,
+        summary: input.notification.summary,
+        dedupeKey: `github:${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}:${input.dedupeSuffix}`,
+        coalesceKey: `github:${input.subscription.owner}/${input.subscription.repo}#${input.subscription.number}`,
+        attributes: {
+          owner: input.subscription.owner,
+          repo: input.subscription.repo,
+          number: input.subscription.number,
+          ...(input.snapshot.title ? { title: input.snapshot.title } : {}),
+          ...(input.snapshot.state ? { state: input.snapshot.state } : {}),
+          ...(input.snapshot.htmlUrl ? { url: input.snapshot.htmlUrl } : {}),
+          ...(input.snapshot.githubUpdatedAt ? { githubUpdatedAt: input.snapshot.githubUpdatedAt } : {}),
+          ...(input.previousGithubUpdatedAt ? { previousGithubUpdatedAt: input.previousGithubUpdatedAt } : {}),
+          ...(input.snapshot.mergeableState ? { mergeableState: input.snapshot.mergeableState } : {}),
+          ...(input.snapshot.ciState ? { ciState: input.snapshot.ciState } : {}),
+          ...(input.snapshot.unresolvedReviewThreads !== undefined
+            ? { unresolvedReviewThreads: input.snapshot.unresolvedReviewThreads }
+            : {}),
+          ...(failingChecks.length > 0 ? { failingChecks: failingChecks.map(check => check.name).join(', ') } : {}),
+          ...(pendingChecks.length > 0 ? { pendingChecks: pendingChecks.map(check => check.name).join(', ') } : {}),
+        },
+        metadata: {
+          github: {
+            owner: input.subscription.owner,
+            repo: input.subscription.repo,
+            number: input.subscription.number,
+            title: input.snapshot.title,
+            state: input.snapshot.state,
+            htmlUrl: input.snapshot.htmlUrl,
+            githubUpdatedAt: input.snapshot.githubUpdatedAt,
+            previousGithubUpdatedAt: input.previousGithubUpdatedAt,
+            contentHash: input.snapshot.contentHash,
+            previousContentHash: input.previousContentHash,
+            threadContentHash: input.snapshot.threadContentHash,
+            headSha: input.snapshot.headSha,
+            headRef: input.snapshot.headRef,
+            mergeableState: input.snapshot.mergeableState,
+            ciState: input.snapshot.ciState,
+            closedAt: input.snapshot.closedAt,
+            mergedAt: input.snapshot.mergedAt,
+            unresolvedReviewThreads: input.snapshot.unresolvedReviewThreads,
+            reviewStateHash: input.snapshot.reviewStateHash,
+            latestReviewThreadAt: input.snapshot.latestReviewThreadAt,
+            latestCommentAuthor: input.snapshot.latestCommentAuthor,
+            latestCommentAuthorType: input.snapshot.latestCommentAuthorType,
+            latestCommentIsBot: input.snapshot.latestCommentIsBot,
+            failingChecks,
+            pendingChecks,
+          },
+        },
+      },
+      input.target,
+    );
+    if (isPlainObject(result) && result.accepted instanceof Promise) await result.accepted;
+  }
+
+  async #sendBaselineNotification(input: {
+    threadId: string;
+    resourceId: string;
+    subscription: GithubPRSubscription;
+    snapshot: GithubPullRequestSnapshot;
+  }): Promise<void> {
+    const agent = this.#getNotificationAgent({});
+    if (!agent?.sendNotificationSignal) return;
+    await this.#sendGithubNotification({
+      agent,
+      subscription: input.subscription,
+      snapshot: input.snapshot,
+      notification: classifyGithubBaselineNotification({ subscription: input.subscription, snapshot: input.snapshot }),
+      target: { resourceId: input.resourceId, threadId: input.threadId },
+      dedupeSuffix: `baseline:${input.subscription.lastSubscribeSignalId}`,
+    });
+  }
+
+  async #sendActivityNotification(input: {
+    polling: GithubPollingThread;
+    subscription: GithubPRSubscription;
+    snapshot: GithubPullRequestSnapshot;
+    previousGithubUpdatedAt?: string;
+    previousContentHash?: string;
+  }): Promise<{ kind: string; priority: 'medium' | 'high'; summary: string } | undefined> {
+    const agent = this.#getNotificationAgent(input.polling);
+    if (!agent?.sendNotificationSignal) return undefined;
+    const notification = classifyGithubActivityNotification({
+      subscription: input.subscription,
+      snapshot: input.snapshot,
+    });
+    if (!notification) return undefined;
+    await this.#sendGithubNotification({
+      agent,
+      subscription: input.subscription,
+      snapshot: input.snapshot,
+      notification,
+      target: { resourceId: input.polling.resourceId, threadId: input.polling.threadId },
+      dedupeSuffix: input.snapshot.contentHash ?? input.snapshot.githubUpdatedAt ?? String(Date.now()),
+      previousGithubUpdatedAt: input.previousGithubUpdatedAt,
+      previousContentHash: input.previousContentHash,
+    });
+    return notification;
+  }
+
+  async #subscribe(
+    input: GithubPRSignal & { threadId?: string; resourceId?: string; abortSignal?: AbortSignal },
+  ): Promise<GithubOperationResult> {
+    const { owner, repo } = await this.#resolveRepository(input);
+    const { threadStore, loadedThread } = await this.#loadThread(input);
     const githubMetadata = getGithubMetadata(loadedThread.metadata);
     const existingIndex = githubMetadata.subscriptions.findIndex(
       subscription =>
-        subscription.owner === owner && subscription.repo === repo && subscription.number === subscribeSignal.number,
+        subscription.owner === owner && subscription.repo === repo && subscription.number === input.number,
     );
     const existing = existingIndex >= 0 ? githubMetadata.subscriptions[existingIndex] : undefined;
-    if (existing?.lastSubscribeSignalId === subscribeSignal.id) return;
+    if (existing?.lastSubscribeSignalId === input.id) {
+      return { owner, repo, number: input.number, subscription: existing, alreadyProcessed: true };
+    }
 
     const now = new Date().toISOString();
     const subscription: GithubPRSubscription = {
       owner,
       repo,
-      number: subscribeSignal.number,
+      number: input.number,
       subscribedAt: existing?.subscribedAt ?? now,
       updatedAt: now,
-      lastSubscribeSignalId: subscribeSignal.id,
+      lastSubscribeSignalId: input.id,
       ...(existing?.lastSyncAt ? { lastSyncAt: existing.lastSyncAt } : {}),
       ...(existing?.lastSyncStatus ? { lastSyncStatus: existing.lastSyncStatus } : {}),
       ...(existing?.lastSyncError ? { lastSyncError: existing.lastSyncError } : {}),
+      ...(existing?.lastObservedGithubUpdatedAt
+        ? { lastObservedGithubUpdatedAt: existing.lastObservedGithubUpdatedAt }
+        : {}),
+      ...(existing?.lastObservedContentHash ? { lastObservedContentHash: existing.lastObservedContentHash } : {}),
+      ...(existing?.lastObservedState ? { lastObservedState: existing.lastObservedState } : {}),
+      ...(existing?.lastObservedMergeableState
+        ? { lastObservedMergeableState: existing.lastObservedMergeableState }
+        : {}),
+      ...(existing?.lastObservedCiState ? { lastObservedCiState: existing.lastObservedCiState } : {}),
+      ...(existing?.lastObservedReviewStateHash
+        ? { lastObservedReviewStateHash: existing.lastObservedReviewStateHash }
+        : {}),
     };
 
     let syncResult: GithubSignalsSyncResult | undefined;
+    let baselineSnapshot: GithubPullRequestSnapshot | undefined;
     if (this.#options.syncOnSubscribe !== false) {
-      syncResult = await this.#syncClient.syncPullRequest({
+      const syncInput = {
         owner,
         repo,
-        number: subscribeSignal.number,
+        number: input.number,
         cwd: this.#options.cwd,
-        abortSignal: args.abortSignal,
-      });
+        abortSignal: input.abortSignal,
+      };
+      syncResult = await this.#syncClient.syncPullRequest(syncInput);
       subscription.lastSyncAt = new Date().toISOString();
       subscription.lastSyncStatus = syncResult.ok ? 'success' : 'error';
       if (syncResult.error) subscription.lastSyncError = syncResult.error;
       else delete subscription.lastSyncError;
+      const snapshot = syncResult.ok ? await this.#syncClient.getPullRequestSnapshot?.(syncInput) : undefined;
+      baselineSnapshot = snapshot;
+      if (snapshot) applySnapshotCursor(subscription, snapshot);
     } else {
       subscription.lastSyncStatus = 'skipped';
     }
@@ -363,43 +1236,66 @@ export class GithubSignals implements Processor<'github-signals'> {
     await threadStore.saveThread({
       thread: {
         ...loadedThread,
-        id: threadId,
-        resourceId,
+        id: input.threadId!,
+        resourceId: input.resourceId!,
         createdAt: loadedThread.createdAt ?? new Date(),
         updatedAt: new Date(),
         metadata: setGithubMetadata(loadedThread.metadata, { subscriptions }),
       },
     });
+    if (baselineSnapshot) {
+      await this.#sendBaselineNotification({
+        threadId: input.threadId!,
+        resourceId: input.resourceId!,
+        subscription,
+        snapshot: baselineSnapshot,
+      });
+    }
+    await this.startPollingForThread({ threadId: input.threadId!, resourceId: input.resourceId! });
 
-    await this.#sendStatus(
-      args,
-      { ...subscribeSignal, owner, repo },
-      {
-        status: syncResult?.ok === false ? 'sync_error' : 'subscribed',
-        message:
-          syncResult?.ok === false
-            ? `Subscribed to ${owner}/${repo}#${subscribeSignal.number}, but gitcrawl sync failed: ${syncResult.error}`
-            : `Subscribed to ${owner}/${repo}#${subscribeSignal.number}.`,
-      },
+    return { owner, repo, number: input.number, subscription, syncResult };
+  }
+
+  async #unsubscribe(
+    input: GithubPRSignal & { threadId?: string; resourceId?: string; abortSignal?: AbortSignal },
+  ): Promise<GithubOperationResult> {
+    const { owner, repo } = await this.#resolveRepository(input);
+    const { threadStore, loadedThread } = await this.#loadThread(input);
+    const githubMetadata = getGithubMetadata(loadedThread.metadata);
+    const subscriptions = githubMetadata.subscriptions.filter(
+      subscription =>
+        !(subscription.owner === owner && subscription.repo === repo && subscription.number === input.number),
     );
+    const removed = subscriptions.length !== githubMetadata.subscriptions.length;
+    if (removed) {
+      await threadStore.saveThread({
+        thread: {
+          ...loadedThread,
+          id: input.threadId!,
+          resourceId: input.resourceId!,
+          createdAt: loadedThread.createdAt ?? new Date(),
+          updatedAt: new Date(),
+          metadata: setGithubMetadata(loadedThread.metadata, { subscriptions }),
+        },
+      });
+      if (subscriptions.length === 0)
+        this.stopPollingForThread({ threadId: input.threadId!, resourceId: input.resourceId! });
+    }
+    return { owner, repo, number: input.number, removed, remainingSubscriptions: subscriptions.length };
   }
 
-  async #resolveThreadStore(): Promise<GithubSignalsThreadStore | undefined> {
-    if (this.#options.threadStore) return this.#options.threadStore;
-    const memoryStore = await this.mastra?.getStorage()?.getStore('memory');
-    return memoryStore as GithubSignalsThreadStore | undefined;
-  }
-
-  #findLatestSubscribeSignal(messages: MastraDBMessage[]): GithubSubscribeSignal | undefined {
+  #findLatestGithubSignal(messages: MastraDBMessage[]): (GithubPRSignal & { tagName: string }) | undefined {
     for (const message of [...messages].reverse()) {
       const signal = getSignalMetadata(message);
-      if (!signal || signal.tagName !== GITHUB_SUBSCRIBE_PR_TAG) continue;
+      if (!signal || (signal.tagName !== GITHUB_SUBSCRIBE_PR_TAG && signal.tagName !== GITHUB_UNSUBSCRIBE_PR_TAG))
+        continue;
       const attributes = isPlainObject(signal.attributes) ? signal.attributes : {};
       const metadata = isPlainObject(signal.metadata) ? signal.metadata : {};
       const github = isPlainObject(metadata.github) ? metadata.github : {};
       const number = readNumber(attributes.number) ?? readNumber(github.number);
       if (!number) continue;
       return {
+        tagName: String(signal.tagName),
         id: readString(signal.id) ?? message.id,
         owner: readString(attributes.owner) ?? readString(github.owner),
         repo: readString(attributes.repo) ?? readString(github.repo),
@@ -411,8 +1307,12 @@ export class GithubSignals implements Processor<'github-signals'> {
 
   async #sendStatus(
     args: ProcessInputStepArgs,
-    signal: GithubSubscribeSignal & { owner?: string; repo?: string },
-    status: { status: 'subscribed' | 'sync_error' | 'error'; message: string },
+    signal: GithubOperationResult,
+    status: {
+      status: 'subscribed' | 'sync_error' | 'error' | 'unsubscribed' | 'not_subscribed';
+      action: 'subscribeToPR' | 'unsubscribeFromPR';
+      message: string;
+    },
   ) {
     await args.sendSignal?.({
       type: 'reactive',
@@ -420,13 +1320,13 @@ export class GithubSignals implements Processor<'github-signals'> {
       contents: status.message,
       attributes: {
         status: status.status,
-        ...(signal.owner ? { owner: signal.owner } : {}),
-        ...(signal.repo ? { repo: signal.repo } : {}),
+        owner: signal.owner,
+        repo: signal.repo,
         number: signal.number,
       },
       metadata: {
         github: {
-          action: 'subscribeToPR',
+          action: status.action,
           status: status.status,
           owner: signal.owner,
           repo: signal.repo,

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -37,6 +37,8 @@ export type GithubPRSubscription = {
   lastSyncError?: string;
   lastObservedGithubUpdatedAt?: string;
   lastObservedContentHash?: string;
+  lastObservedThreadContentHash?: string;
+  lastObservedHeadSha?: string;
   lastObservedState?: string;
   lastObservedMergeableState?: string;
   lastObservedCiState?: string;
@@ -313,6 +315,12 @@ function getGithubMetadata(threadMetadata: Record<string, unknown> | undefined):
       ...(readString(rawSubscription.lastObservedContentHash)
         ? { lastObservedContentHash: readString(rawSubscription.lastObservedContentHash)! }
         : {}),
+      ...(readString(rawSubscription.lastObservedThreadContentHash)
+        ? { lastObservedThreadContentHash: readString(rawSubscription.lastObservedThreadContentHash)! }
+        : {}),
+      ...(readString(rawSubscription.lastObservedHeadSha)
+        ? { lastObservedHeadSha: readString(rawSubscription.lastObservedHeadSha)! }
+        : {}),
       ...(readString(rawSubscription.lastObservedState)
         ? { lastObservedState: readString(rawSubscription.lastObservedState)! }
         : {}),
@@ -550,6 +558,7 @@ function classifyGithubActivityNotification(input: {
       summary: `${pr} has CI still running${names ? `: ${names}` : ''}`,
     };
   }
+  if (input.snapshot.ciState === 'pending' && input.subscription.lastObservedCiState === 'pending') return undefined;
   if (isBotOnlyActivity(input.snapshot)) return undefined;
   return {
     kind: 'pull-request-activity',
@@ -588,6 +597,8 @@ function classifyGithubBaselineNotification(input: {
 function applySnapshotCursor(subscription: GithubPRSubscription, snapshot: GithubPullRequestSnapshot): void {
   if (snapshot.githubUpdatedAt) subscription.lastObservedGithubUpdatedAt = snapshot.githubUpdatedAt;
   if (snapshot.contentHash) subscription.lastObservedContentHash = snapshot.contentHash;
+  if (snapshot.threadContentHash) subscription.lastObservedThreadContentHash = snapshot.threadContentHash;
+  if (snapshot.headSha) subscription.lastObservedHeadSha = snapshot.headSha;
   if (snapshot.state) subscription.lastObservedState = snapshot.state;
   if (snapshot.mergeableState) subscription.lastObservedMergeableState = snapshot.mergeableState;
   if (snapshot.ciState) subscription.lastObservedCiState = snapshot.ciState;
@@ -1203,17 +1214,29 @@ export class GithubSignals implements Processor<'github-signals'> {
 
         const previousGithubUpdatedAt = subscription.lastObservedGithubUpdatedAt;
         const previousContentHash = subscription.lastObservedContentHash;
+        const previousThreadContentHash = subscription.lastObservedThreadContentHash;
+        const previousHeadSha = subscription.lastObservedHeadSha;
         if (snapshot) applySnapshotCursor(nextSubscription, snapshot);
 
         // First observation (no previous cursor) always counts as changed so we
         // emit a baseline notification with the PR's current state.
         const isFirstObservation = syncResult.ok && snapshot && !previousGithubUpdatedAt && !previousContentHash;
 
+        const legacyAggregateChanged =
+          previousContentHash &&
+          snapshot?.contentHash &&
+          previousContentHash !== snapshot.contentHash &&
+          !previousThreadContentHash &&
+          !previousHeadSha;
         const changed =
           isFirstObservation ||
           (syncResult.ok &&
             snapshot &&
-            ((previousContentHash && snapshot.contentHash && previousContentHash !== snapshot.contentHash) ||
+            (legacyAggregateChanged ||
+              (previousThreadContentHash &&
+                snapshot.threadContentHash &&
+                previousThreadContentHash !== snapshot.threadContentHash) ||
+              (previousHeadSha && snapshot.headSha && previousHeadSha !== snapshot.headSha) ||
               (subscription.lastObservedState && snapshot.state && subscription.lastObservedState !== snapshot.state) ||
               (subscription.lastObservedMergeableState &&
                 snapshot.mergeableState &&

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -9,7 +9,12 @@ import type { AgentSignalInput } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import type { Mastra } from '@mastra/core/mastra';
 import type { StorageThreadType } from '@mastra/core/memory';
-import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from '@mastra/core/processors';
+import type {
+  Processor,
+  ProcessInputStepArgs,
+  ProcessInputStepResult,
+  ProcessOutputStepArgs,
+} from '@mastra/core/processors';
 import { createTool } from '@mastra/core/tools';
 import z from 'zod';
 
@@ -44,6 +49,7 @@ export type GithubPRSubscription = {
 
 export type GithubSignalsThreadMetadata = {
   subscriptions: GithubPRSubscription[];
+  subscriptionHintShown?: boolean;
 };
 
 export type GithubPRSignalInput = number | { owner?: string; repo?: string; number: number };
@@ -72,6 +78,10 @@ export type GithubPullRequestCheckSnapshot = {
   workflowName?: string;
   detailsUrl?: string;
   updatedAt?: string;
+};
+
+type GithubPullRequestCheckInput = GithubPullRequestCheckSnapshot & {
+  source: 'check' | 'workflow';
 };
 
 export type GithubPullRequestSnapshot = {
@@ -140,7 +150,10 @@ type GithubSignalAgent = {
   sendNotificationSignal?(notification: unknown, target: unknown): { accepted?: unknown } | Promise<unknown>;
 };
 
-type GithubNotificationSender = (notification: unknown) => Promise<unknown>;
+type GithubNotificationSender = (
+  notification: unknown,
+  target: { resourceId: string; threadId: string },
+) => Promise<unknown>;
 
 type GithubSignalsMastra = {
   getStorage?: () => { getStore?: (name: 'memory') => Promise<unknown> } | undefined;
@@ -315,7 +328,10 @@ function getGithubMetadata(threadMetadata: Record<string, unknown> | undefined):
     });
   }
 
-  return { subscriptions };
+  return {
+    subscriptions,
+    ...(githubSignals.subscriptionHintShown === true ? { subscriptionHintShown: true } : {}),
+  };
 }
 
 function setGithubMetadata(
@@ -347,8 +363,94 @@ function getPrLabel(subscription: GithubPRSubscription, snapshot?: GithubPullReq
   return snapshot?.title ? `${pr}: ${snapshot.title}` : pr;
 }
 
+function getMergedNotificationSummary(label: string): string {
+  return `${label} was merged. This thread has been automatically unsubscribed from this PR. Resubscribe if you still need updates.`;
+}
+
+function getCheckUpdatedTime(check: { updatedAt?: string }): number {
+  const value = check.updatedAt ? Date.parse(check.updatedAt) : Number.NaN;
+  return Number.isFinite(value) ? value : 0;
+}
+
+function getCheckKey(check: GithubPullRequestCheckSnapshot): string {
+  return `${check.name || 'check'}:${check.detailsUrl || check.workflowName || ''}`;
+}
+
+export function normalizeGithubChecksForSnapshot(input: {
+  checkRows: GithubPullRequestCheckInput[];
+  workflowRows: GithubPullRequestCheckInput[];
+}): GithubPullRequestCheckSnapshot[] {
+  const latestCheckUpdatedAt = input.checkRows.reduce(
+    (latest, check) => Math.max(latest, getCheckUpdatedTime(check)),
+    0,
+  );
+  const rows = [
+    ...input.checkRows,
+    ...input.workflowRows.filter(
+      workflow => input.checkRows.length === 0 || getCheckUpdatedTime(workflow) >= latestCheckUpdatedAt,
+    ),
+  ];
+  const byKey = new Map<string, GithubPullRequestCheckInput>();
+
+  for (const row of rows) {
+    const key = getCheckKey(row);
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, row);
+      continue;
+    }
+
+    const rowTime = getCheckUpdatedTime(row);
+    const existingTime = getCheckUpdatedTime(existing);
+    if (
+      rowTime > existingTime ||
+      (rowTime === existingTime && existing.source === 'workflow' && row.source === 'check')
+    ) {
+      byKey.set(key, row);
+    }
+  }
+
+  return [...byKey.values()]
+    .map(({ source: _source, ...check }) => check)
+    .sort((a, b) => `${a.name}:${a.detailsUrl ?? ''}`.localeCompare(`${b.name}:${b.detailsUrl ?? ''}`));
+}
+
 function isBotOnlyActivity(snapshot: GithubPullRequestSnapshot): boolean {
   return snapshot.latestCommentIsBot === true && (!snapshot.ciState || snapshot.ciState === 'unknown');
+}
+
+function stringifyEvidence(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}
+
+function detectPrWorkEvidence(input: {
+  text?: string;
+  toolCalls?: Array<{ toolName: string; args: unknown }>;
+}): { owner?: string; repo?: string; number: number } | undefined {
+  const evidence = [
+    input.text ?? '',
+    ...(input.toolCalls ?? []).map(toolCall => `${toolCall.toolName} ${stringifyEvidence(toolCall.args)}`),
+  ].join('\n');
+  if (!evidence.trim()) return undefined;
+
+  const url = /github\.com\/([^\s/#]+)\/([^\s/#]+)\/pull\/(\d+)/i.exec(evidence);
+  if (url?.[1] && url[2] && url[3]) return { owner: url[1], repo: url[2], number: Number(url[3]) };
+
+  const repoRef = /\b([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#(\d+)\b/.exec(evidence);
+  if (repoRef?.[1] && repoRef[2] && repoRef[3])
+    return { owner: repoRef[1], repo: repoRef[2], number: Number(repoRef[3]) };
+
+  const ghCommand = /\bgh\s+(?:pr\s+(?:view|checks|status|comment|diff|checkout)|run\s+(?:rerun|view))\b/i.test(
+    evidence,
+  );
+  if (!ghCommand) return undefined;
+  const numberMatch = /(?:^|\s)#?(\d{2,})(?:\s|$)/.exec(evidence);
+  return numberMatch?.[1] ? { number: Number(numberMatch[1]) } : undefined;
 }
 
 function classifyGithubActivityNotification(input: {
@@ -359,7 +461,11 @@ function classifyGithubActivityNotification(input: {
   const label = getPrLabel(input.subscription, input.snapshot);
   if (input.snapshot.state && input.subscription.lastObservedState !== input.snapshot.state) {
     if (input.snapshot.state === 'merged')
-      return { kind: 'pull-request-merged', priority: 'high', summary: `${label} was merged` };
+      return {
+        kind: 'pull-request-merged',
+        priority: 'high',
+        summary: getMergedNotificationSummary(label),
+      };
     if (input.snapshot.state === 'closed')
       return { kind: 'pull-request-closed', priority: 'high', summary: `${label} was closed` };
     if (input.subscription.lastObservedState && input.snapshot.state === 'open')
@@ -619,8 +725,9 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
            order by coalesce(c.updated_at_gh, c.created_at_gh) desc
            limit 1`);
 
-      const checks = [
-        ...checkRows.map(row => ({
+      const checks = normalizeGithubChecksForSnapshot({
+        checkRows: checkRows.map(row => ({
+          source: 'check',
           name: readString(row.name) ?? 'check',
           status: readString(row.status),
           conclusion: readString(row.conclusion),
@@ -628,7 +735,8 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
           detailsUrl: readString(row.details_url),
           updatedAt: readString(row.updated_at),
         })),
-        ...workflowRows.map(row => ({
+        workflowRows: workflowRows.map(row => ({
+          source: 'workflow',
           name: readString(row.workflow_name) ?? 'workflow',
           status: readString(row.status),
           conclusion: readString(row.conclusion),
@@ -636,7 +744,7 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
           detailsUrl: readString(row.html_url),
           updatedAt: readString(row.updated_at_gh),
         })),
-      ].sort((a, b) => `${a.name}:${a.detailsUrl ?? ''}`.localeCompare(`${b.name}:${b.detailsUrl ?? ''}`));
+      });
       const ciState = checks.some(check => check.conclusion === 'failure' || check.conclusion === 'timed_out')
         ? 'failure'
         : checks.some(check => check.status && check.status !== 'completed')
@@ -809,6 +917,10 @@ export class GithubSignals implements Processor<'github-signals'> {
     return this.#polling.has(this.#pollingKey(input));
   }
 
+  getPollIntervalMs(): number {
+    return this.#options.pollIntervalMs ?? 60_000;
+  }
+
   stopAllPolling(): void {
     for (const state of this.#polling.values()) clearInterval(state.timer);
     this.#polling.clear();
@@ -852,6 +964,58 @@ export class GithubSignals implements Processor<'github-signals'> {
     return { tools };
   }
 
+  async processOutputStep(args: ProcessOutputStepArgs): Promise<MastraDBMessage[]> {
+    const evidence = detectPrWorkEvidence({ text: args.text, toolCalls: args.toolCalls });
+    if (!evidence) return args.messages;
+
+    const threadContext = this.#getThreadContext(args);
+    if (!threadContext.threadId || !threadContext.resourceId) return args.messages;
+
+    const { threadStore, loadedThread } = await this.#loadThread(threadContext);
+    const githubMetadata = getGithubMetadata(loadedThread.metadata);
+    if (githubMetadata.subscriptionHintShown || githubMetadata.subscriptions.length > 0) return args.messages;
+
+    let repository: GithubRepository;
+    try {
+      repository = await this.#resolveRepository({
+        id: 'github-subscription-hint',
+        owner: evidence.owner,
+        repo: evidence.repo,
+        number: evidence.number,
+      });
+    } catch {
+      return args.messages;
+    }
+
+    await threadStore.saveThread({
+      thread: {
+        ...loadedThread,
+        id: threadContext.threadId,
+        resourceId: threadContext.resourceId,
+        createdAt: loadedThread.createdAt ?? new Date(),
+        updatedAt: new Date(),
+        metadata: setGithubMetadata(loadedThread.metadata, { ...githubMetadata, subscriptionHintShown: true }),
+      },
+    });
+
+    await args.sendSignal?.({
+      type: 'reactive',
+      tagName: 'system-reminder',
+      contents: `Looks like you're working with ${repository.owner}/${repository.repo}#${evidence.number}. Use /github subscribe ${evidence.number} or the github_subscribe_pr tool to follow updates.`,
+      attributes: { type: 'github-subscription-hint' },
+      metadata: {
+        github: {
+          action: 'subscriptionHint',
+          owner: repository.owner,
+          repo: repository.repo,
+          number: evidence.number,
+        },
+      },
+    });
+
+    return args.messages;
+  }
+
   async #resolveThreadStore(): Promise<GithubSignalsThreadStore | undefined> {
     if (this.#options.threadStore) return this.#options.threadStore;
     const storage = this.mastra?.getStorage?.();
@@ -859,7 +1023,10 @@ export class GithubSignals implements Processor<'github-signals'> {
     return memoryStore as GithubSignalsThreadStore | undefined;
   }
 
-  #getThreadContext(args: ProcessInputStepArgs): { threadId?: string; resourceId?: string } {
+  #getThreadContext(args: { requestContext?: ProcessInputStepArgs['requestContext'] }): {
+    threadId?: string;
+    resourceId?: string;
+  } {
     const memoryContext = args.requestContext?.get('MastraMemory') as
       | { thread?: { id?: string }; resourceId?: string }
       | undefined;
@@ -867,6 +1034,7 @@ export class GithubSignals implements Processor<'github-signals'> {
   }
 
   #createTools(args: ProcessInputStepArgs): Record<string, unknown> {
+    const threadContext = this.#getThreadContext(args);
     return {
       ...args.tools,
       github_subscribe_pr: createGithubTool({
@@ -882,8 +1050,8 @@ export class GithubSignals implements Processor<'github-signals'> {
           await this.#sendToolSignal({
             signal: GithubSignals.signals.subscribeToPR(input),
             agentId: context?.agent?.agentId,
-            threadId: context?.agent?.threadId,
-            resourceId: context?.agent?.resourceId,
+            threadId: context?.agent?.threadId ?? threadContext.threadId,
+            resourceId: context?.agent?.resourceId ?? threadContext.resourceId,
           });
           return {
             subscribed: true,
@@ -906,8 +1074,8 @@ export class GithubSignals implements Processor<'github-signals'> {
           await this.#sendToolSignal({
             signal: GithubSignals.signals.unsubscribeFromPR(input),
             agentId: context?.agent?.agentId,
-            threadId: context?.agent?.threadId,
-            resourceId: context?.agent?.resourceId,
+            threadId: context?.agent?.threadId ?? threadContext.threadId,
+            resourceId: context?.agent?.resourceId ?? threadContext.resourceId,
           });
           return {
             unsubscribed: true,
@@ -927,12 +1095,12 @@ export class GithubSignals implements Processor<'github-signals'> {
     threadId?: string;
     resourceId?: string;
   }): Promise<void> {
-    if (!input.agentId || !input.threadId || !input.resourceId) {
-      throw new Error('GitHub tools require agentId, threadId, and resourceId.');
+    if (!input.threadId || !input.resourceId) {
+      throw new Error('GitHub tools require threadId and resourceId.');
     }
-    const agent = this.mastra?.getAgentById?.(input.agentId);
+    const agent = this.#getNotificationAgent({ agentId: input.agentId });
     if (!agent?.sendSignal) {
-      throw new Error(`Could not find agent ${input.agentId} for GitHub tool signal delivery.`);
+      throw new Error('Could not find an agent for GitHub tool signal delivery.');
     }
     const result = agent.sendSignal(input.signal, {
       resourceId: input.resourceId,
@@ -1051,6 +1219,7 @@ export class GithubSignals implements Processor<'github-signals'> {
               (subscription.lastObservedReviewStateHash &&
                 snapshot.reviewStateHash &&
                 subscription.lastObservedReviewStateHash !== snapshot.reviewStateHash)));
+        let shouldKeepSubscription = true;
         if (changed) {
           const notification = await this.#sendActivityNotification({
             polling: input,
@@ -1064,10 +1233,11 @@ export class GithubSignals implements Processor<'github-signals'> {
             nextSubscription.lastNotificationKind = notification.kind;
             nextSubscription.lastNotificationPriority = notification.priority;
             nextSubscription.lastNotificationSummary = notification.summary;
+            shouldKeepSubscription = notification.kind !== 'pull-request-merged';
           }
         }
 
-        subscriptions.push(nextSubscription);
+        if (shouldKeepSubscription) subscriptions.push(nextSubscription);
       }
 
       await threadStore.saveThread({
@@ -1080,6 +1250,7 @@ export class GithubSignals implements Processor<'github-signals'> {
           metadata: setGithubMetadata(loadedThread.metadata, { subscriptions }),
         },
       });
+      if (subscriptions.length === 0) this.stopPollingForThread(input);
       return subscriptions.length;
     } catch (error) {
       throw error;
@@ -1155,7 +1326,7 @@ export class GithubSignals implements Processor<'github-signals'> {
         },
       },
     };
-    if (this.#notificationSender) await this.#notificationSender(notificationInput);
+    if (this.#notificationSender) await this.#notificationSender(notificationInput, input.target);
     else await input.agent?.sendNotificationSignal?.(notificationInput, input.target);
   }
 

--- a/mastracode/src/github-signals/index.ts
+++ b/mastracode/src/github-signals/index.ts
@@ -360,12 +360,18 @@ function setGithubMetadata(
 ): Record<string, unknown> {
   const existing = threadMetadata ?? {};
   const mastra = isPlainObject(existing.mastra) ? existing.mastra : {};
+  const existingGithubSignals = isPlainObject(mastra[GITHUB_SIGNALS_METADATA_KEY])
+    ? mastra[GITHUB_SIGNALS_METADATA_KEY]
+    : {};
 
   return {
     ...existing,
     mastra: {
       ...mastra,
-      [GITHUB_SIGNALS_METADATA_KEY]: githubSignals,
+      [GITHUB_SIGNALS_METADATA_KEY]: {
+        ...existingGithubSignals,
+        ...githubSignals,
+      },
     },
   };
 }
@@ -1437,6 +1443,10 @@ export class GithubSignals implements Processor<'github-signals'> {
         ? { lastObservedGithubUpdatedAt: existing.lastObservedGithubUpdatedAt }
         : {}),
       ...(existing?.lastObservedContentHash ? { lastObservedContentHash: existing.lastObservedContentHash } : {}),
+      ...(existing?.lastObservedThreadContentHash
+        ? { lastObservedThreadContentHash: existing.lastObservedThreadContentHash }
+        : {}),
+      ...(existing?.lastObservedHeadSha ? { lastObservedHeadSha: existing.lastObservedHeadSha } : {}),
       ...(existing?.lastObservedState ? { lastObservedState: existing.lastObservedState } : {}),
       ...(existing?.lastObservedMergeableState
         ? { lastObservedMergeableState: existing.lastObservedMergeableState }

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -409,6 +409,9 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   const efficiencyScorer = createEfficiencyScorer();
 
   // Agent
+  const githubSignalsProcessor = globalSettings.signals?.experimentalGithubSignals
+    ? new GithubSignals({ cwd: project.rootPath, agentId: CODE_AGENT_ID })
+    : undefined;
   const codeAgent = new Agent({
     id: CODE_AGENT_ID,
     name: 'Code Agent',
@@ -436,7 +439,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
           return getStaticallyLoadedInstructionPaths(projectPath);
         },
       }),
-      new GithubSignals({ cwd: project.rootPath }),
+      ...(githubSignalsProcessor ? [githubSignalsProcessor] : []),
       new ProviderHistoryCompat(),
     ],
     errorProcessors: [new StreamErrorRetryProcessor(), new PrefillErrorHandler(), new ProviderHistoryCompat()],
@@ -791,6 +794,22 @@ export async function createMastraCode(config?: MastraCodeConfig) {
         hookManager.setSessionId(event.thread.id);
       }
     });
+  }
+
+  if (githubSignalsProcessor) {
+    const startGithubPollingForCurrentThread = (threadId?: string | null) => {
+      if (!threadId) return;
+      githubSignalsProcessor.stopAllPolling();
+      void githubSignalsProcessor
+        .startPollingForThread({ threadId, resourceId: harness.getResourceId() })
+        .catch(error => console.warn('Failed to start GitHub PR polling:', error));
+    };
+
+    harness.subscribe(event => {
+      if (event.type === 'thread_changed') startGithubPollingForCurrentThread(event.threadId);
+      else if (event.type === 'thread_created') startGithubPollingForCurrentThread(event.thread.id);
+    });
+    startGithubPollingForCurrentThread(harness.getCurrentThreadId());
   }
 
   // Persist MastraCode-owned /om settings per-thread (mastracode-only concern;

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -49,6 +49,7 @@ import { getDynamicWorkspace } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
 import { DEFAULT_CONFIG_DIR, validateConfigDirName } from './constants.js';
 import { createOutcomeScorer, createEfficiencyScorer } from './evals/scorers/index.js';
+import { GithubSignals } from './github-signals/index.js';
 import { HarnessCompat, v1ModeToLegacy } from './HarnessCompat';
 import { HookManager } from './hooks/index.js';
 import { createMcpManager } from './mcp/index.js';
@@ -435,6 +436,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
           return getStaticallyLoadedInstructionPaths(projectPath);
         },
       }),
+      new GithubSignals({ cwd: project.rootPath }),
       new ProviderHistoryCompat(),
     ],
     errorProcessors: [new StreamErrorRetryProcessor(), new PrefillErrorHandler(), new ProviderHistoryCompat()],

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -799,7 +799,9 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   }
 
   if (githubSignalsProcessor) {
-    githubSignalsProcessor.addNotificationSender(notification => harness.sendNotificationSignal(notification as any));
+    githubSignalsProcessor.addNotificationSender((notification, target) =>
+      harness.sendNotificationSignal(notification as any, target),
+    );
 
     const startGithubPollingForCurrentThread = async (threadId?: string | null) => {
       if (!threadId) return;
@@ -846,5 +848,6 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     builtinPacks,
     builtinOmPacks,
     effectiveDefaults,
+    githubSignals: githubSignalsProcessor,
   };
 }

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -11,6 +11,7 @@ import type {
   HarnessConfig,
   HarnessMode,
   HarnessSubagent,
+  HarnessRequestContext,
 } from '@mastra/core/harness';
 import { Harness as HarnessV1 } from '@mastra/core/harness/v1';
 import type { HarnessMode as HarnessModeV1 } from '@mastra/core/harness/v1';
@@ -23,7 +24,7 @@ import {
   ProviderHistoryCompat,
   StreamErrorRetryProcessor,
 } from '@mastra/core/processors';
-import type { RequestContext } from '@mastra/core/request-context';
+import { RequestContext } from '@mastra/core/request-context';
 import type { PublicSchema } from '@mastra/core/schema';
 import { InMemoryHarness, MastraCompositeStore } from '@mastra/core/storage';
 import { DuckDBStore } from '@mastra/duckdb';
@@ -445,7 +446,34 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     errorProcessors: [new StreamErrorRetryProcessor(), new PrefillErrorHandler(), new ProviderHistoryCompat()],
   });
 
-  githubSignalsProcessor?.addAgent(codeAgent);
+  githubSignalsProcessor?.addAgent(codeAgent, {
+    getNotificationStreamOptions: ({ resourceId, threadId }) => {
+      const requestContext = new RequestContext();
+      const harnessContext: HarnessRequestContext = {
+        harnessId: harness.id,
+        state: harness.getState(),
+        getState: () => harness.getState(),
+        setState: updates => harness.setState(updates),
+        threadId,
+        resourceId,
+        modeId: harness.getCurrentModeId(),
+        workspace: harness.getWorkspace(),
+        registerQuestion: params => harness.registerQuestion(params),
+        registerPlanApproval: params => harness.registerPlanApproval(params),
+        getSubagentModelId: params => harness.getSubagentModelId(params),
+      };
+      requestContext.set('harness', harnessContext);
+
+      return {
+        memory: { thread: threadId, resource: resourceId },
+        requestContext,
+        maxSteps: 1000,
+        savePerStep: false,
+        requireToolApproval: (harness.getState() as Record<string, unknown>).yolo !== true,
+        modelSettings: { temperature: 1 },
+      };
+    },
+  });
 
   const defaultSubagents = [exploreSubagent, planSubagent, executeSubagent];
 
@@ -799,10 +827,6 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   }
 
   if (githubSignalsProcessor) {
-    githubSignalsProcessor.addNotificationSender((notification, target) =>
-      harness.sendNotificationSignal(notification as any, target),
-    );
-
     const startGithubPollingForCurrentThread = async (threadId?: string | null) => {
       if (!threadId) return;
       githubSignalsProcessor.stopAllPolling();

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -410,7 +410,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
 
   // Agent
   const githubSignalsProcessor = globalSettings.signals?.experimentalGithubSignals
-    ? new GithubSignals({ cwd: project.rootPath, agentId: CODE_AGENT_ID })
+    ? new GithubSignals({ cwd: project.rootPath })
     : undefined;
   const codeAgent = new Agent({
     id: CODE_AGENT_ID,
@@ -439,11 +439,13 @@ export async function createMastraCode(config?: MastraCodeConfig) {
           return getStaticallyLoadedInstructionPaths(projectPath);
         },
       }),
-      ...(githubSignalsProcessor ? [githubSignalsProcessor] : []),
+      ...(githubSignalsProcessor ? [githubSignalsProcessor as any] : []),
       new ProviderHistoryCompat(),
     ],
     errorProcessors: [new StreamErrorRetryProcessor(), new PrefillErrorHandler(), new ProviderHistoryCompat()],
   });
+
+  githubSignalsProcessor?.addAgent(codeAgent);
 
   const defaultSubagents = [exploreSubagent, planSubagent, executeSubagent];
 
@@ -797,19 +799,31 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   }
 
   if (githubSignalsProcessor) {
-    const startGithubPollingForCurrentThread = (threadId?: string | null) => {
+    githubSignalsProcessor.addNotificationSender(notification => harness.sendNotificationSignal(notification as any));
+
+    const startGithubPollingForCurrentThread = async (threadId?: string | null) => {
       if (!threadId) return;
       githubSignalsProcessor.stopAllPolling();
-      void githubSignalsProcessor
-        .startPollingForThread({ threadId, resourceId: harness.getResourceId() })
-        .catch(error => console.warn('Failed to start GitHub PR polling:', error));
+      try {
+        const threads = await harness.listThreads({ allResources: true });
+        const thread = threads.find(item => item.id === threadId);
+        await githubSignalsProcessor.startPollingForThread(
+          {
+            threadId,
+            resourceId: thread?.resourceId ?? harness.getResourceId(),
+          },
+          { pollImmediately: true },
+        );
+      } catch (error) {
+        console.warn('Failed to start GitHub PR polling:', error);
+      }
     };
 
     harness.subscribe(event => {
-      if (event.type === 'thread_changed') startGithubPollingForCurrentThread(event.threadId);
-      else if (event.type === 'thread_created') startGithubPollingForCurrentThread(event.thread.id);
+      if (event.type === 'thread_changed') void startGithubPollingForCurrentThread(event.threadId);
+      else if (event.type === 'thread_created') void startGithubPollingForCurrentThread(event.thread.id);
     });
-    startGithubPollingForCurrentThread(harness.getCurrentThreadId());
+    void startGithubPollingForCurrentThread(harness.getCurrentThreadId());
   }
 
   // Persist MastraCode-owned /om settings per-thread (mastracode-only concern;

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -102,6 +102,7 @@ async function tuiMain(pipedInput?: string | null) {
     appName: 'Mastra Code',
     version: getCurrentVersion(),
     inlineQuestions: true,
+    githubSignals: result.githubSignals,
     ...(pipedInput ? { initialMessage: `The following was piped via stdin:\n\n${pipedInput}` } : {}),
   });
   tui.run().catch(error => {

--- a/mastracode/src/onboarding/__tests__/settings.test.ts
+++ b/mastracode/src/onboarding/__tests__/settings.test.ts
@@ -225,6 +225,23 @@ describe('customProviders parsing/persistence', () => {
     });
   });
 
+  it('does not clobber experimental GitHub signals from a stale settings object', () => {
+    withTempSettingsFile(filePath => {
+      saveSettings(createSettings(), filePath);
+      const staleSettings = loadSettings(filePath);
+
+      const currentSettings = loadSettings(filePath);
+      currentSettings.signals.experimentalGithubSignals = true;
+      saveSettings(currentSettings, filePath);
+
+      staleSettings.modelUseCounts['openai/gpt-5.5'] = 1;
+      saveSettings(staleSettings, filePath);
+
+      expect(loadSettings(filePath).signals.experimentalGithubSignals).toBe(true);
+      expect(JSON.parse(readFileSync(filePath, 'utf-8')).signals.experimentalGithubSignals).toBe(true);
+    });
+  });
+
   it('defaults new installs to quiet mode with the preference selected', () => {
     withTempSettingsFile(filePath => {
       const settings = loadSettings(filePath);

--- a/mastracode/src/onboarding/__tests__/settings.test.ts
+++ b/mastracode/src/onboarding/__tests__/settings.test.ts
@@ -66,6 +66,7 @@ function createSettings(overrides?: Partial<GlobalSettings>): GlobalSettings {
       stagehand: { env: 'LOCAL' },
     },
     shellPassthrough: { mode: 'default' },
+    signals: { unixSocketPubSub: false, experimentalGithubSignals: false },
     observability: { resources: {}, localTracing: false },
     ...overrides,
   };
@@ -203,6 +204,24 @@ describe('customProviders parsing/persistence', () => {
       });
       expect(loadSettings(filePath).preferences.quietModeMaxToolPreviewLines).toBe(2);
       vi.mocked(JSON.parse).mockRestore();
+    });
+  });
+
+  it('persists experimental GitHub signals enable and disable across reloads', () => {
+    withTempSettingsFile(filePath => {
+      const settings = createSettings();
+      settings.signals.experimentalGithubSignals = true;
+      saveSettings(settings, filePath);
+
+      expect(loadSettings(filePath).signals.experimentalGithubSignals).toBe(true);
+      expect(JSON.parse(readFileSync(filePath, 'utf-8')).signals.experimentalGithubSignals).toBe(true);
+
+      const reloaded = loadSettings(filePath);
+      reloaded.signals.experimentalGithubSignals = false;
+      saveSettings(reloaded, filePath);
+
+      expect(loadSettings(filePath).signals.experimentalGithubSignals).toBe(false);
+      expect(JSON.parse(readFileSync(filePath, 'utf-8')).signals.experimentalGithubSignals).toBe(false);
     });
   });
 

--- a/mastracode/src/onboarding/settings.ts
+++ b/mastracode/src/onboarding/settings.ts
@@ -310,6 +310,23 @@ const DEFAULTS: GlobalSettings = {
 
 const THINKING_LEVEL_VALUES: ThinkingLevelSetting[] = ['off', 'low', 'medium', 'high', 'xhigh'];
 const QUIET_MODE_MAX_TOOL_PREVIEW_LINES_MAX = 8;
+const loadedSignalSettings = new WeakMap<GlobalSettings, SignalSettings>();
+
+function cloneSignalSettings(signals: SignalSettings): SignalSettings {
+  return { ...signals };
+}
+
+function rememberLoadedSettings(settings: GlobalSettings): GlobalSettings {
+  loadedSignalSettings.set(settings, cloneSignalSettings(settings.signals));
+  return settings;
+}
+
+function signalSettingsEqual(left: SignalSettings, right: SignalSettings): boolean {
+  return (
+    left.unixSocketPubSub === right.unixSocketPubSub &&
+    left.experimentalGithubSignals === right.experimentalGithubSignals
+  );
+}
 
 function parseThinkingLevel(value: unknown): ThinkingLevelSetting {
   return typeof value === 'string' && THINKING_LEVEL_VALUES.includes(value as ThinkingLevelSetting)
@@ -667,7 +684,7 @@ export function loadSettings(filePath: string = getSettingsPath()): GlobalSettin
   // One-time migration: move model data from auth.json into settings.json
   migrateFromAuth(filePath);
 
-  if (!existsSync(filePath)) return getNewInstallDefaults();
+  if (!existsSync(filePath)) return rememberLoadedSettings(getNewInstallDefaults());
   try {
     const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
     // Spread raw first to preserve unknown top-level keys (forward-compatibility),
@@ -714,9 +731,9 @@ export function loadSettings(filePath: string = getSettingsPath()): GlobalSettin
       saveSettings(settings, filePath);
     }
 
-    return settings;
+    return rememberLoadedSettings(settings);
   } catch {
-    return structuredClone(DEFAULTS);
+    return rememberLoadedSettings(structuredClone(DEFAULTS));
   }
 }
 
@@ -871,11 +888,33 @@ export function resolveOmModel(
   return resolveOmRoleModel(settings, 'observer', builtinOmPacks);
 }
 
+function getSignalSettingsForSave(settings: GlobalSettings, filePath: string): SignalSettings {
+  const loadedSignals = loadedSignalSettings.get(settings);
+  if (!loadedSignals || !signalSettingsEqual(settings.signals, loadedSignals) || !existsSync(filePath)) {
+    return settings.signals;
+  }
+
+  try {
+    const currentRaw = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+    const currentSignals = parseSignalSettings(currentRaw.signals);
+    if (!signalSettingsEqual(currentSignals, loadedSignals)) {
+      return currentSignals;
+    }
+  } catch {
+    // If the current file is unreadable, fall back to the caller's settings.
+  }
+
+  return settings.signals;
+}
+
 export function saveSettings(settings: GlobalSettings, filePath: string = getSettingsPath()): void {
   const dir = dirname(filePath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
+  const signals = getSignalSettingsForSave(settings, filePath);
+  settings.signals = signals;
+  loadedSignalSettings.set(settings, cloneSignalSettings(signals));
   writeFileSync(filePath, JSON.stringify(settings, null, 2), 'utf-8');
 }
 

--- a/mastracode/src/onboarding/settings.ts
+++ b/mastracode/src/onboarding/settings.ts
@@ -231,6 +231,8 @@ export interface GlobalSettings {
 export interface SignalSettings {
   /** Opt into local Unix socket PubSub for cross-process signal routing. */
   unixSocketPubSub: boolean;
+  /** Experimental: enable GitHub PR subscription signals backed by gitcrawl. */
+  experimentalGithubSignals: boolean;
 }
 
 export interface ObservabilityResourceConfig {
@@ -302,7 +304,7 @@ const DEFAULTS: GlobalSettings = {
     stagehand: { env: 'LOCAL' },
   },
   shellPassthrough: { mode: 'default' },
-  signals: { unixSocketPubSub: false },
+  signals: { unixSocketPubSub: false, experimentalGithubSignals: false },
   observability: { resources: {}, localTracing: false },
 };
 
@@ -329,6 +331,18 @@ function parsePreferences(rawPreferences: unknown): GlobalSettings['preferences'
     ...raw,
     thinkingLevel: parseThinkingLevel(raw.thinkingLevel),
     quietModeMaxToolPreviewLines: parseQuietModeMaxToolPreviewLines(raw.quietModeMaxToolPreviewLines),
+  };
+}
+
+function parseSignalSettings(rawSignals: unknown): SignalSettings {
+  const raw = rawSignals && typeof rawSignals === 'object' ? (rawSignals as Record<string, unknown>) : {};
+  return {
+    unixSocketPubSub:
+      typeof raw.unixSocketPubSub === 'boolean' ? raw.unixSocketPubSub : DEFAULTS.signals.unixSocketPubSub,
+    experimentalGithubSignals:
+      typeof raw.experimentalGithubSignals === 'boolean'
+        ? raw.experimentalGithubSignals
+        : DEFAULTS.signals.experimentalGithubSignals,
   };
 }
 
@@ -555,12 +569,7 @@ function migrateFromAuth(settingsPath: string): boolean {
         lsp: raw.lsp && typeof raw.lsp === 'object' ? (raw.lsp as LSPConfig) : undefined,
         browser: parseBrowserSettings(raw.browser),
         shellPassthrough: parseShellPassthroughSettings(raw.shellPassthrough),
-        signals: {
-          unixSocketPubSub:
-            raw.signals && typeof raw.signals === 'object' && typeof raw.signals.unixSocketPubSub === 'boolean'
-              ? raw.signals.unixSocketPubSub
-              : DEFAULTS.signals.unixSocketPubSub,
-        },
+        signals: parseSignalSettings(raw.signals),
         observability: parseObservabilitySettings(raw.observability),
       };
       applyQuietModePreferenceRollout(settings, raw.onboarding);
@@ -682,12 +691,7 @@ export function loadSettings(filePath: string = getSettingsPath()): GlobalSettin
       lsp: raw.lsp && typeof raw.lsp === 'object' ? (raw.lsp as LSPConfig) : undefined,
       browser: parseBrowserSettings(raw.browser),
       shellPassthrough: parseShellPassthroughSettings(raw.shellPassthrough),
-      signals: {
-        unixSocketPubSub:
-          raw.signals && typeof raw.signals === 'object' && typeof raw.signals.unixSocketPubSub === 'boolean'
-            ? raw.signals.unixSocketPubSub
-            : DEFAULTS.signals.unixSocketPubSub,
-      },
+      signals: parseSignalSettings(raw.signals),
       observability: parseObservabilitySettings(raw.observability),
     };
 

--- a/mastracode/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/src/tui/__tests__/command-dispatch.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   handleGoalCommand: vi.fn().mockResolvedValue(undefined),
   handleSkillCommand: vi.fn().mockResolvedValue(undefined),
   handleJudgeCommand: vi.fn().mockResolvedValue(undefined),
+  handleGithubCommand: vi.fn().mockResolvedValue(undefined),
   processSlashCommand: vi.fn().mockResolvedValue('custom output'),
   startGoalWithDefaults: vi.fn().mockResolvedValue(undefined),
   showError: vi.fn(),
@@ -51,6 +52,7 @@ vi.mock('../commands/index.js', () => ({
   handleApiKeysCommand: vi.fn(),
   handleFeedbackCommand: vi.fn(),
   handleObservabilityCommand: vi.fn(),
+  handleGithubCommand: mocks.handleGithubCommand,
   handleGoalCommand: mocks.handleGoalCommand,
   handleJudgeCommand: mocks.handleJudgeCommand,
 }));
@@ -78,6 +80,7 @@ describe('dispatchSlashCommand models routing', () => {
     mocks.handleGoalCommand.mockClear();
     mocks.handleSkillCommand.mockClear();
     mocks.handleJudgeCommand.mockClear();
+    mocks.handleGithubCommand.mockClear();
     mocks.processSlashCommand.mockClear();
     mocks.startGoalWithDefaults.mockClear();
     mocks.showError.mockClear();
@@ -152,6 +155,17 @@ describe('dispatchSlashCommand models routing', () => {
     expect(handled).toBe(true);
     expect(mocks.handleJudgeCommand).toHaveBeenCalledTimes(1);
     expect(mocks.handleJudgeCommand).toHaveBeenCalledWith(ctx);
+  });
+
+  it('routes /github to handleGithubCommand', async () => {
+    const state = { customSlashCommands: [] } as any;
+    const ctx = {} as any;
+
+    const handled = await dispatchSlashCommand('/github mastra-ai/mastra#17447', state, () => ctx);
+
+    expect(handled).toBe(true);
+    expect(mocks.handleGithubCommand).toHaveBeenCalledTimes(1);
+    expect(mocks.handleGithubCommand).toHaveBeenCalledWith(ctx, ['mastra-ai/mastra#17447']);
   });
 
   it('routes /skill/name to handleSkillCommand', async () => {

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -102,6 +102,26 @@ describe('addUserMessage', () => {
     expect(state.messageComponentsById.get('reactive-signal-1')).toBeInstanceOf(ReactiveSignalComponent);
   });
 
+  it('does not render GitHub subscribe operation signals from history', () => {
+    const state = createState();
+
+    addUserMessage(state, {
+      id: 'github-subscribe-signal-1',
+      role: 'user',
+      content: [
+        {
+          type: 'reactive_signal',
+          tagName: 'github-subscribe-pr',
+          message: 'Subscribe to GitHub PR #17241',
+        },
+      ],
+      createdAt: new Date('2026-05-04T00:00:00.000Z'),
+    } as unknown as HarnessMessage);
+
+    expect(state.chatContainer.children.some(child => child instanceof ReactiveSignalComponent)).toBe(false);
+    expect(state.messageComponentsById.has('github-subscribe-signal-1')).toBe(false);
+  });
+
   it('renders notification summaries as inline notification components', () => {
     const state = createState();
 

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -138,6 +138,15 @@ describe('setupKeyboardShortcuts', () => {
       'clear',
     ]);
     expect(goalCommand?.getArgumentCompletions?.('pa').map(command => command.value)).toEqual(['pause']);
+    const githubCommand = autocompleteProviders[0]?.commands.find(command => command.name === 'github') as
+      | { getArgumentCompletions?: (prefix: string) => Array<{ value: string }> }
+      | undefined;
+    expect(githubCommand?.getArgumentCompletions?.('').map(command => command.value)).toEqual([
+      'subscribe',
+      'unsubscribe',
+      'debug',
+    ]);
+    expect(githubCommand?.getArgumentCompletions?.('un').map(command => command.value)).toEqual(['unsubscribe']);
     expect(commandNames.indexOf('thread')).toBeLessThan(commandNames.indexOf('threads'));
     expect(commandNames.indexOf('goal')).toBeLessThan(commandNames.indexOf('judge'));
     expect(commandNames).toContain('skill/');

--- a/mastracode/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/src/tui/__tests__/status-line.test.ts
@@ -139,7 +139,15 @@ describe('updateStatusLine', () => {
 
   it('shows the active GitHub PR subscription beside the thread path', () => {
     const state = createState();
-    state.activeGithubPrSubscriptions = [{ owner: 'mastra-ai', repo: 'mastra', prNumber: 17439 }];
+    state.activeGithubPrSubscriptions = [
+      {
+        owner: 'mastra-ai',
+        repo: 'mastra',
+        prNumber: 17439,
+        lastNotificationKind: 'pull-request-activity',
+        lastNotificationPriority: 'medium',
+      },
+    ];
     state.options = { githubSignals: { isPollingThread: vi.fn(() => true) } };
 
     updateStatusLine(state);
@@ -147,6 +155,7 @@ describe('updateStatusLine', () => {
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
     expect(rendered).toContain('PR#17439');
     expect(rendered).not.toContain('polling');
+    expect(rendered).not.toContain('updated');
   });
 
   it('does not show GitHub PR status for unsubscribed threads', () => {

--- a/mastracode/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/src/tui/__tests__/status-line.test.ts
@@ -51,6 +51,9 @@ vi.mock('../theme.js', () => ({
     blue: '#3b82f6',
     specialGray: '#6b7280',
   },
+  extendedColors: {
+    skyBlue: '#0ea5e9',
+  },
   tintHex: (_color: string, _amount: number) => '#111111',
   getThemeMode: () => 'dark',
   ensureContrast: (_color: string) => _color,
@@ -65,6 +68,7 @@ function createState() {
   const memorySetText = vi.fn();
 
   return {
+    options: {},
     harness: {
       getDisplayState: vi.fn(() => ({
         omProgress: { status: 'idle' },
@@ -74,6 +78,8 @@ function createState() {
       listModes: vi.fn(() => [{ id: 'build', name: 'build', color: '#00ff00' }]),
       getCurrentMode: vi.fn(() => ({ id: 'build', name: 'build', color: '#00ff00' })),
       getCurrentModeId: vi.fn(() => 'build'),
+      getCurrentThreadId: vi.fn(() => 'thread-1'),
+      getResourceId: vi.fn(() => 'resource-1'),
       getState: vi.fn(() => ({ yolo: false })),
       getObserverModelId: vi.fn(() => 'openai/gpt-4o'),
       getReflectorModelId: vi.fn(() => 'openai/gpt-4o-mini'),
@@ -90,6 +96,7 @@ function createState() {
       gitBranch: 'feat/mc-queueing-ux',
     },
     pendingQueuedActions: [],
+    activeGithubPrSubscriptions: [],
     goalManager: { getGoal: vi.fn(() => null) },
     ui: { requestRender: vi.fn() },
   } as any;
@@ -128,6 +135,27 @@ describe('updateStatusLine', () => {
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
     expect(rendered).not.toContain('queued');
+  });
+
+  it('shows the active GitHub PR subscription beside the thread path', () => {
+    const state = createState();
+    state.activeGithubPrSubscriptions = [{ owner: 'mastra-ai', repo: 'mastra', prNumber: 17439 }];
+    state.options = { githubSignals: { isPollingThread: vi.fn(() => true) } };
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('PR#17439');
+    expect(rendered).not.toContain('polling');
+  });
+
+  it('does not show GitHub PR status for unsubscribed threads', () => {
+    const state = createState();
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).not.toContain('PR#');
   });
 
   it('preserves the gateway prefix when compacting gateway-backed model ids', () => {

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -40,6 +40,7 @@ import {
   handleApiKeysCommand,
   handleFeedbackCommand,
   handleObservabilityCommand,
+  handleGithubCommand,
   handleGoalCommand,
   handleJudgeCommand,
 } from './commands/index.js';
@@ -244,6 +245,9 @@ export async function dispatchSlashCommand(
       return true;
     case 'observability':
       await handleObservabilityCommand(buildCtx(), args);
+      return true;
+    case 'github':
+      await handleGithubCommand(buildCtx(), args);
       return true;
     case 'goal':
       await handleGoalCommand(buildCtx(), args);

--- a/mastracode/src/tui/commands/__tests__/github.test.ts
+++ b/mastracode/src/tui/commands/__tests__/github.test.ts
@@ -168,18 +168,33 @@ describe('handleGithubCommand', () => {
 
     await handleGithubCommand(ctx, ['sync']);
 
-    expect(sendSignal).not.toHaveBeenCalled();
     expect(syncThreadNow).toHaveBeenCalledWith({ threadId: 'thread-1', resourceId: 'resource-from-thread' });
-    expect(ctx.showInfo).toHaveBeenCalledWith('Synced 1 GitHub PR subscription.');
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'reactive',
+        tagName: 'github-sync-status',
+        contents: 'Synced 1 GitHub PR subscription.',
+        attributes: { status: 'synced', count: 1 },
+      }),
+    );
+    expect(ctx.showInfo).not.toHaveBeenCalled();
   });
 
-  it('shows a no-op message when /github sync has no subscriptions', async () => {
-    const { ctx, syncThreadNow } = createContext();
+  it('sends a no-op sync status signal when /github sync has no subscriptions', async () => {
+    const { ctx, sendSignal, syncThreadNow } = createContext();
     syncThreadNow.mockResolvedValue(0);
 
     await handleGithubCommand(ctx, ['sync']);
 
-    expect(ctx.showInfo).toHaveBeenCalledWith('No GitHub PR subscriptions to sync.');
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'reactive',
+        tagName: 'github-sync-status',
+        contents: 'No GitHub PR subscriptions to sync.',
+        attributes: { status: 'not_subscribed' },
+      }),
+    );
+    expect(ctx.showInfo).not.toHaveBeenCalled();
   });
 
   it('shows GitHub subscription debug information for the current thread', async () => {

--- a/mastracode/src/tui/commands/__tests__/github.test.ts
+++ b/mastracode/src/tui/commands/__tests__/github.test.ts
@@ -168,33 +168,18 @@ describe('handleGithubCommand', () => {
 
     await handleGithubCommand(ctx, ['sync']);
 
+    expect(sendSignal).not.toHaveBeenCalled();
     expect(syncThreadNow).toHaveBeenCalledWith({ threadId: 'thread-1', resourceId: 'resource-from-thread' });
-    expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'reactive',
-        tagName: 'github-sync-status',
-        contents: 'Synced 1 GitHub PR subscription.',
-        attributes: { status: 'synced', count: 1 },
-      }),
-    );
     expect(ctx.showInfo).not.toHaveBeenCalled();
   });
 
-  it('sends a no-op sync status signal when /github sync has no subscriptions', async () => {
-    const { ctx, sendSignal, syncThreadNow } = createContext();
+  it('shows a no-op message when /github sync has no subscriptions', async () => {
+    const { ctx, syncThreadNow } = createContext();
     syncThreadNow.mockResolvedValue(0);
 
     await handleGithubCommand(ctx, ['sync']);
 
-    expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'reactive',
-        tagName: 'github-sync-status',
-        contents: 'No GitHub PR subscriptions to sync.',
-        attributes: { status: 'not_subscribed' },
-      }),
-    );
-    expect(ctx.showInfo).not.toHaveBeenCalled();
+    expect(ctx.showInfo).toHaveBeenCalledWith('No GitHub PR subscriptions to sync.');
   });
 
   it('shows GitHub subscription debug information for the current thread', async () => {

--- a/mastracode/src/tui/commands/__tests__/github.test.ts
+++ b/mastracode/src/tui/commands/__tests__/github.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { handleGithubCommand } from '../github.js';
+import type { SlashCommandContext } from '../types.js';
+
+const askModalQuestionMock = vi.fn();
+const execFileMock = vi.fn();
+const loadSettingsMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+vi.mock('../../../onboarding/settings.js', () => ({
+  loadSettings: () => loadSettingsMock(),
+}));
+
+vi.mock('../../modal-question.js', () => ({
+  askModalQuestion: (...args: unknown[]) => askModalQuestionMock(...args),
+}));
+
+function createContext() {
+  const sendSignal = vi.fn(() => ({ id: 'signal-1', accepted: Promise.resolve({ accepted: true, runId: 'run-1' }) }));
+  const ctx = {
+    state: { ui: { requestRender: vi.fn() }, projectInfo: { rootPath: '/repo' } },
+    harness: {
+      sendSignal,
+      getCurrentThreadId: vi.fn(() => 'thread-1'),
+      listThreads: vi.fn(async () => []),
+    },
+    showInfo: vi.fn(),
+    showError: vi.fn(),
+  } as unknown as SlashCommandContext;
+  return { ctx, sendSignal };
+}
+
+describe('handleGithubCommand', () => {
+  beforeEach(() => {
+    askModalQuestionMock.mockReset();
+    execFileMock.mockReset();
+    loadSettingsMock.mockReset();
+    loadSettingsMock.mockReturnValue({ signals: { experimentalGithubSignals: true } });
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(new Error('no current PR'));
+    });
+  });
+
+  it('sends a GitHub subscribe signal for an inline PR number', async () => {
+    const { ctx, sendSignal } = createContext();
+
+    await handleGithubCommand(ctx, ['17447']);
+
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'reactive',
+        tagName: 'github-subscribe-pr',
+        attributes: { number: 17447 },
+      }),
+    );
+    expect(ctx.showInfo).toHaveBeenCalledWith('Subscribed to GitHub PR #17447.');
+  });
+
+  it('sends owner and repo when provided inline', async () => {
+    const { ctx, sendSignal } = createContext();
+
+    await handleGithubCommand(ctx, ['mastra-ai/mastra#17447']);
+
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
+      }),
+    );
+  });
+
+  it('supports the explicit subscribe subcommand', async () => {
+    const { ctx, sendSignal } = createContext();
+
+    await handleGithubCommand(ctx, ['subscribe', '17447']);
+
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tagName: 'github-subscribe-pr',
+        attributes: { number: 17447 },
+      }),
+    );
+  });
+
+  it('sends an unsubscribe signal for /github unsubscribe', async () => {
+    const { ctx, sendSignal } = createContext();
+
+    await handleGithubCommand(ctx, ['unsubscribe', 'mastra-ai/mastra#17447']);
+
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'reactive',
+        tagName: 'github-unsubscribe-pr',
+        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
+      }),
+    );
+    expect(ctx.showInfo).toHaveBeenCalledWith('Unsubscribed from GitHub PR #17447.');
+  });
+
+  it('does not send a signal when experimental GitHub signals are disabled', async () => {
+    const { ctx, sendSignal } = createContext();
+    loadSettingsMock.mockReturnValue({ signals: { experimentalGithubSignals: false } });
+
+    await handleGithubCommand(ctx, ['17447']);
+
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(ctx.showError).toHaveBeenCalledWith(
+      'Experimental GitHub signals are disabled. Enable them in /settings and restart MastraCode.',
+    );
+  });
+
+  it('asks for a PR reference when no inline args are provided', async () => {
+    const { ctx, sendSignal } = createContext();
+    askModalQuestionMock.mockResolvedValue('https://github.com/mastra-ai/mastra/pull/17447');
+
+    await handleGithubCommand(ctx, []);
+
+    expect(askModalQuestionMock).toHaveBeenCalled();
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
+      }),
+    );
+  });
+
+  it('prefills the prompt from gh pr view when possible', async () => {
+    const { ctx, sendSignal } = createContext();
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(null, 'https://github.com/mastra-ai/mastra/pull/17447\n', '');
+    });
+    askModalQuestionMock.mockResolvedValue('https://github.com/mastra-ai/mastra/pull/17447');
+
+    await handleGithubCommand(ctx, []);
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'gh',
+      ['pr', 'view', '--json', 'url', '--jq', '.url'],
+      { cwd: '/repo' },
+      expect.any(Function),
+    );
+    expect(askModalQuestionMock).toHaveBeenCalledWith(
+      ctx.state.ui,
+      expect.objectContaining({ defaultValue: 'https://github.com/mastra-ai/mastra/pull/17447' }),
+    );
+    expect(sendSignal).toHaveBeenCalledWith(expect.objectContaining({ tagName: 'github-subscribe-pr' }));
+  });
+
+  it('shows GitHub subscription debug information for the current thread', async () => {
+    const { ctx, sendSignal } = createContext();
+    vi.mocked((ctx.harness as any).listThreads).mockResolvedValue([
+      {
+        id: 'thread-1',
+        metadata: {
+          mastra: {
+            githubSignals: {
+              subscriptions: [
+                {
+                  owner: 'mastra-ai',
+                  repo: 'mastra',
+                  number: 17447,
+                  lastSyncStatus: 'success',
+                  lastSyncAt: '2026-06-02T18:03:12Z',
+                  lastObservedGithubUpdatedAt: '2026-06-02T18:01:58Z',
+                  lastObservedCiState: 'failure',
+                  lastObservedMergeableState: 'dirty',
+                  lastNotificationAt: '2026-06-02T18:03:13Z',
+                  lastNotificationKind: 'pull-request-ci-failure',
+                  lastNotificationPriority: 'high',
+                  lastNotificationSummary: 'mastra-ai/mastra#17447 has failing CI: Quality assurance',
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+
+    await handleGithubCommand(ctx, ['debug']);
+
+    expect(sendSignal).not.toHaveBeenCalled();
+    const formatLocal = (value: string) =>
+      new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'medium',
+        hour12: true,
+      }).format(new Date(value));
+    expect(ctx.showInfo).toHaveBeenCalledWith(
+      `GitHub Signals debug for thread-1:\n- mastra-ai/mastra#17447 sync=success lastPoll=${formatLocal('2026-06-02T18:03:12Z')} (githubUpdated=${formatLocal('2026-06-02T18:01:58Z')}, ci=failure, merge=dirty)\n  lastNotification=pull-request-ci-failure/high at ${formatLocal('2026-06-02T18:03:13Z')}: mastra-ai/mastra#17447 has failing CI: Quality assurance`,
+    );
+  });
+
+  it('shows an error for invalid PR references', async () => {
+    const { ctx, sendSignal } = createContext();
+
+    await handleGithubCommand(ctx, ['not-a-pr']);
+
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(ctx.showError).toHaveBeenCalledWith(
+      'Usage: /github 123, /github owner/repo#123, /github unsubscribe 123, /github debug, or /github https://github.com/owner/repo/pull/123',
+    );
+  });
+});

--- a/mastracode/src/tui/commands/__tests__/github.test.ts
+++ b/mastracode/src/tui/commands/__tests__/github.test.ts
@@ -22,7 +22,11 @@ vi.mock('../../modal-question.js', () => ({
 function createContext() {
   const sendSignal = vi.fn(() => ({ id: 'signal-1', accepted: Promise.resolve({ accepted: true, runId: 'run-1' }) }));
   const ctx = {
-    state: { ui: { requestRender: vi.fn() }, projectInfo: { rootPath: '/repo' } },
+    state: {
+      ui: { requestRender: vi.fn() },
+      projectInfo: { rootPath: '/repo' },
+      options: { githubSignals: { isPollingThread: vi.fn(() => false), getPollIntervalMs: vi.fn(() => 60_000) } },
+    },
     harness: {
       sendSignal,
       getCurrentThreadId: vi.fn(() => 'thread-1'),
@@ -150,9 +154,11 @@ describe('handleGithubCommand', () => {
 
   it('shows GitHub subscription debug information for the current thread', async () => {
     const { ctx, sendSignal } = createContext();
+    vi.mocked((ctx.state as any).options.githubSignals.isPollingThread).mockReturnValue(true);
     vi.mocked((ctx.harness as any).listThreads).mockResolvedValue([
       {
         id: 'thread-1',
+        resourceId: 'resource-1',
         metadata: {
           mastra: {
             githubSignals: {
@@ -188,7 +194,7 @@ describe('handleGithubCommand', () => {
         hour12: true,
       }).format(new Date(value));
     expect(ctx.showInfo).toHaveBeenCalledWith(
-      `GitHub Signals debug for thread-1:\n- mastra-ai/mastra#17447 sync=success lastPoll=${formatLocal('2026-06-02T18:03:12Z')} (githubUpdated=${formatLocal('2026-06-02T18:01:58Z')}, ci=failure, merge=dirty)\n  lastNotification=pull-request-ci-failure/high at ${formatLocal('2026-06-02T18:03:13Z')}: mastra-ai/mastra#17447 has failing CI: Quality assurance`,
+      `GitHub Signals debug for thread-1: 1 subscription, polling=active, interval=60s\n- mastra-ai/mastra#17447 sync=success lastPoll=${formatLocal('2026-06-02T18:03:12Z')} (githubUpdated=${formatLocal('2026-06-02T18:01:58Z')}, ci=failure, merge=dirty)\n  lastNotification=pull-request-ci-failure/high at ${formatLocal('2026-06-02T18:03:13Z')}: mastra-ai/mastra#17447 has failing CI: Quality assurance`,
     );
   });
 

--- a/mastracode/src/tui/commands/__tests__/github.test.ts
+++ b/mastracode/src/tui/commands/__tests__/github.test.ts
@@ -25,7 +25,7 @@ function createContext() {
     state: {
       ui: { requestRender: vi.fn() },
       projectInfo: { rootPath: '/repo' },
-      options: { githubSignals: { isPollingThread: vi.fn(() => false), getPollIntervalMs: vi.fn(() => 60_000) } },
+      options: { githubSignals: { isPollingThread: vi.fn(() => false), getPollIntervalMs: vi.fn(() => 300_000) } },
     },
     harness: {
       sendSignal,
@@ -194,7 +194,7 @@ describe('handleGithubCommand', () => {
         hour12: true,
       }).format(new Date(value));
     expect(ctx.showInfo).toHaveBeenCalledWith(
-      `GitHub Signals debug for thread-1: 1 subscription, polling=active, interval=60s\n- mastra-ai/mastra#17447 sync=success lastPoll=${formatLocal('2026-06-02T18:03:12Z')} (githubUpdated=${formatLocal('2026-06-02T18:01:58Z')}, ci=failure, merge=dirty)\n  lastNotification=pull-request-ci-failure/high at ${formatLocal('2026-06-02T18:03:13Z')}: mastra-ai/mastra#17447 has failing CI: Quality assurance`,
+      `GitHub Signals debug for thread-1: 1 subscription, polling=active, interval=5m\n- mastra-ai/mastra#17447 sync=success lastPoll=${formatLocal('2026-06-02T18:03:12Z')} (githubUpdated=${formatLocal('2026-06-02T18:01:58Z')}, ci=failure, merge=dirty)\n  lastNotification=pull-request-ci-failure/high at ${formatLocal('2026-06-02T18:03:13Z')}: mastra-ai/mastra#17447 has failing CI: Quality assurance`,
     );
   });
 

--- a/mastracode/src/tui/commands/__tests__/github.test.ts
+++ b/mastracode/src/tui/commands/__tests__/github.test.ts
@@ -21,21 +21,29 @@ vi.mock('../../modal-question.js', () => ({
 
 function createContext() {
   const sendSignal = vi.fn(() => ({ id: 'signal-1', accepted: Promise.resolve({ accepted: true, runId: 'run-1' }) }));
+  const syncThreadNow = vi.fn(async () => 1);
   const ctx = {
     state: {
       ui: { requestRender: vi.fn() },
       projectInfo: { rootPath: '/repo' },
-      options: { githubSignals: { isPollingThread: vi.fn(() => false), getPollIntervalMs: vi.fn(() => 300_000) } },
+      options: {
+        githubSignals: {
+          isPollingThread: vi.fn(() => false),
+          getPollIntervalMs: vi.fn(() => 300_000),
+          syncThreadNow,
+        },
+      },
     },
     harness: {
       sendSignal,
       getCurrentThreadId: vi.fn(() => 'thread-1'),
+      getResourceId: vi.fn(() => 'resource-1'),
       listThreads: vi.fn(async () => []),
     },
     showInfo: vi.fn(),
     showError: vi.fn(),
   } as unknown as SlashCommandContext;
-  return { ctx, sendSignal };
+  return { ctx, sendSignal, syncThreadNow };
 }
 
 describe('handleGithubCommand', () => {
@@ -152,6 +160,28 @@ describe('handleGithubCommand', () => {
     expect(sendSignal).toHaveBeenCalledWith(expect.objectContaining({ tagName: 'github-subscribe-pr' }));
   });
 
+  it('syncs GitHub subscriptions for the current thread', async () => {
+    const { ctx, sendSignal, syncThreadNow } = createContext();
+    vi.mocked((ctx.harness as any).listThreads).mockResolvedValue([
+      { id: 'thread-1', resourceId: 'resource-from-thread' },
+    ]);
+
+    await handleGithubCommand(ctx, ['sync']);
+
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(syncThreadNow).toHaveBeenCalledWith({ threadId: 'thread-1', resourceId: 'resource-from-thread' });
+    expect(ctx.showInfo).toHaveBeenCalledWith('Synced 1 GitHub PR subscription.');
+  });
+
+  it('shows a no-op message when /github sync has no subscriptions', async () => {
+    const { ctx, syncThreadNow } = createContext();
+    syncThreadNow.mockResolvedValue(0);
+
+    await handleGithubCommand(ctx, ['sync']);
+
+    expect(ctx.showInfo).toHaveBeenCalledWith('No GitHub PR subscriptions to sync.');
+  });
+
   it('shows GitHub subscription debug information for the current thread', async () => {
     const { ctx, sendSignal } = createContext();
     vi.mocked((ctx.state as any).options.githubSignals.isPollingThread).mockReturnValue(true);
@@ -205,7 +235,7 @@ describe('handleGithubCommand', () => {
 
     expect(sendSignal).not.toHaveBeenCalled();
     expect(ctx.showError).toHaveBeenCalledWith(
-      'Usage: /github 123, /github owner/repo#123, /github unsubscribe 123, /github debug, or /github https://github.com/owner/repo/pull/123',
+      'Usage: /github 123, /github owner/repo#123, /github unsubscribe 123, /github sync, /github debug, or /github https://github.com/owner/repo/pull/123',
     );
   });
 });

--- a/mastracode/src/tui/commands/__tests__/github.test.ts
+++ b/mastracode/src/tui/commands/__tests__/github.test.ts
@@ -22,6 +22,14 @@ vi.mock('../../modal-question.js', () => ({
 function createContext() {
   const sendSignal = vi.fn(() => ({ id: 'signal-1', accepted: Promise.resolve({ accepted: true, runId: 'run-1' }) }));
   const syncThreadNow = vi.fn(async () => 1);
+  const subscribeThreadToPR = vi.fn(async () => ({ owner: 'mastra-ai', repo: 'mastra', number: 17447 }));
+  const unsubscribeThreadFromPR = vi.fn(async () => ({
+    owner: 'mastra-ai',
+    repo: 'mastra',
+    number: 17447,
+    removed: true,
+    remainingSubscriptions: 0,
+  }));
   const ctx = {
     state: {
       ui: { requestRender: vi.fn() },
@@ -31,6 +39,8 @@ function createContext() {
           isPollingThread: vi.fn(() => false),
           getPollIntervalMs: vi.fn(() => 300_000),
           syncThreadNow,
+          subscribeThreadToPR,
+          unsubscribeThreadFromPR,
         },
       },
     },
@@ -43,7 +53,7 @@ function createContext() {
     showInfo: vi.fn(),
     showError: vi.fn(),
   } as unknown as SlashCommandContext;
-  return { ctx, sendSignal, syncThreadNow };
+  return { ctx, sendSignal, syncThreadNow, subscribeThreadToPR, unsubscribeThreadFromPR };
 }
 
 describe('handleGithubCommand', () => {
@@ -57,59 +67,48 @@ describe('handleGithubCommand', () => {
     });
   });
 
-  it('sends a GitHub subscribe signal for an inline PR number', async () => {
-    const { ctx, sendSignal } = createContext();
+  it('subscribes the current thread to an inline PR number', async () => {
+    const { ctx, sendSignal, subscribeThreadToPR } = createContext();
 
     await handleGithubCommand(ctx, ['17447']);
 
-    expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'reactive',
-        tagName: 'github-subscribe-pr',
-        attributes: { number: 17447 },
-      }),
-    );
-    expect(ctx.showInfo).toHaveBeenCalledWith('Subscribed to GitHub PR #17447.');
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(subscribeThreadToPR).toHaveBeenCalledWith({ threadId: 'thread-1', resourceId: 'resource-1', pr: 17447 });
+    expect(ctx.showInfo).toHaveBeenCalledWith('Subscribed to mastra-ai/mastra#17447.');
   });
 
   it('sends owner and repo when provided inline', async () => {
-    const { ctx, sendSignal } = createContext();
+    const { ctx, subscribeThreadToPR } = createContext();
 
     await handleGithubCommand(ctx, ['mastra-ai/mastra#17447']);
 
-    expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
-      }),
-    );
+    expect(subscribeThreadToPR).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      pr: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
+    });
   });
 
   it('supports the explicit subscribe subcommand', async () => {
-    const { ctx, sendSignal } = createContext();
+    const { ctx, subscribeThreadToPR } = createContext();
 
     await handleGithubCommand(ctx, ['subscribe', '17447']);
 
-    expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tagName: 'github-subscribe-pr',
-        attributes: { number: 17447 },
-      }),
-    );
+    expect(subscribeThreadToPR).toHaveBeenCalledWith({ threadId: 'thread-1', resourceId: 'resource-1', pr: 17447 });
   });
 
-  it('sends an unsubscribe signal for /github unsubscribe', async () => {
-    const { ctx, sendSignal } = createContext();
+  it('unsubscribes the current thread from an inline PR', async () => {
+    const { ctx, sendSignal, unsubscribeThreadFromPR } = createContext();
 
     await handleGithubCommand(ctx, ['unsubscribe', 'mastra-ai/mastra#17447']);
 
-    expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'reactive',
-        tagName: 'github-unsubscribe-pr',
-        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
-      }),
-    );
-    expect(ctx.showInfo).toHaveBeenCalledWith('Unsubscribed from GitHub PR #17447.');
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(unsubscribeThreadFromPR).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      pr: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
+    });
+    expect(ctx.showInfo).toHaveBeenCalledWith('Unsubscribed from mastra-ai/mastra#17447.');
   });
 
   it('does not send a signal when experimental GitHub signals are disabled', async () => {
@@ -125,21 +124,21 @@ describe('handleGithubCommand', () => {
   });
 
   it('asks for a PR reference when no inline args are provided', async () => {
-    const { ctx, sendSignal } = createContext();
+    const { ctx, subscribeThreadToPR } = createContext();
     askModalQuestionMock.mockResolvedValue('https://github.com/mastra-ai/mastra/pull/17447');
 
     await handleGithubCommand(ctx, []);
 
     expect(askModalQuestionMock).toHaveBeenCalled();
-    expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        attributes: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
-      }),
-    );
+    expect(subscribeThreadToPR).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      pr: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
+    });
   });
 
   it('prefills the prompt from gh pr view when possible', async () => {
-    const { ctx, sendSignal } = createContext();
+    const { ctx, subscribeThreadToPR } = createContext();
     execFileMock.mockImplementation((_command, _args, _options, callback) => {
       callback(null, 'https://github.com/mastra-ai/mastra/pull/17447\n', '');
     });
@@ -157,7 +156,37 @@ describe('handleGithubCommand', () => {
       ctx.state.ui,
       expect.objectContaining({ defaultValue: 'https://github.com/mastra-ai/mastra/pull/17447' }),
     );
-    expect(sendSignal).toHaveBeenCalledWith(expect.objectContaining({ tagName: 'github-subscribe-pr' }));
+    expect(subscribeThreadToPR).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      pr: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
+    });
+  });
+
+  it('unsubscribes the only current subscription without prompting', async () => {
+    const { ctx, unsubscribeThreadFromPR } = createContext();
+    vi.mocked((ctx.harness as any).listThreads).mockResolvedValue([
+      {
+        id: 'thread-1',
+        resourceId: 'resource-1',
+        metadata: {
+          mastra: {
+            githubSignals: {
+              subscriptions: [{ owner: 'mastra-ai', repo: 'mastra', number: 17447 }],
+            },
+          },
+        },
+      },
+    ]);
+
+    await handleGithubCommand(ctx, ['unsubscribe']);
+
+    expect(askModalQuestionMock).not.toHaveBeenCalled();
+    expect(unsubscribeThreadFromPR).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      pr: { owner: 'mastra-ai', repo: 'mastra', number: 17447 },
+    });
   });
 
   it('syncs GitHub subscriptions for the current thread', async () => {

--- a/mastracode/src/tui/commands/github.ts
+++ b/mastracode/src/tui/commands/github.ts
@@ -21,6 +21,11 @@ function formatLocalTimestamp(value: unknown): string | undefined {
   }).format(date);
 }
 
+function formatPollInterval(value: number): string {
+  if (value % 60_000 === 0) return `${value / 60_000}m`;
+  return `${Math.round(value / 1000)}s`;
+}
+
 function parseGithubPRReference(input: string): GithubPRSignalInput | undefined {
   const trimmed = input.trim();
   if (!trimmed) return undefined;
@@ -57,7 +62,7 @@ async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<st
     ? (githubSignalsProcessor?.isPollingThread({ threadId, resourceId: thread.resourceId }) ?? false)
     : false;
   const pollIntervalMs = githubSignalsProcessor?.getPollIntervalMs?.();
-  const header = `GitHub Signals debug for ${threadId}: ${subscriptions.length} subscription${subscriptions.length === 1 ? '' : 's'}, polling=${pollingActive ? 'active' : 'inactive'}${pollIntervalMs ? `, interval=${Math.round(pollIntervalMs / 1000)}s` : ''}`;
+  const header = `GitHub Signals debug for ${threadId}: ${subscriptions.length} subscription${subscriptions.length === 1 ? '' : 's'}, polling=${pollingActive ? 'active' : 'inactive'}${pollIntervalMs ? `, interval=${formatPollInterval(pollIntervalMs)}` : ''}`;
 
   const lines = subscriptions.map(subscription => {
     if (!isPlainObject(subscription)) return '- invalid subscription metadata';

--- a/mastracode/src/tui/commands/github.ts
+++ b/mastracode/src/tui/commands/github.ts
@@ -41,7 +41,7 @@ async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<st
     getCurrentThreadId?: () => string | undefined;
     listThreads?: (input?: {
       allResources?: boolean;
-    }) => Promise<Array<{ id: string; metadata?: Record<string, unknown> }>>;
+    }) => Promise<Array<{ id: string; resourceId?: string; metadata?: Record<string, unknown> }>>;
   };
   const threadId = harness.getCurrentThreadId?.();
   if (!threadId) return 'GitHub Signals debug: no current thread.';
@@ -51,6 +51,13 @@ async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<st
   const githubSignals = isPlainObject(mastra[GITHUB_SIGNALS_METADATA_KEY]) ? mastra[GITHUB_SIGNALS_METADATA_KEY] : {};
   const subscriptions = Array.isArray(githubSignals.subscriptions) ? githubSignals.subscriptions : [];
   if (subscriptions.length === 0) return `GitHub Signals debug for ${threadId}: no subscribed PRs.`;
+
+  const githubSignalsProcessor = ctx.state.options?.githubSignals;
+  const pollingActive = thread?.resourceId
+    ? (githubSignalsProcessor?.isPollingThread({ threadId, resourceId: thread.resourceId }) ?? false)
+    : false;
+  const pollIntervalMs = githubSignalsProcessor?.getPollIntervalMs?.();
+  const header = `GitHub Signals debug for ${threadId}: ${subscriptions.length} subscription${subscriptions.length === 1 ? '' : 's'}, polling=${pollingActive ? 'active' : 'inactive'}${pollIntervalMs ? `, interval=${Math.round(pollIntervalMs / 1000)}s` : ''}`;
 
   const lines = subscriptions.map(subscription => {
     if (!isPlainObject(subscription)) return '- invalid subscription metadata';
@@ -74,7 +81,7 @@ async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<st
       : 'lastNotification=none';
     return `- ${pr} ${sync} ${poll}${subscription.lastSyncError ? ` error=${subscription.lastSyncError}` : ''}${observed.length ? ` (${observed.join(', ')})` : ''}\n  ${notification}`;
   });
-  return [`GitHub Signals debug for ${threadId}:`, ...lines].join('\n');
+  return [header, ...lines].join('\n');
 }
 
 async function detectCurrentPullRequest(ctx: SlashCommandContext): Promise<string> {

--- a/mastracode/src/tui/commands/github.ts
+++ b/mastracode/src/tui/commands/github.ts
@@ -1,0 +1,136 @@
+import { execFile } from 'node:child_process';
+
+import { GITHUB_SIGNALS_METADATA_KEY, GithubSignals } from '../../github-signals/index.js';
+import type { GithubPRSignalInput } from '../../github-signals/index.js';
+import { loadSettings } from '../../onboarding/settings.js';
+import { askModalQuestion } from '../modal-question.js';
+import type { SlashCommandContext } from './types.js';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function formatLocalTimestamp(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+    hour12: true,
+  }).format(date);
+}
+
+function parseGithubPRReference(input: string): GithubPRSignalInput | undefined {
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+
+  const numberOnly = /^#?(\d+)$/.exec(trimmed);
+  if (numberOnly?.[1]) return Number(numberOnly[1]);
+
+  const repoReference = /^(?:https:\/\/github\.com\/)?([^\s/#]+)\/([^\s/#]+)(?:\/pull\/|#)(\d+)$/.exec(trimmed);
+  if (repoReference?.[1] && repoReference[2] && repoReference[3]) {
+    return { owner: repoReference[1], repo: repoReference[2], number: Number(repoReference[3]) };
+  }
+
+  return undefined;
+}
+
+async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<string> {
+  const harness = ctx.harness as unknown as {
+    getCurrentThreadId?: () => string | undefined;
+    listThreads?: (input?: {
+      allResources?: boolean;
+    }) => Promise<Array<{ id: string; metadata?: Record<string, unknown> }>>;
+  };
+  const threadId = harness.getCurrentThreadId?.();
+  if (!threadId) return 'GitHub Signals debug: no current thread.';
+
+  const thread = (await harness.listThreads?.({ allResources: true }))?.find(item => item.id === threadId);
+  const mastra = isPlainObject(thread?.metadata?.mastra) ? thread.metadata.mastra : {};
+  const githubSignals = isPlainObject(mastra[GITHUB_SIGNALS_METADATA_KEY]) ? mastra[GITHUB_SIGNALS_METADATA_KEY] : {};
+  const subscriptions = Array.isArray(githubSignals.subscriptions) ? githubSignals.subscriptions : [];
+  if (subscriptions.length === 0) return `GitHub Signals debug for ${threadId}: no subscribed PRs.`;
+
+  const lines = subscriptions.map(subscription => {
+    if (!isPlainObject(subscription)) return '- invalid subscription metadata';
+    const pr = `${subscription.owner}/${subscription.repo}#${subscription.number}`;
+    const sync = subscription.lastSyncStatus ? `sync=${subscription.lastSyncStatus}` : 'sync=unknown';
+    const poll = subscription.lastSyncAt
+      ? `lastPoll=${formatLocalTimestamp(subscription.lastSyncAt)}`
+      : 'lastPoll=never';
+    const observed = [
+      subscription.lastObservedGithubUpdatedAt
+        ? `githubUpdated=${formatLocalTimestamp(subscription.lastObservedGithubUpdatedAt)}`
+        : undefined,
+      subscription.lastObservedState ? `state=${subscription.lastObservedState}` : undefined,
+      subscription.lastObservedCiState ? `ci=${subscription.lastObservedCiState}` : undefined,
+      subscription.lastObservedMergeableState ? `merge=${subscription.lastObservedMergeableState}` : undefined,
+      subscription.lastObservedReviewStateHash ? `reviews=${subscription.lastObservedReviewStateHash}` : undefined,
+    ].filter(Boolean);
+    const notificationTime = formatLocalTimestamp(subscription.lastNotificationAt) ?? 'unknown time';
+    const notification = subscription.lastNotificationKind
+      ? `lastNotification=${subscription.lastNotificationKind}/${subscription.lastNotificationPriority ?? 'unknown'} at ${notificationTime}: ${subscription.lastNotificationSummary ?? ''}`
+      : 'lastNotification=none';
+    return `- ${pr} ${sync} ${poll}${subscription.lastSyncError ? ` error=${subscription.lastSyncError}` : ''}${observed.length ? ` (${observed.join(', ')})` : ''}\n  ${notification}`;
+  });
+  return [`GitHub Signals debug for ${threadId}:`, ...lines].join('\n');
+}
+
+async function detectCurrentPullRequest(ctx: SlashCommandContext): Promise<string> {
+  return new Promise(resolve => {
+    execFile(
+      'gh',
+      ['pr', 'view', '--json', 'url', '--jq', '.url'],
+      { cwd: ctx.state.projectInfo.rootPath },
+      (error, stdout) => {
+        resolve(error ? '' : stdout.trim());
+      },
+    );
+  });
+}
+
+export async function handleGithubCommand(ctx: SlashCommandContext, args: string[] = []): Promise<void> {
+  if (!loadSettings().signals.experimentalGithubSignals) {
+    ctx.showError('Experimental GitHub signals are disabled. Enable them in /settings and restart MastraCode.');
+    return;
+  }
+
+  const [maybeAction, ...restArgs] = args;
+  if (maybeAction === 'debug') {
+    ctx.showInfo(await describeGithubSubscriptions(ctx));
+    return;
+  }
+  const explicitSubscribe = maybeAction === 'subscribe' || maybeAction === 'sub';
+  const action = maybeAction === 'unsubscribe' || maybeAction === 'unsub' ? 'unsubscribe' : 'subscribe';
+  const referenceArgs = action === 'unsubscribe' || explicitSubscribe ? restArgs : args;
+  const inlineReference = referenceArgs.join(' ').trim();
+  const reference = inlineReference
+    ? inlineReference
+    : await askModalQuestion(ctx.state.ui, {
+        question: `GitHub PR to ${action} ${action === 'subscribe' ? 'to' : 'from'}`,
+        defaultValue: await detectCurrentPullRequest(ctx),
+      });
+  if (reference === null) return;
+
+  const parsed = parseGithubPRReference(reference);
+  if (!parsed) {
+    ctx.showError(
+      'Usage: /github 123, /github owner/repo#123, /github unsubscribe 123, /github debug, or /github https://github.com/owner/repo/pull/123',
+    );
+    return;
+  }
+
+  try {
+    const inputSignal =
+      action === 'unsubscribe'
+        ? GithubSignals.signals.unsubscribeFromPR(parsed)
+        : GithubSignals.signals.subscribeToPR(parsed);
+    const signal = ctx.harness.sendSignal({ ...inputSignal, type: 'reactive' });
+    await signal.accepted;
+    const number = typeof parsed === 'number' ? parsed : parsed.number;
+    ctx.showInfo(`${action === 'unsubscribe' ? 'Unsubscribed from' : 'Subscribed to'} GitHub PR #${number}.`);
+  } catch (error) {
+    ctx.showError(`Failed to ${action} GitHub PR: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}

--- a/mastracode/src/tui/commands/github.ts
+++ b/mastracode/src/tui/commands/github.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 
-import { GITHUB_SIGNALS_METADATA_KEY, GithubSignals } from '../../github-signals/index.js';
+import { GITHUB_SIGNALS_METADATA_KEY } from '../../github-signals/index.js';
 import type { GithubPRSignalInput } from '../../github-signals/index.js';
 import { loadSettings } from '../../onboarding/settings.js';
 import { askModalQuestion } from '../modal-question.js';
@@ -58,6 +58,26 @@ async function getCurrentGithubThread(ctx: SlashCommandContext): Promise<{
 
   const thread = (await harness.listThreads?.({ allResources: true }))?.find(item => item.id === threadId);
   return { threadId, resourceId: thread?.resourceId ?? harness.getResourceId?.(), metadata: thread?.metadata };
+}
+
+function getGithubSubscriptionsFromThreadMetadata(metadata: Record<string, unknown> | undefined): Array<{
+  owner?: string;
+  repo?: string;
+  number: number;
+}> {
+  const mastra = isPlainObject(metadata?.mastra) ? metadata.mastra : {};
+  const githubSignals = isPlainObject(mastra[GITHUB_SIGNALS_METADATA_KEY]) ? mastra[GITHUB_SIGNALS_METADATA_KEY] : {};
+  const subscriptions = Array.isArray(githubSignals.subscriptions) ? githubSignals.subscriptions : [];
+  return subscriptions.flatMap(subscription => {
+    if (!isPlainObject(subscription) || typeof subscription.number !== 'number') return [];
+    return [
+      {
+        ...(typeof subscription.owner === 'string' ? { owner: subscription.owner } : {}),
+        ...(typeof subscription.repo === 'string' ? { repo: subscription.repo } : {}),
+        number: subscription.number,
+      },
+    ];
+  });
 }
 
 async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<string> {
@@ -157,31 +177,49 @@ export async function handleGithubCommand(ctx: SlashCommandContext, args: string
   const action = maybeAction === 'unsubscribe' || maybeAction === 'unsub' ? 'unsubscribe' : 'subscribe';
   const referenceArgs = action === 'unsubscribe' || explicitSubscribe ? restArgs : args;
   const inlineReference = referenceArgs.join(' ').trim();
+  const currentThread = await getCurrentGithubThread(ctx);
+  const existingSubscriptions = getGithubSubscriptionsFromThreadMetadata(currentThread.metadata);
   const reference = inlineReference
     ? inlineReference
-    : await askModalQuestion(ctx.state.ui, {
-        question: `GitHub PR to ${action} ${action === 'subscribe' ? 'to' : 'from'}`,
-        defaultValue: await detectCurrentPullRequest(ctx),
-      });
+    : action === 'unsubscribe' && existingSubscriptions.length === 1
+      ? existingSubscriptions[0]!
+      : await askModalQuestion(ctx.state.ui, {
+          question: `GitHub PR to ${action} ${action === 'subscribe' ? 'to' : 'from'}`,
+          defaultValue: await detectCurrentPullRequest(ctx),
+        });
   if (reference === null) return;
 
-  const parsed = parseGithubPRReference(reference);
+  const parsed = typeof reference === 'string' ? parseGithubPRReference(reference) : reference;
   if (!parsed) {
     ctx.showError(
       'Usage: /github 123, /github owner/repo#123, /github unsubscribe 123, /github sync, /github debug, or /github https://github.com/owner/repo/pull/123',
     );
     return;
   }
+  if (!currentThread.threadId || !currentThread.resourceId) {
+    ctx.showError(`GitHub ${action} requires a current thread.`);
+    return;
+  }
+
+  const githubSignalsProcessor = ctx.state.options?.githubSignals;
+  const runOperation =
+    action === 'unsubscribe'
+      ? githubSignalsProcessor?.unsubscribeThreadFromPR
+      : githubSignalsProcessor?.subscribeThreadToPR;
+  if (!runOperation) {
+    ctx.showError('GitHub signals are not available. Enable them in /settings and restart MastraCode.');
+    return;
+  }
 
   try {
-    const inputSignal =
-      action === 'unsubscribe'
-        ? GithubSignals.signals.unsubscribeFromPR(parsed)
-        : GithubSignals.signals.subscribeToPR(parsed);
-    const signal = ctx.harness.sendSignal({ ...inputSignal, type: 'reactive' });
-    await signal.accepted;
-    const number = typeof parsed === 'number' ? parsed : parsed.number;
-    ctx.showInfo(`${action === 'unsubscribe' ? 'Unsubscribed from' : 'Subscribed to'} GitHub PR #${number}.`);
+    const result = await runOperation.call(githubSignalsProcessor, {
+      threadId: currentThread.threadId,
+      resourceId: currentThread.resourceId,
+      pr: parsed,
+    });
+    const prefix =
+      action === 'unsubscribe' ? (result.removed ? 'Unsubscribed from' : 'No subscription found for') : 'Subscribed to';
+    ctx.showInfo(`${prefix} ${result.owner}/${result.repo}#${result.number}.`);
   } catch (error) {
     ctx.showError(`Failed to ${action} GitHub PR: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/mastracode/src/tui/commands/github.ts
+++ b/mastracode/src/tui/commands/github.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 
-import { GITHUB_SIGNALS_METADATA_KEY, GithubSignals } from '../../github-signals/index.js';
+import { GITHUB_SIGNALS_METADATA_KEY, GITHUB_SYNC_STATUS_TAG, GithubSignals } from '../../github-signals/index.js';
 import type { GithubPRSignalInput } from '../../github-signals/index.js';
 import { loadSettings } from '../../onboarding/settings.js';
 import { askModalQuestion } from '../modal-question.js';
@@ -102,6 +102,28 @@ async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<st
   return [header, ...lines].join('\n');
 }
 
+function sendGithubSyncStatusSignal(
+  ctx: SlashCommandContext,
+  input: { status: 'synced' | 'not_subscribed' | 'error'; message: string; count?: number },
+): void {
+  ctx.harness.sendSignal({
+    type: 'reactive',
+    tagName: GITHUB_SYNC_STATUS_TAG,
+    contents: input.message,
+    attributes: {
+      status: input.status,
+      ...(input.count !== undefined ? { count: input.count } : {}),
+    },
+    metadata: {
+      github: {
+        action: 'syncThread',
+        status: input.status,
+        ...(input.count !== undefined ? { count: input.count } : {}),
+      },
+    },
+  });
+}
+
 async function syncGithubSubscriptions(ctx: SlashCommandContext): Promise<void> {
   const githubSignalsProcessor = ctx.state.options?.githubSignals;
   if (!githubSignalsProcessor?.syncThreadNow) {
@@ -118,12 +140,18 @@ async function syncGithubSubscriptions(ctx: SlashCommandContext): Promise<void> 
   try {
     const count = await githubSignalsProcessor.syncThreadNow({ threadId, resourceId });
     if (count === 0) {
-      ctx.showInfo('No GitHub PR subscriptions to sync.');
+      sendGithubSyncStatusSignal(ctx, { status: 'not_subscribed', message: 'No GitHub PR subscriptions to sync.' });
       return;
     }
-    ctx.showInfo(`Synced ${count} GitHub PR subscription${count === 1 ? '' : 's'}.`);
+    sendGithubSyncStatusSignal(ctx, {
+      status: 'synced',
+      message: `Synced ${count} GitHub PR subscription${count === 1 ? '' : 's'}.`,
+      count,
+    });
   } catch (error) {
-    ctx.showError(`Failed to sync GitHub PR subscriptions: ${error instanceof Error ? error.message : String(error)}`);
+    const message = `Failed to sync GitHub PR subscriptions: ${error instanceof Error ? error.message : String(error)}`;
+    sendGithubSyncStatusSignal(ctx, { status: 'error', message });
+    ctx.showError(message);
   }
 }
 

--- a/mastracode/src/tui/commands/github.ts
+++ b/mastracode/src/tui/commands/github.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 
-import { GITHUB_SIGNALS_METADATA_KEY, GITHUB_SYNC_STATUS_TAG, GithubSignals } from '../../github-signals/index.js';
+import { GITHUB_SIGNALS_METADATA_KEY, GithubSignals } from '../../github-signals/index.js';
 import type { GithubPRSignalInput } from '../../github-signals/index.js';
 import { loadSettings } from '../../onboarding/settings.js';
 import { askModalQuestion } from '../modal-question.js';
@@ -102,28 +102,6 @@ async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<st
   return [header, ...lines].join('\n');
 }
 
-function sendGithubSyncStatusSignal(
-  ctx: SlashCommandContext,
-  input: { status: 'synced' | 'not_subscribed' | 'error'; message: string; count?: number },
-): void {
-  ctx.harness.sendSignal({
-    type: 'reactive',
-    tagName: GITHUB_SYNC_STATUS_TAG,
-    contents: input.message,
-    attributes: {
-      status: input.status,
-      ...(input.count !== undefined ? { count: input.count } : {}),
-    },
-    metadata: {
-      github: {
-        action: 'syncThread',
-        status: input.status,
-        ...(input.count !== undefined ? { count: input.count } : {}),
-      },
-    },
-  });
-}
-
 async function syncGithubSubscriptions(ctx: SlashCommandContext): Promise<void> {
   const githubSignalsProcessor = ctx.state.options?.githubSignals;
   if (!githubSignalsProcessor?.syncThreadNow) {
@@ -140,18 +118,10 @@ async function syncGithubSubscriptions(ctx: SlashCommandContext): Promise<void> 
   try {
     const count = await githubSignalsProcessor.syncThreadNow({ threadId, resourceId });
     if (count === 0) {
-      sendGithubSyncStatusSignal(ctx, { status: 'not_subscribed', message: 'No GitHub PR subscriptions to sync.' });
-      return;
+      ctx.showInfo('No GitHub PR subscriptions to sync.');
     }
-    sendGithubSyncStatusSignal(ctx, {
-      status: 'synced',
-      message: `Synced ${count} GitHub PR subscription${count === 1 ? '' : 's'}.`,
-      count,
-    });
   } catch (error) {
-    const message = `Failed to sync GitHub PR subscriptions: ${error instanceof Error ? error.message : String(error)}`;
-    sendGithubSyncStatusSignal(ctx, { status: 'error', message });
-    ctx.showError(message);
+    ctx.showError(`Failed to sync GitHub PR subscriptions: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 

--- a/mastracode/src/tui/commands/github.ts
+++ b/mastracode/src/tui/commands/github.ts
@@ -41,17 +41,30 @@ function parseGithubPRReference(input: string): GithubPRSignalInput | undefined 
   return undefined;
 }
 
-async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<string> {
+async function getCurrentGithubThread(ctx: SlashCommandContext): Promise<{
+  threadId?: string;
+  resourceId?: string;
+  metadata?: Record<string, unknown>;
+}> {
   const harness = ctx.harness as unknown as {
     getCurrentThreadId?: () => string | undefined;
+    getResourceId?: () => string | undefined;
     listThreads?: (input?: {
       allResources?: boolean;
     }) => Promise<Array<{ id: string; resourceId?: string; metadata?: Record<string, unknown> }>>;
   };
   const threadId = harness.getCurrentThreadId?.();
-  if (!threadId) return 'GitHub Signals debug: no current thread.';
+  if (!threadId) return {};
 
   const thread = (await harness.listThreads?.({ allResources: true }))?.find(item => item.id === threadId);
+  return { threadId, resourceId: thread?.resourceId ?? harness.getResourceId?.(), metadata: thread?.metadata };
+}
+
+async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<string> {
+  const { threadId, resourceId, metadata } = await getCurrentGithubThread(ctx);
+  if (!threadId) return 'GitHub Signals debug: no current thread.';
+
+  const thread = { resourceId, metadata };
   const mastra = isPlainObject(thread?.metadata?.mastra) ? thread.metadata.mastra : {};
   const githubSignals = isPlainObject(mastra[GITHUB_SIGNALS_METADATA_KEY]) ? mastra[GITHUB_SIGNALS_METADATA_KEY] : {};
   const subscriptions = Array.isArray(githubSignals.subscriptions) ? githubSignals.subscriptions : [];
@@ -89,6 +102,31 @@ async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<st
   return [header, ...lines].join('\n');
 }
 
+async function syncGithubSubscriptions(ctx: SlashCommandContext): Promise<void> {
+  const githubSignalsProcessor = ctx.state.options?.githubSignals;
+  if (!githubSignalsProcessor?.syncThreadNow) {
+    ctx.showError('GitHub signals are not available. Enable them in /settings and restart MastraCode.');
+    return;
+  }
+
+  const { threadId, resourceId } = await getCurrentGithubThread(ctx);
+  if (!threadId || !resourceId) {
+    ctx.showError('GitHub sync requires a current thread.');
+    return;
+  }
+
+  try {
+    const count = await githubSignalsProcessor.syncThreadNow({ threadId, resourceId });
+    if (count === 0) {
+      ctx.showInfo('No GitHub PR subscriptions to sync.');
+      return;
+    }
+    ctx.showInfo(`Synced ${count} GitHub PR subscription${count === 1 ? '' : 's'}.`);
+  } catch (error) {
+    ctx.showError(`Failed to sync GitHub PR subscriptions: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
 async function detectCurrentPullRequest(ctx: SlashCommandContext): Promise<string> {
   return new Promise(resolve => {
     execFile(
@@ -113,6 +151,10 @@ export async function handleGithubCommand(ctx: SlashCommandContext, args: string
     ctx.showInfo(await describeGithubSubscriptions(ctx));
     return;
   }
+  if (maybeAction === 'sync') {
+    await syncGithubSubscriptions(ctx);
+    return;
+  }
   const explicitSubscribe = maybeAction === 'subscribe' || maybeAction === 'sub';
   const action = maybeAction === 'unsubscribe' || maybeAction === 'unsub' ? 'unsubscribe' : 'subscribe';
   const referenceArgs = action === 'unsubscribe' || explicitSubscribe ? restArgs : args;
@@ -128,7 +170,7 @@ export async function handleGithubCommand(ctx: SlashCommandContext, args: string
   const parsed = parseGithubPRReference(reference);
   if (!parsed) {
     ctx.showError(
-      'Usage: /github 123, /github owner/repo#123, /github unsubscribe 123, /github debug, or /github https://github.com/owner/repo/pull/123',
+      'Usage: /github 123, /github owner/repo#123, /github unsubscribe 123, /github sync, /github debug, or /github https://github.com/owner/repo/pull/123',
     );
     return;
   }

--- a/mastracode/src/tui/commands/index.ts
+++ b/mastracode/src/tui/commands/index.ts
@@ -35,4 +35,5 @@ export { handleMemoryGatewayCommand } from './memory-gateway.js';
 export { handleApiKeysCommand } from './api-keys.js';
 export { handleFeedbackCommand } from './feedback.js';
 export { handleObservabilityCommand } from './observability.js';
+export { handleGithubCommand } from './github.js';
 export { handleGoalCommand, handleJudgeCommand } from './goal.js';

--- a/mastracode/src/tui/commands/settings.ts
+++ b/mastracode/src/tui/commands/settings.ts
@@ -1,7 +1,15 @@
+import { execFile, spawn } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { Box, Spacer, Text, matchesKey } from '@mariozechner/pi-tui';
+import type { TUI } from '@mariozechner/pi-tui';
 import type { StorageBackend, ThinkingLevelSetting } from '../../onboarding/settings.js';
 import { loadSettings, saveSettings } from '../../onboarding/settings.js';
 import { SettingsComponent } from '../components/settings.js';
 import type { IToolExecutionComponent } from '../components/tool-execution-interface.js';
+import { askModalQuestion } from '../modal-question.js';
 import type { NotificationMode } from '../notify.js';
 import { showModalOverlay } from '../overlay.js';
 import { handleApiKeysCommand } from './api-keys.js';
@@ -9,6 +17,161 @@ import type { SlashCommandContext } from './types.js';
 
 function getCurrentModeColor(ctx: SlashCommandContext): string | undefined {
   return ctx.state.harness.getCurrentMode?.()?.color;
+}
+
+function commandExists(command: string): Promise<boolean> {
+  return new Promise(resolve => {
+    execFile('/bin/sh', ['-lc', `command -v ${command}`], error => resolve(!error));
+  });
+}
+
+class GitcrawlSetupProgress extends Box {
+  private lines: string[] = [];
+  private _focused = false;
+
+  constructor(
+    private title: string,
+    private command: string,
+    private onCancel: () => void,
+  ) {
+    super(2, 1);
+    this.rebuild();
+  }
+
+  get focused(): boolean {
+    return this._focused;
+  }
+
+  set focused(value: boolean) {
+    this._focused = value;
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, 'escape') || data === '\x1b' || data === '\x1b\x1b') {
+      this.onCancel();
+    }
+  }
+
+  addOutput(chunk: Buffer | string): void {
+    const text = chunk.toString();
+    const lines = text
+      .split(/\r?\n/)
+      .map(line => line.trimEnd())
+      .filter(Boolean);
+    this.lines = [...this.lines, ...lines].slice(-4);
+    this.rebuild();
+  }
+
+  private rebuild(): void {
+    this.clear();
+    this.addChild(new Text(this.title, 0, 0));
+    this.addChild(new Text(this.command, 0, 0));
+    this.addChild(new Text('Press Esc to cancel.', 0, 0));
+    this.addChild(new Spacer(1));
+    const output = this.lines.length > 0 ? this.lines : ['Waiting for Homebrew output...'];
+    for (const line of output) {
+      this.addChild(new Text(line, 0, 0));
+    }
+  }
+}
+
+function runGitcrawlSetupCommand(
+  tui: TUI,
+  title: string,
+  command: string,
+  executable: string,
+  args: string[],
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      overlay.hide();
+      callback();
+    };
+    const progress = new GitcrawlSetupProgress(title, command, () => {
+      child.kill('SIGTERM');
+      finish(() => reject(new Error(`${title} cancelled`)));
+    });
+    const overlay = showModalOverlay(tui, progress, { maxHeight: '50%' });
+    overlay.focus();
+
+    child.stdout.on('data', chunk => {
+      progress.addOutput(chunk);
+      tui.requestRender();
+    });
+    child.stderr.on('data', chunk => {
+      progress.addOutput(chunk);
+      tui.requestRender();
+    });
+    child.on('error', error => finish(() => reject(error)));
+    child.on('close', code => {
+      finish(() => {
+        if (code === 0) resolve();
+        else reject(new Error(`${command} exited with code ${code}`));
+      });
+    });
+  });
+}
+
+function installGitcrawl(tui: TUI): Promise<void> {
+  return runGitcrawlSetupCommand(tui, 'Installing gitcrawl', 'brew install openclaw/tap/gitcrawl', 'brew', [
+    'install',
+    'openclaw/tap/gitcrawl',
+  ]);
+}
+
+function gitcrawlConfigPath(): string {
+  return join(homedir(), '.config', 'gitcrawl', 'config.toml');
+}
+
+async function gitcrawlConfigExists(): Promise<boolean> {
+  try {
+    await access(gitcrawlConfigPath());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function initGitcrawl(tui: TUI): Promise<void> {
+  return runGitcrawlSetupCommand(tui, 'Configuring gitcrawl', 'gitcrawl init --json', 'gitcrawl', ['init', '--json']);
+}
+
+async function ensureGitcrawlInstalled(ctx: SlashCommandContext): Promise<boolean> {
+  if (await commandExists('gitcrawl')) return true;
+
+  const answer = await askModalQuestion(ctx.state.ui, {
+    question: 'gitcrawl is required for GitHub signals. Install it with Homebrew now?',
+    options: [
+      { label: 'Install', description: 'Run: brew install openclaw/tap/gitcrawl' },
+      { label: 'Cancel', description: 'Leave GitHub signals disabled' },
+    ],
+  });
+  if (answer !== 'Install') return false;
+
+  await installGitcrawl(ctx.state.ui);
+  return true;
+}
+
+async function ensureGitcrawlConfigured(ctx: SlashCommandContext): Promise<boolean> {
+  if (await gitcrawlConfigExists()) return true;
+
+  await initGitcrawl(ctx.state.ui);
+  return true;
+}
+
+async function ensureGitcrawlReady(ctx: SlashCommandContext): Promise<boolean> {
+  try {
+    return (await ensureGitcrawlInstalled(ctx)) && (await ensureGitcrawlConfigured(ctx));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.endsWith(' cancelled')) ctx.showInfo(`${message}.`);
+    else ctx.showError(`Failed to set up gitcrawl: ${message}`);
+    return false;
+  }
 }
 
 function applyQuietModeToRenderedTools(ctx: SlashCommandContext, enabled: boolean, previewLineLimit: number): void {
@@ -39,6 +202,7 @@ export async function handleSettingsCommand(ctx: SlashCommandContext): Promise<v
     storageBackend: globalSettings.storage.backend,
     pgConnectionString: globalSettings.storage.pg?.connectionString ?? '',
     libsqlUrl: globalSettings.storage.libsql?.url ?? '',
+    experimentalGithubSignals: globalSettings.signals.experimentalGithubSignals,
   };
 
   return new Promise<void>(resolve => {
@@ -91,6 +255,14 @@ export async function handleSettingsCommand(ctx: SlashCommandContext): Promise<v
         const label = backend === 'pg' ? 'PostgreSQL' : 'LibSQL';
         console.info(`\nStorage backend changed to ${label}. Restarting is required.\n`);
         process.exit(0);
+      },
+      onExperimentalGithubSignalsChange: async enabled => {
+        if (enabled && !(await ensureGitcrawlReady(ctx))) return false;
+        const current = loadSettings();
+        current.signals.experimentalGithubSignals = enabled;
+        saveSettings(current);
+        ctx.showInfo(`Experimental GitHub signals: ${enabled ? 'on' : 'off'} (restart required)`);
+        return true;
       },
       onApiKeys: () => {
         ctx.state.ui.hideOverlay();

--- a/mastracode/src/tui/components/help-overlay.ts
+++ b/mastracode/src/tui/components/help-overlay.ts
@@ -52,7 +52,7 @@ function getCommands(modes: number): HelpEntry[] {
     { key: '/theme', description: 'Switch color theme (auto/dark/light)' },
     { key: '/update', description: 'Check for and install updates' },
     { key: '/observability', description: 'Configure cloud observability' },
-    { key: '/github', description: 'Subscribe this thread to a GitHub PR' },
+    { key: '/github', description: 'Subscribe/sync GitHub PR signals' },
     { key: '/goal', description: 'Set/manage persistent goal (Ralph loop)' },
     { key: '/judge', description: 'Set goal judge defaults' },
   ];

--- a/mastracode/src/tui/components/help-overlay.ts
+++ b/mastracode/src/tui/components/help-overlay.ts
@@ -52,6 +52,7 @@ function getCommands(modes: number): HelpEntry[] {
     { key: '/theme', description: 'Switch color theme (auto/dark/light)' },
     { key: '/update', description: 'Check for and install updates' },
     { key: '/observability', description: 'Configure cloud observability' },
+    { key: '/github', description: 'Subscribe this thread to a GitHub PR' },
     { key: '/goal', description: 'Set/manage persistent goal (Ralph loop)' },
     { key: '/judge', description: 'Set goal judge defaults' },
   ];

--- a/mastracode/src/tui/components/notification.ts
+++ b/mastracode/src/tui/components/notification.ts
@@ -1,6 +1,6 @@
 import { Container, Spacer, Text, visibleWidth } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { BOX_INDENT, mastra, theme } from '../theme.js';
+import { BOX_INDENT, getTermWidth, mastra, theme } from '../theme.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
 
 export interface NotificationOptions {
@@ -17,8 +17,58 @@ function priorityColor(priority?: string): string {
   return mastra.darkGray;
 }
 
+const MAX_NOTIFICATION_CONTENT_WIDTH = 100;
+const MIN_NOTIFICATION_CONTENT_WIDTH = 24;
+
 function padLine(value: string, width: number): string {
   return value + ' '.repeat(Math.max(0, width - visibleWidth(value)));
+}
+
+function splitLongWord(word: string, maxWidth: number): string[] {
+  const segments: string[] = [];
+  let current = '';
+
+  for (const char of word) {
+    if (current && visibleWidth(current + char) > maxWidth) {
+      segments.push(current);
+      current = char;
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) segments.push(current);
+  return segments;
+}
+
+function wrapText(value: string, maxWidth: number): string[] {
+  const lines: string[] = [];
+
+  for (const paragraph of value.split('\n')) {
+    const words = paragraph.trim().split(/\s+/).filter(Boolean);
+    if (words.length === 0) {
+      lines.push('');
+      continue;
+    }
+
+    let current = '';
+    for (const word of words) {
+      const wordSegments = visibleWidth(word) > maxWidth ? splitLongWord(word, maxWidth) : [word];
+      for (const segment of wordSegments) {
+        const next = current ? `${current} ${segment}` : segment;
+        if (current && visibleWidth(next) > maxWidth) {
+          lines.push(current);
+          current = segment;
+        } else {
+          current = next;
+        }
+      }
+    }
+
+    if (current) lines.push(current);
+  }
+
+  return lines;
 }
 
 export class NotificationComponent extends Container {
@@ -28,34 +78,42 @@ export class NotificationComponent extends Container {
     const titleText = options.source ? `notification from ${options.source}` : 'notification';
     const details = [options.priority, options.kind, options.status].filter(Boolean).join(' · ');
     const message = options.message.trim();
-    const contentWidth = Math.max(visibleWidth(titleText), visibleWidth(details), visibleWidth(message));
+    const maxContentWidth = Math.max(
+      MIN_NOTIFICATION_CONTENT_WIDTH,
+      Math.min(MAX_NOTIFICATION_CONTENT_WIDTH, getTermWidth() - BOX_INDENT - 4),
+    );
+    const titleLines = wrapText(titleText, maxContentWidth);
+    const detailLines = details ? wrapText(details, maxContentWidth) : [];
+    const messageLines = message ? wrapText(message, maxContentWidth) : [];
+    const allLines = [...titleLines, ...detailLines, ...messageLines];
+    const contentWidth = Math.max(...allLines.map(line => visibleWidth(line)), 1);
     const borderColor = chalk.hex(mastra.blue);
     const top = `╭${'─'.repeat(contentWidth + 2)}╮`;
     const bottom = `╰${'─'.repeat(contentWidth + 2)}╯`;
 
     this.addChild(new Text(borderColor(top), BOX_INDENT, 0));
-    this.addChild(
-      new Text(
-        `${borderColor('│')} ${chalk.hex(priorityColor(options.priority)).bold(padLine(titleText, contentWidth))} ${borderColor('│')}`,
-        BOX_INDENT,
-        0,
-      ),
-    );
-
-    if (details) {
+    for (const line of titleLines) {
       this.addChild(
         new Text(
-          `${borderColor('│')} ${theme.fg('dim', padLine(details, contentWidth))} ${borderColor('│')}`,
+          `${borderColor('│')} ${chalk.hex(priorityColor(options.priority)).bold(padLine(line, contentWidth))} ${borderColor('│')}`,
           BOX_INDENT,
           0,
         ),
       );
     }
 
-    if (message) {
+    for (const line of detailLines) {
       this.addChild(
-        new Text(`${borderColor('│')} ${padLine(message, contentWidth)} ${borderColor('│')}`, BOX_INDENT, 0),
+        new Text(
+          `${borderColor('│')} ${theme.fg('dim', padLine(line, contentWidth))} ${borderColor('│')}`,
+          BOX_INDENT,
+          0,
+        ),
       );
+    }
+
+    for (const line of messageLines) {
+      this.addChild(new Text(`${borderColor('│')} ${padLine(line, contentWidth)} ${borderColor('│')}`, BOX_INDENT, 0));
     }
 
     this.addChild(new Text(borderColor(bottom), BOX_INDENT, 0));

--- a/mastracode/src/tui/components/notification.ts
+++ b/mastracode/src/tui/components/notification.ts
@@ -1,4 +1,4 @@
-import { Container, Spacer, Text } from '@mariozechner/pi-tui';
+import { Container, Spacer, Text, visibleWidth } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import { BOX_INDENT, mastra, theme } from '../theme.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
@@ -12,35 +12,51 @@ export interface NotificationOptions {
 }
 
 function priorityColor(priority?: string): string {
-  switch (priority) {
-    case 'urgent':
-      return mastra.red;
-    case 'high':
-      return mastra.orange;
-    case 'medium':
-      return mastra.blue;
-    default:
-      return theme.getTheme().dim;
-  }
+  if (priority === 'urgent' || priority === 'high') return mastra.orange;
+  if (priority === 'medium') return mastra.blue;
+  return mastra.darkGray;
+}
+
+function padLine(value: string, width: number): string {
+  return value + ' '.repeat(Math.max(0, width - visibleWidth(value)));
 }
 
 export class NotificationComponent extends Container {
   constructor(options: NotificationOptions) {
     super();
 
-    const titleParts = ['Notification'];
-    if (options.source) titleParts.push(options.source);
-    if (options.kind) titleParts.push(options.kind);
+    const titleText = options.source ? `notification from ${options.source}` : 'notification';
+    const details = [options.priority, options.kind, options.status].filter(Boolean).join(' · ');
+    const message = options.message.trim();
+    const contentWidth = Math.max(visibleWidth(titleText), visibleWidth(details), visibleWidth(message));
+    const borderColor = chalk.hex(mastra.blue);
+    const top = `╭${'─'.repeat(contentWidth + 2)}╮`;
+    const bottom = `╰${'─'.repeat(contentWidth + 2)}╯`;
 
-    const title = chalk.hex(mastra.orange).bold(titleParts.join(': '));
-    const badges = [options.priority, options.status].filter((part): part is string => Boolean(part));
-    const suffix = badges.length ? ` ${chalk.hex(priorityColor(options.priority))(`[${badges.join(' · ')}]`)}` : '';
-    this.addChild(new Text(`${title}${suffix}`, BOX_INDENT, 0));
+    this.addChild(new Text(borderColor(top), BOX_INDENT, 0));
+    this.addChild(
+      new Text(
+        `${borderColor('│')} ${chalk.hex(priorityColor(options.priority)).bold(padLine(titleText, contentWidth))} ${borderColor('│')}`,
+        BOX_INDENT,
+        0,
+      ),
+    );
 
-    if (options.message.trim()) {
-      this.addChild(new Text(theme.fg('dim', options.message.trim()), BOX_INDENT + 2, 0));
+    if (details) {
+      this.addChild(
+        new Text(
+          `${borderColor('│')} ${theme.fg('dim', padLine(details, contentWidth))} ${borderColor('│')}`,
+          BOX_INDENT,
+          0,
+        ),
+      );
     }
 
+    if (message) {
+      this.addChild(new Text(`${borderColor('│')} ${padLine(message, contentWidth)} ${borderColor('│')}`, BOX_INDENT, 0));
+    }
+
+    this.addChild(new Text(borderColor(bottom), BOX_INDENT, 0));
     this.addChild(new Spacer(1));
   }
 

--- a/mastracode/src/tui/components/notification.ts
+++ b/mastracode/src/tui/components/notification.ts
@@ -53,7 +53,9 @@ export class NotificationComponent extends Container {
     }
 
     if (message) {
-      this.addChild(new Text(`${borderColor('│')} ${padLine(message, contentWidth)} ${borderColor('│')}`, BOX_INDENT, 0));
+      this.addChild(
+        new Text(`${borderColor('│')} ${padLine(message, contentWidth)} ${borderColor('│')}`, BOX_INDENT, 0),
+      );
     }
 
     this.addChild(new Text(borderColor(bottom), BOX_INDENT, 0));

--- a/mastracode/src/tui/components/settings.ts
+++ b/mastracode/src/tui/components/settings.ts
@@ -28,6 +28,7 @@ export interface SettingsConfig {
   storageBackend: StorageBackend;
   pgConnectionString: string;
   libsqlUrl: string;
+  experimentalGithubSignals: boolean;
 }
 
 export interface SettingsCallbacks {
@@ -38,6 +39,7 @@ export interface SettingsCallbacks {
   onQuietModeChange: (enabled: boolean) => void;
   onQuietModeMaxToolPreviewLinesChange: (lines: number) => void;
   onStorageBackendChange: (backend: StorageBackend, connectionUrl?: string) => void;
+  onExperimentalGithubSignalsChange: (enabled: boolean) => boolean | void | Promise<boolean | void>;
   onApiKeys?: () => void;
   onClose: () => void;
 }
@@ -47,7 +49,12 @@ export interface SettingsCallbacks {
 // =============================================================================
 
 class SelectSubmenu extends SelectList {
-  constructor(items: SelectItem[], currentValue: string, onSelect: (value: string) => void, onBack: () => void) {
+  constructor(
+    items: SelectItem[],
+    currentValue: string,
+    onSelect: (value: string) => void | Promise<void>,
+    onBack: () => void,
+  ) {
     super(items, Math.min(items.length, 8), getSelectListTheme());
 
     const currentIndex = items.findIndex(i => i.value === currentValue);
@@ -55,8 +62,8 @@ class SelectSubmenu extends SelectList {
       this.setSelectedIndex(currentIndex);
     }
 
-    this.onSelect = (item: SelectItem) => {
-      onSelect(item.value);
+    this.onSelect = async (item: SelectItem) => {
+      await onSelect(item.value);
     };
     this.onCancel = onBack;
   }
@@ -387,6 +394,35 @@ export class SettingsComponent extends Box implements Focusable {
             },
           ]
         : []),
+      {
+        id: 'experimentalGithubSignals',
+        label: 'Experimental GitHub signals',
+        description: 'Enable local-first GitHub PR subscriptions with gitcrawl (restart required).',
+        currentValue: config.experimentalGithubSignals ? 'On' : 'Off',
+        submenu: (_currentValue, done) =>
+          new SelectSubmenu(
+            [
+              {
+                value: 'on',
+                label: '  On',
+                description: 'Enable GitHub signal processor and PR subscription tools',
+              },
+              {
+                value: 'off',
+                label: '  Off',
+                description: 'Disable GitHub signal processor and tools',
+              },
+            ],
+            config.experimentalGithubSignals ? 'on' : 'off',
+            async value => {
+              const nextValue = value === 'on';
+              const accepted = await callbacks.onExperimentalGithubSignalsChange(nextValue);
+              config.experimentalGithubSignals = accepted === false ? !nextValue : nextValue;
+              done(config.experimentalGithubSignals ? 'On' : 'Off');
+            },
+            () => done(),
+          ),
+      },
       {
         id: 'storageBackend',
         label: 'Storage backend',

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -40,6 +40,7 @@ import {
 } from './handlers/index.js';
 import type { EventHandlerContext } from './handlers/types.js';
 import type { TUIState } from './state.js';
+import { getGithubPrSubscriptionsFromMetadata } from './state.js';
 
 /**
  * Dispatch a HarnessEvent to the appropriate handler.
@@ -164,8 +165,10 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       const currentThread = threads.find((t: HarnessThread) => t.id === event.threadId);
       if (currentThread) {
         state.currentThreadTitle = currentThread.title;
+        const metadata = currentThread.metadata as Record<string, unknown> | undefined;
+        state.activeGithubPrSubscriptions = getGithubPrSubscriptionsFromMetadata(metadata);
         // Load goal state from thread metadata
-        state.goalManager?.loadFromThreadMetadata(currentThread.metadata as Record<string, unknown> | undefined);
+        state.goalManager?.loadFromThreadMetadata(metadata);
       }
       break;
     }
@@ -174,6 +177,9 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       ectx.showInfo(`Created thread: ${event.thread.id}`);
       // Update current thread title for status line display
       state.currentThreadTitle = event.thread.title;
+      state.activeGithubPrSubscriptions = getGithubPrSubscriptionsFromMetadata(
+        event.thread.metadata as Record<string, unknown> | undefined,
+      );
       // If /goal started without an existing thread, save that pending goal to the
       // newly-created thread. Otherwise load the thread's own goal metadata so goals
       // do not bleed into unrelated new threads.

--- a/mastracode/src/tui/handlers/__tests__/message.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/message.test.ts
@@ -121,6 +121,21 @@ describe('handleMessageUpdate system reminders', () => {
     expect(rendered).toContain('Build is still running');
   });
 
+  it('does not render streamed GitHub subscribe operation signals', () => {
+    handleMessageUpdate(
+      ctx,
+      createAssistantMessage([
+        {
+          type: 'reactive_signal',
+          tagName: 'github-subscribe-pr',
+          message: 'Subscribe to GitHub PR #17241',
+        } as never,
+      ]),
+    );
+
+    expect(state.chatContainer.children).toHaveLength(0);
+  });
+
   it('keeps spacing when a streamed reminder is inserted before pending assistant text', () => {
     addUserMessage(state, {
       id: 'user-1',

--- a/mastracode/src/tui/handlers/__tests__/message.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/message.test.ts
@@ -197,6 +197,36 @@ describe('handleMessageUpdate system reminders', () => {
     expect(rendered).toContain('CI failed on main');
   });
 
+  it('wraps long streamed full notifications within the terminal width', () => {
+    const originalColumns = process.stdout.columns;
+    process.stdout.columns = 80;
+
+    try {
+      handleMessageUpdate(
+        ctx,
+        createAssistantMessage([
+          {
+            type: 'notification',
+            message:
+              'mastra-ai/mastra#17449: feat(storage): add notification storage adapters was merged. This thread has been automatically unsubscribed from this PR. Resubscribe if you still need updates.',
+            source: 'github',
+            kind: 'pull-request-merged',
+            priority: 'high',
+            status: 'delivered',
+          } as never,
+        ]),
+      );
+    } finally {
+      process.stdout.columns = originalColumns;
+    }
+
+    const component = state.chatContainer.children[0];
+    expect(component).toBeInstanceOf(NotificationComponent);
+    const renderedLines = stripAnsi((component as NotificationComponent).render(80).join('\n')).split('\n');
+    expect(renderedLines.some(line => line.includes('automatically unsubscribed'))).toBe(true);
+    expect(Math.max(...renderedLines.map(line => line.length))).toBeLessThanOrEqual(80);
+  });
+
   it('deduplicates repeated streamed reminders within the same assistant run', () => {
     const message = createAssistantMessage([
       {

--- a/mastracode/src/tui/handlers/__tests__/message.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/message.test.ts
@@ -189,8 +189,11 @@ describe('handleMessageUpdate system reminders', () => {
     expect(state.chatContainer.children).toHaveLength(1);
     const component = state.chatContainer.children[0];
     expect(component).toBeInstanceOf(NotificationComponent);
-    const rendered = stripAnsi((component as NotificationComponent).render(80).join('\n'));
-    expect(rendered).toContain('Notification: github: ci-status');
+    const rendered = stripAnsi((component as NotificationComponent).render(100).join('\n'));
+    expect(rendered).toContain('notification from github');
+    expect(rendered).toContain('╭');
+    expect(rendered).toContain('╰');
+    expect(rendered).toContain('high · ci-status · delivered');
     expect(rendered).toContain('CI failed on main');
   });
 

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -78,6 +78,8 @@ type StreamedReactiveSignalPart = {
   message?: string;
 };
 
+// These are internal control-plane signals handled by GithubSignals. The user-visible
+// result is rendered by github-sync-status, so showing these would duplicate the UI.
 const HIDDEN_REACTIVE_SIGNAL_TAGS = new Set(['github-subscribe-pr', 'github-unsubscribe-pr']);
 
 function shouldRenderReactiveSignal(tagName: string): boolean {

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -78,6 +78,12 @@ type StreamedReactiveSignalPart = {
   message?: string;
 };
 
+const HIDDEN_REACTIVE_SIGNAL_TAGS = new Set(['github-subscribe-pr', 'github-unsubscribe-pr']);
+
+function shouldRenderReactiveSignal(tagName: string): boolean {
+  return !HIDDEN_REACTIVE_SIGNAL_TAGS.has(tagName);
+}
+
 type StreamedNotificationSummaryPart = {
   type: 'notification_summary';
   message: string;
@@ -373,6 +379,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
   }
 
   for (const reactiveSignal of reactiveSignalParts) {
+    if (!shouldRenderReactiveSignal(reactiveSignal.tagName)) continue;
     const reactiveSignalKey = `${message.id}:${reactiveSignal.tagName}:${reactiveSignal.message ?? ''}`;
     if (!state.currentRunSystemReminderKeys.has(reactiveSignalKey)) {
       state.currentRunSystemReminderKeys.add(reactiveSignalKey);

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -147,6 +147,22 @@ export class MastraTUI {
   constructor(options: MastraTUIOptions) {
     this.state = createTUIState(options);
 
+    options.githubSignals?.onSubscriptionsChanged(event => {
+      const currentThreadId = this.state.harness.getCurrentThreadId?.();
+      const currentResourceId = this.state.harness.getResourceId?.();
+      if (event.threadId !== currentThreadId || (currentResourceId && event.resourceId !== currentResourceId)) return;
+      this.state.activeGithubPrSubscriptions = event.subscriptions.map(subscription => ({
+        owner: subscription.owner,
+        repo: subscription.repo,
+        prNumber: subscription.number,
+        lastSyncStatus: subscription.lastSyncStatus,
+        lastNotificationKind: subscription.lastNotificationKind,
+        lastNotificationPriority: subscription.lastNotificationPriority,
+      }));
+      updateStatusLine(this.state);
+      this.state.ui.requestRender();
+    });
+
     // Load user preferences
     const savedSettings = loadSettings();
     this.state.quietMode = savedSettings.preferences.quietMode;

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -72,7 +72,7 @@ import {
 } from './setup.js';
 import { handleShellPassthrough } from './shell.js';
 import type { MastraTUIOptions, TUIState } from './state.js';
-import { createTUIState } from './state.js';
+import { createTUIState, getGithubPrSubscriptionsFromMetadata } from './state.js';
 import { updateStatusLine } from './status-line.js';
 
 // =============================================================================
@@ -112,7 +112,9 @@ export async function syncInitialThreadState(state: TUIState): Promise<void> {
   if (initThread?.title) {
     state.currentThreadTitle = initThread.title;
   }
-  state.goalManager.loadFromThreadMetadata(initThread?.metadata as Record<string, unknown> | undefined);
+  const metadata = initThread?.metadata as Record<string, unknown> | undefined;
+  state.activeGithubPrSubscriptions = getGithubPrSubscriptionsFromMetadata(metadata);
+  state.goalManager.loadFromThreadMetadata(metadata);
 }
 
 function shouldUseCaffeinate(): boolean {

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -36,6 +36,11 @@ import { BOX_INDENT, getMarkdownTheme, theme, mastra } from './theme.js';
 export { formatToolResult };
 
 const WHILE_ACTIVE_USER_MESSAGE_LABEL = 'steer';
+const HIDDEN_REACTIVE_SIGNAL_TAGS = new Set(['github-subscribe-pr', 'github-unsubscribe-pr']);
+
+function shouldRenderReactiveSignal(tagName: string): boolean {
+  return !HIDDEN_REACTIVE_SIGNAL_TAGS.has(tagName);
+}
 
 type MessageWithAttributes = HarnessMessage & {
   attributes?: Record<string, string | number | boolean | null | undefined>;
@@ -373,6 +378,7 @@ export function addUserMessage(state: TUIState, message: HarnessMessage, options
   ) as { type: 'reactive_signal'; tagName: string; message?: string } | undefined;
 
   if (reactiveSignalPart) {
+    if (!shouldRenderReactiveSignal(reactiveSignalPart.tagName)) return;
     const component = new ReactiveSignalComponent({
       tagName: reactiveSignalPart.tagName,
       message: reactiveSignalPart.message,

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -431,7 +431,6 @@ export function addUserMessage(state: TUIState, message: HarnessMessage, options
     return;
   }
 
-
   const textContent = message.content
     .filter(c => c.type === 'text')
     .map(c => (c as { type: 'text'; text: string }).text)

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -15,7 +15,6 @@ import {
 import { AskQuestionInlineComponent } from './components/ask-question-inline.js';
 import { AssistantMessageComponent } from './components/assistant-message.js';
 import type { ChatSpacingKind } from './components/chat-spacing.js';
-import { NotificationSignalComponent } from './components/notification-signal.js';
 import { NotificationSummaryComponent } from './components/notification-summary.js';
 import { NotificationComponent } from './components/notification.js';
 import { OMMarkerComponent } from './components/om-marker.js';
@@ -432,32 +431,6 @@ export function addUserMessage(state: TUIState, message: HarnessMessage, options
     return;
   }
 
-  const notificationSignalPart = message.content.find(
-    content => (content as { type?: string }).type === 'notification_signal',
-  ) as
-    | {
-        type: 'notification_signal';
-        message: string;
-        source?: string;
-        kind?: string;
-        priority?: string;
-        status?: string;
-      }
-    | undefined;
-
-  if (notificationSignalPart) {
-    const component = new NotificationSignalComponent({
-      message: notificationSignalPart.message,
-      source: notificationSignalPart.source,
-      kind: notificationSignalPart.kind,
-      priority: notificationSignalPart.priority,
-      status: notificationSignalPart.status,
-    });
-    addChildBeforeFollowUps(state, component);
-    state.messageComponentsById.set(message.id, component);
-    state.ui.requestRender();
-    return;
-  }
 
   const textContent = message.content
     .filter(c => c.type === 'text')

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -15,6 +15,7 @@ import {
 import { AskQuestionInlineComponent } from './components/ask-question-inline.js';
 import { AssistantMessageComponent } from './components/assistant-message.js';
 import type { ChatSpacingKind } from './components/chat-spacing.js';
+import { NotificationSignalComponent } from './components/notification-signal.js';
 import { NotificationSummaryComponent } from './components/notification-summary.js';
 import { NotificationComponent } from './components/notification.js';
 import { OMMarkerComponent } from './components/om-marker.js';
@@ -424,6 +425,33 @@ export function addUserMessage(state: TUIState, message: HarnessMessage, options
       message: notificationSummaryPart.message,
       pending: notificationSummaryPart.pending,
       bySource: notificationSummaryPart.bySource,
+    });
+    addChildBeforeFollowUps(state, component);
+    state.messageComponentsById.set(message.id, component);
+    state.ui.requestRender();
+    return;
+  }
+
+  const notificationSignalPart = message.content.find(
+    content => (content as { type?: string }).type === 'notification_signal',
+  ) as
+    | {
+        type: 'notification_signal';
+        message: string;
+        source?: string;
+        kind?: string;
+        priority?: string;
+        status?: string;
+      }
+    | undefined;
+
+  if (notificationSignalPart) {
+    const component = new NotificationSignalComponent({
+      message: notificationSignalPart.message,
+      source: notificationSignalPart.source,
+      kind: notificationSignalPart.kind,
+      priority: notificationSignalPart.priority,
+      status: notificationSignalPart.status,
     });
     addChildBeforeFollowUps(state, component);
     state.messageComponentsById.set(message.id, component);

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -36,6 +36,8 @@ import { BOX_INDENT, getMarkdownTheme, theme, mastra } from './theme.js';
 export { formatToolResult };
 
 const WHILE_ACTIVE_USER_MESSAGE_LABEL = 'steer';
+// These are internal control-plane signals handled by GithubSignals. The user-visible
+// result is rendered by github-sync-status, so showing these would duplicate the UI.
 const HIDDEN_REACTIVE_SIGNAL_TAGS = new Set(['github-subscribe-pr', 'github-unsubscribe-pr']);
 
 function shouldRenderReactiveSignal(tagName: string): boolean {

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -351,11 +351,12 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'observability', description: 'Configure cloud observability' },
     {
       name: 'github',
-      description: 'Subscribe/debug GitHub PR signals',
+      description: 'Subscribe/sync/debug GitHub PR signals',
       getArgumentCompletions: (argumentPrefix: string) =>
         [
           { value: 'subscribe', label: 'subscribe', description: 'Subscribe this thread to a GitHub PR' },
           { value: 'unsubscribe', label: 'unsubscribe', description: 'Unsubscribe this thread from a GitHub PR' },
+          { value: 'sync', label: 'sync', description: 'Immediately sync subscribed GitHub PRs' },
           { value: 'debug', label: 'debug', description: 'Show GitHub signal subscription debug info' },
         ].filter(command => command.value.startsWith(argumentPrefix.toLowerCase())),
     },

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -350,6 +350,16 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'api-keys', description: 'Manage API keys for model providers' },
     { name: 'observability', description: 'Configure cloud observability' },
     {
+      name: 'github',
+      description: 'Subscribe/debug GitHub PR signals',
+      getArgumentCompletions: (argumentPrefix: string) =>
+        [
+          { value: 'subscribe', label: 'subscribe', description: 'Subscribe this thread to a GitHub PR' },
+          { value: 'unsubscribe', label: 'unsubscribe', description: 'Unsubscribe this thread from a GitHub PR' },
+          { value: 'debug', label: 'debug', description: 'Show GitHub signal subscription debug info' },
+        ].filter(command => command.value.startsWith(argumentPrefix.toLowerCase())),
+    },
+    {
       name: 'goal',
       description: 'Set/manage persistent goal (Ralph loop)',
       getArgumentCompletions: (argumentPrefix: string) =>

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -10,6 +10,7 @@ import type { Harness, HarnessMessage } from '@mastra/core/harness';
 import type { SkillMetadata, Workspace } from '@mastra/core/workspace';
 import type { MastraCodeAnalytics } from '../analytics.js';
 import type { AuthStorage } from '../auth/storage.js';
+import type { GithubSignals } from '../github-signals/index.js';
 import type { HookManager } from '../hooks/index.js';
 import type { McpManager } from '../mcp/manager.js';
 import type { OnboardingInlineComponent } from '../onboarding/onboarding-inline.js';
@@ -41,6 +42,46 @@ export interface PendingSignalMessage {
   component: Component;
   text: string;
   isInterjection?: boolean;
+}
+
+export interface GithubPrSubscriptionBadge {
+  owner?: string;
+  repo?: string;
+  prNumber: number;
+  lastSyncStatus?: string;
+  lastNotificationKind?: string;
+  lastNotificationPriority?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function getGithubPrSubscriptionsFromMetadata(
+  metadata: Record<string, unknown> | undefined,
+): GithubPrSubscriptionBadge[] {
+  const mastraMetadata = isRecord(metadata?.mastra) ? metadata.mastra : undefined;
+  const githubSignals = isRecord(mastraMetadata?.githubSignals) ? mastraMetadata.githubSignals : undefined;
+  const subscriptions = Array.isArray(githubSignals?.subscriptions) ? githubSignals.subscriptions : [];
+  const result: GithubPrSubscriptionBadge[] = [];
+  for (const subscription of subscriptions) {
+    if (!isRecord(subscription)) continue;
+    const prNumber = typeof subscription.number === 'number' ? subscription.number : undefined;
+    if (!prNumber) continue;
+    result.push({
+      prNumber,
+      ...(typeof subscription.owner === 'string' ? { owner: subscription.owner } : {}),
+      ...(typeof subscription.repo === 'string' ? { repo: subscription.repo } : {}),
+      ...(typeof subscription.lastSyncStatus === 'string' ? { lastSyncStatus: subscription.lastSyncStatus } : {}),
+      ...(typeof subscription.lastNotificationKind === 'string'
+        ? { lastNotificationKind: subscription.lastNotificationKind }
+        : {}),
+      ...(typeof subscription.lastNotificationPriority === 'string'
+        ? { lastNotificationPriority: subscription.lastNotificationPriority }
+        : {}),
+    });
+  }
+  return result.sort((a, b) => a.prNumber - b.prNumber);
 }
 // =============================================================================
 // MastraTUIOptions
@@ -83,6 +124,9 @@ export interface MastraTUIOptions {
 
   /** Use inline questions instead of dialog overlays */
   inlineQuestions?: boolean;
+
+  /** GitHub PR signal processor used for status-line polling state. */
+  githubSignals?: GithubSignals;
 }
 
 // =============================================================================
@@ -150,6 +194,8 @@ export interface TUIState {
   pendingNewThread: boolean;
   /** Current thread title (for display in status line) */
   currentThreadTitle?: string;
+  /** GitHub PR subscriptions for the current thread. */
+  activeGithubPrSubscriptions: GithubPrSubscriptionBadge[];
   /** Cached thread previews for the current TUI session */
   threadPreviewCache: Map<string, { preview: string; updatedAt: number }>;
   /** Threads whose preview lookup already returned empty during this session */
@@ -291,6 +337,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
     // Thread / conversation
     pendingNewThread: false,
     currentThreadTitle: undefined,
+    activeGithubPrSubscriptions: [],
     threadPreviewCache: new Map(),
     attemptedThreadPreviewIds: new Set(),
 

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -32,7 +32,7 @@ function formatGithubPrLabel(
   const threadId = state.harness.getCurrentThreadId?.();
   const resourceId = state.harness.getResourceId?.();
   const polling = !!threadId && !!resourceId && state.options.githubSignals?.isPollingThread({ threadId, resourceId });
-  const label = subscription.lastNotificationKind ? `${plain} updated` : plain;
+  const label = plain;
   const color = subscription.lastNotificationPriority === 'high' ? mastra.orange : extendedColors.skyBlue;
   if (polling && state.gradientAnimator?.isRunning()) {
     return {

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -6,8 +6,8 @@ import { visibleWidth } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import { applyGradientSweep } from './components/obi-loader.js';
 import { formatObservationStatus, formatReflectionStatus } from './components/om-progress.js';
-import type { TUIState } from './state.js';
-import { theme, mastra, tintHex, getTermWidth } from './theme.js';
+import type { GithubPrSubscriptionBadge, TUIState } from './state.js';
+import { theme, mastra, tintHex, getTermWidth, extendedColors } from './theme.js';
 
 // Colors for OM modes — read from proxy at render time so they pick up contrast adaptation
 const getObserverColor = () => mastra.orange;
@@ -22,6 +22,30 @@ function isGenericTitle(title: string): boolean {
     lower.startsWith('clone of') ||
     lower.startsWith('untitled')
   );
+}
+
+function formatGithubPrLabel(
+  state: TUIState,
+  subscription: GithubPrSubscriptionBadge,
+): { plain: string; styled: string } {
+  const plain = `PR#${subscription.prNumber}`;
+  const threadId = state.harness.getCurrentThreadId?.();
+  const resourceId = state.harness.getResourceId?.();
+  const polling = !!threadId && !!resourceId && state.options.githubSignals?.isPollingThread({ threadId, resourceId });
+  const label = subscription.lastNotificationKind ? `${plain} updated` : plain;
+  const color = subscription.lastNotificationPriority === 'high' ? mastra.orange : extendedColors.skyBlue;
+  if (polling && state.gradientAnimator?.isRunning()) {
+    return {
+      plain: label,
+      styled: applyGradientSweep(
+        label,
+        state.gradientAnimator.getOffset(),
+        color,
+        state.gradientAnimator.getFadeProgress(),
+      ),
+    };
+  }
+  return { plain: label, styled: chalk.hex(color)(label) };
 }
 
 function formatGoalDuration(goal: { startedAt: string; activeStartedAt?: string; activeDurationMs?: number }): string {
@@ -162,6 +186,15 @@ export function updateStatusLine(state: TUIState): void {
   const goalDuration = goalState?.status === 'active' ? formatGoalDuration(goalState) : null;
   const goalLabel = goalDuration ? `pursuing goal (${goalDuration})` : null;
   const shortGoalLabel = goalDuration ? `goal (${goalDuration})` : null;
+  const activeGithubPr = state.activeGithubPrSubscriptions?.[0];
+  const githubPrLabel = activeGithubPr ? formatGithubPrLabel(state, activeGithubPr) : null;
+  const formatDirPart = (value: string) => {
+    if (!githubPrLabel) return { plain: value, styled: theme.fg('dim', value) };
+    return {
+      plain: `${githubPrLabel.plain} ${value}`,
+      styled: `${githubPrLabel.styled} ${theme.fg('dim', value)}`,
+    };
+  };
   // Build progressively shorter directory strings for layout fallback
   // Only show branch when not showing thread title (thread title takes priority)
   const dirFull = !threadTitle && branch ? `${displayPath} (${branch})` : displayPath;
@@ -309,12 +342,14 @@ export function updateStatusLine(state: TUIState): void {
       useBadgeWidth + parts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
 
     if (dirText) {
+      const dirPart = formatDirPart(dirText);
       const availableForDir = termWidth - nonDirWidth - SEP.length - 1; // -1 buffer for ambiguous-width chars
-      const dirWidth = visibleWidth(dirText);
+      const dirWidth = visibleWidth(dirPart.plain);
       const MIN_TRUNCATED_DIR = 10; // don't show a tiny sliver
       if (dirWidth > availableForDir && availableForDir >= MIN_TRUNCATED_DIR) {
-        // Truncate to fit the remaining space
-        dirText = dirText.slice(0, availableForDir - 1) + '…';
+        const reservedPrefix = githubPrLabel ? `${githubPrLabel.plain} ` : '';
+        const availableForText = availableForDir - visibleWidth(reservedPrefix);
+        dirText = availableForText > 1 ? dirText.slice(0, availableForText - 1) + '…' : null;
       } else if (dirWidth > availableForDir) {
         // Not enough room even for a truncated version — drop it
         dirText = null;
@@ -322,10 +357,7 @@ export function updateStatusLine(state: TUIState): void {
     }
 
     if (dirText) {
-      parts.push({
-        plain: dirText,
-        styled: theme.fg('dim', dirText),
-      });
+      parts.push(formatDirPart(dirText));
     }
     const totalPlain =
       useBadgeWidth + parts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -75,8 +75,6 @@ type HarnessStreamState = {
 };
 
 type HarnessSendNotificationSignalOptions = {
-  resourceId?: string;
-  threadId?: string;
   ifActive?: SendAgentNotificationSignalOptions['ifActive'];
   ifIdle?: SendAgentNotificationSignalOptions['ifIdle'];
   tracingContext?: TracingContext;
@@ -1699,20 +1697,16 @@ export class Harness<TState = {}> {
     this.abortRequested = false;
   }
 
-  private getAgentThreadSubscriptionKey(agent: Agent, threadId: string, resourceId = this.resourceId): string {
-    return `${agent.id}:${resourceId}:${threadId}`;
+  private getAgentThreadSubscriptionKey(agent: Agent, threadId: string): string {
+    return `${agent.id}:${this.resourceId}:${threadId}`;
   }
 
-  private async ensureAgentThreadSubscription(
-    agent: Agent,
-    threadId: string,
-    resourceId = this.resourceId,
-  ): Promise<void> {
-    const key = this.getAgentThreadSubscriptionKey(agent, threadId, resourceId);
+  private async ensureAgentThreadSubscription(agent: Agent, threadId: string): Promise<void> {
+    const key = this.getAgentThreadSubscriptionKey(agent, threadId);
     if (this.agentThreadSubscriptionKey === key && this.agentThreadSubscription) return;
 
     this.cleanupAgentThreadSubscription();
-    const subscription = await agent.subscribeToThread({ resourceId, threadId });
+    const subscription = await agent.subscribeToThread({ resourceId: this.resourceId, threadId });
     this.agentThreadSubscription = subscription;
     this.agentThreadSubscriptionKey = key;
     void this.processSubscribedThreadStream(subscription);
@@ -1762,20 +1756,14 @@ export class Harness<TState = {}> {
 
   private async buildAgentMessageStreamOptions({
     requestContext: requestContextInput,
-    resourceId,
-    threadId,
     tracingContext,
     tracingOptions,
   }: {
     requestContext?: RequestContext;
-    resourceId?: string;
-    threadId?: string;
     tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
   }): Promise<Record<string, unknown>> {
-    const memoryThreadId = threadId ?? this.currentThreadId;
-    const memoryResourceId = resourceId ?? this.resourceId;
-    if (!memoryThreadId) {
+    if (!this.currentThreadId) {
       throw new Error('Cannot build stream options without a current thread');
     }
 
@@ -1784,7 +1772,7 @@ export class Harness<TState = {}> {
     const requestContext = await this.buildRequestContext(requestContextInput);
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
     const streamOptions: Record<string, unknown> = {
-      memory: { thread: memoryThreadId, resource: memoryResourceId },
+      memory: { thread: this.currentThreadId, resource: this.resourceId },
       abortSignal: this.abortController.signal,
       requestContext,
       maxSteps: 1000,
@@ -2004,23 +1992,18 @@ export class Harness<TState = {}> {
     options: HarnessSendNotificationSignalOptions = {},
   ): Promise<SendAgentNotificationSignalResult> {
     const { ifActive, ifIdle, requestContext: requestContextInput, tracingContext, tracingOptions } = options;
-    if (!this.currentThreadId && !options.threadId) {
+    if (!this.currentThreadId) {
       const thread = await this.createThread();
       this.currentThreadId = thread.id;
     }
 
     const agent = this.getCurrentAgent();
-    const targetThreadId = options.threadId ?? this.currentThreadId;
-    const targetResourceId = options.resourceId ?? this.resourceId;
-    if (!targetThreadId) {
-      throw new Error('Cannot send notification signal without a thread');
-    }
-    await this.ensureAgentThreadSubscription(agent, targetThreadId, targetResourceId);
+    await this.ensureAgentThreadSubscription(agent, this.currentThreadId);
 
-    if (this.currentRunId && this.agentThreadSubscription?.activeRunId() && targetThreadId === this.currentThreadId) {
+    if (this.currentRunId && this.agentThreadSubscription?.activeRunId()) {
       return agent.sendNotificationSignal(input, {
-        resourceId: targetResourceId,
-        threadId: targetThreadId,
+        resourceId: this.resourceId,
+        threadId: this.currentThreadId,
         ifActive,
         ifIdle,
       });
@@ -2028,15 +2011,13 @@ export class Harness<TState = {}> {
 
     const streamOptions = await this.buildAgentMessageStreamOptions({
       requestContext: requestContextInput,
-      resourceId: targetResourceId,
-      threadId: targetThreadId,
       tracingContext,
       tracingOptions,
     });
 
     return agent.sendNotificationSignal(input, {
-      resourceId: targetResourceId,
-      threadId: targetThreadId,
+      resourceId: this.resourceId,
+      threadId: this.currentThreadId,
       ifActive,
       ifIdle: { ...ifIdle, streamOptions: streamOptions as any },
     });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -75,6 +75,8 @@ type HarnessStreamState = {
 };
 
 type HarnessSendNotificationSignalOptions = {
+  resourceId?: string;
+  threadId?: string;
   ifActive?: SendAgentNotificationSignalOptions['ifActive'];
   ifIdle?: SendAgentNotificationSignalOptions['ifIdle'];
   tracingContext?: TracingContext;
@@ -1697,16 +1699,20 @@ export class Harness<TState = {}> {
     this.abortRequested = false;
   }
 
-  private getAgentThreadSubscriptionKey(agent: Agent, threadId: string): string {
-    return `${agent.id}:${this.resourceId}:${threadId}`;
+  private getAgentThreadSubscriptionKey(agent: Agent, threadId: string, resourceId = this.resourceId): string {
+    return `${agent.id}:${resourceId}:${threadId}`;
   }
 
-  private async ensureAgentThreadSubscription(agent: Agent, threadId: string): Promise<void> {
-    const key = this.getAgentThreadSubscriptionKey(agent, threadId);
+  private async ensureAgentThreadSubscription(
+    agent: Agent,
+    threadId: string,
+    resourceId = this.resourceId,
+  ): Promise<void> {
+    const key = this.getAgentThreadSubscriptionKey(agent, threadId, resourceId);
     if (this.agentThreadSubscriptionKey === key && this.agentThreadSubscription) return;
 
     this.cleanupAgentThreadSubscription();
-    const subscription = await agent.subscribeToThread({ resourceId: this.resourceId, threadId });
+    const subscription = await agent.subscribeToThread({ resourceId, threadId });
     this.agentThreadSubscription = subscription;
     this.agentThreadSubscriptionKey = key;
     void this.processSubscribedThreadStream(subscription);
@@ -1756,14 +1762,20 @@ export class Harness<TState = {}> {
 
   private async buildAgentMessageStreamOptions({
     requestContext: requestContextInput,
+    resourceId,
+    threadId,
     tracingContext,
     tracingOptions,
   }: {
     requestContext?: RequestContext;
+    resourceId?: string;
+    threadId?: string;
     tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
   }): Promise<Record<string, unknown>> {
-    if (!this.currentThreadId) {
+    const memoryThreadId = threadId ?? this.currentThreadId;
+    const memoryResourceId = resourceId ?? this.resourceId;
+    if (!memoryThreadId) {
       throw new Error('Cannot build stream options without a current thread');
     }
 
@@ -1772,7 +1784,7 @@ export class Harness<TState = {}> {
     const requestContext = await this.buildRequestContext(requestContextInput);
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
     const streamOptions: Record<string, unknown> = {
-      memory: { thread: this.currentThreadId, resource: this.resourceId },
+      memory: { thread: memoryThreadId, resource: memoryResourceId },
       abortSignal: this.abortController.signal,
       requestContext,
       maxSteps: 1000,
@@ -1992,18 +2004,23 @@ export class Harness<TState = {}> {
     options: HarnessSendNotificationSignalOptions = {},
   ): Promise<SendAgentNotificationSignalResult> {
     const { ifActive, ifIdle, requestContext: requestContextInput, tracingContext, tracingOptions } = options;
-    if (!this.currentThreadId) {
+    if (!this.currentThreadId && !options.threadId) {
       const thread = await this.createThread();
       this.currentThreadId = thread.id;
     }
 
     const agent = this.getCurrentAgent();
-    await this.ensureAgentThreadSubscription(agent, this.currentThreadId);
+    const targetThreadId = options.threadId ?? this.currentThreadId;
+    const targetResourceId = options.resourceId ?? this.resourceId;
+    if (!targetThreadId) {
+      throw new Error('Cannot send notification signal without a thread');
+    }
+    await this.ensureAgentThreadSubscription(agent, targetThreadId, targetResourceId);
 
-    if (this.currentRunId && this.agentThreadSubscription?.activeRunId()) {
+    if (this.currentRunId && this.agentThreadSubscription?.activeRunId() && targetThreadId === this.currentThreadId) {
       return agent.sendNotificationSignal(input, {
-        resourceId: this.resourceId,
-        threadId: this.currentThreadId,
+        resourceId: targetResourceId,
+        threadId: targetThreadId,
         ifActive,
         ifIdle,
       });
@@ -2011,13 +2028,15 @@ export class Harness<TState = {}> {
 
     const streamOptions = await this.buildAgentMessageStreamOptions({
       requestContext: requestContextInput,
+      resourceId: targetResourceId,
+      threadId: targetThreadId,
       tracingContext,
       tracingOptions,
     });
 
     return agent.sendNotificationSignal(input, {
-      resourceId: this.resourceId,
-      threadId: this.currentThreadId,
+      resourceId: targetResourceId,
+      threadId: targetThreadId,
       ifActive,
       ifIdle: { ...ifIdle, streamOptions: streamOptions as any },
     });

--- a/packages/core/src/notifications/notifications.test.ts
+++ b/packages/core/src/notifications/notifications.test.ts
@@ -211,17 +211,34 @@ describe('notification inbox', () => {
       resourceId: 'resource-1',
       agentId: 'agent-1',
     });
+    await storage.createNotification({
+      id: 'n2',
+      threadId: 'thread-1',
+      source: 'github',
+      kind: 'pull-request-activity',
+      summary: 'CI is still running',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+    });
     const sendSignal = vi.fn(signal => ({ accepted: true, runId: 'run-1', signal }));
     const tool = createNotificationInboxTool({ storage });
 
     await expect(tool.execute?.({ action: 'list' }, { agent: { threadId: 'thread-1' } } as any)).resolves.toMatchObject(
       {
-        notifications: [{ id: 'n1', status: 'pending' }],
+        notifications: expect.arrayContaining([
+          expect.objectContaining({ id: 'n1', status: 'pending' }),
+          expect.objectContaining({ id: 'n2', status: 'pending' }),
+        ]),
       },
     );
     await expect(
       tool.execute?.({ action: 'search', query: 'launch' }, { agent: { threadId: 'thread-1' } } as any),
     ).resolves.toMatchObject({ notifications: [{ id: 'n1' }] });
+    await expect(
+      tool.execute?.({ action: 'search', query: 'github', status: 'pending', source: 'github' }, {
+        agent: { threadId: 'thread-1' },
+      } as any),
+    ).resolves.toMatchObject({ notifications: [{ id: 'n2' }] });
     await expect(
       tool.execute?.({ action: 'read', id: 'n1' }, {
         agent: { agentId: 'agent-1', threadId: 'thread-1', resourceId: 'resource-1' },

--- a/packages/core/src/notifications/storage.ts
+++ b/packages/core/src/notifications/storage.ts
@@ -132,7 +132,10 @@ export class InMemoryNotificationsStorage extends NotificationsStorage {
       .filter(record => !input.agentId || record.agentId === input.agentId)
       .filter(
         record =>
-          !search || record.summary.toLowerCase().includes(search) || record.kind.toLowerCase().includes(search),
+          !search ||
+          record.summary.toLowerCase().includes(search) ||
+          record.kind.toLowerCase().includes(search) ||
+          record.source.toLowerCase().includes(search),
       )
       .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
     return results.slice(0, input.limit ?? results.length).map(cloneRecord);

--- a/packages/core/src/notifications/tool.ts
+++ b/packages/core/src/notifications/tool.ts
@@ -113,7 +113,14 @@ export function createNotificationInboxTool({ storage }: { storage: Notification
       if (input.action === 'search') {
         if (!input.query) throw new Error('notification-inbox search requires query');
         return {
-          notifications: await storage.listNotifications({ threadId, search: input.query, limit: input.limit }),
+          notifications: await storage.listNotifications({
+            threadId,
+            search: input.query,
+            status: input.status,
+            priority: input.priority,
+            source: input.source,
+            limit: input.limit,
+          }),
         };
       }
 


### PR DESCRIPTION
## Summary

Adds a standalone  input processor inside MastraCode so we can test local GitHub PR subscription signals on top of PR6.

- Adds  for typed PR subscription signals
- Consumes  signals as an input processor
- Resolves owner/repo from the current project's GitHub  remote when the signal only includes a PR number
- Stores thread-scoped PR subscriptions in thread metadata
- Runs targeted 
- Emits  reactive signals after subscribe/sync
- Wires the processor into MastraCode's agent config for local testing

Stacked on #17241.