### PR TITLE
fix(client-js): keep client tools for signal continuations

### DIFF
--- a/.changeset/tiny-pianos-wave.md
+++ b/.changeset/tiny-pianos-wave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fixed subscribed client-tool continuations so client tools remain available across multiple continuation runs.

--- a/client-sdks/client-js/src/resources/agent.test.ts
+++ b/client-sdks/client-js/src/resources/agent.test.ts
@@ -607,6 +607,83 @@ describe('Agent signal routes', () => {
     expect(continuationCall[0].streamOptions?.memory).toEqual({ thread: 'thread-123', resource: 'resource-123' });
   });
 
+  it('keeps clientTools available across subscribed continuation runs', async () => {
+    const agent = new Agent(mockClientOptions, 'test-agent');
+    const chunks = [
+      {
+        type: 'tool-call',
+        runId: 'run-initial',
+        payload: { toolCallId: 'call-1', toolName: 'myTool', args: { value: 'first' } },
+      },
+      {
+        type: 'finish',
+        runId: 'run-initial',
+        payload: {
+          stepResult: { reason: 'tool-calls' },
+          messages: {
+            nonUser: [
+              {
+                role: 'assistant',
+                content: [{ type: 'tool-call', toolCallId: 'call-1', toolName: 'myTool', args: { value: 'first' } }],
+              },
+            ],
+          },
+        },
+      },
+      {
+        type: 'tool-call',
+        runId: 'run-continuation',
+        payload: { toolCallId: 'call-2', toolName: 'myTool', args: { value: 'second' } },
+      },
+      {
+        type: 'finish',
+        runId: 'run-continuation',
+        payload: {
+          stepResult: { reason: 'tool-calls' },
+          messages: {
+            nonUser: [
+              {
+                role: 'assistant',
+                content: [{ type: 'tool-call', toolCallId: 'call-2', toolName: 'myTool', args: { value: 'second' } }],
+              },
+            ],
+          },
+        },
+      },
+    ];
+    const sendToolApprovalSpy = vi
+      .spyOn(agent, 'sendToolApproval')
+      .mockResolvedValueOnce({ accepted: true, runId: 'run-continuation' } as never)
+      .mockResolvedValueOnce({ accepted: true, runId: 'run-final' } as never);
+    const executeSpy = vi.fn(async ({ value }: { value: string }) => ({ value }));
+    const clientTools = {
+      myTool: { id: 'myTool', description: 'tool', inputSchema: z.object({ value: z.string() }), execute: executeSpy },
+    };
+
+    await mockSignalAndSubscriptionRequests(agent, 'run-initial', chunks, {
+      signal: { type: 'user-message', contents: 'hello' },
+      resourceId: 'resource-123',
+      threadId: 'thread-123',
+      ifIdle: { streamOptions: { clientTools } },
+    } as SendAgentSignalParams);
+
+    const subscribed = await agent.subscribeToThread({
+      resourceId: 'resource-123',
+      threadId: 'thread-123',
+    } as SubscribeAgentThreadParams);
+
+    const received: any[] = [];
+    await subscribed.processDataStream({ onChunk: async chunk => void received.push(chunk) });
+
+    expect(executeSpy).toHaveBeenCalledTimes(2);
+    expect(executeSpy.mock.calls.map(call => call[0])).toEqual([{ value: 'first' }, { value: 'second' }]);
+    expect(sendToolApprovalSpy).toHaveBeenCalledTimes(2);
+    expect(received.filter(chunk => chunk.type === 'tool-result').map(chunk => chunk.payload.toolCallId)).toEqual([
+      'call-1',
+      'call-2',
+    ]);
+  });
+
   it('preserves assistant non-user messages for stateless client-tool continuations', async () => {
     const agent = new Agent(mockClientOptions, 'test-agent');
     const assistantMessages = [

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -769,6 +769,19 @@ export class Agent extends BaseResource {
             return;
           }
 
+          const continuationStreamOptions = {
+            ...activeRuntimeOptions,
+            requestContext: processedRequestContext,
+            memory: threadId ? { thread: threadId, resource: resourceId } : undefined,
+            clientTools: processedClientTools,
+          } as StreamParamsBaseWithoutMessages<any>;
+
+          agent.setSignalRuntimeOptions({
+            resourceId,
+            threadId,
+            streamOptions: continuationStreamOptions,
+          });
+
           try {
             await agent.sendToolApproval({
               resourceId: resourceId || agent.agentId,
@@ -779,14 +792,10 @@ export class Agent extends BaseResource {
               messages: (threadId
                 ? toolResultMessages
                 : [...(finishPayload.payload?.messages?.nonUser ?? []), ...toolResultMessages]) as MessageListInput,
-              streamOptions: {
-                ...activeRuntimeOptions,
-                requestContext: processedRequestContext,
-                memory: threadId ? { thread: threadId, resource: resourceId } : undefined,
-                clientTools: processedClientTools,
-              } as StreamParamsBaseWithoutMessages<any>,
+              streamOptions: continuationStreamOptions,
             });
           } catch (error) {
+            agent.deleteLatestSignalRuntimeOptions({ resourceId, threadId });
             console.error('Error running client-tool continuation:', error);
           } finally {
             agent.deleteSignalRuntimeOptions(runId);

--- a/examples/agent-builder/AGENTS.md
+++ b/examples/agent-builder/AGENTS.md
@@ -1,0 +1,3 @@
+When testing changes in this example, run `pnpm build:cli` from the repo root before restarting the dev server so linked workspace changes are reflected in Studio/Agent Builder.
+
+Start the example with `pnpm mastra dev` from this directory. Do not use a global `mastra dev` binary.


### PR DESCRIPTION
This fixes subscribed client-tool continuations when an agent calls browser client tools across multiple rounds.

Before, the first signal run stored client tools under the initial run id. When the server started a continuation with a new run id, the browser could lose access to those client tools and stop at `finish: tool-calls`.

```ts
run-initial -> client tool result -> run-continuation -> finish: tool-calls // browser has no clientTools
```

Now the client keeps the thread-scoped runtime options available before sending the continuation result, so follow-up continuation runs can keep executing client tools.

```ts
run-initial -> client tool result -> run-continuation -> client tool result -> ...
```

I also added a regression test for multiple subscribed client-tool continuation rounds and documented that Agent Builder local testing needs `pnpm build:cli` before restarting with `pnpm mastra dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a browser-based AI agent continued a conversation, it could lose access to its special toolbox and stop working. This PR keeps the toolbox available across continuation rounds so the agent can keep using the tools in subsequent runs.

## Changes Overview

### Core Fix: Preserve Client Tools Across Continuations
- client-sdks/client-js/src/resources/agent.ts
  - When a subscribed thread finishes with `tool-calls`, build a single `continuationStreamOptions` from the active runtime options (including processed `clientTools`, `requestContext`, and `memory` when `threadId` exists).
  - Persist that `continuationStreamOptions` into signal-runtime state via `agent.setSignalRuntimeOptions` before sending approvals, and reuse the same object when calling `agent.sendToolApproval`.
  - On `sendToolApproval` failure, delete only the matching latest thread-scoped runtime options (reference-aware cleanup) while still removing run-scoped options in `finally`. This prevents losing client tools across continuation run IDs.

### Test Coverage
- client-sdks/client-js/src/resources/agent.test.ts
  - Added a Vitest regression test that simulates two subscribed continuation cycles across separate run IDs and asserts:
    - client tool `execute` is called for each continuation with the correct per-run args,
    - `sendToolApproval` is invoked for each continuation,
    - emitted `tool-result` stream contains both tool-call IDs.

### Documentation
- examples/agent-builder/AGENTS.md
  - Added local dev instructions: rebuild the CLI with `pnpm build:cli` from the repo root before restarting the example with `pnpm mastra dev` so local changes to the CLI are picked up.

### Release Notes
- .changeset/tiny-pianos-wave.md
  - Bumps `@mastra/client-js` patch and documents the fix keeping client tools available across subscribed continuation runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->