### PR TITLE
feat(core): return ownerStream from sendSignal/sendMessage

### DIFF
--- a/.changeset/signal-owner-stream.md
+++ b/.changeset/signal-owner-stream.md
@@ -1,0 +1,18 @@
+---
+"@mastra/core": minor
+---
+
+Add `ownerStream` to the return value of `Agent.sendSignal`, `Agent.sendMessage`, `Agent.queueMessage`, `Agent.sendStateSignal`, and `Agent.sendNotificationSignal`.
+
+When the call wakes a new agent run from idle, `ownerStream` is the `Promise<MastraModelOutput<OUTPUT>>` for that run. When the signal is delivered to an already-running stream, joins a remote run, is persisted, queued, or otherwise does not start a new stream, `ownerStream` is `undefined`.
+
+Awaiting `ownerStream` keeps the caller alive until the run completes, which is required for serverless environments (Vercel, AWS Lambda, etc.) where the handler would otherwise exit immediately after responding and kill the run mid-flight.
+
+```ts
+const result = await agent.sendMessage(message, target);
+if (result.ownerStream) {
+  // This call woke a new run. Await it so the run can drive any stream
+  // processors (e.g. forwarding to Slack/Discord) to completion.
+  await result.ownerStream;
+}
+```

--- a/.changeset/signal-owner-stream.md
+++ b/.changeset/signal-owner-stream.md
@@ -6,13 +6,16 @@ Add `ownerStream` to the return value of `Agent.sendSignal`, `Agent.sendMessage`
 
 When the call wakes a new agent run from idle, `ownerStream` is the `Promise<MastraModelOutput<OUTPUT>>` for that run. When the signal is delivered to an already-running stream, joins a remote run, is persisted, queued, or otherwise does not start a new stream, `ownerStream` is `undefined`.
 
-Awaiting `ownerStream` keeps the caller alive until the run completes, which is required for serverless environments (Vercel, AWS Lambda, etc.) where the handler would otherwise exit immediately after responding and kill the run mid-flight.
+`MastraModelOutput` is lazy — awaiting the promise itself only resolves to the wrapper. To drive the run to completion, await `consumeStream()` (or any of the delayed-promise getters like `.finishReason`, `.text`, etc., which kick off consumption automatically). This is required for serverless environments (Vercel, AWS Lambda, etc.) where the handler would otherwise exit immediately after responding and kill the run mid-flight.
 
 ```ts
 const result = await agent.sendMessage(message, target);
 if (result.ownerStream) {
-  // This call woke a new run. Await it so the run can drive any stream
-  // processors (e.g. forwarding to Slack/Discord) to completion.
-  await result.ownerStream;
+  // This call woke a new run. Drive it to completion so any stream
+  // processors (e.g. forwarding to Slack/Discord) can finish.
+  const ownerStream = await result.ownerStream;
+  await ownerStream.consumeStream();
 }
 ```
