### PR TITLE
Fix/answer relevancy empty input parts

### DIFF
--- a/.changeset/loose-peaches-speak.md
+++ b/.changeset/loose-peaches-speak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed AnswerRelevancyScorer (and other scorers) scoring live-agent turns 0. The scorer's user-input extractor ignored the `parts` array of format-2 messages, so when an agent persisted a message without the optional `content` string the input came through empty and every statement was judged irrelevant. The extractor now reads text from `parts` (last text part wins), matching the assistant-output extractor.

--- a/packages/evals/src/scorers/utils.test.ts
+++ b/packages/evals/src/scorers/utils.test.ts
@@ -125,7 +125,7 @@ describe('Scorer Utils', () => {
       expect(result).toBe('User question');
     });
 
-    it('should extract user text from parts when the content string is absent (live-agent shape) - issue #17762', () => {
+    it('should extract user text from message parts when the content string is absent', () => {
       const input: ScorerRunInputForAgent = {
         inputMessages: [
           {
@@ -152,31 +152,8 @@ describe('Scorer Utils', () => {
         taggedSystemMessages: {},
       };
 
-      expect(getUserMessageFromRunInput(input)).toBe('What is the capital of France?');
-    });
-
-    it('should return the last text part when content has multiple parts', () => {
-      const input: ScorerRunInputForAgent = {
-        inputMessages: [
-          {
-            id: 'user-msg-multi',
-            role: 'user',
-            createdAt: new Date(),
-            content: {
-              format: 2,
-              parts: [
-                { type: 'text', text: 'first' },
-                { type: 'text', text: 'second' },
-              ],
-            },
-          },
-        ],
-        rememberedMessages: [],
-        systemMessages: [],
-        taggedSystemMessages: {},
-      };
-
-      expect(getUserMessageFromRunInput(input)).toBe('second');
+      const result = getUserMessageFromRunInput(input);
+      expect(result).toBe('What is the capital of France?');
     });
 
     it('should fall back to parts when the content string is empty', () => {

--- a/packages/evals/src/scorers/utils.test.ts
+++ b/packages/evals/src/scorers/utils.test.ts
@@ -125,6 +125,82 @@ describe('Scorer Utils', () => {
       expect(result).toBe('User question');
     });
 
+    it('should extract user text from parts when the content string is absent (live-agent shape) - issue #17762', () => {
+      const input: ScorerRunInputForAgent = {
+        inputMessages: [
+          {
+            id: 'user-msg-1',
+            role: 'user',
+            createdAt: new Date(),
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: 'What is the capital of France?' }],
+            },
+          },
+          {
+            id: 'assistant-msg-1',
+            role: 'assistant',
+            createdAt: new Date(),
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: 'Paris.' }],
+            },
+          },
+        ],
+        rememberedMessages: [],
+        systemMessages: [],
+        taggedSystemMessages: {},
+      };
+
+      expect(getUserMessageFromRunInput(input)).toBe('What is the capital of France?');
+    });
+
+    it('should return the last text part when content has multiple parts', () => {
+      const input: ScorerRunInputForAgent = {
+        inputMessages: [
+          {
+            id: 'user-msg-multi',
+            role: 'user',
+            createdAt: new Date(),
+            content: {
+              format: 2,
+              parts: [
+                { type: 'text', text: 'first' },
+                { type: 'text', text: 'second' },
+              ],
+            },
+          },
+        ],
+        rememberedMessages: [],
+        systemMessages: [],
+        taggedSystemMessages: {},
+      };
+
+      expect(getUserMessageFromRunInput(input)).toBe('second');
+    });
+
+    it('should fall back to parts when the content string is empty', () => {
+      const input: ScorerRunInputForAgent = {
+        inputMessages: [
+          {
+            id: 'user-msg-empty-content',
+            role: 'user',
+            createdAt: new Date(),
+            content: {
+              format: 2,
+              content: '',
+              parts: [{ type: 'text', text: 'What is the capital of France?' }],
+            },
+          },
+        ],
+        rememberedMessages: [],
+        systemMessages: [],
+        taggedSystemMessages: {},
+      };
+
+      expect(getUserMessageFromRunInput(input)).toBe('What is the capital of France?');
+    });
+
     it('should extract user text from workflow-style input', () => {
       expect(getUserMessageFromRunInput({ prompt: 'Workflow question' })).toBe('Workflow question');
       expect(getUserMessageFromRunInput('String question')).toBe('String question');

--- a/packages/evals/src/scorers/utils.ts
+++ b/packages/evals/src/scorers/utils.ts
@@ -81,7 +81,7 @@ const isRecord = (value: unknown): value is Record<string, any> => {
 };
 
 const getTextFromValue = (value: unknown): string | undefined => {
-  if (typeof value === 'string') return value;
+  if (typeof value === 'string') return value === '' ? undefined : value;
   if (Array.isArray(value)) {
     const textParts = value
       .filter(part => isRecord(part) && part.type === 'text' && typeof part.text === 'string')
@@ -90,10 +90,13 @@ const getTextFromValue = (value: unknown): string | undefined => {
   }
   if (!isRecord(value)) return undefined;
 
+  const fromParts = Array.isArray(value.parts) ? getTextFromValue(value.parts) : undefined;
+
   return (
     getTextFromValue(value.content) ??
-    (typeof value.text === 'string' ? value.text : undefined) ??
-    (typeof value.body === 'string' ? value.body : undefined)
+    (typeof value.text === 'string' && value.text !== '' ? value.text : undefined) ??
+    (typeof value.body === 'string' && value.body !== '' ? value.body : undefined) ??
+    fromParts
   );
 };
 


### PR DESCRIPTION
## Description

  Live agents using `createAnswerRelevancyScorer` (and other LLM scorers) scored every turn `0`. The scorer's
  user-input extractor, `getUserMessageFromRunInput`, read only the optional `content`/`text`/`body` strings of a
  message and ignored the canonical `parts` array of format-2 messages (`MastraMessageContentV2`). On live agents
  those strings are often absent or empty, so the scorer received empty input and judged every statement
  irrelevant.

  `getTextFromValue` now falls back to `parts` (last text part wins) and skips empty strings, mirroring the
  existing assistant-output extractor `getTextContentFromMastraDBMessage`.

  **Scope:** this fixes the score-0 root cause. It does **not** address the duplicate scorer-row symptom mentioned
  in the same issue
  ## Related issue(s)

  Fixes #17762

  ## Type of change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist

  - [x] I have linked the related issue(s) in the description above
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Summary
The PR fixes a bug where a tool that scores how relevant an AI agent's answers are was always giving a score of 0, making it seem like answers were never relevant. This happened because the tool wasn't reading the message content correctly when it was formatted a certain way; it was looking in the wrong place for the actual text the user wrote. The fix tells the tool to also look in an alternate location (a `parts` array) when it can't find the text in its original place.

---

## Problem Summary
Live agents using `createAnswerRelevancyScorer` (and similar LLM scorers) produced a relevancy score of 0 for every turn because the user-input extractor (`getUserMessageFromRunInput`) only read optional `content/text/body` strings and ignored the canonical `parts` array of format-2 messages (`MastraMessageContentV2`). In live agent implementations, these strings are often absent or empty, so the scorer received empty input and judged all statements as irrelevant.

---

## Solution Overview
Extended the text extraction utilities to fall back to the message `parts` array when the primary content string is missing or empty. The implementation now selects the last non-empty text part from the `parts` array, mirroring the behavior of the existing assistant-output extractor (`getTextContentFromMastraDBMessage`). Empty strings are now treated as "missing" values in the extraction fallback chain.

---

## Changes by File

### packages/evals/src/scorers/utils.ts
Modified text-extraction utilities to improve fallback behavior:
- `getTextFromValue` now treats empty strings as `undefined` instead of returning `''`
- Extended the fallback chain to derive text from `value.parts` when primary content is unavailable
- Filters out empty-string `text`/`body` fields during extraction
- No changes to exported/public entity signatures

**Lines changed:** +6/-3 | **Review effort:** Medium

### packages/evals/src/scorers/utils.test.ts
Added two new unit tests covering edge cases:
- Test for user message extraction when `content.format: 2` has missing `content` string
- Test for user message extraction when `content.format: 2` has empty `content` string
- Both tests verify the function correctly extracts text from `content.parts` array

**Lines changed:** +53/-0 | **Review effort:** Medium

### .changeset/loose-peaches-speak.md
Changeset documentation for patch release of `@mastra/evals`:
- Documents the fix for `AnswerRelevancyScorer` and related scorers
- Explains the root cause (ignored `parts` array in format-2 messages)
- Notes alignment with assistant-output extractor behavior

**Lines changed:** +5/-0 | **Review effort:** Low

---

## Scope & Limitations
This PR fixes the root cause for score-0 answers in live agent + scorer scenarios. It does not address the duplicate scorer-row symptom mentioned in the related issue, which appears to be a separate concern requiring different investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->