### PR TITLE
fix(ci): auto-run pending release workflow

### DIFF
--- a/.github/actions/app-auth/action.yaml
+++ b/.github/actions/app-auth/action.yaml
@@ -3,7 +3,10 @@ description: 'Create GitHub App installation token, expose outputs, set .netrc'
 inputs:
   client-id:
     description: 'GitHub App Client ID'
-    required: true
+    required: false
+  app-id:
+    description: 'GitHub App ID fallback when client-id is unavailable'
+    required: false
   private-key:
     description: 'GitHub App private key'
     required: true
@@ -36,6 +39,7 @@ runs:
       uses: actions/create-github-app-token@v3
       with:
         client-id: ${{ inputs.client-id }}
+        app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repositories }}

--- a/.github/workflows/issue-pending-release.yml
+++ b/.github/workflows/issue-pending-release.yml
@@ -1,7 +1,7 @@
 name: Issue Pending Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -32,6 +32,7 @@ jobs:
         uses: ./.github/actions/app-auth
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
+          app-id: ${{ vars.DANE_APP_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Setup pnpm and node


### PR DESCRIPTION
This updates the pending release issue workflow so it can run automatically after PRs merge to main instead of needing manual approval.

Before, it used pull_request, which can block access to secrets for some PR contexts. Now it uses pull_request_target while keeping the existing merged-to-main guard, and the checkout still uses the trusted base branch automation scripts.

It also passes DANE_APP_ID as an app-id fallback to the app-auth action, so token creation does not fail when client-id is unavailable in the workflow context.

No changeset included because this only changes GitHub automation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the pending release workflow run automatically when code gets merged to the main branch, instead of needing someone to manually approve it. It also adds a backup way for the workflow to authenticate itself (using an app ID) so it doesn't fail if the main authentication method isn't available.

## Changes

### Workflow Trigger Update
The `Issue Pending Release` workflow has been converted from listening to `pull_request` events to `pull_request_target` events, enabling it to run automatically after PRs merge to main while maintaining the existing merged-to-main guard.

### Authentication Fallback
- The `.github/actions/app-auth` composite action now accepts `client-id` as an optional input (previously required) and adds a new optional `app-id` input that serves as a fallback when `client-id` is unavailable
- The workflow now passes `${{ vars.DANE_APP_ID }}` as the `app-id` parameter to the app-auth action, ensuring token generation succeeds even when `client-id` is not available in the workflow context

## Files Modified
- `.github/actions/app-auth/action.yaml`
- `.github/workflows/issue-pending-release.yml`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->