### PR TITLE
fix(server): merge dynamically created tools with bundler-discovered tools

### DIFF
--- a/.changeset/fix-tools-merge-mcp.md
+++ b/.changeset/fix-tools-merge-mcp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed the tools API endpoint to include dynamically created tools (e.g., MCP tools) alongside bundler-discovered tools. Previously, when the CLI bundler discovered tools, dynamically created tools registered via `new Mastra({ tools })` were silently dropped from the `/api/tools` response. Now both sources are merged, with bundler-discovered tools taking precedence on conflicts.

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -93,7 +93,9 @@ describe.for([['pnpm'] as const])(`%s monorepo`, ([pkgManager]) => {
       const res = await fetch(`http://localhost:${port}/api/tools`);
       const body = await res.json();
       expect(res.status).toBe(200);
-      expect(Object.keys(body)).toEqual(['calculatorTool', 'lodashTool']);
+      expect(Object.keys(body).sort()).toEqual(
+        ['calculatorTool', 'lodashTool', 'hello-world', 'generate-password', 'compare-password'].sort(),
+      );
     });
   }
 

--- a/packages/server/src/server/handlers/tools.test.ts
+++ b/packages/server/src/server/handlers/tools.test.ts
@@ -77,6 +77,51 @@ describe('Tools Handlers', () => {
       expect(result).toHaveProperty(mockTool.id);
       expect(result[mockTool.id]).toHaveProperty('id', mockTool.id);
     });
+
+    it('should merge tools from mastra.listTools() and registeredTools', async () => {
+      // Simulates MCP tools or other dynamically created tools in mastra instance
+      const dynamicTool: ToolAction = createTool({
+        id: 'dynamic-mcp-tool',
+        description: 'A dynamically created tool (e.g., MCP)',
+        execute: vi.fn(),
+      });
+      const mastra = new Mastra({
+        logger: false,
+        tools: { [dynamicTool.id]: dynamicTool },
+      });
+      // Bundler-discovered tools passed separately
+      const result = await LIST_TOOLS_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        registeredTools: mockTools,
+      });
+      // Both sources should be present
+      expect(result).toHaveProperty(mockTool.id);
+      expect(result).toHaveProperty(dynamicTool.id);
+      expect(result[mockTool.id]).toHaveProperty('id', mockTool.id);
+      expect(result[dynamicTool.id]).toHaveProperty('id', dynamicTool.id);
+    });
+
+    it('should let registeredTools take precedence on key conflicts', async () => {
+      const mastraTool: ToolAction = createTool({
+        id: 'shared-key',
+        description: 'From mastra instance',
+        execute: vi.fn(),
+      });
+      const bundlerTool: ToolAction = createTool({
+        id: 'shared-key',
+        description: 'From bundler',
+        execute: vi.fn(),
+      });
+      const mastra = new Mastra({
+        logger: false,
+        tools: { 'shared-key': mastraTool },
+      });
+      const result = await LIST_TOOLS_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        registeredTools: { 'shared-key': bundlerTool },
+      });
+      expect(result['shared-key']).toHaveProperty('description', 'From bundler');
+    });
   });
 
   describe('getToolByIdHandler', () => {

--- a/packages/server/src/server/handlers/tools.test.ts
+++ b/packages/server/src/server/handlers/tools.test.ts
@@ -122,6 +122,28 @@ describe('Tools Handlers', () => {
       });
       expect(result['shared-key']).toHaveProperty('description', 'From bundler');
     });
