### PR TITLE
feat: automated release notifications for linked issues

### DIFF
--- a/.changeset/ccee-22ae-bc05-103f.md
+++ b/.changeset/ccee-22ae-bc05-103f.md
@@ -1,6 +1,0 @@
----
----
-
-Add automated release notifications for linked issues.
-
-When a PR is merged into `main`, linked issues are labeled `pending-release` and receive a comment confirming the fix will be included in the next release. Once the alpha prerelease is published, the comment is updated to indicate availability in the alpha channel. After the stable release, the comment is updated again to reflect the latest stable release and the `pending-release` label is removed.

--- a/.changeset/ccee-22ae-bc05-103f.md
+++ b/.changeset/ccee-22ae-bc05-103f.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add automated release notifications for linked issues.
+
+When a PR is merged into `main`, linked issues are labeled `pending-release` and receive a comment confirming the fix will be included in the next release. Once the alpha prerelease is published, the comment is updated to indicate availability in the alpha channel. After the stable release, the comment is updated again to reflect the latest stable release and the `pending-release` label is removed.

--- a/.github/workflows/issue-pending-release.yml
+++ b/.github/workflows/issue-pending-release.yml
@@ -1,0 +1,56 @@
+name: Issue Pending Release
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  label-linked-issues:
+    if: |
+      github.repository == 'mastra-ai/mastra' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout automation scripts
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions
+            scripts/release-issue-notification
+          sparse-checkout-cone-mode: false
+
+      - name: Generate GitHub App token
+        id: app_token
+        uses: ./.github/actions/app-auth
+        with:
+          client-id: ${{ vars.DANE_CLIENT_ID }}
+          private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+
+      - name: Setup pnpm and node
+        uses: ./.github/actions/setup-pnpm-node
+        with:
+          install-dependencies: false
+          package-manager-cache: false
+          version: '10'
+
+      - name: Install dependencies
+        run: pnpm install --ignore-workspace --ignore-scripts
+        working-directory: scripts/release-issue-notification
+
+      - name: Label linked issues as pending release
+        run: npx tsx index.ts
+        working-directory: scripts/release-issue-notification
+        env:
+          MODE: pending-release
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -138,6 +138,7 @@ jobs:
 
       - name: Notify linked issues (alpha available)
         if: ${{ !inputs.dry_run }}
+        continue-on-error: true
         run: |
           pnpm install --ignore-workspace --ignore-scripts
           npx tsx index.ts
@@ -292,6 +293,7 @@ jobs:
 
       - name: Notify linked issues (stable released)
         if: ${{ !inputs.dry_run }}
+        continue-on-error: true
         run: |
           pnpm install --ignore-workspace --ignore-scripts
           npx tsx index.ts

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: write
       id-token: write
     steps:
@@ -135,6 +136,18 @@ jobs:
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
             --delete
 
+      - name: Notify linked issues (alpha available)
+        if: ${{ !inputs.dry_run }}
+        run: |
+          pnpm install --ignore-workspace --ignore-scripts
+          npx tsx index.ts
+        working-directory: scripts/release-issue-notification
+        env:
+          MODE: alpha-released
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+
   # ===========================================
   # STABLE RELEASE: Manual trigger only
   # ===========================================
@@ -146,6 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: write
       id-token: write
     steps:
@@ -275,6 +289,18 @@ jobs:
         run: |
           pnpm changeset-cli tag
           git push origin --tags
+
+      - name: Notify linked issues (stable released)
+        if: ${{ !inputs.dry_run }}
+        run: |
+          pnpm install --ignore-workspace --ignore-scripts
+          npx tsx index.ts
+        working-directory: scripts/release-issue-notification
+        env:
+          MODE: stable-released
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
 
   enter_prerelease:
     needs: stable

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -290,6 +290,19 @@ jobs:
           pnpm changeset-cli tag
           git push origin --tags
 
