### PR TITLE
feat(loggers): expose messageKey option on PinoLogger

### DIFF
--- a/.changeset/pino-logger-message-key.md
+++ b/.changeset/pino-logger-message-key.md
@@ -1,0 +1,5 @@
+---
+"@mastra/loggers": patch
+---
+
+Added messageKey option to PinoLogger for compatibility with structured-log aggregators. Set messageKey: 'message' to emit log messages under the message field expected by Google Cloud Logging, Datadog, ECS, and AWS CloudWatch.

--- a/packages/loggers/src/pino.ts
+++ b/packages/loggers/src/pino.ts
@@ -23,6 +23,14 @@ export interface PinoLoggerOptions<CustomLevels extends string = never> {
    * @default true
    */
   prettyPrint?: boolean;
+  /**
+   * Override the key used for the log message.
+   * Defaults to Pino's built-in 'msg' key.
+   * Set to 'message' for compatibility with Google Cloud Logging,
+   * Elastic Common Schema (ECS), Datadog, and AWS CloudWatch.
+   * @example 'message'
+   */
+  messageKey?: string;
 }
 
 interface PinoLoggerInternalOptions<CustomLevels extends string = never> extends PinoLoggerOptions<CustomLevels> {
@@ -66,6 +74,7 @@ export class PinoLogger<CustomLevels extends string = never> extends MastraLogge
         redact: options.redact,
         mixin: options.mixin,
         customLevels: options.customLevels,
+        messageKey: options.messageKey,
       },
       options.overrideDefaultTransports
         ? options?.transports?.default


### PR DESCRIPTION
## Description

`PinoLogger` didn't expose Pino's built-in `messageKey` option, forcing users to abandon `PinoLogger` entirely just to emit log messages under a different field name. Structured-log aggregators like Google Cloud Logging, Datadog, ECS, and AWS CloudWatch expect the message under `message` rather than Pino's default `msg`.

Adds `messageKey?: string` to `PinoLoggerOptions` and passes it through to the underlying `pino()` call — the same pattern already used for `formatters`, `redact`, `mixin`, and `customLevels`. Fully backward-compatible: omitting `messageKey` preserves existing behavior.

**Usage:**
```ts
new PinoLogger({
  name: 'my-app',
  level: 'info',
  messageKey: 'message', // GCP / ECS / Datadog / CloudWatch compatible
})
```

## Related issue(s)

Fixes #17444

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets you tell the PinoLogger where to put the log message in its output. By default, it puts it in a field called "msg," but many log collection services (like Google Cloud and AWS) expect it to be called "message" instead. Now you can specify `messageKey: 'message'` when creating a PinoLogger, and it will put the message in the right place for those services.

## Summary

This PR adds support for the `messageKey` option in `PinoLogger`, allowing users to customize the field name used for log messages in the underlying Pino logger configuration.

### Changes

- **`packages/loggers/src/pino.ts`**: Extended the `PinoLoggerOptions` interface with an optional `messageKey?: string` field that gets forwarded to the pino logger configuration
- **`.changeset/pino-logger-message-key.md`**: Added changeset entry documenting the patch release for `@mastra/loggers`

### Motivation

Most structured-log aggregators (Google Cloud Logging, Datadog, ECS/Elasticsearch, AWS CloudWatch) expect the log message to be in a top-level field named `message`, while Pino defaults to using `msg`. This PR removes the friction by allowing users to configure the message field name directly through `PinoLogger` options, eliminating the need to work around the limitation via internal logger access or custom implementations.

### Usage

```typescript
new PinoLogger({
  name: 'my-app',
  level: 'info',
  messageKey: 'message',
})
```

The option is optional and backwards compatible—omitting it preserves current behavior with Pino's default `msg` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->