### PR TITLE
fix(playground): allow esbuild postinstall in kitchen-sink workspace

### DIFF
--- a/.changeset/flat-otters-sleep.md
+++ b/.changeset/flat-otters-sleep.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground': patch
+---
+
+fix(playground): allow esbuild postinstall in kitchen-sink workspace
+
+esbuild 0.27.2 requires its postinstall script to install the platform-specific binary. When blocked, esbuild is non-functional and the dev server silently fails, causing all e2e-kitchen-sink tests to fail with ERR_CONNECTION_REFUSED.

--- a/packages/playground/e2e/kitchen-sink/pnpm-workspace.yaml
+++ b/packages/playground/e2e/kitchen-sink/pnpm-workspace.yaml
@@ -14,5 +14,5 @@ overrides:
   '@internal/test-utils': link:../../../../packages/_test-utils
 
 allowBuilds:
-  esbuild: false
+  esbuild: true
   msw: false


### PR DESCRIPTION
## Problem

The `e2e-kitchen-sink` CI job fails with 94 test failures, all caused by `net::ERR_CONNECTION_REFUSED at http://localhost:4111`. The dev server (`mastra dev`) never starts because esbuild's postinstall script is blocked in the kitchen-sink's nested `pnpm-workspace.yaml`.

## Root Cause

`allowBuilds: esbuild: false` prevents esbuild from installing its platform-specific binary during `pnpm install`. When esbuild is non-functional, `mastra dev` silently fails, and the Playwright webServer never starts on port 4111.

This is the same fix applied to the root `pnpm-workspace.yaml` in commit 56e7f3b4 (renovate/build-tools PR).

## Changes

- Changed `esbuild: false` to `esbuild: true` in `packages/playground/e2e/kitchen-sink/pnpm-workspace.yaml`
- Added patch changeset

## Verification

- The `e2e-kitchen-sink` job should start the dev server successfully on port 4111
- All 94 tests that currently fail with `ERR_CONNECTION_REFUSED` should be able to connect
- The `msw: false` setting remains unchanged — MSW doesn't need its browser extension for server-side e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The e2e tests in the kitchen-sink project were failing because a tool called "esbuild" wasn't working. It turns out esbuild wasn't allowed to finish installing itself, so it was broken. This fix lets esbuild install properly so it can work and the tests can run.

## Changes

**Configuration Update:**
- Modified `packages/playground/e2e/kitchen-sink/pnpm-workspace.yaml` to set `allowBuilds.esbuild: true` (previously `false`), allowing esbuild's postinstall script to run and install its platform-specific binary. The `msw: false` setting remains unchanged.

**Changeset Entry:**
- Added `.changeset/flat-otters-sleep.md` to document the patch release for `@mastra/playground`, explaining that esbuild's postinstall must be allowed to run in the kitchen-sink workspace to prevent the dev server from failing and e2e tests from encountering `ERR_CONNECTION_REFUSED` errors.

## Impact

These changes enable the e2e-kitchen-sink CI job to successfully start the dev server on port 4111, resolving the 94 previously failing test cases that were blocked by connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->