### PR TITLE
[FEATURE] Spanner adapter new domains: experiments, datasets, channels, workspaces, favorites

### DIFF
--- a/.changeset/spanner-new-domains.md
+++ b/.changeset/spanner-new-domains.md
@@ -1,0 +1,30 @@
+---
+'@mastra/spanner': minor
+---
+
+Added five new storage domains to the Google Cloud Spanner adapter: **workspaces**, **datasets**, **experiments**, **favorites**, and **channels**. The Spanner store now covers the full set of editor and evaluation domains.
+
+**What's new**
+
+- **Datasets** versioned dataset items with historical snapshots and as-of reads (time-travel reads, per-item history, batched insert/delete).
+- **Experiments** with per-item results, review-status aggregation, and pagination.
+- **Workspaces** with versioned configuration snapshots (filesystem, sandbox, mounts, search, skills, tools), mirroring the existing thin-record + versions pattern.
+- **Favorites** for agents and skills, maintaining a denormalized `favoriteCount` on the parent record atomically.
+- **Channels** for multi-platform installations and per-platform configuration.
+
+Enabling favorites also adds favorited-first ordering and `favoritedOnly` / `entityIds` filtering to `agents.list()` and `skills.list()`, and surfaces `favoriteCount` on skill records.
+
+```typescript
+const storage = new SpannerStore({
+  id: 'spanner-storage',
+  projectId: process.env.SPANNER_PROJECT_ID!,
+  instanceId: process.env.SPANNER_INSTANCE_ID!,
+  databaseId: process.env.SPANNER_DATABASE_ID!,
+})
+
+const datasets = await storage.getStore('datasets')
+const ds = await datasets?.createDataset({ name: 'eval-set' })
+
+const favorites = await storage.getStore('favorites')
+await favorites?.favorite({ userId: 'u1', entityType: 'agent', entityId: 'agent-1' })
+```

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -57,6 +57,7 @@ Each provider page includes installation instructions, configuration parameters,
 - [DynamoDB](/reference/storage/dynamodb)
 - [LanceDB](/reference/storage/lance)
 - [Microsoft SQL Server](/reference/storage/mssql)
+- [Google Cloud Spanner](/reference/storage/spanner)
 
 :::tip
 libSQL is the easiest way to get started because it doesn’t require running a separate database server.

--- a/docs/src/content/en/reference/storage/spanner.mdx
+++ b/docs/src/content/en/reference/storage/spanner.mdx
@@ -163,6 +163,11 @@ The storage adapter creates the following tables, all using the GoogleSQL dialec
 - `mastra_prompt_blocks` / `mastra_prompt_block_versions`: prompt block records and versioned content snapshots (template content, rules, request-context schema)
 - `mastra_scorer_definitions` / `mastra_scorer_definition_versions`: scorer definition records and versioned config snapshots (judge instructions, model, score range, preset config, default sampling)
 - `mastra_schedules` / `mastra_schedule_triggers`: cron-driven workflow schedules and trigger history, consumed by Mastra's built-in `WorkflowScheduler`
+- `mastra_workspaces` / `mastra_workspace_versions`: workspace records and versioned configuration snapshots (filesystem, sandbox, mounts, search, skills, tools)
+- `mastra_datasets` / `mastra_dataset_items` / `mastra_dataset_versions`: evaluation datasets, SCD-2 versioned items, and version snapshots
+- `mastra_experiments` / `mastra_experiment_results`: experiment runs and their per-item results
+- `mastra_favorites`: per-user favorites for agents and skills, with denormalized `favoriteCount` maintained on the parent record
+- `mastra_channel_installations` / `mastra_channel_config`: multi-platform channel installations and per-platform configuration
 - `mastra_ai_spans`: AI tracing spans for observability (per-trace and per-span records, used to power the Studio traces UI)
 
 Tables are created with `STRING(MAX)` for text and JSON payloads, `INT64`, `FLOAT64`, `BOOL`, and `TIMESTAMP`.

