### PR TITLE
feat(core): add channel resource id resolver

### DIFF
--- a/.changeset/spicy-dodos-join.md
+++ b/.changeset/spicy-dodos-join.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+---
+
+Added `channels.resolveResourceId` to control which `resourceId` owns a channel thread's memory, separately from who sent the message. Useful for SSO apps that want a user's memory shared across web and a Feishu/Lark DM, or group chats scoped to the conversation instead of the sender. Only affects newly-created threads; return the provided default to keep current behavior.
+
+```ts
+new Agent({
+  // ...
+  channels: {
+    adapters: { slack: createSlackAdapter() },
+    resolveResourceId: async ({ thread, message }) => {
+      if (thread.isDM) return resolveSsoUserId(message); // shared with web
+      return thread.channelId; // group owns the memory
+    },
+  },
+});
+```

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -103,6 +103,13 @@ export const supportAgent = new Agent({
     description:
       'Additional options passed directly to the [Chat SDK](https://chat-sdk.dev/docs/usage). Use for advanced configuration such as `dedupeTtlMs`, `fallbackStreamingPlaceholderText`, `lockScope`, and `messageHistory`.',
   },
+  {
+    name: 'resolveResourceId',
+    type: '(ctx: ResolveResourceIdContext) => string | Promise<string>',
+    isOptional: true,
+    description:
+      'Decide which `resourceId` owns resource-level memory for a channel thread, separately from who sent the message. Runs only when a new thread is created; reused threads keep their stored owner and never call the hook. Return `ctx.defaultResourceId` (`${platform}:${message.author.userId}`) to keep the built-in behavior.',
+  },
 ]}
 />
 
