### PR TITLE
fix(core): preserve storage-derived contextWindow in resolveStateSignalHistory

### DIFF
--- a/.changeset/state-signal-context-window-storage-fallback.md
+++ b/.changeset/state-signal-context-window-storage-fallback.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `resolveStateSignalHistory` clobbering the storage-derived `contextWindow.hasSnapshot` with the stale in-prompt value. When the in-prompt window contained no `role:'signal'` rows (observational memory, aggressive context trimming, or any window strategy that drops raw signal rows), the storage fallback correctly found the prior snapshot via `tracking.lastSnapshotSignalId` but the final return statement overrode `contextWindow` with the stale local value, leaving `hasSnapshot=false`. Downstream consumers (e.g. `WorkingMemoryStateProcessor`) saw `shouldRefreshSnapshot=true` and re-emitted full snapshots on every turn instead of unified-diff deltas.

--- a/packages/core/src/agent/state-signals.test.ts
+++ b/packages/core/src/agent/state-signals.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MastraMemory } from '../memory/memory';
+import { MessageList } from './message-list';
+import { createSignal } from './signals';
+import { resolveStateSignalHistory } from './state-signals';
+import type { StateSignalTracking } from './state-signals';
+
+function buildStateSignalDBMessage({
+  id,
+  threadId,
+  resourceId,
+  stateId,
+  cacheKey,
+  mode,
+  createdAt,
+}: {
+  id: string;
+  threadId: string;
+  resourceId: string;
+  stateId: string;
+  cacheKey: string;
+  mode: 'snapshot' | 'delta';
+  createdAt: Date;
+}) {
+  const signal = createSignal({
+    id,
+    type: 'state',
+    tagName: 'state',
+    contents: '# working memory\n- name: Caleb',
+    createdAt,
+    metadata: {
+      state: { id: stateId, threadId, cacheKey, mode },
+    },
+  });
+  return signal.toDBMessage({ threadId, resourceId });
+}
+
+describe('resolveStateSignalHistory', () => {
+  const threadId = 'thread-1';
+  const resourceId = 'resource-1';
+  const stateId = 'working-memory';
+  const cacheKey = 'abc123';
+
+  it('reports hasSnapshot=true when prior snapshot is in storage but outside the in-prompt context window', async () => {
+    // Empty in-prompt window — simulates observational memory or aggressive context trimming
+    // where prior signal rows are not in the current MessageList.
+    const messageList = new MessageList({ threadId, resourceId });
+
+    const storedSnapshot = buildStateSignalDBMessage({
+      id: 'signal-snapshot-1',
+      threadId,
+      resourceId,
+      stateId,
+      cacheKey,
+      mode: 'snapshot',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    });
+
+    const memory = {
+      storage: {
+        getStore: async () => ({
+          listMessages: async () => ({ messages: [storedSnapshot] }),
+        }),
+      },
+    } as unknown as MastraMemory;
+
+    const tracking: StateSignalTracking = {
+      currentCacheKey: cacheKey,
+      currentMode: 'snapshot',
+      version: 1,
+      lastSignalId: 'signal-snapshot-1',
+      lastSnapshotSignalId: 'signal-snapshot-1',
+    };
+
+    const history = await resolveStateSignalHistory({
+      messageList,
+      memory,
+      threadId,
+      resourceId,
+      stateId,
+      tracking,
+    });
+
+    // The processor downstream uses contextWindow.hasSnapshot to decide whether
+    // to emit a delta. When storage finds the prior snapshot, hasSnapshot must
+    // be true so the delta path is reachable — even if the in-prompt window
+    // does not contain the raw signal row.
+    expect(history.lastSnapshot?.id).toBe('signal-snapshot-1');
+    expect(history.contextWindow.hasSnapshot).toBe(true);
+  });
+});

