### PR TITLE
fix(durable-agent): populate MASTRA_THREAD_ID_KEY on step requestContext for input processors

### DIFF
--- a/.changeset/fix-durable-agent-tool-search-thread-id.md
+++ b/.changeset/fix-durable-agent-tool-search-thread-id.md
@@ -1,0 +1,22 @@
+---
+"@mastra/core": patch
+---
+
+fix(durable-agent): populate MASTRA_THREAD_ID_KEY on step requestContext for input processors
+
+The workflow engine injects a fresh RequestContext into each durable step,
+so MASTRA_THREAD_ID_KEY was undefined when ToolSearchProcessor (and other
+input processors) read it. The processor fell back to the 'default' bucket,
+causing all threads to share one loaded-tool set and cold-loaded tools to
+never appear on subsequent turns under DurableAgent.
+
+Fix: before running input processors in the LLM execution step, copy
+threadId and resourceId from typedInput.state onto the step's requestContext
+if not already set — mirroring what preparation.ts does before the initial
+processor run.
+
+Note: the secondary issue (loaded-tool state lost across process boundaries
+on true durable suspend/resume) requires persisting ToolSearchProcessor state
+to working memory and is not addressed here.
+
+Fixes #17714

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -6,7 +6,7 @@ import type { MastraMemory } from '../../memory/memory';
 import type { MemoryConfig, MemoryConfig as _MemoryConfig, StorageThreadType } from '../../memory/types';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow, ErrorProcessorOrWorkflow } from '../../processors';
 import type { ProcessorState } from '../../processors/runner';
-import { RequestContext, MASTRA_VERSIONS_KEY, mergeVersionOverrides } from '../../request-context';
+import { RequestContext, MASTRA_VERSIONS_KEY, MASTRA_THREAD_ID_KEY, MASTRA_RESOURCE_ID_KEY, mergeVersionOverrides } from '../../request-context';
 import type { VersionOverrides } from '../../request-context';
 import type { CoreTool, ToolHooks } from '../../tools/types';
 import type { Workspace } from '../../workspace';
@@ -143,6 +143,8 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
     typeof execOptions?.memory?.thread === 'string' ? { id: execOptions.memory.thread } : execOptions?.memory?.thread;
   const threadId = thread?.id;
   const resourceId = execOptions?.memory?.resource;
+  if (threadId) requestContext.set(MASTRA_THREAD_ID_KEY, threadId);
+  if (resourceId) requestContext.set(MASTRA_RESOURCE_ID_KEY, resourceId);
   let threadObject: StorageThreadType | undefined;
   let threadExists = false;
 

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -236,6 +236,16 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
 
             const registryEntry = globalRunRegistry.get(runId);
             const executionAbortSignal = (registryEntry as any)?.abortSignal ?? abortSignal;
+            // Ensure threadId/resourceId are set on the step's requestContext so input
+            // processors (e.g. ToolSearchProcessor) can read MASTRA_THREAD_ID_KEY.
+            // The workflow engine injects a fresh requestContext per step; we mirror
+            // what preparation.ts does before handing off to processors.
+            if (typedInput.state?.threadId && !requestContext.get(MASTRA_THREAD_ID_KEY)) {
+              requestContext.set(MASTRA_THREAD_ID_KEY, typedInput.state.threadId);
+            }
+            if (typedInput.state?.resourceId && !requestContext.get(MASTRA_RESOURCE_ID_KEY)) {
+              requestContext.set(MASTRA_RESOURCE_ID_KEY, typedInput.state.resourceId);
+            }
             if (registryEntry?.inputProcessors?.length) {
               const inputStepWriter = pubsub
                 ? {


### PR DESCRIPTION
## Description

`ToolSearchProcessor` keys its loaded-tool state by `requestContext.get(MASTRA_THREAD_ID_KEY)`. Under `DurableAgent` this was always `undefined`, so every thread shared the same `'default'` bucket — meaning cold-loaded tools from one thread leaked into others, and on the agent's next turn the loaded tools were missing because the bucket was keyed wrong.

**Root cause:** Two places hand off a `RequestContext` to input processors, and neither was setting `MASTRA_THREAD_ID_KEY`:

1. `preparation.ts` — runs input processors once before the durable workflow starts. `threadId` was extracted from `execOptions.memory.thread` but never written onto `requestContext`.
2. `llm-execution.ts` — runs input processors on every subsequent durable step. The workflow engine injects a **fresh** `RequestContext` per step, so even if `preparation.ts` had set it, the key would be missing again on turns 2, 3, ...

**Fix:** Mirror what the non-durable agent path already does — set `MASTRA_THREAD_ID_KEY` and `MASTRA_RESOURCE_ID_KEY` on `requestContext` from the resolved `threadId`/`resourceId` before handing off to processors, in both places.

**Not addressed:** The secondary issue raised in #17714 — loaded-tool state lost across true durable suspend/resume (different worker process or after TTL expiry) — requires persisting `ToolSearchProcessor.threadLoadedTools` to working memory and is a separate architectural change.

## Related issue(s)

Fixes #17714

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

When the durable agent ran multiple conversations at the same time, tools that were loaded in one conversation would accidentally get mixed up and appear in other conversations. The fix makes sure the system tells the tool processor which conversation it's working on, so tools stay in their own conversation instead of being shared with everyone.

## Changes

This PR fixes a critical bug in DurableAgent where input processors (specifically `ToolSearchProcessor`) were unable to identify which thread they were operating on, causing all threads to share a single bucket of loaded tools instead of maintaining per-thread state.

### Root Cause
The workflow engine injects a fresh `RequestContext` for each durable step, but two code paths were not populating `MASTRA_THREAD_ID_KEY` and `MASTRA_RESOURCE_ID_KEY`:
1. `preparation.ts` — runs input processors once before the durable workflow starts
2. `llm-execution.ts` — runs input processors on every subsequent durable step

Without these keys, `ToolSearchProcessor` falls back to a 'default' bucket, causing cold-loaded tools to leak across threads and disappear on subsequent agent turns within the same thread.

### Solution
Both files were updated to mirror the non-durable agent behavior:

- **preparation.ts**: Now sets `MASTRA_THREAD_ID_KEY` and `MASTRA_RESOURCE_ID_KEY` in `requestContext` when `threadId` and `resourceId` are resolved from `execOptions.memory`

- **llm-execution.ts**: Now ensures `requestContext` has these keys set from `typedInput.state` before passing to input processors

- **Changeset**: Documents the fix and notes that a separate issue—persisting `ToolSearchProcessor.threadLoadedTools` across durable suspend/resume—remains unaddressed and requires architectural changes to persist state to working memory

### Lines Changed
- +35/-0 across affected files (low code complexity)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->