### PR TITLE
feat(mcp): bridge Hono auth into MCP req.auth

### DIFF
--- a/.changeset/afraid-hats-bow.md
+++ b/.changeset/afraid-hats-bow.md
@@ -1,0 +1,20 @@
+---
+'@mastra/mcp': minor
+---
+
+Added an optional `setRequestAuth` hook to `MCPServer.startHTTP`. It runs once per request, immediately before the request reaches the streamable HTTP transport, letting a host server populate `req.auth` (and therefore `extra.authInfo`) on all paths: existing session, new session, and stateless/serverless.
+
+```ts
+await server.startHTTP({
+  url,
+  httpPath,
+  req,
+  res,
+  setRequestAuth: req => {
+    // @ts-ignore - req.auth is read by the MCP SDK
+    req.auth = { token, clientId, scopes, extra };
+  },
+});
+```
+
+The hook is framework-agnostic (receives only the Node request) and optional, so existing behavior is unchanged when it is not provided.

--- a/.changeset/two-gifts-throw.md
+++ b/.changeset/two-gifts-throw.md
@@ -1,0 +1,40 @@
+---
+'@mastra/core': minor
+'@mastra/hono': minor
+---
+
+Bridge Hono-layer authentication into the MCP request's `req.auth` so `extra.authInfo` reaches MCP tools when MCP servers are deployed behind Hono (the default `mastra dev`/`mastra build` server).
+
+Previously this flow only worked under Express-style bare HTTP servers because the Hono deployer regenerates the request, dropping any `req.auth` set in middleware. Two ways to bridge are now available via `mastra.server.mcp`:
+
+**Automatic (provider auto-bridge)**
+
+When a `server.auth` provider is configured, the authenticated user is mapped into `req.auth` automatically. No extra wiring is required. Works with any `MastraAuthProvider`.
+
+```ts
+new Mastra({
+  server: {
+    auth: new MastraJwtAuth({ secret: process.env.JWT_SECRET! }),
+    // optional: customize the user -> AuthInfo mapping
+    mcp: { mapUserToAuthInfo: ({ user, token }) => ({ token, clientId: user.sub, extra: { user } }) },
+  },
+});
+```
+
+**Manual (custom middleware)**
+
+For custom Hono auth gates, read the request context and assign `req.auth` yourself:
+
+```ts
+new Mastra({
+  server: {
+    mcp: {
+      setRequestAuth: ({ req, requestContext, token }) => {
+        const payload = requestContext.get('auth.payload');
+        // @ts-ignore - req.auth is read by the MCP SDK
+        if (payload) req.auth = { token, clientId: payload.azp, extra: payload };
+      },
+    },
+  },
+});
+```

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1392,6 +1392,71 @@ app.all('/mcp', async (req, res) => {
 })
 ```
 
+### Bridging auth on Hono / the Mastra deployer
+
+The Express pattern above mutates the Node `req` directly. When you deploy with `mastra dev`/`mastra build` (or otherwise mount MCP on Hono via `mastra.server`), the request is regenerated from the Hono context before it reaches the MCP SDK, so middleware that sets `req.auth` does not carry over. Configure `mastra.server.mcp` to bridge auth instead.
+
+#### Provider auto-bridge
+
+When a `mastra.server.auth` provider is configured, the authenticated principal is bridged into `req.auth` automatically. Any `MastraAuthProvider` (Clerk, Auth0, Supabase, Firebase, WorkOS, `MastraJwtAuth`, or a custom provider) works without extra wiring.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraJwtAuth } from '@mastra/auth'
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraJwtAuth({ secret: process.env.JWT_SECRET! }),
+    // Auto-bridge is on by default. Customize the user -> AuthInfo mapping when
+    // your provider payload doesn't match the default best-effort fields.
+    mcp: {
+      mapUserToAuthInfo: ({ user, token }) => ({
+        token,
+        clientId: (user as { sub?: string }).sub,
+        scopes: (user as { scope?: string }).scope?.split(' ') ?? [],
+        extra: { user },
+      }),
+    },
+  },
+})
+```
+
+The default mapping is best-effort across providers; supply `mapUserToAuthInfo` for exact control. The auto-bridge only runs when the auth middleware actually resolved a user (MCP HTTP routes require auth by default), and never fabricates `authInfo` otherwise. Set `mcp.autoBridgeAuth: false` to opt out.
+
+#### Manual hook for custom middleware
+
+If you authenticate in your own Hono middleware (rather than through `mastra.server.auth`), store the result on the request context and assign `req.auth` in `mcp.setRequestAuth`. The hook receives the live `requestContext` plus the bearer `token`, and takes precedence over the auto-bridge.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+
+export const mastra = new Mastra({
+  server: {
+    // Your Hono middleware verifies the token and stores the payload, e.g.
+    //   c.get('requestContext')?.set('auth.payload', payload)
+    middleware: [mcpAuthGate],
+    mcp: {
+      setRequestAuth: ({ req, requestContext, token }) => {
+        const payload = requestContext.get('auth.payload') as
+          | { azp?: string; scope?: string }
+          | undefined
+        if (payload) {
+          // @ts-ignore - req.auth is read by the MCP SDK
+          req.auth = {
+            token,
+            clientId: payload.azp,
+            scopes: payload.scope?.split(' ') ?? [],
+            extra: payload,
+          }
+        }
+      },
+    },
+  },
+})
+```
+
+Once `req.auth` is populated by either style, it flows to tools as `context.mcp.extra.authInfo` exactly as with the Express path. If the `MCPServer` also configures [`mapAuthInfoToUser`](#map-auth-data-for-fga), that `authInfo` is additionally mapped into `requestContext.get('user')` for FGA checks.
+
 ### Accessing Auth Data in Tools
 
 The `req.auth` object is available as `context.mcp.extra.authInfo` in your tool's execute function:

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -13,10 +13,13 @@ export type {
   CorsOptions,
   ApiRoute,
   HttpLoggingConfig,
+  MCPServerOptions,
+  MCPRequestAuthInfo,
   ValidationErrorContext,
   ValidationErrorResponse,
   ValidationErrorHook,
 } from './types';
+export { defaultMapUserToAuthInfo } from './types';
 export { MastraAuthProvider } from './auth';
 export type { MastraAuthProviderOptions } from './auth';
 export type { HonoRequestLike, MastraAuthRequest } from './request-types';

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from 'node:http';
 import type { Handler, MiddlewareHandler, Context } from 'hono';
 import type { cors } from 'hono/cors';
 import type { DescribeRouteOptions } from 'hono-openapi';
@@ -43,6 +44,81 @@ export type ApiRoute =
     };
 
 export type Middleware = MiddlewareHandler | { path: string; handler: MiddlewareHandler };
+
+/**
+ * Shape of the auth payload that the MCP SDK reads from `req.auth` and emits as
+ * `extra.authInfo` to tool handlers. Mirrors `@modelcontextprotocol/sdk`'s AuthInfo
+ * (kept local so `@mastra/core` does not depend on the SDK types).
+ */
+export interface MCPRequestAuthInfo {
+  token?: string;
+  clientId?: string;
+  scopes?: string[];
+  extra?: Record<string, unknown>;
+}
+
+/**
+ * MCP-specific server configuration. Bridges auth resolved at the HTTP/Hono layer
+ * into the MCP request's `req.auth`, so `extra.authInfo` flows to MCP tools under
+ * Hono/deployer deployments (where the request is regenerated via `toReqRes`).
+ */
+export interface MCPServerOptions {
+  /**
+   * Style B: manual auth bridge for custom middleware gates.
+   *
+   * Invoked once per MCP HTTP request, before the request reaches the MCP SDK
+   * transport. The server adapter binds the live request context for you, so you
+   * can read values your own middleware stored (e.g. `requestContext.get('auth.payload')`)
+   * and assign `req.auth`.
+   *
+   * When set, this takes precedence over the provider auto-bridge below.
+   *
+   * Note: the underlying `@mastra/mcp` `startHTTP` hook is a framework-agnostic
+   * `(req) => void`; this convenience hook additionally surfaces the resolved
+   * `requestContext` and bearer `token` without exposing framework types.
+   */
+  setRequestAuth?: (args: {
+    req: IncomingMessage;
+    requestContext: RequestContext;
+    token?: string;
+  }) => void | Promise<void>;
+  /**
+   * Style A: whether to auto-bridge the authenticated principal resolved by a
+   * configured `server.auth` provider into `req.auth`. Enabled by default; set
+   * `false` to opt out. No-op when no `user` was resolved into the request context.
+   * @default true
+   */
+  autoBridgeAuth?: boolean;
+  /**
+   * Style A: override the default `user -> AuthInfo` mapping used by the auto-bridge.
+   * Provider payloads differ widely, so the default is best-effort; supply this for
+   * exact control. Receives the resolved `user`, the bearer `token` (if available),
+   * and the request context.
+   */
+  mapUserToAuthInfo?: (args: { user: unknown; token?: string; requestContext: RequestContext }) => MCPRequestAuthInfo;
+}
+
+/**
+ * Default best-effort `user -> AuthInfo` mapping for the Style A auto-bridge.
+ *
+ * Provider payloads differ widely, so this only reads commonly-present fields and
+ * never guesses aggressively. For exact control supply `server.mcp.mapUserToAuthInfo`.
+ */
+export function defaultMapUserToAuthInfo({ user, token }: { user: unknown; token?: string }): MCPRequestAuthInfo {
+  const u = (user ?? {}) as Record<string, unknown>;
+  const clientId = u.clientId ?? u.client_id ?? u.azp ?? u.sub ?? u.id;
+  const scopes = Array.isArray(u.scopes)
+    ? u.scopes.filter((s): s is string => typeof s === 'string')
+    : typeof u.scope === 'string'
+      ? u.scope.split(' ')
+      : [];
+  return {
+    token,
+    clientId: typeof clientId === 'string' ? clientId : undefined,
+    scopes,
+    extra: { user },
+  };
+}
 
 export type CorsOptions = Parameters<typeof cors>[0];
 
@@ -324,6 +400,18 @@ export type ServerConfig = {
      */
     sessionIdGenerator?: () => string;
   };
+
+  /**
+   * MCP auth-bridging configuration. Lets HTTP/Hono-layer authentication reach MCP
+   * tools by populating the MCP request's `req.auth` (so `extra.authInfo` is emitted).
+   *
+   * - Style A: when a `server.auth` provider is configured, the resolved principal is
+   *   auto-bridged into `req.auth` by default (toggle with `autoBridgeAuth`, customize
+   *   with `mapUserToAuthInfo`).
+   * - Style B: for custom middleware gates, provide `setRequestAuth` to read the request
+   *   context and assign `req.auth` yourself (takes precedence over the auto-bridge).
+   */
+  mcp?: MCPServerOptions;
 
   /**
    * A2A-specific server configuration.

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -1382,9 +1382,7 @@ describe('MCPServer', () => {
     });
 
     it('runs the hook on the stateful initialize request (new session path)', async () => {
-      // Track which JSON-RPC method each hook invocation corresponds to, so we can
-      // assert the hook fired on the initialize request that creates the session.
-      const methodsSeenByHook: Array<string | undefined> = [];
+      const hookCalls: string[] = [];
       authServer = new MCPServer({ name: 'AuthHookInitServer', version: '1.0.0', tools: authEchoTools });
 
       authHttpServer = http.createServer(async (req, res) => {
@@ -1396,27 +1394,26 @@ describe('MCPServer', () => {
           res,
           // Stateful: default sessionIdGenerator (sessions enabled)
           setRequestAuth: r => {
-            methodsSeenByHook.push(r.method); // HTTP method (POST/GET) proves hook ran per request
+            hookCalls.push(r.method ?? 'unknown');
             (r as any).auth = { token: 'tkn', clientId: 'cid' };
           },
         });
       });
       currentPort = await listenOnEphemeralPort(authHttpServer);
 
-      const client = new InternalMastraMCPClient({
-        name: 'auth-init-client',
-        server: { url: new URL(`http://localhost:${currentPort}/http`) },
+      const res = await fetch(`http://localhost:${currentPort}/http`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } },
+        }),
       });
