### PR TITLE
docs(agents): add signal providers concept page and tutorial

### DIFF
--- a/docs/src/content/en/docs/agents/code-mode.mdx
+++ b/docs/src/content/en/docs/agents/code-mode.mdx
@@ -7,6 +7,8 @@ packages:
 
 # Code mode
 
+**Added in:** `@mastra/core@1.38.0`
+
 :::experimental
 
 This feature is in alpha. Breaking changes may occur without a major version bump until the API is stable.

--- a/docs/src/content/en/docs/agents/signal-providers.mdx
+++ b/docs/src/content/en/docs/agents/signal-providers.mdx
@@ -22,22 +22,22 @@ A signal provider monitors an external source, such as GitHub, Slack, continuous
 Use a signal provider when an external system produces events that an agent should react to, and you want Mastra to manage the subscription bookkeeping for you.
 
 - The source emits events tied to a resource a thread cares about, such as a pull request, a channel, or a build.
-- You want a single place that tracks which threads are watching which external resources.
+- You want one place that tracks which threads watch which external resources.
 - You want to receive events by polling, by webhook, or both.
 
-If you only need to push a one-off event into a thread, call [`agent.sendNotificationSignal()`](/docs/agents/signals#notification-signals) directly instead.
+If you only need to push a one-off event into a thread, call [`agent.sendNotificationSignal()`](/reference/agents/agent#sendnotificationsignalnotification-options) directly instead.
 
-## How it works
+## How signal providers work
 
 A signal provider is the producing side of the [signals](/docs/agents/signals) system. It brings external events into a thread, while the signal APIs control how the thread consumes them.
 
 A signal provider combines three capabilities:
 
-- **Subscription tracking.** The `SignalProvider` base class keeps an in-memory registry mapping each agent thread to the external resources it watches.
-- **Ingestion.** You override `poll()` for pull-based sources or `handleWebhook()` for push-based sources.
-- **Delivery.** When an event matches a subscription, you call the protected `notify()` helper, which forwards a notification signal to the connected agent's thread.
+- **Subscription tracking:** The `SignalProvider` base class keeps an in-memory registry that maps each agent thread to the external resources it watches.
+- **Ingestion:** You override `poll()` for pull-based sources or `handleWebhook()` for push-based sources.
+- **Delivery:** When an event matches a subscription, call the protected `notify()` helper to forward a notification signal to the connected agent's thread.
 
-You register a provider by passing it to the agent. The agent connects the provider, starts polling if a `pollInterval` is set, and merges any processors or tools the provider exposes. A provider implements only the hooks its source needs.
+Register a provider by passing it to an agent. The agent connects the provider, starts polling if a `pollInterval` is set, and merges any processors or tools the provider exposes.
 
 ```typescript title="src/mastra/agents/support-agent.ts"
 import { Agent } from '@mastra/core/agent'
@@ -58,32 +58,35 @@ Notification delivery requires a storage adapter with notification support, such
 
 ## Quickstart
 
-A minimal provider implements the abstract `id` field and one ingestion hook. The following provider polls a build-status endpoint and emits a notification for each subscribed pipeline that failed.
+The following example demonstrates a polling provider that watches CI pipelines and emits a notification when a subscribed pipeline fails.
 
 ```typescript title="src/mastra/signals/ci-signals.ts"
 import { SignalProvider } from '@mastra/core/signals'
-import type { SignalSubscription } from '@mastra/core/signals'
+import type { SignalProviderTarget, SignalSubscription } from '@mastra/core/signals'
 
 type BuildStatus = {
   id: string
   status: 'passed' | 'failed'
 }
 
-async function fetchBuildStatus(pipeline: string): Promise<BuildStatus> {
-  const response = await fetch(`https://ci.example.com/builds/${pipeline}`)
-  if (!response.ok) {
-    throw new Error(`Failed to fetch build status for ${pipeline}`)
-  }
+const builds = new Map<string, BuildStatus>([
+  ['acme-app-main', { id: 'build_123', status: 'failed' }],
+])
 
-  return response.json() as Promise<BuildStatus>
+async function fetchBuildStatus(pipeline: string): Promise<BuildStatus> {
+  return builds.get(pipeline) ?? { id: 'build_unknown', status: 'passed' }
 }
 
 export class CiSignals extends SignalProvider<'ci-signals'> {
   readonly id = 'ci-signals' as const
   readonly pollInterval = 30_000
 
-  watch(thread: { resourceId: string; threadId: string }, pipeline: string) {
-    return this.subscribe(thread, pipeline)
+  watch(target: SignalProviderTarget, pipeline: string) {
+    return this.subscribe(target, pipeline)
+  }
+
+  unwatch(target: SignalProviderTarget, pipeline: string) {
+    return this.unsubscribe(target, pipeline)
   }
 
   async poll(subscriptions: SignalSubscription[]) {
@@ -126,51 +129,17 @@ export const supportAgent = new Agent({
 ciSignals.watch({ resourceId: 'user_123', threadId: 'thread_456' }, 'acme-app-main')
 ```
 
-The framework calls `poll()` on the `pollInterval` with all active subscriptions. It skips a cycle when there are no subscriptions and never overlaps cycles, so a slow `poll()` doesn't run concurrently with itself.
-
-## Track subscriptions
-
-A subscription links one agent thread to one external resource. The `externalResourceId` is a provider-specific string you choose, such as `"github:mastra-ai/mastra#123"` or `"slack:C0B01RW7A4T"`.
-
-The base class exposes protected methods to manage and query subscriptions. Expose them through your own public API so callers, tools, or processors can subscribe threads.
-
-```typescript title="src/mastra/signals/ci-signals.ts"
-import { SignalProvider } from '@mastra/core/signals'
-import type { SignalProviderTarget, SignalSubscription } from '@mastra/core/signals'
-
-export class CiSignals extends SignalProvider<'ci-signals'> {
-  readonly id = 'ci-signals' as const
-  readonly pollInterval = 30_000
-
-  watch(target: SignalProviderTarget, pipeline: string) {
-    return this.subscribe(target, pipeline)
-  }
-
-  unwatch(target: SignalProviderTarget, pipeline: string) {
-    return this.unsubscribe(target, pipeline)
-  }
-
-  async poll(subscriptions: SignalSubscription[]) {
-    // ...
-  }
-}
-```
-
-```typescript title="src/mastra/index.ts"
-const ci = new CiSignals()
-
-ci.watch({ resourceId: 'user_123', threadId: 'thread_456' }, 'acme/app:main')
-```
-
-The registry is indexed for lookup by resource and by thread. It's in-memory and per-process, so it doesn't survive a restart. If your provider needs durable subscriptions, persist them yourself, for example on thread metadata, and rehydrate the registry in `start()`.
+Mastra calls `poll()` on the `pollInterval` with all active subscriptions. It skips a cycle when there are no subscriptions and doesn't overlap cycles, so a slow `poll()` doesn't run concurrently with itself.
 
 :::note
-Visit [SignalProvider reference](/reference/signals/signal-provider#subscription-tracking) for the full subscription method list.
+For a complete polling-provider build with notification storage, agent registration, thread subscription, and testing, follow [Building a signal provider](/guides/guide/signal-provider).
 :::
 
-## Receive events by webhook
+## Polling and webhook providers
 
-For push-based sources, override `handleWebhook()`. Parse the incoming payload, match it to subscriptions with `getSubscriptionsForResource()`, and call `notify()` for each match.
+Use polling when the external source doesn't push events to your app. Set `pollInterval` and override `poll(subscriptions)`. Each subscription includes the thread target and the external resource id to inspect.
+
+Use webhooks when the external source can call your app. Override `handleWebhook(request)`, parse the payload, find matching subscriptions, and call `notify()` for each match.
 
 ```typescript title="src/mastra/signals/ci-signals.ts"
 import { SignalProvider } from '@mastra/core/signals'
@@ -201,112 +170,15 @@ export class CiSignals extends SignalProvider<'ci-signals'> {
 }
 ```
 
-`handleWebhook()` is a method on the provider, not an auto-mounted HTTP route. Invoke it from your own endpoint, passing the request body, headers, and any route params.
+`handleWebhook()` is a provider method, not an auto-mounted HTTP route. Invoke it from your own endpoint, passing the request body, headers, and any route params.
 
-```typescript title="src/api/ci-webhook.ts"
-import { ci } from '../mastra/signals/ci-signals' // your provider instance
+:::note
+Visit [`SignalProvider` reference](/reference/signals/signal-provider) for subscription, polling, lifecycle, and `notify()` details. For the complete notification payload shape, including deduplication and coalescing fields, visit [`Agent.sendNotificationSignal()` reference](/reference/agents/agent#sendnotificationsignalnotification-options).
+:::
 
-const result = await ci.handleWebhook({
-  body: await request.json(),
-  headers: Object.fromEntries(request.headers),
-})
+## Built-in webhook provider
 
-return Response.json(result.body, { status: result.status ?? 200 })
-```
-
-A provider can support both delivery modes. Leave `pollInterval` undefined for a webhook-only provider, or set it to also poll as a fallback.
-
-## Send notifications
-
-Call the protected `notify()` helper to push a notification signal into a thread. It's a convenience wrapper around the connected agent's `sendNotificationSignal()`, so the notification flows through the agent's [delivery policy](/docs/agents/signals#notification-signals) and lands in the thread's inbox.
-
-```typescript
-await this.notify(
-  {
-    source: this.id,
-    kind: 'mention',
-    priority: 'medium',
-    summary: 'New mention in #support',
-    dedupeKey: `${this.id}:channel-42:msg-987`,
-    coalesceKey: `${this.id}:channel-42`,
-  },
-  { resourceId: sub.resourceId, threadId: sub.threadId },
-)
-```
-
-Use `dedupeKey` to avoid storing the same event twice, and `coalesceKey` to group related events into a single summary. `notify()` throws if the provider isn't connected to an agent, which only happens if it was never passed to `Agent({ signals: [...] })`.
-
-## Add processors and tools
-
-A provider can extend agent execution by returning processors and tools. The agent registers them automatically when the provider is connected. Implement only the hooks you need.
-
-- `getInputProcessors()` and `getOutputProcessors()` return [processors](/docs/agents/processors) the agent runs during execution, for example to inject a subscription hint.
-- `getTools()` returns agent-callable tools, for example `subscribe` and `unsubscribe` commands the model can invoke.
-
-A common pattern is to make the provider its own processor by implementing `processInputStep()` on the class and returning `[this]` from the getter, as the [GitHub provider](#real-world-example) does.
-
-```typescript title="src/mastra/signals/ci-signals.ts"
-import { SignalProvider } from '@mastra/core/signals'
-import { createTool } from '@mastra/core/tools'
-import { z } from 'zod'
-
-export class CiSignals extends SignalProvider<'ci-signals'> {
-  readonly id = 'ci-signals' as const
-
-  getTools() {
-    return {
-      watch_pipeline: createTool({
-        id: 'watch_pipeline',
-        description: 'Subscribe this thread to a CI pipeline.',
-        inputSchema: z.object({ pipeline: z.string() }),
-        execute: async ({ context, runtimeContext }) => {
-          this.subscribe(
-            {
-              resourceId: runtimeContext.get('resourceId') as string,
-              threadId: runtimeContext.get('threadId') as string,
-            },
-            context.pipeline,
-          )
-          return { watching: context.pipeline }
-        },
-      }),
-    }
-  }
-}
-```
-
-Not every signal provider needs processors or tools. A provider that only polls an API and pushes notifications can omit all three hooks.
-
-## Run setup and cleanup
-
-Override the lifecycle hooks for async setup and teardown.
-
-- `start()` runs once after the provider connects to the agent. Use it for setup that needs the agent or Mastra instance, such as rehydrating durable subscriptions.
-- `stop()` runs on shutdown. The default implementation stops polling and clears the registry. Override it to release your own resources, and call `super.stop()`.
-
-```typescript title="src/mastra/signals/ci-signals.ts"
-export class CiSignals extends SignalProvider<'ci-signals'> {
-  readonly id = 'ci-signals' as const
-
-  async start() {
-    const saved = await loadSubscriptionsFromStorage()
-    for (const sub of saved) {
-      this.subscribe({ resourceId: sub.resourceId, threadId: sub.threadId }, sub.resource)
-    }
-  }
-
-  stop() {
-    closeMyConnection()
-    super.stop()
-  }
-}
-```
-
-You can also call `startPolling()` and `stopPolling()` manually, for example to pause polling during maintenance and resume it later.
-
-## Use the built-in webhook provider
-
-For generic webhook sources, use `WebhookSignalProvider` instead of writing a subclass. Configure it with a function that extracts a resource id from the payload, and an optional function that builds the notification.
+For generic webhook sources, use [`WebhookSignalProvider`](/reference/signals/webhook-signal-provider) instead of writing a subclass. Configure it with a function that extracts a resource id from the payload, and an optional function that builds the notification.
 
 ```typescript title="src/mastra/index.ts"
 import { Agent } from '@mastra/core/agent'
@@ -333,19 +205,17 @@ export const supportAgent = new Agent({
 webhooks.subscribeThread({ resourceId: 'user_123', threadId: 'thread_456' }, 'acme/app')
 ```
 
-When a webhook arrives, call `webhooks.handleWebhook({ body, headers })` from your route. The provider matches the extracted resource id against its subscriptions and notifies each matching thread. Without a `buildNotification` function, it emits a default `webhook-event` notification.
+When a webhook arrives, call `webhooks.handleWebhook({ body, headers })` from your route. The provider matches the extracted resource id against its subscriptions and notifies each matching thread.
 
-## Real-world example
+## Advanced provider capabilities
 
-The `@mastra/github-signals` package is a full signal provider that watches GitHub pull requests and notifies threads about new comments, review state, CI status, and merges. It's a useful reference for building your own provider because it exercises every hook on the base class:
+A provider can support more than event ingestion. Add only the capabilities your source needs.
 
-- **Polling.** It sets a configurable poll interval (default five minutes) and overrides `poll()` to fetch each subscribed pull request and emit notifications only when the observed state changes.
-- **Processors.** It returns `[this]` from `getInputProcessors()` and `getOutputProcessors()` and implements `processInputStep()` / `processOutputStep()` on the class to detect subscribe and unsubscribe intent during a run.
-- **Tools and signal factories.** It exposes a `static signals` object with `subscribeToPR()` and `unsubscribeFromPR()` helpers that build reactive signals the agent can act on.
-- **Durable subscriptions.** It persists subscriptions on thread metadata through a thread store and rehydrates them, so subscriptions survive a restart rather than living only in the in-memory registry.
-- **Lifecycle overrides.** It overrides `connect()` and `__registerMastra()` (always calling `super`) to capture the agent and Mastra instance it needs for syncing.
+- **Durable subscriptions:** The base registry is in-memory and per-process. Persist subscriptions yourself when they must survive a restart, then rehydrate them in [`start()`](/reference/signals/signal-provider#start).
+- **Lifecycle hooks:** Override [`start()`](/reference/signals/signal-provider#start) for async setup and [`stop()`](/reference/signals/signal-provider#stop) for cleanup. Call `super.stop()` when overriding `stop()` so the base provider can stop polling and clear its registry.
+- **Processors and tools:** Return processors from [`getInputProcessors()`](/reference/signals/signal-provider#getinputprocessors) or [`getOutputProcessors()`](/reference/signals/signal-provider#getoutputprocessors), and return agent-callable tools from [`getTools()`](/reference/signals/signal-provider#gettools).
 
-Register it the same way as any provider:
+The `@mastra/github-signals` package is a production signal provider that watches GitHub pull requests and notifies threads about comments, review state, continuous integration status, and merges. Use it as a reference for polling, durable subscriptions, tools, processors, and lifecycle hooks.
 
 ```typescript title="src/mastra/agents/dev-agent.ts"
 import { Agent } from '@mastra/core/agent'
@@ -365,7 +235,5 @@ export const devAgent = new Agent({
 - [Guide: Building a signal provider](/guides/guide/signal-provider)
 - [Signals](/docs/agents/signals)
 - [Notification signals](/docs/agents/signals#notification-signals)
-- [Processors](/docs/agents/processors)
-- [Using tools](/docs/agents/using-tools)
 - [`SignalProvider` reference](/reference/signals/signal-provider)
 - [`WebhookSignalProvider` reference](/reference/signals/webhook-signal-provider)

--- a/docs/src/content/en/docs/agents/signal-providers.mdx
+++ b/docs/src/content/en/docs/agents/signal-providers.mdx
@@ -7,6 +7,8 @@ packages:
 
 # Signal providers
 
+**Added in:** `@mastra/core@1.39.0`
+
 :::experimental
 
 This feature is in alpha. Breaking changes may occur without a major version bump until the API is stable.

--- a/docs/src/content/en/docs/agents/signal-providers.mdx
+++ b/docs/src/content/en/docs/agents/signal-providers.mdx
@@ -15,9 +15,7 @@ This feature is in alpha. Breaking changes may occur without a major version bum
 
 :::
 
-A signal provider monitors an external source, such as GitHub, Slack, CI, or your own API, and pushes [notification signals](/docs/agents/signals#notification-signals) into the agent threads that subscribed to it.
-
-[Signals](/docs/agents/signals) are how a thread receives input. A signal provider is the producing side of that system: it brings external events into a thread, while the signal APIs control how the thread consumes them. Each provider extends the `SignalProvider` base class, which supplies a subscription registry, a polling loop, a webhook entry point, and a helper to send notifications back into a thread. A provider implements only the hooks its source needs.
+A signal provider monitors an external source, such as GitHub, Slack, continuous integration (CI), or your own API, and pushes [notification signals](/docs/agents/signals#notification-signals) into subscribed agent threads.
 
 ## When to use a signal provider
 
@@ -31,13 +29,15 @@ If you only need to push a one-off event into a thread, call [`agent.sendNotific
 
 ## How it works
 
+A signal provider is the producing side of the [signals](/docs/agents/signals) system. It brings external events into a thread, while the signal APIs control how the thread consumes them.
+
 A signal provider combines three capabilities:
 
-- **Subscription tracking.** The base class keeps an in-memory registry mapping each agent thread to the external resources it watches.
+- **Subscription tracking.** The `SignalProvider` base class keeps an in-memory registry mapping each agent thread to the external resources it watches.
 - **Ingestion.** You override `poll()` for pull-based sources or `handleWebhook()` for push-based sources.
 - **Delivery.** When an event matches a subscription, you call the protected `notify()` helper, which forwards a notification signal to the connected agent's thread.
 
-You register a provider by passing it to the agent. The agent connects the provider, starts polling if a `pollInterval` is set, and merges any processors or tools the provider exposes.
+You register a provider by passing it to the agent. The agent connects the provider, starts polling if a `pollInterval` is set, and merges any processors or tools the provider exposes. A provider implements only the hooks its source needs.
 
 ```typescript title="src/mastra/agents/support-agent.ts"
 import { Agent } from '@mastra/core/agent'

--- a/docs/src/content/en/docs/agents/signal-providers.mdx
+++ b/docs/src/content/en/docs/agents/signal-providers.mdx
@@ -89,7 +89,7 @@ export class CiSignals extends SignalProvider<'ci-signals'> {
 }
 ```
 
-The framework calls `poll()` on the `pollInterval` with all active subscriptions. It skips a cycle when there are no subscriptions and never overlaps cycles, so a slow `poll()` does not run concurrently with itself.
+The framework calls `poll()` on the `pollInterval` with all active subscriptions. It skips a cycle when there are no subscriptions and never overlaps cycles, so a slow `poll()` doesn't run concurrently with itself.
 
 ## Track subscriptions
 
@@ -125,20 +125,11 @@ const ci = new CiSignals()
 ci.watch({ resourceId: 'user_123', threadId: 'thread_456' }, 'acme/app:main')
 ```
 
-The registry is indexed for lookup by resource and by thread. The protected methods available to subclasses are:
+The registry is indexed for lookup by resource and by thread. It's in-memory and per-process, so it doesn't survive a restart. If your provider needs durable subscriptions, persist them yourself, for example on thread metadata, and rehydrate the registry in `start()`.
 
-| Method | Description |
-| - | - |
-| `subscribe(target, externalResourceId, metadata?)` | Link a thread to a resource. Merges metadata if the subscription already exists. |
-| `unsubscribe(target, externalResourceId)` | Remove a single subscription. Returns `true` if one existed. |
-| `unsubscribeAll(target)` | Remove every subscription for a thread. Returns the number removed. |
-| `getSubscriptions()` | All active subscriptions for the provider. |
-| `getSubscriptionsForResource(externalResourceId)` | All threads watching a resource. |
-| `getSubscriptionsForThread(target)` | All resources a thread watches. |
-| `hasSubscription(target, externalResourceId)` | Whether a thread watches a resource. |
-| `subscriptionCount` | Total number of active subscriptions. |
-
-The registry is in-memory and per-process. It does not survive a restart. If your provider needs durable subscriptions, persist them yourself, for example on thread metadata, and rehydrate the registry in `start()`.
+:::note
+Visit [SignalProvider reference](/reference/signals/signal-provider#subscription-tracking) for the full subscription method list.
+:::
 
 ## Receive events by webhook
 
@@ -190,7 +181,7 @@ A provider can support both delivery modes. Leave `pollInterval` undefined for a
 
 ## Send notifications
 
-Call the protected `notify()` helper to push a notification signal into a thread. It is a convenience wrapper around the connected agent's `sendNotificationSignal()`, so the notification flows through the agent's [delivery policy](/docs/agents/signals#notification-signals) and lands in the thread's inbox.
+Call the protected `notify()` helper to push a notification signal into a thread. It's a convenience wrapper around the connected agent's `sendNotificationSignal()`, so the notification flows through the agent's [delivery policy](/docs/agents/signals#notification-signals) and lands in the thread's inbox.
 
 ```typescript
 await this.notify(
@@ -206,7 +197,7 @@ await this.notify(
 )
 ```
 
-Use `dedupeKey` to avoid storing the same event twice, and `coalesceKey` to group related events into a single summary. `notify()` throws if the provider is not connected to an agent, which only happens if it was never passed to `Agent({ signals: [...] })`.
+Use `dedupeKey` to avoid storing the same event twice, and `coalesceKey` to group related events into a single summary. `notify()` throws if the provider isn't connected to an agent, which only happens if it was never passed to `Agent({ signals: [...] })`.
 
 ## Add processors and tools
 
@@ -309,7 +300,7 @@ When a webhook arrives, call `webhooks.handleWebhook({ body, headers })` from yo
 
 ## Real-world example
 
-The `@mastra/github-signals` package is a full signal provider that watches GitHub pull requests and notifies threads about new comments, review state, CI status, and merges. It is a useful reference for building your own provider because it exercises every hook on the base class:
+The `@mastra/github-signals` package is a full signal provider that watches GitHub pull requests and notifies threads about new comments, review state, CI status, and merges. It's a useful reference for building your own provider because it exercises every hook on the base class:
 
 - **Polling.** It sets a configurable poll interval (default five minutes) and overrides `poll()` to fetch each subscribed pull request and emit notifications only when the observed state changes.
 - **Processors.** It returns `[this]` from `getInputProcessors()` and `getOutputProcessors()` and implements `processInputStep()` / `processOutputStep()` on the class to detect subscribe and unsubscribe intent during a run.

--- a/docs/src/content/en/docs/agents/signal-providers.mdx
+++ b/docs/src/content/en/docs/agents/signal-providers.mdx
@@ -58,15 +58,33 @@ Notification delivery requires a storage adapter with notification support, such
 
 ## Quickstart
 
-A minimal provider implements the abstract `id` field and one ingestion hook. The following provider polls an external API and emits a notification for each subscribed resource that changed.
+A minimal provider implements the abstract `id` field and one ingestion hook. The following provider polls a build-status endpoint and emits a notification for each subscribed pipeline that failed.
 
 ```typescript title="src/mastra/signals/ci-signals.ts"
 import { SignalProvider } from '@mastra/core/signals'
 import type { SignalSubscription } from '@mastra/core/signals'
 
+type BuildStatus = {
+  id: string
+  status: 'passed' | 'failed'
+}
+
+async function fetchBuildStatus(pipeline: string): Promise<BuildStatus> {
+  const response = await fetch(`https://ci.example.com/builds/${pipeline}`)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch build status for ${pipeline}`)
+  }
+
+  return response.json() as Promise<BuildStatus>
+}
+
 export class CiSignals extends SignalProvider<'ci-signals'> {
   readonly id = 'ci-signals' as const
-  readonly pollInterval = 30_000 // poll every 30 seconds
+  readonly pollInterval = 30_000
+
+  watch(thread: { resourceId: string; threadId: string }, pipeline: string) {
+    return this.subscribe(thread, pipeline)
+  }
 
   async poll(subscriptions: SignalSubscription[]) {
     for (const sub of subscriptions) {
@@ -87,6 +105,25 @@ export class CiSignals extends SignalProvider<'ci-signals'> {
     }
   }
 }
+```
+
+Register the provider with an agent and subscribe a thread to the pipeline you want to watch.
+
+```typescript title="src/mastra/agents/support-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { CiSignals } from '../signals/ci-signals'
+
+export const ciSignals = new CiSignals()
+
+export const supportAgent = new Agent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: 'Help the user triage CI updates.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  signals: [ciSignals],
+})
+
+ciSignals.watch({ resourceId: 'user_123', threadId: 'thread_456' }, 'acme-app-main')
 ```
 
 The framework calls `poll()` on the `pollInterval` with all active subscriptions. It skips a cycle when there are no subscriptions and never overlaps cycles, so a slow `poll()` doesn't run concurrently with itself.

--- a/docs/src/content/en/docs/agents/signal-providers.mdx
+++ b/docs/src/content/en/docs/agents/signal-providers.mdx
@@ -1,0 +1,341 @@
+---
+title: "Signal providers | Agents"
+description: "Learn what signal providers are and how to build one that monitors an external source and pushes notifications into agent threads."
+packages:
+  - "@mastra/core"
+---
+
+# Signal providers
+
+:::experimental
+
+This feature is in alpha. Breaking changes may occur without a major version bump until the API is stable.
+
+:::
+
+A signal provider monitors an external source, such as GitHub, Slack, CI, or your own API, and pushes [notification signals](/docs/agents/signals#notification-signals) into the agent threads that subscribed to it.
+
+[Signals](/docs/agents/signals) are how a thread receives input. A signal provider is the producing side of that system: it brings external events into a thread, while the signal APIs control how the thread consumes them. Each provider extends the `SignalProvider` base class, which supplies a subscription registry, a polling loop, a webhook entry point, and a helper to send notifications back into a thread. A provider implements only the hooks its source needs.
+
+## When to use a signal provider
+
+Use a signal provider when an external system produces events that an agent should react to, and you want Mastra to manage the subscription bookkeeping for you.
+
+- The source emits events tied to a resource a thread cares about, such as a pull request, a channel, or a build.
+- You want a single place that tracks which threads are watching which external resources.
+- You want to receive events by polling, by webhook, or both.
+
+If you only need to push a one-off event into a thread, call [`agent.sendNotificationSignal()`](/docs/agents/signals#notification-signals) directly instead.
+
+## How it works
+
+A signal provider combines three capabilities:
+
+- **Subscription tracking.** The base class keeps an in-memory registry mapping each agent thread to the external resources it watches.
+- **Ingestion.** You override `poll()` for pull-based sources or `handleWebhook()` for push-based sources.
+- **Delivery.** When an event matches a subscription, you call the protected `notify()` helper, which forwards a notification signal to the connected agent's thread.
+
+You register a provider by passing it to the agent. The agent connects the provider, starts polling if a `pollInterval` is set, and merges any processors or tools the provider exposes.
+
+```typescript title="src/mastra/agents/support-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { CiSignals } from '../signals/ci-signals'
+
+export const supportAgent = new Agent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: 'Help the user triage updates.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  signals: [new CiSignals()],
+})
+```
+
+:::note
+Notification delivery requires a storage adapter with notification support, such as [libSQL](/reference/storage/libsql), [PostgreSQL](/reference/storage/postgresql), or [MongoDB](/reference/storage/mongodb). Configure storage on the Mastra instance so `notify()` can store notification records.
+:::
+
+## Quickstart
+
+A minimal provider implements the abstract `id` field and one ingestion hook. The following provider polls an external API and emits a notification for each subscribed resource that changed.
+
+```typescript title="src/mastra/signals/ci-signals.ts"
+import { SignalProvider } from '@mastra/core/signals'
+import type { SignalSubscription } from '@mastra/core/signals'
+
+export class CiSignals extends SignalProvider<'ci-signals'> {
+  readonly id = 'ci-signals' as const
+  readonly pollInterval = 30_000 // poll every 30 seconds
+
+  async poll(subscriptions: SignalSubscription[]) {
+    for (const sub of subscriptions) {
+      const build = await fetchBuildStatus(sub.externalResourceId)
+      if (build.status !== 'failed') continue
+
+      await this.notify(
+        {
+          source: this.id,
+          kind: 'ci-status',
+          priority: 'high',
+          summary: `Build failed for ${sub.externalResourceId}`,
+          payload: build,
+          dedupeKey: `${this.id}:${sub.externalResourceId}:${build.id}`,
+        },
+        { resourceId: sub.resourceId, threadId: sub.threadId },
+      )
+    }
+  }
+}
+```
+
+The framework calls `poll()` on the `pollInterval` with all active subscriptions. It skips a cycle when there are no subscriptions and never overlaps cycles, so a slow `poll()` does not run concurrently with itself.
+
+## Track subscriptions
+
+A subscription links one agent thread to one external resource. The `externalResourceId` is a provider-specific string you choose, such as `"github:mastra-ai/mastra#123"` or `"slack:C0B01RW7A4T"`.
+
+The base class exposes protected methods to manage and query subscriptions. Expose them through your own public API so callers, tools, or processors can subscribe threads.
+
+```typescript title="src/mastra/signals/ci-signals.ts"
+import { SignalProvider } from '@mastra/core/signals'
+import type { SignalProviderTarget, SignalSubscription } from '@mastra/core/signals'
+
+export class CiSignals extends SignalProvider<'ci-signals'> {
+  readonly id = 'ci-signals' as const
+  readonly pollInterval = 30_000
+
+  watch(target: SignalProviderTarget, pipeline: string) {
+    return this.subscribe(target, pipeline)
+  }
+
+  unwatch(target: SignalProviderTarget, pipeline: string) {
+    return this.unsubscribe(target, pipeline)
+  }
+
+  async poll(subscriptions: SignalSubscription[]) {
+    // ...
+  }
+}
+```
+
+```typescript title="src/mastra/index.ts"
+const ci = new CiSignals()
+
+ci.watch({ resourceId: 'user_123', threadId: 'thread_456' }, 'acme/app:main')
+```
+
+The registry is indexed for lookup by resource and by thread. The protected methods available to subclasses are:
+
+| Method | Description |
+| - | - |
+| `subscribe(target, externalResourceId, metadata?)` | Link a thread to a resource. Merges metadata if the subscription already exists. |
+| `unsubscribe(target, externalResourceId)` | Remove a single subscription. Returns `true` if one existed. |
+| `unsubscribeAll(target)` | Remove every subscription for a thread. Returns the number removed. |
+| `getSubscriptions()` | All active subscriptions for the provider. |
+| `getSubscriptionsForResource(externalResourceId)` | All threads watching a resource. |
+| `getSubscriptionsForThread(target)` | All resources a thread watches. |
+| `hasSubscription(target, externalResourceId)` | Whether a thread watches a resource. |
+| `subscriptionCount` | Total number of active subscriptions. |
+
+The registry is in-memory and per-process. It does not survive a restart. If your provider needs durable subscriptions, persist them yourself, for example on thread metadata, and rehydrate the registry in `start()`.
+
+## Receive events by webhook
+
+For push-based sources, override `handleWebhook()`. Parse the incoming payload, match it to subscriptions with `getSubscriptionsForResource()`, and call `notify()` for each match.
+
+```typescript title="src/mastra/signals/ci-signals.ts"
+import { SignalProvider } from '@mastra/core/signals'
+import type { SignalProviderWebhookRequest } from '@mastra/core/signals'
+
+export class CiSignals extends SignalProvider<'ci-signals'> {
+  readonly id = 'ci-signals' as const
+
+  async handleWebhook(request: SignalProviderWebhookRequest) {
+    const payload = request.body as { pipeline: string; status: string }
+    const subscriptions = this.getSubscriptionsForResource(payload.pipeline)
+
+    for (const sub of subscriptions) {
+      await this.notify(
+        {
+          source: this.id,
+          kind: 'ci-status',
+          priority: 'high',
+          summary: `Build ${payload.status} for ${payload.pipeline}`,
+          payload,
+        },
+        { resourceId: sub.resourceId, threadId: sub.threadId },
+      )
+    }
+
+    return { status: 200, body: { matched: subscriptions.length } }
+  }
+}
+```
+
+`handleWebhook()` is a method on the provider, not an auto-mounted HTTP route. Invoke it from your own endpoint, passing the request body, headers, and any route params.
+
+```typescript title="src/api/ci-webhook.ts"
+import { ci } from '../mastra/signals/ci-signals' // your provider instance
+
+const result = await ci.handleWebhook({
+  body: await request.json(),
+  headers: Object.fromEntries(request.headers),
+})
+
+return Response.json(result.body, { status: result.status ?? 200 })
+```
+
+A provider can support both delivery modes. Leave `pollInterval` undefined for a webhook-only provider, or set it to also poll as a fallback.
+
+## Send notifications
+
+Call the protected `notify()` helper to push a notification signal into a thread. It is a convenience wrapper around the connected agent's `sendNotificationSignal()`, so the notification flows through the agent's [delivery policy](/docs/agents/signals#notification-signals) and lands in the thread's inbox.
+
+```typescript
+await this.notify(
+  {
+    source: this.id,
+    kind: 'mention',
+    priority: 'medium',
+    summary: 'New mention in #support',
+    dedupeKey: `${this.id}:channel-42:msg-987`,
+    coalesceKey: `${this.id}:channel-42`,
+  },
+  { resourceId: sub.resourceId, threadId: sub.threadId },
+)
+```
+
+Use `dedupeKey` to avoid storing the same event twice, and `coalesceKey` to group related events into a single summary. `notify()` throws if the provider is not connected to an agent, which only happens if it was never passed to `Agent({ signals: [...] })`.
+
+## Add processors and tools
+
+A provider can extend agent execution by returning processors and tools. The agent registers them automatically when the provider is connected. Implement only the hooks you need.
+
+- `getInputProcessors()` and `getOutputProcessors()` return [processors](/docs/agents/processors) the agent runs during execution, for example to inject a subscription hint.
+- `getTools()` returns agent-callable tools, for example `subscribe` and `unsubscribe` commands the model can invoke.
+
+A common pattern is to make the provider its own processor by implementing `processInputStep()` on the class and returning `[this]` from the getter, as the [GitHub provider](#real-world-example) does.
+
+```typescript title="src/mastra/signals/ci-signals.ts"
+import { SignalProvider } from '@mastra/core/signals'
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+export class CiSignals extends SignalProvider<'ci-signals'> {
+  readonly id = 'ci-signals' as const
+
+  getTools() {
+    return {
+      watch_pipeline: createTool({
+        id: 'watch_pipeline',
+        description: 'Subscribe this thread to a CI pipeline.',
+        inputSchema: z.object({ pipeline: z.string() }),
+        execute: async ({ context, runtimeContext }) => {
+          this.subscribe(
+            {
+              resourceId: runtimeContext.get('resourceId') as string,
+              threadId: runtimeContext.get('threadId') as string,
+            },
+            context.pipeline,
+          )
+          return { watching: context.pipeline }
+        },
+      }),
+    }
+  }
+}
+```
+
+Not every signal provider needs processors or tools. A provider that only polls an API and pushes notifications can omit all three hooks.
+
+## Run setup and cleanup
+
+Override the lifecycle hooks for async setup and teardown.
+
+- `start()` runs once after the provider connects to the agent. Use it for setup that needs the agent or Mastra instance, such as rehydrating durable subscriptions.
+- `stop()` runs on shutdown. The default implementation stops polling and clears the registry. Override it to release your own resources, and call `super.stop()`.
+
+```typescript title="src/mastra/signals/ci-signals.ts"
+export class CiSignals extends SignalProvider<'ci-signals'> {
+  readonly id = 'ci-signals' as const
+
+  async start() {
+    const saved = await loadSubscriptionsFromStorage()
+    for (const sub of saved) {
+      this.subscribe({ resourceId: sub.resourceId, threadId: sub.threadId }, sub.resource)
+    }
+  }
+
+  stop() {
+    closeMyConnection()
+    super.stop()
+  }
+}
+```
+
+You can also call `startPolling()` and `stopPolling()` manually, for example to pause polling during maintenance and resume it later.
+
+## Use the built-in webhook provider
+
+For generic webhook sources, use `WebhookSignalProvider` instead of writing a subclass. Configure it with a function that extracts a resource id from the payload, and an optional function that builds the notification.
+
+```typescript title="src/mastra/index.ts"
+import { Agent } from '@mastra/core/agent'
+import { WebhookSignalProvider } from '@mastra/core/signals'
+
+const webhooks = new WebhookSignalProvider({
+  extractResourceId: payload => (payload as { repository: string }).repository,
+  buildNotification: (payload, sub) => ({
+    source: 'ci',
+    kind: 'build-status',
+    priority: 'medium',
+    summary: `Build ${(payload as { status: string }).status} for ${sub.externalResourceId}`,
+  }),
+})
+
+export const supportAgent = new Agent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: 'Help the user triage updates.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  signals: [webhooks],
+})
+
+webhooks.subscribeThread({ resourceId: 'user_123', threadId: 'thread_456' }, 'acme/app')
+```
+
+When a webhook arrives, call `webhooks.handleWebhook({ body, headers })` from your route. The provider matches the extracted resource id against its subscriptions and notifies each matching thread. Without a `buildNotification` function, it emits a default `webhook-event` notification.
+
+## Real-world example
+
+The `@mastra/github-signals` package is a full signal provider that watches GitHub pull requests and notifies threads about new comments, review state, CI status, and merges. It is a useful reference for building your own provider because it exercises every hook on the base class:
+
+- **Polling.** It sets a configurable poll interval (default five minutes) and overrides `poll()` to fetch each subscribed pull request and emit notifications only when the observed state changes.
+- **Processors.** It returns `[this]` from `getInputProcessors()` and `getOutputProcessors()` and implements `processInputStep()` / `processOutputStep()` on the class to detect subscribe and unsubscribe intent during a run.
+- **Tools and signal factories.** It exposes a `static signals` object with `subscribeToPR()` and `unsubscribeFromPR()` helpers that build reactive signals the agent can act on.
+- **Durable subscriptions.** It persists subscriptions on thread metadata through a thread store and rehydrates them, so subscriptions survive a restart rather than living only in the in-memory registry.
+- **Lifecycle overrides.** It overrides `connect()` and `__registerMastra()` (always calling `super`) to capture the agent and Mastra instance it needs for syncing.
+
+Register it the same way as any provider:
+
+```typescript title="src/mastra/agents/dev-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { GithubSignals } from '@mastra/github-signals'
+
+export const devAgent = new Agent({
+  id: 'dev-agent',
+  name: 'Dev Agent',
+  instructions: 'Help triage pull request activity.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  signals: [new GithubSignals()],
+})
+```
+
+## Related
+
+- [Guide: Building a signal provider](/guides/guide/signal-provider)
+- [Signals](/docs/agents/signals)
+- [Notification signals](/docs/agents/signals#notification-signals)
+- [Processors](/docs/agents/processors)
+- [Using tools](/docs/agents/using-tools)
+- [`SignalProvider` reference](/reference/signals/signal-provider)
+- [`WebhookSignalProvider` reference](/reference/signals/webhook-signal-provider)

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -20,6 +20,12 @@ Signals are a way to interact with an agent through a thread. Instead of startin
 
 Use message APIs for user-authored input. Use `sendSignal()` for lower-level system context, such as background task notifications, policy reminders, or processor-generated context.
 
+## When to use signals
+
+Use signals when an agent thread needs new input or context outside the original `stream()` call. Signals are useful when users send follow-up messages while a run is active, when background systems need to add context to a thread, or when external events should wake, update, or notify the agent.
+
+Use `sendMessage()` and `queueMessage()` for user-authored input. Use `sendSignal()` for lower-level system context. Use `sendStateSignal()` for durable state lanes, and use `sendNotificationSignal()` when an external event should create a durable notification inbox record.
+
 ## Quickstart
 
 Create an agent, subscribe to a thread, then send a message to that thread. The subscription receives the active stream when the message wakes the agent or enters a running loop.
@@ -50,7 +56,9 @@ for await (const chunk of subscription.stream) {
 
 When the thread has a running agent stream, `sendMessage()` becomes new input inside that agent loop. When the thread is idle, Mastra starts a stream with the message as the first input.
 
-## Send a message now
+## Message input
+
+### Send a message now
 
 Use `sendMessage()` when the user expects the active agent to see the message immediately.
 
@@ -75,7 +83,7 @@ The model receives attributed messages as XML-wrapped user input:
 
 Messages without attributes are sent as plain user input.
 
-## Queue a message for the next turn
+### Queue a message for the next turn
 
 Use `queueMessage()` when a user sends a follow-up but the active model call should finish first. Mastra waits for the active run to complete, then starts a new run on the same thread.
 
@@ -88,7 +96,9 @@ agent.queueMessage('Also check whether the tests need updates.', {
 
 When the thread is idle, `queueMessage()` starts a run immediately. When the thread is active, it preserves turn order by starting a new run after the active run completes.
 
-## Control low-level signal behavior
+## Signal context
+
+### Control low-level signal behavior
 
 Use `sendSignal()` when you need to send system-generated context instead of user-authored input. For external events, use `type: 'notification'`. By default, Mastra delivers signals to active runs and wakes idle threads. Use `ifActive.behavior` and `ifIdle.behavior` to change that behavior.
 
@@ -116,7 +126,7 @@ Pass `ifIdle.streamOptions` when the idle wake-up stream needs options such as m
 Visit [`Agent.sendSignal()` reference](/reference/agents/agent#sendsignalsignal-options) for `ifActive`, `ifIdle`, branch attributes, and `streamOptions`.
 :::
 
-## Send notification context
+### Send notification context
 
 Signals have a semantic `type` and an LLM-facing `tagName`. Use `type` to describe the signal category. Use `tagName` to control the XML tag the model sees.
 
@@ -147,11 +157,11 @@ The model receives the signal as context like this:
 
 Use XML-safe `tagName` and attribute names. They can contain letters, numbers, underscores, periods, and hyphens. They must start with a letter or underscore.
 
-### Storage support
+#### Storage support
 
 Notification inbox storage is available in the storage adapters that support richer memory and signal workflows: [libSQL](/reference/storage/libsql), [PostgreSQL](/reference/storage/postgresql), and [MongoDB](/reference/storage/mongodb). These adapters expose notification records through `getStore('notifications')`.
 
-## Send processor context
+### Send processor context
 
 Processors can send reactive signals during a run. A processor should inspect the chat history, react to a specific trigger, and avoid sending the same context more than once.
 
@@ -197,7 +207,7 @@ Reactive signals default to `tagName: 'system-reminder'`, so the model receives 
 
 Awaiting `sendSignal()` preserves stream echo ordering when a subscribed thread is active.
 
-## Conditional attributes
+### Conditional attributes
 
 Use `ifActive.attributes` and `ifIdle.attributes` to tag input with context that depends on whether the agent is active or idle at delivery time. Top-level `attributes` always apply, and Mastra merges the selected branch's `attributes` into them when the input is accepted.
 
@@ -205,7 +215,9 @@ Use `ifActive.attributes` and `ifIdle.attributes` to tag input with context that
 Visit [`Agent.sendMessage()` reference](/reference/agents/agent#sendmessagemessage-options) and [`Agent.sendSignal()` reference](/reference/agents/agent#sendsignalsignal-options) for branch-specific attributes.
 :::
 
-## State signals
+## State and notification signals
+
+### State signals
 
 State signals expose named, thread-scoped context lanes. Use them for durable context that changes over time, such as browser state, editor state, or a background watcher result.
 
@@ -270,7 +282,7 @@ Mastra passes `lastSnapshot` and `deltasSinceSnapshot` into `computeStateSignal(
 
 The built-in browser context processor emits state under the `browser` id with snapshot and delta modes.
 
-## Notification signals
+### Notification signals
 
 Notification signals represent external events such as GitHub activity, email, Slack mentions, CI status, incidents, recordings, or direct messages. Use `agent.sendNotificationSignal()` when the event should create a durable inbox record.
 
@@ -322,7 +334,7 @@ Configure a delivery policy on the agent when some notifications should wait for
 Visit [`Agent` constructor reference](/reference/agents/agent#constructor-parameters) for `notifications.deliveryPolicy` and [`Mastra` class reference](/reference/core/mastra-class#constructor-parameters) for runtime notification dispatch configuration.
 :::
 
-### Notification inbox tool
+#### Notification inbox tool
 
 Use `createNotificationInboxTool()` to give agents one tool for inbox actions instead of many CRUD tools. Use `read` after a `<notification-summary>` signal when the agent needs the full records behind the summary. The notification contents are delivered as signals, not as normal tool output.
 
@@ -332,7 +344,9 @@ Visit [`createNotificationInboxTool()` reference](/reference/signals/create-noti
 
 `sendNotificationSignal()` requires a storage domain with `notifications` support. Use `sendSignal({ type: 'notification' })` only for lower-level notification-shaped context that should bypass inbox storage.
 
-## Compatibility
+## Compatibility and APIs
+
+### Compatibility
 
 Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `type: 'system-reminder'`. It normalizes them internally to the new category and tag shape:
 
@@ -345,7 +359,7 @@ Existing stored signal rows and older clients continue to load through the compa
 Visit [Agent signals reference](/reference/agents/agent#thread-signals) for the full message, signal, and subscription types.
 :::
 
-## Approve tool calls
+### Approve tool calls
 
 When a subscribed run pauses for tool approval, approve or decline the tool call with the subscription-native methods. The resumed chunks arrive through the existing thread subscription.
 
@@ -353,11 +367,11 @@ When a subscribed run pauses for tool approval, approve or decline the tool call
 Visit [`client.getAgent().sendToolApproval()` reference](/reference/client-js/agents#sendtoolapproval) and [server agent routes](/reference/server/routes#subscription-tool-approval-routes) for request and response shapes.
 :::
 
-## Use HTTP routes
+### Use HTTP routes
 
 If you call Mastra over HTTP directly, use `POST /api/agents/:agentId/send-message` for immediate messages and `POST /api/agents/:agentId/queue-message` for next-turn messages. For subscription-native tool approval, use `POST /api/agents/:agentId/send-tool-approval`. See [Server routes reference](/reference/server/routes#agent-message-routes) for request and response schemas.
 
-## Use the client SDK
+### Use the client SDK
 
 The JavaScript client exposes thread signal APIs. Use `subscribeToThread()` before sending thread input so the client can render the stream that wakes from, or receives, the input.
 
@@ -385,7 +399,7 @@ await subscription.processDataStream({
 
 Use `reconnect: true` for long-lived subscriptions. Visit [`client.getAgent().subscribeToThread()` reference](/reference/client-js/agents#subscribetothread) for reconnect options.
 
-## Keep custom SSE subscriptions alive
+### Keep custom SSE subscriptions alive
 
 If you expose your own Server-Sent Events (SSE) endpoint for thread subscriptions, send periodic heartbeat frames while the stream is idle. This keeps browsers, proxies, and load balancers from closing the connection before the next signal or model chunk arrives.
 

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -110,29 +110,11 @@ const result = agent.sendSignal(
 await result.persisted
 ```
 
-The behavior options are:
+Pass `ifIdle.streamOptions` when the idle wake-up stream needs options such as model settings, tools, or runtime context.
 
-- `ifActive.behavior: 'deliver'`: Add the signal or message to the running agent loop. This is the default.
-- `ifActive.behavior: 'persist'`: Save the signal or message to memory without adding it to the running loop.
-- `ifActive.behavior: 'discard'`: Ignore the signal or message while the thread is active.
-- `ifIdle.behavior: 'wake'`: Start a stream with the signal or message as the first input. This is the default.
-- `ifIdle.behavior: 'persist'`: Save the signal or message to memory without starting a stream.
-- `ifIdle.behavior: 'discard'`: Ignore the signal or message while the thread is idle.
-
-Pass `ifIdle.streamOptions` when the idle wake-up stream needs options such as model settings, tools, or runtime context. You don't need to repeat `memory.resource` or `memory.thread`; Mastra uses the top-level `resourceId` and `threadId` for the thread.
-
-```typescript title="src/mastra/signals.ts"
-agent.sendMessage('Continue with the next step.', {
-  resourceId: 'user_123',
-  threadId: 'thread_456',
-  ifIdle: {
-    behavior: 'wake',
-    streamOptions: {
-      maxSteps: 3,
-    },
-  },
-})
-```
+:::note
+Visit [`Agent.sendSignal()` reference](/reference/agents/agent#sendsignalsignal-options) for `ifActive`, `ifIdle`, branch attributes, and `streamOptions`.
+:::
 
 ## Send notification context
 
@@ -217,48 +199,17 @@ Awaiting `sendSignal()` preserves stream echo ordering when a subscribed thread 
 
 ## Conditional attributes
 
-Use `ifActive.attributes` and `ifIdle.attributes` to tag input with context that depends on whether the agent is active or idle at delivery time. Mastra resolves the correct branch when the input is accepted.
+Use `ifActive.attributes` and `ifIdle.attributes` to tag input with context that depends on whether the agent is active or idle at delivery time. Top-level `attributes` always apply, and Mastra merges the selected branch's `attributes` into them when the input is accepted.
 
-```typescript title="src/mastra/signals.ts"
-agent.sendMessage(
-  {
-    contents: 'Also cover the edge cases.',
-    attributes: { source: 'chat' },
-  },
-  {
-    resourceId: 'user_123',
-    threadId: 'thread_456',
-    ifActive: { attributes: { delivery: 'while-active' } },
-    ifIdle: { attributes: { delivery: 'new-message' } },
-  },
-)
-```
-
-When the agent is working, the model sees:
-
-```xml
-<user source="chat" delivery="while-active">Also cover the edge cases.</user>
-```
-
-When the agent is idle:
-
-```xml
-<user source="chat" delivery="new-message">Also cover the edge cases.</user>
-```
-
-Top-level `attributes` always apply. The selected branch's `attributes` are merged into them at delivery time. The `delivery` name shown above isn't a special Mastra API field. It's a custom attribute name used for this example. Add any attribute names that suit your use case.
+:::note
+Visit [`Agent.sendMessage()` reference](/reference/agents/agent#sendmessagemessage-options) and [`Agent.sendSignal()` reference](/reference/agents/agent#sendsignalsignal-options) for branch-specific attributes.
+:::
 
 ## State signals
 
 State signals expose named, thread-scoped context lanes. Use them for durable context that changes over time, such as browser state, editor state, or a background watcher result.
 
-Each state signal needs:
-
-- `id`: The state lane name, such as `browser`.
-- `cacheKey`: A producer-owned key for deduping the current state.
-- `mode`: `snapshot` for an authoritative state copy, or `delta` for a change event.
-
-Use `sendStateSignal()` when an external producer detects a state change.
+Use `sendStateSignal()` when an external producer detects a state change. Each state signal identifies a state lane, a producer-owned cache key, and whether the update is a snapshot or delta.
 
 ```typescript title="src/mastra/browser-watcher.ts"
 await agent.sendStateSignal(
@@ -280,16 +231,9 @@ await agent.sendStateSignal(
 )
 ```
 
-When Mastra accepts a state signal, it stores compact tracking metadata on the thread. The metadata records the lane's current `cacheKey`, current mode, version, last signal id, and last snapshot signal id. If a producer sends the same `cacheKey` and mode again while that state is still current, Mastra skips the duplicate.
+When Mastra accepts a state signal, it stores compact tracking metadata on the thread. If a producer sends the same `cacheKey` and mode again while that state is still current, Mastra skips the duplicate.
 
-State signal fields have separate roles:
-
-- `contents`: The representation the model reads.
-- `value`: The structured snapshot for `mode: 'snapshot'`.
-- `delta`: The structured change for `mode: 'delta'`.
-- `metadata.state`: The runtime tracking envelope with `id`, `mode`, `cacheKey`, `version`, and `threadId`.
-
-Use `computeStateSignal()` when a processor owns a state lane. Mastra calls it once per model input step after `processInputStep()`. If the processor omits `id`, Mastra uses the processor id as the state lane id. Set `stateId` when the public state lane should differ from the processor id.
+Use `computeStateSignal()` when a processor owns a state lane. Mastra calls it once per model input step after `processInputStep()`. Visit [`Agent.sendStateSignal()` reference](/reference/agents/agent#sendstatesignalstate-options) for state signal fields and return values.
 
 ```typescript title="src/mastra/processors/browser-state.ts"
 import type { ComputeStateSignalArgs, Processor } from '@mastra/core/processors'
@@ -335,7 +279,7 @@ Notification delivery has two phases. During ingress, `agent.sendNotificationSig
 The default delivery policy is priority-aware. Urgent notifications deliver immediately, while lower-priority notifications may be batched into summaries or wait until the thread is idle.
 
 :::note
-Visit [`Agent.sendNotificationSignal()` reference](/reference/agents/agent#sendnotificationsignalnotification-options) for notification fields, and [`Agent` constructor reference](/reference/agents/agent#constructor-parameters) for `notifications.deliveryPolicy` configuration.
+Visit [`Agent.sendNotificationSignal()` reference](/reference/agents/agent#sendnotificationsignalnotification-options) for notification fields, [`Agent` constructor reference](/reference/agents/agent#constructor-parameters) for `notifications.deliveryPolicy` configuration, and [`createNotificationInboxTool()` reference](/reference/signals/create-notification-inbox-tool) for inbox tool actions.
 :::
 
 ```typescript title="src/mastra/notifications.ts"
@@ -372,77 +316,21 @@ Notification summaries tell the model that inbox records are waiting:
 
 When Mastra emits a summary, it clears `summaryAt` and sets `summarySignalId` on each summarized record. The records stay pending and readable. When Mastra emits a full notification, it sets `deliveredSignalId` and marks the record `delivered`. If the inbox tool reads a notification first, it can inject the full notification signal and mark the record `seen`, which prevents duplicate full delivery.
 
-Configure a delivery policy on the agent when some notifications should wait for a different dispatch window or summary rollup.
+Configure a delivery policy on the agent when some notifications should wait for a different dispatch window or summary rollup. Enable scheduled dispatch at the Mastra level when deferred notifications and summary rollups should be delivered automatically.
 
-```typescript title="src/mastra/agents/support-agent.ts"
-export const supportAgent = new Agent({
-  id: 'support-agent',
-  name: 'Support Agent',
-  instructions: 'Help the user triage updates.',
-  model: '__GATEWAY_OPENAI_MODEL__',
-  notifications: {
-    deliveryPolicy: {
-      priorities: {
-        urgent: 'deliver',
-      },
-      decide: ({ record }) => {
-        if (record.priority === 'low') {
-          return {
-            action: 'summarize',
-            summaryAt: new Date(Date.now() + 30 * 60 * 1000),
-          }
-        }
-      },
-    },
-  },
-})
-```
-
-Enable scheduled dispatch at the Mastra level so deferred notifications and summary rollups are delivered through the existing workflow scheduler.
-
-```typescript title="src/mastra/index.ts"
-export const mastra = new Mastra({
-  agents: { supportAgent },
-  storage,
-  notifications: {
-    dispatch: {
-      enabled: true,
-      cron: '*/1 * * * *',
-      batchSize: 100,
-    },
-  },
-})
-```
-
-`notifications.dispatch.enabled` registers an internal workflow with the default cron `*/1 * * * *`. The dispatcher reads due notification records from storage, groups summaries by `agentId`, `resourceId`, and `threadId`, and emits signals through the Agent thread runtime. It isn't a user-facing entrypoint.
+:::note
+Visit [`Agent` constructor reference](/reference/agents/agent#constructor-parameters) for `notifications.deliveryPolicy` and [`Mastra` class reference](/reference/core/mastra-class#constructor-parameters) for runtime notification dispatch configuration.
+:::
 
 ### Notification inbox tool
 
-Use `createNotificationInboxTool()` to give agents one tool for inbox actions instead of many CRUD tools.
+Use `createNotificationInboxTool()` to give agents one tool for inbox actions instead of many CRUD tools. Use `read` after a `<notification-summary>` signal when the agent needs the full records behind the summary. The notification contents are delivered as signals, not as normal tool output.
 
-```typescript title="src/mastra/agents/support-agent.ts"
-import { createNotificationInboxTool } from '@mastra/core/notifications'
+:::note
+Visit [`createNotificationInboxTool()` reference](/reference/signals/create-notification-inbox-tool) for the setup example, input schema, and action behavior.
+:::
 
-const notificationsStorage = await storage.getStore('notifications')
-
-export const supportAgent = new Agent({
-  id: 'support-agent',
-  name: 'Support Agent',
-  instructions: 'Help the user triage updates.',
-  model: '__GATEWAY_OPENAI_MODEL__',
-  tools: {
-    notificationInbox: createNotificationInboxTool({ storage: notificationsStorage }),
-  },
-})
-```
-
-The tool id is `notification-inbox`. It can list, read, mark seen, dismiss, archive, and search notifications for the current thread.
-
-Use `read` after a `<notification-summary>` signal when the agent needs the full records behind the summary. The notification contents are delivered as signals, not as normal tool output.
-
-`sendNotificationSignal()` requires a storage domain with `notifications` support. LibSQL supports notifications. Other storage adapters need matching notification domain support before they can store notification records.
-
-Use `sendSignal({ type: 'notification' })` only for lower-level notification-shaped context that should bypass inbox storage.
+`sendNotificationSignal()` requires a storage domain with `notifications` support. Use `sendSignal({ type: 'notification' })` only for lower-level notification-shaped context that should bypass inbox storage.
 
 ## Compatibility
 
@@ -459,18 +347,11 @@ Visit [Agent signals reference](/reference/agents/agent#thread-signals) for the 
 
 ## Approve tool calls
 
-When a subscribed run pauses for tool approval, approve or decline the tool call with the subscription-native methods. The call returns a JSON acknowledgement. The resumed chunks arrive through the existing thread subscription.
+When a subscribed run pauses for tool approval, approve or decline the tool call with the subscription-native methods. The resumed chunks arrive through the existing thread subscription.
 
-```typescript title="src/app/chat.ts"
-await agent.sendToolApproval({
-  resourceId: 'user_123',
-  threadId: 'thread_456',
-  toolCallId: 'tool-call_456',
-  approved: true,
-})
-```
-
-Pass `approved: false` to decline the same pending tool call. Use the older `approveToolCall()` and `declineToolCall()` methods only when you are rendering the separate continuation stream directly.
+:::note
+Visit [`client.getAgent().sendToolApproval()` reference](/reference/client-js/agents#sendtoolapproval) and [server agent routes](/reference/server/routes#subscription-tool-approval-routes) for request and response shapes.
+:::
 
 ## Use HTTP routes
 
@@ -502,7 +383,7 @@ await subscription.processDataStream({
 })
 ```
 
-Use `reconnect: true` for long-lived subscriptions. The client resubscribes when the stream closes or a reconnect request fails, such as after a proxy idle timeout or a dropped network connection.
+Use `reconnect: true` for long-lived subscriptions. Visit [`client.getAgent().subscribeToThread()` reference](/reference/client-js/agents#subscribetothread) for reconnect options.
 
 ## Keep custom SSE subscriptions alive
 
@@ -527,7 +408,9 @@ Use heartbeats together with client-side reconnect logic. Heartbeats reduce idle
 - [`Agent.sendMessage()`](/reference/agents/agent#sendmessagemessage-options)
 - [`Agent.queueMessage()`](/reference/agents/agent#queuemessagemessage-options)
 - [`Agent.sendSignal()`](/reference/agents/agent#sendsignalsignal-options)
+- [`Agent.sendStateSignal()`](/reference/agents/agent#sendstatesignalstate-options)
 - [`Agent.subscribeToThread()`](/reference/agents/agent#subscribetothreadoptions)
+- [`createNotificationInboxTool()`](/reference/signals/create-notification-inbox-tool)
 - [`client.getAgent().sendMessage()`](/reference/client-js/agents#sendmessage)
 - [`client.getAgent().queueMessage()`](/reference/client-js/agents#queuemessage)
 - [`client.getAgent().sendSignal()`](/reference/client-js/agents#sendsignal)

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -322,27 +322,13 @@ The built-in browser context processor emits state under the `browser` id with s
 
 Notification signals represent external events such as GitHub activity, email, Slack mentions, CI status, incidents, recordings, or direct messages. Use `agent.sendNotificationSignal()` when the event should create a durable inbox record.
 
-Notification delivery has two phases:
+Notification delivery has two phases. During ingress, `agent.sendNotificationSignal()` stores a notification record and resolves the agent's delivery policy. During dispatch, Mastra consumes due records and emits full notification or summary signals.
 
-- **Ingress**: `agent.sendNotificationSignal()` stores a notification record, then resolves the agent's delivery policy.
-- **Dispatch**: Mastra consumes due records stamped with `deliverAt` or `summaryAt` and emits full notification or summary signals.
+The default delivery policy is priority-aware. Urgent notifications deliver immediately, while lower-priority notifications may be batched into summaries or wait until the thread is idle.
 
-A notification record stores the source, kind, priority, summary, payload, resource id, thread id, agent id, coalescing keys, and delivery metadata. The delivery decision controls what happens after ingress:
-
-- `deliver` or `queue`: Emit a full `<notification>` signal and mark the record `delivered`.
-- `defer`: Keep the record `pending` with `deliverAt`.
-- `summarize`: Keep the record `pending` with `summaryAt`, or emit an immediate summary when the policy requests it.
-- `persist`: Keep the record `pending` in the inbox without scheduled delivery.
-- `discard`: Mark the record `discarded` and emit no signal.
-
-The default delivery policy is priority-aware:
-
-| Priority | Active thread | Idle thread |
-| - | - | - |
-| `urgent` | Deliver a full notification immediately | Deliver a full notification immediately |
-| `high` | Emit a summary immediately, keep `deliverAt`, then deliver the full notification when the thread is idle | Deliver a full notification immediately |
-| `medium` | Batch with `summaryAt` and later deliver one notification summary | Deliver a full notification immediately |
-| `low` | Batch with `summaryAt` and later deliver one notification summary | Batch with `summaryAt` and later deliver one notification summary without waking the model loop |
+:::note
+Visit [`Agent.sendNotificationSignal()` reference](/reference/agents/agent#sendnotificationsignalnotification-options) for notification fields, and [`Agent` constructor reference](/reference/agents/agent#constructor-parameters) for `notifications.deliveryPolicy` configuration.
+:::
 
 ```typescript title="src/mastra/notifications.ts"
 await agent.sendNotificationSignal(
@@ -442,16 +428,9 @@ export const supportAgent = new Agent({
 })
 ```
 
-The tool id is `notification-inbox`. It supports these actions:
+The tool id is `notification-inbox`. It can list, read, mark seen, dismiss, archive, and search notifications for the current thread.
 
-- `list`: List notifications for the current thread.
-- `read`: Deliver readable full notification signals into the chat when possible, then mark records `seen`.
-- `markSeen`: Mark one record `seen`.
-- `dismiss`: Mark one record `dismissed`.
-- `archive`: Mark one record `archived`.
-- `search`: Search notification summaries in the current thread.
-
-The tool uses the current `threadId` from the tool execution context unless one is provided. Use `read` after a `<notification-summary>` signal when the agent needs the full records behind the summary. The `read` result reports how many notifications will be delivered; it doesn't use normal tool output as the main context channel for the notification contents.
+Use `read` after a `<notification-summary>` signal when the agent needs the full records behind the summary. The notification contents are delivered as signals, not as normal tool output.
 
 `sendNotificationSignal()` requires a storage domain with `notifications` support. LibSQL supports notifications. Other storage adapters need matching notification domain support before they can store notification records.
 

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -22,18 +22,26 @@ Use message APIs for user-authored input. Use `sendSignal()` for lower-level sys
 
 ## Quickstart
 
-Subscribe to the thread before sending messages. The subscription receives the active stream when the message wakes the agent or enters a running loop.
+Create an agent, subscribe to a thread, then send a message to that thread. The subscription receives the active stream when the message wakes the agent or enters a running loop.
 
 ```typescript title="src/mastra/signals.ts"
-const subscription = await agent.subscribeToThread({
-  resourceId: 'user_123',
-  threadId: 'thread_456',
+import { Agent } from '@mastra/core/agent'
+
+const agent = new Agent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: 'Help the user compare options.',
+  model: '__GATEWAY_OPENAI_MODEL__',
 })
 
-agent.sendMessage('Compare that with the previous option.', {
+const thread = {
   resourceId: 'user_123',
   threadId: 'thread_456',
-})
+}
+
+const subscription = await agent.subscribeToThread(thread)
+
+await agent.sendMessage('Compare that with the previous option.', thread)
 
 for await (const chunk of subscription.stream) {
   console.log(chunk)

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -8,6 +8,8 @@ packages:
 
 # Signals
 
+**Added in:** `@mastra/core@1.39.0`
+
 :::experimental
 
 This feature is in alpha. Breaking changes may occur without a major version bump until the API is stable.

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -174,6 +174,14 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'agents/signal-providers',
+          label: 'Signal Providers',
+          customProps: {
+            tags: ['alpha'],
+          },
+        },
+        {
+          type: 'doc',
           id: 'agents/networks',
           label: 'Networks',
           customProps: {

--- a/docs/src/content/en/guides/guide/signal-provider.mdx
+++ b/docs/src/content/en/guides/guide/signal-provider.mdx
@@ -1,0 +1,207 @@
+---
+title: "Guide: Building a signal provider"
+description: Build a polling signal provider that watches an external service and pushes notifications into an agent thread.
+---
+
+# Building a signal provider
+
+In this guide, you'll build a signal provider that polls an external service on an interval and pushes a notification into an agent thread whenever a watched resource changes. You'll learn how to extend the `SignalProvider` base class, track subscriptions, emit notifications from a poll loop, and register the provider on an agent.
+
+The example watches build pipelines in a fake CI service, but the pattern applies to any pull-based source: an issue tracker, a status API, a queue, or your own backend.
+
+:::experimental
+
+Signal providers are in alpha. Breaking changes may occur without a major version bump until the API is stable.
+
+:::
+
+## Prerequisites
+
+- Node.js `v22.13.0` or later installed
+- An API key from a supported [Model Provider](/models)
+- An existing Mastra project. Follow the [installation guide](/guides/getting-started/quickstart) if needed.
+
+This guide also assumes you understand [signals](/docs/agents/signals) at a high level. For the full API surface, see the [`SignalProvider` reference](/reference/signals/signal-provider).
+
+## Add notification storage
+
+A signal provider pushes [notification signals](/docs/agents/signals#notification-signals) into threads, and notifications require a storage adapter that supports the notifications domain. Configure storage on your Mastra instance.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { LibSQLStore } from '@mastra/libsql'
+
+export const mastra = new Mastra({
+  storage: new LibSQLStore({
+    url: 'file:./mastra.db',
+  }),
+})
+```
+
+LibSQL, PostgreSQL, and MongoDB all support notification records. Without notification storage, the provider's `notify()` calls throw at runtime.
+
+## Create the external service client
+
+Real providers call an external API. To keep this guide self-contained, create a small fake CI client that returns a build status for a pipeline. Swap this for your real API client later.
+
+```typescript title="src/mastra/signals/ci-client.ts"
+export type BuildStatus = {
+  id: string
+  pipeline: string
+  status: 'passed' | 'failed' | 'running'
+}
+
+// Returns a random status so you can see notifications fire while testing.
+export async function fetchBuildStatus(pipeline: string): Promise<BuildStatus> {
+  const states: BuildStatus['status'][] = ['passed', 'failed', 'running']
+  const status = states[Math.floor(Math.random() * states.length)]!
+  return { id: `build_${Date.now()}`, pipeline, status }
+}
+```
+
+This client returns a random status each call. When you wire in a real API, only this file changes.
+
+## Build the signal provider
+
+Extend `SignalProvider`, implement the abstract `id` field, set a `pollInterval`, and override `poll()`. The base class calls `poll()` on the interval with every active subscription. Emit a notification only for the builds you care about.
+
+```typescript title="src/mastra/signals/ci-signals.ts"
+import { SignalProvider } from '@mastra/core/signals'
+import type { SignalProviderTarget, SignalSubscription } from '@mastra/core/signals'
+import { fetchBuildStatus } from './ci-client'
+
+export class CiSignals extends SignalProvider<'ci-signals'> {
+  readonly id = 'ci-signals' as const
+  readonly pollInterval = 10_000 // poll every 10 seconds
+
+  // Public API so callers can subscribe a thread to a pipeline.
+  watch(target: SignalProviderTarget, pipeline: string): SignalSubscription {
+    return this.subscribe(target, pipeline)
+  }
+
+  unwatch(target: SignalProviderTarget, pipeline: string): boolean {
+    return this.unsubscribe(target, pipeline)
+  }
+
+  async poll(subscriptions: SignalSubscription[]): Promise<void> {
+    for (const sub of subscriptions) {
+      const build = await fetchBuildStatus(sub.externalResourceId)
+      if (build.status !== 'failed') continue
+
+      await this.notify(
+        {
+          source: this.id,
+          kind: 'ci-status',
+          priority: 'high',
+          summary: `Build failed for ${sub.externalResourceId}`,
+          payload: build,
+          dedupeKey: `${this.id}:${sub.externalResourceId}:${build.id}`,
+        },
+        { resourceId: sub.resourceId, threadId: sub.threadId },
+      )
+    }
+  }
+}
+```
+
+A few things to note:
+
+- `subscribe()` and `unsubscribe()` are protected on the base class. Wrap them in your own public methods (`watch` / `unwatch`) so callers can manage subscriptions.
+- `externalResourceId` is any provider-specific string. Here it's the pipeline name; a GitHub provider might use `"github:owner/repo#123"`.
+- `notify()` forwards a notification signal to the connected agent's thread. It throws if the provider was never registered on an agent.
+- `dedupeKey` prevents storing the same failure twice.
+
+## Register the provider on an agent
+
+Pass the provider to the agent through `signals`. The agent connects it and starts the poll loop automatically.
+
+```typescript title="src/mastra/agents/dev-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { CiSignals } from '../signals/ci-signals'
+
+export const ciSignals = new CiSignals()
+
+export const devAgent = new Agent({
+  id: 'dev-agent',
+  name: 'Dev Agent',
+  instructions: 'Help the user triage CI build failures.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  // highlight-next-line
+  signals: [ciSignals],
+})
+```
+
+Register the agent with Mastra and add the storage from the first step.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { LibSQLStore } from '@mastra/libsql'
+// highlight-next-line
+import { devAgent } from './agents/dev-agent'
+
+export const mastra = new Mastra({
+  // highlight-next-line
+  agents: { devAgent },
+  storage: new LibSQLStore({
+    url: 'file:./mastra.db',
+  }),
+})
+```
+
+## Subscribe a thread
+
+A provider only polls resources that a thread is watching. Subscribe a thread to a pipeline so `poll()` has something to check.
+
+```typescript title="src/mastra/subscribe.ts"
+import { ciSignals } from './agents/dev-agent'
+
+ciSignals.watch({ resourceId: 'user_123', threadId: 'thread_456' }, 'acme/app:main')
+```
+
+Run this once after the agent is registered, for example from a setup script or an API route. The subscription lives in the provider's in-memory registry, so re-subscribe after a restart.
+
+## Test the signal provider
+
+Start the dev server:
+
+```bash npm2yarn
+npm run dev
+```
+
+Make sure a thread is subscribed, then watch the logs. The fake client returns a random status each poll, so within a few cycles you'll see a failed build trigger a notification for the subscribed thread.
+
+To see the agent react to the notification, subscribe to the thread and stream it:
+
+```typescript title="src/mastra/watch-thread.ts"
+const subscription = await devAgent.subscribeToThread({
+  resourceId: 'user_123',
+  threadId: 'thread_456',
+})
+
+for await (const chunk of subscription.stream) {
+  console.log(chunk)
+}
+```
+
+When a build fails, the model receives the notification as context:
+
+```xml
+<notification source="ci-signals" type="ci-status" priority="high" status="delivered">Build failed for acme/app:main</notification>
+```
+
+Output is non-deterministic because the fake client randomizes status and the model phrases its reply freely, so the exact wording will vary.
+
+## Next steps
+
+You can extend this signal provider to:
+
+- Replace `fetchBuildStatus()` with a real API client and persist subscriptions so they survive a restart.
+- Add a [webhook](/docs/agents/signal-providers#receive-events-by-webhook) entry point with `handleWebhook()` for push-based sources.
+- Expose `subscribe` and `unsubscribe` [tools](/docs/agents/signal-providers#add-processors-and-tools) so the agent can manage its own subscriptions.
+
+Learn more:
+
+- [Building signal providers](/docs/agents/signal-providers)
+- [Signals](/docs/agents/signals)
+- [`SignalProvider` reference](/reference/signals/signal-provider)
+- [`WebhookSignalProvider` reference](/reference/signals/webhook-signal-provider)

--- a/docs/src/content/en/guides/guide/signal-provider.mdx
+++ b/docs/src/content/en/guides/guide/signal-provider.mdx
@@ -195,9 +195,11 @@ Output is non-deterministic because the fake client randomizes status and the mo
 
 You can extend this signal provider to:
 
-- Replace `fetchBuildStatus()` with a real API client and persist subscriptions so they survive a restart.
-- Add a [webhook](/docs/agents/signal-providers#receive-events-by-webhook) entry point with `handleWebhook()` for push-based sources.
-- Expose `subscribe` and `unsubscribe` [tools](/docs/agents/signal-providers#add-processors-and-tools) so the agent can manage its own subscriptions.
+- Replace `fetchBuildStatus()` with a real API client.
+- Persist subscriptions so they survive a restart, then rehydrate them in [`start()`](/reference/signals/signal-provider#start).
+- Add a [webhook](/docs/agents/signal-providers#polling-and-webhook-providers) entry point with [`handleWebhook()`](/reference/signals/signal-provider#handlewebhookrequest) for push-based sources.
+- Expose `subscribe` and `unsubscribe` tools with [`getTools()`](/reference/signals/signal-provider#gettools) so the agent can manage its own subscriptions.
+- Use [`dedupeKey` and `coalesceKey`](/reference/agents/agent#sendnotificationsignalnotification-options) when notifications need deduplication or batching.
 
 Learn more:
 

--- a/docs/src/content/en/guides/sidebars.js
+++ b/docs/src/content/en/guides/sidebars.js
@@ -216,6 +216,11 @@ const sidebars = {
               id: 'guide/notes-mcp-server',
               label: 'MCP Server: Notes MCP Server',
             },
+            {
+              type: 'doc',
+              id: 'guide/signal-provider',
+              label: 'Signals: CI Signal Provider',
+            },
           ],
         },
         {

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -155,6 +155,35 @@ The model receives this as:
 <user name="Devin" from="slack">Can we simplify the API surface?</user>
 ```
 
+Use `ifActive.attributes` and `ifIdle.attributes` when the message should carry different context depending on whether the thread is currently running:
+
+```typescript title="src/mastra/signals.ts"
+agent.sendMessage(
+  {
+    contents: 'Also cover the edge cases.',
+    attributes: { source: 'chat' },
+  },
+  {
+    resourceId: 'user-123',
+    threadId: 'thread-abc',
+    ifActive: { attributes: { delivery: 'while-active' } },
+    ifIdle: { attributes: { delivery: 'new-message' } },
+  },
+)
+```
+
+When the thread is active, the model sees:
+
+```xml
+<user source="chat" delivery="while-active">Also cover the edge cases.</user>
+```
+
+When the thread is idle, the model sees:
+
+```xml
+<user source="chat" delivery="new-message">Also cover the edge cases.</user>
+```
+
 The UI sees the message contents and can also read `attributes` and `metadata` off the signal message for custom rendering (e.g. showing user names, avatars, or platform badges).
 
 ### `sendMessage(message, options)`
@@ -211,6 +240,13 @@ Sends a user message to an active run or memory thread. Use this when the active
                     isOptional: true,
                     description: 'Controls what happens when the target thread is active. Defaults to `deliver`.',
                   },
+                  {
+                    name: 'attributes',
+                    type: 'Record<string, string | number | boolean>',
+                    isOptional: true,
+                    description:
+                      'Attributes merged into the message when Mastra accepts it while the target thread is active.',
+                  },
                 ],
               },
             ],
@@ -237,6 +273,13 @@ Sends a user message to an active run or memory thread. Use this when the active
                     description:
                       'Options for the stream that starts when `ifIdle.behavior` is `wake`. Mastra uses the top-level `resourceId` and `threadId` for memory context.',
                   },
+                  {
+                    name: 'attributes',
+                    type: 'Record<string, string | number | boolean>',
+                    isOptional: true,
+                    description:
+                      'Attributes merged into the message when Mastra accepts it while the target thread is idle.',
+                  },
                 ],
               },
             ],
@@ -247,6 +290,21 @@ Sends a user message to an active run or memory thread. Use this when the active
   },
 ]}
 />
+
+Set `ifIdle.behavior` to `wake` and pass `ifIdle.streamOptions` when an idle thread should start a new stream with custom execution options:
+
+```typescript title="src/mastra/signals.ts"
+agent.sendMessage('Continue with the next step.', {
+  resourceId: 'user-123',
+  threadId: 'thread-abc',
+  ifIdle: {
+    behavior: 'wake',
+    streamOptions: {
+      maxSteps: 3,
+    },
+  },
+})
+```
 
 Returns `{ accepted: true, runId: string, signal: CreatedAgentSignal, persisted?: Promise<void> }`. `persisted` is only present for `persist` behavior and resolves when Mastra finishes writing the message to memory.
 
@@ -317,6 +375,13 @@ Sends a signal to an active run or memory thread.
                     isOptional: true,
                     description: 'Controls what happens when the target thread is active. Defaults to `deliver`.',
                   },
+                  {
+                    name: 'attributes',
+                    type: 'Record<string, string | number | boolean>',
+                    isOptional: true,
+                    description:
+                      'Attributes merged into the signal when Mastra accepts it while the target thread is active.',
+                  },
                 ],
               },
             ],
@@ -343,6 +408,13 @@ Sends a signal to an active run or memory thread.
                     description:
                       'Options for the stream that starts when `ifIdle.behavior` is `wake`. Mastra uses the top-level `resourceId` and `threadId` for memory context.',
                   },
+                  {
+                    name: 'attributes',
+                    type: 'Record<string, string | number | boolean>',
+                    isOptional: true,
+                    description:
+                      'Attributes merged into the signal when Mastra accepts it while the target thread is idle.',
+                  },
                 ],
               },
             ],
@@ -355,6 +427,101 @@ Sends a signal to an active run or memory thread.
 />
 
 Returns `{ accepted: true, runId: string, signal: CreatedAgentSignal, persisted?: Promise<void> }`. `persisted` is only present for `persist` behavior and resolves when Mastra finishes writing the signal to memory.
+
+### `sendStateSignal(state, options)`
+
+Sends named, thread-scoped state context to an active run or memory thread. Use this when an external producer owns durable context that changes over time, such as browser state, editor state, or watcher output.
+
+```typescript
+const result = await agent.sendStateSignal(
+  {
+    id: 'browser',
+    mode: 'snapshot',
+    cacheKey: 'browser:https://example.com:3-tabs',
+    contents: 'Browser is open on https://example.com with 3 tabs.',
+    value: {
+      activeUrl: 'https://example.com',
+      tabCount: 3,
+      open: true,
+    },
+  },
+  {
+    resourceId: 'user-123',
+    threadId: 'thread-abc',
+  },
+)
+```
+
+<PropertiesTable
+  content={[
+  {
+    name: 'state',
+    type: 'object',
+    description: 'State signal to send to the thread.',
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          { name: 'id', type: 'string', description: 'State lane name, such as `browser` or `editor`.' },
+          {
+            name: 'cacheKey',
+            type: 'string',
+            description: 'Producer-owned key Mastra uses to skip duplicate state for the same lane and mode.',
+          },
+          {
+            name: 'contents',
+            type: 'string | Array<TextPart | FilePart>',
+            description: 'LLM-facing representation of the state.',
+          },
+          {
+            name: 'mode',
+            type: "'snapshot' | 'delta'",
+            isOptional: true,
+            description: 'Whether the state is an authoritative snapshot or a change event. Defaults to `snapshot`.',
+          },
+          {
+            name: 'value',
+            type: 'unknown',
+            isOptional: true,
+            description: "Structured snapshot value for `mode: 'snapshot'`.",
+          },
+          {
+            name: 'delta',
+            type: 'unknown',
+            isOptional: true,
+            description: "Structured change value for `mode: 'delta'`.",
+          },
+          {
+            name: 'attributes',
+            type: 'Record<string, string | number | boolean>',
+            isOptional: true,
+            description: 'Attributes rendered on the state signal tag.',
+          },
+          {
+            name: 'metadata',
+            type: 'Record<string, unknown>',
+            isOptional: true,
+            description: 'Application metadata stored with the state signal.',
+          },
+          {
+            name: 'tagName',
+            type: 'string',
+            isOptional: true,
+            description: 'XML tag name shown to the model. Defaults to `state`.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'options',
+    type: 'object',
+    description: 'Targeting and delivery behavior for the state signal. Accepts the same options as `sendSignal()`.',
+  },
+]}
+/>
+
+Returns `{ accepted: true, runId: string, signal: CreatedAgentSignal, persisted?: Promise<void>, skipped?: false }` when Mastra accepts new state. Returns `{ accepted: true, skipped: true, reason: 'unchanged' }` when the same `cacheKey` and mode are already current for the state lane.
 
 ### `sendNotificationSignal(notification, options)`
 
@@ -490,6 +657,32 @@ Returns `{ accepted: true, record: NotificationRecord, decision: NotificationDel
 
 Default delivery is priority-aware. `urgent` notifications deliver immediately. `high` notifications deliver immediately when the thread is idle; when the thread is active, Mastra emits a summary immediately and keeps `deliverAt` for later full delivery when the thread is idle. `medium` notifications deliver immediately when idle and batch into summaries when active. `low` notifications batch into summaries in both active and idle threads; idle low-priority summaries reach subscribers without waking the model loop. For the full flow, visit [Signals](/docs/agents/signals#notification-signals).
 
+Configure `notifications.deliveryPolicy` on the agent when some notifications should wait for a different dispatch window or summary rollup:
+
+```typescript title="src/mastra/agents/support-agent.ts"
+export const supportAgent = new Agent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: 'Help the user triage updates.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  notifications: {
+    deliveryPolicy: {
+      priorities: {
+        urgent: 'deliver',
+      },
+      decide: ({ record }) => {
+        if (record.priority === 'low') {
+          return {
+            action: 'summarize',
+            summaryAt: new Date(Date.now() + 30 * 60 * 1000),
+          }
+        }
+      },
+    },
+  },
+})
+```
+
 ### `subscribeToThread(options)`
 
 Subscribes to raw stream chunks for a memory thread. Use this before calling `sendMessage()`, `queueMessage()`, or `sendSignal()` when you need to render stream output, observe signal echoes, or abort the active run.
@@ -612,13 +805,6 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
       'Shared policy for transforming tool payloads before display streams or user-visible transcript messages receive them. Use per-tool `transform` on `createTool()` for tool-local rules.',
   },
   {
-    name: 'notifications',
-    type: '{ deliveryPolicy?: NotificationDeliveryPolicyConfig }',
-    isOptional: true,
-    description:
-      'Notification delivery configuration for `sendNotificationSignal()`. `deliveryPolicy` can define `decide`, `sources`, `priorities`, or `default` rules that return `deliver`, `queue`, `defer`, `summarize`, `persist`, or `discard` decisions.',
-  },
-  {
     name: 'workflows',
     type: 'Record<string, Workflow> | ({ requestContext: RequestContext }) => Record<string, Workflow> | Promise<Record<string, Workflow>>',
     isOptional: true,
@@ -659,6 +845,26 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
     type: 'MastraMemory | ({ requestContext: RequestContext }) => MastraMemory | Promise<MastraMemory>',
     isOptional: true,
     description: 'Memory module used for storing and retrieving stateful context.',
+  },
+  {
+    name: 'notifications',
+    type: 'object',
+    isOptional: true,
+    description: 'Notification delivery configuration for durable notification signals.',
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'deliveryPolicy',
+            type: 'NotificationDeliveryPolicyConfig',
+            isOptional: true,
+            description:
+              'Controls how notification records are delivered. Configure a default decision, per-priority decisions, per-source decisions, or a custom `decide()` function.',
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'voice',

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -170,41 +170,80 @@ Sends a user message to an active run or memory thread. Use this when the active
       'User-authored input. Bare strings and parts without attributes are sent to the model as normal user input. When `attributes` are present, Mastra renders the message as a `<user>` XML element with the attributes included.',
   },
   {
-    name: 'options.runId',
-    type: 'string',
+    name: 'options',
+    type: 'object',
     isOptional: true,
-    description: 'Run ID to target directly. Use this when you already know the active run ID.',
-  },
-  {
-    name: 'options.resourceId',
-    type: 'string',
-    isOptional: true,
-    description: 'Resource ID for the memory thread. Required with `threadId` for thread-targeted messages.',
-  },
-  {
-    name: 'options.threadId',
-    type: 'string',
-    isOptional: true,
-    description: 'Thread ID to target. Required with `resourceId` for thread-targeted messages.',
-  },
-  {
-    name: 'options.ifActive.behavior',
-    type: "'deliver' | 'persist' | 'discard'",
-    isOptional: true,
-    description: 'Controls what happens when the target thread is active. Defaults to `deliver`.',
-  },
-  {
-    name: 'options.ifIdle.behavior',
-    type: "'wake' | 'persist' | 'discard'",
-    isOptional: true,
-    description: 'Controls what happens when the target thread is idle. Defaults to `wake`.',
-  },
-  {
-    name: 'options.ifIdle.streamOptions',
-    type: 'AgentExecutionOptions',
-    isOptional: true,
-    description:
-      'Options for the stream that starts when `ifIdle.behavior` is `wake`. Mastra uses the top-level `resourceId` and `threadId` for memory context.',
+    description: 'Targeting and delivery behavior for the message.',
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'runId',
+            type: 'string',
+            isOptional: true,
+            description: 'Run ID to target directly. Use this when you already know the active run ID.',
+          },
+          {
+            name: 'resourceId',
+            type: 'string',
+            isOptional: true,
+            description: 'Resource ID for the memory thread. Required with `threadId` for thread-targeted messages.',
+          },
+          {
+            name: 'threadId',
+            type: 'string',
+            isOptional: true,
+            description: 'Thread ID to target. Required with `resourceId` for thread-targeted messages.',
+          },
+          {
+            name: 'ifActive',
+            type: 'object',
+            isOptional: true,
+            description: 'Controls what happens when the target thread is active.',
+            properties: [
+              {
+                type: 'object',
+                parameters: [
+                  {
+                    name: 'behavior',
+                    type: "'deliver' | 'persist' | 'discard'",
+                    isOptional: true,
+                    description: 'Controls what happens when the target thread is active. Defaults to `deliver`.',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'ifIdle',
+            type: 'object',
+            isOptional: true,
+            description: 'Controls what happens when the target thread is idle.',
+            properties: [
+              {
+                type: 'object',
+                parameters: [
+                  {
+                    name: 'behavior',
+                    type: "'wake' | 'persist' | 'discard'",
+                    isOptional: true,
+                    description: 'Controls what happens when the target thread is idle. Defaults to `wake`.',
+                  },
+                  {
+                    name: 'streamOptions',
+                    type: 'AgentExecutionOptions',
+                    isOptional: true,
+                    description:
+                      'Options for the stream that starts when `ifIdle.behavior` is `wake`. Mastra uses the top-level `resourceId` and `threadId` for memory context.',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
 ]}
 />
@@ -237,41 +276,80 @@ Sends a signal to an active run or memory thread.
       "Signal context to send to the thread. `type` is the semantic signal category. `tagName` controls the XML tag the model sees. For example, `{ type: 'notification', tagName: 'github-review' }` renders as `<github-review>...</github-review>`. Legacy `user-message` and `system-reminder` payloads are still accepted and normalized. Unknown `type` values are rejected; use `tagName` for custom XML tags.",
   },
   {
-    name: 'options.runId',
-    type: 'string',
+    name: 'options',
+    type: 'object',
     isOptional: true,
-    description: 'Run ID to target directly. Use this when you already know the active run ID.',
-  },
-  {
-    name: 'options.resourceId',
-    type: 'string',
-    isOptional: true,
-    description: 'Resource ID for the memory thread. Required with `threadId` for thread-targeted signals.',
-  },
-  {
-    name: 'options.threadId',
-    type: 'string',
-    isOptional: true,
-    description: 'Thread ID to target. Required with `resourceId` for thread-targeted signals.',
-  },
-  {
-    name: 'options.ifActive.behavior',
-    type: "'deliver' | 'persist' | 'discard'",
-    isOptional: true,
-    description: 'Controls what happens when the target thread is active. Defaults to `deliver`.',
-  },
-  {
-    name: 'options.ifIdle.behavior',
-    type: "'wake' | 'persist' | 'discard'",
-    isOptional: true,
-    description: 'Controls what happens when the target thread is idle. Defaults to `wake`.',
-  },
-  {
-    name: 'options.ifIdle.streamOptions',
-    type: 'AgentExecutionOptions',
-    isOptional: true,
-    description:
-      'Options for the stream that starts when `ifIdle.behavior` is `wake`. Mastra uses the top-level `resourceId` and `threadId` for memory context.',
+    description: 'Targeting and delivery behavior for the signal.',
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'runId',
+            type: 'string',
+            isOptional: true,
+            description: 'Run ID to target directly. Use this when you already know the active run ID.',
+          },
+          {
+            name: 'resourceId',
+            type: 'string',
+            isOptional: true,
+            description: 'Resource ID for the memory thread. Required with `threadId` for thread-targeted signals.',
+          },
+          {
+            name: 'threadId',
+            type: 'string',
+            isOptional: true,
+            description: 'Thread ID to target. Required with `resourceId` for thread-targeted signals.',
+          },
+          {
+            name: 'ifActive',
+            type: 'object',
+            isOptional: true,
+            description: 'Controls what happens when the target thread is active.',
+            properties: [
+              {
+                type: 'object',
+                parameters: [
+                  {
+                    name: 'behavior',
+                    type: "'deliver' | 'persist' | 'discard'",
+                    isOptional: true,
+                    description: 'Controls what happens when the target thread is active. Defaults to `deliver`.',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'ifIdle',
+            type: 'object',
+            isOptional: true,
+            description: 'Controls what happens when the target thread is idle.',
+            properties: [
+              {
+                type: 'object',
+                parameters: [
+                  {
+                    name: 'behavior',
+                    type: "'wake' | 'persist' | 'discard'",
+                    isOptional: true,
+                    description: 'Controls what happens when the target thread is idle. Defaults to `wake`.',
+                  },
+                  {
+                    name: 'streamOptions',
+                    type: 'AgentExecutionOptions',
+                    isOptional: true,
+                    description:
+                      'Options for the stream that starts when `ifIdle.behavior` is `wake`. Mastra uses the top-level `resourceId` and `threadId` for memory context.',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
 ]}
 />
@@ -301,71 +379,109 @@ const result = await agent.sendNotificationSignal(
 <PropertiesTable
   content={[
   {
-    name: 'notification.source',
-    type: 'string',
-    description: 'External system that produced the notification, such as `github`, `slack`, or `email`.',
+    name: 'notification',
+    type: 'object',
+    description: 'Notification inbox record to create or coalesce.',
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'source',
+            type: 'string',
+            description: 'External system that produced the notification, such as `github`, `slack`, or `email`.',
+          },
+          {
+            name: 'kind',
+            type: 'string',
+            description: 'Notification kind within the source, such as `ci-status`, `mention`, or `direct-message`.',
+          },
+          {
+            name: 'summary',
+            type: 'string',
+            description: 'LLM-facing summary used as the notification signal contents.',
+          },
+          {
+            name: 'priority',
+            type: "'low' | 'medium' | 'high' | 'urgent'",
+            isOptional: true,
+            description: 'Priority used by the notification delivery policy. Defaults to `medium`.',
+          },
+          {
+            name: 'payload',
+            type: 'unknown',
+            isOptional: true,
+            description: 'Structured payload stored on the inbox record for tools or application code.',
+          },
+          {
+            name: 'dedupeKey',
+            type: 'string',
+            isOptional: true,
+            description: 'Key used to coalesce duplicate pending notifications from the same source and thread.',
+          },
+          {
+            name: 'coalesceKey',
+            type: 'string',
+            isOptional: true,
+            description: 'Key used to combine related pending notifications from the same source and thread.',
+          },
+          {
+            name: 'attributes',
+            type: 'Record<string, JSONValue>',
+            isOptional: true,
+            description: 'Extra attributes copied onto the emitted notification signal.',
+          },
+          {
+            name: 'metadata',
+            type: 'Record<string, unknown>',
+            isOptional: true,
+            description: 'Application metadata stored on the inbox record.',
+          },
+        ],
+      },
+    ],
   },
   {
-    name: 'notification.kind',
-    type: 'string',
-    description: 'Notification kind within the source, such as `ci-status`, `mention`, or `direct-message`.',
-  },
-  {
-    name: 'notification.summary',
-    type: 'string',
-    description: 'LLM-facing summary used as the notification signal contents.',
-  },
-  {
-    name: 'notification.priority',
-    type: "'low' | 'medium' | 'high' | 'urgent'",
-    isOptional: true,
-    description: 'Priority used by the notification delivery policy. Defaults to `medium`.',
-  },
-  {
-    name: 'notification.payload',
-    type: 'unknown',
-    isOptional: true,
-    description: 'Structured payload stored on the inbox record for tools or application code.',
-  },
-  {
-    name: 'notification.dedupeKey',
-    type: 'string',
-    isOptional: true,
-    description: 'Key used to coalesce duplicate pending notifications from the same source and thread.',
-  },
-  {
-    name: 'notification.coalesceKey',
-    type: 'string',
-    isOptional: true,
-    description: 'Key used to combine related pending notifications from the same source and thread.',
-  },
-  {
-    name: 'notification.attributes',
-    type: 'Record<string, JSONValue>',
-    isOptional: true,
-    description: 'Extra attributes copied onto the emitted notification signal.',
-  },
-  {
-    name: 'notification.metadata',
-    type: 'Record<string, unknown>',
-    isOptional: true,
-    description: 'Application metadata stored on the inbox record.',
-  },
-  {
-    name: 'options.resourceId',
-    type: 'string',
-    description: 'Resource ID for the notification inbox and target memory thread.',
-  },
-  {
-    name: 'options.threadId',
-    type: 'string',
-    description: 'Thread ID for the notification inbox and target memory thread.',
-  },
-  {
-    name: 'options.ifIdle.streamOptions',
-    type: 'AgentExecutionOptions',
-    isOptional: true,
-    description: 'Options for the stream that starts when an immediate notification wakes an idle thread.',
+    name: 'options',
+    type: 'object',
+    description: 'Target thread and wake-up behavior for the notification.',
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'resourceId',
+            type: 'string',
+            description: 'Resource ID for the notification inbox and target memory thread.',
+          },
+          {
+            name: 'threadId',
+            type: 'string',
+            description: 'Thread ID for the notification inbox and target memory thread.',
+          },
+          {
+            name: 'ifIdle',
+            type: 'object',
+            isOptional: true,
+            description: 'Controls what happens when the target thread is idle.',
+            properties: [
+              {
+                type: 'object',
+                parameters: [
+                  {
+                    name: 'streamOptions',
+                    type: 'AgentExecutionOptions',
+                    isOptional: true,
+                    description:
+                      'Options for the stream that starts when an immediate notification wakes an idle thread.',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
 ]}
 />
@@ -381,15 +497,27 @@ Subscribes to raw stream chunks for a memory thread. Use this before calling `se
 <PropertiesTable
   content={[
   {
-    name: 'options.resourceId',
-    type: 'string',
-    isOptional: true,
-    description: 'Resource ID for the memory thread.',
-  },
-  {
-    name: 'options.threadId',
-    type: 'string',
-    description: 'Thread ID to subscribe to.',
+    name: 'options',
+    type: 'object',
+    description: 'Thread subscription target.',
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'resourceId',
+            type: 'string',
+            isOptional: true,
+            description: 'Resource ID for the memory thread.',
+          },
+          {
+            name: 'threadId',
+            type: 'string',
+            description: 'Thread ID to subscribe to.',
+          },
+        ],
+      },
+    ],
   },
 ]}
 />

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -277,6 +277,12 @@ Returns `{ accepted: true, runId: string }`.
     description: 'Controls what happens when the target thread is active. Defaults to `deliver`.',
   },
   {
+    name: 'ifActive.attributes',
+    type: 'Record<string, string | number | boolean>',
+    isOptional: true,
+    description: 'Attributes merged into the signal when Mastra accepts it while the target thread is active.',
+  },
+  {
     name: 'ifIdle.behavior',
     type: "'wake' | 'persist' | 'discard'",
     isOptional: true,
@@ -287,6 +293,12 @@ Returns `{ accepted: true, runId: string }`.
     type: "Omit<AgentExecutionOptions, 'messages'>",
     isOptional: true,
     description: 'Options for the stream that starts when `ifIdle.behavior` is `wake`.',
+  },
+  {
+    name: 'ifIdle.attributes',
+    type: 'Record<string, string | number | boolean>',
+    isOptional: true,
+    description: 'Attributes merged into the signal when Mastra accepts it while the target thread is idle.',
   },
 ]}
 />

--- a/docs/src/content/en/reference/core/mastra-class.mdx
+++ b/docs/src/content/en/reference/core/mastra-class.mdx
@@ -36,6 +36,24 @@ export const mastra = new Mastra({
 })
 ```
 
+Enable scheduled notification dispatch when deferred notification records and notification summaries should be delivered automatically through the workflow scheduler:
+
+```typescript title="src/mastra/index.ts"
+export const mastra = new Mastra({
+  agents: { supportAgent },
+  storage,
+  notifications: {
+    dispatch: {
+      enabled: true,
+      cron: '*/1 * * * *',
+      batchSize: 100,
+    },
+  },
+})
+```
+
+`notifications.dispatch.enabled` registers an internal workflow with the default cron `*/1 * * * *`. The dispatcher reads due notification records from storage, groups summaries by `agentId`, `resourceId`, and `threadId`, and emits signals through the agent thread runtime. It isn't a user-facing entrypoint.
+
 ## Constructor parameters
 
 Visit the [Configuration reference](/reference/configuration) for detailed documentation on all available configuration options.
@@ -168,6 +186,54 @@ Visit the [Configuration reference](/reference/configuration) for detailed docum
       'Memory instances to register. These can be referenced by stored agents and resolved at runtime. Structured as a key-value pair, with keys being the registry key and values being memory instances.',
     isOptional: true,
     defaultValue: '{}',
+  },
+  {
+    name: 'notifications',
+    type: 'object',
+    description: 'Runtime configuration for notification signal dispatch.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'dispatch',
+            type: 'NotificationDispatchConfig',
+            isOptional: true,
+            description:
+              'Scheduled dispatch configuration for deferred notifications and notification summaries. Dispatch is enabled by default.',
+            properties: [
+              {
+                type: 'object',
+                parameters: [
+                  {
+                    name: 'enabled',
+                    type: 'boolean',
+                    isOptional: true,
+                    defaultValue: 'true',
+                    description: 'Set to `false` to opt out of automatic scheduled notification dispatch.',
+                  },
+                  {
+                    name: 'cron',
+                    type: 'string',
+                    isOptional: true,
+                    defaultValue: '`*/1 * * * *`',
+                    description: 'Cron schedule used by the internal notification dispatcher workflow.',
+                  },
+                  {
+                    name: 'batchSize',
+                    type: 'number',
+                    isOptional: true,
+                    defaultValue: '100',
+                    description: 'Maximum number of due notification records to process per dispatch run.',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'versions',

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -9,7 +9,7 @@ packages:
 
 **Added in:** `@mastra/core@1.5.0`
 
-:::warning
+:::experimental
 
 The `Harness` class is in alpha stage and subject to change. It won't follow semantic versioning guarantees until it graduates from experimental status. Use with caution and expect breaking changes in minor versions.
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -521,6 +521,12 @@ const sidebars = {
       label: 'Signals',
       collapsed: true,
       items: [
+        {
+          type: 'doc',
+          id: 'signals/create-notification-inbox-tool',
+          label: 'createNotificationInboxTool()',
+          customProps: { tags: ['alpha'] },
+        },
         { type: 'doc', id: 'signals/signal-provider', label: 'SignalProvider', customProps: { tags: ['alpha'] } },
         {
           type: 'doc',

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -189,7 +189,6 @@ const sidebars = {
           type: 'category',
           label: 'Agent Builder',
           collapsed: true,
-          customProps: { tags: ['new'] },
           items: [
             {
               type: 'doc',
@@ -522,8 +521,13 @@ const sidebars = {
       label: 'Signals',
       collapsed: true,
       items: [
-        { type: 'doc', id: 'signals/signal-provider', label: 'SignalProvider' },
-        { type: 'doc', id: 'signals/webhook-signal-provider', label: 'WebhookSignalProvider' },
+        { type: 'doc', id: 'signals/signal-provider', label: 'SignalProvider', customProps: { tags: ['alpha'] } },
+        {
+          type: 'doc',
+          id: 'signals/webhook-signal-provider',
+          label: 'WebhookSignalProvider',
+          customProps: { tags: ['alpha'] },
+        },
       ],
     },
     {

--- a/docs/src/content/en/reference/signals/create-notification-inbox-tool.mdx
+++ b/docs/src/content/en/reference/signals/create-notification-inbox-tool.mdx
@@ -1,0 +1,128 @@
+---
+title: "Reference: createNotificationInboxTool() | Signals"
+description: "API reference for createNotificationInboxTool(), which creates a tool for reading and managing notification inbox records."
+packages:
+  - "@mastra/core"
+---
+
+# createNotificationInboxTool()
+
+**Added in:** `@mastra/core@1.39.0`
+
+`createNotificationInboxTool()` creates a Mastra tool that lets an agent inspect and manage notification inbox records for the current thread.
+
+Use this tool with durable notification signals. For sending notification records, see [`Agent.sendNotificationSignal()`](/reference/agents/agent#sendnotificationsignalnotification-options).
+
+## Usage example
+
+The following example adds the inbox tool to an agent.
+
+```typescript title="src/mastra/agents/support-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { createNotificationInboxTool } from '@mastra/core/notifications'
+
+const notificationsStorage = await storage.getStore('notifications')
+
+export const supportAgent = new Agent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: 'Help the user triage updates.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  tools: {
+    notificationInbox: createNotificationInboxTool({ storage: notificationsStorage }),
+  },
+})
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'options',
+    type: 'object',
+    description: 'Tool configuration.',
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'storage',
+            type: 'NotificationsStorage',
+            description: "Notification storage domain returned by `storage.getStore('notifications')`.",
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+## Tool input
+
+The generated tool has the id `notification-inbox` and accepts these input fields.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'action',
+    type: "'list' | 'read' | 'markSeen' | 'dismiss' | 'archive' | 'search'",
+    description: 'Inbox action to perform.',
+  },
+  {
+    name: 'threadId',
+    type: 'string',
+    isOptional: true,
+    description: 'Thread ID to inspect. Defaults to the current agent thread when available.',
+  },
+  {
+    name: 'id',
+    type: 'string',
+    isOptional: true,
+    description: 'Notification ID. Required for `markSeen`, `dismiss`, and `archive`. Optional for `read`.',
+  },
+  {
+    name: 'status',
+    type: "'pending' | 'delivered' | 'seen' | 'dismissed' | 'archived' | 'discarded'",
+    isOptional: true,
+    description: 'Status filter for list, read, or search actions.',
+  },
+  {
+    name: 'priority',
+    type: "'low' | 'medium' | 'high' | 'urgent'",
+    isOptional: true,
+    description: 'Priority filter for list, read, or search actions.',
+  },
+  {
+    name: 'source',
+    type: 'string',
+    isOptional: true,
+    description: 'Source filter for list, read, or search actions.',
+  },
+  {
+    name: 'query',
+    type: 'string',
+    isOptional: true,
+    description: 'Search query. Required when `action` is `search`.',
+  },
+  {
+    name: 'limit',
+    type: 'number',
+    isOptional: true,
+    description: 'Maximum number of notifications to return. Must be a positive integer.',
+  },
+]}
+/>
+
+## Actions
+
+| Action | Description |
+| - | - |
+| `list` | Returns matching notifications. |
+| `read` | Delivers readable notification contents as signals and marks delivered records as seen. |
+| `markSeen` | Marks one notification as seen. |
+| `dismiss` | Marks one notification as dismissed. |
+| `archive` | Marks one notification as archived. |
+| `search` | Searches notifications by query and optional filters. |
+
+When `read` finds pending or delivered notifications, the tool delivers their contents as notification signals instead of returning the full contents as normal tool output. Use this after a `<notification-summary>` signal when the agent needs the full records behind the summary.

--- a/docs/src/content/en/reference/signals/signal-provider.mdx
+++ b/docs/src/content/en/reference/signals/signal-provider.mdx
@@ -395,31 +395,36 @@ await this.notify(
     description: 'The notification payload.',
     properties: [
       {
-        name: 'source',
-        type: 'string',
-        description: 'Identifier for the notification source.',
-      },
-      {
-        name: 'kind',
-        type: 'string',
-        description: 'Type of event (for example, `"pr-updated"`, `"new-message"`).',
-      },
-      {
-        name: 'summary',
-        type: 'string',
-        description: 'Human-readable summary of the event.',
-      },
-      {
-        name: 'priority',
-        type: '"high" | "medium" | "low"',
-        description: 'Notification priority.',
-        isOptional: true,
-      },
-      {
-        name: 'payload',
-        type: 'unknown',
-        description: 'Arbitrary data attached to the notification.',
-        isOptional: true,
+        type: 'object',
+        parameters: [
+          {
+            name: 'source',
+            type: 'string',
+            description: 'Identifier for the notification source.',
+          },
+          {
+            name: 'kind',
+            type: 'string',
+            description: 'Type of event (for example, `"pr-updated"`, `"new-message"`).',
+          },
+          {
+            name: 'summary',
+            type: 'string',
+            description: 'Human-readable summary of the event.',
+          },
+          {
+            name: 'priority',
+            type: '"high" | "medium" | "low"',
+            description: 'Notification priority.',
+            isOptional: true,
+          },
+          {
+            name: 'payload',
+            type: 'unknown',
+            description: 'Arbitrary data attached to the notification.',
+            isOptional: true,
+          },
+        ],
       },
     ],
   },

--- a/docs/src/content/en/reference/signals/signal-provider.mdx
+++ b/docs/src/content/en/reference/signals/signal-provider.mdx
@@ -7,9 +7,11 @@ packages:
 
 # SignalProvider
 
+**Added in:** `@mastra/core@1.39.0`
+
 Abstract base class for building signal providers. A signal provider monitors external sources (APIs, webhooks, event streams) and pushes notification signals into agent threads through a built-in subscription registry.
 
-Signal providers are not processors by default. Providers that need to intercept agent execution return processors from `getInputProcessors()` or `getOutputProcessors()`. Providers that expose agent-callable tools return them from `getTools()`.
+Signal providers aren't processors by default. Providers that need to intercept agent execution return processors from `getInputProcessors()` or `getOutputProcessors()`. Providers that expose agent-callable tools return them from `getTools()`.
 
 For a ready-to-use webhook-based provider, see [`WebhookSignalProvider`](/reference/signals/webhook-signal-provider).
 

--- a/docs/src/content/en/reference/signals/webhook-signal-provider.mdx
+++ b/docs/src/content/en/reference/signals/webhook-signal-provider.mdx
@@ -7,6 +7,8 @@ packages:
 
 # WebhookSignalProvider
 
+**Added in:** `@mastra/core@1.39.0`
+
 Concrete signal provider for push-based event delivery. Routes incoming webhook payloads to subscribed agent threads by matching the payload against a configurable resource ID extractor.
 
 Extends [`SignalProvider`](/reference/signals/signal-provider) with public subscription management and a built-in `handleWebhook()` implementation.

--- a/docs/src/content/en/reference/signals/webhook-signal-provider.mdx
+++ b/docs/src/content/en/reference/signals/webhook-signal-provider.mdx
@@ -162,14 +162,19 @@ Returns `{ status: 200, body: { matched: N } }` where `N` is the number of subsc
     description: 'The incoming webhook request.',
     properties: [
       {
-        name: 'body',
-        type: 'unknown',
-        description: 'The parsed webhook payload.',
-      },
-      {
-        name: 'headers',
-        type: 'Record<string, string>',
-        description: 'HTTP headers from the webhook request.',
+        type: 'object',
+        parameters: [
+          {
+            name: 'body',
+            type: 'unknown',
+            description: 'The parsed webhook payload.',
+          },
+          {
+            name: 'headers',
+            type: 'Record<string, string>',
+            description: 'HTTP headers from the webhook request.',
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## What

Signal providers had API reference pages but no conceptual or how-to coverage. This adds the two missing documentation layers so integrators can understand what signal providers are and build their own.

## Why

Signal providers are the producing side of the [signals](/docs/agents/signals) system: they monitor an external source and push notifications into agent threads. The existing docs only covered the consumer side (sending signals into a thread) and the raw API reference. There was no page explaining the concept or walking someone through building a provider.

## Changes

- **Concept page** — `docs/agents/signal-providers.mdx`
  - Explains what a signal provider is and where it sits relative to the signal APIs.
  - Covers when to use one, how it works, and how to build one by extending `SignalProvider`: subscription tracking, polling, webhooks, `notify()`, processors and tools, lifecycle hooks, and the built-in `WebhookSignalProvider`.
  - Includes a real-world reference to the `@mastra/github-signals` package.
  - Follows the standard concept-page styleguide (sentence-case title, concept-first intro, `When to use` / `How it works` / `Related`).
- **Tutorial** — `guides/guide/signal-provider.mdx`
  - Builds a polling CI signal provider end-to-end, runnable locally with no external API keys.
  - Follows the tutorial styleguide (Prerequisites, concept-named steps, Test, Next steps).
- **Sidebars** — adds the concept page under Agents and the tutorial under Tutorials > Fundamentals.
- Both pages cross-link the existing `reference/signals` pages.

## Validation

- `npm run format` (prettier) — clean
- `npm run lint:remark` — passes
- `npm run build` (docusaurus) — succeeds; the broken-link check validates all cross-links between the concept, tutorial, and reference pages resolve

Vale was not run locally (the `mdx2vast` helper isn't installed in this environment); it runs in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds beginner-friendly docs and a hands-on tutorial showing how to let AI agents watch external systems (like CI or GitHub) and send notifications into agent threads when things happen. It explains the concept, how to build providers, and gives a runnable example so developers can try it locally.

---

## Overview

Adds complete conceptual and tutorial documentation for signal providers used by Mastra agents: a concept page describing what signal providers are and how they work, plus a step-by-step tutorial that builds a polling CI signal provider example. Also updates sidebars to surface the new pages and links the new content to existing reference docs.

## Changes

### New / Updated documentation

- docs/src/content/en/docs/agents/signal-providers.mdx (+239 lines)
  - Concept page defining signal providers and their role vs. signal APIs.
  - Guidance on when to use providers and how they work.
  - How to build providers by extending SignalProvider: subscription tracking, polling (poll()), webhook ingestion (handleWebhook()/WebhookSignalProvider), and the protected notify() delivery path.
  - Coverage of deduplication (dedupeKey/coalesceKey), processors/tools, lifecycle hooks (start/stop), durable subscriptions, and the built-in WebhookSignalProvider.
  - Real-world reference to `@mastra/github-signals` and code examples/quickstarts.
  - Structured following concept-page style (sentence-case title, concept-first intro, When to use / How it works / Related).

- docs/src/content/en/guides/guide/signal-provider.mdx (+209 lines)
  - Tutorial: end-to-end walkthrough building a polling CI SignalProvider that uses a mock CI client and LibSQLStore for notification storage.
  - Implements watch/unwatch, poll loop, notification creation with dedupeKey, agent registration, subscribing a thread, and local testing instructions.
  - Runnable locally without external API keys; follows tutorial styleguide (Prereqs, named steps, Test, Next steps).

- docs/src/content/en/docs/agents/code-mode.mdx (+2/-0)
  - Added "Added in: `@mastra/core`@1.38.0" notice.

- docs/src/content/en/docs/agents/signals.mdx (+75/-189)
  - Reorganized signals page, added "When to use signals", refinements to quickstart, signal context, notification delivery, storage/tooling notes, and related links.

- Multiple reference docs updated to reflect API shapes and new notification/dispatch features:
  - docs/src/content/en/reference/agents/agent.mdx (+479/-145)
  - docs/src/content/en/reference/client-js/agents.mdx (+12/-0)
  - docs/src/content/en/reference/core/mastra-class.mdx (+66/-0)
  - docs/src/content/en/reference/harness/harness-class.mdx (+1/-1)
  - docs/src/content/en/reference/signals/signal-provider.mdx (+33/-26)
  - docs/src/content/en/reference/signals/webhook-signal-provider.mdx (+15/-8)
  - New reference: docs/src/content/en/reference/signals/create-notification-inbox-tool.mdx (+128/-0)

### Sidebar updates

- docs/src/content/en/docs/sidebars.js (+8 lines)
  - Adds concept doc entry under Agents with customProps.tags: ['alpha'].

- docs/src/content/en/guides/sidebars.js (+5 lines)
  - Adds tutorial entry under Tutorials → Fundamentals.

- docs/src/content/en/reference/sidebars.js (+13/-3)
  - Adds Agent Builder entries and tags SignalProvider/WebhookSignalProvider and new notification-inbox tool as alpha.

### Cross-linking

- Both new pages link to relevant reference pages (SignalProvider, WebhookSignalProvider, notification inbox tool, agent APIs) and to each other for a guided learning path.

## Validation

- npm run format — clean
- npm run lint:remark — passes
- npm run build (Docusaurus) — succeeds; built-in broken-link check validated cross-links between the concept, tutorial, and reference pages
- Vale (mdx2vast) not run locally; CI will run it

## Scope & Impact

- Documentation-only changes; no runtime/public API code changes.
- Estimated review effort: Low–Medium depending on preference for copy/structure edits in the larger signals/agent reference updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->