### PR TITLE
feat(gcs): scope GCS sandbox mounts to a prefix (parity with S3/Azure)

### DIFF
--- a/.changeset/gcs-prefix-scoped-mount.md
+++ b/.changeset/gcs-prefix-scoped-mount.md
@@ -1,0 +1,17 @@
+---
+"@mastra/gcs": patch
+"@mastra/e2b": patch
+---
+
+Add prefix-scoped GCS sandbox mounts (parity with S3 and Azure)
+
+`GCSFilesystem.getMountConfig()` now includes its `prefix` (trailing slash
+stripped), and the E2B `mountGCS` adds the corresponding `gcsfuse --only-dir`
+flag when a prefix is set. This scopes the FUSE mount to the prefixed
+subdirectory so sandbox paths map directly to prefixed GCS keys — matching the
+existing S3 (`bucket:/prefix`) and Azure (`--subdirectory`) mounts. Previously a
+prefixed `GCSFilesystem` dropped the prefix at both layers and mounted the entire
+bucket inside the sandbox.
+
+The prefix is validated with the existing `validatePrefix` (path-traversal guard)
+and shell-escaped with `shellQuote`.

--- a/workspaces/e2b/src/sandbox/mounts/gcs.ts
+++ b/workspaces/e2b/src/sandbox/mounts/gcs.ts
@@ -1,6 +1,7 @@
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
-import { LOG_PREFIX, validateBucketName } from './types';
+import { shellQuote } from '../../utils/shell-quote';
+import { LOG_PREFIX, validateBucketName, validatePrefix } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -15,10 +16,20 @@ export interface E2BGCSMountConfig extends FilesystemMountConfig {
   bucket: string;
   /** Service account key JSON (optional - omit for public buckets) */
   serviceAccountKey?: string;
+  /**
+   * GCS key prefix to scope the mount (without trailing slash).
+   * When set, gcsfuse uses --only-dir to mount only this subdirectory, so
+   * sandbox paths map directly to prefixed GCS keys.
+   */
+  prefix?: string;
 }
 
 /**
  * Mount a GCS bucket using gcsfuse.
+ *
+ * When `config.prefix` is set, gcsfuse uses `--only-dir` to mount only that
+ * subdirectory, aligning sandbox paths with the prefixed GCS keys (mirrors the
+ * S3 `bucket:/prefix` and Azure `--subdirectory` mounts).
  */
 export async function mountGCS(mountPath: string, config: E2BGCSMountConfig, ctx: MountContext): Promise<void> {
   const { sandbox, logger } = ctx;
@@ -50,6 +61,10 @@ export async function mountGCS(mountPath: string, config: E2BGCSMountConfig, ctx
   // Note: gcsfuse uses --uid/--gid flags, not -o uid=X style
   const uidGidFlags = uid && gid ? `--uid=${uid} --gid=${gid}` : '';
 
+  // Scope the mount to a subdirectory when a prefix is set (mirrors S3/Azure mounts).
+  // validatePrefix normalizes and guards against path traversal; shellQuote guards the shell.
+  const onlyDirFlag = config.prefix ? ` --only-dir=${shellQuote(validatePrefix(config.prefix))}` : '';
+
   const hasCredentials = !!config.serviceAccountKey;
   let mountCmd: string;
 
@@ -64,14 +79,14 @@ export async function mountGCS(mountPath: string, config: E2BGCSMountConfig, ctx
     // Mount with credentials using --key-file flag
     // Use sudo for /dev/fuse access (same as s3fs)
     // -o allow_other lets non-root users access the FUSE mount
-    mountCmd = `sudo gcsfuse --key-file=${keyPath} -o allow_other ${uidGidFlags} ${config.bucket} ${mountPath}`;
+    mountCmd = `sudo gcsfuse --key-file=${keyPath} -o allow_other ${uidGidFlags}${onlyDirFlag} ${config.bucket} ${mountPath}`;
   } else {
     // Public bucket mode - read-only access without credentials
     // Use --anonymous-access flag (not -o option)
     // Use sudo for /dev/fuse access (same as s3fs)
     logger.debug(`${LOG_PREFIX} No credentials provided, mounting GCS as public bucket (read-only)`);
 
-    mountCmd = `sudo gcsfuse --anonymous-access -o allow_other ${uidGidFlags} ${config.bucket} ${mountPath}`;
+    mountCmd = `sudo gcsfuse --anonymous-access -o allow_other ${uidGidFlags}${onlyDirFlag} ${config.bucket} ${mountPath}`;
   }
 
   logger.debug(`${LOG_PREFIX} Mounting GCS:`, mountCmd);

--- a/workspaces/gcs/src/filesystem/index.test.ts
+++ b/workspaces/gcs/src/filesystem/index.test.ts
@@ -199,6 +199,36 @@ describe('GCSFilesystem', () => {
 
       expect(config.serviceAccountKey).toBeUndefined();
     });
+
+    it('includes prefix if set (without trailing slash)', () => {
+      const fs = new GCSFilesystem({
+        bucket: 'test',
+        prefix: 'workspace/user1/agents/abc',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBe('workspace/user1/agents/abc');
+    });
+
+    it('strips trailing slash from prefix in mount config', () => {
+      const fs = new GCSFilesystem({
+        bucket: 'test',
+        prefix: '/foo/bar/',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBe('foo/bar');
+    });
+
+    it('excludes prefix if not set', () => {
+      const fs = new GCSFilesystem({ bucket: 'test' });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBeUndefined();
+    });
   });
 
   describe('getInfo()', () => {

--- a/workspaces/gcs/src/filesystem/index.ts
+++ b/workspaces/gcs/src/filesystem/index.ts
@@ -34,6 +34,12 @@ export interface GCSMountConfig extends FilesystemMountConfig {
   bucket: string;
   /** Service account key JSON (optional - omit for public buckets or ADC) */
   serviceAccountKey?: string;
+  /**
+   * GCS key prefix to scope the mount (without trailing slash).
+   * When set, gcsfuse uses --only-dir to mount only this subdirectory, so
+   * sandbox paths map directly to prefixed GCS keys (matches S3/Azure mounts).
+   */
+  prefix?: string;
 }
 
 /**
@@ -264,6 +270,11 @@ export class GCSFilesystem extends MastraFilesystem {
     // Include service account key if credentials are an object
     if (this.credentials && typeof this.credentials === 'object') {
       config.serviceAccountKey = JSON.stringify(this.credentials);
+    }
+
+    // Include prefix so sandbox mounts can use gcsfuse --only-dir for path alignment
+    if (this.prefix) {
+      config.prefix = this.prefix.replace(/\/$/, ''); // Strip trailing slash for mount commands
     }
 
     return config;


### PR DESCRIPTION
## Description

GCS is currently the only sandbox mount that doesn't support prefix scoping. `S3` (`bucket:/prefix`) and Azure (`--subdirectory`) both already scope the FUSE mount to a subdirectory, but a prefixed `GCSFilesystem` drops the prefix at **both** layers and mounts the **entire bucket** inside the sandbox. This PR fills that gap for GCS:

- **`@mastra/gcs`** — `GCSFilesystem.getMountConfig()` now includes its `prefix` (trailing slash stripped), so the mount config carries the prefix to the sandbox layer. `GCSMountConfig` gains a `prefix?: string` field.
- **`@mastra/e2b`** — `mountGCS()` adds `gcsfuse --only-dir=<prefix>` when `config.prefix` is set, so the FUSE mount is scoped to that subdirectory and sandbox paths map directly to the prefixed GCS keys. `E2BGCSMountConfig` gains `prefix?: string`.

The prefix is normalized/path-traversal-guarded by the existing `validatePrefix` and shell-escaped with the existing `shellQuote`, identical to the S3 and Azure mounts.

### Why

Without this, a `GCSFilesystem({ bucket, prefix: 'users/<id>/' })` mounted at e.g. `/mnt/user` exposes the **whole bucket** inside the sandbox — writes land at the bucket root instead of under the prefix, and other tenants' data is visible. Scoping the mount fixes that and brings GCS to parity with S3/Azure.

### Context

This is the GCS-only subset of the previously-closed #13834 (which also bundled S3 + STS). Since then S3 and Azure prefix scoping landed on `main`, leaving GCS as the only mount without it. Real-world demand was noted on #13834 (users patching locally) and the referenced bug.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking; opt-in via `prefix`)
- [x] Test update

## Tests

Added `@mastra/gcs` `getMountConfig()` tests: prefix included, trailing slash stripped, omitted when unset (mirroring the existing S3 tests). The `@mastra/e2b` change mirrors the established S3/Azure `validatePrefix` + `shellQuote` pattern.

## Checklist

- [x] Changeset added (`@mastra/gcs` + `@mastra/e2b`, patch)
- [x] Backward compatible — `prefix` is optional; existing mounts are unchanged

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds the ability to limit Google Cloud Storage (GCS) mounts to a specific folder path instead of the entire bucket. It's an optional feature that makes GCS behave the same way S3 and Azure storage already do, and doesn't break existing code.

---

## Overview

Introduces prefix-scoped mounting for GCS sandbox mounts, achieving feature parity with S3 and Azure. When a prefix is configured, the FUSE mount is restricted to that subdirectory, and sandbox paths automatically map to the corresponding prefixed GCS keys.

## Changes

**`@mastra/gcs`**
- `GCSMountConfig` interface now includes optional `prefix?: string` field
- `GCSFilesystem.getMountConfig()` populates the prefix from the instance's configured value, with trailing slashes stripped for consistent path mapping
- Tests added covering: prefix inclusion, trailing-slash stripping, and omission when not provided

**`@mastra/e2b`**
- `E2BGCSMountConfig` interface updated with optional `prefix?: string` field
- `mountGCS()` implementation adds `gcsfuse --only-dir=<prefix>` flag when prefix is configured, in both credentialed and anonymous-access mount modes
- Prefix validation reuses existing `validatePrefix` helper (path-traversal guard) and `shellQuote` for escaping, matching S3/Azure patterns

**Metadata**
- Changesets added for both `@mastra/gcs` and `@mastra/e2b` (patch-level)

## Impact

- Backwards compatible; prefix is optional and defaults to undefined
- Enables scoped access to GCS subdirectories from sandboxes
- Aligns GCS mounting behavior with existing S3/Azure implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->