### PR TITLE
fix(memory): preserve OM assistant parts across steps

### DIFF
--- a/.changeset/purple-chairs-reply.md
+++ b/.changeset/purple-chairs-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed Observational Memory so multi-step assistant turns keep all persisted message parts.

--- a/packages/memory/src/processors/observational-memory/__tests__/observation-turn-persistence.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observation-turn-persistence.test.ts
@@ -1,0 +1,285 @@
+import type { MastraDBMessage, MastraMessageContentV2, MastraMessagePart } from '@mastra/core/agent';
+import { MessageList } from '@mastra/core/agent';
+import type { ObservationalMemoryRecord } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ObservationTurn } from '../observation-turn/turn';
+
+const threadId = 'om-turn-persistence-thread';
+const resourceId = 'om-turn-persistence-resource';
+const assistantId = 'stable-assistant-message';
+
+function clonePart(part: MastraMessagePart): MastraMessagePart {
+  if (part.type === 'tool-invocation') {
+    return {
+      ...part,
+      toolInvocation: {
+        ...part.toolInvocation,
+      },
+    };
+  }
+
+  return { ...part };
+}
+
+function cloneMessage(message: MastraDBMessage): MastraDBMessage {
+  return {
+    ...message,
+    createdAt: new Date(message.createdAt),
+    content: {
+      ...message.content,
+      parts: message.content.parts.map(clonePart),
+      metadata: message.content.metadata ? { ...message.content.metadata } : undefined,
+    },
+  };
+}
+
+function createRecord(): ObservationalMemoryRecord {
+  return {
+    id: 'om-record',
+    threadId,
+    activeObservations: null,
+    observationTokenCount: 0,
+    lastObservedAt: null,
+    generationCount: 0,
+    bufferedObservationChunks: null,
+    isBufferingObservation: false,
+    lastBufferedAt: null,
+    config: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as ObservationalMemoryRecord;
+}
+
+function createMockOM() {
+  const record = createRecord();
+  const persistedMessages = new Map<string, MastraDBMessage>();
+
+  return {
+    scope: 'thread' as const,
+    reflector: {
+      maybeReflect: vi.fn(async () => {}),
+    },
+    buffering: {
+      isAsyncObservationEnabled: vi.fn(() => false),
+    },
+    observer: {
+      lastExchange: undefined,
+    },
+    getOrCreateRecord: vi.fn(async () => record),
+    getStorage: vi.fn(() => ({
+      getThreadById: vi.fn(async () => ({ metadata: {} })),
+    })),
+    getStatus: vi.fn(async () => ({
+      pendingTokens: 0,
+      threshold: 100_000,
+      effectiveObservationTokensThreshold: 100_000,
+      shouldObserve: false,
+      shouldBuffer: false,
+      shouldReflect: false,
+      canActivate: false,
+      asyncObservationEnabled: false,
+      record,
+    })),
+    getObservationConfig: vi.fn(() => ({
+      bufferOnIdle: false,
+      bufferActivation: 1,
+    })),
+    getUnobservedMessages: vi.fn(() => []),
+    buildContextSystemMessages: vi.fn(async () => undefined),
+    getOtherThreadsContext: vi.fn(async () => undefined),
+    activate: vi.fn(async () => ({ activated: false, record })),
+    resetBufferingState: vi.fn(async () => {}),
+    waitForBuffering: vi.fn(async () => {}),
+    observe: vi.fn(async () => ({ observed: false, record })),
+    cleanupMessages: vi.fn(async () => {}),
+    sealMessagesForBuffering: vi.fn(),
+    persistMessages: vi.fn(async (messages: MastraDBMessage[]) => {
+      for (const message of messages) {
+        persistedMessages.set(message.id, cloneMessage(message));
+      }
+    }),
+    persistedMessages,
+  };
+}
+
+function createMessageList() {
+  return new MessageList({
+    threadId,
+    resourceId,
+    generateMessageId: () => assistantId,
+  });
+}
+
+function createAssistantMessage(
+  parts: MastraMessagePart[],
+  createdAt: Date,
+  opts?: { sealed?: boolean },
+): MastraDBMessage {
+  const content: MastraMessageContentV2 = {
+    format: 2,
+    parts: parts.map(clonePart),
+  };
+
+  if (opts?.sealed) {
+    content.metadata = { mastra: { sealed: true } };
+
+    const lastPart = content.parts.at(-1) as
+      | (MastraMessagePart & { metadata?: { mastra?: { sealedAt?: number } } })
+      | undefined;
+    if (lastPart) {
+      lastPart.metadata = {
+        ...(lastPart.metadata ?? {}),
+        mastra: {
+          ...(lastPart.metadata?.mastra ?? {}),
+          sealedAt: createdAt.getTime(),
+        },
+      };
+    }
+  }
+
+  return {
+    id: assistantId,
+    role: 'assistant',
+    type: 'text',
+    threadId,
+    resourceId,
+    createdAt,
+    content,
+  };
+}
+
+function toolPart(toolCallId: string): MastraMessagePart {
+  return {
+    type: 'tool-invocation',
+    toolInvocation: {
+      toolCallId,
+      toolName: toolCallId,
+      state: 'result',
+      args: {},
+      result: { ok: true },
+    },
+  };
+}
+
+function textPart(text: string): MastraMessagePart {
+  return { type: 'text', text };
+}
+
+async function createStartedTurn(messageList: MessageList, om = createMockOM()) {
+  const turn = new ObservationTurn({
+    om: om as any,
+    threadId,
+    resourceId,
+    messageList,
+  });
+
+  await turn.start();
+
+  return { turn, om };
+}
+
+describe('ObservationTurn assistant persistence', () => {
+  it('persists accumulated assistant parts across step boundary saves', async () => {
+    const messageList = createMessageList();
+    const { turn, om } = await createStartedTurn(messageList);
+
+    messageList.add(
+      createAssistantMessage([toolPart('weather')], new Date('2026-01-01T00:00:00.000Z'), { sealed: true }),
+      'response',
+    );
+    await turn.step(1).prepare();
+
+    messageList.add(createAssistantMessage([toolPart('forecast')], new Date('2026-01-01T00:00:01.000Z')), 'response');
+    await turn.step(2).prepare();
+
+    const persisted = om.persistedMessages.get(assistantId);
+    expect(persisted?.content.parts.map(part => part.type)).toEqual(['tool-invocation', 'tool-invocation']);
+    expect(
+      persisted?.content.parts.map(part =>
+        part.type === 'tool-invocation' ? part.toolInvocation.toolCallId : undefined,
+      ),
+    ).toEqual(['weather', 'forecast']);
+  });
+
+  it('flushes one merged assistant message at turn end after sealed step splits', async () => {
+    const messageList = createMessageList();
+    const { turn, om } = await createStartedTurn(messageList);
+
+    messageList.add(
+      createAssistantMessage([toolPart('weather')], new Date('2026-01-01T00:00:00.000Z'), { sealed: true }),
+      'response',
+    );
+    await turn.step(1).prepare();
+
+    messageList.add(createAssistantMessage([toolPart('forecast')], new Date('2026-01-01T00:00:01.000Z')), 'response');
+    await turn.step(2).prepare();
+
+    messageList.add(
+      createAssistantMessage([textPart('Here is the summary.')], new Date('2026-01-01T00:00:02.000Z')),
+      'response',
+    );
+    await turn.end();
+
+    const persisted = om.persistedMessages.get(assistantId);
+    expect(persisted?.content.parts.map(part => part.type)).toEqual(['tool-invocation', 'tool-invocation', 'text']);
+    expect(
+      persisted?.content.parts.map(part =>
+        part.type === 'tool-invocation' ? part.toolInvocation.toolCallId : part.type === 'text' ? part.text : undefined,
+      ),
+    ).toEqual(['weather', 'forecast', 'Here is the summary.']);
+  });
+
+  it('keeps distinct assistant text parts when merging step snapshots', async () => {
+    const messageList = createMessageList();
+    const { turn, om } = await createStartedTurn(messageList);
+
+    messageList.add(
+      createAssistantMessage(
+        [textPart('I will check the current weather.'), toolPart('weather')],
+        new Date('2026-01-01T00:00:00.000Z'),
+        { sealed: true },
+      ),
+      'response',
+    );
+    await turn.step(1).prepare();
+
+    messageList.add(
+      createAssistantMessage([textPart('Here is the summary.')], new Date('2026-01-01T00:00:01.000Z')),
+      'response',
+    );
+    await turn.end();
+
+    const persisted = om.persistedMessages.get(assistantId);
+    expect(
+      persisted?.content.parts.map(part =>
+        part.type === 'tool-invocation' ? part.toolInvocation.toolCallId : part.type === 'text' ? part.text : undefined,
+      ),
+    ).toEqual(['I will check the current weather.', 'weather', 'Here is the summary.']);
+  });
+
+  it('re-persists tracked memory-source assistant snapshots that gained parts before turn end', async () => {
+    const messageList = createMessageList();
+    const { turn, om } = await createStartedTurn(messageList);
+
+    messageList.add(createAssistantMessage([toolPart('weather')], new Date('2026-01-01T00:00:00.000Z')), 'response');
+    await turn.step(1).prepare();
+
+    messageList.add(
+      createAssistantMessage(
+        [toolPart('weather'), textPart('Here is the summary.')],
+        new Date('2026-01-01T00:00:01.000Z'),
+      ),
+      'memory',
+    );
+    await turn.end();
+
+    const persisted = om.persistedMessages.get(assistantId);
+    expect(persisted?.content.parts.map(part => part.type)).toEqual(['tool-invocation', 'text']);
+    expect(
+      persisted?.content.parts.map(part =>
+        part.type === 'tool-invocation' ? part.toolInvocation.toolCallId : part.type === 'text' ? part.text : undefined,
+      ),
+    ).toEqual(['weather', 'Here is the summary.']);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/observation-turn-persistence.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observation-turn-persistence.test.ts
@@ -166,6 +166,15 @@ function textPart(text: string): MastraMessagePart {
   return { type: 'text', text };
 }
 
+function filePart(providerMetadata: Record<string, unknown>): MastraMessagePart {
+  return {
+    type: 'file',
+    mimeType: 'text/plain',
+    data: 'data:text/plain;base64,SGVsbG8=',
+    providerMetadata,
+  } as MastraMessagePart;
+}
+
 async function createStartedTurn(messageList: MessageList, om = createMockOM()) {
   const turn = new ObservationTurn({
     om: om as any,
@@ -256,6 +265,33 @@ describe('ObservationTurn assistant persistence', () => {
         part.type === 'tool-invocation' ? part.toolInvocation.toolCallId : part.type === 'text' ? part.text : undefined,
       ),
     ).toEqual(['I will check the current weather.', 'weather', 'Here is the summary.']);
+  });
+
+  it('does not duplicate non-tool parts when metadata keys are ordered differently', async () => {
+    const messageList = createMessageList();
+    const { turn, om } = await createStartedTurn(messageList);
+
+    messageList.add(
+      createAssistantMessage(
+        [filePart({ provider: { alpha: 1, beta: 2 } })],
+        new Date('2026-01-01T00:00:00.000Z'),
+        { sealed: true },
+      ),
+      'response',
+    );
+    await turn.step(1).prepare();
+
+    messageList.add(
+      createAssistantMessage(
+        [filePart({ provider: { beta: 2, alpha: 1 } }), textPart('Here is the summary.')],
+        new Date('2026-01-01T00:00:01.000Z'),
+      ),
+      'response',
+    );
+    await turn.end();
+
+    const persisted = om.persistedMessages.get(assistantId);
+    expect(persisted?.content.parts.map(part => part.type)).toEqual(['file', 'text']);
   });
 
   it('re-persists tracked memory-source assistant snapshots that gained parts before turn end', async () => {

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -202,9 +202,17 @@ export class ObservationStep {
       // Save messages from previous step
       const newInput = messageList.clear.input.db();
       const newOutput = messageList.clear.response.db();
-      const messagesToSave = [...newInput, ...newOutput];
+      const messagesToSave = this.turn.prepareMessagesForStepBoundaryPersist([...newInput, ...newOutput]);
       if (messagesToSave.length > 0) {
         await om.persistMessages(messagesToSave, threadId, resourceId);
+
+        const assistantIds = messagesToSave
+          .filter((message): message is typeof message & { role: 'assistant' } => message.role === 'assistant')
+          .map(message => message.id);
+        if (assistantIds.length > 0) {
+          messageList.removeByIds(assistantIds);
+        }
+
         for (const msg of messagesToSave) {
           messageList.add(msg, 'memory');
         }

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -71,7 +71,12 @@ function mergeAssistantParts(
       continue;
     }
 
-    merged.push(part);
+    const existingPartIndex = merged.findIndex(existing => partMatches(existing, part));
+    if (existingPartIndex === -1) {
+      merged.push(part);
+    } else {
+      merged[existingPartIndex] = part;
+    }
   }
 
   return merged;
@@ -100,11 +105,26 @@ function mergeContentMetadata(
   return metadata;
 }
 
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJsonValue);
+  if (!value || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map(key => [key, sortJsonValue((value as Record<string, unknown>)[key])]),
+  );
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJsonValue(JSON.parse(JSON.stringify(value))));
+}
+
 function partsAreEqual(left: MastraMessagePart[], right: MastraMessagePart[]): boolean {
   if (left.length !== right.length) return false;
 
   try {
-    return JSON.stringify(left) === JSON.stringify(right);
+    return stableStringify(left) === stableStringify(right);
   } catch {
     return false;
   }

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -1,4 +1,4 @@
-import type { MessageList } from '@mastra/core/agent';
+import type { MastraDBMessage, MastraMessagePart, MessageList } from '@mastra/core/agent';
 import type { ObservabilityContext } from '@mastra/core/observability';
 import type { ProcessorContext, ProcessorStreamWriter } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
@@ -12,6 +12,103 @@ import type { ObservationModelContext } from '../types';
 import { loadMemoryContextMessages } from './load-memory-context';
 import { ObservationStep } from './step';
 import type { ObservationTurnHooks, TurnContext, TurnResult } from './types';
+
+function getToolCallId(part: MastraMessagePart): string | undefined {
+  return part.type === 'tool-invocation' ? part.toolInvocation?.toolCallId : undefined;
+}
+
+function partMatches(left: MastraMessagePart, right: MastraMessagePart): boolean {
+  const leftToolCallId = getToolCallId(left);
+  const rightToolCallId = getToolCallId(right);
+  if (leftToolCallId || rightToolCallId) {
+    return leftToolCallId === rightToolCallId;
+  }
+
+  if (left.type === 'text' && right.type === 'text') {
+    return left.text === right.text;
+  }
+
+  return partsAreEqual([left], [right]);
+}
+
+function incomingExtendsPrevious(previousParts: MastraMessagePart[], incomingParts: MastraMessagePart[]): boolean {
+  if (incomingParts.length < previousParts.length) return false;
+
+  return previousParts.every((part, index) => {
+    const incomingPart = incomingParts[index];
+    return incomingPart ? partMatches(part, incomingPart) : false;
+  });
+}
+
+function mergeAssistantParts(
+  previousParts: MastraMessagePart[],
+  incomingParts: MastraMessagePart[],
+): MastraMessagePart[] {
+  if (previousParts.length === 0) return [...incomingParts];
+  if (incomingParts.length === 0) return [...previousParts];
+  if (incomingExtendsPrevious(previousParts, incomingParts)) return [...incomingParts];
+
+  const merged = [...previousParts];
+  for (const part of incomingParts) {
+    const toolCallId = getToolCallId(part);
+    if (toolCallId) {
+      const existingToolIndex = merged.findIndex(existing => getToolCallId(existing) === toolCallId);
+      if (existingToolIndex === -1) {
+        merged.push(part);
+      } else {
+        merged[existingToolIndex] = part;
+      }
+      continue;
+    }
+
+    if (part.type === 'text') {
+      const existingTextIndex = merged.findIndex(existing => existing.type === 'text' && existing.text === part.text);
+      if (existingTextIndex === -1) {
+        merged.push(part);
+      } else {
+        merged[existingTextIndex] = part;
+      }
+      continue;
+    }
+
+    merged.push(part);
+  }
+
+  return merged;
+}
+
+function mergeContentMetadata(
+  previous?: MastraDBMessage['content']['metadata'],
+  incoming?: MastraDBMessage['content']['metadata'],
+): MastraDBMessage['content']['metadata'] | undefined {
+  if (!previous && !incoming) return undefined;
+
+  const previousMastra = previous?.mastra as Record<string, unknown> | undefined;
+  const incomingMastra = incoming?.mastra as Record<string, unknown> | undefined;
+  const metadata = {
+    ...(previous ?? {}),
+    ...(incoming ?? {}),
+  };
+
+  if (previousMastra || incomingMastra) {
+    metadata.mastra = {
+      ...(previousMastra ?? {}),
+      ...(incomingMastra ?? {}),
+    };
+  }
+
+  return metadata;
+}
+
+function partsAreEqual(left: MastraMessagePart[], right: MastraMessagePart[]): boolean {
+  if (left.length !== right.length) return false;
+
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Represents a single turn in the agent conversation — one user message → agent response cycle.
@@ -45,6 +142,10 @@ export class ObservationTurn {
 
   /** Generation count at turn start — used to detect if reflection happened during the turn. */
   private _generationCountAtStart = -1;
+
+  private _persistedAssistantIds = new Set<string>();
+  private _assistantPartsAccumulator = new Map<string, MastraMessagePart[]>();
+  private _assistantMessageTemplates = new Map<string, MastraDBMessage>();
 
   /** Memory context provider — set via start(). Used by steps for beforeBuffer persistence. */
   memory?: MemoryContextProvider;
@@ -190,7 +291,7 @@ export class ObservationTurn {
     // Save any unsaved messages from the last step
     const unsavedInput = this.messageList.get.input.db();
     const unsavedOutput = this.messageList.get.response.db();
-    const unsavedMessages = [...unsavedInput, ...unsavedOutput];
+    const unsavedMessages = this.prepareMessagesForTurnEndPersist(unsavedInput, unsavedOutput);
     if (unsavedMessages.length > 0) {
       await this.om.persistMessages(unsavedMessages, this.threadId, this.resourceId);
     }
@@ -277,5 +378,107 @@ export class ObservationTurn {
       ended: this._ended,
       currentStepNumber: this._currentStep?.stepNumber,
     };
+  }
+
+  /**
+   * Merge same-id assistant snapshots before step-boundary persistence.
+   * @internal
+   */
+  prepareMessagesForStepBoundaryPersist(messages: MastraDBMessage[]): MastraDBMessage[] {
+    const preparedMessages: MastraDBMessage[] = [];
+    const assistantMessageIndexes = new Map<string, number>();
+
+    for (const message of messages) {
+      if (message.role !== 'assistant') {
+        preparedMessages.push(message);
+        continue;
+      }
+
+      const mergedMessage = this.mergeAssistantMessageSnapshot(message);
+      this._persistedAssistantIds.add(message.id);
+
+      const existingIndex = assistantMessageIndexes.get(message.id);
+      if (existingIndex === undefined) {
+        assistantMessageIndexes.set(message.id, preparedMessages.length);
+        preparedMessages.push(mergedMessage);
+      } else {
+        preparedMessages[existingIndex] = mergedMessage;
+      }
+    }
+
+    return preparedMessages;
+  }
+
+  private prepareMessagesForTurnEndPersist(
+    unsavedInput: MastraDBMessage[],
+    unsavedOutput: MastraDBMessage[],
+  ): MastraDBMessage[] {
+    if (this._persistedAssistantIds.size === 0) {
+      return [...unsavedInput, ...unsavedOutput];
+    }
+
+    const passthroughOutput: MastraDBMessage[] = [];
+
+    for (const message of unsavedOutput) {
+      if (message.role === 'assistant' && this._persistedAssistantIds.has(message.id)) {
+        this.mergeAssistantMessageSnapshot(message);
+      } else {
+        passthroughOutput.push(message);
+      }
+    }
+
+    for (const message of this.messageList.get.all.db()) {
+      if (message.role === 'assistant' && this._persistedAssistantIds.has(message.id)) {
+        const previousParts = this._assistantPartsAccumulator.get(message.id) ?? [];
+        const incomingParts = message.content.parts ?? [];
+
+        if (!partsAreEqual(previousParts, incomingParts)) {
+          this.mergeAssistantMessageSnapshot(message);
+        } else if (!this._assistantMessageTemplates.has(message.id)) {
+          this._assistantMessageTemplates.set(message.id, message);
+        }
+      }
+    }
+
+    const mergedAssistantMessages: MastraDBMessage[] = [];
+    for (const id of this._persistedAssistantIds) {
+      const template = this._assistantMessageTemplates.get(id);
+      const parts = this._assistantPartsAccumulator.get(id);
+      if (!template || !parts) continue;
+
+      mergedAssistantMessages.push({
+        ...template,
+        content: {
+          ...template.content,
+          parts,
+        },
+      });
+    }
+
+    return [...unsavedInput, ...passthroughOutput, ...mergedAssistantMessages];
+  }
+
+  private mergeAssistantMessageSnapshot(message: MastraDBMessage): MastraDBMessage {
+    const previousTemplate = this._assistantMessageTemplates.get(message.id);
+    const previousParts = this._assistantPartsAccumulator.get(message.id) ?? [];
+    const parts = mergeAssistantParts(previousParts, message.content.parts ?? []);
+    const contentMetadata = mergeContentMetadata(previousTemplate?.content.metadata, message.content.metadata);
+
+    const mergedMessage = {
+      ...(previousTemplate ?? message),
+      ...message,
+      createdAt: previousTemplate?.createdAt ?? message.createdAt,
+      content: {
+        ...(previousTemplate?.content ?? message.content),
+        ...message.content,
+        ...(contentMetadata ? { metadata: contentMetadata } : {}),
+        parts,
+      },
+    };
+
+    this._assistantPartsAccumulator.set(message.id, parts);
+    this._assistantMessageTemplates.set(message.id, mergedMessage);
+
+    return mergedMessage;
   }
 }


### PR DESCRIPTION
Fixes #16561.

This keeps Observational Memory from losing assistant message parts when multi-step turns reuse the same assistant message id. Step-boundary saves now accumulate same-id assistant parts before persisting, remove stale same-id memory snapshots before re-adding the merged snapshot, and the final turn flush writes one merged assistant message per tracked id instead of letting later partial upserts clobber earlier tool parts.

The regression tests cover repeated step-boundary upserts, sealed split messages, memory-source snapshots that gain parts before turn end, and preserving distinct text parts instead of replacing earlier text.

Validation:
- pnpm --filter ./packages/memory exec vitest run src/processors/observational-memory/__tests__/observation-turn-persistence.test.ts --reporter=dot
- pnpm --filter ./packages/memory exec vitest run src/processors/observational-memory/__tests__/observation-turn-persistence.test.ts src/processors/observational-memory/__tests__/idle-buffering.test.ts src/processors/observational-memory/__tests__/mid-loop-observation.test.ts --reporter=dot
- pnpm --filter ./packages/memory check
- pnpm --filter ./packages/memory lint
- pnpm build:memory
- pnpm --filter ./packages/memory test:unit
- pnpm vitest run src/with-libsql-storage.test.ts --reporter=dot (from packages/memory/integration-tests)
- pnpm vitest run src/message-ordering.test.ts src/ai-sdk-duplicate-ids.test.ts --reporter=dot (from packages/memory/integration-tests)

I also attempted pnpm --filter ./packages/memory test:integration after installing the integration harness deps and building linked packages. The full integration run is blocked locally by Docker daemon availability for Postgres/Upstash-backed suites and an unrelated llm-recorder hash mismatch in observer-thread-title/message-ordering replay data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a multi-step assistant response gets saved to Observational Memory, Observational Memory sometimes saved only part of the same assistant message (e.g., tool calls in one save, and text in another) without stitching them together. This fix makes it reliably combine all parts for the same assistant `messageId` so nothing gets lost.

## Problem

Observational Memory regressed when the same assistant `messageId` was reused across steps: step-boundary persistence could write an incomplete assistant snapshot (e.g., only earlier tool-invocation parts), and then later persistence at `turn.end()` could overwrite or omit other parts (e.g., later text parts) that should have belonged to the same assistant message.

## Solution

The PR coordinates persistence across step boundaries and turn end by:
- Tracking assistant message IDs persisted during step-boundary saves.
- Accumulating and merging same-id assistant “snapshots” before persisting at each boundary (`prepareMessagesForStepBoundaryPersist`), and deduplicating by assistant `id`.
- Removing stale same-id assistant snapshots from the live message list after step-boundary persistence so the merged version is what gets persisted.
- Routing turn-end persistence through assistant-snapshot merging (`prepareMessagesForTurnEndPersist`) so the final stored assistant message per tracked ID includes all parts seen across the whole turn.
- Merging message parts with stable comparisons (including tool-invocation `toolCallId` matching and metadata handling) to avoid duplicating non-tool parts when metadata key ordering differs.

## Changes

**Test Coverage**
- Added `observation-turn-persistence.test.ts` (Vitest) with 5 regression tests asserting persisted assistant content behavior across `turn.step(...).prepare()` and `turn.end()`:
  1. Accumulates tool-invocation parts across step-boundary saves into a single assistant message with ordered tool call IDs.
  2. When sealed step snapshots are split, `turn.end()` flushes one merged assistant message that appends a subsequent text part after the tool invocations.
  3. Keeps distinct assistant text parts separate rather than collapsing/replacing earlier text.
  4. Does not duplicate non-tool parts (e.g., file parts) when message content/metadata keys are ordered differently.
  5. Re-persists tracked `"memory"`-source assistant snapshots that gain additional parts before `turn.end()` so the final stored message includes both the original tool part and newly added text.

**Core Logic**
- `ObservationTurn`:
  - Added assistant message snapshot merge logic (`mergeAssistantMessageSnapshot`), including part comparison that respects tool invocation identity (`toolCallId`) and metadata merging rules.
  - Introduced per-turn tracking/accumulation state for assistant IDs and their merged snapshots.
  - Updated turn-end persistence to use `prepareMessagesForTurnEndPersist(...)` so later partial upserts don’t lose earlier assistant parts.
  - Reconciles/merges assistant snapshots for tracked IDs when they appear across prior persisted content.
- `ObservationStep`:
  - For `stepNumber > 0`, changed boundary preparation to call `turn.prepareMessagesForStepBoundaryPersist([...newInput, ...newOutput])` before persisting.
  - After step-boundary persistence, computes assistant IDs among saved messages and removes those assistant messages from the in-memory list (instead of re-adding everything back into the live `"memory"` bucket).

**Release**
- Added a changeset bumping `@mastra/memory` with the Observational Memory multi-step assistant part preservation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->