### PR TITLE
feat(playground-ui): download a full trace as JSON from Studio

### DIFF
--- a/.changeset/plenty-beers-sort.md
+++ b/.changeset/plenty-beers-sort.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a Download trace JSON button to the trace detail panel in Studio. It saves the entire trace — every span with its full input, output, metadata, and attributes — to a `trace-<id>.json` file, so you can share a trace, attach it to a bug report, or build an eval dataset offline. Previously only individual IDs and per-section values could be copied.

--- a/docs/src/content/en/docs/studio/observability.mdx
+++ b/docs/src/content/en/docs/studio/observability.mdx
@@ -92,6 +92,8 @@ When you run an agent or workflow, the Observability tab displays traces that hi
 
 Tracing filters out low-level framework details so your traces stay focused and readable. Visit the [tracing overview](/docs/observability/tracing/overview) for more details.
 
+To export a trace, select **Download trace JSON** in the trace panel header. This saves the entire trace as a `trace-<id>.json` file, with every span and its full input, output, metadata, and attributes. Use it to share a trace, attach it to a bug report, or build an evaluation dataset offline.
+
 <VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1773668518/observability_qmwbao.mp4" />
 
 ## Logs

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -1,7 +1,16 @@
 import type { LightSpanRecord } from '@mastra/core/storage';
-import { CircleGaugeIcon, ChevronsDownUpIcon, ChevronsUpDownIcon, Link2Icon, SaveIcon } from 'lucide-react';
+import {
+  CircleGaugeIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
+  DownloadIcon,
+  Link2Icon,
+  Loader2Icon,
+  SaveIcon,
+} from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getAllSpanIds } from '../hooks/get-all-span-ids';
+import { useDownloadTraceJson } from '../hooks/use-download-trace-json';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
 import { TraceKeysAndValues } from './trace-keys-and-values';
 import { TraceTimeline } from './trace-timeline';
