### PR TITLE
fix(cli): upgrade archiver from v7 to v8

### DIFF
--- a/.changeset/upgrade-archiver-to-v8.md
+++ b/.changeset/upgrade-archiver-to-v8.md
@@ -1,0 +1,12 @@
+---
+'@mastra/cli': patch
+---
+
+Upgrade archiver from v7 to v8 in @mastra/cli
+
+- Bumped `archiver` dependency from `^7.0.1` to `^8.0.0`
+- Migrated `zipOutput` call sites to use the new `ZipArchive` class API (v8 breaking change)
+- Updated test mocks in `deploy.test.ts` (server + studio) from `default` export to `ZipArchive`
+- Confirms minimum Node version (`>=22.13.0`) is compatible with `archiver@8` (requires Node >=18)
+
+Related issue: #17498

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "@expo/devcert": "^1.2.1",
     "@mastra/deployer": "workspace:^",
     "@mastra/loggers": "workspace:^",
-    "archiver": "^7.0.1",
+    "archiver": "^8.0.0",
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
     "execa": "^9.6.1",

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -52,7 +52,7 @@ vi.mock('@clack/prompts', () => ({
 }));
 
 vi.mock('archiver', () => ({
-  default: vi.fn(() => ({
+  ZipArchive: vi.fn(() => ({
     on: vi.fn(),
     pipe: vi.fn(),
     glob: vi.fn(),

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -4,7 +4,7 @@ import { mkdir, rm, stat, access, readFile, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import * as p from '@clack/prompts';
-import archiver from 'archiver';
+import * as archiver from 'archiver';
 import { config } from 'dotenv';
 import { runBuild } from '../../utils/run-build.js';
 import { checkBuildStaleness } from '../../utils/source-hash.js';
@@ -40,7 +40,7 @@ async function zipOutput(projectDir: string): Promise<string> {
 
   return new Promise((resolvePromise, reject) => {
     const output = createWriteStream(zipPath);
-    const archive = archiver('zip', { zlib: { level: 6 } });
+    const archive = new archiver.ZipArchive({ zlib: { level: 6 } });
 
     output.on('close', () => resolvePromise(zipPath));
     archive.on('error', reject);

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -101,7 +101,7 @@ vi.mock('@clack/prompts', () => ({
 }));
 
 vi.mock('archiver', () => ({
-  default: vi.fn(() => ({
+  ZipArchive: vi.fn(() => ({
     on: vi.fn(),
     pipe: vi.fn(),
     glob: vi.fn(),

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -5,7 +5,7 @@ import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import * as p from '@clack/prompts';
-import archiver from 'archiver';
+import * as archiver from 'archiver';
 import { config } from 'dotenv';
 import { runBuild } from '../../utils/run-build.js';
 import { checkBuildStaleness } from '../../utils/source-hash.js';
@@ -70,7 +70,7 @@ async function zipOutput(projectDir: string): Promise<string> {
 
   return new Promise((resolvePromise, reject) => {
     const output = createWriteStream(zipPath);
-    const archive = archiver('zip', { zlib: { level: 6 } });
+    const archive = new archiver.ZipArchive({ zlib: { level: 6 } });
 
     output.on('close', () => resolvePromise(zipPath));
     archive.on('error', reject);


### PR DESCRIPTION
- Bump archiver from ^7.0.1 to ^8.0.0 in packages/cli/package.json
- Migrate zipOutput call sites to use new ZipArchive class API
- Update test mocks from default export to ZipArchive
- Add changeset for the upgrade

Closes #17498

## Description

### Summary
This PR upgrades the `archiver` dependency in `@mastra/cli` from `^7.0.1` to `^8.0.0` to stay current with the actively-maintained line and avoid major-version drift.

### Motivation
- **Avoid major-version drift.** Staying on v7 means falling further behind on the package and its transitive dependencies (`compress-commons`, `crc32-stream`, `zip-stream`, `readdir-glob`), which also get major bumps in v8.
- **Maintenance hygiene.** Picking up the latest major keeps us on the actively-maintained line and ahead of any eventual deprecation of v7.

### Breaking Change Handled
v8 replaces the default factory export with a named `ZipArchive` class:

```typescript
// before (v7)
import archiver from 'archiver';
const archive = archiver('zip', { zlib: { level: 6 } });

// after (v8)
import * as archiver from 'archiver';
const archive = new archiver.ZipArchive({ zlib: { level: 6 } });
```

### Changes Made
- **`packages/cli/package.json`**: Bumped `archiver` from `^7.0.1` to `^8.0.0`
- **`packages/cli/src/commands/server/deploy.ts`**: 
  - Updated import: `import archiver from 'archiver'` → `import * as archiver from 'archiver'`
  - Updated API call: `archiver('zip', opts)` → `new archiver.ZipArchive(opts)`
- **`packages/cli/src/commands/studio/deploy.ts`**: 
  - Updated import: `import archiver from 'archiver'` → `import * as archiver from 'archiver'`
  - Updated API call: `archiver('zip', opts)` → `new archiver.ZipArchive(opts)`
- **`packages/cli/src/commands/server/deploy.test.ts`**: Updated mock from `default` to `ZipArchive`
- **`packages/cli/src/commands/studio/deploy.test.ts`**: Updated mock from `default` to `ZipArchive`
- **`.changeset/upgrade-archiver-to-v8.md`**: Added changeset for the upgrade

### Compatibility
`archiver@8` requires **Node >=18**. The CLI's minimum supported Node version is `>=22.13.0` (see `packages/cli/package.json`), 
### Testing
- [x] Updated test mocks in both `deploy.test.ts` files
- [ ] Test suite passes (CI will verify)
- [x] Changeset added

### Related Issues
Closes #17498

### Screenshots
N/A (dependency upgrade, no UI changes)

---

## ELI5
We updated a tool we use to package files into ZIP archives. The new version (v8) changed how you call it, 
## Checklist
- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR (once they appear)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the tool that creates zip files (archiver) from version 7 to version 8. The new version requires a different way of creating zip files—instead of calling it like a function, you now create a new instance of a class. All the code and tests that use this tool were updated to work with the new version.

## Overview

Upgrades the `archiver` dependency in `@mastra/cli` from v7.0.1 to v8.0.0 and migrates all related code to the new ZipArchive class API introduced in archiver@8.

## Changes

**Dependency Update:**
- `packages/cli/package.json`: Bumped `archiver` from `^7.0.1` to `^8.0.0`

**API Migration:**
- `packages/cli/src/commands/server/deploy.ts`: Changed from default import to namespace import (`import * as archiver`) and replaced `archiver('zip', opts)` with `new archiver.ZipArchive(opts)`
- `packages/cli/src/commands/studio/deploy.ts`: Applied same changes as server deploy

**Test Mock Updates:**
- `packages/cli/src/commands/server/deploy.test.ts`: Updated mock to export `ZipArchive` as a named export instead of default export
- `packages/cli/src/commands/studio/deploy.test.ts`: Updated mock to export `ZipArchive` as a named export instead of default export

**Changelog:**
- `.changeset/upgrade-archiver-to-v8.md`: Added changeset documenting the upgrade and test updates

## Compatibility

The upgrade is compatible with the CLI's minimum Node version (>=22.13.0), which exceeds archiver@8's requirement of Node >=18.

## References

Closes `#17498`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->