### PR TITLE
feat(playground): add date range picker to evaluation page

### DIFF
--- a/packages/playground/src/domains/scores/hooks/use-score-metrics.ts
+++ b/packages/playground/src/domains/scores/hooks/use-score-metrics.ts
@@ -15,12 +15,17 @@ export interface ScoresOverTimePoint {
   [scorer: string]: string | number;
 }
 
-export function useScoreMetrics() {
+export interface UseScoreMetricsParams {
+  dateRange?: { start?: Date; end?: Date };
+}
+
+export function useScoreMetrics(params?: UseScoreMetricsParams) {
   const client = useMastraClient();
   const requestContext = useMergedRequestContext();
+  const dateRange = params?.dateRange;
 
   return useQuery({
-    queryKey: ['score-metrics', requestContext],
+    queryKey: ['score-metrics', requestContext, dateRange?.start?.toISOString(), dateRange?.end?.toISOString()],
     queryFn: async () => {
       const scorersMap = await client.listScorers(requestContext);
       const scorerIds = Object.keys(scorersMap ?? {});
@@ -34,7 +39,7 @@ export function useScoreMetrics() {
       const allResults = await Promise.all(
         scorerIds.map(scorerId =>
           client.listScores({
-            filters: { scorerId },
+            filters: { scorerId, ...(dateRange ? { timestamp: dateRange } : {}) },
             pagination: { page: 0, perPage: 100 },
             orderBy: { field: 'timestamp', direction: 'DESC' },
           }),

--- a/packages/playground/src/pages/evaluation/index.tsx
+++ b/packages/playground/src/pages/evaluation/index.tsx
@@ -1,4 +1,5 @@
 import {
+  DateTimeRangePicker,
   ErrorState,
   MetricsFlexGrid,
   NoDataPageLayout,
@@ -8,7 +9,9 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
-import { useMemo } from 'react';
+import type { DateRangePreset } from '@mastra/playground-ui';
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
 import { DatasetHealthCard } from '@/domains/datasets';
 import { useDatasets } from '@/domains/datasets/hooks/use-datasets';
 import { useExperiments } from '@/domains/datasets/hooks/use-experiments';
@@ -19,7 +22,97 @@ import { computeReviewTotals } from '@/domains/review/review-maps';
 import { useScoreMetrics, useScorers } from '@/domains/scores';
 import { ScoresOverTimeCard } from '@/domains/scores/components/scores-over-time-card';
 
+const PERIOD_PARAM = 'period';
+const DATE_FROM_PARAM = 'dateFrom';
+const DATE_TO_PARAM = 'dateTo';
+
+const EVAL_PRESETS: readonly DateRangePreset[] = [
+  'last-24h',
+  'last-3d',
+  'last-7d',
+  'last-14d',
+  'last-30d',
+  'custom',
+];
+
+const PRESET_MS: Record<string, number> = {
+  'last-24h': 24 * 60 * 60 * 1000,
+  'last-3d': 3 * 24 * 60 * 60 * 1000,
+  'last-7d': 7 * 24 * 60 * 60 * 1000,
+  'last-14d': 14 * 24 * 60 * 60 * 1000,
+  'last-30d': 30 * 24 * 60 * 60 * 1000,
+};
+
+const VALID_PRESETS = new Set<string>(EVAL_PRESETS);
+
+function parseDateParam(raw: string | null): Date | undefined {
+  if (!raw) return undefined;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
 export default function Evaluation() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // ── Date range state from URL ──────────────────────────────────────────
+  const periodParam = searchParams.get(PERIOD_PARAM);
+  const datePreset: DateRangePreset = periodParam && VALID_PRESETS.has(periodParam) ? (periodParam as DateRangePreset) : 'last-24h';
+
+  const customDateFrom = useMemo(() => parseDateParam(searchParams.get(DATE_FROM_PARAM)), [searchParams]);
+  const customDateTo = useMemo(() => parseDateParam(searchParams.get(DATE_TO_PARAM)), [searchParams]);
+
+  const handleDatePresetChange = useCallback(
+    (next: DateRangePreset) => {
+      setSearchParams(
+        prev => {
+          const params = new URLSearchParams(prev);
+          if (next === 'last-24h') {
+            params.delete(PERIOD_PARAM);
+          } else {
+            params.set(PERIOD_PARAM, next);
+          }
+          if (next !== 'custom') {
+            params.delete(DATE_FROM_PARAM);
+            params.delete(DATE_TO_PARAM);
+          }
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleDateChange = useCallback(
+    (value: Date | undefined, type: 'from' | 'to') => {
+      setSearchParams(
+        prev => {
+          const params = new URLSearchParams(prev);
+          const paramKey = type === 'from' ? DATE_FROM_PARAM : DATE_TO_PARAM;
+          if (value) {
+            params.set(paramKey, value.toISOString());
+          } else {
+            params.delete(paramKey);
+          }
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  // ── Compute date range for the data hook ───────────────────────────────
+  const dateRange = useMemo(() => {
+    if (datePreset === 'custom') {
+      return customDateFrom || customDateTo ? { start: customDateFrom, end: customDateTo } : undefined;
+    }
+    const ms = PRESET_MS[datePreset];
+    if (ms) return { start: new Date(Date.now() - ms) };
+    return undefined;
+  }, [datePreset, customDateFrom, customDateTo]);
+
+  // ── Data hooks ─────────────────────────────────────────────────────────
   const { data: scorers, isLoading: isLoadingScorers, error: errorScorers } = useScorers();
   const { data: datasetsData, isLoading: isLoadingDatasets, error: errorDatasets } = useDatasets();
   const { data: experimentsData, isLoading: isLoadingExperiments, error: errorExperiments } = useExperiments();
@@ -28,7 +121,7 @@ export default function Evaluation() {
     isLoading: isLoadingScores,
     isError: isErrorScores,
     error: errorScores,
-  } = useScoreMetrics();
+  } = useScoreMetrics({ dateRange });
   const {
     data: reviewSummary,
     isLoading: isLoadingReview,
@@ -69,6 +162,22 @@ export default function Evaluation() {
 
   return (
     <PageLayout width="wide" height="full">
+      <PageLayout.TopArea>
+        <PageLayout.Row>
+          <PageLayout.Column className="flex flex-wrap items-start justify-start gap-2 w-full">
+            <DateTimeRangePicker
+              preset={datePreset}
+              onPresetChange={handleDatePresetChange}
+              dateFrom={customDateFrom}
+              dateTo={customDateTo}
+              onDateChange={handleDateChange}
+              disabled={isLoadingScores}
+              presets={EVAL_PRESETS}
+            />
+          </PageLayout.Column>
+        </PageLayout.Row>
+      </PageLayout.TopArea>
+
       <div className="flex flex-col gap-6">
         <MetricsFlexGrid>
           <EvaluationKpiCards


### PR DESCRIPTION
## Description

This PR introduces a date picker to the Studio Evaluation Overview page, allowing users to filter evaluation scores by specific time periods (e.g., "last 24 hours", "yesterday", etc.). This addresses the need to analyze how scores change over time, especially before and after prompt updates.

**Changes made:**
- Added the standard `DateTimeRangePicker` component to the top toolbar of the `/evaluation` page (matching the layout of the Metrics and Traces pages).
- Integrated `searchParams` to persist the selected date preset and custom bounds directly in the URL (e.g., `?period=last-24h`).
- Updated the `useScoreMetrics` hook to accept an optional `dateRange` parameter and pass it down to `client.listScores({ filters: { timestamp } })`.
- Wired the URL state into the hook to dynamically filter all downstream evaluation KPIs and time-series charts server-side.

## Related issue(s)

Fixes #17530

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a date picker to the evaluation page so you can filter and view evaluation scores from specific time periods (like "last 24 hours" or "yesterday"). The date range you select is saved in the page URL, and the scores update automatically to show only results from that time period.

---

## Overview

This PR adds date range filtering capability to the Mastra Studio evaluation page, matching the UX pattern already used on the metrics and traces pages. Users can now select preset date ranges or custom date bounds to filter evaluation scores, enabling better analysis of score changes over time and debugging of evaluation data.

## Changes Made

**`packages/playground/src/domains/scores/hooks/use-score-metrics.ts`**

The `useScoreMetrics` hook was updated to accept an optional `dateRange` parameter:
- Added new exported interface `UseScoreMetricsParams` containing optional `dateRange` with `start` and `end` `Date` objects
- Updated hook signature to accept these params
- Enhanced React Query cache key to include ISO string representations of `dateRange.start` and `dateRange.end`, ensuring results are cached separately per date range
- Modified the `listScores` request to conditionally include a `timestamp` filter when a date range is provided (previously only filtered by `scorerId`)

**`packages/playground/src/pages/evaluation/index.tsx`**

The Evaluation page now manages date range selection through URL state:
- Added URL-backed state management for `period` (preset name), `dateFrom`, and `dateTo` with preset definitions and parsing logic
- Added `DateTimeRangePicker` component to the `PageLayout.TopArea` toolbar
- Implemented callbacks to update the URL when date range selections change
- Computed date range object passed to `useScoreMetrics` hook to trigger server-side filtering
- Integrated preset definitions and custom date validation
- Added necessary imports including `DateRangePreset` typing and React hooks (`useCallback`, `useMemo`)
- Disabled the date picker while metrics are loading to prevent state conflicts

## Impact

Users can now filter evaluation scores by specific time periods to analyze score trends, assess the impact of prompt changes, and debug evaluation data more effectively. The implementation maintains consistency with existing date picker patterns on the metrics and observability pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->