### PR TITLE
feat(playground-ui): per-component subpath exports

### DIFF
--- a/.changeset/happy-zebras-admire.md
+++ b/.changeset/happy-zebras-admire.md
@@ -1,0 +1,19 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added per-component entrypoints under `@mastra/playground-ui/components/*` and enabled tree-shaking via the `sideEffects` field.
+
+**New per-component entrypoints**
+
+Every design-system component can now be imported directly, without going through the root barrel:
+
+```ts
+import { Button } from '@mastra/playground-ui/components/Button';
+```
+
+The root `@mastra/playground-ui` import keeps working unchanged — this change is purely additive. Deep imports let bundlers pull in only the components you use instead of the whole library.
+
+**Better tree-shaking**
+
+The package now declares `"sideEffects": ["**/*.css"]`, so bundlers can drop unused re-exports even for apps that keep importing from the root barrel. The CSS contract is unchanged: import `@mastra/playground-ui/style.css` once, then import components from any subpath.

--- a/.claude/skills/react-best-practices/SKILL.md
+++ b/.claude/skills/react-best-practices/SKILL.md
@@ -23,14 +23,14 @@ Reference these guidelines when:
 
 Rules are prioritized by impact:
 
-| Priority | Category                  | Impact      |
-| -------- | ------------------------- | ----------- |
-| 1        | Eliminating Waterfalls    | CRITICAL    |
-| 2        | Bundle Size Optimization  | CRITICAL    |
-| 3        | Client-Side Data Fetching | MEDIUM-HIGH |
-| 4        | Re-render Optimization    | MEDIUM      |
-| 5        | Rendering Performance     | MEDIUM      |
-| 6        | JavaScript Performance    | LOW-MEDIUM  |
+| Priority | Category                  | Impact                        |
+| -------- | ------------------------- | ----------------------------- |
+| 1        | Eliminating Waterfalls    | CRITICAL                      |
+| 2        | Bundle Size Optimization  | CRITICAL                      |
+| 3        | Client-Side Data Fetching | MEDIUM-HIGH                   |
+| 4        | Re-render Optimization    | MEDIUM                        |
+| 5        | Rendering Performance     | MEDIUM                        |
+| 6        | JavaScript Performance    | LOW-MEDIUM                    |
 | 7        | Component Structure       | MEDIUM-HIGH (maintainability) |
 
 ## Quick Reference

--- a/.claude/skills/react-best-practices/references/react-best-practices-reference.md
+++ b/.claude/skills/react-best-practices/references/react-best-practices-reference.md
@@ -668,10 +668,7 @@ export function useProductSearch() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<Category | null>(null);
   const filtered = useMemo(
-    () =>
-      (products ?? []).filter(
-        p => p.name.includes(query) && (!category || p.category === category),
-      ),
+    () => (products ?? []).filter(p => p.name.includes(query) && (!category || p.category === category)),
     [products, query, category],
   );
   return { filtered, query, setQuery, category, setCategory };
