### PR TITLE
fix(core): preserve tool execution error state

### DIFF
--- a/.changeset/soft-bushes-crash.md
+++ b/.changeset/soft-bushes-crash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool execution errors so reloaded history preserves failed tool calls instead of treating them as successful results. Fixes #15569.

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -274,11 +274,11 @@ describe('Agent - network - finalResult token efficiency', () => {
     // But the tool call data should still be present in the messages array
     const messagesInFinalResult = parsedContent.finalResult.messages || [];
     const toolCallMessages = messagesInFinalResult.filter((m: any) => m.type === 'tool-call');
-    const toolResultMessages = messagesInFinalResult.filter((m: any) => m.type === 'tool-result');
+    const toolOutcomeMessages = messagesInFinalResult.filter((m: any) => m.type === 'tool-result' || m.type === 'tool-error');
 
-    // Verify tool calls are preserved in messages
+    // Verify tool calls and their result/error outcomes are preserved in messages
     expect(toolCallMessages.length).toBeGreaterThan(0);
-    expect(toolResultMessages.length).toBeGreaterThan(0);
+    expect(toolOutcomeMessages.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { AIV5Type } from '../types';
-import { addStartStepPartsForAIV5, aiV5UIMessagesToAIV5ModelMessages, sanitizeV5UIMessages } from './output-converter';
+import {
+  addStartStepPartsForAIV5,
+  aiV5UIMessagesToAIV5ModelMessages,
+  sanitizeAIV4UIMessages,
+  sanitizeV5UIMessages,
+} from './output-converter';
 
 /**
  * Tests for provider-executed tool handling in sanitizeV5UIMessages.
@@ -206,6 +211,59 @@ describe('sanitizeV5UIMessages — provider-executed tool handling', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]!.parts).toHaveLength(2);
+  });
+});
+
+describe('sanitizeAIV4UIMessages — output-error compatibility', () => {
+  it('maps output-error tool parts to legacy result parts before AI SDK v4 conversion', () => {
+    const msg = {
+      id: 'msg-1',
+      role: 'assistant',
+      content: '',
+      parts: [
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'output-error',
+            toolCallId: 'call-1',
+            toolName: 'lookupCustomer',
+            args: { customerId: 'cus_123' },
+            errorText: 'Lookup failed',
+          },
+        },
+      ],
+      toolInvocations: [
+        {
+          state: 'output-error',
+          toolCallId: 'call-1',
+          toolName: 'lookupCustomer',
+          args: { customerId: 'cus_123' },
+          errorText: 'Lookup failed',
+        },
+      ],
+    } as any;
+
+    const [sanitized] = sanitizeAIV4UIMessages([msg]);
+
+    expect(sanitized?.parts[0]).toEqual({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'call-1',
+        toolName: 'lookupCustomer',
+        args: { customerId: 'cus_123' },
+        result: 'Lookup failed',
+      },
+    });
+    expect(sanitized?.toolInvocations).toEqual([
+      {
+        state: 'result',
+        toolCallId: 'call-1',
+        toolName: 'lookupCustomer',
+        args: { customerId: 'cus_123' },
+        result: 'Lookup failed',
+      },
+    ]);
   });
 });
 

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -86,16 +86,55 @@ function mergeTextPartsWithDuplicateItemIds<T extends { type: string }>(parts: T
  * Removes messages with empty parts arrays after sanitization.
  */
 export function sanitizeAIV4UIMessages(messages: UIMessageV4[]): UIMessageV4[] {
+  type AIV4ToolInvocation = NonNullable<UIMessageV4['toolInvocations']>[number];
+  type AIV4ToolInvocationWithMastraState = Omit<AIV4ToolInvocation, 'state'> & {
+    state: string;
+    errorText?: string;
+  };
+
+  const getToolInvocationState = (toolInvocation: AIV4ToolInvocation): string => {
+    return (toolInvocation as unknown as AIV4ToolInvocationWithMastraState).state;
+  };
+
+  const toAIV4CompatibleToolInvocation = (toolInvocation: AIV4ToolInvocation): AIV4ToolInvocation => {
+    const invocation = toolInvocation as unknown as AIV4ToolInvocationWithMastraState;
+    if (invocation.state !== 'output-error') {
+      return toolInvocation;
+    }
+
+    const rest = { ...(toolInvocation as unknown as Record<string, unknown>) };
+    const { errorText } = invocation;
+    delete rest.errorText;
+
+    return {
+      ...rest,
+      state: 'result',
+      result: typeof errorText === 'string' && errorText.length > 0 ? errorText : 'Tool execution failed',
+    } as unknown as AIV4ToolInvocation;
+  };
+
   const msgs = messages
     .map(m => {
       if (m.parts.length === 0) return false;
-      const safeParts = m.parts.filter(
-        p =>
-          p.type !== `tool-invocation` ||
-          // calls and partial-calls should be updated to be results at this point
-          // if they haven't we can't send them back to the llm and need to remove them.
-          (p.toolInvocation.state !== `call` && p.toolInvocation.state !== `partial-call`),
-      );
+      const safeParts = m.parts.reduce<UIMessageV4['parts']>((parts, p) => {
+        if (p.type !== 'tool-invocation') {
+          parts.push(p);
+          return parts;
+        }
+
+        const state = getToolInvocationState(p.toolInvocation);
+        // calls and partial-calls should be updated to be results at this point
+        // if they haven't we can't send them back to the llm and need to remove them.
+        if (state === 'call' || state === 'partial-call') {
+          return parts;
+        }
+
+        parts.push({
+          ...p,
+          toolInvocation: toAIV4CompatibleToolInvocation(p.toolInvocation),
+        });
+        return parts;
+      }, []);
 
       // fully remove this message if it has an empty parts array after stripping out incomplete tool calls.
       if (!safeParts.length) return false;
@@ -107,7 +146,9 @@ export function sanitizeAIV4UIMessages(messages: UIMessageV4[]): UIMessageV4[] {
 
       // ensure toolInvocations are also updated to only show results
       if (`toolInvocations` in m && m.toolInvocations) {
-        sanitized.toolInvocations = m.toolInvocations.filter(t => t.state === `result`);
+        sanitized.toolInvocations = m.toolInvocations
+          .filter(t => t.state === `result` || getToolInvocationState(t) === 'output-error')
+          .map(toAIV4CompatibleToolInvocation);
       }
 
       return sanitized;

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
@@ -5,6 +5,62 @@ import { MessageList } from '../../message-list';
 import { convertToV1Messages } from './convert-to-mastra-v1';
 
 describe('convertToV1Messages', () => {
+  it('should preserve output-error tool outcomes as legacy tool-result messages', () => {
+    const messages: MastraDBMessage[] = [
+      {
+        id: 'msg-output-error',
+        role: 'assistant',
+        createdAt: new Date('2024-01-01'),
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'output-error',
+                toolCallId: 'call-1',
+                toolName: 'lookupCustomer',
+                args: { customerId: 'cus_123' },
+                errorText: 'Lookup failed',
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    const v1Messages = convertToV1Messages(messages);
+
+    expect(v1Messages).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        type: 'tool-call',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'lookupCustomer',
+            args: { customerId: 'cus_123' },
+          },
+        ],
+      }),
+      expect.objectContaining({
+        role: 'tool',
+        type: 'tool-result',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'lookupCustomer',
+            result: 'Lookup failed',
+          },
+        ],
+      }),
+    ]);
+  });
+
   it('should preserve toolInvocations when text follows tool invocations (reproduces issue #6087)', () => {
     // This reproduces the exact issue from GitHub issue #6087
     // When an assistant message has tool invocations followed by text,

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
@@ -4,7 +4,7 @@
  */
 import type { AssistantContent, ToolResultPart } from '@internal/ai-sdk-v4';
 import type { MastraMessageV1 } from '../../../memory/types';
-import type { MastraMessageContentV2, MastraDBMessage } from '../../message-list';
+import type { MastraMessageContentV2, MastraDBMessage, MastraToolInvocation } from '../../message-list';
 import { attachmentsToParts } from './attachments-to-parts';
 
 const makePushOrCombine = (v1Messages: MastraMessageV1[]) => {
@@ -54,6 +54,34 @@ const makePushOrCombine = (v1Messages: MastraMessageV1[]) => {
     }
   };
 };
+
+function hasToolOutcome(toolInvocation: MastraToolInvocation): boolean {
+  return (
+    (toolInvocation.state === 'result' && 'result' in toolInvocation) ||
+    toolInvocation.state === 'output-error'
+  );
+}
+
+function toToolResultPart(toolInvocation: MastraToolInvocation): ToolResultPart {
+  const { toolCallId, toolName } = toolInvocation;
+
+  if (toolInvocation.state === 'output-error') {
+    return {
+      type: 'tool-result',
+      toolCallId,
+      toolName,
+      result: toolInvocation.errorText || 'Tool execution failed',
+    };
+  }
+
+  return {
+    type: 'tool-result',
+    toolCallId,
+    toolName,
+    result: toolInvocation.result,
+  };
+}
+
 export function convertToV1Messages(messages: Array<MastraDBMessage>) {
   const v1Messages: MastraMessageV1[] = [];
   const pushOrCombine = makePushOrCombine(v1Messages);
@@ -194,23 +222,15 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
               .map(part => part.toolInvocation)
               .filter(ti => ti.toolName !== 'updateWorkingMemory');
 
-            // Only create tool-result message if there are actual results
-            const invocationsWithResults = stepInvocations.filter(ti => ti.state === 'result' && 'result' in ti);
+            // Only create tool-result message if there are completed tool outcomes
+            const invocationsWithResults = stepInvocations.filter(hasToolOutcome);
 
             if (invocationsWithResults.length > 0) {
               pushOrCombine({
                 role: 'tool',
                 ...fields,
                 type: 'tool-result',
-                content: invocationsWithResults.map((toolInvocation): ToolResultPart => {
-                  const { toolCallId, toolName, result } = toolInvocation;
-                  return {
-                    type: 'tool-result',
-                    toolCallId,
-                    toolName,
-                    result,
-                  };
-                }),
+                content: invocationsWithResults.map(toToolResultPart),
               });
             }
 
@@ -299,23 +319,15 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
                   ],
                 });
 
-                // Only create tool-result message if there are actual results
-                const invocationsWithResults = stepInvocations.filter(ti => ti.state === 'result' && 'result' in ti);
+                // Only create tool-result message if there are completed tool outcomes
+                const invocationsWithResults = stepInvocations.filter(hasToolOutcome);
 
                 if (invocationsWithResults.length > 0) {
                   pushOrCombine({
                     role: 'tool',
                     ...fields,
                     type: 'tool-result',
-                    content: invocationsWithResults.map((toolInvocation): ToolResultPart => {
-                      const { toolCallId, toolName, result } = toolInvocation;
-                      return {
-                        type: 'tool-result',
-                        toolCallId,
-                        toolName,
-                        result,
-                      };
-                    }),
+                    content: invocationsWithResults.map(toToolResultPart),
                   });
                 }
               }
@@ -361,23 +373,15 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
             ],
           });
 
