### PR TITLE
test: initialize playground e2e storage before reset

### DIFF
--- a/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
+++ b/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
@@ -48,6 +48,8 @@ export const mastra = new Mastra({
       registerApiRoute('/e2e/reset-storage', {
         method: 'POST',
         handler: async c => {
+          await storage.init();
+
           const clearTasks: Promise<void>[] = [];
 
           const workflowStore = await storage.getStore('workflows');


### PR DESCRIPTION
## Summary
- initialize the kitchen-sink LibSQL storage schema before `/e2e/reset-storage` clears domain stores
- prevents missing-table reset failures in in-memory E2E runs before scorer tests execute

## Test plan
- `pnpm --filter ./packages/playground typecheck`
- `pnpm --filter ./packages/playground exec playwright test -c e2e/playwright.config.ts e2e/tests/cms/scorers/edit/page.spec.ts --reporter=list`
- `pnpm prettier:changed`