### PR TITLE
perf(pg): batch storage inserts into multi-row statements (#17398)

### DIFF
--- a/.changeset/plenty-lamps-sip.md
+++ b/.changeset/plenty-lamps-sip.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Improved Postgres batch inserts to use fewer queries while keeping span conflict handling unchanged.

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -25,6 +25,8 @@ import { buildConstraintName } from './constraint-utils';
 // Re-export DbClient for external use
 export type { DbClient } from '../client';
 
+const POSTGRES_MAX_BIND_PARAMETERS = 65_535;
+
 /**
  * Configuration for standalone domain usage.
  * Accepts either:
@@ -606,6 +608,141 @@ export class PgDB extends MastraBase {
     } else {
       await client.none(`INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})`, values);
     }
+  }
+
+  private getChunkRowLimit(columnCount: number): number {
+    if (columnCount === 0) {
+      return 0;
+    }
+    return Math.max(1, Math.floor(POSTGRES_MAX_BIND_PARAMETERS / columnCount));
+  }
+
+  private getSpanConflictIdentifier(record: Record<string, any>): string | undefined {
+    const traceId = record.traceId as unknown;
+    const spanId = record.spanId as unknown;
+
+    if (traceId === undefined || spanId === undefined) {
+      return undefined;
+    }
+
+    return `${String(traceId)}|${String(spanId)}`;
+  }
+
+  private async normalizeForInsert(tableName: TABLE_NAMES, record: Record<string, any>): Promise<{
+    columns: string[];
+    values: QueryValues;
+    conflictKey: string | undefined;
+  }> {
+    this.addTimestampZColumns(record);
+    const filteredRecord = await this.filterRecordToKnownColumns(tableName, record);
+    const columns = Object.keys(filteredRecord).map(column => parseSqlIdentifier(column, 'column name'));
+    const values = this.prepareValuesForInsert(filteredRecord, tableName);
+
+    return {
+      columns,
+      values,
+      conflictKey:
+        tableName === TABLE_SPANS ? this.getSpanConflictIdentifier(filteredRecord) : undefined,
+    };
+  }
+
+  private buildMultiRowInsertStatement({
+    tableName,
+    columns,
+    rows,
+  }: {
+    tableName: TABLE_NAMES;
+    columns: string[];
+    rows: QueryValues[];
+  }): { query: string; values: QueryValues } {
+    const fullTableName = getTableName({ indexName: tableName, schemaName: getSchemaName(this.schemaName) });
+    const columnList = columns.map(column => `"${column}"`).join(', ');
+
+    const bindParams: string[] = [];
+    const values: QueryValues = [];
+    let bindIndex = 1;
+
+    for (const rowValues of rows) {
+      const placeholders = rowValues.map(() => `$${bindIndex++}`);
+      bindParams.push(`(${placeholders.join(', ')})`);
+      values.push(...rowValues);
+    }
+
+    let query = `INSERT INTO ${fullTableName} (${columnList}) VALUES ${bindParams.join(', ')}`;
+
+    if (tableName === TABLE_SPANS) {
+      const updateColumns = columns.filter(column => column !== 'traceId' && column !== 'spanId');
+      if (updateColumns.length > 0) {
+        const updateClause = updateColumns.map(column => `"${column}" = EXCLUDED."${column}"`).join(', ');
+        query += ` ON CONFLICT ("traceId", "spanId") DO UPDATE SET ${updateClause}`;
+      } else {
+        query += ` ON CONFLICT ("traceId", "spanId") DO NOTHING`;
+      }
+    }
+
+    return { query, values };
+  }
+
+  private async executeBatchInsert(
+    client: Pick<DbClient, 'none'> | Pick<TxClient, 'none'>,
+    { tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] },
+  ): Promise<void> {
+    const preparedRecords = await Promise.all(
+      records.map(record => this.normalizeForInsert(tableName, record)),
+    );
+
+    let pendingColumns: string[] | undefined;
+    let pendingConflictKeys = new Set<string>();
+    let pendingRows: QueryValues[] = [];
+    let pendingLimit = 0;
+
+    const flush = async () => {
+      if (!pendingColumns || pendingRows.length === 0) {
+        return;
+      }
+
+      const statement = this.buildMultiRowInsertStatement({
+        tableName,
+        columns: pendingColumns,
+        rows: pendingRows,
+      });
+      await client.none(statement.query, statement.values);
+
+      pendingColumns = undefined;
+      pendingRows = [];
+      pendingConflictKeys = new Set();
+      pendingLimit = 0;
+    };
+
+    for (const { columns, values, conflictKey } of preparedRecords) {
+      if (columns.length === 0) {
+        continue;
+      }
+
+      const columnsSignature = columns.join('\u0000');
+      const hasPendingColumns = pendingColumns !== undefined;
+      const isSpans = tableName === TABLE_SPANS;
+      const conflictDuplicate = isSpans && conflictKey !== undefined && pendingConflictKeys.has(conflictKey);
+      const exceedsLimit = pendingRows.length >= pendingLimit;
+      const incompatibleColumns = !hasPendingColumns || columnsSignature !== pendingColumns.join('\u0000');
+
+      if (!hasPendingColumns || conflictDuplicate || exceedsLimit || incompatibleColumns) {
+        await flush();
+
+        pendingColumns = columns;
+        pendingLimit = this.getChunkRowLimit(columns.length);
+        pendingRows = [values];
+        pendingConflictKeys = new Set();
+      } else {
+        pendingRows.push(values);
+      }
+
+      if (isSpans && conflictKey !== undefined) {
+        pendingConflictKeys.add(conflictKey);
+      }
+    }
+
+    await flush();
   }
 
   async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
@@ -1206,9 +1343,7 @@ export class PgDB extends MastraBase {
   async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
     try {
       await this.client.tx(async tx => {
-        for (const record of records) {
-          await this.executeInsert(tx, { tableName, record });
-        }
+        await this.executeBatchInsert(tx, { tableName, records });
       });
     } catch (error) {
       throw new MastraError(

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -687,9 +687,10 @@ export class PgDB extends MastraBase {
     client: Pick<DbClient, 'none'> | Pick<TxClient, 'none'>,
     { tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] },
   ): Promise<void> {
-    const preparedRecords = await Promise.all(
-      records.map(record => this.normalizeForInsert(tableName, record)),
-    );
+    const preparedRecords: Awaited<ReturnType<PgDB['normalizeForInsert']>>[] = [];
+    for (const record of records) {
+      preparedRecords.push(await this.normalizeForInsert(tableName, record));
+    }
 
     let pendingColumns: string[] | undefined;
     let pendingConflictKeys = new Set<string>();

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -721,13 +721,14 @@ export class PgDB extends MastraBase {
       }
 
       const columnsSignature = columns.join('\u0000');
-      const hasPendingColumns = pendingColumns !== undefined;
+      const currentPendingColumns = pendingColumns;
       const isSpans = tableName === TABLE_SPANS;
       const conflictDuplicate = isSpans && conflictKey !== undefined && pendingConflictKeys.has(conflictKey);
       const exceedsLimit = pendingRows.length >= pendingLimit;
-      const incompatibleColumns = !hasPendingColumns || columnsSignature !== pendingColumns.join('\u0000');
+      const incompatibleColumns =
+        currentPendingColumns === undefined || columnsSignature !== currentPendingColumns.join('\u0000');
 
-      if (!hasPendingColumns || conflictDuplicate || exceedsLimit || incompatibleColumns) {
+      if (incompatibleColumns || conflictDuplicate || exceedsLimit) {
         await flush();
 
         pendingColumns = columns;

--- a/stores/pg/src/storage/db/transaction-client.test.ts
+++ b/stores/pg/src/storage/db/transaction-client.test.ts
@@ -96,6 +96,16 @@ describe('PgDB transaction handling', () => {
       return null;
     });
     const client = createMockDbClient(txClient);
+    client.manyOrNone = vi.fn(async () => [
+      { column_name: 'id' },
+      { column_name: 'resourceId' },
+      { column_name: 'title' },
+      { column_name: 'metadata' },
+      { column_name: 'createdAt' },
+      { column_name: 'createdAtZ' },
+      { column_name: 'updatedAt' },
+      { column_name: 'updatedAtZ' },
+    ]);
     const db = new PgDB({ client });
 
     const records = Array.from({ length: 8192 }, (_, index) => ({
@@ -119,6 +129,7 @@ describe('PgDB transaction handling', () => {
     expect(txStatements[0]!.values).toHaveLength(65_528);
     expect(txStatements[1]!.query).toContain('INSERT INTO "public"."mastra_threads"');
     expect(txStatements[1]!.values).toHaveLength(8);
+    expect(client.manyOrNone).toHaveBeenCalledOnce();
   });
 
   it('splits span batch inserts when duplicate (traceId, spanId) targets appear in the same input batch', async () => {

--- a/stores/pg/src/storage/db/transaction-client.test.ts
+++ b/stores/pg/src/storage/db/transaction-client.test.ts
@@ -1,12 +1,17 @@
-import { TABLE_THREADS } from '@mastra/core/storage';
+import { TABLE_SPANS, TABLE_THREADS } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { DbClient, QueryValues, TxClient } from '../client';
 import { PgDB } from './index';
 
+type RecordedQuery = {
+  query: string;
+  values?: QueryValues;
+};
+
 function createMockTxClient(onNone: (query: string, values?: QueryValues) => Promise<null>): TxClient {
   return {
-    none: vi.fn(onNone),
+    none: vi.fn(async (query, values) => onNone(query, values)),
     one: vi.fn(async () => {
       throw new Error('Unexpected tx.one call');
     }),
@@ -59,9 +64,9 @@ function createMockDbClient(
 
 describe('PgDB transaction handling', () => {
   it('uses tx() for batchInsert instead of manual BEGIN/COMMIT/ROLLBACK queries', async () => {
-    const txStatements: string[] = [];
+    const txStatements: RecordedQuery[] = [];
     const txClient = createMockTxClient(async query => {
-      txStatements.push(query);
+      txStatements.push({ query });
       return null;
     });
     const client = createMockDbClient(txClient);
@@ -77,8 +82,89 @@ describe('PgDB transaction handling', () => {
 
     expect(client.txSpy).toHaveBeenCalledOnce();
     expect(client.querySpy).not.toHaveBeenCalled();
+    expect(txStatements).toHaveLength(1);
+    expect(txStatements.every(statement => statement.query.startsWith('INSERT INTO'))).toBe(true);
+    expect(txStatements[0]!.query).toContain(
+      'VALUES ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10)',
+    );
+  });
+
+  it('uses multi-row inserts for ordinary tables and chunks at bind parameter boundaries', async () => {
+    const txStatements: RecordedQuery[] = [];
+    const txClient = createMockTxClient(async (query, values) => {
+      txStatements.push({ query, values });
+      return null;
+    });
+    const client = createMockDbClient(txClient);
+    const db = new PgDB({ client });
+
+    const records = Array.from({ length: 8192 }, (_, index) => ({
+      id: `thread-${index}`,
+      resourceId: `resource-${index}`,
+      title: `thread-title-${index}`,
+      metadata: {},
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    }));
+
+    await db.batchInsert({
+      tableName: TABLE_THREADS,
+      records,
+    });
+
     expect(txStatements).toHaveLength(2);
-    expect(txStatements.every(query => query.startsWith('INSERT INTO'))).toBe(true);
+    expect(txStatements[0]!.query).toContain('INSERT INTO "public"."mastra_threads"');
+    expect(txStatements[0]!.query).toContain('VALUES ($1, $2, $3, $4, $5, $6, $7, $8)');
+    expect(txStatements[0]!.query).toContain('), ($');
+    expect(txStatements[0]!.values).toHaveLength(65_528);
+    expect(txStatements[1]!.query).toContain('INSERT INTO "public"."mastra_threads"');
+    expect(txStatements[1]!.values).toHaveLength(8);
+  });
+
+  it('splits span batch inserts when duplicate (traceId, spanId) targets appear in the same input batch', async () => {
+    const txStatements: RecordedQuery[] = [];
+    const txClient = createMockTxClient(async (query, values) => {
+      txStatements.push({ query, values });
+      return null;
+    });
+    const client = createMockDbClient(txClient);
+    const db = new PgDB({ client });
+
+    await db.batchInsert({
+      tableName: TABLE_SPANS,
+      records: [
+        {
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          name: 'first',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: new Date('2024-01-01T00:00:00.000Z'),
+        },
+        {
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          name: 'second',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
+        {
+          traceId: 'trace-1',
+          spanId: 'span-2',
+          name: 'third',
+          spanType: 'tool_call',
+          isEvent: false,
+          startedAt: new Date('2024-01-01T00:00:02.000Z'),
+        },
+      ],
+    });
+
+    expect(txStatements).toHaveLength(2);
+    expect(txStatements.every(statement => statement.query.startsWith('INSERT INTO "public"."mastra_ai_spans"'))).toBe(true);
+    expect(txStatements[0]!.values).toHaveLength(6);
+    expect(txStatements[1]!.values).toHaveLength(12);
+    expect(txStatements[1]!.query).toContain('ON CONFLICT ("traceId", "spanId") DO UPDATE SET');
   });
 
   it('uses tx() for batchUpdate instead of manual BEGIN/COMMIT/ROLLBACK queries', async () => {


### PR DESCRIPTION
Fixes #17398

## Summary

`PgDB.batchInsert()` already receives batches, but it still sends one `INSERT` per record inside a transaction. This PR converts those sequential inserts into bounded multi-row statements, preserving existing conflict behavior while cutting round trips for high-volume Postgres writes like observability spans.

## What Changed

- `stores/pg/src/storage/db/index.ts`: `batchInsert()` now emits parameterized multi-row inserts with chunking
- Postgres storage tests: cover chunking, span conflicts, duplicate conflict targets inside one input batch, and single schema-column metadata lookup for the batch path

## Why It Matters

Busy observability workloads already batch rows before calling storage. Turning those batches into actual multi-row inserts removes avoidable network and query overhead without changing the storage API.

## Verification

- `pnpm --filter ./stores/pg exec tsc --noEmit -p tsconfig.json` passed. Covers the package typecheck and the reviewed `pendingColumns` narrowing path.
- `pnpm --filter ./stores/pg run build:lib` passed. Covers the `@mastra/pg` library build.
- `pnpm --filter ./stores/pg exec vitest run src/storage/db/transaction-client.test.ts` passed, 4/4 tests. Covers multi-row chunking, duplicate span conflict splitting, transaction ownership, and metadata lookup caching.
- `pnpm --filter ./stores/pg exec eslint src/storage/db/index.ts src/storage/db/transaction-client.test.ts` passed. Covers the changed production and test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR sends many database records in fewer PostgreSQL requests. This reduces database overhead while preserving existing transaction and conflict behavior.

## What changed

- `PgDB.batchInsert()` now uses parameterized multi-row `INSERT` statements.
- Inserts are chunked to stay below PostgreSQL bind-parameter limits.
- Existing transaction boundaries and column filtering remain unchanged.
- Schema metadata is cached before chunking.
- Span inserts preserve `ON CONFLICT ("traceId", "spanId")` behavior.
- Duplicate span conflict targets are split across statements.
- A patch changeset was added for `@mastra/pg`.

## Tests

Updated tests verify:

- Multi-row insert chunking.
- SQL placeholders and bind-value counts.
- Duplicate span conflict targets.
- Span conflict handling.
- Transaction statement recording.

## Impact

High-volume PostgreSQL writes use fewer queries and round trips. The public storage API remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
