### PR TITLE
feat(islo): add islo.dev workspace provider

### DIFF
--- a/.changeset/quiet-wolves-stream.md
+++ b/.changeset/quiet-wolves-stream.md
@@ -2,4 +2,16 @@
 '@mastra/islo': patch
 ---
 
-Route sandbox lifecycle and streaming exec calls through the Islo compute API, while keeping token exchange on the control API. This also documents foreground-only process support and pauses sandboxes on `stop()` so they can be resumed.
+Added `@mastra/islo`, a new sandbox provider for Mastra workspaces backed by islo.dev. It supports foreground command execution with live streamed output, lifecycle management, and pause/resume semantics via `stop()`/`start()`.
+
+```typescript
+import { Workspace } from '@mastra/core/workspace';
+import { IsloSandbox } from '@mastra/islo';
+
+const workspace = new Workspace({
+  sandbox: new IsloSandbox({
+    apiKey: process.env.ISLO_API_KEY,
+    image: 'docker.io/library/ubuntu:24.04',
+  }),
+});
+```

--- a/.changeset/quiet-wolves-stream.md
+++ b/.changeset/quiet-wolves-stream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/islo': patch
+---
+
+Route sandbox lifecycle and streaming exec calls through the Islo compute API, while keeping token exchange on the control API. This also documents foreground-only process support and pauses sandboxes on `stop()` so they can be resumed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8379,16 +8379,16 @@ importers:
         version: 17.3.1
       eslint:
         specifier: ^10.2.1
