### PR TITLE
feat(core): route Gateway embedding models

### DIFF
--- a/.changeset/free-parts-reply.md
+++ b/.changeset/free-parts-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added support for routing embedding models through the Mastra Gateway with mastra/provider/model IDs.

--- a/.changeset/free-parts-reply.md
+++ b/.changeset/free-parts-reply.md
@@ -1,8 +1,9 @@
 ---
 '@mastra/core': minor
-'@mastra/memory': patch
 ---
 
-Added support for routing embedding models through the Mastra Gateway with `mastra/provider/model` IDs.
+Added support for Gateway embedding routing with `mastra/provider/model` IDs:
 
-Updated observational memory processing so agents using Mastra Gateway actor models still run the locally configured observer and reflector models instead of implicitly deferring to Gateway-managed memory behavior.
+```ts
+const embedder = new ModelRouterEmbeddingModel('mastra/__GATEWAY_OPENAI_EMBEDDING_MODEL__');
+```

--- a/.changeset/free-parts-reply.md
+++ b/.changeset/free-parts-reply.md
@@ -1,5 +1,8 @@
 ---
 '@mastra/core': minor
+'@mastra/memory': patch
 ---
 
-Added support for routing embedding models through the Mastra Gateway with mastra/provider/model IDs.
+Added support for routing embedding models through the Mastra Gateway with `mastra/provider/model` IDs.
+
+Updated observational memory processing so agents using Mastra Gateway actor models still run the locally configured observer and reflector models instead of implicitly deferring to Gateway-managed memory behavior.

--- a/docs/src/content/en/models/gateways/mastra.mdx
+++ b/docs/src/content/en/models/gateways/mastra.mdx
@@ -36,6 +36,14 @@ const agent = new Agent({
 });
 ```
 
+Use the same prefix for embedding models that should run through the gateway:
+
+```typescript title="src/mastra/rag/embed.ts"
+import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
+
+const embedder = new ModelRouterEmbeddingModel("mastra/openai/text-embedding-3-small");
+```
+
 Pass `memory.thread` and `memory.resource` when you generate/stream responses to enable Observational Memory:
 
 ```typescript title="src/mastra/run.ts"

--- a/docs/src/content/en/models/gateways/mastra.mdx
+++ b/docs/src/content/en/models/gateways/mastra.mdx
@@ -44,9 +44,7 @@ import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 const embedder = new ModelRouterEmbeddingModel("mastra/__GATEWAY_OPENAI_EMBEDDING_MODEL__");
 ```
 
-Gateway-routed models do not forward local thread/resource context as upstream Gateway memory headers. If you want Observational Memory for a Gateway-routed actor model, configure local observer and reflector models in your Mastra memory setup; those models may also use gateway-prefixed IDs.
-
-Pass `memory.thread` and `memory.resource` when you generate/stream responses to provide local memory context:
+Pass `memory.thread` and `memory.resource` when you generate/stream responses to enable Observational Memory:
 
 ```typescript title="src/mastra/run.ts"
 import { weatherAgent } from "./agents/weather-agent";

--- a/docs/src/content/en/models/gateways/mastra.mdx
+++ b/docs/src/content/en/models/gateways/mastra.mdx
@@ -41,10 +41,12 @@ Use the same prefix for embedding models that should run through the gateway:
 ```typescript title="src/mastra/rag/embed.ts"
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 
-const embedder = new ModelRouterEmbeddingModel("mastra/openai/text-embedding-3-small");
+const embedder = new ModelRouterEmbeddingModel("mastra/__GATEWAY_OPENAI_EMBEDDING_MODEL__");
 ```
 
