### PR TITLE
fix: trust same-repo PRs in changed test gate

### DIFF
--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -44,6 +44,11 @@ jobs:
           if [ ! -s /tmp/changed-test-files ]; then
             echo "has_tests=false" >> "$GITHUB_OUTPUT"
 
+            if [ "$HEAD_REPO_FULL_NAME" = "$BASE_REPOSITORY" ]; then
+              echo "No changed test files detected for a branch in the base repository."
+              exit 0
+            fi
+
             case "$AUTHOR_ASSOCIATION" in
               OWNER|MEMBER|COLLABORATOR)
                 echo "No changed test files detected for an official contributor."
@@ -65,8 +70,10 @@ jobs:
           cat /tmp/changed-test-files
         env:
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          BASE_REPOSITORY: ${{ github.repository }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
+          HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm


### PR DESCRIPTION
This updates the changed test gate so PR branches from mastra-ai/mastra are treated as trusted even if GitHub reports author_association as CONTRIBUTOR in the workflow payload. Fork PRs still use the existing author association check, so external contributors without changed tests are still blocked.\n\nTest plan: parsed .github/workflows/changed-test-gate.yml with Ruby YAML, then exercised the no-tests trust logic for same-repo CONTRIBUTOR, fork MEMBER, and fork CONTRIBUTOR cases. The same-repo and member cases pass; the external contributor fork case still fails as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the test requirement check smarter about where a pull request comes from. If you're making changes directly in the main repository (not a fork), you're automatically trusted and don't need to include tests—even if GitHub marks you as a regular contributor. However, if you're submitting a pull request from a forked copy of the repository, you still need to include tests unless you have special permissions.

## Technical Summary

This change updates the "changed test gate" GitHub Actions workflow to distinguish between internal and external pull requests when enforcing test requirements.

### Key Changes

The "Restore changed test files from PR head" step now includes logic that trusts pull requests originating from the base repository (`mastra-ai/mastra`), treating them as safe even when GitHub's author association indicates `CONTRIBUTOR` status. The workflow now:

1. **Adds a same-repository check**: Before evaluating author association, the workflow checks if the PR head repository matches the base repository. If they match, the workflow exits successfully without requiring test files.

2. **Preserves fork-based author checks**: For pull requests from forked repositories, the existing author association logic remains unchanged. External contributors on forks without OWNER, MEMBER, or COLLABORATOR status still must include changed test files.

3. **Adds `BASE_REPOSITORY` environment variable**: Expands the step's environment to include `BASE_REPOSITORY` (set to `${{ github.repository }}`), enabling the comparison between the head and base repository names.

### Behavior

- **Same-repo PRs**: Always pass the test gate, regardless of author association
- **Fork PRs from OWNER/MEMBER/COLLABORATOR**: Pass without required test files  
- **Fork PRs from external CONTRIBUTOR**: Fail if no test files are present (existing behavior preserved)

This change simplifies the workflow for internal contributors making direct commits to the repository while maintaining security guardrails for external contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->