### PR TITLE
chore(docs): Highlight rubric scorer

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -113,6 +113,7 @@ Once your agent is running, use this table to find the right page for what you w
 | Register subagents | [Tools](/docs/agents/using-tools#agents-as-tools) |
 | Intercept or transform messages before and after generation | [Processors](/docs/agents/processors) |
 | Keep your agent safe | [Guardrails](/docs/agents/guardrails) |
+| Build agents that correct their work | [Rubric scorer](/docs/agents/supervisor-agents#rubric-scorer) |
 | Swap instructions or models based on request context | [Dynamic configuration](/docs/server/request-context) |
 | Add speech-to-text or text-to-speech | [Voice](/docs/agents/adding-voice) |
 | Connect to Slack, Discord, or Telegram | [Channels](/docs/agents/channels) |

--- a/docs/src/content/en/docs/agents/supervisor-agents.mdx
+++ b/docs/src/content/en/docs/agents/supervisor-agents.mdx
@@ -185,7 +185,7 @@ The callback receives `messages` (the full conversation history), `primitiveId` 
 
 ## Subagent result context
 
-When a subagent completes, the supervisor model receives the subagent's text response in later iterations. Nested tool calls and subagent metadata, such as thread and resource IDs, are not added to the supervisor model context.
+When a subagent completes, the supervisor model receives the subagent's text response in later iterations. Nested tool calls and subagent metadata, such as thread and resource IDs, aren't added to the supervisor model context.
 
 Application code and UI integrations can still inspect the raw delegation result, including `subAgentToolResults`, from the tool result payload. This keeps debugging and display data available without sending nested tool arguments or outputs back into the supervisor's next model call.
 
@@ -283,7 +283,7 @@ for await (const chunk of stream.fullStream) {
 
 ## Task completion scoring
 
-Task completion scorers validate whether the task is complete after each iteration. If validation fails, the supervisor continues iterating. Feedback from failed scorers is included in the conversation context so subagents can see what was missing.
+Agents don't always produce a complete, correct output on the first try. Task completion scorers can help with that by validating whether the task is complete after each iteration. If validation fails, the supervisor continues iterating. Feedback from failed scorers is included in the conversation context so subagents can see what was missing.
 
 ```typescript
 import { createScorer } from '@mastra/core/evals'
@@ -309,6 +309,44 @@ const stream = await supervisor.stream('Research AI in education', {
   },
 })
 ```
+
+### Rubric scorer
+
+The built-in rubric scorer lets you define what "correct" looks like as a checklist and have the agent self-evaluate and iterate until every criterion is satisfied or `maxSteps` is reached.
+
+It works as an **LLM-as-judge** scorer: a separate grader model reviews the agent's output against the rubric after each iteration. If every required criterion passes, the loop ends. If anything falls short, per-criterion feedback is injected back into the conversation and the agent tries again.
+
+This is most effective for tasks with clear, verifiable success criteria. You can use it like so:
+
+```typescript title="src/mastra/agents/rubric-scorer.ts"
+import { Agent } from '@mastra/core/agent'
+import { createRubricScorer } from '@mastra/evals/scorers/prebuilt'
+
+const supervisor = new Agent({
+  id: 'supervisor',
+  instructions: 'You coordinate research and writing using specialized agents.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  agents: { researchAgent, writingAgent },
+})
+
+const rubricScorer = createRubricScorer({
+  model: '__GATEWAY_OPENAI_MODEL_MINI__',
+  criteria: [
+    { description: 'The response includes an analysis section' },
+    { description: 'The response includes concrete recommendations' },
+  ],
+})
+
+const stream = await supervisor.stream('Research AI in education', {
+  maxSteps: 10,
+  isTaskComplete: {
+    scorers: [rubricScorer],
+    strategy: 'all',
+  },
+})
+```
+
+For full API details, see the [rubric scorer reference](/reference/evals/rubric).
 
 ## Writing effective instructions
 

--- a/docs/src/content/en/reference/evals/rubric.mdx
+++ b/docs/src/content/en/reference/evals/rubric.mdx
@@ -9,7 +9,9 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 # Rubric scorer
 
-The `createRubricScorer()` function creates an LLM-as-judge scorer that grades an agent's output against a rubric — a checklist of criteria. It returns a **binary** score: `1` only when every required criterion is satisfied, otherwise `0`. The `reason` lists each criterion's verdict so the agent knows exactly what to fix.
+**Added in:** `@mastra/evals@1.3.0`
+
+The `createRubricScorer()` function creates an LLM-as-judge scorer that grades an agent's output against a rubric (a checklist of criteria). It returns a **binary** score: `1` only when every required criterion is satisfied, otherwise `0`. The `reason` lists each criterion's verdict so the agent knows exactly what to fix.
 
 This scorer is designed to drop into [`isTaskComplete`](/reference/streaming/agents/stream). Because `isTaskComplete` treats `score === 1` as "task complete" and injects the `reason` back into the conversation as feedback, the agent keeps iterating until the rubric is satisfied (or `maxSteps` is reached).
 
@@ -93,8 +95,18 @@ This scorer is designed to drop into [`isTaskComplete`](/reference/streaming/age
 Define the rubric once, attach the scorer to `isTaskComplete`, and the agent self-corrects until the rubric is satisfied:
 
 ```typescript
+import { Agent } from '@mastra/core/agent'
+// highlight-next-line
 import { createRubricScorer } from '@mastra/evals/scorers/prebuilt'
 
+const supervisor = new Agent({
+  id: 'supervisor',
+  instructions: `You coordinate research and writing using specialized agents. Delegate to research-agent for facts, then writing-agent for content.`,
+  model: '__GATEWAY_OPENAI_MODEL__',
+  agents: { researchAgent, writingAgent },
+})
+
+// highlight-start
 const rubricScorer = createRubricScorer({
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
   criteria: [
@@ -102,13 +114,16 @@ const rubricScorer = createRubricScorer({
     { description: 'The response includes concrete recommendations' },
   ],
 })
+// highlight-end
 
 const stream = await supervisor.stream('Research AI in education', {
   maxSteps: 10,
+  // highlight-start
   isTaskComplete: {
     scorers: [rubricScorer],
     strategy: 'all',
   },
+  // highlight-end
 })
 ```
 
@@ -119,10 +134,8 @@ A newline-delimited string is parsed into criteria, with common list markers (`-
 ```typescript
 const rubricScorer = createRubricScorer({
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
-  criteria: `
-- All tests pass in the test suite
-- The function is named find_duplicates and accepts a single list argument
-`,
+  criteria: `- All tests pass in the test suite
+- The function is named find_duplicates and accepts a single list argument`,
 })
 ```
 
@@ -163,8 +176,8 @@ If no rubric resolves, the scorer returns `1` and does not gate the loop.
 
 The scorer runs in two phases:
 
-1. **Grade** — the judge model evaluates each criterion independently and returns a per-criterion verdict (`satisfied` / not) with reasoning.
-1. **Score** — the result is `1` only when every required criterion is `satisfied`, otherwise `0`. If no criteria are marked required, all criteria are treated as required.
+1. **Grade**: The judge model evaluates each criterion independently and returns a per-criterion verdict (`satisfied` / not) with reasoning.
+1. **Score**: The result is `1` only when every required criterion is `satisfied`, otherwise `0`. If no criteria are marked required, all criteria are treated as required.
 
 The `reason` summarizes the overall result and lists each criterion with its verdict, so a failing grade gives the agent targeted, actionable feedback rather than a generic "try again".
 


### PR DESCRIPTION
## Description

Add rubric scorer to supervisor agent docs

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds and improves documentation about the "Rubric scorer," which is a tool that helps AI agents check if their work meets specific requirements. The documentation is expanded across three pages to help developers learn about this feature and how to use it in their agents.

---

## Changes

### Documentation Updates

**agents/overview.mdx**
- Added a new row to the "Expand your agent" goals table for "Build agents that correct their work," linking to the Rubric scorer section

**agents/supervisor-agents.mdx**
- Clarified how supervisor agents pass subagent context to the model (noting that nested tool calls and subagent metadata are not included by default)
- Expanded the task completion scoring section to explain that scorers validate completeness after each iteration and inject feedback from failed scorers back into the conversation
- Added new "Rubric scorer" subsection explaining the built-in rubric scorer, including:
  - How it uses an LLM-as-judge model to check required criteria
  - Per-criterion feedback injection on failures
  - Stop condition (all criteria pass or `maxSteps` reached)
  - Configuration example with `createRubricScorer`

**reference/evals/rubric.mdx**
- Added version marker ("Added in: `@mastra/evals`@1.3.0")
- Reorganized and refreshed code examples for better clarity
- Improved formatting of the "Scoring details" section with bolded phase titles ("Grade" and "Score")
- Updated the "String rubric" example to use cleaner template string formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->