### PR TITLE
feat: add agent tool hooks

### DIFF
--- a/.changeset/all-bikes-sing.md
+++ b/.changeset/all-bikes-sing.md
@@ -1,5 +1,0 @@
----
-'mastracode': patch
----
-
-Fixed Mastra Code hooks so they now run for built-in workspace tools like file writes and shell commands.

--- a/.changeset/all-bikes-sing.md
+++ b/.changeset/all-bikes-sing.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed Mastra Code hooks so they now run for built-in workspace tools like file writes and shell commands.

--- a/.changeset/sweet-eels-chew.md
+++ b/.changeset/sweet-eels-chew.md
@@ -2,20 +2,32 @@
 '@mastra/core': minor
 ---
 
-Added a workspace tool wrapper for applications that need to wrap built-in workspace tools before they are exposed to agents.
+Added agent and workspace tool hooks for applications that need to run logic before and after tool calls execute.
 
 **Example**
 
 ```ts
+const agent = new Agent({
+  name: 'Support Agent',
+  instructions: 'Help users.',
+  model,
+  hooks: {
+    beforeToolCall: ({ toolName, input }) => {
+      console.log(`Running ${toolName}`, input);
+    },
+    afterToolCall: ({ toolName, output, error }) => {
+      console.log(`Finished ${toolName}`, { output, error });
+    },
+  },
+});
+
 const workspace = new Workspace({
   tools: {
-    toolWrapper: (tool, { toolName, workspaceToolName }) => ({
-      ...(tool as object),
-      execute: async (input, context) => {
-        console.log(`Running ${toolName} from ${workspaceToolName}`);
-        return (tool as any).execute(input, context);
+    hooks: {
+      beforeToolCall: ({ toolName, workspaceToolName, input }) => {
+        console.log(`Running ${toolName} from ${workspaceToolName}`, input);
       },
-    }),
+    },
   },
 });
 ```

