### PR TITLE
fix(acp): persist tool sessions across executions

### DIFF
--- a/.changeset/free-doors-laugh.md
+++ b/.changeset/free-doors-laugh.md
@@ -1,0 +1,5 @@
+---
+'@mastra/acp': patch
+---
+
+Fixed ACP tools to keep their default session alive across executions.

--- a/agent-sdks/acp/README.md
+++ b/agent-sdks/acp/README.md
@@ -115,7 +115,7 @@ const codeAgentTool = createACPTool({
 
 ## Session and workspace behavior
 
-`createACPTool` and `AcpAgent` start the configured command on first use and create an ACP session. Sessions persist across calls by default. Set `persistSession: false` to stop the ACP process after each prompt.
+`createACPTool` and `AcpAgent` start the configured command on first use and create an ACP session. Sessions persist across calls for the same tool or agent instance by default. Set `persistSession: false` to isolate each prompt and stop the ACP process after it completes.
 
 ```typescript
 const codeAgent = new AcpAgent({

--- a/agent-sdks/acp/README.md
+++ b/agent-sdks/acp/README.md
@@ -115,7 +115,7 @@ const codeAgentTool = createACPTool({
 
 ## Session and workspace behavior
 
-`createACPTool` and `AcpAgent` start the configured command on first use and create an ACP session. Sessions persist across calls for the same tool or agent instance by default. Set `persistSession: false` to isolate each prompt and stop the ACP process after it completes.
+`createACPTool` and `AcpAgent` start the configured command on first use and create an ACP session. Sessions persist across calls by default. Set `persistSession: false` to stop the ACP process after each prompt.
 
 ```typescript
 const codeAgent = new AcpAgent({

--- a/agent-sdks/acp/src/__tests__/tool.test.ts
+++ b/agent-sdks/acp/src/__tests__/tool.test.ts
@@ -132,6 +132,82 @@ describe('createACPTool', () => {
     });
     expect(result).toEqual({ output: '' });
   });
+
+  it('reuses one ACP session across executions by default', async () => {
+    const { createACPTool } = await import('../tool');
+
+    const tool = createACPTool({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude-agent-acp',
+      args: [],
+    });
+
+    await tool.execute?.({ task: 'write tests' } as any, {} as any);
+    await tool.execute?.({ task: 'fix lint' } as any, {} as any);
+
+    expect(mocks.connectionInstances).toHaveLength(1);
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+    expect(mocks.connectionInstances[0]?.newSession).toHaveBeenCalledTimes(1);
+    expect(mocks.connectionInstances[0]?.prompt).toHaveBeenNthCalledWith(1, {
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'write tests' }],
+    });
+    expect(mocks.connectionInstances[0]?.prompt).toHaveBeenNthCalledWith(2, {
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'fix lint' }],
+    });
+  });
+
+  it('creates and disconnects a fresh ACP connection when persistSession is false', async () => {
+    const { createACPTool } = await import('../tool');
+
+    const tool = createACPTool({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude-agent-acp',
+      args: [],
+      persistSession: false,
+    });
+
+    await tool.execute?.({ task: 'write tests' } as any, {} as any);
+    await tool.execute?.({ task: 'fix lint' } as any, {} as any);
+
+    expect(mocks.connectionInstances).toHaveLength(2);
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+    expect(mocks.connectionInstances[0]?.prompt).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'write tests' }],
+    });
+    expect(mocks.connectionInstances[1]?.prompt).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'fix lint' }],
+    });
+    expect((mocks.spawn.mock.results[0]?.value as ReturnType<typeof createProcess>).kill).toHaveBeenCalledTimes(1);
+    expect((mocks.spawn.mock.results[1]?.value as ReturnType<typeof createProcess>).kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the runtime Mastra workspace for ACP file access', async () => {
+    const { createACPTool } = await import('../tool');
+    const readFile = vi.fn().mockResolvedValue('from workspace');
+    const workspace = { filesystem: { readFile } };
+    const mastra = { getWorkspace: vi.fn().mockResolvedValue(workspace) };
+
+    const tool = createACPTool({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude-agent-acp',
+      args: [],
+    });
+
+    await tool.execute?.({ task: 'read file' } as any, { mastra } as any);
+
+    await expect(mocks.connectionInstances[0]?.client.readTextFile({ path: 'src/index.ts' })).resolves.toEqual({
+      content: 'from workspace',
+    });
+    expect(mastra.getWorkspace).toHaveBeenCalledTimes(1);
+    expect(readFile).toHaveBeenCalledWith('src/index.ts');
+  });
 });
 
 describe('ACPConnection', () => {

--- a/agent-sdks/acp/src/session.ts
+++ b/agent-sdks/acp/src/session.ts
@@ -1,0 +1,24 @@
+import { ACPConnection } from './connection';
+import type { CreateACPToolOptions } from './types';
+
+export class ACPToolSession {
+  private connection?: ACPConnection;
+
+  constructor(private readonly options: CreateACPToolOptions) {}
+
+  getConnection(workspace: CreateACPToolOptions['workspace']): ACPConnection {
+    if (this.options.persistSession === false) {
+      return this.createConnection(workspace);
+    }
+
+    this.connection ??= this.createConnection(workspace);
+    return this.connection;
+  }
+
+  private createConnection(workspace: CreateACPToolOptions['workspace']): ACPConnection {
+    return new ACPConnection({
+      ...this.options,
+      workspace: workspace ?? this.options.workspace,
+    });
+  }
+}

--- a/agent-sdks/acp/src/tool.ts
+++ b/agent-sdks/acp/src/tool.ts
@@ -2,10 +2,12 @@ import { compileSchema } from '@internal/types-builder/compile-zod';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod/v4';
 
-import { ACPConnection } from './connection';
+import { ACPToolSession } from './session';
 import type { CreateACPToolOptions } from './types';
 
 export function createACPTool(options: CreateACPToolOptions) {
+  const session = new ACPToolSession(options);
+
   return createTool({
     id: options.id,
     description: options.description,
@@ -45,11 +47,7 @@ export function createACPTool(options: CreateACPToolOptions) {
     ),
     execute: async ({ task }, context) => {
       const workspace = await context?.mastra?.getWorkspace();
-      const connection = new ACPConnection({
-        ...options,
-        workspace,
-      });
-
+      const connection = session.getConnection(workspace);
       const output = await connection.prompt(task, context?.abortSignal);
 
       return { output };


### PR DESCRIPTION
This fixes ACP tool session persistence so a single `createACPTool` instance reuses its ACP connection across executions by default. `persistSession: false` still keeps prompts isolated by creating and disconnecting a fresh connection each time.

Before, repeated calls to the same ACP tool started a new ACP connection even though sessions were documented as persistent. After this change, repeated calls through the same tool instance share the session/process unless persistence is disabled.

Test plan:
- `pnpm --filter ./packages/acp test`
- `pnpm --filter ./packages/acp build:lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're using a tool that needs to talk to an AI assistant. Before this change, every time you used the tool, it would hang up and make a brand new phone call. Now, it stays on the same call the whole time (unless you specifically ask it to hang up), which is faster and lets the assistant remember what you've been talking about.

## Overview

This PR fixes ACP tool session persistence to ensure a single `createACPTool` instance reuses its ACP connection across multiple executions by default, rather than creating a new connection each time.

## Changes

### Core Implementation

**New `ACPToolSession` class** (`agent-sdks/acp/src/session.ts`):
- Manages connection lifecycle for ACP tools
- `getConnection(workspace)` returns a fresh connection when `persistSession === false`, otherwise lazily creates and caches a connection on first use and reuses it for all subsequent calls
- `createConnection(workspace)` helper constructs the `ACPConnection` with proper workspace resolution

**Updated `createACPTool` function** (`agent-sdks/acp/src/tool.ts`):
- Now instantiates an `ACPToolSession` from provided options
- Tool's `execute` handler calls `session.getConnection(workspace)` instead of directly creating new `ACPConnection` instances

### Testing

**New test coverage** (`agent-sdks/acp/src/__tests__/tool.test.ts`):
- Verifies default session reuse: repeated `execute` calls with the same tool instance reuse the same `sessionId`
- Verifies non-persistent mode: when `persistSession: false`, each `execute` creates a fresh connection and calls process `kill`
- Confirms ACP file access uses the runtime Mastra workspace by mocking `mastra.getWorkspace().filesystem.readFile`

### Documentation

**Changeset** (`.changeset/free-doors-laugh.md`):
- Patch version bump for `@mastra/acp`
- Documents fix ensuring ACP tools keep their default session alive across executions

## Impact

Fixes prior behavior where repeated calls to the same ACP tool started a new ACP connection despite sessions being documented as persistent. After this change, repeated calls through the same tool instance share the session/process by default, unless `persistSession: false` is explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->