### PR TITLE
Wire request context through dataset experiments

### DIFF
--- a/.changeset/heavy-flowers-count.md
+++ b/.changeset/heavy-flowers-count.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': patch
+---
+
+Fixed per-item request context being dropped for inline experiment data. When running an experiment with inline `data`, each item's `requestContext` is now passed to the agent or workflow and merged over the global request context (per-item values win on key collisions), matching the behavior of storage-backed datasets.
+
+```ts
+await dataset.startExperiment({
+  data: [{ input: { prompt: 'Hello' }, requestContext: { clinicId: 'clinic-1' } }],
+  targetType: 'agent',
+  targetId: 'support-agent',
+});
+// Tools can now read clinicId from requestContext during inline experiments
+```

--- a/.changeset/silver-trees-attend.md
+++ b/.changeset/silver-trees-attend.md
@@ -2,4 +2,31 @@
 '@internal/playground': patch
 ---
 
-Wire request context into dataset experiments in Studio. You can now define a dataset's `requestContextSchema` when creating or editing a dataset, set per-item `requestContext` values on dataset items, and provide run-level request context when triggering an experiment. The run dialog renders a schema-driven form when the dataset declares a `requestContextSchema`, and falls back to a raw JSON editor otherwise. This lets values like `clinicId` flow from Studio through to agent/workflow experiment runs.
+Wire request context into dataset experiments in Studio.
+
+You can now define a dataset's `requestContextSchema` when creating or editing a dataset. You can set per-item `requestContext` values on dataset items. You can also provide run-level request context when triggering an experiment.
+
+The run dialog renders a schema-driven form when the dataset declares a `requestContextSchema`, and falls back to a raw JSON editor otherwise. This lets values like `clinicId` flow from Studio through to agent/workflow experiment runs.
+
+```ts
+// 1. Dataset declares the request context it expects
+const dataset = await client.createDataset({
+  name: 'patients',
+  requestContextSchema: { type: 'object', properties: { clinicId: { type: 'string' } } },
+});
+
+// 2. A dataset item provides per-item request context
+await client.addDatasetItem({
+  datasetId: dataset.id,
+  input: { patientId: 'p-123' },
+  requestContext: { clinicId: 'clinic-a' },
+});
+
+// 3. Triggering an experiment can supply run-level request context
+await client.triggerDatasetExperiment({
+  datasetId: dataset.id,
+  targetType: 'agent',
+  targetId: 'clinicDirectAgent',
+  requestContext: { clinicId: 'clinic-a' },
+});
+```

--- a/.changeset/silver-trees-attend.md
+++ b/.changeset/silver-trees-attend.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Wire request context into dataset experiments in Studio. You can now define a dataset's `requestContextSchema` when creating or editing a dataset, set per-item `requestContext` values on dataset items, and provide run-level request context when triggering an experiment. The run dialog renders a schema-driven form when the dataset declares a `requestContextSchema`, and falls back to a raw JSON editor otherwise. This lets values like `clinicId` flow from Studio through to agent/workflow experiment runs.

--- a/examples/agent/request-context-presets.json
+++ b/examples/agent/request-context-presets.json
@@ -39,5 +39,15 @@
       "advancedTools": false,
       "analytics": false
     }
+  },
+  "clinic-a": {
+    "clinicId": "clinic-a",
+    "environment": "production",
+    "userId": "clinician-001"
+  },
+  "clinic-b": {
+    "clinicId": "clinic-b",
+    "environment": "production",
+    "userId": "clinician-002"
   }
 }

