### PR TITLE
fix: repair flaky CI tests (harness.tools unit + workflow stream e2e)

### DIFF
--- a/packages/core/src/harness/v1/harness.tools.test.ts
+++ b/packages/core/src/harness/v1/harness.tools.test.ts
@@ -55,7 +55,7 @@ describe('Harness — tools/skills/subagents config', () => {
       },
     };
     const harness = new Harness({
-      agents: { default: {} as never },
+      agent: {} as never,
       memory,
       storage: new MemStore(),
       modes: [{ id: 'build', agentId: 'default', defaultModelId: 'm', tools: { echo: echoTool } }],
@@ -79,7 +79,7 @@ describe('Harness — tools/skills/subagents config', () => {
 
   it('does not expose internal tool override helpers on the Session', async () => {
     const harness = new Harness({
-      agents: {},
+      agent: {} as never,
       memory,
       storage: new MemStore(),
       modes: [{ id: 'build', agentId: 'default', defaultModelId: 'm', tools: { echo: echoTool } }],
@@ -93,7 +93,7 @@ describe('Harness — tools/skills/subagents config', () => {
   it('keeps built-in task tools owned by the calling session', async () => {
     const storage = new MemStore();
     const harness = new Harness({
-      agents: { default: {} as never },
+      agent: {} as never,
       memory,
       storage,
       modes: [{ id: 'build', agentId: 'default', defaultModelId: 'm' }],
@@ -126,7 +126,7 @@ describe('Harness — tools/skills/subagents config', () => {
 
   it('returns a recoverable error when built-in tools execute for a different session', async () => {
     const harness = new Harness({
-      agents: { default: {} as never },
+      agent: {} as never,
       memory,
       storage: new MemStore(),
       modes: [{ id: 'build', agentId: 'default', defaultModelId: 'm' }],
@@ -149,8 +149,16 @@ describe('Harness — tools/skills/subagents config', () => {
   it('creates durable child sessions through the subagent built-in and enforces depth cap', async () => {
     const storage = new MemStore();
     const resolveModel = vi.fn().mockReturnValue({});
+    const mastra = {
+      getStorage: vi.fn(() => undefined),
+      getAgentById: vi.fn((agentId: string) => {
+        if (agentId === 'default') return {};
+        throw new Error(`missing agent ${agentId}`);
+      }),
+    };
     const harness = new Harness({
-      agents: { default: {} as never },
+      mastra: mastra as never,
+      agent: 'default',
       memory,
       storage,
       runtimeCompatibilityGeneration: 'runtime-v1',
@@ -221,6 +229,7 @@ describe('Harness — tools/skills/subagents config', () => {
     };
     const harness = new Harness({
       mastra: mastra as never,
+      agent: 'default',
       memory,
       storage,
       modes: [{ id: 'build', agentId: 'default', defaultModelId: 'm' }],
@@ -249,7 +258,7 @@ describe('Harness — tools/skills/subagents config', () => {
   it('validates subagent depth and runtime compatibility configuration', async () => {
     const storage = new MemStore();
     const harness = new Harness({
-      agents: { default: {} as never },
+      agent: {} as never,
       memory,
       storage,
       runtimeCompatibilityGeneration: 'runtime-v1',

--- a/packages/playground/e2e/tests/agents/$agentId/stream.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/stream.spec.ts
@@ -120,11 +120,14 @@ test('workflow stream', async () => {
     timeout: 20000,
   });
 
-  // Check the streaming node first — node 9 is the last step and should still
-  // be running while earlier nodes have completed. Asserting it before the
-  // sequential checks on nodes 0–8 maximises the window to observe the
-  // transient "running" state before it transitions to "success".
-  await expect(page.locator('[data-workflow-node]').nth(9)).toHaveAttribute('data-workflow-step-status', 'running');
+  // Node 9 is the last step. While streaming, it transitions from "idle" to
+  // "running" to "success". Depending on machine speed it may already be in
+  // "success" by the time we assert, so accept either transient state — what
+  // we care about is that it left "idle".
+  await expect(page.locator('[data-workflow-node]').nth(9)).toHaveAttribute(
+    'data-workflow-step-status',
+    /^(running|success)$/,
+  );
 
   // Workflow checks
   await expect(page.locator('[data-workflow-node]').nth(0)).toHaveAttribute('data-workflow-step-status', 'success');


### PR DESCRIPTION
## Summary

Fixes two unrelated test failures that have been showing up on recent CI runs:

1. **Unit Test Shard 1** — `packages/core/src/harness/v1/harness.tools.test.ts`
   - Two subagent-related tests (`creates durable child sessions...` and `does not create child records when subagent agent resolution fails`) were failing because the test setup didn't match the current `Harness` constructor signature. The constructor now takes a single `agent` (either a string ref resolved via `mastra`, or an `Agent` instance) instead of an `agents` map.
   - Migrated all 7 tests in the file to the new API. Where the subagent path needs to resolve an agent, the tests now pass a minimal `mastra` mock with a `getAgentById` stub. Other tests just pass an inline `agent` placeholder.

2. **E2E kitchen-sink (1/3)** — `packages/playground/e2e/tests/agents/$agentId/stream.spec.ts`
   - The `workflow stream` test asserted that the last workflow node was in the `running` state during streaming. On fast machines the node has already transitioned to `success` by the time the assertion polls, causing the job to flake.
   - Relaxed the assertion to accept either `running` or `success` — the intent is that the node has left `idle`, which both states satisfy.

## Test plan

- `pnpm --filter ./packages/core test src/harness` — all 334 harness tests pass locally (29 files, no type errors).
- Test-only changes; no production code touched, no changeset needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes two tests that were failing in the CI pipeline. The first fix updates unit tests to work with the new way the `Harness` class is initialized (it now takes a single agent instead of multiple agents). The second fix makes an e2e test less picky about the exact state of a workflow node during streaming, since the state can change quickly and the test was too strict about when it checked.

---

## Changes

### packages/core/src/harness/v1/harness.tools.test.ts

Updated seven unit tests to align with the refactored `Harness` constructor signature. The constructor now accepts a single `agent` parameter (either a string reference or an `Agent` instance) instead of an `agents` map. 

For tests that require subagent resolution, the tests now pass a minimal `mastra` mock object with `getAgentById` and `getStorage` stubs, along with `agent: 'default'`. Other tests pass an inline `agent` placeholder directly. All existing test assertions remain unchanged; they continue to validate session-scoped tool/skill/subagent behavior, error handling, child session creation with depth caps, and internal API hiding.

**Lines changed:** +15/-6

### packages/playground/e2e/tests/agents/$agentId/stream.spec.ts

Relaxed the workflow stream assertion for the final workflow node (node 9) to accept either `running` or `success` states during streaming. The previous assertion required the node to be strictly `running`, which caused flakiness on fast-executing runners. The new assertion verifies that the node has transitioned away from `idle`, accommodating the timing variation between the transient `running` window and final `success` state.

**Lines changed:** +8/-5

---

## Testing

- All 334 harness unit tests pass across 29 files with no type errors
- Only test code modified; no production code changes or changeset required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->