### PR TITLE
feat(storage): add notification storage adapters

### DIFF
--- a/.changeset/breezy-rooms-run.md
+++ b/.changeset/breezy-rooms-run.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+Added notification inbox storage support for MongoDB stores.

--- a/.changeset/lemon-moose-leave.md
+++ b/.changeset/lemon-moose-leave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Added notification inbox storage support for Postgres stores.

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -155,6 +155,10 @@ The model receives the signal as context like this:
 
 Use XML-safe `tagName` and attribute names. They can contain letters, numbers, underscores, periods, and hyphens. They must start with a letter or underscore.
 
+### Storage support
+
+Notification inbox storage is available in the storage adapters that support richer memory and signal workflows: [libSQL](/reference/storage/libsql), [PostgreSQL](/reference/storage/postgresql), and [MongoDB](/reference/storage/mongodb). These adapters expose notification records through `getStore('notifications')`.
+
 ## Send processor context
 
 Processors can send reactive signals during a run. A processor should inspect the chat history, react to a specific trigger, and avoid sending the same context more than once.

--- a/docs/src/content/en/reference/storage/libsql.mdx
+++ b/docs/src/content/en/reference/storage/libsql.mdx
@@ -100,6 +100,12 @@ In-memory storage resets when the process changes. Only suitable for development
 ]}
 />
 
+## Managed tables
+
+The storage implementation creates the core storage tables automatically, including `mastra_notifications` for notification inbox records and delivery metadata.
+
+`LibSQLStore` exposes notification storage through `getStore('notifications')`.
+
 ## Initialization
 
 When you pass storage to the Mastra class, `init()` is called automatically to create the [core schema](/reference/storage/overview#core-schema):

--- a/docs/src/content/en/reference/storage/mongodb.mdx
+++ b/docs/src/content/en/reference/storage/mongodb.mdx
@@ -113,6 +113,9 @@ The storage implementation handles collection creation and management automatica
 - `mastra_traces`: Stores telemetry and tracing data
 - `mastra_scorers`: Stores scoring and evaluation data
 - `mastra_resources`: Stores resource working memory data
+- `mastra_notifications`: Stores notification inbox records and delivery metadata
+
+`MongoDBStore` exposes notification storage through `getStore('notifications')`.
 
 ### Initialization
 

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -191,6 +191,9 @@ The storage implementation handles schema creation and updates automatically. It
 - `mastra_traces`: Stores telemetry and tracing data
 - `mastra_scorers`: Stores scoring and evaluation data
 - `mastra_resources`: Stores resource working memory data
+- `mastra_notifications`: Stores notification inbox records and delivery metadata
+
+`PostgresStore` exposes notification storage through `getStore('notifications')`.
 
 ### Observability
 

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -31,6 +31,7 @@ import {
   TABLE_SCHEDULES,
   TABLE_SCHEDULE_TRIGGERS,
   TABLE_TOOL_PROVIDER_CONNECTIONS,
+  TABLE_NOTIFICATIONS,
 } from '@mastra/core/storage';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
@@ -69,6 +70,7 @@ export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   mastra_background_tasks: `ReplacingMergeTree()`,
   [TABLE_SCHEDULES]: `ReplacingMergeTree()`,
   [TABLE_SCHEDULE_TRIGGERS]: `MergeTree()`,
+  [TABLE_NOTIFICATIONS]: `ReplacingMergeTree()`,
   mastra_channel_installations: `ReplacingMergeTree()`,
   mastra_channel_config: `ReplacingMergeTree()`,
 };