@@ -352,6 +359,65 @@ type ChannelHandler = (
   defaultHandler: (thread: Thread, message: Message) => Promise<void>,
 ) => Promise<void>
 ```
+
+## Resource ID resolution
+
+By default a channel thread's memory `resourceId` is `${platform}:${message.author.userId}`. The sender owns the memory, scoped per platform. For apps with a shared identity, such as single sign-on (SSO), this splits memory: the same user gets `feishu:user_123` in a Feishu DM but `user_123` on the web.
+
+Pass `resolveResourceId` to decide memory ownership separately from the sender. It runs only when a new thread is created. Reused threads keep their stored `resourceId` and never call the hook, so existing conversations don't depend on the resolver being available. Return `ctx.defaultResourceId` to fall back to the built-in behavior.
+
+```typescript title="src/mastra/agents/sso-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { createSlackAdapter } from '@chat-adapter/slack'
+
+const agent = new Agent({
+  name: 'SSO Agent',
+  instructions: '...',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  channels: {
+    adapters: {
+      slack: createSlackAdapter(),
+    },
+    resolveResourceId: async ({ thread, message }) => {
+      // DM: share resource-level memory with the web app by using the bare SSO id
+      if (thread.isDM) {
+        return await resolveSsoUserId(message)
+      }
+      // Group chat: the conversation owns the memory; the sender stays the actor
+      return thread.channelId
+    },
+  },
+})
+```
+
+The `ResolveResourceIdContext` passed to the function:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'platform',
+    type: 'string',
+    description: 'Platform name (e.g. `slack`, `discord`).',
+  },
+  {
+    name: 'thread',
+    type: 'Thread',
+    description:
+      'The channel thread the message arrived on. Use `thread.isDM` to tell DMs apart from group/channel threads.',
+  },
+  {
+    name: 'message',
+    type: 'Message',
+    description: 'The incoming message. `message.author.userId` is the actor/sender, not necessarily the memory owner.',
+  },
+  {
+    name: 'defaultResourceId',
+    type: 'string',
+    description:
+      'The built-in default (`${platform}:${message.author.userId}`). Return this to keep the current behavior.',
+  },
+]}
+/>
 
 ## Inline media
 

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -381,6 +381,235 @@ describe('AgentChannels', () => {
     });
   });
 
+  describe('resolveResourceId', () => {
+    function makeChatThread(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'channel-1:thread-1',
+        channelId: 'channel-1',
+        isDM: false,
+        adapter: undefined as any, // set per-test from the channels instance
+        isSubscribed: vi.fn().mockResolvedValue(true),
+        subscribe: vi.fn().mockResolvedValue(undefined),
+        mentionUser: vi.fn((userId: string) => `<@${userId}>`),
+        messages: (async function* () {})(),
+        ...overrides,
+      } as any;
+    }
+
+    const message = {
+      id: 'message-1',
+      text: 'hi',
+      author: { userId: 'user-1', userName: 'tyler', fullName: 'Tyler Barnes' },
+      attachments: [],
+    } as any;
+
+    function makeMastra() {
+      const db = new InMemoryDB();
+      const memoryStore = new InMemoryMemory({ db });
+      return {
+        getStorage: () => ({ getStore: () => memoryStore }),
+        getServer: () => null,
+      } as any;
+    }
+
+    it('uses the default `${platform}:${author.userId}` when no resolver is set', async () => {
+      const mockMastra = makeMastra();
+      await agentChannels.initialize(mockMastra);
+      const chatThread = makeChatThread({ adapter: agentChannels.adapters.discord });
+
+      await (agentChannels as any).processChatMessage(chatThread, message, mockMastra);
+
+      expect(mockAgent.sendMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          resourceId: 'discord:user-1',
+          ifIdle: expect.objectContaining({
+            streamOptions: expect.objectContaining({
+              memory: expect.objectContaining({ resource: 'discord:user-1' }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('uses the resolver return value as the new thread resourceId (DM uses bare SSO id)', async () => {
+      const resolveResourceId = vi.fn(async () => 'sso-user-42');
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        resolveResourceId,
+      });
+      channels.__setAgent(mockAgent);
+
+      const mockMastra = makeMastra();
+      await channels.initialize(mockMastra);
+      const chatThread = makeChatThread({ adapter: channels.adapters.discord, isDM: true });
+
+      await (channels as any).processChatMessage(chatThread, message, mockMastra);
+
+      expect(resolveResourceId).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platform: 'discord',
+          thread: chatThread,
+          message,
+          defaultResourceId: 'discord:user-1',
+        }),
+      );
+      expect(mockAgent.sendMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          resourceId: 'sso-user-42',
+          ifIdle: expect.objectContaining({
+            streamOptions: expect.objectContaining({
+              memory: expect.objectContaining({ resource: 'sso-user-42' }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('scopes a group chat to its channelId while keeping the sender as actor', async () => {
+      const resolveResourceId = vi.fn(async ({ thread, defaultResourceId }: any) =>
+        thread.isDM ? defaultResourceId : thread.channelId,
+      );
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        resolveResourceId,
+      });
+      channels.__setAgent(mockAgent);
+
+      const mockMastra = makeMastra();
+      await channels.initialize(mockMastra);
+      const chatThread = makeChatThread({ adapter: channels.adapters.discord, isDM: false });
+
+      await (channels as any).processChatMessage(chatThread, message, mockMastra);
+
+      expect(mockAgent.sendMessage).toHaveBeenCalledWith(
+        // actor identity stays the sender
+        expect.objectContaining({
+          attributes: expect.objectContaining({ authorId: 'user-1' }),
+        }),
+        // memory owner is the group/channel
+        expect.objectContaining({
+          resourceId: 'channel-1',
+          ifIdle: expect.objectContaining({
+            streamOptions: expect.objectContaining({
+              memory: expect.objectContaining({ resource: 'channel-1' }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('returning defaultResourceId keeps the built-in behavior', async () => {
+      const resolveResourceId = vi.fn(async ({ defaultResourceId }: any) => defaultResourceId);
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        resolveResourceId,
+      });
+      channels.__setAgent(mockAgent);
+
+      const mockMastra = makeMastra();
+      await channels.initialize(mockMastra);
+      const chatThread = makeChatThread({ adapter: channels.adapters.discord });
+
+      await (channels as any).processChatMessage(chatThread, message, mockMastra);
+
+      expect(mockAgent.sendMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ resourceId: 'discord:user-1' }),
+      );
+    });
+
+    it('does not run the resolver when reusing an existing thread (keeps stored owner)', async () => {
+      const resolveResourceId = vi.fn(async () => 'should-not-be-used');
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        resolveResourceId,
+      });
+      channels.__setAgent(mockAgent);
+
+      const mockMastra = makeMastra();
+      await channels.initialize(mockMastra);
+
+      // Pre-create the mastra thread with a fixed owner, using the same channel metadata
+      // the handler queries on, so getOrCreateThread reuses it instead of creating a new one.
+      const memoryStore = await mockMastra.getStorage().getStore('memory');
+      await memoryStore.saveThread({
+        thread: {
+          id: 'pre-existing',
+          title: 'discord conversation',
+          resourceId: 'original-owner',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: {
+            channel_platform: 'discord',
+            channel_externalThreadId: 'channel-1:thread-1',
+            channel_externalChannelId: 'channel-1',
+          },
+        },
+      });
+
+      const chatThread = makeChatThread({ adapter: channels.adapters.discord });
+      await (channels as any).processChatMessage(chatThread, message, mockMastra);
+
+      // The reused thread's stored owner drives memory, and the resolver is never
+      // called; existing conversations don't depend on the resolver being available.
+      expect(resolveResourceId).not.toHaveBeenCalled();
+      expect(mockAgent.sendMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          resourceId: 'original-owner',
+          ifIdle: expect.objectContaining({
+            streamOptions: expect.objectContaining({
+              memory: expect.objectContaining({ resource: 'original-owner' }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('does not fail an existing thread when the resolver throws', async () => {
+      const resolveResourceId = vi.fn(async () => {
+        throw new Error('SSO unavailable');
+      });
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        resolveResourceId,
+      });
+      channels.__setAgent(mockAgent);
+
+      const mockMastra = makeMastra();
+      await channels.initialize(mockMastra);
+
+      // Pre-create the thread so the handler reuses it instead of creating one.
+      const memoryStore = await mockMastra.getStorage().getStore('memory');
+      await memoryStore.saveThread({
+        thread: {
+          id: 'pre-existing',
+          title: 'discord conversation',
+          resourceId: 'original-owner',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: {
+            channel_platform: 'discord',
+            channel_externalThreadId: 'channel-1:thread-1',
+            channel_externalChannelId: 'channel-1',
+          },
+        },
+      });
+
+      const chatThread = makeChatThread({ adapter: channels.adapters.discord });
+
+      // A flaky resolver must not break message handling on an existing thread.
+      await expect((channels as any).processChatMessage(chatThread, message, mockMastra)).resolves.not.toThrow();
+      expect(resolveResourceId).not.toHaveBeenCalled();
+      expect(mockAgent.sendMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ resourceId: 'original-owner' }),
+      );
+    });
+  });
+
   describe('close', () => {
     it('unsubscribes all cached thread subscriptions', () => {
       const unsubscribeA = vi.fn();

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -37,6 +37,7 @@ import type {
   ChannelContext,
   ChannelHandlers,
   PostableMessage,
+  ResolveResourceId,
   StreamingConfig,
   ThreadHistoryMessage,
   ToolDisplay,
@@ -77,6 +78,8 @@ export class AgentChannels {
   private inlineLinkRules: InlineLinkRule[] | undefined;
   /** Whether channel tools (reactions, etc.) are enabled. */
   private toolsEnabled: boolean;
+  /** Optional hook to resolve the memory resourceId (owner) for newly-created channel threads. */
+  private resolveResourceId: ResolveResourceId | undefined;
   /**
    * The original `ChannelConfig` passed to the constructor.
    *
@@ -157,6 +160,7 @@ export class AgentChannels {
     this.shouldInline = buildInlineMediaCheck(config.inlineMedia);
     this.inlineLinkRules = normalizeInlineLinks(config.inlineLinks);
     this.toolsEnabled = config.tools !== false;
+    this.resolveResourceId = config.resolveResourceId;
     this.channelConfig = config;
     this.channelToolNames = new Set(Object.keys(this.getTools()));
   }
@@ -862,11 +866,16 @@ export class AgentChannels {
     // each Slack thread (including top-level DM, DM thread reply, channel mention, and
     // channel thread reply) gets its own mastra thread.
     const externalThreadId = chatThread.id;
+    const defaultResourceId = `${platform}:${message.author.userId}`;
     const mastraThread = await this.getOrCreateThread({
       externalThreadId,
       channelId: chatThread.channelId,
       platform,
-      resourceId: `${platform}:${message.author.userId}`,
+      // Lazily resolved: the hook only runs when we're actually creating a new
+      // thread, never when reusing an existing one (which keeps its stored owner).
+      resourceId: this.resolveResourceId
+        ? () => this.resolveResourceId!({ platform, thread: chatThread, message, defaultResourceId })
+        : defaultResourceId,
       mastra,
     });
 
@@ -1334,7 +1343,12 @@ export class AgentChannels {
     externalThreadId: string;
     channelId: string;
     platform: string;
-    resourceId: string;
+    /**
+     * The owner for a newly-created thread. Pass a function to defer resolution
+     * until we know a new thread is actually needed; it is never called when an
+     * existing thread is reused.
+     */
+    resourceId: string | (() => string | Promise<string>);
     mastra: Mastra;
   }): Promise<StorageThreadType> {
     const storage = mastra.getStorage();
@@ -1364,11 +1378,13 @@ export class AgentChannels {
       return threads[0]!;
     }
 
+    const resolvedResourceId = typeof resourceId === 'function' ? await resourceId() : resourceId;
+
     return memoryStore.saveThread({
       thread: {
         id: crypto.randomUUID(),
         title: `${platform} conversation`,
-        resourceId,
+        resourceId: resolvedResourceId,
         createdAt: new Date(),
         updatedAt: new Date(),
         metadata,

--- a/packages/core/src/channels/index.ts
+++ b/packages/core/src/channels/index.ts
@@ -23,6 +23,8 @@ export type {
   ChannelProvider,
   InlineLinkEntry,
   PostableMessage,
+  ResolveResourceId,
+  ResolveResourceIdContext,
   StaticToolDisplay,
   StreamingConfig,
   StreamingOnlyToolDisplay,

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -304,6 +304,28 @@ export type ChannelHandler = (
  */
 export type ChannelHandlerConfig = ChannelHandler | false | undefined;
 
+/**
+ * Context passed to {@link ChannelConfig.resolveResourceId}.
+ * Lets an app decide who owns resource-level memory for a channel thread,
+ * separately from who sent the message (`message.author`).
+ */
+export interface ResolveResourceIdContext {
+  /** Platform name (e.g. 'slack', 'discord'). */
+  platform: string;
+  /** The channel thread the message arrived on. Use `thread.isDM` to tell DMs from group/channel threads. */
+  thread: Thread;
+  /** The incoming message. `message.author.userId` is the actor/sender, not necessarily the memory owner. */
+  message: Message;
+  /** The built-in default: `${platform}:${message.author.userId}`. Return this to keep current behavior. */
+  defaultResourceId: string;
+}
+
+/**
+ * Resolve the memory `resourceId` (the owner of resource-level memory) for a channel
+ * thread before it's created.
+ */
+export type ResolveResourceId = (ctx: ResolveResourceIdContext) => string | Promise<string>;
+
 /** Handler overrides for built-in channel event handlers. */
 export interface ChannelHandlers {
   /**
@@ -467,6 +489,28 @@ export interface ChannelConfig {
    * ```
    */
   chatOptions?: Omit<ChatConfig, 'adapters' | 'state' | 'userName'>;
