### PR TITLE
Fix flaky output stream processor tracing test

### DIFF
--- a/observability/mastra/src/processor-tracing.test.ts
+++ b/observability/mastra/src/processor-tracing.test.ts
@@ -1044,10 +1044,13 @@ describe('Processor Tracing Tests', () => {
       const registeredAgent = mastra.getAgent('agent');
       const stream = await registeredAgent.stream('Hello');
 
-      // Consume the stream to trigger processOutputStream
-      for await (const _chunk of stream.textStream) {
-        // Just consume
-      }
+      // Await full output to deterministically flush the stream pipeline. This
+      // guarantees the `finish` chunk has propagated through the output
+      // processor chain — which is when the output stream processor spans are
+      // ended — before we assert on them. Draining `textStream` alone does not
+      // guarantee the finish chunk has been processed, causing flaky failures
+      // where processor spans are still incomplete.
+      await stream.getFullOutput();
 
       const agentSpans = testExporter.getAgentSpans();
       const processorSpans = testExporter.getProcessorSpans();


### PR DESCRIPTION
## Summary

Fixes an intermittently failing unit test in `@mastra/observability`: `processor-tracing.test.ts > should trace output stream processor with processOutputStream`. The test fails in CI with `Found incomplete spans: expected [...] to have a length of +0 but got 2`.

## Root cause

The test consumed the agent stream by draining `stream.textStream` and then immediately asserted that every span had ended via `finalExpectations()`.

The two output stream processor spans (`stream-first`, `stream-second`) are only ended when the `finish` chunk propagates through the output processor chain (`packages/core/src/processors/runner.ts` — spans end on the finish chunk). `textStream` only yields text deltas, so iterating it to completion does **not** guarantee the finish chunk has been processed. When the assertions ran before the finish chunk flowed through, both processor spans were still open — exactly the `got 2` seen in CI.

## Fix

Await `stream.getFullOutput()` instead of draining `textStream`. `getFullOutput()` awaits the resolved steps, which deterministically flushes the entire stream pipeline (including the finish chunk and the resulting processor span endings) before assertions run.

## Verification

- Ran `processor-tracing.test.ts` 15+ times in isolation; the previously-flaky test passes every time with zero incomplete-span failures.
- Full file (26 tests) passes consistently.

Test-only change — no product code or public API is affected, so no changeset is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a test that was checking whether tracking/monitoring of data streams was working correctly. The problem was that the test was checking too early—before the tracking system had finished its work—which caused it to sometimes fail and sometimes pass randomly. The fix makes the test wait long enough for all the tracking to completely finish before checking the results.

## Summary

Fixed a flaky unit test in `@mastra/observability` (`processor-tracing.test.ts`) that intermittently failed with "Found incomplete spans" errors when testing output stream processor tracing.

### Root Cause

The test was draining `stream.textStream` and immediately asserting that all spans had ended. However, the output stream processor spans (`stream-first`, `stream-second`) only complete when the `finish` chunk propagates through the output processor chain in `packages/core/src/processors/runner.ts`. Since `textStream` yields only text deltas without guaranteeing the finish chunk has been processed, assertions could run before spans were fully ended, causing intermittent failures.

### Solution

Changed the test to await `stream.getFullOutput()` instead of manually consuming `stream.textStream`. This deterministically flushes the entire stream pipeline (including the finish chunk and processor span endings) before assertions execute, ensuring all spans are closed before verification.

### Testing & Verification

- Test passes consistently when run 15+ times in isolation without incomplete-span failures
- Full test file (26 tests) passes consistently
- Test-only change; no product code or public API modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->