### PR TITLE
Add MastraBowl weekly recap skill

### DIFF
--- a/.claude/skills/mastrabowl-recap/.gitignore
+++ b/.claude/skills/mastrabowl-recap/.gitignore
@@ -1,0 +1,6 @@
+recap.env
+downloads-chart-*.svg
+revenue-*.png
+ce-report-*.png
+result.json
+draft-*.md

--- a/.claude/skills/mastrabowl-recap/SKILL.md
+++ b/.claude/skills/mastrabowl-recap/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: mastrabowl-recap
+description: Help write the weekly MastraBowl Recap that Abhi and Shane publish every Friday. Use when asked to draft, fill in, or update the MastraBowl Recap, or to pull the weekly Open Source stats (merged PRs, open issues/PRs, releases) for mastra-ai/mastra and mastra-ai/platform. Triggers on "MastraBowl", "weekly recap", "Friday recap".
+---
+
+# MastraBowl Recap
+
+The MastraBowl Recap is the weekly internal update Abhi and Shane publish every Friday.
+This skill holds the template, the writing process, and a script to auto-pull the
+Open Source numbers so the recap can be drafted quickly each week.
+
+## What the recap is
+
+A structured weekly summary covering: highlights (Agents Hour, Workshop, Weekly Demos),
+Open Source momentum + stats, releases, and progress across "Road to London" workstreams
+(LRA, Framework, Observability, Agent Learning, Platform, Agent Builder), plus Sales /
+Customer Engineering and Product Revenue. It opens with a "Dear ____," greeting and a
+[song], and closes with "Peace ✌️ — Abhi and Shane".
+
+**The greeting is always an alliterative, playful dev/agent-themed honorific for the
+team**, in the form "Dear [Title of the Thing],". Each week is different and shouldn't
+repeat a past one. Past examples: "Titans of the Traces", "Tamers of the Threads",
+"Guardians of Git", "Barons of the Branch", "Lords of Loops", "Architects of Agents".
+Tie it to the week's biggest theme when you can (e.g. an Agent Builder launch week →
+"Architects of Agents").
+
+**The song is a Suno track** embedded right under the greeting. To make one: open
+https://suno.com/create (Advanced tab, "Write" lyrics mode), paste lyrics written from
+the week's recap (the wins, deals, stats, the greeting hook), set a style, and create.
+Pick a **different genre each week** (past weeks have done country, R&B, etc.; rotate to
+EDM, rock, pop, etc.). Keep the lyrics about the work and the team. Don't put individual
+names (e.g. Abhi/Shane) in the lyrics. After it generates, click the clip's Share button
+(it copies a `https://suno.com/s/...` link to the clipboard) and put it in the draft as
+`@embed https://suno.com/s/...` on its own line under the greeting. The publish script
+turns that into a Notion embed (inline player).
+
+## Process (do this each Friday)
+
+1. **Copy the template.** Start from `template.md`. Keep all section headers and the
+   sign-off intact.
+
+2. **Pull Open Source stats automatically.** Run:
+
+   ```bash
+   .claude/skills/mastrabowl-recap/scripts/oss-stats.sh
+   ```
+
+   With no argument it uses the past 7 days as the week window (the standard Friday
+   recap). Pass an explicit `YYYY-MM-DD` to override (e.g. when recapping a past week
+   or aligning to a Memorial-Day-shifted window):
+
+   ```bash
+   .claude/skills/mastrabowl-recap/scripts/oss-stats.sh 2026-05-29
+   ```
+
+   The script prints, for both `mastra-ai/mastra` and `mastra-ai/platform`:
+   PRs merged this week, open PRs (EoW), open issues (EoW), and the week's releases.
+
+   Map the output into the template:
+   - `**EoW ___ Issues Open | ___ PRs Open**` → use the **mastra-ai/mastra** open numbers.
+   - `**___ PRs have been merged this week in mastra-ai/mastra**`
+   - `**___ PRs merged this week in mastra-ai/platform**`
+   - Releases → the script emits markdown bullets linking each GitHub release published
+     in the window (from https://github.com/mastra-ai/mastra/releases). Drop them under
+     `### Releases`. Volume is usually small; if a week has many per-package tags, curate
+     to the meaningful version bumps but keep the links.
+
+3. **Write the Open Source narrative.** One short line on momentum (up/down vs. last
+   week, holidays, notable spikes). Reference the stats you just pulled.
+
+4. **Fill the qualitative sections.** Highlights links, Kindergarten, Feature
+   Announcements, and each "Road to London" workstream, Sales/CE, Product Revenue.
+   Most are human-supplied — ask Abhi/Shane for inputs or leave as `?` placeholders
+   to fill in. Never invent customer, revenue, or roadmap claims.
+
+   **Highlights (Agents Hour + Workshop) are sourceable from YouTube.** Open
+   https://www.youtube.com/@mastra-ai/streams (sorted Latest first). Take the
+   in-window streams (Sunday → day before today) and map them:
+   - **Agents Hour** → the weekly Agents Hour livestream.
+   - **Workshop** → the weekly workshop livestream.
+   Verify each video's stream date is inside the window before including it — list
+   order alone is not proof. On the watch page, "Streamed N days ago" gives the date
+   (today minus N); exclude anything before Sunday or after the day-before-today.
+   Capture the full `https://www.youtube.com/watch?v=...` permalink and the title.
+   **Weekly Demos** uses a Fireflies link, not YouTube — leave as `?` for manual paste.
+
+   **Kindergarten is sourceable from Slack.** It's the `#kindergarten` channel where
+   the team drops interesting articles/links. Run:
+
+   ```bash
+   node .claude/skills/mastrabowl-recap/scripts/kindergarten.mjs
+   ```
+
+   The script reads `SLACK_TOKEN` + `KINDERGARTEN_SLACK_ID` from `recap.env`, pulls the
+   week's messages (same Sunday → day-before-today window), extracts shared article
+   links, dedupes them, and ranks by engagement (reactions + replies). The Slack token
+   needs `channels:history`, `channels:read`, `reactions:read` (+ `groups:*` if private),
+   and the bot must be a member of the channel (`/invite` it) — or use a user token
+   (`xoxp-`) which already has your channel access.
+
+   From the ranked list, pick the most interesting with judgment: weight engagement
+   (replies/reactions) but also topical relevance to the recap audience (AI/agent news,
+   notable model releases, funding, TS/JS ecosystem). Drop low-signal/no-context drops.
+   Capture each as a link with a short label.
+
+5. **Generate the OSS download chart.** The recap shows the `@mastra/core` "downloads
+   per day" trend for the recap week. The week runs **Sunday → the day before today**
+   (npm download data lags, so never include today/yesterday-incomplete days). Run:
+
+   ```bash
+   node .claude/skills/mastrabowl-recap/scripts/download-chart.mjs
+   ```
+
+   With no args it defaults to the most recent Sunday through yesterday. Override with
+   `--from YYYY-MM-DD --to YYYY-MM-DD` (e.g. `--from 2026-05-31 --to 2026-06-04`).
+   It pulls daily counts from the public npm API, prints the daily numbers + total for
+   the window, and writes `downloads-chart-<to>.svg` to the skill dir.
+
+   The chart data comes from the same source as npm-stat.com (npm's download API), so
+   the totals match. Reference it in the draft with `!downloads-chart-<to>.svg` on its
+   own line; the publish step uploads and embeds it automatically.
+
+   **Product Revenue chart (from Slack / PostHog).** Revenue lives in the `#revenue`
+   Slack channel, where a PostHog "Subscription Revenue by Type" subscription posts a
+   daily message with the chart embedded as an image block (a signed PostHog exporter
+   PNG — no PostHog API key required). Run:
+
+   ```bash
+   node .claude/skills/mastrabowl-recap/scripts/revenue-image.mjs
+   ```
+
+   It reads `SLACK_TOKEN` + `REVENUE_SLACK_ID` from `recap.env`, finds the newest
+   in-window revenue post (Sunday → day before today), downloads the chart to
+   `revenue-<date>.png` in the skill dir, and prints the "View in PostHog" link.
+   Open the saved PNG to read the totals and transcribe the figures under Product
+   Revenue (e.g. plan breakdown + total). The PNG is gitignored — it contains real
+   revenue numbers; never commit it. Reference it in the draft with
+   `!revenue-<date>.png` on its own line and the publish step embeds it automatically.
+   Never invent or round revenue figures — only use what the chart shows.
+
+6. **Feature Announcements (from X/Twitter).** Open https://x.com/mastra and scan posts.
+
+   **Stay strictly within the weekly window.** The window is the same one used everywhere
+   in the recap: **Sunday → the day before today** (run `oss-stats.sh`/`download-chart.mjs`
+   first; they print the exact `from`/`to`). Each post on X shows its date (e.g. "Jun 2").
+   ONLY include posts whose date is `>= from` AND `<= to`. Today's posts and anything
+   before Sunday are out of scope — do not include them even if they look relevant.
+
+   Scroll until you have passed the `from` (Sunday) date — i.e. until you see posts dated
+   before the window — so you know you've covered the whole week. Then collect only the
+   in-window posts. (X lazy-loads; keep scrolling until older-than-window posts appear or
+   the timeline stops loading.)
+
+   From the in-window posts, include genuine Mastra feature/launch announcements (and
+   reposts of team members announcing a Mastra primitive). Capture each as a markdown link
+   using the post permalink (`https://x.com/<author>/status/<id>`) with a short feature
+   description and its date. Order chronologically.
+
+   Exclude: workshop "happening now" / broadcast notices (those are Highlights), customer
+   fundraising or customer-story reposts (those belong under Sales / Customer Engineering),
+   docs/blog follow-up tweets that just point at a feature already listed, and general hype.
+
+7. **Road to London (from merged PRs, bucketed by code AREA).** Do NOT use GitHub
+   labels — they're incomplete and inconsistently applied. Bucket by the file paths a
+   PR touches instead. Run:
+
+   ```bash
+   node .claude/skills/mastrabowl-recap/scripts/road-to-london.mjs
+   ```
+
+   It reads merged PRs in-window (Sunday → day before today) from `mastra-ai/mastra`
+   and `mastra-ai/platform`, fetches each PR's changed files, filters release/chore/deps
+   noise, and buckets by code area:
+   - **LRA (Long Running Agents)** = signals / channels / events / notifications /
+     background-tasks / memory (PubSub, Signals, Memory).
+   - **Observability** = observability / telemetry / logger(s), plus MOBS in Platform.
+   - **Agent Builder** = agent-builder / editor / workspace.
+   - **Agent Learning** = datasets / evals / relevance (mostly research phase, but it
+     does ship eval/dataset tooling some weeks; report what actually landed).
+   - **Platform** = everything in `mastra-ai/platform`.
+   - **Framework** = the rest of `mastra-ai/mastra` (catch-all; the script caps the
+     list and surfaces `feat` PRs first).
+
+   The script prints PRs per bucket with links. Use it as raw material, but **write a
+   narrative, not a changelog.** For each workstream, write a short prose paragraph
+   (2–5 sentences) that tells the story: what theme the week's work points to, why it
+   matters for "the road to London," and where the workstream is heading. Weave the
+   most representative PRs in as **inline markdown links** within the prose (not a bare
+   bullet list of every PR), and close with a one-line throughline when it helps. End
+   on the direction, not the diff. If a workstream is in research phase with no PRs,
+   say so plainly and briefly rather than padding. Never invent work that didn't land.
+   Adjust the area path maps at the top of the script if the codebase reorganizes.
+
+8. **Sales / Customer Engineering (from Slack).** Two channels feed this section:
+   - **Sales** (`SALES_SLACK_ID`): recap the **deals**. Pull the channel and look for
+     signed-deal markers ("X is Signed"), contract values, and active pipeline.
+   - **Customer Engineering** (`CUSTOMER_ENG_SLACK_ID`): recap the **customers** and CE
+     work. The PRIMARY source is **Romain's weekly CE/OSS report**, which he posts to
+     this channel every week. It's a `oss-report-workflow` run (a Mastra agent) attached
+     as two files: an `image.png` briefing card and a `result.json` with the full data.
+     Use that report as the backbone, then layer in the human updates from the channel
+     (deals likely to sign, support/SLA work, triage status).
+
+   Run:
+
+   ```bash
+   node .claude/skills/mastrabowl-recap/scripts/slack-channel.mjs SALES_SLACK_ID --threads
+   node .claude/skills/mastrabowl-recap/scripts/slack-channel.mjs CUSTOMER_ENG_SLACK_ID --files
+   ```
+
+   `--threads` expands reply threads (signed-deal posts put contract details in the
+   thread). `--files` lists attachments with a ready-to-run `curl` download command;
+   use it to find Romain's report files. Downloading files needs the **`files:read`**
+   scope on the Slack token. The `image.png` is the briefing card (reference it in the
+   CE section as `!ce-report-<endDate>.png` so it embeds on publish); `result.json` has `result.briefing`
+   (headline, wins, regressions, watchlist, talkingPoints) and `result.summary` /
+   `initialState.metrics` (backlog, issues opened/closed, PRs opened/merged, category
+   breakdown). Save the card as `ce-report-<endDate>.png` in the skill dir (gitignored).
+
+   Write each section as a short narrative in the same plain voice as Road to London.
+   Customer/deal names and dollar figures are in scope (the recap is internal), but
+   never invent or round numbers — use exactly what the report and channel say.
+
+9. **Publish to Notion.** Recaps live in a Notion database (one page per week).
+   Write the finished draft to a local markdown file, then:
+
+   ```bash
+   # preview blocks without hitting Notion:
+   node .claude/skills/mastrabowl-recap/scripts/publish-notion.mjs draft.md \
+     --title "Week of June 6, 2026" --dry-run
+
+   # create the page:
+   node .claude/skills/mastrabowl-recap/scripts/publish-notion.mjs draft.md \
+     --title "Week of June 6, 2026"
+   ```
+
+   The script converts headings, bullets, **bold** text, and `[links](url)` into
+   Notion blocks. Title defaults to "Week of <today>"; use `--title "2026-MM-DD"` for
+   the ISO date format we use.
+
+   **Images embed automatically.** A line like `!revenue-2026-06-04.png` is uploaded
+   via Notion's Direct File Upload API and inserted as a real image block (no manual
+   drag-in). The file is looked up next to the draft, then in the skill dir. If the
+   file is missing, the script falls back to a 🖼️ "Attach image" callout. Keep the
+   generated chart/report files in the skill dir (gitignored) so they upload cleanly.
+
+   Two API-version notes baked into the script (don't revert these):
+   - File uploads use Notion-Version `2026-03-11` (the upload endpoints don't exist on
+     older versions).
+   - Pages are parented to the database's **data source** (`data_source_id`), not the
+     bare `database_id`. On current API versions the database view reads from a data
+     source, and pages parented to `database_id` won't appear in the view.
+
+## Notion setup (one-time)
+
+1. Create an internal integration at https://www.notion.so/my-integrations (workspace
+   `kepler-inc`) and copy the Internal Integration Secret.
+2. Open the recap database → `•••` → Connections → add the integration. Without this
+   the API returns 404 even with a valid token.
+3. Copy `recap.env.example` to `recap.env` and set `NOTION_TOKEN`. The database ID is
+   already filled in. `recap.env` is gitignored — never commit it.
+
+Verify connectivity:
+
+```bash
+set -a; source .claude/skills/mastrabowl-recap/recap.env; set +a
+curl -s https://api.notion.com/v1/databases/$NOTION_DATABASE_ID \
+  -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" \
+  | head -c 400
+```
+
+## Style notes
+
+- Keep the warm, informal voice (greeting + [song], "Peace ✌️").
+- Stats lines stay **bold**.
+- Don't fabricate numbers, releases, customers, or roadmap status. If a section has no
+  input, leave `?` rather than guessing.
+- **Write like a human, not an AI.** This is the most important style rule for the
+  narrative sections (especially Road to London):
+  - **No em dashes** (—). Use a period, comma, colon, or parentheses instead.
+  - Avoid AI-tell phrasing: "the throughline," "the story is," "it's worth noting,"
+    "in summary," "let's dive in," stacked adjectives ("composable, performant,
+    foundational"), and breathless hype. Just say what happened and why it matters.
+  - Prefer short, plain sentences. Lead with the work, not a thesis statement.
+  - It's fine to be a little dry. Don't editorialize every bullet.
+
+## Files
+
+- `template.md` — the blank weekly template.
+- `scripts/oss-stats.sh` — pulls merged/open PR + issue counts and releases via `gh api`.
+- `scripts/download-chart.mjs` — generates the `@mastra/core` weekly download chart (SVG)
+  from npm's download API (Sunday → day before today).
+- `scripts/publish-notion.mjs` — creates a new page in the recap Notion DB from a
+  markdown file: converts headings/bullets/bold/links, uploads + embeds `!image` lines
+  via the Direct File Upload API, and parents the page to the DB's data source so it
+  shows in the view (no external deps; needs Node 18+).
+- `recap.env.example` / `recap.env` — Notion token + database ID (`recap.env` gitignored).
+
+## Requirements
+
+- `gh` CLI authenticated with access to the `mastra-ai` org.
+- `jq`.
+- Node 18+ (for the Notion publish script's built-in `fetch`).
+- Notion integration token in `recap.env`, with the integration shared on the recap DB.
+- This repo's `gh` predates `gh search`, so the script uses `gh api search/issues`.
+  If `gh` is upgraded, the queries remain compatible.
+
+## TODO / future enhancements
+
+- **OSS chart format.** The OSS download chart is an SVG; Notion's image rendering of SVG
+  can be inconsistent. If it ever renders poorly, render the chart to PNG in
+  `download-chart.mjs` and reference the PNG in the draft instead.
+- **Update in place.** `publish-notion.mjs` currently creates a new page each run. If a
+  stable per-week URL is wanted, extend it to find an existing page by title and replace
+  its blocks rather than creating a new page.
+
+## Iterating on this skill
+
+This skill is meant to evolve. As the recap format changes, update `template.md` and the
+section mapping above. If new automatable data sources appear (e.g. revenue dashboards,
+release-notes generation), add scripts under `scripts/` and document them here.

--- a/.claude/skills/mastrabowl-recap/recap.env.example
+++ b/.claude/skills/mastrabowl-recap/recap.env.example
@@ -1,0 +1,22 @@
+# MastraBowl Recap — local secrets (copy to recap.env and fill in).
+# recap.env is gitignored. Do NOT commit real tokens.
+
+# Internal integration secret from https://www.notion.so/my-integrations
+# (starts with "ntn_" or "secret_"). The integration MUST be added as a
+# Connection on the recap database, or the API returns 404.
+NOTION_TOKEN=
+
+# The recap database ID (32 hex chars, dashes optional).
+# From the DB URL: https://app.notion.com/p/<workspace>/<DATABASE_ID>?v=...
+NOTION_DATABASE_ID=
+
+# Slack bot token (starts with "xoxb-"). Needs scopes: channels:history,
+# channels:read, groups:history, groups:read, reactions:read, files:read.
+SLACK_TOKEN=
+
+# Slack channel IDs (the "C0..." id from the channel URL). Used by the
+# Kindergarten, revenue, and Sales/CE scripts. Fill in the ones you need.
+KINDERGARTEN_SLACK_ID=
+REVENUE_SLACK_ID=
+SALES_SLACK_ID=
+CUSTOMER_ENG_SLACK_ID=

--- a/.claude/skills/mastrabowl-recap/scripts/download-chart.mjs
+++ b/.claude/skills/mastrabowl-recap/scripts/download-chart.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// MastraBowl Recap — npm downloads chart generator.
+//
+// Pulls daily download counts for @mastra/core from the public npm API and
+// renders a "Downloads per day" line chart as a standalone SVG.
+//
+// The recap chart covers the week starting Sunday through the day BEFORE today
+// (npm download data lags, so today's/yesterday's numbers are incomplete).
+//
+// Usage:
+//   node scripts/download-chart.mjs [--package @mastra/core] [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--out FILE]
+//
+// Defaults:
+//   --package @mastra/core
+//   --from    the most recent Sunday on/before (today - 1)
+//   --to      yesterday (today - 1)
+//   --out     downloads-chart-<to>.svg  (in the skill dir)
+//
+// No external deps (Node 18+ fetch). Also prints total downloads for the window.
+
+import { writeFileSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const skillRoot = resolve(here, '..');
+
+function ymd(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+function parseArgs(argv) {
+  const a = { pkg: '@mastra/core', from: null, to: null, out: null };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--package') a.pkg = argv[++i];
+    else if (k === '--from') a.from = argv[++i];
+    else if (k === '--to') a.to = argv[++i];
+    else if (k === '--out') a.out = argv[++i];
+  }
+  return a;
+}
+
+function defaultWindow() {
+  const today = new Date();
+  const to = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+  to.setUTCDate(to.getUTCDate() - 1); // yesterday (last complete-ish day)
+  const from = new Date(to);
+  // back up to the most recent Sunday (getUTCDay: 0 = Sunday)
+  from.setUTCDate(from.getUTCDate() - from.getUTCDay());
+  return { from: ymd(from), to: ymd(to) };
+}
+
+function buildSvg(pkg, points) {
+  const W = 980,
+    H = 400,
+    padL = 70,
+    padR = 20,
+    padT = 60,
+    padB = 50;
+  const plotW = W - padL - padR;
+  const plotH = H - padT - padB;
+  const max = Math.max(...points.map((p) => p.downloads), 1);
+  // round max up to a "nice" number
+  const niceMax = Math.ceil(max / 50000) * 50000 || 50000;
+
+  const x = (i) => padL + (points.length === 1 ? plotW / 2 : (i / (points.length - 1)) * plotW);
+  const y = (v) => padT + plotH - (v / niceMax) * plotH;
+
+  const gridLines = [];
+  const ticks = 4;
+  for (let t = 0; t <= ticks; t++) {
+    const val = (niceMax / ticks) * t;
+    const yy = y(val);
+    gridLines.push(
+      `<line x1="${padL}" y1="${yy.toFixed(1)}" x2="${W - padR}" y2="${yy.toFixed(1)}" stroke="#e0e0e0" stroke-width="1"/>`,
+    );
+    gridLines.push(
+      `<text x="${padL - 8}" y="${(yy + 4).toFixed(1)}" text-anchor="end" font-size="11" fill="#666">${Math.round(val / 1000)}k</text>`,
+    );
+  }
+
+  const xLabels = points.map((p, i) => {
+    const d = new Date(p.day + 'T00:00:00Z');
+    const label = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+    return `<text x="${x(i).toFixed(1)}" y="${H - padB + 18}" text-anchor="middle" font-size="11" fill="#666">${label}</text>`;
+  });
+
+  const line = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${x(i).toFixed(1)} ${y(p.downloads).toFixed(1)}`).join(' ');
+  const dots = points
+    .map((p, i) => `<circle cx="${x(i).toFixed(1)}" cy="${y(p.downloads).toFixed(1)}" r="3" fill="#CC333F"/>`)
+    .join('');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" font-family="Arial, Helvetica, sans-serif">
+  <rect width="${W}" height="${H}" fill="#ffffff"/>
+  <text x="${W / 2}" y="28" text-anchor="middle" font-size="16" fill="#000">Downloads per day — ${pkg}</text>
+  ${gridLines.join('\n  ')}
+  <path d="${line}" fill="none" stroke="#CC333F" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+  ${dots}
+  ${xLabels.join('\n  ')}
+  <text x="20" y="${H / 2}" text-anchor="middle" font-size="12" fill="#000" transform="rotate(270 20 ${H / 2})">Downloads</text>
+</svg>`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const win = defaultWindow();
+  const from = args.from || win.from;
+  const to = args.to || win.to;
+  const pkg = args.pkg;
+
+  const url = `https://api.npmjs.org/downloads/range/${from}:${to}/${pkg}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`npm API ${res.status} for ${url}`);
+  const data = await res.json();
+  const points = data.downloads || [];
+  if (!points.length) throw new Error('No download data returned.');
+
+  const total = points.reduce((s, p) => s + p.downloads, 0);
+  const svg = buildSvg(pkg, points);
+  const out = args.out || join(skillRoot, `downloads-chart-${to}.svg`);
+  writeFileSync(out, svg);
+
+  console.log(`Package: ${pkg}`);
+  console.log(`Window:  ${from} -> ${to} (Sunday -> day before today)`);
+  console.log(`Total downloads: ${total.toLocaleString('en-US')}`);
+  console.log('Daily:');
+  for (const p of points) console.log(`  ${p.day}: ${p.downloads.toLocaleString('en-US')}`);
+  console.log(`Chart SVG: ${out}`);
+}
+
+main().catch((e) => {
+  console.error(String(e.message || e));
+  process.exit(1);
+});

--- a/.claude/skills/mastrabowl-recap/scripts/kindergarten.mjs
+++ b/.claude/skills/mastrabowl-recap/scripts/kindergarten.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Pull the week's article links from the #kindergarten Slack channel and rank
+// them by engagement (reactions + replies) so we can pick the most interesting.
+//
+// Window: Sunday -> day before today (same as the rest of the recap), unless
+// --from / --to (YYYY-MM-DD) are passed.
+//
+// Reads SLACK_TOKEN and KINDERGARTEN_SLACK_ID from recap.env.
+// Usage:
+//   node scripts/kindergarten.mjs
+//   node scripts/kindergarten.mjs --from 2026-05-31 --to 2026-06-04
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENV_PATH = join(__dirname, '..', 'recap.env');
+
+function loadEnv() {
+  const env = {};
+  let raw;
+  try {
+    raw = readFileSync(ENV_PATH, 'utf8');
+  } catch {
+    return env;
+  }
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return env;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--from') args.from = argv[++i];
+    else if (argv[i] === '--to') args.to = argv[++i];
+  }
+  return args;
+}
+
+// Default window: most recent Sunday (inclusive) -> yesterday (inclusive).
+function defaultWindow() {
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const to = new Date(today);
+  to.setUTCDate(to.getUTCDate() - 1); // day before today
+  const from = new Date(today);
+  from.setUTCDate(from.getUTCDate() - today.getUTCDay()); // back to Sunday
+  const fmt = (d) => d.toISOString().slice(0, 10);
+  return { from: fmt(from), to: fmt(to) };
+}
+
+function dayStartTs(dateStr) {
+  return Math.floor(Date.parse(`${dateStr}T00:00:00Z`) / 1000);
+}
+function dayEndTs(dateStr) {
+  return Math.floor(Date.parse(`${dateStr}T23:59:59Z`) / 1000);
+}
+
+async function slack(method, token, params) {
+  const url = new URL(`https://slack.com/api/${method}`);
+  for (const [k, v] of Object.entries(params || {})) url.searchParams.set(k, String(v));
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  const data = await res.json();
+  if (!data.ok) throw new Error(`${method} failed: ${data.error}`);
+  return data;
+}
+
+// Extract URLs from Slack message text. Slack wraps links as <url> or <url|label>.
+function extractLinks(text) {
+  if (!text) return [];
+  const links = [];
+  const re = /<(https?:\/\/[^>|]+)(?:\|([^>]+))?>/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    links.push({ url: m[1], label: m[2] || null });
+  }
+  return links;
+}
+
+function isArticleLink(url) {
+  // Skip links to Slack itself, images, and known non-article hosts.
+  const skip = [/slack\.com/, /\.(png|jpg|jpeg|gif|svg|webp)(\?|$)/i];
+  return !skip.some((re) => re.test(url));
+}
+
+async function main() {
+  const env = loadEnv();
+  const token = env.SLACK_TOKEN;
+  const channel = env.KINDERGARTEN_SLACK_ID;
+  if (!token) throw new Error('SLACK_TOKEN missing in recap.env');
+  if (!channel) throw new Error('KINDERGARTEN_SLACK_ID missing in recap.env');
+
+  const cli = parseArgs(process.argv.slice(2));
+  const win = defaultWindow();
+  const from = cli.from || win.from;
+  const to = cli.to || win.to;
+
+  console.error(`# Kindergarten — week ${from} -> ${to} (channel ${channel})\n`);
+
+  const oldest = dayStartTs(from);
+  const latest = dayEndTs(to);
+
+  // Page through channel history within the window.
+  let messages = [];
+  let cursor;
+  do {
+    const data = await slack('conversations.history', token, {
+      channel,
+      oldest,
+      latest,
+      inclusive: true,
+      limit: 200,
+      ...(cursor ? { cursor } : {}),
+    });
+    messages = messages.concat(data.messages || []);
+    cursor = data.response_metadata && data.response_metadata.next_cursor;
+  } while (cursor);
+
+  // Collect article links with engagement signal.
+  const items = [];
+  for (const msg of messages) {
+    const links = extractLinks(msg.text).filter((l) => isArticleLink(l.url));
+    if (links.length === 0) continue;
+    const reactions = (msg.reactions || []).reduce((sum, r) => sum + (r.count || 0), 0);
+    const replies = msg.reply_count || 0;
+    for (const link of links) {
+      items.push({
+        url: link.url,
+        label: link.label,
+        text: (msg.text || '').replace(/\s+/g, ' ').trim().slice(0, 200),
+        reactions,
+        replies,
+        score: reactions + replies,
+        ts: msg.ts,
+        date: new Date(Number(msg.ts) * 1000).toISOString().slice(0, 10),
+      });
+    }
+  }
+
+  // Dedupe by URL, keeping highest score.
+  const byUrl = new Map();
+  for (const it of items) {
+    const prev = byUrl.get(it.url);
+    if (!prev || it.score > prev.score) byUrl.set(it.url, it);
+  }
+  const ranked = [...byUrl.values()].sort((a, b) => b.score - a.score || b.replies - a.replies);
+
+  if (ranked.length === 0) {
+    console.error('No article links found in the window.');
+    return;
+  }
+
+  console.log(`Found ${ranked.length} article link(s) shared this week, ranked by engagement:\n`);
+  for (const it of ranked) {
+    const eng = `${it.reactions} reactions, ${it.replies} replies`;
+    console.log(`- [${eng}] (${it.date})`);
+    console.log(`  ${it.label ? it.label + ' — ' : ''}${it.url}`);
+    if (it.text) console.log(`  ctx: ${it.text}`);
+    console.log('');
+  }
+}
+
+main().catch((err) => {
+  console.error(String(err.message || err));
+  process.exit(1);
+});

--- a/.claude/skills/mastrabowl-recap/scripts/oss-stats.sh
+++ b/.claude/skills/mastrabowl-recap/scripts/oss-stats.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# MastraBowl Recap — Open Source stats puller
+#
+# Usage:
+#   scripts/oss-stats.sh [SINCE]
+#
+# SINCE: ISO date (YYYY-MM-DD) for the start of the week window.
+#        Defaults to the most recent Friday (the week being recapped).
+#
+# Requires: gh CLI (authenticated), jq.
+# Note: this repo's gh predates `gh search`, so we use `gh api search/issues`.
+
+set -euo pipefail
+
+# --- resolve the week window -------------------------------------------------
+if [[ "${1:-}" != "" ]]; then
+  SINCE="$1"
+else
+  # Default: the past 7 days (the week being recapped on Friday).
+  # macOS/BSD date and GNU date differ; handle both.
+  if date -v-7d >/dev/null 2>&1; then
+    SINCE=$(date -v-7d +%Y-%m-%d)   # BSD/macOS
+  else
+    SINCE=$(date -d "7 days ago" +%Y-%m-%d)  # GNU
+  fi
+fi
+
+count() {
+  # $1 = full search query
+  gh api -X GET search/issues -f q="$1" --jq '.total_count'
+}
+
+echo "## Open Source — week since ${SINCE}"
+echo
+
+for repo in mastra-ai/mastra mastra-ai/platform; do
+  merged=$(count "repo:${repo} is:pr is:merged merged:>=${SINCE}")
+  open_prs=$(count "repo:${repo} is:pr is:open")
+  open_issues=$(count "repo:${repo} is:issue is:open")
+  echo "### ${repo}"
+  echo "- PRs merged this week: **${merged}**"
+  echo "- Open PRs (EoW): **${open_prs}**"
+  echo "- Open Issues (EoW): **${open_issues}**"
+  echo
+done
+
+# --- releases this week ------------------------------------------------------
+# Markdown bullets linking to each GitHub release published in the window.
+echo "### Releases since ${SINCE} (mastra-ai/mastra)"
+releases=$(gh api "repos/mastra-ai/mastra/releases?per_page=100" \
+  --jq "[.[] | select(.published_at >= \"${SINCE}\")] | sort_by(.published_at) | reverse | .[] | \"- [\(.tag_name)](\(.html_url)) — \(.published_at[0:10])\"" 2>/dev/null)
+if [[ -n "$releases" ]]; then
+  echo "$releases"
+else
+  echo "- (none in window / unable to fetch)"
+fi
+echo
+echo "_Fill EoW totals line as: **EoW <issues> Issues Open | <prs> PRs Open** using mastra-ai/mastra numbers above._"

--- a/.claude/skills/mastrabowl-recap/scripts/publish-notion.mjs
+++ b/.claude/skills/mastrabowl-recap/scripts/publish-notion.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+// MastraBowl Recap — publish a markdown file as a new page in the Notion DB.
+//
+// Usage:
+//   node scripts/publish-notion.mjs <markdown-file> [--title "Week of June 6, 2026"] [--dry-run]
+//
+// Reads NOTION_TOKEN and NOTION_DATABASE_ID from recap.env (or the environment).
+// Detects the database's title property automatically and converts a subset of
+// markdown (headings, bullets, paragraphs) into Notion blocks.
+//
+// No external deps — uses Node's built-in fetch (Node 18+).
+
+import { readFileSync, existsSync } from 'node:fs';
+import { basename, dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Page/block/database creation uses the stable version whose database model
+// exposes `properties` directly. The newer 2026-03-11 version moved properties
+// under data sources, so we keep page creation on the stable version and only
+// use the newer version for the Direct File Upload endpoints.
+const NOTION_VERSION = '2022-06-28';
+const UPLOAD_VERSION = '2026-03-11';
+const here = dirname(fileURLToPath(import.meta.url));
+const skillRoot = resolve(here, '..');
+
+function loadEnv() {
+  const env = { ...process.env };
+  try {
+    const text = readFileSync(join(skillRoot, 'recap.env'), 'utf8');
+    for (const line of text.split('\n')) {
+      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+      if (m && !line.trim().startsWith('#')) {
+        const val = m[2].replace(/^["']|["']$/g, '');
+        if (val) env[m[1]] = val;
+      }
+    }
+  } catch {
+    /* recap.env optional if env vars already set */
+  }
+  return env;
+}
+
+function parseArgs(argv) {
+  const args = { file: null, title: null, dryRun: false, new: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--new') args.new = true;
+    else if (a === '--title') args.title = argv[++i];
+    else if (!args.file) args.file = a;
+  }
+  return args;
+}
+
+// --- minimal markdown -> Notion blocks --------------------------------------
+function richText(text) {
+  // Tokenize into markdown links [label](url), **bold**, and plain text.
+  // Notion rich_text supports per-span link + annotations.
+  const parts = [];
+  // Matches either a markdown link or a bold span.
+  const token = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)|\*\*([^*]+)\*\*/g;
+  let last = 0;
+  let m;
+  const pushPlain = (s) => {
+    if (!s) return;
+    // Linkify any bare URLs within plain text.
+    const urlRe = /(https?:\/\/[^\s]+)/g;
+    let lp = 0;
+    let um;
+    while ((um = urlRe.exec(s)) !== null) {
+      if (um.index > lp) parts.push({ type: 'text', text: { content: s.slice(lp, um.index) } });
+      parts.push({ type: 'text', text: { content: um[1], link: { url: um[1] } } });
+      lp = urlRe.lastIndex;
+    }
+    if (lp < s.length) parts.push({ type: 'text', text: { content: s.slice(lp) } });
+  };
+  while ((m = token.exec(text)) !== null) {
+    if (m.index > last) pushPlain(text.slice(last, m.index));
+    if (m[1] && m[2]) {
+      // markdown link
+      parts.push({ type: 'text', text: { content: m[1], link: { url: m[2] } } });
+    } else if (m[3]) {
+      // bold
+      parts.push({ type: 'text', text: { content: m[3] }, annotations: { bold: true } });
+    }
+    last = token.lastIndex;
+  }
+  if (last < text.length) pushPlain(text.slice(last));
+  return parts.length ? parts : [{ type: 'text', text: { content: text } }];
+}
+
+function mdToBlocks(md) {
+  const blocks = [];
+  const lines = md.split('\n');
+  let lastTopBullet = null; // track parent bullet for nested sub-bullets
+  let paraBuf = []; // accumulate wrapped lines into a single paragraph
+
+  const flushPara = () => {
+    if (paraBuf.length === 0) return;
+    const text = paraBuf.join(' ').replace(/\s+/g, ' ').trim();
+    paraBuf = [];
+    if (!text) return;
+    blocks.push({ object: 'block', type: 'paragraph', paragraph: { rich_text: richText(text) } });
+  };
+
+  for (let raw of lines) {
+    const line = raw.replace(/\s+$/, '');
+
+    // Blank line ends the current paragraph.
+    if (line.trim() === '') {
+      flushPara();
+      continue;
+    }
+
+    let m;
+    // Embed: a line like "@embed https://suno.com/s/...". Renders as a Notion
+    // embed block (the Suno player, YouTube, etc.).
+    if ((m = line.match(/^@embed\s+(\S+)$/))) {
+      flushPara();
+      blocks.push({ object: 'block', type: 'embed', embed: { url: m[1] } });
+      lastTopBullet = null;
+    }
+    // Image placeholder: a line like "!image.png". The Notion API can't upload
+    // local files, so emit a callout reminding the author to drag the chart in.
+    else if ((m = line.match(/^!\s*(\S+)$/))) {
+      flushPara();
+      // Defer: resolveImages() turns this marker into an uploaded image block
+      // (or a callout fallback if the local file can't be found).
+      blocks.push({ __imageFile: m[1] });
+      lastTopBullet = null;
+    } else if ((m = line.match(/^(#{1,6})\s+(.*)$/))) {
+      flushPara();
+      const level = m[1].length;
+      // Notion only has h1-h3; clamp deeper headings (h4+) to h3.
+      const key = level === 1 ? 'heading_1' : level === 2 ? 'heading_2' : 'heading_3';
+      blocks.push({ object: 'block', type: key, [key]: { rich_text: richText(m[2]) } });
+      lastTopBullet = null;
+    } else if ((m = line.match(/^(\s*)[-*]\s+(.*)$/))) {
+      flushPara();
+      const indent = m[1].length;
+      const item = {
+        object: 'block',
+        type: 'bulleted_list_item',
+        bulleted_list_item: { rich_text: richText(m[2]) },
+      };
+      if (indent >= 2 && lastTopBullet) {
+        lastTopBullet.bulleted_list_item.children =
+          lastTopBullet.bulleted_list_item.children || [];
+        lastTopBullet.bulleted_list_item.children.push(item);
+      } else {
+        blocks.push(item);
+        lastTopBullet = item;
+      }
+    } else {
+      // Plain text line: part of a (possibly wrapped) paragraph. Accumulate.
+      paraBuf.push(line.trim());
+      lastTopBullet = null;
+    }
+  }
+  flushPara();
+  // Notion caps children at 100 per request; caller should chunk if needed.
+  return blocks;
+}
+
+async function notion(env, path, method = 'GET', body, version = NOTION_VERSION) {
+  const res = await fetch(`https://api.notion.com/v1/${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${env.NOTION_TOKEN}`,
+      'Notion-Version': version,
+      'Content-Type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json();
+  if (!res.ok) {
+    throw new Error(`Notion ${method} ${path} -> ${res.status}: ${json.message || JSON.stringify(json)}`);
+  }
+  return json;
+}
+
+const MIME = { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif', svg: 'image/svg+xml' };
+
+// Upload a local file to Notion via the Direct File Upload API (3 steps) and
+// return the file_upload id to attach to an image block.
+async function uploadFile(env, filePath) {
+  const name = basename(filePath);
+  const ext = name.split('.').pop().toLowerCase();
+  const contentType = MIME[ext] || 'application/octet-stream';
+
+  // 1) create the upload (uses the newer API version for file_uploads)
+  const createRes = await fetch('https://api.notion.com/v1/file_uploads', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.NOTION_TOKEN}`,
+      'Notion-Version': UPLOAD_VERSION,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ filename: name, content_type: contentType }),
+  });
+  const created = await createRes.json();
+  if (!createRes.ok) {
+    throw new Error(`File create failed ${createRes.status}: ${created.message || JSON.stringify(created)}`);
+  }
+
+  // 2) send the bytes (multipart/form-data; let fetch set the boundary)
+  const bytes = readFileSync(filePath);
+  const form = new FormData();
+  form.append('file', new Blob([bytes], { type: contentType }), name);
+  const sendRes = await fetch(`https://api.notion.com/v1/file_uploads/${created.id}/send`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.NOTION_TOKEN}`,
+      'Notion-Version': UPLOAD_VERSION,
+    },
+    body: form,
+  });
+  const sendJson = await sendRes.json();
+  if (!sendRes.ok) {
+    throw new Error(`File send failed ${sendRes.status}: ${sendJson.message || JSON.stringify(sendJson)}`);
+  }
+  return created.id;
+}
+
+// Resolve __imageFile markers into real image blocks by uploading the local
+// file. Looks for the file relative to the markdown file's dir, then the skill
+// root. Falls back to a callout if the file isn't found or dry-run is set.
+async function resolveImages(env, blocks, baseDir, dryRun) {
+  const calloutFor = (file, note) => ({
+    object: 'block',
+    type: 'callout',
+    callout: {
+      icon: { type: 'emoji', emoji: '🖼️' },
+      rich_text: [{ type: 'text', text: { content: `Attach image: ${file}${note ? ` (${note})` : ''}` } }],
+    },
+  });
+
+  const out = [];
+  for (const b of blocks) {
+    if (!b.__imageFile) {
+      out.push(b);
+      continue;
+    }
+    const file = b.__imageFile;
+    const candidates = [resolve(baseDir, file), resolve(skillRoot, file)];
+    const found = candidates.find((p) => existsSync(p));
+    if (!found) {
+      out.push(calloutFor(file, 'file not found'));
+      continue;
+    }
+    if (dryRun) {
+      out.push(calloutFor(file, `would upload from ${found}`));
+      continue;
+    }
+    const id = await uploadFile(env, found);
+    out.push({
+      object: 'block',
+      type: 'image',
+      image: { type: 'file_upload', file_upload: { id } },
+    });
+  }
+  return out;
+}
+
+async function main() {
+  const env = loadEnv();
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.file) {
+    console.error('Usage: node scripts/publish-notion.mjs <markdown-file> [--title "..."] [--dry-run]');
+    process.exit(1);
+  }
+  const mdPath = resolve(process.cwd(), args.file);
+  const md = readFileSync(mdPath, 'utf8');
+  const rawBlocks = mdToBlocks(md);
+
+  // Default title: "Week of <today>"
+  const title =
+    args.title ||
+    `Week of ${new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`;
+
+  if (args.dryRun) {
+    const blocks = await resolveImages(env, rawBlocks, dirname(mdPath), true);
+    const imgMarkers = blocks.filter((b) => b.type === 'callout').length;
+    console.log(`[dry-run] Title: ${title}`);
+    console.log(`[dry-run] ${blocks.length} blocks; ${imgMarkers} image marker(s) resolved to placeholders.`);
+    console.log(JSON.stringify(blocks.slice(0, 5), null, 2));
+    return;
+  }
+
+  if (!env.NOTION_TOKEN) throw new Error('NOTION_TOKEN missing (set it in recap.env).');
+  if (!env.NOTION_DATABASE_ID) throw new Error('NOTION_DATABASE_ID missing (set it in recap.env).');
+
+  // Upload local images and turn markers into real image blocks.
+  const blocks = await resolveImages(env, rawBlocks, dirname(mdPath), false);
+
+  // Newer API versions expose properties via data sources, not the database
+  // directly, and the database VIEW reads from a data source. Pages parented to
+  // a bare database_id don't show up in the view, so we parent to the data
+  // source instead. Resolve the data source id and its title property.
+  const db = await notion(env, `databases/${env.NOTION_DATABASE_ID}`, 'GET', undefined, UPLOAD_VERSION);
+  const dataSourceId = db.data_sources?.[0]?.id;
+  if (!dataSourceId) throw new Error('No data source found on the database.');
+  const ds = await notion(env, `data_sources/${dataSourceId}`, 'GET', undefined, UPLOAD_VERSION);
+  const titleProp = Object.entries(ds.properties).find(([, p]) => p.type === 'title')?.[0];
+  if (!titleProp) throw new Error('Could not find a title property on the data source.');
+
+  // Notion limits children to 100 per create call; send first 100, append rest.
+  const first = blocks.slice(0, 100);
+  const rest = blocks.slice(100);
+
+  // Upsert by title: reuse an existing (non-trashed) page with the same title so
+  // re-publishing doesn't litter the database with duplicates. Pass --new to
+  // always create a fresh page.
+  let existing = null;
+  if (!args.new) {
+    const q = await notion(
+      env,
+      `data_sources/${dataSourceId}/query`,
+      'POST',
+      { filter: { property: titleProp, title: { equals: title } }, page_size: 1 },
+      UPLOAD_VERSION,
+    );
+    existing = q.results?.find((p) => !p.in_trash && !p.archived) || null;
+  }
+
+  let page;
+  if (existing) {
+    // Replace the page's content: delete current children, then append new ones.
+    const kids = await notion(env, `blocks/${existing.id}/children?page_size=100`, 'GET', undefined, UPLOAD_VERSION);
+    for (const child of kids.results || []) {
+      await notion(env, `blocks/${child.id}`, 'DELETE', undefined, UPLOAD_VERSION);
+    }
+    for (let i = 0; i < blocks.length; i += 100) {
+      await notion(env, `blocks/${existing.id}/children`, 'PATCH', { children: blocks.slice(i, i + 100) }, UPLOAD_VERSION);
+    }
+    page = existing;
+    console.log(`Updated Notion page: ${page.url}`);
+  } else {
+    page = await notion(
+      env,
+      'pages',
+      'POST',
+      {
+        parent: { type: 'data_source_id', data_source_id: dataSourceId },
+        properties: { [titleProp]: { title: [{ text: { content: title } }] } },
+        children: first,
+      },
+      UPLOAD_VERSION,
+    );
+    for (let i = 0; i < rest.length; i += 100) {
+      await notion(env, `blocks/${page.id}/children`, 'PATCH', { children: rest.slice(i, i + 100) }, UPLOAD_VERSION);
+    }
+    console.log(`Created Notion page: ${page.url}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(String(err.message || err));
+  process.exit(1);
+});

--- a/.claude/skills/mastrabowl-recap/scripts/revenue-image.mjs
+++ b/.claude/skills/mastrabowl-recap/scripts/revenue-image.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Pull the latest in-window revenue chart from the #revenue Slack channel.
+//
+// The PostHog "Subscription Revenue by Type" subscription posts a daily message
+// with the chart embedded as an `image` block (a signed PostHog exporter PNG —
+// no PostHog API key needed). This grabs the most recent in-window image and
+// saves it next to the recap for attaching to Notion.
+//
+// Window: Sunday -> day before today (same as the rest of the recap), unless
+// --from / --to (YYYY-MM-DD) are passed. Picks the newest image in the window.
+//
+// Reads SLACK_TOKEN and REVENUE_SLACK_ID from recap.env.
+// Usage:
+//   node scripts/revenue-image.mjs
+//   node scripts/revenue-image.mjs --from 2026-05-31 --to 2026-06-04
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENV_PATH = join(__dirname, '..', 'recap.env');
+const OUT_DIR = join(__dirname, '..');
+
+function loadEnv() {
+  const env = {};
+  let raw;
+  try {
+    raw = readFileSync(ENV_PATH, 'utf8');
+  } catch {
+    return env;
+  }
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) continue;
+    const i = t.indexOf('=');
+    if (i === -1) continue;
+    env[t.slice(0, i).trim()] = t.slice(i + 1).trim();
+  }
+  return env;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--from') args.from = argv[++i];
+    else if (argv[i] === '--to') args.to = argv[++i];
+  }
+  return args;
+}
+
+function defaultWindow() {
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const to = new Date(today);
+  to.setUTCDate(to.getUTCDate() - 1);
+  const from = new Date(today);
+  from.setUTCDate(from.getUTCDate() - today.getUTCDay());
+  const fmt = (d) => d.toISOString().slice(0, 10);
+  return { from: fmt(from), to: fmt(to) };
+}
+
+async function main() {
+  const env = loadEnv();
+  const token = env.SLACK_TOKEN;
+  const channel = env.REVENUE_SLACK_ID;
+  if (!token) throw new Error('SLACK_TOKEN missing in recap.env');
+  if (!channel) throw new Error('REVENUE_SLACK_ID missing in recap.env');
+
+  const cli = parseArgs(process.argv.slice(2));
+  const win = defaultWindow();
+  const from = cli.from || win.from;
+  const to = cli.to || win.to;
+
+  const oldest = Math.floor(Date.parse(`${from}T00:00:00Z`) / 1000);
+  const latest = Math.floor(Date.parse(`${to}T23:59:59Z`) / 1000);
+
+  console.error(`# Revenue image — week ${from} -> ${to} (channel ${channel})\n`);
+
+  const url = new URL('https://slack.com/api/conversations.history');
+  url.searchParams.set('channel', channel);
+  url.searchParams.set('oldest', String(oldest));
+  url.searchParams.set('latest', String(latest));
+  url.searchParams.set('inclusive', 'true');
+  url.searchParams.set('limit', '100');
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  const data = await res.json();
+  if (!data.ok) throw new Error(`conversations.history failed: ${data.error}`);
+
+  // messages are newest-first; take the first with a PostHog image block.
+  let imageUrl, viewUrl, ts;
+  for (const m of data.messages) {
+    const img = (m.blocks || []).find(
+      (b) => b.type === 'image' && /posthog/.test(b.image_url || ''),
+    );
+    if (img) {
+      imageUrl = img.image_url;
+      ts = m.ts;
+      const actions = (m.blocks || []).find((b) => b.type === 'actions');
+      viewUrl = actions?.elements?.find((e) => /View in PostHog/.test(e.text?.text || ''))?.url;
+      break;
+    }
+  }
+  if (!imageUrl) {
+    console.error('No PostHog revenue image found in the window.');
+    process.exit(1);
+  }
+
+  const date = new Date(Number(ts) * 1000).toISOString().slice(0, 10);
+  const imgRes = await fetch(imageUrl);
+  if (!imgRes.ok) throw new Error(`image download failed: ${imgRes.status}`);
+  const buf = Buffer.from(await imgRes.arrayBuffer());
+  const outPath = join(OUT_DIR, `revenue-${date}.png`);
+  writeFileSync(outPath, buf);
+
+  console.log(`Revenue chart date: ${date}`);
+  console.log(`Saved: ${outPath} (${buf.length} bytes)`);
+  if (viewUrl) console.log(`View in PostHog: ${viewUrl}`);
+}
+
+main().catch((err) => {
+  console.error(String(err.message || err));
+  process.exit(1);
+});

--- a/.claude/skills/mastrabowl-recap/scripts/road-to-london.mjs
+++ b/.claude/skills/mastrabowl-recap/scripts/road-to-london.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+// Road to London — bucket this week's merged PRs by AREA OF THE CODEBASE
+// (file paths), not labels (labels are incomplete/inconsistent).
+//
+// Window: Sunday -> day before today (same as the rest of the recap), unless
+// --from / --to (YYYY-MM-DD) are passed.
+//
+// Workstreams and the code areas that define them:
+//   LRA (Long Running Agents): signals / channels / events / notifications /
+//       background-tasks / memory  (PubSub, Signals, Memory)
+//   Observability: observability / telemetry / logger(s)  (OSS + platform)
+//   Agent Builder: agent-builder / editor / workspace
+//   Agent Learning (research phase): datasets / evals / relevance
+//   Framework: core agent/workflows/tools/loop/processors/etc (the rest of core)
+//   Platform: everything in mastra-ai/platform
+//
+// A PR is bucketed by the areas its changed files touch; it can appear in more
+// than one workstream if it spans areas. Anything in mastra-ai/mastra that
+// matches no specific area falls into Framework.
+//
+// Requires: gh CLI (authenticated).
+// Usage:
+//   node scripts/road-to-london.mjs
+//   node scripts/road-to-london.mjs --from 2026-05-31 --to 2026-06-04
+
+import { execFileSync } from 'node:child_process';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--from') args.from = argv[++i];
+    else if (argv[i] === '--to') args.to = argv[++i];
+  }
+  return args;
+}
+
+function defaultWindow() {
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const to = new Date(today);
+  to.setUTCDate(to.getUTCDate() - 1);
+  const from = new Date(today);
+  from.setUTCDate(from.getUTCDate() - today.getUTCDay());
+  const fmt = (d) => d.toISOString().slice(0, 10);
+  return { from: fmt(from), to: fmt(to) };
+}
+
+function gh(args) {
+  const out = execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  return out;
+}
+function ghJson(args) {
+  return JSON.parse(gh(args));
+}
+
+// Area matchers against changed-file paths (within mastra-ai/mastra).
+const AREAS = {
+  LRA: [
+    /^packages\/core\/src\/signals\//,
+    /^packages\/core\/src\/channels\//,
+    /^packages\/core\/src\/events\//,
+    /^packages\/core\/src\/notifications\//,
+    /^packages\/core\/src\/background-tasks\//,
+    /^packages\/core\/src\/memory\//,
+    /^packages\/memory\//,
+  ],
+  Observability: [
+    /^packages\/core\/src\/observability\//,
+    /^packages\/core\/src\/telemetry\//,
+    /^packages\/core\/src\/logger\//,
+    /^packages\/loggers\//,
+  ],
+  'Agent Builder': [
+    /^packages\/agent-builder\//,
+    /^packages\/core\/src\/agent-builder\//,
+    /^packages\/editor\//,
+    /^packages\/core\/src\/editor\//,
+    /^packages\/core\/src\/workspace\//,
+  ],
+  'Agent Learning': [
+    /^packages\/core\/src\/datasets\//,
+    /^packages\/evals\//,
+    /^packages\/core\/src\/evals\//,
+    /^packages\/core\/src\/relevance\//,
+  ],
+};
+
+// Skip release/chore/dependency noise — these aren't recap-worthy and they
+// touch many areas (so they pollute every bucket).
+function isNoise(title) {
+  return (
+    /^chore: version packages/i.test(title) ||
+    /^chore\(deps\)/i.test(title) ||
+    /^Turbo changes/i.test(title) ||
+    /update dependency/i.test(title) ||
+    /^ci\b|^chore\(ci\)/i.test(title)
+  );
+}
+
+function bucketsForFiles(files) {
+  const hit = new Set();
+  for (const [area, patterns] of Object.entries(AREAS)) {
+    if (files.some((f) => patterns.some((re) => re.test(f)))) hit.add(area);
+  }
+  // Framework = touched mastra-ai/mastra but matched no specific area above.
+  if (hit.size === 0) hit.add('Framework');
+  return hit;
+}
+
+async function mergedPRs(repo, from, to) {
+  // gh search predates this gh; use search/issues API for merged PRs in window.
+  // The search API caps at 100 results/page, so we MUST paginate or we silently
+  // truncate weeks with >100 merged PRs. Page until we've collected total_count.
+  const q = `repo:${repo} is:pr is:merged merged:${from}..${to}`;
+  const all = [];
+  let page = 1;
+  let total = Infinity;
+  while (all.length < total) {
+    const res = ghJson([
+      'api', '-X', 'GET', 'search/issues',
+      '-f', `q=${q}`,
+      '-f', 'per_page=100',
+      '-f', `page=${page}`,
+      '--jq', '{total_count, items: [.items[] | {number, title, url: .html_url}]}',
+    ]);
+    total = res.total_count;
+    all.push(...res.items);
+    if (res.items.length === 0) break; // safety: no more results
+    if (all.length >= 1000) break; // GitHub search hard cap
+    page++;
+  }
+  if (all.length < total) {
+    console.error(`  WARNING: ${repo} has ${total} merged PRs but only ${all.length} fetched (GitHub search 1000-result cap).`);
+  }
+  return all;
+}
+
+function changedFiles(repo, number) {
+  const files = ghJson([
+    'api', `repos/${repo}/pulls/${number}/files`, '--paginate',
+    '--jq', '[.[].filename]',
+  ]);
+  return files;
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const win = defaultWindow();
+  const from = cli.from || win.from;
+  const to = cli.to || win.to;
+
+  console.error(`# Road to London — merged PRs ${from} -> ${to} (bucketed by code area)\n`);
+
+  const buckets = {
+    LRA: [],
+    Framework: [],
+    Observability: [],
+    'Agent Learning': [],
+    Platform: [],
+    'Agent Builder': [],
+  };
+
+  // mastra-ai/mastra: bucket by file paths.
+  const mastraPRs = (await mergedPRs('mastra-ai/mastra', from, to)).filter((pr) => !isNoise(pr.title));
+  console.error(`mastra-ai/mastra: ${mastraPRs.length} merged PRs (noise filtered), fetching files...`);
+  for (const pr of mastraPRs) {
+    let files = [];
+    try {
+      files = changedFiles('mastra-ai/mastra', pr.number);
+    } catch {
+      files = [];
+    }
+    for (const area of bucketsForFiles(files)) {
+      buckets[area].push({ ...pr, repo: 'mastra-ai/mastra' });
+    }
+  }
+
+  // mastra-ai/platform: entire repo is the Platform workstream.
+  const platformPRs = (await mergedPRs('mastra-ai/platform', from, to)).filter((pr) => !isNoise(pr.title));
+  console.error(`mastra-ai/platform: ${platformPRs.length} merged PRs`);
+  for (const pr of platformPRs) {
+    buckets.Platform.push({ ...pr, repo: 'mastra-ai/platform' });
+    // Observability changes also surface in platform — flag by title heuristic.
+    if (/observ|telemetry|tracing|logg|mobs/i.test(pr.title)) {
+      buckets.Observability.push({ ...pr, repo: 'mastra-ai/platform' });
+    }
+  }
+
+  const order = ['LRA', 'Framework', 'Observability', 'Agent Learning', 'Platform', 'Agent Builder'];
+  for (const area of order) {
+    const prs = buckets[area];
+    console.log(`\n### ${area}  (${prs.length} PR${prs.length === 1 ? '' : 's'})`);
+    if (area === 'Agent Learning' && prs.length === 0) {
+      console.log('- (research phase — no merged PRs this week)');
+      continue;
+    }
+    if (prs.length === 0) {
+      console.log('- (no merged PRs this week)');
+      continue;
+    }
+    // Framework is the catch-all bucket and can be huge. Surface feats first
+    // and cap the listing so the recap stays readable (full count shown above).
+    let list = prs;
+    if (area === 'Framework') {
+      const isFeat = (t) => /^feat/i.test(t);
+      list = [...prs].sort((a, b) => Number(isFeat(b.title)) - Number(isFeat(a.title)));
+      const FEAT_CAP = 15;
+      if (list.length > FEAT_CAP) {
+        const shown = list.slice(0, FEAT_CAP);
+        for (const pr of shown) console.log(`- ${pr.title} (#${pr.number}) — ${pr.url}`);
+        console.log(`- …and ${list.length - FEAT_CAP} more framework PRs`);
+        continue;
+      }
+    }
+    for (const pr of list) {
+      console.log(`- ${pr.title} (#${pr.number}) — ${pr.url}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(String(err.stack || err.message || err));
+  process.exit(1);
+});

--- a/.claude/skills/mastrabowl-recap/scripts/slack-channel.mjs
+++ b/.claude/skills/mastrabowl-recap/scripts/slack-channel.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Dump a Slack channel's messages for the recap week as raw material for a
+// narrative section. Used for SALES (recap the deals) and CUSTOMER_ENG (recap
+// the customers) — channels that are freeform text, not article links.
+//
+// Window: Sunday -> day before today (same as the rest of the recap), unless
+// --from / --to (YYYY-MM-DD) are passed.
+//
+// Reads SLACK_TOKEN + <CHANNEL_KEY> from recap.env, where CHANNEL_KEY is the
+// env var name holding the channel id (e.g. SALES_SLACK_ID).
+//
+// Usage:
+//   node scripts/slack-channel.mjs SALES_SLACK_ID
+//   node scripts/slack-channel.mjs CUSTOMER_ENG_SLACK_ID --threads
+//   node scripts/slack-channel.mjs SALES_SLACK_ID --from 2026-05-31 --to 2026-06-04
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENV_PATH = join(__dirname, '..', 'recap.env');
+
+function loadEnv() {
+  const env = {};
+  let raw;
+  try {
+    raw = readFileSync(ENV_PATH, 'utf8');
+  } catch {
+    return env;
+  }
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) continue;
+    const i = t.indexOf('=');
+    if (i === -1) continue;
+    env[t.slice(0, i).trim()] = t.slice(i + 1).trim();
+  }
+  return env;
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--from') args.from = argv[++i];
+    else if (argv[i] === '--to') args.to = argv[++i];
+    else if (argv[i] === '--threads') args.threads = true;
+    else if (argv[i] === '--files') args.files = true;
+    else args._.push(argv[i]);
+  }
+  return args;
+}
+
+function defaultWindow() {
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const to = new Date(today);
+  to.setUTCDate(to.getUTCDate() - 1);
+  const from = new Date(today);
+  from.setUTCDate(from.getUTCDate() - today.getUTCDay());
+  const fmt = (d) => d.toISOString().slice(0, 10);
+  return { from: fmt(from), to: fmt(to) };
+}
+
+async function slack(method, token, params) {
+  const url = new URL(`https://slack.com/api/${method}`);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, String(v));
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  const data = await res.json();
+  if (!data.ok) throw new Error(`${method} failed: ${data.error}`);
+  return data;
+}
+
+async function main() {
+  const env = loadEnv();
+  const token = env.SLACK_TOKEN;
+  if (!token) throw new Error('SLACK_TOKEN missing in recap.env');
+
+  const cli = parseArgs(process.argv.slice(2));
+  const channelKey = cli._[0];
+  if (!channelKey) throw new Error('Provide a channel env key, e.g. SALES_SLACK_ID');
+  const channel = env[channelKey];
+  if (!channel) throw new Error(`${channelKey} missing in recap.env`);
+
+  const win = defaultWindow();
+  const from = cli.from || win.from;
+  const to = cli.to || win.to;
+  const oldest = Math.floor(Date.parse(`${from}T00:00:00Z`) / 1000);
+  const latest = Math.floor(Date.parse(`${to}T23:59:59Z`) / 1000);
+
+  console.error(`# ${channelKey} (${channel}) — week ${from} -> ${to}\n`);
+
+  let messages = [];
+  let cursor;
+  do {
+    const data = await slack('conversations.history', token, {
+      channel, oldest, latest, inclusive: true, limit: 200,
+      ...(cursor ? { cursor } : {}),
+    });
+    messages = messages.concat(data.messages || []);
+    cursor = data.response_metadata && data.response_metadata.next_cursor;
+  } while (cursor);
+
+  // Oldest-first reads better as a weekly log.
+  messages.reverse();
+
+  const printFiles = (files, indent) => {
+    for (const f of files || []) {
+      console.log(`${indent}FILE: ${f.mimetype} | ${f.name} | ${f.url_private}`);
+      // Reading file bytes requires the files:read scope on the token.
+      console.log(`${indent}  download: curl -sL "${f.url_private}" -H "Authorization: Bearer $SLACK_TOKEN" -o "${f.name}"`);
+    }
+  };
+
+  for (const m of messages) {
+    const date = new Date(Number(m.ts) * 1000).toISOString().slice(0, 10);
+    const reacts = (m.reactions || []).reduce((s, r) => s + (r.count || 0), 0);
+    const replies = m.reply_count || 0;
+    console.log(`--- ${date} [reacts:${reacts} replies:${replies}]`);
+    console.log((m.text || '').trim());
+    if (m.files) printFiles(m.files, '    ');
+
+    if ((cli.threads || cli.files) && replies > 0) {
+      const thread = await slack('conversations.replies', token, { channel, ts: m.ts });
+      for (const r of (thread.messages || []).slice(1)) {
+        if (cli.threads) console.log(`    ↳ ${(r.text || '').replace(/\n/g, ' ').trim()}`);
+        if (r.files) printFiles(r.files, '       ');
+      }
+    }
+    console.log('');
+  }
+}
+
+main().catch((err) => {
+  console.error(String(err.message || err));
+  process.exit(1);
+});

--- a/.claude/skills/mastrabowl-recap/template.md
+++ b/.claude/skills/mastrabowl-recap/template.md
@@ -1,0 +1,71 @@
+# Dear ____,
+
+[song]
+
+### Highlights
+
+- Agents Hour
+    - <youtube link>
+- Workshop
+    - <youtube link>
+- Weekly Demos
+    - <fireflies link>
+
+### Kindergarten
+
+- ?
+
+## Open Source
+
+<one-line narrative on momentum>
+
+!image.png
+
+**EoW ___ Issues Open | ___ PRs Open**
+
+- **___ PRs have been merged this week in mastra-ai/mastra**
+- **___ PRs merged this week in mastra-ai/platform**
+
+### Releases
+
+- ?
+
+#### Feature Announcements
+
+- ?
+
+## Road to London
+
+### LRA
+
+- ?
+
+### Framework
+
+- ?
+
+### Observability
+
+- ?
+
+### Agent Learning
+
+- ?
+
+### Platform
+
+- ?
+
+### Agent Builder
+
+- ?
+
+## Sales / Customer Engineering
+
+- ?
+
+## Product Revenue
+
+### **Peace ✌️**
+
+Abhi and Shane


### PR DESCRIPTION
## Summary

Adds a Claude skill (`.claude/skills/mastrabowl-recap/`) that automates the weekly **MastraBowl Recap** published to Notion every Friday. The recap aggregates data from many sources (GitHub, npm, Slack, PostHog, X) and assembling it by hand is slow. This skill scripts the data gathering and the Notion publishing so the manual effort is reduced to writing narrative, the greeting, and the song.

The skill is documented in `SKILL.md`, which maps each recap section to its data source and the script that produces it, and records the voice/style rules for the recap.

### Scripts

- `oss-stats.sh` — merged/open PR + issue counts and linked releases via `gh api`
- `download-chart.mjs` — `@mastra/core` weekly download chart (SVG) from the public npm API
- `road-to-london.mjs` — merged PRs bucketed by workstream using each PR's changed files (handles GitHub search pagination)
- `kindergarten.mjs` — ranks `#kindergarten` articles by engagement
- `revenue-image.mjs` — pulls the PostHog revenue chart image from `#revenue` Slack
- `slack-channel.mjs` — Sales/CE channel text and file attachments
- `publish-notion.mjs` — converts the markdown draft to Notion blocks, uploads and embeds local images via Notion's Direct File Upload API, embeds the Suno song, and parents the page to the database's data source (so it shows in the database view) with upsert-by-title to avoid duplicates

### Secret handling

No secrets are committed. Tokens, Slack channel IDs, the working draft, and the generated revenue/CE charts live in a gitignored `recap.env` and generated files. Only `recap.env.example` is committed, with **blank** values and documentation of the required scopes/IDs.

## Test plan

- Verified end-to-end publish to the recap Notion database: markdown → blocks, 3 images embedded via Direct File Upload, Suno song embed, page appears in the database view, re-running updates the same page in place (no duplicates).
- Confirmed staged files contain no tokens, channel IDs, customer names, or revenue figures; `.gitignore` covers `recap.env`, draft markdown, and the generated chart/report images.
- Confirmed the unrelated `pnpm-lock.yaml` change was excluded from the commit.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-8) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a collection of helper tools and scripts that automatically gather information from various places (like GitHub, Slack, and npm) and compile it into a weekly recap newsletter. Instead of manually collecting all the data, someone just needs to write a greeting and add a song—the scripts handle pulling the numbers, stats, and highlights from all the sources and publishing everything to Notion.

## Overview

Adds a complete Claude skill at `.claude/skills/mastrabowl-recap/` that automates the weekly MastraBowl Recap publication to Notion. The skill aggregates data from multiple sources (GitHub, npm, Slack, PostHog, and Twitter/X) with scripts that handle data gathering, while manual effort is limited to writing the greeting, narrative sections, and the song.

## Key Changes

### Documentation & Configuration
- **SKILL.md**: Comprehensive skill documentation detailing the weekly recap workflow, section structure (greeting, highlights, kindergarten links, open source stats, releases, road to London workstreams, sales/CE content, product revenue), required tooling (`gh`, `jq`, Node 18+), and publishing instructions via Notion.
- **template.md**: Week-in-review email template with placeholders for greeting, embedded content, and recap sections.
- **recap.env.example**: Example environment file documenting required Notion integration credentials (`NOTION_TOKEN`, `NOTION_DATABASE_ID`) and Slack channel IDs with guidance on setup.
- **.gitignore**: Excludes generated artifacts (`recap.env`, SVG charts, PNG images, `result.json`, draft markdown files).

### Data Gathering Scripts
- **oss-stats.sh**: Bash script that uses GitHub CLI to fetch merged/open PR and issue counts for `mastra-ai/mastra` and `mastra-ai/platform`, and retrieves linked releases within a configurable date window (defaults to 7 days).
- **download-chart.mjs**: Generates an SVG line chart of npm package weekly downloads, supporting configurable date windows (`--from`, `--to`) and output path (`--out`).
- **kindergarten.mjs**: Extracts and ranks `#kindergarten` Slack channel links by engagement (reactions + reply counts) within the recap week.
- **revenue-image.mjs**: Fetches the latest "Subscription Revenue by Type" PostHog chart image from `#revenue` Slack channel and saves it as PNG.
- **road-to-london.mjs**: Uses GitHub CLI to fetch merged PRs for both repositories, filters noise patterns, and buckets by engineering area (LRA, Observability, Agent Builder, Agent Learning, Framework, Platform) with intelligent file path matching and special handling for platform PRs.
- **slack-channel.mjs**: Retrieves and formats Slack channel messages with reaction counts, reply counts, file metadata, and optional thread content for a recap week window.

### Publishing
- **publish-notion.mjs**: Converts markdown draft to Notion blocks with support for headings, paragraphs, bulleted lists with nesting, `@embed` blocks, and `!image.png` image placeholders. Uploads images via Notion Direct File Upload API, handles page upsert-by-title (creates new or updates existing), batches block creation (100-child limit), and parents the page to the recap database.

## Secret Handling
No secrets are committed. All sensitive tokens (`NOTION_TOKEN`, `SLACK_TOKEN`) and environment-specific values (draft path, Slack channel IDs, Notion database ID) are stored in a gitignored `recap.env` file. A `recap.env.example` is committed with blank values and documentation for required scope/IDs.

## Testing
End-to-end workflow verified: markdown draft successfully converted to Notion blocks, three images uploaded via Direct File Upload API, Suno embed embedded, page created in database view, and rerun correctly updates the same page via upsert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->