### PR TITLE
fix(datadog): forward score events from DatadogBridge to LLM Observability

### DIFF
--- a/.changeset/plenty-radios-drum.md
+++ b/.changeset/plenty-radios-drum.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed DatadogBridge score forwarding to Datadog LLM Observability.

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -12,6 +12,7 @@ import type {
   TracingEvent,
   AnyExportedSpan,
   CreateSpanOptions,
+  ScoreEvent,
   SpanType as SpanTypeGeneric,
 } from '@mastra/core/observability';
 import { SpanType, TracingEventType } from '@mastra/core/observability';
@@ -30,7 +31,9 @@ const {
   mockScopeActivate,
   mockScopeActive,
   mockStartSpan,
+  mockSubmitEvaluation,
   mockTrace,
+  mockExportSpan,
 } = vi.hoisted(() => {
   let currentScopeSpan: any = undefined;
   let apmSpanCounter = 0;
@@ -88,7 +91,12 @@ const {
     mockScopeActivate: activate,
     mockScopeActive: active,
     mockStartSpan: startSpan,
+    mockSubmitEvaluation: vi.fn(),
     mockTrace: vi.fn(),
+    mockExportSpan: vi.fn((span: any) => ({
+      traceId: `exported-${span.context().toTraceId(true)}`,
+      spanId: `exported-${span.context().toSpanId(true)}`,
+    })),
   };
 });
 
