### PR TITLE
Simplify deploy package.json

### DIFF
--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -72,14 +72,12 @@ export abstract class Bundler extends MastraBundler {
         {
           name: 'server',
           version: '1.0.0',
-          description: '',
+          private: true,
           type: 'module',
           main: 'index.mjs',
           scripts: {
             start: 'node ./index.mjs',
           },
-          author: 'Mastra',
-          license: 'ISC',
           dependencies: Object.fromEntries(dependenciesMap.entries()),
           ...(Object.keys(resolutions ?? {}).length > 0 && { resolutions }),
         },


### PR DESCRIPTION

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->
Those extra keys are not needed when not publishing, add private so you don't try to publish by accident. And technically it would be cleaner to copy name and version from the actual package

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->
Fixes #17576

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the Mastra deployer bundles code into a package, it creates a generated `package.json` file. This change marks that generated file as private to prevent it from being accidentally published to npm, and simplifies the file by removing unnecessary configuration keys that aren't needed when the package isn't being published.

## Changes Made

The deployer's bundler now marks the generated `package.json` as `private: true` in the `writePackageJson` method in `packages/deployer/src/bundler/index.ts`. This prevents accidental publishing of the bundled deployment package while also removing unnecessary keys from the generated configuration to keep it cleaner and more focused.

The generated package.json now contains only the essential fields:
- `name` and `version` (set to 'server' and '1.0.0' respectively)
- `private: true` (prevents accidental publishing)
- `type: 'module'` (ES modules)
- `main: 'index.mjs'` (entry point)
- `scripts.start` (startup command)
- `dependencies` (declared dependencies)
- `resolutions` (if present)

**Lines changed:** +1/-3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->