### PR TITLE
fix(playground): preserve completed OM badge state

### DIFF
--- a/.changeset/thin-coins-study.md
+++ b/.changeset/thin-coins-study.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed Observational Memory badges so completed cycles stay complete after cancellation and reloaded progress restores when messages arrive.

--- a/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
+++ b/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import { useChat } from '@mastra/react';
 import { act, render, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
@@ -9,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   runtimeProps: undefined as any,
   threadRuntimeState: undefined as any,
   sendMessage: vi.fn(),
+  markCycleIdActivated: vi.fn(),
+  setStreamProgress: vi.fn(),
   chatState: {
     isAwaitingToolApproval: false,
     isRunning: false,
@@ -76,10 +79,10 @@ vi.mock('@tanstack/react-query', () => ({
 
 vi.mock('@/domains/agents/context', () => ({
   useObservationalMemoryContext: vi.fn(() => ({
-    markCycleIdActivated: vi.fn(),
+    markCycleIdActivated: mocks.markCycleIdActivated,
     setIsObservingFromStream: vi.fn(),
     setIsReflectingFromStream: vi.fn(),
-    setStreamProgress: vi.fn(),
+    setStreamProgress: mocks.setStreamProgress,
     signalObservationsUpdated: vi.fn(),
   })),
 }));
@@ -135,6 +138,8 @@ describe('MastraRuntimeProvider', () => {
     mocks.chatState.isAwaitingToolApproval = false;
     mocks.chatState.isRunning = false;
     mocks.sendMessage.mockReset();
+    mocks.markCycleIdActivated.mockReset();
+    mocks.setStreamProgress.mockReset();
     delete (window as any).MASTRA_AGENT_SIGNALS;
   });
 
@@ -204,6 +209,66 @@ describe('MastraRuntimeProvider', () => {
         },
       ],
       metadata: { status: 'error' },
+    });
+  });
+
+  it('restores OM progress when initial messages arrive after mount', async () => {
+    const progress = {
+      windows: {
+        active: {
+          messages: { tokens: 100, threshold: 1000 },
+          observations: { tokens: 50, threshold: 500 },
+        },
+        buffered: {
+          observations: {
+            chunks: 1,
+            messageTokens: 100,
+            projectedMessageRemoval: 80,
+            observationTokens: 20,
+            status: 'complete',
+          },
+          reflection: {
+            inputObservationTokens: 0,
+            observationTokens: 0,
+            status: 'idle',
+          },
+        },
+      },
+      recordId: 'record-1',
+      threadId: 'thread-1',
+      stepNumber: 1,
+      generationCount: 1,
+    };
+    const initialMessages: MastraDBMessage[] = [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        createdAt: new Date('2026-05-29T00:00:00.000Z'),
+        content: {
+          format: 2,
+          parts: [
+            { type: 'data-om-activation', data: { cycleId: 'cycle-1' } },
+            { type: 'data-om-status', data: progress },
+          ],
+        },
+      },
+    ];
+
+    const { rerender } = render(
+      <MastraRuntimeProvider agentId="agent-1" threadId="thread-1" initialMessages={[]} modelVersion="v2">
+        <div />
+      </MastraRuntimeProvider>,
+    );
+
+    rerender(
+      <MastraRuntimeProvider agentId="agent-1" threadId="thread-1" initialMessages={initialMessages} modelVersion="v2">
+        <div />
+      </MastraRuntimeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.markCycleIdActivated).toHaveBeenCalledWith('cycle-1');
+      expect(mocks.setStreamProgress).toHaveBeenCalledWith(progress);
     });
   });
 });

--- a/packages/playground/src/services/__tests__/om-parts-converter.test.ts
+++ b/packages/playground/src/services/__tests__/om-parts-converter.test.ts
@@ -43,6 +43,28 @@ describe('markOmMarkersAsDisconnected', () => {
     const [message] = markOmMarkersAsDisconnected([userMessage]);
     expect(partsOf(message)[0].data?._state).toBeUndefined();
   });
