### PR TITLE
fix(changeset): target internal playground package

### DIFF
--- a/.changeset/flat-otters-sleep.md
+++ b/.changeset/flat-otters-sleep.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/playground': patch
+'@internal/playground': patch
 ---
 
 fix(playground): allow esbuild postinstall in kitchen-sink workspace


### PR DESCRIPTION
Fixes the playground changeset added in #17574 so Changesets can resolve the workspace package.\n\nThe actual package name is `@internal/playground`, not `@mastra/playground`, so CI fails during Changesets release-plan assembly until the changeset header is corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Think of a changeset like a label that tells the release system "Hey, this package changed and needs a new version." The label had the wrong package name on it (`@mastra/playground` instead of `@internal/playground`), so the release system couldn't find the right package to update. This PR fixes the label by correcting the package name so everything works correctly.

## Changes

- **File modified**: `.changeset/flat-otters-sleep.md`
  - Updated the package name in the changeset header from `@mastra/playground` to `@internal/playground`
  - The patch-level version bump directive and changeset description (regarding esbuild postinstall in the kitchen-sink workspace) remain unchanged

## Impact

This fix resolves CI failures during the Changesets release-plan assembly phase, allowing the release process to correctly identify and process the playground package when generating release plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->