--- a/stores/mongodb/src/storage/domains/notifications/index.test.ts
+++ b/stores/mongodb/src/storage/domains/notifications/index.test.ts
@@ -1,0 +1,394 @@
+import { MongoClient } from 'mongodb';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MongoDBStore } from '../..';
+import type { ConnectorHandler } from '../../connectors/base';
+import { NotificationsMongoDB } from './index';
+
+const TEST_URI = process.env.MONGODB_URL || 'mongodb://localhost:27017';
+const TEST_DB_NAME = process.env.MONGODB_DB_NAME || 'mastra-test-db';
+
+const createConnectorHandler = async (): Promise<{ handler: ConnectorHandler; client: MongoClient }> => {
+  const client = new MongoClient(TEST_URI);
+  await client.connect();
+  const db = client.db(TEST_DB_NAME);
+  return {
+    handler: {
+      getCollection: async (name: string) => db.collection(name),
+      close: async () => client.close(),
+    },
+    client,
+  };
+};
+
+describe('NotificationsMongoDB', () => {
+  let client: MongoClient;
+  let store: NotificationsMongoDB;
+
+  beforeEach(async () => {
+    const setup = await createConnectorHandler();
+    client = setup.client;
+    store = new NotificationsMongoDB({ connectorHandler: setup.handler });
+    await store.init();
+    await store.dangerouslyClearAll();
+  });
+
+  afterEach(async () => {
+    await client?.close();
+  });
+
+  it('creates, gets, and lists notifications with document fields and dates', async () => {
+    const createdAt = new Date('2026-01-01T00:00:00.000Z');
+    const deliverAt = new Date('2026-01-01T00:05:00.000Z');
+    const summaryAt = new Date('2026-01-01T00:10:00.000Z');
+
+    const created = await store.createNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'mastracode',
+      kind: 'manual',
+      priority: 'high',
+      summary: 'Review the deployment',
+      payload: { nested: { ok: true }, count: 2 },
+      sourceId: 'source-1',
+      dedupeKey: 'dedupe-1',
+      coalesceKey: 'coalesce-1',
+      attributes: { route: '/notify', important: true, count: 2 },
+      metadata: { origin: { command: 'notify' } },
+      deliverAt,
+      summaryAt,
+      deliveryReason: 'test-reason',
+      createdAt,
+    });
+
+    expect(created.id).toBe('n1');
+    expect(created.createdAt.toISOString()).toBe(createdAt.toISOString());
+    expect(created.deliverAt?.toISOString()).toBe(deliverAt.toISOString());
+    expect(created.summaryAt?.toISOString()).toBe(summaryAt.toISOString());
+    expect(created.payload).toEqual({ nested: { ok: true }, count: 2 });
+    expect(created.attributes).toEqual({ route: '/notify', important: true, count: 2 });
+    expect(created.metadata).toEqual({ origin: { command: 'notify' } });
+
+    const fetched = await store.getNotification({ threadId: 'thread-1', id: 'n1' });
+    expect(fetched).toMatchObject({
+      id: 'n1',
+      threadId: 'thread-1',
+      source: 'mastracode',
+      kind: 'manual',
+      priority: 'high',
+      status: 'pending',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      sourceId: 'source-1',
+      dedupeKey: 'dedupe-1',
+      coalesceKey: 'coalesce-1',
+      coalescedCount: 1,
+      deliveryReason: 'test-reason',
+    });
+    expect(fetched?.payload).toEqual({ nested: { ok: true }, count: 2 });
+    expect(fetched?.createdAt).toBeInstanceOf(Date);
+
+    const listed = await store.listNotifications({ threadId: 'thread-1' });
+    expect(listed.map(record => record.id)).toEqual(['n1']);
+  });
+
+  it('filters notifications by status, priority, source, resource, agent, search, and limit', async () => {
+    await store.createNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'mastracode',
+      kind: 'manual',
+      priority: 'high',
+      summary: 'Release blocker',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'n2',
+      threadId: 'thread-1',
+      resourceId: 'resource-2',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'pull-request',
+      priority: 'low',
+      summary: 'Pull request comment',
+      createdAt: new Date('2026-01-01T00:01:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'n3',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-2',
+      source: 'mastracode',
+      kind: 'reminder',
+      priority: 'medium',
+      summary: 'Daily standup',
+      createdAt: new Date('2026-01-01T00:02:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'other-thread',
+      threadId: 'thread-2',
+      source: 'mastracode',
+      kind: 'manual',
+      summary: 'Other thread',
+    });
+
+    await store.updateNotification({ threadId: 'thread-1', id: 'n2', status: 'delivered' });
+
+    await expectIds({ threadId: 'thread-1', status: 'delivered' }, ['n2']);
+    await expectIds({ threadId: 'thread-1', priority: ['high', 'medium'] }, ['n3', 'n1']);
+    await expectIds({ threadId: 'thread-1', source: 'mastracode' }, ['n3', 'n1']);
+    await expectIds({ threadId: 'thread-1', resourceId: 'resource-1' }, ['n3', 'n1']);
+    await expectIds({ threadId: 'thread-1', agentId: 'agent-2' }, ['n3']);
+    await expectIds({ threadId: 'thread-1', search: 'stand' }, ['n3']);
+    expect(await store.listNotifications({ threadId: 'thread-1', limit: 1 })).toHaveLength(1);
+  });
+
+  it('coalesces pending notifications by dedupeKey or coalesceKey within matching scope', async () => {
+    const first = await store.createNotification({
+      id: 'dedupe-original',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'comment',
+      priority: 'medium',
+      summary: 'Original comment',
+      dedupeKey: 'same-comment',
+      attributes: { first: true },
+      metadata: { first: true },
+    });
+
+    const coalesced = await store.createNotification({
+      id: 'dedupe-new',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'comment',
+      priority: 'urgent',
+      summary: 'Updated comment',
+      payload: { latest: true },
+      dedupeKey: 'same-comment',
+      attributes: { second: true },
+      metadata: { second: true },
+    });
+
+    expect(coalesced.id).toBe(first.id);
+    expect(coalesced.summary).toBe('Updated comment');
+    expect(coalesced.priority).toBe('urgent');
+    expect(coalesced.payload).toEqual({ latest: true });
+    expect(coalesced.attributes).toEqual({ first: true, second: true });
+    expect(coalesced.metadata).toEqual({ first: true, second: true });
+    expect(coalesced.coalescedCount).toBe(2);
+
+    const differentAgent = await store.createNotification({
+      id: 'dedupe-other-agent',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-2',
+      source: 'github',
+      kind: 'comment',
+      summary: 'Different agent',
+      dedupeKey: 'same-comment',
+    });
+    expect(differentAgent.id).toBe('dedupe-other-agent');
+
+    const group = await store.createNotification({
+      id: 'coalesce-original',
+      threadId: 'thread-1',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Build 1 failed',
+      coalesceKey: 'build-failures',
+    });
+    const grouped = await store.createNotification({
+      id: 'coalesce-new',
+      threadId: 'thread-1',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Build 2 failed',
+      coalesceKey: 'build-failures',
+    });
+    expect(grouped.id).toBe(group.id);
+    expect(grouped.coalescedCount).toBe(2);
+  });
+
+  it('updates status timestamps and delivery metadata', async () => {
+    await store.createNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      source: 'mastracode',
+      kind: 'manual',
+      summary: 'Ship it',
+    });
+
+    const deliverAt = new Date('2026-01-01T00:05:00.000Z');
+    const summaryAt = new Date('2026-01-01T00:10:00.000Z');
+    const lastDeliveryAttemptAt = new Date('2026-01-01T00:15:00.000Z');
+
+    const updated = await store.updateNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      status: 'delivered',
+      summary: 'Delivered notification',
+      payload: { delivered: true },
+      attributes: { channel: 'thread' },
+      metadata: { attempt: 1 },
+      deliverAt,
+      summaryAt,
+      deliveryReason: 'urgent',
+      deliveryAttempts: 2,
+      lastDeliveryAttemptAt,
+      lastDeliveryError: 'temporary failure',
+      deliveredSignalId: 'signal-1',
+      summarySignalId: 'summary-1',
+    });
+
+    expect(updated.status).toBe('delivered');
+    expect(updated.deliveredAt).toBeInstanceOf(Date);
+    expect(updated.summary).toBe('Delivered notification');
+    expect(updated.payload).toEqual({ delivered: true });
+    expect(updated.attributes).toEqual({ channel: 'thread' });
+    expect(updated.metadata).toEqual({ attempt: 1 });
+    expect(updated.deliverAt?.toISOString()).toBe(deliverAt.toISOString());
+    expect(updated.summaryAt?.toISOString()).toBe(summaryAt.toISOString());
+    expect(updated.deliveryReason).toBe('urgent');
+    expect(updated.deliveryAttempts).toBe(2);
+    expect(updated.lastDeliveryAttemptAt?.toISOString()).toBe(lastDeliveryAttemptAt.toISOString());
+    expect(updated.lastDeliveryError).toBe('temporary failure');
+    expect(updated.deliveredSignalId).toBe('signal-1');
+    expect(updated.summarySignalId).toBe('summary-1');
+  });
+
+  it('lists due pending notifications sorted by earliest due time with agent/resource filters and limit', async () => {
+    const now = new Date('2026-01-01T12:00:00.000Z');
+
+    await store.createNotification({
+      id: 'due-deliver',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'mastracode',
+      kind: 'manual',
+      summary: 'Deliver due',
+      deliverAt: new Date('2026-01-01T11:50:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'due-summary',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'comment',
+      summary: 'Summary due',
+      summaryAt: new Date('2026-01-01T11:55:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'due-earliest',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Earliest due',
+      deliverAt: new Date('2026-01-01T11:40:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'future',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Future',
+      deliverAt: new Date('2026-01-01T12:10:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'other-agent',
+      threadId: 'thread-1',
+      resourceId: 'resource-2',
+      agentId: 'agent-2',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Other agent due',
+      deliverAt: new Date('2026-01-01T11:45:00.000Z'),
+    });
+    await store.updateNotification({ threadId: 'thread-1', id: 'other-agent', status: 'seen' });
+
+    const due = await store.listDueNotifications({ now });
+    expect(due.map(record => record.id)).toEqual(['due-earliest', 'due-deliver', 'due-summary']);
+
+    const limited = await store.listDueNotifications({ now, limit: 2 });
+    expect(limited.map(record => record.id)).toEqual(['due-earliest', 'due-deliver']);
+
+    const filtered = await store.listDueNotifications({ now, agentId: 'agent-1', resourceId: 'resource-1' });
+    expect(filtered.map(record => record.id)).toEqual(['due-earliest', 'due-deliver', 'due-summary']);
+  });
+
+  it('clears summaryAt while preserving deliverAt and due ordering after summary dispatch metadata updates', async () => {
+    const now = new Date('2026-01-01T12:00:00.000Z');
+    const deliverAt = new Date('2026-01-01T12:00:00.000Z');
+    const summaryAt = new Date('2026-01-01T11:55:00.000Z');
+    await store.createNotification({
+      id: 'summary-then-deliver',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'ci-status',
+      priority: 'high',
+      summary: 'Summarized then delivered',
+      deliverAt,
+      summaryAt,
+    });
+
+    const updated = await store.updateNotification({
+      id: 'summary-then-deliver',
+      threadId: 'thread-1',
+      summaryAt: null,
+      summarySignalId: 'summary-signal-1',
+    });
+
+    expect(updated.status).toBe('pending');
+    expect(updated.summaryAt).toBeUndefined();
+    expect(updated.deliverAt?.toISOString()).toBe(deliverAt.toISOString());
+    expect(updated.summarySignalId).toBe('summary-signal-1');
+
+    const due = await store.listDueNotifications({ now });
+    expect(due.map(record => record.id)).toEqual(['summary-then-deliver']);
+    expect(due[0]?.summaryAt).toBeUndefined();
+    expect(due[0]?.deliverAt?.toISOString()).toBe(deliverAt.toISOString());
+  });
+
+  it('exposes notifications through MongoDBStore', async () => {
+    const composite = new MongoDBStore({ id: 'mongodb-notifications-composite', uri: TEST_URI, dbName: TEST_DB_NAME });
+    try {
+      await composite.init();
+      const notifications = await composite.getStore('notifications');
+      expect(notifications).toBeDefined();
+      await notifications!.dangerouslyClearAll();
+      const record = await notifications!.createNotification({
+        id: 'composite-notification',
+        threadId: 'thread-1',
+        source: 'mastracode',
+        kind: 'manual',
+        summary: 'Composite notification',
+      });
+      expect(record.id).toBe('composite-notification');
+      await expect(
+        notifications!.getNotification({ threadId: 'thread-1', id: 'composite-notification' }),
+      ).resolves.toMatchObject({ summary: 'Composite notification' });
+    } finally {
+      await composite.close();
+    }
+  });
+
+  async function expectIds(input: Parameters<NotificationsMongoDB['listNotifications']>[0], ids: string[]) {
+    const records = await store.listNotifications(input);
+    expect(records.map(record => record.id)).toEqual(ids);
+  }
+});

--- a/stores/mongodb/src/storage/domains/notifications/index.ts
+++ b/stores/mongodb/src/storage/domains/notifications/index.ts
@@ -1,0 +1,354 @@
+import { randomUUID } from 'node:crypto';
+
+import { NotificationsStorage, TABLE_NOTIFICATIONS } from '@mastra/core/storage';
+import type {
+  CreateNotificationInput,
+  ListDueNotificationsInput,
+  ListNotificationsInput,
+  NotificationPriority,
+  NotificationRecord,
+  NotificationSignalAttributes,
+  NotificationStatus,
+  UpdateNotificationInput,
+} from '@mastra/core/storage';
+import type { Collection, Filter, UpdateFilter } from 'mongodb';
+
+import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
+import { resolveMongoDBConfig } from '../../db';
+import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';
+
+const statusTimestamp = (status: NotificationStatus, now: Date) => {
+  if (status === 'delivered') return { deliveredAt: now };
+  if (status === 'seen') return { seenAt: now };
+  if (status === 'dismissed') return { dismissedAt: now };
+  if (status === 'archived') return { archivedAt: now };
+  if (status === 'discarded') return { discardedAt: now };
+  return {};
+};
+
+const cloneDate = (value?: Date) => (value ? new Date(value) : undefined);
+
+const cloneRecord = (record: NotificationRecord): NotificationRecord => ({
+  ...record,
+  createdAt: new Date(record.createdAt),
+  updatedAt: new Date(record.updatedAt),
+  deliveredAt: cloneDate(record.deliveredAt),
+  seenAt: cloneDate(record.seenAt),
+  dismissedAt: cloneDate(record.dismissedAt),
+  archivedAt: cloneDate(record.archivedAt),
+  discardedAt: cloneDate(record.discardedAt),
+  deliverAt: cloneDate(record.deliverAt),
+  summaryAt: cloneDate(record.summaryAt),
+  lastDeliveryAttemptAt: cloneDate(record.lastDeliveryAttemptAt),
+  attributes: record.attributes ? { ...record.attributes } : undefined,
+  metadata: record.metadata ? { ...record.metadata } : undefined,
+});
+
+function rowToNotification(row: Record<string, any>): NotificationRecord {
+  return {
+    id: row.id,
+    threadId: row.threadId,
+    source: row.source,
+    kind: row.kind,
+    priority: row.priority as NotificationPriority,
+    status: row.status as NotificationStatus,
+    summary: row.summary,
+    payload: row.payload ?? undefined,
+    resourceId: row.resourceId ?? undefined,
+    agentId: row.agentId ?? undefined,
+    sourceId: row.sourceId ?? undefined,
+    dedupeKey: row.dedupeKey ?? undefined,
+    coalesceKey: row.coalesceKey ?? undefined,
+    coalescedCount: Number(row.coalescedCount ?? 1),
+    attributes: row.attributes as NotificationSignalAttributes | undefined,
+    createdAt: row.createdAt instanceof Date ? row.createdAt : new Date(row.createdAt),
+    updatedAt: row.updatedAt instanceof Date ? row.updatedAt : new Date(row.updatedAt),
+    deliveredAt: row.deliveredAt
+      ? row.deliveredAt instanceof Date
+        ? row.deliveredAt
+        : new Date(row.deliveredAt)
+      : undefined,
+    seenAt: row.seenAt ? (row.seenAt instanceof Date ? row.seenAt : new Date(row.seenAt)) : undefined,
+    dismissedAt: row.dismissedAt
+      ? row.dismissedAt instanceof Date
+        ? row.dismissedAt
+        : new Date(row.dismissedAt)
+      : undefined,
+    archivedAt: row.archivedAt
+      ? row.archivedAt instanceof Date
+        ? row.archivedAt
+        : new Date(row.archivedAt)
+      : undefined,
+    discardedAt: row.discardedAt
+      ? row.discardedAt instanceof Date
+        ? row.discardedAt
+        : new Date(row.discardedAt)
+      : undefined,
+    deliverAt: row.deliverAt ? (row.deliverAt instanceof Date ? row.deliverAt : new Date(row.deliverAt)) : undefined,
+    summaryAt: row.summaryAt ? (row.summaryAt instanceof Date ? row.summaryAt : new Date(row.summaryAt)) : undefined,
+    deliveryReason: row.deliveryReason ?? undefined,
+    deliveryAttempts: Number(row.deliveryAttempts ?? 0),
+    lastDeliveryAttemptAt: row.lastDeliveryAttemptAt
+      ? row.lastDeliveryAttemptAt instanceof Date
+        ? row.lastDeliveryAttemptAt
+        : new Date(row.lastDeliveryAttemptAt)
+      : undefined,
+    lastDeliveryError: row.lastDeliveryError ?? undefined,
+    deliveredSignalId: row.deliveredSignalId ?? undefined,
+    summarySignalId: row.summarySignalId ?? undefined,
+    metadata: row.metadata ?? undefined,
+  };
+}
+
+function recordToDocument(record: NotificationRecord): Record<string, unknown> {
+  return {
+    ...record,
+    payload: record.payload ?? null,
+    resourceId: record.resourceId ?? null,
+    agentId: record.agentId ?? null,
+    sourceId: record.sourceId ?? null,
+    dedupeKey: record.dedupeKey ?? null,
+    coalesceKey: record.coalesceKey ?? null,
+    attributes: record.attributes ?? null,
+    deliveredAt: record.deliveredAt ?? null,
+    seenAt: record.seenAt ?? null,
+    dismissedAt: record.dismissedAt ?? null,
+    archivedAt: record.archivedAt ?? null,
+    discardedAt: record.discardedAt ?? null,
+    deliverAt: record.deliverAt ?? null,
+    summaryAt: record.summaryAt ?? null,
+    deliveryReason: record.deliveryReason ?? null,
+    lastDeliveryAttemptAt: record.lastDeliveryAttemptAt ?? null,
+    lastDeliveryError: record.lastDeliveryError ?? null,
+    deliveredSignalId: record.deliveredSignalId ?? null,
+    summarySignalId: record.summarySignalId ?? null,
+    metadata: record.metadata ?? null,
+  };
+}
+
+export class NotificationsMongoDB extends NotificationsStorage {
+  #connector: MongoDBConnector;
+  #skipDefaultIndexes?: boolean;
+  #indexes?: MongoDBIndexConfig[];
+
+  static readonly MANAGED_COLLECTIONS = [TABLE_NOTIFICATIONS] as const;
+
+  constructor(config: MongoDBDomainConfig) {
+    super();
+    this.#connector = resolveMongoDBConfig(config);
+    this.#skipDefaultIndexes = config.skipDefaultIndexes;
+    this.#indexes = config.indexes?.filter(idx =>
+      (NotificationsMongoDB.MANAGED_COLLECTIONS as readonly string[]).includes(idx.collection),
+    );
+  }
+
+  private async getCollection(): Promise<Collection<Record<string, any>>> {
+    return this.#connector.getCollection(TABLE_NOTIFICATIONS);
+  }
+
+  async init(): Promise<void> {
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  getDefaultIndexDefinitions(): MongoDBIndexConfig[] {
+    return [
+      { collection: TABLE_NOTIFICATIONS, keys: { id: 1 }, options: { unique: true } },
+      { collection: TABLE_NOTIFICATIONS, keys: { threadId: 1, status: 1, updatedAt: -1 } },
+      {
+        collection: TABLE_NOTIFICATIONS,
+        keys: { threadId: 1, source: 1, status: 1, agentId: 1, resourceId: 1, dedupeKey: 1, coalesceKey: 1 },
+      },
+      { collection: TABLE_NOTIFICATIONS, keys: { status: 1, deliverAt: 1, summaryAt: 1 } },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.#skipDefaultIndexes) return;
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      try {
+        const collection = await this.#connector.getCollection(indexDef.collection);
+        await collection.createIndex(indexDef.keys, indexDef.options);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create index on ${indexDef.collection}:`, error);
+      }
+    }
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.#indexes || this.#indexes.length === 0) return;
+    for (const indexDef of this.#indexes) {
+      try {
+        const collection = await this.#connector.getCollection(indexDef.collection);
+        await collection.createIndex(indexDef.keys, indexDef.options);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create custom index on ${indexDef.collection}:`, error);
+      }
+    }
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    const collection = await this.getCollection();
+    await collection.deleteMany({});
+  }
+
+  async createNotification(input: CreateNotificationInput): Promise<NotificationRecord> {
+    const existing = await this.findCoalescable(input);
+    const collection = await this.getCollection();
+
+    if (existing) {
+      const now = new Date();
+      const attributes = input.attributes ? { ...existing.attributes, ...input.attributes } : existing.attributes;
+      const metadata = input.metadata ? { ...existing.metadata, ...input.metadata } : existing.metadata;
+      await collection.updateOne(
+        { id: existing.id },
+        {
+          $set: {
+            summary: input.summary,
+            payload: input.payload ?? existing.payload ?? null,
+            priority: input.priority ?? existing.priority,
+            attributes: attributes ?? null,
+            updatedAt: now,
+            deliverAt: input.deliverAt ?? existing.deliverAt ?? null,
+            summaryAt: input.summaryAt ?? existing.summaryAt ?? null,
+            deliveryReason: input.deliveryReason ?? existing.deliveryReason ?? null,
+            metadata: metadata ?? null,
+          },
+          $inc: { coalescedCount: 1 },
+        },
+      );
+      const updated = await this.getNotification({ threadId: existing.threadId, id: existing.id });
+      if (!updated) throw new Error(`Notification ${existing.id} was not found for thread ${existing.threadId}`);
+      return updated;
+    }
+
+    const now = input.createdAt ?? new Date();
+    const record: NotificationRecord = {
+      id: input.id ?? randomUUID(),
+      threadId: input.threadId,
+      source: input.source,
+      kind: input.kind,
+      priority: input.priority ?? 'medium',
+      status: 'pending',
+      summary: input.summary,
+      payload: input.payload,
+      resourceId: input.resourceId,
+      agentId: input.agentId,
+      sourceId: input.sourceId,
+      dedupeKey: input.dedupeKey,
+      coalesceKey: input.coalesceKey,
+      coalescedCount: 1,
+      attributes: input.attributes ? { ...input.attributes } : undefined,
+      createdAt: now,
+      updatedAt: now,
+      deliverAt: input.deliverAt,
+      summaryAt: input.summaryAt,
+      deliveryReason: input.deliveryReason,
+      deliveryAttempts: 0,
+      metadata: input.metadata ? { ...input.metadata } : undefined,
+    };
+
+    await collection.insertOne(recordToDocument(record));
+    return cloneRecord(record);
+  }
+
+  async listNotifications(input: ListNotificationsInput): Promise<NotificationRecord[]> {
+    const filter: Filter<Record<string, any>> = { threadId: input.threadId };
+    if (input.status) filter.status = Array.isArray(input.status) ? { $in: input.status } : input.status;
+    if (input.priority) filter.priority = Array.isArray(input.priority) ? { $in: input.priority } : input.priority;
+    if (input.source) filter.source = input.source;
+    if (input.resourceId) filter.resourceId = input.resourceId;
+    if (input.agentId) filter.agentId = input.agentId;
+    if (input.search) {
+      const search = input.search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      filter.$or = [{ summary: { $regex: search, $options: 'i' } }, { kind: { $regex: search, $options: 'i' } }];
+    }
+
+    const collection = await this.getCollection();
+    const cursor = collection.find(filter).sort({ updatedAt: -1 });
+    if (input.limit) cursor.limit(input.limit);
+    const rows = await cursor.toArray();
+    return rows.map(row => rowToNotification(row));
+  }
+
+  async listDueNotifications(input: ListDueNotificationsInput): Promise<NotificationRecord[]> {
+    const filter: Filter<Record<string, any>> = {
+      status: 'pending',
+      $or: [{ deliverAt: { $ne: null, $lte: input.now } }, { summaryAt: { $ne: null, $lte: input.now } }],
+    };
+    if (input.agentId) filter.agentId = input.agentId;
+    if (input.resourceId) filter.resourceId = input.resourceId;
+
+    const collection = await this.getCollection();
+    const rows = await collection.find(filter).sort({ updatedAt: 1 }).toArray();
+    const due = rows
+      .map(row => rowToNotification(row))
+      .sort((a, b) => dueTime(a) - dueTime(b) || a.updatedAt.getTime() - b.updatedAt.getTime());
+    return due.slice(0, input.limit ?? due.length).map(cloneRecord);
+  }
+
+  async getNotification(input: { threadId: string; id: string }): Promise<NotificationRecord | null> {
+    const collection = await this.getCollection();
+    const row = await collection.findOne({ threadId: input.threadId, id: input.id });
+    return row ? rowToNotification(row) : null;
+  }
+
+  async updateNotification(input: UpdateNotificationInput): Promise<NotificationRecord> {
+    const existing = await this.getNotification({ threadId: input.threadId, id: input.id });
+    if (!existing) {
+      throw new Error(`Notification ${input.id} was not found for thread ${input.threadId}`);
+    }
+
+    const now = new Date();
+    const set: Record<string, unknown> = {
+      ...(input.status ? { status: input.status, ...statusTimestamp(input.status, now) } : {}),
+      ...(input.summary !== undefined ? { summary: input.summary } : {}),
+      ...(input.payload !== undefined ? { payload: input.payload } : {}),
+      ...(input.attributes !== undefined ? { attributes: input.attributes } : {}),
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+      ...(input.deliverAt !== undefined ? { deliverAt: input.deliverAt } : {}),
+      ...(input.summaryAt !== undefined ? { summaryAt: input.summaryAt } : {}),
+      ...(input.deliveryReason !== undefined ? { deliveryReason: input.deliveryReason } : {}),
+      ...(input.deliveryAttempts !== undefined ? { deliveryAttempts: input.deliveryAttempts } : {}),
+      ...(input.lastDeliveryAttemptAt !== undefined ? { lastDeliveryAttemptAt: input.lastDeliveryAttemptAt } : {}),
+      ...(input.lastDeliveryError !== undefined ? { lastDeliveryError: input.lastDeliveryError } : {}),
+      ...(input.deliveredSignalId !== undefined ? { deliveredSignalId: input.deliveredSignalId } : {}),
+      ...(input.summarySignalId !== undefined ? { summarySignalId: input.summarySignalId } : {}),
+      updatedAt: now,
+    };
+
+    const collection = await this.getCollection();
+    await collection.updateOne({ id: input.id }, { $set: set } as UpdateFilter<Record<string, any>>);
+
+    const updated = await this.getNotification({ threadId: input.threadId, id: input.id });
+    if (!updated) throw new Error(`Notification ${input.id} was not found for thread ${input.threadId}`);
+    return updated;
+  }
+
+  private async findCoalescable(input: CreateNotificationInput): Promise<NotificationRecord | undefined> {
+    if (!input.dedupeKey && !input.coalesceKey) return undefined;
+    const collection = await this.getCollection();
+    const row = await collection.findOne(
+      {
+        threadId: input.threadId,
+        source: input.source,
+        status: 'pending',
+        agentId: input.agentId ?? null,
+        resourceId: input.resourceId ?? null,
+        $or: [
+          ...(input.dedupeKey ? [{ dedupeKey: input.dedupeKey }] : []),
+          ...(input.coalesceKey ? [{ coalesceKey: input.coalesceKey }] : []),
+        ],
+      },
+      { sort: { updatedAt: -1 } },
+    );
+    return row ? rowToNotification(row) : undefined;
+  }
+}
+
+const dueTime = (record: NotificationRecord): number => {
+  const deliverAt = record.deliverAt?.getTime();
+  const summaryAt = record.summaryAt?.getTime();
+  if (deliverAt !== undefined && summaryAt !== undefined) return Math.min(deliverAt, summaryAt);
+  return deliverAt ?? summaryAt ?? Number.POSITIVE_INFINITY;
+};

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -11,6 +11,7 @@ import { MongoDBExperimentsStorage } from './domains/experiments';
 import { MongoDBMCPClientsStorage } from './domains/mcp-clients';
 import { MongoDBMCPServersStorage } from './domains/mcp-servers';
 import { MemoryStorageMongoDB } from './domains/memory';
+import { NotificationsMongoDB } from './domains/notifications';
 import { ObservabilityMongoDB } from './domains/observability';
 import { MongoDBPromptBlocksStorage } from './domains/prompt-blocks';
 import { SchedulesMongoDB } from './domains/schedules';
@@ -31,6 +32,7 @@ export {
   MongoDBMCPClientsStorage,
   MongoDBMCPServersStorage,
   MemoryStorageMongoDB,
+  NotificationsMongoDB,
   MongoDBPromptBlocksStorage,
   SchedulesMongoDB,
   MongoDBScorerDefinitionsStorage,
@@ -78,6 +80,8 @@ export class MongoDBStore extends MastraCompositeStore {
 
     const memory = new MemoryStorageMongoDB(domainConfig);
 
+    const notifications = new NotificationsMongoDB(domainConfig);
+
     const scores = new ScoresStorageMongoDB(domainConfig);
 
     const workflows = new WorkflowsStorageMongoDB(domainConfig);
@@ -110,6 +114,7 @@ export class MongoDBStore extends MastraCompositeStore {
 
     this.stores = {
       memory,
+      notifications,
       scores,
       workflows,
       observability,

--- a/stores/pg/src/storage/domains/notifications/index.test.ts
+++ b/stores/pg/src/storage/domains/notifications/index.test.ts
@@ -1,0 +1,385 @@
+import { TABLE_NOTIFICATIONS } from '@mastra/core/storage';
+import { Pool } from 'pg';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { exportSchemas, PostgresStore } from '../..';
+import { connectionString } from '../../test-utils';
+import { NotificationsPG } from './index';
+
+const createTestPool = () => new Pool({ connectionString });
+
+describe('NotificationsPG', () => {
+  let pool: Pool;
+  let store: NotificationsPG;
+
+  beforeEach(async () => {
+    pool = createTestPool();
+    store = new NotificationsPG({ pool });
+    await store.init();
+    await store.dangerouslyClearAll();
+  });
+
+  afterEach(async () => {
+    await pool?.end();
+  });
+
+  it('creates, gets, and lists notifications with JSON fields and dates', async () => {
+    const createdAt = new Date('2026-01-01T00:00:00.000Z');
+    const deliverAt = new Date('2026-01-01T00:05:00.000Z');
+    const summaryAt = new Date('2026-01-01T00:10:00.000Z');
+
+    const created = await store.createNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'mastracode',
+      kind: 'manual',
+      priority: 'high',
+      summary: 'Review the deployment',
+      payload: { nested: { ok: true }, count: 2 },
+      sourceId: 'source-1',
+      dedupeKey: 'dedupe-1',
+      coalesceKey: 'coalesce-1',
+      attributes: { route: '/notify', important: true, count: 2 },
+      metadata: { origin: { command: 'notify' } },
+      deliverAt,
+      summaryAt,
+      deliveryReason: 'test-reason',
+      createdAt,
+    });
+
+    expect(created.id).toBe('n1');
+    expect(created.createdAt.toISOString()).toBe(createdAt.toISOString());
+    expect(created.deliverAt?.toISOString()).toBe(deliverAt.toISOString());
+    expect(created.summaryAt?.toISOString()).toBe(summaryAt.toISOString());
+    expect(created.payload).toEqual({ nested: { ok: true }, count: 2 });
+    expect(created.attributes).toEqual({ route: '/notify', important: true, count: 2 });
+    expect(created.metadata).toEqual({ origin: { command: 'notify' } });
+
+    const fetched = await store.getNotification({ threadId: 'thread-1', id: 'n1' });
+    expect(fetched).toMatchObject({
+      id: 'n1',
+      threadId: 'thread-1',
+      source: 'mastracode',
+      kind: 'manual',
+      priority: 'high',
+      status: 'pending',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      sourceId: 'source-1',
+      dedupeKey: 'dedupe-1',
+      coalesceKey: 'coalesce-1',
+      coalescedCount: 1,
+      deliveryReason: 'test-reason',
+    });
+    expect(fetched?.payload).toEqual({ nested: { ok: true }, count: 2 });
+    expect(fetched?.createdAt).toBeInstanceOf(Date);
+
+    const listed = await store.listNotifications({ threadId: 'thread-1' });
+    expect(listed.map(record => record.id)).toEqual(['n1']);
+  });
+
+  it('filters notifications by status, priority, source, resource, agent, search, and limit', async () => {
+    await store.createNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'mastracode',
+      kind: 'manual',
+      priority: 'high',
+      summary: 'Release blocker',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'n2',
+      threadId: 'thread-1',
+      resourceId: 'resource-2',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'pull-request',
+      priority: 'low',
+      summary: 'Pull request comment',
+      createdAt: new Date('2026-01-01T00:01:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'n3',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-2',
+      source: 'mastracode',
+      kind: 'reminder',
+      priority: 'medium',
+      summary: 'Daily standup',
+      createdAt: new Date('2026-01-01T00:02:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'other-thread',
+      threadId: 'thread-2',
+      source: 'mastracode',
+      kind: 'manual',
+      summary: 'Other thread',
+    });
+
+    await store.updateNotification({ threadId: 'thread-1', id: 'n2', status: 'delivered' });
+
+    await expectIds({ threadId: 'thread-1', status: 'delivered' }, ['n2']);
+    await expectIds({ threadId: 'thread-1', priority: ['high', 'medium'] }, ['n3', 'n1']);
+    await expectIds({ threadId: 'thread-1', source: 'mastracode' }, ['n3', 'n1']);
+    await expectIds({ threadId: 'thread-1', resourceId: 'resource-1' }, ['n3', 'n1']);
+    await expectIds({ threadId: 'thread-1', agentId: 'agent-2' }, ['n3']);
+    await expectIds({ threadId: 'thread-1', search: 'stand' }, ['n3']);
+    expect(await store.listNotifications({ threadId: 'thread-1', limit: 1 })).toHaveLength(1);
+  });
+
+  it('coalesces pending notifications by dedupeKey or coalesceKey within matching scope', async () => {
+    const first = await store.createNotification({
+      id: 'dedupe-original',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'comment',
+      priority: 'medium',
+      summary: 'Original comment',
+      dedupeKey: 'same-comment',
+      attributes: { first: true },
+      metadata: { first: true },
+    });
+
+    const coalesced = await store.createNotification({
+      id: 'dedupe-new',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'comment',
+      priority: 'urgent',
+      summary: 'Updated comment',
+      payload: { latest: true },
+      dedupeKey: 'same-comment',
+      attributes: { second: true },
+      metadata: { second: true },
+    });
+
+    expect(coalesced.id).toBe(first.id);
+    expect(coalesced.summary).toBe('Updated comment');
+    expect(coalesced.priority).toBe('urgent');
+    expect(coalesced.payload).toEqual({ latest: true });
+    expect(coalesced.attributes).toEqual({ first: true, second: true });
+    expect(coalesced.metadata).toEqual({ first: true, second: true });
+    expect(coalesced.coalescedCount).toBe(2);
+
+    const differentAgent = await store.createNotification({
+      id: 'dedupe-other-agent',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-2',
+      source: 'github',
+      kind: 'comment',
+      summary: 'Different agent',
+      dedupeKey: 'same-comment',
+    });
+    expect(differentAgent.id).toBe('dedupe-other-agent');
+
+    const group = await store.createNotification({
+      id: 'coalesce-original',
+      threadId: 'thread-1',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Build 1 failed',
+      coalesceKey: 'build-failures',
+    });
+    const grouped = await store.createNotification({
+      id: 'coalesce-new',
+      threadId: 'thread-1',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Build 2 failed',
+      coalesceKey: 'build-failures',
+    });
+    expect(grouped.id).toBe(group.id);
+    expect(grouped.coalescedCount).toBe(2);
+  });
+
+  it('updates status timestamps and delivery metadata', async () => {
+    await store.createNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      source: 'mastracode',
+      kind: 'manual',
+      summary: 'Ship it',
+    });
+
+    const deliverAt = new Date('2026-01-01T00:05:00.000Z');
+    const summaryAt = new Date('2026-01-01T00:10:00.000Z');
+    const lastDeliveryAttemptAt = new Date('2026-01-01T00:15:00.000Z');
+
+    const updated = await store.updateNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      status: 'delivered',
+      summary: 'Delivered notification',
+      payload: { delivered: true },
+      attributes: { channel: 'thread' },
+      metadata: { attempt: 1 },
+      deliverAt,
+      summaryAt,
+      deliveryReason: 'urgent',
+      deliveryAttempts: 2,
+      lastDeliveryAttemptAt,
+      lastDeliveryError: 'temporary failure',
+      deliveredSignalId: 'signal-1',
+      summarySignalId: 'summary-1',
+    });
+
+    expect(updated.status).toBe('delivered');
+    expect(updated.deliveredAt).toBeInstanceOf(Date);
+    expect(updated.summary).toBe('Delivered notification');
+    expect(updated.payload).toEqual({ delivered: true });
+    expect(updated.attributes).toEqual({ channel: 'thread' });
+    expect(updated.metadata).toEqual({ attempt: 1 });
+    expect(updated.deliverAt?.toISOString()).toBe(deliverAt.toISOString());
+    expect(updated.summaryAt?.toISOString()).toBe(summaryAt.toISOString());
+    expect(updated.deliveryReason).toBe('urgent');
+    expect(updated.deliveryAttempts).toBe(2);
+    expect(updated.lastDeliveryAttemptAt?.toISOString()).toBe(lastDeliveryAttemptAt.toISOString());
+    expect(updated.lastDeliveryError).toBe('temporary failure');
+    expect(updated.deliveredSignalId).toBe('signal-1');
+    expect(updated.summarySignalId).toBe('summary-1');
+  });
+
+  it('lists due pending notifications sorted by earliest due time with agent/resource filters and limit', async () => {
+    const now = new Date('2026-01-01T12:00:00.000Z');
+
+    await store.createNotification({
+      id: 'due-deliver',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'mastracode',
+      kind: 'manual',
+      summary: 'Deliver due',
+      deliverAt: new Date('2026-01-01T11:50:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'due-summary',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'comment',
+      summary: 'Summary due',
+      summaryAt: new Date('2026-01-01T11:55:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'due-earliest',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Earliest due',
+      deliverAt: new Date('2026-01-01T11:40:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'future',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Future',
+      deliverAt: new Date('2026-01-01T12:10:00.000Z'),
+    });
+    await store.createNotification({
+      id: 'other-agent',
+      threadId: 'thread-1',
+      resourceId: 'resource-2',
+      agentId: 'agent-2',
+      source: 'alerts',
+      kind: 'build',
+      summary: 'Other agent due',
+      deliverAt: new Date('2026-01-01T11:45:00.000Z'),
+    });
+    await store.updateNotification({ threadId: 'thread-1', id: 'other-agent', status: 'seen' });
+
+    const due = await store.listDueNotifications({ now });
+    expect(due.map(record => record.id)).toEqual(['due-earliest', 'due-deliver', 'due-summary']);
+
+    const limited = await store.listDueNotifications({ now, limit: 2 });
+    expect(limited.map(record => record.id)).toEqual(['due-earliest', 'due-deliver']);
+
+    const filtered = await store.listDueNotifications({ now, agentId: 'agent-1', resourceId: 'resource-1' });
+    expect(filtered.map(record => record.id)).toEqual(['due-earliest', 'due-deliver', 'due-summary']);
+  });
+
+  it('clears summaryAt while preserving deliverAt and due ordering after summary dispatch metadata updates', async () => {
+    const now = new Date('2026-01-01T12:00:00.000Z');
+    const deliverAt = new Date('2026-01-01T12:00:00.000Z');
+    const summaryAt = new Date('2026-01-01T11:55:00.000Z');
+    await store.createNotification({
+      id: 'summary-then-deliver',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+      source: 'github',
+      kind: 'ci-status',
+      priority: 'high',
+      summary: 'Summarized then delivered',
+      deliverAt,
+      summaryAt,
+    });
+
+    const updated = await store.updateNotification({
+      id: 'summary-then-deliver',
+      threadId: 'thread-1',
+      summaryAt: null,
+      summarySignalId: 'summary-signal-1',
+    });
+
+    expect(updated.status).toBe('pending');
+    expect(updated.summaryAt).toBeUndefined();
+    expect(updated.deliverAt?.toISOString()).toBe(deliverAt.toISOString());
+    expect(updated.summarySignalId).toBe('summary-signal-1');
+
+    const due = await store.listDueNotifications({ now });
+    expect(due.map(record => record.id)).toEqual(['summary-then-deliver']);
+    expect(due[0]?.summaryAt).toBeUndefined();
+    expect(due[0]?.deliverAt?.toISOString()).toBe(deliverAt.toISOString());
+  });
+
+  it('exposes notifications through PostgresStore and includes notification DDL in schema export', async () => {
+    const composite = new PostgresStore({ id: 'pg-notifications-composite', pool: createTestPool() });
+    try {
+      await composite.init();
+      const notifications = await composite.getStore('notifications');
+      expect(notifications).toBeDefined();
+      const record = await notifications!.createNotification({
+        id: 'composite-notification',
+        threadId: 'thread-1',
+        source: 'mastracode',
+        kind: 'manual',
+        summary: 'Composite notification',
+      });
+      expect(record.id).toBe('composite-notification');
+      await expect(
+        notifications!.getNotification({ threadId: 'thread-1', id: 'composite-notification' }),
+      ).resolves.toMatchObject({ summary: 'Composite notification' });
+    } finally {
+      await composite.close();
+    }
+
+    const ddl = exportSchemas();
+    expect(ddl).toContain(TABLE_NOTIFICATIONS);
+    expect(ddl).toContain('idx_notifications_thread_status_updated');
+    expect(ddl).toContain('idx_notifications_coalescing');
+    expect(ddl).toContain('idx_notifications_due');
+  });
+
+  async function expectIds(input: Parameters<NotificationsPG['listNotifications']>[0], ids: string[]) {
+    const records = await store.listNotifications(input);
+    expect(records.map(record => record.id)).toEqual(ids);
+  }
+});

--- a/stores/pg/src/storage/domains/notifications/index.ts
+++ b/stores/pg/src/storage/domains/notifications/index.ts
@@ -1,0 +1,401 @@
+import { randomUUID } from 'node:crypto';
+
+import { NotificationsStorage, TABLE_NOTIFICATIONS, TABLE_SCHEMAS } from '@mastra/core/storage';
+import type {
+  CreateIndexOptions,
+  CreateNotificationInput,
+  ListDueNotificationsInput,
+  ListNotificationsInput,
+  NotificationPriority,
+  NotificationRecord,
+  NotificationSignalAttributes,
+  NotificationStatus,
+  UpdateNotificationInput,
+} from '@mastra/core/storage';
+import { parseSqlIdentifier } from '@mastra/core/utils';
+
+import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL } from '../../db';
+import type { PgDomainConfig } from '../../db';
+import { getSchemaName, getTableName, parseJsonResilient } from '../utils';
+
+const statusTimestamp = (status: NotificationStatus, now: Date) => {
+  if (status === 'delivered') return { deliveredAt: now };
+  if (status === 'seen') return { seenAt: now };
+  if (status === 'dismissed') return { dismissedAt: now };
+  if (status === 'archived') return { archivedAt: now };
+  if (status === 'discarded') return { discardedAt: now };
+  return {};
+};
+
+const parseDate = (value: unknown): Date | undefined => {
+  if (value == null) return undefined;
+  return value instanceof Date ? value : new Date(String(value));
+};
+
+function rowToNotification(row: Record<string, unknown>): NotificationRecord {
+  return {
+    id: String(row.id),
+    threadId: String(row.threadId),
+    source: String(row.source),
+    kind: String(row.kind),
+    priority: String(row.priority) as NotificationPriority,
+    status: String(row.status) as NotificationStatus,
+    summary: String(row.summary),
+    payload: parseJsonResilient(row.payload),
+    resourceId: row.resourceId == null ? undefined : String(row.resourceId),
+    agentId: row.agentId == null ? undefined : String(row.agentId),
+    sourceId: row.sourceId == null ? undefined : String(row.sourceId),
+    dedupeKey: row.dedupeKey == null ? undefined : String(row.dedupeKey),
+    coalesceKey: row.coalesceKey == null ? undefined : String(row.coalesceKey),
+    coalescedCount: Number(row.coalescedCount ?? 1),
+    attributes: parseJsonResilient(row.attributes) as NotificationSignalAttributes | undefined,
+    createdAt: parseDate(row.createdAt) ?? new Date(),
+    updatedAt: parseDate(row.updatedAt) ?? new Date(),
+    deliveredAt: parseDate(row.deliveredAt),
+    seenAt: parseDate(row.seenAt),
+    dismissedAt: parseDate(row.dismissedAt),
+    archivedAt: parseDate(row.archivedAt),
+    discardedAt: parseDate(row.discardedAt),
+    deliverAt: parseDate(row.deliverAt),
+    summaryAt: parseDate(row.summaryAt),
+    deliveryReason: row.deliveryReason == null ? undefined : String(row.deliveryReason),
+    deliveryAttempts: Number(row.deliveryAttempts ?? 0),
+    lastDeliveryAttemptAt: parseDate(row.lastDeliveryAttemptAt),
+    lastDeliveryError: row.lastDeliveryError == null ? undefined : String(row.lastDeliveryError),
+    deliveredSignalId: row.deliveredSignalId == null ? undefined : String(row.deliveredSignalId),
+    summarySignalId: row.summarySignalId == null ? undefined : String(row.summarySignalId),
+    metadata: parseJsonResilient(row.metadata) as Record<string, unknown> | undefined,
+  };
+}
+
+function addArrayFilter<T extends string>(conditions: string[], args: unknown[], column: string, value?: T | T[]) {
+  if (!value) return;
+  const values = Array.isArray(value) ? value : [value];
+  const start = args.length + 1;
+  conditions.push(`"${column}" IN (${values.map((_, index) => `$${start + index}`).join(', ')})`);
+  args.push(...values);
+}
+
+function normalizeRecordForInsert(record: NotificationRecord): Record<string, unknown> {
+  return {
+    ...record,
+    payload: record.payload ?? null,
+    attributes: record.attributes ?? null,
+    metadata: record.metadata ?? null,
+    resourceId: record.resourceId ?? null,
+    agentId: record.agentId ?? null,
+    sourceId: record.sourceId ?? null,
+    dedupeKey: record.dedupeKey ?? null,
+    coalesceKey: record.coalesceKey ?? null,
+    deliveredAt: record.deliveredAt ?? null,
+    seenAt: record.seenAt ?? null,
+    dismissedAt: record.dismissedAt ?? null,
+    archivedAt: record.archivedAt ?? null,
+    discardedAt: record.discardedAt ?? null,
+    deliverAt: record.deliverAt ?? null,
+    summaryAt: record.summaryAt ?? null,
+    deliveryReason: record.deliveryReason ?? null,
+    lastDeliveryAttemptAt: record.lastDeliveryAttemptAt ?? null,
+    lastDeliveryError: record.lastDeliveryError ?? null,
+    deliveredSignalId: record.deliveredSignalId ?? null,
+    summarySignalId: record.summarySignalId ?? null,
+  };
+}
+
+export class NotificationsPG extends NotificationsStorage {
+  #db: PgDB;
+  #schema: string;
+  #skipDefaultIndexes?: boolean;
+  #indexes?: CreateIndexOptions[];
+
+  static readonly MANAGED_TABLES = [TABLE_NOTIFICATIONS] as const;
+
+  constructor(config: PgDomainConfig) {
+    super();
+    const { client, schemaName, skipDefaultIndexes, indexes } = resolvePgConfig(config);
+    this.#db = new PgDB({ client, schemaName, skipDefaultIndexes });
+    this.#schema = schemaName || 'public';
+    this.#skipDefaultIndexes = skipDefaultIndexes;
+    this.#indexes = indexes?.filter(idx => (NotificationsPG.MANAGED_TABLES as readonly string[]).includes(idx.table));
+  }
+
+  async init(): Promise<void> {
+    await this.#db.createTable({
+      tableName: TABLE_NOTIFICATIONS,
+      schema: TABLE_SCHEMAS[TABLE_NOTIFICATIONS],
+    });
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  static getDefaultIndexDefs(schemaPrefix: string): CreateIndexOptions[] {
+    return [
+      {
+        name: `${schemaPrefix}idx_notifications_thread_status_updated`,
+        table: TABLE_NOTIFICATIONS,
+        columns: ['threadId', 'status', 'updatedAt'],
+      },
+      {
+        name: `${schemaPrefix}idx_notifications_coalescing`,
+        table: TABLE_NOTIFICATIONS,
+        columns: ['threadId', 'source', 'status', 'agentId', 'resourceId', 'dedupeKey', 'coalesceKey'],
+      },
+      {
+        name: `${schemaPrefix}idx_notifications_due`,
+        table: TABLE_NOTIFICATIONS,
+        columns: ['status', 'deliverAt', 'summaryAt'],
+      },
+    ];
+  }
+
+  static getExportDDL(schemaName?: string): string[] {
+    const statements: string[] = [];
+    const parsedSchema = schemaName ? parseSqlIdentifier(schemaName, 'schema name') : '';
+    const schemaPrefix = parsedSchema && parsedSchema !== 'public' ? `${parsedSchema}_` : '';
+
+    statements.push(
+      generateTableSQL({
+        tableName: TABLE_NOTIFICATIONS,
+        schema: TABLE_SCHEMAS[TABLE_NOTIFICATIONS],
+        schemaName,
+        includeAllConstraints: true,
+      }),
+    );
+
+    for (const idx of NotificationsPG.getDefaultIndexDefs(schemaPrefix)) {
+      statements.push(generateIndexSQL(idx, schemaName));
+    }
+
+    return statements;
+  }
+
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    const schemaPrefix = this.#schema !== 'public' ? `${this.#schema}_` : '';
+    return NotificationsPG.getDefaultIndexDefs(schemaPrefix);
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.#skipDefaultIndexes) return;
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create index ${indexDef.name}:`, error);
+      }
+    }
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.#indexes || this.#indexes.length === 0) return;
+    for (const indexDef of this.#indexes) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create custom index ${indexDef.name}:`, error);
+      }
+    }
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.#db.clearTable({ tableName: TABLE_NOTIFICATIONS });
+  }
+
+  private async updateNotificationRow(id: string, data: Record<string, unknown>): Promise<void> {
+    const entries = Object.entries(data).filter(([, value]) => value !== undefined);
+    if (entries.length === 0) return;
+
+    const schemaName = getSchemaName(this.#schema);
+    const tableName = getTableName({ indexName: TABLE_NOTIFICATIONS, schemaName });
+    const setColumns = entries.map(([key], index) => `"${parseSqlIdentifier(key, 'column name')}" = $${index + 1}`);
+    const values = entries.map(([key, value]) => {
+      const columnSchema = TABLE_SCHEMAS[TABLE_NOTIFICATIONS][key];
+      if (columnSchema?.type === 'jsonb' && value !== null) return JSON.stringify(value);
+      return value;
+    });
+
+    await this.#db.client.none(`UPDATE ${tableName} SET ${setColumns.join(', ')} WHERE "id" = $${values.length + 1}`, [
+      ...values,
+      id,
+    ]);
+  }
+
+  async createNotification(input: CreateNotificationInput): Promise<NotificationRecord> {
+    const existing = await this.findCoalescable(input);
+    if (existing) {
+      const now = new Date();
+      const attributes = input.attributes ? { ...existing.attributes, ...input.attributes } : existing.attributes;
+      const metadata = input.metadata ? { ...existing.metadata, ...input.metadata } : existing.metadata;
+      await this.updateNotificationRow(existing.id, {
+        summary: input.summary,
+        payload: input.payload ?? existing.payload ?? null,
+        priority: input.priority ?? existing.priority,
+        attributes: attributes ?? null,
+        updatedAt: now,
+        deliverAt: input.deliverAt ?? existing.deliverAt ?? null,
+        summaryAt: input.summaryAt ?? existing.summaryAt ?? null,
+        deliveryReason: input.deliveryReason ?? existing.deliveryReason ?? null,
+        coalescedCount: (existing.coalescedCount ?? 1) + 1,
+        metadata: metadata ?? null,
+      });
+      const updated = await this.getNotification({ threadId: existing.threadId, id: existing.id });
+      if (!updated) throw new Error(`Notification ${existing.id} was not found for thread ${existing.threadId}`);
+      return updated;
+    }
+
+    const now = input.createdAt ?? new Date();
+    const record: NotificationRecord = {
+      id: input.id ?? randomUUID(),
+      threadId: input.threadId,
+      source: input.source,
+      kind: input.kind,
+      priority: input.priority ?? 'medium',
+      status: 'pending',
+      summary: input.summary,
+      payload: input.payload,
+      resourceId: input.resourceId,
+      agentId: input.agentId,
+      sourceId: input.sourceId,
+      dedupeKey: input.dedupeKey,
+      coalesceKey: input.coalesceKey,
+      coalescedCount: 1,
+      attributes: input.attributes ? { ...input.attributes } : undefined,
+      createdAt: now,
+      updatedAt: now,
+      deliverAt: input.deliverAt,
+      summaryAt: input.summaryAt,
+      deliveryReason: input.deliveryReason,
+      deliveryAttempts: 0,
+      metadata: input.metadata ? { ...input.metadata } : undefined,
+    };
+
+    await this.#db.insert({ tableName: TABLE_NOTIFICATIONS, record: normalizeRecordForInsert(record) });
+    return record;
+  }
+
+  async listNotifications(input: ListNotificationsInput): Promise<NotificationRecord[]> {
+    const conditions = ['"threadId" = $1'];
+    const args: unknown[] = [input.threadId];
+
+    addArrayFilter(conditions, args, 'status', input.status);
+    addArrayFilter(conditions, args, 'priority', input.priority);
+
+    if (input.source) {
+      args.push(input.source);
+      conditions.push(`"source" = $${args.length}`);
+    }
+    if (input.resourceId) {
+      args.push(input.resourceId);
+      conditions.push(`"resourceId" = $${args.length}`);
+    }
+    if (input.agentId) {
+      args.push(input.agentId);
+      conditions.push(`"agentId" = $${args.length}`);
+    }
+    if (input.search) {
+      const search = `%${input.search.toLowerCase()}%`;
+      args.push(search, search);
+      conditions.push(`(LOWER("summary") LIKE $${args.length - 1} OR LOWER("kind") LIKE $${args.length})`);
+    }
+
+    const limit = input.limit ? ` LIMIT $${args.length + 1}` : '';
+    if (input.limit) args.push(input.limit);
+
+    const schemaName = getSchemaName(this.#schema);
+    const tableName = getTableName({ indexName: TABLE_NOTIFICATIONS, schemaName });
+    const rows = await this.#db.client.manyOrNone(
+      `SELECT * FROM ${tableName} WHERE ${conditions.join(' AND ')} ORDER BY "updatedAt" DESC${limit}`,
+      args,
+    );
+
+    return rows.map(row => rowToNotification(row));
+  }
+
+  async listDueNotifications(input: ListDueNotificationsInput): Promise<NotificationRecord[]> {
+    const conditions = [
+      '"status" = $1',
+      '(("deliverAt" IS NOT NULL AND "deliverAt" <= $2) OR ("summaryAt" IS NOT NULL AND "summaryAt" <= $3))',
+    ];
+    const args: unknown[] = ['pending', input.now, input.now];
+
+    if (input.agentId) {
+      args.push(input.agentId);
+      conditions.push(`"agentId" = $${args.length}`);
+    }
+    if (input.resourceId) {
+      args.push(input.resourceId);
+      conditions.push(`"resourceId" = $${args.length}`);
+    }
+
+    const limit = input.limit ? ` LIMIT $${args.length + 1}` : '';
+    if (input.limit) args.push(input.limit);
+
+    const schemaName = getSchemaName(this.#schema);
+    const tableName = getTableName({ indexName: TABLE_NOTIFICATIONS, schemaName });
+    const rows = await this.#db.client.manyOrNone(
+      `SELECT * FROM ${tableName} WHERE ${conditions.join(' AND ')} ORDER BY CASE WHEN "deliverAt" IS NULL THEN "summaryAt" WHEN "summaryAt" IS NULL THEN "deliverAt" WHEN "deliverAt" <= "summaryAt" THEN "deliverAt" ELSE "summaryAt" END ASC, "updatedAt" ASC${limit}`,
+      args,
+    );
+
+    return rows.map(row => rowToNotification(row));
+  }
+
+  async getNotification(input: { threadId: string; id: string }): Promise<NotificationRecord | null> {
+    const schemaName = getSchemaName(this.#schema);
+    const tableName = getTableName({ indexName: TABLE_NOTIFICATIONS, schemaName });
+    const row = await this.#db.client.oneOrNone(
+      `SELECT * FROM ${tableName} WHERE "threadId" = $1 AND "id" = $2 LIMIT 1`,
+      [input.threadId, input.id],
+    );
+    return row ? rowToNotification(row) : null;
+  }
+
+  async updateNotification(input: UpdateNotificationInput): Promise<NotificationRecord> {
+    const existing = await this.getNotification({ threadId: input.threadId, id: input.id });
+    if (!existing) {
+      throw new Error(`Notification ${input.id} was not found for thread ${input.threadId}`);
+    }
+
+    const now = new Date();
+    await this.updateNotificationRow(input.id, {
+      ...(input.status ? { status: input.status, ...statusTimestamp(input.status, now) } : {}),
+      ...(input.summary !== undefined ? { summary: input.summary } : {}),
+      ...(input.payload !== undefined ? { payload: input.payload } : {}),
+      ...(input.attributes !== undefined ? { attributes: input.attributes } : {}),
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+      ...(input.deliverAt !== undefined ? { deliverAt: input.deliverAt } : {}),
+      ...(input.summaryAt !== undefined ? { summaryAt: input.summaryAt } : {}),
+      ...(input.deliveryReason !== undefined ? { deliveryReason: input.deliveryReason } : {}),
+      ...(input.deliveryAttempts !== undefined ? { deliveryAttempts: input.deliveryAttempts } : {}),
+      ...(input.lastDeliveryAttemptAt !== undefined ? { lastDeliveryAttemptAt: input.lastDeliveryAttemptAt } : {}),
+      ...(input.lastDeliveryError !== undefined ? { lastDeliveryError: input.lastDeliveryError } : {}),
+      ...(input.deliveredSignalId !== undefined ? { deliveredSignalId: input.deliveredSignalId } : {}),
+      ...(input.summarySignalId !== undefined ? { summarySignalId: input.summarySignalId } : {}),
+      updatedAt: now,
+    });
+
+    const updated = await this.getNotification({ threadId: input.threadId, id: input.id });
+    if (!updated) throw new Error(`Notification ${input.id} was not found for thread ${input.threadId}`);
+    return updated;
+  }
+
+  private async findCoalescable(input: CreateNotificationInput): Promise<NotificationRecord | undefined> {
+    if (!input.dedupeKey && !input.coalesceKey) return undefined;
+
+    const schemaName = getSchemaName(this.#schema);
+    const tableName = getTableName({ indexName: TABLE_NOTIFICATIONS, schemaName });
+    const row = await this.#db.client.oneOrNone(
+      `SELECT * FROM ${tableName} WHERE "threadId" = $1 AND "source" = $2 AND "status" = $3 AND (("agentId" = $4::text) OR ("agentId" IS NULL AND $4::text IS NULL)) AND (("resourceId" = $5::text) OR ("resourceId" IS NULL AND $5::text IS NULL)) AND (($6::text IS NOT NULL AND "dedupeKey" = $6::text) OR ($7::text IS NOT NULL AND "coalesceKey" = $7::text)) ORDER BY "updatedAt" DESC LIMIT 1`,
+      [
+        input.threadId,
+        input.source,
+        'pending',
+        input.agentId ?? null,
+        input.resourceId ?? null,
+        input.dedupeKey ?? null,
+        input.coalesceKey ?? null,
+      ],
+    );
+
+    return row ? rowToNotification(row) : undefined;
+  }
+}

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -25,6 +25,7 @@ import { FavoritesPG } from './domains/favorites';
 import { MCPClientsPG } from './domains/mcp-clients';
 import { MCPServersPG } from './domains/mcp-servers';
 import { MemoryPG } from './domains/memory';
