### PR TITLE
fix(mcp): scope MCP server FGA checks independently of agent tool map

### DIFF
--- a/auth/workos/src/fga-provider.ts
+++ b/auth/workos/src/fga-provider.ts
@@ -23,6 +23,7 @@ import type {
 import { FGADeniedError } from '@mastra/core/auth/ee';
 import { WorkOS } from '@workos-inc/node';
 
+import type { FGAProviderConfigOverrides } from '@mastra/core/auth/ee';
 import type { MastraFGAWorkosOptions, FGAResourceMappingEntry, WorkOSUser } from './types';
 
 const FILTER_ACCESSIBLE_CHECK_CONCURRENCY = 5;
@@ -112,6 +113,8 @@ export class MastraFGAWorkos implements IFGAManager<WorkOSUser> {
   readonly resolveRouteFGA?: MastraFGAWorkosOptions['resolveRouteFGA'];
   readonly validatePermissions?: MastraFGAWorkosOptions['validatePermissions'];
 
+  private readonly options: MastraFGAWorkosOptions;
+
   constructor(options: MastraFGAWorkosOptions) {
     const apiKey = options.apiKey ?? process.env.WORKOS_API_KEY;
     const clientId = options.clientId ?? process.env.WORKOS_CLIENT_ID;
@@ -123,6 +126,7 @@ export class MastraFGAWorkos implements IFGAManager<WorkOSUser> {
       );
     }
 
+    this.options = options;
     this.workos = new WorkOS(apiKey, { clientId });
     this.organizationId = options.organizationId;
     this.resourceMapping = options.resourceMapping ?? {};
@@ -131,6 +135,20 @@ export class MastraFGAWorkos implements IFGAManager<WorkOSUser> {
     this.auditProtectedRoutes = options.auditProtectedRoutes;
     this.resolveRouteFGA = options.resolveRouteFGA;
     this.validatePermissions = options.validatePermissions;
+  }
+
+  withConfigOverrides(overrides: FGAProviderConfigOverrides): MastraFGAWorkos {
+    return new MastraFGAWorkos({
+      ...this.options,
+      resourceMapping: {
+        ...this.resourceMapping,
+        ...overrides.resourceMapping,
+      },
+      permissionMapping: {
+        ...this.permissionMapping,
+        ...overrides.permissionMapping,
+      },
+    });
   }
 
   // ──────────────────────────────────────────────────────────────
@@ -537,7 +555,9 @@ export class MastraFGAWorkos implements IFGAManager<WorkOSUser> {
           ? ['workflow', 'workflows']
           : resourceType === 'tool'
             ? ['tool', 'tools']
-            : resourceType === 'thread'
+            : resourceType === 'mcpTool'
+              ? ['mcpTool', 'mcpTools']
+              : resourceType === 'thread'
               ? ['thread', 'threads', 'memory']
               : [resourceType];
 

--- a/docs/src/content/en/docs/server/auth/fga.mdx
+++ b/docs/src/content/en/docs/server/auth/fga.mdx
@@ -219,7 +219,7 @@ When an FGA provider is configured, Mastra automatically checks authorization at
 | Built-in workflow HTTP execution routes and `Workflow.execute()` | `workflows:execute` | `workflow` | `workflowId` |
 | Standalone tool execution | `tools:execute` | `tool` | `toolName` |
 | Agent tool execution | `tools:execute` | `tool` | `${agentId}:${toolName}` |
-| MCP tool execution | `tools:execute` | `tool` | `JSON.stringify([serverName, toolName])` |
+| MCP server tools/list and tools/call | `tools:execute` | `mcpTool` | `JSON.stringify([serverName, toolName])` |
 | Thread and memory access | `memory:read`, `memory:write`, `memory:delete` | `thread` | `threadId` |
 | Stored resource routes | Stored resource permission for the route action | Stored resource type | Route record ID, or the stored-resource scope for collection routes |
 | HTTP resource routes | Configured per route | Configured per route | Configured per route |

--- a/packages/core/src/auth/ee/fga-check.ts
+++ b/packages/core/src/auth/ee/fga-check.ts
@@ -5,6 +5,7 @@
  */
 
 import { captureEEEvent, getEETelemetryFallbackDistinctId } from '../../telemetry/posthog';
+import type { MCPServerFGAConfig } from '../../mcp/types';
 import type { FGACheckContext, IFGAProvider } from './interfaces/fga';
 import type { MastraFGAPermissionInput } from './interfaces/permissions.generated';
 import { getSafeLicenseSummary } from './license';
@@ -63,6 +64,32 @@ export function getAgentToolFGAResourceId(agentId: string, toolName: string): st
 
 export function getMCPToolFGAResourceId(serverName: string, toolName: string): string {
   return JSON.stringify([serverName, toolName]);
+}
+
+export const MCP_SERVER_TOOL_FGA_RESOURCE_TYPE = 'mcpTool';
+
+export function getMCPServerToolFGAResourceType(serverFga?: MCPServerFGAConfig): string {
+  return serverFga?.resourceType ?? MCP_SERVER_TOOL_FGA_RESOURCE_TYPE;
+}
+
+export function resolveMCPServerFGAProvider(
+  fgaProvider: IFGAProvider | undefined,
+  serverFga?: MCPServerFGAConfig,
+): IFGAProvider | undefined {
+  if (!fgaProvider) {
+    return undefined;
+  }
+
+  if (!serverFga?.resourceMapping && !serverFga?.permissionMapping) {
+    return fgaProvider;
+  }
+
+  return (
+    fgaProvider.withConfigOverrides?.({
+      resourceMapping: serverFga.resourceMapping,
+      permissionMapping: serverFga.permissionMapping,
+    }) ?? fgaProvider
+  );
 }
 
 /**

--- a/packages/core/src/auth/ee/index.ts
+++ b/packages/core/src/auth/ee/index.ts
@@ -36,6 +36,9 @@ export {
   getStandaloneToolFGAResourceId,
   getAgentToolFGAResourceId,
   getMCPToolFGAResourceId,
+  getMCPServerToolFGAResourceType,
+  resolveMCPServerFGAProvider,
+  MCP_SERVER_TOOL_FGA_RESOURCE_TYPE,
   type CheckFGAOptions,
   type RequireFGAOptions,
 } from './fga-check';

--- a/packages/core/src/auth/ee/interfaces/fga.ts
+++ b/packages/core/src/auth/ee/interfaces/fga.ts
@@ -52,6 +52,22 @@ export interface FGACheckParams {
   context?: FGACheckContext;
 }
 
+export interface FGAResourceMappingEntry {
+  fgaResourceType: string;
+  parentFgaResourceType?: string;
+  parentResourceTypeSlug?: string;
+  deriveId?: (ctx: {
+    user: any;
+    resourceId?: string;
+    requestContext?: RequestContext<any>;
+  }) => string | undefined;
+}
+
+export interface FGAProviderConfigOverrides {
+  resourceMapping?: Record<string, FGAResourceMappingEntry>;
+  permissionMapping?: Record<string, string>;
+}
+
 /**
  * Route-level FGA metadata.
  */
@@ -333,6 +349,8 @@ export interface IFGAProvider<TUser = unknown> {
     resourceType: string,
     permission: MastraFGAPermissionInput,
   ): Promise<T[]>;
+
+  withConfigOverrides?(overrides: FGAProviderConfigOverrides): IFGAProvider<TUser>;
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/packages/core/src/auth/ee/interfaces/index.ts
+++ b/packages/core/src/auth/ee/interfaces/index.ts
@@ -40,6 +40,8 @@ export type { ResourceIdentifier, ACLGrant, IACLProvider, IACLManager } from './
 export type {
   FGACheckContext,
   FGACheckParams,
+  FGAResourceMappingEntry,
+  FGAProviderConfigOverrides,
   FGARouteConfig,
   FGARouteInfo,
   FGARouteResolver,

--- a/packages/core/src/mcp/types.ts
+++ b/packages/core/src/mcp/types.ts
@@ -1,6 +1,7 @@
 import type * as http from 'node:http';
 import type { Context } from 'hono';
 import type { ToolsInput, Agent } from '../agent';
+import type { FGAResourceMappingEntry } from '../auth/ee/interfaces/fga';
 import type { RequestContext } from '../request-context';
 import type { Workflow } from '../workflows';
 
@@ -206,6 +207,12 @@ export type MCPAuthInfoToUserMapper<TUser = unknown> = (args: {
   requestContext: RequestContext;
 }) => TUser | null | undefined | Promise<TUser | null | undefined>;
 
+export interface MCPServerFGAConfig {
+  resourceType?: string;
+  resourceMapping?: Record<string, FGAResourceMappingEntry>;
+  permissionMapping?: Record<string, string>;
+}
+
 // +++ Authoritative MCPServerConfig +++
 /** Configuration options for creating an MCPServer instance. */
 export interface MCPServerConfig<TId extends string = string> {
@@ -245,6 +252,7 @@ export interface MCPServerConfig<TId extends string = string> {
    * already put a `user` value in the request context.
    */
   mapAuthInfoToUser?: MCPAuthInfoToUserMapper;
+  fga?: MCPServerFGAConfig;
   /** Optional repository information for the server's source code. */
   repository?: Repository;
   /**

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -7,6 +7,7 @@ import { MCPServerBase } from '@mastra/core/mcp';
 import type {
   MCPAuthInfoToUserMapper,
   MCPServerConfig,
+  MCPServerFGAConfig,
   ServerInfo,
   ServerDetailInfo,
   MCPServerHonoSSEOptions,
@@ -102,6 +103,7 @@ export class MCPServer extends MCPServerBase {
   private promptOptions?: MCPServerPrompts;
   private jsonSchemaValidator?: jsonSchemaValidator;
   private mapAuthInfoToUser?: MCPAuthInfoToUserMapper;
+  private fgaConfig?: MCPServerFGAConfig;
   private subscriptions: Set<string> = new Set();
   private currentLoggingLevel: LoggingLevel | undefined;
 
@@ -306,6 +308,7 @@ export class MCPServer extends MCPServerBase {
     this.promptOptions = opts.prompts;
     this.jsonSchemaValidator = opts.jsonSchemaValidator;
     this.mapAuthInfoToUser = opts.mapAuthInfoToUser;
+    this.fgaConfig = opts.fga;
 
     const capabilities: ServerCapabilities = {
       tools: {},
@@ -2259,23 +2262,35 @@ export class MCPServer extends MCPServerBase {
   }
 
   private async enforceToolExecutionFGA(toolId: string, requestContext?: RequestContext): Promise<void> {
-    const fgaProvider = this.mastra?.getServer?.()?.fga;
-    if (!fgaProvider) {
+    const instanceFgaProvider = this.mastra?.getServer?.()?.fga;
+    if (!instanceFgaProvider) {
       return;
     }
 
-    const { getMCPToolFGAResourceId, requireFGA, FGADeniedError, MastraFGAPermissions } =
-      await import('@mastra/core/auth/ee');
+    const {
+      getMCPToolFGAResourceId,
+      getMCPServerToolFGAResourceType,
+      resolveMCPServerFGAProvider,
+      requireFGA,
+      FGADeniedError,
+      MastraFGAPermissions,
+    } = await import('@mastra/core/auth/ee');
+    const fgaProvider = resolveMCPServerFGAProvider(instanceFgaProvider, this.fgaConfig);
+    const resourceType = getMCPServerToolFGAResourceType(this.fgaConfig);
     const resourceId = getMCPToolFGAResourceId(this.id, toolId);
     const user = await this.resolveMappedFGAUser(requestContext);
     if (!user) {
-      throw new FGADeniedError({ id: 'unknown' }, { type: 'tool', id: resourceId }, MastraFGAPermissions.TOOLS_EXECUTE);
+      throw new FGADeniedError(
+        { id: 'unknown' },
+        { type: resourceType, id: resourceId },
+        MastraFGAPermissions.TOOLS_EXECUTE,
+      );
     }
 
     await requireFGA({
       fgaProvider,
       user,
-      resource: { type: 'tool', id: resourceId },
+      resource: { type: resourceType, id: resourceId },
       permission: MastraFGAPermissions.TOOLS_EXECUTE,
       requestContext,
       context: {


### PR DESCRIPTION
#### Description

- MCP server tools/list and tools/call FGA checks now use the mcpTool resource type by default, separate from instance-level tool mapping used by agent/workflow execution. MCPServer accepts optional fga.resourceMapping and fga.permissionMapping overrides, merged via withConfigOverrides on the FGA provider.

#### Related issue(s)
Fixes #17508

#### Type of change
- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Documentation update


#### Checklist
-  I have linked the related issue(s) in the description above
-  I have made corresponding changes to the documentation (if applicable)
-  I have added tests that prove my fix is effective or that my feature works
-  I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Currently, when an MCP server (a type of tool extension) checks if someone is allowed to use its tools, it uses the same authorization rules as regular Mastra tools, making it impossible to restrict MCP tool access separately. This PR lets each MCP server have its own authorization rules, so you can control who can use MCP tools independently from who can use regular tools.

## Summary

This PR fixes MCP server tool authorization (FGA checks) to use a dedicated `mcpTool` resource type by default, rather than sharing the instance-level `tool` resource mapping used by agent/workflow execution. It introduces optional FGA configuration overrides (`resourceMapping` and `permissionMapping`) on `MCPServer` to allow per-server customization of authorization checks.

### Key Changes

**FGA Provider Enhancement**
- Added `withConfigOverrides(overrides: FGAProviderConfigOverrides)` method to `MastraFGAWorkos`, enabling callers to create a new provider instance with merged resource and permission mappings
- Extended `getResourceMapping()` to recognize and handle the `mcpTool` resource type alongside existing aliases (`mcpTools`)

**MCP Server FGA Configuration**
- Introduced `MCPServerFGAConfig` interface in `packages/core/src/mcp/types.ts` with optional properties: `resourceType`, `resourceMapping`, and `permissionMapping`
- Extended `MCPServerConfig` to accept optional `fga?: MCPServerFGAConfig`
- Updated `MCPServer` to store and utilize per-server FGA configuration when enforcing tool execution authorization

**MCP-Specific Authorization Utilities**
- Added `MCP_SERVER_TOOL_FGA_RESOURCE_TYPE` constant as the default resource type for MCP tools
- Added `getMCPServerToolFGAResourceType()` to derive resource type from optional config
- Added `resolveMCPServerFGAProvider()` to conditionally wrap the FGA provider with config overrides when server-level mappings are provided

**Updated Authorization Logic**
- Modified tool execution authorization (`enforceToolExecutionFGA`) to dynamically derive the FGA resource type using MCP-specific helpers instead of hardcoding `"tool"`
- Error messages now include the computed resource type and tool resource ID for better debugging

**Documentation**
- Added enforcement point documentation for MCP server `tools/list` and `tools/call` with `mcpTool` resource type

### Non-Breaking
This change is backward compatible. Existing MCP servers without explicit FGA configuration will automatically use the new `mcpTool` resource type for authorization, while allowing new per-server overrides via `MCPServerConfig.fga` for fine-grained control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->