### PR TITLE
fix(core): preserve failed tool results through agent loop

### DIFF
--- a/.changeset/bumpy-doors-crash.md
+++ b/.changeset/bumpy-doors-crash.md
@@ -3,4 +3,4 @@
 '@mastra/memory': patch
 ---
 
-Fixed failed tool calls being treated as successful results in agent history, live harness streams, and observational memory token counting. Tool errors are now preserved as error outputs when reloading memory, and continued finish chunks no longer stop the harness before the agent can respond to a failed tool call. Fixes #15569.
+Fixed failed tool calls being treated as successful results in agent history, live harness streams, and observational memory. Tool errors are now preserved as error outputs end-to-end: they survive memory reload, the observational-memory observer and recall transcripts include the error so the agent keeps the failure context, the token limiter and tool-call filter account for failed results, and tool-accuracy evals record a failed tool as an unsuccessful step. Continued finish chunks no longer stop the harness before the agent can respond to a failed tool call. Fixes #15569.

--- a/.changeset/bumpy-doors-crash.md
+++ b/.changeset/bumpy-doors-crash.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed tool execution errors being stored as successful results, which caused failed tool calls to reappear as successes when a conversation was reloaded from history. When a tool throws (or a provider-executed tool reports a failure), the result is now persisted as `state: "output-error"` with `errorText` instead of `state: "result"`, so the error survives history reload via `toAISdkV5Messages()` and matches the live streaming behavior. Fixes #15569.
+Fixed failed tool calls showing up as successful when a conversation is reloaded from history. Previously a tool that threw an error displayed correctly while the agent was running, but reappeared as a successful result once the conversation was loaded from memory. The error is now preserved and displayed on reload, matching what you see during the live run. Fixes #15569.

--- a/.changeset/bumpy-doors-crash.md
+++ b/.changeset/bumpy-doors-crash.md
@@ -1,5 +1,6 @@
 ---
 '@mastra/core': patch
+'@mastra/memory': patch
 ---
 
-Fixed failed tool calls showing up as successful when a conversation is reloaded from history. Previously a tool that threw an error displayed correctly while the agent was running, but reappeared as a successful result once the conversation was loaded from memory. The error is now preserved and displayed on reload, matching what you see during the live run. Fixes #15569.
+Fixed failed tool calls being treated as successful results in agent history, live harness streams, and observational memory token counting. Tool errors are now preserved as error outputs when reloading memory, and continued finish chunks no longer stop the harness before the agent can respond to a failed tool call. Fixes #15569.

--- a/.changeset/bumpy-doors-crash.md
+++ b/.changeset/bumpy-doors-crash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool execution errors being stored as successful results, which caused failed tool calls to reappear as successes when a conversation was reloaded from history. When a tool throws (or a provider-executed tool reports a failure), the result is now persisted as `state: "output-error"` with `errorText` instead of `state: "result"`, so the error survives history reload via `toAISdkV5Messages()` and matches the live streaming behavior. Fixes #15569.

--- a/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
@@ -13,6 +13,7 @@ import type {
   MastraDBMessage,
   MastraMessageContentV2,
   MastraMessagePart,
+  MastraToolInvocation,
   UIMessageV4Part,
   MessageSource,
   UIMessageWithMetadata,
@@ -33,10 +34,19 @@ function getDisplayTransform(
 }
 
 function transformV4ToolInvocationForDisplay(
-  invocation: NonNullable<MastraMessageContentV2['toolInvocations']>[number],
+  invocation: MastraToolInvocation,
   providerMetadata: unknown,
   enabled: boolean,
-) {
+): ToolInvocationV4 {
+  if (invocation.state === 'output-error') {
+    return {
+      ...invocation,
+      state: 'result' as const,
+      args: getDisplayTransform(providerMetadata, 'input-available', invocation.args, enabled),
+      result: getDisplayTransform(providerMetadata, 'error', invocation.errorText || '', enabled),
+    };
+  }
+
   return {
     ...invocation,
     args: getDisplayTransform(providerMetadata, 'input-available', invocation.args, enabled),
@@ -50,7 +60,7 @@ function transformV4ToolInvocationForDisplay(
           ),
         }
       : {}),
-  };
+  } as ToolInvocationV4;
 }
 
 /**
@@ -204,30 +214,49 @@ export class AIV4Adapter {
           continue;
         } else if (part.type === 'tool-invocation') {
           // Handle tool invocations with step number logic
-          const toolInvocation = {
-            ...part.toolInvocation,
-            args: getDisplayTransform(
-              part.providerMetadata,
-              'input-available',
-              part.toolInvocation.args,
-              transformToolPayloads,
-            ),
-            ...(part.toolInvocation.state === 'result'
+          const sourceInvocation = part.toolInvocation as MastraToolInvocation;
+          const toolInvocation =
+            sourceInvocation.state === 'output-error'
               ? {
+                  ...sourceInvocation,
+                  state: 'result' as const,
+                  args: getDisplayTransform(
+                    part.providerMetadata,
+                    'input-available',
+                    sourceInvocation.args,
+                    transformToolPayloads,
+                  ),
                   result: getDisplayTransform(
                     part.providerMetadata,
-                    'output-available',
-                    getDisplayTransform(
-                      part.providerMetadata,
-                      'error',
-                      part.toolInvocation.result,
-                      transformToolPayloads,
-                    ),
+                    'error',
+                    sourceInvocation.errorText || '',
                     transformToolPayloads,
                   ),
                 }
-              : {}),
-          };
+              : {
+                  ...sourceInvocation,
+                  args: getDisplayTransform(
+                    part.providerMetadata,
+                    'input-available',
+                    sourceInvocation.args,
+                    transformToolPayloads,
+                  ),
+                  ...(sourceInvocation.state === 'result'
+                    ? {
+                        result: getDisplayTransform(
+                          part.providerMetadata,
+                          'output-available',
+                          getDisplayTransform(
+                            part.providerMetadata,
+                            'error',
+                            sourceInvocation.result,
+                            transformToolPayloads,
+                          ),
+                          transformToolPayloads,
+                        ),
+                      }
+                    : {}),
+                };
 
           // Find the step number for this tool invocation
           let currentStep = -1;
@@ -302,8 +331,8 @@ export class AIV4Adapter {
         reasoning: undefined,
         toolInvocations:
           `toolInvocations` in m.content
-            ? m.content.toolInvocations
-                ?.filter(t => t.state === 'result')
+            ? (m.content.toolInvocations as MastraToolInvocation[] | undefined)
+                ?.filter(t => t.state === 'result' || t.state === 'output-error')
                 .map(toolInvocation => {
                   const partProviderMetadata = m.content.parts?.find(
                     part =>

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -7,6 +7,7 @@ import type {
   MastraDBMessage,
   MastraMessageContentV2,
   MastraMessagePart,
+  MastraToolInvocation,
   MastraToolInvocationPart,
   MessageSource,
 } from '../state/types';
@@ -243,20 +244,29 @@ export class AIV5Adapter {
     const hasToolInvocationParts = dbMsg.content.parts?.some(p => p.type === 'tool-invocation');
     if (dbMsg.content.toolInvocations && !hasToolInvocationParts) {
       for (const invocation of dbMsg.content.toolInvocations) {
-        if (invocation.state === 'result') {
+        const legacyInvocation = invocation as MastraToolInvocation;
+        if (legacyInvocation.state === 'result') {
           parts.push({
-            type: `tool-${invocation.toolName}`,
-            toolCallId: invocation.toolCallId,
+            type: `tool-${legacyInvocation.toolName}`,
+            toolCallId: legacyInvocation.toolCallId,
             state: 'output-available',
-            input: invocation.args,
-            output: invocation.result,
+            input: legacyInvocation.args,
+            output: legacyInvocation.result,
+          });
+        } else if (legacyInvocation.state === 'output-error') {
+          parts.push({
+            type: `tool-${legacyInvocation.toolName}`,
+            toolCallId: legacyInvocation.toolCallId,
+            state: 'output-error',
+            input: legacyInvocation.args,
+            errorText: legacyInvocation.errorText || '',
           });
         } else {
           parts.push({
-            type: `tool-${invocation.toolName}`,
-            toolCallId: invocation.toolCallId,
-            state: invocation.state === 'call' ? 'input-available' : 'input-streaming',
-            input: invocation.args,
+            type: `tool-${legacyInvocation.toolName}`,
+            toolCallId: legacyInvocation.toolCallId,
+            state: legacyInvocation.state === 'call' ? 'input-available' : 'input-streaming',
+            input: legacyInvocation.args,
           });
         }
       }

--- a/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
@@ -246,6 +246,10 @@ function createLegacyToolInvocations(
       continue;
     }
 
+    // Note: failed tools (`output-error`) are intentionally not mirrored into this
+    // synthesized AI SDK v6 back-compat `toolInvocations` array. The error is
+    // preserved on the modern `parts` representation, which downstream consumers read.
+
     if (invocation.state === 'call' || invocation.state === 'partial-call') {
       toolInvocations.push({
         args: invocation.args,

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
@@ -4,7 +4,7 @@
  */
 import type { AssistantContent, ToolResultPart } from '@internal/ai-sdk-v4';
 import type { MastraMessageV1 } from '../../../memory/types';
-import type { MastraMessageContentV2, MastraDBMessage } from '../../message-list';
+import type { MastraDBMessage, MastraMessageContentV2, MastraToolInvocation } from '../../message-list';
 import { attachmentsToParts } from './attachments-to-parts';
 
 const makePushOrCombine = (v1Messages: MastraMessageV1[]) => {
@@ -54,6 +54,21 @@ const makePushOrCombine = (v1Messages: MastraMessageV1[]) => {
     }
   };
 };
+
+const hasTerminalToolOutput = (toolInvocation: MastraToolInvocation) =>
+  (toolInvocation.state === 'result' && 'result' in toolInvocation) ||
+  (toolInvocation.state === 'output-error' && 'errorText' in toolInvocation);
+
+const toToolResultPart = (toolInvocation: MastraToolInvocation): ToolResultPart => {
+  const { toolCallId, toolName } = toolInvocation;
+  return {
+    type: 'tool-result',
+    toolCallId,
+    toolName,
+    result: toolInvocation.state === 'output-error' ? toolInvocation.errorText || '' : toolInvocation.result,
+  };
+};
+
 export function convertToV1Messages(messages: Array<MastraDBMessage>) {
   const v1Messages: MastraMessageV1[] = [];
   const pushOrCombine = makePushOrCombine(v1Messages);
@@ -195,22 +210,14 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
               .filter(ti => ti.toolName !== 'updateWorkingMemory');
 
             // Only create tool-result message if there are actual results
-            const invocationsWithResults = stepInvocations.filter(ti => ti.state === 'result' && 'result' in ti);
+            const invocationsWithResults = stepInvocations.filter(hasTerminalToolOutput);
 
             if (invocationsWithResults.length > 0) {
               pushOrCombine({
                 role: 'tool',
                 ...fields,
                 type: 'tool-result',
-                content: invocationsWithResults.map((toolInvocation): ToolResultPart => {
-                  const { toolCallId, toolName, result } = toolInvocation;
-                  return {
-                    type: 'tool-result',
-                    toolCallId,
-                    toolName,
-                    result,
-                  };
-                }),
+                content: invocationsWithResults.map(toToolResultPart),
               });
             }
 
@@ -300,22 +307,14 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
                 });
 
                 // Only create tool-result message if there are actual results
-                const invocationsWithResults = stepInvocations.filter(ti => ti.state === 'result' && 'result' in ti);
+                const invocationsWithResults = stepInvocations.filter(hasTerminalToolOutput);
 
                 if (invocationsWithResults.length > 0) {
                   pushOrCombine({
                     role: 'tool',
                     ...fields,
                     type: 'tool-result',
-                    content: invocationsWithResults.map((toolInvocation): ToolResultPart => {
-                      const { toolCallId, toolName, result } = toolInvocation;
-                      return {
-                        type: 'tool-result',
-                        toolCallId,
-                        toolName,
-                        result,
-                      };
-                    }),
+                    content: invocationsWithResults.map(toToolResultPart),
                   });
                 }
               }
@@ -362,22 +361,14 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
           });
 
           // Only create tool-result message if there are actual results
