### PR TITLE
feat(core/channels): await ownerStream in AgentChannels webhook

### DIFF
--- a/.changeset/agent-channels-await-owner-stream.md
+++ b/.changeset/agent-channels-await-owner-stream.md
@@ -1,0 +1,9 @@
+---
+"@mastra/core": patch
+---
+
+`AgentChannels` now awaits the agent run to completion when an incoming chat message wakes a new run.
+
+Previously the webhook handler fired `agent.sendMessage(...)` and returned immediately, relying on a side-effect subscription to drive the agent stream. That works in long-lived Node processes but breaks in serverless runtimes (Vercel, AWS Lambda, etc.) where the function exits as soon as it returns and kills the run mid-flight, producing missing or partial responses.
+
+When `sendMessage` returns an `ownerStream` (i.e. the call woke a new run from idle), the handler now awaits `ownerStream.consumeStream()` before returning, keeping the host alive for the duration of the run. Calls that join an in-flight run, queue, persist, or discard are unaffected.

--- a/.changeset/agent-channels-concurrent-chat.md
+++ b/.changeset/agent-channels-concurrent-chat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+`AgentChannels` now configures chat-sdk with `concurrency: { strategy: 'concurrent' }` instead of `'queue'`. Same-thread ordering, wake/deliver/queue, and run lifecycle are already handled by the agent signals layer (`ifActive`/`ifIdle`), so chat-sdk's lock-based queue was redundant. In serverless runtimes a stale lock from a frozen invocation could leave subsequent messages queued indefinitely; switching to `concurrent` removes that failure mode while keeping chat-sdk's deduplication (which runs regardless of strategy).

--- a/.changeset/slack-provider-wait-until.md
+++ b/.changeset/slack-provider-wait-until.md
@@ -3,32 +3,38 @@
 '@mastra/core': minor
 ---
 
-Forward a runtime-provided `waitUntil` from `SlackProvider` to AgentChannels and the
-Chat SDK so background agent runs survive serverless responses. Without `waitUntil`
-the runtime freezes the invocation as soon as the 200 ack returns, killing the agent
-run mid-flight and leaving Slack with no reply.
+Forward a runtime-provided `waitUntil` from channels to the Chat SDK so background
+agent runs survive serverless responses. Without `waitUntil` the runtime freezes the
+invocation as soon as the 200 ack returns, killing the agent run mid-flight and
+leaving the user with no reply.
 
-**`@mastra/core/channels`** now exports a small helper and resolver type:
+**Defaults (no config needed):** `@mastra/core/channels` ships a default resolver
+that reads `waitUntil` from the request context for the common cases:
 
