### PR TITLE
fix(deployer): ignore Mastra shims in local storage preflight

### DIFF
--- a/.changeset/clear-cities-rest.md
+++ b/.changeset/clear-cities-rest.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed deploy preflight checks so bundled Mastra dependency shims do not report example local storage URLs as real project storage paths.

--- a/packages/deployer/src/build/plugins/local-storage-detector.test.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.test.ts
@@ -74,10 +74,7 @@ describe('localStorageDetector', () => {
       `const example = "storage: new LibSQLStore({ url: 'file:./data.db' })";`,
       '/project/.mastra/.build/@mastra__core__mastra.mjs',
     );
-    plugin.transform(
-      `const example = "url: 'file:./data.db'";`,
-      '/project/.mastra/.build/@mastra__core.mjs',
-    );
+    plugin.transform(`const example = "url: 'file:./data.db'";`, '/project/.mastra/.build/@mastra__core.mjs');
 
     const emitted: Array<{ fileName: string; source: string }> = [];
     const ctx = {

--- a/packages/deployer/src/build/plugins/local-storage-detector.test.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.test.ts
@@ -64,6 +64,45 @@ describe('localStorageDetector', () => {
     expect(detections).toHaveLength(0);
   });
 
+  it('ignores deployer .mastra/.build shim files for @mastra/* packages', () => {
+    // Reproduces the false positive triggered when a user sets a `bundler:` field
+    // in `new Mastra({...})`, which causes the optimizer to pre-bundle
+    // `@mastra/core` into `.mastra/.build/@mastra__core__*.mjs` shims. These
+    // shims preserve JSDoc examples like `url: 'file:./data.db'`.
+    const plugin = getPlugin();
+    plugin.transform(
+      `const example = "storage: new LibSQLStore({ url: 'file:./data.db' })";`,
+      '/project/.mastra/.build/@mastra__core__mastra.mjs',
+    );
+    plugin.transform(
+      `const example = "url: 'file:./data.db'";`,
+      '/project/.mastra/.build/@mastra__core.mjs',
+    );
+
+    const emitted: Array<{ fileName: string; source: string }> = [];
+    const ctx = {
+      emitFile(file: { fileName: string; source: string }) {
+        emitted.push(file);
+      },
+    };
+    plugin.generateBundle.call(
+      ctx,
+      {},
+      {
+        'index.mjs': {
+          type: 'chunk',
+          modules: {
+            '/project/.mastra/.build/@mastra__core__mastra.mjs': { renderedLength: 5000 },
+            '/project/.mastra/.build/@mastra__core.mjs': { renderedLength: 5000 },
+          },
+        },
+      },
+    );
+
+    const detections = JSON.parse(emitted[0]!.source);
+    expect(detections).toHaveLength(0);
+  });
+
   it('excludes tree-shaken modules (renderedLength === 0)', () => {
     const plugin = getPlugin();
     plugin.transform(`const url = 'file:./mastra.db';`, '/project/src/unused.ts');

--- a/packages/deployer/src/build/plugins/local-storage-detector.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.ts
@@ -26,13 +26,24 @@ export interface LocalStorageDetection {
 }
 
 /**
+ * Matches the deployer's own intermediate dependency shims emitted under
+ * `.mastra/.build/` (e.g. `@mastra__core.mjs`, `@mastra__core__mastra.mjs`).
+ * These pre-bundled chunks preserve JSDoc examples from the original library
+ * source (e.g. `LibSQLStore({ url: 'file:./data.db' })`) which would otherwise
+ * trip the host-local detector even though they're not user code.
+ */
+const MASTRA_SHIM_PATH = /[\\/]\.mastra[\\/]\.build[\\/]@mastra__/;
+
+/**
  * Rollup plugin that detects host-local storage URLs (e.g. `file:./mastra.db`,
  * `postgres://localhost`) in **user source modules** during bundling.
  *
- * Only modules outside `node_modules` are inspected, so library code (like
- * Agent Builder prompt templates) is naturally excluded.  Tree-shaken modules
- * are excluded via `generateBundle` — only modules that actually contribute
- * rendered code to the output are reported.
+ * Only modules outside `node_modules` (and the deployer's own
+ * `.mastra/.build/@mastra__*` shim files) are inspected, so library code
+ * (like Agent Builder prompt templates or JSDoc examples in `@mastra/core`)
+ * is naturally excluded.  Tree-shaken modules are excluded via
+ * `generateBundle` — only modules that actually contribute rendered code to
+ * the output are reported.
  *
  * Detected paths are emitted as `preflight-local-paths.json` in the output
  * directory for the CLI preflight check to consume.
@@ -45,6 +56,7 @@ export function localStorageDetector(): Plugin {
 
     transform(_code, id) {
       if (id.includes('node_modules')) return null;
+      if (MASTRA_SHIM_PATH.test(id)) return null;
 
       const matches: Array<{ value: string; hint: string }> = [];
       for (const { pattern, hint } of LOCAL_HOST_PATTERNS) {


### PR DESCRIPTION
## Summary

Fix a deploy preflight false positive where generated Mastra dependency shims could be mistaken for user code by the local-storage detector.

When an app configures `bundler`, the deploy optimizer can emit package shims under paths like:

- `.mastra/.build/@mastra__core.mjs`
- `.mastra/.build/@mastra__core__mastra.mjs`

Those files are generated by the deployer, not authored by the user. They can preserve JSDoc/example strings from Mastra packages, including examples such as:

```ts
new LibSQLStore({ url: 'file:./data.db' })
```

Because these shim paths do not include `node_modules`, the local-storage detector treated the example `file:./data.db` string as project code and emitted `preflight-local-paths.json`. The CLI then failed preflight with `LOCAL_STORAGE_PATH`, even though the deployed app was not using local file storage.

This PR ignores deployer-generated Mastra package shims under `.mastra/.build/@mastra__*`, keeping preflight focused on real user/project modules.

## Why this matters

The immediate failure was found while validating the Company Knowledge and Meeting Notes templates, but this is a framework-level issue. Any project that adds a `bundler` config can cause these generated Mastra shims to exist, and users should not get deploy-blocking local-storage errors from example strings inside generated framework files.

The templates now also have a separate workaround that avoids `bundler.dynamicPackages`, but this PR fixes the underlying detector behavior for future users/projects.

## Key changes

- Skip `.mastra/.build/@mastra__*` files in `localStorageDetector()`.
- Add a regression test covering generated `@mastra/core` shim files containing `file:./data.db` example strings.
- Add a patch changeset for `@mastra/deployer`.

## Test plan

- `pnpm --filter ./packages/deployer exec vitest run src/build/plugins/local-storage-detector.test.ts` — 11 tests passed.
- `pnpm --filter ./packages/deployer build:lib` — passed.
- Copied the patched deployer into fresh template installs and ran preflight:
  - `template-meeting-notes: npx mastra lint --preflight` — passed with only missing-env warnings.
  - `template-company-knowledge: npx mastra lint --preflight` — passed with only missing-env warnings.

## Related template workaround

PR #17425 no longer relies on `bundler.dynamicPackages` for the Notion MCP server. It uses an analyzer-visible package reference:

```ts
import '@notionhq/notion-mcp-server/package.json';
```

while keeping `require.resolve('@notionhq/notion-mcp-server/bin/cli.mjs')` for runtime CLI path resolution. That ensures deploy output includes the Notion MCP package and fixes the earlier runtime `Cannot find module` error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The deploy checker was incorrectly flagging internal Mastra build files as if they were user code improperly accessing local storage. This PR fixes that by telling the checker to ignore those internal build files that are auto-generated during deployment.

## Overview

This PR fixes a false positive in the deploy preflight local-storage detector that was triggered by Mastra package shims generated under `.mastra/.build/@mastra__*`. These shim files contain JSDoc/example strings like `file:./data.db` that were previously being treated as user code, since their paths don't include `node_modules`, leading to spurious `LOCAL_STORAGE_PATH` preflight failures.

## Changes

**packages/deployer/src/build/plugins/local-storage-detector.ts**
- Updated the detector to skip `.mastra/.build/@mastra__*` shim files from local storage URL scanning
- Updated plugin documentation to reflect that shim modules are now ignored alongside `node_modules`
- Ensures only matches found in user source modules are aggregated and emitted as `preflight-local-paths.json`

**packages/deployer/src/build/plugins/local-storage-detector.test.ts**
- Added regression test case that verifies the plugin ignores `.mastra/.build` shim files generated for `@mastra/*` packages
- Test validates that code containing `file:./data.db` in shim modules produces no false detections

**.changeset/clear-cities-rest.md**
- Added patch changeset for `@mastra/deployer` documenting the fix

## Testing

- Unit tests: 11 tests passed for local-storage-detector
- Build: `pnpm --filter ./packages/deployer build:lib` passed
- Manual verification: Patched deployer used in template installs; `npx mastra lint --preflight` passed for template-meeting-notes and template-company-knowledge (only missing-env warnings)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->