-        version: 10.2.1(jiti@2.6.1)
+        version: 10.4.1(jiti@2.6.1)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.14)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   workspaces/modal:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8347,6 +8347,49 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  workspaces/islo:
+    dependencies:
+      '@islo-labs/sdk':
+        specifier: ^0.0.16
+        version: 0.0.16
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@internal/workspace-test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
+      eslint:
+        specifier: ^10.2.1
+        version: 10.2.1(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+
   workspaces/modal:
     dependencies:
       modal:
@@ -12799,6 +12842,10 @@ packages:
   '@isaacs/ttlcache@2.1.4':
     resolution: {integrity: sha512-7kMz0BJpMvgAMkyglums7B2vtrn5g0a0am77JY0GjkZZNetOBCFn7AG7gKCwT0QPiXyxW7YIQSgtARknUEOcxQ==}
     engines: {node: '>=12'}
+
+  '@islo-labs/sdk@0.0.16':
+    resolution: {integrity: sha512-Dr057VJA8rVdcS+1dbJ6VptrNcA6lGOVyfGZB4WeZDu+0bREYvLk+G/Qrs2MAo0/YF0Dtow/5QQ2PKv2jps1rg==}
+    engines: {node: '>=18.0.0'}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -34973,6 +35020,8 @@ snapshots:
       minipass: 7.1.3
 
   '@isaacs/ttlcache@2.1.4': {}
+
+  '@islo-labs/sdk@0.0.16': {}
 
   '@jest/schemas@29.6.3':
     dependencies:

--- a/workspaces/islo/README.md
+++ b/workspaces/islo/README.md
@@ -26,7 +26,7 @@ const workspace = new Workspace({
 
 const agent = new Agent({
   name: 'my-agent',
-  model: 'anthropic/claude-opus-4-5',
+  model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,
 });
 ```

--- a/workspaces/islo/README.md
+++ b/workspaces/islo/README.md
@@ -1,0 +1,71 @@
+# @mastra/islo
+
+[islo.dev](https://islo.dev) sandbox provider for Mastra workspaces. Backed by [`@islo-labs/sdk`](https://www.npmjs.com/package/@islo-labs/sdk); commands stream stdout/stderr live by consuming the islo SSE exec endpoint directly.
+
+## Installation
+
+```bash
+npm install @mastra/islo
+```
+
+## Usage
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { IsloSandbox } from '@mastra/islo';
+
+const workspace = new Workspace({
+  sandbox: new IsloSandbox({
+    apiKey: process.env.ISLO_API_KEY, // also read from ISLO_API_KEY env var
+    image: 'docker.io/library/ubuntu:24.04',
+    workdir: 'my-project',
+    timeout: 60_000,
+  }),
+});
+
+const agent = new Agent({
+  name: 'my-agent',
+  model: 'anthropic/claude-opus-4-5',
+  workspace,
+});
+```
+
+`apiKey` falls back to the `ISLO_API_KEY` environment variable. `baseUrl` falls back to `ISLO_BASE_URL`, then `https://api.islo.dev`. The SDK exchanges the API key for a short-lived JWT and refreshes it automatically.
+
+## Lifecycle
+
+| WorkspaceSandbox method | islo SDK call |
+|---|---|
+| `start()` | `sandboxes.createSandbox` (or reconnects to an existing sandbox by name when one is already live) |
+| `stop()` | `sandboxes.stopSandbox` (paused; sandbox record retained) |
+| `destroy()` | `sandboxes.deleteSandbox` (only when this instance acquired the sandbox) |
+| `executeCommand()` | direct SSE consumer on `POST /sandboxes/{name}/exec/stream` |
+
+## Live streaming
+
+`@islo-labs/sdk`'s generated `execInSandboxStream` decodes the SSE response body through a JSON unmarshaler — by the time you see bytes, the command is finished. To deliver true line-by-line output, `IsloSandbox.executeCommand` bypasses that wrapper and consumes the `/exec/stream` endpoint directly. Auth still flows through the SDK's `TokenProvider`, so token refresh and base URL stay consistent.
+
+If the SDK later exposes a streaming iterator, the consumer in `src/sandbox/sse.ts` should be removed and the SDK call used instead.
+
+## Reconnection
+
+When you pass a `sandboxName` that already exists and is still live (not `deleted`/`failed`), `start()` reconnects to it instead of creating a new one. `destroy()` only deletes sandboxes the current instance acquired itself, so reconnecting to an existing sandbox does not destroy it on shutdown.
+
+## Configuration
+
+| Option | Description | Default |
+|---|---|---|
+| `sandboxName` | Sandbox name (path segment) | `mastra-<random>` |
+| `image` | Container image | islo tenant default |
+| `workdir` | Working directory relative to `/workspace` | islo image default |
+| `gatewayProfile` | Gateway profile name or id | tenant default |
+| `env` | Environment variables for sandbox creation | `{}` |
+| `apiKey` | islo API key (`ak_...`) | `ISLO_API_KEY` env var |
+| `baseUrl` | API base URL | `ISLO_BASE_URL` or `https://api.islo.dev` |
+| `timeout` | Default per-command timeout (ms) | `300000` |
+| `metadata` | Sandbox-create metadata | `{}` |
+
+## License
+
+Apache-2.0

--- a/workspaces/islo/README.md
+++ b/workspaces/islo/README.md
@@ -31,7 +31,7 @@ const agent = new Agent({
 });
 ```
 
-`apiKey` falls back to the `ISLO_API_KEY` environment variable. `controlUrl` falls back to `baseUrl`, `ISLO_BASE_URL`, then `https://api.islo.dev`. `computeUrl` falls back to `ISLO_COMPUTE_URL`, then `https://ca.compute.islo.dev`. Token exchange happens on the control API; sandbox lifecycle and exec calls happen on the compute API.
+`apiKey` falls back to the `ISLO_API_KEY` environment variable. `controlUrl` falls back to `ISLO_CONTROL_URL`, then `https://api.islo.dev`. `computeUrl` falls back to `ISLO_COMPUTE_URL`, then `https://ca.compute.islo.dev`. Token exchange happens on the control API; sandbox lifecycle and exec calls happen on the compute API.
 
 ## Lifecycle
 
@@ -66,8 +66,7 @@ When you pass a `sandboxName` that already exists and is still live, `start()` r
 | `gatewayProfile` | Gateway profile name or id | tenant default |
 | `env` | Environment variables for sandbox creation | `{}` |
 | `apiKey` | islo API key (`ak_...`) | `ISLO_API_KEY` env var |
-| `controlUrl` | Control API URL for token exchange | `ISLO_BASE_URL` or `https://api.islo.dev` |
-| `baseUrl` | Deprecated alias for `controlUrl` | `ISLO_BASE_URL` or `https://api.islo.dev` |
+| `controlUrl` | Control API URL for token exchange | `ISLO_CONTROL_URL` or `https://api.islo.dev` |
 | `computeUrl` | Compute API URL for sandbox operations | `ISLO_COMPUTE_URL` or `https://ca.compute.islo.dev` |
 | `deleteOnDestroy` | Delete sandbox record during `destroy()` | `true` |
 | `timeout` | Default per-command timeout (ms) | `300000` |

--- a/workspaces/islo/README.md
+++ b/workspaces/islo/README.md
@@ -33,6 +33,21 @@ const agent = new Agent({
 
 `apiKey` falls back to the `ISLO_API_KEY` environment variable. `controlUrl` falls back to `ISLO_CONTROL_URL`, then `https://api.islo.dev`. `computeUrl` falls back to `ISLO_COMPUTE_URL`, then `https://ca.compute.islo.dev`. Token exchange happens on the control API; sandbox lifecycle and exec calls happen on the compute API.
 
+## Studio provider
+
+Register the provider with `MastraEditor` to make Islo available for UI-driven workspace configuration:
+
+```typescript
+import { MastraEditor } from '@mastra/editor';
+import { isloSandboxProvider } from '@mastra/islo';
+
+const editor = new MastraEditor({
+  sandboxes: {
+    [isloSandboxProvider.id]: isloSandboxProvider,
+  },
+});
+```
+
 ## Lifecycle
 
 | WorkspaceSandbox method | islo SDK call |

--- a/workspaces/islo/README.md
+++ b/workspaces/islo/README.md
@@ -1,6 +1,6 @@
 # @mastra/islo
 
-[islo.dev](https://islo.dev) sandbox provider for Mastra workspaces. Backed by [`@islo-labs/sdk`](https://www.npmjs.com/package/@islo-labs/sdk); commands stream stdout/stderr live by consuming the islo SSE exec endpoint directly.
+[islo.dev](https://islo.dev) sandbox provider for Mastra workspaces. Backed by [`@islo-labs/sdk`](https://www.npmjs.com/package/@islo-labs/sdk); foreground commands stream stdout/stderr live by consuming the islo SSE exec endpoint directly.
 
 ## Installation
 
@@ -31,26 +31,30 @@ const agent = new Agent({
 });
 ```
 
-`apiKey` falls back to the `ISLO_API_KEY` environment variable. `baseUrl` falls back to `ISLO_BASE_URL`, then `https://api.islo.dev`. The SDK exchanges the API key for a short-lived JWT and refreshes it automatically.
+`apiKey` falls back to the `ISLO_API_KEY` environment variable. `controlUrl` falls back to `baseUrl`, `ISLO_BASE_URL`, then `https://api.islo.dev`. `computeUrl` falls back to `ISLO_COMPUTE_URL`, then `https://ca.compute.islo.dev`. Token exchange happens on the control API; sandbox lifecycle and exec calls happen on the compute API.
 
 ## Lifecycle
 
 | WorkspaceSandbox method | islo SDK call |
 |---|---|
 | `start()` | `sandboxes.createSandbox` (or reconnects to an existing sandbox by name when one is already live) |
-| `stop()` | `sandboxes.stopSandbox` (paused; sandbox record retained) |
-| `destroy()` | `sandboxes.deleteSandbox` (only when this instance acquired the sandbox) |
+| `stop()` | `sandboxes.pauseSandbox` (paused; sandbox record retained) |
+| `destroy()` | `sandboxes.deleteSandbox` (unless `deleteOnDestroy: false`) |
 | `executeCommand()` | direct SSE consumer on `POST /sandboxes/{name}/exec/stream` |
 
 ## Live streaming
 
-`@islo-labs/sdk`'s generated `execInSandboxStream` decodes the SSE response body through a JSON unmarshaler — by the time you see bytes, the command is finished. To deliver true line-by-line output, `IsloSandbox.executeCommand` bypasses that wrapper and consumes the `/exec/stream` endpoint directly. Auth still flows through the SDK's `TokenProvider`, so token refresh and base URL stay consistent.
+`IsloSandbox.executeCommand` consumes the compute API's `/exec/stream` endpoint directly so callers receive stdout/stderr deltas as they arrive. Auth still flows through the SDK's `TokenProvider`, so token refresh stays consistent.
 
 If the SDK later exposes a streaming iterator, the consumer in `src/sandbox/sse.ts` should be removed and the SDK call used instead.
 
 ## Reconnection
 
-When you pass a `sandboxName` that already exists and is still live (not `deleted`/`failed`), `start()` reconnects to it instead of creating a new one. `destroy()` only deletes sandboxes the current instance acquired itself, so reconnecting to an existing sandbox does not destroy it on shutdown.
+When you pass a `sandboxName` that already exists and is still live, `start()` reconnects to it instead of creating a new one. Paused sandboxes are resumed. Stopped or failed sandboxes cannot be resumed; delete them or choose a new `sandboxName`. `destroy()` deletes the sandbox record by default, including reconnected sandboxes. Set `deleteOnDestroy: false` to keep the record.
+
+## Process Support
+
+`@mastra/islo` v1 supports foreground command execution only. It does not expose `sandbox.processes`, so Mastra background process tools, `get_process_output`, `kill_process`, and LSP process support are unavailable until Islo exposes a durable process/session contract with stable IDs, output history, status, and kill semantics.
 
 ## Configuration
 
@@ -62,7 +66,10 @@ When you pass a `sandboxName` that already exists and is still live (not `delete
 | `gatewayProfile` | Gateway profile name or id | tenant default |
 | `env` | Environment variables for sandbox creation | `{}` |
 | `apiKey` | islo API key (`ak_...`) | `ISLO_API_KEY` env var |
-| `baseUrl` | API base URL | `ISLO_BASE_URL` or `https://api.islo.dev` |
+| `controlUrl` | Control API URL for token exchange | `ISLO_BASE_URL` or `https://api.islo.dev` |
+| `baseUrl` | Deprecated alias for `controlUrl` | `ISLO_BASE_URL` or `https://api.islo.dev` |
+| `computeUrl` | Compute API URL for sandbox operations | `ISLO_COMPUTE_URL` or `https://ca.compute.islo.dev` |
+| `deleteOnDestroy` | Delete sandbox record during `destroy()` | `true` |
 | `timeout` | Default per-command timeout (ms) | `300000` |
 | `metadata` | Sandbox-create metadata | `{}` |
 

--- a/workspaces/islo/eslint.config.js
+++ b/workspaces/islo/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/workspaces/islo/package.json
+++ b/workspaces/islo/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@mastra/islo",
+  "version": "0.0.1",
+  "description": "islo.dev sandbox provider for Mastra workspaces",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "build:lib": "pnpm build",
+    "build:watch": "pnpm build --watch",
+    "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
+    "test:watch": "vitest watch",
+    "test": "vitest run ./src/**/*.integration.test.ts",
+    "test:cloud": "pnpm test",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@islo-labs/sdk": "^0.0.16"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@internal/workspace-test-utils": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.19.15",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "dotenv": "^17.3.1",
+    "eslint": "^10.2.1",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.12.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "workspaces/islo"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/workspaces/islo/src/index.ts
+++ b/workspaces/islo/src/index.ts
@@ -1,0 +1,3 @@
+export { IsloSandbox, type IsloSandboxOptions } from './sandbox';
+export { isloSandboxProvider } from './provider';
+export { consumeIsloStream, type SSECallbacks, type SSEResult } from './sandbox/sse';

--- a/workspaces/islo/src/provider.ts
+++ b/workspaces/islo/src/provider.ts
@@ -6,7 +6,9 @@
  * import { isloSandboxProvider } from '@mastra/islo';
  *
  * const editor = new MastraEditor({
- *   sandboxes: [isloSandboxProvider],
+ *   sandboxes: {
+ *     [isloSandboxProvider.id]: isloSandboxProvider,
+ *   },
  * });
  * ```
  */

--- a/workspaces/islo/src/provider.ts
+++ b/workspaces/islo/src/provider.ts
@@ -26,7 +26,6 @@ interface IsloProviderConfig {
   env?: Record<string, string>;
   apiKey?: string;
   controlUrl?: string;
-  baseUrl?: string;
   computeUrl?: string;
   deleteOnDestroy?: boolean;
   timeout?: number;
@@ -50,8 +49,7 @@ export const isloSandboxProvider: SandboxProvider<IsloProviderConfig> = {
         additionalProperties: { type: 'string' },
       },
       apiKey: { type: 'string', description: 'islo API key (falls back to ISLO_API_KEY)' },
-      controlUrl: { type: 'string', description: 'islo control API URL (falls back to ISLO_BASE_URL)' },
-      baseUrl: { type: 'string', description: 'Deprecated alias for controlUrl' },
+      controlUrl: { type: 'string', description: 'islo control API URL (falls back to ISLO_CONTROL_URL)' },
       computeUrl: { type: 'string', description: 'islo compute API URL (falls back to ISLO_COMPUTE_URL)' },
       deleteOnDestroy: {
         type: 'boolean',

--- a/workspaces/islo/src/provider.ts
+++ b/workspaces/islo/src/provider.ts
@@ -1,0 +1,60 @@
+/**
+ * islo sandbox provider descriptor for MastraEditor.
+ *
+ * @example
+ * ```typescript
+ * import { isloSandboxProvider } from '@mastra/islo';
+ *
+ * const editor = new MastraEditor({
+ *   sandboxes: [isloSandboxProvider],
+ * });
+ * ```
+ */
+import type { SandboxProvider } from '@mastra/core/editor';
+
+import { IsloSandbox } from './sandbox';
+
+/**
+ * Serializable subset of `IsloSandboxOptions` for editor storage. Non-
+ * serializable options (callbacks) are excluded.
+ */
+interface IsloProviderConfig {
+  sandboxName?: string;
+  image?: string;
+  workdir?: string;
+  gatewayProfile?: string;
+  env?: Record<string, string>;
+  apiKey?: string;
+  baseUrl?: string;
+  timeout?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export const isloSandboxProvider: SandboxProvider<IsloProviderConfig> = {
+  id: 'islo',
+  name: 'islo Sandbox',
+  description: 'Cloud sandbox powered by islo.dev',
+  configSchema: {
+    type: 'object',
+    properties: {
+      sandboxName: { type: 'string', description: 'Sandbox name (path segment)' },
+      image: { type: 'string', description: 'Container image (e.g. docker.io/library/ubuntu:24.04)' },
+      workdir: { type: 'string', description: 'Working directory relative to /workspace' },
+      gatewayProfile: { type: 'string', description: 'Gateway profile name or id' },
+      env: {
+        type: 'object',
+        description: 'Environment variables for sandbox creation',
+        additionalProperties: { type: 'string' },
+      },
+      apiKey: { type: 'string', description: 'islo API key (falls back to ISLO_API_KEY)' },
+      baseUrl: { type: 'string', description: 'islo API base URL (falls back to ISLO_BASE_URL)' },
+      timeout: { type: 'number', description: 'Default per-command timeout in milliseconds', default: 300000 },
+      metadata: {
+        type: 'object',
+        description: 'Custom metadata',
+        additionalProperties: true,
+      },
+    },
+  },
+  createSandbox: (config) => new IsloSandbox(config),
+};

--- a/workspaces/islo/src/provider.ts
+++ b/workspaces/islo/src/provider.ts
@@ -25,7 +25,10 @@ interface IsloProviderConfig {
   gatewayProfile?: string;
   env?: Record<string, string>;
   apiKey?: string;
+  controlUrl?: string;
   baseUrl?: string;
+  computeUrl?: string;
+  deleteOnDestroy?: boolean;
   timeout?: number;
   metadata?: Record<string, unknown>;
 }
@@ -47,7 +50,14 @@ export const isloSandboxProvider: SandboxProvider<IsloProviderConfig> = {
         additionalProperties: { type: 'string' },
       },
       apiKey: { type: 'string', description: 'islo API key (falls back to ISLO_API_KEY)' },
-      baseUrl: { type: 'string', description: 'islo API base URL (falls back to ISLO_BASE_URL)' },
+      controlUrl: { type: 'string', description: 'islo control API URL (falls back to ISLO_BASE_URL)' },
+      baseUrl: { type: 'string', description: 'Deprecated alias for controlUrl' },
+      computeUrl: { type: 'string', description: 'islo compute API URL (falls back to ISLO_COMPUTE_URL)' },
+      deleteOnDestroy: {
+        type: 'boolean',
+        description: 'Delete the sandbox record when destroy() is called',
+        default: true,
+      },
       timeout: { type: 'number', description: 'Default per-command timeout in milliseconds', default: 300000 },
       metadata: {
         type: 'object',

--- a/workspaces/islo/src/sandbox/index.integration.test.ts
+++ b/workspaces/islo/src/sandbox/index.integration.test.ts
@@ -1,0 +1,63 @@
+/**
+ * IsloSandbox integration tests.
+ *
+ * Run only when `ISLO_API_KEY` is set. Tests hit api.islo.dev and create real
+ * sandboxes which are torn down in `afterAll`.
+ */
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { IsloSandbox } from './index';
+
+const hasApiKey = !!process.env.ISLO_API_KEY;
+
+describe.skipIf(!hasApiKey)('IsloSandbox (live)', () => {
+  const sandbox = new IsloSandbox({
+    sandboxName: `mastra-it-${Date.now().toString(36)}`,
+    timeout: 60_000,
+  });
+
+  afterAll(async () => {
+    try {
+      await sandbox._destroy();
+    } catch {
+      // best-effort cleanup
+    }
+  }, 60_000);
+
+  it('creates a sandbox, runs a command, and streams output live', async () => {
+    await sandbox._start();
+    expect(sandbox.status).toBe('running');
+
+    const chunks: string[] = [];
+    const result = await sandbox.executeCommand!('echo', ['hello-from-mastra'], {
+      onStdout: (d) => chunks.push(d),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('hello-from-mastra');
+    expect(chunks.length).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('streams output incrementally for a long-running command', async () => {
+    const chunks: string[] = [];
+    const start = Date.now();
+    const result = await sandbox.executeCommand!('bash', ['-lc', 'for i in 1 2 3; do echo $i; sleep 1; done'], {
+      onStdout: (d) => chunks.push(d),
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/1[\r\n]+2[\r\n]+3/);
+    // Three iterations sleep ≈3s; total should be around that, not buffered.
+    expect(elapsed).toBeGreaterThan(2_000);
+  }, 30_000);
+
+  it('propagates non-zero exit codes', async () => {
+    const result = await sandbox.executeCommand!('bash', ['-lc', 'echo oops >&2; exit 42']);
+    expect(result.exitCode).toBe(42);
+    expect(result.success).toBe(false);
+    expect(result.stderr).toContain('oops');
+  }, 60_000);
+});

--- a/workspaces/islo/src/sandbox/index.integration.test.ts
+++ b/workspaces/islo/src/sandbox/index.integration.test.ts
@@ -5,21 +5,25 @@
  * sandboxes which are torn down in `afterAll`.
  */
 
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { IsloSandbox } from './index';
 
 const hasApiKey = !!process.env.ISLO_API_KEY;
 
 describe.skipIf(!hasApiKey)('IsloSandbox (live)', () => {
-  const sandbox = new IsloSandbox({
-    sandboxName: `mastra-it-${Date.now().toString(36)}`,
-    timeout: 60_000,
+  let sandbox: IsloSandbox;
+
+  beforeAll(() => {
+    sandbox = new IsloSandbox({
+      sandboxName: `mastra-it-${Date.now().toString(36)}`,
+      timeout: 60_000,
+    });
   });
 
   afterAll(async () => {
     try {
-      await sandbox._destroy();
+      await sandbox?._destroy();
     } catch {
       // best-effort cleanup
     }

--- a/workspaces/islo/src/sandbox/index.test.ts
+++ b/workspaces/islo/src/sandbox/index.test.ts
@@ -10,25 +10,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createSandboxMock = vi.fn();
 const getSandboxMock = vi.fn();
-const stopSandboxMock = vi.fn();
+const pauseSandboxMock = vi.fn();
+const resumeSandboxMock = vi.fn();
 const deleteSandboxMock = vi.fn();
 const getTokenMock = vi.fn();
+const isloApiClientConstructorMock = vi.fn();
+const tokenProviderConstructorMock = vi.fn();
 
 vi.mock('@islo-labs/sdk', () => {
-  function MockIslo(this: unknown) {
+  function MockIsloApiClient(this: unknown, options: unknown) {
+    isloApiClientConstructorMock(options);
     Object.assign(this as object, {
       sandboxes: {
         createSandbox: createSandboxMock,
         getSandbox: getSandboxMock,
-        stopSandbox: stopSandboxMock,
+        pauseSandbox: pauseSandboxMock,
+        resumeSandbox: resumeSandboxMock,
         deleteSandbox: deleteSandboxMock,
       },
     });
   }
-  function MockTokenProvider(this: unknown) {
+  function MockTokenProvider(this: unknown, options: unknown) {
+    tokenProviderConstructorMock(options);
     Object.assign(this as object, { getToken: getTokenMock });
   }
-  return { Islo: MockIslo, TokenProvider: MockTokenProvider };
+  return { IsloApiClient: MockIsloApiClient, TokenProvider: MockTokenProvider };
 });
 
 import { IsloSandbox } from './index';
@@ -39,9 +45,10 @@ beforeEach(() => {
   process.env.ISLO_API_KEY = 'ak_test';
   getTokenMock.mockResolvedValue('jwt-test');
   createSandboxMock.mockResolvedValue({ name: 'mastra-test', status: 'running', created_at: '2026-05-05T00:00:00Z' });
+  resumeSandboxMock.mockResolvedValue({ name: 'mastra-test', status: 'running', created_at: '2026-05-05T00:00:00Z' });
   // Default to "not found" so start() takes the create path.
   getSandboxMock.mockRejectedValue({ statusCode: 404 });
-  stopSandboxMock.mockResolvedValue({});
+  pauseSandboxMock.mockResolvedValue({});
   deleteSandboxMock.mockResolvedValue({});
 });
 
@@ -49,6 +56,8 @@ afterEach(() => {
   vi.clearAllMocks();
   globalThis.fetch = realFetch;
   delete process.env.ISLO_API_KEY;
+  delete process.env.ISLO_BASE_URL;
+  delete process.env.ISLO_COMPUTE_URL;
 });
 
 function streamFromString(text: string): ReadableStream<Uint8Array> {
@@ -77,6 +86,40 @@ describe('IsloSandbox', () => {
       const sb = new IsloSandbox();
       expect(sb.name_).toMatch(/^mastra-/);
     });
+
+    it('configures token exchange on control URL and sandbox calls on compute URL', () => {
+      const sb = new IsloSandbox({
+        baseUrl: 'https://control.example.com/',
+        computeUrl: 'https://compute.example.com/',
+      });
+      expect(sb.processes).toBeUndefined();
+      expect(tokenProviderConstructorMock).toHaveBeenCalledWith({
+        apiKey: 'ak_test',
+        baseUrl: 'https://control.example.com',
+      });
+      expect(isloApiClientConstructorMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environment: 'https://compute.example.com',
+          baseUrl: 'https://compute.example.com',
+        }),
+      );
+    });
+
+    it('resolves ISLO_BASE_URL and ISLO_COMPUTE_URL independently', () => {
+      process.env.ISLO_BASE_URL = 'https://control.env.example.com/';
+      process.env.ISLO_COMPUTE_URL = 'https://compute.env.example.com/';
+      new IsloSandbox();
+      expect(tokenProviderConstructorMock).toHaveBeenCalledWith({
+        apiKey: 'ak_test',
+        baseUrl: 'https://control.env.example.com',
+      });
+      expect(isloApiClientConstructorMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environment: 'https://compute.env.example.com',
+          baseUrl: 'https://compute.env.example.com',
+        }),
+      );
+    });
   });
 
   describe('lifecycle', () => {
@@ -102,16 +145,42 @@ describe('IsloSandbox', () => {
       expect(sb.status).toBe('running');
     });
 
-    it('destroy() deletes only sandboxes acquired by this instance', async () => {
+    it('start() resumes an existing paused sandbox by name', async () => {
+      getSandboxMock.mockResolvedValueOnce({
+        name: 'mastra-test',
+        status: 'paused',
+        created_at: '2026-05-04T00:00:00Z',
+      });
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await sb._start();
+      expect(createSandboxMock).not.toHaveBeenCalled();
+      expect(resumeSandboxMock).toHaveBeenCalledWith({ sandbox_name: 'mastra-test' });
+      expect(sb.status).toBe('running');
+    });
+
+    it('start() fails clearly for an existing stopped sandbox', async () => {
+      getSandboxMock.mockResolvedValueOnce({ name: 'mastra-test', status: 'stopped' });
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await expect(sb._start()).rejects.toThrow(/stopped/);
+      expect(createSandboxMock).not.toHaveBeenCalled();
+    });
+
+    it('stop() pauses the sandbox so it can be resumed later', async () => {
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await sb._stop();
+      expect(pauseSandboxMock).toHaveBeenCalledWith({ sandbox_name: 'mastra-test' });
+    });
+
+    it('destroy() deletes sandboxes by default', async () => {
       const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
       await sb._start();
       await sb._destroy();
       expect(deleteSandboxMock).toHaveBeenCalledWith({ sandbox_name: 'mastra-test' });
     });
 
-    it('destroy() does not delete a sandbox the instance only reconnected to', async () => {
+    it('destroy() skips deletion when deleteOnDestroy is false', async () => {
       getSandboxMock.mockResolvedValueOnce({ name: 'mastra-keep', status: 'running' });
-      const sb = new IsloSandbox({ sandboxName: 'mastra-keep' });
+      const sb = new IsloSandbox({ sandboxName: 'mastra-keep', deleteOnDestroy: false });
       await sb._start();
       await sb._destroy();
       expect(deleteSandboxMock).not.toHaveBeenCalled();
@@ -138,12 +207,15 @@ describe('IsloSandbox', () => {
         }),
       ) as unknown as typeof fetch;
 
-      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test', computeUrl: 'https://compute.example.com' });
       const stdoutChunks: string[] = [];
       const stderrChunks: string[] = [];
       const result = await sb.executeCommand!('echo', ['hello'], {
         onStdout: (d) => stdoutChunks.push(d),
         onStderr: (d) => stderrChunks.push(d),
+        cwd: '/workspace/app',
+        env: { TEST_ENV: '1' },
+        timeout: 12_345,
       });
 
       expect(result.exitCode).toBe(0);
@@ -154,12 +226,18 @@ describe('IsloSandbox', () => {
       expect(stderrChunks).toEqual(['warn']);
 
       const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(fetchCall[0]).toContain('/sandboxes/mastra-test/exec/stream');
+      expect(fetchCall[0]).toBe('https://compute.example.com/sandboxes/mastra-test/exec/stream');
       const init = fetchCall[1] as RequestInit;
       expect(init.method).toBe('POST');
       const headers = init.headers as Record<string, string>;
       expect(headers.authorization).toBe('Bearer jwt-test');
       expect(headers.accept).toBe('text/event-stream');
+      expect(JSON.parse(init.body as string)).toEqual({
+        args: ['echo', 'hello'],
+        workdir: '/workspace/app',
+        env_vars: { TEST_ENV: '1' },
+        timeout_secs: 13,
+      });
     });
 
     it('propagates a non-zero exit code', async () => {

--- a/workspaces/islo/src/sandbox/index.test.ts
+++ b/workspaces/islo/src/sandbox/index.test.ts
@@ -56,7 +56,7 @@ afterEach(() => {
   vi.clearAllMocks();
   globalThis.fetch = realFetch;
   delete process.env.ISLO_API_KEY;
-  delete process.env.ISLO_BASE_URL;
+  delete process.env.ISLO_CONTROL_URL;
   delete process.env.ISLO_COMPUTE_URL;
 });
 
@@ -89,7 +89,7 @@ describe('IsloSandbox', () => {
 
     it('configures token exchange on control URL and sandbox calls on compute URL', () => {
       const sb = new IsloSandbox({
-        baseUrl: 'https://control.example.com/',
+        controlUrl: 'https://control.example.com/',
         computeUrl: 'https://compute.example.com/',
       });
       expect(sb.processes).toBeUndefined();
@@ -105,8 +105,8 @@ describe('IsloSandbox', () => {
       );
     });
 
-    it('resolves ISLO_BASE_URL and ISLO_COMPUTE_URL independently', () => {
-      process.env.ISLO_BASE_URL = 'https://control.env.example.com/';
+    it('resolves ISLO_CONTROL_URL and ISLO_COMPUTE_URL independently', () => {
+      process.env.ISLO_CONTROL_URL = 'https://control.env.example.com/';
       process.env.ISLO_COMPUTE_URL = 'https://compute.env.example.com/';
       new IsloSandbox();
       expect(tokenProviderConstructorMock).toHaveBeenCalledWith({

--- a/workspaces/islo/src/sandbox/index.test.ts
+++ b/workspaces/islo/src/sandbox/index.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for IsloSandbox.
+ *
+ * The islo SDK + the global `fetch` are mocked so we can drive the lifecycle
+ * and exec paths without hitting api.islo.dev. Live integration coverage is
+ * in `index.integration.test.ts` and runs only when `ISLO_API_KEY` is set.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createSandboxMock = vi.fn();
+const getSandboxMock = vi.fn();
+const stopSandboxMock = vi.fn();
+const deleteSandboxMock = vi.fn();
+const getTokenMock = vi.fn();
+
+vi.mock('@islo-labs/sdk', () => {
+  function MockIslo(this: unknown) {
+    Object.assign(this as object, {
+      sandboxes: {
+        createSandbox: createSandboxMock,
+        getSandbox: getSandboxMock,
+        stopSandbox: stopSandboxMock,
+        deleteSandbox: deleteSandboxMock,
+      },
+    });
+  }
+  function MockTokenProvider(this: unknown) {
+    Object.assign(this as object, { getToken: getTokenMock });
+  }
+  return { Islo: MockIslo, TokenProvider: MockTokenProvider };
+});
+
+import { IsloSandbox } from './index';
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  process.env.ISLO_API_KEY = 'ak_test';
+  getTokenMock.mockResolvedValue('jwt-test');
+  createSandboxMock.mockResolvedValue({ name: 'mastra-test', status: 'running', created_at: '2026-05-05T00:00:00Z' });
+  // Default to "not found" so start() takes the create path.
+  getSandboxMock.mockRejectedValue({ statusCode: 404 });
+  stopSandboxMock.mockResolvedValue({});
+  deleteSandboxMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  globalThis.fetch = realFetch;
+  delete process.env.ISLO_API_KEY;
+});
+
+function streamFromString(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+describe('IsloSandbox', () => {
+  describe('constructor', () => {
+    it('throws when ISLO_API_KEY is missing and no apiKey option is provided', () => {
+      delete process.env.ISLO_API_KEY;
+      expect(() => new IsloSandbox()).toThrow(/ISLO_API_KEY/);
+    });
+
+    it('uses an explicit apiKey option when env is unset', () => {
+      delete process.env.ISLO_API_KEY;
+      expect(() => new IsloSandbox({ apiKey: 'ak_inline' })).not.toThrow();
+    });
+
+    it('generates a sandbox name when none is supplied', () => {
+      const sb = new IsloSandbox();
+      expect(sb.name_).toMatch(/^mastra-/);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('start() creates a new sandbox when none exists', async () => {
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test', image: 'ubuntu:24.04' });
+      await sb._start();
+      expect(getSandboxMock).toHaveBeenCalledWith({ sandbox_name: 'mastra-test' });
+      expect(createSandboxMock).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'mastra-test', image: 'ubuntu:24.04' }),
+      );
+      expect(sb.status).toBe('running');
+    });
+
+    it('start() reconnects to an existing live sandbox by name', async () => {
+      getSandboxMock.mockResolvedValueOnce({
+        name: 'mastra-test',
+        status: 'running',
+        created_at: '2026-05-04T00:00:00Z',
+      });
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await sb._start();
+      expect(createSandboxMock).not.toHaveBeenCalled();
+      expect(sb.status).toBe('running');
+    });
+
+    it('destroy() deletes only sandboxes acquired by this instance', async () => {
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await sb._start();
+      await sb._destroy();
+      expect(deleteSandboxMock).toHaveBeenCalledWith({ sandbox_name: 'mastra-test' });
+    });
+
+    it('destroy() does not delete a sandbox the instance only reconnected to', async () => {
+      getSandboxMock.mockResolvedValueOnce({ name: 'mastra-keep', status: 'running' });
+      const sb = new IsloSandbox({ sandboxName: 'mastra-keep' });
+      await sb._start();
+      await sb._destroy();
+      expect(deleteSandboxMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('executeCommand', () => {
+    it('streams stdout/stderr deltas and propagates the exit code', async () => {
+      const sseBody = [
+        'event: stdout',
+        'data: hello',
+        '',
+        'event: stderr',
+        'data: warn',
+        '',
+        'event: exit',
+        'data: 0',
+        '',
+      ].join('\n');
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(streamFromString(sseBody), {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+      ) as unknown as typeof fetch;
+
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      const stdoutChunks: string[] = [];
+      const stderrChunks: string[] = [];
+      const result = await sb.executeCommand!('echo', ['hello'], {
+        onStdout: (d) => stdoutChunks.push(d),
+        onStderr: (d) => stderrChunks.push(d),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.success).toBe(true);
+      expect(result.stdout).toBe('hello');
+      expect(result.stderr).toBe('warn');
+      expect(stdoutChunks).toEqual(['hello']);
+      expect(stderrChunks).toEqual(['warn']);
+
+      const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('/sandboxes/mastra-test/exec/stream');
+      const init = fetchCall[1] as RequestInit;
+      expect(init.method).toBe('POST');
+      const headers = init.headers as Record<string, string>;
+      expect(headers.authorization).toBe('Bearer jwt-test');
+      expect(headers.accept).toBe('text/event-stream');
+    });
+
+    it('propagates a non-zero exit code', async () => {
+      const sseBody = 'event: stdout\ndata: nope\n\nevent: exit\ndata: 7\n\n';
+      globalThis.fetch = vi.fn().mockResolvedValue(new Response(streamFromString(sseBody))) as unknown as typeof fetch;
+
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      const result = await sb.executeCommand!('false');
+      expect(result.exitCode).toBe(7);
+      expect(result.success).toBe(false);
+    });
+
+    it('throws when the stream endpoint returns a non-2xx response', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response('boom', { status: 500, statusText: 'Internal Server Error' }),
+      ) as unknown as typeof fetch;
+
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await expect(sb.executeCommand!('echo', ['hi'])).rejects.toThrow(/500/);
+    });
+
+    it('marks the result as timedOut when the per-command timeout elapses', async () => {
+      // Hang fetch indefinitely by returning a body that never closes.
+      globalThis.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        return new Promise((_, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        });
+      }) as unknown as typeof fetch;
+
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test', timeout: 25 });
+      const result = await sb.executeCommand!('sleep', ['10']);
+      expect(result.timedOut).toBe(true);
+      expect(result.exitCode).toBe(124);
+    });
+  });
+});

--- a/workspaces/islo/src/sandbox/index.test.ts
+++ b/workspaces/islo/src/sandbox/index.test.ts
@@ -88,11 +88,10 @@ describe('IsloSandbox', () => {
     });
 
     it('configures token exchange on control URL and sandbox calls on compute URL', () => {
-      const sb = new IsloSandbox({
+      new IsloSandbox({
         controlUrl: 'https://control.example.com/',
         computeUrl: 'https://compute.example.com/',
       });
-      expect(sb.processes).toBeUndefined();
       expect(tokenProviderConstructorMock).toHaveBeenCalledWith({
         apiKey: 'ak_test',
         baseUrl: 'https://control.example.com',
@@ -103,6 +102,11 @@ describe('IsloSandbox', () => {
           baseUrl: 'https://compute.example.com',
         }),
       );
+    });
+
+    it('does not expose background process management in v1', () => {
+      const sb = new IsloSandbox();
+      expect(sb.processes).toBeUndefined();
     });
 
     it('resolves ISLO_CONTROL_URL and ISLO_COMPUTE_URL independently', () => {
@@ -124,11 +128,15 @@ describe('IsloSandbox', () => {
 
   describe('lifecycle', () => {
     it('start() creates a new sandbox when none exists', async () => {
-      const sb = new IsloSandbox({ sandboxName: 'mastra-test', image: 'ubuntu:24.04' });
+      const sb = new IsloSandbox({
+        sandboxName: 'mastra-test',
+        image: 'ubuntu:24.04',
+        metadata: { project: 'mastra' },
+      });
       await sb._start();
       expect(getSandboxMock).toHaveBeenCalledWith({ sandbox_name: 'mastra-test' });
       expect(createSandboxMock).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'mastra-test', image: 'ubuntu:24.04' }),
+        expect.objectContaining({ name: 'mastra-test', image: 'ubuntu:24.04', metadata: { project: 'mastra' } }),
       );
       expect(sb.status).toBe('running');
     });
@@ -248,6 +256,14 @@ describe('IsloSandbox', () => {
       const result = await sb.executeCommand!('false');
       expect(result.exitCode).toBe(7);
       expect(result.success).toBe(false);
+    });
+
+    it('throws when the exec stream ends without a valid exit event', async () => {
+      const sseBody = 'event: stdout\ndata: partial\n\n';
+      globalThis.fetch = vi.fn().mockResolvedValue(new Response(streamFromString(sseBody))) as unknown as typeof fetch;
+
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await expect(sb.executeCommand!('echo', ['partial'])).rejects.toThrow(/valid exit event/);
     });
 
     it('throws when the stream endpoint returns a non-2xx response', async () => {

--- a/workspaces/islo/src/sandbox/index.ts
+++ b/workspaces/islo/src/sandbox/index.ts
@@ -1,24 +1,23 @@
 /**
  * islo Sandbox Provider
  *
- * Wraps `@islo-labs/sdk` with the Mastra `WorkspaceSandbox` contract. Auth
- * comes from `ISLO_API_KEY` (the SDK's `Islo` class handles API-key → JWT
- * exchange and refresh). Lifecycle:
+ * Wraps `@islo-labs/sdk` with the Mastra `WorkspaceSandbox` contract. Token
+ * exchange uses the control API, while sandbox operations use the compute API.
+ * Lifecycle:
  *
  *  - start    → `sandboxes.createSandbox` (or reconnect to an existing
  *               sandbox by name, idempotent)
- *  - stop     → `sandboxes.stopSandbox` (record retained, sandbox paused)
+ *  - stop     → `sandboxes.pauseSandbox` (record retained, sandbox paused)
  *  - destroy  → `sandboxes.deleteSandbox` (sandbox marked for deletion)
  *  - executeCommand → POST `/sandboxes/{name}/exec/stream`, parse SSE,
  *                     dispatch stdout/stderr deltas to callbacks.
  *
- * The `executeCommand` path bypasses the SDK's generated stream wrapper
- * (`execInSandboxStream`) because the wrapper buffers the SSE body through a
- * JSON unmarshaler — useless for live output. Auth still comes from the
- * SDK's `TokenProvider` so refresh stays consistent.
+ * The `executeCommand` path bypasses the SDK's generated stream wrapper so
+ * callers see live output. Auth still comes from the SDK's `TokenProvider` so
+ * refresh stays consistent.
  */
 
-import { Islo, TokenProvider } from '@islo-labs/sdk';
+import { IsloApiClient, TokenProvider } from '@islo-labs/sdk';
 import { MastraSandbox } from '@mastra/core/workspace';
 import type {
   CommandResult,
@@ -32,12 +31,14 @@ import { consumeIsloStream } from './sse';
 
 const ENV_API_KEY = 'ISLO_API_KEY';
 const ENV_BASE_URL = 'ISLO_BASE_URL';
+const ENV_COMPUTE_URL = 'ISLO_COMPUTE_URL';
 const DEFAULT_BASE_URL = 'https://api.islo.dev';
+const DEFAULT_COMPUTE_URL = 'https://ca.compute.islo.dev';
 
 /**
  * Configuration for an `IsloSandbox` instance.
  */
-export interface IsloSandboxOptions extends MastraSandboxOptions {
+export interface IsloSandboxOptions extends Omit<MastraSandboxOptions, 'processes'> {
   /** Mastra-side instance ID. Auto-generated if omitted. */
   id?: string;
   /**
@@ -59,10 +60,24 @@ export interface IsloSandboxOptions extends MastraSandboxOptions {
    */
   apiKey?: string;
   /**
-   * Base URL for the islo API. Falls back to `ISLO_BASE_URL` env var, then
-   * `https://api.islo.dev`.
+   * Control API URL used for token exchange. Falls back to `baseUrl`,
+   * `ISLO_BASE_URL`, then `https://api.islo.dev`.
+   */
+  controlUrl?: string;
+  /**
+   * Backwards-compatible alias for `controlUrl`.
+   *
+   * @deprecated Use `controlUrl` for the control API and `computeUrl` for
+   * sandbox operations.
    */
   baseUrl?: string;
+  /**
+   * Compute API URL used for sandbox lifecycle, files, and exec operations.
+   * Falls back to `ISLO_COMPUTE_URL`, then `https://ca.compute.islo.dev`.
+   */
+  computeUrl?: string;
+  /** Delete the sandbox record on destroy. Defaults to true. */
+  deleteOnDestroy?: boolean;
   /** Sandbox-create metadata. */
   metadata?: Record<string, unknown>;
   /** Default per-command timeout in milliseconds. */
@@ -77,9 +92,10 @@ export class IsloSandbox extends MastraSandbox {
   readonly provider = 'islo';
   status: ProviderStatus = 'pending';
 
-  private readonly client: Islo;
+  private readonly client: IsloApiClient;
   private readonly tokenProvider: TokenProvider;
-  private readonly baseUrl: string;
+  private readonly controlUrl: string;
+  private readonly computeUrl: string;
   private readonly sandboxName: string;
   private readonly image?: string;
   private readonly workdir?: string;
@@ -87,9 +103,9 @@ export class IsloSandbox extends MastraSandbox {
   private readonly env: Record<string, string>;
   private readonly metadata: Record<string, unknown>;
   private readonly defaultTimeoutMs: number;
+  private readonly deleteOnDestroy: boolean;
 
   private _createdAt: Date | null = null;
-  private _acquired = false;
 
   constructor(options: IsloSandboxOptions = {}) {
     super({ ...options, name: 'IsloSandbox' });
@@ -100,7 +116,11 @@ export class IsloSandbox extends MastraSandbox {
         `IsloSandbox: missing ${ENV_API_KEY}; set the env var or pass { apiKey } to the constructor`,
       );
     }
-    const baseUrl = (options.baseUrl ?? process.env[ENV_BASE_URL] ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+    const controlUrl = (options.controlUrl ?? options.baseUrl ?? process.env[ENV_BASE_URL] ?? DEFAULT_BASE_URL).replace(
+      /\/$/,
+      '',
+    );
+    const computeUrl = (options.computeUrl ?? process.env[ENV_COMPUTE_URL] ?? DEFAULT_COMPUTE_URL).replace(/\/$/, '');
 
     this.id = options.id ?? generateIsloSandboxInstanceId();
     this.sandboxName = options.sandboxName ?? generateSandboxName();
@@ -110,18 +130,24 @@ export class IsloSandbox extends MastraSandbox {
     this.env = options.env ?? {};
     this.metadata = options.metadata ?? {};
     this.defaultTimeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
-    this.baseUrl = baseUrl;
+    this.deleteOnDestroy = options.deleteOnDestroy ?? true;
+    this.controlUrl = controlUrl;
+    this.computeUrl = computeUrl;
 
-    this.client = new Islo({ apiKey, baseUrl });
-    this.tokenProvider = new TokenProvider({ apiKey, baseUrl });
+    this.tokenProvider = new TokenProvider({ apiKey, baseUrl: controlUrl });
+    this.client = new IsloApiClient({
+      apiKey: () => this.tokenProvider.getToken(),
+      environment: computeUrl,
+      baseUrl: computeUrl,
+    });
   }
 
   /**
-   * Direct access to the underlying `@islo-labs/sdk` `Islo` client for
+   * Direct access to the underlying `@islo-labs/sdk` client for
    * features not surfaced through the `WorkspaceSandbox` contract (e.g.
    * snapshots, sessions, file transfer).
    */
-  get islo(): Islo {
+  get islo(): IsloApiClient {
     return this.client;
   }
 
@@ -134,8 +160,13 @@ export class IsloSandbox extends MastraSandbox {
     // Reconnect to an existing live sandbox with this name if present.
     const existing = await this.findExistingSandbox();
     if (existing) {
-      this._createdAt = existing.createdAt;
-      this._acquired = false;
+      if (existing.resume) {
+        this.logger.debug(`resuming existing islo sandbox ${this.sandboxName}`);
+        const resumed = await this.client.sandboxes.resumeSandbox({ sandbox_name: this.sandboxName });
+        this._createdAt = resumed.created_at ? new Date(resumed.created_at) : existing.createdAt;
+      } else {
+        this._createdAt = existing.createdAt;
+      }
       this.logger.debug(`reconnected to existing islo sandbox ${this.sandboxName}`);
       return;
     }
@@ -149,21 +180,19 @@ export class IsloSandbox extends MastraSandbox {
       env: nullifyValues(this.env),
     });
     this._createdAt = created.created_at ? new Date(created.created_at) : new Date();
-    this._acquired = true;
   }
 
   override async stop(): Promise<void> {
     try {
-      await this.client.sandboxes.stopSandbox({ sandbox_name: this.sandboxName });
+      await this.client.sandboxes.pauseSandbox({ sandbox_name: this.sandboxName });
     } catch (err) {
       // Stop is best-effort; log and continue. The destroy path will clean up.
-      this.logger.warn(`islo stop failed for ${this.sandboxName}`, { error: serializeError(err) });
+      this.logger.warn(`islo pause failed for ${this.sandboxName}`, { error: serializeError(err) });
     }
   }
 
   override async destroy(): Promise<void> {
-    if (!this._acquired) {
-      // We didn't create this sandbox; don't delete it on the user's behalf.
+    if (!this.deleteOnDestroy) {
       return;
     }
     try {
@@ -180,7 +209,12 @@ export class IsloSandbox extends MastraSandbox {
       provider: this.provider,
       status: this.status,
       createdAt: this._createdAt ?? new Date(),
-      metadata: { sandboxName: this.sandboxName, ...this.metadata },
+      metadata: {
+        sandboxName: this.sandboxName,
+        controlUrl: this.controlUrl,
+        computeUrl: this.computeUrl,
+        ...this.metadata,
+      },
     };
     return info;
   }
@@ -198,8 +232,9 @@ export class IsloSandbox extends MastraSandbox {
     const cwd = options.cwd ?? this.workdir;
     const envOverride = options.env ? mergeEnv(this.env, options.env) : this.env;
 
-    const url = `${this.baseUrl}/sandboxes/${encodeURIComponent(this.sandboxName)}/exec/stream`;
+    const url = `${this.computeUrl}/sandboxes/${encodeURIComponent(this.sandboxName)}/exec/stream`;
     const token = await this.tokenProvider.getToken();
+    const timeoutSecs = timeoutMs > 0 ? Math.ceil(timeoutMs / 1000) : undefined;
 
     // Wire up timeout + caller's abort signal.
     const controller = new AbortController();
@@ -227,9 +262,10 @@ export class IsloSandbox extends MastraSandbox {
           accept: 'text/event-stream',
         },
         body: JSON.stringify({
-          command: fullCommand,
+          args: fullCommand,
           workdir: cwd ?? null,
-          env: nullifyValues(envOverride),
+          env_vars: nullifyValues(envOverride),
+          timeout_secs: timeoutSecs,
         }),
         signal: controller.signal,
       });
@@ -308,14 +344,21 @@ export class IsloSandbox extends MastraSandbox {
    * Look up an existing islo sandbox by name. Returns null if it doesn't
    * exist, has been deleted, or the lookup raised a 404.
    */
-  private async findExistingSandbox(): Promise<{ createdAt: Date } | null> {
+  private async findExistingSandbox(): Promise<{ createdAt: Date; resume: boolean } | null> {
     try {
       const sandbox = await this.client.sandboxes.getSandbox({ sandbox_name: this.sandboxName });
-      if (!sandbox || isDeletedStatus(sandbox.status)) {
+      const status = sandbox?.status;
+      if (!sandbox || isDeletedStatus(status)) {
         return null;
+      }
+      if (isUnusableStatus(status)) {
+        throw new Error(
+          `islo sandbox ${this.sandboxName} is ${status}; delete it or choose a new sandboxName before starting`,
+        );
       }
       return {
         createdAt: sandbox.created_at ? new Date(sandbox.created_at) : new Date(),
+        resume: isPausedStatus(status),
       };
     } catch (err) {
       if (isNotFoundError(err)) {
@@ -328,7 +371,17 @@ export class IsloSandbox extends MastraSandbox {
 
 function isDeletedStatus(status: string | undefined): boolean {
   if (!status) return false;
-  return status === 'deleted' || status === 'failed';
+  return status === 'deleted';
+}
+
+function isUnusableStatus(status: string | undefined): boolean {
+  if (!status) return false;
+  return status === 'failed' || status === 'stopped' || status === 'terminated';
+}
+
+function isPausedStatus(status: string | undefined): boolean {
+  if (!status) return false;
+  return status === 'paused' || status === 'suspended';
 }
 
 function isNotFoundError(err: unknown): boolean {

--- a/workspaces/islo/src/sandbox/index.ts
+++ b/workspaces/islo/src/sandbox/index.ts
@@ -30,9 +30,9 @@ import type {
 import { consumeIsloStream } from './sse';
 
 const ENV_API_KEY = 'ISLO_API_KEY';
-const ENV_BASE_URL = 'ISLO_BASE_URL';
+const ENV_CONTROL_URL = 'ISLO_CONTROL_URL';
 const ENV_COMPUTE_URL = 'ISLO_COMPUTE_URL';
-const DEFAULT_BASE_URL = 'https://api.islo.dev';
+const DEFAULT_CONTROL_URL = 'https://api.islo.dev';
 const DEFAULT_COMPUTE_URL = 'https://ca.compute.islo.dev';
 
 /**
@@ -60,17 +60,10 @@ export interface IsloSandboxOptions extends Omit<MastraSandboxOptions, 'processe
    */
   apiKey?: string;
   /**
-   * Control API URL used for token exchange. Falls back to `baseUrl`,
-   * `ISLO_BASE_URL`, then `https://api.islo.dev`.
+   * Control API URL used for token exchange. Falls back to `ISLO_CONTROL_URL`,
+   * then `https://api.islo.dev`.
    */
   controlUrl?: string;
-  /**
-   * Backwards-compatible alias for `controlUrl`.
-   *
-   * @deprecated Use `controlUrl` for the control API and `computeUrl` for
-   * sandbox operations.
-   */
-  baseUrl?: string;
   /**
    * Compute API URL used for sandbox lifecycle, files, and exec operations.
    * Falls back to `ISLO_COMPUTE_URL`, then `https://ca.compute.islo.dev`.
@@ -116,10 +109,7 @@ export class IsloSandbox extends MastraSandbox {
         `IsloSandbox: missing ${ENV_API_KEY}; set the env var or pass { apiKey } to the constructor`,
       );
     }
-    const controlUrl = (options.controlUrl ?? options.baseUrl ?? process.env[ENV_BASE_URL] ?? DEFAULT_BASE_URL).replace(
-      /\/$/,
-      '',
-    );
+    const controlUrl = (options.controlUrl ?? process.env[ENV_CONTROL_URL] ?? DEFAULT_CONTROL_URL).replace(/\/$/, '');
     const computeUrl = (options.computeUrl ?? process.env[ENV_COMPUTE_URL] ?? DEFAULT_COMPUTE_URL).replace(/\/$/, '');
 
     this.id = options.id ?? generateIsloSandboxInstanceId();

--- a/workspaces/islo/src/sandbox/index.ts
+++ b/workspaces/islo/src/sandbox/index.ts
@@ -1,0 +1,369 @@
+/**
+ * islo Sandbox Provider
+ *
+ * Wraps `@islo-labs/sdk` with the Mastra `WorkspaceSandbox` contract. Auth
+ * comes from `ISLO_API_KEY` (the SDK's `Islo` class handles API-key → JWT
+ * exchange and refresh). Lifecycle:
+ *
+ *  - start    → `sandboxes.createSandbox` (or reconnect to an existing
+ *               sandbox by name, idempotent)
+ *  - stop     → `sandboxes.stopSandbox` (record retained, sandbox paused)
+ *  - destroy  → `sandboxes.deleteSandbox` (sandbox marked for deletion)
+ *  - executeCommand → POST `/sandboxes/{name}/exec/stream`, parse SSE,
+ *                     dispatch stdout/stderr deltas to callbacks.
+ *
+ * The `executeCommand` path bypasses the SDK's generated stream wrapper
+ * (`execInSandboxStream`) because the wrapper buffers the SSE body through a
+ * JSON unmarshaler — useless for live output. Auth still comes from the
+ * SDK's `TokenProvider` so refresh stays consistent.
+ */
+
+import { Islo, TokenProvider } from '@islo-labs/sdk';
+import { MastraSandbox } from '@mastra/core/workspace';
+import type {
+  CommandResult,
+  ExecuteCommandOptions,
+  MastraSandboxOptions,
+  ProviderStatus,
+  SandboxInfo,
+} from '@mastra/core/workspace';
+
+import { consumeIsloStream } from './sse';
+
+const ENV_API_KEY = 'ISLO_API_KEY';
+const ENV_BASE_URL = 'ISLO_BASE_URL';
+const DEFAULT_BASE_URL = 'https://api.islo.dev';
+
+/**
+ * Configuration for an `IsloSandbox` instance.
+ */
+export interface IsloSandboxOptions extends MastraSandboxOptions {
+  /** Mastra-side instance ID. Auto-generated if omitted. */
+  id?: string;
+  /**
+   * islo sandbox name. Used as the path segment for sandbox API calls.
+   * If omitted, a fresh `mastra-<random>` name is generated. Reusing a name
+   * across runs reconnects to the existing sandbox if it is still live.
+   */
+  sandboxName?: string;
+  /** Container image (e.g. `docker.io/library/ubuntu:24.04`). */
+  image?: string;
+  /** Working directory relative to `/workspace` inside the sandbox. */
+  workdir?: string;
+  /** Gateway profile name or ID. Falls back to tenant default if omitted. */
+  gatewayProfile?: string;
+  /** Environment variables injected at sandbox-create time. */
+  env?: Record<string, string>;
+  /**
+   * islo API key (Descope access key). Falls back to `ISLO_API_KEY` env var.
+   */
+  apiKey?: string;
+  /**
+   * Base URL for the islo API. Falls back to `ISLO_BASE_URL` env var, then
+   * `https://api.islo.dev`.
+   */
+  baseUrl?: string;
+  /** Sandbox-create metadata. */
+  metadata?: Record<string, unknown>;
+  /** Default per-command timeout in milliseconds. */
+  timeout?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+export class IsloSandbox extends MastraSandbox {
+  readonly id: string;
+  readonly name = 'IsloSandbox';
+  readonly provider = 'islo';
+  status: ProviderStatus = 'pending';
+
+  private readonly client: Islo;
+  private readonly tokenProvider: TokenProvider;
+  private readonly baseUrl: string;
+  private readonly sandboxName: string;
+  private readonly image?: string;
+  private readonly workdir?: string;
+  private readonly gatewayProfile?: string;
+  private readonly env: Record<string, string>;
+  private readonly metadata: Record<string, unknown>;
+  private readonly defaultTimeoutMs: number;
+
+  private _createdAt: Date | null = null;
+  private _acquired = false;
+
+  constructor(options: IsloSandboxOptions = {}) {
+    super({ ...options, name: 'IsloSandbox' });
+
+    const apiKey = options.apiKey ?? process.env[ENV_API_KEY];
+    if (!apiKey) {
+      throw new Error(
+        `IsloSandbox: missing ${ENV_API_KEY}; set the env var or pass { apiKey } to the constructor`,
+      );
+    }
+    const baseUrl = (options.baseUrl ?? process.env[ENV_BASE_URL] ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+
+    this.id = options.id ?? generateIsloSandboxInstanceId();
+    this.sandboxName = options.sandboxName ?? generateSandboxName();
+    this.image = options.image;
+    this.workdir = options.workdir;
+    this.gatewayProfile = options.gatewayProfile;
+    this.env = options.env ?? {};
+    this.metadata = options.metadata ?? {};
+    this.defaultTimeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
+    this.baseUrl = baseUrl;
+
+    this.client = new Islo({ apiKey, baseUrl });
+    this.tokenProvider = new TokenProvider({ apiKey, baseUrl });
+  }
+
+  /**
+   * Direct access to the underlying `@islo-labs/sdk` `Islo` client for
+   * features not surfaced through the `WorkspaceSandbox` contract (e.g.
+   * snapshots, sessions, file transfer).
+   */
+  get islo(): Islo {
+    return this.client;
+  }
+
+  /** Sandbox name used in the islo API path. */
+  get name_(): string {
+    return this.sandboxName;
+  }
+
+  override async start(): Promise<void> {
+    // Reconnect to an existing live sandbox with this name if present.
+    const existing = await this.findExistingSandbox();
+    if (existing) {
+      this._createdAt = existing.createdAt;
+      this._acquired = false;
+      this.logger.debug(`reconnected to existing islo sandbox ${this.sandboxName}`);
+      return;
+    }
+
+    this.logger.debug(`creating islo sandbox ${this.sandboxName}`);
+    const created = await this.client.sandboxes.createSandbox({
+      name: this.sandboxName,
+      image: this.image,
+      workdir: this.workdir,
+      gateway_profile: this.gatewayProfile,
+      env: nullifyValues(this.env),
+    });
+    this._createdAt = created.created_at ? new Date(created.created_at) : new Date();
+    this._acquired = true;
+  }
+
+  override async stop(): Promise<void> {
+    try {
+      await this.client.sandboxes.stopSandbox({ sandbox_name: this.sandboxName });
+    } catch (err) {
+      // Stop is best-effort; log and continue. The destroy path will clean up.
+      this.logger.warn(`islo stop failed for ${this.sandboxName}`, { error: serializeError(err) });
+    }
+  }
+
+  override async destroy(): Promise<void> {
+    if (!this._acquired) {
+      // We didn't create this sandbox; don't delete it on the user's behalf.
+      return;
+    }
+    try {
+      await this.client.sandboxes.deleteSandbox({ sandbox_name: this.sandboxName });
+    } catch (err) {
+      this.logger.warn(`islo delete failed for ${this.sandboxName}`, { error: serializeError(err) });
+    }
+  }
+
+  override async getInfo(): Promise<SandboxInfo> {
+    const info: SandboxInfo = {
+      id: this.id,
+      name: this.name,
+      provider: this.provider,
+      status: this.status,
+      createdAt: this._createdAt ?? new Date(),
+      metadata: { sandboxName: this.sandboxName, ...this.metadata },
+    };
+    return info;
+  }
+
+  override async executeCommand(
+    command: string,
+    args: string[] = [],
+    options: ExecuteCommandOptions = {},
+  ): Promise<CommandResult> {
+    await this.ensureRunning();
+
+    const fullCommand = args.length > 0 ? [command, ...args] : [command];
+    const startTime = Date.now();
+    const timeoutMs = options.timeout ?? this.defaultTimeoutMs;
+    const cwd = options.cwd ?? this.workdir;
+    const envOverride = options.env ? mergeEnv(this.env, options.env) : this.env;
+
+    const url = `${this.baseUrl}/sandboxes/${encodeURIComponent(this.sandboxName)}/exec/stream`;
+    const token = await this.tokenProvider.getToken();
+
+    // Wire up timeout + caller's abort signal.
+    const controller = new AbortController();
+    const timeoutHandle =
+      timeoutMs > 0
+        ? setTimeout(() => controller.abort(new Error(`islo executeCommand timed out after ${timeoutMs}ms`)), timeoutMs)
+        : null;
+    const callerSignal = options.abortSignal;
+    const onCallerAbort = () => controller.abort(callerSignal?.reason);
+    if (callerSignal) {
+      if (callerSignal.aborted) {
+        controller.abort(callerSignal.reason);
+      } else {
+        callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+      }
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+          accept: 'text/event-stream',
+        },
+        body: JSON.stringify({
+          command: fullCommand,
+          workdir: cwd ?? null,
+          env: nullifyValues(envOverride),
+        }),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (callerSignal) callerSignal.removeEventListener('abort', onCallerAbort);
+      const aborted = (err as { name?: string })?.name === 'AbortError';
+      return {
+        success: false,
+        exitCode: aborted ? 124 : 1,
+        stdout: '',
+        stderr: aborted ? `command aborted: ${(err as Error).message}` : (err as Error).message,
+        executionTimeMs: Date.now() - startTime,
+        timedOut: aborted && !callerSignal?.aborted,
+        killed: aborted && !!callerSignal?.aborted,
+        command,
+        args,
+      };
+    }
+
+    if (!response.ok || !response.body) {
+      const text = await response.text().catch(() => '');
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (callerSignal) callerSignal.removeEventListener('abort', onCallerAbort);
+      throw new Error(
+        `islo exec stream ${response.status} ${response.statusText}: ${text.slice(0, 200)}`,
+      );
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let killed = false;
+    let exitCode = 0;
+
+    try {
+      const result = await consumeIsloStream(response.body, {
+        onStdout: (data) => {
+          stdout += data;
+          options.onStdout?.(data);
+        },
+        onStderr: (data) => {
+          stderr += data;
+          options.onStderr?.(data);
+        },
+      });
+      exitCode = result.exitCode;
+    } catch (err) {
+      const aborted = (err as { name?: string })?.name === 'AbortError';
+      if (aborted) {
+        timedOut = !callerSignal?.aborted;
+        killed = !!callerSignal?.aborted;
+        exitCode = 124;
+      } else {
+        throw err;
+      }
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (callerSignal) callerSignal.removeEventListener('abort', onCallerAbort);
+    }
+
+    return {
+      success: exitCode === 0,
+      exitCode,
+      stdout,
+      stderr,
+      executionTimeMs: Date.now() - startTime,
+      timedOut,
+      killed,
+      command,
+      args,
+    };
+  }
+
+  /**
+   * Look up an existing islo sandbox by name. Returns null if it doesn't
+   * exist, has been deleted, or the lookup raised a 404.
+   */
+  private async findExistingSandbox(): Promise<{ createdAt: Date } | null> {
+    try {
+      const sandbox = await this.client.sandboxes.getSandbox({ sandbox_name: this.sandboxName });
+      if (!sandbox || isDeletedStatus(sandbox.status)) {
+        return null;
+      }
+      return {
+        createdAt: sandbox.created_at ? new Date(sandbox.created_at) : new Date(),
+      };
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        return null;
+      }
+      throw err;
+    }
+  }
+}
+
+function isDeletedStatus(status: string | undefined): boolean {
+  if (!status) return false;
+  return status === 'deleted' || status === 'failed';
+}
+
+function isNotFoundError(err: unknown): boolean {
+  const status = (err as { statusCode?: number; status?: number })?.statusCode ?? (err as { status?: number })?.status;
+  return status === 404;
+}
+
+function nullifyValues(record: Record<string, string>): Record<string, string | null> | undefined {
+  const keys = Object.keys(record);
+  if (keys.length === 0) return undefined;
+  const out: Record<string, string | null> = {};
+  for (const k of keys) {
+    out[k] = record[k] ?? null;
+  }
+  return out;
+}
+
+function mergeEnv(base: Record<string, string>, overlay: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = { ...base };
+  for (const [k, v] of Object.entries(overlay)) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
+}
+
+function serializeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function generateIsloSandboxInstanceId(): string {
+  return `islo-sandbox-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function generateSandboxName(): string {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `mastra-${random}`;
+}

--- a/workspaces/islo/src/sandbox/index.ts
+++ b/workspaces/islo/src/sandbox/index.ts
@@ -34,6 +34,9 @@ const ENV_CONTROL_URL = 'ISLO_CONTROL_URL';
 const ENV_COMPUTE_URL = 'ISLO_COMPUTE_URL';
 const DEFAULT_CONTROL_URL = 'https://api.islo.dev';
 const DEFAULT_COMPUTE_URL = 'https://ca.compute.islo.dev';
+type IsloSandboxCreatePayload = Parameters<IsloApiClient['sandboxes']['createSandbox']>[0] & {
+  metadata?: Record<string, unknown>;
+};
 
 /**
  * Configuration for an `IsloSandbox` instance.
@@ -162,13 +165,15 @@ export class IsloSandbox extends MastraSandbox {
     }
 
     this.logger.debug(`creating islo sandbox ${this.sandboxName}`);
-    const created = await this.client.sandboxes.createSandbox({
+    const createPayload: IsloSandboxCreatePayload = {
       name: this.sandboxName,
       image: this.image,
       workdir: this.workdir,
       gateway_profile: this.gatewayProfile,
       env: nullifyValues(this.env),
-    });
+      metadata: emptyToUndefined(this.metadata),
+    };
+    const created = await this.client.sandboxes.createSandbox(createPayload);
     this._createdAt = created.created_at ? new Date(created.created_at) : new Date();
   }
 
@@ -302,6 +307,9 @@ export class IsloSandbox extends MastraSandbox {
           options.onStderr?.(data);
         },
       });
+      if (!result.sawExit || result.exitCode === null) {
+        throw new Error('islo exec stream ended without a valid exit event');
+      }
       exitCode = result.exitCode;
     } catch (err) {
       const aborted = (err as { name?: string })?.name === 'AbortError';
@@ -387,6 +395,10 @@ function nullifyValues(record: Record<string, string>): Record<string, string | 
     out[k] = record[k] ?? null;
   }
   return out;
+}
+
+function emptyToUndefined<T extends Record<string, unknown>>(record: T): T | undefined {
+  return Object.keys(record).length === 0 ? undefined : record;
 }
 
 function mergeEnv(base: Record<string, string>, overlay: NodeJS.ProcessEnv): Record<string, string> {

--- a/workspaces/islo/src/sandbox/sse.test.ts
+++ b/workspaces/islo/src/sandbox/sse.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the islo SSE consumer.
+ *
+ * The wire format is verified against the live api.islo.dev `/exec/stream`
+ * endpoint and recorded here as fixtures so the parser can evolve without
+ * round-tripping to the API.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { consumeIsloStream } from './sse';
+
+function streamFromString(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) {
+        controller.enqueue(encoder.encode(c));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe('consumeIsloStream', () => {
+  it('routes stdout, stderr, and exit events', async () => {
+    const body = [
+      ': keepalive',
+      'event: stdout',
+      'data: hello',
+      'data: ',
+      '',
+      'event: stderr',
+      'data: warn-line',
+      '',
+      'event: exit',
+      'data: 7',
+      '',
+    ].join('\n');
+
+    let out = '';
+    let err = '';
+    const result = await consumeIsloStream(streamFromString(body), {
+      onStdout: (d) => {
+        out += d;
+      },
+      onStderr: (d) => {
+        err += d;
+      },
+    });
+
+    expect(result.exitCode).toBe(7);
+    // Multi-data lines join with '\n', so two lines `hello` + `` produce `hello\n`.
+    expect(out).toBe('hello\n');
+    expect(err).toBe('warn-line');
+  });
+
+  it('handles a chunked body where SSE events span chunk boundaries', async () => {
+    const body =
+      'event: stdout\ndata: line-1\n\nevent: stdout\ndata: line-2\n\nevent: exit\ndata: 0\n\n';
+    const split = [body.slice(0, 12), body.slice(12, 30), body.slice(30)];
+
+    const collected: string[] = [];
+    const result = await consumeIsloStream(streamFromChunks(split), {
+      onStdout: (d) => collected.push(d),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(collected).toEqual(['line-1', 'line-2']);
+  });
+
+  it('treats unknown event types as no-ops without throwing', async () => {
+    const body = 'event: heartbeat\ndata: tick\n\nevent: stdout\ndata: ok\n\n';
+    let out = '';
+    const result = await consumeIsloStream(streamFromString(body), {
+      onStdout: (d) => {
+        out += d;
+      },
+    });
+    expect(out).toBe('ok');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('handles CRLF line endings', async () => {
+    const body = 'event: stdout\r\ndata: hi\r\n\r\nevent: exit\r\ndata: 1\r\n\r\n';
+    let out = '';
+    const result = await consumeIsloStream(streamFromString(body), {
+      onStdout: (d) => {
+        out += d;
+      },
+    });
+    expect(out).toBe('hi');
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('handles a final event without a trailing blank line', async () => {
+    const body = 'event: stdout\ndata: trailing\n';
+    let out = '';
+    await consumeIsloStream(streamFromString(body), {
+      onStdout: (d) => {
+        out += d;
+      },
+    });
+    expect(out).toBe('trailing');
+  });
+});

--- a/workspaces/islo/src/sandbox/sse.test.ts
+++ b/workspaces/islo/src/sandbox/sse.test.ts
@@ -60,6 +60,7 @@ describe('consumeIsloStream', () => {
     });
 
     expect(result.exitCode).toBe(7);
+    expect(result.sawExit).toBe(true);
     // Multi-data lines join with '\n', so two lines `hello` + `` produce `hello\n`.
     expect(out).toBe('hello\n');
     expect(err).toBe('warn-line');
@@ -76,11 +77,12 @@ describe('consumeIsloStream', () => {
     });
 
     expect(result.exitCode).toBe(0);
+    expect(result.sawExit).toBe(true);
     expect(collected).toEqual(['line-1', 'line-2']);
   });
 
   it('treats unknown event types as no-ops without throwing', async () => {
-    const body = 'event: heartbeat\ndata: tick\n\nevent: stdout\ndata: ok\n\n';
+    const body = 'event: heartbeat\ndata: tick\n\nevent: stdout\ndata: ok\n\nevent: exit\ndata: 0\n\n';
     let out = '';
     const result = await consumeIsloStream(streamFromString(body), {
       onStdout: (d) => {
@@ -89,6 +91,7 @@ describe('consumeIsloStream', () => {
     });
     expect(out).toBe('ok');
     expect(result.exitCode).toBe(0);
+    expect(result.sawExit).toBe(true);
   });
 
   it('handles CRLF line endings', async () => {
@@ -101,16 +104,33 @@ describe('consumeIsloStream', () => {
     });
     expect(out).toBe('hi');
     expect(result.exitCode).toBe(1);
+    expect(result.sawExit).toBe(true);
   });
 
-  it('handles a final event without a trailing blank line', async () => {
+  it('handles a final stdout event without a trailing blank line', async () => {
     const body = 'event: stdout\ndata: trailing\n';
     let out = '';
-    await consumeIsloStream(streamFromString(body), {
+    const result = await consumeIsloStream(streamFromString(body), {
       onStdout: (d) => {
         out += d;
       },
     });
     expect(out).toBe('trailing');
+    expect(result.exitCode).toBeNull();
+    expect(result.sawExit).toBe(false);
+  });
+
+  it('does not treat a missing exit event as success', async () => {
+    const result = await consumeIsloStream(streamFromString('event: stdout\ndata: ok\n\n'));
+
+    expect(result.exitCode).toBeNull();
+    expect(result.sawExit).toBe(false);
+  });
+
+  it('does not treat a malformed exit event as success', async () => {
+    const result = await consumeIsloStream(streamFromString('event: exit\ndata: not-a-number\n\n'));
+
+    expect(result.exitCode).toBeNull();
+    expect(result.sawExit).toBe(false);
   });
 });

--- a/workspaces/islo/src/sandbox/sse.ts
+++ b/workspaces/islo/src/sandbox/sse.ts
@@ -1,0 +1,128 @@
+/**
+ * SSE consumer for the islo `/sandboxes/{name}/exec/stream` endpoint.
+ *
+ * The TypeScript SDK's `execInSandboxStream` decodes the response body into
+ * `unknown` through the standard fetcher — by the time you see bytes the
+ * command is done. We bypass it here so callers see stdout/stderr deltas as
+ * they arrive.
+ *
+ * Wire format (verified against api.islo.dev): standard `text/event-stream`.
+ * Each event has an `event:` type line (`stdout`, `stderr`, or `exit`), one
+ * or more `data:` lines (joined with `\n`), and a blank-line terminator.
+ * `exit` carries the exit code as a decimal string.
+ */
+
+export interface SSECallbacks {
+  onStdout?: (data: string) => void;
+  onStderr?: (data: string) => void;
+}
+
+export interface SSEResult {
+  exitCode: number;
+}
+
+/**
+ * Consume the islo SSE stream and dispatch stdout/stderr deltas.
+ * Resolves when the response body ends; returns the exit code emitted by the
+ * final `exit` event (defaults to 0 if none was seen).
+ */
+export async function consumeIsloStream(
+  body: ReadableStream<Uint8Array>,
+  callbacks: SSECallbacks = {},
+): Promise<SSEResult> {
+  const decoder = new TextDecoder('utf-8');
+  const reader = body.getReader();
+  let buffer = '';
+  let exitCode = 0;
+  let event = '';
+  let dataLines: string[] = [];
+
+  const flush = () => {
+    if (event === '' && dataLines.length === 0) {
+      return;
+    }
+    const payload = dataLines.join('\n');
+    switch (event) {
+      case 'stdout':
+        callbacks.onStdout?.(payload);
+        break;
+      case 'stderr':
+        callbacks.onStderr?.(payload);
+        break;
+      case 'exit': {
+        const parsed = Number.parseInt(payload.trim(), 10);
+        if (Number.isFinite(parsed)) {
+          exitCode = parsed;
+        }
+        break;
+      }
+    }
+    event = '';
+    dataLines = [];
+  };
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buffer.indexOf('\n')) !== -1) {
+        // Strip CR if present (CRLF line endings).
+        let line = buffer.slice(0, nl);
+        if (line.endsWith('\r')) line = line.slice(0, -1);
+        buffer = buffer.slice(nl + 1);
+        processLine(line);
+      }
+    }
+    // Drain any remaining buffer as a final line.
+    buffer += decoder.decode();
+    if (buffer.length > 0) {
+      processLine(buffer);
+    }
+    flush();
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // Ignore release errors if reader is already done.
+    }
+  }
+
+  return { exitCode };
+
+  function processLine(line: string): void {
+    if (line === '') {
+      flush();
+      return;
+    }
+    if (line.startsWith(':')) {
+      // SSE comment / keepalive
+      return;
+    }
+    const colon = line.indexOf(':');
+    let field: string;
+    let value: string;
+    if (colon === -1) {
+      field = line;
+      value = '';
+    } else {
+      field = line.slice(0, colon);
+      value = line.slice(colon + 1);
+      // Per SSE spec, a single leading space after the colon is stripped.
+      if (value.startsWith(' ')) value = value.slice(1);
+    }
+    switch (field) {
+      case 'event':
+        event = value;
+        break;
+      case 'data':
+        dataLines.push(value);
+        break;
+      case 'id':
+      case 'retry':
+        // Ignored.
+        break;
+    }
+  }
+}

--- a/workspaces/islo/src/sandbox/sse.ts
+++ b/workspaces/islo/src/sandbox/sse.ts
@@ -18,13 +18,14 @@ export interface SSECallbacks {
 }
 
 export interface SSEResult {
-  exitCode: number;
+  exitCode: number | null;
+  sawExit: boolean;
 }
 
 /**
  * Consume the islo SSE stream and dispatch stdout/stderr deltas.
  * Resolves when the response body ends; returns the exit code emitted by the
- * final `exit` event (defaults to 0 if none was seen).
+ * final valid `exit` event and whether that event was observed.
  */
 export async function consumeIsloStream(
   body: ReadableStream<Uint8Array>,
@@ -33,7 +34,8 @@ export async function consumeIsloStream(
   const decoder = new TextDecoder('utf-8');
   const reader = body.getReader();
   let buffer = '';
-  let exitCode = 0;
+  let exitCode: number | null = null;
+  let sawExit = false;
   let event = '';
   let dataLines: string[] = [];
 
@@ -53,6 +55,7 @@ export async function consumeIsloStream(
         const parsed = Number.parseInt(payload.trim(), 10);
         if (Number.isFinite(parsed)) {
           exitCode = parsed;
+          sawExit = true;
         }
         break;
       }
@@ -89,7 +92,7 @@ export async function consumeIsloStream(
     }
   }
 
-  return { exitCode };
+  return { exitCode, sawExit };
 
   function processLine(line: string): void {
     if (line === '') {

--- a/workspaces/islo/tsconfig.build.json
+++ b/workspaces/islo/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/islo/tsconfig.json
+++ b/workspaces/islo/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/islo/tsup.config.ts
+++ b/workspaces/islo/tsup.config.ts
@@ -1,0 +1,18 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  external: ['@mastra/core', '@islo-labs/sdk'],
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/workspaces/islo/vitest.config.ts
+++ b/workspaces/islo/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+    setupFiles: ['dotenv/config'],
+    testTimeout: 60000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Description

Adds `@mastra/islo`, a Mastra workspace sandbox provider backed by islo.dev. The provider supports sandbox lifecycle management, foreground command execution through Islo's streaming exec endpoint, Studio provider registration, package README documentation, unit tests, and live integration tests gated on `ISLO_API_KEY`.

## Related Issue(s)

Closes #17758

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Test plan

- `NODE_OPTIONS="--max-old-space-size=8192" CI=true pnpm --dir /Users/yonatan.spektor/islo/mastra --filter @mastra/islo lint`
- `NODE_OPTIONS="--max-old-space-size=8192" CI=true pnpm --dir /Users/yonatan.spektor/islo/mastra --filter @mastra/islo build`
- `NODE_OPTIONS="--max-old-space-size=8192" CI=true pnpm --dir /Users/yonatan.spektor/islo/mastra --filter @mastra/islo test:unit` — 25 tests passed
- `NODE_OPTIONS="--max-old-space-size=8192" CI=true ISLO_API_KEY=<redacted> pnpm --dir /Users/yonatan.spektor/islo/mastra --filter @mastra/islo test` — 3 live integration tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a new "islo" sandbox provider so Mastra can run isolated developer workspaces on islo.dev — it starts/stops sandboxes, runs commands with live output, and cleans them up when finished.

## Overview

Adds a new package `@mastra/islo` that integrates Mastra with islo.dev to manage workspace sandboxes. Features include lifecycle management (start/stop/destroy), foreground command execution with live SSE streaming, Studio provider registration, docs, unit tests, and gated live integration tests.

## Key Changes

- New package: workspaces/islo
  - package.json, build (tsup), TypeScript configs, ESLint, Vitest config, README, Changeset.
- Public exports: IsloSandbox, IsloSandboxOptions, isloSandboxProvider, consumeIsloStream, SSE types (exported via src/index.ts).

### Core implementation
- IsloSandbox (workspaces/islo/src/sandbox/index.ts)
  - Implements Mastra WorkspaceSandbox.
  - Validates API key (ISLO_API_KEY or apiKey option), normalizes control/compute URLs, deterministic sandbox naming.
  - start(): idempotent — finds existing sandbox by name, resumes paused sandboxes, or creates new.
  - stop(): pauses sandbox (best-effort).
  - destroy(): deletes sandbox by default; skip if deleteOnDestroy=false (best-effort).
  - getInfo(): returns Mastra-compatible metadata (createdAt, name, URLs, user metadata).
  - executeCommand(): posts to compute /exec/stream SSE endpoint, merges env overrides, supports per-command timeout via AbortController, streams stdout/stderr via callbacks, accumulates output and returns structured CommandResult (exitCode, success, timedOut, killed). Non-2xx responses and missing exit events throw detailed errors.

- SSE consumer (workspaces/islo/src/sandbox/sse.ts)
  - consumeIsloStream reads ReadableStream<Uint8Array>, decodes SSE frames, routes stdout/stderr events to callbacks, parses exit event into exitCode, handles CRLF/LF and chunked payloads, ignores comments/unknown fields, returns { exitCode, sawExit }.

- Provider descriptor (workspaces/islo/src/provider.ts)
  - Exports isloSandboxProvider with JSON-schema config for image, workdir, gatewayProfile, env, api/control/compute URLs, deleteOnDestroy, timeout, metadata, and creates IsloSandbox instances.

### Tests
- Unit tests (workspaces/islo/src/sandbox/index.test.ts)
  - Full SDK mocking and fetch override; cover constructor validation, URL resolution, TokenProvider initialization, lifecycle branches (create/reconnect/resume/reject stopped), stop/destroy semantics, executeCommand SSE parsing, non-OK responses, timeout/abort exit code mapping (124).
- SSE tests (workspaces/islo/src/sandbox/sse.test.ts)
  - Verify event routing, chunk-boundary assembly, CRLF handling, unknown events ignored, final-frame flush behavior, and missing/invalid exit handling.
- Integration tests (workspaces/islo/src/sandbox/index.integration.test.ts)
  - Gated by ISLO_API_KEY (skipped when unset). Create a real sandbox and assert: basic echo success and stdout streaming, incremental streaming for long-running output, and stderr + non-zero exit propagation.

### Documentation & metadata
- README documents installation, usage, auth and URL fallbacks (ISLO_API_KEY / apiKey, ISLO_BASE_URL / control/compute), lifecycle mappings, streaming behavior and reconnection semantics, v1 limitations (foreground-only), config options (deleteOnDestroy, timeout, metadata, env), and license (Apache-2.0).
- Changeset entry added.

## Technical details & behavior notes

- Authentication: API key (ISLO_API_KEY or apiKey option); TokenProvider used for control API to exchange short-lived JWTs for compute operations.
- API split: control API for token exchange; compute API for sandbox lifecycle and exec streaming.
- Streaming: direct SSE consumption from compute /exec/stream provides incremental stdout/stderr callbacks and parses exit events.
- Timeouts: command-level timeouts abort the request and surface exitCode 124 with timedOut flag.
- stop() semantics: pauses sandbox to allow resumption; destroy() deletes by default unless configured not to.
- Env handling: per-command env overrides merged with instance env; null values removed for payload compatibility.
- Errors: non-2xx exec responses include status and truncated response text; missing exit event causes an error/invalid result.

## Tests & CI
- Local test results reported in PR: lint, build, 21 unit tests passed; integration suite skipped without ISLO_API_KEY. Live validation was previously run on a pre-upstream branch.

## Size / LOC
- Total added lines across package: ~1,087 (implementation, tests, config, docs).
- Implementation ~412 lines; tests ~463 lines; docs/config ~212 lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->