-          // Only create tool-result message if there are actual results
-          const invocationsWithResults = stepInvocations.filter(ti => ti.state === 'result' && 'result' in ti);
+          // Only create tool-result message if there are completed tool outcomes
+          const invocationsWithResults = stepInvocations.filter(hasToolOutcome);
 
           if (invocationsWithResults.length > 0) {
             pushOrCombine({
               role: 'tool',
               ...fields,
               type: 'tool-result',
-              content: invocationsWithResults.map((toolInvocation): ToolResultPart => {
-                const { toolCallId, toolName, result } = toolInvocation;
-                return {
-                  type: 'tool-result',
-                  toolCallId,
-                  toolName,
-                  result,
-                };
-              }),
+              content: invocationsWithResults.map(toToolResultPart),
             });
           }
         }

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -4050,7 +4050,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4083,7 +4083,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4190,7 +4190,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -4334,7 +4334,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4376,7 +4376,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4489,7 +4489,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -4584,7 +4584,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4626,7 +4626,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4739,7 +4739,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -5506,7 +5506,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -5539,7 +5539,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -5654,7 +5654,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "test error",
                       },
                       "toolCallId": "call-1",
@@ -5807,7 +5807,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -5853,7 +5853,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -5978,7 +5978,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "test error",
                       },
                       "toolCallId": "call-1",