-```ts
-import { resolveWaitUntil, type WaitUntilResolver } from '@mastra/core/channels';
-```
+- **Cloudflare Workers** — `c.executionCtx.waitUntil` (populated by Hono's CF adapter).
+- **Netlify Functions** — `c.env.context.waitUntil` (forwarded by `hono/netlify`).
 
-`resolveWaitUntil(c)` reads `c.executionCtx.waitUntil` (populated by Hono's
-Cloudflare Workers adapter) — guarded against Hono's getter that throws in Node.js
-when no ExecutionContext exists.
-
-**`SlackProvider`** accepts an optional `resolveWaitUntil` resolver for runtimes
-Hono doesn't bridge automatically (Vercel, Netlify, custom platforms). The resolver
-receives the request's Hono `Context` and returns the platform's `waitUntil`.
+**Vercel and AWS Lambda** need an explicit `waitUntil` because Vercel exposes
+`waitUntil` via AsyncLocalStorage (not the request context) and AWS Lambda has none
+natively. Pass it via the new `waitUntil` option on `SlackProvider` or `ChannelConfig`:
 
 ```ts
 import { waitUntil } from '@vercel/functions';
+import { SlackProvider } from '@mastra/slack';
 
-new SlackProvider({
-  resolveWaitUntil: () => waitUntil,
+new SlackProvider({ waitUntil });
+```
+
+```ts
+new Agent({
+  channels: {
+    adapters: { slack: createSlackAdapter({ ... }) },
+    waitUntil,
+  },
 });
 ```
 
-Cloudflare Workers users don't need to pass anything — the default helper reads
-`c.executionCtx.waitUntil` automatically.
+For runtimes where `waitUntil` lives on the request context but isn't covered by the
+default helper, pass `resolveWaitUntil: (c) => fn | undefined` instead.
+
+Resolution order: bare `waitUntil` → `resolveWaitUntil(c)` → core default.

--- a/.changeset/slack-provider-wait-until.md
+++ b/.changeset/slack-provider-wait-until.md
@@ -1,0 +1,34 @@
+---
+'@mastra/slack': minor
+'@mastra/core': minor
+---
+
+Forward a runtime-provided `waitUntil` from `SlackProvider` to AgentChannels and the
+Chat SDK so background agent runs survive serverless responses. Without `waitUntil`
+the runtime freezes the invocation as soon as the 200 ack returns, killing the agent
+run mid-flight and leaving Slack with no reply.
+
+**`@mastra/core/channels`** now exports a small helper and resolver type:
+
+```ts
+import { resolveWaitUntil, type WaitUntilResolver } from '@mastra/core/channels';
+```
+
+`resolveWaitUntil(c)` reads `c.executionCtx.waitUntil` (populated by Hono's
+Cloudflare Workers adapter) — guarded against Hono's getter that throws in Node.js
+when no ExecutionContext exists.
+
+**`SlackProvider`** accepts an optional `resolveWaitUntil` resolver for runtimes
+Hono doesn't bridge automatically (Vercel, Netlify, custom platforms). The resolver
+receives the request's Hono `Context` and returns the platform's `waitUntil`.
+
+```ts
+import { waitUntil } from '@vercel/functions';
+
+new SlackProvider({
+  resolveWaitUntil: () => waitUntil,
+});
+```
+
+Cloudflare Workers users don't need to pass anything — the default helper reads
+`c.executionCtx.waitUntil` automatically.

--- a/channels/slack/src/provider.ts
+++ b/channels/slack/src/provider.ts
@@ -7,6 +7,7 @@ import {
   type ChannelConnectResult,
   type ChannelAdapterConfig,
   AgentChannels,
+  resolveWaitUntil,
 } from '@mastra/core/channels';
 import type { ApiRoute, ContextWithMastra } from '@mastra/core/server';
 import { type ChannelsStorage, type ChannelInstallation } from '@mastra/core/storage';
@@ -1431,8 +1432,19 @@ export class SlackProvider implements ChannelProvider {
       body: rawBody,
     });
 
+    // Resolve waitUntil for this request. User-supplied resolver wins (covers Vercel
+    // via `@vercel/functions`, Netlify via Netlify Context, custom runtimes). Falls
+    // back to Hono's `c.executionCtx.waitUntil` (Cloudflare Workers). Without
+    // waitUntil, the serverless invocation freezes after returning 200 and kills the
+    // agent run mid-flight.
+    const waitUntilFn = this.#channelConfig.resolveWaitUntil?.(c) ?? resolveWaitUntil(c);
+
     try {
-      return await agentChannels.handleWebhookEvent('slack', delegateRequest);
+      return await agentChannels.handleWebhookEvent(
+        'slack',
+        delegateRequest,
+        waitUntilFn ? { waitUntil: waitUntilFn } : undefined,
+      );
     } catch (error) {
       console.error('[Slack] Error delegating to AgentChannels:', error);
       return c.json({ ok: true });
@@ -1504,8 +1516,8 @@ export class SlackProvider implements ChannelProvider {
       });
     };
 
