### PR TITLE
feat(telemetry): report aggregated model token usage at server startup

### DIFF
--- a/.changeset/empty-beds-exist.md
+++ b/.changeset/empty-beds-exist.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added anonymous, aggregated model token usage telemetry. When a Mastra server starts and observability metrics are enabled, the input and output token totals per provider and model are sent to Mastra's telemetry. Only aggregate token counts are collected — never prompts, responses, or message content. Opt out by setting MASTRA_TELEMETRY_DISABLED=1.

--- a/.changeset/legal-zebras-change.md
+++ b/.changeset/legal-zebras-change.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Mastra servers now report anonymous, aggregated model token usage at startup when observability metrics are enabled. Opt out by setting MASTRA_TELEMETRY_DISABLED=1.

--- a/.changeset/twenty-experts-hear.md
+++ b/.changeset/twenty-experts-hear.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+The mastra dev and mastra start commands now pass the anonymous analytics ID and command name to the server so aggregated model token usage telemetry can be attributed to the same anonymous install. Opt out by setting MASTRA_TELEMETRY_DISABLED=1.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -1234,7 +1234,9 @@ Prints help message and exits.
 
 By default, Mastra collects anonymous information about your project like your OS, Mastra version or Node.js version. You can read the [source code](https://github.com/mastra-ai/mastra/blob/main/packages/cli/src/analytics/index.ts) to check what's collected.
 
-You can opt out of the CLI analytics by setting an environment variable:
+When a server started with `mastra dev` or `mastra start` has observability metrics enabled, Mastra also sends anonymous, aggregated model usage at startup: input and output token counts per provider and model, plus the command (`dev` or `start`) and `NODE_ENV`. No prompts, responses, or other message content is ever sent. You can read the [source code](https://github.com/mastra-ai/mastra/blob/main/packages/core/src/telemetry/usage-telemetry.ts) to check what's collected.
+
+You can opt out of all CLI and usage analytics by setting an environment variable:
 
 ```bash
 MASTRA_TELEMETRY_DISABLED=1

--- a/packages/cli/src/analytics/index.ts
+++ b/packages/cli/src/analytics/index.ts
@@ -161,6 +161,10 @@ export class PosthogAnalytics {
     });
   }
 
+  getDistinctId(): string {
+    return this.distinctId;
+  }
+
   trackEvent(eventName: string, properties?: Record<string, any>): void {
     try {
       if (!this.client) {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import process from 'node:process';
 import devcert from '@expo/devcert';
 import { FileService } from '@mastra/deployer';
@@ -144,7 +144,7 @@ const startServer = async (
         PORT: port.toString(),
         MASTRA_PACKAGES_FILE: packagesFilePath,
         MASTRA_TELEMETRY_COMMAND: 'dev',
-        MASTRA_PROJECT_ROOT: join(dotMastraPath, '..'),
+        MASTRA_PROJECT_ROOT: resolve(dotMastraPath, '..'),
         ...(getAnalytics()?.getDistinctId() ? { MASTRA_CLI_DISTINCT_ID: getAnalytics()!.getDistinctId() } : {}),
         ...(startOptions?.https
           ? {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -143,6 +143,9 @@ const startServer = async (
         MASTRA_DEV: 'true',
         PORT: port.toString(),
         MASTRA_PACKAGES_FILE: packagesFilePath,
+        MASTRA_TELEMETRY_COMMAND: 'dev',
+        MASTRA_PROJECT_ROOT: join(dotMastraPath, '..'),
+        ...(getAnalytics()?.getDistinctId() ? { MASTRA_CLI_DISTINCT_ID: getAnalytics()!.getDistinctId() } : {}),
         ...(startOptions?.https
           ? {
               MASTRA_HTTPS_KEY: startOptions.https.key.toString('base64'),

--- a/packages/cli/src/commands/start/start.ts
+++ b/packages/cli/src/commands/start/start.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { config } from 'dotenv';
+import { getAnalytics } from '../../analytics/index.js';
 import { logger } from '../../utils/logger';
 import { shouldSkipDotenvLoading } from '../utils';
 interface StartOptions {
@@ -39,6 +40,9 @@ export async function start(options: StartOptions = {}) {
       env: {
         ...process.env,
         NODE_ENV: 'production',
+        MASTRA_TELEMETRY_COMMAND: 'start',
+        MASTRA_PROJECT_ROOT: process.cwd(),
+        ...(getAnalytics()?.getDistinctId() ? { MASTRA_CLI_DISTINCT_ID: getAnalytics()!.getDistinctId() } : {}),
       },
     });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -631,6 +631,16 @@
         "default": "./dist/base.cjs"
       }
     },
+    "./telemetry": {
+      "import": {
+        "types": "./dist/telemetry/index.d.ts",
+        "default": "./dist/telemetry/index.js"
+      },
+      "require": {
+        "types": "./dist/telemetry/index.d.ts",
+        "default": "./dist/telemetry/index.cjs"
+      }
+    },
     "./telemetry/otel-vendor": {
       "import": {
         "types": "./dist/telemetry/otel-vendor.d.ts",

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -1,0 +1,2 @@
+export { syncUsageTelemetry, USAGE_TELEMETRY_EVENT } from './usage-telemetry';
+export type { SyncUsageTelemetryOptions } from './usage-telemetry';

--- a/packages/core/src/telemetry/posthog.ts
+++ b/packages/core/src/telemetry/posthog.ts
@@ -10,6 +10,8 @@ let client: PostHog | null = null;
 
 export type EEEventName = 'ee_license_check' | 'ee_feature_used';
 
+export type TelemetryEventName = EEEventName | 'mastra_model_token_usage';
+
 export function isEETelemetryEnabled(): boolean {
   const value = process.env['MASTRA_TELEMETRY_DISABLED'];
   if (!value) {
@@ -58,8 +60,8 @@ function getSystemProperties(): Record<string, unknown> {
   };
 }
 
-export function captureEEEvent(
-  event: EEEventName,
+export function captureTelemetryEvent(
+  event: TelemetryEventName,
   distinctId: string | undefined,
   properties?: Record<string, unknown>,
 ): void {
@@ -80,6 +82,14 @@ export function captureEEEvent(
   } catch {
     // Telemetry must never affect auth or EE feature behavior.
   }
+}
+
+export function captureEEEvent(
+  event: EEEventName,
+  distinctId: string | undefined,
+  properties?: Record<string, unknown>,
+): void {
+  captureTelemetryEvent(event, distinctId, properties);
 }
 
 export function resetEETelemetryForTests(): void {

--- a/packages/core/src/telemetry/usage-telemetry.test.ts
+++ b/packages/core/src/telemetry/usage-telemetry.test.ts
@@ -1,0 +1,196 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { capture, flush, PostHog } = vi.hoisted(() => {
+  const capture = vi.fn();
+  const flush = vi.fn().mockResolvedValue(undefined);
+  const PostHog = vi.fn(function () {
+    return { capture, flush };
+  });
+  return { capture, flush, PostHog };
+});
+
+vi.mock('posthog-node', () => ({ PostHog }));
+
+import type { Mastra } from '../mastra';
+import type { CreateMetricRecord } from '../storage/domains';
+import { InMemoryStore } from '../storage/mock';
+import { resetEETelemetryForTests } from './posthog';
+import { syncUsageTelemetry, USAGE_TELEMETRY_EVENT } from './usage-telemetry';
+
+const INPUT_METRIC = 'mastra_model_total_input_tokens';
+const OUTPUT_METRIC = 'mastra_model_total_output_tokens';
+
+function makeMetric(overrides: Partial<CreateMetricRecord> & Pick<CreateMetricRecord, 'name' | 'value'>) {
+  return {
+    metricId: overrides.metricId ?? `metric-${Math.random().toString(36).slice(2)}`,
+    timestamp: overrides.timestamp ?? new Date('2026-06-01T00:00:00Z'),
+    provider: 'openai',
+    model: 'gpt-test',
+    labels: {},
+    ...overrides,
+  } as CreateMetricRecord;
+}
+
+function makeMastra(store: InMemoryStore | undefined): Mastra {
+  return { getStorage: () => store } as unknown as Mastra;
+}
+
+describe('syncUsageTelemetry', () => {
+  let tmpDir: string;
+  let cursorPath: string;
+  let store: InMemoryStore;
+  let originalTelemetryDisabled: string | undefined;
+
+  beforeEach(() => {
+    originalTelemetryDisabled = process.env['MASTRA_TELEMETRY_DISABLED'];
+    delete process.env['MASTRA_TELEMETRY_DISABLED'];
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mastra-usage-telemetry-'));
+    cursorPath = path.join(tmpDir, 'cursors', 'usage-telemetry.json');
+    store = new InMemoryStore();
+    capture.mockClear();
+    flush.mockClear();
+    PostHog.mockClear();
+    resetEETelemetryForTests();
+  });
+
+  afterEach(() => {
+    if (originalTelemetryDisabled !== undefined) process.env['MASTRA_TELEMETRY_DISABLED'] = originalTelemetryDisabled;
+    else delete process.env['MASTRA_TELEMETRY_DISABLED'];
+    rmSync(tmpDir, { recursive: true, force: true });
+    resetEETelemetryForTests();
+  });
+
+  async function seedUsage() {
+    const observability = store.stores.observability!;
+    await observability.batchCreateMetrics({
+      metrics: [
+        makeMetric({ name: INPUT_METRIC, value: 100, timestamp: new Date('2026-06-01T00:00:00Z') }),
+        makeMetric({ name: INPUT_METRIC, value: 50, timestamp: new Date('2026-06-02T00:00:00Z') }),
+        makeMetric({ name: OUTPUT_METRIC, value: 30, timestamp: new Date('2026-06-02T00:00:00Z') }),
+        makeMetric({
+          name: INPUT_METRIC,
+          value: 7,
+          timestamp: new Date('2026-06-02T00:00:00Z'),
+          provider: 'anthropic',
+          model: 'claude-test',
+        }),
+      ],
+    });
+  }
+
+  it('sends one event per provider/model with delta and lifetime totals on first sync', async () => {
+    await seedUsage();
+
+    await syncUsageTelemetry(makeMastra(store), { cursorPath, now: new Date('2026-06-03T00:00:00Z') });
+
+    expect(capture).toHaveBeenCalledTimes(2);
+    const events = capture.mock.calls.map(([arg]) => arg);
+    expect(events.every(e => e.event === USAGE_TELEMETRY_EVENT)).toBe(true);
+
+    const openai = events.find(e => e.properties.provider === 'openai');
+    expect(openai!.properties).toMatchObject({
+      model: 'gpt-test',
+      input_tokens: 150,
+      output_tokens: 30,
+      total_input_tokens: 150,
+      total_output_tokens: 30,
+      is_first_sync: true,
+      window_start: null,
+      window_end: '2026-06-03T00:00:00.000Z',
+    });
+
+    const anthropic = events.find(e => e.properties.provider === 'anthropic');
+    expect(anthropic!.properties).toMatchObject({
+      model: 'claude-test',
+      input_tokens: 7,
+      output_tokens: 0,
+      is_first_sync: true,
+    });
+
+    // Cursor file written with the sync timestamp.
+    const cursors = JSON.parse(readFileSync(cursorPath, 'utf-8'));
+    expect(Object.values(cursors.projects)).toEqual(['2026-06-03T00:00:00.000Z']);
+  });
+
+  it('only sends usage recorded after the last sync, with cumulative totals', async () => {
+    await seedUsage();
+    await syncUsageTelemetry(makeMastra(store), { cursorPath, now: new Date('2026-06-03T00:00:00Z') });
+    capture.mockClear();
+
+    // New usage after the first sync, only for openai.
+    await store.stores.observability!.batchCreateMetrics({
+      metrics: [makeMetric({ name: INPUT_METRIC, value: 25, timestamp: new Date('2026-06-04T00:00:00Z') })],
+    });
+
+    await syncUsageTelemetry(makeMastra(store), { cursorPath, now: new Date('2026-06-05T00:00:00Z') });
+
+    // anthropic row had no new usage and is skipped.
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0]![0].properties).toMatchObject({
+      provider: 'openai',
+      model: 'gpt-test',
+      input_tokens: 25,
+      output_tokens: 0,
+      total_input_tokens: 175,
+      total_output_tokens: 30,
+      is_first_sync: false,
+      window_start: '2026-06-03T00:00:00.000Z',
+      window_end: '2026-06-05T00:00:00.000Z',
+    });
+  });
+
+  it('sends nothing when there is no usage', async () => {
+    await syncUsageTelemetry(makeMastra(store), { cursorPath, now: new Date('2026-06-03T00:00:00Z') });
+
+    expect(capture).not.toHaveBeenCalled();
+    // Cursor still advances so the next sync stays incremental.
+    expect(JSON.parse(readFileSync(cursorPath, 'utf-8')).projects).not.toEqual({});
+  });
+
+  it('does nothing when telemetry is disabled', async () => {
+    process.env['MASTRA_TELEMETRY_DISABLED'] = 'true';
+    await seedUsage();
+
+    await syncUsageTelemetry(makeMastra(store), { cursorPath, now: new Date('2026-06-03T00:00:00Z') });
+
+    expect(PostHog).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+    expect(() => readFileSync(cursorPath, 'utf-8')).toThrow();
+  });
+
+  it('does nothing when no storage is configured', async () => {
+    await expect(
+      syncUsageTelemetry(makeMastra(undefined), { cursorPath, now: new Date('2026-06-03T00:00:00Z') }),
+    ).resolves.toBeUndefined();
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the storage query fails', async () => {
+    const observability = store.stores.observability!;
+    vi.spyOn(observability, 'getMetricBreakdown').mockRejectedValue(new Error('storage offline'));
+
+    await expect(
+      syncUsageTelemetry(makeMastra(store), { cursorPath, now: new Date('2026-06-03T00:00:00Z') }),
+    ).resolves.toBeUndefined();
+
+    expect(capture).not.toHaveBeenCalled();
+    // Cursor must not advance on failure so usage is not lost.
+    expect(() => readFileSync(cursorPath, 'utf-8')).toThrow();
+  });
+
+  it('tolerates a corrupt cursor file by treating the sync as first sync', async () => {
+    await seedUsage();
+    const { writeFileSync, mkdirSync } = await import('node:fs');
+    mkdirSync(path.dirname(cursorPath), { recursive: true });
+    writeFileSync(cursorPath, 'not-json');
+
+    await syncUsageTelemetry(makeMastra(store), { cursorPath, now: new Date('2026-06-03T00:00:00Z') });
+
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(capture.mock.calls[0]![0].properties.is_first_sync).toBe(true);
+  });
+});

--- a/packages/core/src/telemetry/usage-telemetry.ts
+++ b/packages/core/src/telemetry/usage-telemetry.ts
@@ -1,0 +1,165 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Mastra } from '../mastra';
+import type { GetMetricBreakdownResponse, ObservabilityStorage } from '../storage/domains';
+import { captureTelemetryEvent, hashTelemetryValue, isEETelemetryEnabled } from './posthog';
+
+const INPUT_TOKENS_METRIC = 'mastra_model_total_input_tokens';
+const OUTPUT_TOKENS_METRIC = 'mastra_model_total_output_tokens';
+const BREAKDOWN_LIMIT = 200;
+
+export const USAGE_TELEMETRY_EVENT = 'mastra_model_token_usage';
+
+export interface SyncUsageTelemetryOptions {
+  /** Override the cursor file location (used by tests). */
+  cursorPath?: string;
+  /** Override the current time (used by tests). */
+  now?: Date;
+}
+
+interface UsageTelemetryCursors {
+  projects: Record<string, string>;
+}
+
+interface UsageRow {
+  provider: string | null;
+  model: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+}
+
+function getDefaultCursorPath(): string {
+  return path.join(os.homedir(), '.mastra', 'usage-telemetry.json');
+}
+
+function readCursors(cursorPath: string): UsageTelemetryCursors {
+  try {
+    const parsed = JSON.parse(readFileSync(cursorPath, 'utf-8')) as Partial<UsageTelemetryCursors> | null;
+    if (parsed && typeof parsed === 'object' && parsed.projects && typeof parsed.projects === 'object') {
+      return { projects: parsed.projects };
+    }
+  } catch {
+    // Missing or corrupt cursor file - treat as first sync.
+  }
+  return { projects: {} };
+}
+
+function readCursor(cursorPath: string, projectId: string): Date | undefined {
+  const value = readCursors(cursorPath).projects[projectId];
+  if (!value) {
+    return undefined;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function writeCursor(cursorPath: string, projectId: string, syncedAt: Date): void {
+  const cursors = readCursors(cursorPath);
+  cursors.projects[projectId] = syncedAt.toISOString();
+  mkdirSync(path.dirname(cursorPath), { recursive: true });
+  writeFileSync(cursorPath, JSON.stringify(cursors));
+}
+
+function applyBreakdown(
+  rows: Map<string, UsageRow>,
+  response: GetMetricBreakdownResponse,
+  field: keyof Pick<UsageRow, 'inputTokens' | 'outputTokens' | 'totalInputTokens' | 'totalOutputTokens'>,
+): void {
+  for (const group of response.groups) {
+    const provider = group.dimensions.provider ?? null;
+    const model = group.dimensions.model ?? null;
+    const key = `${provider}\u0000${model}`;
+    let row = rows.get(key);
+    if (!row) {
+      row = { provider, model, inputTokens: 0, outputTokens: 0, totalInputTokens: 0, totalOutputTokens: 0 };
+      rows.set(key, row);
+    }
+    row[field] += group.value ?? 0;
+  }
+}
+
+/**
+ * Sends aggregated model token usage (input/output tokens per provider+model) to
+ * Mastra's anonymous telemetry when the project has observability metrics enabled.
+ *
+ * Sync strategy: deltas since the last successful sync, tracked per project via a
+ * cursor file in `~/.mastra/usage-telemetry.json`. Each event also carries lifetime
+ * totals so consumers can read either incremental or cumulative usage. Runs once at
+ * server startup; respects `MASTRA_TELEMETRY_DISABLED`. Never throws.
+ */
+export async function syncUsageTelemetry(mastra: Mastra, options: SyncUsageTelemetryOptions = {}): Promise<void> {
+  try {
+    if (!isEETelemetryEnabled()) {
+      return;
+    }
+
+    const observability = mastra.getStorage()?.stores?.observability as ObservabilityStorage | undefined;
+    if (!observability || typeof observability.getMetricBreakdown !== 'function') {
+      return;
+    }
+
+    const projectRoot = process.env.MASTRA_PROJECT_ROOT || process.cwd();
+    const projectId = hashTelemetryValue(projectRoot).slice(0, 16);
+    const cursorPath = options.cursorPath ?? getDefaultCursorPath();
+    const lastSyncedAt = readCursor(cursorPath, projectId);
+    const now = options.now ?? new Date();
+    if (lastSyncedAt && lastSyncedAt.getTime() >= now.getTime()) {
+      return;
+    }
+
+    const baseArgs = {
+      groupBy: ['provider', 'model'],
+      aggregation: 'sum' as const,
+      limit: BREAKDOWN_LIMIT,
+    };
+    const deltaFilters = {
+      timestamp: { ...(lastSyncedAt ? { start: lastSyncedAt, startExclusive: true } : {}), end: now },
+    };
+    const totalFilters = { timestamp: { end: now } };
+
+    const [inputDelta, outputDelta, inputTotal, outputTotal] = await Promise.all([
+      observability.getMetricBreakdown({ ...baseArgs, name: [INPUT_TOKENS_METRIC], filters: deltaFilters }),
+      observability.getMetricBreakdown({ ...baseArgs, name: [OUTPUT_TOKENS_METRIC], filters: deltaFilters }),
+      observability.getMetricBreakdown({ ...baseArgs, name: [INPUT_TOKENS_METRIC], filters: totalFilters }),
+      observability.getMetricBreakdown({ ...baseArgs, name: [OUTPUT_TOKENS_METRIC], filters: totalFilters }),
+    ]);
+
+    const rows = new Map<string, UsageRow>();
+    applyBreakdown(rows, inputDelta, 'inputTokens');
+    applyBreakdown(rows, outputDelta, 'outputTokens');
+    applyBreakdown(rows, inputTotal, 'totalInputTokens');
+    applyBreakdown(rows, outputTotal, 'totalOutputTokens');
+
+    const distinctId = process.env.MASTRA_CLI_DISTINCT_ID || undefined;
+    const command = process.env.MASTRA_TELEMETRY_COMMAND || 'server';
+    const nodeEnv = process.env.NODE_ENV || 'development';
+    const isFirstSync = !lastSyncedAt;
+
+    for (const row of rows.values()) {
+      if (row.inputTokens <= 0 && row.outputTokens <= 0) {
+        continue;
+      }
+      captureTelemetryEvent(USAGE_TELEMETRY_EVENT, distinctId, {
+        provider: row.provider,
+        model: row.model,
+        input_tokens: row.inputTokens,
+        output_tokens: row.outputTokens,
+        total_input_tokens: row.totalInputTokens,
+        total_output_tokens: row.totalOutputTokens,
+        command,
+        node_env: nodeEnv,
+        project_id: projectId,
+        is_first_sync: isFirstSync,
+        window_start: lastSyncedAt?.toISOString() ?? null,
+        window_end: now.toISOString(),
+      });
+    }
+
+    writeCursor(cursorPath, projectId, now);
+  } catch {
+    // Usage telemetry must never affect server startup or runtime behavior.
+  }
+}

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -608,6 +608,13 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
     await workerLifecycle.startEventEngine();
   }
 
+  // Fire-and-forget anonymous token usage telemetry (respects MASTRA_TELEMETRY_DISABLED).
+  // Dynamic import keeps compatibility with older @mastra/core versions without the
+  // `@mastra/core/telemetry` entry point.
+  void import('@mastra/core/telemetry')
+    .then(({ syncUsageTelemetry }) => syncUsageTelemetry(mastra))
+    .catch(() => {});
+
   // Graceful shutdown so storage backends release resources (e.g. DuckDB's
   // native file lock) before the process exits. On `mastra dev` hot reloads
   // the old process is sent SIGINT; without this the lock can linger and the

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -611,9 +611,7 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
   // Fire-and-forget anonymous token usage telemetry (respects MASTRA_TELEMETRY_DISABLED).
   // Dynamic import keeps compatibility with older @mastra/core versions without the
   // `@mastra/core/telemetry` entry point.
-  void import('@mastra/core/telemetry')
-    .then(({ syncUsageTelemetry }) => syncUsageTelemetry(mastra))
-    .catch(() => {});
+  void import('@mastra/core/telemetry').then(({ syncUsageTelemetry }) => syncUsageTelemetry(mastra)).catch(() => {});
 
   // Graceful shutdown so storage backends release resources (e.g. DuckDB's
   // native file lock) before the process exits. On `mastra dev` hot reloads


### PR DESCRIPTION
When a Mastra server starts and the project has observability metrics enabled, it now syncs anonymous aggregated model token usage to Mastra's telemetry. Only aggregate token counts per provider and model are sent — never prompts, responses, or message content.

The aggregation happens locally before anything is sent: the sync queries the observability store with `groupBy: ['provider', 'model']` and `aggregation: 'sum'`, so tens of thousands of requests collapse into one event per provider+model pair (capped at 200). A cursor file in `~/.mastra/usage-telemetry.json` tracks the last sync per project, so each token is only ever reported once as a delta (lifetime totals ride along as separate properties).

`mastra dev` and `mastra start` pass the CLI's existing anonymous distinct ID and the command name to the spawned server so usage is attributed to the same anonymous install. The sync runs once at startup, never throws, and respects `MASTRA_TELEMETRY_DISABLED=1` just like the rest of Mastra's telemetry.

Example event sent to PostHog:

```json
{
  "event": "mastra_model_token_usage",
  "properties": {
    "provider": "openai",
    "model": "MODEL_PLACEHOLDER",
    "input_tokens": 1532,
    "output_tokens": 410,
    "total_input_tokens": 90210,
    "total_output_tokens": 24876,
    "command": "dev",
    "node_env": "development",
    "is_first_sync": false
  }
}
```

Tested with unit tests covering first sync, delta-only follow-up syncs, the disabled env var, missing observability storage, storage failures, and corrupt cursor files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Mastra now quietly reports, at server startup (when observability is enabled), aggregated counts of tokens used by each provider+model so the project can track usage without sending prompts or responses; you can disable this with MASTRA_TELEMETRY_DISABLED=1.

---

## Overview

Adds a one-time, non-blocking startup sync that queries the local observability metrics store grouped by ['provider','model'], sums input/output tokens (capped to 200 provider+model pairs), and sends anonymous aggregated events (including lifetime totals). A per-project cursor (~/.mastra/usage-telemetry.json, test-overridable) ensures only deltas since the last successful sync are reported; the code is robust (never throws), respects the opt-out env var, and preserves anonymous attribution by propagating the CLI distinct ID and command to spawned servers.

## Changes by Category

### Telemetry Core Implementation
- packages/core/src/telemetry/usage-telemetry.ts
  - New syncUsageTelemetry that queries observability storage for four metric series (input/output deltas and totals), aggregates by provider+model, emits mastra_model_token_usage events with delta and lifetime totals, includes window timestamps and first-sync flag, skips zero-delta rows, caps to 200 rows, writes per-project cursor after success, respects MASTRA_TELEMETRY_DISABLED, and swallows errors.
  - Exports USAGE_TELEMETRY_EVENT and SyncUsageTelemetryOptions.
- packages/core/src/telemetry/usage-telemetry.test.ts
  - Vitest tests covering first sync, subsequent delta-only syncs, empty usage, disabled telemetry, missing storage, storage query failures, and corrupt cursor handling.
- packages/core/src/telemetry/posthog.ts
  - Adds TelemetryEventName (includes 'mastra_model_token_usage') and captureTelemetryEvent() to centralize PostHog capture with hashed fallback distinct IDs; refactors captureEEEvent to delegate.
- packages/core/src/telemetry/index.ts
  - Re-exports syncUsageTelemetry, USAGE_TELEMETRY_EVENT, and SyncUsageTelemetryOptions.
- packages/core/package.json
  - Adds ./telemetry export subpath for ESM/CJS and types.

### Server Integration
- packages/deployer/src/server/index.ts
  - After worker/event engine startup, dynamically imports `@mastra/core/telemetry` and calls syncUsageTelemetry(mastra) in fire-and-forget manner; errors swallowed so startup is unaffected.

### CLI Integration
- packages/cli/src/analytics/index.ts
  - Adds PosthogAnalytics.getDistinctId() to expose stored distinct ID for propagation.
- packages/cli/src/commands/dev/dev.ts and packages/cli/src/commands/start/start.ts
  - Pass telemetry context to spawned server via env vars: MASTRA_TELEMETRY_COMMAND ("dev"/"start"), MASTRA_PROJECT_ROOT (resolved absolute path), and MASTRA_CLI_DISTINCT_ID (when available) so events attribute to the same anonymous install.

### Documentation & Release Notes
- docs/src/content/en/reference/cli/mastra.mdx
  - Documents anonymous aggregated model-usage telemetry at startup and clarifies that MASTRA_TELEMETRY_DISABLED=1 disables CLI and usage analytics.
- .changeset/*
  - Adds patch release notes describing the new telemetry behavior and opt-out.

## Key Behaviors and Guarantees
- Runs once at server startup (non-blocking, fire-and-forget).
- Sends only aggregated token counts (input_tokens, output_tokens) per provider+model; never sends prompts, responses, or message content.
- Reports deltas since last successful sync using a per-project cursor; includes lifetime totals as separate properties.
- Caps emitted rows to 200 provider+model pairs; skips zero-delta rows.
- Propagates CLI distinct ID and command to spawned servers for consistent anonymous attribution.
- Respects MASTRA_TELEMETRY_DISABLED=1 (no capture, no cursor write).
- Robust to missing storage, query failures, and corrupt cursor files—errors are swallowed and sync never throws.

## Other Fixes
- CLI: ensure MASTRA_PROJECT_ROOT is resolved to an absolute path (using path.resolve) so the telemetry cursor identity is stable across working directories when --root is passed as a relative path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->