### PR TITLE
test(core): add unit tests for deepMerge, deepEqual, omitKeys, and removeUndefinedValues

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -8,11 +8,15 @@ import { RequestContext } from './request-context';
 import { toStandardSchema } from './schema';
 import { createTool, isVercelTool } from './tools';
 import {
+  deepEqual,
+  deepMerge,
   ensureSerializable,
   fetchWithRetry,
   generateEmptyFromSchema,
   makeCoreTool,
   maskStreamTags,
+  omitKeys,
+  removeUndefinedValues,
   resolveSerializedZodOutput,
   safeStringify,
   selectFields,
@@ -852,5 +856,179 @@ describe('selectFields', () => {
     const result = selectFields(src, ['__proto__.polluted']);
     expect(result).toEqual({});
     expect(({} as any).polluted).toBeUndefined();
+  });
+});
+
+describe('deepMerge', () => {
+  it('merges two flat objects', () => {
+    const result = deepMerge({ a: 1, b: 2 }, { b: 3, c: 4 });
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it('recursively merges nested plain objects', () => {
+    const target = { a: { x: 1, y: 2 }, b: 'hello' };
+    const source = { a: { y: 99, z: 3 } };
+    const result = deepMerge(target, source);
+    expect(result).toEqual({ a: { x: 1, y: 99, z: 3 }, b: 'hello' });
+  });
+
+  it('does not mutate the original target', () => {
+    const target = { a: 1, b: { c: 2 } };
+    const source = { b: { c: 42 } };
+    const result = deepMerge(target, source);
+    expect(target.b.c).toBe(2);
+    expect(result.b.c).toBe(42);
+  });
+
+  it('replaces arrays rather than merging them', () => {
+    const result = deepMerge({ items: [1, 2, 3] }, { items: [4, 5] });
+    expect(result.items).toEqual([4, 5]);
+  });
+
+  it('replaces a nested plain object with an array from source', () => {
+    const result = deepMerge({ a: { x: 1 } } as any, { a: [1, 2, 3] } as any);
+    expect(result.a).toEqual([1, 2, 3]);
+  });
+
+  it('keeps target keys that are absent from source', () => {
+    const result = deepMerge({ a: 1, b: 2 }, { b: 99 });
+    expect(result.a).toBe(1);
+  });
+
+  it('handles a falsy source gracefully', () => {
+    const target = { a: 1 };
+    const result = deepMerge(target, null as any);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('source undefined values do not overwrite target keys', () => {
+    const result = deepMerge({ a: 1 }, { a: undefined });
+    expect(result.a).toBe(1);
+  });
+});
+
+describe('deepEqual', () => {
+  it('returns true for identical primitives', () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual('hello', 'hello')).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+  });
+
+  it('returns false for different primitives', () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual('a', 'b')).toBe(false);
+  });
+
+  it('returns true for the same object reference', () => {
+    const obj = { a: 1 };
+    expect(deepEqual(obj, obj)).toBe(true);
+  });
+
+  it('returns true for deeply equal plain objects', () => {
+    expect(deepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(true);
+  });
+
+  it('returns false when object keys differ', () => {
+    expect(deepEqual({ a: 1 }, { b: 1 })).toBe(false);
+  });
+
+  it('returns false when object values differ', () => {
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('returns false when objects have different key counts', () => {
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+
+  it('returns true for equal arrays', () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+  });
+
+  it('returns false for arrays of different length', () => {
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+
+  it('returns false for arrays with different elements', () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+  });
+
+  it('returns true for equal Date instances', () => {
+    const d1 = new Date('2024-01-01');
+    const d2 = new Date('2024-01-01');
+    expect(deepEqual(d1, d2)).toBe(true);
+  });
+
+  it('returns false for different Date instances', () => {
+    const d1 = new Date('2024-01-01');
+    const d2 = new Date('2025-06-01');
+    expect(deepEqual(d1, d2)).toBe(false);
+  });
+
+  it('returns true for both null values', () => {
+    expect(deepEqual(null, null)).toBe(true);
+  });
+
+  it('returns false when only one side is null', () => {
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual({}, null)).toBe(false);
+  });
+
+  it('returns false for values of different types', () => {
+    expect(deepEqual(1, '1')).toBe(false);
+  });
+});
+
+describe('omitKeys', () => {
+  it('removes specified keys from an object', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    expect(omitKeys(obj, ['b'])).toEqual({ a: 1, c: 3 });
+  });
+
+  it('removes multiple keys at once', () => {
+    const obj = { a: 1, b: 2, c: 3, d: 4 };
+    expect(omitKeys(obj, ['a', 'c'])).toEqual({ b: 2, d: 4 });
+  });
+
+  it('returns the original object structure when no matching keys', () => {
+    const obj = { a: 1, b: 2 };
+    expect(omitKeys(obj, ['z'])).toEqual({ a: 1, b: 2 });
+  });
+
+  it('returns an empty object when all keys are omitted', () => {
+    const obj = { a: 1, b: 2 };
+    expect(omitKeys(obj, ['a', 'b'])).toEqual({});
+  });
+
+  it('does not mutate the original object', () => {
+    const obj = { a: 1, b: 2 };
+    omitKeys(obj, ['a']);
+    expect(obj).toEqual({ a: 1, b: 2 });
+  });
+});
+
+describe('removeUndefinedValues', () => {
+  it('removes keys with undefined values', () => {
+    const obj = { a: 1, b: undefined, c: 'hello' };
+    expect(removeUndefinedValues(obj)).toEqual({ a: 1, c: 'hello' });
+  });
+
+  it('keeps keys with null values', () => {
+    const obj = { a: null, b: undefined };
+    expect(removeUndefinedValues(obj)).toEqual({ a: null });
+  });
+
+  it('keeps keys with falsy-but-defined values', () => {
+    const obj = { a: 0, b: false, c: '', d: undefined };
+    expect(removeUndefinedValues(obj)).toEqual({ a: 0, b: false, c: '' });
+  });
+
+  it('returns an empty object when all values are undefined', () => {
+    const obj = { a: undefined, b: undefined };
+    expect(removeUndefinedValues(obj)).toEqual({});
+  });
+
+  it('returns the same entries when no values are undefined', () => {
+    const obj = { a: 1, b: 'x', c: true };
+    expect(removeUndefinedValues(obj)).toEqual({ a: 1, b: 'x', c: true });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds missing unit test coverage for four utility functions exported from `packages/core/src/utils.ts` that previously had zero tests.

Closes #17699

## Functions covered

| Function | # Tests | What is covered |
|---|---|---|
| `deepMerge` | 8 | flat merge, recursive nested merge, immutability, array replacement, falsy/null source, `undefined` source values not overwriting |
| `deepEqual` | 14 | primitives, deep object equality, key/value mismatches, arrays, `Date` instances, `null`, type mismatches |
| `omitKeys` | 5 | single/multiple key removal, no-match passthrough, all keys removed, immutability |
| `removeUndefinedValues` | 5 | removes `undefined`, preserves `null` and other falsy values, all-undefined input, no-undefined input |

All tests follow the existing conventions in `utils.test.ts` (vitest, no mocking needed).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Test coverage improvement
- [ ] Documentation update

## Notes

Purely additive — no behaviour changes, no new dependencies, no config changes. No changeset required as this is a test-only PR with no public API changes.