+
+`consumeStream()` is idempotent and safe to call even if another consumer is already draining the stream.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6703,8 +6703,13 @@ export class Agent<
   sendMessage<OUTPUT = TOutput>(
     message: AgentMessageInput,
     target: SendAgentMessageOptions<OUTPUT>,
-  ): SendAgentMessageResult {
-    return agentThreadStreamRuntime.sendMessage(this as Agent<any, any, any, any>, message, target, this.getPubSub());
+  ): SendAgentMessageResult<OUTPUT> {
+    return agentThreadStreamRuntime.sendMessage<OUTPUT>(
+      this as Agent<any, any, any, any>,
+      message,
+      target,
+      this.getPubSub(),
+    );
   }
 
   /**
@@ -6713,8 +6718,13 @@ export class Agent<
   queueMessage<OUTPUT = TOutput>(
     message: AgentMessageInput,
     target: QueueAgentMessageOptions<OUTPUT>,
-  ): QueueAgentMessageResult {
-    return agentThreadStreamRuntime.queueMessage(this as Agent<any, any, any, any>, message, target, this.getPubSub());
+  ): QueueAgentMessageResult<OUTPUT> {
+    return agentThreadStreamRuntime.queueMessage<OUTPUT>(
+      this as Agent<any, any, any, any>,
+      message,
+      target,
+      this.getPubSub(),
+    );
   }
 
   /**
@@ -6723,8 +6733,13 @@ export class Agent<
   sendStateSignal<OUTPUT = TOutput>(
     state: AgentStateSignalInput,
     target: SendAgentStateSignalOptions<OUTPUT>,
-  ): Promise<SendAgentStateSignalResult> {
-    return agentThreadStreamRuntime.sendStateSignal(this as Agent<any, any, any, any>, state, target, this.getPubSub());
+  ): Promise<SendAgentStateSignalResult<OUTPUT>> {
+    return agentThreadStreamRuntime.sendStateSignal<OUTPUT>(
+      this as Agent<any, any, any, any>,
+      state,
+      target,
+      this.getPubSub(),
+    );
   }
 
   /**
@@ -6733,7 +6748,7 @@ export class Agent<
   async sendNotificationSignal<OUTPUT = TOutput>(
     notification: SendNotificationSignalInput,
     target: SendAgentNotificationSignalOptions<OUTPUT>,
-  ): Promise<SendAgentNotificationSignalResult> {
+  ): Promise<SendAgentNotificationSignalResult<OUTPUT>> {
     const notifications = await this.#mastra?.getStorage()?.getStore('notifications');
     if (!notifications) {
       throw new Error('sendNotificationSignal requires a notifications storage domain');
@@ -6852,8 +6867,16 @@ export class Agent<
   /**
    * @experimental Agent signals are experimental and may change in a future release.
    */