-    // Process in background
-    (async () => {
+    // Process in background and keep the serverless invocation alive while it runs.
+    const task = (async () => {
       try {
         const result = await agent.generate(prompt);
         const text = typeof result.text === 'string' ? result.text : JSON.stringify(result.text);
@@ -1516,6 +1528,9 @@ export class SlackProvider implements ChannelProvider {
         await sendDelayedResponse(`Error: ${message}`);
       }
     })();
+
+    const slashWaitUntil = this.#channelConfig.resolveWaitUntil?.(c) ?? resolveWaitUntil(c);
+    slashWaitUntil?.(task);
 
     // Return immediate acknowledgment
     return c.json({ response_type: 'ephemeral', text: 'Processing...' });

--- a/channels/slack/src/provider.ts
+++ b/channels/slack/src/provider.ts
@@ -7,6 +7,7 @@ import {
   type ChannelConnectResult,
   type ChannelAdapterConfig,
   AgentChannels,
+  describeWaitUntilContext,
   resolveWaitUntil,
 } from '@mastra/core/channels';
 import type { ApiRoute, ContextWithMastra } from '@mastra/core/server';
@@ -1432,12 +1433,19 @@ export class SlackProvider implements ChannelProvider {
       body: rawBody,
     });
 
-    // Resolve waitUntil for this request. User-supplied resolver wins (covers Vercel
-    // via `@vercel/functions`, Netlify via Netlify Context, custom runtimes). Falls
-    // back to Hono's `c.executionCtx.waitUntil` (Cloudflare Workers). Without
-    // waitUntil, the serverless invocation freezes after returning 200 and kills the
-    // agent run mid-flight.
-    const waitUntilFn = this.#channelConfig.resolveWaitUntil?.(c) ?? resolveWaitUntil(c);
+    // Resolve waitUntil for this request. Lookup order: bare fn from config (Vercel
+    // users pass `waitUntil` from `@vercel/functions` here), user resolver, then the
+    // core default (Cloudflare Workers + Netlify). Without waitUntil, the serverless
+    // invocation freezes after returning 200 and kills the agent run mid-flight.
+    const waitUntilFn =
+      this.#channelConfig.waitUntil ?? this.#channelConfig.resolveWaitUntil?.(c) ?? resolveWaitUntil(c);
+    // TEMP: log context shape so we can diagnose runtime-specific resolution.
+    // Strip before release.
+    try {
+      console.info(
+        `[wait-until] slack resolved=${Boolean(waitUntilFn)} ${JSON.stringify(describeWaitUntilContext(c))}`,
+      );
+    } catch {}
 
     try {
       return await agentChannels.handleWebhookEvent(
@@ -1529,7 +1537,8 @@ export class SlackProvider implements ChannelProvider {
       }
     })();
 
-    const slashWaitUntil = this.#channelConfig.resolveWaitUntil?.(c) ?? resolveWaitUntil(c);
+    const slashWaitUntil =
+      this.#channelConfig.waitUntil ?? this.#channelConfig.resolveWaitUntil?.(c) ?? resolveWaitUntil(c);
     slashWaitUntil?.(task);
 
     // Return immediate acknowledgment

--- a/channels/slack/src/types.ts
+++ b/channels/slack/src/types.ts
@@ -5,6 +5,7 @@ import type {
   StaticToolDisplay,
   StreamingConfig,
   ToolDisplay,
+  WaitUntilResolver,
 } from '@mastra/core/channels';
 import type { ChannelsStorage } from '@mastra/core/storage';
 import type { SlackAdapterConfig } from '@chat-adapter/slack';
@@ -223,6 +224,30 @@ interface SlackProviderConfigBase extends SlackAdapterChannelConfigBase {
    * Use a 32+ character random string. Can be set via MASTRA_ENCRYPTION_KEY env var.
    */
   encryptionKey?: string;
+
+  /**
+   * Resolver that returns a `waitUntil` for the current Slack webhook request.
+   *
+   * Required on serverless runtimes where Hono can't bridge the platform's
+   * `ExecutionContext` automatically (Vercel, Netlify). Without `waitUntil`, the
+   * runtime freezes the invocation as soon as the 200 ack returns, killing the
+   * agent run mid-flight and leaving the user with no Slack reply.
+   *
+   * Receives the request's Hono `Context` (optional — `@vercel/functions`'s
+   * `waitUntil` uses AsyncLocalStorage and ignores the arg).
+   *
+   * Cloudflare Workers users typically don't need this — the default helper
+   * already reads `c.executionCtx.waitUntil` from Hono.
+   *
+   * @example
+   * ```ts
+   * import { waitUntil } from '@vercel/functions';
+   * new SlackProvider({
+   *   resolveWaitUntil: () => waitUntil,
+   * });
+   * ```
+   */
+  resolveWaitUntil?: WaitUntilResolver;
 
   /**
    * Per-adapter overrides applied to the Slack adapter entry inside

--- a/channels/slack/src/types.ts
+++ b/channels/slack/src/types.ts
@@ -5,6 +5,7 @@ import type {
   StaticToolDisplay,
   StreamingConfig,
   ToolDisplay,
+  WaitUntilFn,
   WaitUntilResolver,
 } from '@mastra/core/channels';
 import type { ChannelsStorage } from '@mastra/core/storage';
@@ -229,23 +230,34 @@ interface SlackProviderConfigBase extends SlackAdapterChannelConfigBase {
    * Resolver that returns a `waitUntil` for the current Slack webhook request.
    *
    * Required on serverless runtimes where Hono can't bridge the platform's
-   * `ExecutionContext` automatically (Vercel, Netlify). Without `waitUntil`, the
+   * `ExecutionContext` automatically (Vercel, AWS Lambda). Without `waitUntil`, the
    * runtime freezes the invocation as soon as the 200 ack returns, killing the
    * agent run mid-flight and leaving the user with no Slack reply.
    *
-   * Receives the request's Hono `Context` (optional — `@vercel/functions`'s
-   * `waitUntil` uses AsyncLocalStorage and ignores the arg).
+   * Pass the bare `waitUntil(promise)` function from your platform's SDK. If your
+   * runtime requires the Hono `Context` to derive `waitUntil`, use
+   * {@link resolveWaitUntil} instead.
    *
-   * Cloudflare Workers users typically don't need this — the default helper
-   * already reads `c.executionCtx.waitUntil` from Hono.
+   * Cloudflare Workers and Netlify users typically don't need this — Mastra's
+   * default helper already reads `c.executionCtx.waitUntil` and
+   * `c.env.context.waitUntil`.
    *
    * @example
    * ```ts
    * import { waitUntil } from '@vercel/functions';
-   * new SlackProvider({
-   *   resolveWaitUntil: () => waitUntil,
-   * });
+   * new SlackProvider({ waitUntil });
    * ```
+   */
+  waitUntil?: WaitUntilFn;
+
+  /**
+   * Resolve `waitUntil` from the request's Hono `Context`. Use this when the runtime
+   * exposes `waitUntil` through the request and core's default doesn't cover it.
+   *
+   * For platforms whose `waitUntil` is a bare import (e.g. `@vercel/functions`),
+   * pass it via {@link waitUntil} instead.
+   *
+   * Resolution order: {@link waitUntil} → {@link resolveWaitUntil} → core default.
    */
   resolveWaitUntil?: WaitUntilResolver;
 

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -1049,7 +1049,7 @@ export class AgentChannels {
     // Otherwise pass the parts array directly — both shapes match AgentSignalContents.
     const signalContents: AgentSignalContents = parts.length === 1 && parts[0]?.type === 'text' ? parts[0].text : parts;
 
-    this.agent.sendMessage(
+    const result = this.agent.sendMessage(
       {
         contents: signalContents,
         attributes,
@@ -1073,6 +1073,20 @@ export class AgentChannels {
         },
       },
     );
+
+    // When this call wakes a new run, drive it to completion before returning.
+    // Without this, serverless runtimes (Vercel, Lambda, etc.) terminate the
+    // invocation as soon as the webhook handler returns and kill the run
+    // mid-flight. `consumeStream()` is idempotent and safe to call alongside
+    // the existing per-thread subscription consumer.
+    if (result.ownerStream) {
+      try {
+        const ownerStream = await result.ownerStream;
+        await ownerStream.consumeStream();
+      } catch (err) {
+        this.log('debug', 'ownerStream consume failed', err);
+      }
+    }
   }
 
   /**

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -261,7 +261,12 @@ export class AgentChannels {
         adapters: this.adapters,
         state: this.stateAdapter,
         userName: this.userName,
-        concurrency: { strategy: 'queue' },
+        // Dispatch every incoming message immediately. Concurrency and queueing
+        // for the same thread are handled by the agent signals layer
+        // (ifActive/ifIdle behaviors), so chat-sdk's own lock-based queue would
+        // be redundant — and in serverless runtimes a stale lock from a frozen
+        // Lambda can cause subsequent messages to be queued forever.
+        concurrency: { strategy: 'concurrent' },
         ...this.chatOptions,
       });
 

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -45,7 +45,7 @@ import type {
 } from './types';
 import { defaultTypingStatus } from './typing-status';
 import type { TypingStatusContext, TypingStatusFn } from './typing-status';
-import { resolveWaitUntil } from './wait-until';
+import { describeWaitUntilContext, resolveWaitUntil } from './wait-until';
 
 /**
  * Manages a single Chat SDK instance for an agent, wiring all adapters
@@ -615,7 +615,16 @@ export class AgentChannels {
 
             // Pass platform execution context (e.g. Vercel/Cloudflare waitUntil)
             // to the Chat SDK so background processing survives serverless responses.
-            const waitUntilFn = resolveWaitUntil(c);
+            // Resolution order: bare `waitUntil` fn from config → user resolver → default.
+            const waitUntilFn =
+              self.channelConfig.waitUntil ?? self.channelConfig.resolveWaitUntil?.(c) ?? resolveWaitUntil(c);
+            // TEMP: log context shape so we can diagnose runtime-specific resolution.
+            // Strip before release.
+            try {
+              console.info(
+                `[wait-until] agent-channels resolved=${Boolean(waitUntilFn)} ${JSON.stringify(describeWaitUntilContext(c))}`,
+              );
+            } catch {}
             return webhookHandler(c.req.raw, waitUntilFn ? { waitUntil: waitUntilFn } : undefined);
           };
         },

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -45,6 +45,7 @@ import type {
 } from './types';
 import { defaultTypingStatus } from './typing-status';
 import type { TypingStatusContext, TypingStatusFn } from './typing-status';
+import { resolveWaitUntil } from './wait-until';
 
 /**
  * Manages a single Chat SDK instance for an agent, wiring all adapters
@@ -614,14 +615,7 @@ export class AgentChannels {
 
             // Pass platform execution context (e.g. Vercel/Cloudflare waitUntil)
             // to the Chat SDK so background processing survives serverless responses.
-            // Hono's `executionCtx` getter throws in Node.js when no ExecutionContext exists.
-            let execCtx: { waitUntil?: (p: Promise<unknown>) => void } | undefined;
-            try {
-              execCtx = c.executionCtx as { waitUntil?: (p: Promise<unknown>) => void } | undefined;
-            } catch {
-              execCtx = undefined;
-            }
-            const waitUntilFn = execCtx?.waitUntil?.bind(execCtx);
+            const waitUntilFn = resolveWaitUntil(c);
             return webhookHandler(c.req.raw, waitUntilFn ? { waitUntil: waitUntilFn } : undefined);
           };
         },

--- a/packages/core/src/channels/index.ts
+++ b/packages/core/src/channels/index.ts
@@ -3,7 +3,7 @@ export { ChatChannelProcessor } from './processor';
 export { MastraStateAdapter } from './state-adapter';
 export { defaultTypingStatus } from './typing-status';
 export type { TypingStatusContext, TypingStatusFn, TypingStatusReturn } from './typing-status';
-export { resolveWaitUntil } from './wait-until';
+export { resolveWaitUntil, describeWaitUntilContext } from './wait-until';
 export type { WaitUntilFn, WaitUntilResolver } from './wait-until';
 export type {
   ChannelAdapterBaseConfig,

--- a/packages/core/src/channels/index.ts
+++ b/packages/core/src/channels/index.ts
@@ -3,6 +3,8 @@ export { ChatChannelProcessor } from './processor';
 export { MastraStateAdapter } from './state-adapter';
 export { defaultTypingStatus } from './typing-status';
 export type { TypingStatusContext, TypingStatusFn, TypingStatusReturn } from './typing-status';
+export { resolveWaitUntil } from './wait-until';
+export type { WaitUntilFn, WaitUntilResolver } from './wait-until';
 export type {
   ChannelAdapterBaseConfig,
   ChannelAdapterConfig,

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -4,6 +4,7 @@ import type { Mastra } from '../mastra';
 import type { ApiRoute, CorsOptions } from '../server/types';
 import type { InlineLinkEntry } from './inline-media';
 import type { TypingStatusFn } from './typing-status';
+import type { WaitUntilFn, WaitUntilResolver } from './wait-until';
 
 export type { InlineLinkEntry } from './inline-media';
 
@@ -511,6 +512,40 @@ export interface ChannelConfig {
    * ```
    */
   resolveResourceId?: ResolveResourceId;
+
+  /**
+   * Keep the serverless invocation alive while background work (agent stream → platform)
+   * runs after the webhook returns 200. Required on Vercel/AWS Lambda — without it the
+   * runtime freezes the function as soon as the response is sent, killing in-flight runs.
+   *
+   * Pass the bare `waitUntil(promise)` function imported from your platform's SDK.
+   * Cloudflare Workers and Netlify users typically don't need this — core resolves
+   * `waitUntil` from `c.executionCtx` and `c.env.context` automatically.
+   *
+   * If `waitUntil` requires the request context to derive, use {@link resolveWaitUntil}
+   * instead.
+   *
+   * @example
+   * ```ts
+   * // Vercel
+   * import { waitUntil } from '@vercel/functions';
+   * channels: { adapters: { ... }, waitUntil }
+   * ```
+   */
+  waitUntil?: WaitUntilFn;
+
+  /**
+   * Resolve `waitUntil` from the request's Hono `Context`. Use this when the runtime
+   * exposes `waitUntil` through the request and core's default resolver doesn't cover
+   * it (custom adapters, exotic runtimes).
+   *
+   * For platforms whose `waitUntil` is a bare import (e.g. `@vercel/functions`), pass
+   * it via {@link waitUntil} instead — no resolver needed.
+   *
+   * Resolution order: {@link waitUntil} (if set) → {@link resolveWaitUntil} (if set)
+   * → core's default.
+   */
+  resolveWaitUntil?: WaitUntilResolver;
 }
 
 // =============================================================================

--- a/packages/core/src/channels/wait-until.ts
+++ b/packages/core/src/channels/wait-until.ts
@@ -1,0 +1,53 @@
+import type { Context } from 'hono';
+
+/**
+ * A platform-provided callback that keeps the current serverless invocation alive
+ * until the given promise settles. Without it, serverless runtimes freeze the
+ * invocation as soon as the handler returns, killing any in-flight background work.
+ */
+export type WaitUntilFn = (promise: Promise<unknown>) => void;
+
+/**
+ * User-supplied resolver that returns a `waitUntil` for the current request.
+ *
+ * Receives the request's Hono `Context` (optional — some resolvers don't need it,
+ * e.g. `@vercel/functions`'s `waitUntil` uses AsyncLocalStorage). Channel providers
+ * accept this on construction to support runtimes Hono doesn't bridge automatically
+ * (Vercel, Netlify, custom platforms).
+ *
+ * @example
+ * // Vercel
+ * import { waitUntil } from '@vercel/functions';
+ * new SlackProvider({ resolveWaitUntil: () => waitUntil });
+ *
+ * @example
+ * // Cloudflare Workers (explicit; usually unneeded since core resolves this by default)
+ * new SlackProvider({
+ *   resolveWaitUntil: (c) => c?.executionCtx?.waitUntil?.bind(c.executionCtx),
+ * });
+ */
+export type WaitUntilResolver = (c?: Context) => WaitUntilFn | undefined;
+
+/**
+ * Resolve `waitUntil` from a Hono context's `executionCtx`.
+ *
+ * Hono populates `c.executionCtx` only when the runtime hands it an ExecutionContext
+ * (Cloudflare Workers' `app.fetch(req, env, ctx)` convention). Vercel and Netlify's
+ * Hono adapters do NOT bridge the platform's `waitUntil` here — on those runtimes the
+ * user should import `waitUntil` from `@vercel/functions` (or read it off the Netlify
+ * `Context`) and pass it through a constructor option instead.
+ *
+ * Hono's `executionCtx` getter throws in Node.js when no ExecutionContext exists,
+ * so the access must be guarded by try/catch.
+ *
+ * @returns A bound `waitUntil` function when the runtime provides one, otherwise undefined.
+ */
+export function resolveWaitUntil(c: Context): WaitUntilFn | undefined {
+  let execCtx: { waitUntil?: WaitUntilFn } | undefined;
+  try {
+    execCtx = c.executionCtx as { waitUntil?: WaitUntilFn } | undefined;
+  } catch {
+    execCtx = undefined;
+  }
+  return execCtx?.waitUntil?.bind(execCtx);
+}

--- a/packages/core/src/channels/wait-until.ts
+++ b/packages/core/src/channels/wait-until.ts
@@ -8,34 +8,27 @@ import type { Context } from 'hono';
 export type WaitUntilFn = (promise: Promise<unknown>) => void;
 
 /**
- * User-supplied resolver that returns a `waitUntil` for the current request.
+ * Function that takes the request's Hono `Context` and returns a `waitUntil` for
+ * the current request, or undefined.
  *
- * Receives the request's Hono `Context` (optional — some resolvers don't need it,
- * e.g. `@vercel/functions`'s `waitUntil` uses AsyncLocalStorage). Channel providers
- * accept this on construction to support runtimes Hono doesn't bridge automatically
- * (Vercel, Netlify, custom platforms).
- *
- * @example
- * // Vercel
- * import { waitUntil } from '@vercel/functions';
- * new SlackProvider({ resolveWaitUntil: () => waitUntil });
- *
- * @example
- * // Cloudflare Workers (explicit; usually unneeded since core resolves this by default)
- * new SlackProvider({
- *   resolveWaitUntil: (c) => c?.executionCtx?.waitUntil?.bind(c.executionCtx),
- * });
+ * Use this when the runtime exposes `waitUntil` through the request context and
+ * Mastra's default resolver doesn't cover it (Cloudflare Workers and Netlify are
+ * handled automatically; this is the escape hatch for custom adapters).
  */
-export type WaitUntilResolver = (c?: Context) => WaitUntilFn | undefined;
+export type WaitUntilResolver = (c: Context) => WaitUntilFn | undefined;
 
 /**
- * Resolve `waitUntil` from a Hono context's `executionCtx`.
+ * Resolve `waitUntil` from the Hono context using runtime-specific conventions.
  *
- * Hono populates `c.executionCtx` only when the runtime hands it an ExecutionContext
- * (Cloudflare Workers' `app.fetch(req, env, ctx)` convention). Vercel and Netlify's
- * Hono adapters do NOT bridge the platform's `waitUntil` here — on those runtimes the
- * user should import `waitUntil` from `@vercel/functions` (or read it off the Netlify
- * `Context`) and pass it through a constructor option instead.
+ * Lookup order:
+ *  1. Cloudflare Workers — `c.executionCtx.waitUntil` (Hono populates this when
+ *     the runtime hands `app.fetch(req, env, ctx)` the third arg).
+ *  2. Netlify Functions — `c.env.context.waitUntil` (`hono/netlify` adapter
+ *     forwards Netlify's per-request `context` as Hono's `env`).
+ *
+ * Vercel's `waitUntil` lives in `@vercel/functions` and uses AsyncLocalStorage,
+ * not the request context — users on Vercel must pass `waitUntil` explicitly via
+ * the channel option.
  *
  * Hono's `executionCtx` getter throws in Node.js when no ExecutionContext exists,
  * so the access must be guarded by try/catch.
@@ -43,11 +36,51 @@ export type WaitUntilResolver = (c?: Context) => WaitUntilFn | undefined;
  * @returns A bound `waitUntil` function when the runtime provides one, otherwise undefined.
  */
 export function resolveWaitUntil(c: Context): WaitUntilFn | undefined {
+  // 1. Cloudflare Workers (and anything else that bridges executionCtx through Hono)
   let execCtx: { waitUntil?: WaitUntilFn } | undefined;
   try {
     execCtx = c.executionCtx as { waitUntil?: WaitUntilFn } | undefined;
   } catch {
     execCtx = undefined;
   }
-  return execCtx?.waitUntil?.bind(execCtx);
+  if (typeof execCtx?.waitUntil === 'function') {
+    return execCtx.waitUntil.bind(execCtx);
+  }
+
+  // 2. Netlify Functions (hono/netlify forwards Netlify's per-request context as env)
+  const netlifyCtx = (c.env as { context?: { waitUntil?: WaitUntilFn } } | undefined)?.context;
+  if (typeof netlifyCtx?.waitUntil === 'function') {
+    return netlifyCtx.waitUntil.bind(netlifyCtx);
+  }
+
+  return undefined;
+}
+
+/**
+ * Temporary debug helper: shapes the Hono context for logging so we can diagnose
+ * waitUntil resolution on different runtimes. Strip before release.
+ *
+ * @internal
+ */
+export function describeWaitUntilContext(c: Context): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    envType: typeof c.env,
+    envKeys: c.env && typeof c.env === 'object' ? Object.keys(c.env as object) : undefined,
+    hasContextOnEnv: Boolean((c.env as { context?: unknown } | undefined)?.context),
+    contextKeysOnEnv:
+      (c.env as { context?: object } | undefined)?.context && typeof (c.env as any).context === 'object'
+        ? Object.keys((c.env as any).context)
+        : undefined,
+    envVarVercel: process.env.VERCEL,
+    envVarNetlify: process.env.NETLIFY,
+    envVarCfPages: process.env.CF_PAGES,
+  };
+  try {
+    const execCtx = c.executionCtx as unknown;
+    out.executionCtxType = typeof execCtx;
+    out.executionCtxKeys = execCtx && typeof execCtx === 'object' ? Object.keys(execCtx as object) : undefined;
+  } catch (err) {
+    out.executionCtxAccessError = (err as Error)?.message;
+  }
+  return out;
 }

--- a/signals/github/package.json
+++ b/signals/github/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mastra/github-signals",
   "version": "0.1.0",
+  "private": true,
   "description": "GitHub PR notification signal provider for Mastra agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
**Stacked on top of #17594.** Targets `caleb/agent-channels-await-completion` until that lands, then will be retargeted to `main`.

## Why

`AgentChannels.processChatMessage` fires `agent.sendMessage(...)` and returns immediately. The agent run is driven by a side-effect subscription (`ensureThreadSubscription` + `chatThread.subscribe()`). That works in `mastra dev` because the Node event loop keeps consumer microtasks alive, but it breaks under serverless runtimes (Vercel, AWS Lambda, etc.) where the function process is terminated as soon as the handler returns. The agent stream is killed mid-flight and the user sees nothing, partial replies, or duplicate Slack retries piling up.

See #17065 for user-reported symptoms.

## What this PR does

In `processChatMessage`, capture the `sendMessage` result and, when it carries an `ownerStream` (added in #17594), await `ownerStream.consumeStream()` before returning from the webhook handler:

```ts
const result = this.agent.sendMessage(...);

if (result.ownerStream) {
  try {
    const ownerStream = await result.ownerStream;
    await ownerStream.consumeStream();
  } catch (err) {
    this.log('debug', 'ownerStream consume failed', err);
  }
}
```

`ownerStream` is only present when the call wakes a new run from idle. For deliver / join-remote / queue / persist / discard paths it's `undefined` and the handler returns as before.

`consumeStream()` is idempotent and safe to call alongside the existing per-thread subscription consumer that forwards chunks to the chat platform.

Error handling on the await is intentionally permissive (debug-log + swallow), because the run's own error path is already handled via the stream pipeline.

## What this PR does NOT do

- Does not move platform-forwarding (Slack/Discord API calls) from per-process subscriptions into a stream processor. That's a follow-up that removes the need for cross-Lambda subscription coordination entirely.
- Does not change anything about pubsub. Multi-Lambda deployments still require `@mastra/redis-streams` (or another shared `PubSub`) for signals to cross instances.

## Test plan

- [x] `pnpm build:core`
- [x] `pnpm --filter ./packages/core check`
- [ ] Manual: deploy to Vercel + Slack repro and confirm bot replies arrive end-to-end.

## Related

- #17594 (parent PR adding `ownerStream` to the signals return type)
- #17065
