### PR TITLE
fix(server): scope Agent Builder model list to connected providers

### DIFF
--- a/.changeset/purple-adults-find.md
+++ b/.changeset/purple-adults-find.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed the Agent Builder selecting models from providers with no API key configured. The builder available-models list now only includes providers whose API key is set, so an agent created in the Agent Builder can no longer be assigned a model that can never run.

--- a/packages/server/src/server/handlers/editor-builder.test.ts
+++ b/packages/server/src/server/handlers/editor-builder.test.ts
@@ -1,6 +1,6 @@
 import type { IAgentBuilder } from '@mastra/core/agent-builder/ee';
 import type { IMastraEditor } from '@mastra/core/editor';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {
   GET_EDITOR_BUILDER_AVAILABLE_MODELS_ROUTE,
@@ -613,16 +613,45 @@ describe('GET /editor/builder/infrastructure route metadata', () => {
 describe('GET /editor/builder/models/available', () => {
   const runAvailable = (editor?: Partial<IMastraEditor>) =>
     GET_EDITOR_BUILDER_AVAILABLE_MODELS_ROUTE.handler({ mastra: createMockMastra(editor) } as any) as Promise<{
-      providers: Array<{ id: string; models: string[] }>;
+      providers: Array<{ id: string; models: string[]; connected: boolean }>;
     }>;
 
-  it('returns the full provider list when no editor / policy is configured', async () => {
+  const originalOpenAIKey = process.env.OPENAI_API_KEY;
+  const originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    // The endpoint only surfaces providers with a configured API key, so make
+    // exactly one provider "connected" and ensure another is not.
+    process.env.OPENAI_API_KEY = 'test-key';
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalOpenAIKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = originalOpenAIKey;
+    if (originalAnthropicKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalAnthropicKey;
+  });
+
+  it('returns only providers with a configured API key when no policy is configured', async () => {
     const { providers } = await runAvailable();
 
     expect(providers.length).toBeGreaterThan(0);
+    // Every returned provider is connected (has its API key configured).
+    expect(providers.every(p => p.connected)).toBe(true);
+
     const openai = providers.find(p => p.id === 'openai');
     expect(openai).toBeDefined();
     expect(openai!.models.length).toBeGreaterThan(0);
+  });
+
+  it('omits providers whose API key is not configured', async () => {
+    const { providers } = await runAvailable();
+
+    // anthropic has no API key set in this test, so it must be filtered out
+    // even though it exists in the provider registry.
+    expect(providers.find(p => p.id === 'anthropic')).toBeUndefined();
+    expect(providers.find(p => p.id === 'openai')).toBeDefined();
   });
 
   it('filters models down to the active policy allowlist (provider wildcard)', async () => {

--- a/packages/server/src/server/handlers/editor-builder.ts
+++ b/packages/server/src/server/handlers/editor-builder.ts
@@ -179,14 +179,18 @@ export const GET_EDITOR_BUILDER_SETTINGS_ROUTE = createRoute({
 /**
  * GET /editor/builder/models/available
  *
- * Returns the configured AI providers/models filtered by the active builder
- * model policy. The server is the single authority for the allowlist: it
- * applies `isModelAllowed` here so the Studio model picker can render the
- * response verbatim without importing any EE matcher into the browser.
+ * Returns the configured AI providers/models the agent builder may use. The
+ * server is the single authority: it scopes the list to providers with a
+ * configured API key (`connected`) and applies the active builder model
+ * policy via `isModelAllowed`, so the Studio surfaces can render the response
+ * verbatim without importing any EE matcher into the browser.
  *
- * - Policy inactive (or no allowlist) ⇒ the full provider list is returned.
- * - Policy active with an allowlist ⇒ each provider's models are filtered,
- *   and providers left with no allowed models are omitted entirely.
+ * - Providers without a configured API key are always omitted — the builder
+ *   decides the agent's model from this list, so an unconnected provider would
+ *   produce an agent that can never run.
+ * - Policy inactive (or no allowlist) ⇒ all connected providers are returned.
+ * - Policy active with an allowlist ⇒ each connected provider's models are
+ *   filtered, and providers left with no allowed models are omitted entirely.
  */
 export const GET_EDITOR_BUILDER_AVAILABLE_MODELS_ROUTE = createRoute({
   method: 'GET',
@@ -200,10 +204,14 @@ export const GET_EDITOR_BUILDER_AVAILABLE_MODELS_ROUTE = createRoute({
   requiresPermission: 'stored-agents:read',
   handler: async ({ mastra }) => {
     try {
-      const providers = await buildProvidersList(mastra);
+      // Only surface providers whose API key is configured (`connected`). The
+      // agent builder decides the agent's model from this list, so including
+      // providers without a key lets it pick a model that can never run. We
+      // scope to connected providers so every choice is actually usable.
+      const providers = (await buildProvidersList(mastra)).filter(provider => provider.connected);
       const policy = await resolveBuilderModelPolicy(mastra.getEditor());
 
-      // Inactive policy (or no allowlist) ⇒ nothing to filter.
+      // Inactive policy (or no allowlist) ⇒ no allowlist filtering to apply.
       if (!policy.active || !policy.allowed || policy.allowed.length === 0) {
         return { providers };
       }


### PR DESCRIPTION
The Agent Builder decides the agent's model from `GET /editor/builder/models/available`, but that endpoint returned every registered provider and gateway regardless of whether an API key was configured. So the builder could pick a model from a provider with no key (e.g. `helicone/chatgpt-4o-latest`), leaving you with an agent that can never actually run.

This filters the endpoint to providers that are connected (API key set), so every model the builder can choose is usable.

Before:
```ts
// endpoint returned all providers, including ones with no key
const providers = await buildProvidersList(mastra);
```

After:
```ts
const providers = (await buildProvidersList(mastra)).filter(p => p.connected);
```

The connected info was already computed per provider, so this just stops surfacing the unusable ones. All the playground surfaces (picker, starter, chat, and the set-agent-model tool) read this one list, so they're consistent now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Agent Builder was allowing you to select AI models from services that didn't have API keys set up, which meant agents created with those models couldn't actually run. This fix makes the builder only show you models from services that have API keys configured, so every choice you can make will actually work.

## Changes

**Handler Update** (`editor-builder.ts`)
- Modified the `/editor/builder/models/available` endpoint to filter the provider list to only include providers where `provider.connected === true` (i.e., API key is configured)
- Changed from `buildProvidersList(mastra)` to `(await buildProvidersList(mastra)).filter(provider => provider.connected)`
- Updated endpoint documentation to clarify that only providers with configured API keys are returned, and that model-policy filtering is applied per provider

**Test Updates** (`editor-builder.test.ts`)
- Added environment-variable control for `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` using `beforeEach`/`afterEach` hooks
- Updated test assertions to verify that the endpoint only returns "connected" providers whose API keys are set
- Added tests confirming that providers without configured API keys (e.g., anthropic) are omitted from results even if present in the registry

**Changeset** (`.changeset/purple-adults-find.md`)
- Documents the patch-level fix in `@mastra/server` that prevents the builder from selecting models from unconfigured providers

## Impact

The Agent Builder playground surfaces (model picker, starter, chat, and the set-agent-model tool) now consistently work with a scoped provider list that only includes usable providers. This prevents creating agents that cannot run due to missing API key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->