### PR TITLE
feat(core): add tool governance middleware

### DIFF
--- a/.changeset/runtime-tool-governance.md
+++ b/.changeset/runtime-tool-governance.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': minor
+---
+
+Added runtime governance controls for agent tool calls.
+
+Use `toolGovernance` on `agent.generate()` or `agent.stream()` to configure allowlists, denylists, ordered policies, cost tracking, budget limits, circuit breakers, and structured audit events before Mastra executes tools.

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -267,6 +267,51 @@ See the [`Agent.generate()` reference](/reference/agents/generate) for all runti
 
 :::
 
+## Govern tool execution
+
+Use `toolGovernance` on `.generate()` or `.stream()` to evaluate a deterministic policy before Mastra executes a tool call. Governance runs after the tool is resolved and approved, and before foreground or background execution starts.
+
+The following example allows only `weatherTool`, tracks a fixed cost for each call, enforces a per-run budget, records audit events, and opens a circuit breaker if the tool fails twice:
+
+```typescript
+const auditEvents = []
+
+await agent.generate('Check the forecast', {
+  toolGovernance: {
+    allowlist: ['weatherTool'],
+    costs: {
+      tools: {
+        weatherTool: 1,
+      },
+    },
+    budget: {
+      limit: 5,
+      scope: 'run',
+    },
+    circuitBreaker: {
+      failureThreshold: 2,
+      scope: 'tool',
+    },
+    onAudit: event => {
+      auditEvents.push(event)
+    },
+  },
+})
+```
+
+`toolGovernance` supports:
+
+- `allowlist`: Exact tool names that may run.
+- `denylist`: Exact tool names that must not run. Denylists take precedence over allowlists.
+- `policies`: Custom policies evaluated in array order. The first denial blocks execution.
+- `costs`: Fixed or estimated per-call tool costs.
+- `budget`: Cost limits scoped by run, agent, workflow, resource, thread, tool, or globally.
+- `circuitBreaker`: Failure limits that block later calls after repeated failures.
+- `onAudit`: A structured audit callback for allowed, blocked, completed, failed, and skipped calls.
+- `state`: Shared governance state for budgets and circuit breakers.
+
+When a governance policy blocks a tool call, Mastra returns a `ToolGovernanceError` for that tool result and does not call the tool's `execute` function.
+
 ## Control `toolName` in stream responses
 
 The `toolName` in stream responses is determined by the **object key** you use, not the `id` property of the tool, agent, or workflow.

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -446,6 +446,13 @@ const response = await agent.generate('Help me organize my day', {
               "When true, all tool calls require explicit approval before execution. The generate() method will return with `finishReason: 'suspended'` and include a `suspendPayload` with tool call details (`toolCallId`, `toolName`, `args`). Use `approveToolCallGenerate()` or `declineToolCallGenerate()` to proceed. See [Agent Approval](/docs/agents/agent-approval#tool-approval-with-generate) for details.",
           },
           {
+            name: 'toolGovernance',
+            type: 'ToolGovernanceOptions',
+            isOptional: true,
+            description:
+              'Runtime governance policy for Mastra-executed tool calls. Supports allowlists, denylists, ordered policies, cost tracking, budgets, circuit breakers, and structured audit events.',
+          },
+          {
             name: 'autoResumeSuspendedTools',
             type: 'boolean',
             isOptional: true,

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -651,6 +651,13 @@ const stream = await agent.stream('message for agent')
               'When true, all tool calls require explicit approval before execution. The stream will emit `tool-call-approval` chunks and pause until `approveToolCall()` or `declineToolCall()` is called.',
           },
           {
+            name: 'toolGovernance',
+            type: 'ToolGovernanceOptions',
+            isOptional: true,
+            description:
+              'Runtime governance policy for Mastra-executed tool calls. Supports allowlists, denylists, ordered policies, cost tracking, budgets, circuit breakers, and structured audit events.',
+          },
+          {
             name: 'autoResumeSuspendedTools',
             type: 'boolean',
             isOptional: true,

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -9,7 +9,7 @@ import type { VersionOverrides } from '../mastra/types';
 import type { ObservabilityContext, TracingOptions } from '../observability';
 import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
 import type { RequestContext } from '../request-context';
-import type { ToolPayloadTransformPolicy } from '../tools';
+import type { ToolGovernanceOptions, ToolPayloadTransformPolicy } from '../tools';
 import type { OutputWriter, WorkflowRunState } from '../workflows/types';
 import type { MessageListInput } from './message-list';
 import type {
@@ -570,6 +570,9 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
 
   /** Require approval for all tool calls */
   requireToolApproval?: boolean;
+
+  /** Optional runtime governance policy for Mastra-executed tool calls. */
+  toolGovernance?: ToolGovernanceOptions;
 
   /** Automatically resume suspended tools */
   autoResumeSuspendedTools?: boolean;

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -371,6 +371,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
     processorStates,
     backgroundTaskManager,
     backgroundTasksConfig,
+    toolGovernance: execOptions?.toolGovernance,
     cleanup: () => {},
   };
 

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -18,6 +18,7 @@ import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow, ErrorProcesso
 import type { ProcessorState } from '../../processors/runner';
 import type { RequestContext } from '../../request-context';
 import type { ChunkType } from '../../stream/types';
+import type { ToolGovernanceOptions } from '../../tools';
 import type { CoreTool } from '../../tools/types';
 import type { Workspace } from '../../workspace';
 import type { MessageList } from '../message-list';
@@ -433,6 +434,8 @@ export interface RunRegistryEntry {
   backgroundTaskManager?: BackgroundTaskManager;
   /** Agent background tasks configuration */
   backgroundTasksConfig?: AgentBackgroundConfig;
+  /** Runtime governance policy for tool execution (non-serializable callbacks/state allowed) */
+  toolGovernance?: ToolGovernanceOptions;
 }
 
 /**

--- a/packages/core/src/agent/durable/workflows/steps/tool-call-bg.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call-bg.test.ts
@@ -114,6 +114,46 @@ afterEach(() => {
 });
 
 describe('durable tool-call background task dispatch', () => {
+  it('blocks denied tools before durable execute and emits an audit event', async () => {
+    const pubsub = mockPubsub();
+    const audits: any[] = [];
+    const { entry } = setupRegistry({
+      backgroundTaskManager: undefined,
+      backgroundTasksConfig: undefined,
+      toolGovernance: {
+        denylist: [TOOL_NAME],
+        onAudit: (event: any) => audits.push(event),
+      },
+    });
+    const initData = makeInitData();
+
+    const result = await executeStep(pubsub, initData);
+
+    expect(result.error).toMatchObject({
+      name: 'ToolGovernanceError',
+    });
+    expect(entry.tools[TOOL_NAME].execute).not.toHaveBeenCalled();
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      status: 'blocked',
+      action: 'deny',
+      source: 'durable-agent',
+      toolName: TOOL_NAME,
+    });
+    expect(emitChunkEvent).toHaveBeenCalledWith(
+      pubsub,
+      RUN_ID,
+      expect.objectContaining({
+        type: 'tool-error',
+        payload: expect.objectContaining({
+          toolCallId: TOOL_CALL_ID,
+          toolName: TOOL_NAME,
+          error: expect.objectContaining({ name: 'ToolGovernanceError' }),
+        }),
+      }),
+    );
+  });
+
   it('dispatches a background task and returns a placeholder result', async () => {
     const pubsub = mockPubsub();
     setupRegistry();

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -7,6 +7,13 @@ import type { Mastra } from '../../../../mastra';
 import type { MastraMemory } from '../../../../memory/memory';
 import type { MemoryConfig } from '../../../../memory/types';
 import { ChunkFrom } from '../../../../stream/types';
+import {
+  createToolGovernanceError,
+  emitToolGovernanceSkipped,
+  evaluateToolGovernance,
+  recordToolGovernanceResult,
+} from '../../../../tools/governance';
+import type { ToolGovernanceEvaluation, ToolGovernancePolicyContext } from '../../../../tools/governance';
 import { createStep } from '../../../../workflows';
 import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
 import type { SuspendOptions } from '../../../../workflows/step';
@@ -141,9 +148,26 @@ export function createDurableToolCallStep() {
 
       const { runId, options: agentOptions, state } = initData;
       const logger = (mastra as any)?.getLogger?.();
+      const registryEntry = globalRunRegistry.get(runId);
+      const toolGovernance = registryEntry?.toolGovernance;
 
       // If the tool was already executed by the provider, return the output
       if (providerExecuted && output !== undefined) {
+        await emitToolGovernanceSkipped(
+          toolGovernance,
+          {
+            toolCallId,
+            toolName,
+            args,
+            runId,
+            agentId: initData.agentId,
+            resourceId: state?.resourceId,
+            threadId: state?.threadId,
+            requestContext,
+            source: 'durable-agent',
+          },
+          logger,
+        );
         return {
           ...typedInput,
           result: output,
@@ -151,7 +175,6 @@ export function createDurableToolCallStep() {
       }
 
       // 1. Resolve the tool from global registry first, then Mastra
-      const registryEntry = globalRunRegistry.get(runId);
       let tool = registryEntry?.tools?.[toolName];
 
       if (!tool) {
@@ -394,6 +417,40 @@ export function createDurableToolCallStep() {
         },
       };
 
+      const governanceContext: ToolGovernancePolicyContext = {
+        toolCallId,
+        toolName,
+        args: cleanedArgs,
+        runId,
+        agentId: initData.agentId,
+        resourceId: state?.resourceId,
+        threadId: state?.threadId,
+        requestContext,
+        source: 'durable-agent',
+        tool,
+      };
+      let governanceEvaluation: ToolGovernanceEvaluation | undefined = await evaluateToolGovernance(
+        toolGovernance,
+        governanceContext,
+        logger,
+      );
+      if (governanceEvaluation && !governanceEvaluation.allowed) {
+        const governanceError = serializeError(createToolGovernanceError(governanceEvaluation, toolName));
+        if (pubsub) {
+          await emitChunkEvent(pubsub, runId, {
+            type: 'tool-error',
+            runId,
+            from: ChunkFrom.AGENT,
+            payload: { toolCallId, toolName, args: cleanedArgs, error: governanceError },
+          });
+        }
+        return {
+          ...typedInput,
+          args: cleanedArgs,
+          error: governanceError,
+        };
+      }
+
       // Resolve whether to run in background using the shared config resolver
       if (bgManager && !bgConfig?.disabled && typeof cleanedArgs === 'object' && cleanedArgs !== null) {
         const bgResolved = resolveBackgroundConfig({
@@ -578,8 +635,27 @@ export function createDurableToolCallStep() {
                   );
                 },
 
-                onComplete: toolBgConfig?.onComplete ?? bgConfig?.onTaskComplete,
-                onFailed: toolBgConfig?.onFailed ?? bgConfig?.onTaskFailed,
+                onComplete: async (params: any) => {
+                  await recordToolGovernanceResult({
+                    options: toolGovernance,
+                    context: governanceContext,
+                    evaluation: governanceEvaluation,
+                    status: 'completed',
+                    logger,
+                  });
+                  await (toolBgConfig?.onComplete ?? bgConfig?.onTaskComplete)?.(params);
+                },
+                onFailed: async (params: any) => {
+                  await recordToolGovernanceResult({
+                    options: toolGovernance,
+                    context: governanceContext,
+                    evaluation: governanceEvaluation,
+                    status: 'failed',
+                    error: params.error,
+                    logger,
+                  });
+                  await (toolBgConfig?.onFailed ?? bgConfig?.onTaskFailed)?.(params);
+                },
               },
             });
 
@@ -642,6 +718,13 @@ export function createDurableToolCallStep() {
 
       try {
         const result = await tool.execute(cleanedArgs, toolOptions);
+        await recordToolGovernanceResult({
+          options: toolGovernance,
+          context: governanceContext,
+          evaluation: governanceEvaluation,
+          status: 'completed',
+          logger,
+        });
 
         // Emit tool-result chunk (non-fatal — result is returned regardless)
         if (pubsub) {
@@ -662,6 +745,14 @@ export function createDurableToolCallStep() {
           result,
         };
       } catch (error) {
+        await recordToolGovernanceResult({
+          options: toolGovernance,
+          context: governanceContext,
+          evaluation: governanceEvaluation,
+          status: 'failed',
+          error,
+          logger,
+        });
         const toolError = serializeError(error);
 
         // Emit tool-error chunk (non-fatal — error result is returned regardless)

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -38,7 +38,7 @@ import type {
   StreamChunkType,
   StreamTransportRef,
 } from '../stream/types';
-import type { ToolPayloadTransformPolicy } from '../tools';
+import type { ToolGovernanceOptions, ToolPayloadTransformPolicy } from '../tools';
 import type { MastraIdGenerator } from '../types';
 import type { OutputWriter } from '../workflows/types';
 import type { Workspace } from '../workspace/workspace';
@@ -149,6 +149,7 @@ export type LoopOptions<TOOLS extends ToolSet = ToolSet, OUTPUT = undefined> = {
   downloadConcurrency?: number;
   modelSpanTracker?: IModelSpanTracker;
   requireToolApproval?: boolean;
+  toolGovernance?: ToolGovernanceOptions;
   autoResumeSuspendedTools?: boolean;
   agentId: string;
   toolCallConcurrency?: number;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -242,6 +242,116 @@ describe('createToolCallStep tool execution error handling', () => {
   });
 });
 
+describe('createToolCallStep governance', () => {
+  let controller: { enqueue: Mock };
+  let suspend: Mock;
+  let streamState: { serialize: Mock };
+  let messageList: MessageList;
+
+  const makeExecuteParams = (overrides: any = {}) => ({
+    ...makeBaseExecuteParams(suspend),
+    writer: new ToolStream({
+      prefix: 'tool',
+      callId: 'call-1',
+      name: 'search',
+      runId: 'run-1',
+    }),
+    inputData: {
+      toolCallId: 'call-1',
+      toolName: 'search',
+      args: { q: 'docs' },
+    },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    controller = { enqueue: vi.fn() };
+    suspend = vi.fn();
+    streamState = { serialize: vi.fn().mockReturnValue('serialized-state') };
+    messageList = createMessageList();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('blocks denied tools before execute and emits an audit event', async () => {
+    const execute = vi.fn().mockResolvedValue({ ok: true });
+    const audits: any[] = [];
+    const step = createToolCallStep({
+      tools: { search: { execute } },
+      messageList,
+      controller,
+      runId: 'run-1',
+      agentId: 'agent-1',
+      streamState,
+      toolGovernance: {
+        denylist: ['search'],
+        onAudit: event => audits.push(event),
+      },
+    } as any);
+
+    const result = await step.execute(makeExecuteParams());
+
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.name).toBe('ToolGovernanceError');
+    expect(execute).not.toHaveBeenCalled();
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({ status: 'blocked', action: 'deny', toolName: 'search' });
+  });
+
+  it('tracks budget usage and blocks the call that exceeds the budget', async () => {
+    const execute = vi.fn().mockResolvedValue({ ok: true });
+    const toolGovernance = {
+      costs: { tools: { search: 2 } },
+      budget: { limit: 3, scope: 'run' as const },
+    };
+    const step = createToolCallStep({
+      tools: { search: { execute } },
+      messageList,
+      controller,
+      runId: 'run-1',
+      streamState,
+      toolGovernance,
+    } as any);
+
+    const first = await step.execute(makeExecuteParams());
+    const second = await step.execute(
+      makeExecuteParams({ inputData: { toolCallId: 'call-2', toolName: 'search', args: { q: 'docs' } } }),
+    );
+
+    expect(first.result).toEqual({ ok: true });
+    expect(second.error?.name).toBe('ToolGovernanceError');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens a circuit breaker after tool execution failures', async () => {
+    const execute = vi.fn().mockRejectedValue(new Error('tool failed'));
+    const toolGovernance = {
+      circuitBreaker: { failureThreshold: 1, scope: 'tool' as const },
+    };
+    const step = createToolCallStep({
+      tools: { search: { execute } },
+      messageList,
+      controller,
+      runId: 'run-1',
+      streamState,
+      toolGovernance,
+    } as any);
+
+    const first = await step.execute(makeExecuteParams());
+    const second = await step.execute(
+      makeExecuteParams({ inputData: { toolCallId: 'call-2', toolName: 'search', args: { q: 'docs' } } }),
+    );
+
+    expect(first.error?.message).toBe('tool failed');
+    expect(second.error?.name).toBe('ToolGovernanceError');
+    expect(second.error?.message).toContain('Circuit breaker is open');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('createToolCallStep tool approval workflow', () => {
   let controller: { enqueue: Mock };
   let suspend: Mock;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -11,6 +11,17 @@ import { safeEnqueue } from '../../../stream/base';
 import { ChunkFrom } from '../../../stream/types';
 import type { ChunkType, ProviderMetadata } from '../../../stream/types';
 import {
+  createToolGovernanceError,
+  emitToolGovernanceSkipped,
+  evaluateToolGovernance,
+  recordToolGovernanceResult,
+} from '../../../tools/governance';
+import type {
+  ToolGovernanceEvaluation,
+  ToolGovernancePolicyContext,
+  ToolGovernanceSource,
+} from '../../../tools/governance';
+import {
   getTransformedToolPayload,
   hasTransformedToolPayload,
   transformToolPayloadForTargets,
@@ -58,6 +69,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
   logger,
   agentId,
   mastra,
+  toolGovernance,
 }: OuterLLMRun<Tools, OUTPUT>) {
   return createStep({
     id: 'toolCallStep',
@@ -310,6 +322,22 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
       // Provider-executed tools are handled entirely by the stream path
       // (tool-call and tool-result chunks in llm-execution-step), so skip client execution.
       if (inputData.providerExecuted) {
+        await emitToolGovernanceSkipped(
+          toolGovernance,
+          {
+            toolCallId: inputData.toolCallId,
+            toolName: inputData.toolName,
+            args: inputData.args,
+            runId,
+            agentId,
+            resourceId: _internal?.resourceId,
+            threadId: _internal?.threadId,
+            requestContext,
+            source: 'agent',
+            tool,
+          },
+          logger,
+        );
         return inputData;
       }
 
@@ -348,6 +376,9 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
       if (!tool.execute) {
         return inputData;
       }
+
+      let governanceContext: ToolGovernancePolicyContext | undefined;
+      let governanceEvaluation: ToolGovernanceEvaluation | undefined;
 
       try {
         const requireToolApproval = requestContext.get('__mastra_requireToolApproval');
@@ -460,6 +491,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         // resumeStream instead of stream (otherwise the sub-agent restarts from scratch)
         const isAgentTool = inputData.toolName?.startsWith('agent-');
         const isWorkflowTool = inputData.toolName?.startsWith('workflow-');
+        const governanceSource: ToolGovernanceSource = isWorkflowTool ? 'workflow' : 'agent';
         const resumeDataToPassToToolOptions =
           !isAgentTool && toolRequiresApproval && Object.keys(resumeData).length === 1 && 'approved' in resumeData
             ? undefined
@@ -683,6 +715,27 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             resource: { type: 'tool', id: inputData.toolName },
             permission: MastraFGAPermissions.TOOLS_EXECUTE,
           });
+        }
+
+        governanceContext = {
+          toolCallId: inputData.toolCallId,
+          toolName: inputData.toolName,
+          args,
+          runId,
+          agentId,
+          workflowId: isWorkflowTool ? inputData.toolName : undefined,
+          resourceId: _internal?.resourceId,
+          threadId: _internal?.threadId,
+          requestContext,
+          source: governanceSource,
+          tool,
+        };
+        governanceEvaluation = await evaluateToolGovernance(toolGovernance, governanceContext, logger);
+        if (governanceEvaluation && !governanceEvaluation.allowed) {
+          return {
+            error: createToolGovernanceError(governanceEvaluation, inputData.toolName),
+            ...inputData,
+          };
         }
 
         const llmBgOverrides =
@@ -1051,8 +1104,31 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                 },
 
                 // Per-task callbacks
-                onComplete: toolBgConfig?.onComplete ?? agentBgConfig?.onTaskComplete,
-                onFailed: toolBgConfig?.onFailed ?? agentBgConfig?.onTaskFailed,
+                onComplete: async params => {
+                  if (governanceContext) {
+                    await recordToolGovernanceResult({
+                      options: toolGovernance,
+                      context: governanceContext,
+                      evaluation: governanceEvaluation,
+                      status: 'completed',
+                      logger,
+                    });
+                  }
+                  await (toolBgConfig?.onComplete ?? agentBgConfig?.onTaskComplete)?.(params);
+                },
+                onFailed: async params => {
+                  if (governanceContext) {
+                    await recordToolGovernanceResult({
+                      options: toolGovernance,
+                      context: governanceContext,
+                      evaluation: governanceEvaluation,
+                      status: 'failed',
+                      error: params.error,
+                      logger,
+                    });
+                  }
+                  await (toolBgConfig?.onFailed ?? agentBgConfig?.onTaskFailed)?.(params);
+                },
               },
             });
 
@@ -1106,6 +1182,15 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
 
         const rawResult = await tool.execute(args, toolOptions);
         const result = ensureSerializable(rawResult);
+        if (governanceContext) {
+          await recordToolGovernanceResult({
+            options: toolGovernance,
+            context: governanceContext,
+            evaluation: governanceEvaluation,
+            status: 'completed',
+            logger,
+          });
+        }
 
         // Call onOutput hook after successful execution
         if (tool && 'onOutput' in tool && typeof (tool as any).onOutput === 'function') {
@@ -1126,6 +1211,16 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         // Re-throw FGA authorization errors instead of swallowing them
         if (error instanceof Error && error.name === 'FGADeniedError') {
           throw error;
+        }
+        if (governanceContext) {
+          await recordToolGovernanceResult({
+            options: toolGovernance,
+            context: governanceContext,
+            evaluation: governanceEvaluation,
+            status: 'failed',
+            error,
+            logger,
+          });
         }
         return {
           error: error as Error,

--- a/packages/core/src/tools/governance.test.ts
+++ b/packages/core/src/tools/governance.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import { evaluateToolGovernance, recordToolGovernanceResult, ToolGovernanceState } from './governance';
+import type { ToolGovernanceAuditEvent, ToolGovernanceOptions, ToolGovernancePolicyContext } from './governance';
+
+const context: ToolGovernancePolicyContext = {
+  toolCallId: 'call-1',
+  toolName: 'search',
+  args: { q: 'docs' },
+  runId: 'run-1',
+  agentId: 'agent-1',
+  resourceId: 'user-1',
+  threadId: 'thread-1',
+  source: 'agent',
+};
+
+describe('tool governance', () => {
+  it('evaluates allowlists and denylists deterministically with denylist precedence', async () => {
+    const audits: ToolGovernanceAuditEvent[] = [];
+
+    const decision = await evaluateToolGovernance(
+      {
+        allowlist: ['search'],
+        denylist: ['search'],
+        onAudit: event => audits.push(event),
+      },
+      context,
+    );
+
+    expect(decision?.allowed).toBe(false);
+    expect(decision?.reason).toContain('denied');
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      status: 'blocked',
+      action: 'deny',
+      toolName: 'search',
+      runId: 'run-1',
+    });
+  });
+
+  it('runs custom policies in order and stops on the first denial', async () => {
+    const first = vi.fn().mockReturnValue({ allowed: true, metadata: { checked: 'first' } });
+    const second = vi.fn().mockReturnValue({ action: 'deny', reason: 'blocked by policy' });
+    const third = vi.fn().mockReturnValue(true);
+
+    const decision = await evaluateToolGovernance({ policies: [first, second, third] }, context);
+
+    expect(decision?.allowed).toBe(false);
+    expect(decision?.reason).toBe('blocked by policy');
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+    expect(third).not.toHaveBeenCalled();
+  });
+
+  it('tracks cost and blocks execution when a budget would be exceeded', async () => {
+    const options: ToolGovernanceOptions = {
+      costs: { tools: { search: 2 } },
+      budget: { limit: 3, scope: 'agent' },
+    };
+
+    const first = await evaluateToolGovernance(options, context);
+    const second = await evaluateToolGovernance(options, context);
+
+    expect(first?.allowed).toBe(true);
+    expect(first?.budgets?.[0]).toMatchObject({ key: 'agent:agent-1', used: 2, remaining: 1 });
+    expect(second?.allowed).toBe(false);
+    expect(second?.reason).toContain('budget exceeded');
+    expect(second?.budgets?.[0]).toMatchObject({ key: 'agent:agent-1', used: 4, remaining: -1 });
+  });
+
+  it('opens a circuit breaker after repeated failures', async () => {
+    const state = new ToolGovernanceState();
+    const options: ToolGovernanceOptions = {
+      state,
+      circuitBreaker: { failureThreshold: 2, scope: 'tool' },
+    };
+
+    const first = await evaluateToolGovernance(options, context);
+    await recordToolGovernanceResult({
+      options,
+      context,
+      evaluation: first,
+      status: 'failed',
+      error: new Error('first failure'),
+    });
+
+    const second = await evaluateToolGovernance(options, context);
+    await recordToolGovernanceResult({
+      options,
+      context,
+      evaluation: second,
+      status: 'failed',
+      error: new Error('second failure'),
+    });
+
+    const third = await evaluateToolGovernance(options, context);
+
+    expect(third?.allowed).toBe(false);
+    expect(third?.reason).toContain('Circuit breaker is open');
+    expect(third?.circuitBreaker).toMatchObject({ key: 'tool:search', failures: 2 });
+  });
+
+  it('records structured audit events for success and failure without throwing on audit errors', async () => {
+    const audits: ToolGovernanceAuditEvent[] = [];
+    const logger = { info: vi.fn(), warn: vi.fn() } as any;
+    const options: ToolGovernanceOptions = {
+      costs: { default: 1 },
+      onAudit: event => {
+        audits.push(event);
+        if (event.status === 'completed') {
+          throw new Error('audit sink unavailable');
+        }
+      },
+    };
+
+    const evaluation = await evaluateToolGovernance(options, context, logger);
+    await recordToolGovernanceResult({ options, context, evaluation, status: 'completed', logger });
+
+    expect(audits.map(event => event.status)).toEqual(['allowed', 'completed']);
+    expect(audits[0]).toMatchObject({
+      action: 'allow',
+      estimatedCost: 1,
+      agentId: 'agent-1',
+      resourceId: 'user-1',
+      threadId: 'thread-1',
+    });
+    expect(logger.warn).toHaveBeenCalledWith('[ToolGovernance] audit callback failed', expect.any(Error));
+  });
+});

--- a/packages/core/src/tools/governance.ts
+++ b/packages/core/src/tools/governance.ts
@@ -1,0 +1,537 @@
+import type { IMastraLogger } from '../logger';
+import type { RequestContext } from '../request-context';
+
+export type ToolGovernanceAction = 'allow' | 'deny';
+export type ToolGovernanceAuditStatus = 'allowed' | 'blocked' | 'completed' | 'failed' | 'skipped';
+export type ToolGovernanceSource = 'agent' | 'workflow' | 'durable-agent';
+export type ToolGovernanceScope = 'global' | 'agent' | 'workflow' | 'run' | 'resource' | 'thread' | 'tool';
+
+export interface ToolGovernancePolicyContext {
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+  runId: string;
+  agentId?: string;
+  workflowId?: string;
+  resourceId?: string;
+  threadId?: string;
+  requestContext?: RequestContext | Map<string, unknown>;
+  source: ToolGovernanceSource;
+  tool?: unknown;
+}
+
+export type ToolGovernancePolicyDecision =
+  | boolean
+  | {
+      action?: ToolGovernanceAction;
+      allowed?: boolean;
+      reason?: string;
+      cost?: number;
+      metadata?: Record<string, unknown>;
+    };
+
+export type ToolGovernancePolicy = (
+  context: ToolGovernancePolicyContext,
+) => ToolGovernancePolicyDecision | Promise<ToolGovernancePolicyDecision>;
+
+export interface ToolGovernanceBudget {
+  /** Maximum cumulative estimated cost allowed for this budget. */
+  limit: number;
+  /** Scope used for tracking cumulative usage. Defaults to run. */
+  scope?: ToolGovernanceScope;
+  /** Restrict this budget to a single tool name. */
+  toolName?: string;
+  /** Whether exceeding the budget should block execution or only audit a warning. Defaults to block. */
+  action?: 'block' | 'warn';
+}
+
+export type ToolCostEstimator = (context: ToolGovernancePolicyContext) => number | Promise<number>;
+
+export interface ToolGovernanceCostOptions {
+  /** Cost used when a tool-specific cost or estimator is not provided. Defaults to 0. */
+  default?: number;
+  /** Fixed estimated costs keyed by tool name. */
+  tools?: Record<string, number>;
+  /** Optional estimator for dynamic per-call costs. */
+  estimate?: ToolCostEstimator;
+}
+
+export interface ToolGovernanceCircuitBreakerOptions {
+  /** Number of failures that opens the circuit for a key. */
+  failureThreshold: number;
+  /** How long to keep the circuit open. Omit for an open circuit until the state is reset. */
+  cooldownMs?: number;
+  /** Scope used for breaker keys. Defaults to tool. */
+  scope?: ToolGovernanceScope;
+  /** Whether policy denials should count as failures. Defaults to false. */
+  includePolicyDenials?: boolean;
+}
+
+export interface ToolGovernanceAuditEvent {
+  timestamp: string;
+  status: ToolGovernanceAuditStatus;
+  action: ToolGovernanceAction;
+  reason?: string;
+  toolCallId: string;
+  toolName: string;
+  runId: string;
+  agentId?: string;
+  workflowId?: string;
+  resourceId?: string;
+  threadId?: string;
+  source: ToolGovernanceSource;
+  estimatedCost?: number;
+  budgets?: Array<{
+    scope: ToolGovernanceScope;
+    key: string;
+    limit: number;
+    used: number;
+    remaining: number;
+    action: 'block' | 'warn';
+  }>;
+  circuitBreaker?: {
+    key: string;
+    failures: number;
+    openUntil?: number;
+  };
+  metadata?: Record<string, unknown>;
+  error?: {
+    name?: string;
+    message: string;
+  };
+}
+
+export interface ToolGovernanceOptions {
+  /** Exact tool names that may execute. If omitted, all tools are candidates unless denied. */
+  allowlist?: string[];
+  /** Exact tool names that must never execute. Denylists take precedence over allowlists. */
+  denylist?: string[];
+  /** Additional policies evaluated in array order after allowlist/denylist checks. */
+  policies?: ToolGovernancePolicy[];
+  /** Estimated tool costs used for audit and budget enforcement. */
+  costs?: ToolGovernanceCostOptions;
+  /** One or more budgets evaluated before execution. */
+  budget?: ToolGovernanceBudget | ToolGovernanceBudget[];
+  /** Circuit breaker options for repeated tool failures. */
+  circuitBreaker?: ToolGovernanceCircuitBreakerOptions;
+  /** Callback for structured audit events. */
+  onAudit?: (event: ToolGovernanceAuditEvent) => void | Promise<void>;
+  /** Shared state for budget and circuit-breaker counters. */
+  state?: ToolGovernanceState;
+}
+
+export interface ToolGovernanceEvaluation {
+  allowed: boolean;
+  reason?: string;
+  estimatedCost: number;
+  metadata?: Record<string, unknown>;
+  budgets?: ToolGovernanceAuditEvent['budgets'];
+  circuitBreaker?: ToolGovernanceAuditEvent['circuitBreaker'];
+}
+
+type CircuitState = {
+  failures: number;
+  openUntil?: number;
+};
+
+const optionState = new WeakMap<ToolGovernanceOptions, ToolGovernanceState>();
+
+export class ToolGovernanceError extends Error {
+  constructor(
+    message: string,
+    public readonly decision: ToolGovernanceEvaluation,
+  ) {
+    super(message);
+    this.name = 'ToolGovernanceError';
+  }
+}
+
+export class ToolGovernanceState {
+  #budgetUsage = new Map<string, number>();
+  #circuits = new Map<string, CircuitState>();
+
+  getBudgetUsage(key: string): number {
+    return this.#budgetUsage.get(key) ?? 0;
+  }
+
+  addBudgetUsage(key: string, cost: number): number {
+    const next = this.getBudgetUsage(key) + cost;
+    this.#budgetUsage.set(key, next);
+    return next;
+  }
+
+  getCircuit(key: string): CircuitState {
+    return this.#circuits.get(key) ?? { failures: 0 };
+  }
+
+  recordCircuitSuccess(key: string): CircuitState {
+    const next = { failures: 0 };
+    this.#circuits.set(key, next);
+    return next;
+  }
+
+  recordCircuitFailure(key: string, options: ToolGovernanceCircuitBreakerOptions, now = Date.now()): CircuitState {
+    const current = this.getCircuit(key);
+    const failures = current.failures + 1;
+    const next: CircuitState = { failures };
+    if (failures >= options.failureThreshold) {
+      next.openUntil = options.cooldownMs === undefined ? Number.POSITIVE_INFINITY : now + options.cooldownMs;
+    }
+    this.#circuits.set(key, next);
+    return next;
+  }
+
+  reset(): void {
+    this.#budgetUsage.clear();
+    this.#circuits.clear();
+  }
+}
+
+export function getToolGovernanceState(options: ToolGovernanceOptions): ToolGovernanceState {
+  if (options.state) {
+    return options.state;
+  }
+
+  let state = optionState.get(options);
+  if (!state) {
+    state = new ToolGovernanceState();
+    optionState.set(options, state);
+  }
+  return state;
+}
+
+export function createToolGovernanceError(decision: ToolGovernanceEvaluation, toolName: string): ToolGovernanceError {
+  return new ToolGovernanceError(decision.reason ?? `Tool "${toolName}" was blocked by governance policy`, decision);
+}
+
+export async function evaluateToolGovernance(
+  options: ToolGovernanceOptions | undefined,
+  context: ToolGovernancePolicyContext,
+  logger?: IMastraLogger,
+): Promise<ToolGovernanceEvaluation | undefined> {
+  if (!options) {
+    return undefined;
+  }
+
+  const state = getToolGovernanceState(options);
+  const metadata: Record<string, unknown> = {};
+  const circuitKey = options.circuitBreaker ? getScopeKey(options.circuitBreaker.scope ?? 'tool', context) : undefined;
+
+  if (options.circuitBreaker && circuitKey) {
+    const circuit = state.getCircuit(circuitKey);
+    if (isCircuitOpen(circuit)) {
+      const evaluation = {
+        allowed: false,
+        reason: `Circuit breaker is open for ${circuitKey}`,
+        estimatedCost: 0,
+        circuitBreaker: { key: circuitKey, ...circuit },
+      };
+      await emitToolGovernanceAudit(options, context, evaluation, 'blocked', logger);
+      return evaluation;
+    }
+  }
+
+  if (options.denylist?.includes(context.toolName)) {
+    const evaluation = { allowed: false, reason: `Tool "${context.toolName}" is denied`, estimatedCost: 0, metadata };
+    await emitToolGovernanceAudit(options, context, evaluation, 'blocked', logger);
+    recordPolicyDenial(options, state, circuitKey);
+    return evaluation;
+  }
+
+  if (options.allowlist && !options.allowlist.includes(context.toolName)) {
+    const evaluation = {
+      allowed: false,
+      reason: `Tool "${context.toolName}" is not in the allowlist`,
+      estimatedCost: 0,
+      metadata,
+    };
+    await emitToolGovernanceAudit(options, context, evaluation, 'blocked', logger);
+    recordPolicyDenial(options, state, circuitKey);
+    return evaluation;
+  }
+
+  let policyCost: number | undefined;
+  for (const policy of options.policies ?? []) {
+    const decision = normalizePolicyDecision(await policy(context));
+    if (decision.metadata) {
+      Object.assign(metadata, decision.metadata);
+    }
+    if (decision.cost !== undefined) {
+      policyCost = decision.cost;
+    }
+    if (!decision.allowed) {
+      const evaluation = {
+        allowed: false,
+        reason: decision.reason ?? `Tool "${context.toolName}" was denied by policy`,
+        estimatedCost: policyCost ?? 0,
+        metadata,
+      };
+      await emitToolGovernanceAudit(options, context, evaluation, 'blocked', logger);
+      recordPolicyDenial(options, state, circuitKey);
+      return evaluation;
+    }
+  }
+
+  const estimatedCost = policyCost ?? (await estimateToolCost(options, context));
+  const budgetResult = evaluateBudgets(options, context, state, estimatedCost);
+  const evaluation = {
+    allowed: budgetResult.allowed,
+    reason: budgetResult.reason,
+    estimatedCost,
+    metadata: Object.keys(metadata).length ? metadata : undefined,
+    budgets: budgetResult.budgets,
+    circuitBreaker: circuitKey ? { key: circuitKey, ...state.getCircuit(circuitKey) } : undefined,
+  };
+
+  if (!evaluation.allowed) {
+    await emitToolGovernanceAudit(options, context, evaluation, 'blocked', logger);
+    recordPolicyDenial(options, state, circuitKey);
+    return evaluation;
+  }
+
+  for (const budget of budgetResult.reservedBudgets) {
+    state.addBudgetUsage(budget.key, estimatedCost);
+  }
+
+  await emitToolGovernanceAudit(options, context, evaluation, 'allowed', logger);
+  return evaluation;
+}
+
+export async function recordToolGovernanceResult({
+  options,
+  context,
+  evaluation,
+  status,
+  error,
+  logger,
+}: {
+  options: ToolGovernanceOptions | undefined;
+  context: ToolGovernancePolicyContext;
+  evaluation: ToolGovernanceEvaluation | undefined;
+  status: 'completed' | 'failed';
+  error?: unknown;
+  logger?: IMastraLogger;
+}): Promise<void> {
+  if (!options || !evaluation) {
+    return;
+  }
+
+  const state = getToolGovernanceState(options);
+  const circuitKey = options.circuitBreaker ? getScopeKey(options.circuitBreaker.scope ?? 'tool', context) : undefined;
+  let circuitBreaker = evaluation.circuitBreaker;
+
+  if (options.circuitBreaker && circuitKey) {
+    const circuit =
+      status === 'failed'
+        ? state.recordCircuitFailure(circuitKey, options.circuitBreaker)
+        : state.recordCircuitSuccess(circuitKey);
+    circuitBreaker = { key: circuitKey, ...circuit };
+  }
+
+  await emitToolGovernanceAudit(
+    options,
+    context,
+    {
+      ...evaluation,
+      allowed: status === 'completed',
+      reason: status === 'failed' ? getErrorMessage(error) : evaluation.reason,
+      circuitBreaker,
+    },
+    status,
+    logger,
+    error,
+  );
+}
+
+export async function emitToolGovernanceSkipped(
+  options: ToolGovernanceOptions | undefined,
+  context: ToolGovernancePolicyContext,
+  logger?: IMastraLogger,
+): Promise<void> {
+  if (!options) {
+    return;
+  }
+
+  await emitToolGovernanceAudit(
+    options,
+    context,
+    { allowed: true, estimatedCost: 0, reason: 'Tool execution was skipped' },
+    'skipped',
+    logger,
+  );
+}
+
+async function emitToolGovernanceAudit(
+  options: ToolGovernanceOptions,
+  context: ToolGovernancePolicyContext,
+  evaluation: ToolGovernanceEvaluation,
+  status: ToolGovernanceAuditStatus,
+  logger?: IMastraLogger,
+  error?: unknown,
+): Promise<void> {
+  const event: ToolGovernanceAuditEvent = {
+    timestamp: new Date().toISOString(),
+    status,
+    action: evaluation.allowed ? 'allow' : 'deny',
+    reason: evaluation.reason,
+    toolCallId: context.toolCallId,
+    toolName: context.toolName,
+    runId: context.runId,
+    agentId: context.agentId,
+    workflowId: context.workflowId,
+    resourceId: context.resourceId,
+    threadId: context.threadId,
+    source: context.source,
+    estimatedCost: evaluation.estimatedCost,
+    budgets: evaluation.budgets,
+    circuitBreaker: evaluation.circuitBreaker,
+    metadata: evaluation.metadata,
+    error: error ? normalizeError(error) : undefined,
+  };
+
+  logger?.info?.('[ToolGovernance] audit', event);
+  try {
+    await options.onAudit?.(event);
+  } catch (auditError) {
+    logger?.warn?.('[ToolGovernance] audit callback failed', auditError);
+  }
+}
+
+function normalizePolicyDecision(decision: ToolGovernancePolicyDecision): {
+  allowed: boolean;
+  reason?: string;
+  cost?: number;
+  metadata?: Record<string, unknown>;
+} {
+  if (typeof decision === 'boolean') {
+    return { allowed: decision };
+  }
+
+  const allowed = decision.allowed ?? decision.action !== 'deny';
+  return {
+    allowed,
+    reason: decision.reason,
+    cost: decision.cost,
+    metadata: decision.metadata,
+  };
+}
+
+async function estimateToolCost(options: ToolGovernanceOptions, context: ToolGovernancePolicyContext): Promise<number> {
+  if (options.costs?.estimate) {
+    return normalizeCost(await options.costs.estimate(context));
+  }
+
+  return normalizeCost(options.costs?.tools?.[context.toolName] ?? options.costs?.default ?? 0);
+}
+
+function evaluateBudgets(
+  options: ToolGovernanceOptions,
+  context: ToolGovernancePolicyContext,
+  state: ToolGovernanceState,
+  estimatedCost: number,
+): {
+  allowed: boolean;
+  reason?: string;
+  budgets: NonNullable<ToolGovernanceAuditEvent['budgets']>;
+  reservedBudgets: Array<{ key: string }>;
+} {
+  const budgets = Array.isArray(options.budget) ? options.budget : options.budget ? [options.budget] : [];
+  const auditBudgets: NonNullable<ToolGovernanceAuditEvent['budgets']> = [];
+  const reservedBudgets: Array<{ key: string }> = [];
+
+  for (const budget of budgets) {
+    if (budget.toolName && budget.toolName !== context.toolName) {
+      continue;
+    }
+
+    const scope = budget.scope ?? 'run';
+    const key = getBudgetKey(scope, context, budget);
+    const used = state.getBudgetUsage(key);
+    const nextUsed = used + estimatedCost;
+    const remaining = budget.limit - nextUsed;
+    const action = budget.action ?? 'block';
+
+    auditBudgets.push({
+      scope,
+      key,
+      limit: budget.limit,
+      used: nextUsed,
+      remaining,
+      action,
+    });
+
+    if (nextUsed > budget.limit && action === 'block') {
+      return {
+        allowed: false,
+        reason: `Tool governance budget exceeded for ${key}`,
+        budgets: auditBudgets,
+        reservedBudgets,
+      };
+    }
+
+    reservedBudgets.push({ key });
+  }
+
+  return { allowed: true, budgets: auditBudgets, reservedBudgets };
+}
+
+function getBudgetKey(scope: ToolGovernanceScope, context: ToolGovernancePolicyContext, budget: ToolGovernanceBudget) {
+  const suffix = budget.toolName ? `:tool:${budget.toolName}` : '';
+  return `${getScopeKey(scope, context)}${suffix}`;
+}
+
+function getScopeKey(scope: ToolGovernanceScope, context: ToolGovernancePolicyContext): string {
+  switch (scope) {
+    case 'agent':
+      return `agent:${context.agentId ?? 'unknown'}`;
+    case 'workflow':
+      return `workflow:${context.workflowId ?? 'unknown'}`;
+    case 'resource':
+      return `resource:${context.resourceId ?? 'unknown'}`;
+    case 'thread':
+      return `thread:${context.threadId ?? 'unknown'}`;
+    case 'tool':
+      return `tool:${context.toolName}`;
+    case 'global':
+      return 'global';
+    case 'run':
+    default:
+      return `run:${context.runId}`;
+  }
+}
+
+function normalizeCost(cost: number): number {
+  return Number.isFinite(cost) && cost > 0 ? cost : 0;
+}
+
+function isCircuitOpen(circuit: CircuitState): boolean {
+  if (!circuit.openUntil) {
+    return false;
+  }
+
+  return circuit.openUntil === Number.POSITIVE_INFINITY || circuit.openUntil > Date.now();
+}
+
+function recordPolicyDenial(
+  options: ToolGovernanceOptions,
+  state: ToolGovernanceState,
+  circuitKey: string | undefined,
+) {
+  if (!options.circuitBreaker?.includePolicyDenials || !circuitKey) {
+    return;
+  }
+
+  state.recordCircuitFailure(circuitKey, options.circuitBreaker);
+}
+
+function normalizeError(error: unknown): ToolGovernanceAuditEvent['error'] {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+
+  return { message: getErrorMessage(error) };
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1,6 +1,7 @@
 export * from './tool';
 export * from './types';
 export * from './ui-types';
+export * from './governance';
 export { getTransformedToolPayload, hasTransformedToolPayload } from './payload-transform';
 export { isProviderDefinedTool, isProviderTool, isVercelTool } from './toolchecks';
 export { ToolStream } from './stream';


### PR DESCRIPTION
## Description

This PR introduces an optional tool governance layer for Mastra tool execution and explores a possible implementation of tool execution lifecycle controls that can be used by external governance, auditing, observability, and policy systems.

During investigation, I reviewed the existing architecture around:

* Tool execution
* Tool approval flows
* FGA authorization
* Processors
* Cost guards
* Durable agent execution

While Mastra already provides several adjacent controls, there was no unified mechanism to evaluate policies around actual tool execution, track execution outcomes, or emit structured governance events.

This implementation adds:

* Optional tool governance primitives
* Deterministic policy evaluation
* Tool allowlists and denylists
* Structured audit events
* Budget and cost tracking hooks
* Circuit breaker support
* Support for both standard and durable agent execution paths

The functionality is fully opt-in and existing behavior remains unchanged when governance is not configured.

## Related issue(s)

Related to #17620

## Type of change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [x] Test update

## Implementation Summary

### Core

* Added tool governance primitives
* Added governance evaluator and runtime state handling
* Added structured audit event generation
* Added budget and circuit-breaker tracking

### Execution Integration

Integrated governance checks into:

* Standard tool execution flow
* Durable tool execution flow

### Documentation

Added documentation and reference updates covering:

* Governance configuration
* Tool execution controls
* Usage examples

### Testing

Added coverage for:

* Policy evaluation
* Allow/deny behavior
* Audit generation
* Budget enforcement
* Circuit breaker behavior
* Standard tool execution
* Durable tool execution

## Validation

While implementing this feature I identified existing related functionality:

* activeTools
* requireToolApproval
* FGA authorization
* CostGuardProcessor
* Processors

However, these mechanisms do not currently provide a unified runtime governance layer around actual tool execution.

## Notes

I am aware of the discussion around built-in governance frameworks in Mastra. This implementation is intended as an exploration of reusable execution-layer primitives and extension points that external governance systems can build upon.

Happy to adjust the design based on maintainer feedback.

## Checklist

* [x] I have linked the related issue(s) in the description above
* [x] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have addressed all Coderabbit comments on this PR