--- a/.changeset/sweet-eels-chew.md
+++ b/.changeset/sweet-eels-chew.md
@@ -9,7 +9,7 @@ Added a workspace tool wrapper for applications that need to wrap built-in works
 ```ts
 const workspace = new Workspace({
   tools: {
-    wrapTool: (tool, { toolName, workspaceToolName }) => ({
+    toolWrapper: (tool, { toolName, workspaceToolName }) => ({
       ...(tool as object),
       execute: async (input, context) => {
         console.log(`Running ${toolName} from ${workspaceToolName}`);

--- a/.changeset/sweet-eels-chew.md
+++ b/.changeset/sweet-eels-chew.md
@@ -1,8 +1,9 @@
 ---
 '@mastra/core': minor
+'mastracode': patch
 ---
 
-Added agent and workspace tool hooks for applications that need to run logic before and after tool calls execute.
+Added agent and workspace tool hooks for applications that need to run logic before and after tool calls execute. Mastra Code now uses agent hooks so hook handlers run for built-in workspace tools as well as dynamic tools.
 
 **Example**
 

--- a/.changeset/sweet-eels-chew.md
+++ b/.changeset/sweet-eels-chew.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': minor
+---
+
+Added a workspace tool wrapper for applications that need to wrap built-in workspace tools before they are exposed to agents.
+
+**Example**
+
+```ts
+const workspace = new Workspace({
+  tools: {
+    wrapTool: (tool, { toolName, workspaceToolName }) => ({
+      ...(tool as object),
+      execute: async (input, context) => {
+        console.log(`Running ${toolName} from ${workspaceToolName}`);
+        return (tool as any).execute(input, context);
+      },
+    }),
+  },
+});
+```

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -168,6 +168,7 @@ vi.mock('./agents/subagents/plan.js', () => ({
 
 vi.mock('./agents/tools.js', () => ({
   createDynamicTools: vi.fn(),
+  createToolHooks: vi.fn(),
 }));
 
 vi.mock('./agents/workspace.js', () => ({

--- a/mastracode/src/agents/__tests__/workspace-env.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-env.test.ts
@@ -49,33 +49,4 @@ describe('mastracode workspace sandbox environment', () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
-
-  it('runs hooks around workspace tool execution', async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-workspace-hooks-'));
-
-    try {
-      const input = { path: 'hook.txt', content: 'ok' };
-      const hookManager = {
-        runPreToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
-        runPostToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
-      };
-      const [{ createWorkspaceTools }, { getDynamicWorkspace }] = await Promise.all([
-        import('@mastra/core/workspace'),
-        import('../workspace.js'),
-      ]);
-      const workspace = getDynamicWorkspace({
-        requestContext: createRequestContext(tempDir) as any,
-        hookManager: hookManager as any,
-      });
-      const tools = await createWorkspaceTools(workspace);
-
-      const output = await tools.write_file.execute(input, { workspace });
-
-      expect(output).toContain('Wrote 2 bytes to hook.txt');
-      expect(hookManager.runPreToolUse).toHaveBeenCalledWith('write_file', input);
-      expect(hookManager.runPostToolUse).toHaveBeenCalledWith('write_file', input, output, false);
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
-  });
 });

--- a/mastracode/src/agents/__tests__/workspace-env.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-env.test.ts
@@ -1,6 +1,9 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { Agent } from '@mastra/core/agent';
+import { RequestContext } from '@mastra/core/request-context';
+import { MastraLanguageModelV2Mock } from '@mastra/core/test-utils/llm-mock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../onboarding/settings.js', () => ({
@@ -13,18 +16,26 @@ vi.mock('../../onboarding/settings.js', () => ({
 const originalEnv = { ...process.env };
 
 function createRequestContext(projectPath: string) {
-  return {
-    get: (key: string) =>
-      key === 'harness'
-        ? {
-            modeId: 'build',
-            getState: () => ({
-              projectPath,
-              sandboxAllowedPaths: [],
-            }),
-          }
-        : undefined,
-  };
+  const requestContext = new RequestContext();
+  requestContext.set('harness', {
+    modeId: 'build',
+    getState: () => ({
+      projectPath,
+      sandboxAllowedPaths: [],
+    }),
+  });
+  return requestContext;
+}
+
+function toStream(chunks: any[]) {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
 }
 
 afterEach(() => {
@@ -45,6 +56,96 @@ describe('mastracode workspace sandbox environment', () => {
 
       expect(result.success).toBe(true);
       expect(result.stdout.trim()).toBe('works');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('runs hook manager around workspace tools through agent hooks', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-workspace-hooks-'));
+
+    try {
+      const { getDynamicWorkspace } = await import('../workspace.js');
+      const { createToolHooks } = await import('../tools.js');
+      const requestContext = createRequestContext(tempDir) as any;
+      const hookManager = {
+        runPreToolUse: vi.fn(async () => ({ allowed: true })),
+        runPostToolUse: vi.fn(async () => undefined),
+      };
+      let callCount = 0;
+      await fs.writeFile(path.join(tempDir, 'hooked.txt'), 'original');
+      const workspace = getDynamicWorkspace({ requestContext });
+      const agent = new Agent({
+        id: 'mc-workspace-hook-agent',
+        name: 'MC Workspace Hook Agent',
+        instructions: 'You are a test agent.',
+        model: new MastraLanguageModelV2Mock({
+          doStream: async () => {
+            callCount++;
+            if (callCount === 1) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                warnings: [],
+                stream: toStream([
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'response-metadata', id: 'id-0', modelId: 'mock', timestamp: new Date(0) },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolCallType: 'function',
+                    toolName: 'write_file',
+                    input: JSON.stringify({ path: 'hooked.txt', content: 'hooked', overwrite: true }),
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'tool-calls',
+                    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                  },
+                ]),
+              };
+            }
+
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              warnings: [],
+              stream: toStream([
+                { type: 'stream-start', warnings: [] },
+                { type: 'response-metadata', id: 'id-1', modelId: 'mock', timestamp: new Date(0) },
+                { type: 'text-start', id: 'text-1' },
+                { type: 'text-delta', id: 'text-1', delta: 'Done.' },
+                { type: 'text-end', id: 'text-1' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                },
+              ]),
+            };
+          },
+        }) as any,
+        workspace,
+        hooks: createToolHooks(hookManager as any),
+      });
+
+      const result = await agent.stream('Write hooked.txt', { requestContext });
+      const chunks: any[] = [];
+      for await (const chunk of result.fullStream) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(hookManager.runPreToolUse).toHaveBeenCalledWith('write_file', {
+        path: 'hooked.txt',
+        content: 'hooked',
+        overwrite: true,
+      });
+      expect(hookManager.runPostToolUse).toHaveBeenCalledWith(
+        'write_file',
+        { path: 'hooked.txt', content: 'hooked', overwrite: true },
+        expect.anything(),
+        false,
+      );
+      await expect(fs.readFile(path.join(tempDir, 'hooked.txt'), 'utf8')).resolves.toBe('hooked');
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/mastracode/src/agents/__tests__/workspace-env.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-env.test.ts
@@ -49,4 +49,33 @@ describe('mastracode workspace sandbox environment', () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('runs hooks around workspace tool execution', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-workspace-hooks-'));
+
+    try {
+      const input = { path: 'hook.txt', content: 'ok' };
+      const hookManager = {
+        runPreToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
+        runPostToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
+      };
+      const [{ createWorkspaceTools }, { getDynamicWorkspace }] = await Promise.all([
+        import('@mastra/core/workspace'),
+        import('../workspace.js'),
+      ]);
+      const workspace = getDynamicWorkspace({
+        requestContext: createRequestContext(tempDir) as any,
+        hookManager: hookManager as any,
+      });
+      const tools = await createWorkspaceTools(workspace);
+
+      const output = await tools.write_file.execute(input, { workspace });
+
+      expect(output).toContain('Wrote 2 bytes to hook.txt');
+      expect(hookManager.runPreToolUse).toHaveBeenCalledWith('write_file', input);
+      expect(hookManager.runPostToolUse).toHaveBeenCalledWith('write_file', input, output, false);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/mastracode/src/agents/extra-tools.test.ts
+++ b/mastracode/src/agents/extra-tools.test.ts
@@ -147,7 +147,7 @@ describe('createDynamicTools – extraTools', () => {
     const storage = {
       getStore: vi.fn(async (name: string) => (name === 'notifications' ? notificationStore : undefined)),
     };
-    const getDynamicTools = createDynamicTools(undefined, undefined, undefined, undefined, storage as any);
+    const getDynamicTools = createDynamicTools(undefined, undefined, undefined, storage as any);
     const tools = getDynamicTools({ requestContext: makeRequestContext() });
 
     expect(tools).toHaveProperty(MC_TOOLS.NOTIFICATION_INBOX);
@@ -262,7 +262,7 @@ describe('createDynamicTools – disabledTools filtering', () => {
     const unfilteredTools = createDynamicTools()({ requestContext: makeRequestContext() });
     expect(unfilteredTools).toHaveProperty('request_access');
 
-    const getDynamicTools = createDynamicTools(undefined, undefined, undefined, ['request_access']);
+    const getDynamicTools = createDynamicTools(undefined, undefined, ['request_access']);
 
     const tools = getDynamicTools({ requestContext: makeRequestContext() });
     expect(tools).not.toHaveProperty('request_access');
@@ -278,7 +278,7 @@ describe('createDynamicTools – disabledTools filtering', () => {
       execute: async () => ({ result: 'custom' }),
     });
 
-    const getDynamicTools = createDynamicTools(undefined, { my_tool: myTool }, undefined, ['my_tool']);
+    const getDynamicTools = createDynamicTools(undefined, { my_tool: myTool }, ['my_tool']);
     const tools = getDynamicTools({ requestContext: makeRequestContext() });
     expect(tools).not.toHaveProperty('my_tool');
   });

--- a/mastracode/src/agents/tools.test.ts
+++ b/mastracode/src/agents/tools.test.ts
@@ -7,7 +7,7 @@ vi.mock('../tools/index.js', () => ({
   requestSandboxAccessTool: { description: 'request sandbox access' },
 }));
 
-import { createDynamicTools } from './tools.js';
+import { createDynamicTools, createToolHooks } from './tools.js';
 
 function createRequestContext(state: Record<string, unknown>, modeId: string = 'build') {
   return {
@@ -41,42 +41,26 @@ describe('createDynamicTools', () => {
     });
     expect(allowedTools.custom_tool).toBeDefined();
   });
+});
 
-  it('runs pre/post hooks around tool execution', async () => {
-    const execute = vi.fn(async () => ({ ok: true }));
+describe('createToolHooks', () => {
+  it('maps PreToolUse and PostToolUse hook manager calls to agent tool hooks', async () => {
     const hookManager = {
       runPreToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
       runPostToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
     };
-
-    const getDynamicTools = createDynamicTools(
-      undefined,
-      {
-        custom_tool: {
-          description: 'custom',
-          execute,
-        },
-      },
-      hookManager as any,
-    );
-
-    const tools = getDynamicTools({
-      requestContext: createRequestContext({
-        projectPath: process.cwd(),
-      }),
-    });
-
+    const hooks = createToolHooks(hookManager as any)!;
     const input = { foo: 'bar' };
-    const output = await tools.custom_tool.execute(input, {});
+    const output = { ok: true };
 
-    expect(output).toEqual({ ok: true });
-    expect(execute).toHaveBeenCalledWith(input, {});
+    await hooks.beforeToolCall?.({ toolName: 'custom_tool', input, context: {} });
+    await hooks.afterToolCall?.({ toolName: 'custom_tool', input, context: {}, output });
+
     expect(hookManager.runPreToolUse).toHaveBeenCalledWith('custom_tool', input);
-    expect(hookManager.runPostToolUse).toHaveBeenCalledWith('custom_tool', input, { ok: true }, false);
+    expect(hookManager.runPostToolUse).toHaveBeenCalledWith('custom_tool', input, output, false);
   });
 
   it('blocks tool execution when PreToolUse denies access', async () => {
-    const execute = vi.fn(async () => ({ ok: true }));
     const hookManager = {
       runPreToolUse: vi.fn(async () => ({
         allowed: false,
@@ -86,57 +70,29 @@ describe('createDynamicTools', () => {
       })),
       runPostToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
     };
+    const hooks = createToolHooks(hookManager as any)!;
 
-    const getDynamicTools = createDynamicTools(
-      undefined,
-      {
-        custom_tool: {
-          description: 'custom',
-          execute,
-        },
-      },
-      hookManager as any,
-    );
-
-    const tools = getDynamicTools({
-      requestContext: createRequestContext({
-        projectPath: process.cwd(),
-      }),
-    });
-
-    const result = await tools.custom_tool.execute({ foo: 'bar' }, {});
-    expect(result).toEqual({ error: 'blocked by policy' });
-    expect(execute).not.toHaveBeenCalled();
+    const result = await hooks.beforeToolCall?.({ toolName: 'custom_tool', input: { foo: 'bar' }, context: {} });
+    expect(result).toEqual({ proceed: false, output: { error: 'blocked by policy' } });
     expect(hookManager.runPostToolUse).not.toHaveBeenCalled();
   });
 
-  it('still runs PostToolUse when tool execution throws', async () => {
-    const execute = vi.fn(async () => {
-      throw new Error('boom');
-    });
+  it('records errors in PostToolUse hook calls', async () => {
     const hookManager = {
       runPreToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
       runPostToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
     };
+    const hooks = createToolHooks(hookManager as any)!;
+    const input = { foo: 'bar' };
 
-    const getDynamicTools = createDynamicTools(
-      undefined,
-      {
-        custom_tool: {
-          description: 'custom',
-          execute,
-        },
-      },
-      hookManager as any,
-    );
-
-    const tools = getDynamicTools({
-      requestContext: createRequestContext({
-        projectPath: process.cwd(),
-      }),
+    await hooks.afterToolCall?.({
+      toolName: 'custom_tool',
+      input,
+      context: {},
+      output: undefined,
+      error: new Error('boom'),
     });
 
-    await expect(tools.custom_tool.execute({ foo: 'bar' }, {})).rejects.toThrow('boom');
-    expect(hookManager.runPostToolUse).toHaveBeenCalledWith('custom_tool', { foo: 'bar' }, { error: 'boom' }, true);
+    expect(hookManager.runPostToolUse).toHaveBeenCalledWith('custom_tool', input, { error: 'boom' }, true);
   });
 });

--- a/mastracode/src/agents/tools.ts
+++ b/mastracode/src/agents/tools.ts
@@ -17,7 +17,7 @@ import { MC_TOOLS } from '../tool-names.js';
 import { createWebSearchTool, createWebExtractTool, hasTavilyKey, requestSandboxAccessTool } from '../tools';
 
 /** Minimal shape for tools passed to createDynamicTools. */
-type ToolLike = {
+export type ToolLike = {
   execute?: (...args: any[]) => Promise<unknown> | unknown;
 } & Record<string, any>;
 
@@ -59,7 +59,7 @@ class LazyNotificationsStorage extends NotificationsStorage {
   }
 }
 
-function wrapToolWithHooks(toolName: string, tool: ToolLike, hookManager?: HookManager): ToolLike {
+export function wrapToolWithHooks(toolName: string, tool: ToolLike, hookManager?: HookManager): ToolLike {
   if (!hookManager || typeof tool?.execute !== 'function') {
     return tool;
   }

--- a/mastracode/src/agents/tools.ts
+++ b/mastracode/src/agents/tools.ts
@@ -10,6 +10,7 @@ import type {
 } from '@mastra/core/notifications';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { MastraCompositeStore } from '@mastra/core/storage';
+import type { ToolHooks } from '@mastra/core/tools';
 import type { HookManager } from '../hooks';
 import type { McpManager } from '../mcp';
 import type { MastraCodeState } from '../schema';
@@ -59,35 +60,30 @@ class LazyNotificationsStorage extends NotificationsStorage {
   }
 }
 
-export function wrapToolWithHooks(toolName: string, tool: ToolLike, hookManager?: HookManager): ToolLike {
-  if (!hookManager || typeof tool?.execute !== 'function') {
-    return tool;
-  }
+export function createToolHooks(hookManager?: HookManager): ToolHooks | undefined {
+  if (!hookManager) return undefined;
 
   return {
-    ...tool,
-    async execute(input: unknown, toolContext: unknown) {
+    beforeToolCall: async ({ toolName, input }) => {
       const preResult = await hookManager.runPreToolUse(toolName, input);
       if (!preResult.allowed) {
         return {
-          error: preResult.blockReason ?? `Blocked by PreToolUse hook for tool "${toolName}"`,
+          proceed: false as const,
+          output: {
+            error: preResult.blockReason ?? `Blocked by PreToolUse hook for tool "${toolName}"`,
+          },
         };
       }
-
-      let output: unknown;
-      let toolError = false;
-      try {
-        output = await tool.execute?.(input, toolContext);
-        return output;
-      } catch (error) {
-        toolError = true;
-        output = {
-          error: error instanceof Error ? error.message : String(error),
-        };
-        throw error;
-      } finally {
-        await hookManager.runPostToolUse(toolName, input, output, toolError).catch(() => undefined);
-      }
+    },
+    afterToolCall: async ({ toolName, input, output, error }) => {
+      await hookManager
+        .runPostToolUse(
+          toolName,
+          input,
+          error ? { error: error instanceof Error ? error.message : String(error) } : output,
+          Boolean(error),
+        )
+        .catch(() => undefined);
     },
   };
 }
@@ -95,7 +91,6 @@ export function wrapToolWithHooks(toolName: string, tool: ToolLike, hookManager?
 export function createDynamicTools(
   mcpManager?: McpManager,
   extraTools?: Record<string, ToolLike> | ((ctx: { requestContext: RequestContext }) => Record<string, ToolLike>),
-  hookManager?: HookManager,
   disabledTools?: string[],
   storage?: MastraCompositeStore,
 ) {
@@ -160,10 +155,6 @@ export function createDynamicTools(
           delete tools[name];
         }
       }
-    }
-
-    for (const [toolName, tool] of Object.entries(tools)) {
-      tools[toolName] = wrapToolWithHooks(toolName, tool, hookManager);
     }
 
     return tools;

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -165,7 +165,7 @@ export function getDynamicWorkspace({
     ...(isPlanMode ? { ...TOOL_NAME_OVERRIDES, ...planModeTools } : TOOL_NAME_OVERRIDES),
     ...(hookManager
       ? {
-          wrapTool: (tool, { toolName }) => wrapToolWithHooks(toolName, tool as any, hookManager),
+          toolWrapper: (tool, { toolName }) => wrapToolWithHooks(toolName, tool as any, hookManager),
         }
       : {}),
   };

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -6,11 +6,13 @@ import type { HarnessRequestContext } from '@mastra/core/harness';
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
 import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
-import type { LSPConfig } from '@mastra/core/workspace';
+import type { LSPConfig, WorkspaceToolsConfig } from '@mastra/core/workspace';
 import { DEFAULT_CONFIG_DIR } from '../constants.js';
+import type { HookManager } from '../hooks';
 import { loadSettings } from '../onboarding/settings.js';
 import type { MastraCodeState } from '../schema';
 import { TOOL_NAME_OVERRIDES } from '../tool-names.js';
+import { wrapToolWithHooks } from './tools.js';
 
 // =============================================================================
 // Sandbox Environment
@@ -127,7 +129,15 @@ function detectPackageRunner(projectPath: string): string | undefined {
   return 'npx --yes';
 }
 
-export function getDynamicWorkspace({ requestContext, mastra }: { requestContext: RequestContext; mastra?: Mastra }) {
+export function getDynamicWorkspace({
+  requestContext,
+  mastra,
+  hookManager,
+}: {
+  requestContext: RequestContext;
+  mastra?: Mastra;
+  hookManager?: HookManager;
+}) {
   const ctx = requestContext.get('harness') as HarnessRequestContext<MastraCodeState> | undefined;
   const state = ctx?.getState();
   const modeId = ctx?.modeId ?? 'build';
@@ -151,6 +161,15 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
     mastra_workspace_ast_edit: { ...TOOL_NAME_OVERRIDES.mastra_workspace_ast_edit, enabled: false },
   };
 
+  const workspaceTools: WorkspaceToolsConfig = {
+    ...(isPlanMode ? { ...TOOL_NAME_OVERRIDES, ...planModeTools } : TOOL_NAME_OVERRIDES),
+    ...(hookManager
+      ? {
+          wrapTool: (tool, { toolName }) => wrapToolWithHooks(toolName, tool as any, hookManager),
+        }
+      : {}),
+  };
+
   // Reuse existing workspace if already registered (preserves ProcessManager state)
   let existing: Workspace<LocalFilesystem, LocalSandbox> | undefined;
   try {
@@ -161,7 +180,7 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
 
   if (existing) {
     existing.filesystem.setAllowedPaths(allowedPaths);
-    existing.setToolsConfig(isPlanMode ? { ...TOOL_NAME_OVERRIDES, ...planModeTools } : TOOL_NAME_OVERRIDES);
+    existing.setToolsConfig(workspaceTools);
     return existing;
   }
 
@@ -185,7 +204,7 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
       workingDirectory: projectPath,
       env: buildSandboxEnv(),
     }),
-    tools: isPlanMode ? { ...TOOL_NAME_OVERRIDES, ...planModeTools } : TOOL_NAME_OVERRIDES,
+    tools: workspaceTools,
     ...(skillPaths.length > 0 ? { skills: skillPaths } : {}),
     lsp: lspConfig,
   });

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -8,11 +8,9 @@ import type { RequestContext } from '@mastra/core/request-context';
 import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
 import type { LSPConfig, WorkspaceToolsConfig } from '@mastra/core/workspace';
 import { DEFAULT_CONFIG_DIR } from '../constants.js';
-import type { HookManager } from '../hooks';
 import { loadSettings } from '../onboarding/settings.js';
 import type { MastraCodeState } from '../schema';
 import { TOOL_NAME_OVERRIDES } from '../tool-names.js';
-import { wrapToolWithHooks } from './tools.js';
 
 // =============================================================================
 // Sandbox Environment
@@ -129,15 +127,7 @@ function detectPackageRunner(projectPath: string): string | undefined {
   return 'npx --yes';
 }
 
-export function getDynamicWorkspace({
-  requestContext,
-  mastra,
-  hookManager,
-}: {
-  requestContext: RequestContext;
-  mastra?: Mastra;
-  hookManager?: HookManager;
-}) {
+export function getDynamicWorkspace({ requestContext, mastra }: { requestContext: RequestContext; mastra?: Mastra }) {
   const ctx = requestContext.get('harness') as HarnessRequestContext<MastraCodeState> | undefined;
   const state = ctx?.getState();
   const modeId = ctx?.modeId ?? 'build';
@@ -163,11 +153,6 @@ export function getDynamicWorkspace({
 
   const workspaceTools: WorkspaceToolsConfig = {
     ...(isPlanMode ? { ...TOOL_NAME_OVERRIDES, ...planModeTools } : TOOL_NAME_OVERRIDES),
-    ...(hookManager
-      ? {
-          toolWrapper: (tool, { toolName }) => wrapToolWithHooks(toolName, tool as any, hookManager),
-        }
-      : {}),
   };
 
   // Reuse existing workspace if already registered (preserves ProcessManager state)

--- a/mastracode/src/index.test.ts
+++ b/mastracode/src/index.test.ts
@@ -46,7 +46,7 @@ vi.mock('./agents/model.js', () => ({
 vi.mock('./agents/subagents/execute.js', () => ({ executeSubagent: {} }));
 vi.mock('./agents/subagents/explore.js', () => ({ exploreSubagent: {} }));
 vi.mock('./agents/subagents/plan.js', () => ({ planSubagent: {} }));
-vi.mock('./agents/tools.js', () => ({ createDynamicTools: vi.fn() }));
+vi.mock('./agents/tools.js', () => ({ createDynamicTools: vi.fn(), createToolHooks: vi.fn() }));
 vi.mock('./agents/workspace.js', () => ({ getDynamicWorkspace: vi.fn() }));
 
 vi.mock('./auth/storage.js', () => ({

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -46,7 +46,7 @@ import { executeSubagent } from './agents/subagents/execute.js';
 import { exploreSubagent } from './agents/subagents/explore.js';
 import { planSubagent } from './agents/subagents/plan.js';
 import { attachOMThreadStatePersistence, restoreOMThreadStateForCurrentThread } from './agents/thread-caveman-state.js';
-import { createDynamicTools } from './agents/tools.js';
+import { createDynamicTools, createToolHooks } from './agents/tools.js';
 
 import { getDynamicWorkspace } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
@@ -451,7 +451,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     name: 'Code Agent',
     instructions: getDynamicInstructions,
     model: getDynamicModel,
-    tools: createDynamicTools(mcpManager, config?.extraTools, hookManager, config?.disabledTools, storage),
+    tools: createDynamicTools(mcpManager, config?.extraTools, config?.disabledTools, storage),
+    hooks: createToolHooks(hookManager),
     scorers: {
       outcome: {
         scorer: outcomeScorer,
@@ -715,7 +716,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       // with MCP/hooks/storage which were already initialized with this value.
       configDir,
     },
-    workspace: config?.workspace ?? (args => getDynamicWorkspace({ ...args, hookManager })),
+    workspace: config?.workspace ?? (args => getDynamicWorkspace(args)),
     browser: config?.browser,
     modes,
     heartbeatHandlers,

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -715,7 +715,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       // with MCP/hooks/storage which were already initialized with this value.
       configDir,
     },
-    workspace: config?.workspace ?? getDynamicWorkspace,
+    workspace: config?.workspace ?? (args => getDynamicWorkspace({ ...args, hookManager })),
     browser: config?.browser,
     modes,
     heartbeatHandlers,

--- a/packages/core/src/agent/__tests__/tools.test.ts
+++ b/packages/core/src/agent/__tests__/tools.test.ts
@@ -188,6 +188,137 @@ function toolsTest(version: 'v1' | 'v2' | 'v3') {
       expect(message).toBe('Executed successfully');
     });
 
+    it('runs agent hooks through the public generate path', async () => {
+      const calls: Array<{ phase: 'before' | 'after'; toolName: string; input: unknown; output?: unknown }> = [];
+      const testAgent = new Agent({
+        id: 'test-agent',
+        name: 'Test agent',
+        instructions: 'You are an agent that calls testTool',
+        model: mockModel,
+        tools: integration.getStaticTools(),
+        hooks: {
+          beforeToolCall: ({ toolName, input }) => calls.push({ phase: 'before', toolName, input }),
+          afterToolCall: ({ toolName, input, output }) => calls.push({ phase: 'after', toolName, input, output }),
+        },
+      });
+
+      const mastra = new Mastra({
+        agents: {
+          testAgent,
+        },
+        logger: false,
+      });
+      const agentOne = mastra.getAgent('testAgent');
+
+      if (version === 'v1') {
+        await agentOne.generateLegacy('Call testTool', { toolChoice: 'required' });
+      } else {
+        await agentOne.generate('Call testTool');
+      }
+
+      expect(calls.slice(0, 2)).toEqual([
+        { phase: 'before', toolName: 'testTool', input: {} },
+        {
+          phase: 'after',
+          toolName: 'testTool',
+          input: {},
+          output: { message: 'Executed successfully' },
+        },
+      ]);
+    });
+
+    it('uses per-execution hooks through the public generate path', async () => {
+      const configBeforeToolCall = vi.fn();
+      const runBeforeToolCall = vi.fn(() => ({ proceed: false as const, output: { message: 'blocked' } }));
+      const execute = vi.fn(async () => ({ message: 'executed' }));
+      const testTool = createTool({
+        id: 'testTool',
+        description: 'Test tool',
+        inputSchema: z.object({}),
+        execute,
+      });
+      const testAgent = new Agent({
+        id: 'test-agent',
+        name: 'Test agent',
+        instructions: 'You are an agent that calls testTool',
+        model: mockModel,
+        tools: { testTool },
+        hooks: { beforeToolCall: configBeforeToolCall },
+      });
+      const mastra = new Mastra({
+        agents: {
+          testAgent,
+        },
+        logger: false,
+      });
+      const agentOne = mastra.getAgent('testAgent');
+
+      let toolResult;
+      if (version === 'v1') {
+        const response = await agentOne.generateLegacy('Call testTool', {
+          toolChoice: 'required',
+          hooks: {
+            beforeToolCall: runBeforeToolCall,
+          },
+        });
+        toolResult = response.toolResults.find((result: any) => result.toolName === 'testTool');
+      } else {
+        const response = await agentOne.generate('Call testTool', {
+          hooks: {
+            beforeToolCall: runBeforeToolCall,
+          },
+        });
+        toolResult = response.toolResults.find((result: any) => result.payload.toolName === 'testTool')?.payload;
+      }
+
+      expect(toolResult?.result?.message).toBe('blocked');
+      expect(configBeforeToolCall).not.toHaveBeenCalled();
+      expect(runBeforeToolCall).toHaveBeenCalledWith(expect.objectContaining({ toolName: 'testTool', input: {} }));
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('runs afterToolCall when a tool errors', async () => {
+      const afterToolCall = vi.fn();
+      const testTool = createTool({
+        id: 'testTool',
+        description: 'Test tool',
+        inputSchema: z.object({}),
+        execute: async () => {
+          throw new Error('tool failed');
+        },
+      });
+      const testAgent = new Agent({
+        id: 'test-agent',
+        name: 'Test agent',
+        instructions: 'You are an agent that calls testTool',
+        model: mockModel,
+        tools: { testTool },
+        hooks: { afterToolCall },
+      });
+      const mastra = new Mastra({
+        agents: {
+          testAgent,
+        },
+        logger: false,
+      });
+      const agentOne = mastra.getAgent('testAgent');
+
+      if (version === 'v1') {
+        await agentOne.generateLegacy('Call testTool', { toolChoice: 'required' }).catch(() => undefined);
+      } else {
+        await agentOne.generate('Call testTool').catch(() => undefined);
+      }
+
+      expect(afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: 'testTool',
+          input: {},
+          output: undefined,
+          error: expect.any(Error),
+        }),
+      );
+    });
+
     it('should call findUserTool with parameters', async () => {
       // Create a new mock model for this test that calls findUserTool
       let findUserToolModel: MockLanguageModelV1 | MockLanguageModelV2 | MockLanguageModelV3;

--- a/packages/core/src/agent/__tests__/tools.test.ts
+++ b/packages/core/src/agent/__tests__/tools.test.ts
@@ -1435,6 +1435,85 @@ describe('requireApproval property preservation', () => {
     // can evaluate it per call instead of falling back to the boolean flag.
     expect((tools.transferFunds as any).needsApprovalFn).toBe(needsApprovalFn);
   });
+
+  it('runs configured hooks around agent tool execution', async () => {
+    const calls: Array<{ phase: string; toolName: string; input: unknown; output?: unknown }> = [];
+    const testTool = createTool({
+      id: 'test-tool',
+      description: 'Test tool',
+      inputSchema: z.object({ value: z.string() }),
+      execute: async ({ value }) => ({ value }),
+    });
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent for hooks',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          content: [{ type: 'text', text: 'ok' }],
+          warnings: [],
+        }),
+      }),
+      tools: { testTool },
+      hooks: {
+        beforeToolCall: ({ toolName, input }) => calls.push({ phase: 'before', toolName, input }),
+        afterToolCall: ({ toolName, input, output }) => calls.push({ phase: 'after', toolName, input, output }),
+      },
+    });
+
+    const tools = await agent['convertTools']({
+      requestContext: new RequestContext(),
+      methodType: 'generate',
+    });
+    const input = { value: 'ok' };
+    const output = await tools.testTool.execute?.(input, {} as any);
+
+    expect(output).toEqual({ value: 'ok' });
+    expect(calls).toEqual([
+      { phase: 'before', toolName: 'testTool', input },
+      { phase: 'after', toolName: 'testTool', input, output: { value: 'ok' } },
+    ]);
+  });
+
+  it('allows per-execution hooks to short-circuit agent tool execution', async () => {
+    const execute = vi.fn(async () => ({ value: 'executed' }));
+    const testTool = createTool({
+      id: 'test-tool',
+      description: 'Test tool',
+      inputSchema: z.object({ value: z.string() }),
+      execute,
+    });
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent for hooks',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          content: [{ type: 'text', text: 'ok' }],
+          warnings: [],
+        }),
+      }),
+      tools: { testTool },
+    });
+
+    const tools = await agent['convertTools']({
+      requestContext: new RequestContext(),
+      methodType: 'generate',
+      hooks: {
+        beforeToolCall: () => ({ proceed: false, output: { value: 'blocked' } }),
+      },
+    });
+    const output = await tools.testTool.execute?.({ value: 'ok' }, {} as any);
+
+    expect(output).toEqual({ value: 'blocked' });
+    expect(execute).not.toHaveBeenCalled();
+  });
 });
 
 describe('sub-agent prompt input normalization (GitHub #14154)', () => {

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -32,7 +32,7 @@ import {
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors/index';
 import { RequestContext, MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';
 import type { ChunkType } from '../stream/types';
-import type { CoreTool } from '../tools/types';
+import type { CoreTool, ToolHooks } from '../tools/types';
 import type { DynamicArgument } from '../types';
 import type { OutputWriter } from '../workflows';
 import { MessageList } from './message-list';
@@ -105,6 +105,7 @@ export interface AgentLegacyCapabilities {
       methodType: AgentMethodType;
       memoryConfig?: MemoryConfigInternal;
       inputProcessors?: InputProcessorOrWorkflow[];
+      hooks?: ToolHooks;
     } & ObservabilityContext,
   ): Promise<Record<string, CoreTool>>;
 
@@ -246,6 +247,7 @@ export class AgentLegacyHandler {
     tracingOptions,
     inputProcessors,
     providerOptions,
+    hooks,
     ...rest
   }: {
     instructions: AgentInstructions;
@@ -263,6 +265,7 @@ export class AgentLegacyHandler {
     tracingOptions?: TracingOptions;
     inputProcessors?: InputProcessorOrWorkflow[];
     providerOptions?: ProviderOptions;
+    hooks?: ToolHooks;
   } & Partial<ObservabilityContext>) {
     const observabilityContext = resolveObservabilityContext(rest);
     return {
@@ -314,6 +317,7 @@ export class AgentLegacyHandler {
           methodType: methodType === 'generate' ? 'generateLegacy' : 'streamLegacy',
           memoryConfig,
           inputProcessors,
+          hooks,
         });
 
         let messageList = new MessageList({
@@ -729,6 +733,7 @@ export class AgentLegacyHandler {
     messages: MessageListInput,
     options: (AgentGenerateOptions<Output, ExperimentalOutput> | AgentStreamOptions<Output, ExperimentalOutput>) & {
       writableStream?: WritableStream<ChunkType>;
+      hooks?: ToolHooks;
     } & Record<string, any>,
     methodType: 'generate' | 'stream',
   ): Promise<{
@@ -774,6 +779,7 @@ export class AgentLegacyHandler {
       savePerStep,
       writableStream,
       inputProcessors,
+      hooks,
       ...args
     } = options;
 
@@ -830,6 +836,7 @@ export class AgentLegacyHandler {
       tracingOptions,
       inputProcessors,
       providerOptions: args.providerOptions,
+      hooks,
       ...resolveObservabilityContext(args as Partial<ObservabilityContext>),
     });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -84,7 +84,13 @@ import { createTool } from '../tools';
 import { normalizeToolPayloadTransformPolicy } from '../tools/payload-transform';
 import type { ToolToConvert } from '../tools/tool-builder/builder';
 import { isMastraTool, isProviderTool } from '../tools/toolchecks';
-import type { CoreTool, McpMetadata, ToolPayloadTransformPolicy } from '../tools/types';
+import type {
+  CoreTool,
+  MastraToolInvocationOptions,
+  McpMetadata,
+  ToolHooks,
+  ToolPayloadTransformPolicy,
+} from '../tools/types';
 import type { DynamicArgument } from '../types';
 import { makeCoreTool, createMastraProxy, ensureToolProperties, deepMerge } from '../utils';
 import type { ToolOptions } from '../utils';
@@ -348,6 +354,7 @@ export class Agent<
   #defaultOptions: DynamicArgument<AgentExecutionOptions<TOutput>, TRequestContext>;
   #defaultNetworkOptions: DynamicArgument<NetworkOptions, TRequestContext>;
   #tools: DynamicArgument<TTools, TRequestContext>;
+  #hooks?: ToolHooks;
   #scorers: DynamicArgument<MastraScorers, TRequestContext>;
   #agents: DynamicArgument<Record<string, SubAgent<string, TRequestContext>>, TRequestContext>;
   #voice: DynamicArgument<MastraVoice, TRequestContext>;
@@ -467,6 +474,7 @@ export class Agent<
     );
 
     this.#tools = config.tools || ({} as TTools);
+    this.#hooks = config.hooks;
     this.#pubsub = config.pubsub;
 
     if (config.mastra) {
@@ -5201,6 +5209,7 @@ export class Agent<
     requestContext?: RequestContext;
     memoryConfig?: MemoryConfig;
     autoResumeSuspendedTools?: boolean;
+    hooks?: ToolHooks;
   }): Promise<Record<string, CoreTool>> {
     const requestContext = options.requestContext ?? new RequestContext();
     return this.convertTools({
@@ -5228,6 +5237,7 @@ export class Agent<
     delegation,
     backgroundTaskEnabled,
     inputProcessors,
+    hooks,
     ...rest
   }: {
     toolsets?: ToolsetsInput;
@@ -5243,6 +5253,7 @@ export class Agent<
     delegation?: DelegationConfig;
     backgroundTaskEnabled?: boolean;
     inputProcessors?: InputProcessorOrWorkflow[];
+    hooks?: ToolHooks;
   } & Partial<ObservabilityContext>): Promise<Record<string, CoreTool>> {
     const observabilityContext = resolveObservabilityContext(rest);
     let mastraProxy = undefined;
@@ -5395,7 +5406,58 @@ export class Agent<
       ...browserTools,
       ...inputProcessorLoadedTools,
     };
-    return this.formatTools(allTools);
+
+    const formattedTools = this.formatTools(allTools);
+    return this.wrapToolsWithHooks(formattedTools, this.resolveToolHooks(hooks));
+  }
+
+  private resolveToolHooks(runHooks?: ToolHooks): ToolHooks | undefined {
+    if (!this.#hooks) return runHooks;
+    if (!runHooks) return this.#hooks;
+
+    return deepMerge(this.#hooks as Record<string, unknown>, runHooks as Record<string, unknown>) as ToolHooks;
+  }
+
+  private wrapToolsWithHooks(tools: Record<string, CoreTool>, hooks?: ToolHooks): Record<string, CoreTool> {
+    if (!hooks?.beforeToolCall && !hooks?.afterToolCall) return tools;
+
+    return Object.fromEntries(
+      Object.entries(tools).map(([toolName, tool]) => [toolName, this.wrapToolWithHooks(toolName, tool, hooks)]),
+    );
+  }
+
+  private wrapToolWithHooks(toolName: string, tool: CoreTool, hooks: ToolHooks): CoreTool {
+    if (typeof tool.execute !== 'function') return tool;
+
+    return {
+      ...tool,
+      execute: async (input: unknown, context: MastraToolInvocationOptions) => {
+        const hookContext = {
+          toolName,
+          input,
+          context,
+          metadata: {
+            agentId: this.id,
+            agentName: this.name,
+          },
+        };
+        const beforeResult = await hooks.beforeToolCall?.(hookContext);
+        if (beforeResult?.proceed === false) {
+          return beforeResult.output;
+        }
+
+        let output: unknown;
+        try {
+          output = await tool.execute!(input, context);
+        } catch (error) {
+          await hooks.afterToolCall?.({ ...hookContext, output, error });
+          throw error;
+        }
+
+        await hooks.afterToolCall?.({ ...hookContext, output });
+        return output;
+      },
+    };
   }
 
   /**

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -9,7 +9,7 @@ import type { VersionOverrides } from '../mastra/types';
 import type { ObservabilityContext, TracingOptions } from '../observability';
 import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
 import type { RequestContext } from '../request-context';
-import type { RequireToolApproval, ToolPayloadTransformPolicy } from '../tools';
+import type { RequireToolApproval, ToolHooks, ToolPayloadTransformPolicy } from '../tools';
 import type { OutputWriter, WorkflowRunState } from '../workflows/types';
 import type { MessageListInput } from './message-list';
 import type {
@@ -523,6 +523,8 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
   toolsets?: ToolsetsInput;
   /** Client-side tools available during execution */
   clientTools?: ToolsInput;
+  /** Per-execution hooks that run before and after tool calls. */
+  hooks?: ToolHooks;
   /** Tool selection strategy: 'auto', 'none', 'required', or specific tools */
   toolChoice?: ToolChoice<any>;
 

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -523,7 +523,7 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
   toolsets?: ToolsetsInput;
   /** Client-side tools available during execution */
   clientTools?: ToolsInput;
-  /** Per-execution hooks that run before and after tool calls. */
+  /** Per-execution hooks that run before and after tool calls, overriding matching agent-level hooks. */
   hooks?: ToolHooks;
   /** Tool selection strategy: 'auto', 'none', 'required', or specific tools */
   toolChoice?: ToolChoice<any>;

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -8,7 +8,7 @@ import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow, ErrorProcesso
 import type { ProcessorState } from '../../processors/runner';
 import { RequestContext, MASTRA_VERSIONS_KEY, mergeVersionOverrides } from '../../request-context';
 import type { VersionOverrides } from '../../request-context';
-import type { CoreTool } from '../../tools/types';
+import type { CoreTool, ToolHooks } from '../../tools/types';
 import type { Workspace } from '../../workspace';
 import type { Agent } from '../agent';
 import type { AgentExecutionOptions } from '../agent.types';
@@ -43,6 +43,7 @@ interface DurablePreparationAgent {
     requestContext?: RequestContext;
     memoryConfig?: MemoryConfig;
     autoResumeSuspendedTools?: boolean;
+    hooks?: ToolHooks;
   }): Promise<Record<string, CoreTool>>;
   listInputProcessors(requestContext?: RequestContext): Promise<InputProcessorOrWorkflow[]>;
   listOutputProcessors(requestContext?: RequestContext): Promise<OutputProcessorOrWorkflow[]>;
@@ -255,6 +256,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
       requestContext,
       memoryConfig: execOptions?.memory?.options,
       autoResumeSuspendedTools: execOptions?.autoResumeSuspendedTools,
+      hooks: execOptions?.hooks,
     });
   } catch (error) {
     logger?.warn?.(`[DurableAgent] Error converting tools: ${error}`);

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -460,6 +460,8 @@ interface AgentConfigBase<
   tools?: DynamicArgument<TTools, TRequestContext>;
   /**
    * Hooks that run before and after any tool call made by this agent.
+   * Per-execution hooks passed to `generate`, `stream`, `generateLegacy`, or `streamLegacy` override matching hooks here.
+   * If a workspace also defines tool hooks, workspace hooks wrap the workspace tool first, then agent hooks wrap the exposed tool call.
    */
   hooks?: ToolHooks;
   /**
@@ -711,6 +713,8 @@ export type AgentGenerateOptions<
   /** Additional tool sets that can be used for this generation */
   toolsets?: ToolsetsInput;
   clientTools?: ToolsInput;
+  /** Per-execution hooks that run before and after tool calls, overriding matching agent-level hooks. */
+  hooks?: ToolHooks;
   /** Additional context messages to include */
   context?: CoreMessage[];
   /** New memory options (preferred) */
@@ -802,6 +806,8 @@ export type AgentStreamOptions<
   /** Additional tool sets that can be used for this generation */
   toolsets?: ToolsetsInput;
   clientTools?: ToolsInput;
+  /** Per-execution hooks that run before and after tool calls, overriding matching agent-level hooks. */
+  hooks?: ToolHooks;
   /** Additional context messages to include */
   context?: CoreMessage[];
   /**

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -50,7 +50,7 @@ import type { PublicSchema, StandardSchemaWithJSON } from '../schema';
 import type { SignalProvider } from '../signals/signal-provider';
 import type { MastraModelOutput } from '../stream/base/output';
 import type { AgentChunkType, MastraOnFinishCallbackArgs, ModelManagerModelConfig } from '../stream/types';
-import type { ToolAction, VercelTool, VercelToolV5 } from '../tools';
+import type { ToolAction, ToolHooks, VercelTool, VercelToolV5 } from '../tools';
 import type { ToolPayloadTransformPolicy } from '../tools/types';
 import type { DynamicArgument } from '../types';
 import type { MastraVoice } from '../voice';
@@ -458,6 +458,10 @@ interface AgentConfigBase<
    * Tools that the agent can access. Can be provided statically or resolved dynamically.
    */
   tools?: DynamicArgument<TTools, TRequestContext>;
+  /**
+   * Hooks that run before and after any tool call made by this agent.
+   */
+  hooks?: ToolHooks;
   /**
    * Workflows that the agent can execute. Can be static or dynamically resolved.
    */

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-tools-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-tools-step.ts
@@ -57,6 +57,7 @@ export function createPrepareToolsStep<OUTPUT = undefined>({
         delegation: options.delegation,
         backgroundTaskEnabled,
         inputProcessors: options.inputProcessors,
+        hooks: options.hooks,
       });
 
       // Update the agent span with available tool names for observability

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -80,6 +80,51 @@ export type NeedsApprovalContext = {
  */
 export type NeedsApprovalFn = (input: any, ctx?: NeedsApprovalContext) => boolean | Promise<boolean>;
 
+export interface ToolHookContext<
+  TInput = unknown,
+  TContext = unknown,
+  TMetadata extends Record<string, unknown> = Record<string, unknown>,
+> {
+  /** The name exposed to the model for this tool call. */
+  toolName: string;
+  /** Input passed to the tool. */
+  input: TInput;
+  /** Execution context passed to the tool. */
+  context: TContext;
+  /** Optional adapter-specific metadata. */
+  metadata?: TMetadata;
+}
+
+export interface ToolBeforeHookResult<TOutput = unknown> {
+  /** Set to false to skip the tool execution and return `output` instead. */
+  proceed: false;
+  output: TOutput;
+}
+
+export interface ToolAfterHookContext<
+  TInput = unknown,
+  TOutput = unknown,
+  TContext = unknown,
+  TMetadata extends Record<string, unknown> = Record<string, unknown>,
+> extends ToolHookContext<TInput, TContext, TMetadata> {
+  /** Tool output when execution completed. */
+  output: TOutput;
+  /** Error thrown by the tool, if execution failed. */
+  error?: unknown;
+}
+
+export interface ToolHooks<
+  TInput = unknown,
+  TOutput = unknown,
+  TContext = unknown,
+  TMetadata extends Record<string, unknown> = Record<string, unknown>,
+> {
+  beforeToolCall?: (
+    context: ToolHookContext<TInput, TContext, TMetadata>,
+  ) => void | ToolBeforeHookResult<TOutput> | Promise<void | ToolBeforeHookResult<TOutput>>;
+  afterToolCall?: (context: ToolAfterHookContext<TInput, TOutput, TContext, TMetadata>) => void | Promise<void>;
+}
+
 export type ToolPayloadTransformTarget = 'display' | 'transcript';
 
 export type ToolPayloadTransformPhase =

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -107,8 +107,8 @@ export interface ToolAfterHookContext<
   TContext = unknown,
   TMetadata extends Record<string, unknown> = Record<string, unknown>,
 > extends ToolHookContext<TInput, TContext, TMetadata> {
-  /** Tool output when execution completed. */
-  output: TOutput;
+  /** Tool output when execution completed. Undefined when execution failed before producing output. */
+  output?: TOutput;
   /** Error thrown by the tool, if execution failed. */
   error?: unknown;
 }

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -40,6 +40,8 @@ export {
   type ToolConfigContext,
   type ToolConfigWithArgsContext,
   type DynamicToolConfigValue,
+  type WorkspaceToolWrapper,
+  type WorkspaceToolWrapperContext,
   type ResolvedToolConfig,
   // Individual standalone tools
   readFileTool,

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -40,8 +40,10 @@ export {
   type ToolConfigContext,
   type ToolConfigWithArgsContext,
   type DynamicToolConfigValue,
-  type WorkspaceToolWrapper,
-  type WorkspaceToolWrapperContext,
+  type WorkspaceToolHookContext,
+  type WorkspaceToolBeforeHookResult,
+  type WorkspaceToolAfterHookContext,
+  type WorkspaceToolHooks,
   type ResolvedToolConfig,
   // Individual standalone tools
   readFileTool,

--- a/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
@@ -243,7 +243,7 @@ describe('createWorkspaceTools', () => {
       const workspace = new Workspace({
         filesystem: new LocalFilesystem({ basePath: tempDir }),
         tools: {
-          wrapTool: (tool, context) => ({
+          toolWrapper: (tool, context) => ({
             ...(tool as any),
             execute: async (input: unknown, toolContext: unknown) => {
               calls.push(context);

--- a/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
@@ -236,6 +236,32 @@ describe('createWorkspaceTools', () => {
     });
   });
 
+  describe('tool wrapping', () => {
+    it('should wrap tools using the exposed tool name and original workspace tool name', async () => {
+      await fs.writeFile(path.join(tempDir, 'hello.txt'), 'hello');
+      const calls: Array<{ toolName: string; workspaceToolName: string }> = [];
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        tools: {
+          wrapTool: (tool, context) => ({
+            ...(tool as any),
+            execute: async (input: unknown, toolContext: unknown) => {
+              calls.push(context);
+              return (tool as any).execute(input, toolContext);
+            },
+          }),
+          mastra_workspace_read_file: { name: 'view' },
+        },
+      });
+      const tools = await createWorkspaceTools(workspace);
+
+      const result = await tools['view'].execute({ path: 'hello.txt' }, { workspace });
+
+      expect(result).toContain('hello');
+      expect(calls).toEqual([{ toolName: 'view', workspaceToolName: WORKSPACE_TOOLS.FILESYSTEM.READ_FILE }]);
+    });
+  });
+
   describe('background process tools', () => {
     it('should register process tools when sandbox has processes (LocalSandbox)', async () => {
       const workspace = new Workspace({

--- a/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
@@ -236,20 +236,29 @@ describe('createWorkspaceTools', () => {
     });
   });
 
-  describe('tool wrapping', () => {
-    it('should wrap tools using the exposed tool name and original workspace tool name', async () => {
+  describe('tool hooks', () => {
+    it('should run hooks using the exposed tool name and original workspace tool name', async () => {
       await fs.writeFile(path.join(tempDir, 'hello.txt'), 'hello');
-      const calls: Array<{ toolName: string; workspaceToolName: string }> = [];
+      const calls: Array<{ phase: 'before' | 'after'; toolName: string; workspaceToolName: string }> = [];
       const workspace = new Workspace({
         filesystem: new LocalFilesystem({ basePath: tempDir }),
         tools: {
-          toolWrapper: (tool, context) => ({
-            ...(tool as any),
-            execute: async (input: unknown, toolContext: unknown) => {
-              calls.push(context);
-              return (tool as any).execute(input, toolContext);
+          hooks: {
+            beforeToolCall: context => {
+              calls.push({
+                phase: 'before',
+                toolName: context.toolName,
+                workspaceToolName: context.workspaceToolName,
+              });
             },
-          }),
+            afterToolCall: context => {
+              calls.push({
+                phase: 'after',
+                toolName: context.toolName,
+                workspaceToolName: context.workspaceToolName,
+              });
+            },
+          },
           mastra_workspace_read_file: { name: 'view' },
         },
       });
@@ -258,7 +267,26 @@ describe('createWorkspaceTools', () => {
       const result = await tools['view'].execute({ path: 'hello.txt' }, { workspace });
 
       expect(result).toContain('hello');
-      expect(calls).toEqual([{ toolName: 'view', workspaceToolName: WORKSPACE_TOOLS.FILESYSTEM.READ_FILE }]);
+      expect(calls).toEqual([
+        { phase: 'before', toolName: 'view', workspaceToolName: WORKSPACE_TOOLS.FILESYSTEM.READ_FILE },
+        { phase: 'after', toolName: 'view', workspaceToolName: WORKSPACE_TOOLS.FILESYSTEM.READ_FILE },
+      ]);
+    });
+
+    it('should allow beforeToolCall to skip tool execution with an output', async () => {
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        tools: {
+          hooks: {
+            beforeToolCall: () => ({ proceed: false, output: 'blocked' }),
+          },
+        },
+      });
+      const tools = await createWorkspaceTools(workspace);
+
+      const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'missing.txt' }, { workspace });
+
+      expect(result).toBe('blocked');
     });
   });
 

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -108,7 +108,7 @@ export interface ResolvedToolConfig {
   requireReadBeforeWrite?: DynamicToolConfigValue<ToolConfigWithArgsContext>;
   maxOutputTokens?: number;
   name?: string;
-  wrapTool?: WorkspaceToolWrapper;
+  toolWrapper?: WorkspaceToolWrapper;
 }
 
 /**
@@ -133,7 +133,7 @@ export async function resolveToolConfig(
   let requireReadBeforeWrite: DynamicToolConfigValue<ToolConfigWithArgsContext> | undefined;
   let maxOutputTokens: number | undefined;
   let name: string | undefined;
-  const wrapTool = toolsConfig?.wrapTool;
+  const toolWrapper = toolsConfig?.toolWrapper;
 
   if (toolsConfig) {
     if (toolsConfig.enabled !== undefined) {
@@ -166,7 +166,7 @@ export async function resolveToolConfig(
   // Resolve `enabled` now (tool-listing time) — safe default: false (fail-closed)
   const resolvedEnabled = await resolveDynamicValue(enabled, context, false);
 
-  return { enabled: resolvedEnabled, requireApproval, requireReadBeforeWrite, maxOutputTokens, name, wrapTool };
+  return { enabled: resolvedEnabled, requireApproval, requireReadBeforeWrite, maxOutputTokens, name, toolWrapper };
 }
 
 // ---------------------------------------------------------------------------
@@ -427,8 +427,8 @@ export async function createWorkspaceTools(
       wrapped = { ...wrapped, id: exposedName };
     }
 
-    if (config.wrapTool) {
-      wrapped = config.wrapTool(wrapped, { toolName: exposedName, workspaceToolName: name });
+    if (config.toolWrapper) {
+      wrapped = config.toolWrapper(wrapped, { toolName: exposedName, workspaceToolName: name });
     }
 
     // Write lock is outermost — serializes the entire enriched execute pipeline

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -35,6 +35,7 @@ import type {
   DynamicToolConfigValue,
   ToolConfigContext,
   ToolConfigWithArgsContext,
+  WorkspaceToolWrapper,
 } from './types';
 export type {
   WorkspaceToolConfig,
@@ -46,6 +47,8 @@ export type {
   ToolConfigContext,
   ToolConfigWithArgsContext,
   DynamicToolConfigValue,
+  WorkspaceToolWrapper,
+  WorkspaceToolWrapperContext,
 } from './types';
 import { writeFileTool } from './write-file';
 
@@ -105,6 +108,7 @@ export interface ResolvedToolConfig {
   requireReadBeforeWrite?: DynamicToolConfigValue<ToolConfigWithArgsContext>;
   maxOutputTokens?: number;
   name?: string;
+  wrapTool?: WorkspaceToolWrapper;
 }
 
 /**
@@ -129,6 +133,7 @@ export async function resolveToolConfig(
   let requireReadBeforeWrite: DynamicToolConfigValue<ToolConfigWithArgsContext> | undefined;
   let maxOutputTokens: number | undefined;
   let name: string | undefined;
+  const wrapTool = toolsConfig?.wrapTool;
 
   if (toolsConfig) {
     if (toolsConfig.enabled !== undefined) {
@@ -161,7 +166,7 @@ export async function resolveToolConfig(
   // Resolve `enabled` now (tool-listing time) — safe default: false (fail-closed)
   const resolvedEnabled = await resolveDynamicValue(enabled, context, false);
 
-  return { enabled: resolvedEnabled, requireApproval, requireReadBeforeWrite, maxOutputTokens, name };
+  return { enabled: resolvedEnabled, requireApproval, requireReadBeforeWrite, maxOutputTokens, name, wrapTool };
 }
 
 // ---------------------------------------------------------------------------
@@ -407,11 +412,6 @@ export async function createWorkspaceTools(
       wrapped = wrapTool(wrapped, workspace, opts?.targets ?? {});
     }
 
-    // Write lock is outermost — serializes the entire enriched execute pipeline
-    if (opts?.useWriteLock) {
-      wrapped = wrapWithWriteLock(wrapped, writeLock);
-    }
-
     // Use custom name if provided, otherwise use the default constant name
     const exposedName = config.name ?? name;
     if (tools[exposedName]) {
@@ -426,6 +426,16 @@ export async function createWorkspaceTools(
     if (exposedName !== name && 'id' in wrapped) {
       wrapped = { ...wrapped, id: exposedName };
     }
+
+    if (config.wrapTool) {
+      wrapped = config.wrapTool(wrapped, { toolName: exposedName, workspaceToolName: name });
+    }
+
+    // Write lock is outermost — serializes the entire enriched execute pipeline
+    if (opts?.useWriteLock) {
+      wrapped = wrapWithWriteLock(wrapped, writeLock);
+    }
+
     tools[exposedName] = wrapped;
   };
 

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -35,7 +35,7 @@ import type {
   DynamicToolConfigValue,
   ToolConfigContext,
   ToolConfigWithArgsContext,
-  WorkspaceToolWrapper,
+  WorkspaceToolHooks,
 } from './types';
 export type {
   WorkspaceToolConfig,
@@ -47,8 +47,10 @@ export type {
   ToolConfigContext,
   ToolConfigWithArgsContext,
   DynamicToolConfigValue,
-  WorkspaceToolWrapper,
-  WorkspaceToolWrapperContext,
+  WorkspaceToolHookContext,
+  WorkspaceToolBeforeHookResult,
+  WorkspaceToolAfterHookContext,
+  WorkspaceToolHooks,
 } from './types';
 import { writeFileTool } from './write-file';
 
@@ -108,7 +110,7 @@ export interface ResolvedToolConfig {
   requireReadBeforeWrite?: DynamicToolConfigValue<ToolConfigWithArgsContext>;
   maxOutputTokens?: number;
   name?: string;
-  toolWrapper?: WorkspaceToolWrapper;
+  hooks?: WorkspaceToolHooks;
 }
 
 /**
@@ -133,7 +135,7 @@ export async function resolveToolConfig(
   let requireReadBeforeWrite: DynamicToolConfigValue<ToolConfigWithArgsContext> | undefined;
   let maxOutputTokens: number | undefined;
   let name: string | undefined;
-  const toolWrapper = toolsConfig?.toolWrapper;
+  const hooks = toolsConfig?.hooks;
 
   if (toolsConfig) {
     if (toolsConfig.enabled !== undefined) {
@@ -166,7 +168,7 @@ export async function resolveToolConfig(
   // Resolve `enabled` now (tool-listing time) — safe default: false (fail-closed)
   const resolvedEnabled = await resolveDynamicValue(enabled, context, false);
 
-  return { enabled: resolvedEnabled, requireApproval, requireReadBeforeWrite, maxOutputTokens, name, toolWrapper };
+  return { enabled: resolvedEnabled, requireApproval, requireReadBeforeWrite, maxOutputTokens, name, hooks };
 }
 
 // ---------------------------------------------------------------------------
@@ -318,6 +320,35 @@ function wrapWithReadTracker(
  * read-before-write checks) so concurrent calls to the same path
  * run one at a time.
  */
+function wrapWithToolHooks(
+  tool: any,
+  hooks: WorkspaceToolHooks,
+  toolName: string,
+  workspaceToolName: WorkspaceToolName,
+): any {
+  return {
+    ...tool,
+    execute: async (input: any, context: any = {}) => {
+      const hookContext = { toolName, workspaceToolName, input, context };
+      const beforeResult = await hooks.beforeToolCall?.(hookContext);
+      if (beforeResult?.proceed === false) {
+        return beforeResult.output;
+      }
+
+      let output: unknown;
+      try {
+        output = await tool.execute(input, context);
+      } catch (error) {
+        await hooks.afterToolCall?.({ ...hookContext, output, error });
+        throw error;
+      }
+
+      await hooks.afterToolCall?.({ ...hookContext, output });
+      return output;
+    },
+  };
+}
+
 function wrapWithWriteLock(tool: any, writeLock: FileWriteLock): any {
   return {
     ...tool,
@@ -427,8 +458,8 @@ export async function createWorkspaceTools(
       wrapped = { ...wrapped, id: exposedName };
     }
 
-    if (config.toolWrapper) {
-      wrapped = config.toolWrapper(wrapped, { toolName: exposedName, workspaceToolName: name });
+    if (config.hooks) {
+      wrapped = wrapWithToolHooks(wrapped, config.hooks, exposedName, name);
     }
 
     // Write lock is outermost — serializes the entire enriched execute pipeline

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -55,14 +55,36 @@ export type DynamicToolConfigValue<TContext = ToolConfigContext> =
   | boolean
   | ((context: TContext) => boolean | Promise<boolean>);
 
-export interface WorkspaceToolWrapperContext {
+export interface WorkspaceToolHookContext {
   /** The name exposed to the model after any per-tool `name` remap. */
   toolName: string;
   /** The built-in workspace tool name before any `name` remap. */
   workspaceToolName: WorkspaceToolName;
+  /** Input passed to the tool. */
+  input: unknown;
+  /** Execution context passed to the tool. */
+  context: unknown;
 }
 
-export type WorkspaceToolWrapper = (tool: unknown, context: WorkspaceToolWrapperContext) => unknown;
+export interface WorkspaceToolBeforeHookResult {
+  /** Set to false to skip the tool execution and return `output` instead. */
+  proceed: false;
+  output: unknown;
+}
+
+export interface WorkspaceToolAfterHookContext extends WorkspaceToolHookContext {
+  /** Tool output when execution completed. */
+  output: unknown;
+  /** Error thrown by the tool, if execution failed. */
+  error?: unknown;
+}
+
+export interface WorkspaceToolHooks {
+  beforeToolCall?: (
+    context: WorkspaceToolHookContext,
+  ) => void | WorkspaceToolBeforeHookResult | Promise<void | WorkspaceToolBeforeHookResult>;
+  afterToolCall?: (context: WorkspaceToolAfterHookContext) => void | Promise<void>;
+}
 
 // =============================================================================
 // Tool Configuration Types
@@ -274,8 +296,8 @@ export type WorkspaceToolsConfig = {
   /** Default: whether all tools require user approval (default: false if not specified) */
   requireApproval?: DynamicToolConfigValue<ToolConfigWithArgsContext>;
 
-  /** Optional wrapper applied to every enabled workspace tool after name remapping. */
-  toolWrapper?: WorkspaceToolWrapper;
+  /** Optional hooks run around every enabled workspace tool after name remapping. */
+  hooks?: WorkspaceToolHooks;
 } & {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
 } & {

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -73,8 +73,8 @@ export interface WorkspaceToolBeforeHookResult {
 }
 
 export interface WorkspaceToolAfterHookContext extends WorkspaceToolHookContext {
-  /** Tool output when execution completed. */
-  output: unknown;
+  /** Tool output when execution completed. Undefined when execution failed before producing output. */
+  output?: unknown;
   /** Error thrown by the tool, if execution failed. */
   error?: unknown;
 }
@@ -296,7 +296,10 @@ export type WorkspaceToolsConfig = {
   /** Default: whether all tools require user approval (default: false if not specified) */
   requireApproval?: DynamicToolConfigValue<ToolConfigWithArgsContext>;
 
-  /** Optional hooks run around every enabled workspace tool after name remapping. */
+  /**
+   * Optional hooks run around every enabled workspace tool after name remapping.
+   * If the owning agent also defines hooks, workspace hooks run inside the agent hook wrapper.
+   */
   hooks?: WorkspaceToolHooks;
 } & {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -55,6 +55,15 @@ export type DynamicToolConfigValue<TContext = ToolConfigContext> =
   | boolean
   | ((context: TContext) => boolean | Promise<boolean>);
 
+export interface WorkspaceToolWrapperContext {
+  /** The name exposed to the model after any per-tool `name` remap. */
+  toolName: string;
+  /** The built-in workspace tool name before any `name` remap. */
+  workspaceToolName: WorkspaceToolName;
+}
+
+export type WorkspaceToolWrapper = (tool: unknown, context: WorkspaceToolWrapperContext) => unknown;
+
 // =============================================================================
 // Tool Configuration Types
 // =============================================================================
@@ -264,6 +273,9 @@ export type WorkspaceToolsConfig = {
 
   /** Default: whether all tools require user approval (default: false if not specified) */
   requireApproval?: DynamicToolConfigValue<ToolConfigWithArgsContext>;
+
+  /** Optional wrapper applied to every enabled workspace tool after name remapping. */
+  wrapTool?: WorkspaceToolWrapper;
 } & {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
 } & {

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -275,7 +275,7 @@ export type WorkspaceToolsConfig = {
   requireApproval?: DynamicToolConfigValue<ToolConfigWithArgsContext>;
 
   /** Optional wrapper applied to every enabled workspace tool after name remapping. */
-  wrapTool?: WorkspaceToolWrapper;
+  toolWrapper?: WorkspaceToolWrapper;
 } & {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
 } & {


### PR DESCRIPTION
## Summary

Adds tool-call hooks that can run before and after tools execute:

- `Agent` now accepts `hooks.beforeToolCall` and `hooks.afterToolCall` for all tool calls.
- `generate`, `stream`, `generateLegacy`, and `streamLegacy` can receive per-execution hooks that override matching agent-level hooks.
- `Workspace` tools expose the same hook shape via `tools.hooks`, with workspace metadata for the original workspace tool name.
- Mastra Code now wires its PreToolUse/PostToolUse hook manager through agent hooks, so hooks run for built-in workspace tools as well as dynamic tools.

## Example

```ts
const agent = new Agent({
  name: 'Support Agent',
  instructions: 'Help users.',
  model,
  hooks: {
    beforeToolCall: ({ toolName, input }) => {
      console.log(`Running ${toolName}`, input);
    },
    afterToolCall: ({ toolName, output, error }) => {
      console.log(`Finished ${toolName}`, { output, error });
    },
  },
});

