### PR TITLE
Fix analytics distinct ID collisions

### DIFF
--- a/.changeset/dark-dancers-shave.md
+++ b/.changeset/dark-dancers-shave.md
@@ -1,0 +1,6 @@
+---
+'mastra': patch
+'mastracode': patch
+---
+
+Fixed analytics user tracking to use a private persistent ID instead of the device hostname, so unique user counts are not merged across machines with common names.

--- a/mastracode/src/__tests__/analytics.test.ts
+++ b/mastracode/src/__tests__/analytics.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { hostname, tmpdir } from 'node:os';
+import path from 'node:path';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createMastraCodeAnalytics, getMastraAnalyticsDistinctId, isTelemetryDisabled } from '../analytics.js';
@@ -8,8 +12,50 @@ afterEach(() => {
 });
 
 describe('analytics telemetry disable', () => {
-  it('uses the same distinct id format as the Mastra CLI analytics', () => {
-    expect(getMastraAnalyticsDistinctId('test-host')).toBe('mastra-test-host');
+  it('generates and persists a random distinct id', () => {
+    withTempAnalyticsConfig(configPath => {
+      const distinctId = getMastraAnalyticsDistinctId(configPath);
+
+      expect(distinctId).toMatch(/^mastra-[0-9a-f-]{36}$/);
+      expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toEqual({ distinctId });
+      expect(getMastraAnalyticsDistinctId(configPath)).toBe(distinctId);
+    });
+  });
+
+  it('migrates hostname-derived distinct ids without aliasing collided users', () => {
+    withTempAnalyticsConfig(configPath => {
+      const oldDistinctId = `mastra-${hostname()}`;
+      writeFileSync(configPath, JSON.stringify({ distinctId: oldDistinctId }));
+
+      const distinctId = getMastraAnalyticsDistinctId(configPath);
+
+      expect(distinctId).toMatch(/^mastra-[0-9a-f-]{36}$/);
+      expect(distinctId).not.toBe(oldDistinctId);
+      expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toEqual({ distinctId });
+    });
+  });
+
+  it('regenerates when analytics config is invalid', () => {
+    withTempAnalyticsConfig(configPath => {
+      writeFileSync(configPath, '{invalid');
+
+      const distinctId = getMastraAnalyticsDistinctId(configPath);
+
+      expect(distinctId).toMatch(/^mastra-[0-9a-f-]{36}$/);
+      expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toEqual({ distinctId });
+    });
+  });
+
+  it('regenerates when analytics config has a malformed distinct id', () => {
+    withTempAnalyticsConfig(configPath => {
+      writeFileSync(configPath, JSON.stringify({ distinctId: 'mastra-local' }));
+
+      const distinctId = getMastraAnalyticsDistinctId(configPath);
+
+      expect(distinctId).toMatch(/^mastra-[0-9a-f-]{36}$/);
+      expect(distinctId).not.toBe('mastra-local');
+      expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toEqual({ distinctId });
+    });
   });
 
   it('treats common truthy env values as disabled', () => {
@@ -67,3 +113,13 @@ describe('analytics telemetry disable', () => {
     }
   });
 });
+
+function withTempAnalyticsConfig(run: (configPath: string) => void): void {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mastracode-analytics-'));
+  const configPath = path.join(dir, 'analytics.json');
+  try {
+    run(configPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/mastracode/src/analytics.ts
+++ b/mastracode/src/analytics.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 
 import { PostHog } from 'posthog-node';
 
@@ -7,9 +9,52 @@ const POSTHOG_API_KEY = 'phc_SBLpZVAB6jmHOct9CABq3PF0Yn5FU3G2FgT4xUr2XrT';
 const POSTHOG_HOST = 'https://us.posthog.com';
 const MASTRA_SOURCE = 'mastracode';
 const TRUTHY_DISABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const ANALYTICS_CONFIG_PATH = path.join(os.homedir(), '.mastracode', 'analytics.json');
 
-export function getMastraAnalyticsDistinctId(hostname = os.hostname()): string {
-  return `mastra-${hostname}`;
+interface AnalyticsConfig {
+  distinctId?: string;
+}
+
+function createMastraAnalyticsDistinctId(): string {
+  return `mastra-${randomUUID()}`;
+}
+
+function isHostnameDerivedDistinctId(distinctId: string, hostname = os.hostname()): boolean {
+  return distinctId === `mastra-${hostname}`;
+}
+
+function isValidMastraAnalyticsDistinctId(distinctId: string): boolean {
+  return /^mastra-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(distinctId);
+}
+
+function writeAnalyticsConfig(distinctId: string, configPath = ANALYTICS_CONFIG_PATH): void {
+  try {
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ distinctId }));
+  } catch {
+    // swallow analytics persistence errors
+  }
+}
+
+export function getMastraAnalyticsDistinctId(configPath = ANALYTICS_CONFIG_PATH): string {
+  try {
+    if (existsSync(configPath)) {
+      const config = JSON.parse(readFileSync(configPath, 'utf-8')) as AnalyticsConfig;
+      if (
+        config.distinctId &&
+        isValidMastraAnalyticsDistinctId(config.distinctId) &&
+        !isHostnameDerivedDistinctId(config.distinctId)
+      ) {
+        return config.distinctId;
+      }
+    }
+  } catch {
+    // regenerate below
+  }
+
+  const distinctId = createMastraAnalyticsDistinctId();
+  writeAnalyticsConfig(distinctId, configPath);
+  return distinctId;
 }
 
 function isAnalyticsDebugEnabled(): boolean {

--- a/packages/cli/src/analytics/__tests__/index.test.ts
+++ b/packages/cli/src/analytics/__tests__/index.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../commands/utils.js', () => ({
+  getPackageManager: () => 'pnpm',
+}));
+
+vi.mock('posthog-node', () => ({
+  PostHog: vi.fn().mockImplementation(function () {
+    return {
+      capture: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
+}));
+
+import { PosthogAnalytics } from '../index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.MASTRA_TELEMETRY_DISABLED;
+});
+
+describe('PosthogAnalytics distinct ids', () => {
+  it('generates and persists random distinct and session ids', () => {
+    withTempAnalyticsConfig(configPath => {
+      const analytics = new PosthogAnalytics({
+        version: 'test-version',
+        apiKey: 'test-key',
+        host: 'https://posthog.test',
+      });
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+      expect(config.distinctId).toMatch(/^mastra-[0-9a-f-]{36}$/);
+      expect(config.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+      expect((analytics as unknown as { distinctId: string }).distinctId).toBe(config.distinctId);
+      expect((analytics as unknown as { sessionId: string }).sessionId).toBe(config.sessionId);
+
+      const nextAnalytics = new PosthogAnalytics({
+        version: 'test-version',
+        apiKey: 'test-key',
+        host: 'https://posthog.test',
+      });
+      expect((nextAnalytics as unknown as { distinctId: string }).distinctId).toBe(config.distinctId);
+      expect((nextAnalytics as unknown as { sessionId: string }).sessionId).toBe(config.sessionId);
+    });
+  });
+
+  it('migrates hostname-derived distinct ids without aliasing collided users', () => {
+    withTempAnalyticsConfig(configPath => {
+      const oldDistinctId = `mastra-${os.hostname()}`;
+      writeFileSync(configPath, JSON.stringify({ distinctId: oldDistinctId, sessionId: 'old-session-id' }));
+
+      const analytics = new PosthogAnalytics({
+        version: 'test-version',
+        apiKey: 'test-key',
+        host: 'https://posthog.test',
+      });
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+      expect((analytics as unknown as { distinctId: string }).distinctId).toMatch(/^mastra-[0-9a-f-]{36}$/);
+      expect((analytics as unknown as { distinctId: string }).distinctId).not.toBe(oldDistinctId);
+      expect(config.distinctId).toBe((analytics as unknown as { distinctId: string }).distinctId);
+      expect(config.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+    });
+  });
+
+  it('preserves a valid distinct id when repairing a missing session id', () => {
+    withTempAnalyticsConfig(configPath => {
+      const distinctId = 'mastra-00000000-0000-0000-0000-000000000000';
+      writeFileSync(configPath, JSON.stringify({ distinctId }));
+
+      const analytics = new PosthogAnalytics({
+        version: 'test-version',
+        apiKey: 'test-key',
+        host: 'https://posthog.test',
+      });
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+      expect((analytics as unknown as { distinctId: string }).distinctId).toBe(distinctId);
+      expect(config.distinctId).toBe(distinctId);
+      expect(config.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+      expect((analytics as unknown as { sessionId: string }).sessionId).toBe(config.sessionId);
+    });
+  });
+});
+
+function withTempAnalyticsConfig(run: (configPath: string) => void): void {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'mastra-cli-analytics-'));
+  const configPath = path.join(dir, 'analytics.json');
+  const getOrCreateAnalyticsConfig = Object.getOwnPropertyDescriptor(
+    PosthogAnalytics.prototype,
+    'getOrCreateAnalyticsConfig',
+  );
+
+  vi.spyOn(
+    PosthogAnalytics.prototype as unknown as { getOrCreateAnalyticsConfig: (configPath?: string) => unknown },
+    'getOrCreateAnalyticsConfig',
+  ).mockImplementation(function (this: { getOrCreateAnalyticsConfig: (configPath?: string) => unknown }) {
+    return getOrCreateAnalyticsConfig?.value.call(this, configPath);
+  });
+
+  try {
+    run(configPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/cli/src/analytics/index.ts
+++ b/packages/cli/src/analytics/index.ts
@@ -1,13 +1,11 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { PostHog } from 'posthog-node';
 import { getPackageManager } from '../commands/utils.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const ANALYTICS_CONFIG_PATH = path.join(os.homedir(), '.mastra', 'analytics.json');
 
 interface CommandData {
   command: string;
@@ -52,36 +50,50 @@ export class PosthogAnalytics {
     }
 
     this.packageManager = getPackageManager();
-    const cliConfigPath = path.join(__dirname, 'mastra-cli.json');
-    if (existsSync(cliConfigPath)) {
-      try {
-        const { distinctId, sessionId } = JSON.parse(readFileSync(cliConfigPath, 'utf-8'));
-        this.distinctId = distinctId;
-        this.sessionId = sessionId;
-      } catch {
-        this.sessionId = randomUUID();
-        this.distinctId = this.getDistinctId();
-      }
-
-      this.writeCliConfig({
-        distinctId: this.distinctId,
-        sessionId: this.sessionId,
-      });
-    } else {
-      this.sessionId = randomUUID();
-      this.distinctId = this.getDistinctId();
-      this.writeCliConfig({
-        distinctId: this.distinctId,
-        sessionId: this.sessionId,
-      });
-    }
+    const { distinctId, sessionId } = this.getOrCreateAnalyticsConfig();
+    this.distinctId = distinctId;
+    this.sessionId = sessionId;
 
     this.initializePostHog(apiKey, host);
   }
 
-  private writeCliConfig({ distinctId, sessionId }: { distinctId: string; sessionId: string }): void {
+  private getOrCreateAnalyticsConfig(configPath = ANALYTICS_CONFIG_PATH): { distinctId: string; sessionId: string } {
     try {
-      writeFileSync(path.join(__dirname, 'mastra-cli.json'), JSON.stringify({ distinctId, sessionId }));
+      if (existsSync(configPath)) {
+        const { distinctId, sessionId } = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+          distinctId?: string;
+          sessionId?: string;
+        };
+        if (distinctId && !this.isHostnameDerivedDistinctId(distinctId)) {
+          const config = {
+            distinctId,
+            sessionId: sessionId || randomUUID(),
+          };
+          if (config.sessionId !== sessionId) {
+            this.writeCliConfig(config, configPath);
+          }
+          return config;
+        }
+      }
+    } catch {
+      // regenerate below
+    }
+
+    const config = {
+      distinctId: this.createDistinctId(),
+      sessionId: randomUUID(),
+    };
+    this.writeCliConfig(config, configPath);
+    return config;
+  }
+
+  private writeCliConfig(
+    { distinctId, sessionId }: { distinctId: string; sessionId: string },
+    configPath = ANALYTICS_CONFIG_PATH,
+  ): void {
+    try {
+      mkdirSync(path.dirname(configPath), { recursive: true });
+      writeFileSync(configPath, JSON.stringify({ distinctId, sessionId }));
     } catch {
       //swallow
     }
@@ -110,11 +122,12 @@ export class PosthogAnalytics {
     return true;
   }
 
-  private getDistinctId(): string {
-    // Use machine-id or generate a persistent ID
-    // This helps track unique CLI installations
-    const machineId = os.hostname();
-    return `mastra-${machineId}`;
+  private createDistinctId(): string {
+    return `mastra-${randomUUID()}`;
+  }
+
+  private isHostnameDerivedDistinctId(distinctId: string): boolean {
+    return distinctId === `mastra-${os.hostname()}`;
   }
 
   private getSystemProperties(): Record<string, any> {


### PR DESCRIPTION
## Summary

Fixes analytics user tracking for Mastra Code and the Mastra CLI by replacing hostname-derived PostHog `distinctId` values with persisted UUID-based IDs.

Previously, both tools could identify users as values like `mastra-MacBook-Pro.local`, `mastra-ubuntu`, or `mastra-localhost`. Those hostnames can collide across unrelated users, causing PostHog to group separate users together and undercount unique usage.

This PR:

- Generates random UUID-based distinct IDs in the format `mastra-<uuid>`
- Persists Mastra Code analytics identity in `~/.mastracode/analytics.json`
- Persists CLI analytics identity/session config in `~/.mastra/analytics.json`
- Regenerates old hostname-derived IDs without aliasing them in PostHog, avoiding permanent merges of already-collided users
- Keeps hostname only as event metadata (`machineId` / `machine_id`)
- Adds focused tests for persistence, reuse, invalid config recovery, and hostname-derived ID migration

## Test plan

Passed:

- `pnpm --filter ./packages/cli test src/analytics/__tests__/index.test.ts`
- `pnpm --filter ./mastracode test src/__tests__/analytics.test.ts --run`
- `pnpm --filter ./packages/cli typecheck`

Known unrelated failure:

- `pnpm --filter ./mastracode check` currently fails on existing `main` API drift in `mastracode/src/agents/memory.ts`, `mastracode/src/HarnessCompat.ts`, and `mastracode/src/index.ts` around `observeAttachments` / `HarnessMode.agentId`. The failures are not in the analytics files changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Instead of using your computer's name to track you (which can accidentally group different people), this PR gives each Mastra installation its own permanent random ID stored on your machine so analytics count actual users correctly.

## Overview

Replaces hostname-derived analytics distinct IDs with persisted UUID-based identifiers (prefixed `mastra-`) for both Mastra CLI and Mastra Code to avoid conflating unrelated users in PostHog.

## Key Changes

### Analytics Identity Management
- Distinct IDs now use the format `mastra-<uuid>` instead of deriving from hostname.
- Persisted config locations:
  - CLI: `~/.mastra/analytics.json`
  - Mastra Code: `~/.mastracode/analytics.json`
- Hostname is preserved only as event metadata (`machineId` / `machine_id`), not as the distinct ID.

### Migration & Recovery
- Detects legacy hostname-derived distinct IDs and migrates to a new UUID-based `mastra-...` ID without aliasing in PostHog (avoids permanently merging collided users).
- If analytics config is missing, malformed, or contains an invalid ID, a new UUID-based ID is generated and persisted.
- Persistence/read/JSON errors are handled gracefully (swallowed) to avoid crashing telemetry logic.

## Implementation Details

- Mastra Code (`mastracode/src/analytics.ts`)
  - `getMastraAnalyticsDistinctId` changed to read/persist an analytics config file path and now returns/reuses a stored `mastra-<uuid>` ID, generating and saving one when needed.
  - Adds helper types and filesystem handling for config read/write and validation.

- CLI (`packages/cli/src/analytics/index.ts`)
  - Moves telemetry storage from a project-local file to user-level `~/.mastra/analytics.json`.
  - `PosthogAnalytics` constructor loads/creates `distinctId` and `sessionId` via `getOrCreateAnalyticsConfig`, reusing valid stored values and migrating legacy hostname IDs.
  - Removes prior deterministic hostname-derived distinct-id generation.

## Tests

- Mastra Code tests (`mastracode/src/__tests__/analytics.test.ts`):
  - Validate generation, persistence, reuse of `mastra-<uuid>` IDs.
  - Migration from hostname-derived IDs.
  - Recovery from invalid JSON and malformed stored IDs.
  - Adds `withTempAnalyticsConfig` helper for isolated temp configs.

- CLI tests (`packages/cli/src/analytics/__tests__/index.test.ts`):
  - Validate distinct ID and session ID generation/persistence and reuse.
  - Migration behavior for hostname-derived IDs.
  - Uses mocks/stubs for PostHog and package manager to avoid side effects.

## Test Results / Known Issues

- Passed: CLI analytics tests and typecheck; Mastra Code analytics tests.
- Known unrelated failure: `pnpm --filter ./mastracode check` fails on main due to API drift in unrelated files (`mastracode/src/agents/memory.ts`, `mastracode/src/HarnessCompat.ts`, `mastracode/src/index.ts`).

## Other
- Changeset and release metadata updated to mark patch releases and document the analytics fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->