--- a/stores/spanner/src/storage/db/index.ts
+++ b/stores/spanner/src/storage/db/index.ts
@@ -7,6 +7,7 @@ import {
   TABLE_SPANS,
   TABLE_WORKFLOW_SNAPSHOT,
   TABLE_SCHEMAS,
+  TABLE_CONFIGS,
   getDefaultValue,
 } from '@mastra/core/storage';
 import type {
@@ -414,6 +415,20 @@ export class SpannerDB extends MastraBase {
     }
     if (tableName === TABLE_SPANS) {
       return ['traceId', 'spanId'];
+    }
+    // Tables with composite primary keys (e.g. mastra_favorites,
+    // mastra_dataset_items) declare them in core's TABLE_CONFIGS rather than via
+    // per-column `primaryKey: true` flags. Honor that first so the PRIMARY KEY
+    // clause emitted by createTable matches what the domains expect.
+    const compositePk = TABLE_CONFIGS[tableName]?.compositePrimaryKey;
+    if (compositePk && compositePk.length > 0) {
+      const missing = compositePk.filter(col => !schema[col]);
+      if (missing.length > 0) {
+        throw new Error(
+          `Table ${tableName}: composite primary key references columns not present in schema: ${missing.join(', ')}`,
+        );
+      }
+      return [...compositePk];
     }
     const pk = Object.entries(schema)
       .filter(([, col]) => col.primaryKey)

--- a/stores/spanner/src/storage/domains/agents/index.ts
+++ b/stores/spanner/src/storage/domains/agents/index.ts
@@ -9,6 +9,7 @@ import {
   normalizePerPage,
   TABLE_AGENTS,
   TABLE_AGENT_VERSIONS,
+  TABLE_FAVORITES,
 } from '@mastra/core/storage';
 import type {
   AgentInstructionBlock,
@@ -417,8 +418,26 @@ export class AgentsSpanner extends AgentsStorage {
   async list(args?: StorageListAgentsInput): Promise<StorageListAgentsOutput> {
     // Default to status='published' so list() never leaks drafts/archived to
     // callers that omit the filter.
-    const { page = 0, perPage: perPageInput, orderBy, authorId, metadata, status = 'published' } = args || {};
+    const {
+      page = 0,
+      perPage: perPageInput,
+      orderBy,
+      authorId,
+      metadata,
+      status,
+      entityIds,
+      pinFavoritedFor,
+      favoritedOnly,
+    } = args || {};
     const { field, direction } = this.parseOrderBy(orderBy);
+
+    // Default to status='published' so list() never leaks drafts/archived to
+    // callers that omit the filter. Favorites-feature queries (entityIds /
+    // pinFavoritedFor / favoritedOnly) operate on the favorited candidate set
+    // and must see entities regardless of lifecycle status, so the default is
+    // suppressed for them unless the caller passes an explicit status.
+    const favoritesQuery = entityIds !== undefined || pinFavoritedFor !== undefined || favoritedOnly !== undefined;
+    const effectiveStatus = status ?? (favoritesQuery ? undefined : 'published');
 
     if (page < 0) {
       throw new MastraError(
@@ -436,16 +455,27 @@ export class AgentsSpanner extends AgentsStorage {
     const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
 
     try {
+      // Empty entityIds can never match a row — short-circuit before querying.
+      if (entityIds && entityIds.length === 0) {
+        return { agents: [], total: 0, page, perPage: perPageForResponse, hasMore: false };
+      }
+
       const tableName = quoteIdent(TABLE_AGENTS, 'table name');
+      const favoritesTable = quoteIdent(TABLE_FAVORITES, 'table name');
       const conditions: string[] = [];
       const params: Record<string, any> = {};
 
-      if (status) {
-        conditions.push(`${quoteIdent('status', 'column name')} = @status`);
-        params.status = status;
+      // A favorites JOIN is only needed when a viewer is supplied (favorited-first
+      // ordering and/or favoritedOnly filtering).
+      const useJoin = Boolean(pinFavoritedFor);
+      if (useJoin) params.pinUserId = pinFavoritedFor;
+
+      if (effectiveStatus) {
+        conditions.push(`a.${quoteIdent('status', 'column name')} = @status`);
+        params.status = effectiveStatus;
       }
       if (authorId !== undefined) {
-        conditions.push(`${quoteIdent('authorId', 'column name')} = @authorId`);
+        conditions.push(`a.${quoteIdent('authorId', 'column name')} = @authorId`);
         params.authorId = authorId;
       }
       if (metadata && Object.keys(metadata).length > 0) {
@@ -461,15 +491,34 @@ export class AgentsSpanner extends AgentsStorage {
             });
           }
           const param = `m${i++}`;
-          conditions.push(`JSON_VALUE(metadata, '$.${key}') = @${param}`);
+          conditions.push(`JSON_VALUE(a.metadata, '$.${key}') = @${param}`);
           params[param] = typeof value === 'string' ? value : JSON.stringify(value);
         }
       }
+      if (entityIds && entityIds.length > 0) {
+        const placeholders = entityIds.map((id, i) => {
+          const param = `eid${i}`;
+          params[param] = id;
+          return `@${param}`;
+        });
+        conditions.push(`a.${quoteIdent('id', 'column name')} IN (${placeholders.join(', ')})`);
+      }
+      if (useJoin && favoritedOnly) {
+        conditions.push(`s.${quoteIdent('userId', 'column name')} IS NOT NULL`);
+      } else if (favoritedOnly) {
+        // favoritedOnly without a viewer can never match a real favorite row.
+        conditions.push('1 = 0');
+      }
 
+      const joinClause = useJoin
+        ? `LEFT JOIN ${favoritesTable} s ON s.${quoteIdent('entityType', 'column name')} = 'agent'` +
+          ` AND s.${quoteIdent('entityId', 'column name')} = a.${quoteIdent('id', 'column name')}` +
+          ` AND s.${quoteIdent('userId', 'column name')} = @pinUserId`
+        : '';
       const whereSql = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
       const [countRows] = await this.database.run({
-        sql: `SELECT COUNT(*) AS count FROM ${tableName} ${whereSql}`,
+        sql: `SELECT COUNT(*) AS count FROM ${tableName} a ${joinClause} ${whereSql}`,
         params,
         json: true,
       });
@@ -481,9 +530,16 @@ export class AgentsSpanner extends AgentsStorage {
 
       const limit = perPageInput === false ? total : perPage;
       const dirSql = (direction || 'DESC').toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
+      const orderParts: string[] = [];
+      if (useJoin) {
+        // Favorited entities first, then the requested ordering.
+        orderParts.push(`(s.${quoteIdent('userId', 'column name')} IS NOT NULL) DESC`);
+      }
+      orderParts.push(`a.${quoteIdent(field, 'column name')} ${dirSql}`);
+      orderParts.push(`a.${quoteIdent('id', 'column name')} ${dirSql}`);
       const [rows] = await this.database.run({
-        sql: `SELECT * FROM ${tableName} ${whereSql}
-              ORDER BY ${quoteIdent(field, 'column name')} ${dirSql}, id ${dirSql}
+        sql: `SELECT a.* FROM ${tableName} a ${joinClause} ${whereSql}
+              ORDER BY ${orderParts.join(', ')}
               LIMIT @limit OFFSET @offset`,
         params: { ...params, limit, offset },
         json: true,

--- a/stores/spanner/src/storage/domains/channels/index.ts
+++ b/stores/spanner/src/storage/domains/channels/index.ts
@@ -1,0 +1,385 @@
+import type { Database } from '@google-cloud/spanner';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  ChannelsStorage,
+  createStorageErrorId,
+  TABLE_CHANNEL_CONFIG,
+  TABLE_CHANNEL_INSTALLATIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/core/storage';
+import type { ChannelConfig, ChannelInstallation, CreateIndexOptions } from '@mastra/core/storage';
+import { SpannerDB, resolveSpannerConfig } from '../../db';
+import type { SpannerDomainConfig } from '../../db';
+import { quoteIdent } from '../../db/utils';
+import { transformFromSpannerRow } from '../utils';
+
+const INSTALLATIONS = TABLE_CHANNEL_INSTALLATIONS;
+const CONFIG = TABLE_CHANNEL_CONFIG;
+const WEBHOOK_INDEX = 'mastra_channel_installations_webhookid_idx';
+
+function rowToInstallation(row: Record<string, any>): ChannelInstallation {
+  const t = transformFromSpannerRow<Record<string, any>>({ tableName: INSTALLATIONS, row });
+  return {
+    id: String(t.id),
+    platform: String(t.platform),
+    agentId: String(t.agentId),
+    status: t.status as ChannelInstallation['status'],
+    webhookId: t.webhookId == null ? undefined : String(t.webhookId),
+    data: (t.data ?? {}) as Record<string, unknown>,
+    configHash: t.configHash == null ? undefined : String(t.configHash),
+    error: t.error == null ? undefined : String(t.error),
+    createdAt: t.createdAt instanceof Date ? t.createdAt : new Date(t.createdAt),
+    updatedAt: t.updatedAt instanceof Date ? t.updatedAt : new Date(t.updatedAt),
+  };
+}
+
+function rowToConfig(row: Record<string, any>): ChannelConfig {
+  const t = transformFromSpannerRow<Record<string, any>>({ tableName: CONFIG, row });
+  return {
+    platform: String(t.platform),
+    data: (t.data ?? {}) as Record<string, unknown>,
+    updatedAt: t.updatedAt instanceof Date ? t.updatedAt : new Date(t.updatedAt),
+  };
+}
+
+/**
+ * Spanner-backed storage for multi-platform channel installations and per-platform
+ * configuration. Installations live in `mastra_channel_installations` (keyed by
+ * `id`); platform config lives in `mastra_channel_config` (keyed by `platform`).
+ */
+export class ChannelsSpanner extends ChannelsStorage {
+  private database: Database;
+  private db: SpannerDB;
+  private readonly skipDefaultIndexes?: boolean;
+  private readonly indexes?: CreateIndexOptions[];
+
+  static readonly MANAGED_TABLES = [TABLE_CHANNEL_INSTALLATIONS, TABLE_CHANNEL_CONFIG] as const;
+
+  constructor(config: SpannerDomainConfig) {
+    super();
+    const { database, indexes, skipDefaultIndexes, initMode } = resolveSpannerConfig(config);
+    this.database = database;
+    this.db = new SpannerDB({ database, skipDefaultIndexes, initMode });
+    this.skipDefaultIndexes = skipDefaultIndexes;
+    this.indexes = indexes?.filter(idx => (ChannelsSpanner.MANAGED_TABLES as readonly string[]).includes(idx.table));
+  }
+
+  async init(): Promise<void> {
+    await this.db.createTable({ tableName: INSTALLATIONS, schema: TABLE_SCHEMAS[INSTALLATIONS] });
+    await this.db.createTable({ tableName: CONFIG, schema: TABLE_SCHEMAS[CONFIG] });
+    await this.createDefaultIndexes();
+    await this.ensureWebhookUniqueIndex();
+    await this.createCustomIndexes();
+  }
+
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    return [
+      {
+        // getInstallationByAgent: WHERE platform = @p AND agentId = @a
+        name: 'mastra_channel_installations_platform_agentid_idx',
+        table: INSTALLATIONS,
+        columns: ['platform', 'agentId'],
+      },
+      {
+        // listInstallations: WHERE platform = @p ORDER BY createdAt DESC
+        name: 'mastra_channel_installations_platform_createdat_idx',
+        table: INSTALLATIONS,
+        columns: ['platform', 'createdAt DESC'],
+      },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.skipDefaultIndexes) return;
+    await this.db.createIndexes(this.getDefaultIndexDefinitions());
+  }
+
+  /**
+   * Creates a NULL_FILTERED UNIQUE index on `webhookId`. A plain Spanner UNIQUE
+   * index treats NULL as a value and would reject a second installation without a
+   * webhook (a legitimate state for pending installs). Created via
+   * raw DDL because the shared index helper can't express NULL_FILTERED.
+   */
+  private async ensureWebhookUniqueIndex(): Promise<void> {
+    if (this.skipDefaultIndexes) return;
+    // In validate mode the schema is externally owned, never issue DDL, but
+    // still verify the expected index is present so a drifted schema is caught.
+    if (this.db.initMode === 'validate') {
+      if (!(await this.webhookIndexExists())) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'CHANNEL_WEBHOOK_INDEX', 'VALIDATE_FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Index ${WEBHOOK_INDEX} on ${INSTALLATIONS} does not exist (initMode='validate' will not create it)`,
+          details: { indexName: WEBHOOK_INDEX, tableName: INSTALLATIONS },
+        });
+      }
+      return;
+    }
+    if (await this.webhookIndexExists()) return;
+    const ddl =
+      `CREATE UNIQUE NULL_FILTERED INDEX ${quoteIdent(WEBHOOK_INDEX, 'index name')} ` +
+      `ON ${quoteIdent(INSTALLATIONS, 'table name')} (${quoteIdent('webhookId', 'column name')})`;
+    try {
+      const [operation] = await this.database.updateSchema([ddl]);
+      await operation.promise();
+    } catch (error) {
+      // Tolerate a concurrent creator that won the race, but otherwise surface
+      // the failure: this index enforces webhook uniqueness, a data-integrity
+      // invariant we must not silently drop (mirrors SpannerDB.createIndexes'
+      // handling of unique indexes).
+      if (await this.webhookIndexExists()) return;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'CHANNEL_WEBHOOK_INDEX', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName: WEBHOOK_INDEX },
+        },
+        error,
+      );
+    }
+  }
+
+  /** Returns true when the unique webhookId index already exists. */
+  private async webhookIndexExists(): Promise<boolean> {
+    const [rows] = await this.database.run({
+      sql: `SELECT 1 AS found FROM INFORMATION_SCHEMA.INDEXES
+            WHERE TABLE_SCHEMA = '' AND INDEX_NAME = @indexName`,
+      params: { indexName: WEBHOOK_INDEX },
+      json: true,
+    });
+    return (rows as unknown[]).length > 0;
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.indexes || this.indexes.length === 0) return;
+    await this.db.createIndexes(this.indexes);
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.db.clearTable({ tableName: INSTALLATIONS });
+    await this.db.clearTable({ tableName: CONFIG });
+  }
+
+  async saveInstallation(installation: ChannelInstallation): Promise<void> {
+    try {
+      const now = new Date();
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            const [rows] = await tx.run({
+              sql: `SELECT ${quoteIdent('id', 'column name')} FROM ${quoteIdent(INSTALLATIONS, 'table name')}
+                    WHERE ${quoteIdent('id', 'column name')} = @id LIMIT 1`,
+              params: { id: installation.id },
+              json: true,
+            });
+            const data: Record<string, any> = {
+              platform: installation.platform,
+              agentId: installation.agentId,
+              status: installation.status,
+              webhookId: installation.webhookId ?? null,
+              data: installation.data ?? {},
+              configHash: installation.configHash ?? null,
+              error: installation.error ?? null,
+              updatedAt: now,
+            };
+            if ((rows as unknown[]).length > 0) {
+              // Upsert that preserves the original createdAt
+              await this.db.update({ tableName: INSTALLATIONS, keys: { id: installation.id }, data, transaction: tx });
+            } else {
+              await this.db.insert({
+                tableName: INSTALLATIONS,
+                record: { id: installation.id, ...data, createdAt: installation.createdAt ?? now },
+                transaction: tx,
+              });
+            }
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'SAVE_INSTALLATION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: installation.id, platform: installation.platform },
+        },
+        error,
+      );
+    }
+  }
+
+  async getInstallation(id: string): Promise<ChannelInstallation | null> {
+    try {
+      const row = await this.db.load<Record<string, any>>({ tableName: INSTALLATIONS, keys: { id } });
+      return row ? rowToInstallation(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_INSTALLATION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getInstallationByAgent(platform: string, agentId: string): Promise<ChannelInstallation | null> {
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${quoteIdent(INSTALLATIONS, 'table name')}
+              WHERE ${quoteIdent('platform', 'column name')} = @platform
+                AND ${quoteIdent('agentId', 'column name')} = @agentId
+              ORDER BY CASE ${quoteIdent('status', 'column name')}
+                         WHEN 'active' THEN 0 WHEN 'pending' THEN 1 ELSE 2 END,
+                       ${quoteIdent('updatedAt', 'column name')} DESC
+              LIMIT 1`,
+        params: { platform, agentId },
+        json: true,
+      });
+      const row = (rows as Array<Record<string, any>>)[0];
+      return row ? rowToInstallation(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_INSTALLATION_BY_AGENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { platform, agentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async getInstallationByWebhookId(webhookId: string): Promise<ChannelInstallation | null> {
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${quoteIdent(INSTALLATIONS, 'table name')}
+              WHERE ${quoteIdent('webhookId', 'column name')} = @webhookId LIMIT 1`,
+        params: { webhookId },
+        json: true,
+      });
+      const row = (rows as Array<Record<string, any>>)[0];
+      return row ? rowToInstallation(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_INSTALLATION_BY_WEBHOOK_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { webhookId },
+        },
+        error,
+      );
+    }
+  }
+
+  async listInstallations(platform: string): Promise<ChannelInstallation[]> {
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${quoteIdent(INSTALLATIONS, 'table name')}
+              WHERE ${quoteIdent('platform', 'column name')} = @platform
+              ORDER BY ${quoteIdent('createdAt', 'column name')} DESC`,
+        params: { platform },
+        json: true,
+      });
+      return (rows as Array<Record<string, any>>).map(rowToInstallation);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_INSTALLATIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { platform },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteInstallation(id: string): Promise<void> {
+    try {
+      await this.db.runDml({
+        sql: `DELETE FROM ${quoteIdent(INSTALLATIONS, 'table name')} WHERE ${quoteIdent('id', 'column name')} = @id`,
+        params: { id },
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_INSTALLATION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id },
+        },
+        error,
+      );
+    }
+  }
+
+  async saveConfig(config: ChannelConfig): Promise<void> {
+    try {
+      await this.db.upsert({
+        tableName: CONFIG,
+        record: {
+          platform: config.platform,
+          data: config.data ?? {},
+          updatedAt: config.updatedAt ?? new Date(),
+        },
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'SAVE_CONFIG', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { platform: config.platform },
+        },
+        error,
+      );
+    }
+  }
+
+  async getConfig(platform: string): Promise<ChannelConfig | null> {
+    try {
+      const row = await this.db.load<Record<string, any>>({ tableName: CONFIG, keys: { platform } });
+      return row ? rowToConfig(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_CONFIG', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { platform },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteConfig(platform: string): Promise<void> {
+    try {
+      await this.db.runDml({
+        sql: `DELETE FROM ${quoteIdent(CONFIG, 'table name')} WHERE ${quoteIdent('platform', 'column name')} = @platform`,
+        params: { platform },
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_CONFIG', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { platform },
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/spanner/src/storage/domains/datasets/index.ts
+++ b/stores/spanner/src/storage/domains/datasets/index.ts
@@ -1,0 +1,1040 @@
+import { randomUUID } from 'node:crypto';
+import type { Database, Transaction } from '@google-cloud/spanner';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  calculatePagination,
+  createStorageErrorId,
+  DatasetsStorage,
+  normalizePerPage,
+  TABLE_DATASETS,
+  TABLE_DATASET_ITEMS,
+  TABLE_DATASET_VERSIONS,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
+  TABLE_SCHEMAS,
+} from '@mastra/core/storage';
+import type {
+  AddDatasetItemInput,
+  BatchDeleteItemsInput,
+  BatchInsertItemsInput,
+  CreateDatasetInput,
+  CreateIndexOptions,
+  DatasetItem,
+  DatasetItemRow,
+  DatasetRecord,
+  DatasetVersion,
+  ListDatasetItemsInput,
+  ListDatasetItemsOutput,
+  ListDatasetsInput,
+  ListDatasetsOutput,
+  ListDatasetVersionsInput,
+  ListDatasetVersionsOutput,
+  UpdateDatasetInput,
+  UpdateDatasetItemInput,
+} from '@mastra/core/storage';
+import { SpannerDB, resolveSpannerConfig } from '../../db';
+import type { SpannerDomainConfig } from '../../db';
+import { quoteIdent } from '../../db/utils';
+import { transformFromSpannerRow } from '../utils';
+
+function toDate(value: unknown): Date {
+  return value instanceof Date ? value : new Date(value as string);
+}
+
+function rowToDataset(row: Record<string, any>): DatasetRecord {
+  const t = transformFromSpannerRow<Record<string, any>>({ tableName: TABLE_DATASETS, row });
+  return {
+    id: String(t.id),
+    name: String(t.name),
+    description: t.description ?? undefined,
+    metadata: t.metadata ?? undefined,
+    inputSchema: t.inputSchema ?? undefined,
+    groundTruthSchema: t.groundTruthSchema ?? undefined,
+    requestContextSchema: t.requestContextSchema ?? undefined,
+    tags: t.tags ?? null,
+    targetType: t.targetType ?? null,
+    targetIds: t.targetIds ?? null,
+    scorerIds: t.scorerIds ?? null,
+    version: Number(t.version ?? 0),
+    createdAt: toDate(t.createdAt),
+    updatedAt: toDate(t.updatedAt),
+  };
+}
+
+function rowToItem(row: Record<string, any>): DatasetItem {
+  const t = transformFromSpannerRow<Record<string, any>>({ tableName: TABLE_DATASET_ITEMS, row });
+  return {
+    id: String(t.id),
+    datasetId: String(t.datasetId),
+    datasetVersion: Number(t.datasetVersion),
+    input: t.input,
+    groundTruth: t.groundTruth ?? undefined,
+    expectedTrajectory: t.expectedTrajectory ?? undefined,
+    requestContext: t.requestContext ?? undefined,
+    metadata: t.metadata ?? undefined,
+    source: t.source ?? undefined,
+    createdAt: toDate(t.createdAt),
+    updatedAt: toDate(t.updatedAt),
+  };
+}
+
+function rowToItemRow(row: Record<string, any>): DatasetItemRow {
+  const t = transformFromSpannerRow<Record<string, any>>({ tableName: TABLE_DATASET_ITEMS, row });
+  return {
+    ...rowToItem(row),
+    validTo: t.validTo == null ? null : Number(t.validTo),
+    isDeleted: Boolean(t.isDeleted),
+  };
+}
+
+function rowToVersion(row: Record<string, any>): DatasetVersion {
+  const t = transformFromSpannerRow<Record<string, any>>({ tableName: TABLE_DATASET_VERSIONS, row });
+  return {
+    id: String(t.id),
+    datasetId: String(t.datasetId),
+    version: Number(t.version),
+    createdAt: toDate(t.createdAt),
+  };
+}
+
+/**
+ * Spanner-backed storage for evaluation datasets, their items (SCD-2 versioned),
+ * and version snapshots.
+ *
+ * Items use slowly-changing-dimension type-2 bookkeeping: each item id can have
+ * many rows keyed by `(id, datasetVersion)`. The "current" row is the one with
+ * `validTo IS NULL`; a live item additionally has `isDeleted = false`, a deleted
+ * item has a tombstone row with `isDeleted = true`. Every item mutation bumps the
+ * parent dataset's `version` once (batch ops bump once for the whole batch) and
+ * records a `mastra_dataset_versions` snapshot. All mutations run in a single
+ * Spanner read-write transaction so the version counter, row close-out, and new
+ * row never drift.
+ */
+export class DatasetsSpanner extends DatasetsStorage {
+  private database: Database;
+  private db: SpannerDB;
+  private readonly skipDefaultIndexes?: boolean;
+  private readonly indexes?: CreateIndexOptions[];
+
+  static readonly MANAGED_TABLES = [TABLE_DATASETS, TABLE_DATASET_ITEMS, TABLE_DATASET_VERSIONS] as const;
+
+  constructor(config: SpannerDomainConfig) {
+    super();
+    const { database, indexes, skipDefaultIndexes, initMode } = resolveSpannerConfig(config);
+    this.database = database;
+    this.db = new SpannerDB({ database, skipDefaultIndexes, initMode });
+    this.skipDefaultIndexes = skipDefaultIndexes;
+    this.indexes = indexes?.filter(idx => (DatasetsSpanner.MANAGED_TABLES as readonly string[]).includes(idx.table));
+  }
+
+  async init(): Promise<void> {
+    await this.db.createTable({ tableName: TABLE_DATASETS, schema: TABLE_SCHEMAS[TABLE_DATASETS] });
+    await this.db.createTable({ tableName: TABLE_DATASET_ITEMS, schema: TABLE_SCHEMAS[TABLE_DATASET_ITEMS] });
+    await this.db.createTable({ tableName: TABLE_DATASET_VERSIONS, schema: TABLE_SCHEMAS[TABLE_DATASET_VERSIONS] });
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    return [
+      {
+        // listItems / getItemsByVersion: filter current rows by dataset.
+        name: 'mastra_dataset_items_dataset_validto_idx',
+        table: TABLE_DATASET_ITEMS,
+        columns: ['datasetId', 'validTo'],
+      },
+      {
+        // getItemsByVersion time-travel: datasetId + datasetVersion.
+        name: 'mastra_dataset_items_dataset_version_idx',
+        table: TABLE_DATASET_ITEMS,
+        columns: ['datasetId', 'datasetVersion'],
+      },
+      {
+        // Unique invariant: one snapshot row per (datasetId, version). The DESC
+        // ordering also serves listDatasetVersions' newest-first scan.
+        name: 'mastra_dataset_versions_dataset_version_idx',
+        table: TABLE_DATASET_VERSIONS,
+        columns: ['datasetId', 'version DESC'],
+        unique: true,
+      },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.skipDefaultIndexes) return;
+    await this.db.createIndexes(this.getDefaultIndexDefinitions());
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.indexes || this.indexes.length === 0) return;
+    await this.db.createIndexes(this.indexes);
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.db.clearTable({ tableName: TABLE_DATASET_VERSIONS });
+    await this.db.clearTable({ tableName: TABLE_DATASET_ITEMS });
+    await this.db.clearTable({ tableName: TABLE_DATASETS });
+  }
+
+  // ==========================================================================
+  // Dataset CRUD
+  // ==========================================================================
+
+  async createDataset(input: CreateDatasetInput): Promise<DatasetRecord> {
+    try {
+      const now = new Date();
+      const id = randomUUID();
+      const record: DatasetRecord = {
+        id,
+        name: input.name,
+        description: input.description ?? undefined,
+        metadata: input.metadata ?? undefined,
+        inputSchema: input.inputSchema ?? undefined,
+        groundTruthSchema: input.groundTruthSchema ?? undefined,
+        requestContextSchema: input.requestContextSchema ?? undefined,
+        tags: null,
+        targetType: input.targetType ?? null,
+        targetIds: input.targetIds ?? null,
+        scorerIds: input.scorerIds ?? null,
+        version: 0,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await this.db.insert({
+        tableName: TABLE_DATASETS,
+        record: {
+          id,
+          name: record.name,
+          description: record.description ?? null,
+          metadata: record.metadata ?? null,
+          inputSchema: record.inputSchema ?? null,
+          groundTruthSchema: record.groundTruthSchema ?? null,
+          requestContextSchema: record.requestContextSchema ?? null,
+          tags: record.tags,
+          targetType: record.targetType,
+          targetIds: record.targetIds,
+          scorerIds: record.scorerIds,
+          version: 0,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+      return record;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'CREATE_DATASET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async getDatasetById(args: { id: string }): Promise<DatasetRecord | null> {
+    try {
+      const row = await this.db.load<Record<string, any>>({ tableName: TABLE_DATASETS, keys: { id: args.id } });
+      return row ? rowToDataset(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_DATASET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: args.id },
+        },
+        error,
+      );
+    }
+  }
+
+  protected async _doUpdateDataset(args: UpdateDatasetInput): Promise<DatasetRecord> {
+    try {
+      const data: Record<string, any> = {};
+      if (args.name !== undefined) data.name = args.name;
+      if (args.description !== undefined) data.description = args.description;
+      if (args.metadata !== undefined) data.metadata = args.metadata;
+      if (args.inputSchema !== undefined) data.inputSchema = args.inputSchema;
+      if (args.groundTruthSchema !== undefined) data.groundTruthSchema = args.groundTruthSchema;
+      if (args.requestContextSchema !== undefined) data.requestContextSchema = args.requestContextSchema;
+      if (args.tags !== undefined) data.tags = args.tags;
+      if (args.targetType !== undefined) data.targetType = args.targetType;
+      if (args.targetIds !== undefined) data.targetIds = args.targetIds;
+      if (args.scorerIds !== undefined) data.scorerIds = args.scorerIds;
+      data.updatedAt = new Date();
+
+      await this.db.update({ tableName: TABLE_DATASETS, keys: { id: args.id }, data });
+
+      const updated = await this.getDatasetById({ id: args.id });
+      if (!updated) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'UPDATE_DATASET', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Dataset ${args.id} not found`,
+          details: { id: args.id },
+        });
+      }
+      return updated;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'UPDATE_DATASET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: args.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteDataset(args: { id: string }): Promise<void> {
+    try {
+      // Best-effort detach of experiments referencing this dataset. These tables
+      // may not exist when datasets is used standalone, so failures are swallowed.
+      try {
+        await this.db.runDml({
+          sql: `DELETE FROM ${quoteIdent(TABLE_EXPERIMENT_RESULTS, 'table name')}
+                WHERE ${quoteIdent('experimentId', 'column name')} IN (
+                  SELECT ${quoteIdent('id', 'column name')} FROM ${quoteIdent(TABLE_EXPERIMENTS, 'table name')}
+                  WHERE ${quoteIdent('datasetId', 'column name')} = @id)`,
+          params: { id: args.id },
+        });
+        await this.db.runDml({
+          sql: `UPDATE ${quoteIdent(TABLE_EXPERIMENTS, 'table name')}
+                SET ${quoteIdent('datasetId', 'column name')} = NULL,
+                    ${quoteIdent('datasetVersion', 'column name')} = NULL
+                WHERE ${quoteIdent('datasetId', 'column name')} = @id`,
+          params: { id: args.id },
+        });
+      } catch {
+        // Experiments tables absent — nothing to detach.
+      }
+
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            for (const table of [TABLE_DATASET_VERSIONS, TABLE_DATASET_ITEMS]) {
+              await tx.runUpdate({
+                sql: `DELETE FROM ${quoteIdent(table, 'table name')} WHERE ${quoteIdent('datasetId', 'column name')} = @id`,
+                params: { id: args.id },
+              });
+            }
+            await tx.runUpdate({
+              sql: `DELETE FROM ${quoteIdent(TABLE_DATASETS, 'table name')} WHERE ${quoteIdent('id', 'column name')} = @id`,
+              params: { id: args.id },
+            });
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_DATASET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: args.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listDatasets(args: ListDatasetsInput): Promise<ListDatasetsOutput> {
+    const { page = 0, perPage: perPageInput } = args.pagination;
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+    try {
+      const tableName = quoteIdent(TABLE_DATASETS, 'table name');
+      const [countRows] = await this.database.run({
+        sql: `SELECT COUNT(*) AS count FROM ${tableName}`,
+        json: true,
+      });
+      const total = Number((countRows as Array<{ count: number | string }>)[0]?.count ?? 0);
+      if (total === 0) {
+        return { datasets: [], pagination: { total: 0, page, perPage: perPageForResponse, hasMore: false } };
+      }
+      const limit = perPageInput === false ? total : perPage;
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName}
+              ORDER BY ${quoteIdent('createdAt', 'column name')} DESC, ${quoteIdent('id', 'column name')} ASC
+              LIMIT @limit OFFSET @offset`,
+        params: { limit, offset },
+        json: true,
+      });
+      const datasets = (rows as Array<Record<string, any>>).map(rowToDataset);
+      return {
+        datasets,
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + perPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_DATASETS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // SCD-2 helpers
+  // ==========================================================================
+
+  /** Reads and increments the dataset version inside `tx`; throws if missing. */
+  private async bumpVersion(tx: Transaction, datasetId: string, now: Date): Promise<number> {
+    const [rows] = await tx.run({
+      sql: `SELECT ${quoteIdent('version', 'column name')} AS version FROM ${quoteIdent(TABLE_DATASETS, 'table name')}
+            WHERE ${quoteIdent('id', 'column name')} = @id LIMIT 1`,
+      params: { id: datasetId },
+      json: true,
+    });
+    const row = (rows as Array<{ version: number | string }>)[0];
+    if (!row) {
+      throw new MastraError({
+        id: createStorageErrorId('SPANNER', 'DATASET_ITEM', 'DATASET_NOT_FOUND'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: `Dataset not found: ${datasetId}`,
+        details: { datasetId },
+      });
+    }
+    const newVersion = Number(row.version) + 1;
+    await tx.runUpdate({
+      sql: `UPDATE ${quoteIdent(TABLE_DATASETS, 'table name')}
+            SET ${quoteIdent('version', 'column name')} = @newVersion,
+                ${quoteIdent('updatedAt', 'column name')} = @now
+            WHERE ${quoteIdent('id', 'column name')} = @id`,
+      params: { newVersion, now: now.toISOString(), id: datasetId },
+      types: { now: 'timestamp' },
+    });
+    return newVersion;
+  }
+
+  /** Inserts a dataset version snapshot row inside `tx`. */
+  private async insertVersionRow(tx: Transaction, datasetId: string, version: number, now: Date): Promise<void> {
+    await this.db.insert({
+      tableName: TABLE_DATASET_VERSIONS,
+      record: { id: randomUUID(), datasetId, version, createdAt: now },
+      transaction: tx,
+    });
+  }
+
+  /** Closes the current (validTo IS NULL) row for an item inside `tx`. */
+  private async closeCurrentRow(tx: Transaction, itemId: string, validTo: number): Promise<void> {
+    await tx.runUpdate({
+      sql: `UPDATE ${quoteIdent(TABLE_DATASET_ITEMS, 'table name')}
+            SET ${quoteIdent('validTo', 'column name')} = @validTo
+            WHERE ${quoteIdent('id', 'column name')} = @id
+              AND ${quoteIdent('validTo', 'column name')} IS NULL
+              AND ${quoteIdent('isDeleted', 'column name')} = FALSE`,
+      params: { validTo, id: itemId },
+    });
+  }
+
+  /** Reads the current live row for an item (validTo IS NULL, not deleted). */
+  private async loadCurrentItemRow(itemId: string): Promise<DatasetItemRow | null> {
+    const [rows] = await this.database.run({
+      sql: `SELECT * FROM ${quoteIdent(TABLE_DATASET_ITEMS, 'table name')}
+            WHERE ${quoteIdent('id', 'column name')} = @id
+              AND ${quoteIdent('validTo', 'column name')} IS NULL
+              AND ${quoteIdent('isDeleted', 'column name')} = FALSE LIMIT 1`,
+      params: { id: itemId },
+      json: true,
+    });
+    const row = (rows as Array<Record<string, any>>)[0];
+    return row ? rowToItemRow(row) : null;
+  }
+
+  // ==========================================================================
+  // Item CRUD (SCD-2)
+  // ==========================================================================
+
+  protected async _doAddItem(args: AddDatasetItemInput): Promise<DatasetItem> {
+    try {
+      const now = new Date();
+      const itemId = randomUUID();
+      let created: DatasetItem | null = null;
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            const newVersion = await this.bumpVersion(tx, args.datasetId, now);
+            await this.db.insert({
+              tableName: TABLE_DATASET_ITEMS,
+              record: {
+                id: itemId,
+                datasetId: args.datasetId,
+                datasetVersion: newVersion,
+                validTo: null,
+                isDeleted: false,
+                input: args.input,
+                groundTruth: args.groundTruth ?? null,
+                expectedTrajectory: args.expectedTrajectory ?? null,
+                requestContext: args.requestContext ?? null,
+                metadata: args.metadata ?? null,
+                source: args.source ?? null,
+                createdAt: now,
+                updatedAt: now,
+              },
+              transaction: tx,
+            });
+            await this.insertVersionRow(tx, args.datasetId, newVersion, now);
+            await tx.commit();
+            created = {
+              id: itemId,
+              datasetId: args.datasetId,
+              datasetVersion: newVersion,
+              input: args.input,
+              groundTruth: args.groundTruth,
+              expectedTrajectory: args.expectedTrajectory,
+              requestContext: args.requestContext,
+              metadata: args.metadata,
+              source: args.source,
+              createdAt: now,
+              updatedAt: now,
+            };
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+      return created!;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'ADD_DATASET_ITEM', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { datasetId: args.datasetId },
+        },
+        error,
+      );
+    }
+  }
+
+  protected async _doUpdateItem(args: UpdateDatasetItemInput): Promise<DatasetItem> {
+    try {
+      const existing = await this.loadCurrentItemRow(args.id);
+      if (!existing) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'UPDATE_DATASET_ITEM', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Dataset item not found: ${args.id}`,
+          details: { id: args.id },
+        });
+      }
+      if (existing.datasetId !== args.datasetId) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'UPDATE_DATASET_ITEM', 'DATASET_MISMATCH'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Dataset item ${args.id} does not belong to dataset ${args.datasetId}`,
+          details: { id: args.id, datasetId: args.datasetId },
+        });
+      }
+
+      const merged = {
+        input: args.input !== undefined ? args.input : existing.input,
+        groundTruth: args.groundTruth !== undefined ? args.groundTruth : existing.groundTruth,
+        expectedTrajectory:
+          args.expectedTrajectory !== undefined ? args.expectedTrajectory : existing.expectedTrajectory,
+        requestContext: args.requestContext !== undefined ? args.requestContext : existing.requestContext,
+        metadata: args.metadata !== undefined ? args.metadata : existing.metadata,
+        source: args.source !== undefined ? args.source : existing.source,
+      };
+      const now = new Date();
+      let updated: DatasetItem | null = null;
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            const newVersion = await this.bumpVersion(tx, args.datasetId, now);
+            await this.closeCurrentRow(tx, args.id, newVersion);
+            await this.db.insert({
+              tableName: TABLE_DATASET_ITEMS,
+              record: {
+                id: args.id,
+                datasetId: args.datasetId,
+                datasetVersion: newVersion,
+                validTo: null,
+                isDeleted: false,
+                input: merged.input,
+                groundTruth: merged.groundTruth ?? null,
+                expectedTrajectory: merged.expectedTrajectory ?? null,
+                requestContext: merged.requestContext ?? null,
+                metadata: merged.metadata ?? null,
+                source: merged.source ?? null,
+                createdAt: existing.createdAt,
+                updatedAt: now,
+              },
+              transaction: tx,
+            });
+            await this.insertVersionRow(tx, args.datasetId, newVersion, now);
+            await tx.commit();
+            updated = {
+              id: args.id,
+              datasetId: args.datasetId,
+              datasetVersion: newVersion,
+              input: merged.input,
+              groundTruth: merged.groundTruth,
+              expectedTrajectory: merged.expectedTrajectory,
+              requestContext: merged.requestContext,
+              metadata: merged.metadata,
+              source: merged.source,
+              createdAt: existing.createdAt,
+              updatedAt: now,
+            };
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+      return updated!;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'UPDATE_DATASET_ITEM', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: args.id },
+        },
+        error,
+      );
+    }
+  }
+
+  protected async _doDeleteItem(args: { id: string; datasetId: string }): Promise<void> {
+    try {
+      const existing = await this.loadCurrentItemRow(args.id);
+      if (!existing) return;
+      if (existing.datasetId !== args.datasetId) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'DELETE_DATASET_ITEM', 'DATASET_MISMATCH'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Dataset item ${args.id} does not belong to dataset ${args.datasetId}`,
+          details: { id: args.id, datasetId: args.datasetId },
+        });
+      }
+      const now = new Date();
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            const newVersion = await this.bumpVersion(tx, args.datasetId, now);
+            await this.closeCurrentRow(tx, args.id, newVersion);
+            await this.db.insert({
+              tableName: TABLE_DATASET_ITEMS,
+              record: {
+                id: args.id,
+                datasetId: args.datasetId,
+                datasetVersion: newVersion,
+                validTo: null,
+                isDeleted: true,
+                input: existing.input,
+                groundTruth: existing.groundTruth ?? null,
+                expectedTrajectory: existing.expectedTrajectory ?? null,
+                requestContext: existing.requestContext ?? null,
+                metadata: existing.metadata ?? null,
+                source: existing.source ?? null,
+                createdAt: existing.createdAt,
+                updatedAt: now,
+              },
+              transaction: tx,
+            });
+            await this.insertVersionRow(tx, args.datasetId, newVersion, now);
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_DATASET_ITEM', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: args.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listItems(args: ListDatasetItemsInput): Promise<ListDatasetItemsOutput> {
+    const { page = 0, perPage: perPageInput } = args.pagination;
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+    try {
+      const conditions: string[] = [`${quoteIdent('datasetId', 'column name')} = @datasetId`];
+      const params: Record<string, any> = { datasetId: args.datasetId };
+      if (args.version !== undefined) {
+        conditions.push(`${quoteIdent('datasetVersion', 'column name')} <= @version`);
+        conditions.push(
+          `(${quoteIdent('validTo', 'column name')} IS NULL OR ${quoteIdent('validTo', 'column name')} > @version)`,
+        );
+        conditions.push(`${quoteIdent('isDeleted', 'column name')} = FALSE`);
+        params.version = args.version;
+      } else {
+        conditions.push(`${quoteIdent('validTo', 'column name')} IS NULL`);
+        conditions.push(`${quoteIdent('isDeleted', 'column name')} = FALSE`);
+      }
+      if (args.search) {
+        conditions.push(
+          `(LOWER(TO_JSON_STRING(${quoteIdent('input', 'column name')})) LIKE @search` +
+            ` OR LOWER(COALESCE(TO_JSON_STRING(${quoteIdent('groundTruth', 'column name')}), '')) LIKE @search)`,
+        );
+        params.search = `%${args.search.toLowerCase()}%`;
+      }
+      const whereSql = `WHERE ${conditions.join(' AND ')}`;
+      const tableName = quoteIdent(TABLE_DATASET_ITEMS, 'table name');
+
+      const [countRows] = await this.database.run({
+        sql: `SELECT COUNT(*) AS count FROM ${tableName} ${whereSql}`,
+        params,
+        json: true,
+      });
+      const total = Number((countRows as Array<{ count: number | string }>)[0]?.count ?? 0);
+      if (total === 0) {
+        return { items: [], pagination: { total: 0, page, perPage: perPageForResponse, hasMore: false } };
+      }
+
+      const limit = perPageInput === false ? total : perPage;
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName} ${whereSql}
+              ORDER BY ${quoteIdent('createdAt', 'column name')} DESC, ${quoteIdent('id', 'column name')} ASC
+              LIMIT @limit OFFSET @offset`,
+        params: { ...params, limit, offset },
+        json: true,
+      });
+      const items = (rows as Array<Record<string, any>>).map(rowToItem);
+      return {
+        items,
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + perPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_DATASET_ITEMS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { datasetId: args.datasetId },
+        },
+        error,
+      );
+    }
+  }
+
+  async getItemById(args: { id: string; datasetVersion?: number }): Promise<DatasetItem | null> {
+    try {
+      const tableName = quoteIdent(TABLE_DATASET_ITEMS, 'table name');
+      let sql: string;
+      const params: Record<string, any> = { id: args.id };
+      if (args.datasetVersion !== undefined) {
+        sql = `SELECT * FROM ${tableName}
+               WHERE ${quoteIdent('id', 'column name')} = @id
+                 AND ${quoteIdent('datasetVersion', 'column name')} = @datasetVersion
+                 AND ${quoteIdent('isDeleted', 'column name')} = FALSE LIMIT 1`;
+        params.datasetVersion = args.datasetVersion;
+      } else {
+        sql = `SELECT * FROM ${tableName}
+               WHERE ${quoteIdent('id', 'column name')} = @id
+                 AND ${quoteIdent('validTo', 'column name')} IS NULL
+                 AND ${quoteIdent('isDeleted', 'column name')} = FALSE LIMIT 1`;
+      }
+      const [rows] = await this.database.run({ sql, params, json: true });
+      const row = (rows as Array<Record<string, any>>)[0];
+      return row ? rowToItem(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_DATASET_ITEM', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: args.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getItemsByVersion(args: { datasetId: string; version: number }): Promise<DatasetItem[]> {
+    try {
+      const tableName = quoteIdent(TABLE_DATASET_ITEMS, 'table name');
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName}
+              WHERE ${quoteIdent('datasetId', 'column name')} = @datasetId
+                AND ${quoteIdent('datasetVersion', 'column name')} <= @version
+                AND (${quoteIdent('validTo', 'column name')} IS NULL OR ${quoteIdent('validTo', 'column name')} > @version)
+                AND ${quoteIdent('isDeleted', 'column name')} = FALSE
+              ORDER BY ${quoteIdent('createdAt', 'column name')} DESC, ${quoteIdent('id', 'column name')} ASC`,
+        params: { datasetId: args.datasetId, version: args.version },
+        json: true,
+      });
+      return (rows as Array<Record<string, any>>).map(rowToItem);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_ITEMS_BY_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { datasetId: args.datasetId, version: args.version },
+        },
+        error,
+      );
+    }
+  }
+
+  async getItemHistory(itemId: string): Promise<DatasetItemRow[]> {
+    try {
+      const tableName = quoteIdent(TABLE_DATASET_ITEMS, 'table name');
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName}
+              WHERE ${quoteIdent('id', 'column name')} = @id
+              ORDER BY ${quoteIdent('datasetVersion', 'column name')} DESC`,
+        params: { id: itemId },
+        json: true,
+      });
+      return (rows as Array<Record<string, any>>).map(rowToItemRow);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_ITEM_HISTORY', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: itemId },
+        },
+        error,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Dataset versions
+  // ==========================================================================
+
+  async createDatasetVersion(datasetId: string, version: number): Promise<DatasetVersion> {
+    try {
+      const now = new Date();
+      const id = randomUUID();
+      await this.db.insert({
+        tableName: TABLE_DATASET_VERSIONS,
+        record: { id, datasetId, version, createdAt: now },
+      });
+      return { id, datasetId, version, createdAt: now };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'CREATE_DATASET_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { datasetId, version },
+        },
+        error,
+      );
+    }
+  }
+
+  async listDatasetVersions(input: ListDatasetVersionsInput): Promise<ListDatasetVersionsOutput> {
+    const { page = 0, perPage: perPageInput } = input.pagination;
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+    try {
+      const tableName = quoteIdent(TABLE_DATASET_VERSIONS, 'table name');
+      const [countRows] = await this.database.run({
+        sql: `SELECT COUNT(*) AS count FROM ${tableName} WHERE ${quoteIdent('datasetId', 'column name')} = @datasetId`,
+        params: { datasetId: input.datasetId },
+        json: true,
+      });
+      const total = Number((countRows as Array<{ count: number | string }>)[0]?.count ?? 0);
+      if (total === 0) {
+        return { versions: [], pagination: { total: 0, page, perPage: perPageForResponse, hasMore: false } };
+      }
+      const limit = perPageInput === false ? total : perPage;
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName}
+              WHERE ${quoteIdent('datasetId', 'column name')} = @datasetId
+              ORDER BY ${quoteIdent('version', 'column name')} DESC
+              LIMIT @limit OFFSET @offset`,
+        params: { datasetId: input.datasetId, limit, offset },
+        json: true,
+      });
+      const versions = (rows as Array<Record<string, any>>).map(rowToVersion);
+      return {
+        versions,
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + perPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_DATASET_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { datasetId: input.datasetId },
+        },
+        error,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Batch item operations
+  // ==========================================================================
+
+  protected async _doBatchInsertItems(input: BatchInsertItemsInput): Promise<DatasetItem[]> {
+    try {
+      // An empty batch is a no-op: don't bump the dataset version or write a snapshot.
+      if (input.items.length === 0) return [];
+      const now = new Date();
+      const prepared = input.items.map(item => ({ id: randomUUID(), item }));
+      let result: DatasetItem[] = [];
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            const newVersion = await this.bumpVersion(tx, input.datasetId, now);
+            for (const { id, item } of prepared) {
+              await this.db.insert({
+                tableName: TABLE_DATASET_ITEMS,
+                record: {
+                  id,
+                  datasetId: input.datasetId,
+                  datasetVersion: newVersion,
+                  validTo: null,
+                  isDeleted: false,
+                  input: item.input,
+                  groundTruth: item.groundTruth ?? null,
+                  expectedTrajectory: item.expectedTrajectory ?? null,
+                  requestContext: item.requestContext ?? null,
+                  metadata: item.metadata ?? null,
+                  source: item.source ?? null,
+                  createdAt: now,
+                  updatedAt: now,
+                },
+                transaction: tx,
+              });
+            }
+            await this.insertVersionRow(tx, input.datasetId, newVersion, now);
+            await tx.commit();
+            result = prepared.map(({ id, item }) => ({
+              id,
+              datasetId: input.datasetId,
+              datasetVersion: newVersion,
+              input: item.input,
+              groundTruth: item.groundTruth,
+              expectedTrajectory: item.expectedTrajectory,
+              requestContext: item.requestContext,
+              metadata: item.metadata,
+              source: item.source,
+              createdAt: now,
+              updatedAt: now,
+            }));
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+      return result;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'BATCH_INSERT_ITEMS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { datasetId: input.datasetId },
+        },
+        error,
+      );
+    }
+  }
+
+  protected async _doBatchDeleteItems(input: BatchDeleteItemsInput): Promise<void> {
+    try {
+      // Resolve current rows up front and keep only those belonging to the dataset.
+      const current: DatasetItemRow[] = [];
+      for (const itemId of input.itemIds) {
+        const row = await this.loadCurrentItemRow(itemId);
+        if (row && row.datasetId === input.datasetId) current.push(row);
+      }
+      if (current.length === 0) return;
+
+      const now = new Date();
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            const newVersion = await this.bumpVersion(tx, input.datasetId, now);
+            for (const existing of current) {
+              await this.closeCurrentRow(tx, existing.id, newVersion);
+              await this.db.insert({
+                tableName: TABLE_DATASET_ITEMS,
+                record: {
+                  id: existing.id,
+                  datasetId: input.datasetId,
+                  datasetVersion: newVersion,
+                  validTo: null,
+                  isDeleted: true,
+                  input: existing.input,
+                  groundTruth: existing.groundTruth ?? null,
+                  expectedTrajectory: existing.expectedTrajectory ?? null,
+                  requestContext: existing.requestContext ?? null,
+                  metadata: existing.metadata ?? null,
+                  source: existing.source ?? null,
+                  createdAt: existing.createdAt,
+                  updatedAt: now,
+                },
+                transaction: tx,
+              });
+            }
+            await this.insertVersionRow(tx, input.datasetId, newVersion, now);
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'BATCH_DELETE_ITEMS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { datasetId: input.datasetId },
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/spanner/src/storage/domains/experiments/index.ts
+++ b/stores/spanner/src/storage/domains/experiments/index.ts
@@ -1,0 +1,644 @@
+import { randomUUID } from 'node:crypto';
+import type { Database } from '@google-cloud/spanner';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  calculatePagination,
+  createStorageErrorId,
+  ExperimentsStorage,
+  normalizePerPage,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
+  TABLE_SCHEMAS,
+} from '@mastra/core/storage';
+import type {
+  AddExperimentResultInput,
+  CreateExperimentInput,
+  CreateIndexOptions,
+  Experiment,
+  ExperimentResult,
+  ExperimentReviewCounts,
+  ListExperimentResultsInput,
+  ListExperimentResultsOutput,
+  ListExperimentsInput,
+  ListExperimentsOutput,
+  UpdateExperimentInput,
+  UpdateExperimentResultInput,
+} from '@mastra/core/storage';
+import { SpannerDB, resolveSpannerConfig } from '../../db';
+import type { SpannerDomainConfig } from '../../db';
+import { quoteIdent } from '../../db/utils';
+import { transformFromSpannerRow } from '../utils';
+
+function toDate(value: unknown): Date {
+  return value instanceof Date ? value : new Date(value as string);
+}
+
+function rowToExperiment(row: Record<string, any>): Experiment {
+  const t = transformFromSpannerRow<Record<string, any>>({ tableName: TABLE_EXPERIMENTS, row });
+  return {
+    id: String(t.id),
+    name: t.name ?? undefined,
+    description: t.description ?? undefined,
+    metadata: t.metadata ?? undefined,
+    datasetId: t.datasetId ?? null,
+    datasetVersion: t.datasetVersion == null ? null : Number(t.datasetVersion),
+    targetType: t.targetType,
+    targetId: String(t.targetId),
+    status: t.status,
+    totalItems: Number(t.totalItems ?? 0),
+    succeededCount: Number(t.succeededCount ?? 0),
+    failedCount: Number(t.failedCount ?? 0),
+    skippedCount: Number(t.skippedCount ?? 0),
+    agentVersion: t.agentVersion ?? null,
+    startedAt: t.startedAt == null ? null : toDate(t.startedAt),
+    completedAt: t.completedAt == null ? null : toDate(t.completedAt),
+    createdAt: toDate(t.createdAt),
+    updatedAt: toDate(t.updatedAt),
+  };
+}
+
+function rowToExperimentResult(row: Record<string, any>): ExperimentResult {
+  const t = transformFromSpannerRow<Record<string, any>>({ tableName: TABLE_EXPERIMENT_RESULTS, row });
+  return {
+    id: String(t.id),
+    experimentId: String(t.experimentId),
+    itemId: String(t.itemId),
+    itemDatasetVersion: t.itemDatasetVersion == null ? null : Number(t.itemDatasetVersion),
+    input: t.input ?? null,
+    output: t.output ?? null,
+    groundTruth: t.groundTruth ?? null,
+    error: (t.error ?? null) as ExperimentResult['error'],
+    startedAt: toDate(t.startedAt),
+    completedAt: toDate(t.completedAt),
+    retryCount: Number(t.retryCount ?? 0),
+    traceId: t.traceId ?? null,
+    status: (t.status ?? null) as ExperimentResult['status'],
+    tags: (t.tags ?? null) as string[] | null,
+    createdAt: toDate(t.createdAt),
+  };
+}
+
+/**
+ * Spanner-backed storage for experiments (`mastra_experiments`) and their per-item
+ * results (`mastra_experiment_results`). Both tables are keyed by `id`; results are
+ * additionally constrained to one row per `(experimentId, itemId)`.
+ */
+export class ExperimentsSpanner extends ExperimentsStorage {
+  private database: Database;
+  private db: SpannerDB;
+  private readonly skipDefaultIndexes?: boolean;
+  private readonly indexes?: CreateIndexOptions[];
+
+  static readonly MANAGED_TABLES = [TABLE_EXPERIMENTS, TABLE_EXPERIMENT_RESULTS] as const;
+
+  constructor(config: SpannerDomainConfig) {
+    super();
+    const { database, indexes, skipDefaultIndexes, initMode } = resolveSpannerConfig(config);
+    this.database = database;
+    this.db = new SpannerDB({ database, skipDefaultIndexes, initMode });
+    this.skipDefaultIndexes = skipDefaultIndexes;
+    this.indexes = indexes?.filter(idx => (ExperimentsSpanner.MANAGED_TABLES as readonly string[]).includes(idx.table));
+  }
+
+  async init(): Promise<void> {
+    await this.db.createTable({ tableName: TABLE_EXPERIMENTS, schema: TABLE_SCHEMAS[TABLE_EXPERIMENTS] });
+    await this.db.createTable({ tableName: TABLE_EXPERIMENT_RESULTS, schema: TABLE_SCHEMAS[TABLE_EXPERIMENT_RESULTS] });
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    return [
+      {
+        name: 'mastra_experiments_datasetid_idx',
+        table: TABLE_EXPERIMENTS,
+        columns: ['datasetId'],
+      },
+      {
+        name: 'mastra_experiment_results_experimentid_idx',
+        table: TABLE_EXPERIMENT_RESULTS,
+        columns: ['experimentId', 'startedAt'],
+      },
+      {
+        // One result per (experiment, item).
+        name: 'mastra_experiment_results_exp_item_idx',
+        table: TABLE_EXPERIMENT_RESULTS,
+        columns: ['experimentId', 'itemId'],
+        unique: true,
+      },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.skipDefaultIndexes) return;
+    await this.db.createIndexes(this.getDefaultIndexDefinitions());
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.indexes || this.indexes.length === 0) return;
+    await this.db.createIndexes(this.indexes);
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.db.clearTable({ tableName: TABLE_EXPERIMENT_RESULTS });
+    await this.db.clearTable({ tableName: TABLE_EXPERIMENTS });
+  }
+
+  async createExperiment(input: CreateExperimentInput): Promise<Experiment> {
+    try {
+      const now = new Date();
+      const id = input.id ?? randomUUID();
+      const experiment: Experiment = {
+        id,
+        name: input.name ?? undefined,
+        description: input.description ?? undefined,
+        metadata: input.metadata ?? undefined,
+        datasetId: input.datasetId ?? null,
+        datasetVersion: input.datasetVersion ?? null,
+        targetType: input.targetType,
+        targetId: input.targetId,
+        status: 'pending',
+        totalItems: input.totalItems,
+        succeededCount: 0,
+        failedCount: 0,
+        skippedCount: 0,
+        agentVersion: input.agentVersion ?? null,
+        startedAt: null,
+        completedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await this.db.insert({
+        tableName: TABLE_EXPERIMENTS,
+        record: {
+          id,
+          name: experiment.name ?? null,
+          description: experiment.description ?? null,
+          metadata: experiment.metadata ?? null,
+          datasetId: experiment.datasetId,
+          datasetVersion: experiment.datasetVersion,
+          targetType: experiment.targetType,
+          targetId: experiment.targetId,
+          status: experiment.status,
+          totalItems: experiment.totalItems,
+          succeededCount: 0,
+          failedCount: 0,
+          skippedCount: 0,
+          agentVersion: experiment.agentVersion,
+          startedAt: null,
+          completedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+      return experiment;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'CREATE_EXPERIMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async updateExperiment(input: UpdateExperimentInput): Promise<Experiment> {
+    try {
+      const existing = await this.getExperimentById({ id: input.id });
+      if (!existing) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'UPDATE_EXPERIMENT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Experiment ${input.id} not found`,
+          details: { id: input.id },
+        });
+      }
+
+      const data: Record<string, any> = {};
+      if (input.name !== undefined) data.name = input.name;
+      if (input.description !== undefined) data.description = input.description;
+      if (input.metadata !== undefined) data.metadata = input.metadata;
+      if (input.status !== undefined) data.status = input.status;
+      if (input.totalItems !== undefined) data.totalItems = input.totalItems;
+      if (input.succeededCount !== undefined) data.succeededCount = input.succeededCount;
+      if (input.failedCount !== undefined) data.failedCount = input.failedCount;
+      if (input.skippedCount !== undefined) data.skippedCount = input.skippedCount;
+      if (input.startedAt !== undefined) data.startedAt = input.startedAt;
+      if (input.completedAt !== undefined) data.completedAt = input.completedAt;
+      data.updatedAt = new Date();
+
+      await this.db.update({ tableName: TABLE_EXPERIMENTS, keys: { id: input.id }, data });
+
+      const updated = await this.getExperimentById({ id: input.id });
+      if (!updated) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'UPDATE_EXPERIMENT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Experiment ${input.id} not found`,
+          details: { id: input.id },
+        });
+      }
+      return updated;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'UPDATE_EXPERIMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: input.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getExperimentById(args: { id: string }): Promise<Experiment | null> {
+    try {
+      const row = await this.db.load<Record<string, any>>({ tableName: TABLE_EXPERIMENTS, keys: { id: args.id } });
+      return row ? rowToExperiment(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_EXPERIMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: args.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listExperiments(args: ListExperimentsInput): Promise<ListExperimentsOutput> {
+    const { page = 0, perPage: perPageInput } = args.pagination;
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+    try {
+      const conditions: string[] = [];
+      const params: Record<string, any> = {};
+      if (args.datasetId !== undefined) {
+        conditions.push(`${quoteIdent('datasetId', 'column name')} = @datasetId`);
+        params.datasetId = args.datasetId;
+      }
+      if (args.targetType !== undefined) {
+        conditions.push(`${quoteIdent('targetType', 'column name')} = @targetType`);
+        params.targetType = args.targetType;
+      }
+      if (args.targetId !== undefined) {
+        conditions.push(`${quoteIdent('targetId', 'column name')} = @targetId`);
+        params.targetId = args.targetId;
+      }
+      if (args.agentVersion !== undefined) {
+        conditions.push(`${quoteIdent('agentVersion', 'column name')} = @agentVersion`);
+        params.agentVersion = args.agentVersion;
+      }
+      if (args.status !== undefined) {
+        conditions.push(`${quoteIdent('status', 'column name')} = @status`);
+        params.status = args.status;
+      }
+      const whereSql = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+      const tableName = quoteIdent(TABLE_EXPERIMENTS, 'table name');
+
+      const [countRows] = await this.database.run({
+        sql: `SELECT COUNT(*) AS count FROM ${tableName} ${whereSql}`,
+        params,
+        json: true,
+      });
+      const total = Number((countRows as Array<{ count: number | string }>)[0]?.count ?? 0);
+      if (total === 0) {
+        return { experiments: [], pagination: { total: 0, page, perPage: perPageForResponse, hasMore: false } };
+      }
+
+      const limit = perPageInput === false ? total : perPage;
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName} ${whereSql}
+              ORDER BY ${quoteIdent('createdAt', 'column name')} DESC
+              LIMIT @limit OFFSET @offset`,
+        params: { ...params, limit, offset },
+        json: true,
+      });
+      const experiments = (rows as Array<Record<string, any>>).map(rowToExperiment);
+      return {
+        experiments,
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + perPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_EXPERIMENTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteExperiment(args: { id: string }): Promise<void> {
+    try {
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            await tx.runUpdate({
+              sql: `DELETE FROM ${quoteIdent(TABLE_EXPERIMENT_RESULTS, 'table name')}
+                    WHERE ${quoteIdent('experimentId', 'column name')} = @id`,
+              params: { id: args.id },
+            });
+            await tx.runUpdate({
+              sql: `DELETE FROM ${quoteIdent(TABLE_EXPERIMENTS, 'table name')}
+                    WHERE ${quoteIdent('id', 'column name')} = @id`,
+              params: { id: args.id },
+            });
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_EXPERIMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: args.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async addExperimentResult(input: AddExperimentResultInput): Promise<ExperimentResult> {
+    try {
+      const now = new Date();
+      const id = input.id ?? randomUUID();
+      const result: ExperimentResult = {
+        id,
+        experimentId: input.experimentId,
+        itemId: input.itemId,
+        itemDatasetVersion: input.itemDatasetVersion ?? null,
+        input: input.input ?? null,
+        output: input.output ?? null,
+        groundTruth: input.groundTruth ?? null,
+        error: input.error ?? null,
+        startedAt: input.startedAt,
+        completedAt: input.completedAt,
+        retryCount: input.retryCount,
+        traceId: input.traceId ?? null,
+        status: input.status ?? null,
+        tags: input.tags ?? null,
+        createdAt: now,
+      };
+      await this.db.insert({
+        tableName: TABLE_EXPERIMENT_RESULTS,
+        record: {
+          id,
+          experimentId: result.experimentId,
+          itemId: result.itemId,
+          itemDatasetVersion: result.itemDatasetVersion,
+          input: result.input,
+          output: result.output,
+          groundTruth: result.groundTruth,
+          error: result.error,
+          startedAt: result.startedAt,
+          completedAt: result.completedAt,
+          retryCount: result.retryCount,
+          traceId: result.traceId,
+          status: result.status,
+          tags: result.tags,
+          createdAt: now,
+        },
+      });
+      return result;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'ADD_EXPERIMENT_RESULT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { experimentId: input.experimentId, itemId: input.itemId },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateExperimentResult(input: UpdateExperimentResultInput): Promise<ExperimentResult> {
+    try {
+      if (input.status === undefined && input.tags === undefined) {
+        const existing = await this.getExperimentResultById({ id: input.id });
+        // Honor the experimentId scope even on the no-op path: a result that
+        // belongs to a different experiment must not be returned.
+        if (!existing || (input.experimentId !== undefined && existing.experimentId !== input.experimentId)) {
+          throw new MastraError({
+            id: createStorageErrorId('SPANNER', 'UPDATE_EXPERIMENT_RESULT', 'NOT_FOUND'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.USER,
+            text: `Experiment result ${input.id} not found`,
+            details: { id: input.id },
+          });
+        }
+        return existing;
+      }
+
+      const setClauses: string[] = [];
+      const params: Record<string, any> = { id: input.id };
+      const types: Record<string, any> = {};
+      if (input.status !== undefined) {
+        setClauses.push(`${quoteIdent('status', 'column name')} = @status`);
+        params.status = input.status;
+        if (input.status === null) types.status = 'string';
+      }
+      if (input.tags !== undefined) {
+        setClauses.push(`${quoteIdent('tags', 'column name')} = @tags`);
+        params.tags = input.tags === null ? null : JSON.stringify(input.tags);
+        types.tags = 'json';
+      }
+      const whereClauses = [`${quoteIdent('id', 'column name')} = @id`];
+      if (input.experimentId !== undefined) {
+        whereClauses.push(`${quoteIdent('experimentId', 'column name')} = @experimentId`);
+        params.experimentId = input.experimentId;
+      }
+      const rowCount = await this.db.runDml({
+        sql: `UPDATE ${quoteIdent(TABLE_EXPERIMENT_RESULTS, 'table name')}
+              SET ${setClauses.join(', ')} WHERE ${whereClauses.join(' AND ')}`,
+        params,
+        types,
+      });
+      if (rowCount === 0) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'UPDATE_EXPERIMENT_RESULT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Experiment result ${input.id} not found`,
+          details: { id: input.id },
+        });
+      }
+      const updated = await this.getExperimentResultById({ id: input.id });
+      if (!updated) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'UPDATE_EXPERIMENT_RESULT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Experiment result ${input.id} not found`,
+          details: { id: input.id },
+        });
+      }
+      return updated;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'UPDATE_EXPERIMENT_RESULT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: input.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getExperimentResultById(args: { id: string }): Promise<ExperimentResult | null> {
+    try {
+      const row = await this.db.load<Record<string, any>>({
+        tableName: TABLE_EXPERIMENT_RESULTS,
+        keys: { id: args.id },
+      });
+      return row ? rowToExperimentResult(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_EXPERIMENT_RESULT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: args.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listExperimentResults(args: ListExperimentResultsInput): Promise<ListExperimentResultsOutput> {
+    const { page = 0, perPage: perPageInput } = args.pagination;
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+    try {
+      const conditions: string[] = [`${quoteIdent('experimentId', 'column name')} = @experimentId`];
+      const params: Record<string, any> = { experimentId: args.experimentId };
+      if (args.traceId !== undefined) {
+        conditions.push(`${quoteIdent('traceId', 'column name')} = @traceId`);
+        params.traceId = args.traceId;
+      }
+      if (args.status !== undefined) {
+        conditions.push(`${quoteIdent('status', 'column name')} = @status`);
+        params.status = args.status;
+      }
+      const whereSql = `WHERE ${conditions.join(' AND ')}`;
+      const tableName = quoteIdent(TABLE_EXPERIMENT_RESULTS, 'table name');
+
+      const [countRows] = await this.database.run({
+        sql: `SELECT COUNT(*) AS count FROM ${tableName} ${whereSql}`,
+        params,
+        json: true,
+      });
+      const total = Number((countRows as Array<{ count: number | string }>)[0]?.count ?? 0);
+      if (total === 0) {
+        return { results: [], pagination: { total: 0, page, perPage: perPageForResponse, hasMore: false } };
+      }
+
+      const limit = perPageInput === false ? total : perPage;
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName} ${whereSql}
+              ORDER BY ${quoteIdent('startedAt', 'column name')} ASC
+              LIMIT @limit OFFSET @offset`,
+        params: { ...params, limit, offset },
+        json: true,
+      });
+      const results = (rows as Array<Record<string, any>>).map(rowToExperimentResult);
+      return {
+        results,
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + perPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_EXPERIMENT_RESULTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { experimentId: args.experimentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteExperimentResults(args: { experimentId: string }): Promise<void> {
+    try {
+      await this.db.runDml({
+        sql: `DELETE FROM ${quoteIdent(TABLE_EXPERIMENT_RESULTS, 'table name')}
+              WHERE ${quoteIdent('experimentId', 'column name')} = @experimentId`,
+        params: { experimentId: args.experimentId },
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_EXPERIMENT_RESULTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { experimentId: args.experimentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async getReviewSummary(): Promise<ExperimentReviewCounts[]> {
+    try {
+      const tableName = quoteIdent(TABLE_EXPERIMENT_RESULTS, 'table name');
+      const statusCol = quoteIdent('status', 'column name');
+      const [rows] = await this.database.run({
+        sql: `SELECT ${quoteIdent('experimentId', 'column name')} AS experimentId,
+                     COUNT(*) AS total,
+                     SUM(CASE WHEN ${statusCol} = 'needs-review' THEN 1 ELSE 0 END) AS needsReview,
+                     SUM(CASE WHEN ${statusCol} = 'reviewed' THEN 1 ELSE 0 END) AS reviewed,
+                     SUM(CASE WHEN ${statusCol} = 'complete' THEN 1 ELSE 0 END) AS complete
+              FROM ${tableName}
+              GROUP BY ${quoteIdent('experimentId', 'column name')}`,
+        json: true,
+      });
+      return (rows as Array<Record<string, any>>).map(r => ({
+        experimentId: String(r.experimentId),
+        total: Number(r.total ?? 0),
+        needsReview: Number(r.needsReview ?? 0),
+        reviewed: Number(r.reviewed ?? 0),
+        complete: Number(r.complete ?? 0),
+      }));
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_REVIEW_SUMMARY', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/spanner/src/storage/domains/favorites/index.ts
+++ b/stores/spanner/src/storage/domains/favorites/index.ts
@@ -1,0 +1,371 @@
+import type { Database, Transaction } from '@google-cloud/spanner';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  createStorageErrorId,
+  FavoritesStorage,
+  TABLE_AGENTS,
+  TABLE_FAVORITES,
+  TABLE_SKILLS,
+  TABLE_SCHEMAS,
+} from '@mastra/core/storage';
+import type {
+  CreateIndexOptions,
+  FavoriteToggleResult,
+  StorageDeleteFavoritesForEntityInput,
+  StorageFavoriteEntityType,
+  StorageFavoriteKey,
+  StorageIsFavoritedBatchInput,
+  StorageListFavoritesInput,
+  TABLE_NAMES,
+} from '@mastra/core/storage';
+import { SpannerDB, resolveSpannerConfig } from '../../db';
+import type { SpannerDomainConfig } from '../../db';
+import { quoteIdent } from '../../db/utils';
+
+/**
+ * Maps a favorite entity type to the parent table whose denormalized
+ * `favoriteCount` column the favorites domain keeps in sync.
+ */
+const ENTITY_TABLE: Record<StorageFavoriteEntityType, TABLE_NAMES> = {
+  agent: TABLE_AGENTS,
+  skill: TABLE_SKILLS,
+};
+
+/**
+ * Spanner-backed storage for user favorites.
+ *
+ * Persists `(userId, entityType, entityId)` rows in `mastra_favorites` (composite
+ * primary key) and keeps the denormalized `favoriteCount` on the parent entity
+ * (`mastra_agents` / `mastra_skills`) in sync. All mutating operations run inside
+ * a single read-write transaction so the favorite row and the counter never drift.
+ */
+export class FavoritesSpanner extends FavoritesStorage {
+  private database: Database;
+  private db: SpannerDB;
+  private readonly skipDefaultIndexes?: boolean;
+  private readonly indexes?: CreateIndexOptions[];
+
+  static readonly MANAGED_TABLES = [TABLE_FAVORITES] as const;
+
+  constructor(config: SpannerDomainConfig) {
+    super();
+    const { database, indexes, skipDefaultIndexes, initMode } = resolveSpannerConfig(config);
+    this.database = database;
+    this.db = new SpannerDB({ database, skipDefaultIndexes, initMode });
+    this.skipDefaultIndexes = skipDefaultIndexes;
+    this.indexes = indexes?.filter(idx => (FavoritesSpanner.MANAGED_TABLES as readonly string[]).includes(idx.table));
+  }
+
+  async init(): Promise<void> {
+    await this.db.createTable({ tableName: TABLE_FAVORITES, schema: TABLE_SCHEMAS[TABLE_FAVORITES] });
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    return [
+      {
+        // Supports deleteFavoritesForEntity / counting by entity, and the
+        // entity-scoped lookups used by the agents/skills favorited-first JOIN.
+        name: 'mastra_favorites_entity_idx',
+        table: TABLE_FAVORITES,
+        columns: ['entityType', 'entityId'],
+      },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.skipDefaultIndexes) return;
+    await this.db.createIndexes(this.getDefaultIndexDefinitions());
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.indexes || this.indexes.length === 0) return;
+    await this.db.createIndexes(this.indexes);
+  }
+
+  /**
+   * Reads the current `favoriteCount` for the parent entity inside `tx`.
+   * Returns `null` when the entity row does not exist.
+   */
+  private async readEntityCount(tx: Transaction, entityTable: TABLE_NAMES, entityId: string): Promise<number | null> {
+    const [rows] = await tx.run({
+      sql: `SELECT ${quoteIdent('favoriteCount', 'column name')} AS count
+            FROM ${quoteIdent(entityTable, 'table name')}
+            WHERE ${quoteIdent('id', 'column name')} = @id LIMIT 1`,
+      params: { id: entityId },
+      json: true,
+    });
+    const row = (rows as Array<{ count: number | string | null }>)[0];
+    if (!row) return null;
+    return Number(row.count ?? 0);
+  }
+
+  async favorite(input: StorageFavoriteKey): Promise<FavoriteToggleResult> {
+    const { userId, entityType, entityId } = input;
+    const entityTable = ENTITY_TABLE[entityType];
+    try {
+      let favoriteCount = 0;
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            const existingCount = await this.readEntityCount(tx, entityTable, entityId);
+            if (existingCount === null) {
+              throw new MastraError({
+                id: createStorageErrorId('SPANNER', 'FAVORITE', 'ENTITY_NOT_FOUND'),
+                domain: ErrorDomain.STORAGE,
+                category: ErrorCategory.USER,
+                text: `Cannot favorite ${entityType} "${entityId}": entity does not exist`,
+                details: { entityType, entityId },
+              });
+            }
+
+            const [favRows] = await tx.run({
+              sql: `SELECT 1 AS found FROM ${quoteIdent(TABLE_FAVORITES, 'table name')}
+                    WHERE ${quoteIdent('userId', 'column name')} = @userId
+                      AND ${quoteIdent('entityType', 'column name')} = @entityType
+                      AND ${quoteIdent('entityId', 'column name')} = @entityId LIMIT 1`,
+              params: { userId, entityType, entityId },
+              json: true,
+            });
+
+            if ((favRows as unknown[]).length === 0) {
+              await this.db.insert({
+                tableName: TABLE_FAVORITES,
+                record: { userId, entityType, entityId, createdAt: new Date() },
+                transaction: tx,
+              });
+              await tx.runUpdate({
+                sql: `UPDATE ${quoteIdent(entityTable, 'table name')}
+                      SET ${quoteIdent('favoriteCount', 'column name')} = COALESCE(${quoteIdent('favoriteCount', 'column name')}, 0) + 1
+                      WHERE ${quoteIdent('id', 'column name')} = @id`,
+                params: { id: entityId },
+              });
+            }
+
+            favoriteCount = (await this.readEntityCount(tx, entityTable, entityId)) ?? 0;
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+      return { favorited: true, favoriteCount };
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'FAVORITE', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { entityType, entityId },
+        },
+        error,
+      );
+    }
+  }
+
+  async unfavorite(input: StorageFavoriteKey): Promise<FavoriteToggleResult> {
+    const { userId, entityType, entityId } = input;
+    const entityTable = ENTITY_TABLE[entityType];
+    try {
+      let favoriteCount = 0;
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            const existingCount = await this.readEntityCount(tx, entityTable, entityId);
+            if (existingCount === null) {
+              throw new MastraError({
+                id: createStorageErrorId('SPANNER', 'UNFAVORITE', 'ENTITY_NOT_FOUND'),
+                domain: ErrorDomain.STORAGE,
+                category: ErrorCategory.USER,
+                text: `Cannot unfavorite ${entityType} "${entityId}": entity does not exist`,
+                details: { entityType, entityId },
+              });
+            }
+
+            const [deleted] = await tx.runUpdate({
+              sql: `DELETE FROM ${quoteIdent(TABLE_FAVORITES, 'table name')}
+                    WHERE ${quoteIdent('userId', 'column name')} = @userId
+                      AND ${quoteIdent('entityType', 'column name')} = @entityType
+                      AND ${quoteIdent('entityId', 'column name')} = @entityId`,
+              params: { userId, entityType, entityId },
+            });
+
+            if (Number(deleted ?? 0) > 0) {
+              await tx.runUpdate({
+                sql: `UPDATE ${quoteIdent(entityTable, 'table name')}
+                      SET ${quoteIdent('favoriteCount', 'column name')} = GREATEST(COALESCE(${quoteIdent('favoriteCount', 'column name')}, 0) - 1, 0)
+                      WHERE ${quoteIdent('id', 'column name')} = @id`,
+                params: { id: entityId },
+              });
+            }
+
+            favoriteCount = (await this.readEntityCount(tx, entityTable, entityId)) ?? 0;
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+      return { favorited: false, favoriteCount };
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'UNFAVORITE', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { entityType, entityId },
+        },
+        error,
+      );
+    }
+  }
+
+  async isFavorited(input: StorageFavoriteKey): Promise<boolean> {
+    const { userId, entityType, entityId } = input;
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT 1 AS found FROM ${quoteIdent(TABLE_FAVORITES, 'table name')}
+              WHERE ${quoteIdent('userId', 'column name')} = @userId
+                AND ${quoteIdent('entityType', 'column name')} = @entityType
+                AND ${quoteIdent('entityId', 'column name')} = @entityId LIMIT 1`,
+        params: { userId, entityType, entityId },
+        json: true,
+      });
+      return (rows as unknown[]).length > 0;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'IS_FAVORITED', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { entityType, entityId },
+        },
+        error,
+      );
+    }
+  }
+
+  async isFavoritedBatch(input: StorageIsFavoritedBatchInput): Promise<Set<string>> {
+    const { userId, entityType, entityIds } = input;
+    if (entityIds.length === 0) return new Set();
+    try {
+      const params: Record<string, any> = { userId, entityType };
+      const placeholders = entityIds.map((id, i) => {
+        const param = `e${i}`;
+        params[param] = id;
+        return `@${param}`;
+      });
+      const [rows] = await this.database.run({
+        sql: `SELECT ${quoteIdent('entityId', 'column name')} AS entityId
+              FROM ${quoteIdent(TABLE_FAVORITES, 'table name')}
+              WHERE ${quoteIdent('userId', 'column name')} = @userId
+                AND ${quoteIdent('entityType', 'column name')} = @entityType
+                AND ${quoteIdent('entityId', 'column name')} IN (${placeholders.join(', ')})`,
+        params,
+        json: true,
+      });
+      return new Set((rows as Array<{ entityId: string }>).map(r => r.entityId));
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'IS_FAVORITED_BATCH', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { entityType },
+        },
+        error,
+      );
+    }
+  }
+
+  async listFavoritedIds(input: StorageListFavoritesInput): Promise<string[]> {
+    const { userId, entityType } = input;
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT ${quoteIdent('entityId', 'column name')} AS entityId
+              FROM ${quoteIdent(TABLE_FAVORITES, 'table name')}
+              WHERE ${quoteIdent('userId', 'column name')} = @userId
+                AND ${quoteIdent('entityType', 'column name')} = @entityType
+              ORDER BY ${quoteIdent('createdAt', 'column name')} DESC, ${quoteIdent('entityId', 'column name')} ASC`,
+        params: { userId, entityType },
+        json: true,
+      });
+      return (rows as Array<{ entityId: string }>).map(r => r.entityId);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_FAVORITED_IDS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { entityType },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteFavoritesForEntity(input: StorageDeleteFavoritesForEntityInput): Promise<number> {
+    const { entityType, entityId } = input;
+    const entityTable = ENTITY_TABLE[entityType];
+    try {
+      let removed = 0;
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            const [count] = await tx.runUpdate({
+              sql: `DELETE FROM ${quoteIdent(TABLE_FAVORITES, 'table name')}
+                    WHERE ${quoteIdent('entityType', 'column name')} = @entityType
+                      AND ${quoteIdent('entityId', 'column name')} = @entityId`,
+              params: { entityType, entityId },
+            });
+            removed = Number(count ?? 0);
+            // Reset the denormalized counter; no-ops when the entity row is gone.
+            await tx.runUpdate({
+              sql: `UPDATE ${quoteIdent(entityTable, 'table name')}
+                    SET ${quoteIdent('favoriteCount', 'column name')} = 0
+                    WHERE ${quoteIdent('id', 'column name')} = @id`,
+              params: { id: entityId },
+            });
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+      return removed;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_FAVORITES_FOR_ENTITY', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { entityType, entityId },
+        },
+        error,
+      );
+    }
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.db.clearTable({ tableName: TABLE_FAVORITES });
+    // Reset denormalized counters on parent entities. These tables may not exist
+    // when favorites is used standalone, so failures are swallowed.
+    for (const table of [TABLE_AGENTS, TABLE_SKILLS]) {
+      try {
+        await this.db.runDml({
+          sql: `UPDATE ${quoteIdent(table, 'table name')}
+                SET ${quoteIdent('favoriteCount', 'column name')} = 0
+                WHERE ${quoteIdent('favoriteCount', 'column name')} > 0`,
+        });
+      } catch {
+        // Parent table absent in standalone favorites usage — nothing to reset.
+      }
+    }
+  }
+}

--- a/stores/spanner/src/storage/domains/skills/index.ts
+++ b/stores/spanner/src/storage/domains/skills/index.ts
@@ -7,6 +7,7 @@ import {
   SkillsStorage,
   SKILLS_SCHEMA,
   SKILL_VERSIONS_SCHEMA,
+  TABLE_FAVORITES,
   TABLE_SKILLS,
   TABLE_SKILL_VERSIONS,
 } from '@mastra/core/storage';
@@ -134,9 +135,16 @@ export class SkillsSpanner extends SkillsStorage {
       status: transformed.status,
       activeVersionId: transformed.activeVersionId ?? undefined,
       authorId: transformed.authorId ?? undefined,
+      visibility: (transformed.visibility as 'private' | 'public' | undefined) ?? undefined,
+      // Denormalized favorite counter maintained by the favorites domain. Surface
+      // it as 0 when absent so list/get responses carry a stable numeric value.
+      favoriteCount:
+        transformed.favoriteCount === null || transformed.favoriteCount === undefined
+          ? 0
+          : Number(transformed.favoriteCount),
       createdAt: transformed.createdAt,
       updatedAt: transformed.updatedAt,
-    };
+    } as StorageSkillType;
   }
 
   /** Decodes a raw Spanner version row into the public version shape. */
@@ -195,7 +203,8 @@ export class SkillsSpanner extends SkillsStorage {
     const { skill } = input;
     try {
       const now = new Date();
-      const { id: _id, authorId: _authorId, ...snapshot } = skill;
+      const { id: _id, authorId: _authorId, visibility: _visibility, ...snapshot } = skill as any;
+      const visibility = (skill as any).visibility ?? (skill.authorId ? 'private' : null);
       const versionId = globalThis.crypto?.randomUUID
         ? globalThis.crypto.randomUUID()
         : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -214,6 +223,7 @@ export class SkillsSpanner extends SkillsStorage {
                 status: 'draft',
                 activeVersionId: null,
                 authorId: skill.authorId ?? null,
+                visibility,
                 createdAt: now,
                 updatedAt: now,
               },
@@ -298,6 +308,7 @@ export class SkillsSpanner extends SkillsStorage {
       // a new version through the server's auto-versioning layer.
       const updateData: Record<string, unknown> = { updatedAt: new Date() };
       if (updates.authorId !== undefined) updateData.authorId = updates.authorId;
+      if ((updates as any).visibility !== undefined) updateData.visibility = (updates as any).visibility;
       if (updates.activeVersionId !== undefined) updateData.activeVersionId = updates.activeVersionId;
       if (updates.status !== undefined) updateData.status = updates.status;
 
@@ -365,7 +376,17 @@ export class SkillsSpanner extends SkillsStorage {
 
   /** Paginated listing with optional authorId filter. */
   async list(args?: StorageListSkillsInput): Promise<StorageListSkillsOutput> {
-    const { page = 0, perPage: perPageInput, orderBy, authorId } = args || {};
+    const {
+      page = 0,
+      perPage: perPageInput,
+      orderBy,
+      authorId,
+      status,
+      visibility,
+      entityIds,
+      pinFavoritedFor,
+      favoritedOnly,
+    } = args || {};
     const { field, direction } = this.parseOrderBy(orderBy);
 
     if (page < 0) {
@@ -384,17 +405,53 @@ export class SkillsSpanner extends SkillsStorage {
     const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
 
     try {
-      const tableName = quoteIdent(TABLE_SKILLS, 'table name');
-      const conditions: string[] = [];
-      const params: Record<string, any> = {};
-      if (authorId !== undefined) {
-        conditions.push(`${quoteIdent('authorId', 'column name')} = @authorId`);
-        params.authorId = authorId;
+      // Empty entityIds can never match a row — short-circuit before querying.
+      if (entityIds && entityIds.length === 0) {
+        return { skills: [], total: 0, page, perPage: perPageForResponse, hasMore: false };
       }
 
+      const tableName = quoteIdent(TABLE_SKILLS, 'table name');
+      const favoritesTable = quoteIdent(TABLE_FAVORITES, 'table name');
+      const conditions: string[] = [];
+      const params: Record<string, any> = {};
+
+      const useJoin = Boolean(pinFavoritedFor);
+      if (useJoin) params.pinUserId = pinFavoritedFor;
+
+      if (status !== undefined) {
+        conditions.push(`a.${quoteIdent('status', 'column name')} = @status`);
+        params.status = status;
+      }
+      if (visibility !== undefined) {
+        conditions.push(`a.${quoteIdent('visibility', 'column name')} = @visibility`);
+        params.visibility = visibility;
+      }
+      if (authorId !== undefined) {
+        conditions.push(`a.${quoteIdent('authorId', 'column name')} = @authorId`);
+        params.authorId = authorId;
+      }
+      if (entityIds && entityIds.length > 0) {
+        const placeholders = entityIds.map((id, i) => {
+          const param = `eid${i}`;
+          params[param] = id;
+          return `@${param}`;
+        });
+        conditions.push(`a.${quoteIdent('id', 'column name')} IN (${placeholders.join(', ')})`);
+      }
+      if (useJoin && favoritedOnly) {
+        conditions.push(`s.${quoteIdent('userId', 'column name')} IS NOT NULL`);
+      } else if (favoritedOnly) {
+        conditions.push('1 = 0');
+      }
+
+      const joinClause = useJoin
+        ? `LEFT JOIN ${favoritesTable} s ON s.${quoteIdent('entityType', 'column name')} = 'skill'` +
+          ` AND s.${quoteIdent('entityId', 'column name')} = a.${quoteIdent('id', 'column name')}` +
+          ` AND s.${quoteIdent('userId', 'column name')} = @pinUserId`
+        : '';
       const whereSql = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
       const [countRows] = await this.database.run({
-        sql: `SELECT COUNT(*) AS count FROM ${tableName} ${whereSql}`,
+        sql: `SELECT COUNT(*) AS count FROM ${tableName} a ${joinClause} ${whereSql}`,
         params,
         json: true,
       });
@@ -405,9 +462,15 @@ export class SkillsSpanner extends SkillsStorage {
 
       const limit = perPageInput === false ? total : perPage;
       const dirSql = (direction || 'DESC').toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
+      const orderParts: string[] = [];
+      if (useJoin) {
+        orderParts.push(`(s.${quoteIdent('userId', 'column name')} IS NOT NULL) DESC`);
+      }
+      orderParts.push(`a.${quoteIdent(field, 'column name')} ${dirSql}`);
+      orderParts.push(`a.${quoteIdent('id', 'column name')} ${dirSql}`);
       const [rows] = await this.database.run({
-        sql: `SELECT * FROM ${tableName} ${whereSql}
-              ORDER BY ${quoteIdent(field, 'column name')} ${dirSql}, id ${dirSql}
+        sql: `SELECT a.* FROM ${tableName} a ${joinClause} ${whereSql}
+              ORDER BY ${orderParts.join(', ')}
               LIMIT @limit OFFSET @offset`,
         params: { ...params, limit, offset },
         json: true,

--- a/stores/spanner/src/storage/domains/workspaces/index.ts
+++ b/stores/spanner/src/storage/domains/workspaces/index.ts
@@ -1,0 +1,735 @@
+import type { Database } from '@google-cloud/spanner';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  calculatePagination,
+  createStorageErrorId,
+  normalizePerPage,
+  WorkspacesStorage,
+  WORKSPACES_SCHEMA,
+  WORKSPACE_VERSIONS_SCHEMA,
+  TABLE_WORKSPACES,
+  TABLE_WORKSPACE_VERSIONS,
+} from '@mastra/core/storage';
+import type {
+  CreateIndexOptions,
+  StorageCreateWorkspaceInput,
+  StorageListWorkspacesInput,
+  StorageListWorkspacesOutput,
+  StorageUpdateWorkspaceInput,
+  StorageWorkspaceType,
+} from '@mastra/core/storage';
+import type {
+  CreateWorkspaceVersionInput,
+  ListWorkspaceVersionsInput,
+  ListWorkspaceVersionsOutput,
+  WorkspaceVersion,
+} from '@mastra/core/storage/domains/workspaces';
+import { SpannerDB, resolveSpannerConfig } from '../../db';
+import type { SpannerDomainConfig } from '../../db';
+import { quoteIdent } from '../../db/utils';
+import { transformFromSpannerRow } from '../utils';
+
+/** Snapshot config fields that live exclusively on version rows. */
+const SNAPSHOT_FIELDS = [
+  'name',
+  'description',
+  'filesystem',
+  'sandbox',
+  'mounts',
+  'search',
+  'skills',
+  'tools',
+  'autoSync',
+  'operationTimeout',
+] as const;
+
+/**
+ * Spanner-backed storage for workspaces and their immutable version snapshots.
+ * Mirrors the thin-record + versions pattern used by skills/agents: the
+ * `mastra_workspaces` row holds only metadata (status, activeVersionId, authorId,
+ * metadata) while all configuration lives in `mastra_workspace_versions`.
+ */
+export class WorkspacesSpanner extends WorkspacesStorage {
+  private database: Database;
+  private db: SpannerDB;
+  private readonly skipDefaultIndexes?: boolean;
+  private readonly indexes?: CreateIndexOptions[];
+
+  static readonly MANAGED_TABLES = [TABLE_WORKSPACES, TABLE_WORKSPACE_VERSIONS] as const;
+
+  constructor(config: SpannerDomainConfig) {
+    super();
+    const { database, indexes, skipDefaultIndexes, initMode, cleanupStaleDraftsOnStartup } =
+      resolveSpannerConfig(config);
+    this.database = database;
+    this.db = new SpannerDB({ database, skipDefaultIndexes, initMode, cleanupStaleDraftsOnStartup });
+    this.skipDefaultIndexes = skipDefaultIndexes;
+    this.indexes = indexes?.filter(idx => (WorkspacesSpanner.MANAGED_TABLES as readonly string[]).includes(idx.table));
+  }
+
+  async init(): Promise<void> {
+    await this.db.createTable({ tableName: TABLE_WORKSPACES, schema: WORKSPACES_SCHEMA });
+    await this.db.createTable({ tableName: TABLE_WORKSPACE_VERSIONS, schema: WORKSPACE_VERSIONS_SCHEMA });
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+    await this.cleanupStaleDrafts();
+  }
+
+  private async cleanupStaleDrafts(): Promise<void> {
+    if (this.db.initMode === 'validate') return;
+    if (!this.db.cleanupStaleDraftsOnStartup) return;
+    try {
+      await this.db.runDml({
+        sql: `DELETE FROM ${quoteIdent(TABLE_WORKSPACES, 'table name')}
+              WHERE ${quoteIdent('status', 'column name')} = 'draft'
+                AND ${quoteIdent('activeVersionId', 'column name')} IS NULL
+                AND id NOT IN (
+                  SELECT ${quoteIdent('workspaceId', 'column name')}
+                  FROM ${quoteIdent(TABLE_WORKSPACE_VERSIONS, 'table name')}
+                  WHERE ${quoteIdent('workspaceId', 'column name')} IS NOT NULL
+                )`,
+      });
+    } catch (error) {
+      this.logger?.warn?.('Failed to clean up stale draft workspaces:', error);
+    }
+  }
+
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    return [
+      {
+        name: 'mastra_workspaces_status_createdat_idx',
+        table: TABLE_WORKSPACES,
+        columns: ['status', 'createdAt DESC'],
+      },
+      {
+        name: 'mastra_workspaces_authorid_idx',
+        table: TABLE_WORKSPACES,
+        columns: ['authorId'],
+      },
+      {
+        name: 'mastra_workspace_versions_unique_idx',
+        table: TABLE_WORKSPACE_VERSIONS,
+        columns: ['workspaceId', 'versionNumber'],
+        unique: true,
+      },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.skipDefaultIndexes) return;
+    await this.db.createIndexes(this.getDefaultIndexDefinitions());
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.indexes || this.indexes.length === 0) return;
+    await this.db.createIndexes(this.indexes);
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.db.clearTable({ tableName: TABLE_WORKSPACE_VERSIONS });
+    await this.db.clearTable({ tableName: TABLE_WORKSPACES });
+  }
+
+  private parseWorkspaceRow(row: Record<string, any>): StorageWorkspaceType {
+    const t = transformFromSpannerRow<Record<string, any>>({ tableName: TABLE_WORKSPACES, row });
+    return {
+      id: t.id,
+      status: t.status,
+      activeVersionId: t.activeVersionId ?? undefined,
+      authorId: t.authorId ?? undefined,
+      metadata: t.metadata ?? undefined,
+      createdAt: t.createdAt,
+      updatedAt: t.updatedAt,
+    };
+  }
+
+  private parseVersionRow(row: Record<string, any>): WorkspaceVersion {
+    const t = transformFromSpannerRow<Record<string, any>>({ tableName: TABLE_WORKSPACE_VERSIONS, row });
+    return {
+      id: t.id,
+      workspaceId: t.workspaceId,
+      versionNumber: Number(t.versionNumber),
+      name: t.name,
+      description: t.description ?? undefined,
+      filesystem: t.filesystem ?? undefined,
+      sandbox: t.sandbox ?? undefined,
+      mounts: t.mounts ?? undefined,
+      search: t.search ?? undefined,
+      skills: t.skills ?? undefined,
+      tools: t.tools ?? undefined,
+      autoSync: t.autoSync == null ? undefined : Boolean(t.autoSync),
+      operationTimeout: t.operationTimeout == null ? undefined : Number(t.operationTimeout),
+      changedFields: t.changedFields ?? undefined,
+      changeMessage: t.changeMessage ?? undefined,
+      createdAt: t.createdAt,
+    };
+  }
+
+  async getById(id: string): Promise<StorageWorkspaceType | null> {
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${quoteIdent(TABLE_WORKSPACES, 'table name')} WHERE id = @id LIMIT 1`,
+        params: { id },
+        json: true,
+      });
+      const row = (rows as Array<Record<string, any>>)[0];
+      return row ? this.parseWorkspaceRow(row) : null;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_WORKSPACE_BY_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workspaceId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async create(input: { workspace: StorageCreateWorkspaceInput }): Promise<StorageWorkspaceType> {
+    const { workspace } = input;
+    try {
+      const now = new Date();
+      const { id: _id, authorId: _authorId, metadata: _metadata, ...snapshot } = workspace;
+      const versionId = globalThis.crypto?.randomUUID
+        ? globalThis.crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            await this.db.insert({
+              tableName: TABLE_WORKSPACES,
+              record: {
+                id: workspace.id,
+                status: 'draft',
+                activeVersionId: null,
+                authorId: workspace.authorId ?? null,
+                metadata: workspace.metadata ?? null,
+                createdAt: now,
+                updatedAt: now,
+              },
+              transaction: tx,
+            });
+            await this.db.insert({
+              tableName: TABLE_WORKSPACE_VERSIONS,
+              record: {
+                id: versionId,
+                workspaceId: workspace.id,
+                versionNumber: 1,
+                name: (snapshot as any).name,
+                description: (snapshot as any).description ?? null,
+                filesystem: (snapshot as any).filesystem ?? null,
+                sandbox: (snapshot as any).sandbox ?? null,
+                mounts: (snapshot as any).mounts ?? null,
+                search: (snapshot as any).search ?? null,
+                skills: (snapshot as any).skills ?? null,
+                tools: (snapshot as any).tools ?? null,
+                autoSync: (snapshot as any).autoSync ?? false,
+                operationTimeout: (snapshot as any).operationTimeout ?? null,
+                changedFields: [...SNAPSHOT_FIELDS],
+                changeMessage: 'Initial version',
+                createdAt: now,
+              },
+              transaction: tx,
+            });
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+
+      const created = await this.getById(workspace.id);
+      if (!created) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'CREATE_WORKSPACE', 'NOT_FOUND_AFTER_CREATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Workspace ${workspace.id} not found after creation`,
+          details: { workspaceId: workspace.id },
+        });
+      }
+      return created;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'CREATE_WORKSPACE', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workspaceId: workspace.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async update(input: StorageUpdateWorkspaceInput): Promise<StorageWorkspaceType> {
+    const { id, ...updates } = input;
+    try {
+      const existing = await this.getById(id);
+      if (!existing) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'UPDATE_WORKSPACE', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Workspace ${id} not found`,
+          details: { workspaceId: id },
+        });
+      }
+
+      const { authorId, activeVersionId, metadata, status, ...rawConfigFields } = updates;
+
+      // Strip undefined config keys so omitted PATCH fields don't overwrite values.
+      const configFields: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(rawConfigFields)) {
+        if (value !== undefined) configFields[key] = value;
+      }
+
+      const hasConfigUpdate = SNAPSHOT_FIELDS.some(field => field in configFields);
+      if (hasConfigUpdate) {
+        const latestVersion = await this.getLatestVersion(id);
+        if (!latestVersion) {
+          throw new MastraError({
+            id: createStorageErrorId('SPANNER', 'UPDATE_WORKSPACE', 'NO_VERSIONS'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.SYSTEM,
+            text: `No versions found for workspace ${id}`,
+            details: { workspaceId: id },
+          });
+        }
+
+        const {
+          id: _vid,
+          workspaceId: _wid,
+          versionNumber: _vnum,
+          changedFields: _cf,
+          changeMessage: _cm,
+          createdAt: _ca,
+          ...latestConfig
+        } = latestVersion;
+
+        const newConfig = { ...latestConfig, ...configFields };
+        const changedFields = SNAPSHOT_FIELDS.filter(
+          field =>
+            field in configFields &&
+            JSON.stringify(configFields[field]) !== JSON.stringify((latestConfig as Record<string, unknown>)[field]),
+        );
+
+        if (changedFields.length > 0) {
+          const newVersionId = globalThis.crypto?.randomUUID
+            ? globalThis.crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+          await this.createVersion({
+            id: newVersionId,
+            workspaceId: id,
+            versionNumber: latestVersion.versionNumber + 1,
+            ...(newConfig as object),
+            changedFields: [...changedFields],
+            changeMessage: `Updated ${changedFields.join(', ')}`,
+          } as CreateWorkspaceVersionInput);
+        }
+      }
+
+      const data: Record<string, unknown> = { updatedAt: new Date() };
+      if (authorId !== undefined) data.authorId = authorId;
+      if (activeVersionId !== undefined) {
+        data.activeVersionId = activeVersionId;
+        // Auto-publish when an active version is set (consistent with other adapters).
+        if (status === undefined) data.status = 'published';
+      }
+      if (status !== undefined) data.status = status;
+      if (metadata !== undefined) {
+        data.metadata = { ...(existing.metadata || {}), ...metadata };
+      }
+
+      await this.db.update({ tableName: TABLE_WORKSPACES, keys: { id }, data });
+
+      const updated = await this.getById(id);
+      if (!updated) {
+        throw new MastraError({
+          id: createStorageErrorId('SPANNER', 'UPDATE_WORKSPACE', 'NOT_FOUND_AFTER_UPDATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Workspace ${id} not found after update`,
+          details: { workspaceId: id },
+        });
+      }
+      return updated;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'UPDATE_WORKSPACE', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workspaceId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await this.db.runWithAbortRetry(() =>
+        this.database.runTransactionAsync(async tx => {
+          try {
+            await tx.runUpdate({
+              sql: `DELETE FROM ${quoteIdent(TABLE_WORKSPACE_VERSIONS, 'table name')} WHERE ${quoteIdent('workspaceId', 'column name')} = @workspaceId`,
+              params: { workspaceId: id },
+            });
+            await tx.runUpdate({
+              sql: `DELETE FROM ${quoteIdent(TABLE_WORKSPACES, 'table name')} WHERE id = @id`,
+              params: { id },
+            });
+            await tx.commit();
+          } catch (err) {
+            await tx.rollback().catch(() => {});
+            throw err;
+          }
+        }),
+      );
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_WORKSPACE', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workspaceId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async list(args?: StorageListWorkspacesInput): Promise<StorageListWorkspacesOutput> {
+    const { page = 0, perPage: perPageInput, orderBy, authorId, metadata } = args || {};
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_WORKSPACES', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const tableName = quoteIdent(TABLE_WORKSPACES, 'table name');
+      const conditions: string[] = [];
+      const params: Record<string, any> = {};
+
+      if (authorId !== undefined) {
+        conditions.push(`${quoteIdent('authorId', 'column name')} = @authorId`);
+        params.authorId = authorId;
+      }
+      if (metadata && Object.keys(metadata).length > 0) {
+        let i = 0;
+        for (const [key, value] of Object.entries(metadata)) {
+          if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)) {
+            throw new MastraError({
+              id: createStorageErrorId('SPANNER', 'LIST_WORKSPACES', 'INVALID_METADATA_KEY'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+              text: `Invalid metadata key: ${key}. Keys must be alphanumeric with underscores.`,
+              details: { key },
+            });
+          }
+          const param = `m${i++}`;
+          conditions.push(`JSON_VALUE(${quoteIdent('metadata', 'column name')}, '$.${key}') = @${param}`);
+          params[param] = typeof value === 'string' ? value : JSON.stringify(value);
+        }
+      }
+
+      const whereSql = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+      const [countRows] = await this.database.run({
+        sql: `SELECT COUNT(*) AS count FROM ${tableName} ${whereSql}`,
+        params,
+        json: true,
+      });
+      const total = Number((countRows as Array<{ count: number | string }>)[0]?.count ?? 0);
+      if (total === 0) {
+        return { workspaces: [], total: 0, page, perPage: perPageForResponse, hasMore: false };
+      }
+
+      const limit = perPageInput === false ? total : perPage;
+      const dirSql = (direction || 'DESC').toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName} ${whereSql}
+              ORDER BY ${quoteIdent(field, 'column name')} ${dirSql}, id ${dirSql}
+              LIMIT @limit OFFSET @offset`,
+        params: { ...params, limit, offset },
+        json: true,
+      });
+      const workspaces = (rows as Array<Record<string, any>>).map(r => this.parseWorkspaceRow(r));
+      return {
+        workspaces,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_WORKSPACES', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async createVersion(input: CreateWorkspaceVersionInput): Promise<WorkspaceVersion> {
+    try {
+      const now = new Date();
+      await this.db.insert({
+        tableName: TABLE_WORKSPACE_VERSIONS,
+        record: {
+          id: input.id,
+          workspaceId: input.workspaceId,
+          versionNumber: input.versionNumber,
+          name: input.name,
+          description: input.description ?? null,
+          filesystem: input.filesystem ?? null,
+          sandbox: input.sandbox ?? null,
+          mounts: input.mounts ?? null,
+          search: input.search ?? null,
+          skills: input.skills ?? null,
+          tools: input.tools ?? null,
+          autoSync: input.autoSync ?? false,
+          operationTimeout: input.operationTimeout ?? null,
+          changedFields: input.changedFields ?? null,
+          changeMessage: input.changeMessage ?? null,
+          createdAt: now,
+        },
+      });
+      return { ...input, createdAt: now } as WorkspaceVersion;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'CREATE_WORKSPACE_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: input.id, workspaceId: input.workspaceId },
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersion(id: string): Promise<WorkspaceVersion | null> {
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${quoteIdent(TABLE_WORKSPACE_VERSIONS, 'table name')} WHERE id = @id LIMIT 1`,
+        params: { id },
+        json: true,
+      });
+      const row = (rows as Array<Record<string, any>>)[0];
+      return row ? this.parseVersionRow(row) : null;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_WORKSPACE_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersionByNumber(workspaceId: string, versionNumber: number): Promise<WorkspaceVersion | null> {
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${quoteIdent(TABLE_WORKSPACE_VERSIONS, 'table name')}
+              WHERE ${quoteIdent('workspaceId', 'column name')} = @workspaceId
+                AND ${quoteIdent('versionNumber', 'column name')} = @versionNumber
+              LIMIT 1`,
+        params: { workspaceId, versionNumber },
+        json: true,
+      });
+      const row = (rows as Array<Record<string, any>>)[0];
+      return row ? this.parseVersionRow(row) : null;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_WORKSPACE_VERSION_BY_NUMBER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workspaceId, versionNumber },
+        },
+        error,
+      );
+    }
+  }
+
+  async getLatestVersion(workspaceId: string): Promise<WorkspaceVersion | null> {
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${quoteIdent(TABLE_WORKSPACE_VERSIONS, 'table name')}
+              WHERE ${quoteIdent('workspaceId', 'column name')} = @workspaceId
+              ORDER BY ${quoteIdent('versionNumber', 'column name')} DESC
+              LIMIT 1`,
+        params: { workspaceId },
+        json: true,
+      });
+      const row = (rows as Array<Record<string, any>>)[0];
+      return row ? this.parseVersionRow(row) : null;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_WORKSPACE_LATEST_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workspaceId },
+        },
+        error,
+      );
+    }
+  }
+
+  async listVersions(input: ListWorkspaceVersionsInput): Promise<ListWorkspaceVersionsOutput> {
+    const { workspaceId, page = 0, perPage: perPageInput, orderBy } = input;
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_WORKSPACE_VERSIONS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+    const perPage = normalizePerPage(perPageInput, 20);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const { field, direction } = this.parseVersionOrderBy(orderBy);
+      const dirSql = direction === 'ASC' ? 'ASC' : 'DESC';
+      const tableName = quoteIdent(TABLE_WORKSPACE_VERSIONS, 'table name');
+
+      const [countRows] = await this.database.run({
+        sql: `SELECT COUNT(*) AS count FROM ${tableName} WHERE ${quoteIdent('workspaceId', 'column name')} = @workspaceId`,
+        params: { workspaceId },
+        json: true,
+      });
+      const total = Number((countRows as Array<{ count: number | string }>)[0]?.count ?? 0);
+      if (total === 0) {
+        return { versions: [], total: 0, page, perPage: perPageForResponse, hasMore: false };
+      }
+
+      const limit = perPageInput === false ? total : perPage;
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName}
+              WHERE ${quoteIdent('workspaceId', 'column name')} = @workspaceId
+              ORDER BY ${quoteIdent(field, 'column name')} ${dirSql}, id ${dirSql}
+              LIMIT @limit OFFSET @offset`,
+        params: { workspaceId, limit, offset },
+        json: true,
+      });
+      const versions = (rows as Array<Record<string, any>>).map(r => this.parseVersionRow(r));
+      return {
+        versions,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'LIST_WORKSPACE_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workspaceId },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersion(id: string): Promise<void> {
+    try {
+      await this.db.runDml({
+        sql: `DELETE FROM ${quoteIdent(TABLE_WORKSPACE_VERSIONS, 'table name')} WHERE id = @id`,
+        params: { id },
+      });
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_WORKSPACE_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersionsByParentId(entityId: string): Promise<void> {
+    try {
+      await this.db.runDml({
+        sql: `DELETE FROM ${quoteIdent(TABLE_WORKSPACE_VERSIONS, 'table name')} WHERE ${quoteIdent('workspaceId', 'column name')} = @workspaceId`,
+        params: { workspaceId: entityId },
+      });
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'DELETE_WORKSPACE_VERSIONS_BY_PARENT_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workspaceId: entityId },
+        },
+        error,
+      );
+    }
+  }
+
+  async countVersions(workspaceId: string): Promise<number> {
+    try {
+      const [rows] = await this.database.run({
+        sql: `SELECT COUNT(*) AS count FROM ${quoteIdent(TABLE_WORKSPACE_VERSIONS, 'table name')} WHERE ${quoteIdent('workspaceId', 'column name')} = @workspaceId`,
+        params: { workspaceId },
+        json: true,
+      });
+      return Number((rows as Array<{ count: number | string }>)[0]?.count ?? 0);
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'COUNT_WORKSPACE_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workspaceId },
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/spanner/src/storage/index.test.ts
+++ b/stores/spanner/src/storage/index.test.ts
@@ -16,6 +16,10 @@ import { SpannerDB } from './db';
 import { AgentsSpanner } from './domains/agents';
 import { BackgroundTasksSpanner } from './domains/background-tasks';
 import { BlobsSpanner } from './domains/blobs';
+import { ChannelsSpanner } from './domains/channels';
+import { DatasetsSpanner } from './domains/datasets';
+import { ExperimentsSpanner } from './domains/experiments';
+import { FavoritesSpanner } from './domains/favorites';
 import { MCPClientsSpanner } from './domains/mcp-clients';
 import { MCPServersSpanner } from './domains/mcp-servers';
 import { MemorySpanner } from './domains/memory';
@@ -27,6 +31,7 @@ import { ScorerDefinitionsSpanner } from './domains/scorer-definitions';
 import { ScoresSpanner } from './domains/scores';
 import { SkillsSpanner } from './domains/skills';
 import { WorkflowsSpanner } from './domains/workflows';
+import { WorkspacesSpanner } from './domains/workspaces';
 import { SpannerStore } from '.';
 import type { SpannerConfig } from '.';
 
@@ -134,6 +139,14 @@ if (ENABLE_TESTS) {
       const client = makeClient();
       return new ScoresSpanner({ database: client.instance(INSTANCE_ID).database(directDbId) });
     },
+    createDatasetsDomain: () => {
+      const client = makeClient();
+      return new DatasetsSpanner({ database: client.instance(INSTANCE_ID).database(directDbId) });
+    },
+    createExperimentsDomain: () => {
+      const client = makeClient();
+      return new ExperimentsSpanner({ database: client.instance(INSTANCE_ID).database(directDbId) });
+    },
   });
 
   // Direct-usage smoke test for the Agents domain (the shared
@@ -163,6 +176,776 @@ if (ENABLE_TESTS) {
       await agentsDomain.delete(agentId);
       const afterDelete = await agentsDomain.getById(agentId);
       expect(afterDelete).toBeNull();
+    });
+  });
+
+  // The shared test factory has no slot for workspaces (a versioned domain), so
+  // exercise its thin-record + version snapshot surface inline against the
+  // already-initialized shared database.
+  describe('WorkspacesSpanner integration', () => {
+    let workspaces: WorkspacesSpanner;
+
+    beforeAll(async () => {
+      const store = new SpannerStore(sharedConfig);
+      await store.init();
+      workspaces = (await store.getStore('workspaces')) as WorkspacesSpanner;
+    });
+
+    it('creates a draft workspace with a seed version', async () => {
+      const id = `ws-${randomUUID()}`;
+      const created = await workspaces.create({
+        workspace: { id, name: 'My Workspace', description: 'first', autoSync: true } as any,
+      });
+      expect(created.id).toBe(id);
+      expect(created.status).toBe('draft');
+      expect(created.activeVersionId).toBeUndefined();
+
+      const latest = await workspaces.getLatestVersion(id);
+      expect(latest?.versionNumber).toBe(1);
+      expect(latest?.name).toBe('My Workspace');
+      expect(latest?.autoSync).toBe(true);
+
+      const resolved = await workspaces.getByIdResolved(id, { status: 'draft' });
+      expect(resolved?.name).toBe('My Workspace');
+      expect(resolved?.description).toBe('first');
+    });
+
+    it('creates a new version when config fields change but not for metadata-only updates', async () => {
+      const id = `ws-${randomUUID()}`;
+      await workspaces.create({ workspace: { id, name: 'W', description: 'a' } as any });
+
+      // metadata-only update: no new version
+      await workspaces.update({ id, metadata: { team: 'x' } } as any);
+      expect(await workspaces.countVersions(id)).toBe(1);
+
+      // config change: bumps to version 2
+      const updated = await workspaces.update({ id, description: 'b' } as any);
+      expect(updated).toBeDefined();
+      expect(await workspaces.countVersions(id)).toBe(2);
+      const latest = await workspaces.getLatestVersion(id);
+      expect(latest?.versionNumber).toBe(2);
+      expect(latest?.description).toBe('b');
+      expect(latest?.changedFields).toContain('description');
+
+      // identical config value: no new version
+      await workspaces.update({ id, description: 'b' } as any);
+      expect(await workspaces.countVersions(id)).toBe(2);
+    });
+
+    it('auto-publishes when activeVersionId is set', async () => {
+      const id = `ws-${randomUUID()}`;
+      await workspaces.create({ workspace: { id, name: 'W' } as any });
+      const v1 = await workspaces.getLatestVersion(id);
+      const updated = await workspaces.update({ id, activeVersionId: v1!.id } as any);
+      expect(updated.status).toBe('published');
+      expect(updated.activeVersionId).toBe(v1!.id);
+    });
+
+    it('resolves the active version by default and a specific version by id', async () => {
+      const id = `ws-${randomUUID()}`;
+      await workspaces.create({ workspace: { id, name: 'orig' } as any });
+      const v1 = await workspaces.getLatestVersion(id);
+      await workspaces.update({ id, name: 'orig', description: 'v2desc' } as any);
+      const v2 = await workspaces.getVersionByNumber(id, 2);
+      await workspaces.update({ id, activeVersionId: v2!.id } as any);
+
+      const publishedResolved = await workspaces.getByIdResolved(id);
+      expect(publishedResolved?.description).toBe('v2desc');
+
+      const pinnedResolved = await workspaces.getByIdResolved(id, { versionId: v1!.id });
+      expect(pinnedResolved?.description).toBeUndefined();
+    });
+
+    it('lists workspaces and paginates versions', async () => {
+      const id = `ws-${randomUUID()}`;
+      const authorId = `author-${randomUUID()}`;
+      await workspaces.create({ workspace: { id, name: 'L', authorId } as any });
+      await workspaces.update({ id, description: 'v2' } as any);
+      await workspaces.update({ id, description: 'v3' } as any);
+
+      const listed = await workspaces.list({ authorId });
+      expect(listed.workspaces.map(w => w.id)).toContain(id);
+      expect(listed.total).toBe(1);
+
+      const versions = await workspaces.listVersions({ workspaceId: id, perPage: 2, page: 0 });
+      expect(versions.total).toBe(3);
+      expect(versions.versions).toHaveLength(2);
+      expect(versions.hasMore).toBe(true);
+    });
+
+    it('deletes a workspace and all its versions', async () => {
+      const id = `ws-${randomUUID()}`;
+      await workspaces.create({ workspace: { id, name: 'D' } as any });
+      await workspaces.update({ id, description: 'v2' } as any);
+      expect(await workspaces.countVersions(id)).toBe(2);
+
+      await workspaces.delete(id);
+      expect(await workspaces.getById(id)).toBeNull();
+      expect(await workspaces.countVersions(id)).toBe(0);
+    });
+
+    it('getById / getVersion return null for unknown ids', async () => {
+      expect(await workspaces.getById(`missing-${randomUUID()}`)).toBeNull();
+      expect(await workspaces.getVersion(`missing-${randomUUID()}`)).toBeNull();
+      expect(await workspaces.getVersionByNumber(`missing-${randomUUID()}`, 1)).toBeNull();
+      expect(await workspaces.getLatestVersion(`missing-${randomUUID()}`)).toBeNull();
+    });
+
+    it('createVersion appends a version and getVersion fetches it by id', async () => {
+      const id = `ws-${randomUUID()}`;
+      await workspaces.create({ workspace: { id, name: 'CV' } as any });
+      const versionId = randomUUID();
+      const created = await workspaces.createVersion({
+        id: versionId,
+        workspaceId: id,
+        versionNumber: 2,
+        name: 'CV',
+        description: 'manual v2',
+        autoSync: true,
+        changedFields: ['description'],
+        changeMessage: 'manual',
+      } as any);
+      expect(created.id).toBe(versionId);
+
+      const fetched = await workspaces.getVersion(versionId);
+      expect(fetched?.versionNumber).toBe(2);
+      expect(fetched?.description).toBe('manual v2');
+      expect(fetched?.autoSync).toBe(true);
+      expect(await workspaces.getVersionByNumber(id, 2)).toMatchObject({ id: versionId });
+      expect((await workspaces.getLatestVersion(id))?.versionNumber).toBe(2);
+    });
+
+    it('deleteVersion removes a single version; deleteVersionsByParentId clears all', async () => {
+      const id = `ws-${randomUUID()}`;
+      await workspaces.create({ workspace: { id, name: 'DV' } as any });
+      await workspaces.update({ id, description: 'v2' } as any);
+      const v2 = await workspaces.getVersionByNumber(id, 2);
+
+      await workspaces.deleteVersion(v2!.id);
+      expect(await workspaces.getVersion(v2!.id)).toBeNull();
+      expect(await workspaces.countVersions(id)).toBe(1);
+
+      await workspaces.deleteVersionsByParentId(id);
+      expect(await workspaces.countVersions(id)).toBe(0);
+    });
+
+    it('list paginates and filters by metadata', async () => {
+      const tag = `grp-${randomUUID()}`;
+      for (let i = 0; i < 3; i++) {
+        await workspaces.create({
+          workspace: { id: `ws-${randomUUID()}`, name: `M${i}`, metadata: { grp: tag } } as any,
+        });
+      }
+      const page0 = await workspaces.list({ metadata: { grp: tag }, page: 0, perPage: 2 });
+      expect(page0.total).toBe(3);
+      expect(page0.workspaces).toHaveLength(2);
+      expect(page0.hasMore).toBe(true);
+
+      const all = await workspaces.list({ metadata: { grp: tag }, perPage: false });
+      expect(all.workspaces).toHaveLength(3);
+      expect(all.hasMore).toBe(false);
+    });
+
+    it('listResolved merges the active version config into each record', async () => {
+      const authorId = `author-${randomUUID()}`;
+      const id = `ws-${randomUUID()}`;
+      await workspaces.create({ workspace: { id, name: 'R', description: 'd1', authorId } as any });
+      const resolved = await workspaces.listResolved({ authorId } as any);
+      const row = resolved.workspaces.find(w => w.id === id);
+      expect(row?.name).toBe('R');
+      expect(row?.description).toBe('d1');
+    });
+  });
+
+  // Dedicated, explicit per-method coverage for the favorites domain. The shared
+  // `createTestSuite` (registered at the top of this file) also exercises these
+  // paths; this block guarantees every public method has direct coverage and
+  // pins Spanner-specific behavior (composite primary key, counter persistence).
+  describe('FavoritesSpanner methods', () => {
+    let favorites: FavoritesSpanner;
+    let agents: AgentsSpanner;
+    let skills: SkillsSpanner;
+
+    const makeAgent = async (id: string) => {
+      await agents.create({
+        agent: { id, name: id, instructions: 'x', model: { provider: 'openai', name: 'gpt-4' } } as any,
+      });
+    };
+    const makeSkill = async (id: string) => {
+      await skills.create({ skill: { id, name: id, description: 'd', instructions: 'i' } as any });
+    };
+
+    beforeAll(async () => {
+      const store = new SpannerStore(sharedConfig);
+      await store.init();
+      favorites = (await store.getStore('favorites')) as FavoritesSpanner;
+      agents = (await store.getStore('agents')) as AgentsSpanner;
+      skills = (await store.getStore('skills')) as SkillsSpanner;
+    });
+
+    beforeEach(async () => {
+      await favorites.dangerouslyClearAll();
+    });
+
+    it('favorite increments the counter and is idempotent', async () => {
+      const id = `a-${randomUUID()}`;
+      await makeAgent(id);
+      expect(await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: id })).toEqual({
+        favorited: true,
+        favoriteCount: 1,
+      });
+      expect(await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: id })).toEqual({
+        favorited: true,
+        favoriteCount: 1,
+      });
+      expect(await favorites.favorite({ userId: 'u2', entityType: 'agent', entityId: id })).toEqual({
+        favorited: true,
+        favoriteCount: 2,
+      });
+      expect((await agents.getById(id))?.favoriteCount).toBe(2);
+    });
+
+    it('favorite throws when the entity does not exist', async () => {
+      await expect(
+        favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: `missing-${randomUUID()}` }),
+      ).rejects.toThrow();
+    });
+
+    it('unfavorite decrements, clamps at 0, and is idempotent', async () => {
+      const id = `s-${randomUUID()}`;
+      await makeSkill(id);
+      await favorites.favorite({ userId: 'u1', entityType: 'skill', entityId: id });
+      expect(await favorites.unfavorite({ userId: 'u1', entityType: 'skill', entityId: id })).toEqual({
+        favorited: false,
+        favoriteCount: 0,
+      });
+      // Idempotent + clamped.
+      expect(await favorites.unfavorite({ userId: 'u1', entityType: 'skill', entityId: id })).toEqual({
+        favorited: false,
+        favoriteCount: 0,
+      });
+      expect((await skills.getById(id))?.favoriteCount).toBe(0);
+    });
+
+    it('isFavorited / isFavoritedBatch report state per user', async () => {
+      const a1 = `a-${randomUUID()}`;
+      const a2 = `a-${randomUUID()}`;
+      await makeAgent(a1);
+      await makeAgent(a2);
+      await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: a1 });
+
+      expect(await favorites.isFavorited({ userId: 'u1', entityType: 'agent', entityId: a1 })).toBe(true);
+      expect(await favorites.isFavorited({ userId: 'u2', entityType: 'agent', entityId: a1 })).toBe(false);
+      expect(
+        await favorites.isFavoritedBatch({ userId: 'u1', entityType: 'agent', entityIds: [a1, a2, 'missing'] }),
+      ).toEqual(new Set([a1]));
+      expect((await favorites.isFavoritedBatch({ userId: 'u1', entityType: 'agent', entityIds: [] })).size).toBe(0);
+    });
+
+    it('listFavoritedIds is scoped by user and entity type', async () => {
+      const a1 = `a-${randomUUID()}`;
+      const s1 = `s-${randomUUID()}`;
+      await makeAgent(a1);
+      await makeSkill(s1);
+      await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: a1 });
+      await favorites.favorite({ userId: 'u1', entityType: 'skill', entityId: s1 });
+
+      expect(await favorites.listFavoritedIds({ userId: 'u1', entityType: 'agent' })).toEqual([a1]);
+      expect(await favorites.listFavoritedIds({ userId: 'u1', entityType: 'skill' })).toEqual([s1]);
+      expect(await favorites.listFavoritedIds({ userId: 'u2', entityType: 'agent' })).toEqual([]);
+    });
+
+    it('deleteFavoritesForEntity removes rows, resets the counter, and returns the count', async () => {
+      const id = `a-${randomUUID()}`;
+      await makeAgent(id);
+      await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: id });
+      await favorites.favorite({ userId: 'u2', entityType: 'agent', entityId: id });
+
+      const removed = await favorites.deleteFavoritesForEntity({ entityType: 'agent', entityId: id });
+      expect(removed).toBe(2);
+      expect((await agents.getById(id))?.favoriteCount).toBe(0);
+      expect(await favorites.isFavorited({ userId: 'u1', entityType: 'agent', entityId: id })).toBe(false);
+    });
+
+    it('agent and skill counters with colliding ids stay independent', async () => {
+      const id = `shared-${randomUUID()}`;
+      await makeAgent(id);
+      await makeSkill(id);
+      await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: id });
+      await favorites.favorite({ userId: 'u1', entityType: 'skill', entityId: id });
+      expect((await agents.getById(id))?.favoriteCount).toBe(1);
+      expect((await skills.getById(id))?.favoriteCount).toBe(1);
+    });
+
+    it('concurrent same-user favorite calls are idempotent (counter never exceeds 1)', async () => {
+      const id = `a-${randomUUID()}`;
+      await makeAgent(id);
+      // Fire several concurrent favorite() calls for the same key. Spanner's
+      // serializable isolation + ABORTED retry must collapse them into one row.
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () => favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: id })),
+      );
+      for (const r of results) expect(r.favorited).toBe(true);
+      expect((await agents.getById(id))?.favoriteCount).toBe(1);
+      expect(await favorites.listFavoritedIds({ userId: 'u1', entityType: 'agent' })).toEqual([id]);
+    });
+
+    it('favorites listing on agents respects draft/published/archived isolation rules', async () => {
+      // Favorites-feature queries (entityIds / pinFavoritedFor / favoritedOnly)
+      // intentionally return the favorited candidate set across all statuses —
+      // this matches the cross-adapter conformance contract (and the Postgres
+      // reference, which applies no default status). A normal list() with no
+      // favorites params still defaults to published-only.
+      const u = `u-${randomUUID()}`;
+      const draft = `a-${randomUUID()}`;
+      const published = `a-${randomUUID()}`;
+      await makeAgent(draft); // create() => draft
+      await makeAgent(published);
+      const pubV = await agents.getLatestVersion(published);
+      await agents.update({ id: published, activeVersionId: pubV!.id, status: 'published' } as any);
+
+      await favorites.favorite({ userId: u, entityType: 'agent', entityId: draft });
+      await favorites.favorite({ userId: u, entityType: 'agent', entityId: published });
+
+      // favoritedOnly returns BOTH (draft + published) — favorites span statuses.
+      const favOnly = await agents.list({ favoritedOnly: true, pinFavoritedFor: u, page: 0, perPage: 50 });
+      expect(favOnly.agents.map(a => a.id).sort()).toEqual([draft, published].sort());
+
+      // entityIds also bypasses the published default for the requested set.
+      const byIds = await agents.list({ entityIds: [draft], page: 0, perPage: 50 });
+      expect(byIds.agents.map(a => a.id)).toEqual([draft]);
+
+      // A plain list() (no favorites params) still hides the draft.
+      const plain = await agents.list({ entityIds: undefined, page: 0, perPage: 200 } as any);
+      const plainIds = plain.agents.map(a => a.id);
+      expect(plainIds).toContain(published);
+      expect(plainIds).not.toContain(draft);
+
+      // An explicit status filter is still honored alongside a favorites query.
+      const favPublished = await agents.list({
+        pinFavoritedFor: u,
+        favoritedOnly: true,
+        status: 'published',
+        page: 0,
+        perPage: 50,
+      });
+      expect(favPublished.agents.map(a => a.id)).toEqual([published]);
+
+      // pinFavoritedFor is a favorites-feature query: it suppresses the published
+      // default so the favorited draft surfaces too (matching the conformance
+      // contract / Postgres reference). Both favorited agents appear.
+      const pinned = await agents.list({ pinFavoritedFor: u, page: 0, perPage: 200 });
+      const pinnedIds = pinned.agents.map(a => a.id);
+      expect(pinnedIds).toContain(published);
+      expect(pinnedIds).toContain(draft);
+    });
+  });
+
+  describe('ChannelsSpanner methods', () => {
+    let channels: ChannelsSpanner;
+
+    const sampleInstallation = (over: Partial<any> = {}) => ({
+      id: `inst-${randomUUID()}`,
+      platform: 'slack',
+      agentId: `ag-${randomUUID()}`,
+      status: 'active' as const,
+      webhookId: `wh-${randomUUID()}`,
+      data: { botToken: 'xoxb', teamId: 'T1' },
+      configHash: `hash-${randomUUID()}`,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...over,
+    });
+
+    beforeAll(async () => {
+      const store = new SpannerStore(sharedConfig);
+      await store.init();
+      channels = (await store.getStore('channels')) as ChannelsSpanner;
+    });
+
+    beforeEach(async () => {
+      await channels.dangerouslyClearAll();
+    });
+
+    it('saveInstallation upserts and preserves createdAt; getInstallation round-trips JSON', async () => {
+      const created = new Date('2025-01-01T00:00:00.000Z');
+      const inst = sampleInstallation({ id: 'inst-1', status: 'pending', createdAt: created });
+      await channels.saveInstallation(inst);
+
+      let fetched = await channels.getInstallation('inst-1');
+      expect(fetched?.status).toBe('pending');
+      expect(fetched?.data).toEqual(inst.data);
+      expect(fetched?.createdAt.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+
+      await channels.saveInstallation({ ...inst, status: 'active', data: { ...inst.data, teamId: 'T2' } });
+      fetched = await channels.getInstallation('inst-1');
+      expect(fetched?.status).toBe('active');
+      expect((fetched?.data as any).teamId).toBe('T2');
+      expect(fetched?.createdAt.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+      expect(await channels.getInstallation('nope')).toBeNull();
+    });
+
+    it('getInstallationByAgent prefers active, then pending; scoped per platform', async () => {
+      const agentId = `ag-${randomUUID()}`;
+      await channels.saveInstallation(sampleInstallation({ id: 'p', platform: 'slack', agentId, status: 'pending' }));
+      await channels.saveInstallation(sampleInstallation({ id: 'a', platform: 'slack', agentId, status: 'active' }));
+      expect((await channels.getInstallationByAgent('slack', agentId))?.id).toBe('a');
+      expect(await channels.getInstallationByAgent('discord', agentId)).toBeNull();
+    });
+
+    it('getInstallationByWebhookId finds the row and tolerates missing/absent webhooks', async () => {
+      await channels.saveInstallation(sampleInstallation({ id: 'w', webhookId: 'wh-known' }));
+      // Two installs without a webhookId must coexist (NULL_FILTERED unique index).
+      await channels.saveInstallation(sampleInstallation({ id: 'n1', webhookId: undefined }));
+      await channels.saveInstallation(sampleInstallation({ id: 'n2', webhookId: undefined }));
+      expect((await channels.getInstallationByWebhookId('wh-known'))?.id).toBe('w');
+      expect(await channels.getInstallationByWebhookId('missing')).toBeNull();
+      expect((await channels.getInstallation('n1'))?.webhookId).toBeUndefined();
+    });
+
+    it('listInstallations returns per-platform installs newest-first; deleteInstallation is idempotent', async () => {
+      const t1 = new Date('2024-01-01T00:00:00.000Z');
+      const t2 = new Date('2024-01-02T00:00:00.000Z');
+      await channels.saveInstallation(
+        sampleInstallation({ id: 'i1', platform: 'slack', createdAt: t1, updatedAt: t1 }),
+      );
+      await channels.saveInstallation(
+        sampleInstallation({ id: 'i2', platform: 'slack', createdAt: t2, updatedAt: t2 }),
+      );
+      await channels.saveInstallation(sampleInstallation({ id: 'i3', platform: 'discord' }));
+      const slack = await channels.listInstallations('slack');
+      expect(slack.map(i => i.id)).toEqual(['i2', 'i1']); // newest-first
+      expect(await channels.listInstallations('telegram')).toEqual([]);
+
+      await channels.deleteInstallation('i1');
+      expect(await channels.getInstallation('i1')).toBeNull();
+      await expect(channels.deleteInstallation('i1')).resolves.not.toThrow();
+    });
+
+    it('saveConfig / getConfig upsert and deleteConfig removes per platform', async () => {
+      await channels.saveConfig({ platform: 'slack', data: { appConfigToken: 'old' }, updatedAt: new Date() });
+      await channels.saveConfig({
+        platform: 'slack',
+        data: { appConfigToken: 'new', clientId: 'c1' },
+        updatedAt: new Date(),
+      });
+      const cfg = await channels.getConfig('slack');
+      expect((cfg?.data as any).appConfigToken).toBe('new');
+      expect((cfg?.data as any).clientId).toBe('c1');
+      expect(await channels.getConfig('discord')).toBeNull();
+
+      await channels.deleteConfig('slack');
+      expect(await channels.getConfig('slack')).toBeNull();
+      await expect(channels.deleteConfig('slack')).resolves.not.toThrow();
+    });
+  });
+
+  describe('ExperimentsSpanner methods', () => {
+    let experiments: ExperimentsSpanner;
+
+    const baseExp = (over: Partial<any> = {}) => ({
+      datasetId: null,
+      datasetVersion: null,
+      targetType: 'agent' as const,
+      targetId: 'agent-1',
+      totalItems: 1,
+      ...over,
+    });
+    const baseResult = (experimentId: string, over: Partial<any> = {}) => ({
+      experimentId,
+      itemId: `item-${randomUUID()}`,
+      itemDatasetVersion: null,
+      input: { q: 'x' },
+      output: null,
+      groundTruth: null,
+      error: null,
+      startedAt: new Date(),
+      completedAt: new Date(),
+      retryCount: 0,
+      ...over,
+    });
+
+    beforeAll(async () => {
+      const store = new SpannerStore(sharedConfig);
+      await store.init();
+      experiments = (await store.getStore('experiments')) as ExperimentsSpanner;
+    });
+
+    beforeEach(async () => {
+      await experiments.dangerouslyClearAll();
+    });
+
+    it('createExperiment applies defaults and getExperimentById round-trips', async () => {
+      const exp = await experiments.createExperiment(baseExp({ name: 'e1', metadata: { k: 'v' } }));
+      expect(exp.status).toBe('pending');
+      expect(exp.succeededCount).toBe(0);
+      expect(exp.failedCount).toBe(0);
+      expect(exp.skippedCount).toBe(0);
+      expect(exp.startedAt).toBeNull();
+      const fetched = await experiments.getExperimentById({ id: exp.id });
+      expect(fetched?.name).toBe('e1');
+      expect(fetched?.metadata).toEqual({ k: 'v' });
+      expect(await experiments.getExperimentById({ id: 'missing' })).toBeNull();
+    });
+
+    it('updateExperiment patches fields, bumps counts, and throws when missing', async () => {
+      const exp = await experiments.createExperiment(baseExp());
+      const started = new Date();
+      const updated = await experiments.updateExperiment({
+        id: exp.id,
+        status: 'running',
+        succeededCount: 2,
+        startedAt: started,
+      });
+      expect(updated.status).toBe('running');
+      expect(updated.succeededCount).toBe(2);
+      expect(updated.startedAt?.toISOString()).toBe(started.toISOString());
+      await expect(experiments.updateExperiment({ id: 'missing', status: 'failed' })).rejects.toThrow();
+    });
+
+    it('listExperiments filters and paginates', async () => {
+      const targetId = `t-${randomUUID()}`;
+      for (let i = 0; i < 3; i++) await experiments.createExperiment(baseExp({ targetId }));
+      await experiments.createExperiment(baseExp({ targetId: 'other' }));
+
+      const page0 = await experiments.listExperiments({ targetId, pagination: { page: 0, perPage: 2 } });
+      expect(page0.pagination.total).toBe(3);
+      expect(page0.experiments).toHaveLength(2);
+      expect(page0.pagination.hasMore).toBe(true);
+    });
+
+    it('addExperimentResult stores rich JSON; listExperimentResults orders by startedAt ASC', async () => {
+      const exp = await experiments.createExperiment(baseExp());
+      const errObj = { message: 'boom', code: 'E1' };
+      const r1 = await experiments.addExperimentResult(
+        baseResult(exp.id, { itemId: 'i1', startedAt: new Date(Date.now() - 1000), error: errObj, output: null }),
+      );
+      expect(r1.error).toEqual(errObj);
+      await experiments.addExperimentResult(baseResult(exp.id, { itemId: 'i2', output: { a: 1 } }));
+
+      const fetched = await experiments.getExperimentResultById({ id: r1.id });
+      expect(fetched?.input).toEqual({ q: 'x' });
+      expect(await experiments.getExperimentResultById({ id: 'missing' })).toBeNull();
+
+      const list = await experiments.listExperimentResults({
+        experimentId: exp.id,
+        pagination: { page: 0, perPage: 10 },
+      });
+      expect(list.results).toHaveLength(2);
+      expect(new Date(list.results[0]!.startedAt).getTime()).toBeLessThanOrEqual(
+        new Date(list.results[1]!.startedAt).getTime(),
+      );
+    });
+
+    it('updateExperimentResult sets review status/tags and is a no-op without changes', async () => {
+      const exp = await experiments.createExperiment(baseExp());
+      const r = await experiments.addExperimentResult(baseResult(exp.id, { itemId: 'i1' }));
+      const updated = await experiments.updateExperimentResult({
+        id: r.id,
+        experimentId: exp.id,
+        status: 'reviewed',
+        tags: ['a', 'b'],
+      });
+      expect(updated.status).toBe('reviewed');
+      expect(updated.tags).toEqual(['a', 'b']);
+      // No-op (no status/tags) returns the existing row.
+      const same = await experiments.updateExperimentResult({ id: r.id });
+      expect(same.status).toBe('reviewed');
+      await expect(experiments.updateExperimentResult({ id: 'missing', status: 'complete' })).rejects.toThrow();
+    });
+
+    it('updateExperimentResult honors experimentId scoping (incl. the no-op path)', async () => {
+      const expA = await experiments.createExperiment(baseExp());
+      const expB = await experiments.createExperiment(baseExp());
+      const r = await experiments.addExperimentResult(baseResult(expA.id, { itemId: 'i1' }));
+
+      // Wrong experiment with a patch → not found.
+      await expect(
+        experiments.updateExperimentResult({ id: r.id, experimentId: expB.id, status: 'reviewed' }),
+      ).rejects.toThrow();
+      // Wrong experiment on the no-op path → also not found (scoping honored).
+      await expect(experiments.updateExperimentResult({ id: r.id, experimentId: expB.id })).rejects.toThrow();
+      // Correct experiment on the no-op path → returns the row.
+      const ok = await experiments.updateExperimentResult({ id: r.id, experimentId: expA.id });
+      expect(ok.id).toBe(r.id);
+    });
+
+    it('getReviewSummary aggregates review-status counts per experiment', async () => {
+      const exp = await experiments.createExperiment(baseExp());
+      await experiments.addExperimentResult(baseResult(exp.id, { itemId: 'i1', status: 'needs-review' }));
+      await experiments.addExperimentResult(baseResult(exp.id, { itemId: 'i2', status: 'reviewed' }));
+      await experiments.addExperimentResult(baseResult(exp.id, { itemId: 'i3', status: 'complete' }));
+      await experiments.addExperimentResult(baseResult(exp.id, { itemId: 'i4' })); // null status
+
+      const summary = await experiments.getReviewSummary();
+      const row = summary.find(s => s.experimentId === exp.id);
+      expect(row).toMatchObject({ total: 4, needsReview: 1, reviewed: 1, complete: 1 });
+    });
+
+    it('deleteExperimentResults clears results; deleteExperiment cascades', async () => {
+      const exp = await experiments.createExperiment(baseExp());
+      await experiments.addExperimentResult(baseResult(exp.id, { itemId: 'i1' }));
+      await experiments.deleteExperimentResults({ experimentId: exp.id });
+      expect(
+        (await experiments.listExperimentResults({ experimentId: exp.id, pagination: { page: 0, perPage: 10 } }))
+          .results,
+      ).toHaveLength(0);
+
+      await experiments.addExperimentResult(baseResult(exp.id, { itemId: 'i2' }));
+      await experiments.deleteExperiment({ id: exp.id });
+      expect(await experiments.getExperimentById({ id: exp.id })).toBeNull();
+      expect(
+        (await experiments.listExperimentResults({ experimentId: exp.id, pagination: { page: 0, perPage: 10 } }))
+          .results,
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('DatasetsSpanner methods', () => {
+    let datasets: DatasetsSpanner;
+
+    beforeAll(async () => {
+      const store = new SpannerStore(sharedConfig);
+      await store.init();
+      datasets = (await store.getStore('datasets')) as DatasetsSpanner;
+    });
+
+    beforeEach(async () => {
+      await datasets.dangerouslyClearAll();
+    });
+
+    it('createDataset / getDatasetById / updateDataset / listDatasets', async () => {
+      const ds = await datasets.createDataset({ name: 'd1', description: 'orig', metadata: { a: 1 } });
+      expect(ds.version).toBe(0);
+      expect((await datasets.getDatasetById({ id: ds.id }))?.name).toBe('d1');
+      expect(await datasets.getDatasetById({ id: 'missing' })).toBeNull();
+
+      const updated = await datasets.updateDataset({ id: ds.id, description: 'changed', tags: ['x'] });
+      expect(updated.description).toBe('changed');
+      expect(updated.tags).toEqual(['x']);
+
+      const list = await datasets.listDatasets({ pagination: { page: 0, perPage: 10 } });
+      expect(list.datasets.map(d => d.id)).toContain(ds.id);
+    });
+
+    it('addItem / updateItem / deleteItem drive SCD-2 versioning and history', async () => {
+      const ds = await datasets.createDataset({ name: 'd' });
+      const item = await datasets.addItem({ datasetId: ds.id, input: { q: 'a' }, metadata: { m: 1 } });
+      expect(item.datasetVersion).toBe(1);
+      expect((await datasets.getDatasetById({ id: ds.id }))?.version).toBe(1);
+
+      const updated = await datasets.updateItem({ id: item.id, datasetId: ds.id, input: { q: 'b' } });
+      expect(updated.datasetVersion).toBe(2);
+      expect(updated.input).toEqual({ q: 'b' });
+      // createdAt preserved across the new version.
+      expect(updated.createdAt.toISOString()).toBe(item.createdAt.toISOString());
+
+      const history = await datasets.getItemHistory(item.id);
+      expect(history).toHaveLength(2);
+      expect(history[0]!.datasetVersion).toBeGreaterThan(history[1]!.datasetVersion);
+      expect(history.find(h => h.datasetVersion === 1)!.validTo).toBe(2);
+      expect(history.find(h => h.datasetVersion === 2)!.validTo).toBeNull();
+
+      await datasets.deleteItem({ id: item.id, datasetId: ds.id });
+      expect(await datasets.getItemById({ id: item.id })).toBeNull();
+      const tombstone = (await datasets.getItemHistory(item.id)).find(h => h.isDeleted);
+      expect(tombstone?.validTo).toBeNull();
+    });
+
+    it('getItemById / getItemsByVersion / listItems support time-travel and search', async () => {
+      const ds = await datasets.createDataset({ name: 'd' });
+      const item = await datasets.addItem({ datasetId: ds.id, input: { q: 'findme-alpha' } });
+      await datasets.updateItem({ id: item.id, datasetId: ds.id, input: { q: 'findme-beta' } });
+
+      expect((await datasets.getItemById({ id: item.id }))?.input).toEqual({ q: 'findme-beta' });
+      expect((await datasets.getItemById({ id: item.id, datasetVersion: 1 }))?.input).toEqual({ q: 'findme-alpha' });
+
+      const v1 = await datasets.getItemsByVersion({ datasetId: ds.id, version: 1 });
+      expect(v1.map(i => i.input)).toEqual([{ q: 'findme-alpha' }]);
+
+      const current = await datasets.listItems({ datasetId: ds.id, pagination: { page: 0, perPage: 10 } });
+      expect(current.items).toHaveLength(1);
+      const past = await datasets.listItems({ datasetId: ds.id, version: 1, pagination: { page: 0, perPage: 10 } });
+      expect(past.items[0]!.input).toEqual({ q: 'findme-alpha' });
+
+      const search = await datasets.listItems({
+        datasetId: ds.id,
+        search: 'beta',
+        pagination: { page: 0, perPage: 10 },
+      });
+      expect(search.items).toHaveLength(1);
+      const noHit = await datasets.listItems({ datasetId: ds.id, search: 'zzz', pagination: { page: 0, perPage: 10 } });
+      expect(noHit.items).toHaveLength(0);
+    });
+
+    it('batchInsertItems uses a single version bump; batchDeleteItems tombstones all', async () => {
+      const ds = await datasets.createDataset({ name: 'd' });
+      const items = await datasets.batchInsertItems({
+        datasetId: ds.id,
+        items: [{ input: { i: 1 } }, { input: { i: 2 } }, { input: { i: 3 } }],
+      });
+      expect(items).toHaveLength(3);
+      expect(new Set(items.map(i => i.datasetVersion)).size).toBe(1);
+      expect((await datasets.getDatasetById({ id: ds.id }))?.version).toBe(1);
+      expect((await datasets.listItems({ datasetId: ds.id, pagination: { page: 0, perPage: 10 } })).items).toHaveLength(
+        3,
+      );
+
+      await datasets.batchDeleteItems({ datasetId: ds.id, itemIds: items.map(i => i.id) });
+      expect((await datasets.listItems({ datasetId: ds.id, pagination: { page: 0, perPage: 10 } })).items).toHaveLength(
+        0,
+      );
+      expect((await datasets.getDatasetById({ id: ds.id }))?.version).toBe(2);
+    });
+
+    it('empty batch insert/delete are no-ops and do not bump the version', async () => {
+      const ds = await datasets.createDataset({ name: 'd' });
+      const inserted = await datasets.batchInsertItems({ datasetId: ds.id, items: [] });
+      expect(inserted).toEqual([]);
+      await datasets.batchDeleteItems({ datasetId: ds.id, itemIds: [] });
+      await datasets.batchDeleteItems({ datasetId: ds.id, itemIds: ['does-not-exist'] });
+      expect((await datasets.getDatasetById({ id: ds.id }))?.version).toBe(0);
+      expect(
+        (await datasets.listDatasetVersions({ datasetId: ds.id, pagination: { page: 0, perPage: 10 } })).versions,
+      ).toHaveLength(0);
+    });
+
+    it('enforces a unique (datasetId, version) snapshot invariant', async () => {
+      const ds = await datasets.createDataset({ name: 'd' });
+      await datasets.createDatasetVersion(ds.id, 5);
+      await expect(datasets.createDatasetVersion(ds.id, 5)).rejects.toThrow();
+      // Same version number is allowed under a different dataset.
+      const ds2 = await datasets.createDataset({ name: 'd2' });
+      await expect(datasets.createDatasetVersion(ds2.id, 5)).resolves.toMatchObject({ version: 5 });
+    });
+
+    it('createDatasetVersion / listDatasetVersions record and page snapshots', async () => {
+      const ds = await datasets.createDataset({ name: 'd' });
+      // Item mutations record versions automatically.
+      await datasets.addItem({ datasetId: ds.id, input: { i: 1 } });
+      await datasets.addItem({ datasetId: ds.id, input: { i: 2 } });
+      // Direct snapshot row.
+      const manual = await datasets.createDatasetVersion(ds.id, 99);
+      expect(manual.version).toBe(99);
+
+      const page0 = await datasets.listDatasetVersions({ datasetId: ds.id, pagination: { page: 0, perPage: 2 } });
+      expect(page0.pagination.total).toBe(3);
+      expect(page0.versions).toHaveLength(2);
+      // DESC by version → newest (99) first.
+      expect(page0.versions[0]!.version).toBe(99);
+    });
+
+    it('deleteDataset removes the dataset, its items, and versions', async () => {
+      const ds = await datasets.createDataset({ name: 'd' });
+      await datasets.addItem({ datasetId: ds.id, input: { i: 1 } });
+      await datasets.deleteDataset({ id: ds.id });
+      expect(await datasets.getDatasetById({ id: ds.id })).toBeNull();
+      expect((await datasets.listItems({ datasetId: ds.id, pagination: { page: 0, perPage: 10 } })).items).toHaveLength(
+        0,
+      );
+      expect(
+        (await datasets.listDatasetVersions({ datasetId: ds.id, pagination: { page: 0, perPage: 10 } })).versions,
+      ).toHaveLength(0);
     });
   });
 
@@ -2704,6 +3487,49 @@ if (ENABLE_TESTS) {
           expect(v?.metadata).toEqual({ team: 'core' });
           expect(v?.tree).toEqual({ files: [] });
         });
+
+        it('defaults visibility to private for authored skills and persists explicit values', async () => {
+          const authored = `skill-vis-${randomUUID()}`;
+          await skills.create({ skill: { id: authored, ...baseSnapshot, authorId: 'author-1' } as any });
+          expect(((await skills.getById(authored)) as any)?.visibility).toBe('private');
+
+          const pub = `skill-vis-${randomUUID()}`;
+          await skills.create({
+            skill: { id: pub, ...baseSnapshot, authorId: 'author-1', visibility: 'public' } as any,
+          });
+          expect(((await skills.getById(pub)) as any)?.visibility).toBe('public');
+
+          // update can change visibility on the thin record.
+          await skills.update({ id: pub, visibility: 'private' } as any);
+          expect(((await skills.getById(pub)) as any)?.visibility).toBe('private');
+        });
+      });
+
+      describe('list filters', () => {
+        it('filters by status and visibility', async () => {
+          const authorId = `author-${randomUUID()}`;
+          const draftPrivate = `skill-${randomUUID()}`;
+          const publishedPublic = `skill-${randomUUID()}`;
+          await skills.create({ skill: { id: draftPrivate, ...baseSnapshot, authorId, visibility: 'private' } as any });
+          await skills.create({
+            skill: { id: publishedPublic, ...baseSnapshot, authorId, visibility: 'public' } as any,
+          });
+          await skills.update({ id: publishedPublic, status: 'published' } as any);
+
+          const drafts = await skills.list({ authorId, status: 'draft', perPage: false });
+          expect(drafts.skills.map(s => s.id)).toEqual([draftPrivate]);
+
+          const publicOnes = await skills.list({ authorId, visibility: 'public', perPage: false });
+          expect(publicOnes.skills.map(s => s.id)).toEqual([publishedPublic]);
+
+          const publishedPublics = await skills.list({
+            authorId,
+            status: 'published',
+            visibility: 'public',
+            perPage: false,
+          });
+          expect(publishedPublics.skills.map(s => s.id)).toEqual([publishedPublic]);
+        });
       });
 
       describe('getById', () => {
@@ -4932,7 +5758,7 @@ if (ENABLE_TESTS) {
             filters: { name: ['agent.duration_ms'] } as any,
             pagination: { page: 0, perPage: 50 },
           });
-          const row = result.metrics.find(m => m.metricId === id)!;
+          const row = result.metrics.find((m: { metricId: string }) => m.metricId === id)!;
           expect(row.labels).toEqual({ a: '1', b: '2' });
           expect(row.tags).toEqual(['x', 'y']);
           expect(row.costMetadata).toEqual({ tier: 'pro' });
@@ -5101,7 +5927,9 @@ if (ENABLE_TESTS) {
             aggregation: 'sum',
             groupBy: ['provider'],
           });
-          const byProvider = new Map(result.groups.map(g => [g.dimensions.provider, g.value]));
+          const byProvider = new Map(
+            result.groups.map((g: { dimensions: { provider: any }; value: any }) => [g.dimensions.provider, g.value]),
+          );
           expect(byProvider.get('openai')).toBe(300);
           expect(byProvider.get('anthropic')).toBe(50);
         });
@@ -5113,7 +5941,9 @@ if (ENABLE_TESTS) {
             aggregation: 'sum',
             groupBy: ['env'],
           });
-          const byEnv = new Map(result.groups.map(g => [g.dimensions.env, g.value]));
+          const byEnv = new Map(
+            result.groups.map((g: { dimensions: { env: any }; value: any }) => [g.dimensions.env, g.value]),
+          );
           expect(byEnv.get('prod')).toBe(300);
           expect(byEnv.get('staging')).toBe(50);
         });
@@ -5151,7 +5981,12 @@ if (ENABLE_TESTS) {
           expect(result.series).toHaveLength(1);
           // 3 distinct minutes for agent.duration_ms (T, T+1m, T+2m)
           expect(result.series[0]!.points).toHaveLength(3);
-          const valuesByBucket = new Map(result.series[0]!.points.map(p => [p.timestamp.toISOString(), p.value]));
+          const valuesByBucket = new Map(
+            result.series[0]!.points.map((p: { timestamp: { toISOString: () => any }; value: any }) => [
+              p.timestamp.toISOString(),
+              p.value,
+            ]),
+          );
           expect(valuesByBucket.get(baseDate.toISOString())).toBe(100);
           expect(valuesByBucket.get(new Date(baseDate.getTime() + 60_000).toISOString())).toBe(200);
           expect(valuesByBucket.get(new Date(baseDate.getTime() + 120_000).toISOString())).toBe(50);
@@ -5180,7 +6015,7 @@ if (ENABLE_TESTS) {
             interval: '1h',
             groupBy: ['provider'],
           });
-          const seriesByName = new Map(result.series.map(s => [s.name, s]));
+          const seriesByName = new Map(result.series.map((s: { name: any }) => [s.name, s]));
           expect(seriesByName.has('openai')).toBe(true);
           expect(seriesByName.has('anthropic')).toBe(true);
           expect(seriesByName.get('openai')!.points[0]!.value).toBe(300);
@@ -5206,9 +6041,9 @@ if (ENABLE_TESTS) {
             interval: '1h',
           });
           expect(result.series).toHaveLength(2);
-          const p50 = result.series.find(s => s.percentile === 0.5)!;
+          const p50 = result.series.find((s: { percentile: number }) => s.percentile === 0.5)!;
           expect(p50.points[0]!.value).toBeCloseTo(50.5, 5);
-          const p99 = result.series.find(s => s.percentile === 0.99)!;
+          const p99 = result.series.find((s: { percentile: number }) => s.percentile === 0.99)!;
           expect(p99.points[0]!.value).toBeCloseTo(99.01, 5);
         });
 
@@ -5793,6 +6628,26 @@ if (ENABLE_TESTS) {
           name: 'ObservabilitySpanner',
           create: database =>
             new ObservabilitySpanner({ database: database as any, initMode: 'validate', disableMetrics: false }),
+        },
+        {
+          name: 'ChannelsSpanner',
+          create: database => new ChannelsSpanner({ database: database as any, initMode: 'validate' }),
+        },
+        {
+          name: 'DatasetsSpanner',
+          create: database => new DatasetsSpanner({ database: database as any, initMode: 'validate' }),
+        },
+        {
+          name: 'ExperimentsSpanner',
+          create: database => new ExperimentsSpanner({ database: database as any, initMode: 'validate' }),
+        },
+        {
+          name: 'FavoritesSpanner',
+          create: database => new FavoritesSpanner({ database: database as any, initMode: 'validate' }),
+        },
+        {
+          name: 'WorkspacesSpanner',
+          create: database => new WorkspacesSpanner({ database: database as any, initMode: 'validate' }),
         },
       ];
 

--- a/stores/spanner/src/storage/index.ts
+++ b/stores/spanner/src/storage/index.ts
@@ -8,6 +8,10 @@ import type { SpannerInitMode } from './db';
 import { AgentsSpanner } from './domains/agents';
 import { BackgroundTasksSpanner } from './domains/background-tasks';
 import { BlobsSpanner } from './domains/blobs';
+import { ChannelsSpanner } from './domains/channels';
+import { DatasetsSpanner } from './domains/datasets';
+import { ExperimentsSpanner } from './domains/experiments';
+import { FavoritesSpanner } from './domains/favorites';
 import { MCPClientsSpanner } from './domains/mcp-clients';
 import { MCPServersSpanner } from './domains/mcp-servers';
 import { MemorySpanner } from './domains/memory';
@@ -18,12 +22,17 @@ import { ScorerDefinitionsSpanner } from './domains/scorer-definitions';
 import { ScoresSpanner } from './domains/scores';
 import { SkillsSpanner } from './domains/skills';
 import { WorkflowsSpanner } from './domains/workflows';
+import { WorkspacesSpanner } from './domains/workspaces';
 
 // Export domain classes for direct use with MastraStorage composition
 export {
   AgentsSpanner,
   BackgroundTasksSpanner,
   BlobsSpanner,
+  ChannelsSpanner,
+  DatasetsSpanner,
+  ExperimentsSpanner,
+  FavoritesSpanner,
   MCPClientsSpanner,
   MCPServersSpanner,
   MemorySpanner,
@@ -34,6 +43,7 @@ export {
   ScoresSpanner,
   SkillsSpanner,
   WorkflowsSpanner,
+  WorkspacesSpanner,
 };
 export type { SpannerDomainConfig, SpannerInitMode } from './db';
 
@@ -52,6 +62,11 @@ export const SPANNER_DOMAIN_KEYS = [
   'scorerDefinitions',
   'schedules',
   'observability',
+  'channels',
+  'datasets',
+  'experiments',
+  'favorites',
+  'workspaces',
 ] as const satisfies ReadonlyArray<keyof StorageDomains>;
 
 export type SpannerDomainKey = (typeof SPANNER_DOMAIN_KEYS)[number];
@@ -264,6 +279,11 @@ export class SpannerStore extends MastraCompositeStore {
         ...(wants('scorerDefinitions') && { scorerDefinitions: new ScorerDefinitionsSpanner(domainConfig) }),
         ...(wants('schedules') && { schedules: new SchedulesSpanner(domainConfig) }),
         ...(wants('observability') && { observability: new ObservabilitySpanner(domainConfig) }),
+        ...(wants('channels') && { channels: new ChannelsSpanner(domainConfig) }),
+        ...(wants('datasets') && { datasets: new DatasetsSpanner(domainConfig) }),
+        ...(wants('experiments') && { experiments: new ExperimentsSpanner(domainConfig) }),
+        ...(wants('favorites') && { favorites: new FavoritesSpanner(domainConfig) }),
+        ...(wants('workspaces') && { workspaces: new WorkspacesSpanner(domainConfig) }),
       };
     } catch (e) {
       throw new MastraError(
@@ -326,6 +346,11 @@ export class SpannerStore extends MastraCompositeStore {
         'scorerDefinitions',
         'schedules',
         'observability',
+        'channels',
+        'datasets',
+        'experiments',
+        'workspaces',
+        'favorites',
       ];
       for (const key of domainOrder) {
         const store = this.stores?.[key];


### PR DESCRIPTION
## Description

Implement missing Spanner adapter domains: experiments, datasets, channels, workspaces, favorites

## Related issue(s)

Fixes #17470 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR gives the Spanner storage adapter five new "drawers" so Mastra can save and manage experiments, datasets (with history), platform channels, workspaces (with version snapshots), and favorites (likes) in Google Cloud Spanner. That lets the app store, query, and use these data types the same way other backends do.

## Overview

Implements Spanner storage support for five domains: experiments, datasets, channels, workspaces, and favorites (addresses issue `#17470`). Each domain includes table/index initialization, CRUD and list APIs, transactional behaviors where required, MastraError-wrapped failures with storage error ids, and integration into the SpannerStore. Documentation, changelog, and extensive integration tests were added. Some CodeRabbit review comments remain unaddressed.