--- a/packages/core/src/agent/state-signals.ts
+++ b/packages/core/src/agent/state-signals.ts
@@ -163,14 +163,13 @@ export async function resolveStateSignalHistory({
 }): Promise<StateSignalHistory> {
   const localStateSignals = getActiveStateSignals(messageList, stateId, threadId);
   const localHistory = deriveStateSignalHistory(localStateSignals);
-  const contextWindow = localHistory.contextWindow;
 
   if (localHistory.contextWindow.hasSnapshot || !tracking?.lastSnapshotSignalId) {
-    return { ...localHistory, contextWindow };
+    return localHistory;
   }
 
   const memoryStore = await memory.storage.getStore('memory');
-  if (!memoryStore) return { ...localHistory, contextWindow };
+  if (!memoryStore) return localHistory;
 
   const storedMessages = await memoryStore.listMessages({
     threadId,
@@ -181,10 +180,7 @@ export async function resolveStateSignalHistory({
   const storedStateSignals = dbMessagesToStateSignals(storedMessages.messages, stateId, threadId);
   const resolvedStateSignals = mergeStateSignals(storedStateSignals, localStateSignals);
 
-  return {
-    ...deriveStateSignalHistory(resolvedStateSignals.length > 0 ? resolvedStateSignals : localStateSignals),
-    contextWindow,
-  };
+  return deriveStateSignalHistory(resolvedStateSignals.length > 0 ? resolvedStateSignals : localStateSignals);
 }
 
 export function createStateSignalInput(


### PR DESCRIPTION
## What

Surgical fix for `resolveStateSignalHistory` in `@mastra/core/agent/state-signals.ts` and a regression test.

## Why

When the in-prompt `MessageList` contains no `role:'signal'` rows (observational memory, aggressive context trimming, or any context-window strategy that drops raw signal rows), `resolveStateSignalHistory` falls back to `listMessages()` and merges stored signals to recover the prior snapshot. The merged `deriveStateSignalHistory()` call correctly reports `contextWindow.hasSnapshot=true`. But the final return statement immediately overrode `contextWindow` with the stale local value captured before the storage fallback ran, leaving `hasSnapshot=false`.

Downstream consumers (e.g. `WorkingMemoryStateProcessor`) treat `!contextWindow.hasSnapshot` as "refresh the snapshot", so they re-emitted full snapshots on every turn instead of unified-diff deltas.

Visible to users as: OM-backed agents never emit deltas, always re-snapshot — even when the working memory barely changed.

## The change

```diff
   const localStateSignals = getActiveStateSignals(messageList, stateId, threadId);
   const localHistory = deriveStateSignalHistory(localStateSignals);
-  const contextWindow = localHistory.contextWindow;

   if (localHistory.contextWindow.hasSnapshot || !tracking?.lastSnapshotSignalId) {
-    return { ...localHistory, contextWindow };
+    return localHistory;
   }

   const memoryStore = await memory.storage.getStore('memory');
-  if (!memoryStore) return { ...localHistory, contextWindow };
+  if (!memoryStore) return localHistory;

   const storedMessages = await memoryStore.listMessages({ ... });
   const storedStateSignals = dbMessagesToStateSignals(storedMessages.messages, stateId, threadId);
   const resolvedStateSignals = mergeStateSignals(storedStateSignals, localStateSignals);

-  return {
-    ...deriveStateSignalHistory(resolvedStateSignals.length > 0 ? resolvedStateSignals : localStateSignals),
-    contextWindow,
-  };
+  return deriveStateSignalHistory(resolvedStateSignals.length > 0 ? resolvedStateSignals : localStateSignals);
```

The inner `deriveStateSignalHistory(resolved)` already returns the correct `contextWindow.hasSnapshot=true` when the merged storage+local signals contain a prior snapshot — we were just throwing it away with the explicit override.

## Test plan

Added `packages/core/src/agent/state-signals.test.ts`: empty `MessageList` + mocked memory store returning a prior snapshot row + tracking with `lastSnapshotSignalId`. Asserts `history.contextWindow.hasSnapshot === true` and `lastSnapshot.id` is the stored signal id.

- New test: failed before fix, passes after ✅
- `packages/core` focused (processors + harness + agent + state-signals + loop): 1444 / 1444 ✅
- `packages/memory` `WorkingMemoryStateProcessor` unit: 15 / 15 ✅
- `packages/memory/integration-tests` working-memory-state-signal: 13 / 13 ✅
- Manual browser smoke on `working-memory-signals-tyler-om` (observational memory + `useStateSignals: true`): deltas now emit on subsequent turns instead of full snapshots.

## Base

Stacked on top of #17497 (`feat/working-memory-state-signal-opt-in`) so it can land together with that PR.
