### PR TITLE
fix(repo): repair broken pnpm-lock.yaml causing CI frozen-lockfile failures

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,7 +293,7 @@ importers:
         version: 4.1.5(vitest@4.1.5)
       eslint:
         specifier: ^10.2.1
-        version: 10.3.0(jiti@2.6.1)
+        version: 10.4.1(jiti@2.6.1)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.14)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)


### PR DESCRIPTION
## Problem

CI was failing on most PRs at `pnpm install --frozen-lockfile` with:

```
[ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY] Broken lockfile:
no entry for 'eslint@10.3.0(jiti@2.6.1)' in pnpm-lock.yaml
```

`pnpm-lock.yaml` on `main` was internally inconsistent: the `agent-sdks/openai` importer referenced `eslint 10.3.0(jiti@2.6.1)`, but the `packages` and `snapshots` sections only contained `eslint 10.4.1`. Every other importer was already on `10.4.1(jiti@2.6.1)`.

This is fallout from a bad merge between #17151 (bumped eslint to 10.4.1 across the monorepo) and #17525 (added the `agent-sdks/openai` workspace, generated against the pre-bump lockfile).

Local `pnpm install` silently re-resolved `^10.2.1` to `10.4.1`, which is why contributors saw a mysterious one-line `pnpm-lock.yaml` diff appear on branches with no dependency changes. PRs that committed that diff still failed the **Changed Test Gate** workflow, because it installs against `pull_request.base.sha` (the broken base), not the PR head.

## Fix

One-line edit to `pnpm-lock.yaml`: update the `agent-sdks/openai` importer's eslint entry from `10.3.0(jiti@2.6.1)` to `10.4.1(jiti@2.6.1)` to match the rest of the lockfile.

No `package.json` change (the spec `^10.2.1` already satisfies `10.4.1`). No changeset (lockfile-only repair).

## Verification

`pnpm install --frozen-lockfile` succeeds locally with no further diff:

```
Scope: all 152 workspace projects
Already up to date
Done in 290ms using pnpm v11.3.0
```

After merge, contributors with open PRs carrying the auto-healed `pnpm-lock.yaml` diff should rebase on `main` — the spurious diff will go away and the Changed Test Gate (which installs against base) will stop failing for them.

## Why we're not changing the Changed Test Gate workflow

The gate intentionally installs against `pull_request.base.sha` and only restores changed test files from the PR head. It runs the PR's changed tests against unmodified base source to verify they fail before the PR code is applied (a TDD-discipline check). Installing the PR's lockfile instead would pollute "base" with PR-side dependency changes and weaken that guarantee. The root cause is `main`'s lockfile being broken, not the workflow's install strategy.

## Follow-up (not in this PR)

Add a CI guard on `main` (or as a required PR check) that runs `pnpm install --lockfile-only` and fails if it produces a diff, so the next bad merge gets caught at merge time instead of silently breaking every downstream PR.
