### PR TITLE
chore: format react-best-practices skill docs

### DIFF
--- a/.claude/skills/react-best-practices/SKILL.md
+++ b/.claude/skills/react-best-practices/SKILL.md
@@ -23,14 +23,14 @@ Reference these guidelines when:
 
 Rules are prioritized by impact:
 
-| Priority | Category                  | Impact      |
-| -------- | ------------------------- | ----------- |
-| 1        | Eliminating Waterfalls    | CRITICAL    |
-| 2        | Bundle Size Optimization  | CRITICAL    |
-| 3        | Client-Side Data Fetching | MEDIUM-HIGH |
-| 4        | Re-render Optimization    | MEDIUM      |
-| 5        | Rendering Performance     | MEDIUM      |
-| 6        | JavaScript Performance    | LOW-MEDIUM  |
+| Priority | Category                  | Impact                        |
+| -------- | ------------------------- | ----------------------------- |
+| 1        | Eliminating Waterfalls    | CRITICAL                      |
+| 2        | Bundle Size Optimization  | CRITICAL                      |
+| 3        | Client-Side Data Fetching | MEDIUM-HIGH                   |
+| 4        | Re-render Optimization    | MEDIUM                        |
+| 5        | Rendering Performance     | MEDIUM                        |
+| 6        | JavaScript Performance    | LOW-MEDIUM                    |
 | 7        | Component Structure       | MEDIUM-HIGH (maintainability) |
 
 ## Quick Reference

--- a/.claude/skills/react-best-practices/references/react-best-practices-reference.md
+++ b/.claude/skills/react-best-practices/references/react-best-practices-reference.md
@@ -668,10 +668,7 @@ export function useProductSearch() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<Category | null>(null);
   const filtered = useMemo(
-    () =>
-      (products ?? []).filter(
-        p => p.name.includes(query) && (!category || p.category === category),
-      ),
+    () => (products ?? []).filter(p => p.name.includes(query) && (!category || p.category === category)),
     [products, query, category],
   );
   return { filtered, query, setQuery, category, setCategory };
@@ -684,7 +681,9 @@ export function ProductList({ products, onSelect }: ProductListProps) {
   return (
     <ul>
       {products.map(p => (
-        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+        <li key={p.id} onClick={() => onSelect(p.id)}>
+          {p.name}
+        </li>
       ))}
     </ul>
   );

--- a/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
+++ b/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
@@ -58,10 +58,7 @@ export function useProductSearch() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<Category | null>(null);
   const filtered = useMemo(
-    () =>
-      (products ?? []).filter(
-        p => p.name.includes(query) && (!category || p.category === category),
-      ),
+    () => (products ?? []).filter(p => p.name.includes(query) && (!category || p.category === category)),
     [products, query, category],
   );
   return { filtered, query, setQuery, category, setCategory };
@@ -74,7 +71,9 @@ export function ProductList({ products, onSelect }: ProductListProps) {
   return (
     <ul>
       {products.map(p => (
-        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+        <li key={p.id} onClick={() => onSelect(p.id)}>
+          {p.name}
+        </li>
       ))}
     </ul>
   );


### PR DESCRIPTION
## Summary

`pnpm prettier --check` fails on main for three `.claude/skills/react-best-practices/` files (introduced by #17736), which turns the **Lint / Format** job red on every open PR.

This formats the three files with the repo-pinned prettier (3.8.3) — no content change.

## Test plan

- `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'` passes locally on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR is like tidying up the spacing and line breaks in some instruction documents. The code style checker (Prettier) was complaining that three documentation files about React best practices weren't formatted correctly, so this PR fixes those formatting issues to make the checker happy again. No actual content or instructions changed—it's just cosmetic cleanup.

## Overview
This PR resolves formatting issues in three documentation files under `.claude/skills/react-best-practices/` that were causing the Prettier formatting check to fail in CI. The files were introduced in PR `#17736` but didn't pass the repository's code formatting standards. All changes are formatting-only with no content modifications.

## Changes

**`.claude/skills/react-best-practices/SKILL.md`**
- Adjusted header/column formatting and spacing alignment in the "Priority" table
- Lines changed: +8/-8

**`.claude/skills/react-best-practices/references/react-best-practices-reference.md`**
- Reformatted embedded code examples: consolidated a multi-line filter callback to single-line arrow body
- Expanded an `<li>` JSX example from single-line to multi-line format
- Lines changed: +4/-5

**`.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md`**
- Reformatted code examples: collapsed `useMemo` filter callback to single line
- Expanded `ProductList` `<li>` JSX example to multi-line format with `onClick` and content on separate lines
- Lines changed: +4/-5

## Impact
- **Effort**: Low (formatting only, no logic or content changes)
- **Testing**: Prettier formatting check passes locally on the branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->