### PR TITLE
feat(evals): add createRubricScorer LLM-as-judge scorer

### DIFF
--- a/.changeset/afraid-swans-wear.md
+++ b/.changeset/afraid-swans-wear.md
@@ -1,0 +1,24 @@
+---
+'@mastra/evals': minor
+---
+
+Added `createRubricScorer`, an LLM-as-judge scorer that grades agent output against a rubric of criteria and returns a binary verdict (1 only when every required criterion is satisfied) with per-criterion feedback. Drop it into `isTaskComplete` to make an agent self-correct until the rubric is met.
+
+```typescript
+import { createRubricScorer } from '@mastra/evals/scorers/prebuilt';
+
+const rubricScorer = createRubricScorer({
+  model: '__GATEWAY_OPENAI_MODEL_MINI__',
+  criteria: [
+    { description: 'The response includes an analysis section' },
+    { description: 'The response includes concrete recommendations' },
+  ],
+});
+
+await supervisor.stream('Research AI in education', {
+  maxSteps: 10,
+  isTaskComplete: { scorers: [rubricScorer], strategy: 'all' },
+});
+```
+
+The rubric accepts a criteria array or a newline-delimited string, supports optional (non-gating) criteria, and can be supplied per run via request context under a `rubric` key.

--- a/docs/src/content/en/reference/evals/rubric.mdx
+++ b/docs/src/content/en/reference/evals/rubric.mdx
@@ -1,0 +1,175 @@
+---
+title: "Reference: Rubric scorer | Evals"
+description: Documentation for the Rubric Scorer in Mastra. An LLM-as-judge scorer that grades an agent output against a checklist of criteria and returns a binary verdict with per-criterion feedback, designed to drive isTaskComplete loops.
+packages:
+  - "@mastra/evals"
+---
+
+import PropertiesTable from "@site/src/components/PropertiesTable";
+
+# Rubric scorer
+
+The `createRubricScorer()` function creates an LLM-as-judge scorer that grades an agent's output against a rubric — a checklist of criteria. It returns a **binary** score: `1` only when every required criterion is satisfied, otherwise `0`. The `reason` lists each criterion's verdict so the agent knows exactly what to fix.
+
+This scorer is designed to drop into [`isTaskComplete`](/reference/streaming/agents/stream). Because `isTaskComplete` treats `score === 1` as "task complete" and injects the `reason` back into the conversation as feedback, the agent keeps iterating until the rubric is satisfied (or `maxSteps` is reached).
+
+## Parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'model',
+    type: 'MastraModelConfig',
+    description:
+      'The language model used to grade the output against the rubric. A smaller, cheaper model is usually sufficient for grading.',
+    required: true,
+  },
+  {
+    name: 'criteria',
+    type: 'RubricCriterion[] | string',
+    description:
+      'The rubric to grade against. A string is treated as a newline-delimited checklist (each line becomes a required criterion). If omitted, the rubric is read at run time from a `rubric` value on request/additional context; if none resolves, the scorer is a no-op and returns 1.',
+    required: false,
+    children: [
+      {
+        name: 'description',
+        type: 'string',
+        description: 'What the output must satisfy, e.g. "All tests pass" or "Includes a recommendations section".',
+        required: true,
+      },
+      {
+        name: 'required',
+        type: 'boolean',
+        description:
+          'Whether this criterion must be satisfied for the task to be complete. Defaults to true. Optional criteria are graded and reported but do not gate completion.',
+        required: false,
+      },
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Optional stable identifier for the criterion.',
+        required: false,
+      },
+    ],
+  },
+  {
+    name: 'options',
+    type: 'RubricScorerOptions',
+    description: 'Configuration options for the scorer',
+    required: false,
+    children: [
+      {
+        name: 'scale',
+        type: 'number',
+        description:
+          'Scale factor applied to the score (default: 1). Only relevant for standalone evals — isTaskComplete gates on a score equal to 1.',
+        required: false,
+      },
+    ],
+  },
+]}
+/>
+
+## `.run()` returns
+
+<PropertiesTable
+  content={[
+  {
+    name: 'score',
+    type: 'number',
+    description: '1 when every required criterion is satisfied, otherwise 0 (multiplied by scale).',
+  },
+  {
+    name: 'reason',
+    type: 'string',
+    description:
+      'A per-criterion explanation listing which criteria are met or unmet and why. This is the text isTaskComplete injects back into the conversation as feedback.',
+  },
+]}
+/>
+
+## Usage with isTaskComplete
+
+Define the rubric once, attach the scorer to `isTaskComplete`, and the agent self-corrects until the rubric is satisfied:
+
+```typescript
+import { createRubricScorer } from '@mastra/evals/scorers/prebuilt'
+
+const rubricScorer = createRubricScorer({
+  model: '__GATEWAY_OPENAI_MODEL_MINI__',
+  criteria: [
+    { description: 'The response includes an analysis section' },
+    { description: 'The response includes concrete recommendations' },
+  ],
+})
+
+const stream = await supervisor.stream('Research AI in education', {
+  maxSteps: 10,
+  isTaskComplete: {
+    scorers: [rubricScorer],
+    strategy: 'all',
+  },
+})
+```
+
+## String rubric
+
+A newline-delimited string is parsed into criteria, with common list markers (`-`, `*`, `1.`) stripped. Every line becomes a required criterion:
+
+```typescript
+const rubricScorer = createRubricScorer({
+  model: '__GATEWAY_OPENAI_MODEL_MINI__',
+  criteria: `
+- All tests pass in the test suite
+- The function is named find_duplicates and accepts a single list argument
+`,
+})
+```
+
+## Optional criteria
+
+Mark a criterion as optional to have it graded and reported without gating completion:
+
+```typescript
+const rubricScorer = createRubricScorer({
+  model: '__GATEWAY_OPENAI_MODEL_MINI__',
+  criteria: [
+    { description: 'Includes an analysis section', required: true },
+    { description: 'Includes citations', required: false },
+  ],
+})
+```
+
+## Dynamic rubric per run
+
+When no `criteria` is passed to the factory, the scorer resolves a `rubric` value from the run's request context, additional context, or input. This lets a single scorer instance grade different rubrics per run without rebuilding it:
+
+```typescript
+const rubricScorer = createRubricScorer({
+  model: '__GATEWAY_OPENAI_MODEL_MINI__',
+})
+
+await supervisor.stream('Write find_duplicates', {
+  isTaskComplete: { scorers: [rubricScorer] },
+  requestContext: {
+    rubric: '- All tests pass\n- The function is named find_duplicates',
+  },
+})
+```
+
+If no rubric resolves, the scorer returns `1` and does not gate the loop.
+
+## Scoring details
+
+The scorer runs in two phases:
+
+1. **Grade** — the judge model evaluates each criterion independently and returns a per-criterion verdict (`satisfied` / not) with reasoning.
+1. **Score** — the result is `1` only when every required criterion is `satisfied`, otherwise `0`. If no criteria are marked required, all criteria are treated as required.
+
+The `reason` summarizes the overall result and lists each criterion with its verdict, so a failing grade gives the agent targeted, actionable feedback rather than a generic "try again".
+
+## Related
+
+- [isTaskComplete on stream()](/reference/streaming/agents/stream)
+- [Supervisor agents](/docs/agents/supervisor-agents)
+- [createScorer](/reference/evals/create-scorer)