-      // connect() performs the initialize handshake, exercising the new-session path.
-      await client.connect();
-      const tools = await client.tools();
-      expect(tools).toBeDefined();
-      expect(Object.keys(tools).length).toBeGreaterThan(0);
-      await client.disconnect();
 
-      // The initialize POST must have run the hook at least once.
-      expect(methodsSeenByHook.length).toBeGreaterThan(0);
-      expect(methodsSeenByHook.every(m => m !== undefined)).toBe(true);
+      expect(res.status).toBe(200);
+      expect(hookCalls).toEqual(['POST']);
     });
 
     it('runs the hook on existing-session requests and flows authInfo to tools', async () => {
@@ -2023,6 +2020,14 @@ describe('MCPServer - Agent to Tool Conversion', () => {
     expect(directToolOptions.mcp.extra.authInfo.token).toBe('test-auth-token-123');
     expect(directToolOptions.mcp.extra.authInfo.clientId).toBe('test-client-456');
     expect(directToolOptions.mcp.extra.sessionId).toBe('auth-test-session');
+    expect(Object.keys(directToolOptions)).not.toContain('elicitation');
+    expect(Object.keys(directToolOptions)).not.toContain('extra');
+    expect(Object.getOwnPropertyDescriptor(directToolOptions, 'elicitation')?.enumerable).toBe(false);
+    expect(Object.getOwnPropertyDescriptor(directToolOptions, 'extra')?.enumerable).toBe(false);
+    expect(() => directToolOptions.elicitation).toThrow(
+      'The "elicitation" key is now nested under "mcp.elicitation" in tool arguments',
+    );
+    expect(() => directToolOptions.extra).toThrow('The "extra" key is now nested under "mcp.extra" in tool arguments');
 
     // Verify requestContext is populated from mcp.extra for regular tools
     expect(directToolOptions.requestContext).toBeDefined();

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -10,6 +10,7 @@ import { createTool } from '@mastra/core/tools';
 import { createStep, Workflow } from '@mastra/core/workflows';
 import { isStandardSchemaWithJSON, standardSchemaToJSONSchema } from '@mastra/schema-compat/schema';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type {
   Resource,
   ResourceTemplate,
@@ -1198,6 +1199,261 @@ describe('MCPServer', () => {
       expect(toolResult.authInfo.token).toBe(TOKEN);
       expect(toolResult.authInfo.clientId).toBe('test-client-id');
       expect(toolResult.requestId).toBe('test-request-id');
+    });
+  });
+
+  describe('MCPServer HTTP Transport - setRequestAuth hook', () => {
+    vi.setConfig({ testTimeout: 30_000 });
+
+    let authHttpServer: http.Server;
+    let authServer: MCPServer;
+    let currentPort: number;
+
+    const listenOnEphemeralPort = (server: http.Server): Promise<number> =>
+      new Promise<number>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, () => {
+          const address = server.address();
+          if (address && typeof address === 'object') resolve(address.port);
+          else reject(new Error('Failed to obtain ephemeral port'));
+        });
+      });
+
+    // Tool that echoes back the authInfo seen by the handler, so tests can assert
+    // the hook-populated req.auth flowed through to extra.authInfo.
+    const authEchoTools: ToolsInput = {
+      whoami: {
+        description: 'Echoes the authInfo seen by the handler',
+        parameters: z.object({}),
+        execute: async (_args, context) => {
+          const extra = context?.mcp?.extra as MCPRequestHandlerExtra | undefined;
+          return { authInfo: extra?.authInfo ?? null };
+        },
+      },
+    };
+
+    afterEach(async () => {
+      if (authHttpServer) {
+        authHttpServer.closeAllConnections?.();
+        await new Promise<void>((resolve, reject) => authHttpServer.close(err => (err ? reject(err) : resolve())));
+      }
+      if (authServer) await authServer.close();
+    });
+
+    it('runs the hook before handleRequest and populates extra.authInfo (stateless path)', async () => {
+      const calls: string[] = [];
+      authServer = new MCPServer({ name: 'AuthHookServer', version: '1.0.0', tools: authEchoTools });
+
+      authHttpServer = http.createServer(async (req, res) => {
+        const url = new URL(req.url || '', `http://localhost:${currentPort}`);
+        await authServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          options: { sessionIdGenerator: undefined }, // stateless
+          setRequestAuth: r => {
+            calls.push('hook');
+            (r as any).auth = { token: 'tkn', clientId: 'cid', scopes: ['read'] };
+          },
+        });
+      });
+      currentPort = await listenOnEphemeralPort(authHttpServer);
+
+      const client = new InternalMastraMCPClient({
+        name: 'auth-hook-client',
+        server: { url: new URL(`http://localhost:${currentPort}/http`) },
+      });
+      await client.connect();
+      const tools = await client.tools();
+      const result = await tools['whoami'].execute!({});
+      await client.disconnect();
+
+      const payload = JSON.parse((result.content as any)[0].text);
+      expect(payload.authInfo).toEqual({ token: 'tkn', clientId: 'cid', scopes: ['read'] });
+      // Hook must have run at least once, exactly once per HTTP request reaching the transport.
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    it('invokes the hook exactly once per request', async () => {
+      const perRequestCalls: number[] = [];
+      authServer = new MCPServer({ name: 'AuthHookOnceServer', version: '1.0.0', tools: authEchoTools });
+
+      authHttpServer = http.createServer(async (req, res) => {
+        const url = new URL(req.url || '', `http://localhost:${currentPort}`);
+        let count = 0;
+        await authServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          options: { sessionIdGenerator: undefined },
+          setRequestAuth: r => {
+            count += 1;
+            (r as any).auth = { token: 'tkn' };
+          },
+        });
+        // Record how many times the hook fired for this single HTTP request.
+        perRequestCalls.push(count);
+      });
+      currentPort = await listenOnEphemeralPort(authHttpServer);
+
+      const client = new InternalMastraMCPClient({
+        name: 'auth-once-client',
+        server: { url: new URL(`http://localhost:${currentPort}/http`) },
+      });
+      await client.connect();
+      const tools = await client.tools();
+      await tools['whoami'].execute!({});
+      await client.disconnect();
+
+      // Every HTTP request that reached the transport ran the hook exactly once.
+      expect(perRequestCalls.length).toBeGreaterThan(0);
+      for (const c of perRequestCalls) expect(c).toBe(1);
+    });
+
+    it('does not reach the transport when the hook throws', async () => {
+      authServer = new MCPServer({ name: 'AuthHookThrowServer', version: '1.0.0', tools: authEchoTools });
+      const hookSpy = vi.fn();
+      // Spy the real transport.handleRequest to prove it is never reached when the hook throws.
+      const handleRequestSpy = vi.spyOn(StreamableHTTPServerTransport.prototype, 'handleRequest');
+
+      authHttpServer = http.createServer(async (req, res) => {
+        const url = new URL(req.url || '', `http://localhost:${currentPort}`);
+        await authServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          options: { sessionIdGenerator: undefined },
+          setRequestAuth: () => {
+            hookSpy(); // marker: hook ran
+            throw new Error('auth failed');
+          },
+        });
+      });
+      currentPort = await listenOnEphemeralPort(authHttpServer);
+
+      // Raw POST initialize request; hook throws -> startHTTP's catch returns 500.
+      const res = await fetch(`http://localhost:${currentPort}/http`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } },
+        }),
+      });
+
+      expect(hookSpy).toHaveBeenCalledTimes(1);
+      expect(handleRequestSpy).not.toHaveBeenCalled();
+      expect(res.status).toBe(500);
+      handleRequestSpy.mockRestore();
+    });
+
+    it('is a no-op when no hook is provided (authInfo stays undefined)', async () => {
+      authServer = new MCPServer({ name: 'NoAuthHookServer', version: '1.0.0', tools: authEchoTools });
+
+      authHttpServer = http.createServer(async (req, res) => {
+        const url = new URL(req.url || '', `http://localhost:${currentPort}`);
+        await authServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          options: { sessionIdGenerator: undefined },
+          // no setRequestAuth
+        });
+      });
+      currentPort = await listenOnEphemeralPort(authHttpServer);
+
+      const client = new InternalMastraMCPClient({
+        name: 'no-auth-hook-client',
+        server: { url: new URL(`http://localhost:${currentPort}/http`) },
+      });
+      await client.connect();
+      const tools = await client.tools();
+      const result = await tools['whoami'].execute!({});
+      await client.disconnect();
+
+      const payload = JSON.parse((result.content as any)[0].text);
+      expect(payload.authInfo).toBeNull();
+    });
+
+    it('runs the hook on the stateful initialize request (new session path)', async () => {
+      // Track which JSON-RPC method each hook invocation corresponds to, so we can
+      // assert the hook fired on the initialize request that creates the session.
+      const methodsSeenByHook: Array<string | undefined> = [];
+      authServer = new MCPServer({ name: 'AuthHookInitServer', version: '1.0.0', tools: authEchoTools });
+
+      authHttpServer = http.createServer(async (req, res) => {
+        const url = new URL(req.url || '', `http://localhost:${currentPort}`);
+        await authServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          // Stateful: default sessionIdGenerator (sessions enabled)
+          setRequestAuth: r => {
+            methodsSeenByHook.push(r.method); // HTTP method (POST/GET) proves hook ran per request
+            (r as any).auth = { token: 'tkn', clientId: 'cid' };
+          },
+        });
+      });
+      currentPort = await listenOnEphemeralPort(authHttpServer);
+
+      const client = new InternalMastraMCPClient({
+        name: 'auth-init-client',
+        server: { url: new URL(`http://localhost:${currentPort}/http`) },
+      });
+      // connect() performs the initialize handshake, exercising the new-session path.
+      await client.connect();
+      const tools = await client.tools();
+      expect(tools).toBeDefined();
+      expect(Object.keys(tools).length).toBeGreaterThan(0);
+      await client.disconnect();
+
+      // The initialize POST must have run the hook at least once.
+      expect(methodsSeenByHook.length).toBeGreaterThan(0);
+      expect(methodsSeenByHook.every(m => m !== undefined)).toBe(true);
+    });
+
+    it('runs the hook on existing-session requests and flows authInfo to tools', async () => {
+      let hookCalls = 0;
+      authServer = new MCPServer({ name: 'AuthHookSessionServer', version: '1.0.0', tools: authEchoTools });
+
+      authHttpServer = http.createServer(async (req, res) => {
+        const url = new URL(req.url || '', `http://localhost:${currentPort}`);
+        await authServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          // Stateful: sessions enabled, so tool calls reuse the existing session/transport.
+          setRequestAuth: r => {
+            hookCalls += 1;
+            (r as any).auth = { token: 'tkn', clientId: 'cid', scopes: ['read'] };
+          },
+        });
+      });
+      currentPort = await listenOnEphemeralPort(authHttpServer);
+
+      const client = new InternalMastraMCPClient({
+        name: 'auth-session-client',
+        server: { url: new URL(`http://localhost:${currentPort}/http`) },
+      });
+      await client.connect(); // initialize (new session)
+      const callsAfterConnect = hookCalls;
+      const tools = await client.tools();
+      // Tool call reuses the established session, exercising the existing-session path.
+      const result = await tools['whoami'].execute!({});
+      await client.disconnect();
+
+      // The hook ran again for the post-initialize (existing-session) request(s).
+      expect(hookCalls).toBeGreaterThan(callsAfterConnect);
+      const payload = JSON.parse((result.content as any)[0].text);
+      expect(payload.authInfo).toEqual({ token: 'tkn', clientId: 'cid', scopes: ['read'] });
     });
   });
 

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -704,14 +704,21 @@ export class MCPServer extends MCPServerBase {
             elicitation: sessionElicitation,
             extra,
           },