+
+  /**
+   * Resolve the memory `resourceId` (the owner of resource-level memory) before a
+   * channel thread is created. This lets an app decide memory ownership separately
+   * from who sent the message. For example, share an SSO user's memory across Web and a
+   * Feishu/Lark DM (drop the platform prefix), or scope a group chat to its `chat_id`.
+   *
+   * Only affects **newly-created** threads. Once a thread exists it keeps its stored
+   * `resourceId`, so this never relocates memory on an existing conversation.
+   *
+   * Return `defaultResourceId` (`${platform}:${message.author.userId}`) to keep the
+   * built-in behavior. Not set: behavior is unchanged.
+   *
+   * @example
+   * ```ts
+   * resolveResourceId: async ({ thread, message, defaultResourceId }) => {
+   *   if (thread.isDM) return resolveSsoUserId(message);   // shared with Web
+   *   return thread.channelId;                             // group owns the memory
+   * }
+   * ```
+   */
+  resolveResourceId?: ResolveResourceId;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Closes #17257.

This PR adds an optional channel-level `resolveResourceId` hook for Agent Channels.

By default, channel-created threads continue to use the existing resource owner format:

```ts
resourceId = `${platform}:${message.author.userId}`
```

For SSO-backed products and group-channel integrations, `message.author.userId` is often the transport/platform actor rather than the owner of resource-level memory. This hook lets applications decide the memory `resourceId` for newly-created channel threads while preserving the sender/actor identity on the incoming message metadata.