-          const invocationsWithResults = stepInvocations.filter(ti => ti.state === 'result' && 'result' in ti);
+          const invocationsWithResults = stepInvocations.filter(hasTerminalToolOutput);
 
           if (invocationsWithResults.length > 0) {
             pushOrCombine({
               role: 'tool',
               ...fields,
               type: 'tool-result',
-              content: invocationsWithResults.map((toolInvocation): ToolResultPart => {
-                const { toolCallId, toolName, result } = toolInvocation;
-                return {
-                  type: 'tool-result',
-                  toolCallId,
-                  toolName,
-                  result,
-                };
-              }),
+              content: invocationsWithResults.map(toToolResultPart),
             });
           }
         }

--- a/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
@@ -2203,6 +2203,57 @@ describe('MessageList V5 Support', () => {
       expect(drainedApprovalPart.data.args).toBeNull();
     });
 
+    it('should preserve legacy toolInvocations output-error state in the model prompt', async () => {
+      const list = new MessageList({ threadId, resourceId });
+
+      list.add('List the inaccessible directory', 'input');
+      list.add(
+        {
+          id: 'msg-legacy-output-error',
+          role: 'assistant',
+          createdAt: new Date(),
+          threadId,
+          resourceId,
+          content: {
+            format: 2,
+            toolInvocations: [
+              {
+                toolCallId: 'call-list-error',
+                toolName: 'find_files',
+                state: 'output-error',
+                args: { path: '/restricted' },
+                errorText: 'EACCES: permission denied',
+              },
+            ],
+          },
+        },
+        'response',
+      );
+
+      const uiToolPart = list.get.all.aiV5.ui()[1]!.parts.find((part: any) => part.toolCallId === 'call-list-error');
+      expect(uiToolPart).toEqual(
+        expect.objectContaining({
+          state: 'output-error',
+          errorText: 'EACCES: permission denied',
+        }),
+      );
+
+      const prompt = await list.get.all.aiV5.llmPrompt();
+      const toolMessage = prompt.find(message => message.role === 'tool');
+      const toolResult = (toolMessage as any).content.find((part: any) => part.toolCallId === 'call-list-error');
+
+      expect(toolResult).toEqual(
+        expect.objectContaining({
+          type: 'tool-result',
+          toolName: 'find_files',
+          output: {
+            type: 'error-text',
+            value: 'EACCES: permission denied',
+          },
+        }),
+      );
+    });
+
     it('should preserve modelOutput metadata across db to model to db conversion', () => {
       const list = new MessageList({ threadId, resourceId });
       const toolResultMessage: MastraDBMessage = {

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -127,6 +127,14 @@ export class AgentThreadStreamRuntime {
     return signal;
   }
 
+  #isTerminalStreamPart(part: unknown): boolean {
+    const typedPart = part as { type?: string; payload?: { stepResult?: { isContinued?: boolean } } };
+    if (typedPart.type === 'finish') {
+      return typedPart.payload?.stepResult?.isContinued !== true;
+    }
+    return typedPart.type === 'error' || typedPart.type === 'abort' || typedPart.type === 'tool-call-suspended';
+  }
+
   #publish(pubsub: PubSub | undefined, key: string, event: AgentThreadStreamRuntimeEvent) {
     void this.#publishAndWait(pubsub, key, event).catch(() => {});
   }
@@ -703,6 +711,8 @@ export class AgentThreadStreamRuntime {
       wake();
     };
 
+    const runtime = this;
+
     return {
       activeRunId,
       abort: () => this.abortThread(options, resolvedPubSub),
@@ -728,12 +738,7 @@ export class AgentThreadStreamRuntime {
                 const typedPart = part as any;
                 yield typedPart;
                 if (done) break;
-                if (
-                  typedPart.type === 'finish' ||
-                  typedPart.type === 'error' ||
-                  typedPart.type === 'abort' ||
-                  typedPart.type === 'tool-call-suspended'
-                ) {
+                if (runtime.#isTerminalStreamPart(typedPart)) {
                   // After a terminal chunk, drain remaining stream data in the
                   // background to prevent backpressure from blocking upstream
                   // processing (e.g. OM), while allowing the generator to

--- a/packages/core/src/channels/__tests__/consume-agent-stream.test.ts
+++ b/packages/core/src/channels/__tests__/consume-agent-stream.test.ts
@@ -312,6 +312,46 @@ describe('consumeAgentStream', () => {
       expect(text).toContain('done');
     });
 
+    it("'timeline': marks structured error tool results as error task updates", async () => {
+      const { channels, calls, chatThread } = makeChannels({ streaming: true, toolDisplay: 'timeline' });
+      await drive(
+        channels,
+        [
+          {
+            type: 'tool-call',
+            payload: { toolCallId: 't1', toolName: 'find_files', args: { path: '/outside-workspace' } },
+          },
+          {
+            type: 'tool-result',
+            payload: {
+              toolCallId: 't1',
+              toolName: 'find_files',
+              args: { path: '/outside-workspace' },
+              result: 'Permission denied: path is outside the workspace',
+              isError: true,
+            },
+          },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      const post = calls.find(c => c.kind === 'post') as Extract<Call, { kind: 'post' }>;
+      const drained = await drainStreamingPlan(post.arg);
+      const taskUpdates = drained.filter(
+        (p): p is { type: 'task_update'; status: string; id: string; output?: string } =>
+          typeof p === 'object' && (p as any).type === 'task_update',
+      );
+
+      expect(taskUpdates).toHaveLength(2);
+      expect(taskUpdates[0]).toMatchObject({ id: 't1', status: 'in_progress' });
+      expect(taskUpdates[1]).toMatchObject({
+        id: 't1',
+        status: 'error',
+        output: 'Error: Permission denied: path is outside the workspace',
+      });
+    });
+
     it("'grouped': renders task_updates inside a single plan block (groupTasks: 'plan')", async () => {
       const { channels, calls, chatThread } = makeChannels({ streaming: true, toolDisplay: 'grouped' });
       await drive(

--- a/packages/core/src/channels/chat-driver-streaming.ts
+++ b/packages/core/src/channels/chat-driver-streaming.ts
@@ -602,7 +602,7 @@ export async function runStreamingDriver({
         type: 'task_update',
         id: enr.toolCallId,
         title: taskTitle,
-        status: 'complete',
+        status: chunk.payload.isError ? 'error' : 'complete',
         // Grouped is at-a-glance: suppress the full result body to keep
         // tasks single-line. Timeline shows the full result.
         output: toolDisplay === 'timeline' ? enr.resultText || undefined : undefined,

--- a/packages/core/src/evals/types.test.ts
+++ b/packages/core/src/evals/types.test.ts
@@ -807,6 +807,65 @@ describe('extractTrajectory', () => {
     });
   });
 
+  it('records a failed tool (output-error) as a step with success false', () => {
+    const output = [
+      {
+        role: 'assistant',
+        content: {
+          toolInvocations: [
+            { state: 'output-error', toolCallId: 'c1', toolName: 'flakyTool', args: { q: 'x' }, errorText: 'boom' },
+          ],
+          parts: [],
+        },
+      },
+    ] as any;
+
+    const result = extractTrajectory(output);
+
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0]).toMatchObject({
+      stepType: 'tool_call',
+      name: 'flakyTool',
+      toolArgs: { q: 'x' },
+      toolResult: { value: 'boom' },
+      success: false,
+    });
+  });
+
+  it('records a failed tool (output-error) from V2 content.parts as a step with success false', () => {
+    const output = [
+      {
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'output-error',
+                toolCallId: 'c1',
+                toolName: 'flakyTool',
+                args: { q: 'x' },
+                errorText: 'boom',
+              },
+            },
+          ],
+        },
+      },
+    ] as any;
+
+    const result = extractTrajectory(output);
+
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0]).toMatchObject({
+      stepType: 'tool_call',
+      name: 'flakyTool',
+      toolArgs: { q: 'x' },
+      toolResult: { value: 'boom' },
+      success: false,
+    });
+  });
+
   // --- V2 parts fallback path ---
 
   it('extracts tool calls from V2 content.parts when toolInvocations is absent', () => {

--- a/packages/core/src/evals/types.ts
+++ b/packages/core/src/evals/types.ts
@@ -624,7 +624,11 @@ export function extractTrajectory(output: ScorerRunOutputForAgent): Trajectory {
     if (!toolInvocations?.length) continue;
 
     for (const invocation of toolInvocations) {
-      if (invocation && invocation.toolName && (invocation.state === 'result' || invocation.state === 'call')) {
+      if (
+        invocation &&
+        invocation.toolName &&
+        (invocation.state === 'result' || invocation.state === 'call' || invocation.state === 'output-error')
+      ) {
         const toolArgs =
           invocation.args != null && typeof invocation.args === 'object' && !Array.isArray(invocation.args)
             ? (invocation.args as Record<string, unknown>)
@@ -632,7 +636,12 @@ export function extractTrajectory(output: ScorerRunOutputForAgent): Trajectory {
               ? { value: invocation.args }
               : undefined;
 
-        const rawResult = invocation.state === 'result' ? invocation.result : undefined;
+        const rawResult =
+          invocation.state === 'result'
+            ? invocation.result
+            : invocation.state === 'output-error'
+              ? (invocation.errorText ?? 'Tool execution failed')
+              : undefined;
         const toolResult =
           rawResult != null && typeof rawResult === 'object' && !Array.isArray(rawResult)
             ? (rawResult as Record<string, unknown>)

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -2030,6 +2030,7 @@ export class Harness<TState = {}> {
           args?: unknown;
           result?: unknown;
           isError?: boolean;
+          errorText?: string;
         };
         [key: string]: unknown;
       }>;
@@ -2123,6 +2124,16 @@ export class Harness<TState = {}> {
                 name: inv.toolName,
                 result: inv.result,
                 isError: inv.isError ?? false,
+                ...(partProviderMetadata ? { providerMetadata: partProviderMetadata } : {}),
+              });
+            } else if (inv.state === 'output-error') {
+              const partProviderMetadata = part.providerMetadata as Record<string, unknown> | undefined;
+              content.push({
+                type: 'tool_result',
+                id: inv.toolCallId,
+                name: inv.toolName,
+                result: inv.errorText ?? 'Tool execution failed',
+                isError: true,
                 ...(partProviderMetadata ? { providerMetadata: partProviderMetadata } : {}),
               });
             }

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1786,7 +1786,7 @@ export class Harness<TState = {}> {
           const streamResult = await this.processStreamChunk(currentRun, chunk, requestContext);
           if (
             streamResult ||
-            chunk.type === 'finish' ||
+            this.isTerminalFinishChunk(chunk) ||
             chunk.type === 'error' ||
             chunk.type === 'abort' ||
             chunk.type === 'tool-call-suspended'
@@ -2294,7 +2294,7 @@ export class Harness<TState = {}> {
       }
       if (
         result ||
-        chunk.type === 'finish' ||
+        this.isTerminalFinishChunk(chunk) ||
         chunk.type === 'error' ||
         chunk.type === 'abort' ||
         chunk.type === 'tool-call-suspended' ||
@@ -2324,6 +2324,10 @@ export class Harness<TState = {}> {
     await this.drainFollowUpQueue();
 
     return result;
+  }
+
+  private isTerminalFinishChunk(chunk: any): boolean {
+    return chunk?.type === 'finish' && chunk.payload?.stepResult?.isContinued !== true;
   }
 
   private async processStreamChunk(
@@ -2448,12 +2452,23 @@ export class Harness<TState = {}> {
 
       case 'tool-error': {
         const toolError = chunk.payload;
+        const result = getDisplayTransform(chunk.metadata, 'error', toolError.error);
+        state.currentMessage.content.push({
+          type: 'tool_result',
+          id: toolError.toolCallId,
+          name: toolError.toolName,
+          result,
+          isError: true,
+          ...(toolError.providerMetadata ? { providerMetadata: toolError.providerMetadata } : {}),
+        });
         this.emit({
           type: 'tool_end',
           toolCallId: toolError.toolCallId,
-          result: getDisplayTransform(chunk.metadata, 'error', toolError.error),
+          result,
           isError: true,
+          ...(toolError.providerMetadata ? { providerMetadata: toolError.providerMetadata } : {}),
         });
+        this.emit({ type: 'message_update', message: { ...state.currentMessage } });
         break;
       }
 

--- a/packages/core/src/harness/signal-messages.test.ts
+++ b/packages/core/src/harness/signal-messages.test.ts
@@ -1,5 +1,6 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
 import { Agent } from '../agent';
 import { createSignal } from '../agent/signals';
 import { RequestContext } from '../request-context';
@@ -143,6 +144,136 @@ describe('Harness signal messages', () => {
     expect(assistantEnds).toHaveLength(1);
     expect(assistantEnds[0]?.message.content).toEqual([{ type: 'text', text: 'Hello' }]);
     expect(harness.getCurrentRunId()).toBeNull();
+  });
+
+  it('continues consuming harness streams after non-terminal finish chunks', async () => {
+    const storage = new InMemoryStore();
+    const harness = createHarness(storage);
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+
+    const chunks = [
+      {
+        type: 'finish',
+        runId: 'run-1',
+        payload: {
+          stepResult: {
+            reason: 'tool-calls',
+            isContinued: true,
+          },
+        },
+      },
+      {
+        type: 'text-start',
+        runId: 'run-1',
+        payload: { id: 'text-1' },
+      },
+      {
+        type: 'text-delta',
+        runId: 'run-1',
+        payload: { id: 'text-1', text: 'The tool failed because the path is outside the workspace.' },
+      },
+      {
+        type: 'finish',
+        runId: 'run-1',
+        payload: {
+          stepResult: {
+            reason: 'stop',
+            isContinued: false,
+          },
+        },
+      },
+    ];
+
+    const result = await (harness as any).processStream({
+      fullStream: (async function* () {
+        for (const chunk of chunks) {
+          yield chunk;
+        }
+      })(),
+    });
+
+    expect(result.message.content).toEqual([
+      {
+        type: 'text',
+        text: 'The tool failed because the path is outside the workspace.',
+      },
+    ]);
+    expect(events.filter(event => event.type === 'message_end')).toHaveLength(1);
+  });
+
+  it('continues the subscribed thread stream after a structured tool error result', async () => {
+    const storage = new InMemoryStore();
+    const events: HarnessEvent[] = [];
+    let calls = 0;
+    const agent = new Agent({
+      id: 'tool-error-agent',
+      name: 'tool-error-agent',
+      instructions: 'Use tools when asked.',
+      model: new MockLanguageModelV2({
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream:
+            calls++ === 0
+              ? convertArrayToReadableStream([
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'tool-call', toolCallId: 'call-1', toolName: 'failingTool', input: '{ "path": "/home" }' },
+                  {
+                    type: 'finish',
+                    finishReason: 'tool-calls',
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                  },
+                ])
+              : convertArrayToReadableStream([
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'text-start', id: 'text-1' },
+                  {
+                    type: 'text-delta',
+                    id: 'text-1',
+                    delta: 'The tool failed because the path is outside the workspace.',
+                  },
+                  { type: 'text-end', id: 'text-1' },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                  },
+                ]),
+        }),
+      }),
+      tools: {
+        failingTool: {
+          inputSchema: z.object({ path: z.string() }),
+          execute: async () => ({ message: 'path is outside the workspace', isError: true }),
+        },
+      },
+    });
+    const harness = createHarness(storage, agent);
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+    await harness.setState({ yolo: true } as any);
+    await harness.sendMessage({ content: 'call the failing tool' });
+    await waitFor(() => events.some(event => event.type === 'agent_end'));
+
+    expect(calls).toBe(2);
+    expect(
+      events.some(
+        event =>
+          event.type === 'message_end' &&
+          event.message.role === 'assistant' &&
+          event.message.content.some(
+            part => part.type === 'text' && part.text === 'The tool failed because the path is outside the workspace.',
+          ),
+      ),
+    ).toBe(true);
   });
 
   it('sends active text signals without building idle stream options', async () => {

--- a/packages/core/src/harness/tool-error-reload.test.ts
+++ b/packages/core/src/harness/tool-error-reload.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { Agent } from '../agent';
+import { getDummyResponseModel } from '../agent/__tests__/mock-model';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+
+describe('Harness tool-error reload', () => {
+  async function createHarnessWithThread() {
+    const storage = new InMemoryStore();
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'test',
+      model: getDummyResponseModel('v2'),
+    });
+    const harness = new Harness({
+      id: 'test-harness',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+
+    await harness.init();
+    const thread = await harness.createThread({ title: 'Tool error thread' });
+    const memoryStorage = await storage.getStore('memory');
+    if (!memoryStorage) throw new Error('Expected memory storage');
+
+    return { harness, memoryStorage, thread };
+  }
+
+  it('reconstructs a persisted failed tool (output-error) as an error tool_result', async () => {
+    const { harness, memoryStorage, thread } = await createHarnessWithThread();
+
+    await memoryStorage.saveMessages({
+      messages: [
+        {
+          id: 'assistant-failed-tool',
+          threadId: thread.id,
+          resourceId: 'test-harness',
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  state: 'output-error',
+                  toolCallId: 'call-1',
+                  toolName: 'find_files',
+                  args: { path: '/x' },
+                  errorText: 'Permission denied',
+                },
+              },
+            ],
+          },
+          createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        },
+      ] as any,
+    });
+
+    const messages = await harness.listMessages();
+    const assistant = messages.find(m => m.id === 'assistant-failed-tool');
+    expect(assistant).toBeDefined();
+
+    const content = assistant!.content as Array<Record<string, unknown>>;
+    const toolResult = content.find(c => c.type === 'tool_result' && c.id === 'call-1');
+    expect(toolResult).toBeDefined();
+    expect(toolResult).toMatchObject({
+      type: 'tool_result',
+      name: 'find_files',
+      result: 'Permission denied',
+      isError: true,
+    });
+  });
+});

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -4302,7 +4302,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4335,7 +4335,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4451,7 +4451,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -4602,7 +4602,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4645,7 +4645,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4771,7 +4771,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -4874,7 +4874,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4917,7 +4917,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -5043,7 +5043,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -5842,7 +5842,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -5875,7 +5875,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -5999,7 +5999,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "test error",
                       },
                       "toolCallId": "call-1",
@@ -6158,7 +6158,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6205,7 +6205,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6343,7 +6343,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "test error",
                       },
                       "toolCallId": "call-1",
@@ -6454,7 +6454,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6501,7 +6501,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6639,7 +6639,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "test error",
                       },
                       "toolCallId": "call-1",
@@ -11349,7 +11349,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11382,7 +11382,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11504,7 +11504,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -11667,7 +11667,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11710,7 +11710,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11842,7 +11842,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -11957,7 +11957,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -12000,7 +12000,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -12132,7 +12132,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -4230,10 +4230,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
       "args": {
         "value": "value",
       },
-      "isError": true,
-      "providerExecuted": undefined,
-      "providerMetadata": undefined,
-      "result": {
+      "error": {
         "actual": [
           {
             "content": [
@@ -4261,11 +4258,13 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
         "operator": "deepStrictEqual",
         "showDiff": true,
       },
+      "providerExecuted": undefined,
+      "providerMetadata": undefined,
       "toolCallId": "call-1",
       "toolName": "tool1",
     },
     "runId": "test-run-id",
-    "type": "tool-result",
+    "type": "tool-error",
   },
   {
     "from": "AGENT",
@@ -5795,15 +5794,14 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
       "args": {
         "value": "value",
       },
-      "isError": true,
+      "error": [Error: test error],
       "providerExecuted": undefined,
       "providerMetadata": undefined,
-      "result": [Error: test error],
       "toolCallId": "call-1",
       "toolName": "tool1",
     },
     "runId": "test-run-id",
-    "type": "tool-result",
+    "type": "tool-error",
   },
   {
     "from": "AGENT",
@@ -11281,10 +11279,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
       "args": {
         "value": "value",
       },
-      "isError": true,
-      "providerExecuted": undefined,
-      "providerMetadata": undefined,
-      "result": {
+      "error": {
         "actual": [
           {
             "content": [
@@ -11312,11 +11307,13 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
         "operator": "deepStrictEqual",
         "showDiff": true,
       },
+      "providerExecuted": undefined,
+      "providerMetadata": undefined,
       "toolCallId": "call-1",
       "toolName": "tool1",
     },
     "runId": "test-run-id",
-    "type": "tool-result",
+    "type": "tool-error",
   },
   {
     "from": "AGENT",

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -4230,7 +4230,10 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
       "args": {
         "value": "value",
       },
-      "error": {
+      "isError": true,
+      "providerExecuted": undefined,
+      "providerMetadata": undefined,
+      "result": {
         "actual": [
           {
             "content": [
@@ -4258,12 +4261,11 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
         "operator": "deepStrictEqual",
         "showDiff": true,
       },
-      "providerMetadata": undefined,
       "toolCallId": "call-1",
       "toolName": "tool1",
     },
     "runId": "test-run-id",
-    "type": "tool-error",
+    "type": "tool-result",
   },
   {
     "from": "AGENT",
@@ -5793,13 +5795,15 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
       "args": {
         "value": "value",
       },
-      "error": [Error: test error],
+      "isError": true,
+      "providerExecuted": undefined,
       "providerMetadata": undefined,
+      "result": [Error: test error],
       "toolCallId": "call-1",
       "toolName": "tool1",
     },
     "runId": "test-run-id",
-    "type": "tool-error",
+    "type": "tool-result",
   },
   {
     "from": "AGENT",
@@ -11277,7 +11281,10 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
       "args": {
         "value": "value",
       },
-      "error": {
+      "isError": true,
+      "providerExecuted": undefined,
+      "providerMetadata": undefined,
+      "result": {
         "actual": [
           {
             "content": [
@@ -11305,12 +11312,11 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
         "operator": "deepStrictEqual",
         "showDiff": true,
       },
-      "providerMetadata": undefined,
       "toolCallId": "call-1",
       "toolName": "tool1",
     },
     "runId": "test-run-id",
-    "type": "tool-error",
+    "type": "tool-result",
   },
   {
     "from": "AGENT",

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -8864,4 +8864,364 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
       });
     });
   });
+
+  describe('tool error self-recovery (agent loop)', () => {
+    it('should terminate the loop when a tool fails and the LLM responds with text', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      let responseCount = 0;
+      const resultObject = await loopFn({
+        methodType: 'stream',
+        runId,
+        agentId: 'agent-id',
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                switch (responseCount++) {
+                  case 0:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-1',
+                          toolName: 'failingTool',
+                          input: `{ "value": "test" }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        {
+                          type: 'text-delta',
+                          id: 'text-1',
+                          delta: 'The tool failed, but I can help another way.',
+                        },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage2,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected LLM call #${responseCount} — loop should have terminated`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          failingTool: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => {
+              throw new Error('Tool execution failed');
+            },
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(5),
+        options: {},
+      });
+
+      await resultObject.consumeStream();
+
+      // Loop must terminate in exactly 2 steps: tool-call + recovery text
+      const steps = await resultObject.steps;
+      expect(steps).toHaveLength(2);
+
+      // First step should have the tool call
+      expect(steps[0]!.toolCalls).toHaveLength(1);
+      expect(steps[0]!.toolCalls[0]!.payload.toolName).toBe('failingTool');
+
+      // Second step should be the recovery text with no tool calls
+      expect(steps[1]!.toolCalls).toHaveLength(0);
+      expect(steps[1]!.text).toBe('The tool failed, but I can help another way.');
+
+      // finishReason should be 'stop' (loop stopped naturally, not from step limit)
+      expect(steps[1]!.finishReason).toBe('stop');
+    });
+
+    it('should send the tool error to the LLM so it can self-correct', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      const stepInputs: Array<any> = [];
+      let responseCount = 0;
+      const resultObject = await loopFn({
+        methodType: 'stream',
+        runId,
+        agentId: 'agent-id',
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async ({ prompt }) => {
+                stepInputs.push(prompt);
+                switch (responseCount++) {
+                  case 0:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-err',
+                          toolName: 'brokenTool',
+                          input: `{ "query": "hello" }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        { type: 'text-delta', id: 'text-1', delta: 'recovered' },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage2,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected LLM call #${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          brokenTool: {
+            inputSchema: z.object({ query: z.string() }),
+            execute: async () => {
+              throw new Error('connection refused');
+            },
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(5),
+        options: {},
+      });
+
+      await resultObject.consumeStream();
+
+      // The LLM must have been called twice
+      expect(stepInputs).toHaveLength(2);
+
+      // On the 2nd call, the prompt must include a tool-result with the error text
+      const secondPrompt = stepInputs[1]!;
+      const toolMessages = secondPrompt.filter((m: any) => m.role === 'tool');
+      expect(toolMessages.length).toBeGreaterThanOrEqual(1);
+
+      const toolResultParts = toolMessages.flatMap((m: any) => m.content);
+      const errorResult = toolResultParts.find((p: any) => p.toolCallId === 'call-err');
+      expect(errorResult).toBeDefined();
+      // The error text must be present so the LLM can see what went wrong
+      // AI SDK wraps tool errors as { type: 'error-text', value: '<message>' }
+      expect(errorResult.output).toBeDefined();
+      expect(errorResult.output.type).toBe('error-text');
+      expect(errorResult.output.value).toContain('connection refused');
+    });
+
+    it('should persist output-error state in the message list', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      let responseCount = 0;
+      const resultObject = await loopFn({
+        methodType: 'stream',
+        runId,
+        agentId: 'agent-id',
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                switch (responseCount++) {
+                  case 0:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-persist',
+                          toolName: 'errorTool',
+                          input: `{ "x": 1 }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        { type: 'text-delta', id: 'text-1', delta: 'ok' },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage2,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected LLM call #${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          errorTool: {
+            inputSchema: z.object({ x: z.number() }),
+            execute: async () => {
+              throw new Error('disk full');
+            },
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(5),
+        options: {},
+      });
+
+      await resultObject.consumeStream();
+
+      // Verify the message list contains the tool invocation with output-error state
+      const allMessages = messageList.get.all.aiV5.ui();
+      const assistantMessages = allMessages.filter((m: any) => m.role === 'assistant');
+
+      // Find tool parts across assistant messages (V5 format: type is 'tool-<toolName>')
+      const toolParts = assistantMessages.flatMap((m: any) => m.parts.filter((p: any) => p.type === 'tool-errorTool'));
+      const errorPart = toolParts.find((p: any) => p.toolCallId === 'call-persist');
+      expect(errorPart).toBeDefined();
+      expect((errorPart as any).state).toBe('output-error');
+      expect((errorPart as any).errorText).toContain('disk full');
+    });
+
+    it('should recover when one tool fails and another succeeds in the same turn', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      let responseCount = 0;
+      const resultObject = await loopFn({
+        methodType: 'stream',
+        runId,
+        agentId: 'agent-id',
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                switch (responseCount++) {
+                  case 0:
+                    // LLM calls two tools: one will fail, one will succeed
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-good',
+                          toolName: 'goodTool',
+                          input: `{ "a": "1" }`,
+                        },
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-bad',
+                          toolName: 'badTool',
+                          input: `{ "b": "2" }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    // LLM responds after seeing mixed results
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        {
+                          type: 'text-delta',
+                          id: 'text-1',
+                          delta: 'Good tool worked, bad tool failed.',
+                        },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage2,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected LLM call #${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          goodTool: {
+            inputSchema: z.object({ a: z.string() }),
+            execute: async () => 'success',
+          },
+          badTool: {
+            inputSchema: z.object({ b: z.string() }),
+            execute: async () => {
+              throw new Error('bad tool broke');
+            },
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(5),
+        options: {},
+      });
+
+      await resultObject.consumeStream();
+
+      const steps = await resultObject.steps;
+      expect(steps).toHaveLength(2);
+
+      // First step should have both tool calls
+      expect(steps[0]!.toolCalls).toHaveLength(2);
+
+      // Second step: LLM responds with text, no more tool calls
+      expect(steps[1]!.toolCalls).toHaveLength(0);
+      expect(steps[1]!.finishReason).toBe('stop');
+
+      // Verify the message list has both results — one success, one error
+      // V5 tool parts: type is 'tool-<toolName>', fields are at top level (not nested in toolInvocation)
+      const allMessages = messageList.get.all.aiV5.ui();
+      const assistantParts = allMessages.filter((m: any) => m.role === 'assistant').flatMap((m: any) => m.parts);
+
+      const goodResult = assistantParts.find((p: any) => p.type === 'tool-goodTool' && p.toolCallId === 'call-good');
+      const badResult = assistantParts.find((p: any) => p.type === 'tool-badTool' && p.toolCallId === 'call-bad');
+
+      expect(goodResult).toBeDefined();
+      expect((goodResult as any).state).toBe('output-available');
+
+      expect(badResult).toBeDefined();
+      expect((badResult as any).state).toBe('output-error');
+      expect((badResult as any).errorText).toContain('bad tool broke');
+    });
+  });
 }

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -5023,7 +5023,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
       await resultObject.consumeStream();
     });
 
-    it('should include errored tool-result chunks when a tool throws', async () => {
+    it('should include tool-error chunks when a tool throws', async () => {
       const messageList2 = createMessageListWithUserMessage();
       const errorChunks: Array<ChunkType> = [];
 
@@ -5094,16 +5094,15 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
 
       await resultObject.consumeStream();
 
-      const toolErrorChunks = errorChunks.filter(c => c.type === 'tool-result' && c.payload?.isError);
+      const toolErrorChunks = errorChunks.filter(c => c.type === 'tool-error');
       expect(toolErrorChunks).toHaveLength(1);
       expect(toolErrorChunks[0]).toMatchObject({
-        type: 'tool-result',
+        type: 'tool-error',
         from: 'AGENT',
         payload: expect.objectContaining({
           toolCallId: 'call-1',
           toolName: 'failingTool',
-          result: expect.any(Error),
-          isError: true,
+          error: expect.any(Error),
         }),
       });
     });

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -5023,7 +5023,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
       await resultObject.consumeStream();
     });
 
-    it('should include tool-error chunks when a tool throws', async () => {
+    it('should include errored tool-result chunks when a tool throws', async () => {
       const messageList2 = createMessageListWithUserMessage();
       const errorChunks: Array<ChunkType> = [];
 
@@ -5094,15 +5094,16 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
 
       await resultObject.consumeStream();
 
-      const toolErrorChunks = errorChunks.filter(c => c.type === 'tool-error');
+      const toolErrorChunks = errorChunks.filter(c => c.type === 'tool-result' && c.payload?.isError);
       expect(toolErrorChunks).toHaveLength(1);
       expect(toolErrorChunks[0]).toMatchObject({
-        type: 'tool-error',
+        type: 'tool-result',
         from: 'AGENT',
         payload: expect.objectContaining({
           toolCallId: 'call-1',
           toolName: 'failingTool',
-          error: expect.any(Error),
+          result: expect.any(Error),
+          isError: true,
         }),
       });
     });
@@ -9036,6 +9037,89 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
       expect(errorResult.output).toBeDefined();
       expect(errorResult.output.type).toBe('error-text');
       expect(errorResult.output.value).toContain('connection refused');
+    });
+
+    it('should continue when a tool returns a structured isError result', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      const stepInputs: Array<any> = [];
+      let responseCount = 0;
+      const resultObject = await loopFn({
+        methodType: 'stream',
+        runId,
+        agentId: 'agent-id',
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async ({ prompt }) => {
+                stepInputs.push(prompt);
+                switch (responseCount++) {
+                  case 0:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-structured-error',
+                          toolName: 'structuredErrorTool',
+                          input: `{ "path": "/Users/test" }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        {
+                          type: 'text-delta',
+                          id: 'text-1',
+                          delta: 'The tool failed because the path is outside the workspace.',
+                        },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage2,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected LLM call #${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          structuredErrorTool: {
+            inputSchema: z.object({ path: z.string() }),
+            execute: async () => ({
+              message: 'Permission denied: path is outside the workspace',
+              isError: true,
+            }),
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(5),
+        options: {},
+      });
+
+      await resultObject.consumeStream();
+
+      expect(stepInputs).toHaveLength(2);
+      expect((await resultObject.steps)[1]!.text).toBe('The tool failed because the path is outside the workspace.');
+
+      const secondPrompt = stepInputs[1]!;
+      const toolResultParts = secondPrompt.filter((m: any) => m.role === 'tool').flatMap((m: any) => m.content);
+      const errorResult = toolResultParts.find((p: any) => p.toolCallId === 'call-structured-error');
+      expect(errorResult.output.type).toBe('error-text');
+      expect(errorResult.output.value).toContain('Permission denied');
     });
 
     it('should persist output-error state in the message list', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -238,6 +238,38 @@ describe('buildMessagesFromChunks', () => {
     });
   });
 
+  it('should merge tool-call + errored tool-result into an output-error part', () => {
+    // A provider-executed failure arrives as a tool-result with isError set; it must
+    // persist as output-error, not a successful result (#15569).
+    const result = parts([
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'tc1', toolName: 'myTool', args: { q: 'test' } },
+      },
+      {
+        type: 'tool-result',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          result: 'rate limit exceeded',
+          isError: true,
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'output-error',
+        toolCallId: 'tc1',
+        toolName: 'myTool',
+        args: { q: 'test' },
+        errorText: 'rate limit exceeded',
+      },
+    });
+  });
+
   // ── Source and file parts ───────────────────────────────────
 
   it('should produce a source part', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -239,8 +239,6 @@ describe('buildMessagesFromChunks', () => {
   });
 
   it('should merge tool-call + errored tool-result into an output-error part', () => {
-    // A provider-executed failure arrives as a tool-result with isError set; it must
-    // persist as output-error, not a successful result (#15569).
     const result = parts([
       {
         type: 'tool-call',
@@ -270,7 +268,7 @@ describe('buildMessagesFromChunks', () => {
     });
   });
 
-  it('should merge tool-call + errored nullish tool-result into an output-error part', () => {
+  it('should merge errored tool-result without output', () => {
     const result = parts([
       {
         type: 'tool-call',

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -270,6 +270,36 @@ describe('buildMessagesFromChunks', () => {
     });
   });
 
+  it('should merge tool-call + errored nullish tool-result into an output-error part', () => {
+    const result = parts([
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'tc1', toolName: 'myTool', args: { q: 'test' } },
+      },
+      {
+        type: 'tool-result',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          result: undefined,
+          isError: true,
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'output-error',
+        toolCallId: 'tc1',
+        toolName: 'myTool',
+        args: { q: 'test' },
+        errorText: 'Tool execution failed',
+      },
+    });
+  });
+
   // ── Source and file parts ───────────────────────────────────
 
   it('should produce a source part', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -251,7 +251,6 @@ export function buildMessagesFromChunks({
         const result = toolResults.get(p.toolCallId);
 
         if (result) {
-          // Merge call + result into a single part (output-error when isError is set).
           const resultProviderExecuted = inferProviderExecuted(result.providerExecuted, toolDef);
           parts.push({
             type: 'tool-invocation' as const,

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../../stream/types';
 import { withToolPayloadTransformProviderMetadata } from '../../../tools/payload-transform';
 import { findProviderToolByName, inferProviderExecuted } from '../../../tools/provider-tool-utils';
+import { safeStringify } from '../../../utils';
 
 /**
  * A raw chunk collected during the stream.
@@ -260,7 +261,7 @@ export function buildMessagesFromChunks({
                   toolCallId: p.toolCallId,
                   toolName: p.toolName,
                   args: p.args,
-                  errorText: typeof result.result === 'string' ? result.result : JSON.stringify(result.result),
+                  errorText: typeof result.result === 'string' ? result.result : safeStringify(result.result),
                 }
               : {
                   state: 'result' as const,

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -53,7 +53,14 @@ export function buildMessagesFromChunks({
   // Collect tool results so we can match them to tool calls
   const toolResults = new Map<
     string,
-    { result: any; args: any; providerMetadata: any; providerExecuted: boolean | undefined; toolName: string }
+    {
+      result: any;
+      args: any;
+      providerMetadata: any;
+      providerExecuted: boolean | undefined;
+      toolName: string;
+      isError?: boolean;
+    }
   >();
   for (const chunk of chunks) {
     if (chunk.type === 'tool-result' && chunk.payload.result != null) {
@@ -64,6 +71,7 @@ export function buildMessagesFromChunks({
         providerMetadata: withToolPayloadTransformProviderMetadata(p.providerMetadata, chunk.metadata),
         providerExecuted: p.providerExecuted,
         toolName: p.toolName,
+        isError: p.isError,
       });
     }
   }
@@ -242,17 +250,25 @@ export function buildMessagesFromChunks({
         const result = toolResults.get(p.toolCallId);
 
         if (result) {
-          // Merge call + result into a single 'result' state part
+          // Merge call + result into a single part (output-error when isError is set).
           const resultProviderExecuted = inferProviderExecuted(result.providerExecuted, toolDef);
           parts.push({
             type: 'tool-invocation' as const,
-            toolInvocation: {
-              state: 'result' as const,
-              toolCallId: p.toolCallId,
-              toolName: p.toolName,
-              args: p.args,
-              result: result.result,
-            },
+            toolInvocation: result.isError
+              ? {
+                  state: 'output-error' as const,
+                  toolCallId: p.toolCallId,
+                  toolName: p.toolName,
+                  args: p.args,
+                  errorText: typeof result.result === 'string' ? result.result : JSON.stringify(result.result),
+                }
+              : {
+                  state: 'result' as const,
+                  toolCallId: p.toolCallId,
+                  toolName: p.toolName,
+                  args: p.args,
+                  result: result.result,
+                },
             providerMetadata: result.providerMetadata ?? providerMetadata,
             providerExecuted: resultProviderExecuted,
           } as MastraMessagePart);

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -64,7 +64,7 @@ export function buildMessagesFromChunks({
     }
   >();
   for (const chunk of chunks) {
-    if (chunk.type === 'tool-result' && chunk.payload.result != null) {
+    if (chunk.type === 'tool-result' && (chunk.payload.isError || chunk.payload.result != null)) {
       const p = chunk.payload as ToolResultPayload;
       toolResults.set(p.toolCallId, {
         result: p.result,
@@ -261,7 +261,12 @@ export function buildMessagesFromChunks({
                   toolCallId: p.toolCallId,
                   toolName: p.toolName,
                   args: p.args,
-                  errorText: typeof result.result === 'string' ? result.result : safeStringify(result.result),
+                  errorText:
+                    typeof result.result === 'string'
+                      ? result.result
+                      : result.result == null
+                        ? 'Tool execution failed'
+                        : safeStringify(result.result),
                 }
               : {
                   state: 'result' as const,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -250,7 +250,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     expect(toolResult.result).toBeUndefined();
   });
 
-  it('should persist streamed provider tool errors even when result is undefined', async () => {
+  it('should persist streamed provider tool errors without output', async () => {
     const tools = {
       perplexitySearch: {
         type: 'provider' as const,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -251,6 +251,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
   });
 
   it('should persist streamed provider tool errors without output', async () => {
+    const transformToolPayload = vi.fn(({ phase }) => phase);
     const tools = {
       perplexitySearch: {
         type: 'provider' as const,
@@ -310,6 +311,9 @@ describe('createLLMExecutionStep gateway provider tools', () => {
       },
       _internal: {
         generateId: () => 'generated-id',
+        toolPayloadTransform: {
+          transformToolPayload,
+        },
       },
       logger: {
         error: vi.fn(),
@@ -332,6 +336,15 @@ describe('createLLMExecutionStep gateway provider tools', () => {
         },
       }),
     );
+    const outputErrorUpdate = updateToolInvocation.mock.calls.find(
+      ([update]) => (update as any).toolInvocation?.state === 'output-error',
+    )?.[0] as any;
+    expect(outputErrorUpdate.providerMetadata?.mastra?.toolPayloadTransform?.display?.error).toEqual({
+      transformed: 'error',
+    });
+    expect(
+      outputErrorUpdate.providerMetadata?.mastra?.toolPayloadTransform?.display?.['output-available'],
+    ).toBeUndefined();
   });
 
   it('does not continue when finishReason is length with pending tool calls', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -276,7 +276,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
           model: {
             specificationVersion: 'v2' as const,
             provider: 'mock-provider',
-            modelId: 'mock-model-id',
+            modelId: MODEL_TOKENS.__GATEWAY_OPENAI_MODEL_BASE__,
             supportedUrls: {},
             doGenerate: vi.fn(),
             doStream: vi.fn(async () => ({

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -250,6 +250,90 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     expect(toolResult.result).toBeUndefined();
   });
 
+  it('should persist streamed provider tool errors even when result is undefined', async () => {
+    const tools = {
+      perplexitySearch: {
+        type: 'provider' as const,
+        id: 'gateway.perplexity_search',
+        args: {},
+      },
+    };
+    const updateToolInvocation = vi.spyOn(messageList, 'updateToolInvocation');
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: vi.fn(async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call-1',
+                  toolName: 'perplexity_search',
+                  result: undefined,
+                  isError: true,
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: testUsage,
+                },
+              ]),
+              request: {},
+              response: {
+                headers: undefined,
+              },
+              warnings: [],
+            })),
+          } as any,
+        },
+      ],
+      tools,
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<typeof tools>);
+
+    await llmExecutionStep.execute(createExecuteParams(createIterationInput()));
+
+    expect(updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'output-error',
+          toolCallId: 'call-1',
+          toolName: 'perplexity_search',
+          args: undefined,
+          errorText: 'Tool execution failed',
+        },
+      }),
+    );
+  });
+
   it('does not continue when finishReason is length with pending tool calls', async () => {
     const tools = {
       echo: createTool({

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -684,7 +684,7 @@ async function processOutputStream<OUTPUT = undefined>({
         // so the messageList is up-to-date as early as possible.
         // For same-stream results (call + result in one step), no matching part exists yet
         // so updateToolInvocation returns false — buildMessagesFromChunks handles the merge.
-        if (chunk.payload.result != null) {
+        if (chunk.payload.isError || chunk.payload.result != null) {
           const resultToolDef = resolveDirectOrProviderTool(chunk.payload.toolName);
           messageList.updateToolInvocation({
             type: 'tool-invocation',
@@ -698,7 +698,9 @@ async function processOutputStream<OUTPUT = undefined>({
                   errorText:
                     typeof chunk.payload.result === 'string'
                       ? chunk.payload.result
-                      : safeStringify(chunk.payload.result),
+                      : chunk.payload.result == null
+                        ? 'Tool execution failed'
+                        : safeStringify(chunk.payload.result),
                 }
               : {
                   state: 'result',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -688,7 +688,6 @@ async function processOutputStream<OUTPUT = undefined>({
           const resultToolDef = resolveDirectOrProviderTool(chunk.payload.toolName);
           messageList.updateToolInvocation({
             type: 'tool-invocation',
-            // A failed provider-executed tool sets isError — persist it as output-error.
             toolInvocation: chunk.payload.isError
               ? {
                   state: 'output-error',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -688,13 +688,25 @@ async function processOutputStream<OUTPUT = undefined>({
           const resultToolDef = resolveDirectOrProviderTool(chunk.payload.toolName);
           messageList.updateToolInvocation({
             type: 'tool-invocation',
-            toolInvocation: {
-              state: 'result',
-              toolCallId: chunk.payload.toolCallId,
-              toolName: chunk.payload.toolName,
-              args: chunk.payload.args,
-              result: chunk.payload.result,
-            },
+            // A failed provider-executed tool sets isError — persist it as output-error.
+            toolInvocation: chunk.payload.isError
+              ? {
+                  state: 'output-error',
+                  toolCallId: chunk.payload.toolCallId,
+                  toolName: chunk.payload.toolName,
+                  args: chunk.payload.args,
+                  errorText:
+                    typeof chunk.payload.result === 'string'
+                      ? chunk.payload.result
+                      : JSON.stringify(chunk.payload.result),
+                }
+              : {
+                  state: 'result',
+                  toolCallId: chunk.payload.toolCallId,
+                  toolName: chunk.payload.toolName,
+                  args: chunk.payload.args,
+                  result: chunk.payload.result,
+                },
             providerMetadata: withToolPayloadTransformProviderMetadata(chunk.payload.providerMetadata, chunk.metadata),
             providerExecuted: inferProviderExecuted(chunk.payload.providerExecuted, resultToolDef),
           });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -247,6 +247,7 @@ async function addToolPayloadTransformToChunk<OUTPUT>(
       logger,
     );
   } else if (chunk.type === 'tool-result') {
+    const isErrorResult = (payload as { isError?: boolean }).isError === true;
     chunk = withToolPayloadTransformMetadata(
       chunk,
       await transformToolPayloadForTargets(
@@ -262,14 +263,23 @@ async function addToolPayloadTransformToChunk<OUTPUT>(
       ),
     );
     transform = await transformToolPayloadForTargets(
-      {
-        phase: 'output-available',
-        toolName,
-        toolCallId,
-        input: (payload as { args?: unknown }).args,
-        output: (payload as { result?: unknown }).result,
-        providerMetadata: (payload as { providerMetadata?: Record<string, unknown> }).providerMetadata,
-      },
+      isErrorResult
+        ? {
+            phase: 'error',
+            toolName,
+            toolCallId,
+            input: (payload as { args?: unknown }).args,
+            error: (payload as { result?: unknown }).result,
+            providerMetadata: (payload as { providerMetadata?: Record<string, unknown> }).providerMetadata,
+          }
+        : {
+            phase: 'output-available',
+            toolName,
+            toolCallId,
+            input: (payload as { args?: unknown }).args,
+            output: (payload as { result?: unknown }).result,
+            providerMetadata: (payload as { providerMetadata?: Record<string, unknown> }).providerMetadata,
+          },
       source,
       logger,
     );

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -44,7 +44,7 @@ import {
 import { findProviderToolByName, inferProviderExecuted } from '../../../tools/provider-tool-utils';
 import type { ToolToConvert } from '../../../tools/tool-builder/builder';
 import { getProviderToolName, isMastraTool, isProviderTool } from '../../../tools/toolchecks';
-import { makeCoreTool } from '../../../utils';
+import { makeCoreTool, safeStringify } from '../../../utils';
 import { createStep } from '../../../workflows/workflow';
 import type { Workspace } from '../../../workspace/workspace';
 import type { LoopConfig, OuterLLMRun } from '../../types';
@@ -698,7 +698,7 @@ async function processOutputStream<OUTPUT = undefined>({
                   errorText:
                     typeof chunk.payload.result === 'string'
                       ? chunk.payload.result
-                      : JSON.stringify(chunk.payload.result),
+                      : safeStringify(chunk.payload.result),
                 }
               : {
                   state: 'result',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -603,6 +603,35 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
     expect(result.stepResult.isContinued).toBe(true);
   });
 
+  it('should persist tool execution errors as output-error with errorText', async () => {
+    // A thrown tool error must be stored as output-error, not a successful result, or it
+    // is indistinguishable from a real result on history reload (#15569).
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'myTool',
+        args: { param: 'test' },
+        result: undefined,
+        error: new Error('boom'),
+      },
+    ];
+
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'output-error',
+          toolCallId: 'call-1',
+          toolName: 'myTool',
+          args: { param: 'test' },
+          errorText: 'boom',
+        },
+      }),
+    );
+  });
+
   it('should continue the loop when a tool execution error occurs alongside successful tool results', async () => {
     // Mixed scenario: one tool succeeds, one throws at runtime.
     // The model should see both the success and the error, and be allowed to retry.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -604,8 +604,6 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
   });
 
   it('should persist tool execution errors as output-error with errorText', async () => {
-    // A thrown tool error must be stored as output-error, not a successful result, or it
-    // is indistinguishable from a real result on history reload (#15569).
     const inputData: ToolCallOutput[] = [
       {
         toolCallId: 'call-1',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -14,6 +14,7 @@ type ToolCallOutput = {
   toolName: string;
   args: Record<string, any>;
   result?: any;
+  isError?: boolean;
   error?: Error;
   providerMetadata?: Record<string, any>;
   providerExecuted?: boolean;
@@ -216,7 +217,7 @@ describe('createLLMMappingStep HITL behavior', () => {
     expect(controller.enqueue).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'tool-result' }));
   });
 
-  it('should emit tool-error for tools with errors and continue the loop for self-recovery', async () => {
+  it('should emit errored tool-result chunks for tools with errors and continue the loop for self-recovery', async () => {
     // Arrange: Tools without results but with errors
     const inputData: ToolCallOutput[] = [
       {
@@ -231,13 +232,14 @@ describe('createLLMMappingStep HITL behavior', () => {
     // Act
     const result = await llmMappingStep.execute(createExecuteParams(inputData));
 
-    // Assert: Should emit tool-error chunk
+    // Assert: Should emit errored tool-result chunk
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-error',
+        type: 'tool-result',
         payload: expect.objectContaining({
           toolCallId: 'call-1',
-          error: expect.any(Error),
+          result: expect.any(Error),
+          isError: true,
         }),
       }),
     );
@@ -266,13 +268,14 @@ describe('createLLMMappingStep HITL behavior', () => {
 
     // Assert: Should NOT bail — the agentic loop should continue so the model can self-correct
     expect(bail).not.toHaveBeenCalled();
-    // Should still emit tool-error chunk so the error is visible in the stream
+    // Should still emit an errored tool-result chunk so the error is visible in the stream
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-error',
+        type: 'tool-result',
         payload: expect.objectContaining({
           toolCallId: 'call-1',
-          error: expect.any(Error),
+          result: expect.any(Error),
+          isError: true,
         }),
       }),
     );
@@ -335,13 +338,14 @@ describe('createLLMMappingStep HITL behavior', () => {
     expect(bail).not.toHaveBeenCalled();
     expect(result.stepResult.isContinued).toBe(true);
 
-    // Should emit tool-error for the hallucinated tool
+    // Should emit an errored tool-result for the hallucinated tool
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-error',
+        type: 'tool-result',
         payload: expect.objectContaining({
           toolCallId: 'call-2',
           toolName: 'creating:view',
+          isError: true,
         }),
       }),
     );
@@ -583,14 +587,15 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
 
     const result = await llmMappingStep.execute(createExecuteParams(inputData));
 
-    // The error should be emitted as a tool-error chunk
+    // The error should be emitted as an errored tool-result chunk
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-error',
+        type: 'tool-result',
         payload: expect.objectContaining({
           toolCallId: 'call-1',
           toolName: 'myTool',
-          error: expect.any(Error),
+          result: expect.any(Error),
+          isError: true,
         }),
       }),
     );
@@ -630,6 +635,48 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
     );
   });
 
+  it('should treat isError tool results as output-error and continue the loop', async () => {
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'find_files',
+        args: { path: '/outside-workspace', maxDepth: 1 },
+        result: {
+          content: 'path is outside the workspace; use a path relative to the workspace root',
+          isError: true,
+        },
+      },
+    ];
+
+    const result = await llmMappingStep.execute(createExecuteParams(inputData));
+
+    expect(controller.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-result',
+        payload: expect.objectContaining({
+          toolCallId: 'call-1',
+          toolName: 'find_files',
+          result: 'path is outside the workspace; use a path relative to the workspace root',
+          isError: true,
+        }),
+      }),
+    );
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'output-error',
+          toolCallId: 'call-1',
+          toolName: 'find_files',
+          args: { path: '/outside-workspace', maxDepth: 1 },
+          errorText: 'path is outside the workspace; use a path relative to the workspace root',
+        },
+      }),
+    );
+    expect(bail).not.toHaveBeenCalled();
+    expect(result.stepResult.isContinued).toBe(true);
+  });
+
   it('should continue the loop when a tool execution error occurs alongside successful tool results', async () => {
     // Mixed scenario: one tool succeeds, one throws at runtime.
     // The model should see both the success and the error, and be allowed to retry.
@@ -651,13 +698,14 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
 
     const result = await llmMappingStep.execute(createExecuteParams(inputData));
 
-    // Should emit tool-error for the failed tool
+    // Should emit an errored tool-result for the failed tool
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-error',
+        type: 'tool-result',
         payload: expect.objectContaining({
           toolCallId: 'call-2',
           toolName: 'processData',
+          isError: true,
         }),
       }),
     );
@@ -703,7 +751,7 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
 
     const result = await llmMappingStep.execute(createExecuteParams(inputData));
 
-    // Both errors should be emitted as tool-error chunks
+    // Both errors should be emitted as errored tool-result chunks
     expect(controller.enqueue).toHaveBeenCalledTimes(2);
 
     // Errors should be updated in messageList for the model to see

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -217,7 +217,7 @@ describe('createLLMMappingStep HITL behavior', () => {
     expect(controller.enqueue).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'tool-result' }));
   });
 
-  it('should emit errored tool-result chunks for tools with errors and continue the loop for self-recovery', async () => {
+  it('should emit tool-error chunks for tools with errors and continue the loop for self-recovery', async () => {
     // Arrange: Tools without results but with errors
     const inputData: ToolCallOutput[] = [
       {
@@ -232,14 +232,13 @@ describe('createLLMMappingStep HITL behavior', () => {
     // Act
     const result = await llmMappingStep.execute(createExecuteParams(inputData));
 
-    // Assert: Should emit errored tool-result chunk
+    // Assert: Should emit tool-error chunk
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-result',
+        type: 'tool-error',
         payload: expect.objectContaining({
           toolCallId: 'call-1',
-          result: expect.any(Error),
-          isError: true,
+          error: expect.any(Error),
         }),
       }),
     );
@@ -268,14 +267,13 @@ describe('createLLMMappingStep HITL behavior', () => {
 
     // Assert: Should NOT bail — the agentic loop should continue so the model can self-correct
     expect(bail).not.toHaveBeenCalled();
-    // Should still emit an errored tool-result chunk so the error is visible in the stream
+    // Should still emit a tool-error chunk so the error is visible in the stream
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-result',
+        type: 'tool-error',
         payload: expect.objectContaining({
           toolCallId: 'call-1',
-          result: expect.any(Error),
-          isError: true,
+          error: expect.any(Error),
         }),
       }),
     );
@@ -338,14 +336,14 @@ describe('createLLMMappingStep HITL behavior', () => {
     expect(bail).not.toHaveBeenCalled();
     expect(result.stepResult.isContinued).toBe(true);
 
-    // Should emit an errored tool-result for the hallucinated tool
+    // Should emit tool-error for the hallucinated tool
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-result',
+        type: 'tool-error',
         payload: expect.objectContaining({
           toolCallId: 'call-2',
           toolName: 'creating:view',
-          isError: true,
+          error: expect.any(Error),
         }),
       }),
     );
@@ -587,15 +585,14 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
 
     const result = await llmMappingStep.execute(createExecuteParams(inputData));
 
-    // The error should be emitted as an errored tool-result chunk
+    // The error should be emitted as a tool-error chunk
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-result',
+        type: 'tool-error',
         payload: expect.objectContaining({
           toolCallId: 'call-1',
           toolName: 'myTool',
-          result: expect.any(Error),
-          isError: true,
+          error: expect.any(Error),
         }),
       }),
     );
@@ -698,14 +695,14 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
 
     const result = await llmMappingStep.execute(createExecuteParams(inputData));
 
-    // Should emit an errored tool-result for the failed tool
+    // Should emit a tool-error for the failed tool
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'tool-result',
+        type: 'tool-error',
         payload: expect.objectContaining({
           toolCallId: 'call-2',
           toolName: 'processData',
-          isError: true,
+          error: expect.any(Error),
         }),
       }),
     );
@@ -751,8 +748,28 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
 
     const result = await llmMappingStep.execute(createExecuteParams(inputData));
 
-    // Both errors should be emitted as errored tool-result chunks
+    // Both execution errors should be emitted as tool-error chunks
     expect(controller.enqueue).toHaveBeenCalledTimes(2);
+    expect(controller.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-error',
+        payload: expect.objectContaining({
+          toolCallId: 'call-1',
+          toolName: 'toolA',
+          error: expect.any(Error),
+        }),
+      }),
+    );
+    expect(controller.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-error',
+        payload: expect.objectContaining({
+          toolCallId: 'call-2',
+          toolName: 'toolB',
+          error: expect.any(TypeError),
+        }),
+      }),
+    );
 
     // Errors should be updated in messageList for the model to see
     expect(messageList.updateToolInvocation).toHaveBeenCalled();

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -216,6 +216,38 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
         return hasMetadata ? providerMetadata : undefined;
       }
 
+      function isErrorToolResult(toolCall: { isError?: boolean; result?: unknown }): boolean {
+        if (toolCall.isError) return true;
+        return (
+          toolCall.result != null &&
+          typeof toolCall.result === 'object' &&
+          (toolCall.result as Record<string, unknown>).isError === true
+        );
+      }
+
+      function getToolError(toolCall: { error?: unknown; result?: unknown }): unknown {
+        if (toolCall.error) return toolCall.error;
+        const result = toolCall.result;
+        if (result != null && typeof result === 'object') {
+          const content = (result as Record<string, unknown>).content;
+          if (typeof content === 'string') return content;
+          if (Array.isArray(content)) {
+            const text = content
+              .filter(
+                part =>
+                  part != null &&
+                  typeof part === 'object' &&
+                  (part as Record<string, unknown>).type === 'text' &&
+                  typeof (part as Record<string, unknown>).text === 'string',
+              )
+              .map(part => (part as Record<string, string>).text)
+              .join('\n');
+            if (text) return text;
+          }
+        }
+        return result ?? 'Tool execution failed';
+      }
+
       async function transformToolChunk(
         chunk: ChunkType<OUTPUT>,
         toolCall: {
@@ -223,6 +255,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           toolCallId: string;
           args?: unknown;
           result?: unknown;
+          isError?: boolean;
           error?: unknown;
           providerMetadata?: Record<string, unknown>;
         },
@@ -268,25 +301,34 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
         return withToolPayloadTransformMetadata(withToolPayloadTransformMetadata(chunk, inputTransform), transform);
       }
 
-      if (inputData?.some(toolCall => toolCall?.result === undefined && !toolCall.providerExecuted)) {
-        const errorResults = inputData.filter(toolCall => toolCall?.error && !toolCall.providerExecuted);
+      if (
+        inputData?.some(
+          toolCall => (toolCall?.result === undefined || isErrorToolResult(toolCall)) && !toolCall.providerExecuted,
+        )
+      ) {
+        const errorResults = inputData.filter(
+          toolCall => (toolCall?.error || isErrorToolResult(toolCall)) && !toolCall.providerExecuted,
+        );
 
         if (errorResults?.length) {
           for (const toolCall of errorResults) {
+            const toolError = getToolError(toolCall);
             const chunk = await transformToolChunk(
               {
-                type: 'tool-error',
+                type: 'tool-result',
                 runId: rest.runId,
                 from: ChunkFrom.AGENT,
                 payload: {
-                  error: toolCall.error,
+                  result: toolError,
+                  isError: true,
                   args: toolCall.args,
                   toolCallId: toolCall.toolCallId,
                   toolName: toolCall.toolName,
                   providerMetadata: toolCall.providerMetadata as ProviderMetadata | undefined,
+                  providerExecuted: toolCall.providerExecuted,
                 },
               },
-              toolCall,
+              { ...toolCall, error: toolError },
               'error',
             );
             const processed = await processAndEnqueueChunk(chunk);
@@ -300,11 +342,13 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                 toolName: sanitizeToolName(toolCall.toolName),
                 args: toolCall.args,
                 errorText:
-                  toolCall.error instanceof Error
-                    ? toolCall.error.message
-                    : toolCall.error == null
+                  toolError instanceof Error
+                    ? toolError.message
+                    : toolError == null
                       ? 'Tool execution failed'
-                      : safeStringify(toolCall.error),
+                      : typeof toolError === 'string'
+                        ? toolError
+                        : safeStringify(toolError),
               },
               ...(withToolPayloadTransformProviderMetadata(
                 toolCall.providerMetadata as ProviderMetadata,
@@ -330,13 +374,15 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
         // Check for pending HITL tool calls (tools with no result and no error).
         // In mixed turns with errors and pending HITL tools,
         // the HITL suspension path should take priority over continuing the loop.
-        const hasPendingHITL = inputData.some(tc => tc.result === undefined && !tc.error && !tc.providerExecuted);
+        const hasPendingHITL = inputData.some(
+          tc => tc.result === undefined && !tc.error && !isErrorToolResult(tc) && !tc.providerExecuted,
+        );
 
         if (errorResults?.length > 0 && !hasPendingHITL) {
           // Process any successful tool results from this turn before continuing.
           // In a mixed turn (e.g., one valid tool + one hallucinated), the successful
           // results need their chunks emitted and messages added to the messageList.
-          const successfulResults = inputData.filter(tc => tc.result !== undefined);
+          const successfulResults = inputData.filter(tc => tc.result !== undefined && !isErrorToolResult(tc));
           if (successfulResults.length) {
             for (const toolCall of successfulResults) {
               // Compute modelOutput before emitting the chunk so consumers (e.g. harness)

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -12,6 +12,7 @@ import {
   withToolPayloadTransformProviderMetadata,
 } from '../../../tools/payload-transform';
 import { findProviderToolByName } from '../../../tools/provider-tool-utils';
+import { safeStringify } from '../../../utils';
 import { createStep } from '../../../workflows/workflow';
 import type { OuterLLMRun } from '../../types';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
@@ -298,7 +299,12 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                 toolCallId: toolCall.toolCallId,
                 toolName: sanitizeToolName(toolCall.toolName),
                 args: toolCall.args,
-                errorText: String(toolCall.error?.message ?? toolCall.error),
+                errorText:
+                  toolCall.error instanceof Error
+                    ? toolCall.error.message
+                    : toolCall.error == null
+                      ? 'Tool execution failed'
+                      : safeStringify(toolCall.error),
               },
               ...(withToolPayloadTransformProviderMetadata(
                 toolCall.providerMetadata as ProviderMetadata,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -313,21 +313,36 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
         if (errorResults?.length) {
           for (const toolCall of errorResults) {
             const toolError = getToolError(toolCall);
+            const hasExecutionError = toolCall.error != null;
             const chunk = await transformToolChunk(
-              {
-                type: 'tool-result',
-                runId: rest.runId,
-                from: ChunkFrom.AGENT,
-                payload: {
-                  result: toolError,
-                  isError: true,
-                  args: toolCall.args,
-                  toolCallId: toolCall.toolCallId,
-                  toolName: toolCall.toolName,
-                  providerMetadata: toolCall.providerMetadata as ProviderMetadata | undefined,
-                  providerExecuted: toolCall.providerExecuted,
-                },
-              },
+              hasExecutionError
+                ? {
+                    type: 'tool-error',
+                    runId: rest.runId,
+                    from: ChunkFrom.AGENT,
+                    payload: {
+                      error: toolError,
+                      args: toolCall.args as Record<string, unknown> | undefined,
+                      toolCallId: toolCall.toolCallId,
+                      toolName: toolCall.toolName,
+                      providerMetadata: toolCall.providerMetadata as ProviderMetadata | undefined,
+                      providerExecuted: toolCall.providerExecuted,
+                    },
+                  }
+                : {
+                    type: 'tool-result',
+                    runId: rest.runId,
+                    from: ChunkFrom.AGENT,
+                    payload: {
+                      result: toolError,
+                      isError: true,
+                      args: toolCall.args,
+                      toolCallId: toolCall.toolCallId,
+                      toolName: toolCall.toolName,
+                      providerMetadata: toolCall.providerMetadata as ProviderMetadata | undefined,
+                      providerExecuted: toolCall.providerExecuted,
+                    },
+                  },
               { ...toolCall, error: toolError },
               'error',
             );

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -294,11 +294,11 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
             rest.messageList.updateToolInvocation({
               type: 'tool-invocation' as const,
               toolInvocation: {
-                state: 'result' as const,
+                state: 'output-error' as const,
                 toolCallId: toolCall.toolCallId,
                 toolName: sanitizeToolName(toolCall.toolName),
                 args: toolCall.args,
-                result: toolCall.error?.message ?? toolCall.error,
+                errorText: String(toolCall.error?.message ?? toolCall.error),
               },
               ...(withToolPayloadTransformProviderMetadata(
                 toolCall.providerMetadata as ProviderMetadata,

--- a/packages/core/src/loop/workflows/schema.ts
+++ b/packages/core/src/loop/workflows/schema.ts
@@ -175,4 +175,5 @@ export const toolCallInputSchema = z.object({
 export const toolCallOutputSchema = toolCallInputSchema.extend({
   result: z.any().optional(),
   error: z.any().optional(),
+  isError: z.boolean().optional(),
 });

--- a/packages/core/src/processors/processors/token-limiter.test.ts
+++ b/packages/core/src/processors/processors/token-limiter.test.ts
@@ -709,6 +709,70 @@ describe('TokenLimiterProcessor', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('should count failed tool results (output-error) toward the token limit', async () => {
+      const processor = new TokenLimiterProcessor({ limit: 100 });
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [processor],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const messageList = new MessageList();
+
+      // Oldest message: a failed tool with a large errorText. If the limiter
+      // ignores output-error (the bug), this message counts as ~0 tokens and
+      // survives; once it's counted, it's large enough to be pruned.
+      messageList.add(
+        {
+          id: 'failed-tool',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  state: 'output-error',
+                  toolCallId: 'call_1',
+                  toolName: 'flakyTool',
+                  args: {},
+                  errorText: 'connection timed out while contacting the upstream service '.repeat(30),
+                },
+              },
+            ],
+          },
+          createdAt: new Date('2023-01-01T00:00:00Z'),
+        },
+        'response',
+      );
+      messageList.add(
+        {
+          id: 'user-latest',
+          role: 'user',
+          content: { format: 2, content: 'Please continue', parts: [{ type: 'text', text: 'Please continue' }] },
+          createdAt: new Date('2023-01-01T00:01:00Z'),
+        },
+        'input',
+      );
+
+      expect(messageList.get.all.db().length).toBe(2);
+
+      await runner.runProcessInputStep({
+        messageList,
+        stepNumber: 2,
+        model: createMockModel(),
+        steps: [],
+      });
+
+      const messagesAfter = messageList.get.all.db();
+      // The large failed-tool message must have been counted and pruned;
+      // the newest user message is preserved.
+      expect(messagesAfter.some(m => m.id === 'failed-tool')).toBe(false);
+      expect(messagesAfter.some(m => m.id === 'user-latest')).toBe(true);
+    });
+
     it('should prune old messages at each step to stay within token limit', async () => {
       const processor = new TokenLimiterProcessor({ limit: 50 });
 

--- a/packages/core/src/processors/processors/token-limiter.ts
+++ b/packages/core/src/processors/processors/token-limiter.ts
@@ -231,6 +231,12 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
                   overhead -= 12;
                 }
               }
+            } else if (invocation.state === 'output-error') {
+              // Failed tool result - also becomes a separate CoreMessage
+              toolResultCount++;
+              if (invocation.errorText !== undefined) {
+                tokenString += invocation.errorText;
+              }
             }
           } else {
             tokenString += JSON.stringify(part);
@@ -240,7 +246,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
     }
 
     // Add message formatting overhead
-    // Each MastraDBMessage becomes at least 1 CoreMessage, plus 1 additional CoreMessage per tool-invocation (state: 'result')
+    // Each MastraDBMessage becomes at least 1 CoreMessage, plus 1 additional CoreMessage per terminal tool output.
     // Base overhead for the message itself
     overhead += TokenLimiterProcessor.TOKENS_PER_MESSAGE;
     // Additional overhead for each tool result (which adds an extra CoreMessage)

--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -496,6 +496,85 @@ describe('ToolCallFilter', () => {
       }
     });
 
+    it('should exclude a specified tool whose result failed (output-error)', async () => {
+      const filter = new ToolCallFilter({ exclude: ['weather'] });
+
+      const baseTime = Date.now();
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: {
+            format: 2,
+            content: 'What is the weather?',
+            parts: [{ type: 'text' as const, text: 'What is the weather?' }],
+          },
+          createdAt: new Date(baseTime),
+        },
+        {
+          id: 'msg-2',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'call' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  args: { location: 'NYC' },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(baseTime + 1),
+        },
+        {
+          id: 'msg-3',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'output-error' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  args: {},
+                  errorText: 'weather service unavailable',
+                },
+              },
+            ],
+          },
+          createdAt: new Date(baseTime + 2),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      // The failed weather call and its error result must both be excluded —
+      // a failed excluded tool should not leak its error into the context.
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      for (const msg of resultMessages) {
+        if (typeof msg.content === 'string') continue;
+        const weatherInvocations = (msg.content.parts ?? []).filter(
+          (p: any) => p.type === 'tool-invocation' && p.toolInvocation.toolName === 'weather',
+        );
+        expect(weatherInvocations).toHaveLength(0);
+      }
+    });
+
     it('should exclude multiple specified tools', async () => {
       const filter = new ToolCallFilter({ exclude: ['weather', 'search'] });
 

--- a/packages/core/src/processors/processors/tool-call-filter.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.ts
@@ -339,10 +339,12 @@ export class ToolCallFilter implements Processor {
             return [part];
           }
 
+          const invocationState = invocation.state as string;
+          const hasTerminalOutput = invocationState === 'result' || invocationState === 'output-error';
           const shouldExclude =
-            (invocation.state === 'call' && this.exclude.includes(invocation.toolName)) ||
-            (invocation.state === 'result' && toolCallId !== undefined && excludedToolCallIds.has(toolCallId)) ||
-            (invocation.state === 'result' && this.exclude.includes(invocation.toolName));
+            (invocationState === 'call' && this.exclude.includes(invocation.toolName)) ||
+            (hasTerminalOutput && toolCallId !== undefined && excludedToolCallIds.has(toolCallId)) ||
+            (hasTerminalOutput && this.exclude.includes(invocation.toolName));
 
           if (!shouldExclude) {
             return [part];

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -758,6 +758,12 @@ describe('safeStringify', () => {
     const result = safeStringify(obj);
     expect(JSON.parse(result)).toEqual({ count: '42', name: 'test' });
   });
+
+  it('should return strings for top-level values JSON.stringify omits', () => {
+    expect(safeStringify(undefined)).toBe('undefined');
+    expect(safeStringify(Symbol('tool-error'))).toBe('Symbol(tool-error)');
+    expect(safeStringify(function toolError() {})).toContain('function toolError()');
+  });
 });
 
 describe('ensureSerializable', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -34,7 +34,7 @@ export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, 
  */
 export function safeStringify(value: unknown, space?: string | number): string {
   const stack: unknown[] = [];
-  return JSON.stringify(
+  const result = JSON.stringify(
     value,
     function (this: unknown, _key: string, val: unknown) {
       if (typeof val === 'bigint') return val.toString();
@@ -51,6 +51,8 @@ export function safeStringify(value: unknown, space?: string | number): string {
     },
     space,
   );
+
+  return result ?? String(value);
 }
 
 /**

--- a/packages/memory/integration-tests/src/transform-request.ts
+++ b/packages/memory/integration-tests/src/transform-request.ts
@@ -14,7 +14,7 @@ function normalizeNetworkFinalResultMessages(value: unknown): unknown {
     try {
       const parsed = JSON.parse(value);
       const normalized = normalizeNetworkFinalResultMessages(parsed);
-      return normalized === parsed ? value : JSON.stringify(normalized);
+      return JSON.stringify(normalized);
     } catch {
       return value;
     }
@@ -29,12 +29,9 @@ function normalizeNetworkFinalResultMessages(value: unknown): unknown {
   }
 
   const object = value as Record<string, unknown>;
-  let changed = false;
-  const normalizedEntries = Object.entries(object).map(([key, entry]) => {
-    const normalized = normalizeNetworkFinalResultMessages(entry);
-    if (normalized !== entry) changed = true;
-    return [key, normalized] as const;
-  });
+  const normalizedEntries = Object.entries(object)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => [key, normalizeNetworkFinalResultMessages(entry)] as const);
 
   const normalizedObject = Object.fromEntries(normalizedEntries) as Record<string, unknown>;
   const finalResult = normalizedObject.finalResult;
@@ -49,10 +46,9 @@ function normalizeNetworkFinalResultMessages(value: unknown): unknown {
       const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
       return aTime - bTime;
     });
-    changed = true;
   }
 
-  return changed ? normalizedObject : value;
+  return normalizedObject;
 }
 
 export function transformRequest({ url, body }: { url: string; body: unknown }): { url: string; body: unknown } {

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1613,6 +1613,29 @@ describe('Observer Agent Helpers', () => {
       expect(formatted).not.toContain('x'.repeat(200));
     });
 
+    it('should include failed tool (output-error) results so the observer sees the error', () => {
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'output-error',
+              toolCallId: 'tool-1',
+              toolName: 'find_files',
+              args: { path: '/Users/test' },
+              errorText: 'Permission denied: path is outside the workspace',
+            },
+          },
+        ],
+      } as any;
+
+      const formatted = formatMessagesForObserver([msg]);
+      expect(formatted).toContain('Tool Result find_files');
+      expect(formatted).toContain('Permission denied: path is outside the workspace');
+    });
+
     it('should replace image-data tool-result blocks with attachment placeholders', () => {
       const base64 = 'A'.repeat(2000);
       const msg = createTestMessage('ignored', 'assistant');

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -964,6 +964,27 @@ describe('TokenCounter', () => {
       expect(withToolResultAgain).toBe(withToolResult);
     });
 
+    it('counts output-error tool invocations for observation context', () => {
+      const counter = new TokenCounter();
+      const message = createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'output-error',
+              toolCallId: 'tool-1',
+              toolName: 'find_files',
+              args: { path: '/Users/test' },
+              errorText: 'Permission denied: path is outside the workspace',
+            },
+          },
+        ],
+      });
+
+      expect(counter.countMessage(message)).toBeGreaterThan(0);
+    });
+
     it('prefers stored mastra.modelOutput over raw tool results for token counting', async () => {
       const counter = new TokenCounter();
       const args = { q: 'weather in sf' };

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -983,6 +983,18 @@ function formatObserverMessage(
           return;
         }
 
+        if (inv.state === 'output-error') {
+          pushLine(
+            `Tool Result ${inv.toolName}`,
+            maybeTruncate(
+              formatToolResultForObserver(inv.errorText ?? 'Tool execution failed', { maxTokens: maxToolResultTokens }),
+              maxLen,
+            ),
+            partCreatedAt,
+          );
+          return;
+        }
+
         pushLine(`Tool Call ${inv.toolName}`, maybeTruncate(JSON.stringify(inv.args, null, 2), maxLen), partCreatedAt);
         return;
       }

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -1730,12 +1730,12 @@ export class TokenCounter {
         return { tokens, overheadDelta, toolResultDelta };
       }
 
-      if (invocation.state === 'result') {
+      if (invocation.state === 'result' || invocation.state === 'output-error') {
         toolResultDelta++;
-        const { value: resultForCounting, usingStoredModelOutput } = this.resolveToolResultForTokenCounting(
-          part,
-          invocation.result,
-        );
+        const { value: resultForCounting, usingStoredModelOutput } =
+          invocation.state === 'output-error'
+            ? { value: invocation.errorText ?? 'Tool execution failed', usingStoredModelOutput: false }
+            : this.resolveToolResultForTokenCounting(part, invocation.result);
 
         if (resultForCounting !== undefined) {
           const contentTokens = this.countMultimodalToolResultContent(part, resultForCounting);

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -97,6 +97,47 @@ describe('om-tools', () => {
       expect(result.messages).not.toContain('Message 5');
     });
 
+    it('should include failed tool (output-error) results in the recalled transcript', async () => {
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-err',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    state: 'output-error',
+                    toolCallId: 'call-err',
+                    toolName: 'flakyTool',
+                    args: { path: '/x' },
+                    errorText: 'permission-denied-xyz',
+                  },
+                },
+              ],
+            },
+            createdAt: new Date('2024-01-01T10:05:00Z'),
+          },
+        ] as MastraDBMessage[],
+      });
+
+      const result = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-4',
+        page: 1,
+        limit: 10,
+      });
+
+      expect(result.messages).toContain('Tool Result: flakyTool');
+      expect(result.messages).toContain('permission-denied-xyz');
+    });
+
     it('should return backward results when page is negative', async () => {
       const result = await recallMessages({
         memory: memory as any,

--- a/packages/memory/src/tools/om-tools.ts
+++ b/packages/memory/src/tools/om-tools.ts
@@ -525,6 +525,12 @@ function formatMessageParts(msg: MastraDBMessage, detail: RecallDetail): Formatt
             const resultStr = formatToolResultForObserver(resultValue, { maxTokens: HIGH_DETAIL_TOOL_RESULT_TOKENS });
             const fullText = `[Tool Result: ${inv.toolName}]\n${resultStr}`;
             parts.push(makePart(msg, i, 'tool-result', fullText, detail, inv.toolName));
+          } else if (inv.state === 'output-error') {
+            const resultStr = formatToolResultForObserver(inv.errorText ?? 'Tool execution failed', {
+              maxTokens: HIGH_DETAIL_TOOL_RESULT_TOKENS,
+            });
+            const fullText = `[Tool Result: ${inv.toolName}]\n${resultStr}`;
+            parts.push(makePart(msg, i, 'tool-result', fullText, detail, inv.toolName));
           }
         }
       } else if (partType === 'tool-call') {

--- a/packages/memory/src/tools/working-memory.test.ts
+++ b/packages/memory/src/tools/working-memory.test.ts
@@ -298,4 +298,47 @@ describe('updateWorkingMemoryTool schema validation (issue #17301)', () => {
     expect('issues' in resolved && resolved.issues).toBeFalsy();
     expect(resolved.value).toEqual({ memory: { name: 'Grace', age: 42 } });
   });
+
+  it('strips nullable optional fields from wrapped nested schema updates', async () => {
+    const tool = updateWorkingMemoryTool({
+      workingMemory: {
+        enabled: true,
+        schema: z.object({
+          people: z
+            .array(
+              z.object({
+                contactId: z.string().optional(),
+                name: z.string(),
+                tags: z.array(z.string()).optional(),
+                notes: z.string().optional(),
+              }),
+            )
+            .optional(),
+          extra: z.object({}).optional(),
+        }),
+      },
+    } as any);
+    const inputSchema = tool.inputSchema as any;
+
+    const resolved = await inputSchema['~standard'].validate({
+      memory: {
+        people: [
+          { contactId: null, name: 'Sarah Kim', tags: null, notes: null },
+          { contactId: null, name: 'Dave Martinez', tags: null, notes: null },
+        ],
+        extra: null,
+      },
+    });
+
+    expect('issues' in resolved && resolved.issues).toBeFalsy();
+    expect(resolved.value).toEqual({
+      memory: {
+        people: [
+          { contactId: null, name: 'Sarah Kim', tags: null, notes: null },
+          { contactId: null, name: 'Dave Martinez', tags: null, notes: null },
+        ],
+        extra: null,
+      },
+    });
+  });
 });

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -70,10 +70,12 @@ function stripNullsFromOptional(value: unknown, schema: Record<string, unknown>)
   if (typeof value === 'object' && value !== null) {
     const properties = (schema.properties as Record<string, Record<string, unknown>>) ?? {};
     const required = (schema.required as string[]) ?? [];
+    const optional = (schema['x-optional'] as string[]) ?? [];
     const result: Record<string, unknown> = {};
 
     for (const [key, propertyValue] of Object.entries(value as Record<string, unknown>)) {
-      if (propertyValue === null && !required.includes(key)) {
+      const isOptional = optional.includes(key) || !required.includes(key);
+      if (propertyValue === null && isOptional) {
         continue;
       }
 
@@ -129,8 +131,8 @@ export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfigInternal) => 
     // map a successful result back into the `{ memory }` shape the tool expects.
     const validateMemory = (memoryValue: unknown) => standardSchema['~standard'].validate(memoryValue);
     type ValidateResult = Awaited<ReturnType<typeof validateMemory>>;
-    const toWrappedResult = (result: ValidateResult) =>
-      'issues' in result && result.issues ? result : { value: { memory: result.value } };
+    const toWrappedResult = (result: ValidateResult, memoryValue: unknown) =>
+      'issues' in result && result.issues ? result : { value: { memory: memoryValue } };
 
     inputSchema = {
       '~standard': {
@@ -141,12 +143,13 @@ export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfigInternal) => 
           // stripping nulls from the raw value and validating it as the memory payload.
           const hasWrapper =
             !!value && typeof value === 'object' && !Array.isArray(value) && 'memory' in (value as object);
-          const memoryValue = hasWrapper
-            ? (value as { memory: unknown }).memory
-            : stripNullsFromOptional(value, jsonSchema as Record<string, unknown>);
+          const rawMemoryValue = hasWrapper ? (value as { memory: unknown }).memory : value;
+          const memoryValue = stripNullsFromOptional(rawMemoryValue, jsonSchema as Record<string, unknown>);
 
           const result = validateMemory(memoryValue);
-          return result instanceof Promise ? result.then(toWrappedResult) : toWrappedResult(result);
+          return result instanceof Promise
+            ? result.then(result => toWrappedResult(result, rawMemoryValue))
+            : toWrappedResult(result, rawMemoryValue);
         },
         jsonSchema: {
           input: () => wrappedJsonSchema,


### PR DESCRIPTION
## Description

Fixes the failed-tool agent loop regression that reproduced in MastraCode when a tool returns an error result. This PR makes failed tool results flow through the loop as real error outputs, preserves them in prompt/history state, and prevents downstream memory/stream consumers from dropping or choking on that failed-tool context.

Root cause:

The reintroduced tool-error persistence path stored failed tool calls as `output-error`, but Observational Memory token counting did not handle that state. When MastraCode hit a failed tool call, the failed result could display in the UI, but the follow-up model step either froze or lost the error context because downstream consumers were not consistently treating it as an error result.

What changed:

- Treat structured failed tool results with `isError: true` as failed outputs in the agentic loop.
- Persist failed tool results as `output-error` with the tool error text.
- Preserve legacy `toolInvocations` with `output-error` when converting history back into AI SDK v5 prompt/UI parts.
- Count `output-error` tool invocations in Observational Memory token counting instead of throwing.
- Avoid treating continued step-level `finish` chunks as terminal in harness/subscribed stream consumers.
- Preserve streamed tool errors in harness message state.
- Mark failed structured tool-result rows as `error` in channel timeline rendering instead of `complete`.

Manual MastraCode validation:

```text
Use the find_files tool with path "/Users/anuragojha" and maxDepth 1. Do not use execute_command. After the tool fails, respond with one sentence summarizing the tool error, then stop.
```

Before rebuilding with the fix, the tool error displayed but the next prompt lost context and responded as if there was no prior tool result. After applying the fix and rebuilding `@mastra/core` and `@mastra/memory`, MastraCode correctly summarized the failed `find_files` permission error, preserved the failed result for follow-up questions, and completed the run instead of freezing.

## Related issue(s)

Fixes #15569.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a tool fails while an agent is working on a task, this PR makes sure the error is properly saved and shown throughout the system instead of being lost or causing the agent to get stuck.

## Overview

This PR fixes a regression where tool execution errors could be lost or cause the agent loop to hang. The fix ensures that failed tool results are treated as error outputs (marked with `isError: true` and `errorText`) throughout the stack—from live streaming through persistent history to UI rendering.

## Key Changes

### Core Message & Invocation Handling
- **`buildMessagesFromChunks.ts`**: Now converts `tool-result` chunks with `isError: true` into `tool-invocation` parts with `state: 'output-error'` and `errorText`, using `safeStringify` for non-string error payloads.
- **`convert-to-mastra-v1.ts`**: Added `hasTerminalToolOutput` and `toToolResultPart` helpers to include error tool invocations (`output-error` state) when building tool-result message content, rather than skipping them.
- **`AIV4Adapter.ts`** and **`AIV5Adapter.ts`**: Updated to preserve `output-error` invocations in UI message conversions and map `errorText` to displayable `result` fields for backward compatibility.

### Agent Loop & Execution
- **`llm-mapping-step.ts`**: Enhanced to detect error conditions via both `toolCall.error` and an `isError` flag in `toolCall.result`. Changed to emit `tool-result` chunks with `isError: true` instead of `tool-error` chunks for consistent error handling.
- **`llm-execution-step.ts`**: Extended to update `messageList` for both successful and error tool results, persisting error state as `output-error` with `errorText`.

### Stream Processing
- **`thread-stream-runtime.ts`** and **`harness.ts`**: Added `isTerminalStreamPart` / `isTerminalFinishChunk` helpers to avoid treating continued-step `finish` chunks as terminal, allowing the agent loop to continue after handling tool errors.
- **`harness.ts`**: Enhanced `tool-error` stream handling to record errors as `tool_result` content in the assistant message (instead of only emitting events) and emit corresponding `message_update`.

### UI & Timeline Rendering
- **`chat-driver-streaming.ts`**: Changed task updates for failing tools to set status to `'error'` when `isError` is true, instead of always using `'complete'`.

### Memory & Token Counting
- **`token-counter.ts`**: Extended token counting to include `tool-invocation` parts with `state: 'output-error'`, treating error text similarly to regular tool results.

### Utilities
- **`utils.ts`**: Updated `safeStringify` to always return a string by falling back to `String(value)` when `JSON.stringify` returns `undefined`.

## Test Coverage

Added comprehensive tests across multiple files:
- **Agent loop error recovery** (`test-utils/options.ts`): Tests verify tool failure termination, error details in next-step prompts, recovery with structured error results, message list persistence of error state, and mixed success/failure handling.
- **Stream conversion** (`build-messages-from-chunks.test.ts`): Tests verify `isError: true` tool results are converted to `output-error` invocations with appropriate `errorText`.
- **Provider errors** (`llm-execution-step.test.ts`): Tests verify persisted error state for provider-executed tool failures.
- **LLM mapping** (`llm-mapping-step.test.ts`): Tests verify error tool results are persisted and continue the loop appropriately.
- **Signal messages** (`signal-messages.test.ts`): Tests verify continued finish handling and structured tool error flows through the subscribed thread stream.
- **Channel consumption** (`consume-agent-stream.test.ts`): Tests verify timeline task updates transition to `error` status for failed tools.
- **Message list conversion** (`message-list-v5.test.ts`): Tests verify legacy `output-error` invocations are preserved through V5 conversion.
- **Token counting** (`token-counter.test.ts`): Tests verify error tool invocations are counted.

## Related Issues

Fixes `#15569`. Related to regressions/reverts `#16976`, `#17403`, `#17422`.

## Changeset

Marks `@mastra/core` and `@mastra/memory` for patch version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->