### PR TITLE
docs: add tool hooks reference documentation

### DIFF
--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -798,6 +798,34 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
     description: 'Tools that the agent can access. Can be provided statically or resolved dynamically.',
   },
   {
+    name: 'hooks',
+    type: 'ToolHooks',
+    isOptional: true,
+    description:
+      'Hooks that run before and after every tool call made by this agent. Per-execution hooks passed to `generate()` or `stream()` override matching hooks set here. See Tool hooks below.',
+    properties: [
+      {
+        type: 'ToolHooks',
+        parameters: [
+          {
+            name: 'beforeToolCall',
+            type: '(context: ToolHookContext) => void | ToolBeforeHookResult | Promise<void | ToolBeforeHookResult>',
+            isOptional: true,
+            description:
+              'Runs before a tool executes. Receives `{ toolName, input, context, metadata }`. Return `{ proceed: false, output }` to skip the tool call and use `output` as its result.',
+          },
+          {
+            name: 'afterToolCall',
+            type: '(context: ToolAfterHookContext) => void | Promise<void>',
+            isOptional: true,
+            description:
+              'Runs after a tool executes. Receives `{ toolName, input, context, metadata, output, error }`. `output` is undefined when the tool throws, and `error` is set instead.',
+          },
+        ],
+      },
+    ],
+  },
+  {
     name: 'transform',
     type: 'ToolPayloadTransformPolicy',
     isOptional: true,
@@ -908,6 +936,46 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
   },
 ]}
 />
+
+## Tool hooks
+
+Use `hooks` to run logic around every tool call the agent makes, including assigned tools, memory tools, toolsets, client tools, and workspace tools.
+
+```typescript title="src/mastra/agents/hooked-agent.ts"
+import { Agent } from '@mastra/core/agent'
+
+export const agent = new Agent({
+  name: 'support-agent',
+  instructions: 'Help users with their questions.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  // highlight-start
+  hooks: {
+    beforeToolCall: ({ toolName, input }) => {
+      console.log(`Running ${toolName}`, input)
+    },
+    afterToolCall: ({ toolName, output, error }) => {
+      console.log(`Finished ${toolName}`, { output, error })
+    },
+  },
+  // highlight-end
+})
+```
+
+`beforeToolCall` can short-circuit the tool call by returning `{ proceed: false, output }`. The agent skips execution and uses `output` as the tool result:
+
+```typescript
+const result = await agent.generate('Clean up old records', {
+  hooks: {
+    beforeToolCall: ({ toolName }) => {
+      if (toolName === 'deleteRecord') {
+        return { proceed: false, output: { blocked: true } }
+      }
+    },
+  },
+})
+```
+
+The hook context `metadata` includes `agentId` and `agentName`. Per-execution hooks passed to `generate()` or `stream()` override matching agent-level hooks. When a [workspace](/reference/workspace/workspace-class) also defines `tools.hooks`, workspace hooks run inside the agent hook wrapper.
 
 ## Editor overrides
 

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -763,6 +763,13 @@ const response = await agent.generate('Help me organize my day', {
             description: 'Client-side tools available during execution.',
           },
           {
+            name: 'hooks',
+            type: 'ToolHooks',
+            isOptional: true,
+            description:
+              'Per-execution hooks that run before and after tool calls. Overrides matching agent-level hooks for this execution. `beforeToolCall` can return `{ proceed: false, output }` to skip the tool call.',
+          },
+          {
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,

--- a/docs/src/content/en/reference/agents/generateLegacy.mdx
+++ b/docs/src/content/en/reference/agents/generateLegacy.mdx
@@ -333,6 +333,13 @@ await agent.generateLegacy('message for agent')
               "Tools that are executed on the 'client' side of the request. These tools do not have execute functions in the definition.",
           },
           {
+            name: 'hooks',
+            type: 'ToolHooks',
+            isOptional: true,
+            description:
+              'Per-execution hooks that run before and after tool calls. Overrides matching agent-level hooks for this execution. `beforeToolCall` can return `{ proceed: false, output }` to skip the tool call.',
+          },
+          {
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -638,6 +638,13 @@ const stream = await agent.stream('message for agent')
               "Tools that are executed on the 'client' side of the request. These tools do not have execute functions in the definition.",
           },
           {
+            name: 'hooks',
+            type: 'ToolHooks',
+            isOptional: true,
+            description:
+              'Per-execution hooks that run before and after tool calls. Overrides matching agent-level hooks for this execution. `beforeToolCall` can return `{ proceed: false, output }` to skip the tool call.',
+          },
+          {
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,

--- a/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
+++ b/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
@@ -318,6 +318,13 @@ await agent.streamLegacy('message for agent')
               "Tools that are executed on the 'client' side of the request. These tools do not have execute functions in the definition.",
           },
           {
+            name: 'hooks',
+            type: 'ToolHooks',
+            isOptional: true,
+            description:
+              'Per-execution hooks that run before and after tool calls. Overrides matching agent-level hooks for this execution. `beforeToolCall` can return `{ proceed: false, output }` to skip the tool call.',
+          },
+          {
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -176,6 +176,12 @@ const workspace = new Workspace({
             isOptional: true,
             defaultValue: '2000',
           },
+          {
+            name: 'hooks',
+            type: 'WorkspaceToolHooks',
+            description: 'Hooks that run before and after every enabled workspace tool call. See Tool hooks below.',
+            isOptional: true,
+          },
         ],
       },
     ],
