### PR TITLE
docs(skills): add state-reset and single-responsibility rules to react-best-practices

### DIFF
--- a/.claude/skills/react-best-practices/SKILL.md
+++ b/.claude/skills/react-best-practices/SKILL.md
@@ -7,7 +7,7 @@ description: React performance optimization guidelines from Mastra Engineering. 
 
 ## Overview
 
-Comprehensive performance optimization guide for React applications, containing 12 rules across 6 categories. Rules are prioritized by impact to guide automated refactoring and code generation.
+Comprehensive performance optimization guide for React applications, containing 14 rules across 7 categories. Rules are prioritized by impact to guide automated refactoring and code generation.
 
 ## When to Apply
 
@@ -31,6 +31,7 @@ Rules are prioritized by impact:
 | 4        | Re-render Optimization    | MEDIUM      |
 | 5        | Rendering Performance     | MEDIUM      |
 | 6        | JavaScript Performance    | LOW-MEDIUM  |
+| 7        | Component Structure       | MEDIUM-HIGH (maintainability) |
 
 ## Quick Reference
 
@@ -56,6 +57,11 @@ Rules are prioritized by impact:
 - Use lazy state initialization for expensive values (`rerender-lazy-state-init`)
 - Apply `startTransition` for non-urgent updates (`rerender-transitions`)
 - Minimize `useEffect` function calls (`rerender-useeffect-function-calls`)
+- Never reset state with `useEffect`; lift the discriminant and remount the branch (`rerender-no-useeffect-state-reset`)
+
+**Component Structure:**
+
+- One domain component/hook per file, one responsibility each — split bloated components (`structure-single-responsibility`)
 
 ### Rendering Patterns
 
@@ -88,6 +94,7 @@ grep -l "Tanstack" references/rules/
 - `async-*` - Waterfall elimination (1 rule)
 - `bundle-*` - Bundle size optimization (2 rules)
 - `client-*` - Client-side data fetching (1 rule)
-- `rerender-*` - Re-render optimization (3 rules)
+- `rerender-*` - Re-render optimization (4 rules)
 - `rendering-*` - DOM rendering performance (2 rules)
 - `js-*` - JavaScript micro-optimizations (3 rules)
+- `structure-*` - Component/hook structure (1 rule)

--- a/.claude/skills/react-best-practices/references/react-best-practices-reference.md
+++ b/.claude/skills/react-best-practices/references/react-best-practices-reference.md
@@ -14,7 +14,7 @@ January 2026
 
 ## Abstract
 
-Performance optimization guide for React applications, designed for AI agents and LLMs. Contains 12 rules across 6 categories, prioritized by impact from critical (eliminating waterfalls, reducing bundle size) to incremental (JavaScript micro-optimizations). Each rule includes detailed explanations, real-world examples comparing incorrect vs. correct implementations, and specific impact metrics to guide automated refactoring and code generation.
+Performance optimization guide for React applications, designed for AI agents and LLMs. Contains 14 rules across 7 categories, prioritized by impact from critical (eliminating waterfalls, reducing bundle size) to incremental (JavaScript micro-optimizations). Each rule includes detailed explanations, real-world examples comparing incorrect vs. correct implementations, and specific impact metrics to guide automated refactoring and code generation.
 
 ---
 