Example use cases:

* Web private chat and Feishu/Lark DM can resolve to the same SSO user id.
* Feishu/Lark group chats can scope memory to the external chat/group id.
* The message sender remains available separately as the actor.

## Changes

This PR adds:

* `ResolveResourceIdContext`
* `ResolveResourceId`
* `ChannelConfig.resolveResourceId`
* public exports from `@mastra/core/channels`
* runtime integration in `AgentChannels`
* reference documentation and a changeset

The hook receives:

```ts
{
  platform,
  thread,
  message,
  defaultResourceId,
}
```

and returns either a string or `Promise<string>`.

```ts
channels: {
  adapters: { feishu: createFeishuAdapter() }, // illustrative adapter
  resolveResourceId: async ({ platform, thread, message, defaultResourceId }) => {
    if (platform === 'feishu' && thread.isDM) {
      return await resolveBoundSsoUserId(message);
    }

    if (platform === 'feishu' && !thread.isDM) {
      return thread.channelId;
    }

    return defaultResourceId;
  },
}
```

Changeset: `@mastra/core` minor.

## Behavior

This is intentionally a small resolver-only API rather than a full `getOrCreateThread` override.

Important behavior guarantees:

* Existing default behavior is unchanged when `resolveResourceId` is not configured.
* Returning `defaultResourceId` preserves the built-in behavior.
* The hook only runs when a new Mastra thread is created.
* Existing channel threads keep their stored `resourceId`; this PR does not migrate or rewrite thread ownership.
* Sender/actor identity is preserved separately through message attributes and provider metadata.
* Tool approval actions do not call the resolver with an incomplete context. They continue to resolve the original channel thread by metadata and reuse the stored thread `resourceId`.

