### PR TITLE
fix(core): quiet storage-not-initialized log noise on processor workflows

### DIFF
--- a/.changeset/quiet-storage-processor-workflow.md
+++ b/.changeset/quiet-storage-processor-workflow.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fix `Cannot get workflow run. Mastra storage is not initialized` debug log spam on agents that use memory or any input/output processors.
+
+#17344 fixed this for the internal `execution-workflow`, but agents with memory/processors also build an internal *processor* workflow (`Agent.combineProcessorsIntoWorkflow`, run by `ProcessorRunner.executeWorkflowAsProcessor`) that never received the parent `Mastra` instance — so its `createRun()` → `getWorkflowRunById()` saw no storage and logged the noise on every run. The processor workflow now receives the parent `Mastra` instance and opts out of snapshot persistence (`shouldPersistSnapshot: () => false`), mirroring the execution-workflow fix. Follow-up to #17137 / #17344.

--- a/packages/core/src/agent/__tests__/processor-workflow-storage-noise.test.ts
+++ b/packages/core/src/agent/__tests__/processor-workflow-storage-noise.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression test for the processor-workflow variant of
+ * https://github.com/mastra-ai/mastra/issues/17137 (follow-up to #17344).
+ *
+ * #17344 fixed the internal `execution-workflow`, but agents that use memory or any
+ * input/output processors also build an internal *processor* workflow
+ * (Agent.combineProcessorsIntoWorkflow, executed by ProcessorRunner.executeWorkflowAsProcessor).
+ * That workflow never received the parent Mastra reference, so its createRun() ->
+ * getWorkflowRunById() saw no storage and emitted, on every run:
+ *   "Cannot get workflow run. Mastra storage is not initialized"
+ * before falling back to in-memory state.
+ *
+ * When an agent with a processor is registered to a Mastra instance that has storage
+ * configured, calling agent.generate()/stream() must:
+ *   1. NOT take the no-storage branch for the internal `<agentId>-input-processor` workflow
+ *      (it now receives the parent Mastra reference).
+ *   2. NOT persist a workflow snapshot for that throwaway internal processor workflow.
+ */
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from '../../mastra';
+import type { Processor } from '../../processors';
+import { InMemoryStore } from '../../storage';
+import { Workflow } from '../../workflows/workflow';
+import { Agent } from '../agent';
+
+const AGENT_ID = 'processor-noise-agent';
+const PROCESSOR_WORKFLOW_ID = `${AGENT_ID}-input-processor`;
+
+function createDummyModel() {
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop',
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text', text: 'Dummy response' }],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Dummy response' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+      ]),
+    }),
+  });
+}
+
+// A minimal no-op input processor. A single non-workflow processor forces the agent to build
+// the internal `createWorkflow(...)` processor workflow (the branch that triggers the bug),
+// without pulling in @mastra/memory.
+const noopInputProcessor: Processor = {
+  id: 'noop-input-processor',
+  processInput: async ({ messages }) => messages,
+};
+
+function buildAgentWithProcessor() {
+  const storage = new InMemoryStore();
+  const agent = new Agent({
+    id: AGENT_ID,
+    name: AGENT_ID,
+    instructions: 'test',
+    model: createDummyModel(),
+    inputProcessors: [noopInputProcessor],
+  });
+  const mastra = new Mastra({
+    agents: { [AGENT_ID]: agent },
+    storage,
+    logger: false,
+  });
+  return { mastra, storage };
+}
+
+describe('agent processor-workflow storage noise (issue #17137 follow-up to #17344)', () => {
+  it('gives the internal processor workflow access to storage (no "storage is not initialized" branch)', async () => {
+    // The buggy processor workflow used its own un-registered logger, so spying on the Mastra
+    // logger does not see the noise. Instead, assert the root cause directly: when
+    // getWorkflowRunById runs for the processor workflow it now has storage, so the
+    // no-storage debug branch is unreachable.
+    const seen: Array<{ id: string; hasStorage: boolean }> = [];
+    const original = (Workflow.prototype as unknown as { getWorkflowRunById: (...a: unknown[]) => unknown })
+      .getWorkflowRunById;
+    const spy = vi
+      .spyOn(Workflow.prototype as unknown as Record<string, any>, 'getWorkflowRunById')
+      .mockImplementation(async function (this: any, ...args: unknown[]) {
+        seen.push({ id: this.id, hasStorage: Boolean(this.mastra?.getStorage?.()) });
+        return original.apply(this, args);
+      });
+
+    try {
+      const { mastra } = buildAgentWithProcessor();
+      await mastra.getAgent(AGENT_ID).generate('Hello!');
+    } finally {
+      spy.mockRestore();
+    }
+
+    const processorLookups = seen.filter(s => s.id === PROCESSOR_WORKFLOW_ID);
+    expect(processorLookups.length).toBeGreaterThan(0);
+    expect(processorLookups.every(s => s.hasStorage)).toBe(true);
+  });
+
+  it('does not persist a snapshot for the internal processor workflow on generate', async () => {
+    const { mastra, storage } = buildAgentWithProcessor();
+
+    await mastra.getAgent(AGENT_ID).generate('Hello!');
+
+    const workflowsStore = await storage.getStore('workflows');
+    const { runs, total } = await workflowsStore!.listWorkflowRuns({ workflowName: PROCESSOR_WORKFLOW_ID });
+    expect(total).toBe(0);
+    expect(runs).toEqual([]);
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1077,6 +1077,9 @@ export class Agent<
       type: 'processor',
       options: {
         validateInputs: false,
+        // Internal processor workflows are transient and non-resumable, so they must never
+        // write snapshot rows to the user's storage (mirrors the execution-workflow fix in #17344).
+        shouldPersistSnapshot: () => false,
         tracingPolicy: {
           // mark all workflow spans related to processor execution as internal
           internal: InternalSpans.WORKFLOW,
@@ -1112,6 +1115,14 @@ export class Agent<
     }
 
     const committedWorkflow = workflow.commit() as T;
+    // Register the parent Mastra instance on this internal processor workflow so that its
+    // createRun() -> getWorkflowRunById() can read configured storage instead of logging
+    // "Cannot get workflow run. Mastra storage is not initialized" on every run (then falling
+    // back to in-memory). Combined with shouldPersistSnapshot:()=>false above, this does not
+    // write any processor-workflow rows to storage. Mirrors the execution-workflow fix in #17344.
+    if (this.#mastra && isProcessorWorkflow(committedWorkflow)) {
+      committedWorkflow.__registerMastra(this.#mastra);
+    }
     if (stateSignalProcessors.length > 0 && isProcessorWorkflow(committedWorkflow)) {
       committedWorkflow.__stateSignalProcessors = stateSignalProcessors;
     }


### PR DESCRIPTION
Fixes #17587

## What

Agents that use **memory** or any **input/output processors** still emit this debug log on every `agent.generate()` / `agent.stream()`, even on the latest `@mastra/core`:

```
Cannot get workflow run. Mastra storage is not initialized
```

This is the **processor-workflow** sibling of the bug fixed by #17344 (which only covered the internal `execution-workflow`). Follow-up to #17137 / #17344.

## Root cause

Agent memory and processors run as an internal **processor workflow**, built in `Agent.combineProcessorsIntoWorkflow` and executed by `ProcessorRunner.executeWorkflowAsProcessor` via `workflow.createRun()`. Unlike the `execution-workflow` (fixed in #17344), this processor workflow never receives the parent `Mastra` instance, so `Workflow.createRun()` → `getWorkflowRunById()` sees no storage, takes the no-storage debug branch, logs the line, and falls back to in-memory. The noise scales with call volume (input + output processors, re-run per agentic-loop turn).

`ProcessorRunner` itself has no `mastra` reference, so the fix belongs where the workflow is created and `this.#mastra` is available — exactly the sibling location of #17344's fix.

## Fix

In `Agent.combineProcessorsIntoWorkflow` (mirrors #17344):

- Register the parent `Mastra` instance on the committed processor workflow (`__registerMastra`) so it can read configured storage instead of logging the no-storage branch.
- Set `shouldPersistSnapshot: () => false` on the workflow so the now-storage-aware internal workflow never writes processor-workflow snapshot rows to the user's storage.

## Tests

New `packages/core/src/agent/__tests__/processor-workflow-storage-noise.test.ts`, modeled on the existing `execution-workflow-storage-noise.test.ts`. It uses a trivial no-op input processor (no `@mastra/memory` dependency) to force the internal processor workflow, and asserts:

1. The `<agentId>-input-processor` workflow's `getWorkflowRunById()` lookups now have storage access (the no-storage branch is unreachable).
2. No snapshot is persisted for the internal processor workflow.

Both guards fail on the unpatched code and pass with the fix.

## Notes

This follows the already-merged #17344 pattern (attach Mastra + opt out of snapshot persistence). If the alternative approach in #17176 (have `Workflow.createRun()` skip the storage-recovery lookup when `shouldPersistSnapshot` is false) is preferred, marking these processor workflows non-persistent alone would also suffice — happy to adapt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

When an AI agent uses processors to handle input/output, it was creating lots of "storage not initialized" warning messages every single time the agent ran. This PR fixes that by letting the internal processor workflow access the same storage system as the main agent, so it doesn't try to look for storage that isn't there, and by preventing it from saving unnecessary copies of its own work.

## Summary

This PR fixes noisy debug logs generated by agents that use memory or input/output processors. When agents created internal processor workflows to chain multiple processors together, these workflows didn't have access to the parent Mastra instance, causing `Workflow.createRun()` → `getWorkflowRunById()` to repeatedly log "Cannot get workflow run. Mastra storage is not initialized" and fall back to in-memory operation on every `agent.generate()` or `agent.stream()` call.

## Changes

**packages/core/src/agent/agent.ts**
- Updated `Agent.combineProcessorsIntoWorkflow()` to disable snapshot persistence by setting `shouldPersistSnapshot: () => false` on the internal processor workflow
- Added registration of the parent Mastra instance on the committed processor workflow via `__registerMastra()` so the workflow can access configured storage instead of falling back to in-memory operation

**packages/core/src/agent/__tests__/processor-workflow-storage-noise.test.ts** (new)
- Added regression test suite for issue `#17137` that verifies the internal processor workflow has access to Mastra storage when an agent calls `generate()`
- Tests confirm that the "storage is not initialized" fallback path is not executed
- Tests verify that the internal processor workflow snapshots are not persisted to user storage

**.changeset/quiet-storage-processor-workflow.md** (new)
- Changeset entry documenting the fix for processor workflow storage noise

This approach mirrors the fix previously implemented in PR `#17344` for the execution workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->