--- a/examples/agent/src/mastra/agents/clinic-context-agents.ts
+++ b/examples/agent/src/mastra/agents/clinic-context-agents.ts
@@ -21,7 +21,7 @@ export const clinicDirectAgent = new Agent({
   instructions: `You are a clinic assistant that looks up patient records.
 Always use the clinic-lookup tool to retrieve patient information.
 Include the clinicId and patientId in your response so the caller can verify tenant isolation.`,
-  model: 'openai/gpt-4.1-mini',
+  model: 'openai/gpt-5.4-mini',
   tools: {
     clinicLookupTool,
   },
@@ -33,7 +33,7 @@ export const clinicSpecialistAgent = new Agent({
   description: 'Specialist sub-agent that looks up patient records. Requires clinicId in requestContext.',
   instructions: `You are a clinical specialist. When asked to look up patient data, use the clinic-lookup tool.
 Always include the clinicId and patientId in your response.`,
-  model: 'openai/gpt-4.1-mini',
+  model: 'openai/gpt-5.4-mini',
   tools: {
     clinicLookupTool,
   },
@@ -46,7 +46,7 @@ export const clinicSupervisorAgent = new Agent({
   instructions: `You are a clinic supervisor. When a user asks you to look up patient data, delegate the task to the clinic-specialist-agent.
 Do not look up records yourself — always hand off to the specialist.
 Report back the specialist's response, including the clinicId they used.`,
-  model: 'openai/gpt-4.1-mini',
+  model: 'openai/gpt-5.4-mini',
   agents: {
     clinicSpecialistAgent,
   },

--- a/examples/agent/src/mastra/agents/clinic-context-agents.ts
+++ b/examples/agent/src/mastra/agents/clinic-context-agents.ts
@@ -1,0 +1,53 @@
+import { Agent } from '@mastra/core/agent';
+import { clinicLookupTool } from '../tools/clinic-tools';
+
+/**
+ * Clinic Context Agents
+ *
+ * Test agents for verifying requestContext propagation through dataset
+ * experiments in multi-tenant clinic scenarios.
+ *
+ * - clinicDirectAgent: calls clinicLookupTool directly
+ * - clinicSupervisorAgent: delegates to clinicSpecialistAgent, which calls clinicLookupTool
+ *
+ * The tool throws if clinicId is missing from requestContext, so experiment
+ * items fail visibly instead of hanging silently.
+ */
+
+export const clinicDirectAgent = new Agent({
+  id: 'clinic-direct-agent',
+  name: 'Clinic Direct Agent',
+  description: 'Looks up patient records directly. Requires clinicId in requestContext.',
+  instructions: `You are a clinic assistant that looks up patient records.
+Always use the clinic-lookup tool to retrieve patient information.
+Include the clinicId and patientId in your response so the caller can verify tenant isolation.`,
+  model: 'openai/gpt-4.1-mini',
+  tools: {
+    clinicLookupTool,
+  },
+});
+
+export const clinicSpecialistAgent = new Agent({
+  id: 'clinic-specialist-agent',
+  name: 'Clinic Specialist Agent',
+  description: 'Specialist sub-agent that looks up patient records. Requires clinicId in requestContext.',
+  instructions: `You are a clinical specialist. When asked to look up patient data, use the clinic-lookup tool.
+Always include the clinicId and patientId in your response.`,
+  model: 'openai/gpt-4.1-mini',
+  tools: {
+    clinicLookupTool,
+  },
+});
+
+export const clinicSupervisorAgent = new Agent({
+  id: 'clinic-supervisor-agent',
+  name: 'Clinic Supervisor Agent',
+  description: 'Supervisor agent that delegates patient lookups to the specialist sub-agent. Tests requestContext propagation through agent delegation.',
+  instructions: `You are a clinic supervisor. When a user asks you to look up patient data, delegate the task to the clinic-specialist-agent.
+Do not look up records yourself — always hand off to the specialist.
+Report back the specialist's response, including the clinicId they used.`,
+  model: 'openai/gpt-4.1-mini',
+  agents: {
+    clinicSpecialistAgent,
+  },
+});

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -177,11 +177,11 @@ export const mastra = new Mastra({
       baseUrl: process.env.MASTRA_BASE_URL,
     }),
   },
-  // server: {
-  //   auth: mastraAuth,
-  //   rbac: rbacProvider,
-  //   fga: fgaProvider,
-  // },
+  server: {
+    auth: mastraAuth,
+    rbac: rbacProvider,
+    fga: fgaProvider,
+  },
   backgroundTasks: {
     enabled: true,
     globalConcurrency: 10,

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -88,6 +88,7 @@ import {
 } from './processors/index';
 import { gatewayAgent } from './agents/gateway';
 import { codeModeAgent } from './agents/code-mode-agent';
+import { clinicDirectAgent, clinicSpecialistAgent, clinicSupervisorAgent } from './agents/clinic-context-agents';
 
 const libsqlStore = new LibSQLStore({
   id: 'mastra-storage',
@@ -132,6 +133,9 @@ export const mastra = new Mastra({
     cryptoResearchAgent,
     slackDemoAgent,
     codeModeAgent,
+    clinicDirectAgent,
+    clinicSpecialistAgent,
+    clinicSupervisorAgent,
   },
   processors: {
     moderationProcessor,
@@ -173,11 +177,11 @@ export const mastra = new Mastra({
       baseUrl: process.env.MASTRA_BASE_URL,
     }),
   },
-  server: {
-    auth: mastraAuth,
-    rbac: rbacProvider,
-    fga: fgaProvider,
-  },
+  // server: {
+  //   auth: mastraAuth,
+  //   rbac: rbacProvider,
+  //   fga: fgaProvider,
+  // },
   backgroundTasks: {
     enabled: true,
     globalConcurrency: 10,

--- a/examples/agent/src/mastra/tools/clinic-tools.ts
+++ b/examples/agent/src/mastra/tools/clinic-tools.ts
@@ -19,7 +19,6 @@ export const clinicLookupTool = createTool({
   }),
   execute: async ({ patientId }, { requestContext }) => {
     const clinicId = requestContext?.get('clinicId') as string | undefined;
-    console.log(`Executing clinicLookupTool for clinicId=${clinicId} and patientId=${patientId}`);
 
     if (!clinicId) {
       throw new Error(

--- a/examples/agent/src/mastra/tools/clinic-tools.ts
+++ b/examples/agent/src/mastra/tools/clinic-tools.ts
@@ -1,0 +1,43 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+/**
+ * Clinic-aware patient lookup tool.
+ *
+ * Requires `clinicId` in requestContext — the tool throws if the value is
+ * absent so that missing-tenant failures surface immediately instead of
+ * silently hanging during dataset experiment runs.
+ */
+export const clinicLookupTool = createTool({
+  id: 'clinic-lookup',
+  description: 'Looks up patient records for the current clinic tenant. Requires a clinicId in requestContext.',
+  inputSchema: z.object({
+    patientId: z.string().describe('The patient ID to look up'),
+  }),
+  requestContextSchema: z.object({
+    clinicId: z.string(),
+  }),
+  execute: async ({ patientId }, { requestContext }) => {
+    const clinicId = requestContext?.get('clinicId') as string | undefined;
+    console.log(`Executing clinicLookupTool for clinicId=${clinicId} and patientId=${patientId}`);
+
+    if (!clinicId) {
+      throw new Error(
+        'clinicId is missing from requestContext. The tool cannot execute without tenant isolation.',
+      );
+    }
+
+    return {
+      clinicId,
+      patientId,
+      tenant: clinicId,
+      status: 'success',
+      record: {
+        patientId,
+        clinicId,
+        lastVisit: '2026-06-01',
+        diagnosis: 'routine checkup',
+      },
+    };
+  },
+});

--- a/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
@@ -553,6 +553,32 @@ describe('runExperiment', () => {
       expect(result.results[0].input).toEqual({ prompt: 'from-factory' });
     });
 
+    // Test 2b — Per-item requestContext on inline data reaches agent.generate
+    it('forwards per-item requestContext from inline data, merged over the global context', async () => {
+      const mockAgent = createMockAgent('Response');
+      const localMastra = {
+        ...mastra,
+        getAgent: vi.fn().mockReturnValue(mockAgent),
+        getAgentById: vi.fn().mockReturnValue(mockAgent),
+      } as unknown as Mastra;
+
+      await runExperiment(localMastra, {
+        datasetId,
+        data: [{ input: { prompt: 'Hello' }, requestContext: { clinicId: 'clinic-1' } }],
+        targetType: 'agent',
+        targetId: 'test-agent',
+        // Global context — per-item value should win on key collision
+        requestContext: { clinicId: 'global-clinic', environment: 'development' },
+      });
+
+      const callOptions = (mockAgent.generate as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(callOptions.requestContext).toBeInstanceOf(RequestContext);
+      expect(callOptions.requestContext.all).toEqual({
+        clinicId: 'clinic-1',
+        environment: 'development',
+      });
+    });
+
     // Test 3 — Inline task function
     it('runs experiment with inline task function', async () => {
       const result = await runExperiment(mastra, {

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -122,6 +122,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
           datasetVersion: null,
           input: dataItem.input,
           groundTruth: dataItem.groundTruth,
+          requestContext: dataItem.requestContext,
           metadata: dataItem.metadata,
           resumeSteps: dataItem.resumeSteps,
           resumeData: dataItem.resumeData,

--- a/packages/core/src/datasets/experiment/types.ts
+++ b/packages/core/src/datasets/experiment/types.ts
@@ -17,6 +17,8 @@ export interface DataItem<I = unknown, E = unknown> {
   groundTruth?: E;
   /** Additional metadata */
   metadata?: Record<string, unknown>;
+  /** Per-item request context merged over the global request context (item takes precedence) */
+  requestContext?: Record<string, unknown>;
   /**
    * Resume data for suspended workflow steps, keyed by step ID.
    * When a workflow suspends during experiment execution, the executor

--- a/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
@@ -69,6 +69,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
   const [input, setInput] = useState('{}');
   const [groundTruth, setGroundTruth] = useState('');
   const [expectedTrajectory, setExpectedTrajectory] = useState('');
+  const [requestContext, setRequestContext] = useState('');
   const [validationErrors, setValidationErrors] = useState<SchemaValidationError | null>(null);
   const { addItem } = useDatasetMutations();
 
@@ -105,12 +106,24 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
       }
     }
 
+    // Parse requestContext if provided
+    let parsedRequestContext: Record<string, unknown> | undefined;
+    if (requestContext.trim()) {
+      try {
+        parsedRequestContext = JSON.parse(requestContext);
+      } catch {
+        toast.error('Request Context must be valid JSON');
+        return;
+      }
+    }
+
     try {
       await addItem.mutateAsync({
         datasetId,
         input: parsedInput,
         groundTruth: parsedGroundTruth,
         expectedTrajectory: parsedTrajectory,
+        requestContext: parsedRequestContext,
       });
 
       toast.success('Item added successfully');
@@ -120,6 +133,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
       setInput('{}');
       setGroundTruth('');
       setExpectedTrajectory('');
+      setRequestContext('');
       onOpenChange(false);
 
       onSuccess?.();
@@ -154,6 +168,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
     setInput('{}');
     setGroundTruth('');
     setExpectedTrajectory('');
+    setRequestContext('');
     setValidationErrors(null);
     onOpenChange(false);
   };
@@ -192,6 +207,16 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
               <CodeEditor
                 value={expectedTrajectory}
                 onChange={setExpectedTrajectory}
+                showCopyButton={false}
+                className="min-h-[80px]"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="item-request-context">Request Context (JSON, optional)</Label>
+              <CodeEditor
+                value={requestContext}
+                onChange={setRequestContext}
                 showCopyButton={false}
                 className="min-h-[80px]"
               />

--- a/packages/playground/src/domains/datasets/components/create-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/create-dataset-dialog.tsx
@@ -35,15 +35,18 @@ export function CreateDatasetDialog({
   const [description, setDescription] = useState('');
   const [inputSchema, setInputSchema] = useState<Record<string, unknown> | null>(null);
   const [groundTruthSchema, setGroundTruthSchema] = useState<Record<string, unknown> | null>(null);
+  const [requestContextSchema, setRequestContextSchema] = useState<Record<string, unknown> | null>(null);
   const [showCustomSchema, setShowCustomSchema] = useState(!targetType);
   const { createDataset } = useDatasetMutations();
 
   const handleSchemaChange = (schemas: {
     inputSchema: Record<string, unknown> | null;
     outputSchema: Record<string, unknown> | null;
+    requestContextSchema: Record<string, unknown> | null;
   }) => {
     setInputSchema(schemas.inputSchema);
     setGroundTruthSchema(schemas.outputSchema);
+    setRequestContextSchema(schemas.requestContextSchema);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -60,6 +63,7 @@ export function CreateDatasetDialog({
         description: description.trim() || undefined,
         inputSchema,
         groundTruthSchema,
+        requestContextSchema,
         targetType,
         targetIds,
       })) as { id: string };
@@ -71,6 +75,7 @@ export function CreateDatasetDialog({
       setDescription('');
       setInputSchema(null);
       setGroundTruthSchema(null);
+      setRequestContextSchema(null);
       setShowCustomSchema(!targetType);
       onOpenChange(false);
 
@@ -86,6 +91,7 @@ export function CreateDatasetDialog({
     setDescription('');
     setInputSchema(null);
     setGroundTruthSchema(null);
+    setRequestContextSchema(null);
     setShowCustomSchema(!targetType);
     onOpenChange(false);
   };
@@ -131,6 +137,7 @@ export function CreateDatasetDialog({
               <SchemaConfigSection
                 inputSchema={inputSchema}
                 outputSchema={groundTruthSchema}
+                requestContextSchema={requestContextSchema}
                 onChange={handleSchemaChange}
                 disabled={createDataset.isPending}
               />

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
@@ -40,6 +40,8 @@ export interface EditModeContentProps {
   setMetadataValue: (value: string) => void;
   trajectoryValue: string;
   setTrajectoryValue: (value: string) => void;
+  requestContextValue: string;
+  setRequestContextValue: (value: string) => void;
   validationErrors: SchemaValidationError | null;
   onSave: () => void;
   onCancel: () => void;
@@ -55,6 +57,8 @@ export function EditModeContent({
   setMetadataValue,
   trajectoryValue,
   setTrajectoryValue,
+  requestContextValue,
+  setRequestContextValue,
   validationErrors,
   onSave,
   onCancel,
@@ -93,6 +97,16 @@ export function EditModeContent({
           <CodeEditor
             value={trajectoryValue}
             onChange={setTrajectoryValue}
+            showCopyButton={false}
+            className="min-h-[80px]"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Request Context (JSON, optional)</Label>
+          <CodeEditor
+            value={requestContextValue}
+            onChange={setRequestContextValue}
             showCopyButton={false}
             className="min-h-[80px]"
           />

--- a/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mastra/playground-ui';
 import type { SideDialogRootProps } from '@mastra/playground-ui';
 import { format } from 'date-fns/format';
-import { HashIcon, FileInputIcon, FileOutputIcon, TagIcon, RouteIcon, Pencil, Trash2 } from 'lucide-react';
+import { HashIcon, FileInputIcon, FileOutputIcon, TagIcon, RouteIcon, BracesIcon, Pencil, Trash2 } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { useDatasetMutations } from '../../hooks/use-dataset-mutations';
 
@@ -49,6 +49,7 @@ export function ItemDetailDialog({
   const [groundTruthValue, setGroundTruthValue] = useState('');
   const [metadataValue, setMetadataValue] = useState('');
   const [trajectoryValue, setTrajectoryValue] = useState('');
+  const [requestContextValue, setRequestContextValue] = useState('');
 
   // Delete confirmation state
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -60,9 +61,11 @@ export function ItemDetailDialog({
       setGroundTruthValue(item.groundTruth ? JSON.stringify(item.groundTruth, null, 2) : '');
       setMetadataValue(item.metadata ? JSON.stringify(item.metadata, null, 2) : '');
       setTrajectoryValue(item.expectedTrajectory ? JSON.stringify(item.expectedTrajectory, null, 2) : '');
+      setRequestContextValue(item.requestContext ? JSON.stringify(item.requestContext, null, 2) : '');
       setIsEditing(false); // Exit edit mode on item change
       setShowDeleteConfirm(false); // Reset delete state on item change
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [item?.id]);
 
   if (!item) return null;
@@ -128,6 +131,17 @@ export function ItemDetailDialog({
       }
     }
 
+    // Parse requestContext if provided
+    let parsedRequestContext: Record<string, unknown> | undefined;
+    if (requestContextValue.trim()) {
+      try {
+        parsedRequestContext = JSON.parse(requestContextValue);
+      } catch {
+        toast.error('Request Context must be valid JSON');
+        return;
+      }
+    }
+
     try {
       await updateItem.mutateAsync({
         datasetId,
@@ -136,6 +150,7 @@ export function ItemDetailDialog({
         groundTruth: parsedGroundTruth,
         metadata: parsedMetadata,
         expectedTrajectory: parsedTrajectory,
+        requestContext: parsedRequestContext,
       });
 
       toast.success('Item updated successfully');
@@ -151,6 +166,7 @@ export function ItemDetailDialog({
     setGroundTruthValue(item.groundTruth ? JSON.stringify(item.groundTruth, null, 2) : '');
     setMetadataValue(item.metadata ? JSON.stringify(item.metadata, null, 2) : '');
     setTrajectoryValue(item.expectedTrajectory ? JSON.stringify(item.expectedTrajectory, null, 2) : '');
+    setRequestContextValue(item.requestContext ? JSON.stringify(item.requestContext, null, 2) : '');
     setIsEditing(false);
   };
 
@@ -216,6 +232,8 @@ export function ItemDetailDialog({
             setMetadataValue={setMetadataValue}
             trajectoryValue={trajectoryValue}
             setTrajectoryValue={setTrajectoryValue}
+            requestContextValue={requestContextValue}
+            setRequestContextValue={setRequestContextValue}
             onSave={handleSave}
             onCancel={handleCancel}
             isSaving={updateItem.isPending}
@@ -252,6 +270,7 @@ export function ItemDetailDialog({
 function ReadOnlyContent({ item }: { item: DatasetItem }) {
   const metadataDisplay = item.metadata ? JSON.stringify(item.metadata, null, 2) : null;
   const trajectoryDisplay = item.expectedTrajectory ? JSON.stringify(item.expectedTrajectory, null, 2) : null;
+  const requestContextDisplay = item.requestContext ? JSON.stringify(item.requestContext, null, 2) : null;
 
   return (
     <>
@@ -298,6 +317,10 @@ function ReadOnlyContent({ item }: { item: DatasetItem }) {
           <SideDialog.CodeSection title="Expected Trajectory" icon={<RouteIcon />} codeStr={trajectoryDisplay} />
         )}
 
+        {requestContextDisplay && (
+          <SideDialog.CodeSection title="Request Context" icon={<BracesIcon />} codeStr={requestContextDisplay} />
+        )}
+
         {metadataDisplay && <SideDialog.CodeSection title="Metadata" icon={<TagIcon />} codeStr={metadataDisplay} />}
       </Sections>
     </>
@@ -316,6 +339,8 @@ interface EditModeContentProps {
   setMetadataValue: (value: string) => void;
   trajectoryValue: string;
   setTrajectoryValue: (value: string) => void;
+  requestContextValue: string;
+  setRequestContextValue: (value: string) => void;
   onSave: () => void;
   onCancel: () => void;
   isSaving: boolean;
@@ -330,6 +355,8 @@ function EditModeContent({
   setMetadataValue,
   trajectoryValue,
   setTrajectoryValue,
+  requestContextValue,
+  setRequestContextValue,
   onSave,
   onCancel,
   isSaving,
@@ -363,6 +390,16 @@ function EditModeContent({
           <CodeEditor
             value={trajectoryValue}
             onChange={setTrajectoryValue}
+            showCopyButton={false}
+            className="min-h-[80px]"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Request Context (JSON, optional)</Label>
+          <CodeEditor
+            value={requestContextValue}
+            onChange={setRequestContextValue}
             showCopyButton={false}
             className="min-h-[80px]"
           />

--- a/packages/playground/src/domains/datasets/components/edit-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/edit-dataset-dialog.tsx
@@ -24,6 +24,7 @@ export interface EditDatasetDialogProps {
     description?: string;
     inputSchema?: Record<string, unknown> | null;
     groundTruthSchema?: Record<string, unknown> | null;
+    requestContextSchema?: Record<string, unknown> | null;
   };
   onSuccess?: () => void;
 }
@@ -35,6 +36,9 @@ export function EditDatasetDialog({ open, onOpenChange, dataset, onSuccess }: Ed
   const [groundTruthSchema, setGroundTruthSchema] = useState<Record<string, unknown> | null>(
     dataset.groundTruthSchema ?? null,
   );
+  const [requestContextSchema, setRequestContextSchema] = useState<Record<string, unknown> | null>(
+    dataset.requestContextSchema ?? null,
+  );
   const [validationError, setValidationError] = useState<string | null>(null);
   const { updateDataset } = useDatasetMutations();
 
@@ -45,6 +49,7 @@ export function EditDatasetDialog({ open, onOpenChange, dataset, onSuccess }: Ed
       setDescription(dataset.description ?? '');
       setInputSchema(dataset.inputSchema ?? null);
       setGroundTruthSchema(dataset.groundTruthSchema ?? null);
+      setRequestContextSchema(dataset.requestContextSchema ?? null);
       setValidationError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -53,9 +58,11 @@ export function EditDatasetDialog({ open, onOpenChange, dataset, onSuccess }: Ed
   const handleSchemaChange = (schemas: {
     inputSchema: Record<string, unknown> | null;
     outputSchema: Record<string, unknown> | null;
+    requestContextSchema: Record<string, unknown> | null;
   }) => {
     setInputSchema(schemas.inputSchema);
     setGroundTruthSchema(schemas.outputSchema);
+    setRequestContextSchema(schemas.requestContextSchema);
     // Clear validation error when user changes schema
     setValidationError(null);
   };
@@ -76,6 +83,7 @@ export function EditDatasetDialog({ open, onOpenChange, dataset, onSuccess }: Ed
         description: description.trim() || undefined,
         inputSchema,
         groundTruthSchema,
+        requestContextSchema,
       });
 
       toast.success('Dataset updated successfully');
@@ -101,6 +109,7 @@ export function EditDatasetDialog({ open, onOpenChange, dataset, onSuccess }: Ed
     setDescription(dataset.description ?? '');
     setInputSchema(dataset.inputSchema ?? null);
     setGroundTruthSchema(dataset.groundTruthSchema ?? null);
+    setRequestContextSchema(dataset.requestContextSchema ?? null);
     setValidationError(null);
     onOpenChange(false);
   };
@@ -137,9 +146,10 @@ export function EditDatasetDialog({ open, onOpenChange, dataset, onSuccess }: Ed
             <SchemaConfigSection
               inputSchema={inputSchema}
               outputSchema={groundTruthSchema}
+              requestContextSchema={requestContextSchema}
               onChange={handleSchemaChange}
               disabled={updateDataset.isPending}
-              defaultOpen={!!(dataset.inputSchema || dataset.groundTruthSchema)}
+              defaultOpen={!!(dataset.inputSchema || dataset.groundTruthSchema || dataset.requestContextSchema)}
             />
 
             {validationError && (

--- a/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
@@ -99,7 +99,16 @@ export function ExperimentTriggerDialog({
       return entries.length > 0 ? Object.fromEntries(entries) : undefined;
     }
     if (requestContextRaw.trim()) {
-      return JSON.parse(requestContextRaw) as Record<string, unknown>;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(requestContextRaw);
+      } catch {
+        throw new Error('Request Context must be valid JSON');
+      }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Request Context must be a JSON object');
+      }
+      return parsed as Record<string, unknown>;
     }
     return undefined;
   };
@@ -110,8 +119,9 @@ export function ExperimentTriggerDialog({
     let requestContext: Record<string, unknown> | undefined;
     try {
       requestContext = resolveRequestContext();
-    } catch {
-      toast.error('Request Context must be valid JSON');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Request Context must be valid JSON';
+      toast.error(message);
       return;
     }
 

--- a/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
@@ -8,26 +8,65 @@ import {
   DialogDescription,
   DialogBody,
   DialogFooter,
+  CodeEditor,
+  Label,
 } from '@mastra/playground-ui';
+import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { format } from 'date-fns';
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useDatasetMutations } from '../../hooks/use-dataset-mutations';
 import { ScorerSelector } from './scorer-selector';
 import type { TargetType } from './target-selector';
 import { TargetSelector } from './target-selector';
+import { DynamicForm } from '@/lib/form';
+import { resolveSerializedZodOutput } from '@/lib/form/utils';
 
 export interface ExperimentTriggerDialogProps {
   datasetId: string;
   version?: number;
+  requestContextSchema?: Record<string, unknown>;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess?: (experimentId: string) => void;
 }
 
+/**
+ * Schema-driven request context form. Converts the dataset's plain JSON Schema
+ * into a zod schema and surfaces values via onChange (no global store coupling).
+ */
+function RequestContextForm({
+  requestContextSchema,
+  onChange,
+}: {
+  requestContextSchema: Record<string, unknown>;
+  onChange: (values: Record<string, unknown>) => void;
+}) {
+  const zodSchema = useMemo(() => {
+    try {
+      return resolveSerializedZodOutput(jsonSchemaToZod(requestContextSchema as Parameters<typeof jsonSchemaToZod>[0]));
+    } catch (error) {
+      console.error('Failed to parse requestContextSchema:', error);
+      return null;
+    }
+  }, [requestContextSchema]);
+
+  if (!zodSchema) {
+    return <p className="text-sm text-destructive">Failed to parse request context schema</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label>Request Context</Label>
+      <DynamicForm schema={zodSchema} onValuesChange={onChange} className="[&_button[type=submit]]:hidden" />
+    </div>
+  );
+}
+
 export function ExperimentTriggerDialog({
   datasetId,
   version,
+  requestContextSchema,
   open,
   onOpenChange,
   onSuccess,
@@ -36,14 +75,45 @@ export function ExperimentTriggerDialog({
   const [targetType, setTargetType] = useState<TargetType | ''>('');
   const [targetId, setTargetId] = useState<string>('');
   const [selectedScorers, setSelectedScorers] = useState<string[]>([]);
+  const [requestContextValues, setRequestContextValues] = useState<Record<string, unknown>>({});
+  const [requestContextRaw, setRequestContextRaw] = useState('');
 
   const { triggerExperiment } = useDatasetMutations();
+
+  const hasSchema = Boolean(requestContextSchema && Object.keys(requestContextSchema).length > 0);
 
   const canRun = targetType && targetId;
   const isRunning = triggerExperiment.isPending;
 
+  const resetState = () => {
+    setTargetType('');
+    setTargetId('');
+    setSelectedScorers([]);
+    setRequestContextValues({});
+    setRequestContextRaw('');
+  };
+
+  const resolveRequestContext = (): Record<string, unknown> | undefined => {
+    if (hasSchema) {
+      const entries = Object.entries(requestContextValues).filter(([, v]) => v !== undefined && v !== '');
+      return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+    }
+    if (requestContextRaw.trim()) {
+      return JSON.parse(requestContextRaw) as Record<string, unknown>;
+    }
+    return undefined;
+  };
+
   const handleRun = async () => {
     if (!canRun) return;
+
+    let requestContext: Record<string, unknown> | undefined;
+    try {
+      requestContext = resolveRequestContext();
+    } catch {
+      toast.error('Request Context must be valid JSON');
+      return;
+    }
 
     try {
       const result = await triggerExperiment.mutateAsync({
@@ -52,16 +122,14 @@ export function ExperimentTriggerDialog({
         targetId,
         scorerIds: selectedScorers.length > 0 ? selectedScorers : undefined,
         version,
+        requestContext,
       });
 
       toast.success('Experiment triggered successfully');
       onOpenChange(false);
       onSuccess?.(result.experimentId);
 
-      // Reset state
-      setTargetType('');
-      setTargetId('');
-      setSelectedScorers([]);
+      resetState();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to trigger experiment';
       toast.error(message);
@@ -71,10 +139,7 @@ export function ExperimentTriggerDialog({
   const handleClose = () => {
     if (!isRunning) {
       onOpenChange(false);
-      // Reset state on close
-      setTargetType('');
-      setTargetId('');
-      setSelectedScorers([]);
+      resetState();
     }
   };
 
@@ -107,6 +172,20 @@ export function ExperimentTriggerDialog({
               disabled={isRunning}
               container={contentRef}
             />
+          )}
+
+          {hasSchema ? (
+            <RequestContextForm requestContextSchema={requestContextSchema!} onChange={setRequestContextValues} />
+          ) : (
+            <div className="space-y-2">
+              <Label>Request Context (JSON, optional)</Label>
+              <CodeEditor
+                value={requestContextRaw}
+                onChange={setRequestContextRaw}
+                showCopyButton={false}
+                className="min-h-[80px]"
+              />
+            </div>
           )}
         </DialogBody>
 

--- a/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mastra/playground-ui';
 import { format } from 'date-fns/format';
 import {
+  BracesIcon,
   EllipsisVerticalIcon,
   FileInputIcon,
   FileOutputIcon,
@@ -73,6 +74,7 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
   const [groundTruthValue, setGroundTruthValue] = useState('');
   const [metadataValue, setMetadataValue] = useState('');
   const [trajectoryValue, setTrajectoryValue] = useState('');
+  const [requestContextValue, setRequestContextValue] = useState('');
 
   // Validation error state
   const [validationErrors, setValidationErrors] = useState<SchemaValidationError | null>(null);
@@ -87,6 +89,7 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
       setGroundTruthValue(item.groundTruth ? JSON.stringify(item.groundTruth, null, 2) : '');
       setMetadataValue(item.metadata ? JSON.stringify(item.metadata, null, 2) : '');
       setTrajectoryValue(item.expectedTrajectory ? JSON.stringify(item.expectedTrajectory, null, 2) : '');
+      setRequestContextValue(item.requestContext ? JSON.stringify(item.requestContext, null, 2) : '');
       setIsEditing(false); // Exit edit mode on item change
       setShowDeleteConfirm(false); // Reset delete state on item change
       setValidationErrors(null); // Reset validation errors on item change
@@ -145,6 +148,17 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
       }
     }
 
+    // Parse requestContext if provided
+    let parsedRequestContext: Record<string, unknown> | undefined;
+    if (requestContextValue.trim()) {
+      try {
+        parsedRequestContext = JSON.parse(requestContextValue);
+      } catch {
+        toast.error('Request Context must be valid JSON');
+        return;
+      }
+    }
+
     try {
       await updateItem.mutateAsync({
         datasetId,
@@ -153,6 +167,7 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
         groundTruth: parsedGroundTruth,
         metadata: parsedMetadata,
         expectedTrajectory: parsedTrajectory,
+        requestContext: parsedRequestContext,
       });
 
       toast.success('Item updated successfully');
@@ -175,6 +190,7 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
     setGroundTruthValue(item.groundTruth ? JSON.stringify(item.groundTruth, null, 2) : '');
     setMetadataValue(item.metadata ? JSON.stringify(item.metadata, null, 2) : '');
     setTrajectoryValue(item.expectedTrajectory ? JSON.stringify(item.expectedTrajectory, null, 2) : '');
+    setRequestContextValue(item.requestContext ? JSON.stringify(item.requestContext, null, 2) : '');
     setIsEditing(false);
     setValidationErrors(null);
   };
@@ -268,6 +284,8 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
               setMetadataValue={setMetadataValue}
               trajectoryValue={trajectoryValue}
               setTrajectoryValue={setTrajectoryValue}
+              requestContextValue={requestContextValue}
+              setRequestContextValue={setRequestContextValue}
               validationErrors={validationErrors}
               onSave={handleSave}
               onCancel={handleCancel}
@@ -315,6 +333,13 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
                     title="Expected Trajectory"
                     icon={<RouteIcon />}
                     codeStr={JSON.stringify(item.expectedTrajectory, null, 2)}
+                  />
+                )}
+                {item.requestContext != null && (
+                  <DataPanel.CodeSection
+                    title="Request Context"
+                    icon={<BracesIcon />}
+                    codeStr={JSON.stringify(item.requestContext, null, 2)}
                   />
                 )}
                 <DataPanel.CodeSection

--- a/packages/playground/src/domains/datasets/components/schema-config-section.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-config-section.tsx
@@ -26,9 +26,11 @@ type ScorerTargetType = 'agent' | 'custom';
 interface SchemaConfigSectionProps {
   inputSchema: Record<string, unknown> | null | undefined;
   outputSchema: Record<string, unknown> | null | undefined;
+  requestContextSchema: Record<string, unknown> | null | undefined;
   onChange: (schemas: {
     inputSchema: Record<string, unknown> | null;
     outputSchema: Record<string, unknown> | null;
+    requestContextSchema: Record<string, unknown> | null;
   }) => void;
   disabled?: boolean;
   defaultOpen?: boolean;
@@ -41,6 +43,7 @@ interface SchemaConfigSectionProps {
 export function SchemaConfigSection({
   inputSchema,
   outputSchema,
+  requestContextSchema,
   onChange,
   disabled = false,
   defaultOpen = false,
@@ -137,17 +140,34 @@ export function SchemaConfigSection({
         outputSchema: shouldPopulateOutput
           ? (sourceSchemas.outputSchema as Record<string, unknown>)
           : (outputSchema ?? null),
+        requestContextSchema: requestContextSchema ?? null,
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sourceType, selectedWorkflow, workflowSchema, scorerTargetType]);
 
   const handleInputSchemaChange = (schema: Record<string, unknown> | null) => {
-    onChange({ inputSchema: schema, outputSchema: outputSchema ?? null });
+    onChange({
+      inputSchema: schema,
+      outputSchema: outputSchema ?? null,
+      requestContextSchema: requestContextSchema ?? null,
+    });
   };
 
   const handleOutputSchemaChange = (schema: Record<string, unknown> | null) => {
-    onChange({ inputSchema: inputSchema ?? null, outputSchema: schema });
+    onChange({
+      inputSchema: inputSchema ?? null,
+      outputSchema: schema,
+      requestContextSchema: requestContextSchema ?? null,
+    });
+  };
+
+  const handleRequestContextSchemaChange = (schema: Record<string, unknown> | null) => {
+    onChange({
+      inputSchema: inputSchema ?? null,
+      outputSchema: outputSchema ?? null,
+      requestContextSchema: schema,
+    });
   };
 
   const handleSourceChange = (value: SourceType) => {
@@ -274,6 +294,14 @@ export function SchemaConfigSection({
           onChange={handleOutputSchemaChange}
           sourceSchema={isAutoPopulate ? sourceSchemas.outputSchema : undefined}
           autoPopulate={isAutoPopulate}
+        />
+
+        <SchemaField
+          label="Request Context Schema"
+          schemaType="requestContext"
+          value={requestContextSchema}
+          onChange={handleRequestContextSchemaChange}
+          autoPopulate={false}
         />
       </CollapsibleContent>
     </Collapsible>

--- a/packages/playground/src/domains/datasets/components/schema-settings/schema-field.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-settings/schema-field.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useRef } from 'react';
 
 interface SchemaFieldProps {
   label: string;
-  schemaType: 'input' | 'output';
+  schemaType: 'input' | 'output' | 'requestContext';
   value: Record<string, unknown> | null | undefined;
   onChange: (schema: Record<string, unknown> | null) => void;
   error?: string;

--- a/packages/playground/src/domains/datasets/hooks/__tests__/fixtures/dataset-request-context.ts
+++ b/packages/playground/src/domains/datasets/hooks/__tests__/fixtures/dataset-request-context.ts
@@ -1,0 +1,22 @@
+import type { DatasetItem } from '@mastra/client-js';
+
+export const datasetItemWithRequestContext: DatasetItem = {
+  id: 'item-1',
+  datasetId: 'dataset-1',
+  datasetVersion: 1,
+  input: { question: 'hi' },
+  requestContext: { clinicId: 'clinic-123' },
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+export const triggerExperimentResponse = {
+  experimentId: 'experiment-1',
+  status: 'pending' as const,
+  totalItems: 1,
+  succeededCount: 0,
+  failedCount: 0,
+  startedAt: '2026-01-01T00:00:00.000Z',
+  completedAt: null,
+  results: [],
+};

--- a/packages/playground/src/domains/datasets/hooks/__tests__/use-dataset-mutations-request-context.test.tsx
+++ b/packages/playground/src/domains/datasets/hooks/__tests__/use-dataset-mutations-request-context.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { PropsWithChildren } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useDatasetMutations } from '../use-dataset-mutations';
+import { datasetItemWithRequestContext, triggerExperimentResponse } from './fixtures/dataset-request-context';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+function wrapper({ children }: PropsWithChildren) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useDatasetMutations request context wiring', () => {
+  it('sends run-level requestContext when triggering an experiment', async () => {
+    const capture = vi.fn();
+    server.use(
+      http.post(`${BASE_URL}/api/datasets/dataset-1/experiments`, async ({ request }) => {
+        capture(await request.json());
+        return HttpResponse.json(triggerExperimentResponse);
+      }),
+    );
+
+    const { result } = renderHook(() => useDatasetMutations(), { wrapper });
+
+    await result.current.triggerExperiment.mutateAsync({
+      datasetId: 'dataset-1',
+      targetType: 'agent',
+      targetId: 'agent-1',
+      requestContext: { clinicId: 'clinic-123' },
+    });
+
+    await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+    expect(capture.mock.calls[0][0]).toMatchObject({
+      targetType: 'agent',
+      targetId: 'agent-1',
+      requestContext: { clinicId: 'clinic-123' },
+    });
+  });
+
+  it('sends per-item requestContext when adding an item', async () => {
+    const capture = vi.fn();
+    server.use(
+      http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
+        capture(await request.json());
+        return HttpResponse.json(datasetItemWithRequestContext);
+      }),
+    );
+
+    const { result } = renderHook(() => useDatasetMutations(), { wrapper });
+
+    await result.current.addItem.mutateAsync({
+      datasetId: 'dataset-1',
+      input: { question: 'hi' },
+      requestContext: { clinicId: 'clinic-123' },
+    });
+
+    await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+    expect(capture.mock.calls[0][0]).toMatchObject({
+      input: { question: 'hi' },
+      requestContext: { clinicId: 'clinic-123' },
+    });
+  });
+
+  it('sends per-item requestContext when updating an item', async () => {
+    const capture = vi.fn();
+    server.use(
+      http.patch(`${BASE_URL}/api/datasets/dataset-1/items/item-1`, async ({ request }) => {
+        capture(await request.json());
+        return HttpResponse.json(datasetItemWithRequestContext);
+      }),
+    );
+
+    const { result } = renderHook(() => useDatasetMutations(), { wrapper });
+
+    await result.current.updateItem.mutateAsync({
+      datasetId: 'dataset-1',
+      itemId: 'item-1',
+      requestContext: { clinicId: 'clinic-456' },
+    });
+
+    await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+    expect(capture.mock.calls[0][0]).toMatchObject({
+      requestContext: { clinicId: 'clinic-456' },
+    });
+  });
+});

--- a/packages/playground/src/domains/datasets/hooks/use-dataset-item-versions.ts
+++ b/packages/playground/src/domains/datasets/hooks/use-dataset-item-versions.ts
@@ -8,6 +8,7 @@ export interface DatasetItemVersion {
   input: unknown;
   groundTruth?: unknown;
   expectedTrajectory?: unknown;
+  requestContext?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
   validTo: number | null;
   isDeleted: boolean;

--- a/packages/playground/src/pages/datasets/dataset/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/index.tsx
@@ -195,6 +195,7 @@ function DatasetPage() {
       <ExperimentTriggerDialog
         datasetId={datasetId}
         version={activeVersion ?? undefined}
+        requestContextSchema={dataset?.requestContextSchema}
         open={experimentDialogOpen}
         onOpenChange={setExperimentDialogOpen}
         onSuccess={handleExperimentSuccess}
@@ -213,6 +214,7 @@ function DatasetPage() {
             description: dataset?.description || '',
             inputSchema: dataset.inputSchema,
             groundTruthSchema: dataset.groundTruthSchema,
+            requestContextSchema: dataset.requestContextSchema,
           }}
         />
       )}

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -54,13 +54,15 @@ function DatasetItemPage() {
 
   // Derive form defaults from latest version (recomputes when version changes)
   const formDefaults = useMemo(() => {
-    if (!latestVersion || isDeleted) return { input: '', groundTruth: '', metadata: '', trajectory: '' };
+    if (!latestVersion || isDeleted)
+      return { input: '', groundTruth: '', metadata: '', trajectory: '', requestContext: '' };
     return {
       input: JSON.stringify(latestVersion.input, null, 2),
       groundTruth: latestVersion.groundTruth ? JSON.stringify(latestVersion.groundTruth, null, 2) : '',
       metadata: latestVersion.metadata ? JSON.stringify(latestVersion.metadata, null, 2) : '',
       trajectory:
         latestVersion.expectedTrajectory != null ? JSON.stringify(latestVersion.expectedTrajectory, null, 2) : '',
+      requestContext: latestVersion.requestContext ? JSON.stringify(latestVersion.requestContext, null, 2) : '',
     };
   }, [latestVersion, isDeleted]);
 
@@ -73,6 +75,7 @@ function DatasetItemPage() {
   const [groundTruthValue, setGroundTruthValue] = useState(formDefaults.groundTruth);
   const [metadataValue, setMetadataValue] = useState(formDefaults.metadata);
   const [trajectoryValue, setTrajectoryValue] = useState(formDefaults.trajectory);
+  const [requestContextValue, setRequestContextValue] = useState(formDefaults.requestContext);
 
   // Reset form values when version changes (key-based reset pattern)
   const [prevVersionKey, setPrevVersionKey] = useState(versionKey);
@@ -82,6 +85,7 @@ function DatasetItemPage() {
     setGroundTruthValue(formDefaults.groundTruth);
     setMetadataValue(formDefaults.metadata);
     setTrajectoryValue(formDefaults.trajectory);
+    setRequestContextValue(formDefaults.requestContext);
   }
 
   // Delete dialog state
@@ -161,6 +165,17 @@ function DatasetItemPage() {
       }
     }
 
+    let parsedRequestContext: Record<string, unknown> | undefined;
+    const requestContextChanged = requestContextValue !== formDefaults.requestContext;
+    if (requestContextChanged && requestContextValue.trim()) {
+      try {
+        parsedRequestContext = JSON.parse(requestContextValue);
+      } catch {
+        toast.error('Request Context must be valid JSON');
+        return;
+      }
+    }
+
     try {
       await updateItem.mutateAsync({
         datasetId,
@@ -169,6 +184,7 @@ function DatasetItemPage() {
         groundTruth: parsedGroundTruth,
         metadata: parsedMetadata,
         ...(trajectoryChanged ? { expectedTrajectory: parsedTrajectory ?? null } : {}),
+        ...(requestContextChanged ? { requestContext: parsedRequestContext } : {}),
       });
       toast.success('Item updated successfully');
       setIsEditing(false);
@@ -186,6 +202,7 @@ function DatasetItemPage() {
       setTrajectoryValue(
         latestVersion.expectedTrajectory != null ? JSON.stringify(latestVersion.expectedTrajectory, null, 2) : '',
       );
+      setRequestContextValue(latestVersion.requestContext ? JSON.stringify(latestVersion.requestContext, null, 2) : '');
     }
     setIsEditing(false);
   };
@@ -336,6 +353,8 @@ function DatasetItemPage() {
                     setMetadataValue={setMetadataValue}
                     trajectoryValue={trajectoryValue}
                     setTrajectoryValue={setTrajectoryValue}
+                    requestContextValue={requestContextValue}
+                    setRequestContextValue={setRequestContextValue}
                     validationErrors={null}
                     onSave={handleSave}
                     onCancel={handleCancel}


### PR DESCRIPTION
## Summary

Request context values like `clinicId` could not reach tools during dataset experiment runs, causing experiment items to hang indefinitely in multi-tenant setups. This PR makes request context flow end-to-end through dataset experiments — from Studio, through inline and storage-backed datasets, into agent and workflow runs — including across agent delegation chains.

## What changed

**Core fix (`@mastra/core`)**
- Inline experiment data now passes each item's `requestContext` to the agent/workflow, merged over the global request context (per-item values win on key collisions). Previously this was silently dropped for inline `data`, while storage-backed datasets already worked.

**Studio (`@internal/playground`)**
- Define a dataset's `requestContextSchema` when creating or editing a dataset.
- Set per-item `requestContext` values on dataset items (add / edit / detail dialogs).
- Provide run-level request context when triggering an experiment.
- The trigger dialog renders a schema-driven form when the dataset declares a `requestContextSchema`, and falls back to a raw JSON editor otherwise.

**Examples**
- Added clinic test agents and tools to `examples/agent` that read `clinicId` from `requestContext`, exercising propagation through both direct tool calls and agent delegation, plus `clinic-a` / `clinic-b` request-context presets.

## Test plan

- `@mastra/core` experiment tests (31) pass, including new coverage for per-item request context on inline data.
- New playground MSW test suite (3) covers request context wiring through dataset mutations.
- Manual smoke test in Studio:
  - Direct agent + clinic preset → tool reads `clinicId`.
  - Supervisor agent + clinic preset → delegated sub-agent's tool reads the same `clinicId`.
  - No context provided → tool fails fast instead of hanging.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-8) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Each experiment item can now carry its own little note (request context) — like which clinic it belongs to — and that note is passed to the tools and agents running the test so items behave correctly in multi-tenant setups. The Studio UI and examples were updated so you can edit, validate, and trigger experiments with these per-item or run-level context values.

---

## Core Changes (`@mastra/core`)

- Inline experiment items now preserve and forward per-item `requestContext` into execution:
  - `DataItem<I, E>` gains optional `requestContext?: Record<string, unknown>`.
  - `runExperiment` maps `dataItem.requestContext` into `ExperimentItem` and merges it over the global run-level request context (per-item keys win).
  - New test coverage added (inline-data "Test 2b") asserting per-item context reaches `agent.generate()` as a `RequestContext` instance.

---

## Studio Changes (`@internal/playground`)

- Dataset schemas and item-level context:
  - Datasets may declare a `requestContextSchema` at create/edit.
  - `CreateDatasetDialog` / `EditDatasetDialog` support editing/saving `requestContextSchema`.
  - `SchemaConfigSection` propagates `requestContextSchema`; `SchemaField` now accepts `'requestContext'` as a schemaType.
  - `DatasetItemVersion` and item forms now account for `requestContext`.

- Item CRUD and UI:
  - `AddItemDialog`, `ItemDetailDialog`, `DatasetItemPanel`, and `DatasetItemPage` support viewing/editing per-item `requestContext` with JSON parsing/validation and include it in add/update payloads.
  - Dataset create/edit flows include `requestContextSchema` in payloads and reset behavior.

- Experiment triggering:
  - `ExperimentTriggerDialog` accepts a run-level `requestContext` prop.
  - If a `requestContextSchema` exists, the dialog renders a schema-driven form (via `jsonSchemaToZod` + `DynamicForm`); otherwise it shows a raw JSON editor.
  - Validates/resolves schema form values (drops empty/undefined) or parsed raw JSON (rejects non-object JSON like arrays/null/primitives) and passes resolved `requestContext` to the experiment trigger API.
  - Errors during schema resolution or JSON parsing surface inline/toast messages; state resets on close/success.

- Hooks/tests/types:
  - `useDatasetMutations` tests added to assert request-context is forwarded for trigger/add/update operations (MSW-backed Vitest/jsdom).
  - `use-dataset-item-versions` adds optional `requestContext` to `DatasetItemVersion`.

---

## Examples (`examples/agent`)

- Added clinic request-context presets (`clinic-a`, `clinic-b`) to example presets.
- New clinic example tooling and agents:
  - `clinicLookupTool` reads `clinicId` from `requestContext`, errors when missing, and returns a demo patient record.
  - `clinicDirectAgent`, `clinicSpecialistAgent`, and `clinicSupervisorAgent` exercise direct tool calls and delegation while verifying `clinicId` propagation.
  - Agents registered in example Mastra setup.
- Example agents/workflows demonstrate schema-driven requestContext usage and how agents/tools read values from requestContext.

---

## Testing

- 31 `@mastra/core` experiment tests pass, including the new inline per-item request-context test.
- New playground MSW-backed tests (Vitest/jsdom) verify:
  - Experiment trigger includes run-level `requestContext`.
  - Add item and update item include per-item `requestContext`.
- Manual smoke tests validate direct and delegated agent context propagation and expected failure when context is absent.

---

## Changeset entries

- `@mastra/core`: patch documenting inline experiment datasets now preserve per-item `requestContext`, merging over global context.
- `@internal/playground`: feature entry for dataset `requestContextSchema` support and per-item `requestContext` editing plus schema-driven experiment trigger UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->