### PR TITLE
fix(agent): add persistPartialOnAbort option to save partial output on abort

### DIFF
--- a/.changeset/agent-stream-persist-partial-on-abort.md
+++ b/.changeset/agent-stream-persist-partial-on-abort.md
@@ -1,0 +1,16 @@
+---
+"@mastra/core": patch
+---
+
+Add `persistPartialOnAbort` option to preserve partial streamed assistant output when a request is aborted.
+
+Previously, aborting an agent stream (e.g. user clicking "stop") caused all streamed output to be lost on refresh because `memory.saveMessages` was skipped entirely. The new opt-in option saves partial output when non-empty text was already streamed to the client.
+
+```ts
+const stream = await agent.stream('Hello', {
+  persistPartialOnAbort: true,  // save partial output if user aborts
+  abortSignal: controller.signal,
+});
+```
+
+Defaults to `false` — existing abort behavior is fully preserved when the option is not set.

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -510,6 +510,14 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
    */
   abortSignal?: LoopConfig<OUTPUT>['abortSignal'];
 
+  /**
+   * When true, partial assistant output already streamed to the caller is
+   * persisted to memory even if the request was aborted (e.g. user clicked
+   * "stop"). Only saves when non-empty text was generated. Defaults to false
+   * to preserve existing behavior (skip memory on abort).
+   */
+  persistPartialOnAbort?: boolean;
+
   /** Input processors to use for this execution (overrides agent's default) */
   inputProcessors?: InputProcessorOrWorkflow[];
   /** Output processors to use for this execution (overrides agent's default) */

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -299,21 +299,61 @@ export function createMapResultsStep<OUTPUT = undefined>({
           }
 
           if (payload.finishReason === 'aborted') {
-            agentSpan?.end({
-              output: {
-                status: 'aborted',
-                reason: 'abort',
-              },
-            });
+            // Optionally persist partial output if the caller opted in and
+            // non-empty text was already streamed to the client.
+            // When persisting, let executeOnFinish own the span end so it can
+            // record the output correctly. Only end the span early when skipping.
+            if (options.persistPartialOnAbort && payload.text) {
+              try {
+                const outputText = payload.text;
+                await capabilities.executeOnFinish({
+                  result: payload,
+                  outputText,
+                  thread: result.thread,
+                  threadId: result.threadId,
+                  readOnlyMemory: memoryConfig?.readOnly,
+                  resourceId,
+                  memoryConfig,
+                  requestContext,
+                  agentSpan,
+                  runId,
+                  messageList,
+                  threadExists: memoryData.threadExists,
+                  structuredOutput: !!options.structuredOutput?.schema,
+                  overrideScorers: options.scorers,
+                });
+              } catch (e) {
+                capabilities.logger.error('Error saving partial memory on abort', {
+                  error: e,
+                  runId,
+                });
+                agentSpan?.end({
+                  output: {
+                    status: 'aborted',
+                    reason: 'abort',
+                  },
+                });
+              }
+            } else {
+              agentSpan?.end({
+                output: {
+                  status: 'aborted',
+                  reason: 'abort',
+                },
+              });
+            }
             return;
           }
 
-          // Skip memory persistence when the abort signal has fired.
+          // Skip memory persistence when the abort signal has fired unless
+          // the caller explicitly opted in via persistPartialOnAbort.
           // The LLM response may have continued after the caller disconnected,
-          // and we should not persist a partial or full response for an aborted request.
+          // and by default we do not persist a partial or full response for an
+          // aborted request.
           const aborted = options.abortSignal?.aborted;
+          const shouldPersist = !aborted || (options.persistPartialOnAbort && !!payload.text);
 
-          if (!aborted) {
+          if (shouldPersist) {
             try {
               const outputText =
                 options.structuredOutput?.schema && payload.object != null
@@ -358,6 +398,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
               agentSpan?.error({ error: spanError, endSpan: true });
             }
           } else {
+            // Aborted and persistPartialOnAbort not set (or no text) — skip memory, just end span.
             agentSpan?.end();
           }
 


### PR DESCRIPTION
## Problem

Fixes #17510

When a user aborts an agent stream (e.g. clicking "stop"), `executeOnFinish` 
(and `memory.saveMessages`) was skipped entirely — losing all partial assistant 
output already streamed to the client. On refresh, the entire response is gone.

There are two abort exit points in `map-results-step.ts`:
- `finishReason === 'aborted'` (L299) — AI SDK signaling generation was interrupted
- `abortSignal?.aborted` gate (L312) — Mastra's own abort guard

Both were unconditionally skipping memory persistence.

## Solution

Add a `persistPartialOnAbort?: boolean` option to `AgentExecutionOptionsBase` 
(default `false` — fully preserves existing behavior).

When set to `true`:
- Both abort exit points check `persistPartialOnAbort && payload.text` before 
  calling `executeOnFinish`
- Only persists when non-empty text was generated (guards against saving empty responses)
- At `finishReason=aborted`: `executeOnFinish` owns the span end to avoid 
  double-ending the span
- At `abortSignal.aborted`: existing `shouldPersist` logic extended with opt-in check

## Usage

```ts
const stream = await agent.stream('Hello', {
  persistPartialOnAbort: true,
  abortSignal: controller.signal,
});
```

## Behavior matrix

| Scenario | `persistPartialOnAbort` | `payload.text` | Saves memory |
|---|---|---|---|
| Normal finish | any | any | ✅ always |
| Aborted | `false` (default) | any | ❌ skipped |
| Aborted | `true` | empty | ❌ skipped |
| Aborted | `true` | non-empty | ✅ saved |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you hit “stop” while an AI is still streaming, the system used to throw away what it had already said. This PR adds an opt-in switch so you can save that already-streamed partial text instead of losing it.

## Overview

Fixes the abort-stream persistence gap (issue `#17510`) by adding `persistPartialOnAbort?: boolean` (default `false`) to `AgentExecutionOptionsBase`. When enabled, the agent will persist non-empty partial streamed output on abort paths that previously skipped `executeOnFinish` (including `memory.saveMessages`). Default behavior remains unchanged.

## Changes

- **.changeset/agent-stream-persist-partial-on-abort.md**
  - Documents the new opt-in option and its default (`false`).

- **packages/core/src/agent/agent.types.ts**
  - Adds `persistPartialOnAbort?: boolean` to `AgentExecutionOptionsBase`.

- **packages/core/src/agent/workflows/prepare-stream/map-results-step.ts**
  - **`finishReason === 'aborted'` path:** if `options.persistPartialOnAbort && payload.text` is present, calls `capabilities.executeOnFinish` with `outputText: payload.text` to persist partial output. Span-ending responsibilities are handled to avoid double-ending; failures log an error and end the span with `{ status: 'aborted', reason: 'abort' }`.
  - **`abortSignal.aborted` path:** extends the persistence decision (`shouldPersist`) to include the opt-in condition and requires non-empty `payload.text`.
  - Ensures **empty partial output is never persisted** even when the option is enabled.

## Behavior matrix

- **Normal finish:** persists as before.
- **Aborted + `persistPartialOnAbort: false` (default):** skips persistence (as before).
- **Aborted + `persistPartialOnAbort: true`:**
  - **empty `payload.text`:** does not persist
  - **non-empty `payload.text`:** persists partial output via `executeOnFinish`.

## Usage

Enable via:
```ts
agent.stream(messages, {
  persistPartialOnAbort: true,
  abortSignal: controller.signal,
})
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->