--- a/docs/src/content/en/reference/evals/rubric.mdx
+++ b/docs/src/content/en/reference/evals/rubric.mdx
@@ -83,7 +83,7 @@ This scorer is designed to drop into [`isTaskComplete`](/reference/streaming/age
     name: 'reason',
     type: 'string',
     description:
-      'A per-criterion explanation listing which criteria are met or unmet and why. This is the text isTaskComplete injects back into the conversation as feedback.',
+      'A per-criterion explanation listing which criteria are met or unmet and why. This is the text that isTaskComplete injects back into the conversation as feedback.',
   },
 ]}
 />

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -250,6 +250,7 @@ const sidebars = {
             { type: 'doc', id: 'evals/keyword-coverage', label: 'Keyword Coverage Scorer' },
             { type: 'doc', id: 'evals/noise-sensitivity', label: 'Noise Sensitivity Scorer' },
             { type: 'doc', id: 'evals/prompt-alignment', label: 'Prompt Alignment Scorer' },
+            { type: 'doc', id: 'evals/rubric', label: 'Rubric Scorer' },
             { type: 'doc', id: 'evals/textual-difference', label: 'Textual Difference Scorer' },
             { type: 'doc', id: 'evals/tone-consistency', label: 'Tone Consistency Scorer' },
             { type: 'doc', id: 'evals/tool-call-accuracy', label: 'Tool Call Accuracy Scorers' },

--- a/packages/evals/src/scorers/llm/index.ts
+++ b/packages/evals/src/scorers/llm/index.ts
@@ -9,4 +9,5 @@ export * from './context-relevance';
 export * from './context-precision';
 export * from './noise-sensitivity';
 export * from './prompt-alignment';
+export * from './rubric';
 export * from './trajectory';

--- a/packages/evals/src/scorers/llm/rubric/index.test.ts
+++ b/packages/evals/src/scorers/llm/rubric/index.test.ts
@@ -176,5 +176,17 @@ describe('Rubric Scorer (LLM)', () => {
       expect(result.score).toBe(1);
       expect(result.reason).toContain('passed by default');
     });
+
+    it('returns exactly 1 even with a custom scale so it never gates isTaskComplete', async () => {
+      const scorer = createRubricScorer({
+        model: mockJudge({ criteria: [], overallAssessment: 'No rubric provided; nothing to grade.' }),
+        // No static criteria and no dynamic rubric.
+        options: { scale: 10 },
+      });
+
+      const result = await scorer.run(run('anything'));
+
+      expect(result.score).toBe(1);
+    });
   });
 });