@@ -239,6 +245,49 @@ const workspace = new Workspace({
 ```
 
 Tool names must be unique across all workspace tools. Setting a custom name that conflicts with another tool's default or custom name throws an error.
+
+### Tool hooks
+
+Set `tools.hooks` to run logic before and after every enabled workspace tool call. Hooks run after name remapping, so the context includes both the exposed `toolName` and the original `workspaceToolName`.
+
+```typescript {6-14}
+import { Workspace } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  id: 'my-workspace',
+  tools: {
+    hooks: {
+      beforeToolCall: ({ toolName, workspaceToolName, input }) => {
+        console.log(`Running ${toolName} (${workspaceToolName})`, input)
+      },
+      afterToolCall: ({ toolName, output, error }) => {
+        console.log(`Finished ${toolName}`, { output, error })
+      },
+    },
+  },
+})
+```
+
+<PropertiesTable
+  content={[
+  {
+    name: 'beforeToolCall',
+    type: '(context: WorkspaceToolHookContext) => void | WorkspaceToolBeforeHookResult | Promise<void | WorkspaceToolBeforeHookResult>',
+    isOptional: true,
+    description:
+      'Runs before a workspace tool executes. Receives `{ toolName, workspaceToolName, input, context }`. Return `{ proceed: false, output }` to skip the tool call and use `output` as its result.',
+  },
+  {
+    name: 'afterToolCall',
+    type: '(context: WorkspaceToolAfterHookContext) => void | Promise<void>',
+    isOptional: true,
+    description:
+      'Runs after a workspace tool executes. Receives `{ toolName, workspaceToolName, input, context, output, error }`. `output` is undefined when the tool throws, and `error` is set instead.',
+  },
+]}
+/>
+
+If the owning agent also defines [tool hooks](/reference/agents/agent#tool-hooks), workspace hooks run inside the agent hook wrapper: agent `beforeToolCall` runs first, then workspace `beforeToolCall`, then the tool, then workspace `afterToolCall`, then agent `afterToolCall`.
 
 ## Properties
 


### PR DESCRIPTION
## Summary

Adds reference documentation for the agent and workspace tool hooks shipped in #17637:

- **`Agent` class reference**: documents the `hooks` constructor parameter and adds a *Tool hooks* section covering `beforeToolCall` / `afterToolCall`, short-circuiting with `{ proceed: false, output }`, hook context metadata, and interaction with workspace hooks.
- **Execution method references** (`generate()`, `stream()`, `generateLegacy()`, `streamLegacy()`): documents the per-execution `hooks` option that overrides matching agent-level hooks.
- **`Workspace` class reference**: documents `tools.hooks` with the `workspaceToolName` context field and the agent/workspace hook ordering.

A stacked PR adds the conceptual docs on top of this one.

## Test plan

- `npx prettier --check` on changed files
- `npm run lint:remark` in `docs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds instruction manuals for a new feature called "tool hooks" in the Mastra AI framework. Tool hooks let you run custom code before and after AI agents use tools (like calling APIs), and you can stop a tool from running if needed. The PR documents this feature across different parts of the framework so developers know how to use it.

## Overview

This documentation PR adds comprehensive reference material for agent and workspace tool hooks introduced in `#17637`. The changes span six documentation files covering the Agent class, various execution methods (generate, generateLegacy, stream, streamLegacy), and the Workspace class.

## Documentation additions

**Agent class reference** (`agent.mdx`): 
- Documents the `hooks` constructor parameter accepting `ToolHooks`
- Adds a dedicated "Tool hooks" section with example usage showing `beforeToolCall` and `afterToolCall` lifecycle hooks
- Explains the ability to short-circuit tool execution via `{ proceed: false, output }` return value from `beforeToolCall`
- Clarifies hook context metadata and interaction between agent-level and per-execution hooks
- Documents how per-execution hooks override agent-level hooks (+68 lines)

**Execution method references** (`generate.mdx`, `generateLegacy.mdx`, `stream.mdx`, `streamLegacy.mdx`):
- Each documents a new optional `hooks: ToolHooks` parameter on execution options
- Describes per-execution hooks that override matching agent-level hooks for that specific call
- Notes the `beforeToolCall` short-circuiting capability
- Consistent documentation across all four execution methods (+7 lines each)

**Workspace class reference** (`workspace-class.mdx`):
- Documents `tools.hooks` configuration option in `WorkspaceToolsConfig`
- Adds "Tool hooks" section explaining hook execution timing (before/after tool calls)
- Documents the `workspaceToolName` context field alongside the exposed `toolName`
- Explains both `beforeToolCall` (with short-circuiting) and `afterToolCall` (with output/error handling)
- Clarifies execution ordering when both agent and workspace define hooks (+49 lines)

## Test coverage

Documentation follows project standards:
- Prettier formatting compliance (`npx prettier --check`)
- Remark linting in docs directory (`npm run lint:remark`)

**Total changes**: +145 lines across 6 documentation files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->