### PR TITLE
feat(langfuse): forward custom mastra.metadata.langfuse keys as trace metadata

### DIFF
--- a/.changeset/langfuse-custom-trace-metadata.md
+++ b/.changeset/langfuse-custom-trace-metadata.md
@@ -3,3 +3,26 @@
 ---
 
 Forward custom keys from `mastra.metadata.langfuse` as `langfuse.trace.metadata.*` attributes so users can filter and group Langfuse traces by custom metadata keys.
+
+```ts
+// Before: custom keys were silently dropped
+// After: custom keys are forwarded to Langfuse trace metadata
+
+const result = await agent.generate('Hello', {
+  telemetry: {
+    metadata: {
+      langfuse: {
+        customerId: 'abc-123',
+        environment: 'production',
+        // prompt linking still works as before
+        prompt: { name: 'my-prompt', version: 1 },
+      },
+    },
+  },
+});
+
+// Langfuse trace now contains:
+// langfuse.trace.metadata.customerId = 'abc-123'
+// langfuse.trace.metadata.environment = 'production'
+// langfuse.observation.prompt.name = 'my-prompt'
+```

--- a/.changeset/langfuse-custom-trace-metadata.md
+++ b/.changeset/langfuse-custom-trace-metadata.md
@@ -1,0 +1,5 @@
+---
+"@mastra/langfuse": patch
+---
+
+Forward custom keys from `mastra.metadata.langfuse` as `langfuse.trace.metadata.*` attributes so users can filter and group Langfuse traces by custom metadata keys.

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -273,6 +273,14 @@ function mapMastraToLangfuseAttributes(
           attributes['langfuse.observation.prompt.version'] = parsed.prompt.version;
         }
       }
+      // Forward all top-level keys (except reserved 'prompt') as langfuse.trace.metadata.*
+      // so users can filter and group traces by custom metadata keys in Langfuse.
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        for (const [key, value] of Object.entries(parsed)) {
+          if (key === 'prompt') continue;
+          attributes[`langfuse.trace.metadata.${key}`] = value as any;
+        }
+      }
     } catch {
       // best effort — invalid JSON is silently ignored
     }


### PR DESCRIPTION
## Description
Custom keys set under `mastra.metadata.langfuse` were silently dropped after prompt linking was processed. This meant users had no way to insert custom top-level metadata into Langfuse traces, which is required for filtering and grouping traces by custom keys in the Langfuse UI.

**Fix:** After handling the reserved `prompt` key, all remaining top-level keys in `mastra.metadata.langfuse` are now forwarded as `langfuse.trace.metadata.<key>` attributes. A type guard ensures non-object values are safely skipped.

**Example:**
```ts
// Setting this:
{ 'mastra.metadata.langfuse': { customerId: 'abc', environment: 'prod' } }

// Now produces:
{ 'langfuse.trace.metadata.customerId': 'abc', 'langfuse.trace.metadata.environment': 'prod' }
```

## Related issue(s)
Fixes #17683

## Type of change
- [x] New feature (non-breaking change that adds functionality)

## Checklist
- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Summary

Before, custom labels you put under mastra.metadata.langfuse would get lost; now those custom labels are kept and added to Langfuse traces so you can filter and group traces by them.

## Changes Overview

This PR forwards custom top-level keys from mastra.metadata.langfuse into Langfuse trace attributes as langfuse.trace.metadata.<key>, while preserving existing prompt linking behavior.

### What Changed

**Modified Files:**
- observability/langfuse/src/tracing.ts — Updated mapMastraToLangfuseAttributes to:
  - Type-guard mastra.metadata.langfuse to ensure it's an object.
  - Preserve existing handling for prompt.name and prompt.version.
  - Forward all other top-level keys as langfuse.trace.metadata.<key>.
  - Remove the mastra.metadata.langfuse attribute after processing (behavior unchanged).
- .changeset/langfuse-custom-trace-metadata.md — Added a patch changeset documenting the feature and example usage.

### Implementation Details

- Custom metadata example:
  - Input: { 'mastra.metadata.langfuse': { customerId: 'abc', environment: 'prod', prompt: { name, version } } }
  - Output: { 'langfuse.trace.metadata.customerId': 'abc', 'langfuse.trace.metadata.environment': 'prod', plus preserved prompt linking attributes }
- Non-object mastra.metadata.langfuse values are ignored via a type guard.
- Prompt linking (prompt.name/prompt.version) behavior remains intact.

### Impact

- Fixes issue: `#17683`
- Scope: `@mastra/langfuse` (patch release)
- Breaking changes: None
- User-facing: Yes — enables custom top-level trace metadata for Langfuse filtering/grouping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->