-          // Runtime guard for callers that still read the legacy top-level key.
-          get elicitation() {
-            throw new Error(`The "elicitation" key is now nested under "mcp.elicitation" in tool arguments`);
-          },
-          get extra() {
-            throw new Error(`The "extra" key is now nested under "mcp.extra" in tool arguments`);
-          },
         };
+        Object.defineProperties(mcpOptions, {
+          elicitation: {
+            enumerable: false,
+            get() {
+              throw new Error(`The "elicitation" key is now nested under "mcp.elicitation" in tool arguments`);
+            },
+          },
+          extra: {
+            enumerable: false,
+            get() {
+              throw new Error(`The "extra" key is now nested under "mcp.extra" in tool arguments`);
+            },
+          },
+        });
 
         await this.enforceToolExecutionFGA(request.params.name, proxiedContext);
 

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -704,7 +704,7 @@ export class MCPServer extends MCPServerBase {
             elicitation: sessionElicitation,
             extra,
           },
-          // @ts-expect-error this is to let people know that the elicitation and extra keys are now nested under mcp.elicitation and mcp.extra in tool arguments
+          // Runtime guard for callers that still read the legacy top-level key.
           get elicitation() {
             throw new Error(`The "elicitation" key is now nested under "mcp.elicitation" in tool arguments`);
           },
