### PR TITLE
fix(client-js): preserve client tools across continuations

### DIFF
--- a/.changeset/good-hands-find.md
+++ b/.changeset/good-hands-find.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fixed subscribed client tool continuations so browser-provided tool results keep their original inputs and client tools remain available across continuation runs.

--- a/client-sdks/client-js/src/resources/agent.test.ts
+++ b/client-sdks/client-js/src/resources/agent.test.ts
@@ -53,6 +53,14 @@ describe('Agent signal routes', () => {
       { headers: { 'Content-Type': 'text/event-stream' } },
     );
 
+  const continuationToolResultMessage = (toolCallId: string, toolName: string, input: unknown, output: unknown) => ({
+    role: 'assistant',
+    content: [
+      { type: 'tool-call', toolCallId, toolName, input },
+      { type: 'tool-result', toolCallId, toolName, output: { type: 'json', value: output } },
+    ],
+  });
+
   const mockSignalAndSubscriptionRequests = async (
     agent: Agent,
     runId: string,
@@ -584,6 +592,7 @@ describe('Agent signal routes', () => {
       type: 'tool-result',
       toolCallId: 'call-1',
       toolName: 'myTool',
+      args: { x: 'hi' },
       result: { ok: true },
     });
 
@@ -592,17 +601,7 @@ describe('Agent signal routes', () => {
     expect(sendToolApprovalSpy).toHaveBeenCalled();
     const continuationCall = sendToolApprovalSpy.mock.calls.at(-1) as [any];
     expect(continuationCall[0].messages).toEqual([
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolCallId: 'call-1',
-            toolName: 'myTool',
-            result: { ok: true },
-          },
-        ],
-      },
+      continuationToolResultMessage('call-1', 'myTool', { x: 'hi' }, { ok: true }),
     ]);
     expect(continuationCall[0].streamOptions?.memory).toEqual({ thread: 'thread-123', resource: 'resource-123' });
   });
@@ -684,6 +683,74 @@ describe('Agent signal routes', () => {
     ]);
   });
 
