### PR TITLE
fix(core,memory): keep observational memory local for Gateway models

### DIFF
--- a/.changeset/gateway-memory-handling.md
+++ b/.changeset/gateway-memory-handling.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/memory': patch
+---
+
+Updated observational memory processing so agents using Mastra Gateway actor models still run the locally configured observer and reflector models instead of implicitly deferring to Gateway-managed memory behavior. Internal thread/resource context is no longer forwarded as Gateway request headers, preventing platform-managed Gateway memory from being activated by local agent memory context.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -653,7 +653,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     });
   });
 
-  it('preserves model config headers when modelSettings adds non-conflicting headers', async () => {
+  it('preserves model config headers when modelSettings adds non-conflicting headers without internal memory context', async () => {
     const doStream = vi.fn(async () => ({
       stream: convertArrayToReadableStream([
         {
@@ -732,12 +732,10 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     expect(doStream.mock.calls[0]?.[0]?.headers).toEqual({
       authorization: 'Bearer model-token',
       'x-custom-header': 'settings-value',
-      'x-thread-id': 'thread-123',
-      'x-resource-id': 'resource-456',
     });
   });
 
-  it('should not create headers when neither model nor modelSettings provide them', async () => {
+  it('should not create headers from internal memory context alone', async () => {
     const doStream = vi.fn(async () => ({
       stream: convertArrayToReadableStream([
         {
@@ -805,10 +803,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     await llmExecutionStep.execute(createExecuteParams(input));
 
     expect(doStream).toHaveBeenCalledOnce();
-    expect(doStream.mock.calls[0]?.[0]?.headers).toEqual({
-      'x-thread-id': 'thread-123',
-      'x-resource-id': 'resource-456',
-    });
+    expect(doStream.mock.calls[0]?.[0]?.headers).toBeUndefined();
   });
 
   it('updates model step tracing with final input messages', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1332,14 +1332,11 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                   },
                   includeRawChunks,
                   structuredOutput: currentStep.structuredOutput,
-                  // Merge headers: memory context first, then modelConfig headers, then modelSettings overrides
-                  // x-thread-id / x-resource-id enable server-side memory enrichment (e.g. Memory Gateway)
+                  // Merge headers: modelSettings overrides modelConfig headers.
+                  // Do not forward internal thread/resource context as provider headers; Gateway uses
+                  // x-thread-id/x-resource-id to activate platform-managed memory.
                   headers: (() => {
-                    const memoryHeaders: Record<string, string> = {};
-                    if (_internal?.threadId) memoryHeaders['x-thread-id'] = _internal.threadId;
-                    if (_internal?.resourceId) memoryHeaders['x-resource-id'] = _internal.resourceId;
                     const merged = {
-                      ...memoryHeaders,
                       ...modelHeaders,
                       ...currentStep.modelSettings?.headers,
                     };

--- a/packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts
@@ -1,11 +1,9 @@
 /**
- * Tests that the ObservationalMemoryProcessor skips local processing when the
- * agent is using a Mastra gateway model. The gateway handles OM server-side,
- * so running it locally would double-process messages and cause duplication.
+ * Regression tests for Mastra Gateway models with observational memory.
  *
- * Detection uses a duck-type check (model has gatewayId === 'mastra') and
- * stores the result in per-processor state — this avoids leaking flags
- * through RequestContext to child agents.
+ * Gateway-routed actor models must still run the local ObservationalMemoryProcessor.
+ * Observations/reflections are controlled by the user's memory config and should not
+ * be implicitly delegated to Gateway built-in memory behavior.
  */
 import type { MastraDBMessage } from '@mastra/core/agent';
 import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
@@ -34,10 +32,6 @@ function createStubMemoryProvider(): MemoryContextProvider {
   };
 }
 
-/**
- * Create a plain object mock with the given gatewayId.
- * Detection uses duck typing ('gatewayId' in model), so no real class needed.
- */
 function createMockGatewayModel(gatewayId: string) {
   return {
     gatewayId,
@@ -47,12 +41,34 @@ function createMockGatewayModel(gatewayId: string) {
   };
 }
 
-describe('ObservationalMemoryProcessor — gateway skip', () => {
+async function createMessageListContext(threadId: string, resourceId: string) {
+  const { MessageList } = await import('@mastra/core/agent');
+  const { RequestContext } = await import('@mastra/core/di');
+
+  const requestContext = new RequestContext();
+  requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+
+  const messageList = new MessageList({ threadId, resourceId });
+  const userMsg: MastraDBMessage = {
+    id: 'msg-1',
+    role: 'user',
+    content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+    type: 'text',
+    createdAt: new Date(),
+    threadId,
+    resourceId,
+  };
+
+  return { messageList, requestContext, userMsg };
+}
+
+describe('ObservationalMemoryProcessor — gateway models', () => {
   const threadId = 'test-thread';
   const resourceId = 'test-resource';
 
   let om: ObservationalMemory;
   let processor: ObservationalMemoryProcessor;
+  let memoryProvider: MemoryContextProvider;
 
   beforeEach(() => {
     const storage = createInMemoryStorage();
@@ -62,36 +78,22 @@ describe('ObservationalMemoryProcessor — gateway skip', () => {
       reflection: { observationTokens: 100_000, model: 'test-model' },
       scope: 'thread',
     });
-    processor = new ObservationalMemoryProcessor(om, createStubMemoryProvider());
+    memoryProvider = createStubMemoryProvider();
+    processor = new ObservationalMemoryProcessor(om, memoryProvider);
   });
 
-  it('processInputStep returns messageList unchanged when model is a Mastra gateway model', async () => {
-    const { MessageList } = await import('@mastra/core/agent');
-    const { RequestContext } = await import('@mastra/core/di');
-
-    const requestContext = new RequestContext();
-    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
-
-    const messageList = new MessageList({ threadId, resourceId });
-    const userMsg: MastraDBMessage = {
-      id: 'msg-1',
-      role: 'user',
-      content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
-      type: 'text',
-      createdAt: new Date(),
-      threadId,
-      resourceId,
-    };
-
-    const getThreadContextSpy = vi.spyOn(om, 'getThreadContext');
+  it('processInputStep runs local OM processing when model is routed through Mastra Gateway', async () => {
+    const { messageList, requestContext, userMsg } = await createMessageListContext(threadId, resourceId);
     const gatewayModel = createMockGatewayModel('mastra');
+    const beginTurnSpy = vi.spyOn(om, 'beginTurn');
 
+    const state: Record<string, unknown> = {};
     const result = await processor.processInputStep({
       messageList,
       messages: [userMsg],
       requestContext,
       stepNumber: 0,
-      state: {},
+      state,
       steps: [],
       systemMessages: [],
       model: gatewayModel as any,
@@ -101,23 +103,34 @@ describe('ObservationalMemoryProcessor — gateway skip', () => {
       }) as any,
     });
 
-    // Should return the same messageList without modifications
     expect(result).toBe(messageList);
-    // getThreadContext is called before the gateway check (to validate context exists)
-    expect(getThreadContextSpy).toHaveBeenCalled();
+    expect(beginTurnSpy).toHaveBeenCalled();
+    expect(state.__omTurn).toBeDefined();
+    expect(state.__omActorModelContext).toMatchObject({ provider: 'mastra', modelId: 'openai/gpt-4o' });
   });
 
-  it('processOutputResult returns messageList unchanged when gateway flag was stored in state', async () => {
-    const { MessageList } = await import('@mastra/core/agent');
-    const { RequestContext } = await import('@mastra/core/di');
+  it('processOutputResult ends the local OM turn for Mastra Gateway models', async () => {
+    const { messageList, requestContext, userMsg } = await createMessageListContext(threadId, resourceId);
+    const gatewayModel = createMockGatewayModel('mastra');
+    const state: Record<string, unknown> = {};
 
-    const requestContext = new RequestContext();
-    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+    await processor.processInputStep({
+      messageList,
+      messages: [userMsg],
+      requestContext,
+      stepNumber: 0,
+      state,
+      steps: [],
+      systemMessages: [],
+      model: gatewayModel as any,
+      retryCount: 0,
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+    });
 
-    const messageList = new MessageList({ threadId, resourceId });
-
-    // Simulate what processInputStep would have stored in state
-    const state: Record<string, unknown> = { __isGatewayModel: true };
+    const turn = state.__omTurn as { end: () => Promise<void> };
+    const endSpy = vi.spyOn(turn, 'end');
 
     const result = await processor.processOutputResult({
       messageList,
@@ -132,86 +145,7 @@ describe('ObservationalMemoryProcessor — gateway skip', () => {
     });
 
     expect(result).toBe(messageList);
-  });
-
-  it('does NOT skip when model is a non-mastra gateway', async () => {
-    const { MessageList } = await import('@mastra/core/agent');
-    const { RequestContext } = await import('@mastra/core/di');
-
-    const requestContext = new RequestContext();
-    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
-
-    const messageList = new MessageList({ threadId, resourceId });
-    const userMsg: MastraDBMessage = {
-      id: 'msg-3',
-      role: 'user',
-      content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
-      type: 'text',
-      createdAt: new Date(),
-      threadId,
-      resourceId,
-    };
-
-    // A ModelRouterLanguageModel with a different gatewayId should NOT trigger the skip
-    const nonMastraModel = createMockGatewayModel('netlify');
-
-    const result = await processor.processInputStep({
-      messageList,
-      messages: [userMsg],
-      requestContext,
-      stepNumber: 0,
-      state: {},
-      steps: [],
-      systemMessages: [],
-      model: nonMastraModel as any,
-      retryCount: 0,
-      abort: (() => {
-        throw new Error('aborted');
-      }) as any,
-    });
-
-    // Should proceed with normal OM flow (not early-return the same messageList ref)
-    // The result is still a MessageList but OM would have processed it
-    expect(result).toBeDefined();
-  });
-
-  it('processInputStep proceeds normally with a plain string model', async () => {
-    const { MessageList } = await import('@mastra/core/agent');
-    const { RequestContext } = await import('@mastra/core/di');
-
-    const requestContext = new RequestContext();
-    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
-
-    const messageList = new MessageList({ threadId, resourceId });
-    const userMsg: MastraDBMessage = {
-      id: 'msg-4',
-      role: 'user',
-      content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
-      type: 'text',
-      createdAt: new Date(),
-      threadId,
-      resourceId,
-    };
-
-    const getThreadContextSpy = vi.spyOn(om, 'getThreadContext');
-
-    const result = await processor.processInputStep({
-      messageList,
-      messages: [userMsg],
-      requestContext,
-      stepNumber: 0,
-      state: {},
-      steps: [],
-      systemMessages: [],
-      model: 'test-model' as any,
-      retryCount: 0,
-      abort: (() => {
-        throw new Error('aborted');
-      }) as any,
-    });
-
-    // Should proceed with normal OM flow
-    expect(getThreadContextSpy).toHaveBeenCalled();
-    expect(result).toBeDefined();
+    expect(endSpy).toHaveBeenCalled();
+    expect(state.__omTurn).toBeUndefined();
   });
 });

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -54,14 +54,6 @@ function getOmObservabilityContext(
   };
 }
 
-/** Key used to store gateway detection result in per-processor state. */
-const GATEWAY_STATE_KEY = '__isGatewayModel';
-
-/** Check if the model is routed through a Mastra gateway (duck-type check to avoid cross-package instanceof issues). */
-function isMastraGatewayModel(model: ProcessInputStepArgs['model']): boolean {
-  return typeof model === 'object' && model !== null && 'gatewayId' in model && (model as any).gatewayId === 'mastra';
-}
-
 function injectObservationContextMessages({
   messageList,
   systemMessages,
@@ -143,17 +135,6 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
     const context = this.engine.getThreadContext(requestContext, messageList);
     if (!context) {
       omDebug(`[OM:processInputStep:NO-CONTEXT] getThreadContext returned null — returning early`);
-      return messageList;
-    }
-
-    // When the agent is using a Mastra gateway model, the gateway handles OM
-    // (observation, reflection, context injection) server-side. Running it
-    // locally would double-process messages and cause history duplication.
-    // We detect this from the model directly (not requestContext) so that
-    // the flag doesn't leak to child agents in delegation scenarios.
-    if (isMastraGatewayModel(model)) {
-      state[GATEWAY_STATE_KEY] = true;
-      omDebug(`[OM:processInputStep:GATEWAY] gateway handles OM — skipping local processing`);
       return messageList;
     }
 
@@ -350,9 +331,6 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
 
     const context = this.engine.getThreadContext(requestContext, messageList);
     if (!context) return messageList;
-
-    // Gateway handles OM — skip local output processing (see processInputStep).
-    if (state[GATEWAY_STATE_KEY]) return messageList;
 
     const observabilityContext = getOmObservabilityContext(args);
     state.__omObservabilityContext = observabilityContext;


### PR DESCRIPTION
## Summary

Split out from #17469 so the Gateway embedding routing change can land independently.

Two related fixes that ensure agents using Mastra Gateway actor models still get **locally-configured** Observational Memory instead of silently deferring to platform-managed Gateway memory:

1. **`@mastra/memory`** — Stop short-circuiting OM for Gateway-routed actor models. The processor now runs locally for `provider: 'mastra'` actor models and records the actor model context (`{ provider, modelId }`) so observer/reflector models are invoked as configured.

2. **`@mastra/core`** — Stop auto-forwarding internal `_internal.threadId` / `_internal.resourceId` as `x-thread-id` / `x-resource-id` headers to the Gateway. Those headers are how the platform activates its server-side memory, and forwarding them implicitly bypassed local OM. Explicit user / model-settings headers are still respected.

## Behavior change

Agents whose actor model is a Gateway-routed ID (e.g. `mastra/openai/gpt-5`) will now run the locally configured `observationalMemory.observation` and `observationalMemory.reflection` models, instead of deferring to whatever the Gateway might do.

If you were previously relying on the Gateway to manage memory implicitly via internal thread/resource forwarding, you can opt back in by setting `x-thread-id` / `x-resource-id` explicitly via `modelSettings.headers`.

## Test plan

- `packages/memory` — new `gateway-skip.test.ts` asserts OM begin/end turns fire for Gateway actor models and that actor context is recorded.
- `packages/core` — `llm-execution-step.test.ts` updated to assert internal memory context is **not** auto-forwarded as Gateway headers, while explicit user headers still are.
- Focused suites pass locally:
  - `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts` — 18/18
  - `packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts` — 2/2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

When agents use Mastra's Gateway models, they should use their own configured memory tools (like custom observers) instead of automatically relying on the Gateway's built-in memory system. This PR fixes two things to make that happen: (1) it makes sure the agent's local memory processor actually runs for Gateway models, and (2) it stops automatically sending internal memory context to the Gateway that would trigger its memory handling.

## Key Changes

**Memory Package (`@mastra/memory`)**
- Updated `ObservationalMemoryProcessor` to process Gateway-routed actor models locally instead of short-circuiting
- Local OM processor now runs and records actor model context (`{ provider, modelId }`) so configured observer and reflector models execute as intended
- Added regression test coverage in `gateway-skip.test.ts` verifying local OM processing occurs for Gateway models

**Core Package (`@mastra/core`)**
- Modified `llm-execution-step.ts` to stop auto-forwarding internal `_internal.threadId` and `_internal.resourceId` as `x-thread-id` and `x-resource-id` headers to the Gateway
- Updated header merge semantics so `modelSettings.headers` override model config headers
- Gateway-specific headers are no longer automatically injected; explicit user or model headers remain respected
- Updated corresponding test assertions in `llm-execution-step.test.ts` to verify headers are not auto-generated from internal context

## Behavior Changes

Gateway-routed actor models (e.g., `mastra/openai/gpt-5`) will now execute locally-configured `observationalMemory.observation` and `observationalMemory.reflection` instead of deferring to platform-managed Gateway memory. Users who previously relied on implicit Gateway memory handling can opt back in by explicitly setting `x-thread-id` and `x-resource-id` via `modelSettings.headers`.

## Testing

- New test file `packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts` added with comprehensive coverage of local OM processing for Gateway models
- `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts` updated to verify non-generation of internal-context headers and correct header merge behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->