+      - name: Capture published package versions
+        if: ${{ !inputs.dry_run }}
+        id: published-versions
+        run: |
+          node -e "
+            const { execSync } = require('child_process');
+            const out = execSync('pnpm list -r --json --depth=0', { encoding: 'utf8' });
+            const pkgs = JSON.parse(out).filter(p => p.name && p.version && !p.private);
+            const map = pkgs.map(p => ({ name: p.name, version: p.version, path: p.path }));
+            const fs = require('fs');
+            fs.writeFileSync(process.env.GITHUB_OUTPUT, 'versions=' + JSON.stringify(map) + '\n');
+          "
+
       - name: Notify linked issues (stable released)
         if: ${{ !inputs.dry_run }}
         run: |
@@ -301,6 +314,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
+          PUBLISHED_VERSIONS: ${{ steps.published-versions.outputs.versions }}
 
   enter_prerelease:
     needs: stable

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -290,19 +290,6 @@ jobs:
           pnpm changeset-cli tag
           git push origin --tags
 
-      - name: Capture published package versions
-        if: ${{ !inputs.dry_run }}
-        id: published-versions
-        run: |
-          node -e "
-            const { execSync } = require('child_process');
-            const out = execSync('pnpm list -r --json --depth=0', { encoding: 'utf8' });
-            const pkgs = JSON.parse(out).filter(p => p.name && p.version && !p.private);
-            const map = pkgs.map(p => ({ name: p.name, version: p.version, path: p.path }));
-            const fs = require('fs');
-            fs.writeFileSync(process.env.GITHUB_OUTPUT, 'versions=' + JSON.stringify(map) + '\n');
-          "
-
       - name: Notify linked issues (stable released)
         if: ${{ !inputs.dry_run }}
         run: |
@@ -314,7 +301,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
-          PUBLISHED_VERSIONS: ${{ steps.published-versions.outputs.versions }}
 
   enter_prerelease:
     needs: stable

