### PR TITLE
feat(playground): rework dataset Review tab item panel

### DIFF
--- a/.changeset/dataset-review-tab-ui.md
+++ b/.changeset/dataset-review-tab-ui.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Reworked the dataset Review tab in Studio. Items now open in a consistent detail panel with previous/next navigation, positive/negative rating shown as status badges, and a mark-as-complete action, and the input preview shows more text before truncating.

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-page-tabs.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-page-tabs.tsx
@@ -176,7 +176,7 @@ export function DatasetPageTabs({ datasetId, onAddItemClick, onNavigateToDataset
           </Tab>
         </TabList>
 
-        <TabContent value="items" className="grid overflow-auto mt-5">
+        <TabContent value="items" className="grid overflow-auto mt-5 pb-0">
           <DatasetItems
             datasetId={datasetId}
             items={items}
@@ -204,7 +204,7 @@ export function DatasetPageTabs({ datasetId, onAddItemClick, onNavigateToDataset
           />
         </TabContent>
 
-        <TabContent value="experiments" className="grid overflow-auto mt-5">
+        <TabContent value="experiments" className="grid overflow-auto mt-5 pb-0">
           <DatasetExperiments
             experiments={experiments}
             allExperiments={allExperiments}
@@ -215,7 +215,7 @@ export function DatasetPageTabs({ datasetId, onAddItemClick, onNavigateToDataset
           />
         </TabContent>
 
-        <TabContent value="review" className="overflow-auto mt-0">
+        <TabContent value="review" className="overflow-auto mt-2 pb-0">
           <DatasetReview datasetId={datasetId} />
         </TabContent>
       </Tabs>

--- a/packages/playground/src/domains/review/components/__tests__/review-item-panel.test.tsx
+++ b/packages/playground/src/domains/review/components/__tests__/review-item-panel.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ReviewItem } from '../review-item-card';
+import type { ReviewItemPanelProps } from '../review-item-panel';
+import { ReviewItemPanel } from '../review-item-panel';
+
+const baseItem: ReviewItem = {
+  id: 'item-1',
+  input: 'Test input',
+  output: 'Test output',
+  error: null,
+  itemId: 'dataset-item-1',
+  tags: [],
+};
+
+function renderPanel(overrides: Partial<ReviewItemPanelProps> = {}) {
+  const props: ReviewItemPanelProps = {
+    item: baseItem,
+    tagVocabulary: [],
+    onRate: vi.fn(),
+    onSetTags: vi.fn(),
+    onComment: vi.fn(),
+    onRemove: vi.fn(),
+    onComplete: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  render(<ReviewItemPanel {...props} />);
+  return props;
+}
+
+describe('ReviewItemPanel', () => {
+  afterEach(cleanup);
+
+  it('renders the positive and negative rating controls', () => {
+    renderPanel();
+    expect(screen.getByRole('button', { name: 'Rate positive' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Rate negative' })).toBeDefined();
+  });
+
+  it('calls onRate with the chosen rating when a control is clicked', () => {
+    const props = renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rate positive' }));
+    expect(props.onRate).toHaveBeenCalledWith('positive');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rate negative' }));
+    expect(props.onRate).toHaveBeenCalledWith('negative');
+  });
+
+  it('clears the rating when the already-active control is clicked again', () => {
+    const props = renderPanel({ item: { ...baseItem, rating: 'positive' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rate positive' }));
+    expect(props.onRate).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -2,8 +2,6 @@ import {
   Badge,
   Button,
   Checkbox,
-  Columns,
-  Column,
   DataList,
   DropdownMenu,
   Label,
@@ -393,18 +391,13 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
     return displayItems.find(i => i.id === featuredItemId) ?? null;
   }, [featuredItemId, displayItems]);
 
-  // Navigation
-  const toNextItem = useCallback(() => {
-    if (!featuredItemId || displayItems.length === 0) return;
-    const idx = displayItems.findIndex(i => i.id === featuredItemId);
-    if (idx < displayItems.length - 1) setFeaturedItemId(displayItems[idx + 1].id);
-  }, [featuredItemId, displayItems]);
-
-  const toPreviousItem = useCallback(() => {
-    if (!featuredItemId || displayItems.length === 0) return;
-    const idx = displayItems.findIndex(i => i.id === featuredItemId);
-    if (idx > 0) setFeaturedItemId(displayItems[idx - 1].id);
-  }, [featuredItemId, displayItems]);
+  // Navigation — undefined at the edges so the prev/next buttons disable.
+  const featuredIndex = featuredItemId ? displayItems.findIndex(i => i.id === featuredItemId) : -1;
+  const toPreviousItem = featuredIndex > 0 ? () => setFeaturedItemId(displayItems[featuredIndex - 1].id) : undefined;
+  const toNextItem =
+    featuredIndex >= 0 && featuredIndex < displayItems.length - 1
+      ? () => setFeaturedItemId(displayItems[featuredIndex + 1].id)
+      : undefined;
 
   const gridColumns = 'auto minmax(15rem,1fr) 10rem 8rem 6rem 6rem';
 
@@ -536,9 +529,11 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
       </Dialog>
 
       {/* Main layout: toolbar + List + Detail Panel */}
-      <Columns className={featuredItem ? 'grid-cols-[1fr_1fr]' : ''}>
-        <Column>
-          <Column.Toolbar>
+      <div
+        className={cn('grid w-full h-full grid-cols-1 gap-4 overflow-y-auto', featuredItem && 'grid-cols-[1fr_1fr]')}
+      >
+        <div className="grid gap-8 content-start w-full overflow-y-auto">
+          <div className="flex items-center justify-between w-full flex-wrap gap-4 gap-x-6">
             {/* Filters (left) */}
             <div className="flex items-center gap-3">
               <DropdownMenu>
@@ -710,7 +705,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
                 </DropdownMenu>
               </div>
             )}
-          </Column.Toolbar>
+          </div>
 
           {isLoadingDisplay ? (
             <div className="flex-1 flex items-center justify-center">
@@ -858,7 +853,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
               })}
             </DataList>
           )}
-        </Column>
+        </div>
 
         {featuredItem && (
           <ReviewItemPanel
@@ -882,7 +877,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
             onClose={() => setFeaturedItemId(null)}
           />
         )}
-      </Columns>
+      </div>
     </div>
   );
 }

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -753,7 +753,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
                   <>
                     {/* Input preview */}
                     <DataList.Cell height="compact" className="min-w-0 text-neutral4">
-                      <span className="block truncate">{truncateInput(item.input, 80)}</span>
+                      <span className="block truncate">{truncateInput(item.input, 200)}</span>
                     </DataList.Cell>
 
                     {/* Comment preview */}

--- a/packages/playground/src/domains/review/components/review-item-panel.tsx
+++ b/packages/playground/src/domains/review/components/review-item-panel.tsx
@@ -203,15 +203,11 @@ export function ReviewItemPanel({
           </div>
 
           <div className="grid gap-3">
-            <DataPanel.CodeSection
-              title="Input"
-              icon={<FileInputIcon />}
-              codeStr={JSON.stringify(item.input ?? null, null, 2)}
-            />
+            <DataPanel.CodeSection title="Input" icon={<FileInputIcon />} codeStr={formatUnknown(item.input ?? null)} />
             <DataPanel.CodeSection
               title="Output"
               icon={<FileOutputIcon />}
-              codeStr={JSON.stringify(item.output ?? null, null, 2)}
+              codeStr={formatUnknown(item.output ?? null)}
             />
           </div>
 

--- a/packages/playground/src/domains/review/components/review-item-panel.tsx
+++ b/packages/playground/src/domains/review/components/review-item-panel.tsx
@@ -3,13 +3,13 @@ import {
   Badge,
   Button,
   ButtonsGroup,
-  Column,
-  PrevNextNav,
+  DataKeysAndValues,
+  DataPanel,
   Textarea,
   Txt,
   Icon,
 } from '@mastra/playground-ui';
-import { ThumbsUp, ThumbsDown, Trash2, CheckCircle, XIcon, GaugeIcon } from 'lucide-react';
+import { CheckCircle, FileInputIcon, FileOutputIcon, GaugeIcon, ThumbsDown, ThumbsUp, Trash2 } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';
 import type { ReviewItem } from './review-item-card';
 import { TagPicker } from './tag-picker';
@@ -57,6 +57,9 @@ export function ReviewItemPanel({
     setLocalComment(item.comment || '');
     setCommentSaved(false);
     setShowRemoveConfirm(false);
+    // Intentionally depends on item.id only — re-running on every new `item` object
+    // reference would clobber the user's in-progress comment edit on every parent re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [item.id]);
 
   const commentTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -73,154 +76,144 @@ export function ReviewItemPanel({
 
   return (
     <>
-      <Column withLeftSeparator>
-        <Column.Toolbar>
-          <PrevNextNav
-            onPrevious={onPrevious}
-            onNext={onNext}
-            previousAriaLabel="Previous item"
-            nextAriaLabel="Next item"
-          />
-          <ButtonsGroup>
+      <DataPanel>
+        <DataPanel.Header>
+          <DataPanel.Heading>Review</DataPanel.Heading>
+          <ButtonsGroup className="ml-auto shrink-0">
+            <DataPanel.NextPrevNav
+              onPrevious={onPrevious}
+              onNext={onNext}
+              previousLabel="Previous item"
+              nextLabel="Next item"
+            />
             {!isCompleted && onComplete && (
-              <Button onClick={onComplete} aria-label="Mark as complete">
+              <Button size="md" onClick={onComplete} aria-label="Mark as complete">
                 <CheckCircle />
                 Complete
               </Button>
             )}
-            <Button onClick={onClose} aria-label="Close detail panel">
-              <XIcon />
-            </Button>
+            <DataPanel.CloseButton onClick={onClose} tooltip="Close detail panel" />
           </ButtonsGroup>
-        </Column.Toolbar>
+        </DataPanel.Header>
 
-        <Column.Content>
-          {/* Rating */}
-          {!isCompleted && (
-            <div className="flex items-center gap-2">
-              <Txt variant="ui-xs" className="text-neutral3">
-                Rating
-              </Txt>
-              <div className="flex items-center gap-1">
-                <Button
-                  variant={item.rating === 'positive' ? 'default' : 'ghost'}
-                  size="sm"
-                  onClick={() => onRate(item.rating === 'positive' ? undefined : 'positive')}
-                  aria-label="Rate positive"
-                >
-                  <Icon size="sm" className={item.rating === 'positive' ? 'text-positive1' : ''}>
-                    <ThumbsUp />
-                  </Icon>
-                </Button>
-                <Button
-                  variant={item.rating === 'negative' ? 'default' : 'ghost'}
-                  size="sm"
-                  onClick={() => onRate(item.rating === 'negative' ? undefined : 'negative')}
-                  aria-label="Rate negative"
-                >
-                  <Icon size="sm" className={item.rating === 'negative' ? 'text-negative1' : ''}>
-                    <ThumbsDown />
-                  </Icon>
-                </Button>
+        <DataPanel.Content>
+          <div className="grid gap-4 mb-6">
+            {/* Rating */}
+            {!isCompleted && (
+              <div className="flex items-center gap-2">
+                <Txt variant="ui-sm" className="text-neutral3">
+                  Rating
+                </Txt>
+                <ButtonsGroup spacing="close">
+                  <Button
+                    size="md"
+                    onClick={() => onRate(item.rating === 'positive' ? undefined : 'positive')}
+                    aria-label="Rate positive"
+                  >
+                    <Icon size="sm" className={item.rating === 'positive' ? 'text-positive1' : ''}>
+                      <ThumbsUp />
+                    </Icon>
+                  </Button>
+                  <Button
+                    size="md"
+                    onClick={() => onRate(item.rating === 'negative' ? undefined : 'negative')}
+                    aria-label="Rate negative"
+                  >
+                    <Icon size="sm" className={item.rating === 'negative' ? 'text-negative1' : ''}>
+                      <ThumbsDown />
+                    </Icon>
+                  </Button>
+                </ButtonsGroup>
+                {item.rating && (
+                  <Badge variant={item.rating === 'positive' ? 'success' : 'error'}>
+                    {item.rating === 'positive' ? 'Good' : 'Bad'}
+                  </Badge>
+                )}
               </div>
-              {item.rating && (
+            )}
+
+            {isCompleted && item.rating && (
+              <div className="flex items-center gap-2">
+                <Txt variant="ui-sm" className="text-neutral3">
+                  Rating
+                </Txt>
                 <Badge variant={item.rating === 'positive' ? 'success' : 'error'}>
                   {item.rating === 'positive' ? 'Good' : 'Bad'}
                 </Badge>
+              </div>
+            )}
+
+            {/* Tags */}
+            <div className="flex flex-wrap gap-2">
+              <Txt variant="ui-sm" className="text-neutral3 block mt-0">
+                Tags
+              </Txt>
+              {isCompleted ? (
+                <div className="flex gap-1 flex-wrap">
+                  {item.tags.length > 0 ? (
+                    item.tags.map(tag => (
+                      <Badge key={tag} variant="default">
+                        {tag}
+                      </Badge>
+                    ))
+                  ) : (
+                    <Txt variant="ui-sm" className="text-neutral2">
+                      No tags
+                    </Txt>
+                  )}
+                </div>
+              ) : (
+                <TagPicker tags={item.tags} vocabulary={tagVocabulary} onSetTags={onSetTags} />
               )}
             </div>
-          )}
 
-          {isCompleted && item.rating && (
-            <div className="flex items-center gap-2">
-              <Txt variant="ui-xs" className="text-neutral3">
-                Rating
-              </Txt>
-              <Badge variant={item.rating === 'positive' ? 'success' : 'error'}>
-                {item.rating === 'positive' ? 'Good' : 'Bad'}
-              </Badge>
-            </div>
-          )}
-
-          {/* Tags */}
-          <div>
-            <Txt variant="ui-xs" className="text-neutral3 block mb-2">
-              Tags
-            </Txt>
-            {isCompleted ? (
-              <div className="flex gap-1 flex-wrap">
-                {item.tags.length > 0 ? (
-                  item.tags.map(tag => (
-                    <Badge key={tag} variant="default">
-                      {tag}
-                    </Badge>
-                  ))
-                ) : (
-                  <Txt variant="ui-xs" className="text-neutral2">
-                    No tags
-                  </Txt>
-                )}
+            {/* Scores */}
+            {item.scores && Object.keys(item.scores).length > 0 && (
+              <div>
+                <Txt variant="ui-xs" className="text-neutral3 block mb-2">
+                  Scores
+                </Txt>
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(item.scores).map(([name, score]) => (
+                    <div key={name} className="flex items-center gap-1">
+                      <Icon size="sm" className="text-neutral3">
+                        <GaugeIcon />
+                      </Icon>
+                      <Txt variant="ui-xs" className="text-neutral4">
+                        {name}:
+                      </Txt>
+                      <Badge variant={score >= 0.5 ? 'success' : 'error'}>{score.toFixed(3)}</Badge>
+                    </div>
+                  ))}
+                </div>
               </div>
-            ) : (
-              <TagPicker tags={item.tags} vocabulary={tagVocabulary} onSetTags={onSetTags} />
+            )}
+
+            {item.experimentId && (
+              <DataKeysAndValues>
+                <DataKeysAndValues.Key>Experiment Id</DataKeysAndValues.Key>
+                <DataKeysAndValues.ValueWithCopyBtn
+                  copyTooltip="Copy Experiment Id to clipboard"
+                  copyValue={item.experimentId}
+                >
+                  {item.experimentId}
+                </DataKeysAndValues.ValueWithCopyBtn>
+              </DataKeysAndValues>
             )}
           </div>
 
-          {/* Scores */}
-          {item.scores && Object.keys(item.scores).length > 0 && (
-            <div>
-              <Txt variant="ui-xs" className="text-neutral3 block mb-2">
-                Scores
-              </Txt>
-              <div className="flex flex-wrap gap-2">
-                {Object.entries(item.scores).map(([name, score]) => (
-                  <div key={name} className="flex items-center gap-1">
-                    <Icon size="sm" className="text-neutral3">
-                      <GaugeIcon />
-                    </Icon>
-                    <Txt variant="ui-xs" className="text-neutral4">
-                      {name}:
-                    </Txt>
-                    <Badge variant={score >= 0.5 ? 'success' : 'error'}>{score.toFixed(3)}</Badge>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Experiment ID */}
-          {item.experimentId && (
-            <div>
-              <Txt variant="ui-xs" className="text-neutral3 block mb-1">
-                Experiment
-              </Txt>
-              <Txt variant="ui-xs" className="text-neutral4 font-mono">
-                {item.experimentId}
-              </Txt>
-            </div>
-          )}
-
-          {/* Input */}
-          <div>
-            <Txt variant="ui-xs" className="text-neutral3 block mb-1">
-              Input
-            </Txt>
-            <pre className="text-ui-xs text-neutral4 whitespace-pre-wrap break-words bg-surface2 rounded-md p-3 max-h-48 overflow-auto">
-              {formatUnknown(item.input)}
-            </pre>
+          <div className="grid gap-3">
+            <DataPanel.CodeSection
+              title="Input"
+              icon={<FileInputIcon />}
+              codeStr={JSON.stringify(item.input ?? null, null, 2)}
+            />
+            <DataPanel.CodeSection
+              title="Output"
+              icon={<FileOutputIcon />}
+              codeStr={JSON.stringify(item.output ?? null, null, 2)}
+            />
           </div>
-
-          {/* Output */}
-          {item.output != null && (
-            <div>
-              <Txt variant="ui-xs" className="text-neutral3 block mb-1">
-                Output
-              </Txt>
-              <pre className="text-ui-xs text-neutral4 whitespace-pre-wrap break-words bg-surface2 rounded-md p-3 max-h-48 overflow-auto">
-                {formatUnknown(item.output)}
-              </pre>
-            </div>
-          )}
 
           {/* Error */}
           {item.error != null && (
@@ -228,16 +221,16 @@ export function ReviewItemPanel({
               <Txt variant="ui-xs" className="text-neutral3 block mb-1">
                 Error
               </Txt>
-              <pre className="text-ui-xs text-negative1 whitespace-pre-wrap break-words bg-surface2 rounded-md p-3 max-h-48 overflow-auto">
+              <pre className="text-ui-xs text-negative1 whitespace-pre-wrap wrap-break-word bg-surface2 rounded-md p-3 max-h-48 overflow-auto">
                 {formatUnknown(item.error)}
               </pre>
             </div>
           )}
 
           {/* Comment */}
-          <div>
-            <div className="flex items-center gap-2 mb-1">
-              <Txt variant="ui-xs" className="text-neutral3">
+          <div className="mt-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Txt variant="ui-sm" className="uppercase tracking-widest text-neutral2">
                 Comment
               </Txt>
               {commentSaved && (
@@ -264,25 +257,21 @@ export function ReviewItemPanel({
 
           {/* Actions */}
           {!isCompleted && (
-            <div className="flex items-center gap-2 pt-2 border-t border-border1">
+            <div className="flex items-center gap-2 mt-4 pt-4 border-t border-border1">
               {onComplete && (
-                <Button size="sm" onClick={onComplete}>
-                  <Icon size="sm">
-                    <CheckCircle />
-                  </Icon>
+                <Button size="md" onClick={onComplete}>
+                  <CheckCircle />
                   Mark as complete
                 </Button>
               )}
-              <Button variant="outline" size="sm" onClick={() => setShowRemoveConfirm(true)}>
-                <Icon size="sm">
-                  <Trash2 />
-                </Icon>
+              <Button variant="outline" size="md" onClick={() => setShowRemoveConfirm(true)}>
+                <Trash2 />
                 Remove
               </Button>
             </div>
           )}
-        </Column.Content>
-      </Column>
+        </DataPanel.Content>
+      </DataPanel>
 
       <AlertDialog open={showRemoveConfirm} onOpenChange={setShowRemoveConfirm}>
         <AlertDialog.Content>


### PR DESCRIPTION
before

<img width="2552" height="1323" alt="Screenshot 2026-06-02 at 13 11 10" src="https://github.com/user-attachments/assets/a5e2940a-aa47-42c4-8394-9a254715eaf3" />


after

<img width="2551" height="1311" alt="Screenshot 2026-06-02 at 13 11 29" src="https://github.com/user-attachments/assets/c31d705c-81df-49e0-b8b7-0f971e26d2a9" />


## What

Reworks the dataset **Review** tab in Studio.

- **Consistent detail panel** — review items now open in a `DataPanel` layout matching the rest of the dataset views, with previous/next navigation between items.
- **Rating UX** — positive/negative rating is surfaced as status badges, with a clear mark-as-complete action in the panel header.
- **Wider input preview** — the review item input now shows up to 200 characters before truncating (was 80), so list rows are easier to scan.

## Why

The Review tab's item panel was inconsistent with the redesigned dataset items/detail views. This brings it in line — same panel primitives, navigation, and interaction patterns — so reviewing items feels the same as browsing them.

## Notes

- All changes are in `@internal/playground` (the private Studio app). A changeset is included for it so the Review tab rework lands in the studio changelog.
- Built on top of the dataset items detail rework (#17460), which is now in `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the dataset Review experience in Mastra Studio nicer and easier: review items now open in a consistent side detail panel you can flip through, ratings show as simple "Good/Bad" badges and you can mark items complete from the header, and list previews show more of the input so rows are easier to scan.

---

## Overview

Reworks the Dataset Review tab in Studio (scope: `@internal/playground`) to use a DataPanel detail pattern, improve navigation and rating UX, show more input preview text, and add unit tests and a changelog entry.

## Key Changes

- Layout & navigation
  - Review items now open in a DataPanel detail panel (matches other dataset detail views).
  - Added previous/next navigation via DataPanel.NextPrevNav; close control uses DataPanel.CloseButton.
  - Replaced prior Column layout primitives with plain div/grid containers in the review list.

- Rating & actions UX
  - Rating controls refactored: positive/negative rating surfaced as status Badges ("Good"/"Bad").
  - "Mark as complete" action exposed in the panel header (Complete button).
  - Action area reorganized (spacing/dividers/button sizing adjustments).

- Display & data rendering
  - Input preview/truncation increased from 80 to 200 characters for better scanability.
  - Input/Output shown via DataPanel.CodeSection using JSON.stringify(..., null, 2); output is stringified even when null.
  - Experiment ID rendered with a copy button (DataKeysAndValues.ValueWithCopyBtn).
  - Error, tags, scores, and comment rendering preserved and restyled to fit the panel.

- Small tab styling tweak
  - Tab panels updated to include pb-0 and the Review tab vertical spacing adjusted (mt-0 → mt-2).

- Tests & changelog
  - Added Vitest/RTL tests for ReviewItemPanel verifying rating controls and behavior (click to set/clear ratings).
  - Added a changeset entry documenting the Review tab UI rework (.changeset/dataset-review-tab-ui.md).

## Files Modified

- .changeset/dataset-review-tab-ui.md — changelog entry
- packages/playground/src/domains/datasets/components/dataset-detail/dataset-page-tabs.tsx — tab class tweaks and review tab spacing
- packages/playground/src/domains/review/components/dataset-review.tsx — list/layout/navigation logic, truncation update (200 chars), local state & handlers
- packages/playground/src/domains/review/components/review-item-panel.tsx — full UI refactor into DataPanel, rating badges, copyable Experiment ID, code sections
- packages/playground/src/domains/review/components/__tests__/review-item-panel.test.tsx — tests for rating controls

## Scope & Notes

- All changes are limited to the private Studio app package (`@internal/playground`).
- Built on top of the dataset items detail rework (`#17460`) which is already in main.
- Estimated review effort: Low–Medium.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->