+import { NotificationsPG } from './domains/notifications';
 import { ObservabilityPG } from './domains/observability';
 import { PromptBlocksPG } from './domains/prompt-blocks';
 import { SchedulesPG } from './domains/schedules';
@@ -46,6 +47,7 @@ const DEFAULT_IDLE_TIMEOUT_MS = 30000;
  */
 const ALL_DOMAINS = [
   MemoryPG,
+  NotificationsPG,
   ObservabilityPG,
   ScoresPG,
   ScorerDefinitionsPG,
@@ -91,6 +93,7 @@ export {
   MCPClientsPG,
   MCPServersPG,
   MemoryPG,
+  NotificationsPG,
   ObservabilityPG,
   PromptBlocksPG,
   ScorerDefinitionsPG,
@@ -165,6 +168,7 @@ export class PostgresStore extends MastraCompositeStore {
         scores: new ScoresPG(domainConfig),
         workflows: new WorkflowsPG(domainConfig),
         memory: new MemoryPG(domainConfig),
+        notifications: new NotificationsPG(domainConfig),
         observability: new ObservabilityPG(domainConfig),
         agents: new AgentsPG(domainConfig),
         promptBlocks: new PromptBlocksPG(domainConfig),


### PR DESCRIPTION
Previous PR: #17241 — https://github.com/mastra-ai/mastra/pull/17241

Adds notification inbox storage support for the OM-capable Postgres and MongoDB adapters, keeping them aligned with the LibSQL implementation already in stack 6. Both composite stores now expose `notifications`, and the new domains cover create/get/list, filtering, coalescing, due queries, status timestamps, and summary/full-delivery fields.

After:

```ts
const notifications = await store.getStore('notifications');

await notifications?.createNotification({
  threadId: 'thread-1',
  source: 'github',
  kind: 'pull-request',
  summary: 'PR review is ready',
});
```

I also added focused Docker-backed tests for both adapters and patch changesets for `@mastra/pg` and `@mastra/mongodb`. The focused PG/Mongo notification tests, MongoDB composite storage tests, LibSQL regression tests, PG/Mongo builds and lints, core build/check, and prettier all pass. One broad PG storage test file still has unrelated Background Tasks timestamp failures outside this PR's scope.
