### PR TITLE
add mastracode to pnpm exclusion

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,6 +68,7 @@ minimumReleaseAgeExclude:
   - '@internal/*'
   - 'mastra'
   - 'create-mastra'
+  - 'mastracode'
 trustPolicyExclude:
   # Security fix for GHSA middleware-based route protection bypass (CVE).
   # 3.47.4 is published with provenance attestation rather than trusted publisher,


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds the `mastracode` package to an exclusion list in the pnpm configuration file, which allows it to skip a rule that normally delays installing certain versions of dependencies. Think of it like putting a package on a "fast track" list so it doesn't have to wait like other packages.

## Changes
Updated `pnpm-workspace.yaml` to add the `mastracode` package to the `minimumReleaseAgeExclude` list. This exempts the package from the minimum release age gate, which is a policy that normally delays installing certain third-party dependency versions.

**File modified:** pnpm-workspace.yaml (+1/-0)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->