## Tests

Added coverage for:

* default behavior without a resolver
* DM resolving to a bare SSO-style user id
* group chat resolving to the channel id while preserving sender identity
* returning `defaultResourceId`
* reusing an existing thread without calling the resolver
* ensuring an existing thread still works even if the resolver would throw

Tested with:

```sh
pnpm --filter ./packages/core test src/channels
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR lets you customize who "owns" a conversation's memory in your chat channels. Instead of always assigning memory to the person who sent the message with their platform ID, you can now provide a function that decides the owner based on your business logic—like mapping everyone in a department to a single SSO user, or grouping all messages in a chat channel together. The feature only affects new conversations; existing ones keep working exactly as before.

---

## Overview

This PR introduces an optional channel-level `resolveResourceId` hook to the `@mastra/core` package, enabling applications to customize how channel threads are owned and scoped in memory storage. Previously, the `resourceId` (which determines memory ownership) was always set to `${platform}:${message.author.userId}`. With this change, applications can provide custom logic to determine ownership independently of the sender's identity.

**Key characteristics:**
- The resolver only runs when creating new threads; existing threads retain their stored `resourceId`
- Default behavior is completely unchanged when the hook is not configured
- Actor/sender identity is preserved separately through message attributes and provider metadata
- The hook receives platform, thread, message context, and a defaultResourceId reference

---

## Changes

### Type Definitions & Exports
- Added `ResolveResourceIdContext` interface defining the inputs available to the resolver: `platform`, `thread`, `message`, and `defaultResourceId`
- Added `ResolveResourceId` function type: `(ctx: ResolveResourceIdContext) => string | Promise<string>`
- Extended `ChannelConfig` with optional `resolveResourceId` property
- Exported both new types from `@mastra/core/channels` for public consumption

### Runtime Integration
- Updated `AgentChannels` to accept and store the `resolveResourceId` hook from channel configuration
- Modified `processChatMessage` to pass the resolver (or default resolver) to `getOrCreateThread`
- Enhanced `getOrCreateThread` to accept `resourceId` as either a string or a function; when a function is provided, it is awaited and used for the persisted thread `resourceId`

### Testing
- Added comprehensive test suite (`describe('resolveResourceId')`) covering:
  - Default behavior without resolver (uses `${platform}:${author.userId}`)
  - Custom resolver returning different values for DMs vs group chats
  - Preserving actor identity while scoping memory to channel/group
  - Returning `defaultResourceId` to keep built-in behavior
  - Resolver not being called when reusing existing threads
  - Graceful handling when resolver throws on existing threads

### Documentation
- Added new "Resource ID resolution" section documenting the feature, its use cases (SSO mapping, group chat scoping), and behavior guarantees
- Included `ResolveResourceIdContext` field documentation
- Provided TypeScript example implementation

### Changelog
- Changeset entry for `@mastra/core` (minor version bump) documenting the new `channels.resolveResourceId` option

---

## Impact & Guarantees

- **Backward Compatible**: No changes to default behavior; existing users unaffected
- **Thread Creation Only**: Resolver runs only on new thread creation, not on reuse
- **Identity Preservation**: Sender/actor identity tracked separately through message metadata
- **Safe Integration**: Tool approval and existing thread handling unaffected; resolver not invoked in degraded scenarios
- **No Migration Required**: Existing stored thread `resourceId` values remain unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->