### PR TITLE
repo(docs): Remove pkgManager key in package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -125,6 +125,5 @@
       "last 3 firefox version",
       "last 5 safari version"
     ]
-  },
-  "packageManager": "pnpm@11.3.0"
+  }
 }


### PR DESCRIPTION
## Description

Local build wasn't working for me because of:

```bash
mastra-docs:build: [ERROR] This project is configured to use 11.5.1 of pnpm. Your current pnpm is v11.3.0
mastra-docs:build: Corepack invoked pnpm with this version, and pnpm does not switch versions when running under corepack.
mastra-docs:build: Align the "packageManager" field in package.json with "devEngines.packageManager", or invoke pnpm directly (without corepack) so it can switch versions automatically.
mastra-docs:build: If you want to bypass this version check, you can set the "pmOnFail" configuration to "warn" or "ignore" (e.g. via --pm-on-fail=ignore). If using "devEngines.packageManager", you can set its "onFail" to "warn" or "ignore"
```

This removes the "packageManager" key from the docs package.json

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes a configuration line from the docs folder's package.json file that told the system to use a specific package manager (pnpm version 11.3.0). It's like removing an instruction that specified which tool to use for managing code packages.

## Changes

The `packageManager` field (`"pnpm@11.3.0"`) was removed from `docs/package.json`.

**File affected:**
- `docs/package.json`

**Alterations:**
- Removed property: `packageManager: "pnpm@11.3.0"`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->