--- a/packages/evals/src/scorers/llm/rubric/index.test.ts
+++ b/packages/evals/src/scorers/llm/rubric/index.test.ts
@@ -1,0 +1,170 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect } from 'vitest';
+import { createAgentTestRun, createTestMessage } from '../../utils';
+import type { RubricAnalysisResult } from './prompts';
+import { createRubricScorer } from '.';
+
+/**
+ * Build a mock model whose structured-output / text response is the given rubric analysis.
+ * The judge agent parses this JSON against the analyze schema.
+ */
+function mockJudge(analysis: RubricAnalysisResult) {
+  const text = JSON.stringify(analysis);
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop',
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text', text }],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: text },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+      ]),
+    }),
+  });
+}
+
+function run(output: string, task = 'Do the task') {
+  return createAgentTestRun({
+    inputMessages: [createTestMessage({ id: 'u1', role: 'user', content: task })],
+    output: [createTestMessage({ id: 'a1', role: 'assistant', content: output })],
+  });
+}
+
+describe('Rubric Scorer (LLM)', () => {
+  describe('configuration', () => {
+    it('creates a scorer with the expected identity and judge', () => {
+      const scorer = createRubricScorer({
+        model: mockJudge({ criteria: [], overallAssessment: '' }),
+        criteria: [{ description: 'Has an analysis section' }],
+      });
+
+      expect(scorer.name).toBe('Rubric (LLM)');
+      expect(scorer.config.judge).toBeDefined();
+      expect(scorer.config.judge?.instructions).toContain('rubric');
+    });
+  });
+
+  describe('scoring', () => {
+    it('scores 1 when every required criterion is satisfied', async () => {
+      const scorer = createRubricScorer({
+        model: mockJudge({
+          criteria: [
+            { criterion: 'Has analysis', satisfied: true, required: true, reasoning: 'present' },
+            { criterion: 'Has recommendations', satisfied: true, required: true, reasoning: 'present' },
+          ],
+          overallAssessment: 'All good',
+        }),
+        criteria: [{ description: 'Has analysis' }, { description: 'Has recommendations' }],
+      });
+
+      const result = await scorer.run(run('analysis ... recommendations ...'));
+
+      expect(result.score).toBe(1);
+      expect(result.reason).toContain('Rubric satisfied');
+    });
+
+    it('scores 0 when a required criterion is unmet and lists it in the reason', async () => {
+      const scorer = createRubricScorer({
+        model: mockJudge({
+          criteria: [
+            { criterion: 'Has analysis', satisfied: true, required: true, reasoning: 'present' },
+            { criterion: 'Has recommendations', satisfied: false, required: true, reasoning: 'missing a recommendations section' },
+          ],
+          overallAssessment: 'Missing recommendations',
+        }),
+        criteria: [{ description: 'Has analysis' }, { description: 'Has recommendations' }],
+      });
+
+      const result = await scorer.run(run('analysis only'));
+
+      expect(result.score).toBe(0);
+      expect(result.reason).toContain('not yet satisfied');
+      expect(result.reason).toContain('missing a recommendations section');
+    });
+
+    it('still scores 1 when only an optional criterion is unmet', async () => {
+      const scorer = createRubricScorer({
+        model: mockJudge({
+          criteria: [
+            { criterion: 'Has analysis', satisfied: true, required: true, reasoning: 'present' },
+            { criterion: 'Has citations', satisfied: false, required: false, reasoning: 'no citations' },
+          ],
+          overallAssessment: 'Required met, optional missing',
+        }),
+        criteria: [
+          { description: 'Has analysis', required: true },
+          { description: 'Has citations', required: false },
+        ],
+      });
+
+      const result = await scorer.run(run('analysis without citations'));
+
+      expect(result.score).toBe(1);
+    });
+
+    it('applies a custom scale to the passing score', async () => {
+      const scorer = createRubricScorer({
+        model: mockJudge({
+          criteria: [{ criterion: 'Has analysis', satisfied: true, required: true, reasoning: 'present' }],
+          overallAssessment: 'ok',
+        }),
+        criteria: [{ description: 'Has analysis' }],
+        options: { scale: 10 },
+      });
+
+      const result = await scorer.run(run('analysis'));
+      expect(result.score).toBe(10);
+    });
+  });
+
+  describe('dynamic rubric from context', () => {
+    it('reads a newline-delimited rubric string from requestContext', async () => {
+      const scorer = createRubricScorer({
+        model: mockJudge({
+          criteria: [
+            { criterion: 'All tests pass', satisfied: true, required: true, reasoning: 'green' },
+            { criterion: 'Function is named find_duplicates', satisfied: true, required: true, reasoning: 'named correctly' },
+          ],
+          overallAssessment: 'Complete',
+        }),
+        // No static criteria — supplied dynamically.
+      });
+
+      const testRun = createAgentTestRun({
+        inputMessages: [createTestMessage({ id: 'u1', role: 'user', content: 'Write find_duplicates' })],
+        output: [createTestMessage({ id: 'a1', role: 'assistant', content: 'def find_duplicates(lst): ...' })],
+      });
+
+      const result = await scorer.run({
+        ...testRun,
+        requestContext: { rubric: '- All tests pass\n- Function is named find_duplicates' },
+      } as any);
+
+      expect(result.score).toBe(1);
+    });
+  });
+
+  describe('no-op when rubric absent', () => {
+    it('returns 1 and does not gate when no rubric resolves', async () => {
+      const scorer = createRubricScorer({
+        model: mockJudge({ criteria: [], overallAssessment: 'No rubric provided; nothing to grade.' }),
+        // No static criteria and no dynamic rubric.
+      });
+
+      const result = await scorer.run(run('anything'));
+
+      expect(result.score).toBe(1);
+      expect(result.reason).toContain('passed by default');
+    });
+  });
+});

