### PR TITLE
fix: hydrate persisted signal data parts

### DIFF
--- a/.changeset/polite-signals-load.md
+++ b/.changeset/polite-signals-load.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed Studio chat reloads so persisted signal messages render the same way as live streamed signals.

--- a/packages/playground/src/services/__tests__/to-assistant-ui-message.test.ts
+++ b/packages/playground/src/services/__tests__/to-assistant-ui-message.test.ts
@@ -2,7 +2,7 @@ import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent/mess
 import { describe, expect, it } from 'vitest';
 
 import { buildGlobalOmPartsByCycleId, convertOmPartsInMastraMessage } from '../om-parts-converter';
-import { toAssistantUIMessage } from '../to-assistant-ui-message';
+import { toAssistantUIMessage, toAssistantUIMessages } from '../to-assistant-ui-message';
 
 const OM_TOOL_NAME = 'mastra-memory-om-observation';
 
@@ -61,6 +61,42 @@ const assistantMessage = (parts: MastraMessagePart[]): MastraDBMessage => ({
   },
 });
 
+const signalMessage = (
+  parts: MastraMessagePart[],
+  signalType: string,
+  signalMetadata: Record<string, unknown> = {},
+): MastraDBMessage => ({
+  id: 'signal-msg-1',
+  role: 'signal',
+  type: signalType,
+  createdAt: new Date('2026-05-29T00:00:00.000Z'),
+  threadId: 'thread-1',
+  resourceId: 'resource-1',
+  content: {
+    format: 2,
+    parts,
+    metadata: {
+      signal: {
+        id: 'signal-1',
+        type: signalType,
+        tagName: signalType,
+        createdAt: '2026-05-29T00:00:00.000Z',
+        ...signalMetadata,
+      },
+    },
+  },
+});
+
+const hydratedSignalData = (message: MastraDBMessage): Record<string, unknown> => {
+  const converted = toAssistantUIMessage(message);
+  if (typeof converted.content === 'string') throw new Error('expected structured content parts');
+  const part = converted.content[0];
+  if (part?.type !== 'data' || !part.data || typeof part.data !== 'object') {
+    throw new Error('expected signal data part');
+  }
+  return part.data as Record<string, unknown>;
+};
+
 /**
  * Run a message through the real OM conversion pipeline (the same one
  * `mastra-runtime-provider` uses) so the runtime-only `dynamic-tool` part is
@@ -74,6 +110,163 @@ const firstConvertedPart = (parts: MastraMessagePart[]) => {
   if (typeof content === 'string') throw new Error('expected structured content parts');
   return content[0];
 };
+
+describe('toAssistantUIMessage signal messages', () => {
+  it('hydrates persisted non-user signal rows into assistant signal data parts', () => {
+    const signalPart: MastraMessagePart = {
+      type: 'text',
+      text: '# User\n- name: Tyler\n- location: Vancouver',
+    };
+
+    const converted = toAssistantUIMessage(signalMessage([signalPart], 'state'));
+    if (typeof converted.content === 'string') throw new Error('expected structured content parts');
+
+    expect(converted.role).toBe('assistant');
+    expect(converted.content).toEqual([
+      expect.objectContaining({
+        type: 'data',
+        name: 'signal',
+        data: expect.objectContaining({
+          id: 'signal-1',
+          type: 'state',
+          tagName: 'state',
+          contents: '# User\n- name: Tyler\n- location: Vancouver',
+          createdAt: '2026-05-29T00:00:00.000Z',
+        }),
+      }),
+    ]);
+  });
+
+  it('matches the live data-signal projection for persisted non-user signal rows', () => {
+    const liveSignalData = {
+      id: 'signal-1',
+      type: 'state',
+      tagName: 'state',
+      contents: '# User\n- name: Tyler\n- location: Vancouver',
+      createdAt: '2026-05-29T00:00:00.000Z',
+    };
+    const persisted = toAssistantUIMessage(signalMessage([{ type: 'text', text: liveSignalData.contents }], 'state'));
+    const live = toAssistantUIMessage(assistantMessage([omPart('signal', liveSignalData)]));
+
+    if (typeof persisted.content === 'string' || typeof live.content === 'string') {
+      throw new Error('expected structured content parts');
+    }
+
+    expect(persisted.role).toBe(live.role);
+    expect(persisted.content).toHaveLength(1);
+    expect(live.content).toHaveLength(1);
+    expect(persisted.content[0]).toMatchObject({
+      type: live.content[0]?.type,
+      name: 'signal',
+      data: live.content[0]?.type === 'data' ? live.content[0].data : undefined,
+    });
+  });
+
+  it('uses message fields as fallbacks when signal metadata is incomplete', () => {
+    const data = hydratedSignalData(
+      signalMessage([{ type: 'text', text: 'fallback content' }], 'state', {
+        id: undefined,
+        type: undefined,
+        tagName: undefined,
+        createdAt: undefined,
+      }),
+    );
+
+    expect(data).toMatchObject({
+      id: 'signal-msg-1',
+      type: 'state',
+      tagName: 'state',
+      contents: 'fallback content',
+      createdAt: '2026-05-29T00:00:00.000Z',
+    });
+  });
+
+  it('preserves optional signal metadata fields on hydrated data parts', () => {
+    const data = hydratedSignalData(
+      signalMessage([{ type: 'text', text: 'notification summary' }], 'notification', {
+        acceptedAt: '2026-05-29T00:00:01.000Z',
+        attributes: { priority: 'high', unread: true },
+        metadata: { recordId: 'notification-1' },
+      }),
+    );
+
+    expect(data).toMatchObject({
+      acceptedAt: '2026-05-29T00:00:01.000Z',
+      attributes: { priority: 'high', unread: true },
+      metadata: { recordId: 'notification-1' },
+    });
+  });
+
+  it('hydrates multi-part text and file signal contents', () => {
+    const filePart = {
+      type: 'file',
+      data: 'data:text/plain;base64,aGVsbG8=',
+      mimeType: 'text/plain',
+      filename: 'notes.txt',
+    } as MastraMessagePart;
+
+    const data = hydratedSignalData(signalMessage([{ type: 'text', text: 'attached notes' }, filePart], 'state'));
+
+    expect(data.contents).toEqual([
+      { type: 'text', text: 'attached notes' },
+      {
+        type: 'file',
+        data: 'data:text/plain;base64,aGVsbG8=',
+        mediaType: 'text/plain',
+        filename: 'notes.txt',
+      },
+    ]);
+  });
+
+  it('merges adjacent signal and assistant rows to match live streaming spacing', () => {
+    const messages = toAssistantUIMessages([
+      signalMessage([{ type: 'text', text: 'state contents' }], 'state'),
+      assistantMessage([{ type: 'text', text: 'assistant response' }]),
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.role).toBe('assistant');
+    expect(messages[0]?.content).toEqual([
+      expect.objectContaining({ type: 'data', name: 'signal' }),
+      expect.objectContaining({ type: 'text', text: 'assistant response' }),
+    ]);
+  });
+
+  it('does not merge unrelated adjacent assistant rows', () => {
+    const messages = toAssistantUIMessages([
+      assistantMessage([{ type: 'text', text: 'first assistant row' }]),
+      assistantMessage([{ type: 'text', text: 'second assistant row' }]),
+    ]);
+
+    expect(messages).toHaveLength(2);
+  });
+
+  it('does not merge signal rows across user messages', () => {
+    const messages = toAssistantUIMessages([
+      signalMessage([{ type: 'text', text: 'state contents' }], 'state'),
+      signalMessage([{ type: 'text', text: 'user says hello' }], 'user'),
+      assistantMessage([{ type: 'text', text: 'assistant response' }]),
+    ]);
+
+    expect(messages).toHaveLength(3);
+    expect(messages.map(message => message.role)).toEqual(['assistant', 'user', 'assistant']);
+  });
+
+  it('still renders persisted user signals as user content', () => {
+    const userPart: MastraMessagePart = { type: 'text', text: 'hello through a signal' };
+
+    const converted = toAssistantUIMessage(signalMessage([userPart], 'user'));
+    if (typeof converted.content === 'string') throw new Error('expected structured content parts');
+
+    expect(converted.role).toBe('user');
+    expect(converted.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: 'hello through a signal',
+      }),
+    ]);
+  });
+});
 
 describe('toAssistantUIMessage dynamic-tool conversion (via OM pipeline)', () => {
   it('converts a loading OM observation into a tool-call without a result', () => {
@@ -471,11 +664,11 @@ describe('toAssistantUIMessage signal role mapping', () => {
     expect(toAssistantUIMessage(message).role).toBe('user');
   });
 
-  it('renders a non-user signal as a system message', () => {
+  it('renders non-user signals as assistant messages', () => {
     const tagSignal = signalMessage({ signal: { type: 'tag' } }, 'tagged');
     const noTypeSignal = signalMessage({}, 'no type');
 
-    expect(toAssistantUIMessage(tagSignal).role).toBe('system');
-    expect(toAssistantUIMessage(noTypeSignal).role).toBe('system');
+    expect(toAssistantUIMessage(tagSignal).role).toBe('assistant');
+    expect(toAssistantUIMessage(noTypeSignal).role).toBe('assistant');
   });
 });

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -21,7 +21,7 @@ import {
   buildStreamErrorMessage,
   isMaxStepsFinishChunk,
 } from './stream-error-message';
-import { toAssistantUIMessage } from './to-assistant-ui-message';
+import { toAssistantUIMessages } from './to-assistant-ui-message';
 import { ToolCallProvider } from './tool-call-provider';
 import { useObservationalMemoryContext } from '@/domains/agents/context';
 import { useWorkingMemory } from '@/domains/agents/context/agent-working-memory-context';
@@ -550,11 +550,10 @@ export function MastraRuntimeProvider({
   // tracked in `streamErrors` (which survives the post-stream initialMessages
   // refresh). Without filtering here we would briefly render duplicate errors
   // during the streaming window.
-  const vnextmessages = [...messages.filter(msg => msg.content?.metadata?.status !== 'error'), ...streamErrors].map(
-    msg => {
-      const converted = convertOmPartsInMastraMessage(msg, globalOmParts);
-      return toAssistantUIMessage(converted);
-    },
+  const vnextmessages = toAssistantUIMessages(
+    [...messages.filter(msg => msg.content?.metadata?.status !== 'error'), ...streamErrors].map(msg =>
+      convertOmPartsInMastraMessage(msg, globalOmParts),
+    ),
   );
 
   const runtime = useExternalStoreRuntime({

--- a/packages/playground/src/services/to-assistant-ui-message.ts
+++ b/packages/playground/src/services/to-assistant-ui-message.ts
@@ -25,26 +25,88 @@ type ContentPart = { metadata?: Record<string, unknown> } & (Exclude<
  * stored under `content.metadata.signal.type`, falling back to the top-level
  * `message.type`.
  */
