### PR TITLE
docs: correct header level for "workflow stream properties"

### DIFF
--- a/docs/src/content/en/docs/streaming/overview.mdx
+++ b/docs/src/content/en/docs/streaming/overview.mdx
@@ -139,7 +139,7 @@ The event structure includes `runId` and `from` at the top level, making it easi
 }
 ```
 
-## Workflow stream properties
+### Workflow stream properties
 
 A workflow stream provides access to various response properties:
 


### PR DESCRIPTION
## Description

Correct header level for **workflow stream properties**.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR fixes how the documentation is organized by moving one section heading down one level in the outline. "Workflow stream properties" was incorrectly at the same level as its parent section, so it's been moved down to be a proper sub-section underneath "Streaming with workflows."

## Changes
- **File modified**: `docs/src/content/en/docs/streaming/overview.mdx`
- **Change**: Corrected the heading level for "Workflow stream properties" from `##` (second-level heading) to `###` (third-level heading)
- **Impact**: Improves the documentation hierarchy and structure for the streaming overview documentation, making the section properly nested under "Streaming with workflows"

## Type
Documentation update

<!-- end of auto-generated comment: release notes by coderabbit.ai -->