### PR TITLE
fix(core,cli): surface channel startup errors

### DIFF
--- a/.changeset/orange-pugs-obey.md
+++ b/.changeset/orange-pugs-obey.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent channels so initialization runs after Mastra construction and startup failures are logged instead of being silently swallowed. Fixes #17692.

--- a/.changeset/orange-wasps-laugh.md
+++ b/.changeset/orange-wasps-laugh.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra start` so server stderr is shown while the process is running, making channel startup errors visible in production. Fixes #17692.

--- a/packages/cli/src/commands/start/start.test.ts
+++ b/packages/cli/src/commands/start/start.test.ts
@@ -89,4 +89,29 @@ describe('start command - customArgs handling', () => {
 
     expect(commands).toEqual(['index.mjs']);
   });
+
+  it('should stream server stderr while the process is still running', async () => {
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    let stderrHandler: ((data: Buffer) => void) | undefined;
+    const mockProcess = {
+      stderr: {
+        on: vi.fn((event: string, handler: (data: Buffer) => void) => {
+          if (event === 'data') {
+            stderrHandler = handler;
+          }
+        }),
+      },
+      on: vi.fn(),
+      kill: vi.fn(),
+    };
+    spawnMock.mockReturnValue(mockProcess);
+    const { start } = await import('./start');
+
+    await start();
+    stderrHandler?.(Buffer.from('channel failed\n'));
+
+    expect(stderrWrite).toHaveBeenCalledWith(Buffer.from('channel failed\n'));
+
+    stderrWrite.mockRestore();
+  });
 });

--- a/packages/cli/src/commands/start/start.ts
+++ b/packages/cli/src/commands/start/start.ts
@@ -45,6 +45,7 @@ export async function start(options: StartOptions = {}) {
     let stderrBuffer = '';
     server.stderr.on('data', data => {
       stderrBuffer += data.toString();
+      process.stderr.write(data);
     });
 
     server.on('exit', code => {

--- a/packages/core/src/channels/__tests__/integration.test.ts
+++ b/packages/core/src/channels/__tests__/integration.test.ts
@@ -1,5 +1,5 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../../agent';
 import { Mastra } from '../../mastra';
@@ -57,6 +57,10 @@ function createTestAgent(id: string, options?: { channels?: ChannelConfig }) {
     }),
     channels: options?.channels,
   });
+}
+
+function waitForChannelInit() {
+  return new Promise(resolve => setImmediate(resolve));
 }
 
 describe('Mastra Channel Integration', () => {
@@ -136,6 +140,63 @@ describe('Mastra Channel Integration', () => {
       expect(typeof channelLogger.info).toBe('function');
       expect(typeof channelLogger.debug).toBe('function');
       expect(typeof channelLogger.warn).toBe('function');
+    });
+  });
+
+  describe('initialization', () => {
+    it('defers agent channel initialization until the Mastra constructor finishes', async () => {
+      const agent = createTestAgent('bot-1', {
+        channels: { adapters: { discord: createMockAdapter('discord') } },
+      });
+      const channels = agent.getChannels()!;
+      const initializedAfterConstructor: boolean[] = [];
+      let constructorFinished = false;
+
+      vi.spyOn(channels, 'initialize').mockImplementation(async () => {
+        initializedAfterConstructor.push(constructorFinished);
+      });
+
+      new Mastra({
+        logger: false,
+        agents: { 'bot-1': agent },
+        storage: new InMemoryStore(),
+      });
+      constructorFinished = true;
+
+      await waitForChannelInit();
+
+      expect(initializedAfterConstructor).toEqual([true]);
+    });
+
+    it('logs agent channel initialization failures instead of silently swallowing them', async () => {
+      const agent = createTestAgent('bot-1', {
+        channels: { adapters: { discord: createMockAdapter('discord') } },
+      });
+      const channels = agent.getChannels()!;
+      const initError = new Error('channel init failed');
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        cleanup: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+        trackException: vi.fn(),
+        listLogs: vi.fn(),
+        listLogsByRunId: vi.fn(),
+      };
+
+      vi.spyOn(channels, 'initialize').mockRejectedValue(initError);
+
+      new Mastra({
+        logger: logger as any,
+        agents: { 'bot-1': agent },
+        storage: new InMemoryStore(),
+      });
+
+      await waitForChannelInit();
+
+      expect(logger.error).toHaveBeenCalledWith('Failed to initialize channels for agent "bot-1":', initError);
     });
   });
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1736,6 +1736,14 @@ export class Mastra<
     return this.#agents;
   }
 
+  #initializeAgentChannels(agentKey: string, agentChannelsInstance: AgentChannels): void {
+    void Promise.resolve()
+      .then(() => agentChannelsInstance.initialize(this))
+      .catch(err => {
+        this.#logger?.error(`Failed to initialize channels for agent "${agentKey}":`, err);
+      });
+  }
+
   /**
    * Adds a new agent to the Mastra instance.
    *
@@ -1902,7 +1910,7 @@ export class Mastra<
           apiRoutes: [...(this.#server?.apiRoutes ?? []), ...channelRoutes],
         };
       }
-      void agentChannelsInstance.initialize(this);
+      this.#initializeAgentChannels(agentKey, agentChannelsInstance);
     }
   }
 


### PR DESCRIPTION
## Summary
- Defer agent-level channel initialization until after the `Mastra` constructor finishes.
- Log agent channel initialization failures through the Mastra logger instead of leaving rejected promises silent/unhandled.
- Stream child server stderr live from `mastra start`, matching `mastra worker`, so channel/adapter startup errors are visible while the server keeps running.
- Add regression coverage for constructor-time deferral, initialization failure logging, and live stderr forwarding.

Fixes #17692.

## Testing
- Red test confirmed before the core fix: `pnpm --filter ./packages/core exec vitest run src/channels/__tests__/integration.test.ts`
- Red test confirmed before the CLI fix: `pnpm --filter ./packages/cli exec vitest run src/commands/start/start.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/channels/__tests__/integration.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/channels/__tests__/agent-channels.test.ts src/channels/__tests__/integration.test.ts src/channels/__tests__/state-adapter.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/mastra/processor-workflow-registration.test.ts src/mastra/workspace-registration.test.ts src/mastra/config-spread.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm test:core`
- `pnpm --filter ./packages/core lint`
- `pnpm build:core`
- `pnpm --filter ./packages/cli exec vitest run src/commands/start/start.test.ts`
- `pnpm build:cli`
- `pnpm --filter ./packages/cli typecheck`
- `pnpm --filter ./packages/cli lint`
- `pnpm test:cli`
- `git diff --check`

CodeRabbit CLI was not available locally (`coderabbit` and `cr` were not found).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a bug where the Mastra server was silently ignoring errors that happened when starting up agent channels. The problem was that initialization was happening too early (before everything was ready) and errors weren't being shown to anyone. The fix makes sure initialization happens at the right time and that any errors get logged and displayed so developers can see what went wrong.

## Summary

This PR addresses issue `#17692` by fixing how agent channel initialization errors are handled in Mastra's production setup (`mastra start`). The core issue was that channels were being initialized during the Mastra constructor (before storage was wired), causing initialization failures to be silently swallowed as unhandled rejected promises.

