### PR TITLE
fix(mcp): map authInfo to FGA user context

### DIFF
--- a/.changeset/mighty-years-drop.md
+++ b/.changeset/mighty-years-drop.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/mcp': patch
+---
+
+Fixed FGA-enabled MCP servers so OAuth authInfo can be mapped to a Mastra user before tools/list and tools/call authorization.

--- a/docs/src/content/en/docs/server/auth/fga.mdx
+++ b/docs/src/content/en/docs/server/auth/fga.mdx
@@ -4,6 +4,7 @@ description: "Add resource-level authorization to your Mastra application with F
 packages:
   - "@mastra/auth-workos"
   - "@mastra/core"
+  - "@mastra/mcp"
 ---
 
 # Fine-Grained Authorization (FGA)
@@ -222,6 +223,8 @@ When an FGA provider is configured, Mastra automatically checks authorization at
 | Thread and memory access | `memory:read`, `memory:write`, `memory:delete` | `thread` | `threadId` |
 | Stored resource routes | Stored resource permission for the route action | Stored resource type | Route record ID, or the stored-resource scope for collection routes |
 | HTTP resource routes | Configured per route | Configured per route | Configured per route |
+
+For OAuth-protected MCP servers, HTTP MCP transports pass authenticated data as `extra.authInfo`. If an `MCPServer` is registered on an FGA-enabled Mastra instance, configure `mapAuthInfoToUser` so Mastra can set `requestContext.get('user')` before checking `tools/list` and `tools/call`. See [MCPServer authentication context](/reference/tools/mcp-server#map-auth-data-for-fga).
 
 Direct SDK calls to `createRun().start()`, `resume()`, or `restart()` are not independently checked by core FGA in this release. Make those calls from a protected route or guard them in application code. Pass a `requestContext` with an authenticated user when invoking protected entry points directly.
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -114,6 +114,13 @@ The constructor accepts an `MCPServerConfig` object with the following propertie
     description: 'Optional instructions describing how to use the server and its features.',
   },
   {
+    name: 'mapAuthInfoToUser',
+    type: '({ authInfo, extra, requestContext }) => unknown | null | undefined | Promise<unknown | null | undefined>',
+    isOptional: true,
+    description:
+      'Maps MCP transport auth data from `extra.authInfo` into the `user` value used by Mastra FGA checks. Use this when an OAuth-protected MCP server is registered on a Mastra instance with an FGA provider.',
+  },
+  {
     name: 'repository',
     type: 'Repository', // { url: string; source: string; id: string; }
     isOptional: true,
@@ -1323,6 +1330,36 @@ Whatever you set on `req.auth` in your HTTP middleware becomes available as `con
 
 ```
 req.auth = { ... }  →  context?.mcp?.extra?.authInfo.extra = { ... }
+```
+
+### Map auth data for FGA
+
+When an `MCPServer` is registered on a Mastra instance with a fine-grained authorization (FGA) provider, Mastra checks `requestContext.get('user')` before listing or calling tools. HTTP MCP transports pass authenticated data as `extra.authInfo`, so use `mapAuthInfoToUser` to set the user shape expected by your FGA provider.
+
+```typescript
+const server = new MCPServer({
+  id: 'my-server',
+  name: 'My Server',
+  version: '1.0.0',
+  tools: { getUserData },
+  mapAuthInfoToUser: ({ authInfo }) => {
+    const user = authInfo as {
+      extra?: {
+        userId?: string
+        organizationMembershipId?: string
+      }
+    }
+
+    if (!user.extra?.userId) {
+      return null
+    }
+
+    return {
+      id: user.extra.userId,
+      organizationMembershipId: user.extra.organizationMembershipId,
+    }
+  },
+})
 ```
 
 ### Setting Up Authentication Middleware

--- a/packages/core/src/auth/ee/index.ts
+++ b/packages/core/src/auth/ee/index.ts
@@ -27,7 +27,18 @@ export {
 } from './license';
 
 // FGA check utility
-export { checkFGA, requireFGA, FGADeniedError, type CheckFGAOptions, type RequireFGAOptions } from './fga-check';
+export {
+  checkFGA,
+  requireFGA,
+  FGADeniedError,
+  getAgentFGAResourceId,
+  getWorkflowFGAResourceId,
+  getStandaloneToolFGAResourceId,
+  getAgentToolFGAResourceId,
+  getMCPToolFGAResourceId,
+  type CheckFGAOptions,
+  type RequireFGAOptions,
+} from './fga-check';
 
 // Default implementations
 export * from './defaults';

--- a/packages/core/src/mcp/types.ts
+++ b/packages/core/src/mcp/types.ts
@@ -1,6 +1,7 @@
 import type * as http from 'node:http';
 import type { Context } from 'hono';
 import type { ToolsInput, Agent } from '../agent';
+import type { RequestContext } from '../request-context';
 import type { Workflow } from '../workflows';
 
 interface MCPServerSSEOptionsBase {
@@ -189,6 +190,22 @@ export interface RemoteInfo {
   url: string;
 }
 
+export type MCPAuthInfoToUserMapper<TUser = unknown> = (args: {
+  /**
+   * Authentication data provided by the MCP SDK request handler `extra.authInfo`.
+   */
+  authInfo: unknown;
+  /**
+   * Full MCP SDK request handler extra object when available.
+   */
+  extra: Record<string, unknown>;
+  /**
+   * RequestContext that will be used for the MCP tool list or execution.
+   * The mapper may read or set additional request-scoped values on it.
+   */
+  requestContext: RequestContext;
+}) => TUser | null | undefined | Promise<TUser | null | undefined>;
+
 // +++ Authoritative MCPServerConfig +++
 /** Configuration options for creating an MCPServer instance. */
 export interface MCPServerConfig<TId extends string = string> {
@@ -218,6 +235,16 @@ export interface MCPServerConfig<TId extends string = string> {
   description?: string;
   /** Optional instructions describing how to use the server and its features. */
   instructions?: string;
+  /**
+   * Maps MCP transport auth information into the user object used by Mastra FGA.
+   *
+   * Self-hosted OAuth MCP transports pass authenticated identity to request
+   * handlers as `extra.authInfo`; Mastra FGA checks read the authenticated user
+   * from `requestContext.get('user')`. Provide this hook when the MCP server is
+   * registered on an FGA-enabled Mastra instance and the transport does not
+   * already put a `user` value in the request context.
+   */
+  mapAuthInfoToUser?: MCPAuthInfoToUserMapper;
   /** Optional repository information for the server's source code. */
   repository?: Repository;
   /**

--- a/packages/mcp/src/server/__tests__/server-fga.test.ts
+++ b/packages/mcp/src/server/__tests__/server-fga.test.ts
@@ -101,10 +101,19 @@ describe('MCP Server FGA checks', () => {
     expect(execute).not.toHaveBeenCalled();
     expect(mockFGAProvider.require).toHaveBeenCalledWith(
       { id: 'user-1' },
-      {
+      expect.objectContaining({
         resource: { type: 'tool', id: JSON.stringify([mcpServer.getServerInfo().id, 'test-tool']) },
         permission: MastraFGAPermissions.TOOLS_EXECUTE,
-      },
+        context: expect.objectContaining({
+          resourceId: JSON.stringify([mcpServer.getServerInfo().id, 'test-tool']),
+          requestContext,
+          metadata: expect.objectContaining({
+            mcpServerId: mcpServer.getServerInfo().id,
+            mcpServerName: 'test-server',
+            toolId: 'test-tool',
+          }),
+        }),
+      }),
     );
   });
 
@@ -226,5 +235,132 @@ describe('MCP Server FGA checks', () => {
 
     expect(result.tools).toEqual([]);
     expect(mockFGAProvider.require).not.toHaveBeenCalled();
+  });
+
+  it('should map MCP authInfo to user before FGA filtering tools/list', async () => {
+    const authInfo = {
+      subject: 'user-1',
+      organizationMembershipId: 'org-member-1',
+    };
+    const mapAuthInfoToUser = vi.fn(({ authInfo }: { authInfo: any }) => ({
+      id: authInfo.subject,
+      organizationMembershipId: authInfo.organizationMembershipId,
+    }));
+    mcpServer = new MCPServer({
+      name: 'test-server',
+      version: '1.0.0',
+      tools: {
+        'test-tool': createTool({
+          id: 'test-tool',
+          description: 'A test tool',
+          inputSchema: z.object({}),
+          execute: vi.fn(),
+        }),
+      },
+      mapAuthInfoToUser,
+    });
+    const mockFGAProvider = {
+      check: vi.fn(),
+      require: vi.fn(),
+      filterAccessible: vi.fn(),
+    };
+    mcpServer.__registerMastra(createMockMastra(mockFGAProvider) as any);
+
+    const requestHandlers = (mcpServer.getServer() as any)._requestHandlers;
+    const listToolsHandler = requestHandlers.get('tools/list');
+    const result = await listToolsHandler(
+      {
+        jsonrpc: '2.0',
+        id: 'test-list',
+        method: 'tools/list',
+      },
+      {
+        authInfo,
+        signal: new AbortController().signal,
+        sendNotification: vi.fn(),
+        sendRequest: vi.fn(),
+      },
+    );
+
+    expect(result.tools.map((tool: { name: string }) => tool.name)).toEqual(['test-tool']);
+    expect(mapAuthInfoToUser).toHaveBeenCalledWith({
+      authInfo,
+      extra: expect.objectContaining({ authInfo }),
+      requestContext: expect.objectContaining({
+        get: expect.any(Function),
+        set: expect.any(Function),
+      }),
+    });
+    expect(mockFGAProvider.require).toHaveBeenCalledWith(
+      { id: 'user-1', organizationMembershipId: 'org-member-1' },
+      expect.objectContaining({
+        resource: { type: 'tool', id: JSON.stringify([mcpServer.getServerInfo().id, 'test-tool']) },
+        permission: MastraFGAPermissions.TOOLS_EXECUTE,
+      }),
+    );
+  });
+
+  it('should map MCP authInfo to user before FGA enforcing tools/call', async () => {
+    const authInfo = {
+      subject: 'user-1',
+      organizationMembershipId: 'org-member-1',
+    };
+    const execute = vi.fn(async (_args: unknown, options: { requestContext: { get: (key: string) => any } }) => ({
+      output: options.requestContext.get('user').id,
+    }));
+    const mapAuthInfoToUser = vi.fn(({ authInfo }: { authInfo: any }) => ({
+      id: authInfo.subject,
+      organizationMembershipId: authInfo.organizationMembershipId,
+    }));
+    mcpServer = new MCPServer({
+      name: 'test-server',
+      version: '1.0.0',
+      tools: {
+        'test-tool': createTool({
+          id: 'test-tool',
+          description: 'A test tool',
+          inputSchema: z.object({ input: z.string() }),
+          execute,
+        }),
+      },
+      mapAuthInfoToUser,
+    });
+    const mockFGAProvider = {
+      check: vi.fn(),
+      require: vi.fn(),
+      filterAccessible: vi.fn(),
+    };
+    mcpServer.__registerMastra(createMockMastra(mockFGAProvider) as any);
+
+    const requestHandlers = (mcpServer.getServer() as any)._requestHandlers;
+    const callToolHandler = requestHandlers.get('tools/call');
+    const result = await callToolHandler(
+      {
+        jsonrpc: '2.0',
+        id: 'test-call',
+        method: 'tools/call',
+        params: {
+          name: 'test-tool',
+          arguments: { input: 'hello' },
+        },
+      },
+      {
+        authInfo,
+        signal: new AbortController().signal,
+        sendNotification: vi.fn(),
+        sendRequest: vi.fn(),
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.content[0].text)).toEqual({ output: 'user-1' });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(mockFGAProvider.require).toHaveBeenCalledWith(
+      { id: 'user-1', organizationMembershipId: 'org-member-1' },
+      expect.objectContaining({
+        resource: { type: 'tool', id: JSON.stringify([mcpServer.getServerInfo().id, 'test-tool']) },
+        permission: MastraFGAPermissions.TOOLS_EXECUTE,
+      }),
+    );
   });
 });

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -5,6 +5,7 @@ import type { ToolsInput, Agent } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { MCPServerBase } from '@mastra/core/mcp';
 import type {
+  MCPAuthInfoToUserMapper,
   MCPServerConfig,
   ServerInfo,
   ServerDetailInfo,
@@ -100,6 +101,7 @@ export class MCPServer extends MCPServerBase {
   private definedPrompts?: MastraPrompt[];
   private promptOptions?: MCPServerPrompts;
   private jsonSchemaValidator?: jsonSchemaValidator;
+  private mapAuthInfoToUser?: MCPAuthInfoToUserMapper;
   private subscriptions: Set<string> = new Set();
   private currentLoggingLevel: LoggingLevel | undefined;
 
@@ -209,6 +211,7 @@ export class MCPServer extends MCPServerBase {
    * @param opts.prompts - Optional prompt configuration for exposing reusable templates
    * @param opts.id - Optional unique identifier (generated if not provided)
    * @param opts.description - Optional description of what the server does
+   * @param opts.mapAuthInfoToUser - Optional mapper from MCP `extra.authInfo` to the FGA user context
    *
    * @example
    * ```typescript
@@ -302,6 +305,7 @@ export class MCPServer extends MCPServerBase {
     this.resourceOptions = this.mergeAppResources(opts.resources, opts.appResources);
     this.promptOptions = opts.prompts;
     this.jsonSchemaValidator = opts.jsonSchemaValidator;
+    this.mapAuthInfoToUser = opts.mapAuthInfoToUser;
 
     const capabilities: ServerCapabilities = {
       tools: {},
@@ -598,7 +602,7 @@ export class MCPServer extends MCPServerBase {
   private registerHandlersOnServer(serverInstance: Server) {
     // List tools handler
     serverInstance.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
-      const proxiedContext = this.createProxiedRequestContext(extra);
+      const proxiedContext = await this.createProxiedRequestContext(extra);
       const tools = await this.getAuthorizedConvertedToolEntries(proxiedContext);
       return {
         tools: tools.map(([, tool]) => {
@@ -688,12 +692,7 @@ export class MCPServer extends MCPServerBase {
           },
         };
 
-        const proxiedContext = new RequestContext();
-        if (extra) {
-          Object.entries(extra).forEach(([key, value]) => {
-            proxiedContext.set(key, value);
-          });
-        }
+        const proxiedContext = await this.createProxiedRequestContext(extra);
 
         const mcpOptions: MastraToolInvocationOptions = {
           messages: [],
@@ -2181,14 +2180,51 @@ export class MCPServer extends MCPServerBase {
     };
   }
 
-  private createProxiedRequestContext(extra?: unknown): RequestContext {
+  private async createProxiedRequestContext(extra?: unknown): Promise<RequestContext> {
     const proxiedContext = new RequestContext();
+    let extraRecord: Record<string, unknown> | undefined;
     if (extra && typeof extra === 'object') {
-      Object.entries(extra as Record<string, unknown>).forEach(([key, value]) => {
+      extraRecord = extra as Record<string, unknown>;
+      Object.entries(extraRecord).forEach(([key, value]) => {
         proxiedContext.set(key, value);
       });
     }
+    await this.resolveMappedFGAUser(proxiedContext, extraRecord);
     return proxiedContext;
+  }
+
+  private async resolveMappedFGAUser(
+    requestContext?: RequestContext,
+    extra?: Record<string, unknown>,
+  ): Promise<unknown> {
+    if (!requestContext) {
+      return undefined;
+    }
+
+    const existingUser = requestContext.get('user');
+    if (existingUser) {
+      return existingUser;
+    }
+
+    if (!this.mapAuthInfoToUser) {
+      return undefined;
+    }
+
+    const authInfo = extra && 'authInfo' in extra ? extra.authInfo : requestContext.get('authInfo');
+    if (!authInfo) {
+      return undefined;
+    }
+
+    const user = await this.mapAuthInfoToUser({
+      authInfo,
+      extra: extra ?? { authInfo },
+      requestContext,
+    });
+    if (user) {
+      requestContext.set('user', user);
+    }
+
+    return user;
   }
 
   private async getAuthorizedConvertedToolEntries(
@@ -2200,7 +2236,7 @@ export class MCPServer extends MCPServerBase {
       return entries;
     }
 
-    const user = requestContext.get('user');
+    const user = await this.resolveMappedFGAUser(requestContext);
     if (!user) {
       return [];
     }
@@ -2228,18 +2264,28 @@ export class MCPServer extends MCPServerBase {
       return;
     }
 
-    const { checkFGA, FGADeniedError, MastraFGAPermissions } = await import('@mastra/core/auth/ee');
-    const resourceId = JSON.stringify([this.id, toolId]);
-    const user = requestContext?.get('user');
+    const { getMCPToolFGAResourceId, requireFGA, FGADeniedError, MastraFGAPermissions } =
+      await import('@mastra/core/auth/ee');
+    const resourceId = getMCPToolFGAResourceId(this.id, toolId);
+    const user = await this.resolveMappedFGAUser(requestContext);
     if (!user) {
       throw new FGADeniedError({ id: 'unknown' }, { type: 'tool', id: resourceId }, MastraFGAPermissions.TOOLS_EXECUTE);
     }
 
-    await checkFGA({
+    await requireFGA({
       fgaProvider,
       user,
       resource: { type: 'tool', id: resourceId },
       permission: MastraFGAPermissions.TOOLS_EXECUTE,
+      requestContext,
+      context: {
+        resourceId,
+      },
+      metadata: {
+        mcpServerId: this.id,
+        mcpServerName: this.name,
+        toolId,
+      },
     });
   }
 


### PR DESCRIPTION
## Description

Adds `mapAuthInfoToUser` so OAuth-protected MCP servers can map transport `authInfo` into the Mastra user context before FGA filters `tools/list` or enforces `tools/call`. This also forwards request context and MCP metadata into the FGA check, updates FGA/MCP docs, adds regression coverage, and includes patch changesets for `@mastra/core` and `@mastra/mcp`.

## Related Issue(s)

Fixes #17467

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When MCP servers use OAuth to authenticate users, the system needs to know "who is this user?" before it decides whether they're allowed to use certain tools. This PR adds a new configuration option called `mapAuthInfoToUser` that lets developers tell the system how to convert that OAuth authentication data into a user identity, so the security checks work correctly and don't accidentally block everyone.

## Overview

This PR adds a `mapAuthInfoToUser` hook to MCPServer that enables OAuth-protected MCP transports to map transport authentication info (authInfo) into the Mastra user context before Fine-Grained Authorization (FGA) evaluates tool access for both `tools/list` and `tools/call` operations. This fixes authorization failures that occurred when requestContext lacked a user identity.

## Key Changes

### New Public API
- Added `MCPAuthInfoToUserMapper<TUser>` type in `packages/core/src/mcp/types.ts` that defines the function signature for mapping MCP authentication data to a user object
- Added optional `mapAuthInfoToUser` configuration property to `MCPServerConfig` interface

### Server Implementation
- Updated `MCPServer` in `packages/mcp/src/server/server.ts` to:
  - Accept and use the `mapAuthInfoToUser` configuration option
  - Resolve mapped user identity before tool listing and execution
  - Cache the mapped user on RequestContext as `user` for downstream FGA checks
  - Refactored tool authorization to use `getMCPToolFGAResourceId` for resource identifiers
  - Enhanced FGA enforcement with additional request context and metadata

### Documentation
- Updated FGA documentation (`docs/src/content/en/docs/server/auth/fga.mdx`) to reference `@mastra/mcp` and explain `mapAuthInfoToUser` usage
- Added comprehensive MCPServer reference documentation (`docs/src/content/en/reference/tools/mcp-server.mdx`) with:
  - Configuration property signature and description
  - New "Map auth data for FGA" subsection with TypeScript example showing how to map `authInfo.extra.userId` into FGA user shape

### Testing
- Expanded test coverage in `packages/mcp/src/server/__tests__/server-fga.test.ts`:
  - Verified `mapAuthInfoToUser` is invoked and mapped user is used for `tools/list` filtering
  - Verified `mapAuthInfoToUser` is invoked and mapped user is used for `tools/call` enforcement
  - Updated FGA denial assertions to include detailed permission check metadata

### Other Changes
- Reformatted FGA re-exports in `packages/core/src/auth/ee/index.ts` for consistency
- Added changeset documenting patch updates for `@mastra/core` and `@mastra/mcp`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->