### PR TITLE
fix(server): memory status no longer falsely reports memory enabled for agents without memory

### DIFF
--- a/.changeset/fuzzy-loops-fix.md
+++ b/.changeset/fuzzy-loops-fix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed memory status incorrectly reporting memory as enabled for agents without memory configured. The /api/memory/status endpoint now returns false for a resolved agent that has no memory, even when the Mastra instance has storage configured. Previously, Studio would render memory UI for such agents.

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -142,6 +142,45 @@ describe('Memory Handlers', () => {
       expect(result).toEqual({ result: false });
     });
 
+    it('detects memory via hasOwnMemory(): resolved agent without memory is false, with memory is true', async () => {
+      const withoutMemory = new Agent({
+        id: 'agent-without-own-memory',
+        name: 'Agent Without Own Memory',
+        instructions: 'test-instructions',
+        model: {} as any,
+      });
+      const withMemory = new Agent({
+        id: 'agent-with-own-memory',
+        name: 'Agent With Own Memory',
+        instructions: 'test-instructions',
+        model: {} as any,
+        memory: new MockMemory({ storage }),
+      });
+      const mastra = new Mastra({
+        logger: false,
+        storage,
+        agents: {
+          'agent-without-own-memory': withoutMemory,
+          'agent-with-own-memory': withMemory,
+        },
+      });
+
+      expect(withoutMemory.hasOwnMemory()).toBe(false);
+      expect(withMemory.hasOwnMemory()).toBe(true);
+
+      const negative = await GET_MEMORY_STATUS_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        agentId: 'agent-without-own-memory',
+      });
+      expect(negative).toEqual({ result: false });
+
+      const positive = await GET_MEMORY_STATUS_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        agentId: 'agent-with-own-memory',
+      });
+      expect(positive).toMatchObject({ result: true });
+    });
+
     it('should return false when an agent explicitly does not support Mastra memory', async () => {
       const agentWithoutMemorySupport = Object.assign(
         new Agent({

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -121,7 +121,7 @@ describe('Memory Handlers', () => {
       expect(result).toMatchObject({ result: true });
     });
 
-    it('should use storage fallback when a registered agent has no local memory', async () => {
+    it('should return false when a registered agent has no local memory even if storage is configured', async () => {
       const agentWithoutMemory = new Agent({
         id: 'no-memory-agent',
         name: 'Agent Without Memory',
@@ -139,7 +139,7 @@ describe('Memory Handlers', () => {
         agentId: 'no-memory-agent',
       });
 
-      expect(result).toEqual({ result: true });
+      expect(result).toEqual({ result: false });
     });
 
     it('should return false when an agent explicitly does not support Mastra memory', async () => {

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -551,7 +551,14 @@ export const GET_MEMORY_STATUS_ROUTE = createRoute({
         return { result: false };
       }
 
-      // Fallback to storage (covers stored agents whose memory can't be resolved)
+      // A resolved agent with no memory genuinely has memory disabled — do not
+      // fall back to storage (that fallback only covers agents we couldn't resolve,
+      // e.g. stored agents that can't be hydrated, or requests with no agentId).
+      if (agentId && agent) {
+        return { result: false };
+      }
+
+      // Fallback to storage (covers unresolved/stored agents and the no-agentId case)
       const storage = getStorageFromContext({ mastra });
       if (storage) {
         return { result: true };

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -270,10 +270,24 @@ function getStorageFromContext({ mastra }: Pick<MemoryContext, 'mastra'>): Mastr
 }
 
 function agentSupportsMemory(agent: Agent | null): boolean {
-  if (!agent) return true;
+  if (!agent) return true; // unresolved → storage fallback still applies
 
-  const candidate = agent as Agent & { supportsMemory?: () => boolean };
-  return typeof candidate.supportsMemory === 'function' ? candidate.supportsMemory() : true;
+  const candidate = agent as Agent & {
+    supportsMemory?: () => boolean;
+    hasOwnMemory?: () => boolean;
+  };
+
+  // Explicit opt-out via duck-typed supportsMemory() (kept as an escape hatch)
+  if (typeof candidate.supportsMemory === 'function' && !candidate.supportsMemory()) {
+    return false;
+  }
+
+  // A resolved agent with no own memory genuinely has memory disabled
+  if (typeof candidate.hasOwnMemory === 'function' && !candidate.hasOwnMemory()) {
+    return false;
+  }
+
+  return true;
 }
 
 /**
@@ -548,13 +562,6 @@ export const GET_MEMORY_STATUS_ROUTE = createRoute({
       }
 
       if (!agentSupportsMemory(agent)) {
-        return { result: false };
-      }
-
-      // A resolved agent with no memory genuinely has memory disabled — do not
-      // fall back to storage (that fallback only covers agents we couldn't resolve,
-      // e.g. stored agents that can't be hydrated, or requests with no agentId).
-      if (agentId && agent) {
         return { result: false };
       }
 


### PR DESCRIPTION
`GET /api/memory/status?agentId=<id>` was returning `{ result: true }` for code-defined agents that have no memory configured, as long as the Mastra instance had any storage. That made Studio render memory UI for agents without memory (e.g. an agent with `memory` commented out).

The storage fallback was only meant for agents that couldn't be resolved (stored agents that can't be hydrated) and the no-agentId case. It was firing for resolved agents that simply have no memory.

Before:

```ts
if (!agentSupportsMemory(agent)) {
  return { result: false };
}
// fired even for a resolved agent with no memory
const storage = getStorageFromContext({ mastra });
if (storage) return { result: true };
return { result: false };
```

After:

```ts
if (!agentSupportsMemory(agent)) {
  return { result: false };
}
// a resolved agent with no memory genuinely has memory disabled
if (agentId && agent) {
  return { result: false };
}
const storage = getStorageFromContext({ mastra });
if (storage) return { result: true };
return { result: false };
```

The no-agentId and unresolved/stored-agent fallbacks are preserved.

Test plan: `pnpm test:server` (memory.test.ts, 84 tests pass, including the updated status matrix) and `pnpm build:server`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

A status check was mistakenly saying some agents had memory just because the system had storage; this change makes the check ask each agent directly—if an agent doesn't have memory, the endpoint now says "no" even when storage exists.

## Overview

Fixes a bug in GET /api/memory/status where code-defined (resolved) agents with no memory configured were reported as having memory when the Mastra instance had storage configured. The storage fallback is still used for the no-agentId case and for unresolved/stored agents whose memory couldn't be hydrated; it no longer overrides a resolved agent that explicitly has no memory.

## Changes Made

- Refactored detection of "memory-less" resolved agents into agentSupportsMemory(agent) which:
  - Returns true for unresolved agents to preserve storage fallback.
  - Honors an explicit opt-out via a duck-typed supportsMemory() method.
  - Uses the agent's hasOwnMemory() (when present) to detect resolved agents that intentionally have no memory; guarded with typeof checks for compatibility with older core versions and the supportsMemory escape hatch.
- Removed the redundant guard from the status handler; the handler now calls agentSupportsMemory and:
  - Returns { result: true, memoryType: 'local' } when an agent's memory resolves.
  - Returns { result: false } when a resolved agent exposes hasOwnMemory() === false.
  - Preserves storage fallback (returning true) only when agent is unresolved/null or no agentId is provided.
- Tests updated:
  - memory.test.ts adjusted expected matrix and added a focused test exercising both hasOwnMemory() branches (agent with no MockMemory vs. agent with MockMemory).
- Changeset:
  - .changeset/fuzzy-loops-fix.md added to document the patch for `@mastra/server`.

## Impact

- Studio will no longer render memory UI for resolved agents that do not have memory configured.
- Behavior remains backward-compatible for older core versions and for unresolved/stored-agent cases where storage should be used as a fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->