### PR TITLE
[codex] feat(playground-ui): add spinner variants

### DIFF
--- a/.changeset/petite-beds-work.md
+++ b/.changeset/petite-beds-work.md
@@ -1,0 +1,20 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Changed `Spinner` to render the new compact loader by default and added `variant="pulse"` for longer data-loading states. Removed the `color` prop so the loader defaults to the neutral text token and color overrides go through `className`.
+
+**Migration note**
+
+Before:
+
+```tsx
+<Spinner color={Colors.neutral3} />
+```
+
+After:
+
+```tsx
+<Spinner className="text-neutral3" />
+<Spinner variant="pulse" className="text-neutral1" />
+```

--- a/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel-loading-data.tsx
+++ b/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel-loading-data.tsx
@@ -8,7 +8,7 @@ export interface DataDetailsPanelLoadingDataProps {
 export function DataDetailsPanelLoadingData({ children }: DataDetailsPanelLoadingDataProps) {
   return (
     <div className="flex items-center justify-center gap-2 px-4 py-6 text-ui-sm text-neutral3">
-      <Spinner /> {children ?? 'Loading...'}
+      <Spinner size="sm" variant="pulse" className="text-neutral3" /> {children ?? 'Loading...'}
     </div>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-loading-data.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-loading-data.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 import { Spinner } from '@/ds/components/Spinner';
-import { Colors } from '@/ds/tokens';
 
 export interface DataPanelLoadingDataProps {
   children?: ReactNode;
@@ -9,7 +8,7 @@ export interface DataPanelLoadingDataProps {
 export function DataPanelLoadingData({ children }: DataPanelLoadingDataProps) {
   return (
     <div className="flex items-center justify-center gap-2 px-4 py-6 text-ui-sm text-neutral2 min-h-32">
-      <Spinner size="sm" color={Colors.neutral1} /> {children ?? 'Loading...'}
+      <Spinner size="sm" variant="pulse" className="text-neutral1" /> {children ?? 'Loading...'}
     </div>
   );
 }

--- a/packages/playground-ui/src/ds/components/MetricsCard/metrics-card-loading.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsCard/metrics-card-loading.tsx
@@ -1,11 +1,10 @@
 import { Spinner } from '@/ds/components/Spinner/spinner';
-import { Colors } from '@/ds/tokens';
 import { cn } from '@/lib/utils';
 
 export function MetricsCardLoading({ className }: { className?: string }) {
   return (
     <div className={cn('flex items-center justify-center', className)}>
-      <Spinner size="md" color={Colors.neutral1} />
+      <Spinner size="md" variant="pulse" className="text-neutral1" />
     </div>
   );
 }

--- a/packages/playground-ui/src/ds/components/MetricsKpiCard/metrics-kpi-card-loading.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsKpiCard/metrics-kpi-card-loading.tsx
@@ -1,11 +1,10 @@
 import { Spinner } from '@/ds/components/Spinner/spinner';
-import { Colors } from '@/ds/tokens';
 import { cn } from '@/lib/utils';
 
 export function MetricsKpiCardLoading({ className }: { className?: string }) {
   return (
     <span className={cn('text-sm', className)}>
-      <Spinner size="md" color={Colors.neutral1} />
+      <Spinner size="md" variant="pulse" className="text-neutral1" />
     </span>
   );
 }

--- a/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
@@ -61,7 +61,7 @@ export function PickMultiPanel({ field, tokens, onChange }: PickMultiPanelProps)
 
       {field.isLoading ? (
         <div className="flex items-center gap-2 px-2 py-1.5 text-ui-sm text-neutral3">
-          <Spinner size="sm" className="w-3 h-3" color="var(--neutral3)" />
+          <Spinner size="sm" className="size-3 text-neutral3" />
           Loading options…
         </div>
       ) : filteredOptions.length === 0 ? (

--- a/packages/playground-ui/src/ds/components/Spinner/spinner.css
+++ b/packages/playground-ui/src/ds/components/Spinner/spinner.css
@@ -1,0 +1,114 @@
+.spinner {
+  --spinner-stroke: 2.2;
+  --spinner-pulse-ring-stroke: 2;
+
+  shape-rendering: geometricprecision;
+}
+
+.spinner[data-size='sm'] {
+  --spinner-stroke: 2.8;
+  --spinner-pulse-ring-stroke: 2.4;
+}
+
+.spinner[data-variant='default'] {
+  transform-origin: center;
+  animation: spinner-spin 1.1s linear infinite;
+}
+
+.spinner-ring {
+  fill: none;
+  stroke: currentcolor;
+  stroke-width: var(--spinner-stroke, 2.2);
+  stroke-linecap: round;
+  stroke-dashoffset: 0;
+  stroke-dasharray: 8 200;
+  animation: spinner-flex 1.4s ease-in-out infinite;
+}
+
+.spinner[data-variant='pulse'] {
+  overflow: visible;
+}
+
+.spinner-pulse-core,
+.spinner-pulse-ring {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.spinner-pulse-core {
+  fill: currentcolor;
+  animation: spinner-pulse-breath 1.5s ease-in-out infinite;
+}
+
+.spinner-pulse-ring {
+  fill: none;
+  stroke: currentcolor;
+  stroke-width: var(--spinner-pulse-ring-stroke, 2);
+  animation: spinner-pulse-ping 1.5s ease-out infinite;
+}
+
+@keyframes spinner-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes spinner-flex {
+  0%,
+  100% {
+    stroke-dasharray: 8 200;
+  }
+
+  50% {
+    stroke-dasharray: 40 200;
+  }
+}
+
+@keyframes spinner-pulse-breath {
+  0%,
+  100% {
+    transform: scale(0.78);
+  }
+
+  45% {
+    transform: scale(1.05);
+  }
+}
+
+@keyframes spinner-pulse-ping {
+  0% {
+    transform: scale(0.62);
+    opacity: 0;
+  }
+
+  18% {
+    opacity: 0.5;
+  }
+
+  75%,
+  100% {
+    transform: scale(1.7);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner[data-variant='default'],
+  .spinner-ring,
+  .spinner-pulse-core,
+  .spinner-pulse-ring {
+    animation: none;
+  }
+
+  .spinner-ring {
+    stroke-dasharray: 40 200;
+  }
+
+  .spinner-pulse-core {
+    transform: scale(0.92);
+  }
+
+  .spinner-pulse-ring {
+    opacity: 0.35;
+  }
+}

--- a/packages/playground-ui/src/ds/components/Spinner/spinner.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Spinner/spinner.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../Button';
 import { Spinner } from './spinner';
 
 const meta: Meta<typeof Spinner> = {
@@ -6,10 +7,35 @@ const meta: Meta<typeof Spinner> = {
   component: Spinner,
   parameters: {
     layout: 'centered',
+    controls: {
+      disable: true,
+    },
   },
   argTypes: {
-    color: {
-      control: { type: 'color' },
+    size: {
+      table: {
+        disable: true,
+      },
+    },
+    variant: {
+      table: {
+        disable: true,
+      },
+    },
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+    'aria-label': {
+      table: {
+        disable: true,
+      },
+    },
+    role: {
+      table: {
+        disable: true,
+      },
     },
   },
 };
@@ -21,52 +47,53 @@ export const Default: Story = {
   args: {},
 };
 
-export const White: Story = {
+export const Pulse: Story = {
   args: {
-    color: '#ffffff',
+    variant: 'pulse',
   },
 };
 
-export const Blue: Story = {
+export const ClassNameColor: Story = {
   args: {
-    color: '#3b82f6',
-  },
-};
-
-export const Green: Story = {
-  args: {
-    color: '#22c55e',
+    className: 'text-neutral3',
   },
 };
 
 export const Small: Story = {
   args: {
-    className: 'h-4 w-4',
-  },
-};
-
-export const Large: Story = {
-  args: {
-    className: 'h-8 w-8',
+    size: 'sm',
   },
 };
 
 export const InButton: Story = {
   render: () => (
-    <button className="flex items-center gap-2 px-4 py-2 bg-surface2 border border-border1 rounded-md text-neutral6">
-      <Spinner className="h-4 w-4" />
+    <Button>
+      <Spinner />
       Loading...
-    </button>
+    </Button>
   ),
 };
 
-export const AllSizes: Story = {
+export const Sizes: Story = {
   render: () => (
     <div className="flex items-center gap-4">
-      <Spinner className="h-4 w-4" />
-      <Spinner className="h-6 w-6" />
-      <Spinner className="h-8 w-8" />
-      <Spinner className="h-12 w-12" />
+      <Spinner size="sm" />
+      <Spinner />
+    </div>
+  ),
+};
+
+export const ClassNameSizeOverride: Story = {
+  args: {
+    className: 'size-3',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Spinner />
+      <Spinner variant="pulse" />
     </div>
   ),
 };

--- a/packages/playground-ui/src/ds/components/Spinner/spinner.test.tsx
+++ b/packages/playground-ui/src/ds/components/Spinner/spinner.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Spinner } from './spinner';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Spinner', () => {
+  it('renders the default spinner with md sizing hooks', () => {
+    const { container } = render(<Spinner />);
+
+    const spinner = screen.getByRole('status', { name: 'Loading' });
+    expect(spinner.tagName).toBe('svg');
+    expect(spinner.getAttribute('data-size')).toBe('md');
+    expect(spinner.getAttribute('data-variant')).toBe('default');
+    expect(spinner.classList.contains('w-6')).toBe(true);
+    expect(spinner.classList.contains('h-6')).toBe(true);
+    expect(container.querySelector('.spinner-ring')).not.toBeNull();
+  });
+
+  it('supports the small size variant', () => {
+    render(<Spinner size="sm" />);
+
+    const spinner = screen.getByRole('status', { name: 'Loading' });
+    expect(spinner.getAttribute('data-size')).toBe('sm');
+    expect(spinner.classList.contains('w-4')).toBe(true);
+    expect(spinner.classList.contains('h-4')).toBe(true);
+    expect(spinner.classList.contains('w-6')).toBe(false);
+    expect(spinner.classList.contains('h-6')).toBe(false);
+  });
+
+  it('renders the pulse variant with pulse-specific shapes', () => {
+    const { container } = render(<Spinner variant="pulse" />);
+
+    const spinner = screen.getByRole('status', { name: 'Loading' });
+    expect(spinner.getAttribute('data-variant')).toBe('pulse');
+    expect(container.querySelector('.spinner-pulse-core')).not.toBeNull();
+    expect(container.querySelector('.spinner-pulse-ring')).not.toBeNull();
+    expect(container.querySelector('.spinner-ring')).toBeNull();
+  });
+
+  it('merges className overrides without adding color props', () => {
+    render(<Spinner aria-label="Saving" className="size-3 text-neutral3" />);
+
+    const spinner = screen.getByRole('status', { name: 'Saving' });
+    expect(spinner.classList.contains('spinner')).toBe(true);
+    expect(spinner.classList.contains('size-3')).toBe(true);
+    expect(spinner.classList.contains('text-neutral3')).toBe(true);
+  });
+});

--- a/packages/playground-ui/src/ds/components/Spinner/spinner.tsx
+++ b/packages/playground-ui/src/ds/components/Spinner/spinner.tsx
@@ -1,33 +1,64 @@
+import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
+import type { ComponentPropsWithoutRef } from 'react';
+
 import { cn } from '@/lib/utils';
 
-export type SpinnerProps = {
-  color?: string;
-  className?: string;
-  size?: 'sm' | 'md' | 'lg';
-};
+import './spinner.css';
 
-const sizeClasses = {
-  sm: 'w-4 h-4',
-  md: 'w-6 h-6',
-  lg: 'w-8 h-8',
-};
+const spinnerVariants = cva('spinner inline-block text-neutral6', {
+  variants: {
+    size: {
+      sm: 'w-4 h-4',
+      md: 'w-6 h-6',
+    },
+    variant: {
+      default: '',
+      pulse: '',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    variant: 'default',
+  },
+});
 
-function Spinner({ color, className, size = 'md' }: SpinnerProps) {
+type SpinnerVariantsProps = VariantProps<typeof spinnerVariants>;
+export type SpinnerVariant = NonNullable<SpinnerVariantsProps['variant']>;
+export type SpinnerSize = NonNullable<SpinnerVariantsProps['size']>;
+
+export type SpinnerProps = Omit<ComponentPropsWithoutRef<'svg'>, 'color' | 'size'> & SpinnerVariantsProps;
+
+function Spinner({
+  className,
+  size = 'md',
+  variant = 'default',
+  'aria-label': ariaLabel = 'Loading',
+  role = 'status',
+  ...props
+}: SpinnerProps) {
+  const resolvedSize = size ?? 'md';
+  const resolvedVariant = variant ?? 'default';
+
   return (
     <svg
-      className={cn('animate-spin', sizeClasses[size], className)}
-      style={{ animationDuration: '800ms', animationTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}
+      {...props}
+      role={role}
+      aria-label={ariaLabel}
+      data-size={resolvedSize}
+      data-variant={resolvedVariant}
+      className={cn(spinnerVariants({ size: resolvedSize, variant: resolvedVariant }), className)}
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
       viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
     >
-      <path d="M21 12a9 9 0 1 1-6.219-8.56" stroke={color || 'currentColor'} className="text-accent1" />
+      {resolvedVariant === 'pulse' ? (
+        <>
+          <circle className="spinner-pulse-ring" cx="12" cy="12" r="7" />
+          <circle className="spinner-pulse-core" cx="12" cy="12" r="5" />
+        </>
+      ) : (
+        <circle className="spinner-ring" cx="12" cy="12" r="8.5" />
+      )}
     </svg>
   );
 }

--- a/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
@@ -95,7 +95,7 @@ export const MastraVersionFooter = ({ collapsed }: MastraVersionFooterProps) => 
             Mastra
           </Txt>
           <span className="flex flex-col items-end gap-1 shrink-0">
-            {isLoadingUpdates && <Spinner className="w-3 h-3 text-neutral3" color="currentColor" />}
+            {isLoadingUpdates && <Spinner className="size-3 text-neutral3" />}
             {outdatedCount > 0 && <CountBadge count={outdatedCount} variant="warning" />}
             {deprecatedCount > 0 && <CountBadge count={deprecatedCount} variant="error" />}
             <span className={versionBadgeClassName}>

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-import-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-import-dialog.tsx
@@ -404,7 +404,7 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
       case 'importing':
         return (
           <div className="flex flex-col items-center gap-4 py-8">
-            <Spinner size="lg" />
+            <Spinner />
             <div className="text-center">
               <div className="text-lg font-medium text-neutral1">Importing items...</div>
               <div className="text-sm text-neutral4 mt-1">

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-upload-step.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-upload-step.tsx
@@ -103,7 +103,7 @@ export function CSVUploadStep({ onFileSelect, isParsing, error }: CSVUploadStepP
       >
         {isParsing ? (
           <>
-            <Spinner size="lg" />
+            <Spinner />
             <span className="text-sm text-neutral4">Parsing CSV...</span>
           </>
         ) : (

--- a/packages/playground/src/domains/datasets/components/json-import/json-import-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-import-dialog.tsx
@@ -162,7 +162,7 @@ export function JSONImportDialog({ datasetId, open, onOpenChange, onSuccess }: J
       case 'importing':
         return (
           <div className="flex flex-col items-center gap-4 py-8">
-            <Spinner size="lg" />
+            <Spinner />
             <div className="text-center">
               <div className="text-lg font-medium text-neutral1">Importing items...</div>
               <div className="text-sm text-neutral4 mt-1">

--- a/packages/playground/src/domains/datasets/components/json-import/json-upload-step.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-upload-step.tsx
@@ -103,7 +103,7 @@ export function JSONUploadStep({ onFileSelect, isParsing, error }: JSONUploadSte
       >
         {isParsing ? (
           <>
-            <Spinner size="lg" />
+            <Spinner />
             <span className="text-sm text-neutral4">Parsing JSON...</span>
           </>
         ) : (

--- a/packages/playground/src/lib/ai-ui/attachments/attachment.tsx
+++ b/packages/playground/src/lib/ai-ui/attachments/attachment.tsx
@@ -15,7 +15,7 @@ const ComposerTxtAttachment = ({ document }: { document: AttachmentState }) => {
 
   return (
     <div className="flex items-center justify-center h-full w-full">
-      {isLoading ? <Spinner className="animate-spin" /> : <TxtEntry data={text} />}
+      {isLoading ? <Spinner /> : <TxtEntry data={text} />}
     </div>
   );
 };
@@ -45,11 +45,7 @@ const ComposerPdfAttachment = ({ document }: { document: AttachmentState }) => {
 
   return (
     <div className="flex items-center justify-center h-full w-full">
-      {state.isLoading ? (
-        <Spinner className="animate-spin" />
-      ) : (
-        <PdfEntry data={state.text} url={isUrl ? document.file?.name : undefined} />
-      )}
+      {state.isLoading ? <Spinner /> : <PdfEntry data={state.text} url={isUrl ? document.file?.name : undefined} />}
     </div>
   );
 };

--- a/packages/playground/src/lib/ai-ui/tools/badges/loading-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/loading-badge.tsx
@@ -1,10 +1,10 @@
-import { Skeleton, Spinner, Colors } from '@mastra/playground-ui';
+import { Skeleton, Spinner } from '@mastra/playground-ui';
 import { BadgeWrapper } from './badge-wrapper';
 
 export const LoadingBadge = () => {
   return (
     <BadgeWrapper
-      icon={<Spinner color={Colors.neutral3} />}
+      icon={<Spinner className="text-neutral3" />}
       title={<Skeleton className="ml-2 w-12 h-2" />}
       collapsible={false}
     />


### PR DESCRIPTION
Updates `Spinner` so the new compact loader is the default and the longer wait-state loader is available as `variant="pulse"`. The dedicated `color` prop is removed in favor of the existing `className` path, so consumers can override color with token classes like `text-neutral3` while the default stays neutral.

Before:

```tsx
<Spinner color={Colors.neutral3} />
```

After:

```tsx
<Spinner className="text-neutral3" />
<Spinner variant="pulse" />
```

<img width="1060" height="747" alt="CleanShot 2026-06-02 at 13 05 12" src="https://github.com/user-attachments/assets/c6f3c575-f083-4c90-add1-a36410081652" />


The Spinner Storybook docs now show `sm` and default `md`, use the DS `Button` in the button example, and hide internal accessibility defaults from the controls table.

Validated with `pnpm --filter ./packages/playground-ui typecheck`, `pnpm --filter ./packages/playground-ui lint`, `pnpm --filter ./packages/playground-ui build-storybook`, and `npx -y react-doctor@latest . --verbose --diff`. CodeRabbit CLI is installed but not signed in locally, so I could not run its local review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the loading spinner small and snappy by default, adds a slower "breathing" pulse variant for longer waits, and changes color customization to use CSS classes (e.g., className="text-neutral3") instead of a dedicated color prop.

## Overview

Reworks the Spinner API and styling:
- Default is now a compact loader; use variant="pulse" for a longer breathing/ping loader.
- Removes the dedicated color prop — consumers should style color via className.
- New CSS and animations added with a reduced-motion fallback.
- Storybook updated to showcase sizes/variants and hide internal accessibility props from controls.

## Changes

Spinner implementation and assets
- packages/playground-ui/src/ds/components/Spinner/spinner.tsx
  - Refactored to a CVA-driven SVG using <circle> elements.
  - Adds exported types SpinnerVariant and SpinnerSize.
  - Props now omit native color/size; new defaults: aria-label="Loading", role="status", variant="default", size="md".
  - Forwards data-size and data-variant attributes and composes className with CVA.
- packages/playground-ui/src/ds/components/Spinner/spinner.css
  - New file (+114 lines) with base .spinner styles, data-size='sm' override, data-variant='default' and data-variant='pulse' rules, keyframes (spinner-spin, spinner-flex, spinner-pulse-breath, spinner-pulse-ping), and prefers-reduced-motion handling.
- packages/playground-ui/src/ds/components/Spinner/spinner.stories.tsx
  - Storybook reorganized: removed color-focused stories; added Pulse, ClassNameColor, Small, Sizes, ClassNameSizeOverride, AllVariants. InButton now uses design-system Button. Controls disabled; certain props hidden from table.

Consumer updates (UI codebase)
- Replaced color prop usage with className-based color classes and added variant="pulse" where appropriate.
- Removed explicit large size usage (size="lg") in import dialogs to rely on the new default compact spinner.
- Affected files include components across packages/playground-ui and packages/playground such as:
  - data-details-panel-loading-data.tsx, data-panel-loading-data.tsx, metrics-card-loading.tsx, metrics-kpi-card-loading.tsx, pick-multi-panel.tsx, mastra-version-footer.tsx, csv-import-dialog.tsx, csv-upload-step.tsx, json-import-dialog.tsx, json-upload-step.tsx, attachment.tsx, loading-badge.tsx

Tests and docs
- packages/playground-ui/src/ds/components/Spinner/spinner.test.tsx
  - New Vitest/jsdom tests validating role/label, data-size/data-variant, size behavior, pulse DOM, and className merging.
- .changeset/petite-beds-work.md
  - Adds migration note with Before/After JSX examples showing migration from color prop to className and optional variant="pulse".

Validation
- Ran pnpm --filter ./packages/playground-ui typecheck, lint, build-storybook and npx -y react-doctor@latest . --verbose --diff.
- CodeRabbit CLI present but not signed in; local CodeRabbit review not executed.

Notes
- No exported public API signatures were removed; SpinnerProps/types were updated to reflect the new prop shape and exported SpinnerSize/SpinnerVariant types were added.
- PR labeled "tests: no tests added" despite spinner tests being added in this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->