### PR TITLE
fix(playground-ui): polish DataList overflow and separators

### DIFF
--- a/.changeset/kind-places-design.md
+++ b/.changeset/kind-places-design.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Improved DataList pagination controls, separators, overflow handling, truncation, and empty-cell rendering.
+Improved DataList pagination controls, row and header separators, wrapped-row spacing, text truncation, horizontal overflow handling, and empty-cell rendering.

--- a/.changeset/kind-places-design.md
+++ b/.changeset/kind-places-design.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved DataList pagination controls, separators, and overflow handling.

--- a/.changeset/kind-places-design.md
+++ b/.changeset/kind-places-design.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Improved DataList pagination controls, separators, overflow handling, and empty-cell rendering.
+Improved DataList pagination controls, separators, overflow handling, truncation, and empty-cell rendering.

--- a/.changeset/kind-places-design.md
+++ b/.changeset/kind-places-design.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Improved DataList pagination controls, separators, and overflow handling.
+Improved DataList pagination controls, separators, overflow handling, and empty-cell rendering.

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -84,7 +84,7 @@ export function DataListSelectCell({ checked, onToggle, ...rest }: DataListSelec
     <DataListCell
       as="label"
       height="compact"
-      className="cursor-pointer justify-items-center rounded-lg transition-colors duration-200 hover:bg-surface4 px-4"
+      className="h-8 w-8 self-center cursor-pointer justify-items-center px-0 py-0!"
       onClick={e => e.stopPropagation()}
     >
       <Checkbox

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -4,7 +4,7 @@ import { Checkbox } from '@/ds/components/Checkbox';
 import { cn } from '@/lib/utils';
 
 export type DataListCellProps = {
-  children: ReactNode;
+  children?: ReactNode;
   className?: string;
   height?: 'default' | 'compact';
   /**
@@ -20,7 +20,7 @@ export function DataListCell({ children, className, height = 'default', as, ...r
   return (
     <Component
       className={cn(
-        'relative grid min-w-0 items-center text-ui-md whitespace-nowrap text-neutral3',
+        'relative grid min-w-0 items-center text-ui-md whitespace-nowrap text-neutral3 empty:before:content-["—"] empty:before:text-neutral2',
         height === 'compact' ? 'py-1.5' : 'py-2.5',
         className,
       )}
@@ -38,7 +38,7 @@ export function DataListTextCell({ children, className }: DataListCellProps) {
 export function DataListNameCell({ children, className }: DataListCellProps) {
   return (
     <DataListCell className={cn('text-left text-neutral4', className)}>
-      <span className="truncate">{children}</span>
+      <span className='truncate empty:before:content-["—"] empty:before:text-neutral2'>{children}</span>
     </DataListCell>
   );
 }
@@ -46,7 +46,7 @@ export function DataListNameCell({ children, className }: DataListCellProps) {
 export function DataListDescriptionCell({ children, className }: DataListCellProps) {
   return (
     <DataListCell className={cn('text-neutral2', className)}>
-      <span className="truncate">{children}</span>
+      <span className='truncate empty:before:content-["—"]'>{children}</span>
     </DataListCell>
   );
 }
@@ -115,7 +115,9 @@ export interface DataListMonoCellProps {
 export function DataListMonoCell({ children, className, height = 'compact' }: DataListMonoCellProps) {
   return (
     <DataListCell height={height} className="min-w-0">
-      <span className={cn('block text-ui-smd font-mono text-neutral3 truncate', className)}>{children}</span>
+      <span className={cn('block text-ui-smd font-mono text-neutral3 truncate empty:before:content-["—"]', className)}>
+        {children}
+      </span>
     </DataListCell>
   );
 }
@@ -134,7 +136,7 @@ export function DataListDateCell({ timestamp }: DataListDateCellProps) {
   const date = toDate(timestamp);
   return (
     <DataListCell height="compact" className="text-ui-smd text-neutral2">
-      {date ? (isToday(date) ? 'Today' : format(date, 'MMM dd')) : '-'}
+      {date ? (isToday(date) ? 'Today' : format(date, 'MMM dd')) : null}
     </DataListCell>
   );
 }
@@ -153,9 +155,7 @@ export function DataListTimeCell({ timestamp }: DataListTimeCellProps) {
           {format(date, 'HH:mm:ss')}
           <span className="text-neutral2">.{String(date.getMilliseconds()).padStart(3, '0')}</span>
         </>
-      ) : (
-        '-'
-      )}
+      ) : null}
     </DataListCell>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -1,4 +1,5 @@
 import { format, isToday } from 'date-fns';
+import { Children, cloneElement, isValidElement } from 'react';
 import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
 import { Checkbox } from '@/ds/components/Checkbox';
 import { cn } from '@/lib/utils';
@@ -20,7 +21,7 @@ export function DataListCell({ children, className, height = 'default', as, ...r
   return (
     <Component
       className={cn(
-        'relative grid min-w-0 items-center text-ui-md whitespace-nowrap text-neutral3 empty:before:content-["—"] empty:before:text-neutral2',
+        'relative grid min-w-0 max-w-full items-center overflow-hidden text-ui-md whitespace-nowrap text-neutral3 empty:before:content-["—"] empty:before:text-neutral2',
         height === 'compact' ? 'py-1.5' : 'py-2.5',
         className,
       )}
@@ -31,14 +32,53 @@ export function DataListCell({ children, className, height = 'default', as, ...r
   );
 }
 
-export function DataListTextCell({ children, className }: DataListCellProps) {
-  return <DataListCell className={className}>{children}</DataListCell>;
+const dataListTruncateContentStyles =
+  'block min-w-0 max-w-full truncate empty:before:content-["—"] empty:before:text-neutral2 [&>*]:min-w-0 [&>*]:max-w-full [&>*]:overflow-hidden [&>*]:text-ellipsis [&>*]:whitespace-nowrap';
+const dataListInlineTextTruncateStyles = 'min-w-0 flex-1 truncate';
+
+function DataListInlineText({ children }: { children: string | number }) {
+  return <span className={dataListInlineTextTruncateStyles}>{children}</span>;
+}
+
+function DataListTruncatedTextNodes({ children }: { children: ReactNode }) {
+  return Children.map(children, child => {
+    if (typeof child === 'string' || typeof child === 'number') {
+      return <DataListInlineText>{child}</DataListInlineText>;
+    }
+
+    return child;
+  });
+}
+
+function DataListTruncatedCellContent({ children }: { children: ReactNode }) {
+  return Children.map(children, child => {
+    if (!isValidElement<{ children?: ReactNode; className?: string }>(child) || typeof child.type !== 'string') {
+      return child;
+    }
+
+    return cloneElement(child, {
+      className: cn('min-w-0 max-w-full overflow-hidden', child.props.className),
+      children: <DataListTruncatedTextNodes>{child.props.children}</DataListTruncatedTextNodes>,
+    });
+  });
+}
+
+export function DataListTextCell({ children, className, ...rest }: DataListCellProps) {
+  return (
+    <DataListCell className={className} {...rest}>
+      <span className={dataListTruncateContentStyles}>
+        <DataListTruncatedCellContent>{children}</DataListTruncatedCellContent>
+      </span>
+    </DataListCell>
+  );
 }
 
 export function DataListNameCell({ children, className }: DataListCellProps) {
   return (
     <DataListCell className={cn('text-left text-neutral4', className)}>
-      <span className='truncate empty:before:content-["—"] empty:before:text-neutral2'>{children}</span>
+      <span className={dataListTruncateContentStyles}>
+        <DataListTruncatedCellContent>{children}</DataListTruncatedCellContent>
+      </span>
     </DataListCell>
   );
 }
@@ -46,7 +86,9 @@ export function DataListNameCell({ children, className }: DataListCellProps) {
 export function DataListDescriptionCell({ children, className }: DataListCellProps) {
   return (
     <DataListCell className={cn('text-neutral2', className)}>
-      <span className='truncate empty:before:content-["—"]'>{children}</span>
+      <span className={dataListTruncateContentStyles}>
+        <DataListTruncatedCellContent>{children}</DataListTruncatedCellContent>
+      </span>
     </DataListCell>
   );
 }
@@ -114,8 +156,13 @@ export interface DataListMonoCellProps {
  */
 export function DataListMonoCell({ children, className, height = 'compact' }: DataListMonoCellProps) {
   return (
-    <DataListCell height={height} className="min-w-0">
-      <span className={cn('block text-ui-smd font-mono text-neutral3 truncate empty:before:content-["—"]', className)}>
+    <DataListCell height={height}>
+      <span
+        className={cn(
+          'block min-w-0 max-w-full text-ui-smd font-mono text-neutral3 truncate empty:before:content-["—"]',
+          className,
+        )}
+      >
         {children}
       </span>
     </DataListCell>

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -20,8 +20,8 @@ export function DataListCell({ children, className, height = 'default', as, ...r
   return (
     <Component
       className={cn(
-        'relative grid items-center text-ui-md whitespace-nowrap text-neutral3',
-        height === 'compact' ? 'py-2' : 'py-3',
+        'relative grid min-w-0 items-center text-ui-md whitespace-nowrap text-neutral3',
+        height === 'compact' ? 'py-1.5' : 'py-2.5',
         className,
       )}
       {...rest}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -126,7 +126,7 @@ export function DataListSelectCell({ checked, onToggle, ...rest }: DataListSelec
     <DataListCell
       as="label"
       height="compact"
-      className="h-8 w-8 self-center cursor-pointer justify-items-center px-0 py-0!"
+      className="h-8 w-8 self-center cursor-pointer justify-items-center overflow-visible px-0 py-0!"
       onClick={e => e.stopPropagation()}
     >
       <Checkbox

--- a/packages/playground-ui/src/ds/components/DataList/data-list-pagination.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-pagination.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { Button } from '@/ds/components/Button';
 
 export type DataListPaginationProps = {
   currentPage?: number;
@@ -12,29 +12,23 @@ export function DataListPagination({ currentPage, hasMore, onNextPage, onPrevPag
   const showNavigation = (typeof currentPage === 'number' && currentPage > 0) || hasMore;
 
   return (
-    <div className={cn('col-span-full flex py-4 items-center justify-center text-neutral3 text-ui-md gap-8')}>
+    <div className="col-span-full flex py-4 items-center justify-center text-neutral3 text-ui-md gap-8">
       <span>
         Page <b>{currentPage ? currentPage + 1 : '1'}</b>
       </span>
       {showNavigation && (
-        <div
-          className={cn(
-            'flex gap-4',
-            '[&>button]:flex [&>button]:items-center [&>button]:gap-2 [&>button]:text-neutral4 [&>button:hover]:text-neutral5 [&>button]:transition-colors [&>button]:border [&>button]:border-border1 [&>button]:p-1 [&>button]:px-2 [&>button]:rounded-md',
-            '[&_svg]:w-[1em] [&_svg]:h-[1em] [&_svg]:text-neutral3',
-          )}
-        >
+        <div className="flex gap-4">
           {typeof currentPage === 'number' && currentPage > 0 && (
-            <button type="button" onClick={onPrevPage}>
+            <Button type="button" variant="outline" size="sm" onClick={onPrevPage}>
               <ArrowLeftIcon />
               Previous
-            </button>
+            </Button>
           )}
           {hasMore && (
-            <button type="button" onClick={onNextPage}>
+            <Button type="button" variant="outline" size="sm" onClick={onNextPage}>
               Next
               <ArrowRightIcon />
-            </button>
+            </Button>
           )}
         </div>
       )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -18,7 +18,7 @@ export function DataListRoot({ children, columns, className, scrollRef }: DataLi
     <div
       ref={scrollRef}
       className={cn(
-        'grid bg-surface2 border max-h-full border-border1 rounded-xl overflow-y-auto content-start',
+        'grid bg-surface2 border max-h-full border-border1 rounded-xl overflow-auto content-start',
         className,
       )}
       style={{ gridTemplateColumns: columns }}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -18,7 +18,7 @@ export function DataListRoot({ children, columns, className, scrollRef }: DataLi
     <div
       ref={scrollRef}
       className={cn(
-        'grid bg-surface2 border max-h-full border-border1 rounded-xl overflow-auto content-start [&>.data-list-top+.data-list-row]:mt-[3px]',
+        'grid min-w-0 max-w-full bg-surface2 border max-h-full border-border1 rounded-xl overflow-auto content-start [&>.data-list-top+.data-list-row]:mt-[3px]',
         className,
       )}
       style={{ gridTemplateColumns: columns }}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -18,7 +18,7 @@ export function DataListRoot({ children, columns, className, scrollRef }: DataLi
     <div
       ref={scrollRef}
       className={cn(
-        'grid min-w-0 max-w-full bg-surface2 border max-h-full border-border1 rounded-xl overflow-auto content-start [&>.data-list-top+.data-list-row]:mt-[3px]',
+        'grid min-w-0 max-w-full bg-surface2 border max-h-full border-border1 rounded-xl overflow-auto content-start',
         className,
       )}
       style={{ gridTemplateColumns: columns }}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -18,7 +18,7 @@ export function DataListRoot({ children, columns, className, scrollRef }: DataLi
     <div
       ref={scrollRef}
       className={cn(
-        'grid bg-surface2 border max-h-full border-border1 rounded-xl overflow-auto content-start',
+        'grid bg-surface2 border max-h-full border-border1 rounded-xl overflow-auto content-start [&>.data-list-top+.data-list-row]:mt-[3px]',
         className,
       )}
       style={{ gridTemplateColumns: columns }}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
-import { dataListRowStyles } from './shared';
+import { useDataListRowWrapperContext } from './data-list-row-wrapper-context';
+import { dataListRowInteractiveStyles, dataListRowStyles } from './shared';
 import type { DataListRowSharedProps } from './shared';
 import { cn } from '@/lib/utils';
 
@@ -15,6 +16,7 @@ export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButton
     { children, className, type = 'button', flushLeft, flushRight, colStart, colEnd, featured, style, ...rest },
     ref,
   ) => {
+    const isWrapped = useDataListRowWrapperContext();
     const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
     const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
     return (
@@ -22,10 +24,10 @@ export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButton
         ref={ref}
         type={type}
         className={cn(
-          ...dataListRowStyles,
+          ...(isWrapped ? dataListRowInteractiveStyles : dataListRowStyles),
           'text-left',
-          flushLeft && 'ml-0!',
-          flushRight && 'mr-0!',
+          !isWrapped && flushLeft && 'ml-0!',
+          !isWrapped && flushRight && 'mr-0!',
           featured && 'bg-surface4',
           className,
         )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactNode } from 'react';
-import { dataListRowStyles } from './shared';
+import { useDataListRowWrapperContext } from './data-list-row-wrapper-context';
+import { dataListRowInteractiveStyles, dataListRowStyles } from './shared';
 import type { DataListRowSharedProps } from './shared';
 import type { LinkComponent } from '@/ds/types/link-component';
 import { cn } from '@/lib/utils';
@@ -24,15 +25,16 @@ export function DataListRowLink({
   colEnd,
   featured,
 }: DataListRowLinkProps) {
+  const isWrapped = useDataListRowWrapperContext();
   const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
   const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
   return (
     <Link
       href={to}
       className={cn(
-        ...dataListRowStyles,
-        flushLeft && 'ml-0!',
-        flushRight && 'mr-0!',
+        ...(isWrapped ? dataListRowInteractiveStyles : dataListRowStyles),
+        !isWrapped && flushLeft && 'ml-0!',
+        !isWrapped && flushRight && 'mr-0!',
         featured && 'bg-surface4',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-static.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-static.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
-import { dataListRowOuterStyles } from './shared';
+import { useDataListRowWrapperContext } from './data-list-row-wrapper-context';
+import { dataListRowStaticStyles } from './shared';
 import type { DataListRowSharedProps } from './shared';
 import { cn } from '@/lib/utils';
 
@@ -12,16 +13,18 @@ export type DataListRowStaticProps = ComponentPropsWithoutRef<'div'> & DataListR
  */
 export const DataListRowStatic = forwardRef<HTMLDivElement, DataListRowStaticProps>(
   ({ children, className, flushLeft, flushRight, colStart, colEnd, featured, style, ...rest }, ref) => {
+    const isWrapped = useDataListRowWrapperContext();
     const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
     const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
     return (
       <div
         ref={ref}
         className={cn(
-          'mx-1 grid grid-cols-subgrid gap-8 px-5',
-          ...dataListRowOuterStyles,
-          flushLeft && 'ml-0!',
-          flushRight && 'mr-0!',
+          isWrapped
+            ? 'grid grid-cols-subgrid gap-8 px-5 transition-colors duration-200 rounded-lg'
+            : dataListRowStaticStyles,
+          !isWrapped && flushLeft && 'ml-0!',
+          !isWrapped && flushRight && 'mr-0!',
           featured && 'bg-surface4',
           className,
         )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper-context.ts
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper-context.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+export const DataListRowWrapperContext = createContext(false);
+
+export function useDataListRowWrapperContext() {
+  return useContext(DataListRowWrapperContext);
+}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
+import { DataListRowWrapperContext } from './data-list-row-wrapper-context';
 import { dataListRowOuterStyles } from './shared';
 import { cn } from '@/lib/utils';
 
@@ -17,13 +18,15 @@ export type DataListRowWrapperProps = ComponentPropsWithoutRef<'div'>;
 export const DataListRowWrapper = forwardRef<HTMLDivElement, DataListRowWrapperProps>(
   ({ children, className, ...rest }, ref) => {
     return (
-      <div
-        ref={ref}
-        className={cn('grid grid-cols-subgrid gap-0 mx-1', ...dataListRowOuterStyles, className)}
-        {...rest}
-      >
-        {children}
-      </div>
+      <DataListRowWrapperContext.Provider value>
+        <div
+          ref={ref}
+          className={cn('grid grid-cols-subgrid gap-0 mx-1', ...dataListRowOuterStyles, className)}
+          {...rest}
+        >
+          {children}
+        </div>
+      </DataListRowWrapperContext.Provider>
     );
   },
 );

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
@@ -110,7 +110,7 @@ export function DataListTopSelectCell({ checked, onToggle, ...rest }: DataListTo
   return (
     <DataListTopCell
       as="label"
-      className="cursor-pointer justify-center rounded-lg transition-colors duration-200 hover:bg-surface4 px-4"
+      className="w-8 cursor-pointer justify-center px-0 py-0!"
       onClick={e => e.stopPropagation()}
     >
       <Checkbox checked={checked} onCheckedChange={() => onToggle()} aria-label={rest['aria-label']} />

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
@@ -110,7 +110,7 @@ export function DataListTopSelectCell({ checked, onToggle, ...rest }: DataListTo
   return (
     <DataListTopCell
       as="label"
-      className="w-8 cursor-pointer justify-center px-0 py-0!"
+      className="w-8 cursor-pointer justify-center overflow-visible px-0 py-0!"
       onClick={e => e.stopPropagation()}
     >
       <Checkbox checked={checked} onCheckedChange={() => onToggle()} aria-label={rest['aria-label']} />

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
@@ -21,7 +21,7 @@ export const DataListTopCell = forwardRef<HTMLSpanElement, DataListTopCellProps>
       <Component
         ref={ref}
         className={cn(
-          'h-8 py-1 flex items-center uppercase whitespace-nowrap text-neutral2 tracking-widest text-ui-xs',
+          'h-8 min-w-0 max-w-full overflow-hidden py-1 flex items-center uppercase whitespace-nowrap text-neutral2 tracking-widest text-ui-xs',
           className,
         )}
         {...rest}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top.tsx
@@ -17,7 +17,7 @@ export function DataListTop({ children, className, hasLeadingCell }: DataListTop
   return (
     <div
       className={cn(
-        'mx-1 grid grid-cols-subgrid gap-8 col-span-full border-b border-border1 px-5 bg-surface2 sticky top-0 z-10',
+        'mx-1 grid grid-cols-subgrid gap-8 col-span-full relative px-5 bg-surface2 sticky top-0 z-10 after:absolute after:inset-x-[-0.25rem] after:bottom-0 after:h-px after:bg-border1 after:content-[""] after:pointer-events-none',
         hasLeadingCell && 'gap-0 pl-0!',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top.tsx
@@ -17,7 +17,7 @@ export function DataListTop({ children, className, hasLeadingCell }: DataListTop
   return (
     <div
       className={cn(
-        'mx-1 grid grid-cols-subgrid gap-8 col-span-full relative px-5 bg-surface2 sticky top-0 z-10 after:absolute after:inset-x-[-0.25rem] after:bottom-0 after:h-px after:bg-border1 after:content-[""] after:pointer-events-none',
+        'data-list-top mx-1 grid grid-cols-subgrid gap-8 col-span-full relative px-5 bg-surface2 sticky top-0 z-10 after:absolute after:inset-x-[-0.25rem] after:bottom-0 after:h-px after:bg-border1 after:content-[""] after:pointer-events-none',
         hasLeadingCell && 'gap-0 pl-0!',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
@@ -88,12 +88,12 @@ export const Default: Story = {
       </DataList.Top>
       {[
         { name: 'Research Agent', description: 'Reads articles and produces summaries.', status: 'active' },
-        { name: 'Writing Agent', description: 'Drafts long-form content from outlines.', status: 'active' },
+        { name: 'Writing Agent', description: '', status: 'active' },
         { name: 'Translation Agent', description: 'Translates text between supported languages.', status: 'idle' },
       ].map(item => (
         <DataList.RowButton key={item.name} onClick={() => {}}>
           <DataList.Cell className="text-neutral6 font-medium">{item.name}</DataList.Cell>
-          <DataList.Cell>{item.description}</DataList.Cell>
+          <DataList.DescriptionCell>{item.description}</DataList.DescriptionCell>
           <DataList.Cell>{item.status}</DataList.Cell>
         </DataList.RowButton>
       ))}

--- a/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
@@ -3,6 +3,8 @@ import { Pencil, Trash2 } from 'lucide-react';
 import { forwardRef, useState } from 'react';
 import { DataList } from './data-list';
 import { DataListSkeleton } from './data-list-skeleton';
+import { Badge } from '@/ds/components/Badge';
+import { Button } from '@/ds/components/Button';
 import type { LinkComponent } from '@/ds/types/link-component';
 
 const meta: Meta = {
@@ -45,6 +47,11 @@ const SAMPLE_RUNS = [
 
 const COMPACT_COLUMNS = 'auto minmax(0,1fr) auto auto auto';
 const DEFAULT_COLUMNS = 'auto minmax(0,1fr) auto';
+const WIDE_COLUMNS =
+  'minmax(12rem,14rem) minmax(18rem,24rem) minmax(16rem,20rem) minmax(10rem,12rem) minmax(12rem,14rem) minmax(9rem,11rem) minmax(12rem,14rem) minmax(11rem,13rem) minmax(10rem,12rem) minmax(12rem,14rem)';
+const VERY_LONG_BADGE =
+  'production-critical-evaluation-run-with-an-extraordinarily-long-status-label-that-must-truncate-inside-the-cell';
+const MODEL_TOKEN_PLACEHOLDERS = ['__GATEWAY_OPENAI_MODEL_BASE__', '__GATEWAY_ANTHROPIC_MODEL_SONNET__'];
 
 /** The standard condensed look used by Traces, Logs, Scores, Dataset Items, and Skills. */
 export const Compact: Story = {
@@ -219,22 +226,26 @@ export const WithTrailingCell: Story = {
           </DataList.RowButton>
           <DataList.Cell className="py-0">
             <div className="flex items-center justify-end gap-1 pr-3 w-full">
-              <button
+              <Button
                 type="button"
-                className="p-1 text-neutral3 hover:text-neutral5"
+                variant="ghost"
+                size="icon-xs"
+                tooltip={`Edit ${item.name}`}
                 aria-label={`Edit ${item.name}`}
                 onClick={e => e.stopPropagation()}
               >
                 <Pencil className="h-4 w-4" />
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
-                className="p-1 text-neutral3 hover:text-red-400"
+                variant="ghost"
+                size="icon-xs"
+                tooltip={`Delete ${item.name}`}
                 aria-label={`Delete ${item.name}`}
                 onClick={e => e.stopPropagation()}
               >
                 <Trash2 className="h-4 w-4" />
-              </button>
+              </Button>
             </div>
           </DataList.Cell>
         </DataList.RowWrapper>
@@ -304,6 +315,51 @@ export const Empty: Story = {
       </DataList.Top>
       <DataList.NoMatch message="No runs match your search" />
     </DataList>
+  ),
+};
+
+/** Wide grid with constrained columns, horizontal scrolling, and a long badge that must stay inside its cell. */
+export const WideColumnsOverflow: Story = {
+  render: () => (
+    <div className="max-w-[760px]">
+      <DataList columns={WIDE_COLUMNS} className="max-h-[360px]">
+        <DataList.Top>
+          <DataList.TopCell>Run</DataList.TopCell>
+          <DataList.TopCell>Input</DataList.TopCell>
+          <DataList.TopCell>Status badge</DataList.TopCell>
+          <DataList.TopCell>Model</DataList.TopCell>
+          <DataList.TopCell>Workflow</DataList.TopCell>
+          <DataList.TopCell>Owner</DataList.TopCell>
+          <DataList.TopCell>Environment</DataList.TopCell>
+          <DataList.TopCell>Duration</DataList.TopCell>
+          <DataList.TopCell>Date</DataList.TopCell>
+          <DataList.TopCell>Trace</DataList.TopCell>
+        </DataList.Top>
+        {Array.from({ length: 14 }, (_, index) => {
+          const run = SAMPLE_RUNS[index % SAMPLE_RUNS.length];
+          return (
+            <DataList.RowButton key={`${run.id}-${index}`} onClick={() => {}}>
+              <DataList.IdCell id={`${run.id}_${index}`} />
+              <DataList.MonoCell>
+                {run.input} with enough extra context to verify truncation in a narrow scrolling grid
+              </DataList.MonoCell>
+              <DataList.Cell height="compact" className="min-w-0">
+                <Badge variant={index % 3 === 0 ? 'warning' : 'success'} className="max-w-full min-w-0 overflow-hidden">
+                  <span className="min-w-0 truncate">{index === 2 ? VERY_LONG_BADGE : run.status}</span>
+                </Badge>
+              </DataList.Cell>
+              <DataList.MonoCell>{MODEL_TOKEN_PLACEHOLDERS[index % MODEL_TOKEN_PLACEHOLDERS.length]}</DataList.MonoCell>
+              <DataList.MonoCell>daily-evaluation-pipeline-{index + 1}</DataList.MonoCell>
+              <DataList.Cell height="compact">Team {index % 5}</DataList.Cell>
+              <DataList.Cell height="compact">{index % 2 === 0 ? 'production' : 'staging'}</DataList.Cell>
+              <DataList.Cell height="compact">{120 + index * 37}ms</DataList.Cell>
+              <DataList.DateCell timestamp={run.createdAt} />
+              <DataList.MonoCell>trace_{String(index + 1).padStart(4, '0')}</DataList.MonoCell>
+            </DataList.RowButton>
+          );
+        })}
+      </DataList>
+    </div>
   ),
 };
 

--- a/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
@@ -46,7 +46,7 @@ const SAMPLE_RUNS = [
 ];
 
 const COMPACT_COLUMNS = 'auto minmax(0,1fr) auto auto auto';
-const DEFAULT_COLUMNS = 'auto minmax(0,1fr) auto';
+const DEFAULT_COLUMNS = 'minmax(0,1fr) minmax(0,2fr) auto';
 const WIDE_COLUMNS =
   'minmax(12rem,14rem) minmax(18rem,24rem) minmax(16rem,20rem) minmax(10rem,12rem) minmax(12rem,14rem) minmax(9rem,11rem) minmax(12rem,14rem) minmax(11rem,13rem) minmax(10rem,12rem) minmax(12rem,14rem)';
 const VERY_LONG_BADGE =
@@ -89,10 +89,17 @@ export const Default: Story = {
       {[
         { name: 'Research Agent', description: 'Reads articles and produces summaries.', status: 'active' },
         { name: 'Writing Agent', description: '', status: 'active' },
+        {
+          name: 'Answer Relevancy Scorer With A Very Long Display Name That Must Truncate',
+          description: 'Evaluates whether generated answers stay aligned with the retrieved evidence.',
+          status: 'active',
+        },
         { name: 'Translation Agent', description: 'Translates text between supported languages.', status: 'idle' },
       ].map(item => (
         <DataList.RowButton key={item.name} onClick={() => {}}>
-          <DataList.Cell className="text-neutral6 font-medium">{item.name}</DataList.Cell>
+          <DataList.NameCell className="font-medium">
+            <span className="flex items-center">{item.name}</span>
+          </DataList.NameCell>
           <DataList.DescriptionCell>{item.description}</DataList.DescriptionCell>
           <DataList.Cell>{item.status}</DataList.Cell>
         </DataList.RowButton>

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -1,7 +1,7 @@
 /**
- * Row-level styling shared by anything that participates in the row sibling
+ * Row-level styling for the element that participates in the row sibling
  * chain — applied to `DataList.RowButton` / `DataList.RowLink` when used
- * standalone, and to `DataList.RowWrapper` when used as a wrapper around them.
+ * standalone, and to `DataList.RowWrapper` when used as a shell around them.
  *
  * Contains the `.data-list-row` marker class (used by the sibling-aware
  * separator rules), the full-width separator treatment, and rounded corners.
@@ -13,11 +13,15 @@ export const dataListRowOuterStyles = [
   'transition-colors duration-200 rounded-lg',
 ] as const;
 
-export const dataListRowStyles = [
-  'mx-1 grid grid-cols-subgrid gap-8 px-5 outline-none cursor-pointer',
+export const dataListRowInteractiveStyles = [
+  'grid grid-cols-subgrid gap-8 px-5 outline-none cursor-pointer',
   'hover:bg-surface4 focus-visible:bg-surface4 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent1',
-  ...dataListRowOuterStyles,
+  'transition-colors duration-200 rounded-lg',
 ] as const;
+
+export const dataListRowStyles = ['mx-1', ...dataListRowInteractiveStyles, ...dataListRowOuterStyles] as const;
+
+export const dataListRowStaticStyles = ['mx-1 grid grid-cols-subgrid gap-8 px-5', ...dataListRowOuterStyles] as const;
 
 /**
  * Layout/state modifiers shared by interactive row primitives

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -3,21 +3,19 @@
  * chain — applied to `DataList.RowButton` / `DataList.RowLink` when used
  * standalone, and to `DataList.RowWrapper` when used as a wrapper around them.
  *
- * Contains the `.data-list-row` marker class (used by the sibling-aware border
- * rules), the bottom/top border treatment, and rounded corners.
+ * Contains the `.data-list-row` marker class (used by the sibling-aware
+ * separator rules), the full-width separator treatment, and rounded corners.
  */
 export const dataListRowOuterStyles = [
-  'data-list-row col-span-full border-y border-b-border1 border-t-transparent',
-  '[.data-list-row:hover+&]:border-t-transparent [.data-list-row:focus-visible+&]:border-t-transparent',
-  '[.data-list-subheader+&]:border-t-transparent',
-  '[&:has(+.data-list-subheader)]:border-b-transparent',
-  '[&:not(:has(~.data-list-row))]:border-b-transparent',
+  'data-list-row col-span-full relative mt-1 mb-[3px]',
+  'after:absolute after:inset-x-[-0.25rem] after:bottom-[-0.25rem] after:h-px after:bg-border1 after:content-[""] after:pointer-events-none',
+  '[&:has(+.data-list-subheader)]:after:bg-transparent [&:not(:has(~.data-list-row))]:after:bg-transparent',
   'transition-colors duration-200 rounded-lg',
 ] as const;
 
 export const dataListRowStyles = [
   'mx-1 grid grid-cols-subgrid gap-8 px-5 outline-none cursor-pointer',
-  'hover:bg-surface4 hover:border-transparent focus-visible:bg-surface4 focus-visible:border-transparent focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent1',
+  'hover:bg-surface4 focus-visible:bg-surface4 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent1',
   ...dataListRowOuterStyles,
 ] as const;
 

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -9,7 +9,7 @@
 export const dataListRowOuterStyles = [
   'data-list-row col-span-full relative mt-1 mb-[3px]',
   'after:absolute after:inset-x-[-0.25rem] after:bottom-[-0.25rem] after:h-px after:bg-border1 after:content-[""] after:pointer-events-none',
-  '[&:has(+.data-list-subheader)]:after:bg-transparent [&:not(:has(~.data-list-row))]:after:bg-transparent',
+  '[&:has(+.data-list-subheader)]:after:hidden [&:not(:has(~.data-list-row))]:after:hidden',
   'transition-colors duration-200 rounded-lg',
 ] as const;
 

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -7,7 +7,7 @@
  * separator rules), the full-width separator treatment, and rounded corners.
  */
 export const dataListRowOuterStyles = [
-  'data-list-row col-span-full relative mt-1 mb-[3px]',
+  'data-list-row col-span-full relative mt-[3px] mb-1',
   'after:absolute after:inset-x-[-0.25rem] after:bottom-[-0.25rem] after:h-px after:bg-border1 after:content-[""] after:pointer-events-none',
   '[&:has(+.data-list-subheader)]:after:hidden [&:not(:has(~.data-list-row))]:after:hidden',
   'transition-colors duration-200 rounded-lg',

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -20,6 +20,15 @@ export interface DatasetsListProps {
 
 const COLUMNS = 'auto 1fr auto 5rem 9rem 10rem 7rem 8rem';
 
+function getDatasetRowLayout(hasExperimentsAction: boolean, hasReviewAction: boolean) {
+  return {
+    rowLinkColEnd: hasExperimentsAction ? -3 : hasReviewAction ? -2 : -1,
+    showExperimentsPlaceholder: !hasExperimentsAction,
+    showReviewPlaceholderInLink: !hasExperimentsAction && !hasReviewAction,
+    showReviewPlaceholderAfterExperiments: hasExperimentsAction && !hasReviewAction,
+  };
+}
+
 function formatDate(dateStr: string | Date | undefined | null): string {
   if (!dateStr) return '—';
   const d = typeof dateStr === 'string' ? new Date(dateStr) : dateStr;
@@ -94,11 +103,16 @@ export function DatasetsList({
         const review = reviewByDataset?.get(ds.id);
         const tags = Array.isArray(ds.tags) ? (ds.tags as string[]) : [];
         const hasExperimentsAction = ds.experimentCount > 0;
-        const rowLinkColEnd = hasExperimentsAction ? -3 : review ? -2 : -1;
+        const rowLayout = getDatasetRowLayout(hasExperimentsAction, Boolean(review));
 
         return (
           <EntityList.RowWrapper key={ds.id}>
-            <EntityList.RowLink flushRight colEnd={rowLinkColEnd} to={paths.datasetLink(ds.id)} LinkComponent={Link}>
+            <EntityList.RowLink
+              flushRight
+              colEnd={rowLayout.rowLinkColEnd}
+              to={paths.datasetLink(ds.id)}
+              LinkComponent={Link}
+            >
               <EntityList.NameCell>{ds.name}</EntityList.NameCell>
               <EntityList.DescriptionCell>{ds.description}</EntityList.DescriptionCell>
               <EntityList.Cell>
@@ -120,8 +134,8 @@ export function DatasetsList({
                 {ds.targetType ? ds.targetType : <span className="text-neutral2">—</span>}
               </EntityList.TextCell>
               <EntityList.TextCell>{formatDate(ds.updatedAt)}</EntityList.TextCell>
-              {!hasExperimentsAction ? <EntityList.Cell className="justify-center" /> : null}
-              {!review && !hasExperimentsAction ? <EntityList.Cell className="justify-center" /> : null}
+              {rowLayout.showExperimentsPlaceholder ? <EntityList.Cell className="justify-center" /> : null}
+              {rowLayout.showReviewPlaceholderInLink ? <EntityList.Cell className="justify-center" /> : null}
             </EntityList.RowLink>
 
             {hasExperimentsAction ? (
@@ -152,7 +166,7 @@ export function DatasetsList({
                   <Chip color="green">{review.complete} reviewed</Chip>
                 )}
               </Button>
-            ) : hasExperimentsAction ? (
+            ) : rowLayout.showReviewPlaceholderAfterExperiments ? (
               <EntityList.Cell className="justify-center" />
             ) : null}
           </EntityList.RowWrapper>

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -93,12 +93,14 @@ export function DatasetsList({
 
         const review = reviewByDataset?.get(ds.id);
         const tags = Array.isArray(ds.tags) ? (ds.tags as string[]) : [];
+        const hasExperimentsAction = ds.experimentCount > 0;
+        const rowLinkColEnd = hasExperimentsAction ? -3 : review ? -2 : -1;
 
         return (
           <EntityList.RowWrapper key={ds.id}>
-            <EntityList.RowLink flushRight colEnd={-3} to={paths.datasetLink(ds.id)} LinkComponent={Link}>
+            <EntityList.RowLink flushRight colEnd={rowLinkColEnd} to={paths.datasetLink(ds.id)} LinkComponent={Link}>
               <EntityList.NameCell>{ds.name}</EntityList.NameCell>
-              <EntityList.DescriptionCell>{ds.description || ''}</EntityList.DescriptionCell>
+              <EntityList.DescriptionCell>{ds.description}</EntityList.DescriptionCell>
               <EntityList.Cell>
                 {tags.length > 0 ? (
                   <div className="flex max-w-48 items-center gap-1 overflow-hidden" title={tags.join(', ')}>
@@ -118,9 +120,11 @@ export function DatasetsList({
                 {ds.targetType ? ds.targetType : <span className="text-neutral2">—</span>}
               </EntityList.TextCell>
               <EntityList.TextCell>{formatDate(ds.updatedAt)}</EntityList.TextCell>
+              {!hasExperimentsAction ? <EntityList.Cell className="justify-center" /> : null}
+              {!review && !hasExperimentsAction ? <EntityList.Cell className="justify-center" /> : null}
             </EntityList.RowLink>
 
-            {ds.experimentCount > 0 ? (
+            {hasExperimentsAction ? (
               <Button
                 as={Link}
                 to={`${paths.datasetLink(ds.id)}?tab=experiments`}
@@ -132,9 +136,7 @@ export function DatasetsList({
                   {ds.experimentCount} ({ds.successPct ?? 0}%)
                 </Chip>
               </Button>
-            ) : (
-              <span />
-            )}
+            ) : null}
 
             {review ? (
               <Button
@@ -150,9 +152,9 @@ export function DatasetsList({
                   <Chip color="green">{review.complete} reviewed</Chip>
                 )}
               </Button>
-            ) : (
-              <span />
-            )}
+            ) : hasExperimentsAction ? (
+              <EntityList.Cell className="justify-center" />
+            ) : null}
           </EntityList.RowWrapper>
         );
       })}

--- a/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
@@ -11,7 +11,7 @@ export interface ScorersListProps {
   sourceFilter?: string;
 }
 
-const COLUMNS = 'auto 1fr auto auto auto';
+const COLUMNS = 'minmax(0,1fr) minmax(0,1.5fr) auto auto auto';
 
 export function ScorersList({ scorers, isLoading, search = '', sourceFilter = 'all' }: ScorersListProps) {
   const { paths, Link } = useLinkComponent();
@@ -71,10 +71,10 @@ export function ScorersList({ scorers, isLoading, search = '', sourceFilter = 'a
         return (
           <EntityList.RowLink key={scorer.id} to={paths.scorerLink(scorer.id)} LinkComponent={Link}>
             <EntityList.NameCell>
-              <span className="flex items-center gap-1.5">
-                {name}
+              <span className="flex min-w-0 max-w-full items-center gap-1.5">
+                <span className="min-w-0 truncate">{name}</span>
                 {isTrajectory && (
-                  <Chip size="small" color="purple">
+                  <Chip size="small" color="purple" className="shrink-0">
                     trajectory
                   </Chip>
                 )}


### PR DESCRIPTION
Polishes DataList behavior in playground-ui so row shells, wrapped rows, separators, empty cells, and text overflow behave consistently. Pagination now uses the shared Button component, header and row separators are full-width pseudo-elements, empty cells render a neutral dash by default, and text-style cells constrain/truncate direct flex children such as scorer names.

The row wrapper now owns the row shell when selection or trailing cells are used, so consumers no longer need duplicate margin/padding handling. The first-row spacing is handled by the shared row margin itself instead of a root-level selector, and selection checkbox cells keep their compact fixed size without clipping overflow.

Adds Storybook coverage for pagination, selection rows, wide horizontal scrolling with a long badge, and a long flex-wrapped name case. Also simplifies the dataset row layout helper after CodeRabbit's review nitpick.

Validated locally with `pnpm exec prettier --check ...`, `pnpm --filter ./packages/playground-ui typecheck`, `pnpm --filter ./packages/playground-ui lint`, `pnpm --filter ./packages/playground-ui build-storybook`, `pnpm --filter ./packages/playground typecheck`, `pnpm --filter ./packages/playground lint`, `npx -y react-doctor@latest . --verbose --diff`, and Playwright measurements confirming no unintended overflow in the DataList stories. CodeRabbit has no unresolved review threads; its single nitpick was addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the DataList look and behave more consistent: separators are full-width lines, long text gets truncated with ellipses, empty cells show a neutral dash, and pagination & row controls use the shared Button and cleaner wrapper-driven styling so consumers don't have to duplicate layout fixes.

---

## Overview

Draft PR that polishes visual/layout behavior for the `DataList` in `@mastra/playground-ui`: consistent separators, overflow/truncation, empty-cell rendering, wrapper-aware row ownership, and Storybook coverage for edge cases.

## Key Changes

### Component Structure & Context
- Added `DataListRowWrapperContext` and `useDataListRowWrapperContext()` so wrapped rows own their shell and children can conditionally style themselves.
- `DataListRowWrapper` now provides the wrapper context value to descendants.

### Separator & Layout Rendering
- Row separators reworked from border-based lines to full-width CSS `after` pseudo-elements that correctly hide for subheaders or at group ends.
- `DataListTop` uses an `after` pseudo-element for its bottom divider.
- `DataListRoot` uses `overflow-auto` (both axes) instead of vertical-only scrolling.

### Text Truncation & Empty Cell Handling
- Introduced truncation helpers (`DataListInlineText`, `DataListTruncatedTextNodes`, `DataListTruncatedCellContent`) to consistently truncate strings and element children in text/name/description cells.
- Text-style cells apply `min-w-0` constraints so flex children (e.g., long names) truncate properly.
- Empty cells now render a neutral dash by default; `DataListDateCell` and `DataListTimeCell` now return `null` for invalid/absent values.
- `DataListCellProps.children` made optional.

### Cell & Control Styling
- `DataListSelectCell` / `DataListTopSelectCell` compacted to a fixed small area (`w-8`) with adjusted overflow and zero padding, removing rounded/padded appearance.
- `DataListRowButton`, `DataListRowLink`, and `DataListRowStatic` now read wrapper context and switch between interactive vs. non-wrapped styling (uses `dataListRowInteractiveStyles` when wrapped and `dataListRowStyles` / `dataListRowStaticStyles` otherwise).
- Decomposed shared row styles:
  - `dataListRowInteractiveStyles` — grid, hover, focus-visible behaviors
  - `dataListRowOuterStyles` — separator pseudo-element and sibling-based hiding logic (updated)
  - `dataListRowStaticStyles` — non-interactive layout

### Pagination & Storybook
- `DataListPagination` now uses the shared `Button` component (variant="outline", size="sm") instead of raw `<button>` elements.
- Storybook:
  - Added `WideColumnsOverflow` story demonstrating horizontal constraints & badge truncation.
  - Updated `Default` story with longer name/description examples.
  - Refactored `WithTrailingCell` story to use shared `Button` for actions.
  - Imported `Badge` and `Button` where needed and added related constants.

### Consumer Updates
- `ScorersList`: updated grid columns to responsive `minmax(0,...)` values and constrained/truncated name layout (`min-w-0 max-w-full` + `truncate`).
- `DatasetsList`: improved conditional rendering for experiment/review action placeholders; returns `null` when actions are absent and centers placeholder cells appropriately.

## Types / API Surface
- Only public type change: `DataListCellProps.children` changed from required to optional.
- New exports: `DataListRowWrapperContext`, `useDataListRowWrapperContext()`, `dataListRowInteractiveStyles`, `dataListRowStaticStyles`.
- No other public API signature changes.

## Testing & Validation
- Changeset updated for a patch release of `@mastra/playground-ui`.
- PR marked "tests: no tests added".
- Local validations performed: Prettier, TypeScript typecheck, lint, Storybook build, react-doctor, and Playwright measurements to detect unintended overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->