+  it('sends all same-tool client results from a subscribed tool-call finish', async () => {
+    const agent = new Agent(mockClientOptions, 'test-agent');
+    const chunks = [
+      {
+        type: 'tool-call',
+        runId: 'run-initial',
+        payload: { toolCallId: 'call-1', toolName: 'myTool', args: { value: 'first' } },
+      },
+      {
+        type: 'tool-call',
+        runId: 'run-initial',
+        payload: { toolCallId: 'call-2', toolName: 'myTool', args: { value: 'second' } },
+      },
+      {
+        type: 'finish',
+        runId: 'run-initial',
+        payload: {
+          stepResult: { reason: 'tool-calls' },
+          messages: {
+            nonUser: [
+              {
+                role: 'assistant',
+                content: [
+                  { type: 'tool-call', toolCallId: 'call-1', toolName: 'myTool', args: { value: 'first' } },
+                  { type: 'tool-call', toolCallId: 'call-2', toolName: 'myTool', args: { value: 'second' } },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    ];
+    const sendToolApprovalSpy = vi
+      .spyOn(agent, 'sendToolApproval')
+      .mockResolvedValueOnce({ accepted: true, runId: 'run-continuation' } as never);
+    const executeSpy = vi.fn(async ({ value }: { value: string }) => ({ value }));
+    const clientTools = {
+      myTool: { id: 'myTool', description: 'tool', inputSchema: z.object({ value: z.string() }), execute: executeSpy },
+    };
+
+    await mockSignalAndSubscriptionRequests(agent, 'run-initial', chunks, {
+      signal: { type: 'user-message', contents: 'hello' },
+      resourceId: 'resource-123',
+      threadId: 'thread-123',
+      ifIdle: { streamOptions: { clientTools } },
+    } as SendAgentSignalParams);
+
+    const subscribed = await agent.subscribeToThread({
+      resourceId: 'resource-123',
+      threadId: 'thread-123',
+    } as SubscribeAgentThreadParams);
+
+    const received: any[] = [];
+    await subscribed.processDataStream({ onChunk: async chunk => void received.push(chunk) });
+
+    expect(executeSpy).toHaveBeenCalledTimes(2);
+    expect(executeSpy.mock.calls.map(call => call[0])).toEqual([{ value: 'first' }, { value: 'second' }]);
+    expect(received.filter(chunk => chunk.type === 'tool-result').map(chunk => chunk.payload.toolCallId)).toEqual([
+      'call-1',
+      'call-2',
+    ]);
+    const [continuationCall] = sendToolApprovalSpy.mock.calls.at(-1) as [any];
+    expect(continuationCall.messages).toEqual([
+      continuationToolResultMessage('call-1', 'myTool', { value: 'first' }, { value: 'first' }),
+      continuationToolResultMessage('call-2', 'myTool', { value: 'second' }, { value: 'second' }),
+    ]);
+  });
+
   it('preserves assistant non-user messages for stateless client-tool continuations', async () => {
     const agent = new Agent(mockClientOptions, 'test-agent');
     const assistantMessages = [
@@ -729,10 +796,7 @@ describe('Agent signal routes', () => {
     const [continuation] = sendToolApprovalSpy.mock.calls.at(-1) as [any];
     expect(continuation.messages).toEqual([
       ...assistantMessages,
-      {
-        role: 'tool',
-        content: [{ type: 'tool-result', toolCallId: 'call-1', toolName: 'myTool', result: { ok: true } }],
-      },
+      continuationToolResultMessage('call-1', 'myTool', { x: 'hi' }, { ok: true }),
     ]);
     expect(continuation.streamOptions?.memory).toBeUndefined();
   });
@@ -798,14 +862,8 @@ describe('Agent signal routes', () => {
     const [continuation] = sendToolApprovalSpy.mock.calls.at(-1) as [any];
     const continuationMessages = continuation.messages;
     expect(continuationMessages).toEqual([
-      {
-        role: 'tool',
-        content: [{ type: 'tool-result', toolCallId: 'call-1', toolName: 'firstTool', result: { first: true } }],
-      },
-      {
-        role: 'tool',
-        content: [{ type: 'tool-result', toolCallId: 'call-2', toolName: 'secondTool', result: { second: true } }],
-      },
+      continuationToolResultMessage('call-1', 'firstTool', { value: 'one' }, { first: true }),
+      continuationToolResultMessage('call-2', 'secondTool', { value: 'two' }, { second: true }),
     ]);
   });
 
@@ -915,17 +973,15 @@ describe('Agent signal routes', () => {
       type: 'tool-result',
       toolCallId: 'call-error',
       toolName: 'myTool',
+      args: {},
       result: { error: 'Error: boom' },
     });
     expect(streamUntilIdleSpy).not.toHaveBeenCalled();
     const [continuation] = sendToolApprovalSpy.mock.calls.at(-1) as [any];
     const continuationMessages = continuation.messages;
-    expect(continuationMessages.at(-1)).toEqual({
-      role: 'tool',
-      content: [
-        { type: 'tool-result', toolCallId: 'call-error', toolName: 'myTool', result: { error: 'Error: boom' } },
-      ],
-    });
+    expect(continuationMessages.at(-1)).toEqual(
+      continuationToolResultMessage('call-error', 'myTool', {}, { error: 'Error: boom' }),
+    );
   });
 
   it('scopes pending client tool calls by runId', async () => {
@@ -992,10 +1048,7 @@ describe('Agent signal routes', () => {
     const [continuation] = sendToolApprovalSpy.mock.calls.at(-1) as [any];
     const continuationMessages = continuation.messages;
     expect(continuationMessages).toEqual([
-      {
-        role: 'tool',
-        content: [{ type: 'tool-result', toolCallId: 'call-a', toolName: 'myTool', result: { args: { run: 'a' } } }],
-      },
+      continuationToolResultMessage('call-a', 'myTool', { run: 'a' }, { args: { run: 'a' } }),
     ]);
   });
 
@@ -1184,9 +1237,14 @@ describe('Agent signal routes', () => {
     expect(streamUntilIdleSpy).not.toHaveBeenCalled();
     const [continuation] = sendToolApprovalSpy.mock.calls.at(-1) as [any];
     const continuationMessages = continuation.messages;
-    const continuationToolContent = continuationMessages.at(-1).content[0];
-    expect(continuationToolContent).toBe(toolResult.payload);
-    expect(continuationToolContent.__mastraObservability).toEqual(toolResult.payload.__mastraObservability);
+    const continuationToolContent = continuationMessages.at(-1).content[1];
+    expect(continuationToolContent).toEqual({
+      type: 'tool-result',
+      toolCallId: 'call-observe',
+      toolName: 'observeTool',
+      output: { type: 'json', value: { ok: true } },
+      __mastraObservability: toolResult.payload.__mastraObservability,
+    });
   });
 
   it('does not execute client tools when no clientTools are provided', async () => {

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -10,7 +10,7 @@ import type {
 } from '@ai-sdk/ui-utils';
 import { v4 as uuid } from '@lukeed/uuid';
 import type { AgentExecutionOptionsBase, SerializableStructuredOutputOptions } from '@mastra/core/agent';
-import type { MessageListInput } from '@mastra/core/agent/message-list';
+import type { AIV5Type, MessageListInput } from '@mastra/core/agent/message-list';
 import { getErrorFromUnknown } from '@mastra/core/error';
 import type { GenerateReturn, CoreMessage } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
@@ -709,7 +709,7 @@ export class Agent extends BaseResource {
           const processedClientTools = processClientTools(activeClientTools);
           const processedRequestContext = parseClientRequestContext(activeRequestContext);
 
-          const toolResultMessages: CoreMessage[] = [];
+          const toolResultMessages: AIV5Type.ModelMessage[] = [];
           for (const toolCall of pendingToolCalls) {
             const clientTool = activeClientTools[toolCall.toolName] as Tool | undefined;
             if (!clientTool || typeof clientTool.execute !== 'function') continue;
@@ -741,16 +741,17 @@ export class Agent extends BaseResource {
               result = { error: String(error) };
             }
 
-            const toolResultContent: Record<string, unknown> = {
+            const toolResultContent = {
               type: 'tool-result',
               toolCallId: toolCall.toolCallId,
               toolName: toolCall.toolName,
+              args: toolCall.args,
               result,
+              ...(observability ? { __mastraObservability: observability } : {}),
+            } satisfies Extract<CoreMessage, { role: 'tool' }>['content'][number] & {
+              args?: unknown;
+              __mastraObservability?: ClientToolObservabilityEnvelope;
             };
-
-            if (observability) {
-              toolResultContent.__mastraObservability = observability;
-            }
 
             await onChunk({
               type: 'tool-result',
@@ -758,10 +759,24 @@ export class Agent extends BaseResource {
               payload: toolResultContent,
             } as never);
 
+            const continuationToolCall = {
+              type: 'tool-call',
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              input: toolCall.args,
+            } satisfies AIV5Type.ToolCallPart;
+            const continuationToolResult = {
+              type: 'tool-result',
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              output: { type: 'json', value: result as JSONValue },
+              ...(observability ? { __mastraObservability: observability } : {}),
+            } satisfies AIV5Type.ToolResultPart & { __mastraObservability?: ClientToolObservabilityEnvelope };
+
             toolResultMessages.push({
-              role: 'tool',
-              content: [toolResultContent],
-            } as unknown as CoreMessage);
+              role: 'assistant',
+              content: [continuationToolCall, continuationToolResult],
+            });
           }
 
           if (toolResultMessages.length === 0) {
@@ -782,6 +797,10 @@ export class Agent extends BaseResource {
             streamOptions: continuationStreamOptions,
           });
 
+          const continuationMessages = (
+            threadId ? toolResultMessages : [...(finishPayload.payload?.messages?.nonUser ?? []), ...toolResultMessages]
+          ) as MessageListInput;
+
           try {
             await agent.sendToolApproval({
               resourceId: resourceId || agent.agentId,
@@ -789,9 +808,7 @@ export class Agent extends BaseResource {
               toolCallId: pendingToolCalls[0]!.toolCallId,
               approved: true,
               requestContext: processedRequestContext,
-              messages: (threadId
-                ? toolResultMessages
-                : [...(finishPayload.payload?.messages?.nonUser ?? []), ...toolResultMessages]) as MessageListInput,
+              messages: continuationMessages,
               streamOptions: continuationStreamOptions,
             });
           } catch (error) {


### PR DESCRIPTION
This fixes subscribed client tool continuations in Agent Builder.

Before, client-side tool results were sent back as tool-only messages and the continuation run could lose both the client tool runtime options and the original tool call input. That made the builder stop after `finish: tool-calls`, or retry the same client tools because the model saw empty inputs.

Now the client keeps thread-scoped runtime options available for continuation run IDs and sends the continuation as model-message-shaped tool call/result pairs:

```ts
[
  { role: 'assistant', content: [{ type: 'tool-call', input }] },
  { role: 'tool', content: [{ type: 'tool-result', output }] },
]
```

I verified this with the focused client-js tests and a local Agent Builder smoke run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

Imagine you're building with blocks and you ask a helper to grab specific blocks for you. The problem was that when the helper would continue working with new instructions, they'd forget what blocks you originally asked for. This fix makes sure the helper remembers both the original request AND the blocks they grabbed, so they can keep helping correctly without getting confused or asking for the same blocks again.

## Changes Summary

### Overview
This PR fixes client-side tool continuations in the Agent Builder by ensuring that:
1. Browser-provided tool inputs are preserved when continuation runs receive new IDs
2. Client tools remain available across server-side continuation execution
3. Tool results are sent as properly structured AI message pairs instead of simple tool-only messages

### Key Technical Changes

**client-sdks/client-js/src/resources/agent.ts**
- Updated `subscribeToThread` to send client tool results as `AIV5Type.ModelMessage[]` instead of `CoreMessage[]`
- Changed the tool-result message format from a single `role: 'tool'` message to a message pair:
  - First: `{ role: 'assistant', content: [{ type: 'tool-call', input }] }`
  - Second: `{ role: 'tool', content: [{ type: 'tool-result', output }] }`
- Modified `sendToolApproval` to send the recomputed messages list, ensuring thread-scoped execution uses only the newly built `toolResultMessages` and stateless runs properly prepend non-user messages from the finish payload
- Updated imports to include `AIV5Type` and `MessageListInput` from the message-list module

**client-sdks/client-js/src/resources/agent.test.ts**
- Added `continuationToolResultMessage` helper function to standardize the shape of synthetic tool-result messages for client-tool continuations
- Updated all client-tool continuation tests to use the new helper instead of inline message structures
- Tests now verify that continuation messages preserve the original `input` and wrap outputs in the `{ type: 'json', value: ... }` format
- Added new test to verify that subscribed tool-call finish sends all same-tool client results via the helper-generated continuation messages
- Updated observability assertions to verify that `__mastraObservability` is carried over from produced tool-result payloads

**.changeset/good-hands-find.md**
- Added changeset documenting the patch-level fix for `@mastra/client-js`

### Why This Matters
Previously, when the Agent Builder encountered `finish: tool-calls`, continuation runs would:
- Lose the original tool call inputs
- Lose client tool runtime options (scope, threading, etc.)
- Either stop execution or retry client tools with empty/incorrect inputs

With this fix, the message structure now preserves all necessary context for the AI model and message adapters to correctly handle tool continuations, enabling the Agent Builder to successfully execute multi-step workflows with client tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->