### PR TITLE
Add source-backed agent storage foundation

### DIFF
--- a/.changeset/code-source-01-core-storage.md
+++ b/.changeset/code-source-01-core-storage.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': minor
+'@mastra/editor': minor
+---
+
+Added source-backed storage primitives for code-mode agent editing.
+
+Mastra now exposes a `SourceStorageProvider` interface for hosted source-control-backed editor storage, and `MastraEditor` can persist code-mode agent overrides through either local filesystem storage or a source provider.
+
+```ts
+const editor = new MastraEditor({
+  source: 'code',
+  sourceStorageProvider,
+});
+```
+
+Code-defined agents still respect their `editor` ownership config, while source-backed storage can read, write, list history, and open change requests through a provider implementation.

--- a/.changeset/code-source-01-core-storage.md
+++ b/.changeset/code-source-01-core-storage.md
@@ -5,12 +5,12 @@
 
 Added source-backed storage primitives for code-mode agent editing.
 
-Mastra now exposes a `SourceStorageProvider` interface for hosted source-control-backed editor storage, and `MastraEditor` can persist code-mode agent overrides through either local filesystem storage or a source provider.
+Mastra now exposes a `SourceControlProvider` interface for hosted source-control-backed editor storage, and `MastraEditor` can persist code-mode agent overrides through either local filesystem storage or a source provider.
 
 ```ts
 const editor = new MastraEditor({
   source: 'code',
-  sourceStorageProvider,
+  sourceControlProvider,
 });
 ```
 

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -8,6 +8,7 @@ import type { MCPServerBase } from '../mcp';
 import type { ProcessorProvider } from '../processor-provider';
 import type { RequestContext } from '../request-context';
 import type { BlobStore } from '../storage/domains/blobs/base';
