### PR TITLE
chore(docs): Callout not having llms-full.txt

### DIFF
--- a/docs/src/content/en/docs/getting-started/build-with-ai.mdx
+++ b/docs/src/content/en/docs/getting-started/build-with-ai.mdx
@@ -58,9 +58,9 @@ Each `dist/docs` includes:
 
 ## Context files
 
-Mastra provides a root [`llms.txt`](https://mastra.ai/llms.txt) file that contains an overview of all available documentation pages.
+Mastra provides a root [`llms.txt`](https://mastra.ai/llms.txt) file that contains an overview of all available documentation pages. It doesn't provide an `llms-full.txt` file as it's not useful to have all documentation in one file.
 
-Each documentation page also has its own `llms.txt` file. These files are streamlined markdown files. At the end of each docs page you'll find a link to the corresponding `llms.txt` file.
+Instead, each documentation page has its own `llms.txt` file. These files are streamlined markdown files. At the end of each docs page you'll find a link to the corresponding `llms.txt` file.
 
 Add `/llms.txt` to any Mastra docs URL to access it. You can also request it by adding a `.md` extension to the end of the URL.
 


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR is a small documentation fix that explains what files are available for AI models to read. It clarifies that Mastra has `llms.txt` files (one main one at the root, plus smaller ones for each documentation page), but does NOT have a file called `llms-full.txt`. This prevents confusion for people trying to find this file.

## Summary

Updated the "Context files" section in the getting-started documentation to clarify the available LLM context files. The PR explicitly notes that Mastra provides a root `llms.txt` overview and that there is no `llms-full.txt` file available. The documentation also explains that each documentation page has its own streamlined `llms.txt` file.

**Changes:**
- File: `docs/src/content/en/docs/getting-started/build-with-ai.mdx`
- Lines changed: +2/-2
- Review effort: Low

<!-- end of auto-generated comment: release notes by coderabbit.ai -->