### PR TITLE
fix(core): don't downgrade settled tool-invocation parts in updateToolInvocation

### DIFF
--- a/.changeset/cold-shoes-read.md
+++ b/.changeset/cold-shoes-read.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Don't downgrade settled tool-invocation parts in updateToolInvocation, preventing duplicate background task dispatch

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1138,7 +1138,7 @@ export class MessageList {
           const existingState = part.toolInvocation?.state;
           const isAlreadySettled =
             existingState === 'result' ||
-            existingState === 'output-available' ||
+            (existingState as string) === 'output-available' ||
             existingState === 'output-denied' ||
             existingState === 'output-error';
           if (!isAlreadySettled) {

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1131,18 +1131,30 @@ export class MessageList {
                 } as AIV5Type.ProviderMetadata)
               : undefined;
 
-          msg.content.parts[i] = {
-            ...inputPart,
-            toolInvocation: {
-              ...inputPart.toolInvocation,
-              args: part.toolInvocation.args,
-            },
-            // Preserve providerExecuted from original call if not in result
-            ...(originalPart.providerExecuted !== undefined && inputPartWithMeta.providerExecuted === undefined
-              ? { providerExecuted: originalPart.providerExecuted }
-              : {}),
-            ...(mergedProviderMetadata !== undefined ? { providerMetadata: mergedProviderMetadata } : {}),
-          };
+          // Do not downgrade a part that already has a result — only merge metadata.
+          // This guards against onExecution (which always passes state:'call') clobbering
+          // an output-available placeholder written by a background-dispatched tool call,
+          // which would make the call disappear from the model prompt and cause re-dispatch.
+          const existingState = part.toolInvocation?.state;
+          const isAlreadySettled =
+            existingState === 'result' ||
+            existingState === 'output-available' ||
+            existingState === 'output-denied' ||
+            existingState === 'output-error';
+          if (!isAlreadySettled) {
+            msg.content.parts[i] = {
+              ...inputPart,
+              toolInvocation: {
+                ...inputPart.toolInvocation,
+                args: part.toolInvocation.args,
+              },
+              // Preserve providerExecuted from original call if not in result
+              ...(originalPart.providerExecuted !== undefined && inputPartWithMeta.providerExecuted === undefined
+                ? { providerExecuted: originalPart.providerExecuted }
+                : {}),
+              ...(mergedProviderMetadata !== undefined ? { providerMetadata: mergedProviderMetadata } : {}),
+            };
+          }
           this.lastCreatedAt = Math.max(this.lastCreatedAt || 0, Date.now());
           this.updateLastCreatedAt(msg);
 

--- a/packages/core/src/agent/message-list/tests/update-tool-invocation.test.ts
+++ b/packages/core/src/agent/message-list/tests/update-tool-invocation.test.ts
@@ -703,4 +703,272 @@ describe('MessageList.updateToolInvocation', () => {
       mastra: { modelOutput: true },
     });
   });