@@ -76,6 +85,8 @@ export function TraceDataPanelView({
   const collapsed = controlledCollapsed ?? internalCollapsed;
   const setCollapsed = onCollapsedChange ?? setInternalCollapsed;
 
+  const { download: downloadTraceJson, isPending: isDownloadingTrace } = useDownloadTraceJson();
+
   const contentRef = useRef<HTMLDivElement>(null);
   const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>(initialSpanId ?? undefined);
 
@@ -132,11 +143,28 @@ export function TraceDataPanelView({
 
   const showOpenTracePageLink = !isOnTracePage && LinkComponent && traceHref;
 
+  // Shared across both header layouts (list side panel and full trace page) so a trace can be
+  // downloaded from wherever it's being inspected.
+  const downloadTraceButton = (
+    <Button
+      size="md"
+      tooltip="Download trace JSON"
+      aria-label="Download trace JSON"
+      disabled={isDownloadingTrace}
+      onClick={() => downloadTraceJson(traceId)}
+    >
+      {isDownloadingTrace ? <Loader2Icon className="animate-spin" /> : <DownloadIcon />}
+    </Button>
+  );
+
   return (
     <DataPanel collapsed={collapsed}>
       <DataPanel.Header>
         {isOnTracePage ? (
-          <DataPanel.Heading>Trace Timeline</DataPanel.Heading>
+          <>
+            <DataPanel.Heading>Trace Timeline</DataPanel.Heading>
+            <ButtonsGroup className="ml-auto shrink-0">{downloadTraceButton}</ButtonsGroup>
+          </>
         ) : (
           <>
             <DataPanel.Heading>
@@ -171,6 +199,7 @@ export function TraceDataPanelView({
                   <Link2Icon />
                 </Button>
               )}
+              {downloadTraceButton}
               <DataPanel.CloseButton onClick={onClose} />
             </ButtonsGroup>
           </>

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import type { TraceRecord } from '@mastra/core/storage';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import type { ReactNode } from 'react';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDownloadTraceJson } from '../use-download-trace-json';
+
+// jsdom's Blob exposes no `.text()`, and the global `Response` doesn't recognize it.
+function readBlobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+// Keep the toast side effect out of the test, but still consume the promise so its
+// rejection is handled and `isPending` can settle.
+vi.mock('@/lib/toast', () => ({
+  toast: { promise: ({ myPromise }: { myPromise: Promise<unknown> }) => myPromise.catch(() => {}) },
+}));
+
+const BASE_URL = 'http://localhost:4111';
+const TRACE_ID = '566f00c7d2e2';
+const server = setupServer();
+
+// Minimal full-trace payload. The download serializes whatever `getTrace` returns, so the
+// downloaded bytes must equal this fixture — including the heavy input/output fields that the
+// lightweight panel spans omit.
+const traceFixture = {
+  traceId: TRACE_ID,
+  spans: [
+    {
+      spanId: 'span-1',
+      traceId: TRACE_ID,
+      parentSpanId: null,
+      name: 'agent run',
+      spanType: 'agent_run',
+      input: { prompt: 'hello' },
+      output: { text: 'hi there' },
+      metadata: { foo: 'bar' },
+      attributes: { usage: { totalTokens: 42 } },
+    },
+  ],
+} as unknown as TraceRecord;
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+}
+
+let createObjectURL: ReturnType<typeof vi.spyOn>;
+let clickedDownloadAttr: string | undefined;
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+
+beforeEach(() => {
+  clickedDownloadAttr = undefined;
+  createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+    clickedDownloadAttr = this.download;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  server.resetHandlers();
+  vi.restoreAllMocks();
+});
+
+afterAll(() => server.close());
+
+describe('useDownloadTraceJson', () => {
+  it('fetches the full trace and downloads it as trace-<id>.json', async () => {
+    server.use(http.get(`${BASE_URL}/api/observability/traces/:traceId`, () => HttpResponse.json(traceFixture)));
+
+    const { result } = renderHook(() => useDownloadTraceJson(), { wrapper: makeWrapper() });
+
+    act(() => result.current.download(TRACE_ID));
+    expect(result.current.isPending).toBe(true);
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0]![0] as Blob;
+    await expect(readBlobText(blob)).resolves.toBe(JSON.stringify(traceFixture, null, 2));
+    expect(clickedDownloadAttr).toBe(`trace-${TRACE_ID}.json`);
+  });
+
+  it('does not download when the trace fetch fails and resets the pending state', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/observability/traces/:traceId`, () => new HttpResponse(null, { status: 500 })),
+    );
+
+    const { result } = renderHook(() => useDownloadTraceJson(), { wrapper: makeWrapper() });
+
+    act(() => result.current.download(TRACE_ID));
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+});

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { SpanType } from '@mastra/core/observability';
 import type { TraceRecord } from '@mastra/core/storage';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -32,6 +33,7 @@ const server = setupServer();
 // Minimal full-trace payload. The download serializes whatever `getTrace` returns, so the
 // downloaded bytes must equal this fixture — including the heavy input/output fields that the
 // lightweight panel spans omit.
+const timestamp = new Date('2026-06-10T00:00:00.000Z');
 const traceFixture = {
   traceId: TRACE_ID,
   spans: [
@@ -40,14 +42,18 @@ const traceFixture = {
       traceId: TRACE_ID,
       parentSpanId: null,
       name: 'agent run',
-      spanType: 'agent_run',
+      spanType: SpanType.AGENT_RUN,
+      isEvent: false,
+      startedAt: timestamp,
       input: { prompt: 'hello' },
       output: { text: 'hi there' },
       metadata: { foo: 'bar' },
       attributes: { usage: { totalTokens: 42 } },
+      createdAt: timestamp,
+      updatedAt: timestamp,
     },
   ],
-} as unknown as TraceRecord;
+} satisfies TraceRecord;
 
 function makeWrapper() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/packages/playground-ui/src/domains/traces/hooks/index.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/index.ts
@@ -1,5 +1,6 @@
 export { getAllSpanIds, getSpanDescendantIds } from './get-all-span-ids';
 export { useBranch, type UseBranchArgs } from './use-branch';
+export { useDownloadTraceJson } from './use-download-trace-json';
 export { useSpanDetail } from './use-span-detail';
 export { useTraceLightSpans } from './use-trace-light-spans';
 export {

--- a/packages/playground-ui/src/domains/traces/hooks/use-download-trace-json.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-download-trace-json.ts
@@ -1,0 +1,36 @@
+import { useMastraClient } from '@mastra/react';
+import { useState } from 'react';
+import { downloadJson } from '@/lib/file';
+import { toast } from '@/lib/toast';
+
+/**
+ * Downloads a full trace (every span with its complete input, output, metadata, and
+ * attributes) as a `trace-<traceId>.json` file.
+ *
+ * Fetches the full trace on demand via `getTrace` — NOT the lightweight spans the trace
+ * panel renders from, which omit the heavy payload fields. The fetch only runs when
+ * `download` is called, so opening the panel stays cheap.
+ */
+export function useDownloadTraceJson() {
+  const client = useMastraClient();
+  const [isPending, setIsPending] = useState(false);
+
+  const download = (traceId: string) => {
+    if (isPending) return;
+    setIsPending(true);
+
+    const task = client
+      .getTrace(traceId)
+      .then(trace => downloadJson(`trace-${traceId}.json`, trace))
+      .finally(() => setIsPending(false));
+
+    toast.promise({
+      myPromise: task,
+      loadingMessage: 'Preparing trace download…',
+      successMessage: 'Trace downloaded',
+      errorMessage: 'Failed to download trace',
+    });
+  };
+
+  return { download, isPending };
+}

--- a/packages/playground-ui/src/domains/traces/hooks/use-download-trace-json.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-download-trace-json.ts
@@ -3,14 +3,6 @@ import { useState } from 'react';
 import { downloadJson } from '@/lib/file';
 import { toast } from '@/lib/toast';
 
-/**
- * Downloads a full trace (every span with its complete input, output, metadata, and
- * attributes) as a `trace-<traceId>.json` file.
- *
- * Fetches the full trace on demand via `getTrace` — NOT the lightweight spans the trace
- * panel renders from, which omit the heavy payload fields. The fetch only runs when
- * `download` is called, so opening the panel stays cheap.
- */
 export function useDownloadTraceJson() {
   const client = useMastraClient();
   const [isPending, setIsPending] = useState(false);
@@ -19,6 +11,7 @@ export function useDownloadTraceJson() {
     if (isPending) return;
     setIsPending(true);
 
+    // getTrace returns the full payload (heavy input/output), unlike the light spans the panel renders.
     const task = client
       .getTrace(traceId)
       .then(trace => downloadJson(`trace-${traceId}.json`, trace))

--- a/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { downloadJson } from '../downloadJson';
+
+// jsdom's Blob exposes no `.text()`, and the global `Response` doesn't recognize it.
+// Read it the way the rest of this package does — via FileReader.
+function readBlobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('downloadJson', () => {
+  it('serializes data to a pretty-printed application/json blob and triggers a download', async () => {
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    const data = { traceId: 'abc', spans: [{ spanId: 's1', input: { prompt: 'hi' } }] };
+    downloadJson('trace-abc.json', data);
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0]![0] as Blob;
+    expect(blob.type).toBe('application/json');
+    await expect(readBlobText(blob)).resolves.toBe(JSON.stringify(data, null, 2));
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('sets the download filename and removes the anchor afterwards', () => {
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    let downloadAttr: string | undefined;
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+      downloadAttr = this.download;
+    });
+
+    downloadJson('trace-xyz.json', {});
+
+    expect(downloadAttr).toBe('trace-xyz.json');
+    // Anchor is appended only for the click, then removed — none should linger in the DOM.
+    expect(document.querySelector('a')).toBeNull();
+  });
+});

--- a/packages/playground-ui/src/lib/file/downloadJson.ts
+++ b/packages/playground-ui/src/lib/file/downloadJson.ts
@@ -1,0 +1,19 @@
+/**
+ * Serialize `data` to pretty-printed JSON and trigger a browser file download.
+ *
+ * @param filename - Name for the downloaded file (e.g. `trace-abc123.json`).
+ * @param data - Any JSON-serializable value.
+ */
+export const downloadJson = (filename: string, data: unknown): void => {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+
+  URL.revokeObjectURL(url);
+};

--- a/packages/playground-ui/src/lib/file/downloadJson.ts
+++ b/packages/playground-ui/src/lib/file/downloadJson.ts
@@ -1,9 +1,4 @@
-/**
- * Serialize `data` to pretty-printed JSON and trigger a browser file download.
- *
- * @param filename - Name for the downloaded file (e.g. `trace-abc123.json`).
- * @param data - Any JSON-serializable value.
- */
+// Serialize data to pretty-printed JSON and trigger a browser file download.
 export const downloadJson = (filename: string, data: unknown): void => {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);

--- a/packages/playground-ui/src/lib/file/index.ts
+++ b/packages/playground-ui/src/lib/file/index.ts
@@ -1,3 +1,4 @@
 export * from './constants';
 export * from './contentTypeFromUrl';
+export * from './downloadJson';
 export * from './toBase64';


### PR DESCRIPTION
## Description

Adds a Download trace JSON action to the trace detail panel in Studio. It saves the entire trace — every span with its full input, output, metadata, and attributes — to a `trace-<id>.json` file, so users can share a trace, attach it to a bug report, or build an eval dataset offline. Previously only individual IDs and per-section values could be copied. 
Downloaded Trace JSON: 
[trace-6e9483a884efb1e4090de383d37bb981.json](https://github.com/user-attachments/files/28784320/trace-6e9483a884efb1e4090de383d37bb981.json)

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/972232b6-22a5-4fc1-9d69-7cbb1b96e282" />

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/b8207f06-8e56-4d72-b497-0ce5c1768040" />

## Related Issue(s)

Fixes #17749

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

Studio gained a button that saves everything about a trace as a JSON file to your computer so you can share it, attach it to bug reports, or analyze it offline.

---

## Changes Overview

This PR adds a "Download trace JSON" feature to Studio's trace detail panel and full trace page, enabling export of complete trace payloads (all spans with inputs, outputs, metadata, and attributes) as files named trace-<id>.json.

### New Utility
- packages/playground-ui/src/lib/file/downloadJson.ts
  - downloadJson(filename, data): pretty-prints JSON into an application/json Blob, creates an object URL, appends a temporary anchor, triggers a download, removes the anchor, and revokes the URL.
- packages/playground-ui/src/lib/file/index.ts
  - Re-exports downloadJson.

### New Hook
- packages/playground-ui/src/domains/traces/hooks/use-download-trace-json.ts
  - useDownloadTraceJson(): fetches full trace via useMastraClient().getTrace(traceId), calls downloadJson(`trace-${traceId}.json`, trace), manages isPending to prevent concurrent downloads, and wraps the flow with toast.promise for loading/success/error UX.
- packages/playground-ui/src/domains/traces/hooks/index.ts
  - Re-exports useDownloadTraceJson.

### UI Integration
- packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
  - Adds a download button to the DataPanel header (used in both traces list side panel and full trace page) that uses useDownloadTraceJson; button disables and shows a spinner while fetching.

### Tests
- packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
  - Vitest/jsdom tests verifying Blob creation, pretty-printed JSON content, correct filename, anchor cleanup, and URL revocation (mocks URL and anchor behaviors).
- packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
  - Vitest/jsdom tests with MSW to mock getTrace; covers success (creates blob URL, triggers download with filename trace-<id>.json, validates blob contents) and failure (HTTP 500: no object URL, isPending resets). Mocks toast and uses FileReader helper to read Blob text.

### Documentation & Release Notes
- docs/src/content/en/docs/studio/observability.mdx
  - Adds documentation for the new "Download trace JSON" action and its usage.
- .changeset/plenty-beers-sort.md
  - Release notes: minor bump documenting the new Download trace JSON button.

---

## Purpose & Linked Issue

Implements the request from issue `#17749` by providing a direct download action that retrieves the full trace payload and saves it as trace-<id>.json for sharing, bug reporting, or offline evaluation datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->