### PR TITLE
fix(mastracode): preserve selected model id in harness state

### DIFF
--- a/.changeset/tiny-cooks-strive.md
+++ b/.changeset/tiny-cooks-strive.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed model selection being lost so the agent no longer prompts you to choose a model after you've already selected a models pack. The harness state schema was dropping the selected model id, leaving every pack (built-in or custom) with no active model.

--- a/mastracode/src/schema.test.ts
+++ b/mastracode/src/schema.test.ts
@@ -24,4 +24,22 @@ describe('stateSchema', () => {
       },
     ]);
   });
+
+  // Regression: the legacy Harness validates its state against this schema and
+  // assigns the parsed result back to state. Zod strips unknown keys, so if
+  // currentModelId/modeId are not declared here, the seeded model is silently
+  // discarded and the harness reports "no model selected" for every pack.
+  it('preserves currentModelId through parse', () => {
+    const parsed = stateSchema.parse({
+      currentModelId: 'anthropic/claude-opus-4-8',
+    });
+
+    expect(parsed.currentModelId).toBe('anthropic/claude-opus-4-8');
+  });
+
+  it('preserves modeId through parse', () => {
+    const parsed = stateSchema.parse({ modeId: 'build' });
+
+    expect(parsed.modeId).toBe('build');
+  });
 });

--- a/mastracode/src/schema.ts
+++ b/mastracode/src/schema.ts
@@ -64,6 +64,12 @@ export interface MastraCodeState {
 }
 
 export const stateSchema = z.object({
+  // Session-scoped selection. The legacy Harness stores these in its state and
+  // validates state against this schema, so they MUST be declared here — Zod
+  // strips unknown keys on parse, which would otherwise silently discard the
+  // seeded model and leave the harness with no model selected.
+  currentModelId: z.string().optional(),
+  modeId: z.string().optional(),
   subagentModelId: z.string().optional(),
   projectPath: z.string().optional(),
   projectName: z.string().optional(),


### PR DESCRIPTION
Fixes mastracode re-prompting you to pick a model even after you'd already selected a models pack.

The mastracode `stateSchema` didn't declare `currentModelId` / `modeId`. The legacy Harness validates state against this schema and assigns the parsed result back, and Zod strips keys it doesn't know about, so the selected model id was silently dropped on every state update. That left the harness thinking no model was selected for every pack.

Before:

```ts
export const stateSchema = z.object({
  subagentModelId: z.string().optional(),
  // ...
});
```

After:

```ts
export const stateSchema = z.object({
  currentModelId: z.string().optional(),
  modeId: z.string().optional(),
  subagentModelId: z.string().optional(),
  // ...
});
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you pick a model in Mastracode, the system was forgetting your choice every time it updated and kept asking you to pick again. This PR fixes it by making sure the system remembers to save and keep your choice.

## Changes

### Changeset
Added a changelog entry declaring a `patch` release for `mastracode` documenting the fix for harness state losing the selected model id.

### Schema Updates
Updated `mastracode/src/schema.ts` to add two new optional fields to `stateSchema`:
- `currentModelId: z.string().optional()`
- `modeId: z.string().optional()`

These fields are necessary because the legacy Harness validates state against this schema using Zod, which strips any keys not explicitly defined. By adding these fields to the schema, the selected model id and mode id are now preserved during state updates instead of being discarded.

### Test Coverage
Added regression tests in `mastracode/src/schema.test.ts` to verify that `stateSchema.parse` correctly preserves both `currentModelId` and `modeId` in the parsed result. The tests document the scenario where Zod would otherwise strip unknown keys, ensuring this fix prevents future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->