### PR TITLE
fix(core): attach subscribers to active remote streams

### DIFF
--- a/.changeset/humble-sloths-lick.md
+++ b/.changeset/humble-sloths-lick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed thread subscribers so they can join an already-running remote stream and receive new output without waiting for the next run.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -2448,6 +2448,67 @@ describe('Agent signals', () => {
   );
 
   it.runIf(process.platform !== 'win32')(
+    'lets a remote subscriber join an already-active UnixSocketPubSub run',
+    async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'mastra-agent-late-subscriber-'));
+      const ownerPubSub = new UnixSocketPubSub(join(tempDir, 'signals.sock'));
+      const followerPubSub = new UnixSocketPubSub(join(tempDir, 'signals.sock'));
+      const ownerRuntime = new AgentThreadStreamRuntime();
+      const followerRuntime = new AgentThreadStreamRuntime();
+      const owner = { id: 'late-subscriber-agent' } as Agent<any, any, any, any>;
+      const follower = { id: 'late-subscriber-agent' } as Agent<any, any, any, any>;
+      const runId = 'late-subscriber-run';
+      let firstPartBroadcasted!: () => void;
+      let continueRun!: () => void;
+      let finishRun!: () => void;
+      const firstPart = new Promise<void>(resolve => (firstPartBroadcasted = resolve));
+      const continuePromise = new Promise<void>(resolve => (continueRun = resolve));
+      const finished = new Promise<void>(resolve => (finishRun = resolve));
+      const output = {
+        runId,
+        status: 'running',
+        fullStream: (async function* () {
+          yield { type: 'text-delta', runId, payload: { text: 'before subscriber' } };
+          firstPartBroadcasted();
+          await continuePromise;
+          yield { type: 'text-delta', runId, payload: { text: 'after subscriber' } };
+          yield { type: 'finish', runId, payload: {} };
+          finishRun();
+        })(),
+        _waitUntilFinished: () => finished,
+      } as any;
+
+      try {
+        ownerRuntime.registerRun(
+          owner,
+          output,
+          { runId, memory: { resource: 'late-subscriber-resource', thread: 'late-subscriber-thread' } } as any,
+          ownerPubSub,
+        );
+        await withTimeout(firstPart, 'Timed out waiting for owner run to start');
+
+        const followerSubscription = await followerRuntime.subscribeToThread(
+          follower,
+          { resourceId: 'late-subscriber-resource', threadId: 'late-subscriber-thread' },
+          followerPubSub,
+        );
+        const followerRun = readNextRun(followerSubscription.stream[Symbol.asyncIterator]());
+
+        continueRun();
+
+        await expect(withTimeout(followerRun, 'Timed out waiting for late subscriber')).resolves.toMatchObject({
+          value: { runId, text: 'after subscriber' },
+          done: false,
+        });
+        followerSubscription.unsubscribe();
+      } finally {
+        await Promise.allSettled([ownerPubSub.close(), followerPubSub.close()]);
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')(
     'broadcasts to a remote subscriber without a same-runtime subscriber',
     async () => {
       const tempDir = await mkdtemp(join(tmpdir(), 'mastra-agent-remote-only-'));

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -900,8 +900,16 @@ export class AgentThreadStreamRuntime {
       }
       if (data.type === 'stream-part') {
         if (data.sourceId === this.#id) return;
-        const remoteRun = remoteRuns.get(data.runId);
-        if (!remoteRun) return;
+        let remoteRun = remoteRuns.get(data.runId);
+        if (!remoteRun) {
+          // A subscriber can attach after another runtime already broadcast run-registered.
+          // Treat the first stream-part on this thread topic as proof of the remote run and
+          // create the local proxy stream from that point forward.
+          state.activeThreadRunIds.set(key, data.runId);
+          enqueueRun(createRemoteRun(data.runId));
+          remoteRun = remoteRuns.get(data.runId);
+          if (!remoteRun) return;
+        }
         remoteRun.parts.push(data.part);
         while (remoteRun.waiters.length) remoteRun.waiters.shift()?.();
         return;


### PR DESCRIPTION
This fixes thread subscriptions that attach after another runtime has already started streaming. Previously, if the subscriber missed the `run-registered` event, later `stream-part` events for that run were ignored until a new run started.

Before:

```ts
const remoteRun = remoteRuns.get(data.runId);
if (!remoteRun) return;
```

After:

```ts
let remoteRun = remoteRuns.get(data.runId);
if (!remoteRun) {
  enqueueRun(createRemoteRun(data.runId));
  remoteRun = remoteRuns.get(data.runId);
}
```

The subscriber now creates the local proxy stream from the first observed stream part on that thread topic, so it can receive new output from the active run. Added a regression test using UnixSocketPubSub because that covers the cross-runtime case.

Tested with:

```sh
pnpm vitest packages/core/src/agent/__tests__/agent-signals.test.ts --run -t "lets a remote subscriber join an already-active UnixSocketPubSub run" --reporter=dot
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Imagine a streaming conversation between two computers. If one computer tries to listen in after the conversation has already started, it used to miss everything because it didn't know the conversation existed. This PR fixes that by making the listener create a note about the conversation as soon as it hears the first message, so it can start receiving messages from that point forward instead of missing them all.

## Overview
This PR fixes an issue where thread subscribers that attach after a remote runtime has already begun streaming would miss subsequent stream events. The problem occurred when a subscriber joined after the `run-registered` event had been emitted—the runtime would return early when it couldn't find an existing remote run proxy, causing the subscriber to ignore all future stream parts for that run.

## Changes

### Core Fix
Modified `subscribeToThread`'s `stream-part` event handler in `packages/core/src/agent/thread-stream-runtime.ts` to support late-arriving subscribers. When a `stream-part` event arrives for a `runId` that doesn't yet have a remote-run proxy, the runtime now:
1. Creates a new remote-run proxy for that `runId` (instead of discarding the event)
2. Marks the thread as active for that run
3. Enqueues the run and buffers subsequent stream parts into the proxy

This allows subscribers to transparently join already-active runs and receive remaining stream content.

### Testing
Added a regression test in `packages/core/src/agent/__tests__/agent-signals.test.ts` that verifies a follower runtime joining an already-active `UnixSocketPubSub`-broadcast run correctly receives the remaining stream content. The test:
- Starts a temporary Unix socket pubsub
- Registers an owner run first
- Subscribes a follower runtime after the owner has begun streaming
- Asserts the follower receives only the remaining (post-subscription) stream parts
- Verifies proper cleanup of pubsubs and temporary directories

### Release
Updated changeset entry documenting a patch version bump for `@mastra/core` with a note that thread subscribers can now join already-running remote streams and receive new output without waiting for the next run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->