@@ -1552,12 +1552,28 @@ export class MCPServer extends MCPServerBase {
     req,
     res,
     options,
+    setRequestAuth,
   }: {
     url: URL;
     httpPath: string;
     req: http.IncomingMessage;
     res: http.ServerResponse<http.IncomingMessage>;
     options?: Partial<StreamableHTTPServerTransportOptions> & { serverless?: boolean };
+    /**
+     * Optional framework-agnostic hook invoked immediately before the request is
+     * handed to the underlying StreamableHTTPServerTransport. Use it to populate
+     * `req.auth` so the MCP SDK can emit `extra.authInfo` to tool handlers.
+     *
+     * The hook receives only the Node `IncomingMessage` (no framework types). The
+     * surrounding server adapter (e.g. Hono) is responsible for closing over its
+     * own request context and producing this callback.
+     *
+     * It runs once per request, ahead of every transport path (existing session,
+     * new session initialize, and stateless/serverless). If it throws, the request
+     * does not reach the transport and the error propagates to the existing error
+     * handling (which responds 500).
+     */
+    setRequestAuth?: (req: http.IncomingMessage) => void | Promise<void>;
   }) {
     this.logger.debug('Received HTTP request', { method: req.method, path: url.pathname });
 
@@ -1574,7 +1590,7 @@ export class MCPServer extends MCPServerBase {
 
     if (isStatelessMode) {
       this.logger.debug('Running in stateless mode');
-      await this.handleServerlessRequest(req, res);
+      await this.handleServerlessRequest(req, res, setRequestAuth);
       return;
     }
 
@@ -1605,6 +1621,7 @@ export class MCPServer extends MCPServerBase {
         // Need to parse body for POST requests before passing to handleRequest
         const body = req.method === 'POST' ? await this.readJsonBody(req) : undefined;
 
+        await this.applyRequestAuth(req, setRequestAuth);
         await transport.handleRequest(req, res, body);
       } else if (sessionId) {
         // Session ID provided but not found (e.g. server restarted, session expired).
@@ -1674,6 +1691,7 @@ export class MCPServer extends MCPServerBase {
             }
 
             // Handle the initialize request
+            await this.applyRequestAuth(req, setRequestAuth);
             return await transport.handleRequest(req, res, body);
           } else {
             // POST request but not initialize, and no session ID
@@ -1736,6 +1754,28 @@ export class MCPServer extends MCPServerBase {
   }
 
   /**
+   * Invokes the optional `setRequestAuth` hook exactly once, immediately before a
+   * request is handed to the transport's `handleRequest`. Centralizing the call
+   * here (rather than at the `startHTTP` entry) guarantees it runs on every path
+   * - existing session, new session initialize, and stateless/serverless - without
+   * double-invoking or missing a branch.
+   *
+   * The hook is awaited (token verification is typically async). If it throws, the
+   * error propagates so the request never reaches `handleRequest`.
+   *
+   * @private
+   */
+  private async applyRequestAuth(
+    req: http.IncomingMessage,
+    setRequestAuth?: (req: http.IncomingMessage) => void | Promise<void>,
+  ): Promise<void> {
+    if (!setRequestAuth) {
+      return;
+    }
+    await setRequestAuth(req);
+  }
+
+  /**
    * Handles a stateless, serverless HTTP request without session management.
    *
    * This method bypasses all session/transport state and handles each request independently.
@@ -1748,7 +1788,11 @@ export class MCPServer extends MCPServerBase {
    * @param res - HTTP response object
    * @private
    */
-  private async handleServerlessRequest(req: http.IncomingMessage, res: http.ServerResponse<http.IncomingMessage>) {
+  private async handleServerlessRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse<http.IncomingMessage>,
+    setRequestAuth?: (req: http.IncomingMessage) => void | Promise<void>,
+  ) {
     try {
       this.logger.debug('Received serverless request', { method: req.method });
 
@@ -1778,6 +1822,7 @@ export class MCPServer extends MCPServerBase {
 
       // Handle the request through the transport
       // The transport will send the response and this instance will be garbage collected
+      await this.applyRequestAuth(req, setRequestAuth);
       await tempTransport.handleRequest(req, res, body);
 
       this.logger.debug('Completed serverless request', { method: body?.method, id: body?.id });

--- a/server-adapters/hono/src/__tests__/mcp-auth-bridge.test.ts
+++ b/server-adapters/hono/src/__tests__/mcp-auth-bridge.test.ts
@@ -1,0 +1,355 @@
+import type { IncomingMessage } from 'node:http';
+import type { Mastra } from '@mastra/core/mastra';
+import { RequestContext, MASTRA_AUTH_TOKEN_KEY } from '@mastra/core/request-context';
+import { Hono } from 'hono';
+import { describe, it, expect, vi } from 'vitest';
+import { MastraServer } from '../index';
+
+/**
+ * Unit tests for the MCP req.auth bridge that the Hono adapter constructs in the
+ * `mcp-http` branch. The bridge closes over the live Hono context and produces a
+ * framework-agnostic `(req) => void` callback for `MCPServer.startHTTP` to invoke
+ * before `transport.handleRequest`.
+ *
+ * Two modes are exercised here:
+ * - Style B: explicit `server.mcp.setRequestAuth` receives `{ req, requestContext, token }`.
+ * - Style A: provider-backed auto-bridge reads `user`/`token` already written into
+ *   the Hono request context by the auth middleware and assigns `req.auth`.
+ */
+
+// Tiny subclass that exposes the otherwise-protected bridge builder for unit testing.
+class TestableAdapter extends MastraServer {
+  public expose_buildBridge(c: any) {
+    return this.buildMcpRequestAuthBridge(c);
+  }
+}
+
+interface BuildAdapterOpts {
+  serverConfig?: Record<string, unknown>;
+}
+
+function buildAdapter({ serverConfig = {} }: BuildAdapterOpts = {}) {
+  const app = new Hono<any, any, any>();
+  const mastra = {
+    getServer: () => serverConfig,
+    getLogger: () => undefined,
+    setMastraServer: vi.fn(),
+  } as unknown as Mastra;
+
+  return new TestableAdapter({ app: app as any, mastra });
+}
+
+function makeMockRequestContext(initial: Record<string, unknown> = {}) {
+  const rc = new RequestContext();
+  for (const [k, v] of Object.entries(initial)) rc.set(k, v);
+  return rc;
+}
+
+function makeMockHonoContext(opts: { requestContext: RequestContext; authHeader?: string }) {
+  const { requestContext, authHeader } = opts;
+  return {
+    get: (key: string) => (key === 'requestContext' ? requestContext : undefined),
+    req: {
+      header: (name: string) => (name === 'Authorization' ? authHeader : undefined),
+    },
+  } as any;
+}
+
+function makeMockReq() {
+  return {} as IncomingMessage & { auth?: unknown };
+}
+
+describe('Hono adapter: buildMcpRequestAuthBridge', () => {
+  it('returns undefined when no provider and no manual hook configured', () => {
+    const adapter = buildAdapter();
+    const c = makeMockHonoContext({ requestContext: makeMockRequestContext() });
+    expect(adapter.expose_buildBridge(c)).toBeUndefined();
+  });
+
+  describe('Style B: manual setRequestAuth hook', () => {
+    it('passes the live requestContext and bearer token from the Authorization header', async () => {
+      const calls: Array<{ req: unknown; requestContext: RequestContext; token?: string }> = [];
+      const adapter = buildAdapter({
+        serverConfig: {
+          mcp: {
+            setRequestAuth: (args: { req: IncomingMessage; requestContext: RequestContext; token?: string }) => {
+              calls.push(args);
+              (args.req as any).auth = { token: args.token, clientId: 'demo' };
+            },
+          },
+        },
+      });
+
+      const requestContext = makeMockRequestContext({ 'auth.payload': { sub: 'u1' } });
+      const c = makeMockHonoContext({ requestContext, authHeader: 'Bearer raw-token-from-header' });
+
+      const bridge = adapter.expose_buildBridge(c)!;
+      expect(bridge).toBeTypeOf('function');
+
+      const req = makeMockReq();
+      await bridge(req);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].requestContext).toBe(requestContext);
+      expect(calls[0].requestContext.get('auth.payload')).toEqual({ sub: 'u1' });
+      expect(calls[0].token).toBe('raw-token-from-header');
+      expect((req as any).auth).toEqual({ token: 'raw-token-from-header', clientId: 'demo' });
+    });
+
+    it('falls back to the requestContext token when no Authorization header is present', async () => {
+      const calls: Array<{ token?: string }> = [];
+      const adapter = buildAdapter({
+        serverConfig: {
+          mcp: {
+            setRequestAuth: (args: { token?: string }) => calls.push({ token: args.token }),
+          },
+        },
+      });
+
+      const requestContext = makeMockRequestContext({ [MASTRA_AUTH_TOKEN_KEY]: 'token-from-context' });
+      const c = makeMockHonoContext({ requestContext });
+      await adapter.expose_buildBridge(c)!(makeMockReq());
+
+      expect(calls[0].token).toBe('token-from-context');
+    });
+
+    it('takes precedence over the auto-bridge even when an auth provider is configured', async () => {
+      const manualHook = vi.fn();
+      const adapter = buildAdapter({
+        serverConfig: {
+          mcp: { setRequestAuth: manualHook },
+          auth: { authenticateToken: () => ({ id: 'u1' }) }, // looks like a provider
+        },
+      });
+
+      const requestContext = makeMockRequestContext({ user: { id: 'u1' }, [MASTRA_AUTH_TOKEN_KEY]: 'tkn' });
+      const c = makeMockHonoContext({ requestContext });
+      const req = makeMockReq();
+      await adapter.expose_buildBridge(c)!(req);
+
+      expect(manualHook).toHaveBeenCalledTimes(1);
+      // Manual hook didn't assign req.auth itself, and the auto-bridge never ran.
+      expect((req as any).auth).toBeUndefined();
+    });
+
+    it('ignores a non-string token written into the requestContext', async () => {
+      const calls: Array<{ token?: string }> = [];
+      const adapter = buildAdapter({
+        serverConfig: {
+          mcp: { setRequestAuth: (args: { token?: string }) => calls.push({ token: args.token }) },
+        },
+      });
+
+      // Defensive: someone wrote a non-string under the token key.
+      const requestContext = makeMockRequestContext({ [MASTRA_AUTH_TOKEN_KEY]: { not: 'a string' } });
+      const c = makeMockHonoContext({ requestContext });
+      await adapter.expose_buildBridge(c)!(makeMockReq());
+
+      expect(calls[0].token).toBeUndefined();
+    });
+  });
+
+  describe('Style A: provider auto-bridge', () => {
+    it('detects an auth provider via capability (typeof authenticateToken === function), not instanceof', () => {
+      const adapter = buildAdapter({
+        serverConfig: {
+          // Plain object with MastraAuthProvider capability, no class identity needed.
+          auth: { authenticateToken: () => null },
+        },
+      });
+      const c = makeMockHonoContext({ requestContext: makeMockRequestContext({ user: { id: 'u1' } }) });
+      expect(adapter.expose_buildBridge(c)).toBeTypeOf('function');
+    });
+
+    it('writes req.auth using the default mapping when user + token are present', () => {
+      const adapter = buildAdapter({
+        serverConfig: { auth: { authenticateToken: () => null } },
+      });
+      const requestContext = makeMockRequestContext({
+        user: { sub: 'u-1', scope: 'read write' },
+        [MASTRA_AUTH_TOKEN_KEY]: 'tkn',
+      });
+      const c = makeMockHonoContext({ requestContext });
+      const req = makeMockReq();
+      adapter.expose_buildBridge(c)!(req);
+
+      expect((req as any).auth).toMatchObject({
+        token: 'tkn',
+        clientId: 'u-1',
+        scopes: ['read', 'write'],
+      });
+      // user is preserved under .extra so callers can recover provider-specific fields.
+      expect((req as any).auth.extra).toEqual({ user: { sub: 'u-1', scope: 'read write' } });
+    });
+
+    it('honors mapUserToAuthInfo override', () => {
+      const adapter = buildAdapter({
+        serverConfig: {
+          auth: { authenticateToken: () => null },
+          mcp: {
+            mapUserToAuthInfo: ({ user, token }: { user: any; token?: string }) => ({
+              token,
+              clientId: `custom:${user.id}`,
+              scopes: ['admin'],
+              extra: {},
+            }),
+          },
+        },
+      });
+      const requestContext = makeMockRequestContext({
+        user: { id: '42' },
+        [MASTRA_AUTH_TOKEN_KEY]: 'tkn',
+      });
+      const c = makeMockHonoContext({ requestContext });
+      const req = makeMockReq();
+      adapter.expose_buildBridge(c)!(req);
+
+      expect((req as any).auth).toEqual({
+        token: 'tkn',
+        clientId: 'custom:42',
+        scopes: ['admin'],
+        extra: {},
+      });
+    });
+
+    it('is a no-op when no user is in the request context (never fabricates authInfo)', () => {
+      const adapter = buildAdapter({
+        serverConfig: { auth: { authenticateToken: () => null } },
+      });
+      // No user written: auth middleware did not run / route was not protected.
+      const c = makeMockHonoContext({ requestContext: makeMockRequestContext() });
+      const req = makeMockReq();
+      adapter.expose_buildBridge(c)!(req);
+
+      expect((req as any).auth).toBeUndefined();
+    });
+
+    it('returns undefined when autoBridgeAuth is explicitly disabled', () => {
+      const adapter = buildAdapter({
+        serverConfig: {
+          auth: { authenticateToken: () => null },
+          mcp: { autoBridgeAuth: false },
+        },
+      });
+      const c = makeMockHonoContext({ requestContext: makeMockRequestContext({ user: { id: 'u1' } }) });
+      expect(adapter.expose_buildBridge(c)).toBeUndefined();
+    });
+  });
+});
+
+/**
+ * Wiring test: proves the `mcp-http` branch of `sendResponse` actually passes the
+ * bridge-built `setRequestAuth` into `server.startHTTP`. The bridge semantics are
+ * covered above; this guards the integration seam against future refactors of
+ * `sendResponse` silently dropping the hook.
+ */
+describe('Hono adapter: sendResponse(mcp-http) wires setRequestAuth into startHTTP', () => {
+  function makeRouteContext(opts: { requestContext: RequestContext; url: string }) {
+    // Real web Request so toReqRes(response.req.raw) works inside sendResponse.
+    const raw = new Request(opts.url, { method: 'POST' });
+    return {
+      get: (key: string) => (key === 'requestContext' ? opts.requestContext : undefined),
+      header: () => undefined,
+      req: {
+        raw,
+        url: opts.url,
+        header: () => undefined,
+      },
+    } as any;
+  }
+
+  it('passes a setRequestAuth callback to startHTTP when server.mcp.setRequestAuth is configured', async () => {
+    const userHook = vi.fn();
+    const adapter = buildAdapter({
+      serverConfig: { mcp: { setRequestAuth: userHook } },
+    });
+
+    let captured: ((req: IncomingMessage) => void | Promise<void>) | undefined;
+    const fakeServer = {
+      startHTTP: vi.fn(async (args: { res: any; setRequestAuth?: (req: IncomingMessage) => void | Promise<void> }) => {
+        captured = args.setRequestAuth;
+        // End the response so sendResponse's toFetchResponse(res) can resolve.
+        args.res.writeHead(200, { 'Content-Type': 'application/json' });
+        args.res.end('{}');
+      }),
+    };
+
+    const requestContext = makeMockRequestContext({ 'auth.payload': { sub: 'u1' } });
+    const c = makeRouteContext({ requestContext, url: 'http://localhost/api/mcp/my-server/mcp' });
+
+    await adapter.sendResponse({ responseType: 'mcp-http' } as any, c, {
+      server: fakeServer,
+      httpPath: '/mcp/my-server/mcp',
+    } as any);
+
+    expect(fakeServer.startHTTP).toHaveBeenCalledTimes(1);
+    expect(captured).toBeTypeOf('function');
+
+    // The captured callback must be the bridge: invoking it forwards to the user hook
+    // with the live requestContext.
+    await captured!({} as IncomingMessage);
+    expect(userHook).toHaveBeenCalledTimes(1);
+    expect(userHook.mock.calls[0][0].requestContext).toBe(requestContext);
+  });
+
+  it('passes setRequestAuth: undefined to startHTTP when no bridge applies', async () => {
+    const adapter = buildAdapter({ serverConfig: {} }); // no auth provider, no manual hook
+
+    const calls: Array<{ setRequestAuth?: unknown }> = [];
+    const fakeServer = {
+      startHTTP: vi.fn(async (args: { res: any; setRequestAuth?: unknown }) => {
+        calls.push({ setRequestAuth: args.setRequestAuth });
+        args.res.writeHead(200, { 'Content-Type': 'application/json' });
+        args.res.end('{}');
+      }),
+    };
+
+    const c = makeRouteContext({
+      requestContext: makeMockRequestContext(),
+      url: 'http://localhost/api/mcp/my-server/mcp',
+    });
+
+    await adapter.sendResponse({ responseType: 'mcp-http' } as any, c, {
+      server: fakeServer,
+      httpPath: '/mcp/my-server/mcp',
+    } as any);
+
+    expect(fakeServer.startHTTP).toHaveBeenCalledTimes(1);
+    expect(calls[0].setRequestAuth).toBeUndefined();
+  });
+
+  it('does not leak server.mcp auth config into the transport options', async () => {
+    const adapter = buildAdapter({
+      serverConfig: { mcp: { setRequestAuth: vi.fn(), autoBridgeAuth: true, mapUserToAuthInfo: vi.fn() } },
+    });
+
+    let capturedOptions: Record<string, unknown> | undefined;
+    const fakeServer = {
+      startHTTP: vi.fn(async (args: { res: any; options?: Record<string, unknown> }) => {
+        capturedOptions = args.options;
+        args.res.writeHead(200, { 'Content-Type': 'application/json' });
+        args.res.end('{}');
+      }),
+    };
+
+    const c = makeRouteContext({
+      requestContext: makeMockRequestContext(),
+      url: 'http://localhost/api/mcp/my-server/mcp',
+    });
+
+    await adapter.sendResponse({ responseType: 'mcp-http' } as any, c, {
+      server: fakeServer,
+      httpPath: '/mcp/my-server/mcp',
+    } as any);
+
+    // options is undefined here (no transport mcpOptions). Crucially, none of the
+    // auth-bridge fields leaked into transport options.
+    if (capturedOptions) {
+      expect(capturedOptions).not.toHaveProperty('setRequestAuth');
+      expect(capturedOptions).not.toHaveProperty('autoBridgeAuth');
+      expect(capturedOptions).not.toHaveProperty('mapUserToAuthInfo');
+    } else {
+      expect(capturedOptions).toBeUndefined();
+    }
+  });
+});

--- a/server-adapters/hono/src/__tests__/mcp-auth-bridge.test.ts
+++ b/server-adapters/hono/src/__tests__/mcp-auth-bridge.test.ts
@@ -113,6 +113,23 @@ describe('Hono adapter: buildMcpRequestAuthBridge', () => {
       expect(calls[0].token).toBe('token-from-context');
     });
 
+    it('prefers the resolved requestContext token over the raw Authorization header', async () => {
+      const calls: Array<{ token?: string }> = [];
+      const adapter = buildAdapter({
+        serverConfig: {
+          mcp: {
+            setRequestAuth: (args: { token?: string }) => calls.push({ token: args.token }),
+          },
+        },
+      });
+
+      const requestContext = makeMockRequestContext({ [MASTRA_AUTH_TOKEN_KEY]: 'context-token' });
+      const c = makeMockHonoContext({ requestContext, authHeader: 'Bearer raw-token-from-header' });
+      await adapter.expose_buildBridge(c)!(makeMockReq());
+
+      expect(calls[0].token).toBe('context-token');
+    });
+
     it('takes precedence over the auto-bridge even when an auth provider is configured', async () => {
       const manualHook = vi.fn();
       const adapter = buildAdapter({

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -1,6 +1,10 @@
+import type { IncomingMessage } from 'node:http';
 import type { ToolsInput } from '@mastra/core/agent';
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
+import { MASTRA_AUTH_TOKEN_KEY } from '@mastra/core/request-context';
+import { defaultMapUserToAuthInfo } from '@mastra/core/server';
+import type { MCPServerOptions } from '@mastra/core/server';
 import type { InMemoryTaskStore } from '@mastra/server/a2a/store';
 
 import type { MCPHttpTransportResult, MCPSseTransportResult } from '@mastra/server/handlers/mcp';
@@ -297,6 +301,58 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
     return result;
   }
 
+  /**
+   * Builds the framework-agnostic `setRequestAuth` callback passed to
+   * `MCPServer.startHTTP`, closing over the live Hono context `c`.
+   *
+   * Two modes (Style B takes precedence over Style A):
+   * - Style B: `server.mcp.setRequestAuth` is configured: surface the request
+   *   context + bearer token to the user hook so it can assign `req.auth`.
+   * - Style A: a `server.auth` provider is configured and `autoBridgeAuth !== false`
+   *   map the principal resolved into the request context to `req.auth`.
+   *
+   * Returns `undefined` when neither applies, so behavior is unchanged by default.
+   * The "read from Hono context" logic lives entirely here; `@mastra/mcp` only ever
+   * sees a plain `(req) => void` callback.
+   */
+  protected buildMcpRequestAuthBridge(c: Context): ((req: IncomingMessage) => void | Promise<void>) | undefined {
+    const serverConfig = this.mastra.getServer();
+    const mcpConfig: MCPServerOptions | undefined = serverConfig?.mcp;
+
+    // Style B: explicit manual hook wins.
+    if (mcpConfig?.setRequestAuth) {
+      const userHook = mcpConfig.setRequestAuth;
+      return async (req: IncomingMessage) => {
+        const requestContext = c.get('requestContext') as RequestContext;
+        const ctxToken = requestContext?.get(MASTRA_AUTH_TOKEN_KEY);
+        // Only extract a Bearer token; other schemes (e.g. Basic) are not bearer tokens.
+        const headerToken = c.req.header('Authorization')?.match(/^Bearer\s+(.+)$/i)?.[1];
+        const token = headerToken ?? (typeof ctxToken === 'string' ? ctxToken : undefined);
+        await userHook({ req, requestContext, token });
+      };
+    }
+
+    // Style A: provider auto-bridge (default on). Detect a provider via capability,
+    // not instanceof (robust across monorepo / multi-version packages).
+    const auth = serverConfig?.auth as { authenticateToken?: unknown } | undefined;
+    const hasAuthProvider = typeof auth?.authenticateToken === 'function';
+    if (hasAuthProvider && mcpConfig?.autoBridgeAuth !== false) {
+      const mapUserToAuthInfo = mcpConfig?.mapUserToAuthInfo ?? defaultMapUserToAuthInfo;
+      return (req: IncomingMessage) => {
+        const requestContext = c.get('requestContext') as RequestContext;
+        // coreAuthMiddleware writes the resolved principal under 'user'.
+        // No user => no-op, never fabricate authInfo.
+        const user = requestContext?.get('user');
+        if (!user) return;
+        const rawToken = requestContext?.get(MASTRA_AUTH_TOKEN_KEY);
+        const token = typeof rawToken === 'string' ? rawToken : undefined;
+        (req as IncomingMessage & { auth?: unknown }).auth = mapUserToAuthInfo({ user, token, requestContext });
+      };
+    }
+
+    return undefined;
+  }
+
   async sendResponse(route: ServerRoute, response: Context, result: unknown, prefix?: string): Promise<any> {
     const resolvedPrefix = prefix ?? this.prefix ?? '';
 
@@ -321,10 +377,17 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
       const { server, httpPath, mcpOptions: routeMcpOptions } = result as MCPHttpTransportResult;
       const { req, res } = toReqRes(response.req.raw);
 
-      // Merge class-level mcpOptions with route-specific options (route takes precedence)
+      // Merge class-level mcpOptions with route-specific options (route takes precedence).
+      // NOTE: `options` carries ONLY StreamableHTTP transport options. The auth-bridge
+      // config (server.mcp) is intentionally kept separate so it never leaks into the SDK.
       const options = { ...this.mcpOptions, ...routeMcpOptions };
 
-      // Do NOT await startHTTP — let it run in the background so SSE
+      // Build the framework-agnostic req.auth bridge (Style B manual hook or Style A
+      // provider auto-bridge), closing over the live Hono context. Returns undefined
+      // when neither applies, so default behavior is byte-for-byte unchanged.
+      const setRequestAuth = this.buildMcpRequestAuthBridge(response);
+
+      // Do NOT await startHTTP; let it run in the background so SSE
       // notifications stream to the client as they are written.
       // toFetchResponse resolves when headers are sent, not when the body finishes.
       server
@@ -334,6 +397,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           req,
           res,
           options: Object.keys(options).length > 0 ? options : undefined,
+          setRequestAuth,
         })
         .catch((e: unknown) => {
           this.mastra.getLogger()?.error('[MCP HTTP] Error in background startHTTP:', {

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -327,7 +327,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
         const ctxToken = requestContext?.get(MASTRA_AUTH_TOKEN_KEY);
         // Only extract a Bearer token; other schemes (e.g. Basic) are not bearer tokens.
         const headerToken = c.req.header('Authorization')?.match(/^Bearer\s+(.+)$/i)?.[1];
-        const token = headerToken ?? (typeof ctxToken === 'string' ? ctxToken : undefined);
+        const token = typeof ctxToken === 'string' ? ctxToken : headerToken;
         await userHook({ req, requestContext, token });
       };
     }


### PR DESCRIPTION
## Summary

Fixes #17291.

This PR bridges Hono-layer authentication into MCP `req.auth` for streamable HTTP deployments.

Previously, the documented `req.auth -> extra.authInfo` flow worked for Express-style Node HTTP servers, but not for Mastra's default Hono/deployer path. The Hono adapter regenerates a Node `IncomingMessage` via `toReqRes(...)`, so auth data stored by Hono middleware in `requestContext` was not visible to the MCP SDK when it read `req.auth`. As a result, MCP tools saw `context.mcp.extra.authInfo` as `undefined`.

This PR adds a framework-agnostic hook to `MCPServer.startHTTP` and wires the Hono adapter to populate `req.auth` before the streamable HTTP transport handles the request.

## What changed

* Added an optional `setRequestAuth(req)` hook to `MCPServer.startHTTP`.

  * The hook is framework-agnostic and receives only the Node `IncomingMessage`.
  * It runs before `transport.handleRequest`.
  * It covers existing-session, new-session initialize, and stateless/serverless paths.
  * No hook configured means existing behavior is unchanged.

* Added `server.mcp` configuration for Hono/deployer deployments.

  * `server.mcp.setRequestAuth({ req, requestContext, token })` supports custom Hono middleware auth gates.
  * Provider-backed auto-bridge is enabled by default.
  * `server.mcp.autoBridgeAuth: false` can be used to opt out.
  * `server.mcp.mapUserToAuthInfo` lets users override the default `user -> AuthInfo` mapping.

* Added provider auto-bridge support.

  * When `server.auth` resolves a user into the Hono request context, the adapter maps that user into `req.auth`.
  * The default mapping is conservative and best-effort.
  * If no user is present in the request context, the bridge is a no-op and does not fabricate `authInfo`.

* Added manual bridge support for custom middleware.

  * Custom Hono middleware can store auth payloads in `requestContext`.
  * `server.mcp.setRequestAuth` can then read that payload and assign `req.auth`.
  * Manual bridge takes precedence over provider auto-bridge.

* Kept transport options separate from auth bridge config.

  * `server.mcp` auth fields are not spread into streamable HTTP transport options.

## Tests

Added/updated tests covering:

* `setRequestAuth` execution before streamable HTTP transport handling.
* Hook behavior across stateless/serverless, new-session initialize, and existing-session paths.
* Hook is called once per request.
* Hook errors stop the request before `transport.handleRequest`.
* Style A provider auto-bridge behavior.
* Style B manual `server.mcp.setRequestAuth` behavior.
* Manual hook precedence over auto-bridge.
* Token extraction and request context fallback behavior.
* No-op behavior when no bridge applies.
* `sendResponse(mcp-http) -> buildMcpRequestAuthBridge -> startHTTP({ setRequestAuth })` wiring.
* Ensuring auth bridge config does not leak into transport options.

I did not add a full Hono MCP handshake E2E test in this PR. The existing shared transport suite covers the base Hono MCP handshake, while this PR adds focused tests for the new auth bridge semantics, hook timing, and Hono adapter wiring. A full end-to-end auth handshake test can be added as a follow-up if needed.

## Validation

* `vitest run ./src/server/server.test.ts` in `packages/mcp`: 91 tests passed.
* Prettier check passed for changed files.
* `git diff --check` passed.
* Confirmed changed files use LF line endings.

The focused Hono bridge test is included, but local execution is currently blocked by the known unbuilt internal package environment issue: `@mastra/server/server-adapter` cannot be resolved from `server-adapters/hono`.

## SSE

This PR focuses on streamable HTTP. The new `setRequestAuth` hook is framework-agnostic, so a similar bridge can be added for SSE before the stream opens in a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

When MCP is run behind Hono, the authentication info Hono middleware set wasn't reaching MCP tools. This PR adds a small bridge so that Hono-authenticated data can be copied into MCP's request auth field (req.auth) before MCP handles the request, either automatically from an auth provider or via a user hook.

---

## Overview

Implements auth bridging so Hono-layer authentication is surfaced into MCP requests (resolving `#17291`). Introduces a framework-agnostic hook passed into MCPServer.startHTTP (setRequestAuth) that runs after Hono-to-Node request conversion but before the streamable HTTP transport handles the request, ensuring MCP tools see auth via extra.authInfo across stateless, new-session, and existing-session flows.

## Configuration & API Changes

- MCPServer.startHTTP:
  - new optional parameter: setRequestAuth?: (req: IncomingMessage) => void | Promise<void>
- ServerConfig.mcp (new optional object) supports:
  - setRequestAuth({ req, requestContext, token }) — manual hook for custom Hono middleware bridging
  - autoBridgeAuth?: boolean — enable/disable provider-backed auto-bridge (default: true)
  - mapUserToAuthInfo?(user, token) — custom mapping from authenticated principal → MCPRequestAuthInfo
- New/core types exported:
  - MCPRequestAuthInfo (token, clientId, scopes, extra)
  - MCPServerOptions
  - defaultMapUserToAuthInfo(user, token) helper

## Implementation Details

- MCP server (packages/mcp/src/server/server.ts)
  - Threads setRequestAuth through HTTP handling paths and invokes it exactly once per request via applyRequestAuth before forwarding to StreamableHTTPServerTransport.
  - Ensures behavior covers stateless/serverless, new-session initialize, and existing-session requests.
  - Tool invocation args: legacy top-level elicitation/extra replaced by guarded non-enumerable properties and nested under mcp.*.

- Hono adapter (server-adapters/hono/src/index.ts)
  - Adds buildMcpRequestAuthBridge(c: Context) to create a per-request setRequestAuth callback when applicable.
  - Two modes:
    1. Manual: when server.mcp.setRequestAuth is provided, bridge extracts bearer token (Authorization header or RequestContext token) and calls user hook with { req, requestContext, token }.
    2. Auto-bridge: when a server.auth.authenticateToken capability exists and autoBridgeAuth !== false, maps requestContext.user → req.auth using mapUserToAuthInfo (defaults to defaultMapUserToAuthInfo) and includes token.
  - Manual hook takes precedence over provider auto-bridge.
  - If no bridge applies, undefined is passed and existing behavior is unchanged.
  - Ensures MCP config does not leak into transport options.

## Tests

- packages/mcp tests: added suite verifying setRequestAuth execution timing, single-call semantics, behavior across stateless/new/existing sessions, error handling (throws → 500, transport not reached), and that no hook leaves authInfo null.
- Hono adapter tests: verify manual hook behavior (token extraction and precedence), provider auto-bridge behavior (default mapping and mapUserToAuthInfo override), token fallbacks and filtering, and that MCP auth settings are not passed into transport options.

## Documentation

- Docs updated with "Bridging auth on Hono / the Mastra deployer" explaining why req.auth may be lost with Hono, how to use auto-bridge vs manual hook, token sourcing, and mapping into extra.authInfo (and optionally into FGA requestContext user mapping).

## Key Behaviors and Safety

- No-op by default: existing deployments unchanged if no bridge/provider configured.
- Conservative: auto-bridge only sets req.auth when a real user exists; no fabricated auth.
- Token source: Authorization header or RequestContext token (RequestContext preferred for manual hook).
- Error handling: exceptions in setRequestAuth abort transport and return HTTP 500.
- Config isolation: MCP auth settings are kept separate from transport options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->