--- a/scripts/release-issue-notification/index.ts
+++ b/scripts/release-issue-notification/index.ts
@@ -1,0 +1,269 @@
+import { Octokit } from 'octokit';
+
+const OWNER = requireEnv('OWNER');
+const REPO = requireEnv('REPO');
+const GITHUB_TOKEN = requireEnv('GITHUB_TOKEN');
+const MODE = process.env.MODE ?? 'pending-release';
+const PR_NUMBER = process.env.PR_NUMBER;
+
+const PENDING_RELEASE_LABEL = 'pending-release';
+const PENDING_RELEASE_LABEL_COLOR = 'ededed';
+const PENDING_CLOSE_LABEL = 'status: pending-close';
+const PENDING_CLOSE_LABEL_COLOR = 'ededed';
+const COMMENT_MARKER = '<!-- mastra-release-notification -->';
+
+const octokit = new Octokit({ auth: GITHUB_TOKEN });
+
+type LinkedIssue = {
+  number: number;
+  title: string;
+  url: string;
+};
+
+async function main() {
+  if (MODE === 'pending-release') {
+    if (!PR_NUMBER) {
+      throw new Error('PR_NUMBER is required in pending-release mode');
+    }
+    await pendingRelease(Number(PR_NUMBER));
+    return;
+  }
+
+  if (MODE === 'alpha-released') {
+    await alphaReleased();
+    return;
+  }
+
+  if (MODE === 'stable-released') {
+    await stableReleased();
+    return;
+  }
+
+  throw new Error(`Unknown MODE "${MODE}". Expected "pending-release", "alpha-released", or "stable-released".`);
+}
+
+async function pendingRelease(prNumber: number) {
+  const linkedIssues = await getLinkedIssues(prNumber);
+
+  if (linkedIssues.length === 0) {
+    console.log(`PR #${prNumber} has no linked issues`);
+    return;
+  }
+
+  console.log(`PR #${prNumber} links ${linkedIssues.length} issue(s)`);
+
+  await ensurePendingReleaseLabel();
+
+  for (const issue of linkedIssues) {
+    await addLabel(issue.number, PENDING_RELEASE_LABEL);
+    await upsertReleaseComment(
+      issue.number,
+      `This issue has been resolved in PR #${prNumber} and will be included in the next release.`,
+    );
+    console.log(`Added pending-release label and comment to issue #${issue.number}`);
+  }
+}
+
+async function alphaReleased() {
+  const issues = await listIssuesWithLabel(PENDING_RELEASE_LABEL, 'all');
+  console.log(`Found ${issues.length} issue(s) with ${PENDING_RELEASE_LABEL} label`);
+
+  for (const issue of issues) {
+    await upsertReleaseComment(
+      issue.number,
+      `This issue has been resolved and is available in the **alpha** channel. Install with \`npm install <package>@alpha\`.`,
+    );
+    console.log(`Updated comment on issue #${issue.number} (alpha released)`);
+  }
+}
+
+async function ensurePendingCloseLabel() {
+  try {
+    await octokit.rest.issues.createLabel({
+      owner: OWNER,
+      repo: REPO,
+      name: PENDING_CLOSE_LABEL,
+      color: PENDING_CLOSE_LABEL_COLOR,
+      description: 'Issue is fixed in stable but still open — needs manual review/close',
+    });
+    console.log(`Created label ${PENDING_CLOSE_LABEL}`);
+  } catch (error) {
+    if (isOctokitError(error, 422)) {
+      await octokit.rest.issues.updateLabel({
+        owner: OWNER,
+        repo: REPO,
+        name: PENDING_CLOSE_LABEL,
+        color: PENDING_CLOSE_LABEL_COLOR,
+        description: 'Issue is fixed in stable but still open — needs manual review/close',
+      });
+      console.log(`Updated label ${PENDING_CLOSE_LABEL}`);
+      return;
+    }
+
+    throw error;
+  }
+}
+
+async function stableReleased() {
+  const issues = await listIssuesWithLabel(PENDING_RELEASE_LABEL, 'all');
+  console.log(`Found ${issues.length} issue(s) with ${PENDING_RELEASE_LABEL} label`);
+
+  await ensurePendingCloseLabel();
+
+  for (const issue of issues) {
+    await upsertReleaseComment(
+      issue.number,
+      `This issue has been resolved and is available in the **latest stable** release.`,
+    );
+    await removeLabelIfPresent(issue.number, PENDING_RELEASE_LABEL);
+
+    // If the issue is still open, add pending-close label for manual triage
+    if (issue.state === 'open') {
+      await addLabel(issue.number, PENDING_CLOSE_LABEL);
+      console.log(`Updated comment, removed pending-release, added pending-close on open issue #${issue.number}`);
+    } else {
+      console.log(`Updated comment and removed pending-release label from closed issue #${issue.number}`);
+    }
+  }
+}
+
+async function getLinkedIssues(prNumber: number): Promise<LinkedIssue[]> {
+  const result = await octokit.graphql<{
+    repository: {
+      pullRequest: {
+        closingIssuesReferences: {
+          nodes: LinkedIssue[];
+        };
+      } | null;
+    } | null;
+  }>(
+    `query($owner: String!, $repo: String!, $prNumber: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $prNumber) {
+          closingIssuesReferences(first: 10) {
+            nodes { number title url }
+          }
+        }
+      }
+    }`,
+    { owner: OWNER, repo: REPO, prNumber },
+  );
+
+  return result.repository?.pullRequest?.closingIssuesReferences.nodes ?? [];
+}
+
+async function listIssuesWithLabel(label: string, state: 'open' | 'closed' | 'all') {
+  return octokit.paginate(octokit.rest.issues.listForRepo, {
+    owner: OWNER,
+    repo: REPO,
+    state,
+    labels: label,
+    per_page: 100,
+  });
+}
+
+async function upsertReleaseComment(issueNumber: number, message: string) {
+  const comments = await listIssueComments(issueNumber);
+  const existing = comments.find(comment => comment.body?.includes(COMMENT_MARKER));
+  const body = `${COMMENT_MARKER}\n${message}`;
+
+  if (existing) {
+    await octokit.rest.issues.updateComment({
+      owner: OWNER,
+      repo: REPO,
+      comment_id: existing.id,
+      body,
+    });
+    console.log(`Updated release notification comment on issue #${issueNumber}`);
+    return;
+  }
+
+  await octokit.rest.issues.createComment({
+    owner: OWNER,
+    repo: REPO,
+    issue_number: issueNumber,
+    body,
+  });
+  console.log(`Created release notification comment on issue #${issueNumber}`);
+}
+
+async function listIssueComments(issueNumber: number) {
+  return octokit.paginate(octokit.rest.issues.listComments, {
+    owner: OWNER,
+    repo: REPO,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+}
+
+async function ensurePendingReleaseLabel() {
+  try {
+    await octokit.rest.issues.createLabel({
+      owner: OWNER,
+      repo: REPO,
+      name: PENDING_RELEASE_LABEL,
+      color: PENDING_RELEASE_LABEL_COLOR,
+      description: 'Issue is fixed but not yet released',
+    });
+    console.log(`Created label ${PENDING_RELEASE_LABEL}`);
+  } catch (error) {
+    if (isOctokitError(error, 422)) {
+      await octokit.rest.issues.updateLabel({
+        owner: OWNER,
+        repo: REPO,
+        name: PENDING_RELEASE_LABEL,
+        color: PENDING_RELEASE_LABEL_COLOR,
+        description: 'Issue is fixed but not yet released',
+      });
+      console.log(`Updated label ${PENDING_RELEASE_LABEL}`);
+      return;
+    }
+
+    throw error;
+  }
+}
+
+async function addLabel(issueNumber: number, label: string) {
+  await octokit.rest.issues.addLabels({
+    owner: OWNER,
+    repo: REPO,
+    issue_number: issueNumber,
+    labels: [label],
+  });
+}
+
+async function removeLabelIfPresent(issueNumber: number, label: string) {
+  try {
+    await octokit.rest.issues.removeLabel({
+      owner: OWNER,
+      repo: REPO,
+      issue_number: issueNumber,
+      name: label,
+    });
+    console.log(`Removed label ${label} from #${issueNumber}`);
+  } catch (error) {
+    if (isOctokitError(error, 404)) {
+      return;
+    }
+
+    throw error;
+  }
+}
+
+function requireEnv(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+
+  return value;
+}
+
+function isOctokitError(error: unknown, status: number) {
+  return typeof error === 'object' && error !== null && 'status' in error && error.status === status;
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/release-issue-notification/index.ts
+++ b/scripts/release-issue-notification/index.ts
@@ -104,17 +104,30 @@ async function ensurePendingCloseLabel() {
   }
 }
 
+type PublishedVersion = {
+  name: string;
+  version: string;
+  path: string;
+};
+
 async function stableReleased() {
   const issues = await listIssuesWithLabel(PENDING_RELEASE_LABEL, 'all');
   console.log(`Found ${issues.length} issue(s) with ${PENDING_RELEASE_LABEL} label`);
 
   await ensurePendingCloseLabel();
 
+  const publishedVersions = parsePublishedVersions();
+
   for (const issue of issues) {
-    await upsertReleaseComment(
-      issue.number,
-      `This issue has been resolved and is available in the **latest stable** release.`,
-    );
+    const versions = await getVersionsForIssue(issue.number, publishedVersions);
+
+    let message = `This issue has been resolved and is available in the **latest stable** release.`;
+    if (versions.length > 0) {
+      message += `\n\n**Published packages:**\n`;
+      message += versions.map(v => `- \`${v.name}@${v.version}\``).join('\n');
+    }
+
+    await upsertReleaseComment(issue.number, message);
     await removeLabelIfPresent(issue.number, PENDING_RELEASE_LABEL);
 
     // If the issue is still open, add pending-close label for manual triage
@@ -125,6 +138,135 @@ async function stableReleased() {
       console.log(`Updated comment and removed pending-release label from closed issue #${issue.number}`);
     }
   }
+}
+
+function parsePublishedVersions(): PublishedVersion[] {
+  const raw = process.env.PUBLISHED_VERSIONS;
+  if (!raw) {
+    console.log('PUBLISHED_VERSIONS not set, skipping version detection');
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as PublishedVersion[];
+    if (!Array.isArray(parsed)) {
+      console.log('PUBLISHED_VERSIONS is not an array, skipping');
+      return [];
+    }
+    return parsed.filter(v => v.name && v.version);
+  } catch (e) {
+    console.log('Failed to parse PUBLISHED_VERSIONS, skipping version detection');
+    return [];
+  }
+}
+
+async function getVersionsForIssue(
+  issueNumber: number,
+  publishedVersions: PublishedVersion[],
+): Promise<PublishedVersion[]> {
+  if (publishedVersions.length === 0) return [];
+
+  const prs = await getClosingPRsForIssue(issueNumber);
+  if (prs.length === 0) return [];
+
+  const changedPaths = new Set<string>();
+  for (const prNumber of prs) {
+    const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
+      owner: OWNER,
+      repo: REPO,
+      pull_number: prNumber,
+      per_page: 100,
+    });
+    for (const file of Array.from(files as Array<{ filename?: string }>)) {
+      if (file.filename) {
+        changedPaths.add(file.filename);
+      }
+    }
+  }
+
+  if (changedPaths.size === 0) return [];
+
+  // Normalize published package paths to relative paths for matching
+  const workspaceRoot = process.env.GITHUB_WORKSPACE ?? '';
+  const normalizedPackages = publishedVersions.map(pv => {
+    let relativePath = pv.path;
+    if (workspaceRoot && relativePath.startsWith(workspaceRoot)) {
+      relativePath = relativePath.slice(workspaceRoot.length).replace(/^\/+/, '');
+    }
+    return { ...pv, relativePath };
+  });
+
+  const matched = new Map<string, PublishedVersion>();
+  for (const file of Array.from(changedPaths)) {
+    for (const pkg of normalizedPackages) {
+      // Match if the changed file is inside the package directory
+      // e.g. packages/core/src/foo.ts matches package at packages/core
+      const pkgDir = pkg.relativePath.replace(/\/+$/, '');
+      if (file === pkgDir || file.startsWith(pkgDir + '/')) {
+        matched.set(pkg.name, { name: pkg.name, version: pkg.version, path: pkg.path });
+      }
+    }
+  }
+
+  return Array.from(matched.values());
+}
+
+async function getClosingPRsForIssue(issueNumber: number): Promise<number[]> {
+  const result = await octokit.graphql<{
+    repository: {
+      issue: {
+        timelineItems: {
+          nodes: Array<{
+            source: {
+              __typename: string;
+              number: number;
+            } | null;
+          }>;
+        };
+      } | null;
+    } | null;
+  }>(
+    `query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          timelineItems(first: 100, itemTypes: [CLOSED_EVENT, CROSS_REFERENCED_EVENT]) {
+            nodes {
+              ... on ClosedEvent {
+                closer {
+                  __typename
+                  ... on PullRequest {
+                    number
+                  }
+                }
+              }
+              ... on CrossReferencedEvent {
+                source {
+                  __typename
+                  ... on PullRequest {
+                    number
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+    { owner: OWNER, repo: REPO, number: issueNumber },
+  );
+
+  const prs = new Set<number>();
+  const nodes = result.repository?.issue?.timelineItems.nodes ?? [];
+  for (const node of nodes) {
+    if (node.source && node.source.__typename === 'PullRequest') {
+      prs.add(node.source.number);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const closer = (node as any).closer;
+    if (closer && closer.__typename === 'PullRequest') {
+      prs.add(closer.number as number);
+    }
+  }
+  return Array.from(prs);
 }
 
 async function getLinkedIssues(prNumber: number): Promise<LinkedIssue[]> {

--- a/scripts/release-issue-notification/index.ts
+++ b/scripts/release-issue-notification/index.ts
@@ -104,29 +104,15 @@ async function ensurePendingCloseLabel() {
   }
 }
 
-type PublishedVersion = {
-  name: string;
-  version: string;
-  path: string;
-};
-
 async function stableReleased() {
   const issues = await listIssuesWithLabel(PENDING_RELEASE_LABEL, 'all');
   console.log(`Found ${issues.length} issue(s) with ${PENDING_RELEASE_LABEL} label`);
 
   await ensurePendingCloseLabel();
 
-  const publishedVersions = parsePublishedVersions();
+  const message = 'This issue has been resolved and is available in the **latest stable** release.';
 
   for (const issue of issues) {
-    const versions = await getVersionsForIssue(issue.number, publishedVersions);
-
-    let message = `This issue has been resolved and is available in the **latest stable** release.`;
-    if (versions.length > 0) {
-      message += `\n\n**Published packages:**\n`;
-      message += versions.map(v => `- \`${v.name}@${v.version}\``).join('\n');
-    }
-
     await upsertReleaseComment(issue.number, message);
     await removeLabelIfPresent(issue.number, PENDING_RELEASE_LABEL);
 
