### PR TITLE
fix(core): keep part timestamps out of message ordering

### DIFF
--- a/.changeset/old-news-press.md
+++ b/.changeset/old-news-press.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed prompt cache invalidation caused by recalled memory message timestamps changing across turns.

--- a/.changeset/old-news-press.md
+++ b/.changeset/old-news-press.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed prompt cache invalidation caused by recalled memory message timestamps changing across turns.
+Fixed message part timestamps affecting transcript ordering by ensuring only message-level timestamps advance the ordering watermark.

--- a/packages/core/src/agent/message-list/merge/MessageMerger.ts
+++ b/packages/core/src/agent/message-list/merge/MessageMerger.ts
@@ -91,12 +91,9 @@ export class MessageMerger {
    * - Updating tool invocations with their results
    * - Adding new parts in the correct order using anchor maps
    * - Inserting step-start markers where needed
-   * - Updating timestamps and content strings
+   * - Updating content strings
    */
   static merge(latestMessage: MastraDBMessage, incomingMessage: MastraDBMessage): void {
-    // Update timestamp
-    latestMessage.createdAt = incomingMessage.createdAt || latestMessage.createdAt;
-
     if (incomingMessage.content.metadata) {
       latestMessage.content.metadata = {
         ...(latestMessage.content.metadata ?? {}),
@@ -208,9 +205,6 @@ export class MessageMerger {
       partsToAdd,
     });
 
-    if (latestMessage.createdAt.getTime() < incomingMessage.createdAt.getTime()) {
-      latestMessage.createdAt = incomingMessage.createdAt;
-    }
     if (!latestMessage.content.content && incomingMessage.content.content) {
       latestMessage.content.content = incomingMessage.content.content;
     }

--- a/packages/core/src/agent/message-list/merge/MessageMerger.ts
+++ b/packages/core/src/agent/message-list/merge/MessageMerger.ts
@@ -85,7 +85,11 @@ export class MessageMerger {
   }
 
   /**
-   * Merge an incoming assistant message into the latest assistant message
+   * Merge an incoming assistant message into the latest assistant message.
+   *
+   * This preserves the existing message-level createdAt. OM uses that timestamp
+   * as its observation boundary, so moving it forward can make an already
+   * observed message look unobserved and eligible for reprocessing.
    *
    * This handles:
    * - Updating tool invocations with their results

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1597,14 +1597,16 @@ export class MessageList {
 
   private updateLastCreatedAt(message: MastraDBMessage): void {
     const latestMessageTime = message.createdAt.getTime();
-    const latestPartTime = Array.isArray(message.content.parts)
-      ? message.content.parts.reduce((latest, part) => {
-          if (typeof part.createdAt === 'number' && part.createdAt > latest) {
-            return part.createdAt;
-          }
-          return latest;
-        }, latestMessageTime)
-      : latestMessageTime;
+    const shouldIncludePartTimestamps = !this.stateManager.isMemoryMessage(message);
+    const latestPartTime =
+      shouldIncludePartTimestamps && Array.isArray(message.content.parts)
+        ? message.content.parts.reduce((latest, part) => {
+            if (typeof part.createdAt === 'number' && part.createdAt > latest) {
+              return part.createdAt;
+            }
+            return latest;
+          }, latestMessageTime)
+        : latestMessageTime;
 
     this.lastCreatedAt = Math.max(this.lastCreatedAt || 0, latestPartTime);
   }

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1596,19 +1596,10 @@ export class MessageList {
   private lastCreatedAt?: number;
 
   private updateLastCreatedAt(message: MastraDBMessage): void {
-    const latestMessageTime = message.createdAt.getTime();
-    const shouldIncludePartTimestamps = !this.stateManager.isMemoryMessage(message);
-    const latestPartTime =
-      shouldIncludePartTimestamps && Array.isArray(message.content.parts)
-        ? message.content.parts.reduce((latest, part) => {
-            if (typeof part.createdAt === 'number' && part.createdAt > latest) {
-              return part.createdAt;
-            }
-            return latest;
-          }, latestMessageTime)
-        : latestMessageTime;
-
-    this.lastCreatedAt = Math.max(this.lastCreatedAt || 0, latestPartTime);
+    // Message-level createdAt controls transcript ordering and OM observation boundaries.
+    // Part timestamps are event metadata within a message and must not advance the
+    // ordering watermark used to timestamp later messages/signals.
+    this.lastCreatedAt = Math.max(this.lastCreatedAt || 0, message.createdAt.getTime());
   }
 
   // this makes sure messages added in order will always have a date atleast 1ms apart.
@@ -1634,10 +1625,9 @@ export class MessageList {
 
     const now = new Date();
     const nowTime = startDate?.getTime() || now.getTime();
-    // find the latest createdAt in stored messages and parts
     const lastTime = this.lastCreatedAt || 0;
 
-    // make sure our new message is created later than the latest known message time
+    // make sure our new message is created later than the latest known ordering timestamp
     // it's expected that messages are added to the list in order if they don't have a createdAt date on them
     if (nowTime <= lastTime) {
       const newDate = new Date(lastTime + 1);

--- a/packages/core/src/agent/message-list/tests/message-list-om-multistep.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-om-multistep.test.ts
@@ -13,11 +13,12 @@ const resourceId = 'om-user';
 describe('MessageList — OM multi-step source handoff', () => {
   it('removes memory source when merged assistant content is promoted to response', () => {
     const assistantId = 'asst-om-1';
+    const originalCreatedAt = new Date(1);
     const step1: MastraDBMessage = {
       id: assistantId,
       role: 'assistant',
       type: 'text',
-      createdAt: new Date(1),
+      createdAt: originalCreatedAt,
       threadId,
       resourceId,
       content: {
@@ -72,6 +73,7 @@ describe('MessageList — OM multi-step source handoff', () => {
     const responseDb = list.get.response.db();
     expect(responseDb).toHaveLength(1);
     expect(responseDb[0]!.id).toBe(assistantId);
+    expect(responseDb[0]!.createdAt).toEqual(originalCreatedAt);
     expect(responseDb[0]!.content.parts?.some(p => p.type === 'text' && p.text === 'Done.')).toBe(true);
 
     // Must not still be tracked as a memory-only row for the same object identity

--- a/packages/core/src/agent/message-list/tests/message-list-om-multistep.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-om-multistep.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { MastraDBMessage } from '../../../memory';
+import { createSignal } from '../../signals';
 import { MessageList } from '../index';
 
 const threadId = 'om-thread';
@@ -82,5 +83,75 @@ describe('MessageList — OM multi-step source handoff', () => {
     const secondClear = list.clear.response.db();
     expect(secondClear).toHaveLength(1);
     expect(secondClear[0]!.content.parts?.some(p => p.type === 'text' && p.text === 'Done.')).toBe(true);
+  });
+
+  it('does not let promoted memory part timestamps advance signal timestamps', () => {
+    const now = Date.now();
+    const assistantId = 'asst-om-late-part';
+    const messageCreatedAt = new Date(now);
+    const latePartCreatedAt = now + 30_000;
+
+    const list = new MessageList({ threadId, resourceId });
+    list.add(
+      {
+        id: assistantId,
+        role: 'assistant',
+        type: 'text',
+        createdAt: messageCreatedAt,
+        threadId,
+        resourceId,
+        content: {
+          format: 2,
+          parts: [
+            { type: 'text', text: 'Observed response start' },
+            {
+              type: 'tool-invocation',
+              createdAt: latePartCreatedAt,
+              toolInvocation: { state: 'call', toolCallId: 'tc-late', toolName: 'noop', args: {} },
+            },
+          ],
+        },
+      },
+      'memory',
+    );
+
+    list.add(
+      {
+        id: assistantId,
+        role: 'assistant',
+        type: 'text',
+        createdAt: new Date(now + 2_000),
+        threadId,
+        resourceId,
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'tc-late',
+                toolName: 'noop',
+                args: {},
+                result: { ok: true },
+              },
+            },
+            { type: 'text', text: 'Observed response complete' },
+          ],
+        },
+      },
+      'response',
+    );
+
+    const signalForTranscript = list.addSignal(
+      createSignal({
+        id: 'next-signal',
+        type: 'user-message',
+        contents: 'Next signal',
+        createdAt: new Date(now + 3_000),
+      }),
+    );
+
+    expect(signalForTranscript.createdAt.getTime()).toBeLessThan(latePartCreatedAt);
   });
 });

--- a/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
@@ -517,7 +517,8 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
       const storedSignal = list.get.all.db().at(-1)!;
       const recalledSignal = mastraDBMessageToSignal(storedSignal);
       expect(storedSignal.id).toBe(signal.id);
-      expect(storedSignal.createdAt.getTime()).toBe(toolPartTime + 1);
+      expect(storedSignal.createdAt.getTime()).toBe(responseTime.getTime() + 1);
+      expect(storedSignal.createdAt.getTime()).toBeLessThan(toolPartTime);
       expect(recalledSignal.createdAt).toEqual(storedSignal.createdAt);
       expect(recalledSignal.acceptedAt).toEqual(signalTime);
       expect(storedSignal.content.metadata?.signal).toMatchObject({


### PR DESCRIPTION
This keeps message part timestamps from affecting transcript ordering. Part timestamps are still preserved as event metadata, but only the message-level `createdAt` advances the ordering watermark used for later messages/signals.

Before, a late part timestamp could push a later signal forward:

```ts
message.createdAt = 10:00:00
part.createdAt = 10:00:30
nextSignal.createdAt = 10:00:30.001
```

After, later messages/signals are ordered from the message-level timestamp:

```ts
message.createdAt = 10:00:00
part.createdAt = 10:00:30
nextSignal.createdAt = 10:00:03
```

Also preserves the existing message-level `createdAt` when merging response content into a memory-loaded assistant message, since OM uses that timestamp to decide whether a message has already been observed.

Verified with the focused message-list regression test, `pnpm build:core`, and `pnpm --filter ./packages/core check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Imagine you're organizing messages by time. This PR fixes a bug where a late timestamp on a piece of a message (a "part") could reorder later messages — now only the main message timestamp controls ordering, while part timestamps are preserved as metadata and no longer affect transcript ordering.

## Changes

**Changeset Entry** (.changeset/old-news-press.md)
- Adds a patch release note for `@mastra/core` describing the fix: message-part timestamps no longer advance the transcript ordering watermark.

**Message Merging** (packages/core/src/agent/message-list/merge/MessageMerger.ts)
- Preserve an existing message's `createdAt` when merging incoming content; removed logic that would update/advance `createdAt` from the incoming message.
- Documentation updated to clarify that `createdAt` must remain unchanged so previously observed messages are not reprocessed.

**Message List Ordering** (packages/core/src/agent/message-list/message-list.ts)
- `MessageList.updateLastCreatedAt` now advances the ordering watermark using only message-level `createdAt`.
- Removed prior logic that inspected part-level timestamps when updating the watermark.
- Comments updated to reflect that `lastCreatedAt` is the message-level ordering timestamp.

**Tests** (packages/core/src/agent/message-list/tests)
- message-list-om-multistep.test.ts:
  - Updated OM multi-step test to ensure promoted (memory-loaded) assistant responses retain the original `createdAt`.
  - Added a regression test asserting that a tool-part with a later timestamp does not advance subsequent signal timestamps.
- message-list-ordering.test.ts:
  - Adjusted assertions so signals are normalized using the response (message-level) timestamp rather than a later part timestamp.

## Verification
- Focused regression tests added/updated.
- Build and check commands referenced: `pnpm build:core` (runs turbo build --filter ./packages/core) and `pnpm --filter ./packages/core check` (typecheck/check step used in CI).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->