@@ -31,6 +31,7 @@ Performance optimization guide for React applications, designed for AI agents an
    - 4.1 [Use Lazy State Initialization](#41-use-lazy-state-initialization)
    - 4.2 [Use Transitions for Non-Urgent Updates](#42-use-transitions-for-non-urgent-updates)
    - 4.3 [useEffectEvent for Functions in useEffect](#43-useeffectevent-for-functions-in-useeffect)
+   - 4.4 [Never Reset State with useEffect](#44-never-reset-state-with-useeffect)
 5. [Rendering Performance](#5-rendering-performance) — **MEDIUM**
    - 5.1 [Animate SVG Wrapper Instead of SVG Element](#51-animate-svg-wrapper-instead-of-svg-element)
    - 5.2 [CSS content-visibility for Long Lists](#52-css-content-visibility-for-long-lists)
@@ -38,6 +39,8 @@ Performance optimization guide for React applications, designed for AI agents an
    - 6.1 [Early Length Check for Array Comparisons](#61-early-length-check-for-array-comparisons)
    - 6.2 [Use Set/Map for O(1) Lookups](#62-use-setmap-for-o1-lookups)
    - 6.3 [Use toSorted() Instead of sort() for Immutability](#63-use-tosorted-instead-of-sort-for-immutability)
+7. [Component Structure](#7-component-structure) — **MEDIUM-HIGH**
+   - 7.1 [One Component or Hook = One Responsibility = One File](#71-one-component-or-hook--one-responsibility--one-file)
 
 ---
 
@@ -342,6 +345,75 @@ export function App() {
 
 Reserve `useCallback` and `useMemo` for expensive computations (e.g., processing 200+ entries) where memoization provides measurable performance benefits. For typical event handlers, `useEffectEvent` is the preferred approach.
 
+### 4.4 Never Reset State with useEffect
+
+Never use `useEffect` to reset or re-sync local state when an upstream identity changes (e.g., a form's initial values when the selected product changes). Instead, restructure the component hierarchy: lift the discriminant (the product id) to the top of the tree, fetch the new entity there, and render a skeleton while loading. The skeleton unmounts the branch containing the form, so when the data arrives the form remounts and its `useState` initializers naturally pick up the fresh `initialValues`.
+
+**Incorrect (useEffect syncs state when product changes):**
+
+```tsx
+function ProductForm({ product }: { product: Product }) {
+  const [name, setName] = useState(product.name);
+  const [price, setPrice] = useState(product.price);
+
+  // Anti-pattern: re-syncing state with an effect.
+  // Renders once with stale values, then again after the effect runs.
+  // Every new field must be added here too — easy to forget, causes drift.
+  useEffect(() => {
+    setName(product.name);
+    setPrice(product.price);
+  }, [product.id]);
+
+  return (
+    <form>
+      <input value={name} onChange={e => setName(e.target.value)} />
+      <input value={price} onChange={e => setPrice(e.target.value)} />
+    </form>
+  );
+}
+```
+
+**Correct (lift the discriminant; skeleton unmounts the branch, form remounts fresh):**
+
+```tsx
+// Top of the tree: the product id is the discriminant
+function ProductPage({ productId }: { productId: string }) {
+  const { data: product, isLoading } = useQuery({
+    queryKey: ['product', productId],
+    queryFn: () => fetchProduct(productId),
+  });
+
+  // While the new product loads, the skeleton replaces the form branch.
+  // The old ProductForm unmounts, so its state is discarded.
+  if (isLoading) return <ProductFormSkeleton />;
+
+  // Fresh mount: useState initializers run again with the new values.
+  return <ProductForm initialValues={product} />;
+}
+
+function ProductForm({ initialValues }: { initialValues: Product }) {
+  // Initialized once per mount — no sync effect needed, ever.
+  const [name, setName] = useState(initialValues.name);
+  const [price, setPrice] = useState(initialValues.price);
+
+  return (
+    <form>
+      <input value={name} onChange={e => setName(e.target.value)} />
+      <input value={price} onChange={e => setPrice(e.target.value)} />
+    </form>
+  );
+}
+```
+
+**Fallback when data is already local (no fetch boundary):**
+
+```tsx
+// key forces a remount when the product changes
+<ProductForm key={product.id} initialValues={product} />
+```
+
+Prefer the hierarchy restructure (fetch high + skeleton) over `key`: it also removes the stale-data problem because the form can never render with the previous product's values. Use `key` as the minimal fix when no async boundary exists.
+
 ---
 
 ## 5. Rendering Performance
@@ -534,6 +606,123 @@ const sorted = [...items].sort((a, b) => a.value - b.value);
 - `.toReversed()` - immutable reverse
 - `.toSpliced()` - immutable splice
 - `.with()` - immutable element replacement
+
+---
+
+## 7. Component Structure
+
+**Impact: MEDIUM-HIGH (maintainability)**
+
+Bloated components are hard to test, review, and reuse, and unrelated state changes re-render everything.
+
+### 7.1 One Component or Hook = One Responsibility = One File
+
+Domain components and hooks must each own exactly one responsibility. If one part of a component fetches data, another filters it, another manages form state — split it. Don't fear refactoring: extracting hooks and components is cheap, while bloated components are hard to test, review, and reuse. Enforce **1 file = 1 component (or hook)**.
+
+**Exemption:** UI/design-system components (Button, Card, layout primitives) are composition-focused and out of scope for this rule. It targets domain components.
+
+**Incorrect (one file, one component, four responsibilities):**
+
+```tsx
+// products-page.tsx — fetching + filtering + selection + form, all entangled
+function ProductsPage() {
+  // Responsibility 1: data fetching
+  const { data: products } = useQuery({
+    queryKey: ['products'],
+    queryFn: fetchProducts,
+  });
+
+  // Responsibility 2: filtering logic
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<Category | null>(null);
+  const filtered = useMemo(
+    () =>
+      (products ?? []).filter(
+        p => p.name.includes(query) && (!category || p.category === category),
+      ),
+    [products, query, category],
+  );
+
+  // Responsibility 3: selection
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // Responsibility 4: edit-form state for the selected product
+  const selected = filtered.find(p => p.id === selectedId);
+  const [name, setName] = useState('');
+  const [price, setPrice] = useState(0);
+  // ...100 more lines of form handlers, validation, submit logic
+
+  return (/* one giant JSX tree mixing filters, list, and form */);
+}
+```
+
+**Correct (each responsibility in its own file):**
+
+```tsx
+// use-product-search.ts — hook: fetching + filtering
+export function useProductSearch() {
+  const { data: products } = useQuery({
+    queryKey: ['products'],
+    queryFn: fetchProducts,
+  });
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<Category | null>(null);
+  const filtered = useMemo(
+    () =>
+      (products ?? []).filter(
+        p => p.name.includes(query) && (!category || p.category === category),
+      ),
+    [products, query, category],
+  );
+  return { filtered, query, setQuery, category, setCategory };
+}
+```
+
+```tsx
+// product-list.tsx — component: render the list, report selection
+export function ProductList({ products, onSelect }: ProductListProps) {
+  return (
+    <ul>
+      {products.map(p => (
+        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+```tsx
+// product-edit-form.tsx — component: edit one product
+export function ProductEditForm({ initialValues }: { initialValues: Product }) {
+  const [name, setName] = useState(initialValues.name);
+  const [price, setPrice] = useState(initialValues.price);
+  // form handlers live here, and only here
+  return (/* form JSX */);
+}
+```
+
+```tsx
+// products-page.tsx — component: composition only
+export function ProductsPage() {
+  const { filtered, query, setQuery, category, setCategory } = useProductSearch();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = filtered.find(p => p.id === selectedId);
+
+  return (
+    <>
+      <ProductFilters query={query} onQueryChange={setQuery} category={category} onCategoryChange={setCategory} />
+      <ProductList products={filtered} onSelect={setSelectedId} />
+      {selected && <ProductEditForm key={selected.id} initialValues={selected} />}
+    </>
+  );
+}
+```
+
+Splitting also narrows re-render scope: typing in the filter no longer re-renders the form.
+
+Smells that trigger a split: multiple unrelated `useState`/`useQuery` clusters, comment headers separating "sections", a component you can't name without "And".
+
+The page/container component's single responsibility is composition — wiring hooks and children together is fine.
 
 ---
 

--- a/.claude/skills/react-best-practices/references/rules/rerender-no-useeffect-state-reset.md
+++ b/.claude/skills/react-best-practices/references/rules/rerender-no-useeffect-state-reset.md
@@ -1,0 +1,75 @@
+---
+title: Never Reset State with useEffect — Remount via Component Hierarchy
+impact: MEDIUM-HIGH
+impactDescription: extra render cycles, stale-state flashes, and sync bugs
+tags: rerender, useEffect, state, remount, forms
+---
+
+## Never Reset State with useEffect — Remount via Component Hierarchy
+
+Never use `useEffect` to reset or re-sync local state when an upstream identity changes (e.g., a form's initial values when the selected product changes). Instead, restructure the component hierarchy: lift the discriminant (the product id) to the top of the tree, fetch the new entity there, and render a skeleton while loading. The skeleton unmounts the branch containing the form, so when the data arrives the form remounts and its `useState` initializers naturally pick up the fresh `initialValues`.
+
+**Incorrect (useEffect syncs state when product changes):**
+
+```tsx
+function ProductForm({ product }: { product: Product }) {
+  const [name, setName] = useState(product.name);
+  const [price, setPrice] = useState(product.price);
+
+  // Anti-pattern: re-syncing state with an effect.
+  // Renders once with stale values, then again after the effect runs.
+  // Every new field must be added here too — easy to forget, causes drift.
+  useEffect(() => {
+    setName(product.name);
+    setPrice(product.price);
+  }, [product.id]);
+
+  return (
+    <form>
+      <input value={name} onChange={e => setName(e.target.value)} />
+      <input value={price} onChange={e => setPrice(e.target.value)} />
+    </form>
+  );
+}
+```
+
+**Correct (lift the discriminant; skeleton unmounts the branch, form remounts fresh):**
+
+```tsx
+// Top of the tree: the product id is the discriminant
+function ProductPage({ productId }: { productId: string }) {
+  const { data: product, isLoading } = useQuery({
+    queryKey: ['product', productId],
+    queryFn: () => fetchProduct(productId),
+  });
+
+  // While the new product loads, the skeleton replaces the form branch.
+  // The old ProductForm unmounts, so its state is discarded.
+  if (isLoading) return <ProductFormSkeleton />;
+
+  // Fresh mount: useState initializers run again with the new values.
+  return <ProductForm initialValues={product} />;
+}
+
+function ProductForm({ initialValues }: { initialValues: Product }) {
+  // Initialized once per mount — no sync effect needed, ever.
+  const [name, setName] = useState(initialValues.name);
+  const [price, setPrice] = useState(initialValues.price);
+
+  return (
+    <form>
+      <input value={name} onChange={e => setName(e.target.value)} />
+      <input value={price} onChange={e => setPrice(e.target.value)} />
+    </form>
+  );
+}
+```
+
+**Fallback when data is already local (no fetch boundary):**
+
+```tsx
+// key forces a remount when the product changes
+<ProductForm key={product.id} initialValues={product} />
+```
+
+Prefer the hierarchy restructure (fetch high + skeleton) over `key`: it also removes the stale-data problem because the form can never render with the previous product's values. Use `key` as the minimal fix when no async boundary exists.

--- a/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
+++ b/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
@@ -1,0 +1,115 @@
+---
+title: One Component or Hook = One Responsibility = One File
+impact: MEDIUM-HIGH
+impactDescription: bloated components are hard to test, review, and reuse; unrelated state changes re-render everything
+tags: structure, refactoring, single-responsibility, hooks, maintainability
+---
+
+## One Component or Hook = One Responsibility = One File
+
+Domain components and hooks must each own exactly one responsibility. If one part of a component fetches data, another filters it, another manages form state — split it. Don't fear refactoring: extracting hooks and components is cheap, while bloated components are hard to test, review, and reuse. Enforce **1 file = 1 component (or hook)**.
+
+**Exemption:** UI/design-system components (Button, Card, layout primitives) are composition-focused and out of scope for this rule. It targets domain components.
+
+**Incorrect (one file, one component, four responsibilities):**
+
+```tsx
+// products-page.tsx — fetching + filtering + selection + form, all entangled
+function ProductsPage() {
+  // Responsibility 1: data fetching
+  const { data: products } = useQuery({
+    queryKey: ['products'],
+    queryFn: fetchProducts,
+  });
+
+  // Responsibility 2: filtering logic
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<Category | null>(null);
+  const filtered = useMemo(
+    () =>
+      (products ?? []).filter(
+        p => p.name.includes(query) && (!category || p.category === category),
+      ),
+    [products, query, category],
+  );
+
+  // Responsibility 3: selection
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // Responsibility 4: edit-form state for the selected product
+  const selected = filtered.find(p => p.id === selectedId);
+  const [name, setName] = useState('');
+  const [price, setPrice] = useState(0);
+  // ...100 more lines of form handlers, validation, submit logic
+
+  return (/* one giant JSX tree mixing filters, list, and form */);
+}
+```
+
+**Correct (each responsibility in its own file):**
+
+```tsx
+// use-product-search.ts — hook: fetching + filtering
+export function useProductSearch() {
+  const { data: products } = useQuery({
+    queryKey: ['products'],
+    queryFn: fetchProducts,
+  });
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<Category | null>(null);
+  const filtered = useMemo(
+    () =>
+      (products ?? []).filter(
+        p => p.name.includes(query) && (!category || p.category === category),
+      ),
+    [products, query, category],
+  );
+  return { filtered, query, setQuery, category, setCategory };
+}
+```
+
+```tsx
+// product-list.tsx — component: render the list, report selection
+export function ProductList({ products, onSelect }: ProductListProps) {
+  return (
+    <ul>
+      {products.map(p => (
+        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+```tsx
+// product-edit-form.tsx — component: edit one product
+export function ProductEditForm({ initialValues }: { initialValues: Product }) {
+  const [name, setName] = useState(initialValues.name);
+  const [price, setPrice] = useState(initialValues.price);
+  // form handlers live here, and only here
+  return (/* form JSX */);
+}
+```
+
+```tsx
+// products-page.tsx — component: composition only
+export function ProductsPage() {
+  const { filtered, query, setQuery, category, setCategory } = useProductSearch();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = filtered.find(p => p.id === selectedId);
+
+  return (
+    <>
+      <ProductFilters query={query} onQueryChange={setQuery} category={category} onCategoryChange={setCategory} />
+      <ProductList products={filtered} onSelect={setSelectedId} />
+      {selected && <ProductEditForm key={selected.id} initialValues={selected} />}
+    </>
+  );
+}
+```
+
+Splitting also narrows re-render scope: typing in the filter no longer re-renders the form.
+
+Smells that trigger a split: multiple unrelated `useState`/`useQuery` clusters, comment headers separating "sections", a component you can't name without "And".
+
+The page/container component's single responsibility is composition — wiring hooks and children together is fine.


### PR DESCRIPTION
Adds two new rules to the react-best-practices skill (.claude/skills/react-best-practices), bringing it to 14 rules across 7 categories.

The first rule bans resetting state with useEffect. Instead of syncing a form when the selected entity changes, lift the discriminant to the top of the tree, fetch there, and show a skeleton while loading so the form branch unmounts and remounts with fresh initialValues.

```tsx

useEffect(() => {
  setName(product.name);
  setPrice(product.price);
}, [product.id]);

// after: skeleton unmounts the branch, form remounts fresh
if (isLoading) return <ProductFormSkeleton />;
return <ProductForm initialValues={product} />;
```

The second rule targets bloated components: one domain component or hook = one responsibility = one file. A page mixing fetching, filtering, selection, and form state gets split into a hook plus focused components, with the page reduced to composition. UI/design-system components are exempt since they're composition-focused by nature.

Both rules follow the existing format (frontmatter + incorrect/correct examples) and SKILL.md plus the full reference doc were updated to keep counts, quick reference, and TOC consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds two new best-practice rules to a React developer skill guide: one warns against using `useEffect` to reset component state (and suggests a better approach), and another rule says each component should only handle one responsibility. The documentation is updated to reflect the expansion from 12 to 14 total rules.

---

## Changes Overview

This PR expands the React best-practices skill documentation from 12 rules across 6 categories to 14 rules across 7 categories, adding two new rules with comprehensive documentation:

### New Rules Added

1. **rerender-no-useeffect-state-reset** (Re-render Optimization category)
   - Prohibits resetting local component state from `useEffect` when an upstream identity changes
   - Recommends lifting the discriminant (identity) to a higher component level and fetching there
   - Suggests rendering a loading skeleton to force the form branch to unmount and remount with fresh `useState` initializers
   - Includes a fallback approach using `key` prop for cases without async loading boundaries

2. **structure-single-responsibility** (New Component Structure category)
   - Enforces one domain component or hook per responsibility per file
   - Encourages splitting bloated components that mix fetching, filtering, selection, and form state
   - Explicitly exempts UI/design-system components
   - Provides before/after examples showing refactoring a monolithic page into composed, focused hooks and components

### Documentation Updates

- **SKILL.md**: Updated rule counts (+9/-2 lines), added "Component Structure" category to the prioritized guidelines table, expanded "Re-render Optimization" guidance, and updated the "Rule Categories" list
- **react-best-practices-reference.md**: Expanded from Version 0.2.0 with new Section 4.4 on useEffect state reset and new Section 7.1 on single responsibility pattern (+190/-1 lines)
- **New rule files**: Created two new documentation files (`rerender-no-useeffect-state-reset.md` and `structure-single-responsibility.md`) with detailed explanations and code examples

### Code Impact

No changes to exported or public code entities—this is a documentation-only update to the skill definition files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->