## Key Changes

- Added domain implementations and exports
  - ChannelsSpanner
    - Tables: mastra_channel_installations, mastra_channel_config
    - Upsert-preserving createdAt, webhookId NULL-filtered unique index (DDL skip in validate mode), CRUD/list/delete, per-platform config APIs
  - DatasetsSpanner
    - SCD-2 versioned items, transactional version bumps, dataset-version snapshots, item time-travel/history, batch insert/delete (tombstoning), search, pagination, and cascade behaviors
  - ExperimentsSpanner
    - Experiments + experiment results, create/update/list/delete, add/update/list results, review-summary aggregation, and cascade deletion of results
  - WorkspacesSpanner
    - Workspace rows + immutable version snapshots, create/update/delete, changedFields detection (JSON diff), auto-publish when activeVersionId is set, version APIs, optional stale-draft cleanup
  - FavoritesSpanner
    - mastra_favorites table, atomic favorite/unfavorite with denormalized favoriteCount counters on parent tables, batch/isFavorited helpers, listFavoritedIds, delete/reset helpers

- Integration with existing domains
  - Agents and Skills: list() updated to support favorites-aware filtering/pinning and favorited-first ordering; skills now include favoriteCount and visibility handling; skills.create/update persist visibility appropriately.

- Core/storage-level updates
  - DB primary-key resolution now prefers compositePrimaryKey from TABLE_CONFIGS when present and validates referenced PK columns.
  - SpannerStore: exports new domain classes, extends SPANNER_DOMAIN_KEYS, conditionally constructs new domain instances, and updates domain init order to include channels, datasets, experiments, workspaces, and favorites.