@@ -138,135 +124,6 @@ async function stableReleased() {
       console.log(`Updated comment and removed pending-release label from closed issue #${issue.number}`);
     }
   }
-}
-
-function parsePublishedVersions(): PublishedVersion[] {
-  const raw = process.env.PUBLISHED_VERSIONS;
-  if (!raw) {
-    console.log('PUBLISHED_VERSIONS not set, skipping version detection');
-    return [];
-  }
-  try {
-    const parsed = JSON.parse(raw) as PublishedVersion[];
-    if (!Array.isArray(parsed)) {
-      console.log('PUBLISHED_VERSIONS is not an array, skipping');
-      return [];
-    }
-    return parsed.filter(v => v.name && v.version);
-  } catch (e) {
-    console.log('Failed to parse PUBLISHED_VERSIONS, skipping version detection');
-    return [];
-  }
-}
-
-async function getVersionsForIssue(
-  issueNumber: number,
-  publishedVersions: PublishedVersion[],
-): Promise<PublishedVersion[]> {
-  if (publishedVersions.length === 0) return [];
-
-  const prs = await getClosingPRsForIssue(issueNumber);
-  if (prs.length === 0) return [];
-
-  const changedPaths = new Set<string>();
-  for (const prNumber of prs) {
-    const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
-      owner: OWNER,
-      repo: REPO,
-      pull_number: prNumber,
-      per_page: 100,
-    });
-    for (const file of Array.from(files as Array<{ filename?: string }>)) {
-      if (file.filename) {
-        changedPaths.add(file.filename);
-      }
-    }
-  }
-
-  if (changedPaths.size === 0) return [];
-
-  // Normalize published package paths to relative paths for matching
-  const workspaceRoot = process.env.GITHUB_WORKSPACE ?? '';
-  const normalizedPackages = publishedVersions.map(pv => {
-    let relativePath = pv.path;
-    if (workspaceRoot && relativePath.startsWith(workspaceRoot)) {
-      relativePath = relativePath.slice(workspaceRoot.length).replace(/^\/+/, '');
-    }
-    return { ...pv, relativePath };
-  });
-
-  const matched = new Map<string, PublishedVersion>();
-  for (const file of Array.from(changedPaths)) {
-    for (const pkg of normalizedPackages) {
-      // Match if the changed file is inside the package directory
-      // e.g. packages/core/src/foo.ts matches package at packages/core
-      const pkgDir = pkg.relativePath.replace(/\/+$/, '');
-      if (file === pkgDir || file.startsWith(pkgDir + '/')) {
-        matched.set(pkg.name, { name: pkg.name, version: pkg.version, path: pkg.path });
-      }
-    }
-  }
-
-  return Array.from(matched.values());
-}
-
-async function getClosingPRsForIssue(issueNumber: number): Promise<number[]> {
-  const result = await octokit.graphql<{
-    repository: {
-      issue: {
-        timelineItems: {
-          nodes: Array<{
-            source: {
-              __typename: string;
-              number: number;
-            } | null;
-          }>;
-        };
-      } | null;
-    } | null;
-  }>(
-    `query($owner: String!, $repo: String!, $number: Int!) {
-      repository(owner: $owner, name: $repo) {
-        issue(number: $number) {
-          timelineItems(first: 100, itemTypes: [CLOSED_EVENT, CROSS_REFERENCED_EVENT]) {
-            nodes {
-              ... on ClosedEvent {
-                closer {
-                  __typename
-                  ... on PullRequest {
-                    number
-                  }
-                }
-              }
-              ... on CrossReferencedEvent {
-                source {
-                  __typename
-                  ... on PullRequest {
-                    number
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }`,
-    { owner: OWNER, repo: REPO, number: issueNumber },
-  );
-
-  const prs = new Set<number>();
-  const nodes = result.repository?.issue?.timelineItems.nodes ?? [];
-  for (const node of nodes) {
-    if (node.source && node.source.__typename === 'PullRequest') {
-      prs.add(node.source.number);
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const closer = (node as any).closer;
-    if (closer && closer.__typename === 'PullRequest') {
-      prs.add(closer.number as number);
-    }
-  }
-  return Array.from(prs);
 }
 
 async function getLinkedIssues(prNumber: number): Promise<LinkedIssue[]> {

--- a/scripts/release-issue-notification/package.json
+++ b/scripts/release-issue-notification/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "release-issue-notification",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.ts",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "octokit": "^5.0.5"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.15",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/scripts/release-issue-notification/pnpm-lock.yaml
+++ b/scripts/release-issue-notification/pnpm-lock.yaml
@@ -1,0 +1,648 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      octokit:
+        specifier: ^5.0.5
+        version: 5.0.5
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      tsx:
+        specifier: ^4.21.0
+        version: 4.22.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@octokit/app@16.1.2':
+    resolution: {integrity: sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-app@8.2.0':
+    resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-app@9.0.3':
+    resolution: {integrity: sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-device@8.0.3':
+    resolution: {integrity: sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-user@6.0.2':
+    resolution: {integrity: sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-unauthenticated@7.0.3':
+    resolution: {integrity: sha512-8Jb1mtUdmBHL7lGmop9mU9ArMRUTRhg8vp0T1VtZ4yd9vEm3zcLwmjQkhNEduKawOOORie61xhtYIhTDN+ZQ3g==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-app@8.0.3':
+    resolution: {integrity: sha512-jnAjvTsPepyUaMu9e69hYBuozEPgYqP4Z3UnpmvoIzHDpf8EXDGvTY1l1jK0RsZ194oRd+k6Hm13oRU8EoDFwg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.2':
+    resolution: {integrity: sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-webhooks-types@12.1.0':
+    resolution: {integrity: sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==}
+
+  '@octokit/plugin-paginate-graphql@6.0.0':
+    resolution: {integrity: sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@8.1.0':
+    resolution: {integrity: sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
+
+  '@octokit/plugin-throttling@11.0.3':
+    resolution: {integrity: sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': ^7.0.0
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.10':
+    resolution: {integrity: sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/webhooks-methods@6.0.0':
+    resolution: {integrity: sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/webhooks@14.2.0':
+    resolution: {integrity: sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==}
+    engines: {node: '>= 20'}
+
+  '@types/aws-lambda@8.10.161':
+    resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
+
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
+  octokit@5.0.5:
+    resolution: {integrity: sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==}
+    engines: {node: '>= 20'}
+
+  toad-cache@3.7.1:
+    resolution: {integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==}
+    engines: {node: '>=20'}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@octokit/app@16.1.2':
+    dependencies:
+      '@octokit/auth-app': 8.2.0
+      '@octokit/auth-unauthenticated': 7.0.3
+      '@octokit/core': 7.0.6
+      '@octokit/oauth-app': 8.0.3
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/types': 16.0.0
+      '@octokit/webhooks': 14.2.0
+
+  '@octokit/auth-app@8.2.0':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.10
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      toad-cache: 3.7.1
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@9.0.3':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.10
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@8.0.3':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.10
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@6.0.2':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.10
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/auth-unauthenticated@7.0.3':
+    dependencies:
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.10
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.10
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-app@8.0.3':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/auth-unauthenticated': 7.0.3
+      '@octokit/core': 7.0.6
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/oauth-methods': 6.0.2
+      '@types/aws-lambda': 8.10.161
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.2':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.10
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-webhooks-types@12.1.0': {}
+
+  '@octokit/plugin-paginate-graphql@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-retry@8.1.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/plugin-throttling@11.0.3(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.10':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/webhooks-methods@6.0.0': {}
+
+  '@octokit/webhooks@14.2.0':
+    dependencies:
+      '@octokit/openapi-webhooks-types': 12.1.0
+      '@octokit/request-error': 7.1.0
+      '@octokit/webhooks-methods': 6.0.0
+
+  '@types/aws-lambda@8.10.161': {}
+
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
+
+  before-after-hook@4.0.0: {}
+
+  bottleneck@2.19.5: {}
+
+  content-type@2.0.0: {}
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  json-with-bigint@3.5.8: {}
+
+  octokit@5.0.5:
+    dependencies:
+      '@octokit/app': 16.1.2
+      '@octokit/core': 7.0.6
+      '@octokit/oauth-app': 8.0.3
+      '@octokit/plugin-paginate-graphql': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-retry': 8.1.0(@octokit/core@7.0.6)
+      '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      '@octokit/webhooks': 14.2.0
+
+  toad-cache@3.7.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  universal-github-app-jwt@2.2.2: {}
+
+  universal-user-agent@7.0.3: {}


### PR DESCRIPTION
Adds a three-stage release notification workflow for issues linked to merged PRs:

- **On PR merge** — linked issues get a `pending-release` label and a comment saying the fix will be in the next release.
- **On alpha publish** — the comment is updated to say the fix is available in the alpha channel.
- **On stable publish** — the comment is updated to say the fix is in the latest stable release, and the `pending-release` label is removed.

The new `scripts/release-issue-notification/index.ts` script handles all three stages via a `MODE` env var, and the existing `npm-publish.yml` workflow is extended with notification steps in both the prerelease and stable jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When someone fixes a bug in code and merges their changes, this PR automatically tells everyone who reported that bug about it. It notifies them three times: when the fix is ready to test (alpha), when it's officially released, and updates the message each time to keep them informed of progress.

## Changes Overview

### New Workflow: Issue Pending Release
Added `.github/workflows/issue-pending-release.yml` to handle the first notification stage when PRs merge into `main`:
- Triggers on merged pull requests
- Identifies issues linked to the PR
- Adds a `pending-release` label to each linked issue
- Posts a comment on linked issues indicating the fix will be in the next release
- Uses GitHub App authentication for secure API access

### Extended npm-publish Workflow  
Updated `.github/workflows/npm-publish.yml` to add two notification stages:
- **Alpha Release Stage**: After alpha publish completes, notifies linked issues that the fix is available in the alpha channel
- **Stable Release Stage**: After stable publish completes, updates linked issues with stable release availability and removes the `pending-release` label
- Both stages use the existing marker-delimited comment approach to update previous notifications
- Notification failures won't block the publish workflow (marked with `continue-on-error`)

### Release Notification Script
Implemented `scripts/release-issue-notification/index.ts` with three operational modes controlled by `MODE` environment variable:

**pending-release mode:**
- Fetches linked issues from a merged PR via GraphQL
- Creates `pending-release` label if it doesn't exist
- Adds label and comment to each linked issue

**alpha-released mode:**
- Finds all open issues with the `pending-release` label
- Updates the notification comment to indicate alpha availability

**stable-released mode:**
- Finds all issues with the `pending-release` label
- Updates the notification comment for stable release availability
- Removes the `pending-release` label and adds `status: pending-close` for open issues

### Dependencies
Added `scripts/release-issue-notification/package.json` with:
- Runtime: `octokit` for GitHub API interactions
- Dev tools: `typescript`, `tsx`, `@types/node`

## Implementation Details

The workflow integrates three GitHub Actions:
1. On PR merge: `.github/workflows/issue-pending-release.yml` triggers the `pending-release` notification
2. On alpha publish: A step in `npm-publish.yml` runs the script in `alpha-released` mode
3. On stable publish: A step in `npm-publish.yml` runs the script in `stable-released` mode

All notification steps handle errors gracefully and won't block the release process if transient issues (rate limits, permissions) occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->