-Pass `memory.thread` and `memory.resource` when you generate/stream responses to enable Observational Memory:
+Gateway-routed models do not forward local thread/resource context as upstream Gateway memory headers. If you want Observational Memory for a Gateway-routed actor model, configure local observer and reflector models in your Mastra memory setup; those models may also use gateway-prefixed IDs.
+
+Pass `memory.thread` and `memory.resource` when you generate/stream responses to provide local memory context:
 
 ```typescript title="src/mastra/run.ts"
 import { weatherAgent } from "./agents/weather-agent";

--- a/docs/src/plugins/remark-model-tokens/models.ts
+++ b/docs/src/plugins/remark-model-tokens/models.ts
@@ -15,7 +15,7 @@ export const MODEL_TOKENS: Record<string, string> = {
   __GATEWAY_OPENAI_MODEL_MINI__: 'openai/gpt-5-mini',
   __GATEWAY_OPENAI_MODEL_NANO__: 'openai/gpt-5-nano',
   __GATEWAY_OPENAI_MODEL_BASE__: 'openai/gpt-5',
-  __AI_SDK_OPENAI_MODEL_BASE__: 'gpt-5.5',
+  __AI_SDK_OPENAI_MODEL_BASE__: 'gpt-5',
   __GATEWAY_OPENAI_EMBEDDING_MODEL__: 'openai/text-embedding-3-small',
   __AI_SDK_OPENAI_EMBEDDING_MODEL__: 'text-embedding-3-small',
   __AI_SDK_OPENAI_MODEL_REALTIME__: 'gpt-5.1-realtime',

--- a/docs/src/plugins/remark-model-tokens/models.ts
+++ b/docs/src/plugins/remark-model-tokens/models.ts
@@ -16,6 +16,8 @@ export const MODEL_TOKENS: Record<string, string> = {
   __GATEWAY_OPENAI_MODEL_NANO__: 'openai/gpt-5-nano',
   __GATEWAY_OPENAI_MODEL_BASE__: 'openai/gpt-5',
   __AI_SDK_OPENAI_MODEL_BASE__: 'gpt-5.5',
+  __GATEWAY_OPENAI_EMBEDDING_MODEL__: 'openai/text-embedding-3-small',
+  __AI_SDK_OPENAI_EMBEDDING_MODEL__: 'text-embedding-3-small',
   __AI_SDK_OPENAI_MODEL_REALTIME__: 'gpt-5.1-realtime',
 
   // Anthropic

--- a/packages/core/src/llm/model/embedding-router.e2e.test.ts
+++ b/packages/core/src/llm/model/embedding-router.e2e.test.ts
@@ -129,6 +129,35 @@ describe('ModelRouterEmbeddingModel Integration', () => {
       });
     });
 
+    it('falls back to the default Mastra Gateway URL for empty configured URLs', () => {
+      process.env.MASTRA_GATEWAY_URL = '   ';
+      new ModelRouterEmbeddingModel(GATEWAY_OPENAI_EMBEDDING_MODEL);
+
+      expect(createOpenAICompatible).toHaveBeenLastCalledWith({
+        name: 'mastra',
+        apiKey: 'test-gateway-key',
+        baseURL: 'https://gateway-api.mastra.ai/v1',
+        headers: {
+          'User-Agent': MASTRA_USER_AGENT,
+        },
+      });
+
+      new ModelRouterEmbeddingModel({
+        id: GATEWAY_OPENAI_EMBEDDING_MODEL,
+        apiKey: 'explicit-gateway-key',
+        url: '',
+      });
+
+      expect(createOpenAICompatible).toHaveBeenLastCalledWith({
+        name: 'mastra',
+        apiKey: 'explicit-gateway-key',
+        baseURL: 'https://gateway-api.mastra.ai/v1',
+        headers: {
+          'User-Agent': MASTRA_USER_AGENT,
+        },
+      });
+    });
+
     it('requires MASTRA_GATEWAY_API_KEY for mastra-prefixed embedding models', () => {
       delete process.env.MASTRA_GATEWAY_API_KEY;
 

--- a/packages/core/src/llm/model/embedding-router.e2e.test.ts
+++ b/packages/core/src/llm/model/embedding-router.e2e.test.ts
@@ -63,6 +63,60 @@ describe('ModelRouterEmbeddingModel Integration', () => {
     });
   });
 
+  describe('Mastra Gateway embedding routing', () => {
+    beforeEach(() => {
+      process.env.MASTRA_GATEWAY_API_KEY = 'test-gateway-key';
+      process.env.MASTRA_GATEWAY_URL = 'https://gateway.example.com';
+      vi.mocked(createOpenAICompatible).mockReturnValue({
+        textEmbeddingModel: vi.fn((_modelId: string) => ({
+          specificationVersion: 'v2',
+          modelId: _modelId,
+          maxEmbeddingsPerCall: 2048,
+          supportsParallelCalls: true,
+          doEmbed: vi.fn(async ({ values }: { values: string[] }) => ({
+            embeddings: values.map(() => new Array(1536).fill(0.1)),
+          })),
+        })),
+      } as any);
+    });
+
+    afterEach(() => {
+      delete process.env.MASTRA_GATEWAY_API_KEY;
+      delete process.env.MASTRA_GATEWAY_URL;
+      vi.clearAllMocks();
+    });
+
+    it('routes mastra-prefixed embedding models through the Mastra Gateway', async () => {
+      const model = new ModelRouterEmbeddingModel('mastra/openai/text-embedding-3-small');
+
+      expect(model.provider).toBe('mastra');
+      expect(model.modelId).toBe('openai/text-embedding-3-small');
+      expect(createOpenAICompatible).toHaveBeenCalledWith({
+        name: 'mastra',
+        apiKey: 'test-gateway-key',
+        baseURL: 'https://gateway.example.com/v1',
+        headers: {
+          'User-Agent': 'mastra',
+        },
+      });
+
+      const mockInstance = vi.mocked(createOpenAICompatible).mock.results[0].value;
+      expect(mockInstance.textEmbeddingModel).toHaveBeenCalledWith('openai/text-embedding-3-small');
+
+      const result = await model.doEmbed({ values: ['hello gateway'] });
+      expect(result.embeddings).toHaveLength(1);
+      expect(result.embeddings[0]).toHaveLength(1536);
+    });
+
+    it('requires MASTRA_GATEWAY_API_KEY for mastra-prefixed embedding models', () => {
+      delete process.env.MASTRA_GATEWAY_API_KEY;
+
+      expect(() => new ModelRouterEmbeddingModel('mastra/openai/text-embedding-3-small')).toThrow(
+        'API key not found for provider mastra. Set MASTRA_GATEWAY_API_KEY',
+      );
+    });
+  });
+
   describe('OpenAI embedding (with real API)', () => {
     it('should successfully embed text using OpenAI', async () => {
       if (!process.env.OPENAI_API_KEY) {

--- a/packages/core/src/llm/model/embedding-router.e2e.test.ts
+++ b/packages/core/src/llm/model/embedding-router.e2e.test.ts
@@ -2,6 +2,7 @@ import { getLLMTestMode } from '@internal/llm-recorder';
 import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
 import { afterAll, describe, it, expect, beforeAll, vi, beforeEach, afterEach } from 'vitest';
 import { ModelRouterEmbeddingModel } from './embedding-router.js';
+import { MASTRA_USER_AGENT } from './gateways/constants.js';
 
 const MODE = getLLMTestMode();
 setupDummyApiKeys(MODE, ['openai', 'google']);
@@ -20,6 +21,9 @@ const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible-v5');
 const mock = createGatewayMock();
 beforeAll(() => mock.start());
 afterAll(() => mock.saveAndStop());
+
+const GATEWAY_OPENAI_EMBEDDING_MODEL = 'mastra/openai/__AI_SDK_OPENAI_EMBEDDING_MODEL__';
+const OPENAI_EMBEDDING_MODEL = 'openai/__AI_SDK_OPENAI_EMBEDDING_MODEL__';
 
 describe('ModelRouterEmbeddingModel Integration', () => {
   beforeAll(() => {
@@ -87,31 +91,48 @@ describe('ModelRouterEmbeddingModel Integration', () => {
     });
 
     it('routes mastra-prefixed embedding models through the Mastra Gateway', async () => {
-      const model = new ModelRouterEmbeddingModel('mastra/openai/text-embedding-3-small');
+      const model = new ModelRouterEmbeddingModel(GATEWAY_OPENAI_EMBEDDING_MODEL);
 
       expect(model.provider).toBe('mastra');
-      expect(model.modelId).toBe('openai/text-embedding-3-small');
+      expect(model.modelId).toBe(OPENAI_EMBEDDING_MODEL);
       expect(createOpenAICompatible).toHaveBeenCalledWith({
         name: 'mastra',
         apiKey: 'test-gateway-key',
         baseURL: 'https://gateway.example.com/v1',
         headers: {
-          'User-Agent': 'mastra',
+          'User-Agent': MASTRA_USER_AGENT,
         },
       });
 
       const mockInstance = vi.mocked(createOpenAICompatible).mock.results[0].value;
-      expect(mockInstance.textEmbeddingModel).toHaveBeenCalledWith('openai/text-embedding-3-small');
+      expect(mockInstance.textEmbeddingModel).toHaveBeenCalledWith(OPENAI_EMBEDDING_MODEL);
 
       const result = await model.doEmbed({ values: ['hello gateway'] });
       expect(result.embeddings).toHaveLength(1);
       expect(result.embeddings[0]).toHaveLength(1536);
     });
 
+    it('normalizes explicit Mastra Gateway URLs before creating the provider', () => {
+      new ModelRouterEmbeddingModel({
+        id: GATEWAY_OPENAI_EMBEDDING_MODEL,
+        apiKey: 'explicit-gateway-key',
+        url: 'https://gateway.example.com/',
+      });
+
+      expect(createOpenAICompatible).toHaveBeenCalledWith({
+        name: 'mastra',
+        apiKey: 'explicit-gateway-key',
+        baseURL: 'https://gateway.example.com/v1',
+        headers: {
+          'User-Agent': MASTRA_USER_AGENT,
+        },
+      });
+    });
+
     it('requires MASTRA_GATEWAY_API_KEY for mastra-prefixed embedding models', () => {
       delete process.env.MASTRA_GATEWAY_API_KEY;
 
-      expect(() => new ModelRouterEmbeddingModel('mastra/openai/text-embedding-3-small')).toThrow(
+      expect(() => new ModelRouterEmbeddingModel(GATEWAY_OPENAI_EMBEDDING_MODEL)).toThrow(
         'API key not found for provider mastra. Set MASTRA_GATEWAY_API_KEY',
       );
     });

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -7,8 +7,7 @@ type EmbeddingModelV2<VALUE> = Exclude<EmbeddingModel<VALUE>, string>;
 
 const MASTRA_GATEWAY_ID = 'mastra';
 
-function getMastraGatewayBaseUrl(): string {
-  const raw = process.env['MASTRA_GATEWAY_URL'] ?? 'https://gateway-api.mastra.ai';
+function getMastraGatewayBaseUrl(raw = process.env['MASTRA_GATEWAY_URL'] ?? 'https://gateway-api.mastra.ai'): string {
   return `${raw.replace(/\/+$/, '').replace(/\/v1$/, '')}/v1`;
 }
 
@@ -180,7 +179,7 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
       this.providerModel = createOpenAICompatible({
         name: MASTRA_GATEWAY_ID,
         apiKey,
-        baseURL: normalizedConfig.url ?? getMastraGatewayBaseUrl(),
+        baseURL: getMastraGatewayBaseUrl(normalizedConfig.url),
         headers: {
           'User-Agent': MASTRA_USER_AGENT,
           ...normalizedConfig.headers,

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -19,8 +19,9 @@ function trimTrailingSlashes(value: string): string {
   return value.slice(0, end);
 }
 
-function getMastraGatewayBaseUrl(raw = process.env['MASTRA_GATEWAY_URL'] ?? 'https://gateway-api.mastra.ai'): string {
-  const withoutTrailingSlashes = trimTrailingSlashes(raw);
+function getMastraGatewayBaseUrl(raw = process.env['MASTRA_GATEWAY_URL']): string {
+  const baseUrl = raw?.trim() || 'https://gateway-api.mastra.ai';
+  const withoutTrailingSlashes = trimTrailingSlashes(baseUrl);
   const withoutVersion = withoutTrailingSlashes.endsWith('/v1')
     ? withoutTrailingSlashes.slice(0, -'/v1'.length)
     : withoutTrailingSlashes;

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -5,6 +5,14 @@ import type { EmbeddingModel } from '@internal/ai-sdk-v5';
 
 type EmbeddingModelV2<VALUE> = Exclude<EmbeddingModel<VALUE>, string>;
 
+const MASTRA_GATEWAY_ID = 'mastra';
+
+function getMastraGatewayBaseUrl(): string {
+  const raw = process.env['MASTRA_GATEWAY_URL'] ?? 'https://gateway-api.mastra.ai';
+  return `${raw.replace(/\/+$/, '').replace(/\/v1$/, '')}/v1`;
+}
+
+import { MASTRA_USER_AGENT } from './gateways/constants.js';
 import { GatewayRegistry } from './provider-registry.js';
 import type { OpenAICompatibleConfig } from './shared.types.js';
 
@@ -109,13 +117,20 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
     };
 
     if (typeof config === 'string') {
-      // Parse provider/model from string (e.g., "openai/text-embedding-3-small")
+      // Parse provider/model or gateway/provider/model from string.
       const parts = config.split('/');
-      if (parts.length !== 2) {
-        throw new Error(`Invalid model string format: "${config}". Expected format: "provider/model"`);
+      if (parts[0] === MASTRA_GATEWAY_ID) {
+        if (parts.length < 3) {
+          throw new Error(`Invalid model string format: "${config}". Expected format: "mastra/provider/model"`);
+        }
+        normalizedConfig = { providerId: MASTRA_GATEWAY_ID, modelId: parts.slice(1).join('/') };
+      } else {
+        if (parts.length !== 2) {
+          throw new Error(`Invalid model string format: "${config}". Expected format: "provider/model"`);
+        }
+        const [providerId, modelId] = parts as [string, string];
+        normalizedConfig = { providerId, modelId };
       }
-      const [providerId, modelId] = parts as [string, string];
-      normalizedConfig = { providerId, modelId };
     } else if ('providerId' in config && 'modelId' in config) {
       normalizedConfig = {
         providerId: config.providerId,
@@ -127,25 +142,53 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
     } else {
       // config has 'id' field
       const parts = config.id.split('/');
-      if (parts.length !== 2) {
-        throw new Error(`Invalid model string format: "${config.id}". Expected format: "provider/model"`);
+      if (parts[0] === MASTRA_GATEWAY_ID) {
+        if (parts.length < 3) {
+          throw new Error(`Invalid model string format: "${config.id}". Expected format: "mastra/provider/model"`);
+        }
+        normalizedConfig = {
+          providerId: MASTRA_GATEWAY_ID,
+          modelId: parts.slice(1).join('/'),
+          url: config.url,
+          apiKey: config.apiKey,
+          headers: config.headers,
+        };
+      } else {
+        if (parts.length !== 2) {
+          throw new Error(`Invalid model string format: "${config.id}". Expected format: "provider/model"`);
+        }
+        const [providerId, modelId] = parts as [string, string];
+        normalizedConfig = {
+          providerId,
+          modelId,
+          url: config.url,
+          apiKey: config.apiKey,
+          headers: config.headers,
+        };
       }
-      const [providerId, modelId] = parts as [string, string];
-      normalizedConfig = {
-        providerId,
-        modelId,
-        url: config.url,
-        apiKey: config.apiKey,
-        headers: config.headers,
-      };
     }
 
     this.provider = normalizedConfig.providerId;
     this.modelId = normalizedConfig.modelId;
 
-    // If custom URL is provided, skip provider registry validation
-    // and use the provided API key (or empty string if not provided)
-    if (normalizedConfig.url) {
+    if (normalizedConfig.providerId === MASTRA_GATEWAY_ID) {
+      const apiKey = normalizedConfig.apiKey ?? process.env['MASTRA_GATEWAY_API_KEY'];
+      if (!apiKey) {
+        throw new Error('API key not found for provider mastra. Set MASTRA_GATEWAY_API_KEY');
+      }
+
+      this.providerModel = createOpenAICompatible({
+        name: MASTRA_GATEWAY_ID,
+        apiKey,
+        baseURL: normalizedConfig.url ?? getMastraGatewayBaseUrl(),
+        headers: {
+          'User-Agent': MASTRA_USER_AGENT,
+          ...normalizedConfig.headers,
+        },
+      }).textEmbeddingModel(normalizedConfig.modelId) as EmbeddingModelV2<VALUE>;
+    } else if (normalizedConfig.url) {
+      // If custom URL is provided, skip provider registry validation
+      // and use the provided API key (or empty string if not provided)
       const apiKey = normalizedConfig.apiKey || '';
       this.providerModel = createOpenAICompatible({
         name: normalizedConfig.providerId,

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -5,15 +5,28 @@ import type { EmbeddingModel } from '@internal/ai-sdk-v5';
 
 type EmbeddingModelV2<VALUE> = Exclude<EmbeddingModel<VALUE>, string>;
 
-const MASTRA_GATEWAY_ID = 'mastra';
-
-function getMastraGatewayBaseUrl(raw = process.env['MASTRA_GATEWAY_URL'] ?? 'https://gateway-api.mastra.ai'): string {
-  return `${raw.replace(/\/+$/, '').replace(/\/v1$/, '')}/v1`;
-}
-
 import { MASTRA_USER_AGENT } from './gateways/constants.js';
 import { GatewayRegistry } from './provider-registry.js';
 import type { OpenAICompatibleConfig } from './shared.types.js';
+
+const MASTRA_GATEWAY_ID = 'mastra';
+
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+function getMastraGatewayBaseUrl(raw = process.env['MASTRA_GATEWAY_URL'] ?? 'https://gateway-api.mastra.ai'): string {
+  const withoutTrailingSlashes = trimTrailingSlashes(raw);
+  const withoutVersion = withoutTrailingSlashes.endsWith('/v1')
+    ? withoutTrailingSlashes.slice(0, -'/v1'.length)
+    : withoutTrailingSlashes;
+
+  return `${withoutVersion}/v1`;
+}
 
 /**
  * Information about a known embedding model


### PR DESCRIPTION
## Summary
- route `mastra/provider/model` embedding model IDs through Mastra Gateway
- add embedding-router coverage for Gateway routing
- document Gateway embedding model usage
- keep observational memory local for Gateway-routed actor models, so users opt in with explicit observer/reflector model config instead of implicit Gateway-managed memory behavior

## Test plan
- `pnpm --filter @mastra/core test:unit embedding-router.e2e.test.ts`
- `pnpm --filter @mastra/core typecheck`
- `pnpm vitest run packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts --reporter=dot`
- `pnpm --filter ./packages/memory check`

Depends on platform support for `/v1/embeddings`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds support for routing embedding model requests through Mastra's Gateway service. Users can now use special model IDs like `mastra/openai/text-embedding-3-small` to send embeddings through the Gateway instead of directly to providers. The PR also ensures that local memory processing continues to work correctly and prevents accidental interference with platform-managed memory.

## Overview

Introduces first-class Gateway embedding routing support by enabling `ModelRouterEmbeddingModel` to accept `mastra/provider/model` identifiers, which resolve to upstream Gateway endpoints. Includes comprehensive test coverage, documentation updates, and related observational-memory refinements.

## Key Changes

### Core Gateway Embedding Support
- Extended `ModelRouterEmbeddingModel` to handle `mastra/provider/model` format in model ID parsing
- When `providerId` resolves to `mastra`, the constructor now requires `MASTRA_GATEWAY_API_KEY` (with `config.apiKey` as an override option)
- Initializes OpenAI-compatible embedding models using the Gateway base URL (defaults to `https://gateway-api.mastra.ai/v1` or respects explicitly configured `MASTRA_GATEWAY_URL`)
- Normalizes configured Gateway URLs to `/v1` form and includes `MASTRA_USER_AGENT` in request headers
- Maintains backward compatibility for existing non-Mastra provider routing

### Testing & Documentation
- Added comprehensive e2e test suite (`embedding-router.e2e.test.ts`) covering:
  - Mastra-prefixed ID normalization and model ID rewriting
  - Gateway base URL handling (explicit, blank/whitespace fallback, normalization)
  - OpenAI-compatible client initialization with correct headers and configuration
  - Error handling when `MASTRA_GATEWAY_API_KEY` is missing
- Updated Mastra Gateway documentation (`docs/src/content/en/models/gateways/mastra.mdx`) with TypeScript examples for Gateway-routed embeddings
- Updated `MODEL_TOKENS` in documentation plugins with new Gateway and SDK embedding model token references

### Related Changes
- Changeset metadata updated to bump `@mastra/core` as minor and `@mastra/memory` as patch
- No breaking changes to existing public API signatures

## Impact
- Enables users to route embedding requests through Mastra Gateway using intuitive `mastra/provider/model` identifiers
- Maintains full backward compatibility with existing embedding routing
- Properly handles API key validation and URL configuration for Gateway endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->