+
+  describe('isAlreadySettled guard (background task fix)', () => {
+    it('should not downgrade a result part back to call when onExecution fires', () => {
+      const messageList = new MessageList();
+
+      const msg = makeAssistantMessage([
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'result',
+            toolCallId: 'tc-bg',
+            toolName: 'delegate_agent',
+            args: { task: 'summarise' },
+            result: { output: 'task dispatched' },
+          },
+        },
+      ]);
+      messageList.add(msg, 'response');
+
+      // onExecution always passes state:'call' to attach metadata — must not downgrade
+      messageList.updateToolInvocation({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-bg',
+          toolName: 'delegate_agent',
+          args: {},
+        },
+      });
+
+      const part = msg.content.parts[0] as any;
+      expect(part.toolInvocation.state).toBe('result');
+      expect(part.toolInvocation.result).toEqual({ output: 'task dispatched' });
+    });
+
+    it('should not downgrade an output-available part back to call', () => {
+      const messageList = new MessageList();
+
+      const msg = makeAssistantMessage([
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'output-available' as any,
+            toolCallId: 'tc-bg2',
+            toolName: 'delegate_agent',
+            args: { task: 'analyse' },
+            result: { output: 'running in background' },
+          },
+        },
+      ]);
+      messageList.add(msg, 'response');
+
+      messageList.updateToolInvocation({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-bg2',
+          toolName: 'delegate_agent',
+          args: {},
+        },
+      });
+
+      const part = msg.content.parts[0] as any;
+      expect(part.toolInvocation.state).toBe('output-available');
+    });
+
+    it('should still merge backgroundTasks metadata even when part is settled', () => {
+      const messageList = new MessageList();
+
+      const msg = makeAssistantMessage([
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'result',
+            toolCallId: 'tc-bg3',
+            toolName: 'delegate_agent',
+            args: { task: 'run' },
+            result: { output: 'dispatched' },
+          },
+        },
+      ]);
+      messageList.add(msg, 'response');
+
+      messageList.updateToolInvocation(
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'call',
+            toolCallId: 'tc-bg3',
+            toolName: 'delegate_agent',
+            args: {},
+          },
+        },
+        { backgroundTasks: { 'tc-bg3': { taskId: 'task-123', startedAt: 1000 } } } as any,
+      );
+
+      const part = msg.content.parts[0] as any;
+      expect(part.toolInvocation.state).toBe('result');
+      expect((msg.content.metadata as any)?.backgroundTasks?.['tc-bg3']?.taskId).toBe('task-123');
+    });
+
+    it('should still update a non-settled call part normally', () => {
+      const messageList = new MessageList();
+
+      const msg = makeAssistantMessage([
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'call',
+            toolCallId: 'tc-normal',
+            toolName: 'web_search',
+            args: { query: 'test' },
+          },
+        },
+      ]);
+      messageList.add(msg, 'response');
+
+      messageList.updateToolInvocation({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'tc-normal',
+          toolName: 'web_search',
+          args: {},
+          result: { data: 'found' },
+        },
+      });
+
+      const part = msg.content.parts[0] as any;
+      expect(part.toolInvocation.state).toBe('result');
+      expect(part.toolInvocation.result).toEqual({ data: 'found' });
+    });
+  });
+});
+
+describe('isAlreadySettled guard (background task fix)', () => {
+  it('should not downgrade a result part back to call when onExecution fires', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'tc-bg',
+          toolName: 'delegate_agent',
+          args: { task: 'summarise' },
+          result: { output: 'task dispatched' },
+        },
+      },
+    ]);
+    messageList.add(msg, 'response');
+
+    // onExecution always passes state:'call' to attach metadata — must not downgrade
+    messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'call',
+        toolCallId: 'tc-bg',
+        toolName: 'delegate_agent',
+        args: {},
+      },
+    });
+
+    const part = msg.content.parts[0] as any;
+    expect(part.toolInvocation.state).toBe('result');
+    expect(part.toolInvocation.result).toEqual({ output: 'task dispatched' });
+  });
+
+  it('should not downgrade an output-available part back to call', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'output-available' as any,
+          toolCallId: 'tc-bg2',
+          toolName: 'delegate_agent',
+          args: { task: 'analyse' },
+          result: { output: 'running in background' },
+        },
+      },
+    ]);
+    messageList.add(msg, 'response');
+
+    messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'call',
+        toolCallId: 'tc-bg2',
+        toolName: 'delegate_agent',
+        args: {},
+      },
+    });
+
+    const part = msg.content.parts[0] as any;
+    expect(part.toolInvocation.state).toBe('output-available');
+  });
+
+  it('should still merge backgroundTasks metadata even when part is settled', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'tc-bg3',
+          toolName: 'delegate_agent',
+          args: { task: 'run' },
+          result: { output: 'dispatched' },
+        },
+      },
+    ]);
+    messageList.add(msg, 'response');
+
+    messageList.updateToolInvocation(
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-bg3',
+          toolName: 'delegate_agent',
+          args: {},
+        },
+      },
+      { backgroundTasks: { 'tc-bg3': { taskId: 'task-123', startedAt: 1000 } } } as any,
+    );
+
+    const part = msg.content.parts[0] as any;
+    // State must not be downgraded
+    expect(part.toolInvocation.state).toBe('result');
+    // backgroundTasks metadata must be merged
+    expect((msg.content.metadata as any)?.backgroundTasks?.['tc-bg3']?.taskId).toBe('task-123');
+  });
+
+  it('should still update a non-settled call part normally', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-normal',
+          toolName: 'web_search',
+          args: { query: 'test' },
+        },
+      },
+    ]);
+    messageList.add(msg, 'response');
+
+    messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'tc-normal',
+        toolName: 'web_search',
+        args: {},
+        result: { data: 'found' },
+      },
+    });
+
+    const part = msg.content.parts[0] as any;
+    expect(part.toolInvocation.state).toBe('result');
+    expect(part.toolInvocation.result).toEqual({ data: 'found' });
+  });
 });