@@ -684,7 +681,9 @@ export function ProductList({ products, onSelect }: ProductListProps) {
   return (
     <ul>
       {products.map(p => (
-        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+        <li key={p.id} onClick={() => onSelect(p.id)}>
+          {p.name}
+        </li>
       ))}
     </ul>
   );

--- a/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
+++ b/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
@@ -58,10 +58,7 @@ export function useProductSearch() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<Category | null>(null);
   const filtered = useMemo(
-    () =>
-      (products ?? []).filter(
-        p => p.name.includes(query) && (!category || p.category === category),
-      ),
+    () => (products ?? []).filter(p => p.name.includes(query) && (!category || p.category === category)),
     [products, query, category],
   );
   return { filtered, query, setQuery, category, setCategory };
@@ -74,7 +71,9 @@ export function ProductList({ products, onSelect }: ProductListProps) {
   return (
     <ul>
       {products.map(p => (
-        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+        <li key={p.id} onClick={() => onSelect(p.id)}>
+          {p.name}
+        </li>
       ))}
     </ul>
   );

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -6,6 +6,9 @@
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "files": [
     "dist",
     "theme.css",
@@ -38,6 +41,12 @@
       "require": {
         "types": "./dist/utils.d.ts",
         "default": "./dist/utils.cjs.js"
+      }
+    },
+    "./components/*": {
+      "import": {
+        "types": "./dist/components/*.d.ts",
+        "default": "./dist/components/*.es.js"
       }
     },
     "./package.json": "./package.json"

--- a/packages/playground-ui/src/components-exports.test.ts
+++ b/packages/playground-ui/src/components-exports.test.ts
@@ -37,7 +37,7 @@ describe('components/* subpath exports', () => {
   // index.ts actually exports the public symbol the subpath promises.
   it('Button entry exports Button', async () => {
     const mod = await import('./ds/components/Button');
-    expect(mod.Button).toBeTypeOf('object'); // forwardRef component
+    expect(mod.Button).toBeDefined();
   });
 
   it('Drawer entry (scoped CSS) exports Drawer', async () => {

--- a/packages/playground-ui/src/components-exports.test.ts
+++ b/packages/playground-ui/src/components-exports.test.ts
@@ -1,0 +1,52 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Guards the @mastra/playground-ui/components/* contract: every folder under
+// src/ds/components is published as its own entrypoint (wired up dynamically
+// in vite.config.ts), so consumers can deep-import a single component instead
+// of the root barrel. The entry enumeration assumes one index.ts per folder —
+// if that invariant breaks, the component silently disappears from dist.
+const pkgRoot = resolve(__dirname, '..');
+const pkg = JSON.parse(readFileSync(resolve(pkgRoot, 'package.json'), 'utf8'));
+const componentsDir = resolve(pkgRoot, 'src/ds/components');
+
+describe('components/* subpath exports', () => {
+  it('exposes the wildcard export pointing into dist/components', () => {
+    expect(pkg.exports['./components/*']).toEqual({
+      import: {
+        types: './dist/components/*.d.ts',
+        default: './dist/components/*.es.js',
+      },
+    });
+  });
+
+  it('marks only CSS as side-effectful so bundlers can tree-shake JS', () => {
+    expect(pkg.sideEffects).toEqual(['**/*.css']);
+  });
+
+  it('has an index.ts in every component folder (the entry enumeration invariant)', () => {
+    const folders = readdirSync(componentsDir, { withFileTypes: true }).filter(d => d.isDirectory());
+    expect(folders.length).toBeGreaterThan(0);
+    const missing = folders.filter(d => !existsSync(resolve(componentsDir, d.name, 'index.ts'))).map(d => d.name);
+    expect(missing).toEqual([]);
+  });
+
+  // Representative entry modules: a plain primitive, a component with its own
+  // scoped CSS, and a composite. Importing the source entries guards that each
+  // index.ts actually exports the public symbol the subpath promises.
+  it('Button entry exports Button', async () => {
+    const mod = await import('./ds/components/Button');
+    expect(mod.Button).toBeTypeOf('object'); // forwardRef component
+  });
+
+  it('Drawer entry (scoped CSS) exports Drawer', async () => {
+    const mod = await import('./ds/components/Drawer');
+    expect(mod.Drawer).toBeDefined();
+  });
+
+  it('DataPanel entry exports DataPanel', async () => {
+    const mod = await import('./ds/components/DataPanel');
+    expect(mod.DataPanel).toBeDefined();
+  });
+});

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -1,3 +1,4 @@
+import { existsSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
@@ -6,6 +7,22 @@ import type { PluginOption, UserConfig } from 'vite';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
+
+// One library entry per design-system component folder, exposed publicly as
+// `@mastra/playground-ui/components/<Name>` (see the `./components/*` exports
+// wildcard in package.json). Deep imports let consumers skip the root barrel
+// so bundlers only pull the components they use.
+const componentsDir = resolve(__dirname, 'src/ds/components');
+const componentEntries = Object.fromEntries(
+  readdirSync(componentsDir, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => [`components/${dirent.name}`, resolve(componentsDir, dirent.name, 'index.ts')] as const)
+    .filter(([, file]) => {
+      if (existsSync(file)) return true;
+      console.warn(`[playground-ui] skipping component without index.ts: ${file}`);
+      return false;
+    }),
+);
 
 const baseConfig: UserConfig = {
   plugins: [react(), tailwindcss()],
@@ -42,6 +59,8 @@ const libConfig: UserConfig = {
         index: resolve(__dirname, 'src/index.ts'),
         utils: resolve(__dirname, 'src/utils.ts'),
         tokens: resolve(__dirname, 'src/ds/tokens/index.ts'),
+        // Slashed keys make Rollup emit nested output: dist/components/<Name>.<format>.js
+        ...componentEntries,
       },
       formats: ['es', 'cjs'],
       fileName: (format, entryName) => {
@@ -55,6 +74,19 @@ const libConfig: UserConfig = {
     minify: false,
     rollupOptions: {
       external: ['motion/react'],
+      output: {
+        // With ~98 entries, hoisted transitive imports would bloat every entry
+        // chunk with empty side-effect imports of shared chunks.
+        hoistTransitiveImports: false,
+        // Pin the global Tailwind stylesheet to a chunk named `index` so its
+        // compiled CSS keeps emitting as dist/index.css — the target of the
+        // public `./style.css` export. With many entries Rollup would
+        // otherwise attach it to an arbitrary shared chunk (and an arbitrary
+        // .css filename), breaking the export.
+        manualChunks(id) {
+          if (id.includes('src/index.css')) return 'index';
+        },
+      },
     },
   },
 };

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -84,7 +84,7 @@ const libConfig: UserConfig = {
         // otherwise attach it to an arbitrary shared chunk (and an arbitrary
         // .css filename), breaking the export.
         manualChunks(id) {
-          if (id.includes('src/index.css')) return 'index';
+          if (id === resolve(__dirname, 'src/index.css')) return 'index';
         },
       },
     },


### PR DESCRIPTION
Opens one entrypoint per design-system component so consumers can skip the root barrel:

```ts
// still works (root barrel unchanged)
import { Button } from '@mastra/playground-ui';
// new, pulls ~9 files instead of the ~118-file barrel graph
import { Button } from '@mastra/playground-ui/components/Button';
```

The vite config enumerates `src/ds/components/*/index.ts` (95 folders) into per-component Rollup entries, and package.json gains a `./components/*` wildcard export plus `"sideEffects": ["**/*.css"]` so bundlers can tree-shake unused JS while keeping CSS side-effect imports.

Two build details worth knowing: `src/index.css` is pinned to a chunk named `index` via `manualChunks`, because with ~98 entries Rollup attached the compiled Tailwind stylesheet to an arbitrary shared chunk and `dist/index.css` (the `./style.css` export) stopped existing. And `hoistTransitiveImports: false` keeps entry chunks free of empty side-effect imports. The CSS contract is unchanged: import `style.css` once, then components from any subpath. The 7 components with scoped CSS keep injecting it via their chunks.

The subpath export is import-only, matching the root `.` export (the package is `type: module`, so the existing `.cjs.js` require targets don't work under native Node anyway).

This is infrastructure only — no consumer migration here. Migrating `packages/playground` imports (and an ESLint guard on the barrel) are follow-ups. Verified: build, new colocated export-contract test, typecheck, lint, and a graph walk showing deep imports stay small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes it possible to import a single design-system component directly (e.g., `@mastra/playground-ui/components/Button`) so apps only pull the code they need, which makes bundles smaller while keeping the stylesheet behavior the same.

## Summary

Adds per-component subpath exports to `@mastra/playground-ui` so consumers can import components from `@mastra/playground-ui/components/`* in addition to the existing root barrel. The change is infrastructure-only (no consumer migration) and preserves the existing CSS contract: consumers still import `@mastra/playground-ui/style.css` once.

### Changes

- package.json
  - Adds a wildcard export pattern "./components/*" mapping to typed ESM entrypoints (./dist/components/*.d.ts and ./dist/components/*.es.js).
  - Adds "sideEffects": ["**/*.css"] so bundlers can tree-shake unused JS while preserving CSS side-effect imports.

- vite.config.ts
  - Scans src/ds/components/* for index.ts and generates per-component Rollup entries (about 95 components).
  - Injects component entries alongside existing index, utils, and tokens entries.
  - Sets hoistTransitiveImports: false to avoid shared-chunk bloat across many entries.
  - Adds a manualChunks rule to pin the compiled Tailwind stylesheet (src/index.css) to a deterministic index chunk so the public ./style.css export emits as dist/index.css.
  - Retains existing type-generation, CSS injection behavior, externals handling, and conditional base/lib mode.

- packages/playground-ui/src/components-exports.test.ts (new)
  - Vitest suite validating package.json exports and sideEffects, ensuring each component folder has index.ts, and dynamically importing representative components (Button, Drawer, DataPanel) to assert exported symbols exist.

### Build / behavior notes

- The CSS contract is unchanged: consumers import the package stylesheet once; components remain usable from subpaths.
- Seven components with scoped CSS still inject their CSS via their chunks.
- The package remains ESM-first (package.json type: "module"); the subpath export is import-only and does not change existing .cjs.js require targets.
- hoistTransitiveImports: false and "sideEffects" CSS glob enable better per-component tree-shaking and keep entry chunks free of empty side-effect imports.
- Verified: local build, colocated export-contract test, typecheck, lint, and dependency-graph checks showing much smaller per-component deep imports.

### Impact

- Improves tree-shaking and reduces consumer bundle sizes by allowing per-component deep imports.
- No consumer-facing API changes; follow-ups will migrate internal imports and add an ESLint guard on the barrel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->