-const getSignalType = (message: MastraDBMessage): string | undefined => {
+const getSignalMetadata = (message: MastraDBMessage): Record<string, unknown> | undefined => {
   const signal = message.content.metadata?.signal;
-  if (signal && typeof signal === 'object' && !Array.isArray(signal)) {
-    const type = (signal as Record<string, unknown>).type;
-    return typeof type === 'string' ? type : message.type;
-  }
-  return message.type;
+  return signal && typeof signal === 'object' && !Array.isArray(signal)
+    ? (signal as Record<string, unknown>)
+    : undefined;
+};
+
+const getSignalType = (message: MastraDBMessage): string | undefined => {
+  const type = getSignalMetadata(message)?.type;
+  return typeof type === 'string' ? type : message.type;
 };
 
 /**
  * User-message signals (the persisted echo of a user turn sent via `sendSignal`)
- * use `type: 'user'` or `'user-message'`. They must render as a user bubble on
- * reload, matching core's adapters; all other signals stay `system`.
+ * use `type: 'user'` or `'user-message'`. They render as user text on reload.
+ * Every other signal mirrors the old streaming accumulator's `data-*` behavior:
+ * a signal data part on an assistant message.
  */
 const isUserSignalType = (type: string | undefined): boolean => type === 'user' || type === 'user-message';
+
+const toAssistantUIRole = (message: MastraDBMessage): ThreadMessageLike['role'] => {
+  if (message.role !== 'signal') return message.role;
+  return isUserSignalType(getSignalType(message)) ? 'user' : 'assistant';
+};
 
 const getPartMetadata = (message: MastraDBMessage, part: MastraMessagePart) => ({
   ...message.content.metadata,
   ...('providerMetadata' in part && part.providerMetadata ? { providerMetadata: part.providerMetadata } : {}),
 });
+
+type SignalContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'file'; data: string; mediaType: string; filename?: string };
+
+const signalPartsToContents = (parts: MastraMessagePart[]): unknown => {
+  const contents: SignalContentPart[] = [];
+  for (const part of parts) {
+    if (part.type === 'text') {
+      contents.push({ type: 'text', text: part.text });
+      continue;
+    }
+
+    if (part.type === 'file') {
+      const data = 'data' in part ? part.data : undefined;
+      if (typeof data !== 'string') continue;
+      contents.push({
+        type: 'file',
+        data,
+        mediaType:
+          ('mediaType' in part && typeof part.mediaType === 'string' ? part.mediaType : undefined) ??
+          ('mimeType' in part && typeof part.mimeType === 'string' ? part.mimeType : undefined) ??
+          'application/octet-stream',
+        ...('filename' in part && typeof part.filename === 'string' ? { filename: part.filename } : {}),
+      });
+    }
+  }
+
+  return contents.length === 1 && contents[0]?.type === 'text' ? contents[0].text : contents;
+};
+
+const toSignalDataContentPart = (message: MastraDBMessage): ContentPart => {
+  const signal = getSignalMetadata(message) ?? {};
+  return {
+    type: 'data',
+    name: 'signal',
+    data: {
+      id: typeof signal.id === 'string' ? signal.id : message.id,
+      type: getSignalType(message),
+      tagName: typeof signal.tagName === 'string' ? signal.tagName : message.type,
+      contents: signalPartsToContents(message.content.parts),
+      createdAt: typeof signal.createdAt === 'string' ? signal.createdAt : message.createdAt.toISOString(),
+      ...(typeof signal.acceptedAt === 'string' ? { acceptedAt: signal.acceptedAt } : {}),
+      ...(signal.attributes && typeof signal.attributes === 'object' && !Array.isArray(signal.attributes)
+        ? { attributes: signal.attributes }
+        : {}),
+      ...(signal.metadata && typeof signal.metadata === 'object' && !Array.isArray(signal.metadata)
+        ? { metadata: signal.metadata }
+        : {}),
+    },
+    metadata: message.content.metadata,
+  };
+};
 
 const getToolArgs = (toolInvocation: MastraToolInvocationPart['toolInvocation']) => {
   const invocation = toolInvocation as MastraToolInvocationPart['toolInvocation'] & {
@@ -338,6 +400,14 @@ const toContentPart = (message: MastraDBMessage, part: MastraMessagePart): Conte
   return { type: 'text', text: '', metadata: getPartMetadata(message, part) };
 };
 
+const toContent = (message: MastraDBMessage): ThreadMessageLike['content'] => {
+  if (message.role === 'signal' && !isUserSignalType(getSignalType(message))) {
+    return [toSignalDataContentPart(message)];
+  }
+
+  return message.content.parts.map(part => toContentPart(message, part));
+};
+
 const toStatus = (message: MastraDBMessage): MessageStatus | undefined => {
   if (message.role !== 'assistant' || message.content.parts.length === 0) return undefined;
 
@@ -364,8 +434,8 @@ const toStatus = (message: MastraDBMessage): MessageStatus | undefined => {
 export const toAssistantUIMessage = (message: MastraDBMessage): ThreadMessageLike =>
   ({
     id: message.id,
-    role: message.role === 'signal' ? (isUserSignalType(getSignalType(message)) ? 'user' : 'system') : message.role,
-    content: message.content.parts.map(part => toContentPart(message, part)),
+    role: toAssistantUIRole(message),
+    content: toContent(message),
     status: toStatus(message),
     createdAt: message.createdAt,
     metadata: {
@@ -375,3 +445,32 @@ export const toAssistantUIMessage = (message: MastraDBMessage): ThreadMessageLik
       createdAt: message.createdAt,
     } as ThreadMessageLike['metadata'],
   }) as ThreadMessageLike;
+
+const hasSignalDataPart = (message: ThreadMessageLike): boolean =>
+  Array.isArray(message.content) && message.content.some(part => part.type === 'data' && part.name === 'signal');
+
+const shouldMergeAssistantMessages = (previous: ThreadMessageLike, next: ThreadMessageLike): boolean =>
+  previous.role === 'assistant' &&
+  next.role === 'assistant' &&
+  (hasSignalDataPart(previous) || hasSignalDataPart(next));
+
+export const toAssistantUIMessages = (messages: MastraDBMessage[]): ThreadMessageLike[] =>
+  messages.map(toAssistantUIMessage).reduce<ThreadMessageLike[]>((result, message) => {
+    const previous = result.at(-1);
+    if (
+      previous &&
+      shouldMergeAssistantMessages(previous, message) &&
+      Array.isArray(previous.content) &&
+      Array.isArray(message.content)
+    ) {
+      result[result.length - 1] = {
+        ...previous,
+        content: [...previous.content, ...message.content],
+        status: message.status ?? previous.status,
+      };
+      return result;
+    }
+
+    result.push(message);
+    return result;
+  }, []);


### PR DESCRIPTION
Persisted Studio signal messages were hydrating differently after reload than they did during live streaming, which made state signals show up as normal text instead of the signal card.

Before reload, streaming handled non-user signals as assistant data parts:

```ts
{ type: 'data', name: 'signal', data: { type: 'state', contents: '...' } }
```

After reload, persisted signal rows now project back to that same shape. User-message signals still hydrate as normal user text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Saved "signal" messages (special state/data cards) were showing as plain text after reloading Studio chat. This PR makes reloaded signals render the same way as live-streamed signals by reconstructing them into the same assistant data-card shape they have during streaming.

## Changes

### Changeset
- Added `.changeset/polite-signals-load.md` to mark `@internal/playground` as a patch and document the fix so persisted signal messages render identically to live streamed signals.

### Tests
- Added `signalMessage` test helper to build persisted `MastraDBMessage` rows with `role: 'signal'` and `content.metadata.signal`.
- Added `hydratedSignalData` helper to validate hydrated signal data parts.
- New `describe('toAssistantUIMessage signal messages')` suite covering:
  - Persisted non-user signals convert to assistant `data` parts with hydrated metadata (id, type, tagName, contents, createdAt).
  - Multi-part signal contents (text + file) are hydrated into the signal `contents` array.
  - Signals merge with adjacent assistant rows to match streaming spacing but do not merge across user boundaries.
  - Persisted user signals continue to render as user text.
  - Role mapping updated: non-user signals (including those missing `signal.type`) map to `assistant` rather than `system`.

### Implementation
- packages/playground/src/services/to-assistant-ui-message.ts:
  - Added reconstruction of persisted signals:
    - `getSignalMetadata` and updated `getSignalType` to prefer `content.metadata.signal.type` with fallback to `message.type`.
    - `toAssistantUIRole` to map `role: 'signal'` messages to `user` vs `assistant`.
    - `signalPartsToContents` and `toSignalDataContentPart` to normalize signal parts (including files) into a single assistant-ui `content: { type: 'data', name: 'signal', data: { ... } }` structure with normalized metadata and timing.
    - `toContent` helper that emits reconstructed `signal` data parts for non-user signals and falls back to existing `toContentPart` for others.
    - `toAssistantUIMessage` updated to use `toAssistantUIRole(message)` and `toContent(message)`.
    - Added exported `toAssistantUIMessages(messages)` to post-process arrays of messages and merge consecutive assistant messages when a neighboring message contains a `data` content part named `signal`, preserving status and concatenating contents.

- packages/playground/src/services/mastra-runtime-provider.tsx:
  - Replaced per-message conversion with batch-oriented pipeline that filters error-status messages, appends local `streamErrors`, converts OM parts, and calls `toAssistantUIMessages` for consistent batch hydration and merging.

## API/Exports
- Exported: `toAssistantUIMessages` added.
- No breaking signature changes to `toAssistantUIMessage`; behavior updated internally.

## Motivation / Impact
- Fixes a UI regression where persisted signals rendered as plain text after reload.
- Ensures persisted signal rows are hydrated back into the same assistant `data/signal` shape used during live streaming, preserving metadata and multi-part contents so Studio renders signal cards consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->