### PR TITLE
fix(mcp): eliminate flaky server tests by mocking weather tool

### DIFF
--- a/.changeset/petite-bees-dress.md
+++ b/.changeset/petite-bees-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed flaky MCP server tests by replacing real weather API calls with deterministic mock tool

--- a/packages/mcp/src/__fixtures__/tools.ts
+++ b/packages/mcp/src/__fixtures__/tools.ts
@@ -92,3 +92,22 @@ function getWeatherCondition(code: number): string {
   };
   return conditions[code] || 'Unknown';
 }
+
+export const mockWeatherTool = createTool({
+  id: 'get-weather',
+  description: 'Get current weather for a location',
+  inputSchema: z.object({
+    location: z.string().describe('City name'),
+  }),
+  execute: async input => {
+    return {
+      temperature: 72,
+      feelsLike: 75,
+      humidity: 45,
+      windSpeed: 8,
+      windGust: 12,
+      conditions: 'Clear sky',
+      location: input.location,
+    };
+  },
+});

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -22,7 +22,7 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai/test';
 import { Hono } from 'hono';
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi, beforeEach } from 'vitest';
 import { z } from 'zod/v3';
-import { weatherTool } from '../__fixtures__/tools';
+import { mockWeatherTool } from '../__fixtures__/tools';
 import { InternalMastraMCPClient } from '../client/client';
 import { MCPClient } from '../client/configuration';
 import { MCPServer } from './server';
@@ -158,7 +158,6 @@ describe('MCPServer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // @ts-expect-error - accessing internal for testing - Mocking Date completely
     // Must use a regular function (not arrow function) to support `new Date()` constructor calls
     global.Date = vi.fn(function (this: any, ...args: any[]) {
       if (args.length === 0) {
@@ -169,7 +168,6 @@ describe('MCPServer', () => {
       return new OriginalDate(...args); // new Date('some-string') or new Date(timestamp)
     }) as any;
 
-    // @ts-expect-error - accessing internal for testing
     global.Date.now = vi.fn(() => mockDate.getTime());
     // @ts-expect-error - accessing internal for testing
     global.Date.prototype = OriginalDate.prototype;
@@ -920,7 +918,7 @@ describe('MCPServer', () => {
       server = new MCPServer({
         name: 'Test MCP Server',
         version: '0.1.0',
-        tools: { weatherTool },
+        tools: { weatherTool: mockWeatherTool },
       });
 
       httpServer = http.createServer(async (req, res) => {
@@ -1058,7 +1056,7 @@ describe('MCPServer', () => {
         name: 'Test MCP Server',
         version: '0.1.0',
         tools: {
-          weatherTool,
+          weatherTool: mockWeatherTool,
           testAuthTool: {
             description: 'Test tool to validate auth information from extra params',
             parameters: z.object({
@@ -1212,7 +1210,7 @@ describe('MCPServer', () => {
       server = new MCPServer({
         name: 'Test MCP Server',
         version: '0.1.0',
-        tools: { weatherTool },
+        tools: { weatherTool: mockWeatherTool },
       });
 
       hono = new Hono();


### PR DESCRIPTION
Replace real weatherTool with mockWeatherTool in MCP server tests
that use HTTP and Hono SSE transports. The real tool makes
external API calls to open-meteo which cause intermittent failures.

- Add mockWeatherTool to __fixtures__/tools.ts
- Update HTTP transport test block to use mockWeatherTool
- Update Hono SSE transport test block to use mockWeatherTool

Co-Authored-By: Mastra Code (alibaba-mastra/kimi-k2.6) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

These tests were failing randomly because they were calling a real weather API service that sometimes didn't respond fast enough or returned different results. This PR fixes that by using a fake weather tool that always returns the same predictable answer, making the tests reliable every time they run.

## Summary

This PR improves test reliability by replacing real external API calls with mock implementations in the MCP server test suite. The flaky tests were making calls to the open-meteo weather API, causing intermittent failures.

**Changes:**
- Added `mockWeatherTool` to the test fixtures that returns consistent, hardcoded weather data (temperature: 72, conditions: 'Clear sky')
- Updated MCP server tests for HTTP transport and Hono SSE transport to use the mock tool instead of the real one
- Removed redundant TypeScript expect-error comments that were no longer needed

The mock tool maintains the same interface as the original tool (`location` input parameter) but eliminates the non-deterministic behavior of external API calls, making tests more stable and faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->