- Documentation & changelog
  - Added Spanner to supported providers list, updated Spanner schema documentation, and added a changeset describing the new domains and behaviors (favorites ordering/filtering and dataset SCD-2 semantics).

- Tests
  - Extensive integration tests added/extended for Workspaces, Favorites, Channels, Experiments, Datasets, Skills, and Agents favorites behaviors; validate-mode coverage included.

## Notable implementation details / behaviors

- Favorites: stored in mastra_favorites and denormalized favoriteCount is maintained in transactions with non-negative clamping and correct idempotency semantics.
- Datasets: SCD-2 semantics (live/tombstoned rows, version snapshots, transactional version bumps) enabling item history and time-travel queries.
- Workspaces: snapshot-based versioning with changedFields detection and automatic publish behavior when activeVersionId is set without an explicit status.
- Channels: enforces webhook uniqueness via a NULL-filtered unique index (created via raw DDL; index creation skipped in validate mode but verified).
- DB creation: PRIMARY KEY generation prefers compositePrimaryKey from TABLE_CONFIGS and validates column presence.
- Error handling: domain methods wrap errors as MastraError with generated storage error ids and contextual details.

## Misc / Metadata

- Related issue: `#17470` (implements the missing domains).
- Tests and documentation updated.
- Checklist: linked issues and docs/tests done; some CodeRabbit comments remain unaddressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->