@@ -111,6 +119,8 @@ vi.mock('dd-trace', () => {
         annotate: mockAnnotate,
         flush: mockFlush,
         trace: mockTrace,
+        submitEvaluation: mockSubmitEvaluation,
+        exportSpan: mockExportSpan,
       },
       _tracer: {
         started: false,
@@ -145,6 +155,22 @@ function createMockSpan(overrides: Partial<AnyExportedSpan> = {}): AnyExportedSp
 
 function createTracingEvent(type: TracingEventType, span: AnyExportedSpan): TracingEvent {
   return { type, exportedSpan: span } as TracingEvent;
+}
+
+function createScoreEvent(overrides: Partial<ScoreEvent['score']> = {}): ScoreEvent {
+  return {
+    type: 'score',
+    score: {
+      id: 'score-1',
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000001',
+      scorerId: 'scorer-1',
+      scorerName: 'Quality scorer',
+      score: 0.75,
+      timestamp: new Date('2024-01-01T00:00:02Z'),
+      ...overrides,
+    },
+  } as ScoreEvent;
 }
 
 function createMockSpanOptions(
@@ -635,6 +661,78 @@ describe('DatadogBridge', () => {
           metadata: { other: 'value' },
           tags: { tenantId: 'tenant-123' },
         }),
+      );
+    });
+
+    it('forwards score events with exportSpan ids after the span finishes', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+      await bridge.onScoreEvent(
+        createScoreEvent({
+          traceId: spanResult.traceId,
+          spanId: spanResult.spanId,
+          metadata: { source: 'unit-test' },
+          reason: 'looks good',
+        }),
+      );
+
+      expect(mockSubmitEvaluation).toHaveBeenCalledWith(
+        {
+          traceId: `exported-${spanResult.traceId}`,
+          spanId: `exported-${spanResult.spanId}`,
+        },
+        {
+          label: 'Quality scorer',
+          value: 0.75,
+          metricType: 'score',
+          mlApp: 'test',
+          timestampMs: new Date('2024-01-01T00:00:02Z').getTime(),
+          reasoning: 'looks good',
+          metadata: { source: 'unit-test' },
+        },
+      );
+    });
+
+    it('drops score events when the finished span context has been evicted', async () => {
+      const bridge = new DatadogBridge({
+        mlApp: 'test',
+        agentless: false,
+        finishedSpanContextCacheMaxEntries: 1,
+      });
+      const firstSpanResult = bridge.createSpan(createMockSpanOptions({ name: 'first' }))!;
+      const secondSpanResult = bridge.createSpan(createMockSpanOptions({ name: 'second' }))!;
+
+      await bridge.exportTracingEvent(
+        createTracingEvent(
+          TracingEventType.SPAN_ENDED,
+          createMockSpan({ id: firstSpanResult.spanId, traceId: firstSpanResult.traceId }),
+        ),
+      );
+      await bridge.exportTracingEvent(
+        createTracingEvent(
+          TracingEventType.SPAN_ENDED,
+          createMockSpan({ id: secondSpanResult.spanId, traceId: secondSpanResult.traceId }),
+        ),
+      );
+
+      await bridge.onScoreEvent(createScoreEvent({ traceId: firstSpanResult.traceId, spanId: firstSpanResult.spanId }));
+      await bridge.onScoreEvent(
+        createScoreEvent({ traceId: secondSpanResult.traceId, spanId: secondSpanResult.spanId }),
+      );
+
+      expect(mockSubmitEvaluation).toHaveBeenCalledTimes(1);
+      expect(mockSubmitEvaluation).toHaveBeenCalledWith(
+        {
+          traceId: `exported-${secondSpanResult.traceId}`,
+          spanId: `exported-${secondSpanResult.spanId}`,
+        },
+        expect.any(Object),
       );
     });
 

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -236,7 +236,7 @@ describe('DatadogBridge', () => {
 
       expect(mockStartSpan).toHaveBeenCalledWith('my-agent', expect.any(Object));
       expect(result).toEqual({
-        spanId: '1',
+        spanId: '0000000000000001',
         traceId: '00000000000000000000000000000001',
         parentSpanId: undefined,
       });
@@ -658,9 +658,11 @@ describe('DatadogBridge', () => {
       );
     });
 
-    it('forwards score events directly with bridge-created dd-trace ids', async () => {
+    it('forwards score events directly with Datadog decimal span ids', async () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
       const spanResult = bridge.createSpan(createMockSpanOptions())!;
+
+      const datadogSpanId = BigInt(`0x${spanResult.spanId}`).toString(10);
 
       await bridge.onScoreEvent(
         createScoreEvent({
@@ -674,7 +676,7 @@ describe('DatadogBridge', () => {
       expect(mockSubmitEvaluation).toHaveBeenCalledWith(
         {
           traceId: spanResult.traceId,
-          spanId: spanResult.spanId,
+          spanId: datadogSpanId,
         },
         {
           label: 'Quality scorer',
@@ -694,12 +696,12 @@ describe('DatadogBridge', () => {
       await bridge.onScoreEvent(
         createScoreEvent({
           traceId: 'remote-trace-id',
-          spanId: '123456789',
+          spanId: '000000000000000f',
         }),
       );
 
       expect(mockSubmitEvaluation).toHaveBeenCalledWith(
-        { traceId: 'remote-trace-id', spanId: '123456789' },
+        { traceId: 'remote-trace-id', spanId: '15' },
         expect.objectContaining({
           label: 'Quality scorer',
           value: 0.75,

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -639,6 +639,26 @@ describe('DatadogBridge', () => {
       expect(apmSpan.finish).toHaveBeenCalledWith(span.endTime!.getTime());
     });
 
+    it('still finishes the eager dd span when exportSpan throws', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      mockExportSpan.mockImplementationOnce(() => {
+        throw new Error('exportSpan failed');
+      });
+
+      const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockExportSpan).toHaveBeenCalled();
+      expect(apmSpan.finish).toHaveBeenCalledWith(span.endTime!.getTime());
+    });
+
     it('promotes requestContextKeys to flat LLMObs tags during annotation', async () => {
       const bridge = new DatadogBridge({
         mlApp: 'test',

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -33,7 +33,6 @@ const {
   mockStartSpan,
   mockSubmitEvaluation,
   mockTrace,
-  mockExportSpan,
 } = vi.hoisted(() => {
   let currentScopeSpan: any = undefined;
   let apmSpanCounter = 0;
@@ -69,8 +68,8 @@ const {
       finish: vi.fn(),
       setTag: vi.fn(),
       context: vi.fn(() => ({
-        toSpanId: (_hex?: boolean) => spanHex,
-        toTraceId: (_hex?: boolean) => traceHex,
+        toSpanId: (hex?: boolean) => (hex ? spanHex : BigInt(`0x${spanHex}`).toString(10)),
+        toTraceId: (hex?: boolean) => (hex ? traceHex : BigInt(`0x${traceHex.slice(-16)}`).toString(10)),
       })),
     };
 
@@ -93,10 +92,6 @@ const {
     mockStartSpan: startSpan,
     mockSubmitEvaluation: vi.fn(),
     mockTrace: vi.fn(),
-    mockExportSpan: vi.fn((span: any) => ({
-      traceId: `exported-${span.context().toTraceId(true)}`,
-      spanId: `exported-${span.context().toSpanId(true)}`,
-    })),
   };
 });
 
@@ -120,7 +115,6 @@ vi.mock('dd-trace', () => {
         flush: mockFlush,
         trace: mockTrace,
         submitEvaluation: mockSubmitEvaluation,
-        exportSpan: mockExportSpan,
       },
       _tracer: {
         started: false,
@@ -242,7 +236,7 @@ describe('DatadogBridge', () => {
 
       expect(mockStartSpan).toHaveBeenCalledWith('my-agent', expect.any(Object));
       expect(result).toEqual({
-        spanId: '0000000000000001',
+        spanId: '1',
         traceId: '00000000000000000000000000000001',
         parentSpanId: undefined,
       });
@@ -639,26 +633,6 @@ describe('DatadogBridge', () => {
       expect(apmSpan.finish).toHaveBeenCalledWith(span.endTime!.getTime());
     });
 
-    it('still finishes the eager dd span when exportSpan throws', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-      const spanResult = bridge.createSpan(createMockSpanOptions())!;
-      const apmSpan = capturedApmSpans[0];
-
-      mockExportSpan.mockImplementationOnce(() => {
-        throw new Error('exportSpan failed');
-      });
-
-      const span = createMockSpan({
-        id: spanResult.spanId,
-        traceId: spanResult.traceId,
-      });
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
-
-      expect(mockExportSpan).toHaveBeenCalled();
-      expect(apmSpan.finish).toHaveBeenCalledWith(span.endTime!.getTime());
-    });
-
     it('promotes requestContextKeys to flat LLMObs tags during annotation', async () => {
       const bridge = new DatadogBridge({
         mlApp: 'test',
@@ -684,15 +658,10 @@ describe('DatadogBridge', () => {
       );
     });
 
-    it('forwards score events with exportSpan ids after the span finishes', async () => {
+    it('forwards score events directly with bridge-created dd-trace ids', async () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
       const spanResult = bridge.createSpan(createMockSpanOptions())!;
-      const span = createMockSpan({
-        id: spanResult.spanId,
-        traceId: spanResult.traceId,
-      });
 
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
       await bridge.onScoreEvent(
         createScoreEvent({
           traceId: spanResult.traceId,
@@ -704,8 +673,8 @@ describe('DatadogBridge', () => {
 
       expect(mockSubmitEvaluation).toHaveBeenCalledWith(
         {
-          traceId: `exported-${spanResult.traceId}`,
-          spanId: `exported-${spanResult.spanId}`,
+          traceId: spanResult.traceId,
+          spanId: spanResult.spanId,
         },
         {
           label: 'Quality scorer',
@@ -719,40 +688,24 @@ describe('DatadogBridge', () => {
       );
     });
 
-    it('drops score events when the finished span context has been evicted', async () => {
-      const bridge = new DatadogBridge({
-        mlApp: 'test',
-        agentless: false,
-        finishedSpanContextCacheMaxEntries: 1,
-      });
-      const firstSpanResult = bridge.createSpan(createMockSpanOptions({ name: 'first' }))!;
-      const secondSpanResult = bridge.createSpan(createMockSpanOptions({ name: 'second' }))!;
+    it('forwards score events without local finished span context', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
-      await bridge.exportTracingEvent(
-        createTracingEvent(
-          TracingEventType.SPAN_ENDED,
-          createMockSpan({ id: firstSpanResult.spanId, traceId: firstSpanResult.traceId }),
-        ),
-      );
-      await bridge.exportTracingEvent(
-        createTracingEvent(
-          TracingEventType.SPAN_ENDED,
-          createMockSpan({ id: secondSpanResult.spanId, traceId: secondSpanResult.traceId }),
-        ),
-      );
-
-      await bridge.onScoreEvent(createScoreEvent({ traceId: firstSpanResult.traceId, spanId: firstSpanResult.spanId }));
       await bridge.onScoreEvent(
-        createScoreEvent({ traceId: secondSpanResult.traceId, spanId: secondSpanResult.spanId }),
+        createScoreEvent({
+          traceId: 'remote-trace-id',
+          spanId: '123456789',
+        }),
       );
 
-      expect(mockSubmitEvaluation).toHaveBeenCalledTimes(1);
       expect(mockSubmitEvaluation).toHaveBeenCalledWith(
-        {
-          traceId: `exported-${secondSpanResult.traceId}`,
-          spanId: `exported-${secondSpanResult.spanId}`,
-        },
-        expect.any(Object),
+        { traceId: 'remote-trace-id', spanId: '123456789' },
+        expect.objectContaining({
+          label: 'Quality scorer',
+          value: 0.75,
+          metricType: 'score',
+          mlApp: 'test',
+        }),
       );
     });
 

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -510,9 +510,17 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       });
     }
 
-    const exported = tracer.llmobs?.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
-    if (exported?.traceId && exported?.spanId) {
-      this.rememberFinishedSpanContext(span.traceId, span.id, exported);
+    try {
+      const exported = tracer.llmobs?.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
+      if (exported?.traceId && exported?.spanId) {
+        this.rememberFinishedSpanContext(span.traceId, span.id, exported);
+      }
+    } catch (error) {
+      this.logger.error('[DatadogBridge] Failed to export dd span for score lookup', {
+        error,
+        spanId: span.id,
+        spanName: span.name,
+      });
     }
 
     try {

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -23,6 +23,7 @@ import type {
   ModelStepAttributes,
   ObservabilityBridge,
   CreateSpanOptions,
+  ScoreEvent,
   SpanType,
   SpanIds,
 } from '@mastra/core/observability';
@@ -62,6 +63,13 @@ interface TraceContext {
   userId?: string;
   sessionId?: string;
 }
+
+interface FinishedSpanContext {
+  traceId: string;
+  spanId: string;
+}
+
+const DEFAULT_FINISHED_SPAN_CONTEXT_CACHE_MAX_ENTRIES = 10_000;
 
 function flushApmExporter(): Promise<void> {
   const exporterFlush = (tracer as any)?._tracer?._exporter?.flush;
@@ -152,6 +160,11 @@ export interface DatadogBridgeConfig extends BaseExporterConfig {
    * LLM Observability tags instead of being nested in annotations.metadata.
    */
   requestContextKeys?: string[];
+
+  /**
+   * Maximum number of finished span contexts to retain for score forwarding.
+   */
+  finishedSpanContextCacheMaxEntries?: number;
 }
 
 /**
@@ -164,10 +177,12 @@ export interface DatadogBridgeConfig extends BaseExporterConfig {
 export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
   name = 'datadog-bridge';
 
-  private config: Required<Pick<DatadogBridgeConfig, 'mlApp' | 'site'>> & DatadogBridgeConfig;
+  private config: Required<Pick<DatadogBridgeConfig, 'mlApp' | 'site' | 'finishedSpanContextCacheMaxEntries'>> &
+    DatadogBridgeConfig;
   private ddSpanMap = new Map<string, any>();
   private traceContext = new Map<string, TraceContext>();
   private openSpanCounts = new Map<string, number>();
+  private finishedSpanContexts = new Map<string, FinishedSpanContext>();
 
   constructor(config: DatadogBridgeConfig = {}) {
     super(config);
@@ -195,7 +210,16 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       return;
     }
 
-    this.config = { ...config, mlApp, site, apiKey, agentless, env };
+    this.config = {
+      ...config,
+      mlApp,
+      site,
+      apiKey,
+      agentless,
+      env,
+      finishedSpanContextCacheMaxEntries:
+        config.finishedSpanContextCacheMaxEntries ?? DEFAULT_FINISHED_SPAN_CONTEXT_CACHE_MAX_ENTRIES,
+    };
 
     ensureTracer({
       mlApp,
@@ -289,6 +313,53 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
    */
   executeInContextSync<T>(spanId: string, fn: () => T): T {
     return this.executeWithSpanContext(spanId, fn);
+  }
+
+  async onScoreEvent(event: ScoreEvent): Promise<void> {
+    if (this.isDisabled || !(tracer as any).llmobs?.submitEvaluation) return;
+
+    const { score } = event;
+    if (!score.traceId || !score.spanId) {
+      this.logger.warn('Datadog bridge: dropping score with no traceId/spanId', {
+        scorerId: score.scorerId,
+      });
+      return;
+    }
+
+    const exported = this.getFinishedSpanContext(score.traceId, score.spanId);
+    if (!exported) {
+      this.logger.warn(
+        'Datadog bridge: dropping score for span that has not been finished and exported to dd-trace yet',
+        {
+          traceId: score.traceId,
+          spanId: score.spanId,
+          scorerId: score.scorerId,
+        },
+      );
+      return;
+    }
+
+    try {
+      tracer.llmobs.submitEvaluation(
+        { traceId: exported.traceId, spanId: exported.spanId },
+        {
+          label: score.scorerName ?? score.scorerId,
+          value: score.score,
+          metricType: 'score',
+          mlApp: this.config.mlApp,
+          timestampMs: score.timestamp instanceof Date ? score.timestamp.getTime() : Date.now(),
+          ...(score.reason ? { reasoning: score.reason } : {}),
+          ...(score.metadata ? { metadata: score.metadata } : {}),
+        },
+      );
+    } catch (error) {
+      this.logger.error('Datadog bridge: Failed to submit evaluation', {
+        error,
+        traceId: score.traceId,
+        spanId: score.spanId,
+        scorerId: score.scorerId,
+      });
+    }
   }
 
   private executeWithSpanContext<T>(spanId: string, fn: () => T): T {
@@ -439,6 +510,11 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       });
     }
 
+    const exported = tracer.llmobs?.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
+    if (exported?.traceId && exported?.spanId) {
+      this.rememberFinishedSpanContext(span.traceId, span.id, exported);
+    }
+
     try {
       if (typeof ddSpan.finish === 'function') {
         ddSpan.finish(endTime.getTime());
@@ -484,6 +560,32 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
 
     this.openSpanCounts.delete(traceId);
     this.traceContext.delete(traceId);
+  }
+
+  private getFinishedSpanContext(traceId: string, spanId: string): FinishedSpanContext | undefined {
+    const key = this.finishedSpanContextKey(traceId, spanId);
+    const context = this.finishedSpanContexts.get(key);
+    if (context) {
+      this.finishedSpanContexts.delete(key);
+      this.finishedSpanContexts.set(key, context);
+    }
+    return context;
+  }
+
+  private rememberFinishedSpanContext(traceId: string, spanId: string, context: FinishedSpanContext): void {
+    const key = this.finishedSpanContextKey(traceId, spanId);
+    this.finishedSpanContexts.delete(key);
+    this.finishedSpanContexts.set(key, context);
+
+    while (this.finishedSpanContexts.size > this.config.finishedSpanContextCacheMaxEntries) {
+      const oldestKey = this.finishedSpanContexts.keys().next().value;
+      if (!oldestKey) break;
+      this.finishedSpanContexts.delete(oldestKey);
+    }
+  }
+
+  private finishedSpanContextKey(traceId: string, spanId: string): string {
+    return `${traceId}:${spanId}`;
   }
 
   private buildAnnotations(span: AnyExportedSpan): Record<string, any> {
@@ -623,6 +725,7 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     this.ddSpanMap.clear();
     this.openSpanCounts.clear();
     this.traceContext.clear();
+    this.finishedSpanContexts.clear();
 
     await this.flush();
 

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -64,13 +64,6 @@ interface TraceContext {
   sessionId?: string;
 }
 
-interface FinishedSpanContext {
-  traceId: string;
-  spanId: string;
-}
-
-const DEFAULT_FINISHED_SPAN_CONTEXT_CACHE_MAX_ENTRIES = 10_000;
-
 function flushApmExporter(): Promise<void> {
   const exporterFlush = (tracer as any)?._tracer?._exporter?.flush;
   if (typeof exporterFlush !== 'function') {
@@ -160,11 +153,6 @@ export interface DatadogBridgeConfig extends BaseExporterConfig {
    * LLM Observability tags instead of being nested in annotations.metadata.
    */
   requestContextKeys?: string[];
-
-  /**
-   * Maximum number of finished span contexts to retain for score forwarding.
-   */
-  finishedSpanContextCacheMaxEntries?: number;
 }
 
 /**
@@ -177,12 +165,10 @@ export interface DatadogBridgeConfig extends BaseExporterConfig {
 export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
   name = 'datadog-bridge';
 
-  private config: Required<Pick<DatadogBridgeConfig, 'mlApp' | 'site' | 'finishedSpanContextCacheMaxEntries'>> &
-    DatadogBridgeConfig;
+  private config: Required<Pick<DatadogBridgeConfig, 'mlApp' | 'site'>> & DatadogBridgeConfig;
   private ddSpanMap = new Map<string, any>();
   private traceContext = new Map<string, TraceContext>();
   private openSpanCounts = new Map<string, number>();
-  private finishedSpanContexts = new Map<string, FinishedSpanContext>();
 
   constructor(config: DatadogBridgeConfig = {}) {
     super(config);
@@ -217,8 +203,6 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       apiKey,
       agentless,
       env,
-      finishedSpanContextCacheMaxEntries:
-        config.finishedSpanContextCacheMaxEntries ?? DEFAULT_FINISHED_SPAN_CONTEXT_CACHE_MAX_ENTRIES,
     };
 
     ensureTracer({
@@ -276,12 +260,12 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
             toTraceId?: (hex?: boolean) => string;
           }
         | undefined;
-      const spanId = ddContext?.toSpanId?.(true) ?? generateSpanId();
+      const spanId = ddContext?.toSpanId?.() ?? generateSpanId();
       const traceId =
         ddContext?.toTraceId?.(true) ??
         (externalParentId ? (options.parent?.traceId ?? generateTraceId()) : generateTraceId());
       const parentContext = apmParentDdSpan?.context?.() as { toSpanId?: (hex?: boolean) => string } | undefined;
-      const parentSpanId = parentContext?.toSpanId?.(true) ?? externalParentId;
+      const parentSpanId = parentContext?.toSpanId?.() ?? externalParentId;
 
       this.captureTraceContext(traceId, options);
       this.openSpanCounts.set(traceId, (this.openSpanCounts.get(traceId) ?? 0) + 1);
@@ -326,22 +310,9 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       return;
     }
 
-    const exported = this.getFinishedSpanContext(score.traceId, score.spanId);
-    if (!exported) {
-      this.logger.warn(
-        'Datadog bridge: dropping score for span that has not been finished and exported to dd-trace yet',
-        {
-          traceId: score.traceId,
-          spanId: score.spanId,
-          scorerId: score.scorerId,
-        },
-      );
-      return;
-    }
-
     try {
       tracer.llmobs.submitEvaluation(
-        { traceId: exported.traceId, spanId: exported.spanId },
+        { traceId: score.traceId, spanId: score.spanId },
         {
           label: score.scorerName ?? score.scorerId,
           value: score.score,
@@ -511,19 +482,6 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     }
 
     try {
-      const exported = tracer.llmobs?.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
-      if (exported?.traceId && exported?.spanId) {
-        this.rememberFinishedSpanContext(span.traceId, span.id, exported);
-      }
-    } catch (error) {
-      this.logger.error('[DatadogBridge] Failed to export dd span for score lookup', {
-        error,
-        spanId: span.id,
-        spanName: span.name,
-      });
-    }
-
-    try {
       if (typeof ddSpan.finish === 'function') {
         ddSpan.finish(endTime.getTime());
       }
@@ -568,32 +526,6 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
 
     this.openSpanCounts.delete(traceId);
     this.traceContext.delete(traceId);
-  }
-
-  private getFinishedSpanContext(traceId: string, spanId: string): FinishedSpanContext | undefined {
-    const key = this.finishedSpanContextKey(traceId, spanId);
-    const context = this.finishedSpanContexts.get(key);
-    if (context) {
-      this.finishedSpanContexts.delete(key);
-      this.finishedSpanContexts.set(key, context);
-    }
-    return context;
-  }
-
-  private rememberFinishedSpanContext(traceId: string, spanId: string, context: FinishedSpanContext): void {
-    const key = this.finishedSpanContextKey(traceId, spanId);
-    this.finishedSpanContexts.delete(key);
-    this.finishedSpanContexts.set(key, context);
-
-    while (this.finishedSpanContexts.size > this.config.finishedSpanContextCacheMaxEntries) {
-      const oldestKey = this.finishedSpanContexts.keys().next().value;
-      if (!oldestKey) break;
-      this.finishedSpanContexts.delete(oldestKey);
-    }
-  }
-
-  private finishedSpanContextKey(traceId: string, spanId: string): string {
-    return `${traceId}:${spanId}`;
   }
 
   private buildAnnotations(span: AnyExportedSpan): Record<string, any> {
@@ -733,7 +665,6 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     this.ddSpanMap.clear();
     this.openSpanCounts.clear();
     this.traceContext.clear();
-    this.finishedSpanContexts.clear();
 
     await this.flush();
 
@@ -776,7 +707,8 @@ function fillRandomBytes(bytes: Uint8Array): void {
 function generateSpanId(): string {
   const bytes = new Uint8Array(8);
   fillRandomBytes(bytes);
-  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+  const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+  return BigInt(`0x${hex}`).toString(10);
 }
 
 function generateTraceId(): string {

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -260,12 +260,12 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
             toTraceId?: (hex?: boolean) => string;
           }
         | undefined;
-      const spanId = ddContext?.toSpanId?.() ?? generateSpanId();
+      const spanId = ddContext?.toSpanId?.(true) ?? generateSpanId();
       const traceId =
         ddContext?.toTraceId?.(true) ??
         (externalParentId ? (options.parent?.traceId ?? generateTraceId()) : generateTraceId());
       const parentContext = apmParentDdSpan?.context?.() as { toSpanId?: (hex?: boolean) => string } | undefined;
-      const parentSpanId = parentContext?.toSpanId?.() ?? externalParentId;
+      const parentSpanId = parentContext?.toSpanId?.(true) ?? externalParentId;
 
       this.captureTraceContext(traceId, options);
       this.openSpanCounts.set(traceId, (this.openSpanCounts.get(traceId) ?? 0) + 1);
@@ -312,7 +312,7 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
 
     try {
       tracer.llmobs.submitEvaluation(
-        { traceId: score.traceId, spanId: score.spanId },
+        { traceId: score.traceId, spanId: toDatadogSpanId(score.spanId) },
         {
           label: score.scorerName ?? score.scorerId,
           value: score.score,
@@ -704,11 +704,17 @@ function fillRandomBytes(bytes: Uint8Array): void {
   }
 }
 
+function toDatadogSpanId(spanId: string): string {
+  if (/^[0-9a-f]{16}$/i.test(spanId)) {
+    return BigInt(`0x${spanId}`).toString(10);
+  }
+  return spanId;
+}
+
 function generateSpanId(): string {
   const bytes = new Uint8Array(8);
   fillRandomBytes(bytes);
-  const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
-  return BigInt(`0x${hex}`).toString(10);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
 }
 
 function generateTraceId(): string {


### PR DESCRIPTION
## Description

DatadogBridge previously did not implement `onScoreEvent`, so `ScoreEvent`s were silently dropped when the bridge was used instead of `DatadogExporter`. This PR adds score/evaluation forwarding to Datadog LLM Observability via `tracer.llmobs.submitEvaluation`, matching `DatadogExporter` semantics .

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/9f9623ce-430c-4b9c-94bf-dbe389781111" />

## Related Issue(s)

Fixes #17527

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

DatadogBridge now sends evaluation scores to Datadog so scorer results show up in Datadog LLM Observability instead of being silently dropped.

## Overview

Implements ScoreEvent handling in DatadogBridge by adding onScoreEvent(event: ScoreEvent) that forwards scorer results to tracer.llmobs.submitEvaluation (metricType: 'score') when the tracer LLMObs API is available. The bridge converts hex span IDs produced by its dd-trace spans into Datadog's decimal span IDs before submission, logs and drops events missing required IDs, and guards against submit/export errors. Tests were added to validate forwarding and related edge cases.

## Changes

- DatadogBridge (observability/datadog/src/bridge.ts)
  - Added public method: onScoreEvent(event: ScoreEvent): Promise<void> to forward ScoreEvent payloads via tracer.llmobs.submitEvaluation.
  - Introduced toDatadogSpanId helper to convert 16-hex span IDs to decimal BigInt strings; uses converted IDs when submitting evaluations.
  - Refactored constructor/config assignment to explicitly set mlApp, site, apiKey, agentless, env.
  - onScoreEvent warns and drops events missing traceId/spanId and logs errors if submitEvaluation throws.

- Tests (observability/datadog/src/bridge.test.ts)
  - Extended dd-trace mock with mockSubmitEvaluation and adjusted mock span context to return hex or decimal IDs depending on the hex flag.
  - Added createScoreEvent helper for typed score payloads.
  - New tests verify:
    - onScoreEvent forwards scores to submitEvaluation using bridge-created trace/span IDs.
    - Forwarding works when no local finished-span context exists by using event-provided identifiers.
    - Edge behaviors: missing IDs are dropped; submission errors are logged and do not crash.

- Changeset (changeset/plenty-radios-drum.md)
  - Patch release note documenting that DatadogBridge now forwards scores to Datadog LLM Observability.

## Notes / Behavior changes

- Score forwarding requires available traceId/spanId (either bridge-produced decimal IDs or event-provided IDs); missing IDs result in a dropped event with a warning.
- The bridge no longer relies on a finished-span cache for score submission — it submits evaluations using decimal span IDs derived from dd-trace spans to preserve live APM correlation while surfacing evaluations in Datadog LLM Observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->