### PR TITLE
fix(agent-builder): keep generated instructions concise

### DIFF
--- a/.changeset/short-builders-breathe.md
+++ b/.changeset/short-builders-breathe.md
@@ -1,0 +1,6 @@
+---
+'@mastra/editor': patch
+'@internal/playground': patch
+---
+
+Improved Agent Builder defaults so generated agent instructions stay concise while still covering the required operating checklist. Agent Builder chat requests now also use lower OpenAI reasoning effort by default.

--- a/packages/editor/src/ee/agent-builder-agent.ts
+++ b/packages/editor/src/ee/agent-builder-agent.ts
@@ -129,9 +129,9 @@ The form snapshot lists what's currently attached. Use it together with the avai
 - Only call \`createSkillTool\` when (a) no existing stored skill matches reusable operating instructions the produced agent needs, AND (b) that operating instruction is genuinely needed for the outcome. Do not use stored skills as a substitute for missing integrations or tools.
 - If a specific external connection is required (e.g. a sheet tool for a spreadsheet-driven outcome) and none is available, the new agent's system prompt must instruct it to refuse cleanly and explain what the user needs to connect.
 
-## Step D — Synthesize the run contract
+## Step D — Synthesize concise operating instructions
 
-Before calling \`set-agent-instructions\`, privately write a concrete run contract for the produced agent. The system prompt must instantiate each item:
+Before calling \`set-agent-instructions\`, privately write a concrete run contract for the produced agent. The system prompt must instantiate each item, but keep each item brief:
 
 1. **Trigger / input** — what user request, schedule, event, file, row, ticket, or message starts a run.
 2. **Owned outcome** — the exact result the produced agent is responsible for finishing.
@@ -139,6 +139,8 @@ Before calling \`set-agent-instructions\`, privately write a concrete run contra
 4. **Missing-capability fallback** — what the produced agent does when a required integration, workspace, credential, or source is absent.
 5. **Done criteria** — verifiable conditions that prove the job is finished, including tool confirmation or an explicit "not run" reason when verification is impossible.
 6. **Final response format** — the receipt, summary, draft, diff summary, report, or confirmation the user receives.
+
+Write the final system prompt as 2–4 short paragraphs or compact bullet groups. Target 1,200–2,000 characters and stay under 2,500 characters. Do not include worked examples, FAQs, long edge-case lists, or exhaustive policies unless the user's request explicitly requires them. Prefer one clear default over several branches.
 
 ## Step E — Write the agent
 
@@ -149,9 +151,10 @@ Before calling \`set-agent-instructions\`, self-audit the draft. It must pass ev
 - No internal tool ids, file paths, schemas, or builder-only terms appear.
 - No generic "helpful assistant" identity remains.
 - No unsupported capabilities are promised.
-- Completion criteria are present, concrete, and tool-aware.
-- Refusal / fallback path is present for missing integrations, credentials, permissions, workspace, or sources.
-- Final response format is specified.
+- Completion criteria are concrete.
+- Missing-access fallback is included when relevant.
+- Final response expectations are clear.
+- The prompt is specific to the agent's outcome and under 2,500 characters.
 
 ## Step F — Confirm the agent configuration to the user
 
@@ -174,7 +177,7 @@ Bad:
 
 # Quality bar for the produced agent's system prompt
 
-The system prompt written into \`set-agent-instructions\` MUST include all of the following:
+The system prompt written into \`set-agent-instructions\` MUST be short, concrete, and useful. It should cover all of the following, but each item should usually be one sentence or a compact bullet:
 
 1. **Role and outcome.** Define what the agent is and the concrete result it owns.
 2. **Trigger and input.** Define what starts a run and what input the agent expects.
@@ -182,10 +185,11 @@ The system prompt written into \`set-agent-instructions\` MUST include all of th
 4. **Capability awareness.** Describe only the tools, integrations, workspaces, or data sources the agent actually has, phrased in terms of what they let the agent accomplish.
 5. **Missing-capability fallback.** Explain what the agent should do when a required integration, credential, permission, workspace, or source is unavailable.
 6. **Completion criteria.** Define exactly when the task is done in observable, verifiable terms.
-7. **Final response format.** Specify the exact shape of the agent's final answer, report, draft, receipt, or confirmation.
+7. **Final response format.** Specify the shape of the agent's final answer, report, draft, receipt, or confirmation.
 8. **Communication style.** Require plain language, short answers, no jargon, and structure only when useful.
 9. **Refusal rules.** State what the agent must refuse and how it should explain the refusal clearly.
-10. **Worked example.** Include at least one short input → output example showing a complete successful run.
+
+Keep this to 2–4 focused paragraphs or compact bullet groups. Do not include worked examples, FAQs, or exhaustive edge-case lists by default.
 
 # Hard rules
 

--- a/packages/playground/src/domains/agent-builder/contexts/__tests__/stream-chat-provider.instructions.msw.test.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/__tests__/stream-chat-provider.instructions.msw.test.tsx
@@ -107,6 +107,7 @@ describe('StreamChatProvider — modelSettings.instructions on the wire', () => 
     expect(captured.body.modelSettings.maxRetries).toBe(3);
     expect(captured.body.modelSettings.maxOutputTokens).toBe(5000);
     expect(captured.body.modelSettings.temperature).toBe(1);
+    expect(captured.body.providerOptions).toEqual({ openai: { reasoningEffort: 'low' } });
 
     // Confirm the snapshot is NOT smuggled into the user-facing messages array.
     const messages = captured.body.messages ?? [];

--- a/packages/playground/src/domains/agent-builder/contexts/__tests__/stream-chat-provider.test.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/__tests__/stream-chat-provider.test.tsx
@@ -234,7 +234,10 @@ describe('StreamChatProvider', () => {
     expect(payload).toMatchObject({
       message: 'hi',
       threadId: 'thread-xyz',
-      modelSettings: { instructions: 'snapshot-text' },
+      modelSettings: {
+        instructions: 'snapshot-text',
+        providerOptions: { openai: { reasoningEffort: 'low' } },
+      },
     });
     expect(payload).not.toHaveProperty('instructions');
   });
@@ -262,6 +265,9 @@ describe('StreamChatProvider', () => {
     expect((sentMessages[0] as { modelSettings?: { instructions?: string } }).modelSettings).not.toHaveProperty(
       'instructions',
     );
+    expect(sentMessages[0]).toMatchObject({
+      modelSettings: { providerOptions: { openai: { reasoningEffort: 'low' } } },
+    });
 
     rerender(
       <StreamChatProvider agentId="a" threadId="thread-xyz" initialMessages={[]} extraInstructions="">
@@ -273,6 +279,9 @@ describe('StreamChatProvider', () => {
     expect((sentMessages[1] as { modelSettings?: { instructions?: string } }).modelSettings).not.toHaveProperty(
       'instructions',
     );
+    expect(sentMessages[1]).toMatchObject({
+      modelSettings: { providerOptions: { openai: { reasoningEffort: 'low' } } },
+    });
   });
 
   it('does not call sendMessage when extraInstructions changes between sends', () => {
@@ -306,7 +315,12 @@ describe('StreamChatProvider', () => {
 
     send!('go');
     expect(sentMessages).toHaveLength(1);
-    expect(sentMessages[0]).toMatchObject({ modelSettings: { instructions: 'v2' } });
+    expect(sentMessages[0]).toMatchObject({
+      modelSettings: {
+        instructions: 'v2',
+        providerOptions: { openai: { reasoningEffort: 'low' } },
+      },
+    });
   });
 
   it('keeps the chat messages state limited to the user message after a send (snapshot is invisible)', () => {

--- a/packages/playground/src/domains/agent-builder/contexts/stream-chat-provider.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/stream-chat-provider.tsx
@@ -92,6 +92,11 @@ export const StreamChatProvider = ({
           // server_error on the next request.
           maxTokens: 5000,
           temperature: 1,
+          providerOptions: {
+            openai: {
+              reasoningEffort: 'low',
+            },
+          },
         },
         requestContext,
       };

--- a/packages/playground/src/domains/agent-builder/hooks/use-set-agent-instructions-tool.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-set-agent-instructions-tool.ts
@@ -15,12 +15,12 @@ export function useSetAgentInstructionsTool() {
     () =>
       createTool({
         id: SET_AGENT_INSTRUCTIONS_TOOL_NAME,
-        description: `Set the agent instructions (its system prompt). Use this when the user provides or revises the body of guidance the agent should follow. HARD limit: ${MAX_GENERATED_INSTRUCTIONS_CHARS} characters. Over-limit calls are REJECTED (no persistence) — you must re-submit a tighter version. Plan length BEFORE calling and drop whole sections rather than shaving words when over budget.`,
+        description: `Set the agent instructions (its system prompt). Use this when the user provides or revises the body of guidance the agent should follow. Prefer a few focused paragraphs or compact bullet groups, target 1,200–2,000 characters, and stay under 2,500 characters unless the user explicitly needs more detail. HARD limit: ${MAX_GENERATED_INSTRUCTIONS_CHARS} characters. Over-limit calls are REJECTED (no persistence) — you must re-submit a tighter version. Plan length BEFORE calling and drop whole sections rather than shaving words when over budget.`,
         inputSchema: z.object({
           instructions: z
             .string()
             .describe(
-              `The full instructions / system prompt for the agent. May be multi-paragraph markdown. Replaces the previous instructions. HARD ${MAX_GENERATED_INSTRUCTIONS_CHARS}-character limit; over-limit calls are rejected without persisting. Count characters before calling.`,
+              `The full instructions / system prompt for the agent. Should usually be 2–4 short paragraphs or compact bullet groups, targeting 1,200–2,000 characters and staying under 2,500 characters. Replaces the previous instructions. HARD ${MAX_GENERATED_INSTRUCTIONS_CHARS}-character limit; over-limit calls are rejected without persisting. Count characters before calling.`,
             ),
         }),
         outputSchema: z.object({


### PR DESCRIPTION
This tightens the Agent Builder defaults so generated agent instructions stay useful without ballooning past the tool limit.

Before, the builder prompt required a full checklist and a worked example, which made it easy for generated instructions to get too long and trigger repeated `set-agent-instructions` retries.

Now the checklist is still there, but the builder is told to keep each item brief, target 1,200–2,000 characters, and avoid examples or exhaustive edge-case lists by default.

```ts
providerOptions: {
  openai: {
    reasoningEffort: 'low',
  },
}
```

I also updated the instruction-setting tool guidance and covered the request shape in the focused playground tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Agent Builder is a tool that helps create AI agents by automatically writing instructions. These instructions were getting too long and hitting system limits. This PR fixes it by making the builder write shorter, simpler instructions and turning down the "thinking effort" setting for smarter reasoning, so everything stays within size limits.

## Overview

This PR tightens the Agent Builder's default configuration to prevent generated agent instructions from exceeding size limits. The changes focus on reducing instruction verbosity while maintaining essential functionality, and adding configuration for lower OpenAI reasoning effort to help with token budgets.

## Changes

### Agent Builder Instruction Refinement

The builder agent's system prompt was updated to emphasize instruction conciseness:

- **Step D (Synthesize instructions)**: Now explicitly requires each checklist item to be brief (targeted 1,200–2,000 characters per item) and removes the prior requirement for worked input→output examples
- **Step E (Self-audit)**: Simplified the checklist for `set-agent-instructions`, removing wordy "tool-aware" phrasing and adding an explicit under-2,500-character constraint for the final system prompt
- **Quality bar**: Updated to emphasize brevity and concrete format (2–4 paragraphs or compact bullet groups) while retaining all critical requirements (role, trigger, decision rules, capability awareness, fallback handling, completion criteria, response format, style, and refusal rules)

### Provider Options for Lower Reasoning Effort

- Added `providerOptions.openai.reasoningEffort: 'low'` to the StreamChatProvider's model settings to bias OpenAI reasoning cost lower by default
- Updated tests to verify this option is sent with each message when `extraInstructions` is provided

### Tool Guidance Updates

Updated the `set-agent-instructions` tool's description and field documentation to clarify:
- Recommended instruction length targets
- Over-limit handling (rejected with no persistence)
- Guidance to plan/drop whole sections when over budget

### Test Coverage

Added and updated playground tests to verify:
- The `providerOptions` structure is correctly sent on the wire with `{ openai: { reasoningEffort: 'low' } }`
- Various payload shapes for `modelSettings` with and without `extraInstructions`
- Proper handling of `extraInstructions` changes between sends

## Release Notes

- `@mastra/editor`: Patch release
- `@internal/playground`: Patch release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->