### PR TITLE
fix(core): preserve provider tool metadata in history

### DIFF
--- a/.changeset/forty-socks-strive.md
+++ b/.changeset/forty-socks-strive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed provider-executed tool history so cross-provider conversations preserve provider metadata during replay.

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
@@ -254,6 +254,54 @@ describe('aiV5UIMessagesToAIV5ModelMessages — provider-executed tool metadata'
     expect((toolCall as any)?.providerOptions).toEqual(providerMetadata);
     expect((toolResult as any)?.providerOptions).toEqual(providerMetadata);
   });
+
+  it('keeps previously captured provider metadata when later same-id tool parts are sparse', () => {
+    const providerMetadata = {
+      anthropic: {
+        itemId: 'srvtoolu_sparse_metadata',
+      },
+    };
+
+    const messages: AIV5Type.UIMessage[] = [
+      {
+        id: 'assistant-with-repeated-server-tool',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-webSearch_20250305',
+            toolCallId: 'srvtoolu_sparse_metadata',
+            state: 'output-available',
+            input: { query: 'latest USD/CNY rate' },
+            output: { results: ['7.12'] },
+            providerExecuted: true,
+            providerMetadata,
+          } as AIV5Type.ToolUIPart,
+          {
+            type: 'tool-webSearch_20250305',
+            toolCallId: 'srvtoolu_sparse_metadata',
+            state: 'output-available',
+            input: { query: 'latest USD/CNY rate' },
+            output: { results: ['7.12'] },
+            providerExecuted: true,
+          } as AIV5Type.ToolUIPart,
+        ],
+      },
+    ];
+
+    const result = aiV5UIMessagesToAIV5ModelMessages(messages, [], true);
+    const providerToolParts = result.flatMap(message =>
+      typeof message.content === 'string'
+        ? []
+        : message.content.filter(
+            part =>
+              (part.type === 'tool-call' || part.type === 'tool-result') &&
+              (part as any).toolCallId === 'srvtoolu_sparse_metadata',
+          ),
+    );
+
+    expect(providerToolParts).not.toHaveLength(0);
+    expect(providerToolParts.every(part => (part as any).providerOptions === providerMetadata)).toBe(true);
+  });
 });
 
 /**

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
@@ -209,6 +209,53 @@ describe('sanitizeV5UIMessages — provider-executed tool handling', () => {
   });
 });
 
+describe('aiV5UIMessagesToAIV5ModelMessages — provider-executed tool metadata', () => {
+  it('preserves provider metadata and providerExecuted when converting provider-executed tool history', () => {
+    const providerMetadata = {
+      anthropic: {
+        itemId: 'srvtoolu_01MkPKoctHhE9KDNjDvEHnSD',
+      },
+    };
+
+    const messages: AIV5Type.UIMessage[] = [
+      {
+        id: 'assistant-with-server-tool',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-webSearch_20250305',
+            toolCallId: 'srvtoolu_01MkPKoctHhE9KDNjDvEHnSD',
+            state: 'output-available',
+            input: { query: 'latest USD/CNY rate' },
+            output: { results: ['7.12'] },
+            providerExecuted: true,
+            providerMetadata,
+          } as AIV5Type.ToolUIPart,
+        ],
+      },
+    ];
+
+    const result = aiV5UIMessagesToAIV5ModelMessages(messages, [], true);
+    const assistantMessage = result.find(message => message.role === 'assistant');
+    const toolMessage = result.find(message => message.role === 'tool');
+    if (!assistantMessage || typeof assistantMessage.content === 'string') {
+      throw new Error('Expected assistant model message with array content');
+    }
+
+    const toolCall = assistantMessage.content.find(part => part.type === 'tool-call');
+    const inlineToolResult = assistantMessage.content.find(part => part.type === 'tool-result');
+    const toolMessageResult =
+      toolMessage && typeof toolMessage.content !== 'string'
+        ? toolMessage.content.find(part => part.type === 'tool-result')
+        : undefined;
+    const toolResult = inlineToolResult ?? toolMessageResult;
+
+    expect((toolCall as any)?.providerExecuted).toBe(true);
+    expect((toolCall as any)?.providerOptions).toEqual(providerMetadata);
+    expect((toolResult as any)?.providerOptions).toEqual(providerMetadata);
+  });
+});
+
 /**
  * Regression tests for https://github.com/mastra-ai/mastra/issues/15668
  *

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-options.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-options.test.ts
@@ -89,4 +89,50 @@ describe('aiV5UIMessagesToAIV5ModelMessages — message-level providerOptions', 
     const toolMsg = llmPrompt.find((m: any) => m.role === 'tool');
     expect(toolMsg?.providerOptions).toBeUndefined();
   });
+
+  it('preserves provider-executed tool metadata from DB history in llmPrompt', async () => {
+    const messageList = new MessageList();
+    const providerMetadata = {
+      anthropic: { itemId: 'srvtoolu_01MkPKoctHhE9KDNjDvEHnSD' },
+    };
+
+    messageList.add({ role: 'user', content: 'Search the latest USD/CNY exchange rate' }, 'memory');
+
+    const assistantWithProviderTool: MastraDBMessage = {
+      id: 'asst-provider-tool-history',
+      role: 'assistant',
+      createdAt: new Date(),
+      content: {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'srvtoolu_01MkPKoctHhE9KDNjDvEHnSD',
+              toolName: 'webSearch_20250305',
+              args: { query: 'latest USD/CNY rate' },
+              result: { results: ['7.12'] },
+            },
+            providerExecuted: true,
+            providerMetadata,
+          },
+        ],
+      },
+    };
+    messageList.add(assistantWithProviderTool, 'memory');
+    messageList.add({ role: 'user', content: 'Continue the conversation' }, 'input');
+
+    const llmPrompt = await messageList.get.all.aiV5.llmPrompt();
+    const assistantMsg = llmPrompt.find((m: any) => m.role === 'assistant');
+    const toolMsg = llmPrompt.find((m: any) => m.role === 'tool');
+    const toolCall = (assistantMsg?.content as any[] | undefined)?.find(part => part.type === 'tool-call');
+    const inlineToolResult = (assistantMsg?.content as any[] | undefined)?.find(part => part.type === 'tool-result');
+    const toolMessageResult = (toolMsg?.content as any[] | undefined)?.find(part => part.type === 'tool-result');
+    const toolResult = inlineToolResult ?? toolMessageResult;
+
+    expect(toolCall?.providerExecuted).toBe(true);
+    expect(toolCall?.providerOptions).toEqual(expect.objectContaining(providerMetadata));
+    expect(toolResult?.providerOptions).toEqual(expect.objectContaining(providerMetadata));
+  });
 });

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -440,9 +440,10 @@ function restoreToolProviderMetadata(
 
       if (!providerMetadata && part.providerExecuted === undefined) continue;
 
+      const existing = toolMetadata.get(part.toolCallId);
       toolMetadata.set(part.toolCallId, {
-        providerMetadata,
-        providerExecuted: part.providerExecuted,
+        providerMetadata: providerMetadata ?? existing?.providerMetadata,
+        providerExecuted: part.providerExecuted ?? existing?.providerExecuted,
       });
     }
   }

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -420,6 +420,72 @@ function restoreAssistantFileProviderMetadata(
   });
 }
 
+function restoreToolProviderMetadata(
+  modelMessages: AIV5Type.ModelMessage[],
+  uiMessages: AIV5Type.UIMessage[],
+): AIV5Type.ModelMessage[] {
+  const toolMetadata = new Map<string, { providerMetadata?: AIV5Type.ProviderMetadata; providerExecuted?: boolean }>();
+
+  for (const msg of uiMessages) {
+    if (msg.role !== 'assistant') continue;
+
+    for (const part of msg.parts) {
+      if (!AIV5.isToolUIPart(part)) continue;
+      const uiToolPart = part as typeof part & {
+        callProviderMetadata?: AIV5Type.ProviderMetadata;
+        providerMetadata?: AIV5Type.ProviderMetadata;
+      };
+      const callProviderMetadata = 'callProviderMetadata' in uiToolPart ? uiToolPart.callProviderMetadata : undefined;
+      const providerMetadata = callProviderMetadata ?? uiToolPart.providerMetadata;
+
+      if (!providerMetadata && part.providerExecuted === undefined) continue;
+
+      toolMetadata.set(part.toolCallId, {
+        providerMetadata,
+        providerExecuted: part.providerExecuted,
+      });
+    }
+  }
+
+  if (toolMetadata.size === 0) return modelMessages;
+
+  return modelMessages.map(msg => {
+    if (typeof msg.content === 'string') return msg;
+
+    let modified = false;
+    const content = msg.content.map(part => {
+      if (part.type !== 'tool-call' && part.type !== 'tool-result') return part;
+
+      const partWithMetadata = part as typeof part & {
+        providerExecuted?: boolean;
+        providerOptions?: AIV5Type.ProviderMetadata;
+      };
+      const metadata = toolMetadata.get(part.toolCallId);
+      if (!metadata) return part;
+
+      const nextPart = { ...partWithMetadata };
+
+      if (!partWithMetadata.providerOptions && metadata.providerMetadata) {
+        nextPart.providerOptions = metadata.providerMetadata;
+        modified = true;
+      }
+
+      if (
+        part.type === 'tool-call' &&
+        partWithMetadata.providerExecuted === undefined &&
+        metadata.providerExecuted !== undefined
+      ) {
+        nextPart.providerExecuted = metadata.providerExecuted;
+        modified = true;
+      }
+
+      return nextPart;
+    });
+
+    return modified ? ({ ...msg, content } as AIV5Type.ModelMessage) : msg;
+  });
+}
+
 /**
  * Converts AIV5 UI messages to AIV5 Model messages.
  * Handles sanitization, step-start insertion, provider options restoration, and Anthropic compatibility.
@@ -466,7 +532,8 @@ export function aiV5UIMessagesToAIV5ModelMessages(
   }
 
   const withFileMetadata = restoreAssistantFileProviderMetadata(converted, preprocessed);
-  const withMcpContentOutputs = applyMcpContentToolResultOutputs(withFileMetadata, dbMessages);
+  const withToolMetadata = restoreToolProviderMetadata(withFileMetadata, preprocessed);
+  const withMcpContentOutputs = applyMcpContentToolResultOutputs(withToolMetadata, dbMessages);
 
   // Add input field to tool-result parts for Anthropic API compatibility (fixes issue #11376)
   const anthropicCompat = ensureAnthropicCompatibleMessages(withMcpContentOutputs, dbMessages);


### PR DESCRIPTION
## Summary
- Restore provider metadata on provider-executed tool-call and tool-result model parts after AI SDK v5 UI-to-model conversion.
- Support both `providerMetadata` and `callProviderMetadata` tool UI fields so persisted DB history replays correctly.
- Add regressions for direct conversion and the `MessageList.get.all.aiV5.llmPrompt()` DB history path.

## Root Cause
Mastra preserved provider-executed tool metadata in stored messages, but the AI SDK v5 `convertToModelMessages` path could drop that metadata when replaying history. Cross-provider conversations could then leak provider-specific tool IDs without the provider metadata clients need to handle them safely.

Fixes #15729.

## Validation
- `pnpm --filter ./packages/core exec vitest run src/agent/message-list/conversion/output-converter-provider-executed.test.ts src/agent/message-list/conversion/output-converter-provider-options.test.ts --reporter=dot`
- `pnpm --filter ./packages/core exec vitest run src/agent/message-list/conversion/output-converter-provider-executed.test.ts src/agent/message-list/conversion/output-converter-provider-options.test.ts src/agent/message-list/adapters/AIV5Adapter-provider-executed.test.ts src/agent/message-list/tests/message-list-v5.test.ts --reporter=dot`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm build:core`
- `pnpm --filter ./packages/core test:unit -- --reporter=dot`
- `pnpm prettier --check packages/core/src/agent/message-list/conversion/output-converter.ts packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts packages/core/src/agent/message-list/conversion/output-converter-provider-options.test.ts .changeset/forty-socks-strive.md`
- `git diff --check`

CodeRabbit CLI was not available locally (`coderabbit`/`cr` not found`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you replay a conversation that included tool calls from one AI provider (e.g., Anthropic) into another provider (e.g., OpenAI), the system must remember which provider “owned” each tool call. This PR fixes a conversion bug that could drop that tool metadata, so the next provider could mis-handle the tool call and error.

---

## Problem Statement

Cross-provider agent conversations could fail when replaying stored tool-use history:

- An Anthropic `server_tool_use` could appear with provider-specific tool-call IDs like `srvtoolu_*` and be marked `providerExecuted: true`.
- During Mastra’s UI→model conversion/replay, the provider metadata (`providerMetadata` / `callProviderMetadata`) could be dropped.
- The next provider (e.g., OpenAI) might then fall back to raw `toolCallId` handling without the needed provider context, leading to request validation failure (commonly a 404) because the referenced item ID can’t be resolved.

This fix targets `#15729`.

---

## Solution

In `packages/core/src/agent/message-list/conversion/output-converter.ts`, the PR adds an internal restoration step `restoreToolProviderMetadata` that:

- Reconstructs missing provider tool metadata after UI→model conversion.
- Builds a lookup per `toolCallId`, merging sparse cases where later parts omit `providerMetadata` by preferring `callProviderMetadata` when present.
- Restores `providerOptions` onto the converted AI SDK model parts:
  - Ensures `providerOptions` are restored for both `tool-call` and `tool-result`.
  - Restores `providerExecuted` on the model `tool-call` when available.
- Runs this restoration after `restoreAssistantFileProviderMetadata` and before MCP tool-result output conversion (`applyMcpContentToolResultOutputs`), so downstream handling sees correct provider context.

---

## Changes

- **Added** `restoreToolProviderMetadata` into the `aiV5UIMessagesToAIV5ModelMessages` conversion pipeline to preserve provider-executed tool metadata during history replay.
- **Added regression tests** to cover:
  - Direct conversion of provider-executed tool parts and the merging behavior when metadata appears only on an earlier part.
  - The database history replay path via `MessageList.get.all.aiV5.llmPrompt()` to ensure persisted `providerExecuted` tool metadata survives prompt generation.

---

## Testing

- New Vitest coverage in:
  - `output-converter-provider-executed.test.ts` (verifies provider-executed tool conversion preserves `providerMetadata`/`callProviderMetadata`, `providerExecuted`, and `providerOptions`, including sparse/partial metadata across repeated tool parts)
  - `output-converter-provider-options.test.ts` (verifies DB history replay through `MessageList.get.all.aiV5.llmPrompt()` preserves provider-executed tool metadata in the produced prompt)
- Includes the changeset `@mastra/core` patch bump documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->