### Changes

**Core initialization logic** (`packages/core/src/mastra/index.ts`):
- Added a private `#initializeAgentChannels()` helper that asynchronously initializes agent channels and logs any errors through the Mastra logger instead of leaving rejected promises unhandled
- Updated `addAgent()` to defer channel initialization by routing through this new helper after the Mastra constructor completes

**CLI server output** (`packages/cli/src/commands/start/start.ts`):
- Modified the `start` command to stream child server stderr in real-time to the parent process, ensuring startup and channel initialization errors are visible immediately during server boot (matching the behavior of `mastra worker`)

**Testing** (`packages/core/src/channels/__tests__/integration.test.ts` and `packages/cli/src/commands/start/start.test.ts`):
- Added integration test verifying that `channels.initialize()` is deferred until after the Mastra constructor completes
- Added integration test validating that channel initialization failures are logged via the Mastra logger
- Added unit test for stderr forwarding in the start command

**Documentation** (`.changeset/` entries):
- Added changelog entries for both `@mastra/core` and `mastra` packages documenting these fixes

### Impact

With these changes, channel initialization failures that previously caused the server to boot without active channel connections (and without any visible error logging) will now:
1. Initialize at the correct time when storage is available
2. Have their errors properly logged through the Mastra logger
3. Be visible in real-time during server startup via stderr forwarding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->