### PR TITLE
fix(core,pg): reduce workflow snapshot bloat on tool-approval suspends

### DIFF
--- a/.changeset/workflow-snapshot-suspend-bloat-core.md
+++ b/.changeset/workflow-snapshot-suspend-bloat-core.md
@@ -2,8 +2,8 @@
 '@mastra/core': patch
 ---
 
-Reduced workflow snapshot bloat when tool approval suspends with large tool payloads.
+Fixed memory exhaustion during tool-approval workflows with large tool payloads.
 
-When tool approval is enabled, every approval cycle suspends the agent loop and persists a stream-state snapshot. The serialized state now keeps per-step message deltas instead of cumulative `request`/`response` per buffered step, and replaces large tool-result payloads in step content with references to the message-list copy that get rehydrated on resume. Snapshots written by older versions still resume.
+Tool-approval snapshots now stay significantly smaller — large tool results (e.g. Figma exports) are no longer duplicated across the snapshot, and message history no longer grows quadratically with each approval cycle. This prevents Node OOM crashes in long-running approval flows. Snapshots written by older versions still resume without changes.
 
 Fixes [#17738](https://github.com/mastra-ai/mastra/issues/17738).

--- a/.changeset/workflow-snapshot-suspend-bloat-core.md
+++ b/.changeset/workflow-snapshot-suspend-bloat-core.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Reduced workflow snapshot bloat when tool approval suspends with large tool payloads.
+
+When tool approval is enabled, every approval cycle suspends the agent loop and persists a stream-state snapshot. The serialized state now keeps per-step message deltas instead of cumulative `request`/`response` per buffered step, and replaces large tool-result payloads in step content with references to the message-list copy that get rehydrated on resume. Snapshots written by older versions still resume.
+
+Fixes [#17738](https://github.com/mastra-ai/mastra/issues/17738).

--- a/.changeset/workflow-snapshot-suspend-bloat-pg.md
+++ b/.changeset/workflow-snapshot-suspend-bloat-pg.md
@@ -1,0 +1,9 @@
+---
+'@mastra/pg': patch
+---
+
+Cut per-step workflow snapshot update cost in the PostgreSQL storage adapter.
+
+`updateWorkflowResults` and `updateWorkflowState` previously read the entire snapshot row over the wire, parsed it, merged the change in Node, and rewrote the whole row on every step update — so each step paid the cost of the cumulative snapshot. The adapter now applies these updates with `jsonb_set` / `||` against the row in-place, so only the new step-result fragment crosses the wire. The transactional read-and-merge path is kept for foreach iteration results (where element-wise array merging is required) and as a fallback when the row does not exist yet.
+
+Related to [#17738](https://github.com/mastra-ai/mastra/issues/17738).

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -4,7 +4,7 @@ import { MessageList } from '../../agent/message-list';
 import type { Processor, ProcessorStreamWriter } from '../../processors';
 import { ChunkFrom } from '../types';
 import type { ChunkType } from '../types';
-import { MastraModelOutput, serializeBufferedSteps, deserializeBufferedSteps } from './output';
+import { MastraModelOutput, serializeBufferedSteps, deserializeBufferedSteps, collectToolResultRefs } from './output';
 
 /**
  * Creates a ReadableStream that emits the given chunks in order.
@@ -961,5 +961,114 @@ describe('buffered step serialization', () => {
     const slimSize = JSON.stringify(serializeBufferedSteps(steps)).length;
 
     expect(slimSize).toBeLessThan(fatSize / 3);
+  });
+});
+
+describe('tool result deduplication in serialized state', () => {
+  const bigResult = { data: 'x'.repeat(50_000), nodes: [{ id: 1 }, { id: 2 }] };
+
+  function makeDbMessage(toolCallId: string, result: unknown) {
+    return {
+      id: 'msg-tool',
+      role: 'assistant',
+      createdAt: new Date().toISOString(),
+      content: {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'result', toolCallId, toolName: 'figma_export', args: {}, result },
+          },
+        ],
+      },
+    };
+  }
+
+  function makeToolResultChunk(toolCallId: string, result: unknown) {
+    return {
+      type: 'tool-result',
+      runId: 'run-1',
+      from: 'AGENT',
+      payload: { toolCallId, toolName: 'figma_export', result },
+    } as any;
+  }
+
+  it('replaces matching chunk payloads with refs and rehydrates them', () => {
+    const refs = collectToolResultRefs([makeDbMessage('call-1', bigResult)]);
+    const chunks = [makeToolResultChunk('call-1', structuredClone(bigResult))];
+
+    const step = {
+      toolResults: chunks,
+      dynamicToolResults: [],
+      staticToolResults: [],
+      content: [],
+      response: { messages: [] },
+    } as any;
+
+    const [slimStep] = serializeBufferedSteps([step], refs);
+    expect(slimStep!.toolResults[0]!.payload.result).toEqual({ __toolResultRef: 'call-1' });
+
+    const [restored] = deserializeBufferedSteps(structuredClone([slimStep!]) as any, refs);
+    expect(restored!.toolResults[0]!.payload.result).toEqual(bigResult);
+  });
+
+  it('keeps payloads that do not match the message list copy', () => {
+    const refs = collectToolResultRefs([makeDbMessage('call-1', bigResult)]);
+    const transformed = { summary: 'shrunk by toModelOutput' };
+    const step = {
+      toolResults: [makeToolResultChunk('call-1', transformed)],
+      dynamicToolResults: [],
+      staticToolResults: [],
+      content: [],
+      response: { messages: [] },
+    } as any;
+
+    const [slimStep] = serializeBufferedSteps([step], refs);
+    expect(slimStep!.toolResults[0]!.payload.result).toEqual(transformed);
+  });
+
+  it('dedupes tool-result content parts with wrapped output values', () => {
+    const refs = collectToolResultRefs([makeDbMessage('call-1', bigResult)]);
+    const step = {
+      toolResults: [],
+      dynamicToolResults: [],
+      staticToolResults: [],
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'figma_export',
+          output: { type: 'json', value: structuredClone(bigResult) },
+        },
+      ],
+      response: { messages: [] },
+    } as any;
+
+    const [slimStep] = serializeBufferedSteps([step], refs);
+    expect((slimStep!.content[0] as any).output.value).toEqual({ __toolResultRef: 'call-1' });
+
+    const [restored] = deserializeBufferedSteps(structuredClone([slimStep!]) as any, refs);
+    expect((restored!.content[0] as any).output.value).toEqual(bigResult);
+  });
+
+  it('shrinks serialized size when large results appear in multiple places', () => {
+    const refs = collectToolResultRefs([makeDbMessage('call-1', bigResult)]);
+    const step = {
+      toolResults: [makeToolResultChunk('call-1', structuredClone(bigResult))],
+      dynamicToolResults: [makeToolResultChunk('call-1', structuredClone(bigResult))],
+      staticToolResults: [],
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          output: { type: 'json', value: structuredClone(bigResult) },
+        },
+      ],
+      response: { messages: [] },
+    } as any;
+
+    const fat = JSON.stringify([step]).length;
+    const slim = JSON.stringify(serializeBufferedSteps([step], refs)).length;
+    expect(slim).toBeLessThan(fat / 10);
   });
 });

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -4,7 +4,7 @@ import { MessageList } from '../../agent/message-list';
 import type { Processor, ProcessorStreamWriter } from '../../processors';
 import { ChunkFrom } from '../types';
 import type { ChunkType } from '../types';
-import { MastraModelOutput } from './output';
+import { MastraModelOutput, serializeBufferedSteps, deserializeBufferedSteps } from './output';
 
 /**
  * Creates a ReadableStream that emits the given chunks in order.
@@ -842,5 +842,124 @@ describe('MastraModelOutput', () => {
       expect(result.toolCalls).toHaveLength(1);
       expect(result.toolCalls[0]?.payload.observability).toEqual(observability);
     });
+  });
+});
+
+describe('buffered step serialization', () => {
+  function makeStep(messages: Array<Record<string, unknown>>, overrides: Record<string, unknown> = {}) {
+    return {
+      stepType: 'initial',
+      toolCalls: [],
+      toolResults: [],
+      dynamicToolCalls: [],
+      dynamicToolResults: [],
+      staticToolCalls: [],
+      staticToolResults: [],
+      files: [],
+      sources: [],
+      text: 'hello',
+      reasoning: [],
+      content: [],
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      warnings: [],
+      request: { body: 'full prompt with entire conversation' },
+      response: {
+        id: 'resp-1',
+        modelId: 'test-model',
+        messages,
+        dbMessages: [{ id: 'db-1' }],
+        uiMessages: [{ id: 'ui-1' }],
+      },
+      reasoningText: undefined,
+      providerMetadata: undefined,
+      ...overrides,
+    } as any;
+  }
+
+  const m = (text: string) => ({ role: 'assistant', content: [{ type: 'text', text }] });
+
+  it('persists only the messages each step added', () => {
+    const m1 = m('one');
+    const m2 = m('two');
+    const m3 = m('three');
+    const steps = [makeStep([m1]), makeStep([m1, m2]), makeStep([m1, m2, m3])];
+
+    const serialized = serializeBufferedSteps(steps);
+
+    expect(serialized[0]!.response.messages).toEqual([m1]);
+    expect(serialized[1]!.response.messages).toEqual([m2]);
+    expect(serialized[2]!.response.messages).toEqual([m3]);
+    expect(serialized[2]!.response.messagesDeltaFrom).toBe(2);
+  });
+
+  it('drops cumulative request, dbMessages and uiMessages from persisted steps', () => {
+    const serialized = serializeBufferedSteps([makeStep([m('one')])]);
+
+    expect(serialized[0]!.request).toEqual({});
+    expect(serialized[0]!.response.dbMessages).toBeUndefined();
+    expect(serialized[0]!.response.uiMessages).toBeUndefined();
+  });
+
+  it('restores the cumulative message history on deserialize', () => {
+    const m1 = m('one');
+    const m2 = m('two');
+    const steps = [makeStep([m1]), makeStep([m1, m2])];
+
+    const restored = deserializeBufferedSteps(serializeBufferedSteps(steps));
+
+    expect(restored[0]!.response.messages).toEqual([m1]);
+    expect(restored[1]!.response.messages).toEqual([m1, m2]);
+    expect(restored[1]!.response.messagesDeltaFrom).toBeUndefined();
+  });
+
+  it('stores the full history when a step does not extend the previous one', () => {
+    const m1 = m('one');
+    const replaced = m('replaced after retry');
+    const steps = [makeStep([m1]), makeStep([replaced])];
+
+    const serialized = serializeBufferedSteps(steps);
+    expect(serialized[1]!.response.messages).toEqual([replaced]);
+    expect(serialized[1]!.response.messagesDeltaFrom).toBeUndefined();
+
+    const restored = deserializeBufferedSteps(serialized);
+    expect(restored[1]!.response.messages).toEqual([replaced]);
+  });
+
+  it('passes legacy snapshots through unchanged', () => {
+    const m1 = m('one');
+    const m2 = m('two');
+    const legacy = [makeStep([m1]), makeStep([m1, m2])];
+
+    const restored = deserializeBufferedSteps(legacy);
+
+    expect(restored[0]!.response.messages).toEqual([m1]);
+    expect(restored[1]!.response.messages).toEqual([m1, m2]);
+    expect(restored[1]!.response.dbMessages).toEqual([{ id: 'db-1' }]);
+  });
+
+  it('is stable across repeated serialize/deserialize round trips', () => {
+    const m1 = m('one');
+    const m2 = m('two');
+    const steps = [makeStep([m1]), makeStep([m1, m2])];
+
+    const first = serializeBufferedSteps(steps);
+    const second = serializeBufferedSteps(deserializeBufferedSteps(structuredClone(first)));
+
+    expect(second).toEqual(first);
+  });
+
+  it('keeps serialized size linear in step count', () => {
+    const payload = 'x'.repeat(10_000);
+    const cumulative: Array<Record<string, unknown>> = [];
+    const steps = [];
+    for (let i = 0; i < 8; i++) {
+      cumulative.push(m(`${payload}-${i}`));
+      steps.push(makeStep([...cumulative]));
+    }
+
+    const fatSize = JSON.stringify(steps).length;
+    const slimSize = JSON.stringify(serializeBufferedSteps(steps)).length;
+
+    expect(slimSize).toBeLessThan(fatSize / 3);
   });
 });

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -925,6 +925,22 @@ describe('buffered step serialization', () => {
     expect(restored[1]!.response.messages).toEqual([replaced]);
   });
 
+  it('rejects a diverging prefix even when the boundary message matches', () => {
+    const a = m('a');
+    const b = m('b');
+    const x = m('x');
+    const c = m('c');
+    const steps = [makeStep([a, b]), makeStep([x, b, c])];
+
+    const serialized = serializeBufferedSteps(steps);
+    // Second step's prefix diverges (a replaced by x), so full history is stored
+    expect(serialized[1]!.response.messagesDeltaFrom).toBeUndefined();
+    expect(serialized[1]!.response.messages).toEqual([x, b, c]);
+
+    const restored = deserializeBufferedSteps(serialized);
+    expect(restored[1]!.response.messages).toEqual([x, b, c]);
+  });
+
   it('passes legacy snapshots through unchanged', () => {
     const m1 = m('one');
     const m2 = m('two');
@@ -1010,6 +1026,25 @@ describe('tool result deduplication in serialized state', () => {
 
     const [restored] = deserializeBufferedSteps(structuredClone([slimStep!]) as any, refs);
     expect(restored!.toolResults[0]!.payload.result).toEqual(bigResult);
+  });
+
+  it('ignores user payloads that coincidentally contain __toolResultRef', () => {
+    const userResult = { __toolResultRef: 'call-1', extra: 'user-data' };
+    const refs = collectToolResultRefs([makeDbMessage('call-1', bigResult)]);
+    const step = {
+      toolResults: [makeToolResultChunk('call-1', userResult)],
+      dynamicToolResults: [],
+      staticToolResults: [],
+      content: [],
+      response: { messages: [] },
+    } as any;
+
+    const [slimStep] = serializeBufferedSteps([step], refs);
+    // Not treated as a ref marker because it has extra keys
+    expect(slimStep!.toolResults[0]!.payload.result).toEqual(userResult);
+
+    const [restored] = deserializeBufferedSteps(structuredClone([slimStep!]) as any, refs);
+    expect(restored!.toolResults[0]!.payload.result).toEqual(userResult);
   });
 
   it('keeps payloads that do not match the message list copy', () => {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1846,7 +1846,13 @@ function toToolResultRefMarker(toolCallId: string) {
 }
 
 function getToolResultRefId(value: unknown): string | undefined {
-  if (value && typeof value === 'object' && TOOL_RESULT_REF_KEY in value) {
+  if (
+    value &&
+    typeof value === 'object' &&
+    TOOL_RESULT_REF_KEY in value &&
+    Object.keys(value).length === 1 &&
+    typeof (value as Record<string, unknown>)[TOOL_RESULT_REF_KEY] === 'string'
+  ) {
     return (value as Record<string, string>)[TOOL_RESULT_REF_KEY];
   }
   return undefined;
@@ -1958,7 +1964,7 @@ export function serializeBufferedSteps<OUTPUT>(
     const boundary = prev.length;
     const extendsPrev =
       messages.length >= boundary &&
-      (boundary === 0 || JSON.stringify(messages[boundary - 1]) === JSON.stringify(prev[boundary - 1]));
+      (boundary === 0 || prev.every((prevMsg, i) => JSON.stringify(prevMsg) === JSON.stringify(messages[i])));
     const slimmed: LLMStepResult<OUTPUT> = {
       ...slimStepToolResults(step, toolResultRefs),
       request: {},

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1763,11 +1763,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
   serializeState() {
     return {
       status: this.#status,
-      bufferedSteps: this.#bufferedSteps,
+      bufferedSteps: serializeBufferedSteps(this.#bufferedSteps),
       bufferedReasoningDetails: this.#bufferedReasoningDetails,
       bufferedByStep: this.#bufferedByStep,
       bufferedText: this.#bufferedText,
-      bufferedTextChunks: this.#bufferedTextChunks,
       bufferedSources: this.#bufferedSources,
       bufferedReasoning: this.#bufferedReasoning,
       bufferedFiles: this.#bufferedFiles,
@@ -1787,11 +1786,11 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
   deserializeState(state: any) {
     this.#status = state.status;
-    this.#bufferedSteps = state.bufferedSteps;
+    this.#bufferedSteps = deserializeBufferedSteps(state.bufferedSteps ?? []);
     this.#bufferedReasoningDetails = state.bufferedReasoningDetails;
     this.#bufferedByStep = state.bufferedByStep;
     this.#bufferedText = state.bufferedText;
-    this.#bufferedTextChunks = state.bufferedTextChunks;
+    this.#bufferedTextChunks = state.bufferedTextChunks ?? {};
     this.#bufferedSources = state.bufferedSources;
     this.#bufferedReasoning = state.bufferedReasoning;
     this.#bufferedFiles = state.bufferedFiles;
@@ -1807,4 +1806,50 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     this.#tripwire = state.tripwire;
     this.messageList = this.messageList.deserialize(state.messageList);
   }
+}
+
+type BufferedStepMessages = NonNullable<LLMStepResult<any>['response']['messages']>;
+
+/**
+ * Each buffered step's `response.messages` holds the cumulative response history at the
+ * time the step finished, which makes serialized stream state grow quadratically with
+ * step count. Persist only the messages each step added (`messagesDeltaFrom` marks the
+ * boundary) and rebuild the cumulative view on deserialize. Steps whose history is not
+ * an extension of the previous step (e.g. after a processor retry removed messages) are
+ * stored in full. Cumulative `request`, `dbMessages` and `uiMessages` are not persisted:
+ * the live loop recomputes them from the message list when the run finishes.
+ */
+export function serializeBufferedSteps<OUTPUT>(steps: LLMStepResult<OUTPUT>[]): LLMStepResult<OUTPUT>[] {
+  let prev: BufferedStepMessages = [];
+  return steps.map(step => {
+    const messages = step.response?.messages ?? [];
+    const boundary = prev.length;
+    const extendsPrev =
+      messages.length >= boundary &&
+      (boundary === 0 || JSON.stringify(messages[boundary - 1]) === JSON.stringify(prev[boundary - 1]));
+    const slimmed: LLMStepResult<OUTPUT> = {
+      ...step,
+      request: {},
+      response: {
+        ...step.response,
+        dbMessages: undefined,
+        uiMessages: undefined,
+        messages: extendsPrev ? messages.slice(boundary) : messages,
+        ...(extendsPrev ? { messagesDeltaFrom: boundary } : {}),
+      },
+    };
+    prev = messages;
+    return slimmed;
+  });
+}
+
+export function deserializeBufferedSteps<OUTPUT>(steps: LLMStepResult<OUTPUT>[]): LLMStepResult<OUTPUT>[] {
+  let running: BufferedStepMessages = [];
+  return steps.map(step => {
+    const { messagesDeltaFrom, ...response } = step.response ?? {};
+    const stored = (response.messages ?? []) as BufferedStepMessages;
+    const messages = messagesDeltaFrom === undefined ? stored : [...running, ...stored];
+    running = messages;
+    return { ...step, response: { ...response, messages } };
+  });
 }

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1761,11 +1761,13 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
   }
 
   serializeState() {
+    const messageList = this.messageList.serialize();
+    const toolResultRefs = collectToolResultRefs(messageList.messages as unknown[]);
     return {
       status: this.#status,
-      bufferedSteps: serializeBufferedSteps(this.#bufferedSteps),
+      bufferedSteps: serializeBufferedSteps(this.#bufferedSteps, toolResultRefs),
       bufferedReasoningDetails: this.#bufferedReasoningDetails,
-      bufferedByStep: this.#bufferedByStep,
+      bufferedByStep: slimStepToolResults(this.#bufferedByStep, toolResultRefs),
       bufferedText: this.#bufferedText,
       bufferedSources: this.#bufferedSources,
       bufferedReasoning: this.#bufferedReasoning,
@@ -1774,21 +1776,22 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       toolCallDeltaIdNameMap: this.#toolCallDeltaIdNameMap,
       toolCallStreamingMeta: this.#toolCallStreamingMeta,
       toolCalls: this.#toolCalls,
-      toolResults: this.#toolResults,
+      toolResults: slimToolResultChunks(this.#toolResults, toolResultRefs),
       warnings: this.#warnings,
       finishReason: this.#finishReason,
       request: this.#request,
       usageCount: this.#usageCount,
       tripwire: this.#tripwire,
-      messageList: this.messageList.serialize(),
+      messageList,
     };
   }
 
   deserializeState(state: any) {
+    const toolResultRefs = collectToolResultRefs(state.messageList?.messages ?? []);
     this.#status = state.status;
-    this.#bufferedSteps = deserializeBufferedSteps(state.bufferedSteps ?? []);
+    this.#bufferedSteps = deserializeBufferedSteps(state.bufferedSteps ?? [], toolResultRefs);
     this.#bufferedReasoningDetails = state.bufferedReasoningDetails;
-    this.#bufferedByStep = state.bufferedByStep;
+    this.#bufferedByStep = restoreStepToolResults(state.bufferedByStep, toolResultRefs);
     this.#bufferedText = state.bufferedText;
     this.#bufferedTextChunks = state.bufferedTextChunks ?? {};
     this.#bufferedSources = state.bufferedSources;
@@ -1798,7 +1801,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     this.#toolCallDeltaIdNameMap = state.toolCallDeltaIdNameMap;
     this.#toolCallStreamingMeta = state.toolCallStreamingMeta ?? {};
     this.#toolCalls = state.toolCalls;
-    this.#toolResults = state.toolResults;
+    this.#toolResults = restoreToolResultChunks(state.toolResults, toolResultRefs);
     this.#warnings = state.warnings;
     this.#finishReason = state.finishReason;
     this.#request = state.request;
@@ -1810,6 +1813,132 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
 type BufferedStepMessages = NonNullable<LLMStepResult<any>['response']['messages']>;
 
+const TOOL_RESULT_REF_KEY = '__toolResultRef';
+
+type ToolResultRef = { json: string; value: unknown };
+type ToolResultRefs = Map<string, ToolResultRef>;
+
+/**
+ * Tool result payloads are duplicated across the serialized state: once inside the
+ * message list (the canonical copy) and again in the tool result chunks and step
+ * content. Large tool outputs make this duplication dominate snapshot size, so the
+ * extra copies are replaced with `{ __toolResultRef: toolCallId }` markers on
+ * serialize and rehydrated from the message list on deserialize. Payloads that do not
+ * match the message list copy (e.g. transformed by toModelOutput) are kept verbatim.
+ */
+export function collectToolResultRefs(messages: unknown[]): ToolResultRefs {
+  const refs: ToolResultRefs = new Map();
+  for (const message of messages ?? []) {
+    const parts = (message as any)?.content?.parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      const invocation = part?.type === 'tool-invocation' ? part.toolInvocation : undefined;
+      if (invocation?.state === 'result' && typeof invocation.toolCallId === 'string' && 'result' in invocation) {
+        refs.set(invocation.toolCallId, { json: JSON.stringify(invocation.result), value: invocation.result });
+      }
+    }
+  }
+  return refs;
+}
+
+function toToolResultRefMarker(toolCallId: string) {
+  return { [TOOL_RESULT_REF_KEY]: toolCallId };
+}
+
+function getToolResultRefId(value: unknown): string | undefined {
+  if (value && typeof value === 'object' && TOOL_RESULT_REF_KEY in value) {
+    return (value as Record<string, string>)[TOOL_RESULT_REF_KEY];
+  }
+  return undefined;
+}
+
+function slimToolResultChunks<T extends { payload?: any }>(chunks: T[], refs: ToolResultRefs): T[] {
+  if (!refs.size || !Array.isArray(chunks)) return chunks;
+  return chunks.map(chunk => {
+    const toolCallId = chunk?.payload?.toolCallId;
+    const ref = typeof toolCallId === 'string' ? refs.get(toolCallId) : undefined;
+    if (!ref || chunk.payload.result === undefined) return chunk;
+    if (JSON.stringify(chunk.payload.result) !== ref.json) return chunk;
+    return { ...chunk, payload: { ...chunk.payload, result: toToolResultRefMarker(toolCallId) } };
+  });
+}
+
+function restoreToolResultChunks<T extends { payload?: any }>(chunks: T[], refs: ToolResultRefs): T[] {
+  if (!Array.isArray(chunks)) return chunks;
+  return chunks.map(chunk => {
+    const refId = getToolResultRefId(chunk?.payload?.result);
+    const ref = refId !== undefined ? refs.get(refId) : undefined;
+    if (!ref) return chunk;
+    return { ...chunk, payload: { ...chunk.payload, result: ref.value } };
+  });
+}
+
+function slimContentToolResults<T>(content: T[], refs: ToolResultRefs): T[] {
+  if (!refs.size || !Array.isArray(content)) return content;
+  return content.map(part => {
+    const candidate = part as any;
+    if (candidate?.type !== 'tool-result' || typeof candidate.toolCallId !== 'string') return part;
+    const ref = refs.get(candidate.toolCallId);
+    if (!ref) return part;
+    const output = candidate.output;
+    if (output && typeof output === 'object' && 'value' in output && JSON.stringify(output.value) === ref.json) {
+      return { ...candidate, output: { ...output, value: toToolResultRefMarker(candidate.toolCallId) } };
+    }
+    if (JSON.stringify(output) === ref.json) {
+      return { ...candidate, output: toToolResultRefMarker(candidate.toolCallId) };
+    }
+    return part;
+  });
+}
+
+function restoreContentToolResults<T>(content: T[], refs: ToolResultRefs): T[] {
+  if (!Array.isArray(content)) return content;
+  return content.map(part => {
+    const candidate = part as any;
+    if (candidate?.type !== 'tool-result') return part;
+    const outerRefId = getToolResultRefId(candidate.output);
+    const outerRef = outerRefId !== undefined ? refs.get(outerRefId) : undefined;
+    if (outerRef) {
+      return { ...candidate, output: outerRef.value };
+    }
+    const innerRefId = getToolResultRefId(candidate.output?.value);
+    const innerRef = innerRefId !== undefined ? refs.get(innerRefId) : undefined;
+    if (innerRef) {
+      return { ...candidate, output: { ...candidate.output, value: innerRef.value } };
+    }
+    return part;
+  });
+}
+
+type StepWithToolResults = {
+  toolResults?: any[];
+  dynamicToolResults?: any[];
+  staticToolResults?: any[];
+  content?: any[];
+};
+
+function slimStepToolResults<T extends StepWithToolResults>(step: T, refs: ToolResultRefs): T {
+  if (!step || !refs.size) return step;
+  return {
+    ...step,
+    toolResults: slimToolResultChunks(step.toolResults ?? [], refs),
+    dynamicToolResults: slimToolResultChunks(step.dynamicToolResults ?? [], refs),
+    staticToolResults: slimToolResultChunks(step.staticToolResults ?? [], refs),
+    content: slimContentToolResults(step.content ?? [], refs),
+  };
+}
+
+function restoreStepToolResults<T extends StepWithToolResults>(step: T, refs: ToolResultRefs): T {
+  if (!step) return step;
+  return {
+    ...step,
+    toolResults: restoreToolResultChunks(step.toolResults ?? [], refs),
+    dynamicToolResults: restoreToolResultChunks(step.dynamicToolResults ?? [], refs),
+    staticToolResults: restoreToolResultChunks(step.staticToolResults ?? [], refs),
+    content: restoreContentToolResults(step.content ?? [], refs),
+  };
+}
+
 /**
  * Each buffered step's `response.messages` holds the cumulative response history at the
  * time the step finished, which makes serialized stream state grow quadratically with
@@ -1819,7 +1948,10 @@ type BufferedStepMessages = NonNullable<LLMStepResult<any>['response']['messages
  * stored in full. Cumulative `request`, `dbMessages` and `uiMessages` are not persisted:
  * the live loop recomputes them from the message list when the run finishes.
  */
-export function serializeBufferedSteps<OUTPUT>(steps: LLMStepResult<OUTPUT>[]): LLMStepResult<OUTPUT>[] {
+export function serializeBufferedSteps<OUTPUT>(
+  steps: LLMStepResult<OUTPUT>[],
+  toolResultRefs: ToolResultRefs = new Map(),
+): LLMStepResult<OUTPUT>[] {
   let prev: BufferedStepMessages = [];
   return steps.map(step => {
     const messages = step.response?.messages ?? [];
@@ -1828,7 +1960,7 @@ export function serializeBufferedSteps<OUTPUT>(steps: LLMStepResult<OUTPUT>[]): 
       messages.length >= boundary &&
       (boundary === 0 || JSON.stringify(messages[boundary - 1]) === JSON.stringify(prev[boundary - 1]));
     const slimmed: LLMStepResult<OUTPUT> = {
-      ...step,
+      ...slimStepToolResults(step, toolResultRefs),
       request: {},
       response: {
         ...step.response,
@@ -1843,13 +1975,16 @@ export function serializeBufferedSteps<OUTPUT>(steps: LLMStepResult<OUTPUT>[]): 
   });
 }
 
-export function deserializeBufferedSteps<OUTPUT>(steps: LLMStepResult<OUTPUT>[]): LLMStepResult<OUTPUT>[] {
+export function deserializeBufferedSteps<OUTPUT>(
+  steps: LLMStepResult<OUTPUT>[],
+  toolResultRefs: ToolResultRefs = new Map(),
+): LLMStepResult<OUTPUT>[] {
   let running: BufferedStepMessages = [];
   return steps.map(step => {
     const { messagesDeltaFrom, ...response } = step.response ?? {};
     const stored = (response.messages ?? []) as BufferedStepMessages;
     const messages = messagesDeltaFrom === undefined ? stored : [...running, ...stored];
     running = messages;
-    return { ...step, response: { ...response, messages } };
+    return { ...restoreStepToolResults(step, toolResultRefs), response: { ...response, messages } };
   });
 }

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -165,6 +165,45 @@ export class WorkflowsPG extends WorkflowsStorage {
     await this.#db.clearTable({ tableName: TABLE_WORKFLOW_SNAPSHOT });
   }
 
+  /**
+   * Writes a single step result into the snapshot with jsonb_set instead of
+   * round-tripping the whole row through the client. Only valid when the step
+   * result is a plain replacement: foreach results (array output) need the
+   * element-wise merge in the transactional path. Returns undefined when the
+   * row does not exist yet or has no context object.
+   */
+  async #updateStepResultInPlace({
+    workflowName,
+    runId,
+    stepId,
+    result,
+    requestContext,
+  }: {
+    workflowName: string;
+    runId: string;
+    stepId: string;
+    result: StepResult<any, any, any, any>;
+    requestContext: Record<string, any>;
+  }): Promise<Record<string, StepResult<any, any, any, any>> | undefined> {
+    const tableName = getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: getSchemaName(this.#schema) });
+    const sanitizedResult = sanitizeJsonForPg(JSON.stringify(result));
+    const sanitizedRequestContext = sanitizeJsonForPg(JSON.stringify(requestContext ?? {}));
+    const row = await this.#db.client.oneOrNone<{ context: Record<string, StepResult<any, any, any, any>> }>(
+      `UPDATE ${tableName}
+       SET snapshot = jsonb_set(
+             jsonb_set(snapshot, ARRAY['context', $3::text], $4::jsonb, true),
+             '{requestContext}',
+             COALESCE(snapshot->'requestContext', '{}'::jsonb) || $5::jsonb,
+             true
+           ),
+           "updatedAt" = $6
+       WHERE workflow_name = $1 AND run_id = $2 AND jsonb_typeof(snapshot->'context') = 'object'
+       RETURNING snapshot->'context' AS context`,
+      [workflowName, runId, stepId, sanitizedResult, sanitizedRequestContext, new Date()],
+    );
+    return row?.context;
+  }
+
   async updateWorkflowResults({
     workflowName,
     runId,
@@ -179,6 +218,13 @@ export class WorkflowsPG extends WorkflowsStorage {
     requestContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
     try {
+      if (!Array.isArray((result as { output?: unknown })?.output)) {
+        const context = await this.#updateStepResultInPlace({ workflowName, runId, stepId, result, requestContext });
+        if (context) {
+          return context;
+        }
+      }
+
       // Use a transaction with row-level locking to ensure atomicity
       return await this.#db.client.tx(async t => {
         const tableName = getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: getSchemaName(this.#schema) });
@@ -256,41 +302,30 @@ export class WorkflowsPG extends WorkflowsStorage {
     opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     try {
-      // Use a transaction with row-level locking to ensure atomicity
-      return await this.#db.client.tx(async t => {
-        const tableName = getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: getSchemaName(this.#schema) });
+      const tableName = getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: getSchemaName(this.#schema) });
 
-        // Load existing snapshot within transaction with FOR UPDATE to lock the row
-        // This prevents concurrent updates from reading stale data
-        const existingSnapshotResult = await t.oneOrNone<{ snapshot: WorkflowRunState }>(
-          `SELECT snapshot FROM ${tableName} WHERE workflow_name = $1 AND run_id = $2 FOR UPDATE`,
-          [workflowName, runId],
-        );
+      // Merge the options into the snapshot in place; only the option fragment
+      // crosses the wire instead of the full row
+      const sanitizedOpts = sanitizeJsonForPg(JSON.stringify(opts));
+      const row = await this.#db.client.oneOrNone<{ snapshot: WorkflowRunState }>(
+        `UPDATE ${tableName}
+         SET snapshot = snapshot || $3::jsonb, "updatedAt" = $4
+         WHERE workflow_name = $1 AND run_id = $2 AND jsonb_typeof(snapshot->'context') = 'object'
+         RETURNING snapshot`,
+        [workflowName, runId, sanitizedOpts, new Date()],
+      );
+      if (row) {
+        return row.snapshot;
+      }
 
-        if (!existingSnapshotResult) {
-          return undefined;
-        }
-
-        // Parse existing snapshot
-        const existingSnapshot = existingSnapshotResult.snapshot;
-        const snapshot = typeof existingSnapshot === 'string' ? JSON.parse(existingSnapshot) : existingSnapshot;
-
-        if (!snapshot || !snapshot?.context) {
-          throw new Error(`Snapshot not found for runId ${runId}`);
-        }
-
-        // Merge the new options with the existing snapshot
-        const updatedSnapshot = { ...snapshot, ...opts };
-
-        // Update the snapshot within the same transaction
-        const sanitizedSnapshot = sanitizeJsonForPg(JSON.stringify(updatedSnapshot));
-        await t.none(
-          `UPDATE ${tableName} SET snapshot = $1, "updatedAt" = $2 WHERE workflow_name = $3 AND run_id = $4`,
-          [sanitizedSnapshot, new Date(), workflowName, runId],
-        );
-
-        return updatedSnapshot;
-      });
+      const existing = await this.#db.client.oneOrNone(
+        `SELECT 1 FROM ${tableName} WHERE workflow_name = $1 AND run_id = $2`,
+        [workflowName, runId],
+      );
+      if (!existing) {
+        return undefined;
+      }
+      throw new Error(`Snapshot not found for runId ${runId}`);
     } catch (error) {
       throw new MastraError(
         {

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -727,3 +727,116 @@ describe('PostgresStore.init() — concurrency & disableInit (issue #18282)', ()
     }
   });
 });
+
+describe('WorkflowsPG step result updates', () => {
+  it('merges foreach array outputs element-wise across sequential updates', async () => {
+    const pool = createTestPool();
+    const workflows = new WorkflowsPG({ pool });
+    const workflowName = `foreach-merge-${Date.now()}`;
+    const runId = `run-${Date.now()}`;
+
+    try {
+      await workflows.init();
+      await workflows.persistWorkflowSnapshot({
+        workflowName,
+        runId,
+        snapshot: { status: 'running', context: {} } as any,
+      });
+
+      await workflows.updateWorkflowResults({
+        workflowName,
+        runId,
+        stepId: 'foreach-step',
+        result: { status: 'running', output: ['first', null, null], payload: {}, startedAt: Date.now() } as any,
+        requestContext: {},
+      });
+
+      const merged = await workflows.updateWorkflowResults({
+        workflowName,
+        runId,
+        stepId: 'foreach-step',
+        result: {
+          status: 'success',
+          output: [null, 'second', 'third'],
+          payload: {},
+          startedAt: Date.now(),
+          endedAt: Date.now(),
+        } as any,
+        requestContext: {},
+      });
+
+      expect((merged['foreach-step'] as any).output).toEqual(['first', 'second', 'third']);
+
+      const snapshot = await workflows.loadWorkflowSnapshot({ workflowName, runId });
+      expect((snapshot?.context['foreach-step'] as any).output).toEqual(['first', 'second', 'third']);
+    } finally {
+      await pool.query(`DELETE FROM mastra_workflow_snapshot WHERE workflow_name = $1`, [workflowName]);
+      await pool.end();
+    }
+  });
+
+  it('creates the snapshot when updating results for a new run', async () => {
+    const pool = createTestPool();
+    const workflows = new WorkflowsPG({ pool });
+    const workflowName = `fresh-run-${Date.now()}`;
+    const runId = `run-${Date.now()}`;
+
+    try {
+      await workflows.init();
+
+      const context = await workflows.updateWorkflowResults({
+        workflowName,
+        runId,
+        stepId: 'step-1',
+        result: { status: 'success', output: { data: 'ok' }, payload: {}, startedAt: Date.now() } as any,
+        requestContext: { tenant: 'a' },
+      });
+
+      expect((context['step-1'] as any).output).toEqual({ data: 'ok' });
+
+      const snapshot = await workflows.loadWorkflowSnapshot({ workflowName, runId });
+      expect((snapshot?.context['step-1'] as any).status).toBe('success');
+      expect(snapshot?.requestContext).toEqual({ tenant: 'a' });
+    } finally {
+      await pool.query(`DELETE FROM mastra_workflow_snapshot WHERE workflow_name = $1`, [workflowName]);
+      await pool.end();
+    }
+  });
+
+  it('sanitizes problematic unicode in step results written in place', async () => {
+    const pool = createTestPool();
+    const workflows = new WorkflowsPG({ pool });
+    const workflowName = `unicode-fragment-${Date.now()}`;
+    const runId = `run-${Date.now()}`;
+
+    try {
+      await workflows.init();
+      await workflows.persistWorkflowSnapshot({
+        workflowName,
+        runId,
+        snapshot: { status: 'running', context: {} } as any,
+      });
+
+      const context = await workflows.updateWorkflowResults({
+        workflowName,
+        runId,
+        stepId: 'step-1',
+        result: {
+          status: 'success',
+          output: { text: 'prefix suffix', escape: 'Omschr\\vijving' },
+          payload: {},
+          startedAt: Date.now(),
+        } as any,
+        requestContext: {},
+      });
+
+      expect((context['step-1'] as any).output.text).toBe('prefixsuffix');
+
+      const snapshot = await workflows.loadWorkflowSnapshot({ workflowName, runId });
+      expect((snapshot?.context['step-1'] as any).output.text).toBe('prefixsuffix');
+    } finally {
+      await pool.query(`DELETE FROM mastra_workflow_snapshot WHERE workflow_name = $1`, [workflowName]);
+      await pool.end();
+    }
+  });
+});

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -823,7 +823,7 @@ describe('WorkflowsPG step result updates', () => {
         stepId: 'step-1',
         result: {
           status: 'success',
-          output: { text: 'prefix suffix', escape: 'Omschr\\vijving' },
+          output: { text: 'prefix\u0000suffix', escape: 'Omschr\\vijving' },
           payload: {},
           startedAt: Date.now(),
         } as any,

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -840,3 +840,53 @@ describe('WorkflowsPG step result updates', () => {
     }
   });
 });
+
+describe('WorkflowsPG updateWorkflowState', () => {
+  it('merges options into the snapshot in place and returns the updated snapshot', async () => {
+    const pool = createTestPool();
+    const workflows = new WorkflowsPG({ pool });
+    const workflowName = `state-merge-${Date.now()}`;
+    const runId = `run-${Date.now()}`;
+
+    try {
+      await workflows.init();
+      await workflows.persistWorkflowSnapshot({
+        workflowName,
+        runId,
+        snapshot: { status: 'running', context: { input: { x: 1 } } } as any,
+      });
+
+      const updated = await workflows.updateWorkflowState({
+        workflowName,
+        runId,
+        opts: { status: 'suspended', suspendedPaths: { 'step-1': [0] } } as any,
+      });
+
+      expect(updated).toBeDefined();
+      expect(updated!.status).toBe('suspended');
+      expect((updated as any).suspendedPaths).toEqual({ 'step-1': [0] });
+      expect((updated as any).context.input).toEqual({ x: 1 });
+    } finally {
+      await pool.query(`DELETE FROM mastra_workflow_snapshot WHERE workflow_name = $1`, [workflowName]);
+      await pool.end();
+    }
+  });
+
+  it('returns undefined for a non-existent run', async () => {
+    const pool = createTestPool();
+    const workflows = new WorkflowsPG({ pool });
+
+    try {
+      await workflows.init();
+      const result = await workflows.updateWorkflowState({
+        workflowName: 'nonexistent',
+        runId: 'nonexistent',
+        opts: { status: 'suspended' } as any,
+      });
+
+      expect(result).toBeUndefined();
+    } finally {
+      await pool.end();
+    }
+  });
+});


### PR DESCRIPTION
## Description

Tool-approval workflows suspend on every approval cycle and persist the agent stream-state into the workflow snapshot. With large tool payloads (e.g. Figma) the snapshot grew tens of MB per step and `@mastra/pg` read-modified-wrote the whole row on every update, producing the `parseRow` (~266 MB self) and `persistWorkflowSnapshot` (~143 MB self) heap hotspots in #17738 and causing Node OOM crashes. This PR shrinks what gets serialized into the snapshot and removes the full-row round-trip on per-step updates.

- Trim `__streamState` in `packages/core/src/stream/base/output.ts` so buffered steps persist per-step request/response deltas instead of cumulative history; the full view is rebuilt on deserialize for resume.
- Deduplicate large tool-result payloads in serialized stream state by replacing matching `toolResults`, `dynamicToolResults`, and tool-result content-part outputs with `{ __toolResultRef: toolCallId }` references that rehydrate from the single message-list copy on resume; non-matching (transformed) outputs are kept as-is.
- In `stores/pg/src/storage/domains/workflows/index.ts`, switch `updateWorkflowResults` to a single in-place `jsonb_set` UPDATE for non-foreach step results and switch `updateWorkflowState` to a `snapshot || $3::jsonb` merge, so per-step updates no longer SELECT, parse, merge and rewrite the full snapshot row.
- Keep the transactional read-merge-write path as a fallback for foreach element-wise array merges and for the first-write-creates-row case; sanitize only the fragment being written for invalid JSON escapes / null chars.
- Add size-regression and dedup-rehydration tests in `output.test.ts`, plus pg integration tests covering foreach element-wise merge, snapshot auto-create on first `updateWorkflowResults`, and in-place unicode sanitization.

## Related Issue(s)

Fixes #17738

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When a workflow pauses for tool approval, it saves “where it left off” so it can continue later. This PR makes that saved progress much smaller and easier to update, so memory doesn’t keep growing with every approval—and Postgres updates don’t repeatedly rewrite huge snapshots.

### What changed
- **`@mastra/core`**
  - Reduced workflow snapshot bloat by persisting **only per-step stream deltas** (avoids repeatedly saving cumulative `request`, `dbMessages`, `uiMessages`).
  - Reduced serialized size further by **deduplicating large tool results** into reference markers and **rehydrating** them on resume.
  - Updated serialization/deserialization logic to rebuild buffered steps and restore tool-result payloads from refs; **stops serializing `bufferedTextChunks`** (defaults on deserialize instead).
- **`@mastra/pg`**
  - Optimized workflow snapshot persistence to avoid full **read/parse/merge/rewrite** for common updates.
  - Added an **in-place fast path** using PostgreSQL `jsonb_set`/merge-style updates for:
    - `updateWorkflowResults` when the step output is **not** a foreach/array merge
    - `updateWorkflowState` when `snapshot.context` is a JSON object
  - Kept the **transactional read-merge-write fallback** for foreach array merges and for cases where the snapshot row must be created.
- **Release notes (changesets)**
  - Added changesets for both `@mastra/core` and `@mastra/pg` documenting the memory/snapshot bloat mitigation.

### Tests added/updated
- **Core unit tests** for:
  - snapshot size regression / linear JSON growth
  - buffered-step delta serialization round-trips (including legacy behavior)
  - tool-result dedup + rehydration
  - foreach-related delta behavior
  - unicode sanitization
- **PG integration tests** for:
  - in-place step-result updates
  - foreach element-wise merge semantics
  - implicit workflow snapshot creation on first update
  - unicode sanitization
- Fixed a test-fixture regression involving **a NUL byte** in the unicode sanitization test (replaced with a space during rebase), restoring CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->