### PR TITLE
fix(server): require getUser in author-enrichment provider guard

### DIFF
--- a/packages/server/src/server/handlers/author-enrichment.test.ts
+++ b/packages/server/src/server/handlers/author-enrichment.test.ts
@@ -99,6 +99,13 @@ describe('prepareAuthorEnrichment', () => {
     expect(map).toBeNull();
   });
 
+  it('returns null when provider has getCurrentUser but no getUser', async () => {
+    const provider = { authenticateToken: vi.fn(), getCurrentUser: vi.fn() }; // no getUser
+    const mastra = makeMastra(provider);
+    const map = await prepareAuthorEnrichment(mastra, ctx, ['a']);
+    expect(map).toBeNull();
+  });
+
   it('returns null when auth is a config object (no authenticateToken)', async () => {
     const mastra = makeMastra({ public: [] }); // looks like MastraAuthConfig, not provider
     const map = await prepareAuthorEnrichment(mastra, ctx, ['a']);

--- a/packages/server/src/server/handlers/author-enrichment.ts
+++ b/packages/server/src/server/handlers/author-enrichment.ts
@@ -32,7 +32,10 @@ function getAuthProvider(mastra: Mastra): MastraAuthProvider | null {
 
 function isUserProvider(p: unknown): p is IUserProvider {
   return (
-    p !== null && typeof p === 'object' && typeof (p as { getCurrentUser?: unknown }).getCurrentUser === 'function'
+    p !== null &&
+    typeof p === 'object' &&
+    typeof (p as { getCurrentUser?: unknown }).getCurrentUser === 'function' &&
+    typeof (p as { getUser?: unknown }).getUser === 'function'
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes a latent runtime crash in author enrichment for stored agents.

`isUserProvider` (in `author-enrichment.ts`) only checked for `getCurrentUser`, but `prepareAuthorEnrichment` always calls `provider.getUser(...)` on the per-id fallback path. A provider that implements `getCurrentUser` but not `getUser` would pass the guard and then throw at runtime. This tightens the guard to also require `getUser`.

Flagged by CodeRabbit during review of #17205. Targeting the feature branch so it lands inside #17205 before that merges to `main`.

## Changes

- `author-enrichment.ts` — `isUserProvider` now also requires `getUser` to be a function
- `author-enrichment.test.ts` — add case: provider with `getCurrentUser` but no `getUser` returns `null`

## Test plan

- `pnpm --filter ./packages/server lint` — clean
- `pnpm --filter ./packages/server tsc --noEmit` — no errors
- `pnpm --filter ./packages/server vitest run src/server/handlers/author-enrichment.test.ts` — 15 passed
- `pnpm --filter ./packages/server vitest run src/server/handlers/stored-agents.test.ts` — 59 passed, 1 skipped

No changeset: behavior-preserving guard fix, no user-visible API change.