-  sendSignal<OUTPUT = TOutput>(signal: AgentSignal, target: SendAgentSignalOptions<OUTPUT>): SendAgentSignalResult {
-    return agentThreadStreamRuntime.sendSignal(this as Agent<any, any, any, any>, signal, target, this.getPubSub());
+  sendSignal<OUTPUT = TOutput>(
+    signal: AgentSignal,
+    target: SendAgentSignalOptions<OUTPUT>,
+  ): SendAgentSignalResult<OUTPUT> {
+    return agentThreadStreamRuntime.sendSignal<OUTPUT>(
+      this as Agent<any, any, any, any>,
+      signal,
+      target,
+      this.getPubSub(),
+    );
   }
 
   async stream<

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -1054,8 +1054,8 @@ export class AgentThreadStreamRuntime {
     message: AgentMessageInput,
     target: SendAgentMessageOptions<OUTPUT>,
     pubsub?: PubSub,
-  ): SendAgentMessageResult {
-    return this.sendSignal(agent, createMessageSignal(message, { acceptedAt: new Date() }), target, pubsub);
+  ): SendAgentMessageResult<OUTPUT> {
+    return this.sendSignal<OUTPUT>(agent, createMessageSignal(message, { acceptedAt: new Date() }), target, pubsub);
   }
 
   queueMessage<OUTPUT = unknown>(
@@ -1063,7 +1063,7 @@ export class AgentThreadStreamRuntime {
     message: AgentMessageInput,
     target: QueueAgentMessageOptions<OUTPUT>,
     pubsub?: PubSub,
-  ): QueueAgentMessageResult {
+  ): QueueAgentMessageResult<OUTPUT> {
     const state = this.#getState(pubsub);
     const signal = createMessageSignal(message, { acceptedAt: new Date() });
     let key: string | undefined;
@@ -1106,7 +1106,7 @@ export class AgentThreadStreamRuntime {
       return { accepted: true, runId: queuedRunId, signal };
     }
 
-    return this.sendSignal(
+    return this.sendSignal<OUTPUT>(
       agent,
       signal,
       { ...target, runId, resourceId, threadId, ifIdle: { ...target.ifIdle, behavior: 'wake' } },
@@ -1119,7 +1119,7 @@ export class AgentThreadStreamRuntime {
     stateInput: AgentStateSignalInput,
     target: SendAgentStateSignalOptions<OUTPUT>,
     pubsub?: PubSub,
-  ): Promise<SendAgentStateSignalResult> {
+  ): Promise<SendAgentStateSignalResult<OUTPUT>> {
     if (!target.resourceId || !target.threadId) {
       throw new Error('resourceId and threadId are required to send a state signal');
     }
@@ -1161,7 +1161,7 @@ export class AgentThreadStreamRuntime {
       return { accepted: true, skipped: true, reason: 'unchanged' };
     }
 
-    return this.sendSignal(agent, applied.signal, target, pubsub);
+    return this.sendSignal<OUTPUT>(agent, applied.signal, target, pubsub);
   }
 
   /**
@@ -1181,7 +1181,7 @@ export class AgentThreadStreamRuntime {
     signalInput: AgentSignal,
     target: SendAgentSignalOptions<OUTPUT>,
     pubsub?: PubSub,
-  ): SendAgentSignalResult {
+  ): SendAgentSignalResult<OUTPUT> {
     const state = this.#getState(pubsub);
     let signal = createSignal({ ...signalInput, acceptedAt: new Date() });
     let key: string | undefined;
@@ -1320,21 +1320,26 @@ export class AgentThreadStreamRuntime {
     // the idle stream so concurrent callers do not launch duplicate runs.
     state.activeThreadRunIds.set(key, runId);
     state.threadKeysByRunId.set(runId, key);
-    void agent
+    const ownerStream = agent
       .stream(signal, {
         ...(target.ifIdle?.streamOptions as any),
         runId,
         memory: withThreadMemory(target.ifIdle?.streamOptions?.memory, resourceId, threadId),
       })
-      .catch(() => {
+      .catch(error => {
         state.threadKeysByRunId.delete(runId);
         this.#cleanupPreparedRun(state, runId);
         if (state.activeThreadRunIds.get(key) === runId) {
           state.activeThreadRunIds.delete(key);
         }
+        throw error;
       });
+    // Always attach a no-op catch to the promise we keep internally so an unawaited
+    // ownerStream cannot surface as an unhandled rejection. Callers that opt in to
+    // `ownerStream` will see the rejection via their own await/catch.
+    void ownerStream.catch(() => {});
 
-    return { accepted: true, runId, signal };
+    return { accepted: true, runId, signal, ownerStream: ownerStream as Promise<MastraModelOutput<OUTPUT>> };
   }
 }
 

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -152,12 +152,24 @@ export type SendAgentSignalOptions<OUTPUT = unknown> =
 /**
  * @experimental Agent signals are experimental and may change in a future release.
  */
-export interface SendAgentSignalResult {
+export interface SendAgentSignalResult<OUTPUT = unknown> {
   accepted: true;
   runId: string;
   signal: CreatedAgentSignal;
   /** Resolves when a `persist` behavior finishes writing the signal to memory. */
   persisted?: Promise<void>;
+  /**
+   * Present only when this call woke a new run (idle → wake path). The promise resolves
+   * with the `MastraModelOutput` for the newly-started run so the caller can drive it to
+   * completion. In serverless environments, awaiting this keeps the function alive long
+   * enough for the run (and any stream processors attached to it) to finish.
+   *
+   * When the signal is delivered to an already-running stream, joins a remote run, is
+   * persisted, queued, or otherwise does not start a new stream, this field is `undefined`.
+   *
+   * @experimental
+   */
+  ownerStream?: Promise<MastraModelOutput<OUTPUT>>;
 }
 
 /**
@@ -168,7 +180,7 @@ export type SendAgentMessageOptions<OUTPUT = unknown> = SendAgentSignalOptions<O
 /**
  * @experimental Agent message APIs are experimental and may change in a future release.
  */
-export type SendAgentMessageResult = SendAgentSignalResult;
+export type SendAgentMessageResult<OUTPUT = unknown> = SendAgentSignalResult<OUTPUT>;
 
 /**
  * @experimental Agent message APIs are experimental and may change in a future release.
@@ -178,7 +190,7 @@ export type QueueAgentMessageOptions<OUTPUT = unknown> = SendAgentSignalOptions<
 /**
  * @experimental Agent message APIs are experimental and may change in a future release.
  */
-export type QueueAgentMessageResult = SendAgentSignalResult;
+export type QueueAgentMessageResult<OUTPUT = unknown> = SendAgentSignalResult<OUTPUT>;
 
 /**
  * @experimental Agent state signal APIs are experimental and may change in a future release.
@@ -188,8 +200,8 @@ export type SendAgentStateSignalOptions<OUTPUT = unknown> = SendAgentSignalOptio
 /**
  * @experimental Agent state signal APIs are experimental and may change in a future release.
  */
-export type SendAgentStateSignalResult =
-  | (SendAgentSignalResult & { skipped?: false })
+export type SendAgentStateSignalResult<OUTPUT = unknown> =
+  | (SendAgentSignalResult<OUTPUT> & { skipped?: false })
   | { accepted: true; skipped: true; reason: 'unchanged'; runId?: string; signal?: undefined };
 
 /**
@@ -215,13 +227,20 @@ export type AgentNotificationConfig = {
 /**
  * @experimental Agent notification signal APIs are experimental and may change in a future release.
  */
-export type SendAgentNotificationSignalResult = {
+export type SendAgentNotificationSignalResult<OUTPUT = unknown> = {
   accepted: boolean;
   record: NotificationRecord;
   decision: NotificationDeliveryDecision;
   runId?: string;
   signal?: CreatedAgentSignal;
   persisted?: Promise<void>;
+  /**
+   * Present only when the notification's underlying signal woke a new run.
+   * See {@link SendAgentSignalResult.ownerStream}.
+   *
+   * @experimental
+   */
+  ownerStream?: Promise<MastraModelOutput<OUTPUT>>;
 };
 
 export interface AgentThreadRun<OUTPUT = unknown> {


### PR DESCRIPTION
## Why

`Agent.sendSignal` (and the `sendMessage` / `queueMessage` / `sendStateSignal` / `sendNotificationSignal` wrappers) has no way to hand the caller the run it just woke. When the call transitions a thread from idle into a new run, the runtime fires `agent.stream(...)` as `void agent.stream(...).catch(...)` and the promise is unreachable.

That makes it impossible for a caller to:

- drive the run to completion before doing follow-up work
- attach its own consumer to the run's `MastraModelOutput`
- decide whether to keep its host process alive while the run drains

This PR exposes that promise so callers can opt into any of the above.

## What this PR does

Threads an optional `ownerStream` through the signals return types:

- `SendAgentSignalResult`
- `SendAgentMessageResult`
- `QueueAgentMessageResult`
- `SendAgentStateSignalResult`
- `SendAgentNotificationSignalResult`

`ownerStream` is `Promise<MastraModelOutput<OUTPUT>>` and is **only set when the call wakes a new run from idle**. For deliver / join-remote / queue-into-active-run / persist / discard paths it is `undefined`.

Internally, the wake path in `thread-stream-runtime.sendSignal` already calls `void agent.stream(...)` and detaches it. This PR captures the promise instead and returns it. The existing `.catch` for cleanup is preserved, and an internal no-op `.catch` is attached so callers that don't opt in still don't see unhandled rejection warnings.

`MastraModelOutput` is lazy, so awaiting `ownerStream` alone just resolves to the wrapper. To drive the run to completion, await `consumeStream()` (or any of the delayed-promise getters like `.finishReason` / `.text`, which kick off consumption automatically). `consumeStream()` is idempotent and safe to call even if another consumer is already draining.

```ts
const result = await agent.sendMessage(message, target);
if (result.ownerStream) {
  const ownerStream = await result.ownerStream;
  await ownerStream.consumeStream();
}
```

The generics on `Agent.sendMessage` / `queueMessage` / `sendSignal` / `sendStateSignal` / `sendNotificationSignal` are threaded through so `ownerStream` carries the agent's `OUTPUT` type.

## Scope

Pure addition to the signals return type. No behavior changes for existing callers that ignore the new field.

## Test plan

- [x] `pnpm build:core`
- [x] `pnpm --filter ./packages/core check`