const workspace = new Workspace({
  tools: {
    hooks: {
      beforeToolCall: ({ toolName, workspaceToolName, input }) => {
        console.log(`Running ${toolName} from ${workspaceToolName}`, input);
      },
    },
  },
});
```

## Test plan

- `pnpm --filter ./packages/core test src/agent/__tests__/tools.test.ts -- --bail 1 --reporter=dot`
- `pnpm --filter ./packages/core test src/workspace/tools/__tests__/tool-creation.test.ts -- --bail 1 --reporter=dot`
- `pnpm --filter ./mastracode test src/agents/__tests__/workspace-env.test.ts -- --bail 1 --reporter=dot`
- `pnpm --filter ./mastracode test src/agents/tools.test.ts -- --bail 1 --reporter=dot`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds **hooks** (custom code that runs at specific moments) around tool calls at multiple levels. You can set default hooks on an Agent that apply to all its tools, or override them for specific executions. Think of it like security checkpoints—you can inspect what a tool is about to do before it runs, and then do something after it finishes (log it, validate it, block it, etc.).

## Summary

This PR introduces tool hook support across the Mastra framework, enabling custom logic to execute before and after tool calls at multiple levels:

### Core Additions

**Agent-level hooks**: Agents now accept `hooks` configuration with `beforeToolCall` and `afterToolCall` callbacks that apply to all tool invocations.

**Per-execution hooks**: All execution methods (`generate`, `stream`, `generateLegacy`, `streamLegacy`) support per-execution hooks that override matching agent-level hooks.

**Workspace tool hooks**: Workspace now exposes `tools.hooks` with the same hook shape, providing both the remapped `toolName` and the original `workspaceToolName` to allow precise tool identification.

**Hook semantics**: 
- `beforeToolCall` receives the tool name, input, and context; can return `{ proceed: false, output: ... }` to short-circuit execution
- `afterToolCall` receives tool name, input, context, and either output or error; runs regardless of success/failure
- Hooks support both synchronous and asynchronous implementations

### Mastra Code Integration

Mastra Code's PreToolUse/PostToolUse hook manager is now wired through agent-level hooks, enabling hooks to run for both built-in workspace tools and dynamically-created tools through a unified API.

### Implementation Details

- New types added: `ToolHookContext`, `ToolBeforeHookResult`, `ToolAfterHookContext`, `ToolHooks` in core tools module
- `Agent` class stores optional hooks and applies them during tool execution via a deep merge with per-execution overrides
- `ResolvedToolConfig` in workspace tools now supports optional `hooks`; tools are wrapped to invoke hooks around the execute function
- Mastra Code refactored to extract hook creation into a new `createToolHooks` helper that converts `HookManager` instances into standardized `ToolHooks`
- Legacy agent paths (`agent-legacy.ts`) updated to thread hooks through the entire execution pipeline

### Testing

New test coverage includes:
- Agent hook execution during `generate` with both success and error scenarios
- Per-execution hooks overriding agent-level hooks and blocking execution
- Workspace tool hooks receiving both exposed and workspace tool names
- Mastra Code hook manager integration with workspace environment
- Edge cases like error propagation through `afterToolCall` and blocked execution flow

### Files Modified

Core framework: `packages/core/src/agent/`, `packages/core/src/workspace/`, `packages/core/src/tools/`  
Mastra Code: `mastracode/src/agents/`, `mastracode/src/index.ts`  
Changeset: `.changeset/sweet-eels-chew.md`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->