### PR TITLE
fix(react): settle optimistic messages on signal fallback

### DIFF
--- a/client-sdks/react/src/agent/hooks.test.ts
+++ b/client-sdks/react/src/agent/hooks.test.ts
@@ -1116,6 +1116,47 @@ describe('useChat optimistic pending user message', () => {
     expect(second?.[CLIENT_MESSAGE_ID_KEY]).toBeUndefined();
   });
 
+  it('replaces optimistic messages when both signal APIs fall back to the legacy stream path', async () => {
+    sendMessageMock.mockRejectedValueOnce(Object.assign(new Error('sendMessage unavailable'), { status: 404 }));
+    sendSignalMock.mockRejectedValueOnce(Object.assign(new Error('sendSignal unavailable'), { status: 404 }));
+
+    const { result } = renderHook(
+      () =>
+        useChat({
+          agentId: 'test-agent',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+          enableThreadSignals: true,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.sendMessage({
+        mode: 'stream',
+        message: 'first',
+        threadId: 'thread-1',
+        coreUserMessages: [{ role: 'user', content: [{ type: 'text', text: 'second' }] }],
+      });
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendSignalMock).toHaveBeenCalledTimes(1);
+    expect(streamMock).toHaveBeenCalledTimes(1);
+
+    const userMessages = result.current.messages.filter(m => m.role === 'user');
+    expect(userMessages).toHaveLength(2);
+    expect(userMessages.map(message => message.content.parts[0])).toEqual([
+      { type: 'text', text: 'first' },
+      { type: 'text', text: 'second' },
+    ]);
+    for (const message of userMessages) {
+      const metadata = message.content.metadata as MastraDBMessageMetadata | undefined;
+      expect(metadata?.status).toBeUndefined();
+      expect(metadata?.[CLIENT_MESSAGE_ID_KEY]).toBeUndefined();
+    }
+  });
+
   it('keys two sequential sends as independent pending messages', async () => {
     const { result } = renderHook(
       () =>

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -128,6 +128,17 @@ const resolveInitialMessages = (messages: MastraDBMessage[]): MastraDBMessage[] 
       };
     });
 
+const replaceOptimisticMessagesForLegacyFallback = (
+  messages: MastraDBMessage[],
+  optimisticMessages: MastraDBMessage[] | undefined,
+  fallbackMessages: MastraDBMessage[],
+): MastraDBMessage[] => {
+  const optimisticIds = new Set(optimisticMessages?.map(message => message.id) ?? []);
+  if (!optimisticIds.size) return [...messages, ...fallbackMessages];
+
+  return [...messages.filter(message => !optimisticIds.has(message.id)), ...fallbackMessages];
+};
+
 type SignalContinuationOptions = {
   maxSteps?: number;
   modelSettings?: {
@@ -202,6 +213,10 @@ export type StreamArgs = SharedArgs & {
 
 export type NetworkArgs = SharedArgs & {
   onNetworkChunk?: (chunk: NetworkChunkType) => Promise<void>;
+};
+
+type InternalStreamArgs = StreamArgs & {
+  optimisticUserMessages?: MastraDBMessage[];
 };
 
 const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
@@ -623,7 +638,8 @@ export const useChat = ({
     clientTools,
     signalId,
     clientMessageId,
-  }: StreamArgs) => {
+    optimisticUserMessages,
+  }: InternalStreamArgs) => {
     const {
       frequencyPenalty,
       presencePenalty,
@@ -791,7 +807,13 @@ export const useChat = ({
           onSignalEcho?.(resolvedSignalId);
           if (isThreadSignalUnsupportedError(signalError)) {
             markThreadSignalsUnsupported();
-            setMessages(prev => [...prev, ...coreUserMessages.map(fromCoreUserMessageToMastraDBMessage)]);
+            setMessages(prev =>
+              replaceOptimisticMessagesForLegacyFallback(
+                prev,
+                optimisticUserMessages,
+                optimisticUserMessages ?? coreUserMessages.map(fromCoreUserMessageToMastraDBMessage),
+              ),
+            );
             await streamWithLegacyRoute();
             return;
           }
@@ -1141,7 +1163,13 @@ export const useChat = ({
     if (mode === 'generate') {
       await generate({ ...args, coreUserMessages });
     } else if (mode === 'stream') {
-      await stream({ ...args, coreUserMessages, signalId, clientMessageId });
+      await stream({
+        ...args,
+        coreUserMessages,
+        signalId,
+        clientMessageId,
+        optimisticUserMessages: signalId ? dbUserMessages : undefined,
+      });
     } else if (mode === 'network') {
       await network({ ...args, coreUserMessages });
     }


### PR DESCRIPTION
Stacked on #17688.

This fixes the double-unsupported signal fallback path by replacing the optimistic user messages with plain legacy-stream messages before falling back to `agent.stream`, so the UI does not keep a stuck pending bubble or duplicate the user turn.

Validation:
- `pnpm --filter ./client-sdks/react exec vitest run src/agent/hooks.test.ts`
- `git diff --check`

Notes: CodeRabbit CLI is installed but local review could not run because `coderabbit doctor` reports the CLI is not signed in. Fresh-worktree React package build still reports existing type/declaration errors against workspace package exports outside this patch, but the emitted JS was enough to run the targeted Vitest test.