@@ -6082,7 +6082,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6128,7 +6128,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6253,7 +6253,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "test error",
                       },
                       "toolCallId": "call-1",
@@ -10657,7 +10657,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -10690,7 +10690,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -10802,7 +10802,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -10957,7 +10957,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -10999,7 +10999,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11117,7 +11117,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -11222,7 +11222,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11264,7 +11264,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11382,7 +11382,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -246,6 +246,33 @@ describe('createLLMMappingStep HITL behavior', () => {
     expect(result.stepResult.isContinued).toBe(true);
   });
 
+  it('should persist tool execution errors as output-error history parts', async () => {
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'brokenTool',
+        args: { param: 'test' },
+        result: undefined,
+        error: new Error('Tool execution failed'),
+      },
+    ];
+
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'output-error',
+          toolCallId: 'call-1',
+          toolName: 'brokenTool',
+          args: { param: 'test' },
+          errorText: 'Tool execution failed',
+        },
+      }),
+    );
+  });
+
   it('should continue the agentic loop (not bail) when all errors are tool-not-found', async () => {
     // Arrange: Tool call with ToolNotFoundError (set by tool-call-step when tool name is hallucinated)
     const { ToolNotFoundError } = await import('../errors');

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -299,7 +299,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
             rest.messageList.updateToolInvocation({
               type: 'tool-invocation' as const,
               toolInvocation: {
-                state: 'result' as const,
+                state: 'output-error' as const,
                 toolCallId: toolCall.toolCallId,
                 toolName: sanitizeToolName(toolCall.toolName),
                 args: toolCall.args,
@@ -307,7 +307,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                 // plain {name,message,stack} shape after the pubsub JSON round-trip).
                 // Without reification the `instanceof Error` check below falls through to
                 // `safeStringify`, dumping the whole stringified payload into the history.
-                result: reifiedError.message || 'Tool execution failed',
+                errorText: reifiedError.message || 'Tool execution failed',
               },
               ...(withToolPayloadTransformProviderMetadata(
                 toolCall.providerMetadata as ProviderMetadata,


### PR DESCRIPTION
## Summary
- Persist failed tool executions as `output-error` history parts instead of successful `result` parts.
- Keep legacy AI SDK v4 and Mastra v1 conversion paths compatible by mapping stored tool errors back to legacy tool-result messages when needed.
- Add regression coverage for persisted tool errors, v4 sanitization, v1 conversion, and the agent-network final result shape.

Fixes #15569.

## Testing
- `pnpm --filter ./packages/core exec vitest run src/loop/workflows/agentic-execution/llm-mapping-step.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/agent/message-list/conversion/output-converter-provider-executed.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/agent/message-list/prompt/convert-to-mastra-v1.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/agent/agent-network.test.ts --testNamePattern "should NOT store redundant toolCalls"`
- `pnpm --filter ./packages/core exec vitest run src/loop/loop.test.ts -u`
- `pnpm --filter ./packages/core exec vitest run src/loop/loop.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm test:core`
- `pnpm --filter ./packages/core lint`
- `pnpm build:core`
- `git diff --check`

CodeRabbit CLI was not available locally (`coderabbit` and `cr` were not found).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a tool breaks and throws an error, the system now correctly saves that failure to the conversation history instead of marking it as a successful result. When the conversation is reloaded later, the error stays properly marked as an error—with all the error details preserved—instead of being confusingly converted to a successful output.

## Summary

This PR fixes a data persistence issue where tool execution errors were incorrectly stored and loaded from conversation history. Previously, when a tool's `execute()` method threw an error, the error was persisted with `state: "result"` and the error text in the `result` field. Upon reloading from history, this appeared as a successful tool execution with the error message in the output, losing the semantic meaning that the tool had failed.

## Changes Overview

**Core Fix — llm-mapping-step.ts**  
Modified the tool error handling in `createLLMMappingStep` to persist failed tool executions with the correct state and error field. When a tool throws, it now calls `messageList.updateToolInvocation` with:
- `state: 'output-error'` (instead of `'result'`)
- `errorText: reifiedError.message` (instead of putting the error in a `result` field)

**Compatibility Layer — output-converter.ts**  
Extended `sanitizeAIV4UIMessages` to handle `output-error` tool invocations when converting to legacy AI SDK v4 format. Introduced `toAIV4CompatibleToolInvocation` helper that maps `output-error` invocations back to `state: 'result'` with the `errorText` moved to the `result` field, ensuring backward compatibility. Also updated `toolInvocations` filtering to preserve both successful results and errors.

**V1 Conversion — convert-to-mastra-v1.ts**  
Added two helper functions to support tool errors in Mastra v1 message format:
- `hasToolOutcome`: Returns true for tool invocations with `state: 'result'` (with a result field) or `state: 'output-error'`
- `toToolResultPart`: Maps both successful and error tool invocations to v1 tool-result messages, converting `output-error` by using `errorText` as the result content

These helpers ensure that both successful and failed tool executions are properly included in tool-result messages during v1 conversion.

**Tests**  
- Added regression test in `llm-mapping-step.test.ts` verifying that tool errors are persisted with `state: 'output-error'` and `errorText`
- Added test in `output-converter-provider-executed.test.ts` validating v4 sanitization converts `output-error` to legacy `result` format
- Added test in `convert-to-mastra-v1.test.ts` confirming v1 conversion handles `output-error` tool invocations
- Updated test in `agent-network.test.ts` to accept both `tool-result` and `tool-error` entries in final results

**Changeset**  
Added `@mastra/core` patch release note documenting that tool execution errors are now properly preserved in reloaded conversation history (closes `#15569`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->