### PR TITLE
feat(core): add system actor FGA signal

### DIFF
--- a/.changeset/curly-facts-jog.md
+++ b/.changeset/curly-facts-jog.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added a system actor signal to core FGA checks for trusted server-side membership bypasses.

--- a/packages/core/src/auth/ee/__tests__/ee-telemetry.test.ts
+++ b/packages/core/src/auth/ee/__tests__/ee-telemetry.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { RequestContext } from '../../../request-context';
 import type * as PosthogTelemetry from '../../../telemetry/posthog';
 
 const { captureEEEvent } = vi.hoisted(() => ({
@@ -170,6 +171,63 @@ describe('EE telemetry', () => {
     );
     expect(JSON.stringify(captureEEEvent.mock.calls)).not.toContain('license-key-that-is-long-enough-for-tests');
     expect(JSON.stringify(captureEEEvent.mock.calls)).not.toContain('user2@test.com');
+  });
+
+  it('emits FGA feature usage for system actor bypasses', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('organizationId', 'org-1');
+
+    await checkFGA({
+      fgaProvider: createMockFGAProvider(),
+      user: undefined,
+      resource: { type: 'workflow', id: 'nightly-workflow' },
+      permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+      requestContext,
+      systemActor: { actorKind: 'system', sourceWorkflow: 'nightly-workflow' },
+    });
+
+    expect(captureEEEvent).toHaveBeenCalledWith(
+      'ee_feature_used',
+      expect.any(String),
+      expect.objectContaining({
+        feature: 'fga',
+        actor_kind: 'system',
+        resource_type: 'workflow',
+        resource_id: 'nightly-workflow',
+        permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+        user_id: null,
+        organization_membership_id: null,
+        source_workflow: 'nightly-workflow',
+      }),
+    );
+  });
+
+  it('uses metadata sourceWorkflow when a system actor omits one', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('organizationId', 'org-1');
+
+    await checkFGA({
+      fgaProvider: createMockFGAProvider(),
+      user: undefined,
+      resource: { type: 'workflow', id: 'nightly-workflow' },
+      permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+      requestContext,
+      systemActor: { actorKind: 'system' },
+      context: {
+        metadata: {
+          sourceWorkflow: 'metadata-workflow',
+        },
+      },
+    });
+
+    expect(captureEEEvent).toHaveBeenCalledWith(
+      'ee_feature_used',
+      expect.any(String),
+      expect.objectContaining({
+        actor_kind: 'system',
+        source_workflow: 'metadata-workflow',
+      }),
+    );
   });
 
   it('does not let telemetry failures break FGA checks', async () => {

--- a/packages/core/src/auth/ee/__tests__/fga-check.test.ts
+++ b/packages/core/src/auth/ee/__tests__/fga-check.test.ts
@@ -2,6 +2,7 @@
  * @license Mastra Enterprise License - see ee/LICENSE
  */
 import { describe, it, expect, vi } from 'vitest';
+import { RequestContext } from '../../../request-context';
 
 import { checkFGA, FGADeniedError, requireFGA } from '../fga-check';
 import type { IFGAProvider } from '../interfaces/fga';
@@ -117,6 +118,65 @@ describe('checkFGA', () => {
           requestContext,
         },
       },
+    );
+  });
+
+  it('should bypass provider membership resolution for a tenant-scoped system actor', async () => {
+    const provider = createMockFGAProvider(true);
+    const requestContext = new RequestContext();
+    requestContext.set('organizationId', 'org-1');
+
+    await requireFGA({
+      fgaProvider: provider,
+      user: undefined,
+      resource: { type: 'workflow', id: 'nightly-workflow' },
+      permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+      requestContext,
+      systemActor: { actorKind: 'system', sourceWorkflow: 'nightly-workflow' },
+    });
+
+    expect(provider.require).not.toHaveBeenCalled();
+  });
+
+  it('should fail loudly when a system actor has no tenant scope', async () => {
+    const provider = createMockFGAProvider(true);
+
+    await expect(
+      requireFGA({
+        fgaProvider: provider,
+        user: undefined,
+        resource: { type: 'workflow', id: 'nightly-workflow' },
+        permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+        requestContext: new RequestContext(),
+        systemActor: true,
+      }),
+    ).rejects.toThrow('system actor requires organizationId / tenant scope');
+
+    expect(provider.require).not.toHaveBeenCalled();
+  });
+
+  it('should not treat user or request-context data as the trusted system actor signal', async () => {
+    const provider = createMockFGAProvider(true);
+    const requestContext = new RequestContext();
+    requestContext.set('organizationId', 'org-1');
+    requestContext.set('systemActor', true);
+
+    await expect(
+      requireFGA({
+        fgaProvider: provider,
+        user: { id: 'user-controlled', systemActor: true },
+        resource: { type: 'workflow', id: 'nightly-workflow' },
+        permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+        requestContext,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(provider.require).toHaveBeenCalledWith(
+      { id: 'user-controlled', systemActor: true },
+      expect.objectContaining({
+        resource: { type: 'workflow', id: 'nightly-workflow' },
+        permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+      }),
     );
   });
 });

--- a/packages/core/src/auth/ee/fga-check.ts
+++ b/packages/core/src/auth/ee/fga-check.ts
@@ -9,16 +9,24 @@ import type { FGACheckContext, IFGAProvider } from './interfaces/fga';
 import type { MastraFGAPermissionInput } from './interfaces/permissions.generated';
 import { getSafeLicenseSummary } from './license';
 
+export type SystemActorSignal =
+  | boolean
+  | {
+      actorKind: 'system';
+      sourceWorkflow?: string;
+    };
+
 export interface CheckFGAOptions {
   fgaProvider: IFGAProvider | undefined;
   user: any;
   resource: { type: string; id: string };
   permission: MastraFGAPermissionInput | MastraFGAPermissionInput[];
   context?: FGACheckContext;
+  requestContext?: FGACheckContext['requestContext'];
+  systemActor?: SystemActorSignal;
 }
 
 export interface RequireFGAOptions extends CheckFGAOptions {
-  requestContext?: FGACheckContext['requestContext'];
   metadata?: Record<string, unknown>;
 }
 
@@ -82,13 +90,46 @@ export async function checkFGA(options: CheckFGAOptions): Promise<void> {
  * user fails closed.
  */
 export async function requireFGA(options: RequireFGAOptions): Promise<void> {
-  const { fgaProvider, user, resource, permission, context, requestContext, metadata } = options;
+  const { fgaProvider, user, resource, permission, context, requestContext, metadata, systemActor } = options;
 
   if (!fgaProvider) {
     return;
   }
 
   const fgaContext = mergeFGAContext({ context, requestContext, metadata });
+  const license = getSafeLicenseSummary();
+
+  if (systemActor) {
+    const tenantOrganizationId = fgaContext?.requestContext?.get('organizationId');
+    if (typeof tenantOrganizationId !== 'string' || tenantOrganizationId.length === 0) {
+      throw new FGADeniedError(user, resource, permission, 'system actor requires organizationId / tenant scope');
+    }
+
+    const sourceWorkflow =
+      (typeof systemActor === 'object' ? systemActor.sourceWorkflow : undefined) ??
+      (typeof fgaContext?.metadata?.['sourceWorkflow'] === 'string'
+        ? fgaContext.metadata['sourceWorkflow']
+        : undefined);
+
+    try {
+      captureEEEvent('ee_feature_used', license.anonymousId || getEETelemetryFallbackDistinctId(), {
+        feature: 'fga',
+        actor_kind: 'system',
+        resource_type: resource.type,
+        resource_id: resource.id,
+        permission,
+        user_id: null,
+        organization_membership_id: null,
+        source_workflow: sourceWorkflow,
+        license_valid: license.valid,
+        license_hash: license.licenseHash,
+        is_dev_environment: license.isDevEnvironment,
+      });
+    } catch {
+      // Telemetry must never affect auth or EE feature behavior.
+    }
+    return;
+  }
 
   if (!user) {
     throw new FGADeniedError(user, resource, permission, 'authenticated user is required');
@@ -99,15 +140,15 @@ export async function requireFGA(options: RequireFGAOptions): Promise<void> {
     fgaContext ? { resource, permission, context: fgaContext } : { resource, permission },
   );
 
-  const license = getSafeLicenseSummary();
   try {
     captureEEEvent('ee_feature_used', user?.id || license.anonymousId || getEETelemetryFallbackDistinctId(), {
       feature: 'fga',
+      actor_kind: 'user',
       resource_type: resource.type,
       resource_id: resource.id,
       permission,
-      user_id: user?.id,
-      organization_membership_id: user?.organizationMembershipId,
+      user_id: user?.id ?? null,
+      organization_membership_id: user?.organizationMembershipId ?? null,
       license_valid: license.valid,
       license_hash: license.licenseHash,
       is_dev_environment: license.isDevEnvironment,

--- a/packages/core/src/auth/ee/index.ts
+++ b/packages/core/src/auth/ee/index.ts
@@ -38,6 +38,7 @@ export {
   getMCPToolFGAResourceId,
   type CheckFGAOptions,
   type RequireFGAOptions,
+  type SystemActorSignal,
 } from './fga-check';
 
 // Default implementations


### PR DESCRIPTION
Part of #17216.

This adds the core FGA primitive for trusted server-side system actors. `requireFGA` and `checkFGA` now accept an explicit `systemActor` option, require an `organizationId` in the request context before bypassing provider membership resolution, and emit FGA telemetry with `actor_kind: "system"` plus null user and membership IDs.

This PR intentionally does not plumb the option through agent, workflow, tool, or WorkOS docs surfaces. Those are intended for follow-up stacked PRs.

Validation:
- `pnpm --filter ./packages/core exec vitest run src/auth/ee/__tests__/fga-check.test.ts src/auth/ee/__tests__/ee-telemetry.test.ts`
- `git diff --check`
- `pnpm build:core`
- `coderabbit review --plain --type uncommitted --base origin/main --dir packages/core/src/auth/ee`