### PR TITLE
fix(playground-ui): highlight first combobox search result

### DIFF
--- a/.changeset/curly-lizards-like.md
+++ b/.changeset/curly-lizards-like.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed combobox keyboard selection after filtering so pressing Enter chooses the first matching option.

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx
@@ -74,6 +74,27 @@ describe('Combobox', () => {
     });
   });
 
+  it('selects the first filtered item when pressing Enter after searching', async () => {
+    const onValueChange = vi.fn();
+    renderCombobox({ onValueChange });
+
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const search = await screen.findByPlaceholderText('Search providers');
+    fireEvent.input(search, { target: { value: 'goo' }, inputType: 'insertText' });
+
+    const google = await screen.findByRole('option', { name: 'Google' });
+    await waitFor(() => {
+      expect(google.hasAttribute('data-highlighted')).toBe(true);
+    });
+
+    fireEvent.keyDown(search, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(onValueChange).toHaveBeenCalledWith('google');
+    });
+  });
+
   it('renders a pill-shaped trigger from the shared buttonVariants recipe', () => {
     render(<Combobox options={options} placeholder="Pick provider" />);
 

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -64,6 +64,7 @@ export function Combobox({
   return (
     <div className={comboboxStyles.root}>
       <BaseCombobox.Root
+        autoHighlight
         items={options}
         value={selectedOption}
         onValueChange={handleSelect}


### PR DESCRIPTION
This fixes the combobox keyboard flow after filtering. When a user types a query that narrows the list, Base UI now highlights the first matching option so pressing Enter selects it.

The regression test opens the design-system combobox, types a query for an option that is not originally first, confirms the filtered option is highlighted, and verifies Enter selects it.

Validated with `pnpm build:playground-ui`, `pnpm --filter ./packages/playground-ui lint`, `pnpm --filter ./packages/playground-ui typecheck`, `pnpm --filter ./packages/playground-ui exec vitest run`, and Prettier checks on the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a combobox (a search dropdown) so that when you type to filter the list, the first matching result is automatically highlighted. That way, you can just press Enter to select it instead of having to click or navigate to it manually.

## Changes

### Combobox Component Enhancement
- **File**: `packages/playground-ui/src/ds/components/Combobox/combobox.tsx`
- Enabled `autoHighlight` property on the `BaseCombobox.Root` component to automatically highlight the first matching option when the combobox is filtered via user search input

### Test Coverage
- **File**: `packages/playground-ui/src/ds/components/Combobox/combobox.test.tsx`
- Added a regression test that verifies the expected keyboard behavior: when a user opens the combobox, enters a search query that filters options, and presses Enter, the first matching option (Google) is selected and `onValueChange` is called with the correct value ("google")

### Changelog Entry
- **File**: `.changeset/curly-lizards-like.md`
- Added a changeset documenting this patch-level fix to `@mastra/playground-ui`

## Validation
The changes have been validated through:
- Unit tests (Vitest)
- Build, lint, and typecheck processes
- Code formatting (Prettier)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->