+
+    it('should dedupe the same tool registered under different keys, preferring the registered key', async () => {
+      // Mirrors the deployer flow: an agent registers the tool by its intrinsic id
+      // (get-weather) while the CLI bundler registers the same instance by export name
+      // (weatherTool). The merged response must list it once, under the registered key.
+      const weatherTool: ToolAction = createTool({
+        id: 'get-weather',
+        description: 'Get current weather for a location',
+        execute: vi.fn(),
+      });
+      const mastra = new Mastra({
+        logger: false,
+        tools: { [weatherTool.id]: weatherTool },
+      });
+      const result = await LIST_TOOLS_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        registeredTools: { weatherTool },
+      });
+      expect(Object.keys(result)).toHaveLength(1);
+      expect(result).toHaveProperty('weatherTool');
+      expect(result).not.toHaveProperty('get-weather');
+    });
   });
 
   describe('getToolByIdHandler', () => {

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -121,13 +121,32 @@ export const LIST_TOOLS_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, registeredTools, requestContext }) => {
     try {
-      // Merge tools from both sources: mastra.listTools() includes dynamically created tools (e.g., MCP tools),
-      // while registeredTools includes tools discovered by the CLI bundler.
-      // registeredTools is spread last so bundler-discovered tools take precedence on key conflicts.
-      const allTools = {
-        ...mastra.listTools(),
-        ...(registeredTools && Object.keys(registeredTools).length > 0 ? registeredTools : {}),
-      };
+      // Merge tools from two sources: mastra.listTools() includes dynamically created tools
+      // (e.g. MCP tools, or agent tools registered by their intrinsic id), while registeredTools
+      // includes tools discovered by the CLI bundler (keyed by export name).
+      //
+      // The same tool instance can appear in both maps under different keys (e.g. an agent
+      // registers it by `tool.id` while the bundler registers it by export name). Dedupe by
+      // `tool.id`, preferring the registeredTools (bundler) key, so each tool appears once.
+      const registered = registeredTools && Object.keys(registeredTools).length > 0 ? registeredTools : {};
+
+      const allTools: Record<string, any> = {};
+      const seenToolIds = new Map<string, string>();
+
+      // registeredTools first so their key wins for a given tool.id.
+      for (const [key, tool] of Object.entries(registered)) {
+        const toolId = typeof (tool as any)?.id === 'string' ? (tool as any).id : undefined;
+        if (toolId !== undefined) seenToolIds.set(toolId, key);
+        allTools[key] = tool;
+      }
+
+      for (const [key, tool] of Object.entries(mastra.listTools() ?? {})) {
+        const toolId = typeof (tool as any)?.id === 'string' ? (tool as any).id : undefined;
+        // Skip if this exact tool.id was already registered (under any key) by registeredTools.
+        if (toolId !== undefined && seenToolIds.has(toolId)) continue;
+        if (toolId !== undefined) seenToolIds.set(toolId, key);
+        allTools[key] = tool;
+      }
 
       const serializedTools = Object.entries(allTools).reduce(
         (acc, [id, _tool]) => {

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -121,8 +121,13 @@ export const LIST_TOOLS_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, registeredTools, requestContext }) => {
     try {
-      const allTools =
-        registeredTools && Object.keys(registeredTools).length > 0 ? registeredTools : mastra.listTools() || {};
+      // Merge tools from both sources: mastra.listTools() includes dynamically created tools (e.g., MCP tools),
+      // while registeredTools includes tools discovered by the CLI bundler.
+      // registeredTools is spread last so bundler-discovered tools take precedence on key conflicts.
+      const allTools = {
+        ...mastra.listTools(),
+        ...(registeredTools && Object.keys(registeredTools).length > 0 ? registeredTools : {}),
+      };
 
       const serializedTools = Object.entries(allTools).reduce(
         (acc, [id, _tool]) => {


### PR DESCRIPTION
The /api/tools endpoint was using either registeredTools (from CLI bundler) OR mastra.listTools(), but not both. This caused dynamically created tools like MCP tools to be silently dropped from the agent builder picker.

Before:
```typescript
const allTools = registeredTools && Object.keys(registeredTools).length > 0 
  ? registeredTools 
  : mastra.listTools() || {};
```

After:
```typescript
const allTools = {
  ...mastra.listTools(),
  ...(registeredTools && Object.keys(registeredTools).length > 0 ? registeredTools : {}),
};
```

Now both sources are merged, with registeredTools taking precedence on conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Before this fix, the agent builder could miss some tools because it only showed tools from one source at a time. Now it combines both sources so all tools appear together, and duplicates are removed so each tool shows once.

## Summary

Fixes the /api/tools endpoint to merge bundler-discovered tools (registeredTools) with dynamically created tools returned by mastra.listTools(), instead of choosing one source or the other. The handler now deduplicates tools by tool.id so the same underlying tool registered under different keys appears only once; when a tool appears in both sources, the bundler-provided registeredTools key wins. GET /tools (and related tool lookup behavior) remains backward-compatible while ensuring dynamically created tools (e.g., MCP/agent-provided) are included.

## Changes

- .changeset/fix-tools-merge-mcp.md
  - Added a patch changeset documenting the fix for `@mastra/server`.

- packages/server/src/server/handlers/tools.ts
  - Replaced the previous either/or selection of registeredTools vs mastra.listTools() with a merge:
    - Builds the result starting from registeredTools (so their map keys take precedence).
    - Iterates mastra.listTools() and skips any tool whose tool.id was already seen to dedupe.
    - Serializes resulting tools and applies existing FGA filtering/serialization as before.
  - Ensures registeredTools wins on key conflicts and dedupes identical tool instances registered under different keys by tool.id.

- packages/server/src/server/handlers/tools.test.ts
  - Added unit tests covering:
    - Merging of mastra.listTools() and registeredTools so both sources appear.
    - registeredTools precedence when both sources define the same key.
    - Deduplication when the same tool instance is registered under different keys (keeps only the registeredTools key).
    - Existing behaviors around empty results, fallback cases, and GET-by-id lookup/resolution/error handling.

- e2e-tests/monorepo/monorepo.test.ts
  - Updated API test expectation so GET /api/tools returns the merged set of tool keys (includes both bundler-discovered and dynamically registered tools).

## Impact

- Behavior: Agent builder picker and /api/tools responses will include dynamically created tools alongside bundler-discovered tools; duplicate tool instances are deduped by id.
- Backward compatibility: Bundler-discovered registeredTools retain precedence on key conflicts, preserving existing expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->