### PR DESCRIPTION
## Description
When a tool is dispatched as a background task, `onExecution` calls `updateToolInvocation` with `state: 'call'` to attach `startedAt`/`taskId` metadata. Because `updateToolInvocation` replaced the part wholesale, it overwrote an already-settled `output-available` placeholder back to `input-available`, dropping the result.

`sanitizeV5UIMessages` then correctly filtered out the `input-available` client-side call (to preserve the provider tool-call/tool-result invariant), making the dispatched delegation invisible to the model — which then re-dispatched the same task, spawning a duplicate sub-agent.

**Fix:** Added an `isAlreadySettled` guard in `updateToolInvocation` — if the existing part is already `result`, `output-available`, `output-denied`, or `output-error`, the part is not replaced. Only the `backgroundTasks` metadata is merged (which was already handled correctly below the replacement block).

The two root causes described in the issue are actually one cascading failure: fixing the downgrade keeps the part as `output-available`, which `sanitizeV5UIMessages` correctly preserves, so the model sees the placeholder result and does not re-dispatch.

## Related issue(s)
Fixes #17659

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes sure that once a background tool call has produced (or is already safely “done enough” to use) its output placeholder, we don’t accidentally overwrite it with an older “still pending” version. That way, the model keeps seeing the task and doesn’t try to run it again.

## Problem

When a tool is dispatched as a background task, `onExecution` later calls `updateToolInvocation` to attach metadata like `startedAt`/`taskId` (and related fields). Previously, `updateToolInvocation` could overwrite an already-settled tool-invocation part (e.g. `result` / `output-available`), downgrading it back to an “input-available”-style placeholder. Then `sanitizeV5UIMessages` could remove that downgraded call from the prompt, and the model could re-dispatch the same background task.

## Solution

`MessageList.updateToolInvocation` now adds an `isAlreadySettled` guard:

- If the existing `toolInvocation.state` on the matching part is already settled (`result`, `output-available`, `output-denied`, `output-error`), it **skips replacing** that part—preventing the downgrade.
- If not settled, it updates the part as before.
- Even when skipping the destructive overwrite, it **still merges** incoming `backgroundTasks` metadata (and preserves applicable runtime/provider fields like `providerExecuted` and merged `providerMetadata` when applicable).

## Changes

- `packages/core/src/agent/message-list/message-list.ts`
  - Updated `updateToolInvocation` to avoid clobbering already-settled tool-invocation parts while still merging `backgroundTasks` metadata.
  - Lines changed: **+24 / -12**
- `.changeset/cold-shoes-read.md`
  - Adds a **patch** changeset for `@mastra/core` documenting the behavior change.
- Tests
  - Added coverage in `update-tool-invocation.test.ts` to verify:
    - settled `result` / `output-available` parts are not downgraded
    - `backgroundTasks` metadata still merges on settled parts
    - non-settled parts continue updating normally

## Effect

Prevents a “downgrade cascade” so background-dispatched tool-call placeholders remain visible to `sanitizeV5UIMessages`, avoiding duplicate re-dispatch/re-start behavior.

## Related issue

Fixes **`#17659`**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->