### PR TITLE
docs: polish notification signal docs

### DIFF
--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -109,7 +109,7 @@ The behavior options are:
 - `ifIdle.behavior: 'persist'`: Save the signal or message to memory without starting a stream.
 - `ifIdle.behavior: 'discard'`: Ignore the signal or message while the thread is idle.
 
-Pass `ifIdle.streamOptions` when the idle wake-up stream needs options such as model settings, tools, or runtime context. You do not need to repeat `memory.resource` or `memory.thread`; Mastra uses the top-level `resourceId` and `threadId` for the thread.
+Pass `ifIdle.streamOptions` when the idle wake-up stream needs options such as model settings, tools, or runtime context. You don't need to repeat `memory.resource` or `memory.thread`; Mastra uses the top-level `resourceId` and `threadId` for the thread.
 
 ```typescript title="src/mastra/signals.ts"
 agent.sendMessage('Continue with the next step.', {
@@ -232,7 +232,7 @@ When the agent is idle:
 <user source="chat" delivery="new-message">Also cover the edge cases.</user>
 ```
 
-Top-level `attributes` always apply. The selected branch's `attributes` are merged into them at delivery time. The `delivery` name shown above is not a special Mastra API field. It is a custom attribute name used for this example, you can add any attribute names that suit your use case.
+Top-level `attributes` always apply. The selected branch's `attributes` are merged into them at delivery time. The `delivery` name shown above isn't a special Mastra API field. It's a custom attribute name used for this example. Add any attribute names that suit your use case.
 
 ## State signals
 
