### PR TITLE
docs: add tool hooks conceptual documentation

### DIFF
--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -250,6 +250,66 @@ If a transform is configured and it fails, Mastra does not fall back to the raw 
 
 See the [`createTool()` reference](/reference/tools/create-tool#example-with-transform) for a `transform` example. For shared rules across several tools, configure the agent-level `transform` policy in the [`Agent` constructor](/reference/agents/agent#constructor-parameters).
 
+## Run logic around tool calls
+
+Use `hooks` to run custom logic before and after every tool call an agent makes. Hooks apply to all tool sources: assigned tools, memory tools, toolsets, client tools, agent and workflow tools, and [workspace tools](/docs/workspace/overview#tool-hooks). Common uses include logging, auditing, input validation, and blocking specific calls.
+
+```typescript title="src/mastra/agents/support-agent.ts"
+import { Agent } from '@mastra/core/agent'
+
+export const supportAgent = new Agent({
+  name: 'support-agent',
+  instructions: 'Help users with their questions.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  // highlight-start
+  hooks: {
+    beforeToolCall: ({ toolName, input }) => {
+      console.log(`Running ${toolName}`, input)
+    },
+    afterToolCall: ({ toolName, output, error }) => {
+      console.log(`Finished ${toolName}`, { output, error })
+    },
+  },
+  // highlight-end
+})
+```
+
+`beforeToolCall` runs before the tool executes and receives the tool name, input, and execution context. Return `{ proceed: false, output }` to skip the tool call entirely — the agent receives `output` as the tool result:
+
+```typescript
+const guardedAgent = new Agent({
+  name: 'guarded-agent',
+  instructions: 'Run shell commands for the user.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  hooks: {
+    beforeToolCall: ({ toolName, input }) => {
+      const command = (input as { command?: string }).command ?? ''
+      if (toolName === 'execute_command' && command.includes('rm -rf')) {
+        return { proceed: false, output: 'Command blocked by policy.' }
+      }
+    },
+  },
+})
+```
+
+`afterToolCall` runs after the tool finishes, whether it succeeded or failed. On success it receives `output`; if the tool threw, it receives `error` instead and the error is re-thrown after the hook runs.
+
+### Per-execution hooks
+
+Pass `hooks` to `.generate()` or `.stream()` to set hooks for a single execution. Per-execution hooks override matching agent-level hooks:
+
+```typescript
+await supportAgent.generate('Look up the order status', {
+  hooks: {
+    beforeToolCall: ({ toolName }) => {
+      console.log(`This run only: ${toolName}`)
+    },
+  },
+})
+```
+
+Agent-level and per-execution hooks merge per key: passing only `beforeToolCall` at execution time keeps the agent-level `afterToolCall`.
+
 ## Control tool selection
 
 Pass `toolChoice` or `activeTools` to `.generate()` or `.stream()` to control which tools the agent uses at runtime.

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -310,6 +310,32 @@ const workspace = new Workspace({
 
 The agent sees `view`, `search_content`, `find_files`, `execute_command`, and `lsp_inspect` instead of the default `mastra_workspace_*` names. Tool names must be unique — duplicate names or conflicts with other default names throw an error.
 
+### Tool hooks
+
+Set `tools.hooks` to run logic before and after every enabled workspace tool call. Hooks run after name remapping, so the hook context includes both the exposed `toolName` and the original `workspaceToolName`:
+
+```typescript title="src/mastra/workspaces.ts"
+import { Workspace, LocalFilesystem } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  tools: {
+    hooks: {
+      beforeToolCall: ({ toolName, workspaceToolName, input }) => {
+        console.log(`Running ${toolName} (${workspaceToolName})`, input)
+      },
+      afterToolCall: ({ toolName, output, error }) => {
+        console.log(`Finished ${toolName}`, { output, error })
+      },
+    },
+  },
+})
+```
+
+Return `{ proceed: false, output }` from `beforeToolCall` to skip the tool call and use `output` as its result.
+
+If the owning agent also defines [tool hooks](/docs/agents/using-tools#run-logic-around-tool-calls), workspace hooks run inside the agent hook wrapper: agent `beforeToolCall` first, then workspace `beforeToolCall`, then the tool, then workspace `afterToolCall`, then agent `afterToolCall`.
+
 ## LSP inspection
 
 Enable `lsp` on a workspace to add semantic code inspection through language servers. This adds the `mastra_workspace_lsp_inspect` tool by default, which can return hover information, definition locations, and implementations for a symbol at a specific cursor position.

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -798,6 +798,34 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
     description: 'Tools that the agent can access. Can be provided statically or resolved dynamically.',
   },
   {
+    name: 'hooks',
+    type: 'ToolHooks',
+    isOptional: true,
+    description:
+      'Hooks that run before and after every tool call made by this agent. Per-execution hooks passed to `generate()` or `stream()` override matching hooks set here. See Tool hooks below.',
+    properties: [
+      {
+        type: 'ToolHooks',
+        parameters: [
+          {
+            name: 'beforeToolCall',
+            type: '(context: ToolHookContext) => void | ToolBeforeHookResult | Promise<void | ToolBeforeHookResult>',
+            isOptional: true,
+            description:
+              'Runs before a tool executes. Receives `{ toolName, input, context, metadata }`. Return `{ proceed: false, output }` to skip the tool call and use `output` as its result.',
+          },
+          {
+            name: 'afterToolCall',
+            type: '(context: ToolAfterHookContext) => void | Promise<void>',
+            isOptional: true,
+            description:
+              'Runs after a tool executes. Receives `{ toolName, input, context, metadata, output, error }`. `output` is undefined when the tool throws, and `error` is set instead.',
+          },
+        ],
+      },
+    ],
+  },
+  {
     name: 'transform',
     type: 'ToolPayloadTransformPolicy',
     isOptional: true,
@@ -908,6 +936,46 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
   },
 ]}
 />
+
+## Tool hooks
+
+Use `hooks` to run logic around every tool call the agent makes, including assigned tools, memory tools, toolsets, client tools, and workspace tools.
+
+```typescript title="src/mastra/agents/hooked-agent.ts"
+import { Agent } from '@mastra/core/agent'
+
+export const agent = new Agent({
+  name: 'support-agent',
+  instructions: 'Help users with their questions.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  // highlight-start
+  hooks: {
+    beforeToolCall: ({ toolName, input }) => {
+      console.log(`Running ${toolName}`, input)
+    },
+    afterToolCall: ({ toolName, output, error }) => {
+      console.log(`Finished ${toolName}`, { output, error })
+    },
+  },
+  // highlight-end
+})
+```
+
+`beforeToolCall` can short-circuit the tool call by returning `{ proceed: false, output }`. The agent skips execution and uses `output` as the tool result:
+
+```typescript
+const result = await agent.generate('Clean up old records', {
+  hooks: {
+    beforeToolCall: ({ toolName }) => {
+      if (toolName === 'deleteRecord') {
+        return { proceed: false, output: { blocked: true } }
+      }
+    },
+  },
+})
+```
+
+The hook context `metadata` includes `agentId` and `agentName`. Per-execution hooks passed to `generate()` or `stream()` override matching agent-level hooks. When a [workspace](/reference/workspace/workspace-class) also defines `tools.hooks`, workspace hooks run inside the agent hook wrapper.
 
 ## Editor overrides
 

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -763,6 +763,13 @@ const response = await agent.generate('Help me organize my day', {
             description: 'Client-side tools available during execution.',
           },
           {
+            name: 'hooks',
+            type: 'ToolHooks',
+            isOptional: true,
+            description:
+              'Per-execution hooks that run before and after tool calls. Overrides matching agent-level hooks for this execution. `beforeToolCall` can return `{ proceed: false, output }` to skip the tool call.',
+          },
+          {
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,

--- a/docs/src/content/en/reference/agents/generateLegacy.mdx
+++ b/docs/src/content/en/reference/agents/generateLegacy.mdx
@@ -333,6 +333,13 @@ await agent.generateLegacy('message for agent')
               "Tools that are executed on the 'client' side of the request. These tools do not have execute functions in the definition.",
           },
           {
+            name: 'hooks',
+            type: 'ToolHooks',
+            isOptional: true,
+            description:
+              'Per-execution hooks that run before and after tool calls. Overrides matching agent-level hooks for this execution. `beforeToolCall` can return `{ proceed: false, output }` to skip the tool call.',
+          },
+          {
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -638,6 +638,13 @@ const stream = await agent.stream('message for agent')
               "Tools that are executed on the 'client' side of the request. These tools do not have execute functions in the definition.",
           },
           {
+            name: 'hooks',
+            type: 'ToolHooks',
+            isOptional: true,
+            description:
+              'Per-execution hooks that run before and after tool calls. Overrides matching agent-level hooks for this execution. `beforeToolCall` can return `{ proceed: false, output }` to skip the tool call.',
+          },
+          {
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,

--- a/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
+++ b/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
@@ -318,6 +318,13 @@ await agent.streamLegacy('message for agent')
               "Tools that are executed on the 'client' side of the request. These tools do not have execute functions in the definition.",
           },
           {
+            name: 'hooks',
+            type: 'ToolHooks',
+            isOptional: true,
+            description:
+              'Per-execution hooks that run before and after tool calls. Overrides matching agent-level hooks for this execution. `beforeToolCall` can return `{ proceed: false, output }` to skip the tool call.',
+          },
+          {
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -176,6 +176,12 @@ const workspace = new Workspace({
             isOptional: true,
             defaultValue: '2000',
           },
+          {
+            name: 'hooks',
+            type: 'WorkspaceToolHooks',
+            description: 'Hooks that run before and after every enabled workspace tool call. See Tool hooks below.',
+            isOptional: true,
+          },
         ],
       },
     ],
@@ -239,6 +245,49 @@ const workspace = new Workspace({
 ```
 
 Tool names must be unique across all workspace tools. Setting a custom name that conflicts with another tool's default or custom name throws an error.
+
+### Tool hooks
+
+Set `tools.hooks` to run logic before and after every enabled workspace tool call. Hooks run after name remapping, so the context includes both the exposed `toolName` and the original `workspaceToolName`.
+
+```typescript {6-14}
+import { Workspace } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  id: 'my-workspace',
+  tools: {
+    hooks: {
+      beforeToolCall: ({ toolName, workspaceToolName, input }) => {
+        console.log(`Running ${toolName} (${workspaceToolName})`, input)
+      },
+      afterToolCall: ({ toolName, output, error }) => {
+        console.log(`Finished ${toolName}`, { output, error })
+      },
+    },
+  },
+})
+```
+
+<PropertiesTable
+  content={[
+  {
+    name: 'beforeToolCall',
+    type: '(context: WorkspaceToolHookContext) => void | WorkspaceToolBeforeHookResult | Promise<void | WorkspaceToolBeforeHookResult>',
+    isOptional: true,
+    description:
+      'Runs before a workspace tool executes. Receives `{ toolName, workspaceToolName, input, context }`. Return `{ proceed: false, output }` to skip the tool call and use `output` as its result.',
+  },
+  {
+    name: 'afterToolCall',
+    type: '(context: WorkspaceToolAfterHookContext) => void | Promise<void>',
+    isOptional: true,
+    description:
+      'Runs after a workspace tool executes. Receives `{ toolName, workspaceToolName, input, context, output, error }`. `output` is undefined when the tool throws, and `error` is set instead.',
+  },
+]}
+/>
+
+If the owning agent also defines [tool hooks](/reference/agents/agent#tool-hooks), workspace hooks run inside the agent hook wrapper: agent `beforeToolCall` runs first, then workspace `beforeToolCall`, then the tool, then workspace `afterToolCall`, then agent `afterToolCall`.
 
 ## Properties
 


### PR DESCRIPTION
## Summary

Stacked on #17732.

Adds conceptual documentation for the tool hooks shipped in #17637:

- **Using tools guide** (`docs/agents/using-tools`): new *Run logic around tool calls* section explaining agent-level hooks, blocking tool calls with `{ proceed: false, output }`, error behavior of `afterToolCall`, and per-execution hook overrides.
- **Workspace overview** (`docs/workspace/overview`): new *Tool hooks* section explaining `tools.hooks`, the `workspaceToolName` context field, and hook ordering when both agent and workspace hooks are defined.

## Test plan

- `npx prettier --check` on changed files
- `npm run lint:remark` in `docs/`