### PR TITLE
fix(build): unblock docs and TypeScript builds

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "dev": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "BROWSERSLIST='>0.5%, not dead, not op_mini all' docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "isolatedModules": true,
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "module": "ES2022",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "target": "es2022",
+    "ignoreDeprecations": "6.0",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary

This is PR 1 of 2 split from the mixed model-picker/build-fix branch.

It unblocks the monorepo build by fixing two independent build failures:

- Sets the docs build Browserslist target explicitly so PostCSS/Autoprefixer does not pick up the malformed browser query seen during `docs` builds.
- Adds TypeScript 6 deprecation suppression to shared tsconfig files so packages inheriting deprecated `baseUrl` config can continue building until those configs are migrated.

## Scope

- `docs/package.json`
- `tsconfig.json`
- `tsconfig.node.json`

## Intentionally excluded

- Studio model picker/provider dropdown fix. That is isolated in the separate `fix/model-picker-dropdowns` PR.

## Verification

- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes two broken build processes in the project: it tells the documentation build exactly which web browsers to support (so it doesn't get confused), and it tells TypeScript to ignore some warning messages about old features that are going away (so the code can keep building while the team plans to update it properly later).

## Changes

### docs/package.json
Updated the `docs` build script to explicitly set the Browserslist environment variable before running the Docusaurus build:
```
BROWSERSLIST='>0.5%, not dead, not op_mini all' docusaurus build
```

This prevents PostCSS and Autoprefixer from picking up a malformed browser query configuration during the build process.

### tsconfig.json & tsconfig.node.json
Added TypeScript 6 deprecation suppression to both shared tsconfig files:
```json
"compilerOptions": {
  "ignoreDeprecations": "6.0"
}
```

This allows packages that inherit the deprecated `baseUrl` configuration to continue building without TypeScript 6 deprecation warnings, providing time for these configurations to be properly migrated.

## Scope
This PR is part of a larger build-fix effort, intentionally excluding the studio model picker/provider dropdown fix which is being handled in a separate PR (`fix/model-picker-dropdowns`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->