### PR TITLE
fix(studio): repair trace evaluation and entity icons

### DIFF
--- a/.changeset/sour-carrots-beg.md
+++ b/.changeset/sour-carrots-beg.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed the Evaluate Trace button in Studio (Agents → Traces) doing nothing on the first click. Selecting the anchor span and opening the scoring tab now happen in a single URL update instead of two racing ones, so the scoring panel opens immediately.

--- a/.changeset/ten-ads-relate.md
+++ b/.changeset/ten-ads-relate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed the Agent and Workflow icon not appearing in the Traces and Logs entity column. The icon now matches the stored lowercase entity types (`agent`, `workflow_run`) instead of only uppercase values, so you can tell agent runs from workflow runs at a glance.

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-url-state.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-url-state.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react';
+import { useCallback, useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { SetURLSearchParamsLike, UseTraceUrlStateResult } from '../use-trace-url-state';
+import { useTraceUrlState } from '../use-trace-url-state';
+
+// Capture the hook API + the live URL from a harness that owns the search-param state, mimicking
+// react-router's `useSearchParams` (functional updater receives the latest committed params).
+let api: UseTraceUrlStateResult;
+let currentSearch: string;
+const setSpy = vi.fn();
+
+function Harness({ initial }: { initial: string }) {
+  const [params, setParams] = useState(() => new URLSearchParams(initial));
+  currentSearch = params.toString();
+  const setSearchParams = useCallback<SetURLSearchParamsLike>(next => {
+    setSpy(next);
+    setParams(prev => (typeof next === 'function' ? next(new URLSearchParams(prev)) : new URLSearchParams(next)));
+  }, []);
+  api = useTraceUrlState(params, setSearchParams);
+  return null;
+}
+
+afterEach(() => {
+  cleanup();
+  setSpy.mockClear();
+});
+
+describe('useTraceUrlState.handleSpanChangeWithTab', () => {
+  it('selects the span and switches the tab in a SINGLE atomic URL update', () => {
+    render(<Harness initial="traceId=t1" />);
+
+    act(() => api.handleSpanChangeWithTab('s1', 'scoring'));
+
+    const p = new URLSearchParams(currentSearch);
+    expect(p.get('traceId')).toBe('t1');
+    expect(p.get('spanId')).toBe('s1');
+    expect(p.get('tab')).toBe('scoring');
+    // The whole point of the fix: one navigation, not two racing ones (span + tab separately).
+    expect(setSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a stale scoreId when jumping to scoring', () => {
+    render(<Harness initial="traceId=t1&spanId=old&scoreId=sc1&tab=details" />);
+
+    act(() => api.handleSpanChangeWithTab('s2', 'scoring'));
+
+    const p = new URLSearchParams(currentSearch);
+    expect(p.get('spanId')).toBe('s2');
+    expect(p.get('tab')).toBe('scoring');
+    expect(p.get('scoreId')).toBeNull();
+  });
+
+  it('skips the navigation entirely when span, tab and score already match', () => {
+    render(<Harness initial="traceId=t1&spanId=s1&tab=scoring" />);
+
+    act(() => api.handleSpanChangeWithTab('s1', 'scoring'));
+
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('still navigates when only a stale scoreId needs clearing', () => {
+    render(<Harness initial="traceId=t1&spanId=s1&tab=scoring&scoreId=sc1" />);
+
+    act(() => api.handleSpanChangeWithTab('s1', 'scoring'));
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(new URLSearchParams(currentSearch).get('scoreId')).toBeNull();
+  });
+
+  it("omits the tab param for the default 'details' tab", () => {
+    render(<Harness initial="traceId=t1" />);
+
+    act(() => api.handleSpanChangeWithTab('s1', 'details'));
+
+    const p = new URLSearchParams(currentSearch);
+    expect(p.get('spanId')).toBe('s1');
+    expect(p.get('tab')).toBeNull();
+  });
+});

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-url-state.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-url-state.tsx
@@ -98,6 +98,12 @@ export interface UseTraceUrlStateResult {
   /** Convenience: clears the featured span selection. Equivalent to `handleSpanChange(null)`. */
   handleSpanClose: () => void;
   handleSpanTabChange: (tab: SpanTab) => void;
+  /** Selects a span AND switches its panel tab in a single URL update. Use when both must change
+   *  from one interaction (e.g. "Evaluate Trace"). Calling `handleSpanChange` + `handleSpanTabChange`
+   *  separately races: each functional `setSearchParams` updater reads the same pre-update
+   *  `searchParams` snapshot, so the second navigation overwrites the first (last write wins) and one
+   *  of the two changes is lost on the first click. */
+  handleSpanChangeWithTab: (spanId: string, tab: SpanTab) => void;
   handleScoreChange: (scoreId: string | null) => void;
   /** Switches the list view between traces and branches. Clears the current selection. */
   handleListModeChange: (mode: TraceListMode) => void;
@@ -265,6 +271,35 @@ export function useTraceUrlState(
     [searchParams, setSearchParams],
   );
 
+  const handleSpanChangeWithTab = useCallback(
+    (spanId: string, tab: SpanTab) => {
+      const nextTab = tab && tab !== 'details' ? tab : null;
+      // No-op guard (same pattern as the sibling handlers): skip the navigation only when span,
+      // tab AND score are already exactly what this call would produce.
+      const isNoOp =
+        spanId === (searchParams.get(SPAN_ID_PARAM) || null) &&
+        nextTab === (searchParams.get(TAB_PARAM) || null) &&
+        !searchParams.get(SCORE_ID_PARAM);
+      if (isNoOp) return;
+
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev);
+          next.set(SPAN_ID_PARAM, spanId);
+          if (nextTab) {
+            next.set(TAB_PARAM, nextTab);
+          } else {
+            next.delete(TAB_PARAM);
+          }
+          next.delete(SCORE_ID_PARAM);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [searchParams, setSearchParams],
+  );
+
   const handleScoreChange = useCallback(
     (scoreId: string | null) => {
       const currentScoreId = searchParams.get(SCORE_ID_PARAM) || null;
@@ -419,6 +454,7 @@ export function useTraceUrlState(
     handleSpanChange,
     handleSpanClose,
     handleSpanTabChange,
+    handleSpanChangeWithTab,
     handleScoreChange,
     handleListModeChange,
     handleFilterTokensChange,

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/__tests__/traces-data-list-cells.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/__tests__/traces-data-list-cells.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { EntityType } from '@mastra/core/observability';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { TracesDataListEntityCell } from '../traces-data-list-cells';
+
+afterEach(cleanup);
+
+// The observability `EntityType` enum values are lowercase. These guard that the icon helper follows
+// the enum values while still tolerating uppercase strings from stale URLs or fixtures.
+describe('TracesDataListEntityCell entity icon', () => {
+  const renderCell = (entityType: string) =>
+    render(<TracesDataListEntityCell entityType={entityType} entityName="x" />);
+
+  it('renders an icon for the lowercase stored value "agent"', () => {
+    expect(renderCell(EntityType.AGENT).container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders an icon for the lowercase stored value "workflow_run"', () => {
+    expect(renderCell(EntityType.WORKFLOW_RUN).container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('still renders an icon for legacy uppercase values', () => {
+    expect(renderCell('AGENT').container.querySelector('svg')).not.toBeNull();
+    expect(renderCell('WORKFLOW').container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders no icon for entity types that are neither agent nor workflow', () => {
+    expect(renderCell('memory').container.querySelector('svg')).toBeNull();
+  });
+});

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
@@ -1,3 +1,4 @@
+import { EntityType } from '@mastra/core/observability';
 import { CornerDownRightIcon, ListTreeIcon } from 'lucide-react';
 import { DataListCell, DataListMonoCell } from '../data-list-cells';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
@@ -61,11 +62,13 @@ export function TracesDataListInputCell({ input }: TracesDataListInputCellProps)
 
 function EntityTypeIcon({ entityType, className }: { entityType: string; className?: string }) {
   const iconClass = cn('size-3.5 shrink-0 text-neutral2', className);
-  switch (entityType) {
-    case 'AGENT':
+  const normalizedEntityType = entityType.toLowerCase();
+
+  switch (normalizedEntityType) {
+    case EntityType.AGENT:
       return <AgentIcon className={iconClass} aria-hidden />;
-    case 'WORKFLOW':
-    case 'WORKFLOW_RUN':
+    case 'workflow':
+    case EntityType.WORKFLOW_RUN:
       return <WorkflowIcon className={iconClass} aria-hidden />;
     default:
       return null;

--- a/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list-cells.tsx
@@ -1,3 +1,4 @@
+import { EntityType } from '@mastra/core/observability';
 import { DataListCell, DataListMonoCell } from '../DataList/data-list-cells';
 type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
@@ -39,12 +40,15 @@ export function LogsDataListLevelCell({ level }: LogsDataListLevelCellProps) {
 
 function EntityTypeIcon({ entityType, className }: { entityType: string; className?: string }) {
   const iconClass = cn('size-3.5 shrink-0 text-neutral2', className);
-  switch (entityType) {
-    case 'AGENT':
+  const normalizedEntityType = entityType.toLowerCase();
+
+  switch (normalizedEntityType) {
+    case EntityType.AGENT:
       return <AgentIcon className={iconClass} aria-hidden />;
-    case 'WORKFLOW':
+    case 'workflow':
+    case EntityType.WORKFLOW_RUN:
       return <WorkflowIcon className={iconClass} aria-hidden />;
-    case 'TOOL':
+    case EntityType.TOOL:
       return <ToolsIcon className={iconClass} aria-hidden />;
     default:
       return null;

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -246,8 +246,10 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
       ? lightSpans?.find(s => s.spanId === anchorSpanId)
       : lightSpans?.find(s => s.parentSpanId == null);
     if (!anchorSpan) return;
-    url.handleSpanChange(anchorSpan.spanId);
-    url.handleSpanTabChange('scoring');
+    // Select span + switch to scoring in ONE URL update. Two separate calls race (each reads the
+    // same pre-update searchParams snapshot, last write wins) and the tab switch was lost on the
+    // first click.
+    url.handleSpanChangeWithTab(anchorSpan.spanId, 'scoring');
   }, [lightSpans, anchorSpanId, url]);
 
   const filtersApplied =


### PR DESCRIPTION
## Summary

Fixes two Studio trace/log issues:

- Applies Evaluate Trace span, score, and tab URL params atomically so selecting a span does not lose state from another same-tick URL update.
- Uses the observability EntityType constants when rendering trace/log entity icons, so persisted lowercase entity types render the expected Agent and Workflow icons without duplicating raw casing variants.

Dataset target persistence/filtering was split into #17767.

## Verification

- pnpm --filter ./packages/playground-ui exec prettier --check <touched playground-ui files>
- pnpm --filter ./packages/playground-ui exec eslint <touched playground-ui files>
- pnpm --filter ./packages/playground-ui exec vitest run src/domains/traces/hooks/__tests__/use-trace-url-state.test.tsx src/ds/components/DataList/TracesDataList/__tests__/traces-data-list-cells.test.tsx
- pnpm --filter ./packages/playground exec eslint src/pages/traces/index.tsx
- pnpm --filter ./packages/playground-ui typecheck
- pnpm --filter ./packages/playground-ui build
- pnpm --filter ./packages/playground typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes three problems in the Studio UI: (1) the "Evaluate Trace" button now reliably opens the scoring panel on the first click instead of requiring a second click, (2) dataset target types are now properly preserved when creating, editing, or duplicating datasets, and (3) entity icons (like whether something is an Agent or Workflow) now correctly display when stored as lowercase text instead of uppercase.

## Overview

This PR addresses three critical Studio UI issues affecting trace evaluation, dataset management, and entity icon rendering. The fixes ensure that URL state updates happen atomically, dataset configuration persists through workflows, and icons normalize text inputs for proper display.

## Changes by Component

### Evaluate Trace URL State (Traces Page)

**Problem**: Clicking "Evaluate Trace" required two separate URL updates (span selection + tab change), causing the second update to overwrite the first and leaving the scoring panel closed.

**Solution**: 
- Added `handleSpanChangeWithTab` handler to `useTraceUrlState` hook that updates both `spanId` and `tab` in a single atomic URL state change
- Updated `TracesPage`'s "Evaluate Trace" handler to use this new combined handler instead of two sequential calls
- Includes guard logic to skip redundant navigation when URL state already matches

**Files**:
- `packages/playground-ui/src/domains/traces/hooks/use-trace-url-state.tsx` - New hook handler with atomic update logic
- `packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-url-state.test.tsx` - Comprehensive test suite validating span/tab combinations and stale scoreId clearing
- `packages/playground/src/pages/traces/index.tsx` - Updated button handler to use new combined update method

### Entity Type Icon Normalization (Traces & Logs)

**Problem**: Entity icons (Agent/Workflow distinction) only rendered correctly for uppercase stored values; lowercase values (e.g., `agent`, `workflow_run`) failed to match icon selection logic.

**Solution**:
- Updated `EntityTypeIcon` components in both Traces and Logs data lists to normalize `entityType` to lowercase before icon selection
- Modified icon switch statements to use normalized `EntityType` enum constants
- Added support for both `workflow` and `workflow_run` variations

**Files**:
- `packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx` - Normalize entity type before icon selection
- `packages/playground-ui/src/ds/components/LogsDataList/logs-data-list-cells.tsx` - Similar normalization with expanded workflow handling
- `packages/playground-ui/src/ds/components/DataList/TracesDataList/__tests__/traces-data-list-cells.test.tsx` - Tests for lowercase and legacy uppercase value handling

### Changesets

Two patch-level changesets document public fixes:
- `sour-carrots-beg.md` - Evaluate Trace URL state atomicity fix
- `ten-ads-relate.md` - Entity icon rendering for lowercase types

## Known Limitations

Clearing a dataset target type back to `null` requires a separate server/schema update because the API accepts optional string values but not `null` values for the target type field.

## Verification Status

- All package tests and typechecks pass for playground and playground-ui
- Vitest tests implemented for dataset and trace UI code paths
- GitHub checks pass (commit 04ae25105bff12bc262777ccc3ded633cc76f3e0)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->