@@ -306,34 +306,37 @@ export const browserStateProcessor: Processor = {
 }
 ```
 
-Mastra passes `lastSnapshot` and `deltasSinceSnapshot` into `computeStateSignal()`. It resolves them from message history when the current message list does not contain the latest snapshot. The processor still owns merge and diff logic.
+Mastra passes `lastSnapshot` and `deltasSinceSnapshot` into `computeStateSignal()`. It resolves them from message history when the current message list doesn't contain the latest snapshot. The processor still owns merge and diff logic.
 
-`contextWindow.hasSnapshot` tells the processor whether the active message window already contains a snapshot for this state lane. If it is `false`, return a fresh `snapshot` so the model sees the current state even after older state messages are trimmed from the context window.
+`contextWindow.hasSnapshot` tells the processor whether the active message window already contains a snapshot for this state lane. If it's `false`, return a fresh `snapshot` so the model sees the current state even after older state messages are trimmed from the context window.
 
 The built-in browser context processor emits state under the `browser` id with snapshot and delta modes.
 
 ## Notification signals
 
-Notification signals represent external events such as GitHub activity, email, Slack mentions, CI status, incidents, recordings, or direct messages. Use `agent.sendNotificationSignal()` for these events when they should create durable inbox records.
+Notification signals represent external events such as GitHub activity, email, Slack mentions, CI status, incidents, recordings, or direct messages. Use `agent.sendNotificationSignal()` when the event should create a durable inbox record.
 
-`sendNotificationSignal()` writes the inbox record before it decides delivery. The record stores the source, kind, priority, payload, resource id, thread id, agent id, coalescing keys, and delivery metadata. After the record is stored, the agent evaluates its notification delivery policy:
+Notification delivery has two phases:
 
-- `deliver` or `queue`: Mastra sends a `type: 'notification'` signal into the normal thread signal runtime, then marks the inbox record as `delivered`.
-- `defer`: Mastra keeps the record `pending` with `deliverAt`.
-- `summarize`: Mastra keeps the record `pending` with `summaryAt` so the dispatcher can include it in a rollup.
-- `persist`: Mastra keeps the record `pending` in the inbox without scheduling delivery.
-- `discard`: Mastra marks the record `discarded` and does not emit a signal.
+- **Ingress**: `agent.sendNotificationSignal()` stores a notification record, then resolves the agent's delivery policy.
+- **Dispatch**: Mastra consumes due records stamped with `deliverAt` or `summaryAt` and emits full notification or summary signals.
+
+A notification record stores the source, kind, priority, summary, payload, resource id, thread id, agent id, coalescing keys, and delivery metadata. The delivery decision controls what happens after ingress:
+
+- `deliver` or `queue`: Emit a full `<notification>` signal and mark the record `delivered`.
+- `defer`: Keep the record `pending` with `deliverAt`.
+- `summarize`: Keep the record `pending` with `summaryAt`, or emit an immediate summary when the policy requests it.
+- `persist`: Keep the record `pending` in the inbox without scheduled delivery.
+- `discard`: Mark the record `discarded` and emit no signal.
 
 The default delivery policy is priority-aware:
 
 | Priority | Active thread | Idle thread |
 | - | - | - |
 | `urgent` | Deliver a full notification immediately | Deliver a full notification immediately |
-| `high` | Batch with `deliverAt` and later deliver each full notification | Deliver a full notification immediately |
+| `high` | Emit a summary immediately, keep `deliverAt`, then deliver the full notification when the thread is idle | Deliver a full notification immediately |
 | `medium` | Batch with `summaryAt` and later deliver one notification summary | Deliver a full notification immediately |
-| `low` | Batch with `summaryAt` and later deliver one notification summary | Batch with `summaryAt` and later deliver one notification summary |
-
-Low-priority notifications avoid interrupting the current run, but they still schedule a summary so the agent can learn that inbox records are waiting.
+| `low` | Batch with `summaryAt` and later deliver one notification summary | Batch with `summaryAt` and later deliver one notification summary without waking the model loop |
 
 ```typescript title="src/mastra/notifications.ts"
 await agent.sendNotificationSignal(
@@ -355,13 +358,21 @@ await agent.sendNotificationSignal(
 )
 ```
 
-The model receives immediate notifications as context:
+The model receives full notifications as context:
 
 ```xml
-<notification source="github" type="ci-status" priority="high">CI failed on main: 3 tests failed.</notification>
+<notification source="github" type="ci-status" priority="high" status="delivered">CI failed on main: 3 tests failed.</notification>
 ```
 
-Configure a delivery policy on the agent when some notifications should wait for a scheduled dispatch window or summary rollup.
+Notification summaries tell the model that inbox records are waiting:
+
+```xml
+<notification-summary pending="10">github: 3, email: 5, slack: 2</notification-summary>
+```
+
+When Mastra emits a summary, it clears `summaryAt` and sets `summarySignalId` on each summarized record. The records stay pending and readable. When Mastra emits a full notification, it sets `deliveredSignalId` and marks the record `delivered`. If the inbox tool reads a notification first, it can inject the full notification signal and mark the record `seen`, which prevents duplicate full delivery.
+
+Configure a delivery policy on the agent when some notifications should wait for a different dispatch window or summary rollup.
 
 ```typescript title="src/mastra/agents/support-agent.ts"
 export const supportAgent = new Agent({
@@ -403,13 +414,40 @@ export const mastra = new Mastra({
 })
 ```
 
-When deferred records are due, Mastra emits each record as its own full `notification` signal. When summary records are due, Mastra emits one `notification-summary` signal for each `agentId`, `resourceId`, and `threadId` group. The summary metadata includes the inbox record ids, so agents and tools can inspect the full records later.
+`notifications.dispatch.enabled` registers an internal workflow with the default cron `*/1 * * * *`. The dispatcher reads due notification records from storage, groups summaries by `agentId`, `resourceId`, and `threadId`, and emits signals through the Agent thread runtime. It isn't a user-facing entrypoint.
 
-```xml
-<notification-summary pending="10">github: 3, email: 5, slack: 2</notification-summary>
+### Notification inbox tool
+
+Use `createNotificationInboxTool()` to give agents one tool for inbox actions instead of many CRUD tools.
+
+```typescript title="src/mastra/agents/support-agent.ts"
+import { createNotificationInboxTool } from '@mastra/core/notifications'
+
+const notificationsStorage = await storage.getStore('notifications')
+
+export const supportAgent = new Agent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: 'Help the user triage updates.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  tools: {
+    notificationInbox: createNotificationInboxTool({ storage: notificationsStorage }),
+  },
+})
 ```
 
-Use `createNotificationInboxTool()` to give agents one flexible tool for `list`, `read`, `markSeen`, `dismiss`, `archive`, and `search` actions instead of many small CRUD tools. Source, resource, and agent ids are filters or routing metadata; `threadId` remains the primary inbox scope.
+The tool id is `notification-inbox`. It supports these actions:
+
+- `list`: List notifications for the current thread.
+- `read`: Deliver readable full notification signals into the chat when possible, then mark records `seen`.
+- `markSeen`: Mark one record `seen`.
+- `dismiss`: Mark one record `dismissed`.
+- `archive`: Mark one record `archived`.
+- `search`: Search notification summaries in the current thread.
+
+The tool uses the current `threadId` from the tool execution context unless one is provided. Use `read` after a `<notification-summary>` signal when the agent needs the full records behind the summary. The `read` result reports how many notifications will be delivered; it doesn't use normal tool output as the main context channel for the notification contents.
+
+`sendNotificationSignal()` requires a storage domain with `notifications` support. LibSQL supports notifications. Other storage adapters need matching notification domain support before they can store notification records.
 
 Use `sendSignal({ type: 'notification' })` only for lower-level notification-shaped context that should bypass inbox storage.
 

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -155,7 +155,7 @@ The model receives this as:
 <user name="Devin" from="slack">Can we simplify the API surface?</user>
 ```
 
-The UI sees just the message contents but can also read `attributes` and `metadata` off the signal message for custom rendering (e.g. showing user names, avatars, or platform badges).
+The UI sees the message contents and can also read `attributes` and `metadata` off the signal message for custom rendering (e.g. showing user names, avatars, or platform badges).
 
 ### `sendMessage(message, options)`
 
@@ -370,9 +370,9 @@ const result = await agent.sendNotificationSignal(
 ]}
 />
 
-Returns `{ accepted: true, record: NotificationRecord, decision: NotificationDeliveryDecision, runId?: string, signal?: CreatedAgentSignal, persisted?: Promise<void> }`. `signal` and `runId` are present for immediate delivery decisions. Deferred, summarized, persisted, and discarded notifications return the stored record and decision without starting a stream.
+Returns `{ accepted: true, record: NotificationRecord, decision: NotificationDeliveryDecision, runId?: string, signal?: CreatedAgentSignal, persisted?: Promise<void> }`. `record` is the stored inbox record. `decision` is the delivery-policy result. `signal` and `runId` are present when ingress emits a signal immediately, including the immediate summary emitted for active high-priority notifications. `persisted` is present when the emitted signal is persisted without waking an idle thread.
 
-Default delivery is priority-aware. `urgent` notifications deliver immediately. `high` notifications deliver immediately when the thread is idle and batch as full notifications when the thread is active. `medium` notifications deliver immediately when idle and batch into summaries when active. `low` notifications batch into summaries when active and stay inbox-only when idle.
+Default delivery is priority-aware. `urgent` notifications deliver immediately. `high` notifications deliver immediately when the thread is idle; when the thread is active, Mastra emits a summary immediately and keeps `deliverAt` for later full delivery when the thread is idle. `medium` notifications deliver immediately when idle and batch into summaries when active. `low` notifications batch into summaries in both active and idle threads; idle low-priority summaries reach subscribers without waking the model loop. For the full flow, visit [Signals](/docs/agents/signals#notification-signals).
 
 ### `subscribeToThread(options)`
 
@@ -488,7 +488,7 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
     type: '{ deliveryPolicy?: NotificationDeliveryPolicyConfig }',
     isOptional: true,
     description:
-      'Notification delivery configuration for `sendNotificationSignal()`. The policy can return `deliver`, `queue`, `defer`, `summarize`, `persist`, or `discard` decisions.',
+      'Notification delivery configuration for `sendNotificationSignal()`. `deliveryPolicy` can define `decide`, `sources`, `priorities`, or `default` rules that return `deliver`, `queue`, `defer`, `summarize`, `persist`, or `discard` decisions.',
   },
   {
     name: 'workflows',

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -195,7 +195,7 @@ await agent.queueMessage({
 
 ### `sendSignal()`
 
-Send a lower-level signal to an active agent run or memory thread. Use this for system-generated context such as reactive reminders or notifications. For user-authored input, prefer `sendMessage()` or `queueMessage()`.
+Send a lower-level signal to an active agent run or memory thread. Use this for system-generated context such as reactive reminders or notification-shaped context that doesn't need inbox storage. For durable notification records, use the server-side [`Agent.sendNotificationSignal()`](/reference/agents/agent#sendnotificationsignalnotification-options) API. For user-authored input, prefer `sendMessage()` or `queueMessage()`.
 
 ```typescript
 const agent = mastraClient.getAgent('support-agent')
@@ -293,7 +293,7 @@ Returns `{ accepted: true, runId: string }`.
 
 ### `subscribeToThread()`
 
-Subscribe to raw stream chunks for a memory thread. Use this to render output from a thread that may be started or continued by `sendMessage()`, `queueMessage()`, or `sendSignal()`.
+Subscribe to raw stream chunks for a memory thread. Use this to render output from a thread that may be started or continued by `sendMessage()`, `queueMessage()`, `sendSignal()`, or server-side notification dispatch.
 
 ```typescript
 const agent = mastraClient.getAgent('support-agent')


### PR DESCRIPTION
This tightens the notification signal docs to match the final stack 6 implementation.

It explains notification signals as a record-first API: `sendNotificationSignal()` stores a durable record, the delivery policy stamps due work, and dispatch emits either full notification signals or summary signals. It also clarifies inbox `read` behavior and the current storage requirement.

After:

```ts
await agent.sendNotificationSignal(notification, {
  resourceId: 'user_123',
  threadId: 'thread_456',
})
```

High-priority notifications now document the actual behavior: active threads get an immediate summary and keep `deliverAt` for later full delivery when idle. Low-priority idle notifications are documented as summarized without waking the model loop.

I also updated the client SDK reference to keep `sendSignal()` as the lower-level signal API and avoid implying there are durable notification client routes in this stack.
