### PR TITLE
fix snapshot release?

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -439,6 +439,9 @@ jobs:
           echo "Finished updating workspace dependencies. $changed_count files updated."
         shell: bash
 
+      - name: Update lockfile
+        run: pnpm install --no-frozen-lockfile --lockfile-only
+
       - name: Build
         run: pnpm turbo --filter "!./examples/**/*" --filter "!./docs/" build
 


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the team wants to publish a snapshot (test release) of their code, there's an automated workflow that prepares everything. This fix makes sure that when the workflow updates the list of dependencies (lockfile), it properly saves those changes so nothing gets messed up during the release process.

## Changes

### GitHub Actions Workflow - npm-publish.yml

Modified the `snapshot` workflow job to include an additional step that regenerates the `pnpm-lock.yaml` lockfile after updating workspace dependency configurations. The workflow now runs `pnpm install --no-frozen-lockfile --lockfile-only` to ensure the lockfile is updated without freezing package versions, preventing potential dependency resolution issues during snapshot releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->