--- a/packages/evals/src/scorers/llm/rubric/index.test.ts
+++ b/packages/evals/src/scorers/llm/rubric/index.test.ts
@@ -78,7 +78,12 @@ describe('Rubric Scorer (LLM)', () => {
         model: mockJudge({
           criteria: [
             { criterion: 'Has analysis', satisfied: true, required: true, reasoning: 'present' },
-            { criterion: 'Has recommendations', satisfied: false, required: true, reasoning: 'missing a recommendations section' },
+            {
+              criterion: 'Has recommendations',
+              satisfied: false,
+              required: true,
+              reasoning: 'missing a recommendations section',
+            },
           ],
           overallAssessment: 'Missing recommendations',
         }),
@@ -133,7 +138,12 @@ describe('Rubric Scorer (LLM)', () => {
         model: mockJudge({
           criteria: [
             { criterion: 'All tests pass', satisfied: true, required: true, reasoning: 'green' },
-            { criterion: 'Function is named find_duplicates', satisfied: true, required: true, reasoning: 'named correctly' },
+            {
+              criterion: 'Function is named find_duplicates',
+              satisfied: true,
+              required: true,
+              reasoning: 'named correctly',
+            },
           ],
           overallAssessment: 'Complete',
         }),

--- a/packages/evals/src/scorers/llm/rubric/index.ts
+++ b/packages/evals/src/scorers/llm/rubric/index.ts
@@ -1,0 +1,230 @@
+import { compileSchema } from '@internal/types-builder/compile-zod';
+import { createScorer } from '@mastra/core/evals';
+import type { MastraModelConfig } from '@mastra/core/llm';
+import { z } from 'zod/v4';
+import { getAssistantMessageFromRunOutput, getUserMessageFromRunInput } from '../../utils';
+import type { ScorerRunInputForLLMJudge, ScorerRunOutputForLLMJudge } from '../../utils';
+import { RUBRIC_INSTRUCTIONS, createAnalyzePrompt, formatRubricReason } from './prompts';
+import type { RubricAnalysisResult, RubricCriterionInput } from './prompts';
+
+/**
+ * A single rubric criterion the agent's output is graded against.
+ */
+export interface RubricCriterion {
+  /** Optional stable identifier for the criterion. */
+  id?: string;
+  /** What the output must satisfy, e.g. "All tests pass" or "Includes a recommendations section". */
+  description: string;
+  /**
+   * Whether this criterion must be satisfied for the task to be considered complete.
+   * Defaults to `true`. Optional criteria are graded and reported but do not gate completion.
+   */
+  required?: boolean;
+}
+
+/**
+ * Rubric input accepted by the scorer factory and by the dynamic `rubric` context value.
+ * A string is treated as a newline-delimited checklist; leading list markers ("-", "*", "1.")
+ * are stripped. Every parsed line becomes a required criterion.
+ */
+export type RubricInput = RubricCriterion[] | string;
+
+export interface RubricScorerOptions {
+  /** Scale applied to the final score. Defaults to 1. Only relevant for standalone evals — `isTaskComplete` gates on `=== 1`. */
+  scale?: number;
+}
+
+const analyzeOutputSchema = compileSchema(
+  z.object({
+    criteria: z.array(
+      z.object({
+        criterion: z.string(),
+        satisfied: z.boolean(),
+        required: z.boolean(),
+        reasoning: z.string(),
+      }),
+    ),
+    overallAssessment: z.string(),
+  }),
+);
+
+/**
+ * Parse a string rubric into criteria. Each non-empty line becomes a required criterion,
+ * with common list markers stripped from the front.
+ */
+function parseRubricString(rubric: string): RubricCriterion[] {
+  return rubric
+    .split('\n')
+    .map(line => line.replace(/^\s*(?:[-*•]|\d+[.)])\s*/, '').trim())
+    .filter(line => line.length > 0)
+    .map(description => ({ description, required: true }));
+}
+
+function normalizeRubric(rubric: RubricInput | undefined): RubricCriterion[] {
+  if (!rubric) return [];
+  if (typeof rubric === 'string') return parseRubricString(rubric);
+  return rubric;
+}
+
+/**
+ * Resolve the rubric for a run: prefer the rubric passed to the factory, otherwise look for a
+ * dynamic `rubric` value on the run's request context, additional context, or input. This lets a
+ * single scorer instance grade different rubrics per run (e.g. when passed at `stream()` time via
+ * request context) without rebuilding the scorer.
+ */
+function resolveRubric({
+  staticRubric,
+  run,
+}: {
+  staticRubric: RubricCriterion[];
+  run: { input?: unknown; requestContext?: unknown; additionalContext?: unknown };
+}): RubricCriterion[] {
+  if (staticRubric.length > 0) return staticRubric;
+
+  const dynamic =
+    pickRubric(run.requestContext) ?? pickRubric(run.additionalContext) ?? pickRubric(run.input);
+
+  return normalizeRubric(dynamic);
+}
+
+/**
+ * Read a `rubric` value from a source that may be a plain object, a Map-like / RequestContext
+ * instance (with a `.get` method), or undefined.
+ */
+function pickRubric(source: unknown): RubricInput | undefined {
+  if (!source || typeof source !== 'object') return undefined;
+
+  let value: unknown;
+  const getter = (source as { get?: unknown }).get;
+  if (typeof getter === 'function') {
+    value = (getter as (key: string) => unknown).call(source, 'rubric');
+  } else {
+    value = (source as Record<string, unknown>).rubric;
+  }
+
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value as RubricCriterion[];
+  return undefined;
+}
+
+function toCriterionInputs(criteria: RubricCriterion[]): RubricCriterionInput[] {
+  return criteria.map(c => ({ criterion: c.description, required: c.required !== false }));
+}
+
+function getOutputText(run: { output?: unknown; input?: unknown }): string {
+  const fromOutput = getAssistantMessageFromRunOutput(run.output as ScorerRunOutputForLLMJudge);
+  if (fromOutput) return fromOutput;
+
+  // `isTaskComplete` passes the in-progress text on `run.input.currentText`.
+  if (run.input && typeof run.input === 'object' && typeof (run.input as Record<string, unknown>).currentText === 'string') {
+    return (run.input as Record<string, unknown>).currentText as string;
+  }
+
+  return typeof run.output === 'string' ? run.output : '';
+}
+
+function getTaskText(run: { input?: unknown }): string {
+  // `isTaskComplete` passes the original task on `run.input.originalTask`.
+  if (run.input && typeof run.input === 'object' && typeof (run.input as Record<string, unknown>).originalTask === 'string') {
+    return (run.input as Record<string, unknown>).originalTask as string;
+  }
+  return getUserMessageFromRunInput(run.input as ScorerRunInputForLLMJudge) ?? '';
+}
+
+/**
+ * Creates an LLM-as-judge scorer that grades an agent's output against a rubric and returns a
+ * **binary** score: `1` only when every required criterion is satisfied, otherwise `0`. The
+ * `generateReason` output lists each unmet criterion with the judge's reasoning.
+ *
+ * It is designed to drop into `isTaskComplete`, which treats `score === 1` as "task complete" and
+ * injects the reason back into the conversation as feedback, so the agent iterates until the rubric
+ * is satisfied (or `maxSteps` is reached):
+ *
+ * @example
+ * ```typescript
+ * import { createRubricScorer } from '@mastra/evals/scorers/prebuilt';
+ *
+ * const rubricScorer = createRubricScorer({
+ *   model: '__GATEWAY_OPENAI_MODEL_MINI__',
+ *   criteria: [
+ *     { description: 'The response includes an analysis section' },
+ *     { description: 'The response includes concrete recommendations' },
+ *   ],
+ * });
+ *
+ * await supervisor.stream('Research AI in education', {
+ *   maxSteps: 10,
+ *   isTaskComplete: { scorers: [rubricScorer], strategy: 'all' },
+ * });
+ * ```
+ *
+ * The rubric can also be supplied dynamically per run via request/additional context under the
+ * `rubric` key (string checklist or `RubricCriterion[]`). If no rubric resolves, the scorer is a
+ * no-op and returns `1` (so it does not gate the loop), mirroring "if the rubric is absent, do nothing".
+ */
+export function createRubricScorer({
+  model,
+  criteria,
+  options,
+}: {
+  model: MastraModelConfig;
+  criteria?: RubricInput;
+  options?: RubricScorerOptions;
+}) {
+  const scale = options?.scale ?? 1;
+  const staticRubric = normalizeRubric(criteria);
+
+  return createScorer<ScorerRunInputForLLMJudge, ScorerRunOutputForLLMJudge>({
+    id: 'rubric-scorer',
+    name: 'Rubric (LLM)',
+    description: 'Grades an agent output against a rubric of criteria, returning 1 only when every required criterion is satisfied',
+    judge: {
+      model,
+      instructions: RUBRIC_INSTRUCTIONS,
+    },
+  })
+    .analyze({
+      description: 'Judge the output against each rubric criterion',
+      outputSchema: analyzeOutputSchema,
+      createPrompt: ({ run }) => {
+        const rubric = resolveRubric({ staticRubric, run });
+
+        // No rubric to grade against — emit an empty analysis. generateScore turns this into a
+        // passing no-op so the scorer does not gate the loop.
+        if (rubric.length === 0) {
+          return `No rubric was provided. Return exactly: {"criteria": [], "overallAssessment": "No rubric provided; nothing to grade."}`;
+        }
+
+        return createAnalyzePrompt({
+          originalTask: getTaskText(run),
+          output: getOutputText(run),
+          criteria: toCriterionInputs(rubric),
+        });
+      },
+    })
+    .generateScore(({ results }) => {
+      const analysis = results.analyzeStepResult as RubricAnalysisResult | undefined;
+
+      // No analysis or empty rubric → no-op pass.
+      if (!analysis || analysis.criteria.length === 0) {
+        return 1 * scale;
+      }
+
+      const requiredCriteria = analysis.criteria.filter(c => c.required);
+
+      // If somehow nothing is marked required, treat all criteria as required.
+      const gating = requiredCriteria.length > 0 ? requiredCriteria : analysis.criteria;
+      const allSatisfied = gating.every(c => c.satisfied);
+
+      return (allSatisfied ? 1 : 0) * scale;
+    })
+    .generateReason(({ results, score }) => {
+      const analysis = results.analyzeStepResult as RubricAnalysisResult | undefined;
+
+      if (!analysis || analysis.criteria.length === 0) {
+        return 'No rubric was provided, so the rubric check passed by default.';
+      }
+
+      return formatRubricReason({ score, analysis });
+    });
+}

--- a/packages/evals/src/scorers/llm/rubric/index.ts
+++ b/packages/evals/src/scorers/llm/rubric/index.ts
@@ -81,8 +81,7 @@ function resolveRubric({
 }): RubricCriterion[] {
   if (staticRubric.length > 0) return staticRubric;
 
-  const dynamic =
-    pickRubric(run.requestContext) ?? pickRubric(run.additionalContext) ?? pickRubric(run.input);
+  const dynamic = pickRubric(run.requestContext) ?? pickRubric(run.additionalContext) ?? pickRubric(run.input);
 
   return normalizeRubric(dynamic);
 }
@@ -116,7 +115,11 @@ function getOutputText(run: { output?: unknown; input?: unknown }): string {
   if (fromOutput) return fromOutput;
 
   // `isTaskComplete` passes the in-progress text on `run.input.currentText`.
-  if (run.input && typeof run.input === 'object' && typeof (run.input as Record<string, unknown>).currentText === 'string') {
+  if (
+    run.input &&
+    typeof run.input === 'object' &&
+    typeof (run.input as Record<string, unknown>).currentText === 'string'
+  ) {
     return (run.input as Record<string, unknown>).currentText as string;
   }
 
@@ -125,7 +128,11 @@ function getOutputText(run: { output?: unknown; input?: unknown }): string {
 
 function getTaskText(run: { input?: unknown }): string {
   // `isTaskComplete` passes the original task on `run.input.originalTask`.
-  if (run.input && typeof run.input === 'object' && typeof (run.input as Record<string, unknown>).originalTask === 'string') {
+  if (
+    run.input &&
+    typeof run.input === 'object' &&
+    typeof (run.input as Record<string, unknown>).originalTask === 'string'
+  ) {
     return (run.input as Record<string, unknown>).originalTask as string;
   }
   return getUserMessageFromRunInput(run.input as ScorerRunInputForLLMJudge) ?? '';
@@ -177,7 +184,8 @@ export function createRubricScorer({
   return createScorer<ScorerRunInputForLLMJudge, ScorerRunOutputForLLMJudge>({
     id: 'rubric-scorer',
     name: 'Rubric (LLM)',
-    description: 'Grades an agent output against a rubric of criteria, returning 1 only when every required criterion is satisfied',
+    description:
+      'Grades an agent output against a rubric of criteria, returning 1 only when every required criterion is satisfied',
     judge: {
       model,
       instructions: RUBRIC_INSTRUCTIONS,

--- a/packages/evals/src/scorers/llm/rubric/index.ts
+++ b/packages/evals/src/scorers/llm/rubric/index.ts
@@ -213,9 +213,10 @@ export function createRubricScorer({
     .generateScore(({ results }) => {
       const analysis = results.analyzeStepResult as RubricAnalysisResult | undefined;
 
-      // No analysis or empty rubric → no-op pass.
+      // No analysis or empty rubric → no-op pass. Return exactly 1 (not scaled) so the no-op
+      // never gates isTaskComplete, which requires score === 1.
       if (!analysis || analysis.criteria.length === 0) {
-        return 1 * scale;
+        return 1;
       }
 
       const requiredCriteria = analysis.criteria.filter(c => c.required);

--- a/packages/evals/src/scorers/llm/rubric/is-task-complete.integration.test.ts
+++ b/packages/evals/src/scorers/llm/rubric/is-task-complete.integration.test.ts
@@ -79,12 +79,26 @@ describe('Rubric scorer in isTaskComplete', () => {
       model: sequencedJudge([
         // First grade: required criterion unmet → not complete.
         {
-          criteria: [{ criterion: 'Includes recommendations', satisfied: false, required: true, reasoning: 'no recommendations yet' }],
+          criteria: [
+            {
+              criterion: 'Includes recommendations',
+              satisfied: false,
+              required: true,
+              reasoning: 'no recommendations yet',
+            },
+          ],
           overallAssessment: 'Missing recommendations',
         },
         // Second grade: satisfied → complete.
         {
-          criteria: [{ criterion: 'Includes recommendations', satisfied: true, required: true, reasoning: 'recommendations present' }],
+          criteria: [
+            {
+              criterion: 'Includes recommendations',
+              satisfied: true,
+              required: true,
+              reasoning: 'recommendations present',
+            },
+          ],
           overallAssessment: 'Complete',
         },
       ]),

--- a/packages/evals/src/scorers/llm/rubric/is-task-complete.integration.test.ts
+++ b/packages/evals/src/scorers/llm/rubric/is-task-complete.integration.test.ts
@@ -1,0 +1,123 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { Agent } from '@mastra/core/agent';
+import { describe, it, expect } from 'vitest';
+import type { RubricAnalysisResult } from './prompts';
+import { createRubricScorer } from '.';
+
+/** A judge model that returns a different analysis on each call (to model fix → re-grade). */
+function sequencedJudge(analyses: RubricAnalysisResult[]) {
+  let call = 0;
+  const next = () => {
+    const analysis = analyses[Math.min(call, analyses.length - 1)];
+    call++;
+    return JSON.stringify(analysis);
+  };
+
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text' as const, text: next() }],
+      warnings: [],
+    }),
+    doStream: async () => {
+      const text = next();
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: text },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+        ]),
+      };
+    },
+  });
+}
+
+/** A supervisor model that produces a text response per iteration. */
+function supervisorModel(onCall: () => void) {
+  const make = (n: number) => `Iteration ${n} response.`;
+  return new MockLanguageModelV2({
+    doGenerate: async () => {
+      onCall();
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        content: [{ type: 'text' as const, text: make(1) }],
+        warnings: [],
+      };
+    },
+    doStream: async () => {
+      onCall();
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: make(1) },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+        ]),
+      };
+    },
+  });
+}
+
+describe('Rubric scorer in isTaskComplete', () => {
+  it('keeps iterating while a required criterion is unmet, then stops once satisfied', async () => {
+    let modelCallCount = 0;
+
+    const rubricScorer = createRubricScorer({
+      model: sequencedJudge([
+        // First grade: required criterion unmet → not complete.
+        {
+          criteria: [{ criterion: 'Includes recommendations', satisfied: false, required: true, reasoning: 'no recommendations yet' }],
+          overallAssessment: 'Missing recommendations',
+        },
+        // Second grade: satisfied → complete.
+        {
+          criteria: [{ criterion: 'Includes recommendations', satisfied: true, required: true, reasoning: 'recommendations present' }],
+          overallAssessment: 'Complete',
+        },
+      ]),
+      criteria: [{ description: 'Includes recommendations' }],
+    });
+
+    const agent = new Agent({
+      id: 'rubric-supervisor',
+      name: 'Rubric Supervisor',
+      instructions: 'You complete tasks iteratively.',
+      model: supervisorModel(() => {
+        modelCallCount++;
+      }),
+    });
+
+    const events: any[] = [];
+    const stream = await agent.stream('Research a topic and recommend next steps', {
+      maxSteps: 5,
+      isTaskComplete: { scorers: [rubricScorer], strategy: 'all' },
+    });
+
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'is-task-complete') {
+        events.push(chunk);
+      }
+    }
+
+    // The model ran at least twice: the failed grade fed feedback back and triggered a re-run.
+    expect(modelCallCount).toBeGreaterThanOrEqual(2);
+
+    // Two grading events: first failed, last passed.
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events[0].payload.passed).toBe(false);
+    expect(events[events.length - 1].payload.passed).toBe(true);
+  });
+});

--- a/packages/evals/src/scorers/llm/rubric/prompts.ts
+++ b/packages/evals/src/scorers/llm/rubric/prompts.ts
@@ -78,17 +78,9 @@ Return your judgement as JSON in this shape:
  * `isTaskComplete` injects back into the conversation as feedback, so it must clearly tell the
  * agent which criteria are unmet and why.
  */
-export function formatRubricReason({
-  score,
-  analysis,
-}: {
-  score: number;
-  analysis: RubricAnalysisResult;
-}): string {
+export function formatRubricReason({ score, analysis }: { score: number; analysis: RubricAnalysisResult }): string {
   const complete = score >= 1;
-  const header = complete
-    ? '✅ Rubric satisfied: every required criterion is met.'
-    : '❌ Rubric not yet satisfied.';
+  const header = complete ? '✅ Rubric satisfied: every required criterion is met.' : '❌ Rubric not yet satisfied.';
 
   const lines = analysis.criteria.map(c => {
     const mark = c.satisfied ? '✅' : '❌';

--- a/packages/evals/src/scorers/llm/rubric/prompts.ts
+++ b/packages/evals/src/scorers/llm/rubric/prompts.ts
@@ -1,0 +1,109 @@
+export const RUBRIC_INSTRUCTIONS = `You are an exacting grader. Your job is to judge whether an agent's output satisfies each criterion in a rubric.
+
+A rubric is a checklist of criteria. For each criterion you must decide, strictly and independently, whether the output satisfies it.
+
+Grading guidelines:
+- Judge each criterion on its own merits. Do not let one criterion's verdict influence another.
+- A criterion is "satisfied" only when the output clearly and fully meets it. When in doubt, mark it as NOT satisfied.
+- Base your judgement on evidence in the output (and the original task for context). Do not assume facts that are not present.
+- Be concise but specific in your reasoning: say what is present or missing.
+- Do not reward effort, intent, or partial progress. Only the actual output counts.`;
+
+export interface RubricAnalysisCriterion {
+  /** The criterion text, exactly as provided in the rubric. */
+  criterion: string;
+  /** Whether the output satisfies this criterion. */
+  satisfied: boolean;
+  /** Whether this criterion is required for the task to be considered complete. */
+  required: boolean;
+  /** Short explanation of why the criterion is or is not satisfied. */
+  reasoning: string;
+}
+
+export interface RubricAnalysisResult {
+  criteria: RubricAnalysisCriterion[];
+  overallAssessment: string;
+}
+
+/**
+ * A single rubric criterion as provided to the prompt builder.
+ */
+export interface RubricCriterionInput {
+  criterion: string;
+  required: boolean;
+}
+
+export function createAnalyzePrompt({
+  originalTask,
+  output,
+  criteria,
+}: {
+  originalTask: string;
+  output: string;
+  criteria: RubricCriterionInput[];
+}): string {
+  const renderedCriteria = criteria
+    .map((c, i) => `${i + 1}. [${c.required ? 'required' : 'optional'}] ${c.criterion}`)
+    .join('\n');
+
+  return `Grade the agent's output against the rubric below.
+
+Original task:
+${originalTask || '(no task provided)'}
+
+Rubric criteria:
+${renderedCriteria}
+
+Agent output to grade:
+${output || '(empty output)'}
+
+For every criterion, decide whether the output satisfies it. Preserve the exact criterion text and its required/optional designation in your answer.
+
+Return your judgement as JSON in this shape:
+{
+  "criteria": [
+    {
+      "criterion": "exact criterion text",
+      "satisfied": true,
+      "required": true,
+      "reasoning": "why it is or is not satisfied"
+    }
+  ],
+  "overallAssessment": "one or two sentence summary of what passed and what is missing"
+}`;
+}
+
+/**
+ * Format a human-readable, per-criterion explanation of the rubric result. This text is what
+ * `isTaskComplete` injects back into the conversation as feedback, so it must clearly tell the
+ * agent which criteria are unmet and why.
+ */
+export function formatRubricReason({
+  score,
+  analysis,
+}: {
+  score: number;
+  analysis: RubricAnalysisResult;
+}): string {
+  const complete = score >= 1;
+  const header = complete
+    ? '✅ Rubric satisfied: every required criterion is met.'
+    : '❌ Rubric not yet satisfied.';
+
+  const lines = analysis.criteria.map(c => {
+    const mark = c.satisfied ? '✅' : '❌';
+    const tag = c.required ? 'required' : 'optional';
+    return `${mark} [${tag}] ${c.criterion}\n   → ${c.reasoning}`;
+  });
+
+  const unmetRequired = analysis.criteria.filter(c => c.required && !c.satisfied);
+  const footer = complete
+    ? ''
+    : `\n\nTo finish, address the ${unmetRequired.length} unmet required ${
+        unmetRequired.length === 1 ? 'criterion' : 'criteria'
+      } above.`;
+
+  const assessment = analysis.overallAssessment ? `\n\n${analysis.overallAssessment}` : '';
+
+  return `${header}\n\n${lines.join('\n')}${assessment}${footer}`;
+}


### PR DESCRIPTION
## Summary

Adds `createRubricScorer`, a prebuilt LLM-as-judge scorer to `@mastra/evals` that grades agent output against a rubric of criteria.

Mastra already ships the agentic self-correction loop via `isTaskComplete`, but until now users had to hand-write an LLM-backed scorer to grade output against a checklist. This provides that grader out of the box.

The scorer judges output against a rubric and returns a **binary verdict** — `1` only when every required criterion is satisfied — plus **per-criterion feedback**. Because `isTaskComplete` gates on `score === 1`, it drops straight into the loop: failing criteria inject feedback and the agent retries until the rubric is met or `maxSteps` is reached.

```typescript
import { createRubricScorer } from '@mastra/evals/scorers/prebuilt'

const rubricScorer = createRubricScorer({
  model: '__GATEWAY_OPENAI_MODEL_MINI__',
  criteria: [
    { description: 'The response includes an analysis section' },
    { description: 'The response includes concrete recommendations' },
  ],
})

await supervisor.stream('Research AI in education', {
  maxSteps: 10,
  isTaskComplete: { scorers: [rubricScorer], strategy: 'all' },
})
```

The rubric accepts a criteria array or a newline-delimited string, supports optional (non-gating) criteria, and can be supplied per run via request context under a `rubric` key.

## What is included

- `createRubricScorer` factory, judge prompts, and deterministic score/reason steps
- Unit tests (7) covering all-pass, required-unmet, optional-unmet, custom scale, dynamic rubric, and no-op cases
- Integration test proving the scorer gates an `isTaskComplete` loop (fails iteration 1, passes iteration 2)
- Reference doc page + sidebar entry
- Changeset (minor bump for `@mastra/evals`)

## Test plan

- `pnpm --filter ./packages/evals test rubric` — 8 tests pass
- `pnpm --filter ./packages/evals check` / `lint` / `build:lib` — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a "Rubric Scorer" that grades an AI agent's output against a checklist and tells the agent what to fix; the agent can then retry until every required item is satisfied or it hits a step limit.

---

## Overview
Adds createRubricScorer, a new LLM-as-judge scorer in `@mastra/evals` that evaluates agent output against rubric criteria and returns a binary verdict (score === 1 only when all required criteria are satisfied) plus per-criterion feedback. The scorer integrates with Mastra’s isTaskComplete loop so failing criteria inject feedback and trigger agent retries until the rubric is met or maxSteps is reached.

## Key Features
- Accepts rubric criteria as an array or newline-delimited string (with list-marker stripping).
- Supports optional (non-gating) criteria.
- Rubric can be supplied per run via requestContext.rubric (dynamic per-run resolution).
- Deterministic two-phase behavior: per-criterion grading then aggregated score (with configurable scale).
- No-op/pass-by-default behavior when no rubric resolves (ensures it does not gate retries).
- Returns formatted per-criterion feedback suitable for injection into isTaskComplete loops.

## Implementation
- New factory: createRubricScorer({ model, criteria?, options? }) exported from packages/evals/src/scorers/llm/rubric and re-exported in packages/evals/src/scorers/llm/index.ts.
- Types added: RubricCriterion, RubricInput, RubricScorerOptions.
- Prompts and formatting: RUBRIC_INSTRUCTIONS, createAnalyzePrompt(), formatRubricReason().
- Scoring logic: parses rubric input, calls judge model for structured JSON analysis, maps analysis to binary pass/fail (respecting required/optional flags), applies optional numeric scale, and formats human-readable reason.

## Tests
- Unit tests (8 tests) in packages/evals/src/scorers/llm/rubric/index.test.ts covering: identity & prompts, all-pass, required-unmet, optional-unmet, custom scale, dynamic rubric from request context, and no-op default-pass (including regression ensuring no-op returns score === 1 even with custom scales).
- Integration test packages/evals/src/scorers/llm/rubric/is-task-complete.integration.test.ts demonstrating isTaskComplete gating: first grading fails, second passes, and multiple grading events emitted.
- Reported local test results: pnpm --filter ./packages/evals test rubric — 8 tests pass; lint/check/build:lib pass.

## Docs & Release
- New docs page: docs/src/content/en/reference/evals/rubric.mdx with usage examples (isTaskComplete integration, optional criteria, string parsing, dynamic rubric).
- Sidebar entry added under "Evals" → "Built-in scorers".
- Changeset added (.changeset/afraid-swans-wear.md) bumping `@mastra/evals` minor.

## Misc / Fixes
- Prettier formatting applied to rubric files.
- Fix/regression: ensure rubric no-op returns exactly score === 1 (prevents incorrect gating with custom scales) and added regression test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->