### PR TITLE
fix: unblock CI for agent author enrichment

### DIFF
--- a/packages/playground/src/pages/agent-builder/agents/__tests__/index.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/index.test.tsx
@@ -220,8 +220,8 @@ describe('AgentBuilderAgentsPage', () => {
       expect(screen.getByText('Beta')).toBeTruthy();
     });
 
-    expect(screen.getByText('Alice Doe')).toBeTruthy();
-    expect(screen.getByText('bob@example.com')).toBeTruthy();
+    expect(screen.getAllByText('Alice Doe').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('bob@example.com').length).toBeGreaterThan(0);
   });
 
   it('omits authorId when no current user is available', async () => {

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -22,7 +22,6 @@ import type { ServerRoute, RouteSchemas, InferParams } from '../server-adapter/r
 import { createRoute } from '../server-adapter/routes/route-builder';
 import { assertStoredResourceScope, getStoredResourceScope, scopeStoredResourceMetadata, toSlug } from '../utils';
 
-import { resolveBuilderModelPolicy } from '../utils/resolve-builder-model-policy';
 import { attachAuthor, prepareAuthorEnrichment } from './author-enrichment';
 import {
   assertReadAccess,


### PR DESCRIPTION
## What

Unblocks CI for #17205 with two minimal, behavior-preserving fixes.

### 1. Lint — drop orphaned `resolveBuilderModelPolicy` import

`packages/server/src/server/handlers/stored-agents.ts` imported `resolveBuilderModelPolicy` but had zero call sites. Save-path model-policy enforcement was intentionally removed on `main` (commit `a45fd541d1`); the merge from `main` into this branch left the import dangling. Comments at lines ~500 and ~664 already document the intentional removal of the check itself.

### 2. Test — use `getAllByText` for duplicated DOM nodes

`packages/playground/src/pages/agent-builder/agents/__tests__/index.test.tsx` used `screen.getByText('Alice Doe')` and `getByText('bob@example.com')`. `AgentBuilderList` renders the `AuthorBadge` twice per row (once for mobile `md:hidden`, once for desktop `hidden md:flex`); jsdom doesn't apply CSS, so both nodes are queryable and `getByText` throws "multiple elements found".

Switched to `getAllByText(...).length > 0`, matching the pattern already used in the colocated `agent-builder-list.test.tsx`. This is also what CodeRabbit flagged in its review.

## Verification

- `pnpm --filter ./packages/server lint` — exit 0
- `pnpm --filter ./packages/server tsc --noEmit` — no errors
- `pnpm --filter ./packages/server vitest run src/server/handlers/stored-agents.test.ts src/server/handlers/author-enrichment.test.ts` — 73 passed, 1 skipped (pre-existing)
- `pnpm --filter ./packages/playground vitest run src/pages/agent-builder/agents/__tests__/index.test.tsx src/domains/agent-builder/components/agent-list/__tests__/agent-builder-list.test.tsx` — 18/18 pass (was 17/18)

## No changeset

These are CI-fix-only edits with no user-visible behavior change.