+
+  it('does not mark completed observation cycles as disconnected', () => {
+    const [message] = markOmMarkersAsDisconnected([
+      assistantMessage([
+        omPart('om-observation-start', { cycleId: 'cycle-done' }),
+        omPart('om-observation-end', { cycleId: 'cycle-done', completedAt: '2026-05-29T00:00:01.000Z' }),
+      ]),
+    ]);
+
+    expect(partsOf(message)[0].data?.disconnectedAt).toBeUndefined();
+    expect(partsOf(message)[0].data?._state).toBeUndefined();
+  });
+
+  it('does not mark buffering cycles with a later activation as disconnected', () => {
+    const [startMessage] = markOmMarkersAsDisconnected([
+      assistantMessage([omPart('om-buffering-start', { cycleId: 'cycle-activated' })], 'msg-start'),
+      assistantMessage([omPart('om-activation', { cycleId: 'cycle-activated' })], 'msg-activation'),
+    ]);
+
+    expect(partsOf(startMessage)[0].data?.disconnectedAt).toBeUndefined();
+    expect(partsOf(startMessage)[0].data?._state).toBeUndefined();
+  });
 });
 
 describe('injectBufferingEnds', () => {
@@ -65,6 +87,28 @@ describe('injectBufferingEnds', () => {
       assistantMessage([omPart('om-buffering-start', { cycleId: 'cycle-3', disconnectedAt: 'yes' })]),
     ]);
     expect(partsOf(message)).toHaveLength(1);
+  });
+
+  it('does not duplicate synthetic buffering-end parts when called repeatedly', () => {
+    const messages = [
+      assistantMessage([omPart('om-buffering-start', { cycleId: 'cycle-repeat', operationType: 'observation' })]),
+    ];
+
+    const once = injectBufferingEnds(messages);
+    const twice = injectBufferingEnds(once);
+
+    expect(partsOf(twice[0]).filter(part => part.type === 'data-om-buffering-end')).toHaveLength(1);
+  });
+
+  it('does not inject an end when the cycle already has a terminal marker later', () => {
+    const [message] = injectBufferingEnds([
+      assistantMessage([
+        omPart('om-buffering-start', { cycleId: 'cycle-complete', operationType: 'observation' }),
+        omPart('om-buffering-end', { cycleId: 'cycle-complete', completedAt: '2026-05-29T00:00:01.000Z' }),
+      ]),
+    ]);
+
+    expect(partsOf(message).filter(part => part.type === 'data-om-buffering-end')).toHaveLength(1);
   });
 });
 

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -207,19 +207,22 @@ export function MastraRuntimeProvider({
   };
 
   // Helper to update progress from streamed data-om-status parts
-  const handleProgressUpdate = (data: any) => {
-    // Ignore progress from a different thread (e.g., if user switched threads mid-stream)
-    if (data.threadId && data.threadId !== threadId) {
-      return;
-    }
-    setStreamProgress({
-      windows: data.windows,
-      recordId: data.recordId,
-      threadId: data.threadId,
-      stepNumber: data.stepNumber,
-      generationCount: data.generationCount,
-    });
-  };
+  const handleProgressUpdate = useCallback(
+    (data: any) => {
+      // Ignore progress from a different thread (e.g., if user switched threads mid-stream)
+      if (data.threadId && data.threadId !== threadId) {
+        return;
+      }
+      setStreamProgress({
+        windows: data.windows,
+        recordId: data.recordId,
+        threadId: data.threadId,
+        stepNumber: data.stepNumber,
+        generationCount: data.generationCount,
+      });
+    },
+    [setStreamProgress, threadId],
+  );
 
   // Helper to refresh OM sidebar when observation/reflection completes
   const refreshObservationalMemory = (operationType?: string) => {
@@ -272,8 +275,7 @@ export function MastraRuntimeProvider({
     if (lastProgress) {
       handleProgressUpdate(lastProgress);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run once on mount
+  }, [handleProgressUpdate, initialMessages, markCycleIdActivated]);
 
   const {
     frequencyPenalty,

--- a/packages/playground/src/services/om-parts-converter.ts
+++ b/packages/playground/src/services/om-parts-converter.ts
@@ -228,17 +228,62 @@ const mapAssistantParts = (
     };
   });
 
+const collectTerminalCycleIds = (messages: MastraDBMessage[]) => {
+  const observation = new Set<string>();
+  const buffering = new Set<string>();
+
+  for (const msg of messages) {
+    const parts = msg.content?.parts;
+    if (!Array.isArray(parts)) continue;
+
+    for (const part of parts as any[]) {
+      const cycleId = part?.data?.cycleId;
+      if (!cycleId) continue;
+
+      if (part.type === 'data-om-observation-end' || part.type === 'data-om-observation-failed') {
+        observation.add(cycleId);
+      }
+
+      if (
+        part.type === 'data-om-buffering-end' ||
+        part.type === 'data-om-buffering-failed' ||
+        part.type === 'data-om-activation'
+      ) {
+        buffering.add(cycleId);
+      }
+    }
+  }
+
+  return { observation, buffering };
+};
+
 /**
  * Mark in-progress OM markers as disconnected when a stream is interrupted
  * (user cancel, network error, process exit). Preserves the original part type so
  * the badge stays anchored, only adding disconnection metadata to the data payload.
  */
-export const markOmMarkersAsDisconnected = (messages: MastraDBMessage[]): MastraDBMessage[] =>
-  mapAssistantParts(messages, parts => {
+export const markOmMarkersAsDisconnected = (messages: MastraDBMessage[]): MastraDBMessage[] => {
+  const terminalCycleIds = collectTerminalCycleIds(messages);
+
+  return mapAssistantParts(messages, parts => {
     let changed = false;
     const nextParts = parts.map((part: any) => {
       // Raw start markers (keep original type for badge anchoring).
-      if (part.type === 'data-om-observation-start' || part.type === 'data-om-buffering-start') {
+      if (part.type === 'data-om-observation-start') {
+        const cycleId = part.data?.cycleId;
+        if (!cycleId || part.data?.disconnectedAt || terminalCycleIds.observation.has(cycleId)) return part;
+
+        changed = true;
+        return {
+          ...part,
+          data: { ...part.data, disconnectedAt: new Date().toISOString(), _state: 'disconnected' },
+        };
+      }
+
+      if (part.type === 'data-om-buffering-start') {
+        const cycleId = part.data?.cycleId;
+        if (!cycleId || part.data?.disconnectedAt || terminalCycleIds.buffering.has(cycleId)) return part;
+
         changed = true;
         return {
           ...part,
@@ -263,6 +308,7 @@ export const markOmMarkersAsDisconnected = (messages: MastraDBMessage[]): Mastra
     });
     return { parts: nextParts, changed };
   });
+};
 
 /**
  * Inject synthetic `data-om-buffering-end` parts after buffer-status resolves so
@@ -271,6 +317,8 @@ export const markOmMarkersAsDisconnected = (messages: MastraDBMessage[]): Mastra
  */
 export const injectBufferingEnds = (messages: MastraDBMessage[], record?: any): MastraDBMessage[] => {
   const chunksByCycleId = new Map<string, any>();
+  const terminalCycleIds = collectTerminalCycleIds(messages).buffering;
+
   if (record?.bufferedObservationChunks) {
     for (const chunk of record.bufferedObservationChunks) {
       if (chunk.cycleId) chunksByCycleId.set(chunk.cycleId, chunk);
@@ -283,7 +331,12 @@ export const injectBufferingEnds = (messages: MastraDBMessage[], record?: any): 
 
     for (const part of parts) {
       newParts.push(part);
-      if (part.type === 'data-om-buffering-start' && part.data?.cycleId && !part.data?.disconnectedAt) {
+      if (
+        part.type === 'data-om-buffering-start' &&
+        part.data?.cycleId &&
+        !part.data?.disconnectedAt &&
+        !terminalCycleIds.has(part.data.cycleId)
+      ) {
         const cycleId = part.data.cycleId;
         const opType = part.data.operationType;
 
@@ -307,6 +360,7 @@ export const injectBufferingEnds = (messages: MastraDBMessage[], record?: any): 
         }
 
         newParts.push({ type: 'data-om-buffering-end', data: endData });
+        terminalCycleIds.add(cycleId);
         changed = true;
       }
     }


### PR DESCRIPTION
## Summary

- Keep completed/failed/activated Observational Memory cycles from being marked disconnected when a later stream is canceled or errors.
- Make synthetic buffering-end injection idempotent so repeated buffer-status handling does not add duplicate OM completion markers.
- Restore OM sidebar progress when persisted initial messages arrive after the runtime provider mounts.

## Verification

- pnpm --filter ./packages/playground exec vitest run src/services/__tests__/om-parts-converter.test.ts src/services/__tests__/mastra-runtime-provider.test.tsx --bail 1 --reporter=dot
- pnpm --filter ./packages/playground typecheck
- git diff --check
