### PR TITLE
chore: prettier formatting on react-best-practices skill docs

### DIFF
--- a/.claude/skills/react-best-practices/SKILL.md
+++ b/.claude/skills/react-best-practices/SKILL.md
@@ -23,14 +23,14 @@ Reference these guidelines when:
 
 Rules are prioritized by impact:
 
-| Priority | Category                  | Impact      |
-| -------- | ------------------------- | ----------- |
-| 1        | Eliminating Waterfalls    | CRITICAL    |
-| 2        | Bundle Size Optimization  | CRITICAL    |
-| 3        | Client-Side Data Fetching | MEDIUM-HIGH |
-| 4        | Re-render Optimization    | MEDIUM      |
-| 5        | Rendering Performance     | MEDIUM      |
-| 6        | JavaScript Performance    | LOW-MEDIUM  |
+| Priority | Category                  | Impact                        |
+| -------- | ------------------------- | ----------------------------- |
+| 1        | Eliminating Waterfalls    | CRITICAL                      |
+| 2        | Bundle Size Optimization  | CRITICAL                      |
+| 3        | Client-Side Data Fetching | MEDIUM-HIGH                   |
+| 4        | Re-render Optimization    | MEDIUM                        |
+| 5        | Rendering Performance     | MEDIUM                        |
+| 6        | JavaScript Performance    | LOW-MEDIUM                    |
 | 7        | Component Structure       | MEDIUM-HIGH (maintainability) |
 
 ## Quick Reference

--- a/.claude/skills/react-best-practices/references/react-best-practices-reference.md
+++ b/.claude/skills/react-best-practices/references/react-best-practices-reference.md
@@ -668,10 +668,7 @@ export function useProductSearch() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<Category | null>(null);
   const filtered = useMemo(
-    () =>
-      (products ?? []).filter(
-        p => p.name.includes(query) && (!category || p.category === category),
-      ),
+    () => (products ?? []).filter(p => p.name.includes(query) && (!category || p.category === category)),
     [products, query, category],
   );
   return { filtered, query, setQuery, category, setCategory };
@@ -684,7 +681,9 @@ export function ProductList({ products, onSelect }: ProductListProps) {
   return (
     <ul>
       {products.map(p => (
-        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+        <li key={p.id} onClick={() => onSelect(p.id)}>
+          {p.name}
+        </li>
       ))}
     </ul>
   );

--- a/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
+++ b/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
@@ -58,10 +58,7 @@ export function useProductSearch() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<Category | null>(null);
   const filtered = useMemo(
-    () =>
-      (products ?? []).filter(
-        p => p.name.includes(query) && (!category || p.category === category),
-      ),
+    () => (products ?? []).filter(p => p.name.includes(query) && (!category || p.category === category)),
     [products, query, category],
   );
   return { filtered, query, setQuery, category, setCategory };
@@ -74,7 +71,9 @@ export function ProductList({ products, onSelect }: ProductListProps) {
   return (
     <ul>
       {products.map(p => (
-        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+        <li key={p.id} onClick={() => onSelect(p.id)}>
+          {p.name}
+        </li>
       ))}
     </ul>
   );


### PR DESCRIPTION
The three `.claude/skills/react-best-practices` markdown files landed on `main` unformatted, so the repo-wide `prettier --check` in the **Lint** job currently fails for **every PR** (example: the Lint run on #17730 fails only on these three files, which that branch does not touch).

This is `prettier --write` on those three files, nothing else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR formats three markdown documentation files that were accidentally committed without proper formatting. The incorrect formatting was causing the entire project's formatting check to fail for every PR. This PR simply cleans up the formatting in those files so the check passes again—no content changes, just prettier spacing and alignment.

## Changes

### `.claude/skills/react-best-practices/SKILL.md`

Updated the "Priority-Ordered Guidelines" section by reformatting the markdown table that lists rules 1–6, changing its column alignment/spacing and delimiter formatting while preserving the same priority categories and impact labels.

**Lines changed:** +8/-8

### `.claude/skills/react-best-practices/references/react-best-practices-reference.md`

Updated the React "One Component or Hook = One Responsibility = One File" example by reformatting the `useMemo` filter expression (consolidating it to a single-line arrow function) and reformatting the `ProductList` `<li>` rendering snippet (splitting `{p.name}` and the `onClick` handler across multiple lines). No functional guidance text outside these code blocks was changed.

**Lines changed:** +4/-5

### `.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md`

Updated documentation example formatting to demonstrate a single-responsibility split: reflows the `useMemo` filtering expression into a single-line arrow callback (preserving the same filter logic and dependencies) and reformats the `ProductList` `<li>` rendering from a single-line element into a multi-line layout with `key`, `onClick`, and `{p.name}` on separate lines. No functional behavior in the examples is changed.

**Lines changed:** +4/-5

## Summary

This is a formatting-only change using Prettier. Three markdown documentation files are reformatted to restore the repository's linting compliance. No functional or content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->