### PR TITLE
fix(core): resolve harness v1 agents by id

### DIFF
--- a/.changeset/dry-paws-wash.md
+++ b/.changeset/dry-paws-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Harness v1 mode and subagent agent lookup when using agent ids.

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -38,12 +38,13 @@ export class Harness<MODES extends HarnessMode[], TState = {}> {
   readonly #storage?: HarnessStorage;
   readonly #compositeStorage?: MastraCompositeStore;
   readonly #mastra?: Mastra;
+  readonly #agents?: Record<string, Agent>;
   readonly #memory: MastraMemory | DynamicArgument<MastraMemory>;
   readonly #events: EventEmitter;
   readonly #stateSchema?: HarnessConfig<MODES, TState>['stateSchema'];
   readonly #initialState?: Partial<TState>;
   readonly #workspace?: DynamicArgument<Workspace | undefined>;
-  readonly #agent: Agent;
+  readonly #agent?: Agent;
   readonly #subagents?: SubagentRegistryConfig;
   readonly #resolveModel?: ModelResolver;
   readonly #runtimeCompatibilityGeneration?: string | null;
@@ -59,6 +60,7 @@ export class Harness<MODES extends HarnessMode[], TState = {}> {
     this.#defaultMode = config.defaultModeId ?? config.modes[0]!.id;
     this.#storage = config.storage;
     this.#mastra = config.mastra;
+    this.#agents = 'agents' in config ? (config.agents as Record<string, Agent> | undefined) : undefined;
     this.#compositeStorage = config.mastra?.getStorage();
     this.#memory = config.memory;
     this.#events = new EventEmitter();
@@ -75,7 +77,11 @@ export class Harness<MODES extends HarnessMode[], TState = {}> {
       this.#workspace = new Workspace(config.workspace);
     }
 
-    this.#agent = this.#mastra ? this.#mastra.getAgentById(config.agent) : (config.agent as Agent);
+    if (this.#mastra) {
+      this.#agent = config.agent ? (this.#mastra.getAgentById(config.agent) as Agent) : undefined;
+    } else {
+      this.#agent = (config as { agent?: Agent }).agent;
+    }
 
     if (config.subagents) {
       const entries = Object.entries(config.subagents.types ?? {});
@@ -288,7 +294,7 @@ export class Harness<MODES extends HarnessMode[], TState = {}> {
       model: record.modelId,
       createdAt: record.createdAt,
       lastActivityAt: record.lastActivityAt,
-      agent: this.#agent,
+      agent: this.#agentForMode(mode),
       memory: this.#memory,
       storage,
       record,
@@ -306,8 +312,22 @@ export class Harness<MODES extends HarnessMode[], TState = {}> {
     });
   }
 
-  #resolveAgent(agentId: string): Agent {
+  #agentForMode(mode: HarnessMode): Agent {
+    if (mode.agentId) {
+      const agent = this.#tryResolveAgent(mode.agentId);
+      if (agent) return agent;
+    }
+    return this.#agent as Agent;
+  }
+
+  #tryResolveAgent(agentId: string): Agent | undefined {
     if (this.#mastra) return this.#mastra.getAgentById(agentId) as Agent;
+    return this.#agents?.[agentId];
+  }
+
+  #resolveAgent(agentId: string): Agent {
+    const agent = this.#tryResolveAgent(agentId);
+    if (agent) return agent;
     throw new Error(`Harness mode references unknown agent "${agentId}"`);
   }
 

--- a/packages/core/src/harness/v1/harness.types.ts
+++ b/packages/core/src/harness/v1/harness.types.ts
@@ -306,13 +306,16 @@ export type HarnessConfig<MODES extends HarnessMode[], TState = {}> = HarnessCon
          */
         mastra: Mastra;
         /**
-         * Backing agent. Must reference a key in `HarnessConfig.agents`.
-         * Validated at construction — unknown id throws `HarnessConfigError`.
+         * Optional default backing agent id. Modes with `agentId` resolve their
+         * own backing agent lazily when the session needs it.
          */
-        agent: string;
+        agent?: string;
       }
     | {
         mastra?: never;
-        agent: Agent;
+        /** Inline agent registry used by mode and subagent `agentId` bindings. */
+        agents?: Record<string, Agent>;
+        /** Optional default backing agent for modes without `agentId`. */
+        agent?: Agent;
       }
   );

--- a/packages/core/src/harness/v1/mode.ts
+++ b/packages/core/src/harness/v1/mode.ts
@@ -13,6 +13,9 @@ export interface HarnessMode {
   /** Unique within `HarnessConfig.modes`. Validated at construction. */
   id: string;
 
+  /** Backing agent id for sessions in this mode. */
+  agentId?: string;
+
   /** bootstrap model default when a session enters this mode. */
   defaultModelId: string;
 


### PR DESCRIPTION
Fixes Harness v1 agent id resolution so modes and subagents can use the agentId-based config shape.

The harness now resolves mode agent ids from either a Mastra instance or the inline agents map when creating sessions. Subagent agent lookup still happens during tool execution, so missing subagent agents return the expected recoverable tool error instead of failing during harness construction.

Test plan:
- pnpm test:unit src/harness/v1/harness.tools.test.ts
- pnpm test:unit src/harness/v1/harness.state-workspace.test.ts src/harness/v1/harness.tools.test.ts
- pnpm test:unit src/harness/v1
- pnpm --filter ./packages/core check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes it easier to tell the Harness which agent to use by allowing you to just specify an agent ID instead of having to pass the entire agent object. The system now knows how to look up the actual agent from a registry, similar to how you might look up a phone number by a name instead of having to write out the whole contact card.

## Changes

### Configuration Updates
- `HarnessConfig` now makes the default `agent` field optional in both configuration styles (when using a `Mastra` instance or inline agents registry)
- `HarnessMode` now supports an optional `agentId` field to specify the backing agent for sessions entered into that mode

### Harness v1 Implementation
- The `Harness` class now stores an inline `agents` registry when provided in config
- Added private helper methods to resolve agents dynamically:
  - `#agentForMode(mode)` - prefers a mode-specific `agentId`, falls back to the harness-level agent
  - `#tryResolveAgent(agentId)` - looks up agents via the `Mastra` instance or inline registry
  - Updated `#resolveAgent` to use the new lookup mechanism
- Session construction now passes per-mode agents instead of a single global agent

### Changeset
- Updated `.changeset/dry-paws-wash.md` to document the patch release for `@mastra/core`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->