### PR TITLE
fix(ai-sdk): only warn about requestContext conflict when route context has entries

### DIFF
--- a/client-sdks/ai-sdk/src/workflow-route.ts
+++ b/client-sdks/ai-sdk/src/workflow-route.ts
@@ -239,14 +239,13 @@ export function workflowRoute({
         throw new Error('Workflow ID is required');
       }
 
-      if (contextRequestContext && params.requestContext) {
+      if (contextRequestContext && params.requestContext && contextRequestContext.size() > 0) {
         mastra
           .getLogger()
           ?.warn(
             `"requestContext" from the request body will be ignored because "requestContext" is already set in the route options.`,
           );
       }
-
       const handlerOptions = {
         mastra,
         workflowId: workflowToUse,

--- a/client-sdks/ai-sdk/src/workflow-route.ts
+++ b/client-sdks/ai-sdk/src/workflow-route.ts
@@ -239,13 +239,6 @@ export function workflowRoute({
         throw new Error('Workflow ID is required');
       }
 
-      if (contextRequestContext && params.requestContext && contextRequestContext.size() > 0) {
-        mastra
-          .getLogger()
-          ?.warn(
-            `"requestContext" from the request body will be ignored because "requestContext" is already set in the route options.`,
-          );
-      }
       const handlerOptions = {
         mastra,
         workflowId: workflowToUse,


### PR DESCRIPTION
## Description
The `requestContext` warning in `workflowRoute` was firing on every request that included a `requestContext` in the body, even when there was no real conflict.

Root cause: the server middleware at `server-adapter/index.ts` always sets `c.set('requestContext', c.env?.requestContext ?? new RequestContext())` — so `contextRequestContext` is never `undefined`, it's at least an empty `RequestContext` instance. This made the `contextRequestContext && params.requestContext` check always truthy when a body `requestContext` was present.

Fix: only warn when `contextRequestContext` actually has entries (`size() > 0`), meaning it was explicitly populated — not just defaulted to an empty instance by the middleware.

## Related issue(s)
Fixes #17653

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The system was warning that request info from the request body would be ignored even when there was no real conflict. The fix: only show that warning when the route's requestContext actually contains entries, not when it's just an empty default.

## Summary

This PR fixes a spurious warning in workflowRoute that was emitted whenever a request body included requestContext, even if the route's requestContext was only the middleware-provided empty default.

- Root cause: server middleware always sets c.set('requestContext', c.env?.requestContext ?? new RequestContext()), so contextRequestContext was never undefined and the previous check (contextRequestContext && params.requestContext) became truthy whenever the body included requestContext.
- Fix: tighten the warning condition to require contextRequestContext.size() > 0 in addition to params.requestContext, so the warning is only logged when the route context's requestContext contains actual entries.
- File changed: client-sdks/ai-sdk/src/workflow-route.ts — warning condition updated in the route handler.

Related Issue: fixes `#17653`  
Type: Bug fix
<!-- end of auto-generated comment: release notes by coderabbit.ai -->