### PR TITLE
fix(schema-compat): apply `.default()` / `.optional()` semantics when models return `null`

### DIFF
--- a/.changeset/schema-compat-optional-default-null.md
+++ b/.changeset/schema-compat-optional-default-null.md
@@ -4,9 +4,14 @@
 
 Fixed tool-call and structured-output validation failing with "expected <type>, received null" when a tool or output schema used `.default()` or `.optional()` fields and the model left them out.
 
-In strict structured-output / tool-calling mode, providers return `null` for a non-required field instead of omitting it. The AI SDK schema produced by `processToAISDKSchema` was built from Zod's *output* projection, where `.default()` fields are required, and only the OpenAI compat layer normalized the returned `null` back to `undefined`. As a result `.default()` fields broke on every provider, and `.optional()` fields broke on Google, Anthropic, DeepSeek, and Meta.
+In strict structured-output and tool-calling mode, validation now handles missing optional and defaulted fields consistently across providers.
 
-The schema is now built from the *input* projection (so defaulted fields are optional, matching what the model is asked to produce), and a shared `convertOptionalNullsToUndefined` helper normalizes `null` → `undefined` for optional/defaulted fields across all providers, while preserving explicit `null` for `.nullable()` fields.
+Fixed behavior:
+- `.optional()` fields now treat model-returned `null` as missing input.
+- `.default()` fields now apply fallback values when models return `null`.
+- `.nullable()` fields still preserve explicit `null`.
+
+This fix applies to OpenAI, Google, Anthropic, DeepSeek, and Meta.
 
 ```ts
 // Before: this tool failed when the model omitted `limit`

--- a/.changeset/schema-compat-optional-default-null.md
+++ b/.changeset/schema-compat-optional-default-null.md
@@ -1,0 +1,23 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed tool-call and structured-output validation failing with "expected <type>, received null" when a tool or output schema used `.default()` or `.optional()` fields and the model left them out.
+
+In strict structured-output / tool-calling mode, providers return `null` for a non-required field instead of omitting it. The AI SDK schema produced by `processToAISDKSchema` was built from Zod's *output* projection, where `.default()` fields are required, and only the OpenAI compat layer normalized the returned `null` back to `undefined`. As a result `.default()` fields broke on every provider, and `.optional()` fields broke on Google, Anthropic, DeepSeek, and Meta.
+
+The schema is now built from the *input* projection (so defaulted fields are optional, matching what the model is asked to produce), and a shared `convertOptionalNullsToUndefined` helper normalizes `null` → `undefined` for optional/defaulted fields across all providers, while preserving explicit `null` for `.nullable()` fields.
+
+```ts
+// Before: this tool failed when the model omitted `limit`
+const search = createTool({
+  id: 'search',
+  inputSchema: z.object({
+    query: z.string(),
+    limit: z.number().default(10), // model returns null → "expected number, received null"
+  }),
+  // ...
+});
+
+// After: `limit` correctly falls back to 10
+```

--- a/packages/schema-compat/src/index.ts
+++ b/packages/schema-compat/src/index.ts
@@ -30,7 +30,7 @@ export { SchemaCompatLayer } from './schema-compatibility';
 
 // Utility functions
 export { convertZodSchemaToAISDKSchema, applyCompatLayer, convertSchemaToZod, isZodType } from './utils';
-export { wrapSchemaWithNullTransform } from './null-to-undefined';
+export { wrapSchemaWithNullTransform, convertOptionalNullsToUndefined } from './null-to-undefined';
 export { ensureAllPropertiesRequired, prepareJsonSchemaForOpenAIStrictMode } from './zod-to-json';
 
 // Standard Schema compatibility utilities

--- a/packages/schema-compat/src/null-to-undefined.ts
+++ b/packages/schema-compat/src/null-to-undefined.ts
@@ -46,6 +46,87 @@ export function transformNullToUndefined(value: unknown, jsonSchema: Record<stri
 }
 
 /**
+ * Resolve a nullable wrapper (`anyOf: [<schema>, { type: 'null' }]`) down to its
+ * non-null variant, matching the resolution the provider `#traverse` helpers do.
+ */
+function resolveNullableVariant(schema: Record<string, unknown>): Record<string, unknown> {
+  if (Array.isArray(schema.anyOf)) {
+    const nonNull = (schema.anyOf as unknown[]).find(
+      (s): s is Record<string, unknown> =>
+        !!s && typeof s === 'object' && (s as Record<string, unknown>).type !== 'null',
+    );
+    if (nonNull) {
+      return nonNull;
+    }
+  }
+  return schema;
+}
+
+/**
+ * Recursively convert `null` → `undefined` for the optional fields of a
+ * processed schema.
+ *
+ * Providers return `null` for an "absent" optional/defaulted field, but the
+ * different compat layers express optionality two ways:
+ *
+ * - **Standard JSON Schema** (Anthropic, Google, DeepSeek, Meta): the field is
+ *   simply omitted from the object's `required` array.
+ * - **OpenAI strict mode**: every property must appear in `required`, so the
+ *   originally optional / defaulted fields are instead tracked in `x-optional`.
+ *
+ * A field is therefore treated as optional when it is listed in `x-optional`
+ * **or** not present in `required`. Genuinely required fields — including
+ * `.nullable()` ones, which stay in `required` — keep their `null` so explicit
+ * null values survive. Converting optional nulls back to `undefined` lets the
+ * original Zod schema apply `.optional()` / `.default()` semantics when the
+ * tool-call / structured-output result is validated; without it the result
+ * fails with "expected <type>, received null".
+ *
+ * Mutates and returns `value` (matching the provider `#traverse` convention).
+ */
+export function convertOptionalNullsToUndefined(value: unknown, jsonSchema: Record<string, unknown>): unknown {
+  if (value === null || value === undefined || typeof jsonSchema !== 'object' || jsonSchema === null) {
+    return value;
+  }
+
+  const resolved = resolveNullableVariant(jsonSchema);
+
+  const isArrayType =
+    resolved.type === 'array' || (Array.isArray(resolved.type) && (resolved.type as string[]).includes('array'));
+  if (isArrayType) {
+    const items = resolved.items;
+    if (Array.isArray(value) && items && typeof items === 'object') {
+      const itemSchema = items as Record<string, unknown>;
+      for (let i = 0; i < value.length; i++) {
+        value[i] = convertOptionalNullsToUndefined(value[i], itemSchema);
+      }
+    }
+    return value;
+  }
+
+  const isObjectType =
+    resolved.type === 'object' || (Array.isArray(resolved.type) && (resolved.type as string[]).includes('object'));
+  if (!isObjectType || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+
+  const properties = resolved.properties as Record<string, Record<string, unknown>> | undefined;
+  const requiredKeys = new Set((resolved.required as string[] | undefined) ?? []);
+  const optionalKeys = new Set((resolved['x-optional'] as string[] | undefined) ?? []);
+  const isOptional = (key: string) => optionalKeys.has(key) || !requiredKeys.has(key);
+  const obj = value as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (obj[key] === null && isOptional(key)) {
+      obj[key] = undefined;
+    } else if (properties?.[key]) {
+      obj[key] = convertOptionalNullsToUndefined(obj[key], properties[key]);
+    }
+  }
+
+  return obj;
+}
+
+/**
  * Wraps a StandardSchemaWithJSON to transform null values to undefined for
  * optional fields before validation. This is a schema-agnostic solution for
  * OpenAI strict mode, which sends null for optional fields.

--- a/packages/schema-compat/src/provider-compats/anthropic.ts
+++ b/packages/schema-compat/src/provider-compats/anthropic.ts
@@ -13,6 +13,7 @@ import {
   isStringSchema,
   isUnionSchema,
 } from '../json-schema/utils';
+import { convertOptionalNullsToUndefined } from '../null-to-undefined';
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { PublicSchema, ZodType } from '../schema.types';
 import { standardSchemaToJSONSchema, toStandardSchema } from '../standard-schema/standard-schema';
@@ -67,11 +68,18 @@ export class AnthropicSchemaCompatLayer extends SchemaCompatLayer {
 
   processToAISDKSchema(zodSchema: ZodTypeV3 | ZodTypeV4) {
     const compat = this.processToCompatSchema(zodSchema);
-    const transformedJsonSchema = standardSchemaToJSONSchema(compat);
+    // Use the 'input' projection so fields with `.default()` are optional.
+    const transformedJsonSchema = standardSchemaToJSONSchema(compat, { io: 'input' });
 
     return jsonSchema(transformedJsonSchema, {
       validate: (value: unknown) => {
-        const transformed = this.#traverse(value, transformedJsonSchema as Record<string, unknown>);
+        const dateNormalized = this.#traverse(value, transformedJsonSchema as Record<string, unknown>);
+        // Strict-mode schemas return `null` for absent optional/defaulted fields;
+        // convert those back to `undefined` so Zod can apply optional/default semantics.
+        const transformed = convertOptionalNullsToUndefined(
+          dateNormalized,
+          transformedJsonSchema as Record<string, unknown>,
+        );
         const result = zodSchema.safeParse(transformed);
         return result.success ? { success: true, value: result.data } : { success: false, error: result.error };
       },

--- a/packages/schema-compat/src/provider-compats/deepseek.ts
+++ b/packages/schema-compat/src/provider-compats/deepseek.ts
@@ -5,6 +5,7 @@ import type { ZodType as ZodTypeV4 } from 'zod/v4';
 import type { Targets } from 'zod-to-json-schema';
 import { jsonSchema } from '../json-schema';
 import { isAllOfSchema, isArraySchema, isObjectSchema, isStringSchema, isUnionSchema } from '../json-schema/utils';
+import { convertOptionalNullsToUndefined } from '../null-to-undefined';
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { PublicSchema } from '../schema.types';
 import { standardSchemaToJSONSchema, toStandardSchema } from '../standard-schema/standard-schema';
@@ -48,11 +49,18 @@ export class DeepSeekSchemaCompatLayer extends SchemaCompatLayer {
 
   processToAISDKSchema(zodSchema: ZodTypeV3 | ZodTypeV4) {
     const compat = this.processToCompatSchema(zodSchema);
-    const transformedJsonSchema = standardSchemaToJSONSchema(compat);
+    // Use the 'input' projection so fields with `.default()` are optional.
+    const transformedJsonSchema = standardSchemaToJSONSchema(compat, { io: 'input' });
 
     return jsonSchema(transformedJsonSchema, {
       validate: (value: unknown) => {
-        const transformed = this.#traverse(value, transformedJsonSchema as Record<string, unknown>);
+        const dateNormalized = this.#traverse(value, transformedJsonSchema as Record<string, unknown>);
+        // Strict-mode schemas return `null` for absent optional/defaulted fields;
+        // convert those back to `undefined` so Zod can apply optional/default semantics.
+        const transformed = convertOptionalNullsToUndefined(
+          dateNormalized,
+          transformedJsonSchema as Record<string, unknown>,
+        );
         const result = zodSchema.safeParse(transformed);
         return result.success ? { success: true, value: result.data } : { success: false, error: result.error };
       },

--- a/packages/schema-compat/src/provider-compats/google.ts
+++ b/packages/schema-compat/src/provider-compats/google.ts
@@ -13,6 +13,7 @@ import {
   isStringSchema,
   isUnionSchema,
 } from '../json-schema/utils';
+import { convertOptionalNullsToUndefined } from '../null-to-undefined';
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { PublicSchema } from '../schema.types';
 import { standardSchemaToJSONSchema, toStandardSchema } from '../standard-schema/standard-schema';
@@ -244,12 +245,16 @@ export class GoogleSchemaCompatLayer extends SchemaCompatLayer {
 
   processToAISDKSchema(zodSchema: ZodTypeV3 | ZodTypeV4): Schema {
     const compat = this.processToCompatSchema(zodSchema);
-    const transformedJsonSchema = standardSchemaToJSONSchema(compat);
+    // Use the 'input' projection so fields with `.default()` are optional.
+    const transformedJsonSchema = standardSchemaToJSONSchema(compat, { io: 'input' });
     const fixedJsonSchema = fixAISDKNullableUnionTypes(transformedJsonSchema as Record<string, any>) as JSONSchema7;
 
     return jsonSchema(fixedJsonSchema, {
       validate: (value: unknown) => {
-        const transformed = this.#traverse(value, fixedJsonSchema as Record<string, unknown>);
+        const dateNormalized = this.#traverse(value, fixedJsonSchema as Record<string, unknown>);
+        // Strict-mode schemas return `null` for absent optional/defaulted fields;
+        // convert those back to `undefined` so Zod can apply optional/default semantics.
+        const transformed = convertOptionalNullsToUndefined(dateNormalized, fixedJsonSchema as Record<string, unknown>);
         const result = zodSchema.safeParse(transformed);
         return result.success ? { success: true, value: result.data } : { success: false, error: result.error };
       },

--- a/packages/schema-compat/src/provider-compats/meta.ts
+++ b/packages/schema-compat/src/provider-compats/meta.ts
@@ -5,6 +5,7 @@ import type { ZodType as ZodTypeV4 } from 'zod/v4';
 import type { Targets } from 'zod-to-json-schema';
 import { jsonSchema } from '../json-schema';
 import { isAllOfSchema, isArraySchema, isObjectSchema, isStringSchema, isUnionSchema } from '../json-schema/utils';
+import { convertOptionalNullsToUndefined } from '../null-to-undefined';
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { PublicSchema } from '../schema.types';
 import { standardSchemaToJSONSchema, toStandardSchema } from '../standard-schema/standard-schema';
@@ -49,11 +50,18 @@ export class MetaSchemaCompatLayer extends SchemaCompatLayer {
 
   processToAISDKSchema(zodSchema: ZodTypeV3 | ZodTypeV4) {
     const compat = this.processToCompatSchema(zodSchema);
-    const transformedJsonSchema = standardSchemaToJSONSchema(compat);
+    // Use the 'input' projection so fields with `.default()` are optional.
+    const transformedJsonSchema = standardSchemaToJSONSchema(compat, { io: 'input' });
 
     return jsonSchema(transformedJsonSchema, {
       validate: (value: unknown) => {
-        const transformed = this.#traverse(value, transformedJsonSchema as Record<string, unknown>);
+        const dateNormalized = this.#traverse(value, transformedJsonSchema as Record<string, unknown>);
+        // Strict-mode schemas return `null` for absent optional/defaulted fields;
+        // convert those back to `undefined` so Zod can apply optional/default semantics.
+        const transformed = convertOptionalNullsToUndefined(
+          dateNormalized,
+          transformedJsonSchema as Record<string, unknown>,
+        );
         const result = zodSchema.safeParse(transformed);
         return result.success ? { success: true, value: result.data } : { success: false, error: result.error };
       },

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -153,8 +153,11 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
   processToAISDKSchema(zodSchema: ZodTypeV3 | ZodTypeV4): Schema {
     const compat = this.processToCompatSchema(zodSchema);
 
-    // Apply the same JSON Schema fixes as processToJSONSchema
-    const transformedJsonSchema = standardSchemaToJSONSchema(compat);
+    // Apply the same JSON Schema fixes as processToJSONSchema.
+    // Use the 'input' projection so fields with `.default()` are treated as
+    // optional (and marked `x-optional`) instead of required — matching what
+    // the model is expected to produce. See `#traverse` for the null handling.
+    const transformedJsonSchema = standardSchemaToJSONSchema(compat, { io: 'input' });
 
     // Post-process the raw LLM value: strip falsy optional fields and convert
     // date strings back to Date objects, then validate against the original Zod schema.

--- a/packages/schema-compat/src/provider-compats/test-suite.ts
+++ b/packages/schema-compat/src/provider-compats/test-suite.ts
@@ -264,6 +264,67 @@ export function createSuite(layer: SchemaCompatLayer) {
       expect(layer.processToJSONSchema(schema)).toMatchSnapshot();
     });
   });
+
+  // Models return `null` for non-required fields in strict structured-output /
+  // tool-calling mode. The AI SDK schema produced by `processToAISDKSchema` must
+  // round-trip those nulls so the underlying Zod schema can apply `.optional()` /
+  // `.default()` semantics. This block runs for every provider — previously only
+  // OpenAI exercised null handling, which let the bug hide for the others.
+  describe('AI SDK schema null handling for optional/default fields', () => {
+    const validate = (schema: z.ZodTypeAny, value: unknown) => {
+      const aiSchema = layer.processToAISDKSchema(schema as any);
+      return aiSchema.validate!(value) as { success: boolean; value?: unknown };
+    };
+
+    it('treats null as undefined for an optional field', () => {
+      const schema = z.object({ keep: z.string(), maybe: z.string().optional() });
+      const result = validate(schema, { keep: 'k', maybe: null });
+      expect(result.success).toBe(true);
+      expect(result.value).toEqual({ keep: 'k' });
+    });
+
+    it('applies a string default when the model returns null', () => {
+      const schema = z.object({ keep: z.string(), label: z.string().default('fallback') });
+      const result = validate(schema, { keep: 'k', label: null });
+      expect(result.success).toBe(true);
+      expect(result.value).toEqual({ keep: 'k', label: 'fallback' });
+    });
+
+    it('applies a numeric default when the model returns null', () => {
+      const schema = z.object({ keep: z.string(), confidence: z.number().default(1) });
+      const result = validate(schema, { keep: 'k', confidence: null });
+      expect(result.success).toBe(true);
+      expect(result.value).toEqual({ keep: 'k', confidence: 1 });
+    });
+
+    it('applies a default for a nested defaulted field', () => {
+      const schema = z.object({ inner: z.object({ theme: z.string().default('light') }) });
+      const result = validate(schema, { inner: { theme: null } });
+      expect(result.success).toBe(true);
+      expect(result.value).toEqual({ inner: { theme: 'light' } });
+    });
+
+    it('applies a default for a defaulted field inside an array element', () => {
+      const schema = z.object({ items: z.array(z.object({ tag: z.string().default('x') })) });
+      const result = validate(schema, { items: [{ tag: null }, { tag: 'set' }] });
+      expect(result.success).toBe(true);
+      expect(result.value).toEqual({ items: [{ tag: 'x' }, { tag: 'set' }] });
+    });
+
+    it('preserves an explicit null for a required nullable field', () => {
+      const schema = z.object({ deletedAt: z.string().nullable() });
+      const result = validate(schema, { deletedAt: null });
+      expect(result.success).toBe(true);
+      expect(result.value).toEqual({ deletedAt: null });
+    });
+
+    it('preserves provided values for default fields', () => {
+      const schema = z.object({ label: z.string().default('fallback') });
+      const result = validate(schema, { label: 'real' });
+      expect(result.success).toBe(true);
+      expect(result.value).toEqual({ label: 'real' });
+    });
+  });
 }
 
 /**

--- a/packages/schema-compat/src/utils.ts
+++ b/packages/schema-compat/src/utils.ts
@@ -197,11 +197,13 @@ export function applyCompatLayer({
       if (compat.shouldApply()) {
         const compatSchema = compat.processToCompatSchema(standardSchema);
 
-        return standardSchemaToJSONSchema(compatSchema);
+        // Use the 'input' projection so fields with `.default()` are optional
+        // (matches the schema the model is expected to produce).
+        return standardSchemaToJSONSchema(compatSchema, { io: 'input' });
       }
     }
 
-    return standardSchemaToJSONSchema(standardSchema);
+    return standardSchemaToJSONSchema(standardSchema, { io: 'input' });
   } else {
     let zodSchema: ZodSchema;
 


### PR DESCRIPTION
Fixes #17655

## Problem

In strict structured-output / tool-calling mode, providers return `null` for a non-required field
the model chose not to fill. Mastra’s schema-compat layer didn’t consistently translate that `null`
back into the “absent” value Zod expects, so validation threw `expected <type>, received null`.

- `.default()` fields broke on **every** provider.
- `.optional()` fields broke on every provider **except OpenAI**.

Two root causes:

1. `processToAISDKSchema` built the model-facing schema from Zod’s **output** projection
   (`standardSchemaToJSONSchema(compat)` defaults to `io: 'output'`), where `.default()` fields are
   required and not tagged `x-optional`. This contradicts the documented intent of
   `processToJSONSchema` / `toJSONSchema` (*“Use input mode so fields with defaults are optional”*).
2. Only OpenAI’s `#traverse` normalized the strict-mode `null` back to `undefined`.

The null-handling tests lived in `createOpenAISuite` (OpenAI only), so the gap was invisible for the
other providers.

## Fix

- **Use the input projection** for AI-facing schemas: pass `{ io: 'input' }` to
  `standardSchemaToJSONSchema` in every provider `processToAISDKSchema` and in
  `applyCompatLayer`’s `jsonSchema` branch. Tool *output* schemas keep `io: 'output'`.
- **Add a shared `convertOptionalNullsToUndefined` helper** that converts `null → undefined` for
  optional fields, honoring both conventions — `x-optional` (OpenAI strict) and absence from
  `required` (standard JSON Schema) — while preserving explicit `null` for `.nullable()` fields. It
  resolves nullable `anyOf` wrappers and recurses into arrays/nested objects.
- **Wire the helper** into Google, Anthropic, DeepSeek and Meta validation (after the existing
  date-converting `#traverse`). OpenAI already normalizes inline and only needed the projection fix.
- **Close the coverage gap**: move the null-handling round-trip into the universal `createSuite`
  (runs for all providers) and add unit tests for the helper.

## Before / after

```ts
const schema = z.object({ query: z.string(), limit: z.number().default(10) });
const aiSchema = new GoogleSchemaCompatLayer(model).processToAISDKSchema(schema);

aiSchema.validate({ query: 'cats', limit: null });
// before → { success: false, error: "expected number, received null" }
// after  → { success: true, value: { query: 'cats', limit: 10 } }
```

## Provider matrix (manual repro, `{ field: null }` → validate)

| | optional | default | nested default | array default | nullable keeps null |
| --- | :---: | :---: | :---: | :---: | :---: |
| OpenAI | ✅ | ✅ | ✅ | ✅ | ✅ |
| Google | ✅ | ✅ | ✅ | ✅ | ✅ |
| Anthropic | ✅ | ✅ | ✅ | ✅ | ✅ |
| DeepSeek | ✅ | ✅ | ✅ | ✅ | ✅ |
| Meta | ✅ | ✅ | ✅ | ✅ | ✅ |

(Every cell was ❌ for `.default()` and ❌ for non-OpenAI `.optional()` before this PR.)

## Tests

- `pnpm --filter @mastra/schema-compat test` → **863 passed** (+61 new), 9 skipped.
- New shared block in `createSuite` exercises optional/default/nullable null handling for all providers.
- New unit tests for `convertOptionalNullsToUndefined` (both optionality conventions, nullable
  preservation, anyOf resolution, array/nested recursion).
- Lint + typecheck clean.

## Notes for reviewers

- Behavior-only change; no public API additions beyond exporting the new helper.
- Downstream `@mastra/core`: model-facing JSON Schema for `.default()` fields now reads as optional
  rather than required (strictly more correct). Snapshot tests that capture generated tool schemas
  with defaults may need regeneration — no runtime behavior regresses.

## Changeset

`.changeset/schema-compat-optional-default-null.md` (`@mastra/schema-compat`, patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When AI models are asked to fill in structured forms (like tool inputs), sometimes they skip optional fields by sending back `null` to mean "I didn't provide this." The validation system was treating that `null` as a bad value instead of recognizing it as "missing," so default values weren't being applied. This PR teaches the system to understand that `null` from the model means "this field is missing" for optional or defaulted fields, so defaults work properly.

---

## Overview

This PR fixes cross-provider validation failures in `@mastra/schema-compat` when AI models return `null` for non-required fields in strict structured-output and tool-calling scenarios. The fix consists of two main strategies: (1) using the input projection when generating AI-facing JSON schemas so that `.default()` and optional fields are properly recognized, and (2) introducing a shared utility to convert model-returned `null` to `undefined` for optional/default fields before Zod validation, allowing `.default()` and `.optional()` semantics to work correctly.

## Changes by File

**packages/schema-compat/src/index.ts:**
- Exports new utility `convertOptionalNullsToUndefined` alongside existing `wrapSchemaWithNullTransform`

**packages/schema-compat/src/null-to-undefined.ts:**
- Introduces `resolveNullableVariant` helper to unwrap nullable `anyOf` schemas
- Adds new exported `convertOptionalNullsToUndefined` function that mutates objects/arrays by converting `null` to `undefined` for fields treated as optional (identified via `required` array absence or `x-optional` marker), while preserving `null` for explicitly required or `.nullable()` fields
- Preserves existing `wrapSchemaWithNullTransform` function

**packages/schema-compat/src/provider-compats/openai.ts:**
- Updates `processToAISDKSchema` to explicitly use input projection (`{ io: 'input' }`) when generating the JSON schema
- Ensures `.default()` fields are treated as optional in the schema sent to the model

**packages/schema-compat/src/provider-compats/google.ts:**
- Uses input projection in `processToAISDKSchema`
- Applies `convertOptionalNullsToUndefined` during `jsonSchema` validation to normalize `null` values back to `undefined` before Zod parsing

**packages/schema-compat/src/provider-compats/anthropic.ts:**
- Uses input projection in `processToAISDKSchema`
- Integrates `convertOptionalNullsToUndefined` alongside date-handling traversal during validation

**packages/schema-compat/src/provider-compats/deepseek.ts:**
- Uses input projection and applies `convertOptionalNullsToUndefined` during JSON schema validation

**packages/schema-compat/src/provider-compats/meta.ts:**
- Uses input projection in `processToAISDKSchema`
- Applies `convertOptionalNullsToUndefined` after traversal but before Zod validation

**packages/schema-compat/src/utils.ts:**
- Updates `applyCompatLayer` to use input projection when calling `standardSchemaToJSONSchema` in `jsonSchema` mode for both primary compat layer and fallback paths

**packages/schema-compat/src/provider-compats/test-suite.ts:**
- Adds comprehensive test coverage for null-handling across all providers via a new test block in `createSuite`
- Tests verify: `null` is treated as `undefined` for optional fields, `.default()` values apply when model returns `null`, `null` is preserved for required nullable fields, nested object and array defaults work correctly, and provided non-null values aren't overwritten

**.changeset/schema-compat-optional-default-null.md:**
- Adds changeset documentation describing the fix and before/after behavior with a TypeScript example

## Results

- Schema-compat test suite: 863 passed (+61), 9 skipped
- All providers (OpenAI, Google, Anthropic, DeepSeek, Meta) now consistently handle optional/default fields when models return `null`
- Linting and type checking pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->