+import type { SourceStorageProvider } from '../storage/source-storage';
 import type {
   AgentInstructionBlock,
   StorageCreateAgentInput,
@@ -195,6 +196,15 @@ export interface MastraEditorConfig {
    * Defaults to `./mastra/editor/`. Ignored when `source` is not `'code'`.
    */
   codePath?: string;
+  /**
+   * Optional provider used by the `'code'` source to persist overrides in a
+   * source-control backed system instead of the local filesystem.
+   *
+   * Local development can omit this and use `codePath`. Hosted deployments
+   * should provide a source provider or expose code-source editing as
+   * unavailable.
+   */
+  sourceStorageProvider?: SourceStorageProvider;
 }
 
 export interface GetByIdOptions {
@@ -462,4 +472,7 @@ export interface IMastraEditor {
    * backwards compatibility.
    */
   getSource?(): 'code' | 'db' | undefined;
+
+  /** Returns the source storage provider configured for code source, if any. */
+  getSourceStorageProvider?(): SourceStorageProvider | undefined;
 }

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -8,7 +8,7 @@ import type { MCPServerBase } from '../mcp';
 import type { ProcessorProvider } from '../processor-provider';
 import type { RequestContext } from '../request-context';
 import type { BlobStore } from '../storage/domains/blobs/base';
-import type { SourceStorageProvider } from '../storage/source-storage';
+import type { SourceControlProvider } from '../storage/source-control';
 import type {
   AgentInstructionBlock,
   StorageCreateAgentInput,
@@ -204,7 +204,7 @@ export interface MastraEditorConfig {
    * should provide a source provider or expose code-source editing as
    * unavailable.
    */
-  sourceStorageProvider?: SourceStorageProvider;
+  sourceControlProvider?: SourceControlProvider;
 }
 
 export interface GetByIdOptions {
@@ -473,6 +473,6 @@ export interface IMastraEditor {
    */
   getSource?(): 'code' | 'db' | undefined;
 
-  /** Returns the source storage provider configured for code source, if any. */
-  getSourceStorageProvider?(): SourceStorageProvider | undefined;
+  /** Returns the source control provider configured for code source, if any. */
+  getSourceControlProvider?(): SourceControlProvider | undefined;
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -3,7 +3,7 @@ import type { DescribeRouteOptions } from 'hono-openapi';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
 import type { Mastra } from '../mastra';
 import type { RequestContext } from '../request-context';
-import type { ApiRoute, MastraAuthConfig, Methods } from './types';
+import type { ApiRoute, ApiRouteHandler, MastraAuthConfig, Methods } from './types';
 
 export type {
   MastraAuthConfig,
@@ -50,15 +50,7 @@ type RegisterApiRouteOptions<P extends string> = {
     P,
     ParamsFromPath<P>
   >;
-  createHandler?: (c: Context) => Promise<
-    Handler<
-      {
-        Variables: CustomRouteVariables;
-      },
-      P,
-      ParamsFromPath<P>
-    >
-  >;
+  createHandler?: (c: Context) => Promise<ApiRouteHandler>;
   middleware?: MiddlewareHandler | MiddlewareHandler[];
   /**
    * Route-specific CORS configuration.

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -12,6 +12,7 @@ export type {
   ContextWithMastra,
   CorsOptions,
   ApiRoute,
+  ApiRouteHandler,
   HttpLoggingConfig,
   ValidationErrorContext,
   ValidationErrorResponse,

--- a/packages/core/src/server/server.test-d.ts
+++ b/packages/core/src/server/server.test-d.ts
@@ -50,14 +50,12 @@ describe('registerApiRoute Type Tests', () => {
       });
     });
 
-    it('should allow accessing requestContext in createHandler', () => {
+    it('should avoid leaking Hono context types from createHandler', () => {
       registerApiRoute('/user-profile', {
         method: 'GET',
         createHandler: async () => {
           return async c => {
-            // requestContext should also be typed in createHandler's returned handler
-            const requestContext = c.get('requestContext');
-            expectTypeOf(requestContext).toEqualTypeOf<RequestContext>();
+            expectTypeOf(c).toBeAny();
 
             return c.json({ ok: true });
           };

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -14,6 +14,8 @@ type RouteFGAConfig = FGARouteConfig;
 
 export type Methods = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'ALL';
 
+export type ApiRouteHandler = (c: any) => Response | Promise<Response>;
+
 export type ApiRoute =
   | {
       path: string;
@@ -31,7 +33,7 @@ export type ApiRoute =
   | {
       path: string;
       method: Methods;
-      createHandler: ({ mastra }: { mastra: Mastra }) => Promise<Handler>;
+      createHandler: ({ mastra }: { mastra: Mastra }) => Promise<ApiRouteHandler>;
       middleware?: MiddlewareHandler | MiddlewareHandler[];
       openapi?: DescribeRouteOptions;
       cors?: CorsOptions;

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -239,6 +239,7 @@ export interface MastraCompositeStoreConfig {
  */
 export interface StorageMastraRef {
   getAgentById?: (id: string) => { source?: string; __getEditorConfig?: () => unknown } | undefined;
+  listAgents?: () => Record<string, { id: string; source?: string; __getEditorConfig?: () => unknown }> | undefined;
   getEditor?: () => { getSource?: () => 'code' | 'db' | undefined } | undefined;
 }
 

--- a/packages/core/src/storage/domains/agents/index.ts
+++ b/packages/core/src/storage/domains/agents/index.ts
@@ -1,3 +1,4 @@
 export * from './base';
 export * from './inmemory';
 export * from './filesystem';
+export * from './source';

--- a/packages/core/src/storage/domains/agents/source.test.ts
+++ b/packages/core/src/storage/domains/agents/source.test.ts
@@ -253,6 +253,33 @@ describe('SourceAgentsStorage', () => {
     await expect(storage.getById('weather-agent')).resolves.toBeNull();
   });
 
+  it('reads and writes through an activated provider ref', async () => {
+    const provider = new MockSourceProvider();
+    provider.files.set(getSourceAgentFilePath('weather-agent'), JSON.stringify({ instructions: 'From main' }));
+    const draft = new Map<string, string>();
+    draft.set(getSourceAgentFilePath('weather-agent'), JSON.stringify({ instructions: 'From proposal' }));
+    provider.refs.set('mastra/weather-agent', draft);
+    const storage = new SourceAgentsStorage({ provider });
+
+    await expect(storage.getByIdResolved('weather-agent')).resolves.toMatchObject({ instructions: 'From main' });
+
+    await storage.useProviderRef('weather-agent', 'mastra/weather-agent');
+
+    await expect(storage.getByIdResolved('weather-agent')).resolves.toMatchObject({ instructions: 'From proposal' });
+
+    await storage.createVersion({
+      id: 'version-2',
+      agentId: 'weather-agent',
+      versionNumber: 2,
+      name: 'Weather Agent',
+      instructions: 'Updated proposal',
+      model,
+      changedFields: ['instructions'],
+    });
+
+    expect(provider.writes.at(-1)?.ref).toBe('mastra/weather-agent');
+  });
+
   it('does not create an in-memory version when source persistence fails', async () => {
     const provider = new MockSourceProvider();
     const storage = new SourceAgentsStorage({ provider });

--- a/packages/core/src/storage/domains/agents/source.test.ts
+++ b/packages/core/src/storage/domains/agents/source.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type {
   SourceFile,
   SourceFileHistoryEntry,
@@ -229,7 +229,7 @@ describe('SourceAgentsStorage', () => {
     expect(versions.versions.map(version => version.instructions)).toEqual(['First', 'Second']);
   });
 
-  it('rejects writes when the source provider cannot write', async () => {
+  it('rejects writes when the source provider cannot write without mutating memory', async () => {
     const provider = new MockSourceProvider();
     provider.capabilities = {
       canRead: true,
@@ -250,6 +250,90 @@ describe('SourceAgentsStorage', () => {
         },
       }),
     ).rejects.toThrow('missing-permissions');
+    await expect(storage.getById('weather-agent')).resolves.toBeNull();
+  });
+
+  it('does not create an in-memory version when source persistence fails', async () => {
+    const provider = new MockSourceProvider();
+    const storage = new SourceAgentsStorage({ provider });
+    await storage.create({
+      agent: {
+        id: 'weather-agent',
+        name: 'Weather Agent',
+        instructions: 'Use weather data.',
+        model,
+      },
+    });
+
+    provider.writeFile = vi.fn().mockRejectedValue(new Error('provider-write-failed'));
+
+    await expect(
+      storage.createVersion({
+        id: 'version-2',
+        agentId: 'weather-agent',
+        versionNumber: 2,
+        name: 'Weather Agent',
+        instructions: 'Updated instructions',
+        model,
+        changedFields: ['instructions'],
+      }),
+    ).rejects.toThrow('provider-write-failed');
+    await expect(storage.getVersion('version-2')).resolves.toBeNull();
+  });
+
+  it('retries provider discovery after transient failures', async () => {
+    const provider = new MockSourceProvider();
+    provider.files.set(
+      getSourceAgentFilePath('retry-agent'),
+      JSON.stringify({ name: 'Retry Agent', instructions: 'Loaded after retry.' }),
+    );
+    const listFiles = vi
+      .spyOn(provider, 'listFiles')
+      .mockRejectedValueOnce(new Error('temporary-list-failure'))
+      .mockImplementation(input => MockSourceProvider.prototype.listFiles.call(provider, input));
+    const storage = new SourceAgentsStorage({ provider });
+
+    await expect(storage.listResolved()).rejects.toThrow('temporary-list-failure');
+    const list = await storage.listResolved();
+
+    expect(listFiles).toHaveBeenCalledTimes(2);
+    expect(list.agents[0]).toMatchObject({ id: 'retry-agent', instructions: 'Loaded after retry.' });
+  });
+
+  it('retries provider hydration after transient failures', async () => {
+    const provider = new MockSourceProvider();
+    provider.files.set(getSourceAgentFilePath('retry-agent'), JSON.stringify({ instructions: 'Loaded after retry.' }));
+    const readFile = vi
+      .spyOn(provider, 'readFile')
+      .mockRejectedValueOnce(new Error('temporary-read-failure'))
+      .mockImplementation(input => MockSourceProvider.prototype.readFile.call(provider, input));
+    const storage = new SourceAgentsStorage({ provider });
+
+    await expect(storage.getByIdResolved('retry-agent')).rejects.toThrow('temporary-read-failure');
+    const agent = await storage.getByIdResolved('retry-agent');
+
+    expect(readFile).toHaveBeenCalledTimes(2);
+    expect(agent).toMatchObject({ id: 'retry-agent', instructions: 'Loaded after retry.' });
+  });
+
+  it('retries provider history loading after transient failures', async () => {
+    const provider = new MockSourceProvider();
+    const ref = new Map<string, string>();
+    ref.set(getSourceAgentFilePath('weather-agent'), JSON.stringify({ instructions: 'From history' }));
+    provider.refs.set('sha-1', ref);
+    provider.history = [{ id: 'sha-1', ref: 'sha-1', message: 'History save', createdAt: '2026-06-01T01:00:00.000Z' }];
+    const listFileHistory = vi
+      .spyOn(provider, 'listFileHistory')
+      .mockRejectedValueOnce(new Error('temporary-history-failure'))
+      .mockImplementation(input => MockSourceProvider.prototype.listFileHistory.call(provider, input));
+    const storage = new SourceAgentsStorage({ provider });
+
+    await expect(storage.listVersions({ agentId: 'weather-agent' })).rejects.toThrow('temporary-history-failure');
+    const versions = await storage.listVersions({ agentId: 'weather-agent' });
+
+    expect(listFileHistory).toHaveBeenCalledTimes(2);
+    expect(versions.versions).toHaveLength(1);
+    expect(versions.versions[0]).toMatchObject({ instructions: 'From history' });
   });
 
   it('checks provider capabilities during init', async () => {

--- a/packages/core/src/storage/domains/agents/source.test.ts
+++ b/packages/core/src/storage/domains/agents/source.test.ts
@@ -6,15 +6,15 @@ import type {
   SourceFileListEntry,
   SourceFileListInput,
   SourceFileRef,
-  SourceStorageCapabilities,
-  SourceStorageProvider,
+  SourceControlCapabilities,
+  SourceControlProvider,
   SourceWriteFileInput,
   SourceWriteResult,
-} from '../../source-storage';
-import { getSourceAgentFilePath } from '../../source-storage';
-import { SourceAgentsStorage } from './source';
+} from '../../source-control';
+import { getSourceAgentFilePath } from '../../source-control';
+import { SourceAgentsSourceControl } from './source';
 
-class MockSourceProvider implements SourceStorageProvider {
+class MockSourceProvider implements SourceControlProvider {
   id = 'mock-source';
   displayName = 'Mock Source';
 
@@ -22,14 +22,14 @@ class MockSourceProvider implements SourceStorageProvider {
   refs = new Map<string, Map<string, string>>();
   writes: SourceWriteFileInput[] = [];
   history: SourceFileHistoryEntry[] = [];
-  capabilities: SourceStorageCapabilities = {
+  capabilities: SourceControlCapabilities = {
     canRead: true,
     canWrite: true,
     canListHistory: true,
     canOpenChangeRequest: false,
   };
 
-  async getCapabilities(): Promise<SourceStorageCapabilities> {
+  async getCapabilities(): Promise<SourceControlCapabilities> {
     return this.capabilities;
   }
 
@@ -59,10 +59,10 @@ class MockSourceProvider implements SourceStorageProvider {
 
 const model = { provider: 'openai', name: 'gpt-4' };
 
-describe('SourceAgentsStorage', () => {
+describe('SourceAgentsSourceControl', () => {
   it('persists code-source snapshots through the source provider using canonical paths', async () => {
     const provider = new MockSourceProvider();
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
     storage.__registerMastra({
       getAgentById: () => ({
         source: 'code',
@@ -90,7 +90,7 @@ describe('SourceAgentsStorage', () => {
 
   it('omits instructions for descriptions-only code agents', async () => {
     const provider = new MockSourceProvider();
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
     storage.__registerMastra({
       getAgentById: () => ({
         source: 'code',
@@ -117,7 +117,7 @@ describe('SourceAgentsStorage', () => {
 
   it('persists editable snapshots for storage-only agents without a code definition', async () => {
     const provider = new MockSourceProvider();
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     await storage.create({
       agent: {
@@ -144,7 +144,7 @@ describe('SourceAgentsStorage', () => {
 
   it('still strips non-editable fields when getAgentById throws for storage-only agents', async () => {
     const provider = new MockSourceProvider();
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
     storage.__registerMastra({
       getAgentById: () => {
         throw new Error('Agent with id storage-only not found');
@@ -174,7 +174,7 @@ describe('SourceAgentsStorage', () => {
       getSourceAgentFilePath('weather-agent'),
       JSON.stringify({ instructions: 'Stored instructions', tools: { weatherTool: { description: 'Stored' } } }),
     );
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     const agent = await storage.getByIdResolved('weather-agent');
 
@@ -190,9 +190,9 @@ describe('SourceAgentsStorage', () => {
     const provider = new MockSourceProvider();
     provider.files.set(
       getSourceAgentFilePath('studio only'),
-      JSON.stringify({ name: 'Studio Only', instructions: 'Persisted in source storage.', model }),
+      JSON.stringify({ name: 'Studio Only', instructions: 'Persisted in source control.', model }),
     );
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     await storage.init();
     const list = await storage.listResolved();
@@ -201,7 +201,7 @@ describe('SourceAgentsStorage', () => {
     expect(list.agents[0]).toMatchObject({
       id: 'studio only',
       name: 'Studio Only',
-      instructions: 'Persisted in source storage.',
+      instructions: 'Persisted in source control.',
     });
   });
 
@@ -217,7 +217,7 @@ describe('SourceAgentsStorage', () => {
       { id: 'sha-2', ref: 'sha-2', message: 'Second save', createdAt: '2026-06-01T02:00:00.000Z' },
       { id: 'sha-1', ref: 'sha-1', message: 'First save', createdAt: '2026-06-01T01:00:00.000Z' },
     ];
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     const versions = await storage.listVersions({
       agentId: 'weather-agent',
@@ -238,7 +238,7 @@ describe('SourceAgentsStorage', () => {
       canOpenChangeRequest: false,
       reason: 'missing-permissions',
     };
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     await expect(
       storage.create({
@@ -259,7 +259,7 @@ describe('SourceAgentsStorage', () => {
     const draft = new Map<string, string>();
     draft.set(getSourceAgentFilePath('weather-agent'), JSON.stringify({ instructions: 'From proposal' }));
     provider.refs.set('mastra/weather-agent', draft);
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     await expect(storage.getByIdResolved('weather-agent')).resolves.toMatchObject({ instructions: 'From main' });
 
@@ -282,7 +282,7 @@ describe('SourceAgentsStorage', () => {
 
   it('does not create an in-memory version when source persistence fails', async () => {
     const provider = new MockSourceProvider();
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
     await storage.create({
       agent: {
         id: 'weather-agent',
@@ -318,7 +318,7 @@ describe('SourceAgentsStorage', () => {
       .spyOn(provider, 'listFiles')
       .mockRejectedValueOnce(new Error('temporary-list-failure'))
       .mockImplementation(input => MockSourceProvider.prototype.listFiles.call(provider, input));
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     await expect(storage.listResolved()).rejects.toThrow('temporary-list-failure');
     const list = await storage.listResolved();
@@ -334,7 +334,7 @@ describe('SourceAgentsStorage', () => {
       .spyOn(provider, 'readFile')
       .mockRejectedValueOnce(new Error('temporary-read-failure'))
       .mockImplementation(input => MockSourceProvider.prototype.readFile.call(provider, input));
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     await expect(storage.getByIdResolved('retry-agent')).rejects.toThrow('temporary-read-failure');
     const agent = await storage.getByIdResolved('retry-agent');
@@ -353,7 +353,7 @@ describe('SourceAgentsStorage', () => {
       .spyOn(provider, 'listFileHistory')
       .mockRejectedValueOnce(new Error('temporary-history-failure'))
       .mockImplementation(input => MockSourceProvider.prototype.listFileHistory.call(provider, input));
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     await expect(storage.listVersions({ agentId: 'weather-agent' })).rejects.toThrow('temporary-history-failure');
     const versions = await storage.listVersions({ agentId: 'weather-agent' });
@@ -372,7 +372,7 @@ describe('SourceAgentsStorage', () => {
       canOpenChangeRequest: false,
       reason: 'provider-unavailable',
     };
-    const storage = new SourceAgentsStorage({ provider });
+    const storage = new SourceAgentsSourceControl({ provider });
 
     await expect(storage.init()).rejects.toThrow('provider-unavailable');
   });

--- a/packages/core/src/storage/domains/agents/source.test.ts
+++ b/packages/core/src/storage/domains/agents/source.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  SourceFile,
+  SourceFileHistoryEntry,
+  SourceFileHistoryInput,
+  SourceFileListEntry,
+  SourceFileListInput,
+  SourceFileRef,
+  SourceStorageCapabilities,
+  SourceStorageProvider,
+  SourceWriteFileInput,
+  SourceWriteResult,
+} from '../../source-storage';
+import { getSourceAgentFilePath } from '../../source-storage';
+import { SourceAgentsStorage } from './source';
+
+class MockSourceProvider implements SourceStorageProvider {
+  id = 'mock-source';
+  displayName = 'Mock Source';
+
+  files = new Map<string, string>();
+  refs = new Map<string, Map<string, string>>();
+  writes: SourceWriteFileInput[] = [];
+  history: SourceFileHistoryEntry[] = [];
+  capabilities: SourceStorageCapabilities = {
+    canRead: true,
+    canWrite: true,
+    canListHistory: true,
+    canOpenChangeRequest: false,
+  };
+
+  async getCapabilities(): Promise<SourceStorageCapabilities> {
+    return this.capabilities;
+  }
+
+  async readFile(input: SourceFileRef): Promise<SourceFile | null> {
+    const content = input.ref ? this.refs.get(input.ref)?.get(input.path) : this.files.get(input.path);
+    return content === undefined ? null : { path: input.path, ref: input.ref, content };
+  }
+
+  async writeFile(input: SourceWriteFileInput): Promise<SourceWriteResult> {
+    this.writes.push(input);
+    this.files.set(input.path, input.content);
+    return { path: input.path, commitSha: `commit-${this.writes.length}` };
+  }
+
+  async listFileHistory(_input: SourceFileHistoryInput): Promise<SourceFileHistoryEntry[]> {
+    return this.history;
+  }
+
+  async listFiles(input: SourceFileListInput): Promise<SourceFileListEntry[]> {
+    const prefix = `${input.path.replace(/^\/+|\/+$/g, '')}/`;
+    return [...this.files.keys()]
+      .filter(path => path.startsWith(prefix))
+      .map(path => ({ path }))
+      .sort((a, b) => a.path.localeCompare(b.path));
+  }
+}
+
+const model = { provider: 'openai', name: 'gpt-4' };
+
+describe('SourceAgentsStorage', () => {
+  it('persists code-source snapshots through the source provider using canonical paths', async () => {
+    const provider = new MockSourceProvider();
+    const storage = new SourceAgentsStorage({ provider });
+    storage.__registerMastra({
+      getAgentById: () => ({
+        source: 'code',
+        __getEditorConfig: () => ({ instructions: true, tools: true }),
+      }),
+    });
+
+    await storage.create({
+      agent: {
+        id: 'weather agent',
+        name: 'Weather Agent',
+        instructions: 'Use weather data.',
+        model,
+        tools: { weatherTool: { description: 'Get weather' } },
+      },
+    });
+
+    expect(provider.writes).toHaveLength(1);
+    expect(provider.writes[0]?.path).toBe('agents/weather%20agent.json');
+    expect(JSON.parse(provider.writes[0]?.content ?? '{}')).toEqual({
+      instructions: 'Use weather data.',
+      tools: { weatherTool: { description: 'Get weather' } },
+    });
+  });
+
+  it('omits instructions for descriptions-only code agents', async () => {
+    const provider = new MockSourceProvider();
+    const storage = new SourceAgentsStorage({ provider });
+    storage.__registerMastra({
+      getAgentById: () => ({
+        source: 'code',
+        __getEditorConfig: () => ({ tools: { description: true } }),
+      }),
+    });
+
+    await storage.create({
+      agent: {
+        id: 'descriptions-only',
+        name: 'Descriptions Only',
+        instructions: 'Code owns these instructions.',
+        model,
+        tools: { weatherTool: { description: 'Editable description' } },
+        integrationTools: { composio: {} },
+        mcpClients: { local: {} },
+      },
+    });
+
+    expect(JSON.parse(provider.writes[0]?.content ?? '{}')).toEqual({
+      tools: { weatherTool: { description: 'Editable description' } },
+    });
+  });
+
+  it('persists editable snapshots for storage-only agents without a code definition', async () => {
+    const provider = new MockSourceProvider();
+    const storage = new SourceAgentsStorage({ provider });
+
+    await storage.create({
+      agent: {
+        id: 'storage-only',
+        name: 'Storage Only',
+        instructions: 'Created in studio.',
+        model,
+        scorers: { quality: { description: 'Quality scorer' } },
+        skills: { coding: { description: 'Coding skill' } },
+        integrationTools: { composio: {} },
+        mcpClients: { local: {} },
+        tools: { weatherTool: { description: 'Get weather' } },
+      },
+    });
+
+    expect(provider.writes).toHaveLength(1);
+    expect(provider.writes[0]?.path).toBe('agents/storage-only.json');
+    expect(JSON.parse(provider.writes[0]?.content ?? '{}')).toEqual({
+      name: 'Storage Only',
+      instructions: 'Created in studio.',
+      tools: { weatherTool: { description: 'Get weather' } },
+    });
+  });
+
+  it('still strips non-editable fields when getAgentById throws for storage-only agents', async () => {
+    const provider = new MockSourceProvider();
+    const storage = new SourceAgentsStorage({ provider });
+    storage.__registerMastra({
+      getAgentById: () => {
+        throw new Error('Agent with id storage-only not found');
+      },
+    });
+
+    await expect(
+      storage.create({
+        agent: {
+          id: 'storage-only',
+          name: 'Storage Only',
+          instructions: 'Created in studio.',
+          model,
+        },
+      }),
+    ).resolves.toBeDefined();
+
+    expect(JSON.parse(provider.writes[0]?.content ?? '{}')).toEqual({
+      name: 'Storage Only',
+      instructions: 'Created in studio.',
+    });
+  });
+
+  it('hydrates an agent snapshot from the source provider on demand', async () => {
+    const provider = new MockSourceProvider();
+    provider.files.set(
+      getSourceAgentFilePath('weather-agent'),
+      JSON.stringify({ instructions: 'Stored instructions', tools: { weatherTool: { description: 'Stored' } } }),
+    );
+    const storage = new SourceAgentsStorage({ provider });
+
+    const agent = await storage.getByIdResolved('weather-agent');
+
+    expect(agent).toMatchObject({
+      id: 'weather-agent',
+      status: 'published',
+      instructions: 'Stored instructions',
+      tools: { weatherTool: { description: 'Stored' } },
+    });
+  });
+
+  it('discovers storage-only agents from provider files on cold start', async () => {
+    const provider = new MockSourceProvider();
+    provider.files.set(
+      getSourceAgentFilePath('studio only'),
+      JSON.stringify({ name: 'Studio Only', instructions: 'Persisted in source storage.', model }),
+    );
+    const storage = new SourceAgentsStorage({ provider });
+
+    await storage.init();
+    const list = await storage.listResolved();
+
+    expect(list.agents).toHaveLength(1);
+    expect(list.agents[0]).toMatchObject({
+      id: 'studio only',
+      name: 'Studio Only',
+      instructions: 'Persisted in source storage.',
+    });
+  });
+
+  it('maps source file history to versions with snapshot content from each ref', async () => {
+    const provider = new MockSourceProvider();
+    const firstRef = new Map<string, string>();
+    firstRef.set(getSourceAgentFilePath('weather-agent'), JSON.stringify({ instructions: 'First' }));
+    const secondRef = new Map<string, string>();
+    secondRef.set(getSourceAgentFilePath('weather-agent'), JSON.stringify({ instructions: 'Second' }));
+    provider.refs.set('sha-1', firstRef);
+    provider.refs.set('sha-2', secondRef);
+    provider.history = [
+      { id: 'sha-2', ref: 'sha-2', message: 'Second save', createdAt: '2026-06-01T02:00:00.000Z' },
+      { id: 'sha-1', ref: 'sha-1', message: 'First save', createdAt: '2026-06-01T01:00:00.000Z' },
+    ];
+    const storage = new SourceAgentsStorage({ provider });
+
+    const versions = await storage.listVersions({
+      agentId: 'weather-agent',
+      orderBy: { field: 'versionNumber', direction: 'ASC' },
+    });
+
+    expect(versions.versions).toHaveLength(2);
+    expect(versions.versions.map(version => version.changeMessage)).toEqual(['First save', 'Second save']);
+    expect(versions.versions.map(version => version.instructions)).toEqual(['First', 'Second']);
+  });
+
+  it('rejects writes when the source provider cannot write', async () => {
+    const provider = new MockSourceProvider();
+    provider.capabilities = {
+      canRead: true,
+      canWrite: false,
+      canListHistory: true,
+      canOpenChangeRequest: false,
+      reason: 'missing-permissions',
+    };
+    const storage = new SourceAgentsStorage({ provider });
+
+    await expect(
+      storage.create({
+        agent: {
+          id: 'weather-agent',
+          name: 'Weather Agent',
+          instructions: 'Use weather data.',
+          model,
+        },
+      }),
+    ).rejects.toThrow('missing-permissions');
+  });
+
+  it('checks provider capabilities during init', async () => {
+    const provider = new MockSourceProvider();
+    provider.capabilities = {
+      canRead: false,
+      canWrite: true,
+      canListHistory: true,
+      canOpenChangeRequest: false,
+      reason: 'provider-unavailable',
+    };
+    const storage = new SourceAgentsStorage({ provider });
+
+    await expect(storage.init()).rejects.toThrow('provider-unavailable');
+  });
+});

--- a/packages/core/src/storage/domains/agents/source.ts
+++ b/packages/core/src/storage/domains/agents/source.ts
@@ -193,9 +193,15 @@ export class SourceAgentsStorage extends AgentsStorage {
   }
 
   async create(input: { agent: StorageCreateAgentInput }): Promise<StorageAgentType> {
+    await this.hydrateAgent(input.agent.id);
+    const existing = await this.memory.getById(input.agent.id);
+    if (existing) {
+      throw new Error(`Agent with id ${input.agent.id} already exists`);
+    }
+
+    await this.persistSnapshot(input.agent.id, { ...input.agent }, 'Initial version');
     const created = await this.memory.create(input);
     this.knownAgentIds.add(input.agent.id);
-    await this.persistSnapshot(input.agent.id, { ...input.agent }, 'Initial version');
     return created;
   }
 
@@ -225,8 +231,18 @@ export class SourceAgentsStorage extends AgentsStorage {
 
   async createVersion(input: CreateVersionInput): Promise<AgentVersion> {
     await this.hydrateAgent(input.agentId);
+    const existingVersion = await this.memory.getVersion(input.id);
+    if (existingVersion) {
+      throw new Error(`Version with id ${input.id} already exists`);
+    }
+    const existingVersionNumber = await this.memory.getVersionByNumber(input.agentId, input.versionNumber);
+    if (existingVersionNumber) {
+      throw new Error(`Version number ${input.versionNumber} already exists for agent ${input.agentId}`);
+    }
+
+    const snapshot = snapshotFromVersion({ ...input, createdAt: new Date() } as AgentVersion);
+    const result = await this.persistSnapshot(input.agentId, snapshot, input.changeMessage);
     const version = await this.memory.createVersion(input);
-    const result = await this.persistSnapshot(input.agentId, snapshotFromVersion(version), input.changeMessage);
     this.rememberProviderVersion(input.agentId, version, result);
     return version;
   }
@@ -318,7 +334,6 @@ export class SourceAgentsStorage extends AgentsStorage {
 
   private async discoverProviderAgentIds(): Promise<void> {
     if (this.providerAgentIdsDiscovered || !this.provider.listFiles) return;
-    this.providerAgentIdsDiscovered = true;
 
     const files = await this.provider.listFiles({ path: SOURCE_STORAGE_AGENTS_DIR });
     for (const file of files) {
@@ -327,19 +342,26 @@ export class SourceAgentsStorage extends AgentsStorage {
         this.knownAgentIds.add(agentId);
       }
     }
+    this.providerAgentIdsDiscovered = true;
   }
 
   private async hydrateAgent(agentId: string): Promise<void> {
     if (this.hydratedAgents.has(agentId)) return;
-    this.hydratedAgents.add(agentId);
 
     const file = await this.provider.readFile({ path: getSourceAgentFilePath(agentId) });
-    if (!file) return;
+    if (!file) {
+      this.hydratedAgents.add(agentId);
+      return;
+    }
 
     const snapshot = parseJsonObject(file.content);
-    if (!snapshot) return;
+    if (!snapshot) {
+      this.hydratedAgents.add(agentId);
+      return;
+    }
 
     this.knownAgentIds.add(agentId);
+    this.hydratedAgents.add(agentId);
     const now = new Date();
     const versionId = `hydrated-${agentId}-v1`;
     this.db.agents.set(agentId, {
@@ -390,13 +412,16 @@ export class SourceAgentsStorage extends AgentsStorage {
 
   private async loadHistory(agentId: string): Promise<void> {
     if (this.loadedHistory.has(agentId)) return;
-    this.loadedHistory.add(agentId);
 
     const capabilities = await this.provider.getCapabilities();
-    if (!capabilities.canListHistory) return;
+    if (!capabilities.canListHistory) {
+      this.loadedHistory.add(agentId);
+      return;
+    }
 
     const entries = await this.provider.listFileHistory({ path: getSourceAgentFilePath(agentId) });
     const orderedEntries = [...entries].reverse();
+    const versions = new Map<string, AgentVersion>();
     let versionNumber = 0;
     for (const entry of orderedEntries) {
       const file = await this.provider.readFile({ path: getSourceAgentFilePath(agentId), ref: entry.ref ?? entry.id });
@@ -405,8 +430,12 @@ export class SourceAgentsStorage extends AgentsStorage {
       if (!snapshot) continue;
       versionNumber += 1;
       const version = this.versionFromHistoryEntry(agentId, entry, versionNumber, snapshot);
-      this.providerVersions.set(version.id, version);
+      versions.set(version.id, version);
     }
+    for (const [versionId, version] of versions) {
+      this.providerVersions.set(versionId, version);
+    }
+    this.loadedHistory.add(agentId);
   }
 
   private rememberProviderVersion(agentId: string, version: AgentVersion, result: SourceWriteResult): void {

--- a/packages/core/src/storage/domains/agents/source.ts
+++ b/packages/core/src/storage/domains/agents/source.ts
@@ -157,6 +157,7 @@ export class SourceAgentsStorage extends AgentsStorage {
   private readonly providerVersions = new Map<string, AgentVersion>();
   private readonly loadedHistory = new Set<string>();
   private readonly hydratedAgents = new Set<string>();
+  private readonly activeRefs = new Map<string, string>();
   private providerAgentIdsDiscovered = false;
 
   constructor({ provider, agentIds = [] }: SourceAgentsStorageConfig) {
@@ -183,8 +184,22 @@ export class SourceAgentsStorage extends AgentsStorage {
     this.hydratedAgents.clear();
     this.loadedHistory.clear();
     this.providerVersions.clear();
+    this.activeRefs.clear();
     this.providerAgentIdsDiscovered = false;
     await this.memory.dangerouslyClearAll();
+  }
+
+  async useProviderRef(agentId: string, ref: string): Promise<void> {
+    this.activeRefs.set(agentId, ref);
+    this.hydratedAgents.delete(agentId);
+    this.loadedHistory.delete(agentId);
+    for (const [versionId, version] of this.providerVersions.entries()) {
+      if (version.agentId === agentId) {
+        this.providerVersions.delete(versionId);
+      }
+    }
+    await this.memory.delete(agentId);
+    await this.hydrateAgent(agentId);
   }
 
   async getById(id: string): Promise<StorageAgentType | null> {
@@ -348,7 +363,8 @@ export class SourceAgentsStorage extends AgentsStorage {
   private async hydrateAgent(agentId: string): Promise<void> {
     if (this.hydratedAgents.has(agentId)) return;
 
-    const file = await this.provider.readFile({ path: getSourceAgentFilePath(agentId) });
+    const ref = this.activeRefs.get(agentId);
+    const file = await this.provider.readFile({ path: getSourceAgentFilePath(agentId), ref });
     if (!file) {
       this.hydratedAgents.add(agentId);
       return;
@@ -405,6 +421,7 @@ export class SourceAgentsStorage extends AgentsStorage {
     const filtered = filterSourceSnapshot(snapshot, agent?.__getEditorConfig?.(), Boolean(agent));
     return this.provider.writeFile({
       path: getSourceAgentFilePath(agentId),
+      ref: this.activeRefs.get(agentId),
       content: `${stableStringify(filtered)}\n`,
       message,
     });
@@ -419,7 +436,8 @@ export class SourceAgentsStorage extends AgentsStorage {
       return;
     }
 
-    const entries = await this.provider.listFileHistory({ path: getSourceAgentFilePath(agentId) });
+    const activeRef = this.activeRefs.get(agentId);
+    const entries = await this.provider.listFileHistory({ path: getSourceAgentFilePath(agentId), ref: activeRef });
     const orderedEntries = [...entries].reverse();
     const versions = new Map<string, AgentVersion>();
     let versionNumber = 0;

--- a/packages/core/src/storage/domains/agents/source.ts
+++ b/packages/core/src/storage/domains/agents/source.ts
@@ -1,7 +1,7 @@
 import { calculatePagination, normalizePerPage } from '../../base';
 import type { StorageMastraRef } from '../../base';
-import { SOURCE_STORAGE_AGENTS_DIR, getSourceAgentFilePath } from '../../source-storage';
-import type { SourceFileHistoryEntry, SourceStorageProvider, SourceWriteResult } from '../../source-storage';
+import { SOURCE_CONTROL_AGENTS_DIR, getSourceAgentFilePath } from '../../source-control';
+import type { SourceFileHistoryEntry, SourceControlProvider, SourceWriteResult } from '../../source-control';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,
@@ -47,8 +47,8 @@ const OWNED_FIELDS_BY_GROUP = {
   tools: ['tools'],
 } as const;
 
-export interface SourceAgentsStorageConfig {
-  provider: SourceStorageProvider;
+export interface SourceAgentsSourceControlConfig {
+  provider: SourceControlProvider;
   agentIds?: string[];
 }
 
@@ -135,7 +135,7 @@ function stableStringify(value: unknown): string {
 }
 
 function agentIdFromSourcePath(path: string): string | undefined {
-  const prefix = `${SOURCE_STORAGE_AGENTS_DIR}/`;
+  const prefix = `${SOURCE_CONTROL_AGENTS_DIR}/`;
   if (!path.startsWith(prefix) || !path.endsWith('.json')) return undefined;
 
   const filename = path.slice(prefix.length, -'.json'.length);
@@ -148,8 +148,8 @@ function agentIdFromSourcePath(path: string): string | undefined {
   }
 }
 
-export class SourceAgentsStorage extends AgentsStorage {
-  private readonly provider: SourceStorageProvider;
+export class SourceAgentsSourceControl extends AgentsStorage {
+  private readonly provider: SourceControlProvider;
   private readonly knownAgentIds: Set<string>;
   private readonly db = new InMemoryDB();
   private readonly memory = new InMemoryAgentsStorage({ db: this.db });
@@ -160,7 +160,7 @@ export class SourceAgentsStorage extends AgentsStorage {
   private readonly activeRefs = new Map<string, string>();
   private providerAgentIdsDiscovered = false;
 
-  constructor({ provider, agentIds = [] }: SourceAgentsStorageConfig) {
+  constructor({ provider, agentIds = [] }: SourceAgentsSourceControlConfig) {
     super();
     this.provider = provider;
     this.knownAgentIds = new Set(agentIds);
@@ -350,7 +350,7 @@ export class SourceAgentsStorage extends AgentsStorage {
   private async discoverProviderAgentIds(): Promise<void> {
     if (this.providerAgentIdsDiscovered || !this.provider.listFiles) return;
 
-    const files = await this.provider.listFiles({ path: SOURCE_STORAGE_AGENTS_DIR });
+    const files = await this.provider.listFiles({ path: SOURCE_CONTROL_AGENTS_DIR });
     for (const file of files) {
       const agentId = agentIdFromSourcePath(file.path);
       if (agentId) {

--- a/packages/core/src/storage/domains/agents/source.ts
+++ b/packages/core/src/storage/domains/agents/source.ts
@@ -1,0 +1,456 @@
+import { calculatePagination, normalizePerPage } from '../../base';
+import type { StorageMastraRef } from '../../base';
+import { SOURCE_STORAGE_AGENTS_DIR, getSourceAgentFilePath } from '../../source-storage';
+import type { SourceFileHistoryEntry, SourceStorageProvider, SourceWriteResult } from '../../source-storage';
+import type {
+  StorageAgentType,
+  StorageCreateAgentInput,
+  StorageListAgentsInput,
+  StorageListAgentsOutput,
+  StorageUpdateAgentInput,
+} from '../../types';
+import { InMemoryDB } from '../inmemory-db';
+import type {
+  AgentVersion,
+  CreateVersionInput,
+  ListVersionsInput,
+  ListVersionsOutput,
+  VersionOrderBy,
+  VersionSortDirection,
+} from './base';
+import { AgentsStorage } from './base';
+import { InMemoryAgentsStorage } from './inmemory';
+
+const SOURCE_VERSION_PREFIX = 'source:';
+
+const COMMON_EXCLUDED_FIELDS = new Set([
+  'id',
+  'model',
+  'scorers',
+  'skills',
+  'workflows',
+  'agents',
+  'integrationTools',
+  'toolProviders',
+  'inputProcessors',
+  'outputProcessors',
+  'memory',
+  'mcpClients',
+  'workspace',
+  'browser',
+  'defaultOptions',
+]);
+const CODE_SOURCE_EXCLUDED_FIELDS = new Set(['name']);
+
+const OWNED_FIELDS_BY_GROUP = {
+  instructions: ['instructions'],
+  tools: ['tools'],
+} as const;
+
+export interface SourceAgentsStorageConfig {
+  provider: SourceStorageProvider;
+  agentIds?: string[];
+}
+
+function ownershipFromEditorConfig(editorConfig: unknown): {
+  ownsInstructions: boolean;
+  ownsTools: boolean;
+} {
+  if (editorConfig === false) {
+    return { ownsInstructions: false, ownsTools: false };
+  }
+  if (editorConfig === undefined || editorConfig === null) {
+    return { ownsInstructions: true, ownsTools: true };
+  }
+  if (typeof editorConfig !== 'object') {
+    return { ownsInstructions: false, ownsTools: false };
+  }
+  const cfg = editorConfig as { instructions?: unknown; tools?: unknown };
+  const ownsInstructions = cfg.instructions === true;
+  const toolsCfg = cfg.tools;
+  const ownsTools =
+    toolsCfg === true ||
+    (typeof toolsCfg === 'object' && toolsCfg !== null && (toolsCfg as { description?: unknown }).description === true);
+  return { ownsInstructions, ownsTools };
+}
+
+function snapshotFromVersion(version: AgentVersion): Record<string, unknown> {
+  const { id, agentId, versionNumber, changedFields, changeMessage, createdAt, ...snapshot } = version;
+  void id;
+  void agentId;
+  void versionNumber;
+  void changedFields;
+  void changeMessage;
+  void createdAt;
+  return snapshot;
+}
+
+function filterSourceSnapshot(
+  snapshot: Record<string, unknown>,
+  editorConfig: unknown,
+  isCodeDefinedAgent: boolean,
+): Record<string, unknown> {
+  const excludedByOwnership = new Set<string>();
+  if (isCodeDefinedAgent) {
+    const { ownsInstructions, ownsTools } = ownershipFromEditorConfig(editorConfig);
+    if (!ownsInstructions) {
+      for (const field of OWNED_FIELDS_BY_GROUP.instructions) excludedByOwnership.add(field);
+    }
+    if (!ownsTools) {
+      for (const field of OWNED_FIELDS_BY_GROUP.tools) excludedByOwnership.add(field);
+    }
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (COMMON_EXCLUDED_FIELDS.has(key)) continue;
+    if (isCodeDefinedAgent && CODE_SOURCE_EXCLUDED_FIELDS.has(key)) continue;
+    if (excludedByOwnership.has(key)) continue;
+    if (value === undefined) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+function parseJsonObject(content: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+    return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function agentIdFromSourcePath(path: string): string | undefined {
+  const prefix = `${SOURCE_STORAGE_AGENTS_DIR}/`;
+  if (!path.startsWith(prefix) || !path.endsWith('.json')) return undefined;
+
+  const filename = path.slice(prefix.length, -'.json'.length);
+  if (!filename || filename.includes('/')) return undefined;
+
+  try {
+    return decodeURIComponent(filename);
+  } catch {
+    return filename;
+  }
+}
+
+export class SourceAgentsStorage extends AgentsStorage {
+  private readonly provider: SourceStorageProvider;
+  private readonly knownAgentIds: Set<string>;
+  private readonly db = new InMemoryDB();
+  private readonly memory = new InMemoryAgentsStorage({ db: this.db });
+  private storageMastra?: StorageMastraRef;
+  private readonly providerVersions = new Map<string, AgentVersion>();
+  private readonly loadedHistory = new Set<string>();
+  private readonly hydratedAgents = new Set<string>();
+  private providerAgentIdsDiscovered = false;
+
+  constructor({ provider, agentIds = [] }: SourceAgentsStorageConfig) {
+    super();
+    this.provider = provider;
+    this.knownAgentIds = new Set(agentIds);
+  }
+
+  __registerMastra(mastra: StorageMastraRef): void {
+    this.storageMastra = mastra;
+  }
+
+  override async init(): Promise<void> {
+    const capabilities = await this.provider.getCapabilities();
+    if (!capabilities.canRead) {
+      throw new Error(capabilities.reason ?? `Source provider ${this.provider.displayName} cannot read files`);
+    }
+    this.refreshKnownAgentIds();
+    await this.discoverProviderAgentIds();
+    await Promise.all([...this.knownAgentIds].map(agentId => this.hydrateAgent(agentId)));
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    this.hydratedAgents.clear();
+    this.loadedHistory.clear();
+    this.providerVersions.clear();
+    this.providerAgentIdsDiscovered = false;
+    await this.memory.dangerouslyClearAll();
+  }
+
+  async getById(id: string): Promise<StorageAgentType | null> {
+    await this.hydrateAgent(id);
+    return this.memory.getById(id);
+  }
+
+  async create(input: { agent: StorageCreateAgentInput }): Promise<StorageAgentType> {
+    const created = await this.memory.create(input);
+    this.knownAgentIds.add(input.agent.id);
+    await this.persistSnapshot(input.agent.id, { ...input.agent }, 'Initial version');
+    return created;
+  }
+
+  async update(input: StorageUpdateAgentInput): Promise<StorageAgentType> {
+    await this.hydrateAgent(input.id);
+    return this.memory.update(input);
+  }
+
+  async delete(id: string): Promise<void> {
+    this.knownAgentIds.delete(id);
+    this.hydratedAgents.delete(id);
+    this.loadedHistory.delete(id);
+    for (const versionId of this.providerVersions.keys()) {
+      if (this.providerVersions.get(versionId)?.agentId === id) {
+        this.providerVersions.delete(versionId);
+      }
+    }
+    await this.memory.delete(id);
+  }
+
+  async list(args?: StorageListAgentsInput): Promise<StorageListAgentsOutput> {
+    this.refreshKnownAgentIds();
+    await this.discoverProviderAgentIds();
+    await Promise.all([...this.knownAgentIds].map(agentId => this.hydrateAgent(agentId)));
+    return this.memory.list(args);
+  }
+
+  async createVersion(input: CreateVersionInput): Promise<AgentVersion> {
+    await this.hydrateAgent(input.agentId);
+    const version = await this.memory.createVersion(input);
+    const result = await this.persistSnapshot(input.agentId, snapshotFromVersion(version), input.changeMessage);
+    this.rememberProviderVersion(input.agentId, version, result);
+    return version;
+  }
+
+  async getVersion(id: string): Promise<AgentVersion | null> {
+    const providerVersion = this.providerVersions.get(id);
+    if (providerVersion) {
+      return structuredClone(providerVersion);
+    }
+    return this.memory.getVersion(id);
+  }
+
+  async getVersionByNumber(agentId: string, versionNumber: number): Promise<AgentVersion | null> {
+    await this.loadHistory(agentId);
+    const providerVersion = [...this.providerVersions.values()].find(
+      version => version.agentId === agentId && version.versionNumber === versionNumber,
+    );
+    if (providerVersion) {
+      return structuredClone(providerVersion);
+    }
+    return this.memory.getVersionByNumber(agentId, versionNumber);
+  }
+
+  async getLatestVersion(agentId: string): Promise<AgentVersion | null> {
+    await this.loadHistory(agentId);
+    const providerLatest = [...this.providerVersions.values()]
+      .filter(version => version.agentId === agentId)
+      .sort((a, b) => b.versionNumber - a.versionNumber)[0];
+    if (providerLatest) {
+      return structuredClone(providerLatest);
+    }
+    return this.memory.getLatestVersion(agentId);
+  }
+
+  async listVersions(input: ListVersionsInput): Promise<ListVersionsOutput> {
+    await this.loadHistory(input.agentId);
+    const providerVersions = [...this.providerVersions.values()].filter(version => version.agentId === input.agentId);
+    if (providerVersions.length === 0) {
+      return this.memory.listVersions(input);
+    }
+
+    const { page = 0, perPage: perPageInput, orderBy } = input;
+    const { field, direction } = this.parseVersionOrderBy(orderBy);
+    const perPage = normalizePerPage(perPageInput, 20);
+    const sortedVersions = this.sortVersions(providerVersions, field, direction).map(version =>
+      structuredClone(version),
+    );
+    const total = sortedVersions.length;
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    return {
+      versions: sortedVersions.slice(offset, offset + perPage),
+      total,
+      page,
+      perPage: perPageForResponse,
+      hasMore: offset + perPage < total,
+    };
+  }
+
+  async deleteVersion(id: string): Promise<void> {
+    this.providerVersions.delete(id);
+    await this.memory.deleteVersion(id);
+  }
+
+  async deleteVersionsByParentId(entityId: string): Promise<void> {
+    for (const [versionId, version] of this.providerVersions.entries()) {
+      if (version.agentId === entityId) {
+        this.providerVersions.delete(versionId);
+      }
+    }
+    await this.memory.deleteVersionsByParentId(entityId);
+  }
+
+  async countVersions(entityId: string): Promise<number> {
+    await this.loadHistory(entityId);
+    const providerCount = [...this.providerVersions.values()].filter(version => version.agentId === entityId).length;
+    return providerCount || this.memory.countVersions(entityId);
+  }
+
+  private refreshKnownAgentIds(): void {
+    const agents = this.storageMastra?.listAgents?.();
+    if (!agents) return;
+    for (const agent of Object.values(agents)) {
+      if (agent.source === 'code') {
+        this.knownAgentIds.add(agent.id);
+      }
+    }
+  }
+
+  private async discoverProviderAgentIds(): Promise<void> {
+    if (this.providerAgentIdsDiscovered || !this.provider.listFiles) return;
+    this.providerAgentIdsDiscovered = true;
+
+    const files = await this.provider.listFiles({ path: SOURCE_STORAGE_AGENTS_DIR });
+    for (const file of files) {
+      const agentId = agentIdFromSourcePath(file.path);
+      if (agentId) {
+        this.knownAgentIds.add(agentId);
+      }
+    }
+  }
+
+  private async hydrateAgent(agentId: string): Promise<void> {
+    if (this.hydratedAgents.has(agentId)) return;
+    this.hydratedAgents.add(agentId);
+
+    const file = await this.provider.readFile({ path: getSourceAgentFilePath(agentId) });
+    if (!file) return;
+
+    const snapshot = parseJsonObject(file.content);
+    if (!snapshot) return;
+
+    this.knownAgentIds.add(agentId);
+    const now = new Date();
+    const versionId = `hydrated-${agentId}-v1`;
+    this.db.agents.set(agentId, {
+      id: agentId,
+      status: 'published',
+      activeVersionId: versionId,
+      favoriteCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+    this.db.agentVersions.set(versionId, {
+      id: versionId,
+      agentId,
+      versionNumber: 1,
+      ...snapshot,
+      createdAt: now,
+    } as AgentVersion);
+  }
+
+  private getCodeDefinedAgent(agentId: string): { source?: string; __getEditorConfig?: () => unknown } | undefined {
+    try {
+      const agent = this.storageMastra?.getAgentById?.(agentId) as
+        | { source?: string; __getEditorConfig?: () => unknown }
+        | undefined;
+      return agent?.source === 'code' ? agent : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async persistSnapshot(
+    agentId: string,
+    snapshot: Record<string, unknown>,
+    message?: string,
+  ): Promise<SourceWriteResult> {
+    const capabilities = await this.provider.getCapabilities();
+    if (!capabilities.canWrite) {
+      throw new Error(capabilities.reason ?? `Source provider ${this.provider.displayName} cannot write files`);
+    }
+    const agent = this.getCodeDefinedAgent(agentId);
+    const filtered = filterSourceSnapshot(snapshot, agent?.__getEditorConfig?.(), Boolean(agent));
+    return this.provider.writeFile({
+      path: getSourceAgentFilePath(agentId),
+      content: `${stableStringify(filtered)}\n`,
+      message,
+    });
+  }
+
+  private async loadHistory(agentId: string): Promise<void> {
+    if (this.loadedHistory.has(agentId)) return;
+    this.loadedHistory.add(agentId);
+
+    const capabilities = await this.provider.getCapabilities();
+    if (!capabilities.canListHistory) return;
+
+    const entries = await this.provider.listFileHistory({ path: getSourceAgentFilePath(agentId) });
+    const orderedEntries = [...entries].reverse();
+    let versionNumber = 0;
+    for (const entry of orderedEntries) {
+      const file = await this.provider.readFile({ path: getSourceAgentFilePath(agentId), ref: entry.ref ?? entry.id });
+      if (!file) continue;
+      const snapshot = parseJsonObject(file.content);
+      if (!snapshot) continue;
+      versionNumber += 1;
+      const version = this.versionFromHistoryEntry(agentId, entry, versionNumber, snapshot);
+      this.providerVersions.set(version.id, version);
+    }
+  }
+
+  private rememberProviderVersion(agentId: string, version: AgentVersion, result: SourceWriteResult): void {
+    const versionId = result.commitSha ? `${SOURCE_VERSION_PREFIX}${result.commitSha}:${agentId}` : version.id;
+    this.providerVersions.set(versionId, {
+      ...structuredClone(version),
+      id: versionId,
+      agentId,
+      versionNumber: this.nextProviderVersionNumber(agentId),
+    });
+  }
+
+  private versionFromHistoryEntry(
+    agentId: string,
+    entry: SourceFileHistoryEntry,
+    versionNumber: number,
+    snapshot: Record<string, unknown>,
+  ): AgentVersion {
+    return {
+      id: `${SOURCE_VERSION_PREFIX}${entry.id}:${agentId}`,
+      agentId,
+      versionNumber,
+      changeMessage: entry.message,
+      ...snapshot,
+      createdAt: new Date(entry.createdAt),
+    } as AgentVersion;
+  }
+
+  private nextProviderVersionNumber(agentId: string): number {
+    const latest = [...this.providerVersions.values()]
+      .filter(version => version.agentId === agentId)
+      .sort((a, b) => b.versionNumber - a.versionNumber)[0];
+    return (latest?.versionNumber ?? 0) + 1;
+  }
+
+  private sortVersions(
+    versions: AgentVersion[],
+    field: VersionOrderBy,
+    direction: VersionSortDirection,
+  ): AgentVersion[] {
+    return versions.sort((a, b) => {
+      const aVal = field === 'createdAt' ? a.createdAt.getTime() : a.versionNumber;
+      const bVal = field === 'createdAt' ? b.createdAt.getTime() : b.versionNumber;
+      return direction === 'ASC' ? aVal - bVal : bVal - aVal;
+    });
+  }
+}

--- a/packages/core/src/storage/filesystem-versioned.ts
+++ b/packages/core/src/storage/filesystem-versioned.ts
@@ -8,7 +8,7 @@ import type {
 
 import type { FilesystemDB } from './filesystem-db';
 import { GitHistory } from './git-history';
-import { getSourceStorageEntityFilePath } from './source-storage';
+import { getSourceControlEntityFilePath } from './source-control';
 import type { StorageOrderBy } from './types';
 
 /**
@@ -161,7 +161,7 @@ export class FilesystemVersionedHelpers<
     if (!this.perEntityFilesDir) {
       throw new Error(`${this.name}: per-entity files directory is not configured`);
     }
-    return getSourceStorageEntityFilePath(this.perEntityFilesDir, entityId);
+    return getSourceControlEntityFilePath(this.perEntityFilesDir, entityId);
   }
 
   private entityIdFromPerEntityFilename(filename: string): string {

--- a/packages/core/src/storage/filesystem-versioned.ts
+++ b/packages/core/src/storage/filesystem-versioned.ts
@@ -8,6 +8,7 @@ import type {
 
 import type { FilesystemDB } from './filesystem-db';
 import { GitHistory } from './git-history';
+import { getSourceStorageEntityFilePath } from './source-storage';
 import type { StorageOrderBy } from './types';
 
 /**
@@ -160,7 +161,7 @@ export class FilesystemVersionedHelpers<
     if (!this.perEntityFilesDir) {
       throw new Error(`${this.name}: per-entity files directory is not configured`);
     }
-    return `${this.perEntityFilesDir}/${encodeURIComponent(entityId)}.json`;
+    return getSourceStorageEntityFilePath(this.perEntityFilesDir, entityId);
   }
 
   private entityIdFromPerEntityFilename(filename: string): string {

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -6,7 +6,7 @@ export * from './filesystem';
 export * from './filesystem-db';
 export * from './filesystem-versioned';
 export * from './git-history';
-export * from './source-storage';
+export * from './source-control';
 export * from './providers';
 export * from './domains';
 export * from './utils';

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -6,5 +6,7 @@ export * from './filesystem';
 export * from './filesystem-db';
 export * from './filesystem-versioned';
 export * from './git-history';
+export * from './source-storage';
+export * from './providers';
 export * from './domains';
 export * from './utils';

--- a/packages/core/src/storage/providers/github.test.ts
+++ b/packages/core/src/storage/providers/github.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { GitHubSourceStorageProvider, createGitHubSourceStorageProviderFromEnv } from './github';
+import { GitHubSourceControlProvider, createGitHubSourceControlProviderFromEnv } from './github';
 
-describe('GitHubSourceStorageProvider', () => {
-  it('routes source storage operations through the Platform broker', async () => {
+describe('GitHubSourceControlProvider', () => {
+  it('routes source control operations through the Platform broker', async () => {
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       expect(init?.headers).toMatchObject({ Authorization: 'Bearer token-1' });
 
@@ -44,7 +44,7 @@ describe('GitHubSourceStorageProvider', () => {
       throw new Error(`Unexpected request: ${url}`);
     });
 
-    const provider = new GitHubSourceStorageProvider({
+    const provider = new GitHubSourceControlProvider({
       endpoint: 'https://api.mastra.ai/v1/',
       token: 'token-1',
       pathPrefix: 'custom',
@@ -72,14 +72,14 @@ describe('GitHubSourceStorageProvider', () => {
     ).resolves.toMatchObject({ id: 12 });
   });
 
-  it('creates a provider from hosted source storage environment variables', () => {
-    const provider = createGitHubSourceStorageProviderFromEnv({
+  it('creates a provider from hosted source control environment variables', () => {
+    const provider = createGitHubSourceControlProviderFromEnv({
       MASTRA_SOURCE_PROVIDER: 'github',
       MASTRA_SHARED_API_URL: 'https://api.mastra.ai/v1',
       MASTRA_PLATFORM_ACCESS_TOKEN: 'token-1',
     });
 
-    expect(provider).toBeInstanceOf(GitHubSourceStorageProvider);
+    expect(provider).toBeInstanceOf(GitHubSourceControlProvider);
   });
 });
 

--- a/packages/core/src/storage/providers/github.test.ts
+++ b/packages/core/src/storage/providers/github.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { GitHubSourceStorageProvider, createGitHubSourceStorageProviderFromEnv } from './github';
+
+describe('GitHubSourceStorageProvider', () => {
+  it('routes source storage operations through the Platform broker', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(init?.headers).toMatchObject({ Authorization: 'Bearer token-1' });
+
+      if (url === 'https://api.mastra.ai/v1/server/source-storage/github/capabilities') {
+        return jsonResponse({ canRead: true, canWrite: true, canListHistory: true, canOpenChangeRequest: true });
+      }
+
+      if (url.includes('/files?')) {
+        expect(url).toContain('path=custom%2Fagents%2Fagent-1.json');
+        return jsonResponse({ path: 'custom/agents/agent-1.json', ref: 'main', content: '{}', sha: 'file-sha' });
+      }
+
+      if (url.endsWith('/files')) {
+        expect(JSON.parse(String(init?.body))).toMatchObject({ path: 'custom/agents/agent-1.json', content: '{}' });
+        return jsonResponse({
+          path: 'custom/agents/agent-1.json',
+          ref: 'main',
+          sha: 'new-file-sha',
+          commitSha: 'commit-sha',
+        });
+      }
+
+      if (url.includes('/files/list?')) {
+        expect(url).toContain('path=custom%2Fagents');
+        return jsonResponse([{ path: 'custom/agents/agent-1.json', sha: 'file-sha' }]);
+      }
+
+      if (url.includes('/files/history?')) {
+        expect(url).toContain('path=custom%2Fagents%2Fagent-1.json');
+        return jsonResponse([{ id: 'commit-sha', createdAt: '2026-06-01T00:00:00.000Z' }]);
+      }
+
+      if (url.endsWith('/change-requests')) {
+        expect(JSON.parse(String(init?.body)).files[0]).toMatchObject({ path: 'custom/agents/agent-1.json' });
+        return jsonResponse({ id: 12, url: 'https://github.com/acme/repo/pull/12', ref: 'mastra/agent-1' });
+      }
+
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    const provider = new GitHubSourceStorageProvider({
+      endpoint: 'https://api.mastra.ai/v1/',
+      token: 'token-1',
+      pathPrefix: 'custom',
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(provider.getCapabilities()).resolves.toMatchObject({ canWrite: true });
+    await expect(provider.readFile({ path: 'agents/agent-1.json' })).resolves.toMatchObject({
+      path: 'agents/agent-1.json',
+      sha: 'file-sha',
+    });
+    await expect(provider.writeFile({ path: 'agents/agent-1.json', content: '{}' })).resolves.toMatchObject({
+      path: 'agents/agent-1.json',
+      commitSha: 'commit-sha',
+    });
+    await expect(provider.listFileHistory({ path: 'agents/agent-1.json' })).resolves.toHaveLength(1);
+    await expect(provider.listFiles({ path: 'agents' })).resolves.toEqual([
+      { path: 'agents/agent-1.json', sha: 'file-sha' },
+    ]);
+    await expect(
+      provider.openChangeRequest({
+        title: 'Update agent',
+        files: [{ path: 'agents/agent-1.json', content: '{}' }],
+      }),
+    ).resolves.toMatchObject({ id: 12 });
+  });
+
+  it('creates a provider from hosted source storage environment variables', () => {
+    const provider = createGitHubSourceStorageProviderFromEnv({
+      MASTRA_SOURCE_PROVIDER: 'github',
+      MASTRA_SHARED_API_URL: 'https://api.mastra.ai/v1',
+      MASTRA_PLATFORM_ACCESS_TOKEN: 'token-1',
+    });
+
+    expect(provider).toBeInstanceOf(GitHubSourceStorageProvider);
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/packages/core/src/storage/providers/github.ts
+++ b/packages/core/src/storage/providers/github.ts
@@ -7,13 +7,13 @@ import type {
   SourceFileListEntry,
   SourceFileListInput,
   SourceFileRef,
-  SourceStorageCapabilities,
-  SourceStorageProvider,
+  SourceControlCapabilities,
+  SourceControlProvider,
   SourceWriteFileInput,
   SourceWriteResult,
-} from '../source-storage';
+} from '../source-control';
 
-export type GitHubSourceStorageProviderConfig = {
+export type GitHubSourceControlProviderConfig = {
   endpoint: string;
   token: string;
   pathPrefix?: string;
@@ -25,7 +25,7 @@ type BrokerErrorResponse = {
   detail?: string;
 };
 
-export class GitHubSourceStorageProvider implements SourceStorageProvider {
+export class GitHubSourceControlProvider implements SourceControlProvider {
   readonly id = 'github';
   readonly displayName = 'GitHub';
 
@@ -34,15 +34,15 @@ export class GitHubSourceStorageProvider implements SourceStorageProvider {
   private readonly pathPrefix: string;
   private readonly fetch: typeof fetch;
 
-  constructor(config: GitHubSourceStorageProviderConfig) {
+  constructor(config: GitHubSourceControlProviderConfig) {
     this.endpoint = normalizeApiEndpoint(config.endpoint);
     this.token = config.token;
     this.pathPrefix = normalizePathPrefix(config.pathPrefix ?? 'mastra/editor');
     this.fetch = config.fetch ?? fetch;
   }
 
-  async getCapabilities(): Promise<SourceStorageCapabilities> {
-    return this.request<SourceStorageCapabilities>('/capabilities');
+  async getCapabilities(): Promise<SourceControlCapabilities> {
+    return this.request<SourceControlCapabilities>('/capabilities');
   }
 
   async readFile(input: SourceFileRef): Promise<SourceFile | null> {
@@ -112,7 +112,7 @@ export class GitHubSourceStorageProvider implements SourceStorageProvider {
     });
 
     if (!res.ok) {
-      let detail = `GitHub source storage request failed: ${res.status}`;
+      let detail = `GitHub source control request failed: ${res.status}`;
       try {
         const body = (await res.json()) as BrokerErrorResponse;
         detail = body.detail ?? detail;
@@ -126,10 +126,10 @@ export class GitHubSourceStorageProvider implements SourceStorageProvider {
   }
 }
 
-export function createGitHubSourceStorageProviderFromEnv(
+export function createGitHubSourceControlProviderFromEnv(
   env: Record<string, string | undefined> = process.env,
   defaults?: { pathPrefix?: string },
-): GitHubSourceStorageProvider | undefined {
+): GitHubSourceControlProvider | undefined {
   if (env.MASTRA_SOURCE_PROVIDER !== 'github') return undefined;
 
   const endpoint = env.MASTRA_SOURCE_PROVIDER_ENDPOINT ?? env.MASTRA_SHARED_API_URL ?? env.MASTRA_CLOUD_API_ENDPOINT;
@@ -137,7 +137,7 @@ export function createGitHubSourceStorageProviderFromEnv(
 
   if (!endpoint || !token) return undefined;
 
-  return new GitHubSourceStorageProvider({
+  return new GitHubSourceControlProvider({
     endpoint: normalizeApiEndpoint(endpoint),
     token,
     pathPrefix: env.MASTRA_SOURCE_STORAGE_PATH_PREFIX ?? defaults?.pathPrefix,

--- a/packages/core/src/storage/providers/github.ts
+++ b/packages/core/src/storage/providers/github.ts
@@ -1,0 +1,153 @@
+import type {
+  SourceChangeRequestInput,
+  SourceChangeRequestResult,
+  SourceFile,
+  SourceFileHistoryEntry,
+  SourceFileHistoryInput,
+  SourceFileListEntry,
+  SourceFileListInput,
+  SourceFileRef,
+  SourceStorageCapabilities,
+  SourceStorageProvider,
+  SourceWriteFileInput,
+  SourceWriteResult,
+} from '../source-storage';
+
+export type GitHubSourceStorageProviderConfig = {
+  endpoint: string;
+  token: string;
+  pathPrefix?: string;
+  fetch?: typeof fetch;
+};
+
+type BrokerErrorResponse = {
+  type?: string;
+  detail?: string;
+};
+
+export class GitHubSourceStorageProvider implements SourceStorageProvider {
+  readonly id = 'github';
+  readonly displayName = 'GitHub';
+
+  private readonly endpoint: string;
+  private readonly token: string;
+  private readonly pathPrefix: string;
+  private readonly fetch: typeof fetch;
+
+  constructor(config: GitHubSourceStorageProviderConfig) {
+    this.endpoint = normalizeApiEndpoint(config.endpoint);
+    this.token = config.token;
+    this.pathPrefix = normalizePathPrefix(config.pathPrefix ?? 'mastra/editor');
+    this.fetch = config.fetch ?? fetch;
+  }
+
+  async getCapabilities(): Promise<SourceStorageCapabilities> {
+    return this.request<SourceStorageCapabilities>('/capabilities');
+  }
+
+  async readFile(input: SourceFileRef): Promise<SourceFile | null> {
+    const path = this.sourcePath(input.path);
+    const query = new URLSearchParams({ path });
+    if (input.ref) query.set('ref', input.ref);
+
+    const result = await this.request<SourceFile | null>(`/files?${query.toString()}`);
+    return result ? { ...result, path: input.path } : null;
+  }
+
+  async writeFile(input: SourceWriteFileInput): Promise<SourceWriteResult> {
+    const result = await this.request<SourceWriteResult>('/files', {
+      method: 'POST',
+      body: JSON.stringify({ ...input, path: this.sourcePath(input.path) }),
+    });
+
+    return { ...result, path: input.path };
+  }
+
+  async listFileHistory(input: SourceFileHistoryInput): Promise<SourceFileHistoryEntry[]> {
+    const query = new URLSearchParams({ path: this.sourcePath(input.path) });
+    if (input.ref) query.set('ref', input.ref);
+    if (input.limit) query.set('limit', String(input.limit));
+
+    return this.request<SourceFileHistoryEntry[]>(`/files/history?${query.toString()}`);
+  }
+
+  async listFiles(input: SourceFileListInput): Promise<SourceFileListEntry[]> {
+    const query = new URLSearchParams({ path: this.sourcePath(input.path) });
+    if (input.ref) query.set('ref', input.ref);
+
+    const files = await this.request<SourceFileListEntry[]>(`/files/list?${query.toString()}`);
+    return files.map(file => ({ ...file, path: this.unsourcePath(file.path) }));
+  }
+
+  async openChangeRequest(input: SourceChangeRequestInput): Promise<SourceChangeRequestResult> {
+    return this.request<SourceChangeRequestResult>('/change-requests', {
+      method: 'POST',
+      body: JSON.stringify({
+        ...input,
+        files: input.files.map(file => ({ ...file, path: this.sourcePath(file.path) })),
+      }),
+    });
+  }
+
+  private sourcePath(path: string): string {
+    const normalizedPath = path.replace(/^\/+/, '');
+    return this.pathPrefix ? `${this.pathPrefix}/${normalizedPath}` : normalizedPath;
+  }
+
+  private unsourcePath(path: string): string {
+    const normalizedPath = path.replace(/^\/+/, '');
+    const prefix = this.pathPrefix ? `${this.pathPrefix}/` : '';
+    return prefix && normalizedPath.startsWith(prefix) ? normalizedPath.slice(prefix.length) : normalizedPath;
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await this.fetch(`${this.endpoint}/v1/server/source-storage/github${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...init?.headers,
+      },
+    });
+
+    if (!res.ok) {
+      let detail = `GitHub source storage request failed: ${res.status}`;
+      try {
+        const body = (await res.json()) as BrokerErrorResponse;
+        detail = body.detail ?? detail;
+      } catch {
+        // Ignore non-JSON error bodies.
+      }
+      throw new Error(detail);
+    }
+
+    return (await res.json()) as T;
+  }
+}
+
+export function createGitHubSourceStorageProviderFromEnv(
+  env: Record<string, string | undefined> = process.env,
+  defaults?: { pathPrefix?: string },
+): GitHubSourceStorageProvider | undefined {
+  if (env.MASTRA_SOURCE_PROVIDER !== 'github') return undefined;
+
+  const endpoint = env.MASTRA_SOURCE_PROVIDER_ENDPOINT ?? env.MASTRA_SHARED_API_URL ?? env.MASTRA_CLOUD_API_ENDPOINT;
+  const token = env.MASTRA_PLATFORM_ACCESS_TOKEN ?? env.MASTRA_CLOUD_ACCESS_TOKEN;
+
+  if (!endpoint || !token) return undefined;
+
+  return new GitHubSourceStorageProvider({
+    endpoint: normalizeApiEndpoint(endpoint),
+    token,
+    pathPrefix: env.MASTRA_SOURCE_STORAGE_PATH_PREFIX ?? defaults?.pathPrefix,
+  });
+}
+
+function normalizeApiEndpoint(endpoint: string): string {
+  return endpoint.replace(/\/v1\/?$/, '').replace(/\/$/, '');
+}
+
+function normalizePathPrefix(pathPrefix: string): string {
+  return pathPrefix.replace(/^\/+|\/+$/g, '');
+}

--- a/packages/core/src/storage/providers/github.ts
+++ b/packages/core/src/storage/providers/github.ts
@@ -90,12 +90,12 @@ export class GitHubSourceStorageProvider implements SourceStorageProvider {
   }
 
   private sourcePath(path: string): string {
-    const normalizedPath = path.replace(/^\/+/, '');
+    const normalizedPath = stripLeadingSlashes(path);
     return this.pathPrefix ? `${this.pathPrefix}/${normalizedPath}` : normalizedPath;
   }
 
   private unsourcePath(path: string): string {
-    const normalizedPath = path.replace(/^\/+/, '');
+    const normalizedPath = stripLeadingSlashes(path);
     const prefix = this.pathPrefix ? `${this.pathPrefix}/` : '';
     return prefix && normalizedPath.startsWith(prefix) ? normalizedPath.slice(prefix.length) : normalizedPath;
   }
@@ -145,9 +145,23 @@ export function createGitHubSourceStorageProviderFromEnv(
 }
 
 function normalizeApiEndpoint(endpoint: string): string {
-  return endpoint.replace(/\/v1\/?$/, '').replace(/\/$/, '');
+  const trimmed = stripTrailingSlashes(endpoint);
+  const withoutV1 = trimmed.endsWith('/v1') ? trimmed.slice(0, -3) : trimmed;
+  return stripTrailingSlashes(withoutV1);
 }
 
 function normalizePathPrefix(pathPrefix: string): string {
-  return pathPrefix.replace(/^\/+|\/+$/g, '');
+  return stripTrailingSlashes(stripLeadingSlashes(pathPrefix));
+}
+
+function stripLeadingSlashes(value: string): string {
+  let start = 0;
+  while (start < value.length && value[start] === '/') start += 1;
+  return value.slice(start);
+}
+
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
 }

--- a/packages/core/src/storage/providers/index.ts
+++ b/packages/core/src/storage/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './github';

--- a/packages/core/src/storage/source-control.ts
+++ b/packages/core/src/storage/source-control.ts
@@ -1,16 +1,16 @@
-export type SourceStorageCapabilityReason =
+export type SourceControlCapabilityReason =
   | 'provider-not-configured'
   | 'provider-unavailable'
   | 'missing-permissions'
   | 'project-not-linked'
   | 'unsupported';
 
-export type SourceStorageCapabilities = {
+export type SourceControlCapabilities = {
   canRead: boolean;
   canWrite: boolean;
   canListHistory: boolean;
   canOpenChangeRequest: boolean;
-  reason?: SourceStorageCapabilityReason | string;
+  reason?: SourceControlCapabilityReason | string;
 };
 
 export type SourceProviderInfo = {
@@ -82,18 +82,18 @@ export type SourceChangeRequestResult = {
   ref?: string;
 };
 
-export const SOURCE_STORAGE_AGENTS_DIR = 'agents';
+export const SOURCE_CONTROL_AGENTS_DIR = 'agents';
 
-export function getSourceStorageEntityFilePath(directory: string, entityId: string): string {
+export function getSourceControlEntityFilePath(directory: string, entityId: string): string {
   return `${directory}/${encodeURIComponent(entityId)}.json`;
 }
 
 export function getSourceAgentFilePath(agentId: string): string {
-  return getSourceStorageEntityFilePath(SOURCE_STORAGE_AGENTS_DIR, agentId);
+  return getSourceControlEntityFilePath(SOURCE_CONTROL_AGENTS_DIR, agentId);
 }
 
-export interface SourceStorageProvider extends SourceProviderInfo {
-  getCapabilities(): Promise<SourceStorageCapabilities>;
+export interface SourceControlProvider extends SourceProviderInfo {
+  getCapabilities(): Promise<SourceControlCapabilities>;
   readFile(input: SourceFileRef): Promise<SourceFile | null>;
   writeFile(input: SourceWriteFileInput): Promise<SourceWriteResult>;
   listFileHistory(input: SourceFileHistoryInput): Promise<SourceFileHistoryEntry[]>;
@@ -103,7 +103,7 @@ export interface SourceStorageProvider extends SourceProviderInfo {
 
 export type EditorSourceCapabilities = {
   source: 'db' | 'code';
-  storage: 'database' | 'filesystem' | 'source-provider' | 'unavailable';
+  storage: 'database' | 'filesystem' | 'source-control' | 'unavailable';
   provider?: SourceProviderInfo;
   canSave: boolean;
   canOpenChangeRequest: boolean;

--- a/packages/core/src/storage/source-storage.ts
+++ b/packages/core/src/storage/source-storage.ts
@@ -73,6 +73,7 @@ export type SourceChangeRequestInput = {
   files: SourceWriteFileInput[];
   baseRef?: string;
   headRef?: string;
+  inspectOnly?: boolean;
 };
 
 export type SourceChangeRequestResult = {

--- a/packages/core/src/storage/source-storage.ts
+++ b/packages/core/src/storage/source-storage.ts
@@ -1,0 +1,110 @@
+export type SourceStorageCapabilityReason =
+  | 'provider-not-configured'
+  | 'provider-unavailable'
+  | 'missing-permissions'
+  | 'project-not-linked'
+  | 'unsupported';
+
+export type SourceStorageCapabilities = {
+  canRead: boolean;
+  canWrite: boolean;
+  canListHistory: boolean;
+  canOpenChangeRequest: boolean;
+  reason?: SourceStorageCapabilityReason | string;
+};
+
+export type SourceProviderInfo = {
+  id: string;
+  displayName: string;
+};
+
+export type SourceFileRef = {
+  path: string;
+  ref?: string;
+};
+
+export type SourceFile = SourceFileRef & {
+  content: string;
+  sha?: string;
+};
+
+export type SourceWriteFileInput = SourceFileRef & {
+  content: string;
+  message?: string;
+  expectedSha?: string;
+};
+
+export type SourceWriteResult = {
+  path: string;
+  ref?: string;
+  sha?: string;
+  commitSha?: string;
+  url?: string;
+};
+
+export type SourceFileHistoryInput = {
+  path: string;
+  ref?: string;
+  limit?: number;
+};
+
+export type SourceFileListInput = {
+  path: string;
+  ref?: string;
+};
+
+export type SourceFileListEntry = {
+  path: string;
+  sha?: string;
+};
+
+export type SourceFileHistoryEntry = {
+  id: string;
+  ref?: string;
+  message?: string;
+  author?: string;
+  createdAt: string;
+  url?: string;
+};
+
+export type SourceChangeRequestInput = {
+  title: string;
+  body?: string;
+  files: SourceWriteFileInput[];
+  baseRef?: string;
+  headRef?: string;
+};
+
+export type SourceChangeRequestResult = {
+  id?: string | number;
+  url: string;
+  ref?: string;
+};
+
+export const SOURCE_STORAGE_AGENTS_DIR = 'agents';
+
+export function getSourceStorageEntityFilePath(directory: string, entityId: string): string {
+  return `${directory}/${encodeURIComponent(entityId)}.json`;
+}
+
+export function getSourceAgentFilePath(agentId: string): string {
+  return getSourceStorageEntityFilePath(SOURCE_STORAGE_AGENTS_DIR, agentId);
+}
+
+export interface SourceStorageProvider extends SourceProviderInfo {
+  getCapabilities(): Promise<SourceStorageCapabilities>;
+  readFile(input: SourceFileRef): Promise<SourceFile | null>;
+  writeFile(input: SourceWriteFileInput): Promise<SourceWriteResult>;
+  listFileHistory(input: SourceFileHistoryInput): Promise<SourceFileHistoryEntry[]>;
+  listFiles?(input: SourceFileListInput): Promise<SourceFileListEntry[]>;
+  openChangeRequest?(input: SourceChangeRequestInput): Promise<SourceChangeRequestResult>;
+}
+
+export type EditorSourceCapabilities = {
+  source: 'db' | 'code';
+  storage: 'database' | 'filesystem' | 'source-provider' | 'unavailable';
+  provider?: SourceProviderInfo;
+  canSave: boolean;
+  canOpenChangeRequest: boolean;
+  unavailableReason?: string;
+};

--- a/packages/core/src/tools/provider-tools-ordering.e2e.test.ts
+++ b/packages/core/src/tools/provider-tools-ordering.e2e.test.ts
@@ -9,7 +9,7 @@ import { createTool } from '../tools';
 
 setupDummyApiKeys(getLLMTestMode(), ['anthropic']);
 
-const mock = createGatewayMock({ exactMatch: true });
+const mock = createGatewayMock();
 beforeAll(() => mock.start());
 afterAll(() => mock.saveAndStop());
 

--- a/packages/editor/src/editor.test.ts
+++ b/packages/editor/src/editor.test.ts
@@ -4,7 +4,7 @@ import { Mastra } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { createScorer } from '@mastra/core/evals';
 import { RequestContext } from '@mastra/core/request-context';
-import { InMemoryStore, type SourceStorageProvider } from '@mastra/core/storage';
+import { InMemoryStore, type SourceControlProvider } from '@mastra/core/storage';
 import { createTool } from '@mastra/core/tools';
 import { createWorkflow, createStep } from '@mastra/core/workflows';
 import { MastraEditor } from './index';
@@ -37,7 +37,7 @@ const sampleStoredAgent2 = {
   model: { provider: 'anthropic', name: 'claude-3' },
 };
 
-function createMockSourceProvider(): SourceStorageProvider & { writes: Array<{ path: string; content: string }> } {
+function createMockSourceProvider(): SourceControlProvider & { writes: Array<{ path: string; content: string }> } {
   const writes: Array<{ path: string; content: string }> = [];
   const files = new Map<string, string>();
 
@@ -63,10 +63,10 @@ function createMockSourceProvider(): SourceStorageProvider & { writes: Array<{ p
   };
 }
 
-describe('code source storage', () => {
+describe('code source control', () => {
   it('routes code-source agent storage through the configured source provider', async () => {
     const provider = createMockSourceProvider();
-    const editor = new MastraEditor({ source: 'code', sourceStorageProvider: provider });
+    const editor = new MastraEditor({ source: 'code', sourceControlProvider: provider });
     const codeAgent = new Agent({
       id: 'source-backed-agent',
       name: 'Source Backed Agent',
@@ -85,7 +85,7 @@ describe('code source storage', () => {
       changeMessage: 'Update instructions',
     });
 
-    expect(editor.getSourceStorageProvider()).toBe(provider);
+    expect(editor.getSourceControlProvider()).toBe(provider);
     expect(provider.writes).toEqual([
       {
         path: 'agents/source-backed-agent.json',
@@ -96,7 +96,7 @@ describe('code source storage', () => {
 
   it('keeps filesystem-backed editor domains when agents use a source provider', async () => {
     const provider = createMockSourceProvider();
-    const editor = new MastraEditor({ source: 'code', sourceStorageProvider: provider });
+    const editor = new MastraEditor({ source: 'code', sourceControlProvider: provider });
     const defaultStorage = new InMemoryStore();
 
     const mastra = new Mastra({ storage: defaultStorage, editor, agents: {} });
@@ -109,7 +109,7 @@ describe('code source storage', () => {
 
   it('returns the existing code-defined agent when creating a stored override', async () => {
     const provider = createMockSourceProvider();
-    const editor = new MastraEditor({ source: 'code', sourceStorageProvider: provider });
+    const editor = new MastraEditor({ source: 'code', sourceControlProvider: provider });
     const codeAgent = new Agent({
       id: 'descriptions-only-agent',
       name: 'Descriptions Only Agent',

--- a/packages/editor/src/editor.test.ts
+++ b/packages/editor/src/editor.test.ts
@@ -4,7 +4,7 @@ import { Mastra } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { createScorer } from '@mastra/core/evals';
 import { RequestContext } from '@mastra/core/request-context';
-import { InMemoryStore } from '@mastra/core/storage';
+import { InMemoryStore, type SourceStorageProvider } from '@mastra/core/storage';
 import { createTool } from '@mastra/core/tools';
 import { createWorkflow, createStep } from '@mastra/core/workflows';
 import { MastraEditor } from './index';
@@ -36,6 +36,95 @@ const sampleStoredAgent2 = {
   instructions: 'You are another test assistant',
   model: { provider: 'anthropic', name: 'claude-3' },
 };
+
+function createMockSourceProvider(): SourceStorageProvider & { writes: Array<{ path: string; content: string }> } {
+  const writes: Array<{ path: string; content: string }> = [];
+  const files = new Map<string, string>();
+
+  return {
+    id: 'mock-source',
+    displayName: 'Mock Source',
+    writes,
+    async getCapabilities() {
+      return { canRead: true, canWrite: true, canListHistory: false, canOpenChangeRequest: false };
+    },
+    async readFile({ path }) {
+      const content = files.get(path);
+      return content === undefined ? null : { path, content };
+    },
+    async writeFile({ path, content }) {
+      files.set(path, content);
+      writes.push({ path, content });
+      return { path, commitSha: `commit-${writes.length}` };
+    },
+    async listFileHistory() {
+      return [];
+    },
+  };
+}
+
+describe('code source storage', () => {
+  it('routes code-source agent storage through the configured source provider', async () => {
+    const provider = createMockSourceProvider();
+    const editor = new MastraEditor({ source: 'code', sourceStorageProvider: provider });
+    const codeAgent = new Agent({
+      id: 'source-backed-agent',
+      name: 'Source Backed Agent',
+      instructions: 'Code instructions',
+      model: 'openai/gpt-4o',
+    });
+
+    const mastra = new Mastra({ storage: new InMemoryStore(), editor, agents: { codeAgent } });
+    const agentsStore = await mastra.getStorage()?.getStore('agents');
+
+    await agentsStore?.createVersion({
+      agentId: 'source-backed-agent',
+      versionNumber: 1,
+      instructions: 'Stored instructions',
+      model: { provider: 'openai', name: 'gpt-4' },
+      changeMessage: 'Update instructions',
+    });
+
+    expect(editor.getSourceStorageProvider()).toBe(provider);
+    expect(provider.writes).toEqual([
+      {
+        path: 'agents/source-backed-agent.json',
+        content: `${JSON.stringify({ instructions: 'Stored instructions' })}\n`,
+      },
+    ]);
+  });
+
+  it('returns the existing code-defined agent when creating a stored override', async () => {
+    const provider = createMockSourceProvider();
+    const editor = new MastraEditor({ source: 'code', sourceStorageProvider: provider });
+    const codeAgent = new Agent({
+      id: 'descriptions-only-agent',
+      name: 'Descriptions Only Agent',
+      instructions: 'Code-owned instructions',
+      model: 'openai/gpt-4o',
+      tools: { weatherTool: mockTool },
+      editor: { tools: { description: true } },
+    });
+
+    const mastra = new Mastra({ storage: new InMemoryStore(), editor, agents: { codeAgent } });
+
+    // Creating a partial override (descriptions-only) must not try to hydrate it
+    // as a standalone agent — Agent requires a model. It should persist the
+    // override and return the existing code-defined runtime agent.
+    const created = await editor.agent.create({
+      id: 'descriptions-only-agent',
+      tools: { weatherTool: { description: 'Editable description' } },
+    } as any);
+
+    expect(created).toBe(mastra.getAgentById('descriptions-only-agent'));
+    expect(provider.writes).toEqual([
+      {
+        path: 'agents/descriptions-only-agent.json',
+        content: `${JSON.stringify({ tools: { weatherTool: { description: 'Editable description' } } })}\n`,
+      },
+    ]);
+  });
+});
 
 describe('agent.clearCache', () => {
   it('should clear agent from Editor cache and Mastra registry when agentId is provided', async () => {

--- a/packages/editor/src/editor.test.ts
+++ b/packages/editor/src/editor.test.ts
@@ -94,6 +94,19 @@ describe('code source storage', () => {
     ]);
   });
 
+  it('keeps filesystem-backed editor domains when agents use a source provider', async () => {
+    const provider = createMockSourceProvider();
+    const editor = new MastraEditor({ source: 'code', sourceStorageProvider: provider });
+    const defaultStorage = new InMemoryStore();
+
+    const mastra = new Mastra({ storage: defaultStorage, editor, agents: {} });
+    const storage = mastra.getStorage();
+
+    await expect(storage?.getStore('agents')).resolves.not.toBe(defaultStorage.stores.agents);
+    await expect(storage?.getStore('promptBlocks')).resolves.not.toBe(defaultStorage.stores.promptBlocks);
+    await expect(storage?.getStore('workflows')).resolves.toBe(defaultStorage.stores.workflows);
+  });
+
   it('returns the existing code-defined agent when creating a stored override', async () => {
     const provider = createMockSourceProvider();
     const editor = new MastraEditor({ source: 'code', sourceStorageProvider: provider });

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -11,8 +11,13 @@ import type {
 import type { IMastraLogger as Logger } from '@mastra/core/logger';
 import { BUILT_IN_PROCESSOR_PROVIDERS } from '@mastra/core/processor-provider';
 import type { ProcessorProvider } from '@mastra/core/processor-provider';
-import { FilesystemStore, MastraCompositeStore } from '@mastra/core/storage';
-import type { BlobStore } from '@mastra/core/storage';
+import {
+  createGitHubSourceStorageProviderFromEnv,
+  FilesystemStore,
+  MastraCompositeStore,
+  SourceAgentsStorage,
+} from '@mastra/core/storage';
+import type { BlobStore, SourceStorageProvider } from '@mastra/core/storage';
 import { UnknownToolProviderError } from '@mastra/core/tool-provider';
 import type { ToolProvider } from '@mastra/core/tool-provider';
 
@@ -60,6 +65,7 @@ export class MastraEditor implements IMastraEditor {
   private __processorProviders: Record<string, ProcessorProvider>;
   private __source?: 'code' | 'db';
   private __codePath: string;
+  private __sourceStorageProvider?: SourceStorageProvider;
   private readonly __builderConfig?: AgentBuilderOptions;
   private __builderInstance?: IAgentBuilder;
   private __builderResolved = false;
@@ -108,6 +114,9 @@ export class MastraEditor implements IMastraEditor {
     this.__processorProviders = { ...BUILT_IN_PROCESSOR_PROVIDERS, ...config?.processorProviders };
     this.__source = config?.source;
     this.__codePath = config?.codePath ?? './mastra/editor';
+    this.__sourceStorageProvider =
+      config?.sourceStorageProvider ??
+      createGitHubSourceStorageProviderFromEnv(process.env, { pathPrefix: this.__codePath });
 
     // Built-in providers are always registered first, then merged with user-provided ones
     this.__filesystems = new Map<string, FilesystemProvider>();
@@ -158,23 +167,39 @@ export class MastraEditor implements IMastraEditor {
       this.__logger = mastra.getLogger();
     }
 
-    // Code mode routes editor-owned domains to a FilesystemStore at `codePath`.
-    // If app storage already exists, keep it as the default for non-editor domains
-    // and overlay filesystem storage for editor saves.
+    // Code source routes editor-owned domains away from the app's primary storage.
+    // Local development uses a FilesystemStore at `codePath`; hosted/self-hosted
+    // environments can provide a source provider so agent overrides are persisted
+    // through source-control operations instead of a local container filesystem.
     if (this.__source === 'code') {
-      const filesystemStore = new FilesystemStore({ dir: this.__codePath });
       const existingStorage = mastra.getStorage();
 
-      if (existingStorage) {
+      if (this.__sourceStorageProvider) {
+        const sourceAgentsStore = new SourceAgentsStorage({
+          provider: this.__sourceStorageProvider,
+        });
+
         mastra.setStorage(
           new MastraCompositeStore({
-            id: `${existingStorage.id}-with-editor-filesystem`,
-            default: existingStorage,
-            editor: filesystemStore,
+            id: `${existingStorage?.id ?? 'mastra'}-with-editor-source-provider`,
+            ...(existingStorage ? { default: existingStorage } : {}),
+            domains: { agents: sourceAgentsStore },
           }),
         );
       } else {
-        mastra.setStorage(filesystemStore);
+        const filesystemStore = new FilesystemStore({ dir: this.__codePath });
+
+        if (existingStorage) {
+          mastra.setStorage(
+            new MastraCompositeStore({
+              id: `${existingStorage.id}-with-editor-filesystem`,
+              default: existingStorage,
+              editor: filesystemStore,
+            }),
+          );
+        } else {
+          mastra.setStorage(filesystemStore);
+        }
       }
     }
 
@@ -379,6 +404,11 @@ export class MastraEditor implements IMastraEditor {
   /** Returns the editor's configured source, or undefined if unset. */
   getSource(): 'code' | 'db' | undefined {
     return this.__source;
+  }
+
+  /** Returns the configured source storage provider, if any. */
+  getSourceStorageProvider(): SourceStorageProvider | undefined {
+    return this.__sourceStorageProvider;
   }
 
   /** Registered tool providers */

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -12,12 +12,12 @@ import type { IMastraLogger as Logger } from '@mastra/core/logger';
 import { BUILT_IN_PROCESSOR_PROVIDERS } from '@mastra/core/processor-provider';
 import type { ProcessorProvider } from '@mastra/core/processor-provider';
 import {
-  createGitHubSourceStorageProviderFromEnv,
+  createGitHubSourceControlProviderFromEnv,
   FilesystemStore,
   MastraCompositeStore,
-  SourceAgentsStorage,
+  SourceAgentsSourceControl,
 } from '@mastra/core/storage';
-import type { BlobStore, SourceStorageProvider } from '@mastra/core/storage';
+import type { BlobStore, SourceControlProvider } from '@mastra/core/storage';
 import { UnknownToolProviderError } from '@mastra/core/tool-provider';
 import type { ToolProvider } from '@mastra/core/tool-provider';
 
@@ -65,7 +65,7 @@ export class MastraEditor implements IMastraEditor {
   private __processorProviders: Record<string, ProcessorProvider>;
   private __source?: 'code' | 'db';
   private __codePath: string;
-  private __sourceStorageProvider?: SourceStorageProvider;
+  private __sourceControlProvider?: SourceControlProvider;
   private readonly __builderConfig?: AgentBuilderOptions;
   private __builderInstance?: IAgentBuilder;
   private __builderResolved = false;
@@ -114,9 +114,9 @@ export class MastraEditor implements IMastraEditor {
     this.__processorProviders = { ...BUILT_IN_PROCESSOR_PROVIDERS, ...config?.processorProviders };
     this.__source = config?.source;
     this.__codePath = config?.codePath ?? './mastra/editor';
-    this.__sourceStorageProvider =
-      config?.sourceStorageProvider ??
-      createGitHubSourceStorageProviderFromEnv(process.env, { pathPrefix: this.__codePath });
+    this.__sourceControlProvider =
+      config?.sourceControlProvider ??
+      createGitHubSourceControlProviderFromEnv(process.env, { pathPrefix: this.__codePath });
 
     // Built-in providers are always registered first, then merged with user-provided ones
     this.__filesystems = new Map<string, FilesystemProvider>();
@@ -174,15 +174,15 @@ export class MastraEditor implements IMastraEditor {
     if (this.__source === 'code') {
       const existingStorage = mastra.getStorage();
 
-      if (this.__sourceStorageProvider) {
-        const sourceAgentsStore = new SourceAgentsStorage({
-          provider: this.__sourceStorageProvider,
+      if (this.__sourceControlProvider) {
+        const sourceAgentsStore = new SourceAgentsSourceControl({
+          provider: this.__sourceControlProvider,
         });
         const filesystemStore = new FilesystemStore({ dir: this.__codePath });
 
         mastra.setStorage(
           new MastraCompositeStore({
-            id: `${existingStorage?.id ?? 'mastra'}-with-editor-source-provider`,
+            id: `${existingStorage?.id ?? 'mastra'}-with-editor-source-control`,
             ...(existingStorage ? { default: existingStorage } : {}),
             editor: filesystemStore,
             domains: { agents: sourceAgentsStore },
@@ -408,9 +408,9 @@ export class MastraEditor implements IMastraEditor {
     return this.__source;
   }
 
-  /** Returns the configured source storage provider, if any. */
-  getSourceStorageProvider(): SourceStorageProvider | undefined {
-    return this.__sourceStorageProvider;
+  /** Returns the configured source control provider, if any. */
+  getSourceControlProvider(): SourceControlProvider | undefined {
+    return this.__sourceControlProvider;
   }
 
   /** Registered tool providers */

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -178,11 +178,13 @@ export class MastraEditor implements IMastraEditor {
         const sourceAgentsStore = new SourceAgentsStorage({
           provider: this.__sourceStorageProvider,
         });
+        const filesystemStore = new FilesystemStore({ dir: this.__codePath });
 
         mastra.setStorage(
           new MastraCompositeStore({
             id: `${existingStorage?.id ?? 'mastra'}-with-editor-source-provider`,
             ...(existingStorage ? { default: existingStorage } : {}),
+            editor: filesystemStore,
             domains: { agents: sourceAgentsStore },
           }),
         );

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -221,7 +221,30 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
     // Ensure the workspace referenced by the agent exists in stored workspaces
     await this.ensureStoredWorkspace(finalInput.workspace as StorageWorkspaceRef | undefined);
 
+    // When creating a stored override for an agent that is already defined in
+    // code, the stored snapshot is an intentionally partial override (e.g.
+    // descriptions-only agents carry no instructions/model/name). Hydrating it
+    // as a standalone agent would fail because Agent requires a model. Persist
+    // the override and return the existing code-defined runtime agent instead.
+    const existingCodeAgent = this.getCodeDefinedAgent(finalInput.id);
+    if (existingCodeAgent) {
+      const adapter = await this.getStorageAdapter();
+      await adapter.create(finalInput);
+      this._cache.set(finalInput.id, existingCodeAgent);
+      return existingCodeAgent;
+    }
+
     return super.create(finalInput);
+  }
+
+  private getCodeDefinedAgent(id: string): Agent | undefined {
+    let agent: Agent | undefined;
+    try {
+      agent = this.mastra?.getAgentById(id);
+    } catch {
+      return undefined;
+    }
+    return agent?.source === 'code' ? agent : undefined;
   }
 
   /**
@@ -955,14 +978,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
     // When a stored config is an override for a code agent, adding it would create a
     // duplicate entry under a different key (agent.id vs config key), causing the list
     // endpoint to show the agent as "stored" instead of "code".
-    const existingCodeAgent = (() => {
-      try {
-        return this.mastra?.getAgentById(storedAgent.id);
-      } catch {
-        return undefined;
-      }
-    })();
-    if (!existingCodeAgent || existingCodeAgent.source !== 'code') {
+    if (!this.getCodeDefinedAgent(storedAgent.id)) {
       this.mastra?.addAgent(agent, storedAgent.id, { source: 'stored' });
     }
     this.logger?.debug(`[createAgentFromStoredConfig] Successfully created agent "${storedAgent.id}"`);


### PR DESCRIPTION
## Summary
- Add source storage contracts and source-provider capability types
- Add GitHub source provider client and source-backed agent storage adapter
- Wire editor agent storage selection so code-source agents can use provider-backed storage

## Test plan
- pnpm --filter @mastra/editor test -- src/editor.test.ts src/editor-libsql.integration.test.ts src/editor-integration-tools.test.ts src/editor-workspace-reconciliation.test.ts
- pnpm build:core

Stack: PR 1 of 4 in the Mastra code-source stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the editor able to save and version agent configurations in source-controlled files (e.g., GitHub) instead of only local files or DB, so changes can be reviewed and tracked like code.

## Overview

First PR in a multi-part code-source stack: introduces provider-agnostic source-storage contracts, a GitHub provider, and a source-backed agent storage adapter; wires the editor to optionally use provider-backed storage for code-mode agent overrides; and adds tests and robustness/fallback behavior.

## Key Changes

- Core contracts
  - packages/core/src/storage/source-storage.ts
    - Adds SourceStorageProvider interface, capability/reason modeling, SourceFile/Write/History/List/ChangeRequest shapes, SOURCE_STORAGE_AGENTS_DIR, and helpers getSourceStorageEntityFilePath / getSourceAgentFilePath.

- Source-backed storage implementation
  - packages/core/src/storage/domains/agents/source.ts
    - Adds SourceAgentsStorage: hybrid provider + in-memory storage with discovery, lazy hydration, CRUD, versioning, mapping provider history → AgentVersion, snapshot filtering by editor ownership, deterministic stable-stringify, provider-version bookkeeping, transient-retry behavior, and provider-capability enforcement.

- Provider implementation
  - packages/core/src/storage/providers/github.ts
    - Adds GitHubSourceStorageProvider and createGitHubSourceStorageProviderFromEnv; normalizes endpoints/path-prefix handling, performs broker-authenticated requests, translates source paths, and surfaces descriptive errors.

- Editor integration
  - packages/editor/src/index.ts
    - MastraEditor accepts optional sourceStorageProvider in config (or auto-creates GitHub provider from env + codePath), exposes getSourceStorageProvider(), and when source: 'code' mounts SourceAgentsStorage via MastraCompositeStore while retaining a filesystem store for editor files.
  - packages/editor/src/namespaces/agent.ts
    - Creating a stored override for an existing code-defined agent persists the snapshot via the provider but continues using the original code-defined Agent instance; hydration registers stored agents only if no code-defined agent exists.

- Types & API surface
  - packages/core/src/editor/types.ts
    - Adds MastraEditorConfig.sourceStorageProvider?: SourceStorageProvider and IMastraEditor.getSourceStorageProvider?().
  - packages/core/src/storage/base.ts
    - StorageMastraRef gains optional listAgents?: () => Record<...> for discovery.
  - packages/core/src/server/types.ts
    - Introduces ApiRouteHandler type and updates ApiRoute.createHandler to return Promise<ApiRouteHandler> to avoid leaking Hono handler types.
  - Re-exports added:
    - packages/core/src/storage/domains/agents/index.ts: export * from './source';
    - packages/core/src/storage/index.ts: export * from './source-storage'; export * from './providers';
    - packages/core/src/storage/providers/index.ts: export * from './github';

- Filesystem/versioning helper
  - packages/core/src/storage/filesystem-versioned.ts
    - Uses getSourceStorageEntityFilePath for per-entity JSON filenames.

## Tests

- packages/core/src/storage/domains/agents/source.test.ts
  - Large suite covering snapshot persistence, filtered field writes (code vs storage-only), lazy hydration, cold-start discovery, provider history → versions mapping, create/createVersion failure semantics, retries on transient provider failures, and capability enforcement for read/write.

- packages/core/src/storage/providers/github.test.ts
  - Verifies network routing through broker, Authorization header, endpoints/payload shapes, history/list/read/write behaviors, and env-based factory.

- packages/editor/src/editor.test.ts
  - Verifies editor wiring: MastraEditor configured with a source provider writes expected agent file paths/payloads, partial/description-only overrides persist without creating standalone runtime agents, and editor filesystem domains remain filesystem-backed.

## Notable robustness and review-driven fixes

- Persist provider-backed snapshots before mutating in-memory state to avoid inconsistent in-memory changes on provider failure.
- Retry provider read/list/history on transient failures.
- Keep filesystem editor-domain fallback even when using a hosted/source provider.
- Avoid regex-based path-prefix trimming; use explicit trimming/normalization.
- Ensure failed provider writes do not leave in-memory versions behind.

## Changeset / Documentation

- .changeset/code-source-01-core-storage.md documents the new source-backed storage primitives and editor configuration for `@mastra/core` and `@mastra/editor`.

## Impact & Migration Notes

- Adds a provider-agnostic source-storage surface with a GitHub provider as the initial implementation.
- Editor consumers can opt into source-backed persistence by passing sourceStorageProvider or via env-based GitHub factory.
- Code-defined agent ownership rules continue to control which fields are persisted to source files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->