### PR TITLE
chore(docs): Fix styleguide issues

### DIFF
--- a/.claude/skills/mastra-docs/references/STYLEGUIDE.md
+++ b/.claude/skills/mastra-docs/references/STYLEGUIDE.md
@@ -33,6 +33,10 @@ Use this file as the default writing guide for Mastra's documentation.
 - Address the reader in the present tense.
 - Use sentence case for titles.
 - Use conjunctions where they make the sentence sound more natural.
+- Use contractions for common phrases like `don't`, `doesn't`, `can't`, and `isn't`.
+- Remove filler, weak adverbs, weasel words, clichés, and wordy phrases.
+- Do not start sentences with `So`, `There is`, or `There are`.
+- Use inclusive, gender-neutral, person-first wording.
 - Write out abbreviations on first use, then add the abbreviation in parentheses.
 - Avoid gerunds in titles when a clearer verb phrase works.
 - Prefer active voice.

--- a/docs/src/content/en/docs/agent-builder/browser.mdx
+++ b/docs/src/content/en/docs/agent-builder/browser.mdx
@@ -56,7 +56,7 @@ new MastraEditor({
 
 - `id` — provider identifier, matched against `StorageBrowserConfig.provider` (e.g., `'stagehand'`).
 - `name` — display name shown in the Builder UI.
-- `createBrowser(config)` — hydrates a stored browser config into a runtime `MastraBrowser`. This is where you inject runtime-only credentials (API keys, project IDs) that are not stored in the agent snapshot.
+- `createBrowser(config)` — hydrates a stored browser config into a runtime `MastraBrowser`. This is where you inject runtime-only credentials (API keys, project IDs) that aren't stored in the agent snapshot.
 
 Browser classes ship as separate packages (e.g., `@mastra/stagehand`, `@mastra/agent-browser`). The provider entry is a plain object wrapping the class — register one entry per browser you want the Builder to expose to end users. See the [StorageBrowserRef reference](/reference/editor/storage-browser-ref) for the full `browser` field schema, including all `StorageBrowserConfig` options.
 

--- a/docs/src/content/en/docs/agent-builder/channels.mdx
+++ b/docs/src/content/en/docs/agent-builder/channels.mdx
@@ -54,7 +54,7 @@ The Slack provider handles app creation, OAuth, slash commands, and message rout
 
 `SlackProvider` requires one environment variable and accepts one optional override:
 
-- `SLACK_APP_CONFIG_REFRESH_TOKEN` (required): the refresh token from your Slack app configuration tokens, available under **Your App Configuration Tokens** on [api.slack.com/apps](https://api.slack.com/apps). The refresh token does not expire, but the access tokens it issues rotate every 12 hours and are auto-persisted to `Mastra.storage`.
+- `SLACK_APP_CONFIG_REFRESH_TOKEN` (required): the refresh token from your Slack app configuration tokens, available under **Your App Configuration Tokens** on [api.slack.com/apps](https://api.slack.com/apps). The refresh token doesn't expire, but the access tokens it issues rotate every 12 hours and are auto-persisted to `Mastra.storage`.
 - `baseUrl` (optional): the public URL Slack should send events and OAuth callbacks to. Defaults to the running Mastra server's host and port (for example, `http://localhost:4111` in local development). Pass `baseUrl` explicitly when the public URL differs from the server's resolved address — typically a tunnel for local development (`cloudflared tunnel --url http://localhost:4111`) or a deployed URL in production.
 
 ## Storage requirement

--- a/docs/src/content/en/docs/agents/adding-voice.mdx
+++ b/docs/src/content/en/docs/agents/adding-voice.mdx
@@ -177,7 +177,7 @@ await voice.connect()
 When you use a resolver:
 
 - Each call to `getVoice()` returns a new instance, so concurrent sessions never share state.
-- Mastra does not add tools or instructions to a resolver instance. Configure those inside the resolver or on the provider.
+- Mastra doesn't add tools or instructions to a resolver instance. Configure those inside the resolver or on the provider.
 - You own the lifecycle of the returned instance, so call `disconnect()` or `close()` when the session ends.
 
 The `agent.voice` getter has no request context, so it throws when `voice` is a resolver. Use `agent.getVoice({ requestContext })` instead.

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -109,7 +109,7 @@ const stream = await agent.stream('Clean up old records', {
 })
 ```
 
-A tool's own `requireApproval` setting still takes precedence: if a tool defines its own approval rule, that rule decides for that tool and the function above does not override it. If the function throws, the call requires approval (fail-safe).
+A tool's own `requireApproval` setting still takes precedence: if a tool defines its own approval rule, that rule decides for that tool and the function above doesn't override it. If the function throws, the call requires approval (fail-safe).
 
 :::note
 
@@ -125,7 +125,7 @@ The stream emits a `tool-call-suspended` chunk with a custom payload defined by 
 
 :::note
 
-`suspend()` does not throw — return immediately after calling it (e.g. `return await suspend({ ... })`). Code after `await suspend(...)` still runs before the tool pauses.
+`suspend()` doesn't throw — return immediately after calling it (e.g. `return await suspend({ ... })`). Code after `await suspend(...)` still runs before the tool pauses.
 
 :::
 

--- a/docs/src/content/en/docs/agents/background-tasks.mdx
+++ b/docs/src/content/en/docs/agents/background-tasks.mdx
@@ -120,7 +120,7 @@ When a tool is registered on an agent that has background tasks enabled, the mod
 }
 ```
 
-The `_background` override is a _modifier_ on tools the developer has already opted in at the tool or agent layer — it is not a standalone opt-in. If a tool hasn't been opted in, `_background.enabled: true` from the model is ignored and the tool runs in the foreground. This keeps deterministic, foreground-only tools (calculators, lookups, schema validators) from being silently dispatched as tasks.
+The `_background` override is a _modifier_ on tools the developer has already opted in at the tool or agent layer — it's not a standalone opt-in. If a tool hasn't been opted in, `_background.enabled: true` from the model is ignored and the tool runs in the foreground. This keeps deterministic, foreground-only tools (calculators, lookups, schema validators) from being silently dispatched as tasks.
 
 ### Resolution order
 

--- a/docs/src/content/en/docs/agents/channels.mdx
+++ b/docs/src/content/en/docs/agents/channels.mdx
@@ -91,7 +91,7 @@ When a user mentions the agent mid-conversation in a channel thread, the agent m
 1. On the **first mention** in a thread, the agent fetches recent messages from the platform.
 1. These messages are prepended to the user's message as conversation context.
 1. After responding, the agent subscribes to the thread and has full history via Mastra's memory.
-1. Subsequent messages in that thread do **not** re-fetch from the platform.
+1. Subsequent messages in that thread **don't** re-fetch from the platform.
 
 Set `threadContext: { maxMessages: 0 }` to disable this behavior. This only applies to non-DM threads.
 
@@ -121,7 +121,7 @@ const deleteFile = createTool({
 
 When the agent calls this tool, users see a card with the tool name, arguments, and Approve/Deny buttons. The tool only executes after approval.
 
-Set `toolDisplay: 'text'` on an adapter to render tool calls as plain text instead of interactive cards. In `'hidden'` mode the agent uses `autoResumeSuspendedTools` to let the LLM decide based on the conversation context, since hidden mode does not post approval buttons.
+Set `toolDisplay: 'text'` on an adapter to render tool calls as plain text instead of interactive cards. In `'hidden'` mode the agent uses `autoResumeSuspendedTools` to let the LLM decide based on the conversation context, since hidden mode doesn't post approval buttons.
 
 ## Multi-user awareness
 

--- a/docs/src/content/en/docs/agents/sdk-agents.mdx
+++ b/docs/src/content/en/docs/agents/sdk-agents.mdx
@@ -358,7 +358,7 @@ const result = await openaiSDKAgent.generate<{ summary: string }>('Summarize thi
 console.log(result.object.summary)
 ```
 
-Cursor SDK agents throw a clear error when `structuredOutput` is requested because the Cursor TypeScript SDK does not expose a schema-constrained output API.
+Cursor SDK agents throw a clear error when `structuredOutput` is requested because the Cursor TypeScript SDK doesn't expose a schema-constrained output API.
 
 ## Observability
 

--- a/docs/src/content/en/docs/agents/supervisor-agents.mdx
+++ b/docs/src/content/en/docs/agents/supervisor-agents.mdx
@@ -185,7 +185,7 @@ The callback receives `messages` (the full conversation history), `primitiveId` 
 
 ## Subagent result context
 
-When a subagent completes, the supervisor model receives the subagent's text response in later iterations. Nested tool calls and subagent metadata, such as thread and resource IDs, are not added to the supervisor model context.
+When a subagent completes, the supervisor model receives the subagent's text response in later iterations. Nested tool calls and subagent metadata, such as thread and resource IDs, aren't added to the supervisor model context.
 
 Application code and UI integrations can still inspect the raw delegation result, including `subAgentToolResults`, from the tool result payload. This keeps debugging and display data available without sending nested tool arguments or outputs back into the supervisor's next model call.
 

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -246,7 +246,7 @@ export const weatherTool = createTool({
 
 Use `transform` when a tool returns raw data your application needs, but browser-facing streams or user-visible transcript messages should receive a smaller or safer shape. `transform` is separate from `toModelOutput`: `toModelOutput` shapes the payload sent back to the model, while `transform` shapes tool input, output, errors, approval payloads, and suspension payloads for `display` and `transcript` targets.
 
-If a transform is configured and it fails, Mastra does not fall back to the raw payload for display or transcript targets. Input deltas are suppressed when no safe `inputDelta` transform is available.
+If a transform is configured and it fails, Mastra doesn't fall back to the raw payload for display or transcript targets. Input deltas are suppressed when no safe `inputDelta` transform is available.
 
 See the [`createTool()` reference](/reference/tools/create-tool#example-with-transform) for a `transform` example. For shared rules across several tools, configure the agent-level `transform` policy in the [`Agent` constructor](/reference/agents/agent#constructor-parameters).
 

--- a/docs/src/content/en/docs/browser/agent-browser.mdx
+++ b/docs/src/content/en/docs/browser/agent-browser.mdx
@@ -62,7 +62,7 @@ When the agent uses the `browser_screenshot` tool, it captures a PNG image of th
 
 Use screenshots when you need to visually inspect the page — for example, evaluating images, layout, or colors. For text or structured data, use `browser_snapshot` instead.
 
-To disable the screenshot tool for models that do not support vision, use `excludeTools`:
+To disable the screenshot tool for models that don't support vision, use `excludeTools`:
 
 ```typescript
 const browser = new AgentBrowser({

--- a/docs/src/content/en/docs/browser/browser-viewer.mdx
+++ b/docs/src/content/en/docs/browser/browser-viewer.mdx
@@ -84,7 +84,7 @@ When the agent runs a CLI command like `browser-use open https://example.com`, M
 
 BrowserViewer supports three CLI providers. Each CLI must be installed separately in your workspace environment. Each CLI also publishes a [skill](/docs/workspace/skills) that teaches the agent its commands and workflows.
 
-### agent-browser
+### `agent-browser`
 
 ```bash
 npm install -g agent-browser
@@ -93,7 +93,7 @@ npx skills add vercel-labs/agent-browser
 
 CDP flag: `--cdp`
 
-### browser-use
+### `browser-use`
 
 ```bash
 pip install browser-use
@@ -102,7 +102,7 @@ npx skills add browser-use/browser-use --skill browser-use
 
 CDP flag: `--cdp-url`
 
-### browse-cli
+### `browse-cli`
 
 ```bash
 npm install -g @browserbasehq/browse-cli

--- a/docs/src/content/en/docs/browser/overview.mdx
+++ b/docs/src/content/en/docs/browser/overview.mdx
@@ -116,7 +116,7 @@ npm install ws @hono/node-ws
 
 :::note
 
-These packages are not included by default because they are incompatible with serverless environments like Cloudflare Workers. If they are not installed, screencast is disabled but all other browser functionality works normally.
+These packages aren't included by default because they're incompatible with serverless environments like Cloudflare Workers. If they'ren't installed, screencast is disabled but all other browser functionality works normally.
 
 :::
 

--- a/docs/src/content/en/docs/browser/overview.mdx
+++ b/docs/src/content/en/docs/browser/overview.mdx
@@ -116,7 +116,7 @@ npm install ws @hono/node-ws
 
 :::note
 
-These packages aren't included by default because they're incompatible with serverless environments like Cloudflare Workers. If they'ren't installed, screencast is disabled but all other browser functionality works normally.
+These packages aren't included by default because they're incompatible with serverless environments like Cloudflare Workers. If they aren't installed, screencast is disabled but all other browser functionality works normally.
 
 :::
 

--- a/docs/src/content/en/docs/browser/stagehand.mdx
+++ b/docs/src/content/en/docs/browser/stagehand.mdx
@@ -108,7 +108,7 @@ const browser = new StagehandBrowser({
 })
 ```
 
-To disable the screenshot tool for models that do not support vision, use `excludeTools`:
+To disable the screenshot tool for models that don't support vision, use `excludeTools`:
 
 ```typescript
 const browser = new StagehandBrowser({

--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -92,7 +92,7 @@ When `source` is `'code'`, the editor writes each override to a deterministic JS
 
 ### Versioning with the code source
 
-The code source uses the Git history of each per-agent JSON file as its version history. Each commit that changes a file appears as a read-only version in Studio, labeled with the commit message. Saving in Studio updates the working file in place rather than creating a database draft, so the version dropdown reflects your actual commit history.
+The code source uses the Git history of each per-agent JSON file as its version history. Each commit that changes a file is shown as a read-only version in Studio, labeled with the commit message. Saving in Studio updates the working file in place rather than creating a database draft, so the version dropdown reflects your actual commit history.
 
 This means versions and rollbacks are managed through Git rather than through draft and publish actions.
 
@@ -156,11 +156,11 @@ The same operations are available over HTTP through the Mastra server. Use these
 | `GET` | `/stored/agents/:storedAgentId/dependents` | List agents that reference this agent as a sub-agent. |
 | `POST` | `/stored/agents/:storedAgentId/export` | Export a stored agent's override as a deterministic JSON config. |
 
-The dependents endpoint helps warn before deleting or unsharing an agent that other agents depend on: `dependents` lists caller-readable agents by `id` and `name`, while `hiddenCount` aggregates cross-workspace references the caller cannot read (surfaced only when the target is public). The export endpoint returns only the fields the agent's [`editor` config](/reference/agents/agent#editor-overrides) allows, so the output matches the per-agent file the code source writes to disk. The Client SDK wraps these endpoints with `client.listStoredAgents()`, `client.createStoredAgent()`, `client.getStoredAgent()`, `client.getStoredAgent(id).dependents()`, and `client.getStoredAgent(id).export()`. Version management endpoints live under `/stored/agents/:storedAgentId/versions`, see [version management](/reference/client-js/agents#version-management) for the full list.
+The dependents endpoint helps warn before deleting or unsharing an agent that other agents depend on: `dependents` lists caller-readable agents by `id` and `name`, while `hiddenCount` aggregates cross-workspace references the caller can't read (surfaced only when the target is public). The export endpoint returns only the fields the agent's [`editor` config](/reference/agents/agent#editor-overrides) allows, so the output matches the per-agent file the code source writes to disk. The Client SDK wraps these endpoints with `client.listStoredAgents()`, `client.createStoredAgent()`, `client.getStoredAgent()`, `client.getStoredAgent(id).dependents()`, and `client.getStoredAgent(id).export()`. Version management endpoints live under `/stored/agents/:storedAgentId/versions`, see [version management](/reference/client-js/agents#version-management) for the full list.
 
 ### Automated experimentation
 
-Because stored agents are just data, you can build automation loops that tune agents without human involvement. A common pattern is to pair the editor API with [datasets](/docs/evals/datasets/overview) and [experiments](/docs/evals/datasets/running-experiments):
+Because stored agents are data, you can build automation loops that tune agents without human involvement. A common pattern is to pair the editor API with [datasets](/docs/evals/datasets/overview) and [experiments](/docs/evals/datasets/running-experiments):
 
 - Run a dataset through the current version of an agent and score the results.
 - Have another agent read the failing cases and propose changes to the instructions or tools.
@@ -187,7 +187,7 @@ When you edit a code-defined agent through the editor, only specific fields can 
 
 Fields like the agent's `id`, `name`, and `model` come from your code and can't be changed through the editor for code-defined agents. The variables are also read-only.
 
-### Controlling what is editable
+### Controlling what's editable
 
 Use the `editor` field on a code-defined agent to control which fields the editor can override. This lets you keep some fields code-owned while allowing edits to others:
 
@@ -227,7 +227,7 @@ Each version has one of three statuses:
 | - | - |
 | Draft | The latest working copy. Every save creates a new draft version. |
 | Published | The active version used in production. Only one version can be published at a time. |
-| Archived | A previous version that is no longer active. You can restore any archived version. |
+| Archived | A previous version that's no longer active. You can restore any archived version. |
 
 The typical flow is: Edit the draft, test it, then activate it to make it the published version. The previously published version becomes archived so you can restore it if needed. You can do this through Studio or programmatically through the API.
 
@@ -345,7 +345,7 @@ curl -X POST http://localhost:4111/agents/supervisor/generate \
 
 Version overrides propagate automatically through sub-agent delegation via `requestContext`. When a supervisor delegates to a sub-agent, the framework checks if a version override exists for that sub-agent's ID. If one is found, it resolves the stored version from the editor and uses it instead of the code-defined default.
 
-If version resolution fails (for example, when the editor is not configured or the version ID doesn't exist), the framework logs a warning and falls back to the code-defined agent.
+If version resolution fails (for example, when the editor isn't configured or the version ID doesn't exist), the framework logs a warning and falls back to the code-defined agent.
 
 ## Next steps
 

--- a/docs/src/content/en/docs/editor/prompts.mdx
+++ b/docs/src/content/en/docs/editor/prompts.mdx
@@ -18,7 +18,7 @@ Prompt blocks are reusable instruction templates that you compose into an agent'
 1. Open an agent's **Instructions** section and select **Add block**.
 1. Pick the saved prompt block from the block picker dialog.
 
-The block appears as a reference in the agent's instruction list. Changes to the original prompt block update every agent that references it.
+The block is added as a reference in the agent's instruction list. Changes to the original prompt block update every agent that references it.
 
 ## Block types
 
@@ -52,7 +52,7 @@ Variables are passed through the agent's `variables` configuration or through [r
 
 Each block can have a **display condition**. A rule group that controls whether the block is included in the final prompt. Conditions are evaluated at runtime against the agent's variables and request context.
 
-A rule group uses **AND** or **OR** logic with one or more conditions. Each condition checks a context field against a value using an operator:
+A rule group uses `AND` or `OR` logic with one or more conditions. Each condition checks a context field against a value using an operator:
 
 | Operator | Description |
 | - | - |
@@ -63,7 +63,7 @@ A rule group uses **AND** or **OR** logic with one or more conditions. Each cond
 | `in` / `not_in` | Checks if a value is in an array. |
 | `exists` / `not_exists` | Checks if the field is present. |
 
-Rule groups can be nested, so you can combine AND and OR conditions for complex logic.
+Rule groups can be nested, so you can combine `AND` and `OR` conditions for complex logic.
 
 In the Studio, open a block's **Display conditions** panel to set up rules visually. You can also configure conditions programmatically through the API. Blocks without conditions are always included.
 

--- a/docs/src/content/en/docs/editor/tools.mdx
+++ b/docs/src/content/en/docs/editor/tools.mdx
@@ -32,7 +32,7 @@ In the Studio, select a tool in the agent's tool list and edit the **Description
 
 Each tool in an agent can have display conditions — rule groups that control whether the tool is available at runtime. This uses the same rule system as [prompt blocks](/docs/editor/prompts#display-conditions).
 
-When a request comes in, the editor evaluates each tool's rules against the current context (agent variables and request context). Tools whose conditions are not met are excluded from that run.
+When a request comes in, the editor evaluates each tool's rules against the current context (agent variables and request context). Tools whose conditions aren't met are excluded from that run.
 
 Use display conditions to:
 
@@ -138,7 +138,7 @@ Tools from MCP servers are namespaced as `serverName_toolName` to avoid conflict
 
 ### Conditional activation
 
-MCP client references in an agent can have display conditions, just like [prompt blocks](/docs/editor/prompts). This lets you conditionally include MCP tools based on request context or agent variables.
+MCP client references in an agent can have display conditions, like [prompt blocks](/docs/editor/prompts). This lets you conditionally include MCP tools based on request context or agent variables.
 
 ## How tools are merged
 

--- a/docs/src/content/en/docs/evals/evals-with-memory.mdx
+++ b/docs/src/content/en/docs/evals/evals-with-memory.mdx
@@ -21,10 +21,10 @@ This page covers the three working patterns for running Mastra evals against mem
 | Goal | Approach |
 | - | - |
 | One shared conversation across every item | [`runEvals` with global `targetOptions.memory`](#shared-thread-with-runevals) |
-| One independent thread per item, simple CI loop | [`runEvals` per item](#per-item-threads-with-runevals) |
+| One independent thread per item, focused CI loop | [`runEvals` per item](#per-item-threads-with-runevals) |
 | Per-item threads driven by a stored `Dataset` | [`dataset.startExperiment` with an inline task](#dataset-experiments-with-an-inline-task) |
 
-Pre-seeding `RequestContext` with `MastraMemory` is **not** a supported way to drive memory into an agent. Thread resolution reads `args.memory.thread` — `RequestContext.MastraMemory` is populated by `prepare-memory-step` after the agent has already resolved its thread.
+Pre-seeding `RequestContext` with `MastraMemory` **isn't** a supported way to drive memory into an agent. Thread resolution reads `args.memory.thread` — `RequestContext.MastraMemory` is populated by `prepare-memory-step` after the agent has already resolved its thread.
 
 ## Shared thread with `runEvals`
 
@@ -51,7 +51,7 @@ const result = await runEvals({
 })
 ```
 
-`targetOptions` is **global per call**. There is no per-item override on `RunEvalsDataItem` today.
+`targetOptions` is **global per call**. No per-item override on `RunEvalsDataItem` is available today.
 
 ## Per-item threads with `runEvals`
 
@@ -96,7 +96,7 @@ Create the thread before running the eval. Observational memory in `thread` scop
 
 ## Dataset experiments with an inline task
 
-`dataset.startExperiment({ target: agent })` does **not** forward a `memory` option to the agent — only `requestContext`. To run a stored dataset against a memory-enabled agent, use an inline `task` function and stash `{ threadId, resourceId }` in each item's `metadata`. The scorer pipeline still runs as normal.
+`dataset.startExperiment({ target: agent })` **doesn't** forward a `memory` option to the agent — only `requestContext`. To run a stored dataset against a memory-enabled agent, use an inline `task` function and stash `{ threadId, resourceId }` in each item's `metadata`. The scorer pipeline still runs as normal.
 
 ```typescript title="src/mastra/evals/dataset-experiment.ts"
 import { randomUUID } from 'node:crypto'

--- a/docs/src/content/en/docs/mastra-platform/observability.mdx
+++ b/docs/src/content/en/docs/mastra-platform/observability.mdx
@@ -33,7 +33,7 @@ The CLI authenticates with Mastra platform, creates a platform project, writes t
 
 ### Existing non-Mastra projects
 
-If you already have an application, such as a Next.js app, but have not added Mastra yet, run `mastra init` and enable Mastra Observability when prompted:
+If you already have an application, such as a Next.js app, but haven't added Mastra yet, run `mastra init` and enable Mastra Observability when prompted:
 
 ```bash npm2yarn
 npx mastra init

--- a/docs/src/content/en/docs/mastra-platform/server.mdx
+++ b/docs/src/content/en/docs/mastra-platform/server.mdx
@@ -67,7 +67,7 @@ A deploy transitions through **queued → uploading → building → deploying �
 
 ## CI/CD
 
-Automate deployments from GitHub Actions, GitLab CI, or any CI provider. After your first interactive deploy, CI/CD needs just two things: an API token and the `.mastra-project.json` file committed to your repository.
+Automate deployments from GitHub Actions, GitLab CI, or any CI provider. After your first interactive deploy, CI/CD needs two things: an API token and the `.mastra-project.json` file committed to your repository.
 
 ### Create an API token
 

--- a/docs/src/content/en/docs/mcp/mcp-apps.mdx
+++ b/docs/src/content/en/docs/mcp/mcp-apps.mdx
@@ -94,7 +94,7 @@ Visit [MCPServer reference](/reference/tools/mcp-server#mcp-apps-appresources) f
 
 ## Connecting MCP Apps to agents
 
-Agents consume tools — they do not need to know about MCP servers. Pass tools to the agent's `tools` config, and register the MCP server at the Mastra level so Studio can resolve app resources.
+Agents consume tools — they don't need to know about MCP servers. Pass tools to the agent's `tools` config, and register the MCP server at the Mastra level so Studio can resolve app resources.
 
 ```typescript title="src/mastra/agents/index.ts"
 import { Agent } from '@mastra/core/agent'
@@ -169,8 +169,8 @@ Agent calls tool → Tool returns brief content + structuredContent
 
 Tools with app resources should return two fields:
 
-- `content`: A brief text summary for the model. Keep this short so the agent does not parrot the full result.
-- `structuredContent`: The data payload that hydrates the UI. The model does not see this field.
+- `content`: A brief text summary for the model. Keep this short so the agent doesn't parrot the full result.
+- `structuredContent`: The data payload that hydrates the UI. The model doesn't see this field.
 
 ```typescript
 execute: async ({ num1, num2, operation }) => {
@@ -317,7 +317,7 @@ App iframes are sandboxed with the following permissions:
 - `allow-forms`: Allows form submission
 - `allow-popups`: Permits `window.open()` and link targets
 
-The iframe does not have access to the parent page's DOM, cookies, or storage. All communication happens through the JSON-RPC postMessage protocol managed by `@mcp-ui/client`'s `AppRenderer` on the host side and `@modelcontextprotocol/ext-apps`'s `App` class on the guest side.
+The iframe doesn't have access to the parent page's DOM, cookies, or storage. All communication happens through the JSON-RPC postMessage protocol managed by `@mcp-ui/client`'s `AppRenderer` on the host side and `@modelcontextprotocol/ext-apps`'s `App` class on the guest side.
 
 ## Related
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -150,7 +150,7 @@ const memory = new Memory({
 })
 ```
 
-`bufferOnIdle` is off by default. It is separate from `bufferTokens`: `bufferTokens` controls step-time async buffering, while `bufferOnIdle` controls end-of-turn buffering for idle turns.
+`bufferOnIdle` is off by default. It's separate from `bufferTokens`: `bufferTokens` controls step-time async buffering, while `bufferOnIdle` controls end-of-turn buffering for idle turns.
 
 See [the API reference](/reference/memory/observational-memory#configuration) for the full configuration shape.
 

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -436,12 +436,12 @@ const memory = new Memory({
 What changes:
 
 - **Storage is identical.** The same resource/thread `workingMemory` field is read and written.
-- **The tool is the same shape, exposed under a new name.** Writes still flow through the same underlying tool; on this path it is registered as `setWorkingMemory` (instead of `updateWorkingMemory`). The rename keeps legacy strip filters from removing tool-call parts so they persist as a normal audit trail and the next model step picks the new value up automatically.
+- **The tool is the same shape, exposed under a new name.** Writes still flow through the same underlying tool; on this path it's registered as `setWorkingMemory` (instead of `updateWorkingMemory`). The rename keeps legacy strip filters from removing tool-call parts so they persist as a normal audit trail and the next model step picks the new value up automatically.
 - **Delivery only.** Instead of folding into the system prompt, `Memory` auto-attaches a `WorkingMemoryStateProcessor` that emits the current working memory as a `state` signal with `stateId: 'working-memory'`.
 
 You inherit the standard state-signal benefits: thread-scoped tracking metadata, `cacheKey` dedup so identical snapshots are only emitted once, and `contextWindow.hasSnapshot` re-injection when an older snapshot rolls out of the window.
 
-The default (`useStateSignals: false`) keeps the existing system-message behavior unchanged. `useStateSignals` is not supported with template working memory `version: 'vnext'`.
+The default (`useStateSignals: false`) keeps the existing system-message behavior unchanged. `useStateSignals` isn't supported with template working memory `version: 'vnext'`.
 
 ## Examples
 

--- a/docs/src/content/en/docs/observability/integrations/bridges/datadog.mdx
+++ b/docs/src/content/en/docs/observability/integrations/bridges/datadog.mdx
@@ -147,7 +147,7 @@ new DatadogBridge({
 ```
 
 :::note
-For most bridge users, agent mode is the right choice. APM data cannot be sent in agentless mode, so enabling agentless splits LLM Observability traffic away from APM traffic. If you want LLM Observability only without an agent, use the [Datadog Exporter](/docs/observability/integrations/exporters/datadog) instead.
+For most bridge users, agent mode is the right choice. APM data can't be sent in agentless mode, so enabling agentless splits LLM Observability traffic away from APM traffic. If you want LLM Observability only without an agent, use the [Datadog Exporter](/docs/observability/integrations/exporters/datadog) instead.
 :::
 
 ## Trace hierarchy

--- a/docs/src/content/en/docs/observability/integrations/bridges/otel.mdx
+++ b/docs/src/content/en/docs/observability/integrations/bridges/otel.mdx
@@ -149,7 +149,7 @@ const sdk = new NodeSDK({
 
 Logs that originate inside a Mastra span are emitted under that span's OTEL context, so backends like Datadog, Grafana, and Honeycomb correlate them with the surrounding trace automatically. Logs without trace context fall through to the currently active OTEL context.
 
-If you do not register a `LoggerProvider`, log emission is a silent no-op — traces continue to work as configured.
+If you don't register a `LoggerProvider`, log emission is a silent no-op — traces continue to work as configured.
 
 ### Running Your Application
 

--- a/docs/src/content/en/docs/observability/integrations/exporters/laminar.mdx
+++ b/docs/src/content/en/docs/observability/integrations/exporters/laminar.mdx
@@ -90,7 +90,7 @@ export const mastra = new Mastra({
 For advanced usage, including the full `MastraExporter` options and multi-agent trace examples, see [Laminar's Mastra integration guide](https://laminar.sh/docs/tracing/integrations/mastra).
 :::
 
-Mastra also ships a standalone [`LaminarExporter`](/reference/observability/tracing/exporters/laminar) in `@mastra/laminar` that sends spans over OTLP/HTTP. It cannot inherit an active OTel context and does not fully map Mastra spans to Laminar's native format, so use the `@lmnr-ai/lmnr` integration above for `observe()` wrappers, multi-agent root spans, and accurate Laminar rendering.
+Mastra also ships a standalone [`LaminarExporter`](/reference/observability/tracing/exporters/laminar) in `@mastra/laminar` that sends spans over OTLP/HTTP. It can't inherit an active OTel context and doesn't fully map Mastra spans to Laminar's native format, so use the `@lmnr-ai/lmnr` integration above for `observe()` wrappers, multi-agent root spans, and accurate Laminar rendering.
 
 ## Related
 

--- a/docs/src/content/en/docs/observability/integrations/exporters/langfuse.mdx
+++ b/docs/src/content/en/docs/observability/integrations/exporters/langfuse.mdx
@@ -177,13 +177,13 @@ To scope an evaluator to a specific agent, configure either filter in Langfuse:
 - **Trace name**: equals the agent name (for example, `weather-agent`).
 - **Metadata**: `agentId` equals the agent id.
 
-The trace name dropdown in Langfuse evaluator filters lists every distinct value seen, so each agent appears as its own entry once it has produced at least one trace.
+The trace name dropdown in Langfuse evaluator filters lists every distinct value seen, so each agent is shown as its own entry once it has produced at least one trace.
 
 If you set a custom `traceName` via `mastra.metadata.traceName`, your value takes precedence over the default agent name.
 
 ## Custom trace metadata
 
-Langfuse filters and groups traces by top-level metadata only. Nested metadata keys cannot be used for filtering or grouping.
+Langfuse filters and groups traces by top-level metadata only. Nested metadata keys can't be used for filtering or grouping.
 
 To add your own top-level metadata, set keys under `langfuse` in your span metadata. The exporter forwards each key to `langfuse.trace.metadata.<key>`, where it becomes filterable in Langfuse:
 
@@ -202,7 +202,7 @@ This example produces `langfuse.trace.metadata.customerId` and `langfuse.trace.m
 
 Notes:
 
-- The reserved `prompt` key is used for [prompt linking](#prompt-linking) and is not forwarded as trace metadata.
+- The reserved `prompt` key is used for [prompt linking](#prompt-linking) and isn't forwarded as trace metadata.
 - The reserved identity keys `agentId`, `agentName`, `workflowId`, and `workflowName` are set from the root span and take precedence over custom values with the same name.
 - Values are sent as strings, because Langfuse maps trace metadata attributes as strings. Numbers, booleans, and objects are serialized with JSON. Langfuse Cloud restores them to their original types on ingestion.
 

--- a/docs/src/content/en/docs/observability/integrations/exporters/mastra-platform.mdx
+++ b/docs/src/content/en/docs/observability/integrations/exporters/mastra-platform.mdx
@@ -11,7 +11,7 @@ The `MastraPlatformExporter` sends traces, logs, metrics, scores, and feedback t
 
 :::note
 
-`MastraPlatformExporter` was previously called `CloudExporter`. The original `CloudExporter` class is still exported from `@mastra/observability` for backward compatibility, but it is deprecated. New code should use `MastraPlatformExporter`.
+`MastraPlatformExporter` was previously called `CloudExporter`. The original `CloudExporter` class is still exported from `@mastra/observability` for backward compatibility, but it's deprecated. New code should use `MastraPlatformExporter`.
 
 :::
 

--- a/docs/src/content/en/docs/observability/integrations/exporters/mastra-storage.mdx
+++ b/docs/src/content/en/docs/observability/integrations/exporters/mastra-storage.mdx
@@ -11,7 +11,7 @@ The `MastraStorageExporter` persists traces to your configured storage backend, 
 
 :::note
 
-`MastraStorageExporter` was previously called `DefaultExporter`. The original `DefaultExporter` class is still exported from `@mastra/observability` for backward compatibility, but it is deprecated. New code should use `MastraStorageExporter`.
+`MastraStorageExporter` was previously called `DefaultExporter`. The original `DefaultExporter` class is still exported from `@mastra/observability` for backward compatibility, but it's deprecated. New code should use `MastraStorageExporter`.
 
 :::
 
@@ -191,11 +191,11 @@ The MastraStorageExporter includes robust error handling for production use:
 
 ## Dropped observability events
 
-`DefaultExporter` emits structured drop events when it cannot persist observability data. Register an exporter or bridge with `onDroppedEvent` to forward these drops to alerting or monitoring.
+`DefaultExporter` emits structured drop events when it can't persist observability data. Register an exporter or bridge with `onDroppedEvent` to forward these drops to alerting or monitoring.
 
-There are two drop reasons:
+For two reasons events are dropped:
 
-- `unsupported-storage`: The storage provider does not implement the signal type.
+- `unsupported-storage`: The storage provider doesn't implement the signal type.
 - `retry-exhausted`: The exporter retried a batch up to `maxRetries` times and then dropped it.
 
 The following example demonstrates forwarding drop details to a monitoring endpoint:

--- a/docs/src/content/en/docs/observability/integrations/exporters/otel.mdx
+++ b/docs/src/content/en/docs/observability/integrations/exporters/otel.mdx
@@ -395,7 +395,7 @@ npm install @opentelemetry/exporter-logs-otlp-proto
 npm install @opentelemetry/exporter-logs-otlp-grpc @grpc/grpc-js
 ```
 
-If the matching log exporter package is not installed, log export is silently disabled and traces continue to work.
+If the matching log exporter package isn't installed, log export is silently disabled and traces continue to work.
 
 ## Configuration options
 

--- a/docs/src/content/en/docs/observability/integrations/overview.mdx
+++ b/docs/src/content/en/docs/observability/integrations/overview.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Integrations overview
 
-Mastra observability integrations control where observability data goes and how it is transformed on the way out. Use integrations to store data in Mastra storage, send it to Mastra platform, connect to external observability providers, or redact exported span data.
+Mastra observability integrations control where observability data goes and how it's transformed on the way out. Use integrations to store data in Mastra storage, send it to Mastra platform, connect to external observability providers, or redact exported span data.
 
 ## When to use integrations
 

--- a/docs/src/content/en/docs/observability/logging.mdx
+++ b/docs/src/content/en/docs/observability/logging.mdx
@@ -36,7 +36,7 @@ Visit [PinoLogger](/reference/logging/pino-logger) for all available configurati
 
 ## Logging to observability storage
 
-When [observability](/docs/observability/overview) is configured, all logger calls are automatically forwarded to your observability storage. This means every `debug`, `info`, `warn`, `error`, and `trackException` call from your application and from Mastra's internal components appears alongside your traces.
+When [observability](/docs/observability/overview) is configured, all logger calls are automatically forwarded to your observability storage. This means every `debug`, `info`, `warn`, `error`, and `trackException` call from your application and from Mastra's internal components is stored alongside your traces.
 
 No code changes are required. Mastra wraps the configured logger so that it writes to both the original logger (console, file, or custom transport) and the observability system simultaneously.
 

--- a/docs/src/content/en/docs/observability/metrics/overview.mdx
+++ b/docs/src/content/en/docs/observability/metrics/overview.mdx
@@ -17,11 +17,11 @@ Three categories of metrics are emitted automatically:
 
 :::note
 
-Metrics require an OLAP-capable store for observability. Relational databases like PostgreSQL, LibSQL, etc. are not supported for metrics. In-memory storage resets on restart.
+Metrics require an OLAP-capable store for observability. Relational databases like PostgreSQL, LibSQL, etc. aren't supported for metrics. In-memory storage resets on restart.
 
 For local development, use [DuckDB](https://duckdb.org/) through `@mastra/duckdb`. For production, use [ClickHouse](https://clickhouse.com/) through `@mastra/clickhouse`.
 
-Google Cloud Spanner supports metrics, but it is not recommended for heavy metrics workloads. The Spanner adapter disables metrics by default because metrics are write-heavy and scan-heavy. Set `disableMetrics: false` only for light workloads, or route metrics to an OLAP store.
+Google Cloud Spanner supports metrics, but it's not recommended for heavy metrics workloads. The Spanner adapter disables metrics by default because metrics are write-heavy and scan-heavy. Set `disableMetrics: false` only for light workloads, or route metrics to an OLAP store.
 
 :::
 

--- a/docs/src/content/en/docs/observability/metrics/querying.mdx
+++ b/docs/src/content/en/docs/observability/metrics/querying.mdx
@@ -20,7 +20,7 @@ Mastra exposes the same five OLAP queries (`getMetricAggregate`, `getMetricBreak
 For setup of the observability store itself, see the [Metrics overview](/docs/observability/metrics/overview). For the list of metric names you can query, see the [Automatic metrics reference](/reference/observability/metrics/automatic-metrics).
 
 :::note
-Metric queries are served by the observability domain, which requires an OLAP-capable store (DuckDB locally, ClickHouse in production). See [Metrics overview](/docs/observability/metrics/overview) for setup. If the observability store is not configured, `getStore('observability')` returns `null`.
+Metric queries are served by the observability domain, which requires an OLAP-capable store (DuckDB locally, ClickHouse in production). See [Metrics overview](/docs/observability/metrics/overview) for setup. If the observability store isn't configured, `getStore('observability')` returns `null`.
 :::
 
 ## Surfaces
@@ -56,7 +56,7 @@ export const agentLatencyTool = createTool({
 })
 ```
 
-`getStore('observability')` returns `null` when the configured backend does not support OLAP queries.
+`getStore('observability')` returns `null` when the configured backend doesn't support OLAP queries.
 
 ### HTTP
 

--- a/docs/src/content/en/docs/observability/storage.mdx
+++ b/docs/src/content/en/docs/observability/storage.mdx
@@ -56,7 +56,7 @@ Mastra storage-backed observability currently depends on an OLAP-capable backend
 - ClickHouse: Recommended for production observability.
 - Mastra platform: Use `MastraPlatformExporter` if you want hosted observability without managing the backend yourself.
 
-Primary application stores such as LibSQL or PostgreSQL should not be used as the observability store. Route the `observability` domain separately with composite storage when you use `MastraStorageExporter`.
+Primary application stores such as LibSQL or PostgreSQL shouldn't be used as the observability store. Route the `observability` domain separately with composite storage when you use `MastraStorageExporter`.
 
 ## Local development
 
@@ -74,7 +74,7 @@ Observability traffic is usually more write-heavy than the rest of the applicati
 
 - Use `MastraStorageExporter` with ClickHouse for the `observability` domain when you keep observability in your own storage.
 - Use `MastraPlatformExporter` if you want hosted Mastra platform observability instead of managing the backend yourself.
-- Do not route observability to your primary application store.
+- Don't route observability to your primary application store.
 
 For backend compatibility details and exporter batching behavior, see [Mastra Storage exporter](/docs/observability/integrations/exporters/mastra-storage).
 

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -140,7 +140,7 @@ export const mastra = new Mastra({
 })
 ```
 
-If `environment` is not set, Mastra falls back to `process.env.NODE_ENV`. If neither is set, the field is left undefined rather than guessed.
+If `environment` isn't set, Mastra falls back to `process.env.NODE_ENV`. If neither is set, the field is left undefined rather than guessed.
 
 Per-call `tracingOptions.metadata.environment` always takes precedence, so individual calls can override the value when needed.
 

--- a/docs/src/content/en/docs/server/auth/fga.mdx
+++ b/docs/src/content/en/docs/server/auth/fga.mdx
@@ -64,7 +64,7 @@ When using `MastraFGAWorkos`, set `fetchMemberships: true` on `MastraAuthWorkos`
 
 Use `thread` as the resource-mapping key for memory authorization. `MastraFGAWorkos` still accepts the legacy alias `memory`, but new configs should prefer `thread`.
 
-When `server.fga` is configured, Mastra enforces FGA on protected actions. If a protected action has no authenticated user, Mastra denies it. If `server.fga` is not configured, these FGA checks are skipped and Mastra keeps the previous behavior.
+When `server.fga` is configured, Mastra enforces FGA on protected actions. If a protected action has no authenticated user, Mastra denies it. If `server.fga` isn't configured, these FGA checks are skipped and Mastra keeps the previous behavior.
 
 ### Resource mapping
 
@@ -111,7 +111,7 @@ Use `validatePermissions()` to validate the full set of permissions Mastra may e
 
 ### Stored resource scoping
 
-FGA authorizes access to a resource. It does not automatically filter stored records that live in shared storage. Enable stored resource scoping when the built-in stored resource APIs are used in a multi-tenant app.
+FGA authorizes access to a resource. It doesn't automatically filter stored records that live in shared storage. Enable stored resource scoping when the built-in stored resource APIs are used in a multi-tenant app.
 
 ```typescript prettier: false
 const mastra = new Mastra({
@@ -147,7 +147,7 @@ If `requireScope` is `true` or omitted, scoped stored resource routes fail when 
 
 Mastra includes route-level FGA metadata for built-in resource routes, including agents, workflows, tools, MCP tools, memory threads, responses, conversations, and stored resources. Stored resource route coverage includes `/stored/agents`, `/stored/mcp-clients`, `/stored/prompt-blocks`, `/stored/scorers`, `/stored/skills`, and `/stored/workspaces`. A route is checked when it has route-level `fga` metadata, when Mastra can derive built-in metadata for that route, or when the provider supplies metadata with `resolveRouteFGA()`.
 
-To deny protected routes that do not resolve FGA metadata, configure route policy coverage on the FGA provider:
+To deny protected routes that don't resolve FGA metadata, configure route policy coverage on the FGA provider:
 
 ```typescript prettier: false
 const fga = new MastraFGAWorkos({
@@ -226,7 +226,7 @@ When an FGA provider is configured, Mastra automatically checks authorization at
 
 For OAuth-protected MCP servers, HTTP MCP transports pass authenticated data as `extra.authInfo`. If an `MCPServer` is registered on an FGA-enabled Mastra instance, configure `mapAuthInfoToUser` so Mastra can set `requestContext.get('user')` before checking `tools/list` and `tools/call`. Use the server-level `fga` option when MCP tool checks need different resource or permission mapping than internal agent and workflow tool checks. See [MCPServer authentication context](/reference/tools/mcp-server#map-auth-data-for-fga).
 
-Direct SDK calls to `createRun().start()`, `resume()`, or `restart()` are not independently checked by core FGA in this release. Make those calls from a protected route or guard them in application code. Pass a `requestContext` with an authenticated user when invoking protected entry points directly.
+Direct SDK calls to `createRun().start()`, `resume()`, or `restart()` aren't independently checked by core FGA in this release. Make those calls from a protected route or guard them in application code. Pass a `requestContext` with an authenticated user when invoking protected entry points directly.
 
 Core agent, internal workflow, tool, and memory checks also pass `requestContext` and action metadata to the FGA provider. Route checks pass `requestContext`. Thread checks pass the owning `resourceId` when available.
 

--- a/docs/src/content/en/docs/server/auth/okta.mdx
+++ b/docs/src/content/en/docs/server/auth/okta.mdx
@@ -34,7 +34,7 @@ OKTA_API_TOKEN=your-api-token
 
 :::note
 
-`OKTA_COOKIE_PASSWORD` encrypts session cookies. If omitted, an auto-generated value is used that does not survive server restarts. Set it explicitly for production.
+`OKTA_COOKIE_PASSWORD` encrypts session cookies. If omitted, an auto-generated value is used that doesn't survive server restarts. Set it explicitly for production.
 
 `OKTA_API_TOKEN` is only required when using `MastraRBACOkta` to map Okta groups to permissions.
 
@@ -144,7 +144,7 @@ const rbac = new MastraRBACOkta({
 })
 ```
 
-The `_default` key assigns permissions to users whose Okta groups do not match any other key.
+The `_default` key assigns permissions to users whose Okta groups don't match any other key.
 
 ## Client-side setup
 

--- a/docs/src/content/en/docs/server/auth/workos.mdx
+++ b/docs/src/content/en/docs/server/auth/workos.mdx
@@ -121,7 +121,7 @@ const workosAuth = new MastraAuthWorkos({
 })
 ```
 
-This is useful when your JWT template already includes the exact FGA context Mastra needs, such as `organizationMembershipId`, tenant IDs, or service-principal identifiers. When `trustJwtClaims` is enabled, Mastra can fall back to those verified claims if a bearer token is not meant to round-trip through `workos.userManagement.getUser()`.
+This is useful when your JWT template already includes the exact FGA context Mastra needs, such as `organizationMembershipId`, tenant IDs, or service-principal identifiers. When `trustJwtClaims` is enabled, Mastra can fall back to those verified claims if a bearer token isn't meant to round-trip through `workos.userManagement.getUser()`.
 
 ### Custom authorization
 

--- a/docs/src/content/en/docs/server/custom-api-routes.mdx
+++ b/docs/src/content/en/docs/server/custom-api-routes.mdx
@@ -270,7 +270,7 @@ For more information about authentication providers, see the [Auth documentation
 
 Built-in streaming helpers such as [`chatRoute()`](/reference/ai-sdk/chat-route) forward the incoming request's `AbortSignal` to `agent.stream()`. That's the right default when a browser disconnect should cancel the model call.
 
-For custom streaming routes that should stop when the client disconnects, pass `c.req.raw.signal` to long-running work such as `agent.stream()`. Mastra's Node-based adapters also stop reading streamed `Response` bodies from custom routes when the client connection closes. Streamed response body errors that are not caused by client disconnects still propagate through the adapter's normal error handling. In Hono, disconnect behavior depends on the host runtime forwarding connection closes to `request.signal`.
+For custom streaming routes that should stop when the client disconnects, pass `c.req.raw.signal` to long-running work such as `agent.stream()`. Mastra's Node-based adapters also stop reading streamed `Response` bodies from custom routes when the client connection closes. Streamed response body errors that aren't caused by client disconnects still propagate through the adapter's normal error handling. In Hono, disconnect behavior depends on the host runtime forwarding connection closes to `request.signal`.
 
 ```typescript title="src/mastra/index.ts"
 registerApiRoute('/stream', {

--- a/docs/src/content/en/docs/server/pubsub.mdx
+++ b/docs/src/content/en/docs/server/pubsub.mdx
@@ -36,7 +36,7 @@ Subscribers can also opt into work distribution. A group of subscribers that sha
 
 ## Default backend
 
-When you do not set the `pubsub` option, Mastra uses [`EventEmitterPubSub`](/reference/pubsub/event-emitter). It delivers events in process using a Node.js [`EventEmitter`](https://nodejs.org/api/events.html#class-eventemitter), so it works without any external service.
+When you don't set the `pubsub` option, Mastra uses [`EventEmitterPubSub`](/reference/pubsub/event-emitter). It delivers events in process using a Node.js [`EventEmitter`](https://nodejs.org/api/events.html#class-eventemitter), so it works without any external service.
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -45,11 +45,11 @@ import { Mastra } from '@mastra/core'
 export const mastra = new Mastra({})
 ```
 
-Because it runs in process, events are not persisted and do not reach other processes. The default suits a single instance, which covers most applications.
+Because it runs in process, events aren't persisted and don't reach other processes. The default suits a single instance, which covers most applications.
 
 ## Choosing a backend
 
-Set the `pubsub` option on the `Mastra` instance to choose a backend. Each backend implements the same [`PubSub`](/reference/pubsub/base) contract, so the rest of your application does not change.
+Set the `pubsub` option on the `Mastra` instance to choose a backend. Each backend implements the same [`PubSub`](/reference/pubsub/base) contract, so the rest of your application doesn't change.
 
 The deciding question is where the subscriber runs.
 
@@ -109,7 +109,7 @@ export const mastra = new Mastra({
 
 Resumable streams let a client reconnect and replay events it missed, which requires the backend to keep recent history. Distributed backends such as [`RedisStreamsPubSub`](/reference/pubsub/redis-streams) persist events, so they support replay on their own.
 
-In-process delivery does not keep history. To add replay on top of [`EventEmitterPubSub`](/reference/pubsub/event-emitter), wrap it in [`CachingPubSub`](/reference/pubsub/caching-pubsub), which records published events per topic so a late or reconnecting subscriber can catch up before continuing with live events.
+In-process delivery doesn't keep history. To add replay on top of [`EventEmitterPubSub`](/reference/pubsub/event-emitter), wrap it in [`CachingPubSub`](/reference/pubsub/caching-pubsub), which records published events per topic so a late or reconnecting subscriber can catch up before continuing with live events.
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'

--- a/docs/src/content/en/docs/studio/auth.mdx
+++ b/docs/src/content/en/docs/studio/auth.mdx
@@ -73,7 +73,7 @@ Studio handles the token as follows:
 
 - It reads `auth_header` once on load and sends the value as the `Authorization` header on every API request in that session.
 - It removes `auth_header` from the address bar while preserving other query parameters and the hash.
-- It keeps the token in memory only and never writes it to local storage, so the token stays transient and does not persist across page reloads.
+- It keeps the token in memory only and never writes it to local storage, so the token stays transient and doesn't persist across page reloads.
 
 The token rides in a URL parameter, so the host application is responsible for how that URL is generated and transmitted. URL parameters can be exposed through browser history, referrer headers, and server access logs.
 

--- a/docs/src/content/en/docs/workflows/scheduled-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/scheduled-workflows.mdx
@@ -41,13 +41,13 @@ export const dailyReport = createWorkflow({
   .commit()
 ```
 
-There is no separate "register schedule" call. The scheduler reads `schedule` straight off the workflow when `Mastra` boots.
+A separate "register schedule" call won't happen. The scheduler reads `schedule` straight off the workflow when `Mastra` boots.
 
 ## What `schedule` changes
 
 A workflow that declares `schedule` is auto-promoted to the **evented execution engine**. The public API (`workflow.start()`, `workflow.startAsync()`, `streamLegacy()`, `resume()`) is unchanged — `EventedWorkflow extends Workflow` and overrides each method with matching signatures. From your code, scheduled fires and manual runs are indistinguishable.
 
-The promotion has one practical implication: evented runs require a storage adapter that supports concurrent updates, for example `@mastra/libsql`. If your adapter does not, `createRun()` throws a clear error pointing at the `schedule` field. Switch adapters or remove the schedule.
+The promotion has one practical implication: evented runs require a storage adapter that supports concurrent updates, for example `@mastra/libsql`. If your adapter doesn't, `createRun()` throws a clear error pointing at the `schedule` field. Switch adapters or remove the schedule.
 
 ## Single schedule
 
@@ -68,7 +68,7 @@ const dailyReport = createWorkflow({
 Fields:
 
 - `cron` (required): a 5-, 6-, or 7-part cron expression. Validated at workflow construction time.
-- `timezone` (optional): IANA timezone, for example `America/New_York`. Defaults to the host's local timezone. Set this explicitly in production so fire times do not depend on server locale.
+- `timezone` (optional): IANA timezone, for example `America/New_York`. Defaults to the host's local timezone. Set this explicitly in production so fire times don't depend on server locale.
 - `inputData` (optional): payload passed as the workflow's input on every fire.
 - `initialState` (optional): initial state for the run.
 - `requestContext` (optional): request context attached to the run.
@@ -112,14 +112,14 @@ Every fire records a trigger row with the run id, scheduled time, actual fire ti
 - The run's status (`running`, `success`, `failed`, `suspended`, `canceled`) as a badge.
 - The run's start time and duration.
 - A link to the run's full graph view at `/workflows/:workflowId/graph/:runId`.
-- A `pending` badge for triggers whose run record has not been written yet, due to a race between trigger publish and run snapshot.
-- A `publish failed` badge with the publish error when the scheduler could not enqueue the run at all.
+- A `pending` badge for triggers whose run record hasn't been written yet, due to a race between trigger publish and run snapshot.
+- A `publish failed` badge with the publish error when the scheduler couldn't enqueue the run at all.
 
-Triggers in a non-terminal state cause the panel to poll every five seconds until they reach a terminal state. The list paginates, so long-running schedules do not load thousands of rows up front.
+Triggers in a non-terminal state cause the panel to poll every five seconds until they reach a terminal state. The list paginates, so long-running schedules don't load thousands of rows up front.
 
 ## Pausing a schedule at runtime
 
-When a scheduled workflow misfires in production, you do not have to redeploy or hand-edit the database. Pause it from the SDK:
+When a scheduled workflow misfires in production, you don't have to redeploy or hand-edit the database. Pause it from the SDK:
 
 ```typescript
 import { MastraClient } from '@mastra/client-js'
@@ -139,8 +139,8 @@ In Studio, open the schedule detail page and select **Pause** or **Resume** in t
 A few rules worth knowing:
 
 - Pause is durable. The status is written to the schedules table and survives process restarts and redeploys. The declarative-config upsert never overwrites a user-set status, even when you change `cron`, `timezone`, or other fields.
-- Resume recomputes `nextFireAt` from now. A schedule paused for a week does not fire seven backlogged runs the moment you resume it. It fires on the next regular cron tick.
-- The only way to unpause is `resumeSchedule` (or the **Resume** button in Studio). Editing the workflow's `schedule` config does not unpause a paused row.
+- Resume recomputes `nextFireAt` from now. A schedule paused for a week doesn't fire seven backlogged runs the moment you resume it. It fires on the next regular cron tick.
+- The only way to unpause is `resumeSchedule` (or the **Resume** button in Studio). Editing the workflow's `schedule` config doesn't unpause a paused row.
 - Pause and resume are idempotent. Calling pause on an already-paused schedule is a no-op.
 - This is an operational override, not a way to author schedules. Creating, deleting, and editing schedules still happens in code via the `schedule` field on `createWorkflow`.
 
@@ -166,7 +166,7 @@ Deploy targets such as Fly Machines, Railway, Render, AWS ECS, GKE, or your own 
 
 ### Serverless platforms
 
-Functions-as-a-service platforms such as Vercel, Netlify, AWS Lambda, and Cloudflare Workers shut the process down after each request. The tick loop never gets a second tick. Schedules declared in code do not fire on these platforms with the built-in scheduler today.
+Functions-as-a-service platforms such as Vercel, Netlify, AWS Lambda, and Cloudflare Workers shut the process down after each request. The tick loop never gets a second tick. Schedules declared in code don't fire on these platforms with the built-in scheduler today.
 
 On these platforms, use [`@mastra/inngest`](#inngest-workflows) instead. Inngest is serverless-native and holds the cron state for you.
 
@@ -176,9 +176,9 @@ The `schedule` field documented on this page drives Mastra's built-in scheduler.
 
 Practical implications:
 
-- Inngest schedules do not appear in Studio's `/workflows/schedules` view.
-- The workflow header **Schedules** action does not show for Inngest workflows.
-- `client.pauseSchedule` and `client.resumeSchedule` do not control Inngest schedules.
+- Inngest schedules don't appear in Studio's `/workflows/schedules` view.
+- The workflow header **Schedules** action doesn't show for Inngest workflows.
+- `client.pauseSchedule` and `client.resumeSchedule` don't control Inngest schedules.
 
 Manage Inngest schedules from the [Inngest dashboard](https://www.inngest.com/docs/guides/scheduled-functions). Use Mastra schedules when you want Mastra to own scheduling end to end.
 

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -165,7 +165,7 @@ const workspace = new Workspace({
 
 :::note
 
-`filesystem` and `mounts` are mutually exclusive. You cannot use a resolver function together with `mounts` in the same workspace.
+`filesystem` and `mounts` are mutually exclusive. You can't use a resolver function together with `mounts` in the same workspace.
 
 :::
 

--- a/docs/src/content/en/docs/workspace/lsp.mdx
+++ b/docs/src/content/en/docs/workspace/lsp.mdx
@@ -184,7 +184,7 @@ const workspace = new Workspace({
 - LSP inspection only works for file types with a matching built-in or custom language server
 - The `path` you inspect must resolve inside the workspace filesystem or allowed paths
 - External package inspection may resolve to declaration files such as `.d.ts` instead of runtime source files
-- `lsp_inspect` complements `view` and `search_content`, but does not replace reading implementation code when you need full context
+- `lsp_inspect` complements `view` and `search_content`, but doesn't replace reading implementation code when you need full context
 
 ## Related
 

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -91,7 +91,7 @@ export const myAgent = new Agent({
 
 Mastra registers global and agent workspaces so they can be listed and retrieved at runtime. When you call `mastra.shutdown()`, Mastra destroys registered workspaces that it owns. This closes workspace resources such as language servers, browsers, sandbox processes, and filesystem provider handles.
 
-For manual cleanup, use [`mastra.removeWorkspace()`](/reference/core/removeWorkspace). Pass `{ destroy: true }` when the workspace should be destroyed before it is removed from the registry.
+For manual cleanup, use [`mastra.removeWorkspace()`](/reference/core/removeWorkspace). Pass `{ destroy: true }` when the workspace should be destroyed before it's removed from the registry.
 
 Static providers are owned by the workspace. Resolver-backed providers are owned by your application because the workspace creates them at request time. See [dynamic sandbox lifecycle ownership](/docs/workspace/sandbox#lifecycle-ownership) for the resolver cleanup model.
 
@@ -285,7 +285,7 @@ const workspace = new Workspace({
 })
 ```
 
-Functions for `enabled` receive `{ requestContext, workspace }`. Functions for `requireApproval` and `requireReadBeforeWrite` also receive `args` since they are evaluated when the tool is called.
+Functions for `enabled` receive `{ requestContext, workspace }`. Functions for `requireApproval` and `requireReadBeforeWrite` also receive `args` since they're evaluated when the tool is called.
 
 ### Tool name remapping
 

--- a/docs/src/content/en/docs/workspace/sandbox.mdx
+++ b/docs/src/content/en/docs/workspace/sandbox.mdx
@@ -116,7 +116,7 @@ const workspace = new Workspace({
 
 When the sandbox is a static instance, `workspace.init()` calls its `start()` method and `workspace.destroy()` calls its `destroy()` method. With a resolver, the workspace has no instance to manage at construction time — the caller owns the returned sandbox's lifecycle.
 
-The resolver must return a sandbox that is ready to use, either already started or able to handle calls without explicit startup. The caller also owns cleanup timing for returned sandboxes. Cleanup might happen per request, per tenant, per user, or as part of a long-lived sandbox pool; `workspace.destroy()` does not destroy resolver-returned sandboxes.
+The resolver must return a sandbox that's ready to use, either already started or able to handle calls without explicit startup. The caller also owns cleanup timing for returned sandboxes. Cleanup might happen per request, per tenant, per user, or as part of a long-lived sandbox pool; `workspace.destroy()` doesn't destroy resolver-returned sandboxes.
 
 :::note
 
@@ -126,7 +126,7 @@ The resolver must return a sandbox that is ready to use, either already started 
 
 ### Tool registration
 
-With a static sandbox, the workspace inspects the instance to decide which tools to register. With a resolver, the workspace assumes full capabilities and registers `execute_command` (with `background` support), `get_process_output`, and `kill_process`. If the resolved sandbox does not implement a capability, the runtime throws a clear `SandboxFeatureNotSupportedError`.
+With a static sandbox, the workspace inspects the instance to decide which tools to register. With a resolver, the workspace assumes full capabilities and registers `execute_command` (with `background` support), `get_process_output`, and `kill_process`. If the resolved sandbox doesn't implement a capability, the runtime throws a clear `SandboxFeatureNotSupportedError`.
 
 ### Background process continuity
 
@@ -145,7 +145,7 @@ When a cached sandbox is no longer needed, destroy the sandbox in your own lifec
 
 ### Workspace instructions
 
-Workspace instructions describe the environment in the agent's system message. With a sandbox resolver, the workspace does not call the resolver to build these instructions. It emits stable placeholder text, so constructing the prompt never provisions a caller-owned sandbox and the system message stays consistent across requests, which keeps prompt caching effective.
+Workspace instructions describe the environment in the agent's system message. With a sandbox resolver, the workspace doesn't call the resolver to build these instructions. It emits stable placeholder text, so constructing the prompt never provisions a caller-owned sandbox and the system message stays consistent across requests, which keeps prompt caching effective.
 
 To include concrete per-request sandbox details, set `instructions.dynamicSandbox` to `'resolve'`:
 

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -407,7 +407,7 @@ Mastra streams data to the frontend as "parts" within messages. Each part has a 
 | - | - | - |
 | `tool-{toolKey}` | AI SDK built-in | Tool invocation with states: `input-available`, `output-available`, `output-error` |
 | `data-workflow` | `workflowRoute()` | Workflow execution state snapshots with step status and final outputs |
-| `data-workflow-step` | `workflowRoute()` | Workflow step delta with the full payload for the step that just changed |
+| `data-workflow-step` | `workflowRoute()` | Workflow step delta with the full payload for the changed step |
 | `data-network` | `networkRoute()` | Agent network execution with ordered steps and outputs |
 | `data-tool-agent` | Nested agent in tool | Agent output streamed from within a tool's `execute()` |
 | `data-tool-workflow` | Nested workflow in tool | Workflow output streamed from within a tool's `execute()` |
@@ -526,7 +526,7 @@ The tool part type follows the pattern `tool-{toolKey}`, where `toolKey` is the 
 
 ### Rendering workflow data
 
-When using `workflowRoute()` or `handleWorkflowStream()`, Mastra emits `data-workflow` parts for workflow state snapshots and `data-workflow-step` parts for the full payload of the step that just changed. This keeps long-running workflows from repeating every completed step output in every intermediate snapshot.
+When using `workflowRoute()` or `handleWorkflowStream()`, Mastra emits `data-workflow` parts for workflow state snapshots and `data-workflow-step` parts for the full payload of the changed step. This keeps long-running workflows from repeating every completed step output in every intermediate snapshot.
 
 <Tabs>
   <TabItem value="backend" label="Backend">

--- a/docs/src/content/en/guides/deployment/aws-bedrock-agentcore.mdx
+++ b/docs/src/content/en/guides/deployment/aws-bedrock-agentcore.mdx
@@ -5,7 +5,7 @@ description: "Learn how to deploy a Mastra application to Amazon Bedrock AgentCo
 
 # Deploy Mastra to Amazon Bedrock AgentCore
 
-Deploy your Mastra application to [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/) using the [AgentCore CLI](https://github.com/aws/agentcore-cli). The CLI scaffolds a bring-your-own-code (BYO) TypeScript project, builds the container with AWS CodeBuild, and provisions the runtime. A local Docker daemon is not required for deployment.
+Deploy your Mastra application to [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/) using the [AgentCore CLI](https://github.com/aws/agentcore-cli). The CLI scaffolds a bring-your-own-code (BYO) TypeScript project, builds the container with AWS CodeBuild, and provisions the runtime. A local Docker daemon isn't required for deployment.
 
 This guide follows the [official AgentCore TypeScript walkthrough](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-cli-typescript.html) and adapts it to call a Mastra agent from the invocation handler.
 
@@ -103,7 +103,7 @@ export const weatherAgent = new Agent({
 
 :::
 
-Replace the generated `src/mastra/index.ts` to remove the default file-based storage and observability config. AgentCore Runtime containers run as a non-root user with a read-only application directory, so the default `LibSQLStore` cannot open `./mastra.db` and the runtime fails at startup:
+Replace the generated `src/mastra/index.ts` to remove the default file-based storage and observability config. AgentCore Runtime containers run as a non-root user with a read-only application directory, so the default `LibSQLStore` can't open `./mastra.db` and the runtime fails at startup:
 
 ```ts title="app/MastraAgent/src/mastra/index.ts"
 import { Mastra } from '@mastra/core/mastra'
@@ -285,7 +285,7 @@ Run `agentcore status` to view the runtime ARN, endpoint, and recent invocations
 npx @aws/agentcore invoke "What is the weather in Tokyo?"
 ```
 
-To stream tokens as they are generated, use `--stream`:
+To stream tokens as they're generated, use `--stream`:
 
 ```bash
 npx @aws/agentcore invoke --stream "Plan a 3-day trip to Tokyo"

--- a/docs/src/content/en/guides/deployment/inngest.mdx
+++ b/docs/src/content/en/guides/deployment/inngest.mdx
@@ -81,7 +81,7 @@ export const inngest = new Inngest({
 ```
 
 :::warning
-Do not set `INNGEST_DEV` in production. It disables signature verification, which is required to securely receive events from Inngest Cloud.
+Don't set `INNGEST_DEV` in production. It disables signature verification, which is required to securely receive events from Inngest Cloud.
 :::
 
 The `isDev` option on `new Inngest()` overrides `INNGEST_DEV` when both are set.
@@ -246,7 +246,7 @@ Before you begin, make sure you have:
 1. Sync with the [Inngest dashboard](https://app.inngest.com/env/production/apps) by selecting **Sync new app with Vercel** and following the instructions
 
    :::warning
-   Inngest's auto-discover convention assumes `/api/inngest`. Because this guide uses `/inngest/api`, set the **URL** field on the Inngest app to your deployed origin plus `/inngest/api` (for example `https://your-app.vercel.app/inngest/api`). If you leave it on the default, the Inngest dashboard will not find your app's functions.
+   Inngest's auto-discover convention assumes `/api/inngest`. Because this guide uses `/inngest/api`, set the **URL** field on the Inngest app to your deployed origin plus `/inngest/api` (for example `https://your-app.vercel.app/inngest/api`). If you leave it on the default, the Inngest dashboard won't find your app's functions.
    :::
 
 1. Invoke the workflow by going to **Functions**, selecting `workflow.increment-workflow`, selecting **All actions** > **Invoke**, and providing the following input:
@@ -428,10 +428,10 @@ The `createServe` function works with any Inngest adapter. See the [Inngest serv
 
 ## Running as a Connect worker
 
-`serve()` exposes an HTTP endpoint that Inngest calls into. As an alternative, `connect()` opens a long-lived outbound connection from your worker to Inngest, so the worker does not need a publicly reachable endpoint. Use this for long-running worker processes on runtimes such as Kubernetes, Docker, ECS, Fly.io, or Render.
+`serve()` exposes an HTTP endpoint that Inngest calls into. As an alternative, `connect()` opens a long-lived outbound connection from your worker to Inngest, so the worker doesn't need a publicly reachable endpoint. Use this for long-running worker processes on runtimes such as Kubernetes, Docker, ECS, Fly.io, or Render.
 
 :::note
-Inngest Connect is in public beta. Serverless runtimes such as Vercel and AWS Lambda are not supported for Connect workers.
+Inngest Connect is in public beta. Serverless runtimes such as Vercel and AWS Lambda aren't supported for Connect workers.
 :::
 
 ### When to use `connect()` instead of `serve()`
@@ -450,7 +450,7 @@ Use the same Mastra workflow definitions with either `serve()` or `connect()`. T
 
 ### Setup
 
-Run the Mastra server and the Connect worker as two processes. The Mastra server in this setup does not need to expose `/inngest/api`:
+Run the Mastra server and the Connect worker as two processes. The Mastra server in this setup doesn't need to expose `/inngest/api`:
 
 ```ts title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'

--- a/docs/src/content/en/guides/deployment/temporal.mdx
+++ b/docs/src/content/en/guides/deployment/temporal.mdx
@@ -142,7 +142,7 @@ const worker = await Worker.create({
 await worker.run()
 ```
 
-`MastraPlugin` rewrites the entry file into a workflow-only bundle and wires step handlers in as Temporal activities. You do not need to pass `activities` or `workflowsPath` to `Worker.create()` manually.
+`MastraPlugin` rewrites the entry file into a workflow-only bundle and wires step handlers in as Temporal activities. You don't need to pass `activities` or `workflowsPath` to `Worker.create()` manually.
 
 ## Running workflows
 
@@ -188,7 +188,7 @@ TEMPORAL_API_KEY=your-api-key
 See the [Temporal Cloud connection docs](https://docs.temporal.io/cloud/get-started) for mTLS and API key options.
 
 :::warning
-The Temporal worker must run as a long-lived process. Do not deploy it to serverless platforms with short execution limits, such as AWS Lambda or Vercel functions. Use a container, VM, or worker-friendly platform such as Fly.io, Railway, or Kubernetes.
+The Temporal worker must run as a long-lived process. Don't deploy it to serverless platforms with short execution limits, such as AWS Lambda or Vercel functions. Use a container, VM, or worker-friendly platform such as Fly.io, Railway, or Kubernetes.
 :::
 
 ## Configuration options
@@ -212,7 +212,7 @@ export const { createWorkflow, createStep } = init({
 ## Constraints and notes
 
 - Workflow ids must be static string literals. The build-time transformer reads the literal value to derive Temporal workflow export names.
-- Activities are generated automatically from `createStep()` handlers. Do not pass them in `Worker.create({ activities })`.
+- Activities are generated automatically from `createStep()` handlers. Don't pass them in `Worker.create({ activities })`.
 
 ## Related
 

--- a/docs/src/content/en/guides/getting-started/nestjs.mdx
+++ b/docs/src/content/en/guides/getting-started/nestjs.mdx
@@ -77,7 +77,7 @@ export class AppModule {}
 
 :::note
 
-`MastraModule` registers a catch-all controller (`@All('*')`). If it is imported before your app modules, it can intercept unrelated routes and return 404s. To avoid conflicts, import `MastraModule` last or mount it under a dedicated prefix (e.g., `/api/v1/mastra`).
+`MastraModule` registers a catch-all controller (`@All('*')`). If it's imported before your app modules, it can intercept unrelated routes and return 404s. To avoid conflicts, import `MastraModule` last or mount it under a dedicated prefix (e.g., `/api/v1/mastra`).
 
 :::
 

--- a/docs/src/content/en/guides/migrations/mastra-cloud.mdx
+++ b/docs/src/content/en/guides/migrations/mastra-cloud.mdx
@@ -52,7 +52,7 @@ The Mastra platform replaces Mastra Cloud with separate Studio and Server produc
 
 ## Replace Mastra Cloud Store with a hosted database
 
-Mastra Cloud provided a managed libSQL database, backed by [Turso](https://turso.tech). The Mastra platform does not host a database for you, so you need to point your storage at an externally hosted instance.
+Mastra Cloud provided a managed libSQL database, backed by [Turso](https://turso.tech). The Mastra platform doesn't host a database for you, so you need to point your storage at an externally hosted instance.
 
 If you were already using a hosted database ("bring your own"), no changes are needed. Ensure the connection string is set as an environment variable in the dashboard rather than hardcoded.
 
@@ -60,7 +60,7 @@ If you were using Cloud Store, follow the steps below to export your data and lo
 
 ### Export your Cloud Store data
 
-There are two ways to export your Cloud Store data: a one-click download from the dashboard, or a manual dump via the Turso CLI.
+You can export your Cloud Store data in two ways: download it from the dashboard, or create a manual dump with the Turso CLI.
 
 #### Option A — Export from the dashboard (recommended)
 
@@ -279,7 +279,7 @@ See [Studio deployment](/docs/studio/deployment#mastra-platform) for details.
 
 ### Multiple environments
 
-Mastra platform projects do not have a built-in concept of named environments (for example `staging` vs `production`). To deploy the same codebase to multiple environments, create one project per environment and pair each deploy with the matching env file using `--env-file`.
+Mastra platform projects don't have a built-in concept of named environments (for example `staging` vs `production`). To deploy the same codebase to multiple environments, create one project per environment and pair each deploy with the matching env file using `--env-file`.
 
 The pattern below uses one `.env.<env>` file per environment, deploys to a project named `my-app-<env>`, and overrides `.mastra-project.json` per deploy with `MASTRA_ORG_ID` and `MASTRA_PROJECT_ID`:
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/overview.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/overview.mdx
@@ -18,7 +18,7 @@ Need help with the migration? Join our [Discord community](https://discord.gg/BT
 :::
 
 :::warning[Coming from Mastra Cloud?]
-The legacy Mastra Cloud product has been replaced by the [Mastra platform](/docs/mastra-platform/overview), which splits hosting into two separate products: **Studio** (visual environment, observability) and **Server** (production API). Old Mastra Cloud access tokens do not work with Mastra platform — you must create new ones with `mastra auth tokens create`.
+The legacy Mastra Cloud product has been replaced by the [Mastra platform](/docs/mastra-platform/overview), which splits hosting into two separate products: **Studio** (visual environment, observability) and **Server** (production API). Old Mastra Cloud access tokens don't work with Mastra platform — you must create new ones with `mastra auth tokens create`.
 
 If you upgrade to v1 packages without also migrating your `telemetry:` config to `observability:` and creating a Studio project, observability data will stop flowing. Follow the [Mastra Cloud migration guide](/guides/migrations/mastra-cloud) end to end.
 :::

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
@@ -15,7 +15,7 @@ Complete this migration in the same change that bumps your Mastra packages, and 
 
 :::note[Exporter rename]
 
-`MastraPlatformExporter` (sends data to Mastra platform) replaces the previous `CloudExporter`, and `MastraStorageExporter` (persists data to Mastra Storage) replaces the previous `DefaultExporter`. The original classes still ship from `@mastra/observability` and behave identically, but they are deprecated. New code should use `MastraPlatformExporter` and `MastraStorageExporter`; existing imports of `CloudExporter`/`DefaultExporter` continue to work until they are removed in a future major version.
+`MastraPlatformExporter` (sends data to Mastra platform) replaces the previous `CloudExporter`, and `MastraStorageExporter` (persists data to Mastra Storage) replaces the previous `DefaultExporter`. The original classes still ship from `@mastra/observability` and behave identically, but they're deprecated. New code should use `MastraPlatformExporter` and `MastraStorageExporter`; existing imports of `CloudExporter`/`DefaultExporter` continue to work until they're removed in a future major version.
 
 :::
 

--- a/docs/src/content/en/reference/acp/acp-agent.mdx
+++ b/docs/src/content/en/reference/acp/acp-agent.mdx
@@ -208,7 +208,7 @@ for await (const chunk of result.fullStream) {
 }
 ```
 
-`resumeGenerate()` and `resumeStream()` are not supported and throw an error when called.
+`resumeGenerate()` and `resumeStream()` aren't supported and throw an error when called.
 
 ### Model management
 
@@ -252,7 +252,7 @@ With `persistSession: false`, `@mastra/acp` stops the ACP process after each pro
 
 ## Workspace integration
 
-ACP file operations go through Mastra's `Workspace` abstraction. If you do not pass `workspace`, `@mastra/acp` creates a `Workspace` backed by `LocalFilesystem` and uses `cwd` or `process.cwd()` as the filesystem base path.
+ACP file operations go through Mastra's `Workspace` abstraction. If you don't pass `workspace`, `@mastra/acp` creates a `Workspace` backed by `LocalFilesystem` and uses `cwd` or `process.cwd()` as the filesystem base path.
 
 Pass a custom `Workspace` when the ACP agent should read and write through a specific filesystem implementation:
 

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -421,7 +421,7 @@ The `ResolveResourceIdContext` passed to the function:
 
 ## Inline media
 
-Controls which attachment types (images, video, PDFs, etc.) are sent as file parts to the model. Types that do not match are described as text summaries so the agent knows about the file without crashing models that reject unsupported types.
+Controls which attachment types (images, video, PDFs, etc.) are sent as file parts to the model. Types that don't match are described as text summaries so the agent knows about the file without crashing models that reject unsupported types.
 
 The default (`['image/png', 'image/jpeg', 'image/webp', 'application/pdf']`) matches the formats supported by major vision models. Override `inlineMedia` to expand the list (e.g. `['image/*', 'audio/*']`) or replace it entirely with a predicate function.
 

--- a/docs/src/content/en/reference/agents/durable-agent.mdx
+++ b/docs/src/content/en/reference/agents/durable-agent.mdx
@@ -103,7 +103,7 @@ Returns: `DurableAgent`
 
 ## `createEventedAgent(options)`
 
-Wraps an `Agent` with fire-and-forget durable execution on the built-in workflow engine. Like `createDurableAgent`, it returns a result you stream from, but the underlying workflow runs non-blocking (via `startAsync`) instead of running to completion before the stream is wired up. Use it when you want the run to progress independently of the caller. It does not accept `id` or `name` overrides.
+Wraps an `Agent` with fire-and-forget durable execution on the built-in workflow engine. Like `createDurableAgent`, it returns a result you stream from, but the underlying workflow runs non-blocking (via `startAsync`) instead of running to completion before the stream is wired up. Use it when you want the run to progress independently of the caller. It doesn't accept `id` or `name` overrides.
 
 ```typescript
 import { createEventedAgent } from '@mastra/core/agent/durable'
@@ -255,7 +255,7 @@ Returns: `Promise<DurableAgentStreamResult>`
 
 :::warning
 
-The `cleanup()` returned by `observe()` destroys the run's registry entries and cached events. Only call it when you are done with the run. If the run is suspended and you intend to resume later, do not call `cleanup()` — let the auto-cleanup timer handle it after the run finishes or errors. Auto-cleanup does not fire on suspended events.
+The `cleanup()` returned by `observe()` destroys the run's registry entries and cached events. Only call it when you are done with the run. If the run is suspended and you intend to resume later, don't call `cleanup()` — let the auto-cleanup timer handle it after the run finishes or errors. Auto-cleanup doesn't fire on suspended events.
 
 :::
 

--- a/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
@@ -30,7 +30,7 @@ When you pass `structuredOutput` to the underlying agent execution, the final st
 }
 ```
 
-The `object` field contains your full structured output value. Mastra emits this event for the final structured output object only. Partial structured output chunks are not exposed in the UI stream.
+The `object` field contains your full structured output value. Mastra emits this event for the final structured output object only. Partial structured output chunks aren't exposed in the UI stream.
 
 Read this event with AI SDK UI's custom data handling, such as `onData`, or render it from message data parts.
 

--- a/docs/src/content/en/reference/ai-sdk/to-ai-sdk-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/to-ai-sdk-stream.mdx
@@ -30,7 +30,7 @@ When the source agent stream includes a final structured output object, `toAISdk
 }
 ```
 
-The `object` field contains your full structured output value. This maps Mastra's final structured output chunk into the AI SDK UI stream. Partial structured output chunks are not emitted.
+The `object` field contains your full structured output value. This maps Mastra's final structured output chunk into the AI SDK UI stream. Partial structured output chunks aren't emitted.
 
 ## Usage example
 

--- a/docs/src/content/en/reference/auth/okta.mdx
+++ b/docs/src/content/en/reference/auth/okta.mdx
@@ -145,7 +145,7 @@ You can omit the constructor parameters if you have the appropriately named envi
 
 ### Environment variables
 
-The following environment variables are automatically used when constructor options are not provided:
+The following environment variables are automatically used when constructor options aren't provided:
 
 <PropertiesTable
   content={[

--- a/docs/src/content/en/reference/auth/workos.mdx
+++ b/docs/src/content/en/reference/auth/workos.mdx
@@ -154,7 +154,7 @@ const auth = new MastraAuthWorkos({
 })
 ```
 
-When `trustJwtClaims` is enabled, Mastra can authenticate verified bearer tokens for service principals even if `getUser()` is not the right lookup path. This is the preferred way to pass pre-resolved `organizationMembershipId` values into FGA checks for machine-to-machine flows.
+When `trustJwtClaims` is enabled, Mastra can authenticate verified bearer tokens for service principals even if `getUser()` isn't the right lookup path. This is the preferred way to pass pre-resolved `organizationMembershipId` values into FGA checks for machine-to-machine flows.
 
 ## Custom authorization
 

--- a/docs/src/content/en/reference/browser/agent-browser.mdx
+++ b/docs/src/content/en/reference/browser/agent-browser.mdx
@@ -418,7 +418,7 @@ Capture a screenshot of the current page as PNG (viewport by default; set `fullP
 
 | Parameter | Type | Description |
 | - | - | - |
-| `fullPage` | `boolean` | Capture the full scrollable page instead of just the viewport (optional, default: false) |
+| `fullPage` | `boolean` | Capture the full scrollable page instead of only the viewport (optional, default: false) |
 
 ### `browser_close`
 

--- a/docs/src/content/en/reference/browser/browser-viewer.mdx
+++ b/docs/src/content/en/reference/browser/browser-viewer.mdx
@@ -271,7 +271,7 @@ await viewer.injectKeyboardEvent({
 
 Each CLI must be installed separately. Each also publishes a [skill](/docs/workspace/skills) that teaches the agent its commands and workflows. When a CLI command runs through `workspace_execute_command`, Mastra detects it and injects the CDP URL automatically using the correct flag.
 
-Unlike SDK providers, `BrowserViewer` does not provide agent tools. The agent uses CLI commands through `workspace_execute_command` instead.
+Unlike SDK providers, `BrowserViewer` doesn't provide agent tools. The agent uses CLI commands through `workspace_execute_command` instead.
 
 ### [agent-browser](https://www.npmjs.com/package/agent-browser)
 

--- a/docs/src/content/en/reference/browser/browser-viewer.mdx
+++ b/docs/src/content/en/reference/browser/browser-viewer.mdx
@@ -273,7 +273,7 @@ Each CLI must be installed separately. Each also publishes a [skill](/docs/works
 
 Unlike SDK providers, `BrowserViewer` doesn't provide agent tools. The agent uses CLI commands through `workspace_execute_command` instead.
 
-### [agent-browser](https://www.npmjs.com/package/agent-browser)
+### [`agent-browser`](https://www.npmjs.com/package/agent-browser)
 
 Config value: `'agent-browser'` · CDP flag: `--cdp`
 
@@ -282,7 +282,7 @@ npm install -g agent-browser
 npx skills add vercel-labs/agent-browser
 ```
 
-### [browser-use](https://pypi.org/project/browser-use/)
+### [`browser-use`](https://pypi.org/project/browser-use/)
 
 Config value: `'browser-use'` · CDP flag: `--cdp-url`
 
@@ -291,7 +291,7 @@ pip install browser-use
 npx skills add browser-use/browser-use --skill browser-use
 ```
 
-### [browse-cli](https://www.npmjs.com/package/@browserbasehq/browse-cli) (command: `browse`)
+### [`browse-cli`](https://www.npmjs.com/package/@browserbasehq/browse-cli) (command: `browse`)
 
 Config value: `'browse-cli'` · CDP flag: `--ws`
 

--- a/docs/src/content/en/reference/browser/stagehand-browser.mdx
+++ b/docs/src/content/en/reference/browser/stagehand-browser.mdx
@@ -342,7 +342,7 @@ Capture a screenshot of the current page as PNG (viewport by default; set `fullP
 
 | Parameter | Type | Description |
 | - | - | - |
-| `fullPage` | `boolean` | Capture the full scrollable page instead of just the viewport (optional, default: false) |
+| `fullPage` | `boolean` | Capture the full scrollable page instead of only the viewport (optional, default: false) |
 
 ### `stagehand_close`
 

--- a/docs/src/content/en/reference/client-js/responses.mdx
+++ b/docs/src/content/en/reference/client-js/responses.mdx
@@ -137,7 +137,7 @@ Use [`client.conversations`](/reference/client-js/conversations) when you want t
 
 `response.tools` contains the configured function definitions available for the request.
 
-If the model calls a function, that activity appears in `response.output` as `function_call` and `function_call_output` items alongside the final assistant `message`.
+If the model calls a function, that activity is included in `response.output` as `function_call` and `function_call_output` items alongside the final assistant `message`.
 
 When `stream: true`, function calls are also emitted as Responses stream events. Read `response.function_call_arguments.delta` events for partial argument chunks and prefer `response.function_call_arguments.done` for the finalized arguments payload and tool name. Read `response.output_item.done` events for completed `function_call` and `function_call_output` items. Tool output items use `<toolCallId>:output` IDs.
 
@@ -174,7 +174,7 @@ const response = await client.responses.create({
 
 ## Provider-backed requests
 
-Use `providerOptions` when you need provider-specific options that Mastra does not normalize at the Responses layer.
+Use `providerOptions` when you need provider-specific options that Mastra doesn't normalize at the Responses layer.
 
 ```typescript
 const response = await client.responses.create({

--- a/docs/src/content/en/reference/client-js/workflows.mdx
+++ b/docs/src/content/en/reference/client-js/workflows.mdx
@@ -264,7 +264,7 @@ await mastraClient.pauseSchedule('daily-report')
 
 ### `resumeSchedule()`
 
-Resume a paused schedule. The next fire time is recomputed from now, so a long-paused schedule does not fire a backlog. Returns the updated schedule. Idempotent.
+Resume a paused schedule. The next fire time is recomputed from now, so a long-paused schedule doesn't fire a backlog. Returns the updated schedule. Idempotent.
 
 ```typescript
 await mastraClient.resumeSchedule('daily-report')

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -775,7 +775,7 @@ export const mastra = new Mastra({
 **Type:** `object`\
 **Default:** `undefined`
 
-MCP transport options applied to all MCP HTTP and SSE routes. Use this to enable stateless mode for serverless environments (Cloudflare Workers, Vercel Edge, AWS Lambda, etc.) where persistent connections and in-memory session state are not available.
+MCP transport options applied to all MCP HTTP and SSE routes. Use this to enable stateless mode for serverless environments (Cloudflare Workers, Vercel Edge, AWS Lambda, etc.) where persistent connections and in-memory session state aren't available.
 
 | Property | Type | Default | Description |
 | - | - | - | - |

--- a/docs/src/content/en/reference/core/removeWorkspace.mdx
+++ b/docs/src/content/en/reference/core/removeWorkspace.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Mastra.removeWorkspace()
 
-The `.removeWorkspace()` method removes a workspace from the Mastra runtime registry. Pass `{ destroy: true }` to destroy the workspace before it is removed.
+The `.removeWorkspace()` method removes a workspace from the Mastra runtime registry. Pass `{ destroy: true }` to destroy the workspace before it's removed.
 
 ## Usage example
 

--- a/docs/src/content/en/reference/editor/browser-provider.mdx
+++ b/docs/src/content/en/reference/editor/browser-provider.mdx
@@ -9,7 +9,7 @@ packages:
 
 `BrowserProvider` is the interface a package implements to register a browser with [`MastraEditor`](/reference/editor/mastra-editor). The editor calls `createBrowser(config)` at agent hydration time, using the `provider` id from the stored [`StorageBrowserRef`](/reference/editor/storage-browser-ref) as the lookup key.
 
-There are no built-in browser providers. To use the `browser` feature in the Agent Builder, register a provider package (for example, `@mastra/stagehand`).
+No built-in browser providers are available. To use the `browser` feature in the Agent Builder, register a provider package (for example, `@mastra/stagehand`).
 
 ## Usage example
 

--- a/docs/src/content/en/reference/editor/storage-browser-ref.mdx
+++ b/docs/src/content/en/reference/editor/storage-browser-ref.mdx
@@ -43,7 +43,7 @@ new MastraEditor({
 type StorageBrowserRef = { type: 'inline'; config: StorageBrowserConfig }
 ```
 
-A `{ type: 'id' }` variant for browsers is not available — they're always inlined.
+A `{ type: 'id' }` variant for browsers isn't available — they're always inlined.
 
 ## Properties
 

--- a/docs/src/content/en/reference/editor/storage-browser-ref.mdx
+++ b/docs/src/content/en/reference/editor/storage-browser-ref.mdx
@@ -9,7 +9,7 @@ packages:
 
 `StorageBrowserRef` is the inline browser configuration attached to a stored agent. The `provider` id is resolved at hydration time against the [`BrowserProvider`](/reference/editor/browser-provider) registered on [`MastraEditor.browsers`](/reference/editor/mastra-editor).
 
-It is the type used by [`BuilderAgentDefaults.browser`](/reference/editor/agent-builder/builder-agent-defaults) and by stored agent records.
+It's the type used by [`BuilderAgentDefaults.browser`](/reference/editor/agent-builder/builder-agent-defaults) and by stored agent records.
 
 ## Usage example
 
@@ -43,7 +43,7 @@ new MastraEditor({
 type StorageBrowserRef = { type: 'inline'; config: StorageBrowserConfig }
 ```
 
-There is no `{ type: 'id' }` variant for browsers — they are always inlined.
+A `{ type: 'id' }` variant for browsers is not available — they're always inlined.
 
 ## Properties
 
@@ -147,7 +147,7 @@ The shape embedded under `config`. Defined in `@mastra/core/storage`.
 
 ## Hydration
 
-`StorageBrowserRef` is resolved lazily on `mastra.editor.agent.getById()`. The editor looks up `config.provider` on `MastraEditor.browsers` and calls `provider.createBrowser(config)`. If the provider is not registered, the editor logs a warning and returns `undefined` — the agent still loads, but without a browser.
+`StorageBrowserRef` is resolved lazily on `mastra.editor.agent.getById()`. The editor looks up `config.provider` on `MastraEditor.browsers` and calls `provider.createBrowser(config)`. If the provider isn't registered, the editor logs a warning and returns `undefined` — the agent still loads, but without a browser.
 
 ## Related
 

--- a/docs/src/content/en/reference/editor/storage-workspace-ref.mdx
+++ b/docs/src/content/en/reference/editor/storage-workspace-ref.mdx
@@ -9,7 +9,7 @@ packages:
 
 `StorageWorkspaceRef` is the discriminated union used to attach a workspace to a stored agent. It either points at a workspace registered on the Mastra runtime by ID, or embeds a workspace snapshot inline.
 
-It is the type used by [`BuilderAgentDefaults.workspace`](/reference/editor/agent-builder/builder-agent-defaults) and by stored agent records.
+It's the type used by [`BuilderAgentDefaults.workspace`](/reference/editor/agent-builder/builder-agent-defaults) and by stored agent records.
 
 ## Usage example
 

--- a/docs/src/content/en/reference/evals/rubric.mdx
+++ b/docs/src/content/en/reference/evals/rubric.mdx
@@ -157,7 +157,7 @@ await supervisor.stream('Write find_duplicates', {
 })
 ```
 
-If no rubric resolves, the scorer returns `1` and does not gate the loop.
+If no rubric resolves, the scorer returns `1` and doesn't gate the loop.
 
 ## Scoring details
 

--- a/docs/src/content/en/reference/evals/trajectory-accuracy.mdx
+++ b/docs/src/content/en/reference/evals/trajectory-accuracy.mdx
@@ -39,7 +39,7 @@ workflow_run
 
 ### Fallback extraction
 
-When storage is not available, the pipeline falls back to:
+When storage isn't available, the pipeline falls back to:
 
 - **Agents:** `extractTrajectory()` — Extracts `ToolCallStep` entries from `toolInvocations` in the agent's message output. Produces a flat list of tool calls.
 - **Workflows:** `extractWorkflowTrajectory()` — Extracts `WorkflowStepStep` entries from `stepResults`. Produces a flat list of workflow steps.
@@ -217,7 +217,7 @@ In this example, the parent workflow requires strict ordering of its steps, but 
 ### Use the LLM-based scorer when:
 
 - You need **semantic understanding** of whether steps were appropriate
-- The optimal trajectory is **not predetermined** (evaluate based on task requirements)
+- The optimal trajectory **isn't predetermined** (evaluate based on task requirements)
 - You want to detect **unnecessary, redundant, or missing** steps
 - You need **explanations** for scoring decisions
 - You are evaluating **production agent behavior**
@@ -432,7 +432,7 @@ console.log(result.scores.trajectory['trajectory-accuracy'])
 
 ### Comparing step data
 
-Validates not just the step names but also step-specific data. For tool calls, this compares `toolArgs` and `toolResult`. For workflow steps, this compares `output`.
+Validates the step names and step-specific data. For tool calls, this compares `toolArgs` and `toolResult`. For workflow steps, this compares `output`.
 
 ```typescript title="src/example-trajectory-with-data.ts"
 const scorer = createTrajectoryAccuracyScorerCode({

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -962,7 +962,7 @@ unsubscribe()
 
 Returns: `() => void`
 
-`subscribeDisplayState()` does not call the listener immediately. Call [`getDisplayState`](#getdisplaystate) first if the UI needs an initial render before the next harness event.
+`subscribeDisplayState()` doesn't call the listener immediately. Call [`getDisplayState`](#getdisplaystate) first if the UI needs an initial render before the next harness event.
 
 #### `subscribe(listener)`
 

--- a/docs/src/content/en/reference/memory/serialized-memory-config.mdx
+++ b/docs/src/content/en/reference/memory/serialized-memory-config.mdx
@@ -9,7 +9,7 @@ packages:
 
 `SerializedMemoryConfig` is the JSON-serializable subset of [`Memory`](/reference/memory/memory-class) configuration that lives on a stored agent record. The runtime hydrates it back into a `Memory` instance by resolving the vector and embedder IDs against the configured `Mastra` instance.
 
-It is the type used by [`BuilderAgentDefaults.memory`](/reference/editor/agent-builder/builder-agent-defaults) and by `EditorAgentNamespace.create({ memory })`.
+It's the type used by [`BuilderAgentDefaults.memory`](/reference/editor/agent-builder/builder-agent-defaults) and by `EditorAgentNamespace.create({ memory })`.
 
 ## Usage example
 

--- a/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
+++ b/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
@@ -22,7 +22,7 @@ Two conditions must be true for a metric to reach storage:
 1. `MastraStorageExporter` is configured as an exporter.
 1. The storage backend supports metrics (ClickHouse or DuckDB).
 
-If metrics aren't appearing, see [troubleshooting](#troubleshooting).
+If metrics aren't available, see [troubleshooting](#troubleshooting).
 
 ## Duration metrics
 
@@ -119,11 +119,11 @@ When you spot a spike in latency or token usage on the Metrics dashboard, correl
 
 ## Troubleshooting
 
-### No metrics are appearing
+### No metrics are available
 
 - **Observability is configured**: Verify that your `Mastra` instance has an `observability` config with at least one exporter.
 - **`MastraStorageExporter` or `MastraPlatformExporter` is present**: Other exporters (Datadog, Langfuse, etc.) don't surface metrics in Mastra. `MastraStorageExporter` is required for the local Studio dashboard, and `MastraPlatformExporter` is required to view metrics in Mastra platform.
-- **Storage supports metrics**: Metrics require an OLAP-capable store (ClickHouse or DuckDB). Row-oriented databases (PostgreSQL, LibSQL, MSSQL) and document stores (MongoDB) are not supported for metrics.
+- **Storage supports metrics**: Metrics require an OLAP-capable store (ClickHouse or DuckDB). Row-oriented databases (PostgreSQL, LibSQL, MSSQL) and document stores (MongoDB) aren't supported for metrics.
 - **Sampling isn't 0%**: If sampling probability is `0` or strategy is `never`, all spans become no-ops and no metrics are extracted.
 
 ### Duration metrics are missing

--- a/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
@@ -228,7 +228,7 @@ new DatadogBridge({
 })
 ```
 
-Note: APM data cannot be sent in agentless mode. If you only need LLM Observability data without `dd-trace` APM, the [Datadog Exporter](/reference/observability/tracing/exporters/datadog) is a simpler choice.
+Note: APM data can't be sent in agentless mode. If you only need LLM Observability data without `dd-trace` APM, the [Datadog Exporter](/reference/observability/tracing/exporters/datadog) is a simpler choice.
 
 ### With Additional Exporters
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -150,7 +150,7 @@ async onMetricEvent(event: MetricEvent): Promise<void>
 
 Processes metric signals for Cloud export.
 
-Every `MetricEvent` passed to this handler is buffered and exported to the Cloud metrics endpoint derived from the configured base endpoint. Additional filtering by metric subtype or status inside `CloudExporter` is not performed; the exporter forwards every metric event it receives unless it's disabled.
+Every `MetricEvent` passed to this handler is buffered and exported to the Cloud metrics endpoint derived from the configured base endpoint. Additional filtering by metric subtype or status inside `CloudExporter` isn't performed; the exporter forwards every metric event it receives unless it's disabled.
 
 <PropertiesTable
   props={[

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -150,7 +150,7 @@ async onMetricEvent(event: MetricEvent): Promise<void>
 
 Processes metric signals for Cloud export.
 
-Every `MetricEvent` passed to this handler is buffered and exported to the Cloud metrics endpoint derived from the configured base endpoint. There is no additional filtering by metric subtype or status inside `CloudExporter`; the exporter forwards every metric event it receives unless it is disabled.
+Every `MetricEvent` passed to this handler is buffered and exported to the Cloud metrics endpoint derived from the configured base endpoint. Additional filtering by metric subtype or status inside `CloudExporter` is not performed; the exporter forwards every metric event it receives unless it's disabled.
 
 <PropertiesTable
   props={[
@@ -173,7 +173,7 @@ async onScoreEvent(event: ScoreEvent): Promise<void>
 
 Processes score signals for Cloud export.
 
-Every `ScoreEvent` passed to this handler is buffered and exported to the Cloud scores endpoint derived from the configured base endpoint. There is no extra filtering at the exporter layer beyond the disabled-exporter check, so all score events received by this method are forwarded.
+Every `ScoreEvent` passed to this handler is buffered and exported to the Cloud scores endpoint derived from the configured base endpoint. No extra filtering at the exporter layer beyond the disabled-exporter check is performed, so all score events received by this method are forwarded.
 
 <PropertiesTable
   props={[
@@ -196,7 +196,7 @@ async onFeedbackEvent(event: FeedbackEvent): Promise<void>
 
 Processes feedback signals for Cloud export.
 
-Every `FeedbackEvent` passed to this handler is buffered and exported to the Cloud feedback endpoint derived from the configured base endpoint. There is no feedback-type filtering inside `CloudExporter`; all feedback events received here are forwarded unless the exporter is disabled.
+Every `FeedbackEvent` passed to this handler is buffered and exported to the Cloud feedback endpoint derived from the configured base endpoint. No feedback-type filtering inside `CloudExporter` is performed; all feedback events received here are forwarded unless the exporter is disabled.
 
 <PropertiesTable
   props={[

--- a/docs/src/content/en/reference/observability/tracing/exporters/default-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/default-exporter.mdx
@@ -178,7 +178,7 @@ Failed flushes are retried with exponential backoff:
 - Maximum attempts: `maxRetries`
 - Batch is dropped after all retries fail
 
-When storage does not support a signal or retries are exhausted, `DefaultExporter` emits an `ObservabilityDropEvent` through `onDroppedEvent` handlers registered on exporters and bridges. The drop event includes the signal, reason, count, exporter name, storage name when known, and sanitized error details.
+When storage doesn't support a signal or retries are exhausted, `DefaultExporter` emits an `ObservabilityDropEvent` through `onDroppedEvent` handlers registered on exporters and bridges. The drop event includes the signal, reason, count, exporter name, storage name when known, and sanitized error details.
 
 ### Out-of-Order Handling
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
@@ -15,7 +15,7 @@ Sends tracing spans, logs, metrics, scores, and feedback to the Mastra platform 
 
 :::note
 
-`MastraPlatformExporter` was previously called `CloudExporter`. The original `CloudExporter` class is still exported from `@mastra/observability` so existing imports keep working, but it is deprecated and will be removed in a future major version. New code should use `MastraPlatformExporter`.
+`MastraPlatformExporter` was previously called `CloudExporter`. The original `CloudExporter` class is still exported from `@mastra/observability` so existing imports keep working, but it's deprecated and will be removed in a future major version. New code should use `MastraPlatformExporter`.
 
 :::
 
@@ -152,7 +152,7 @@ async onMetricEvent(event: MetricEvent): Promise<void>
 
 Processes metric signals for export.
 
-Every `MetricEvent` passed to this handler is buffered and exported to the metrics endpoint derived from the configured base endpoint. There is no additional filtering by metric subtype or status inside `MastraPlatformExporter`; the exporter forwards every metric event it receives unless it is disabled.
+Every `MetricEvent` passed to this handler is buffered and exported to the metrics endpoint derived from the configured base endpoint. No additional filtering by metric subtype or status inside `MastraPlatformExporter` is performed; the exporter forwards every metric event it receives unless it's disabled.
 
 <PropertiesTable
   props={[
@@ -175,7 +175,7 @@ async onScoreEvent(event: ScoreEvent): Promise<void>
 
 Processes score signals for export.
 
-Every `ScoreEvent` passed to this handler is buffered and exported to the scores endpoint derived from the configured base endpoint. There is no extra filtering at the exporter layer beyond the disabled-exporter check, so all score events received by this method are forwarded.
+Every `ScoreEvent` passed to this handler is buffered and exported to the scores endpoint derived from the configured base endpoint. No extra filtering at the exporter layer beyond the disabled-exporter check is performed, so all score events received by this method are forwarded.
 
 <PropertiesTable
   props={[
@@ -198,7 +198,7 @@ async onFeedbackEvent(event: FeedbackEvent): Promise<void>
 
 Processes feedback signals for export.
 
-Every `FeedbackEvent` passed to this handler is buffered and exported to the feedback endpoint derived from the configured base endpoint. There is no feedback-type filtering inside `MastraPlatformExporter`; all feedback events received here are forwarded unless the exporter is disabled.
+Every `FeedbackEvent` passed to this handler is buffered and exported to the feedback endpoint derived from the configured base endpoint. No feedback-type filtering inside `MastraPlatformExporter` is performed; all feedback events received here are forwarded unless the exporter is disabled.
 
 <PropertiesTable
   props={[
@@ -269,7 +269,7 @@ Errors raised by `MastraPlatformExporter` use the `MASTRA_PLATFORM_EXPORTER_*` `
 
 ## Span wire format
 
-The shape of each span sent to Mastra platform is documented here for reference only — it is not exported from `@mastra/observability` and should not be imported. The exporter spreads the original `AnyExportedSpan` (so the source field names are preserved) and layers a small set of platform-friendly aliases on top:
+The shape of each span sent to Mastra platform is documented here for reference only — it's not exported from `@mastra/observability` and shouldn't be imported. The exporter spreads the original `AnyExportedSpan` (so the source field names are preserved) and layers a small set of platform-friendly aliases on top:
 
 ```typescript
 type MastraPlatformSpanRecord = AnyExportedSpan & {

--- a/docs/src/content/en/reference/observability/tracing/exporters/mastra-storage-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/mastra-storage-exporter.mdx
@@ -13,7 +13,7 @@ Persists traces to Mastra's configured storage with automatic batching and retry
 
 :::note
 
-`MastraStorageExporter` was previously called `DefaultExporter`. The original `DefaultExporter` class is still exported from `@mastra/observability` so existing imports keep working, but it is deprecated and will be removed in a future major version. New code should use `MastraStorageExporter`.
+`MastraStorageExporter` was previously called `DefaultExporter`. The original `DefaultExporter` class is still exported from `@mastra/observability` so existing imports keep working, but it's deprecated and will be removed in a future major version. New code should use `MastraStorageExporter`.
 
 :::
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
@@ -340,7 +340,7 @@ const exporter = new OtelExporter({
 
 ## Protocol requirements
 
-Different providers require different OTEL exporter packages. Trace and log export are independent: install only the trace package if you only need traces, or install both the trace and log packages for the chosen protocol if you also want log export. Zipkin does not support OTLP logs.
+Different providers require different OTEL exporter packages. Trace and log export are independent: install only the trace package if you only need traces, or install both the trace and log packages for the chosen protocol if you also want log export. Zipkin doesn't support OTLP logs.
 
 | Protocol | Trace package | Log package |
 | - | - | - |

--- a/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
@@ -13,7 +13,7 @@ A SpanOutputProcessor that redacts sensitive information from span fields.
 
 ## Auto-applied by default
 
-`Observability` automatically appends a `SensitiveDataFilter` to every configured instance's `spanOutputProcessors` so secrets are redacted before they reach exporters such as the Mastra cloud exporter. The filter runs last (after any user-provided processors) so that sensitive data introduced or surfaced by upstream processors is still redacted. You do not need to add it manually unless you want to customize its options.
+`Observability` automatically appends a `SensitiveDataFilter` to every configured instance's `spanOutputProcessors` so secrets are redacted before they reach exporters such as the Mastra cloud exporter. The filter runs last (after any user-provided processors) so that sensitive data introduced or surfaced by upstream processors is still redacted. You don't need to add it manually unless you want to customize its options.
 
 To opt out or customize the auto-applied filter, use the `sensitiveDataFilter` option on the [`Observability` registry config](/reference/observability/tracing/configuration#observabilityregistryconfig):
 
@@ -31,7 +31,7 @@ new Observability({
 })
 ```
 
-If a config already includes a `SensitiveDataFilter` in `spanOutputProcessors`, the auto-applied filter is skipped to avoid double redaction. Pre-instantiated `ObservabilityInstance` values are not modified — add a `SensitiveDataFilter` to their processors yourself if needed.
+If a config already includes a `SensitiveDataFilter` in `spanOutputProcessors`, the auto-applied filter is skipped to avoid double redaction. Pre-instantiated `ObservabilityInstance` values aren't modified — add a `SensitiveDataFilter` to their processors yourself if needed.
 
 ## Constructor
 

--- a/docs/src/content/en/reference/processors/cost-guard-processor.mdx
+++ b/docs/src/content/en/reference/processors/cost-guard-processor.mdx
@@ -166,10 +166,10 @@ When the `block` strategy is active (default), `CostGuardProcessor` calls `abort
 | `resource` | Yes | `resourceId` + time window | `resourceId` in `RequestContext` |
 | `thread` | Yes | `threadId` + time window | `threadId` in `RequestContext` |
 
-All scopes require observability storage with `getMetricAggregate` support. If the Mastra instance does not have observability storage configured, an error is thrown at registration time.
+All scopes require observability storage with `getMetricAggregate` support. If the Mastra instance doesn't have observability storage configured, an error is thrown at registration time.
 
 For `run` scope, the processor reads the trace ID from the current span's tracing context. If no tracing context is available, the check is skipped (fail-open).
 
 For `resource` and `thread` scopes, if the required context ID is missing at runtime, the check is skipped. Observability query failures are handled with a fail-open strategy: if a query fails, cost is treated as zero.
 
-> **Note on metric persistence delay.** The observability pipeline uses buffered exporters that flush metrics asynchronously. There is a short delay between when an LLM call completes and when its cost metrics are available for query. During high-frequency agent execution, the cost guard may not detect a limit breach until one or more steps after the actual cost exceeded the threshold.
+> **Note on metric persistence delay.** The observability pipeline uses buffered exporters that flush metrics asynchronously. A short delay exists between when an LLM call completes and when its cost metrics are available for query. During high-frequency agent execution, the cost guard may not detect a limit breach until one or more steps after the actual cost exceeded the threshold.

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -574,7 +574,7 @@ System messages are **reset to their original values** at the start of each step
 
 Processes the final LLM request after Mastra converts the `MessageList` into `LanguageModelV2Prompt` and before the provider call. Use this method for transient, model-aware rewrites that should affect only the current outbound request.
 
-Returned prompt changes are forwarded to the model for the current call only. They are not persisted back to `MessageList`, memory, UI history, or later provider calls.
+Returned prompt changes are forwarded to the model for the current call only. They're not persisted back to `MessageList`, memory, UI history, or later provider calls.
 
 ```typescript prettier:false
 processLLMRequest?(
@@ -1430,8 +1430,8 @@ export class WordCounter implements Processor {
 
 Every processor receives a `state` object in `processLLMRequest`, `processLLMResponse`, `processOutputStream`, `processOutputStep`, `processOutputResult`, and `processAPIError`. State has three important properties:
 
-- **Per-processor**: Each processor gets its own `state` object, keyed by the processor's `id`. Two processors with different ids cannot read or overwrite each other's state.
-- **Per-request**: A fresh state object is created at the start of every `agent.generate()` or `agent.stream()` call. State does not leak between requests or between users.
+- **Per-processor**: Each processor gets its own `state` object, keyed by the processor's `id`. Two processors with different ids can't read or overwrite each other's state.
+- **Per-request**: A fresh state object is created at the start of every `agent.generate()` or `agent.stream()` call. State doesn't leak between requests or between users.
 - **Shared across methods**: Within one request, the same `state` object is passed to `processLLMRequest` (before the provider call), `processLLMResponse` (after the step completes), `processOutputStream` (for every chunk), `processOutputStep` (after every LLM step), `processOutputResult` (once at the end), and `processAPIError` (when an LLM call fails). For example, `processLLMRequest` can stash a cache key and `processLLMResponse` can read it back to write the response.
 
 Initialize fields defensively on first access, because `state` starts as an empty object:
@@ -1495,7 +1495,7 @@ await writer.custom({
 })
 ```
 
-By default, processors do **not** see `data-*` chunks in `processOutputStream` so they don't accidentally process tool telemetry or their own output. Opt in by setting `processDataParts: true` on the processor:
+By default, processors **don't** see `data-*` chunks in `processOutputStream` so they don't accidentally process tool telemetry or their own output. Opt in by setting `processDataParts: true` on the processor:
 
 ```typescript
 class ModerationCollector implements Processor {

--- a/docs/src/content/en/reference/processors/response-cache.mdx
+++ b/docs/src/content/en/reference/processors/response-cache.mdx
@@ -11,7 +11,7 @@ packages:
 
 The cache key is derived from the resolved `LanguageModelV2Prompt` Mastra is about to send to the model — i.e. _after_ memory has loaded and earlier input processors have transformed the prompt — so two users with different memory contexts produce different cache keys. Each step in an agentic tool loop is independently cached.
 
-There is no agent-level option for response caching; register `ResponseCache` explicitly on `inputProcessors`. Per-call overrides flow through `RequestContext` via [`ResponseCache.context()`](#static-helpers) and [`ResponseCache.applyContext()`](#static-helpers).
+No agent-level option for response caching exists; register `ResponseCache` explicitly on `inputProcessors`. Per-call overrides flow through `RequestContext` via [`ResponseCache.context()`](#static-helpers) and [`ResponseCache.applyContext()`](#static-helpers).
 
 ## Usage example
 
@@ -147,7 +147,7 @@ The shape passed to `ResponseCache.context()` / `ResponseCache.applyContext()`.
 ]}
 />
 
-`cache`, `ttl`, and `agentId` are intentionally not overridable per call — they are instance-level concerns that should not vary per request.
+`cache`, `ttl`, and `agentId` are intentionally not overridable per call — they're instance-level concerns that shouldn't vary per request.
 
 ## ResponseCacheKeyInputs
 

--- a/docs/src/content/en/reference/processors/skill-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/skill-search-processor.mdx
@@ -11,7 +11,7 @@ The `SkillSearchProcessor` is an **input processor** that enables on-demand skil
 
 By default, when you attach only `SkillSearchProcessor` to an agent with a skill-enabled `Workspace`, the agent treats skills as on-demand:
 
-- The default eager `SkillsProcessor` is not auto-added.
+- The default eager `SkillsProcessor` isn't auto-added.
 - `search_skills` and `load_skill` are exposed for discovery and instruction loading.
 - Overlapping `skill` and `skill_search` tools are hidden.
 - `skill_read` remains available so the agent can read supporting skill files such as references, scripts, and assets.
@@ -159,11 +159,11 @@ The agent workflow is:
 
 ## Workspace file tools
 
-`SkillSearchProcessor` loads skill instructions into the conversation. It does not block workspace file tools from reading files.
+`SkillSearchProcessor` loads skill instructions into the conversation. It doesn't block workspace file tools from reading files.
 
 Use `skill_read` for supporting files that belong to a loaded skill, such as files under `references/`, `scripts/`, or `assets/`.
 
-Reserve workspace file tools such as `mastra_workspace_read_file` for explicit file inspection or editing workflows. During normal task execution, the agent does not need to read the same `SKILL.md` file after `load_skill` succeeds.
+Reserve workspace file tools such as `mastra_workspace_read_file` for explicit file inspection or editing workflows. During normal task execution, the agent doesn't need to read the same `SKILL.md` file after `load_skill` succeeds.
 
 ## Compared to SkillsProcessor
 

--- a/docs/src/content/en/reference/processors/tool-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/tool-search-processor.mdx
@@ -136,7 +136,7 @@ const toolSearch = new ToolSearchProcessor({
 
 ### State inspection (legacy `'in-memory'` store)
 
-These methods operate on the default `'in-memory'` store only. They are no-ops for the `'context'` store, whose state lives in the conversation messages rather than an in-process map.
+These methods operate on the default `'in-memory'` store only. They're no-ops for the `'context'` store, whose state lives in the conversation messages rather than an in-process map.
 
 #### `clearState(threadId)`
 
@@ -199,7 +199,7 @@ The `phase` value describes where the filter is being applied:
 
 - `search`: Filters results returned by `search_tools`.
 - `load`: Blocks `load_tool` from loading disallowed tools.
-- `active`: Hides already-loaded tools from the current request if they are no longer allowed.
+- `active`: Hides already-loaded tools from the current request if they're no longer allowed.
 
 If the hook throws or rejects, `ToolSearchProcessor` treats the tool as disallowed for that request. The hook may run for every matching search candidate, so keep async policy checks cheap or cached. The `search_tools` meta-tool is always available; `load_tool` is available unless `search.autoLoad` is enabled. Tools passed directly through the agent or `processInputStep` remain available unless you filter them outside `ToolSearchProcessor`.
 
@@ -245,7 +245,7 @@ The agent workflow is:
 
 ## Single-step discovery with `autoLoad`
 
-Set `search.autoLoad` to `true` to skip the separate load step. The tools returned by `search_tools` are activated immediately, and the `load_tool` meta-tool is not exposed. This removes one model turn per discovery, which lowers token usage and latency, and works the same across providers.
+Set `search.autoLoad` to `true` to skip the separate load step. The tools returned by `search_tools` are activated immediately, and the `load_tool` meta-tool isn't exposed. This removes one model turn per discovery, which lowers token usage and latency, and works the same across providers.
 
 ```typescript
 const toolSearch = new ToolSearchProcessor({
@@ -264,7 +264,7 @@ With `autoLoad` the workflow becomes:
 1. The matching tools are activated automatically and become available on the next turn
 1. Agent uses the tool normally
 
-Every match is activated, so keep `topK` small (for example, `3`) to avoid adding tools the agent did not need. Activated tools are appended after existing tools, which keeps the cached prompt prefix stable for providers that support prompt caching.
+Every match is activated, so keep `topK` small (for example, `3`) to avoid adding tools the agent didn't need. Activated tools are appended after existing tools, which keeps the cached prompt prefix stable for providers that support prompt caching.
 
 ## Loaded-tool storage
 

--- a/docs/src/content/en/reference/pubsub/base.mdx
+++ b/docs/src/content/en/reference/pubsub/base.mdx
@@ -228,7 +228,7 @@ await pubsub.subscribeFromOffset('my-topic', 42, event => {
 
 ### `SubscribeBatchOptions`
 
-Per-subscription batching policy. The callback signature does not change; a batch of N events becomes N consecutive callback invocations in publish order.
+Per-subscription batching policy. The callback signature doesn't change; a batch of N events becomes N consecutive callback invocations in publish order.
 
 <PropertiesTable
   content={[

--- a/docs/src/content/en/reference/pubsub/caching-pubsub.mdx
+++ b/docs/src/content/en/reference/pubsub/caching-pubsub.mdx
@@ -9,9 +9,9 @@ packages:
 
 `CachingPubSub` wraps any [`PubSub`](/reference/pubsub/base) implementation and adds event caching and replay. It records every published event per topic in a cache, so a subscriber that connects late or reconnects after a disconnect can replay the events it missed before continuing with live events.
 
-Use it to build resumable streams on top of a transport that does not keep history, such as [`EventEmitterPubSub`](/reference/pubsub/event-emitter). Transports that already persist events, such as [`RedisStreamsPubSub`](/reference/pubsub/redis-streams), do not need this wrapper.
+Use it to build resumable streams on top of a transport that doesn't keep history, such as [`EventEmitterPubSub`](/reference/pubsub/event-emitter). Transports that already persist events, such as [`RedisStreamsPubSub`](/reference/pubsub/redis-streams), don't need this wrapper.
 
-`CachingPubSub` is transparent to batching: `subscribe()` forwards `options.batch` to the inner pub/sub, and `supportsNativeBatching` mirrors the inner's value. Wrapping an inner that does not support batching results in unbatched delivery even when `options.batch` is passed.
+`CachingPubSub` is transparent to batching: `subscribe()` forwards `options.batch` to the inner pub/sub, and `supportsNativeBatching` mirrors the inner's value. Wrapping an inner that doesn't support batching results in unbatched delivery even when `options.batch` is passed.
 
 ## Usage example
 

--- a/docs/src/content/en/reference/pubsub/event-emitter.mdx
+++ b/docs/src/content/en/reference/pubsub/event-emitter.mdx
@@ -11,11 +11,11 @@ packages:
 
 Use it for single-process applications. For delivery across processes on one host, see [`UnixSocketPubSub`](/reference/pubsub/unix-socket-pubsub). For distributed delivery, see [`RedisStreamsPubSub`](/reference/pubsub/redis-streams) or [`GoogleCloudPubSub`](/reference/pubsub/google-cloud-pubsub).
 
-Because it is in-process, events are not persisted and are not shared with other processes. Wrap it in [`CachingPubSub`](/reference/pubsub/caching-pubsub) when you need replay for resumable streams.
+Because it's in-process, events aren't persisted and aren't shared with other processes. Wrap it in [`CachingPubSub`](/reference/pubsub/caching-pubsub) when you need replay for resumable streams.
 
 ## Usage example
 
-`EventEmitterPubSub` is used automatically when you do not configure a `pubsub` option, so most applications never construct it directly. Create one explicitly only when you want to configure or share it.
+`EventEmitterPubSub` is used automatically when you don't configure a `pubsub` option, so most applications never construct it directly. Create one explicitly only when you want to configure or share it.
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -145,4 +145,4 @@ await pubsub.subscribe(
 )
 ```
 
-The buffer is in-memory and per-process, so batched state is not persisted and does not survive a restart. A flush triggered by `maxWaitMs` is best-effort: if a step such as a throwing `coalesce` fails, the error is surfaced through the configured `logger` rather than thrown. `flush()` drains every batched subscriber buffer before resolving.
+The buffer is in-memory and per-process, so batched state isn't persisted and doesn't survive a restart. A flush triggered by `maxWaitMs` is best-effort: if a step such as a throwing `coalesce` fails, the error is surfaced through the configured `logger` rather than thrown. `flush()` drains every batched subscriber buffer before resolving.

--- a/docs/src/content/en/reference/pubsub/google-cloud-pubsub.mdx
+++ b/docs/src/content/en/reference/pubsub/google-cloud-pubsub.mdx
@@ -55,7 +55,7 @@ export const mastra = new Mastra({
 
 ### `init(topicName, group?)`
 
-Creates the topic and a subscription if they do not already exist, and returns the subscription. `subscribe` calls this internally, so you rarely call it directly.
+Creates the topic and a subscription if they don't already exist, and returns the subscription. `subscribe` calls this internally, so you rarely call it directly.
 
 ```typescript
 await pubsub.init('workflow.events')

--- a/docs/src/content/en/reference/pubsub/redis-streams.mdx
+++ b/docs/src/content/en/reference/pubsub/redis-streams.mdx
@@ -152,4 +152,4 @@ await pubsub.close()
 
 ## Redelivery and reclaim
 
-When a subscriber calls `nack`, the event is republished with an incremented `deliveryAttempt` and the original is acknowledged. Once an event reaches `maxDeliveryAttempts`, it is dropped instead of redelivered. Separately, each subscription periodically reclaims events that an earlier consumer in the group read but never acknowledged, controlled by `reclaimIntervalMs` and `reclaimIdleMs`.
+When a subscriber calls `nack`, the event is republished with an incremented `deliveryAttempt` and the original is acknowledged. Once an event reaches `maxDeliveryAttempts`, it's dropped instead of redelivered. Separately, each subscription periodically reclaims events that an earlier consumer in the group read but never acknowledged, controlled by `reclaimIntervalMs` and `reclaimIdleMs`.

--- a/docs/src/content/en/reference/pubsub/unix-socket-pubsub.mdx
+++ b/docs/src/content/en/reference/pubsub/unix-socket-pubsub.mdx
@@ -11,7 +11,7 @@ packages:
 
 Use it when several local processes need to share a stream, such as coordinating thread streams across the Mastra Code terminal interface. For single-process delivery, use [`EventEmitterPubSub`](/reference/pubsub/event-emitter). For distributed delivery across hosts, use [`RedisStreamsPubSub`](/reference/pubsub/redis-streams) or [`GoogleCloudPubSub`](/reference/pubsub/google-cloud-pubsub).
 
-`UnixSocketPubSub` is a push transport: events arrive without a read loop, so Mastra does not run a pull worker for it.
+`UnixSocketPubSub` is a push transport: events arrive without a read loop, so Mastra doesn't run a pull worker for it.
 
 ## Usage example
 

--- a/docs/src/content/en/reference/server/nestjs-adapter.mdx
+++ b/docs/src/content/en/reference/server/nestjs-adapter.mdx
@@ -11,7 +11,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 The `@mastra/nestjs` package provides a NestJS module for running Mastra with the Express-based NestJS platform.
 
-It is intentionally Express-only for v1. If Nest is bootstrapped with a different HTTP adapter, `MastraModule` throws during startup instead of attempting a partial integration.
+It's intentionally Express-only for v1. If Nest is bootstrapped with a different HTTP adapter, `MastraModule` throws during startup instead of attempting a partial integration.
 
 :::info
 
@@ -46,7 +46,7 @@ export class AppModule {}
 
 :::note
 
-`MastraModule` registers a catch-all controller (`@All('*')`). If it is imported before your app modules, it can intercept unrelated routes and return 404s. To avoid conflicts, import `MastraModule` last or mount it under a dedicated prefix (e.g., `/api/v1/mastra`).
+`MastraModule` registers a catch-all controller (`@All('*')`). If it's imported before your app modules, it can intercept unrelated routes and return 404s. To avoid conflicts, import `MastraModule` last or mount it under a dedicated prefix (e.g., `/api/v1/mastra`).
 
 :::
 

--- a/docs/src/content/en/reference/storage/clickhouse.mdx
+++ b/docs/src/content/en/reference/storage/clickhouse.mdx
@@ -16,7 +16,7 @@ ClickHouse is most commonly used as the dedicated observability backend in a [co
 
 Production observability for traces, logs, metrics, scores, and feedback.
 
-For local development, use a composite store that combines [LibSQL](/reference/storage/libsql) (for memory and workflows) and `@mastra/duckdb` (for observability). Neither alone covers a development setup: LibSQL does not implement the observability domain, and DuckDB does not implement the other domains. See the [observability overview](/docs/observability/overview) for an example.
+For local development, use a composite store that combines [LibSQL](/reference/storage/libsql) (for memory and workflows) and `@mastra/duckdb` (for observability). Neither alone covers a development setup: LibSQL doesn't implement the observability domain, and DuckDB doesn't implement the other domains. See the [observability overview](/docs/observability/overview) for an example.
 
 ## Installation
 
@@ -32,7 +32,7 @@ You will also need a running ClickHouse server. See [Hosting options](#hosting-o
 
 `ObservabilityStorageClickhouseVNext` is the current observability domain implementation. It uses an insert-only schema backed by `ReplacingMergeTree` and is optimized for the volume produced by traces, logs, metrics, scores, and feedback.
 
-Compose it with another storage adapter so observability writes do not contend with your application data:
+Compose it with another storage adapter so observability writes don't contend with your application data:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -73,7 +73,7 @@ export const mastra = new Mastra({
 
 ### Observability with the legacy domain
 
-`ObservabilityStorageClickhouse` is the original observability adapter and remains supported for projects that have not migrated to the vNext schema. The configuration shape is the same as the vNext class.
+`ObservabilityStorageClickhouse` is the original observability adapter and remains supported for projects that haven't migrated to the vNext schema. The configuration shape is the same as the vNext class.
 
 ```typescript
 import { ObservabilityStorageClickhouse } from '@mastra/clickhouse'
@@ -289,7 +289,7 @@ Two ways to provision the database:
 The same approach applies to other hosts with ephemeral filesystems. For application data that should also live off-host, pair this setup with a managed PostgreSQL or LibSQL/Turso instance for the `default` storage.
 
 :::warning
-Do not point an embedded backend like DuckDB at a path inside an ephemeral container filesystem. Data written there is lost when the container restarts, and on some platforms the path is read-only.
+Don't point an embedded backend like DuckDB at a path inside an ephemeral container filesystem. Data written there is lost when the container restarts, and on some platforms the path is read-only.
 :::
 
 ## Initialization

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -274,7 +274,7 @@ const storage = new MastraCompositeStore({
 
 :::note
 
-`ObservabilityStorageClickhouseVNext` is the current observability domain implementation. The legacy `ObservabilityStorageClickhouse` class is also exported and remains supported for projects that have not migrated. See the [ClickHouse storage reference](/reference/storage/clickhouse) for details.
+`ObservabilityStorageClickhouseVNext` is the current observability domain implementation. The legacy `ObservabilityStorageClickhouse` class is also exported and remains supported for projects that haven't migrated. See the [ClickHouse storage reference](/reference/storage/clickhouse) for details.
 
 :::
 

--- a/docs/src/content/en/reference/storage/convex.mdx
+++ b/docs/src/content/en/reference/storage/convex.mdx
@@ -223,13 +223,13 @@ For very large cache namespaces, clear incrementally or use narrower prefixes to
 
 During batched cleanup, cache metadata can temporarily use an internal `deleted` state. The next cleanup pass removes those rows. Avoid writing new values with the same prefix until `clear()` finishes.
 
-`clear()` only removes rows whose stored `keyPrefix` exactly matches the configured `keyPrefix`. It does not clear nested prefixes by string prefix matching. Each `listPush()` refreshes the list TTL using the cache's configured `ttlMs`.
+`clear()` only removes rows whose stored `keyPrefix` exactly matches the configured `keyPrefix`. It doesn't clear nested prefixes by string prefix matching. Each `listPush()` refreshes the list TTL using the cache's configured `ttlMs`.
 
 Use a non-empty `keyPrefix` unless you intentionally want `clear()` to remove every cache key in the deployment. Expired list rows are reclaimed incrementally during reads and writes; `clear()` removes all rows for the prefix.
 
 `ConvexServerCache` works best for durable replay of moderate-frequency events. For high-frequency token streams, prefer batching events or using a lower-latency cache backend.
 
-`ConvexServerCache` does not replace a distributed pub/sub transport. If your app needs live cross-process event delivery, configure a production pub/sub backend separately.
+`ConvexServerCache` doesn't replace a distributed pub/sub transport. If your app needs live cross-process event delivery, configure a production pub/sub backend separately.
 
 ## Additional notes
 

--- a/docs/src/content/en/reference/storage/dsql.mdx
+++ b/docs/src/content/en/reference/storage/dsql.mdx
@@ -11,7 +11,7 @@ packages:
 
 The Aurora DSQL storage implementation provides storage using Amazon Aurora DSQL with IAM authentication.
 
-Aurora DSQL does not support PostgreSQL extensions (`CREATE EXTENSION`), including `pgvector`. For vector storage, use a separate vector store such as `@mastra/s3vectors`.
+Aurora DSQL doesn't support PostgreSQL extensions (`CREATE EXTENSION`), including `pgvector`. For vector storage, use a separate vector store such as `@mastra/s3vectors`.
 
 ## Installation
 
@@ -252,7 +252,7 @@ const thread = await memoryStore?.getThreadById({ threadId: '...' })
 ```
 
 :::warning
-If `init()` is not called, tables won't be created and storage operations will fail silently or throw errors.
+If `init()` isn't called, tables won't be created and storage operations will fail silently or throw errors.
 :::
 
 ### Direct Database and Pool Access
@@ -276,7 +276,7 @@ This approach is intended for advanced scenarios where low-level access is requi
 
 #### IAM-only authentication
 
-Connections are authenticated with IAM. There are no database passwords. `@mastra/dsql` uses `@aws/aurora-dsql-node-postgres-connector` to generate short-lived auth tokens. You can provide a custom credentials provider via `customCredentialsProvider`.
+Connections are authenticated with IAM. No database passwords are required. `@mastra/dsql` uses `@aws/aurora-dsql-node-postgres-connector` to generate short-lived auth tokens. You can provide a custom credentials provider via `customCredentialsProvider`.
 
 #### Single database, schema-based isolation
 
@@ -284,7 +284,7 @@ Each cluster exposes a single database named `postgres`. Logical separation is d
 
 #### No PostgreSQL extensions
 
-`CREATE EXTENSION` is not supported. This includes `pgvector`, `PostGIS`, and others. For vector storage, use a separate store such as `@mastra/s3vectors` alongside `DSQLStore`.
+`CREATE EXTENSION` isn't supported. This includes `pgvector`, `PostGIS`, and others. For vector storage, use a separate store such as `@mastra/s3vectors` alongside `DSQLStore`.
 
 #### JSON stored as text
 
@@ -292,7 +292,7 @@ JSON/JSONB are available as query types but not as column types. `@mastra/dsql` 
 
 #### Schema and DDL constraints
 
-Some PostgreSQL features are not available:
+Some PostgreSQL features aren't available:
 
 - Foreign key constraints
 - `TRUNCATE`
@@ -302,7 +302,7 @@ Indexes are created asynchronously using `CREATE INDEX ASYNC`. The store's `init
 
 #### Transactions and optimistic concurrency
 
-Aurora DSQL uses optimistic concurrency control (OCC) and may return retriable OCC errors under contention. There are limits on transaction duration and size. Large bulk operations should be split into smaller batches at the application level.
+Aurora DSQL uses optimistic concurrency control (OCC) and may return retriable OCC errors under contention. Limits exist on transaction duration and size. Large bulk operations should be split into smaller batches at the application level.
 
 #### Connection lifetime
 
@@ -415,7 +415,7 @@ await storage.createIndex({
 })
 ```
 
-Aurora DSQL does not allow `ASC`/`DESC` in `CREATE INDEX ASYNC`. If you include them, they will be automatically stripped.
+Aurora DSQL doesn't allow `ASC`/`DESC` in `CREATE INDEX ASYNC`. If you include them, they will be automatically stripped.
 
 ### Index Options
 

--- a/docs/src/content/en/reference/storage/duckdb.mdx
+++ b/docs/src/content/en/reference/storage/duckdb.mdx
@@ -14,12 +14,12 @@ For vector search, see the [DuckDB vector store reference](/reference/vectors/du
 
 ## When to use DuckDB
 
-Local development of observability features. DuckDB is embedded and file-based, so it does not require a server and starts instantly. It supports the same observability signals as ClickHouse, which makes it useful for testing dashboards and trace exploration before deploying to a production backend.
+Local development of observability features. DuckDB is embedded and file-based, so it doesn't require a server and starts instantly. It supports the same observability signals as ClickHouse, which makes it useful for testing dashboards and trace exploration before deploying to a production backend.
 
 DuckDB currently implements only the `observability` domain. Pair it with another storage adapter (such as [LibSQL](/reference/storage/libsql)) for `memory` and `workflows` in a [composite storage](/reference/storage/composite) setup.
 
 :::warning
-DuckDB is for development and not recommended for production. It runs in-process, persists to a single local file, and does not work on platforms with ephemeral filesystems (such as Railway, Fly.io, Render, Heroku, or serverless containers). For production observability, use [ClickHouse](/reference/storage/clickhouse).
+DuckDB is for development and not recommended for production. It runs in-process, persists to a single local file, and doesn't work on platforms with ephemeral filesystems (such as Railway, Fly.io, Render, Heroku, or serverless containers). For production observability, use [ClickHouse](/reference/storage/clickhouse).
 :::
 
 ## Installation
@@ -115,7 +115,7 @@ const duckdb = new DuckDBStore({ path: ':memory:' })
 
 ### Lower-level types
 
-`@mastra/duckdb` also exports `DuckDBConnection` for sharing a single underlying database across multiple Mastra storage instances, and the corresponding `DuckDBStorageConfig` type. Most applications will not need these directly.
+`@mastra/duckdb` also exports `DuckDBConnection` for sharing a single underlying database across multiple Mastra storage instances, and the corresponding `DuckDBStorageConfig` type. Most applications won't need these directly.
 
 ## Supported domains
 

--- a/docs/src/content/en/reference/storage/redis.mdx
+++ b/docs/src/content/en/reference/storage/redis.mdx
@@ -9,7 +9,7 @@ packages:
 
 # Redis Storage
 
-The Redis storage implementation provides a high-performance storage solution using direct Redis connections via [node-redis](https://github.com/redis/node-redis) (the official Redis client for Node.js). It supports standalone Redis, and through custom client configuration, Redis Sentinel and Cluster deployments.
+The Redis storage implementation provides a high-performance storage solution using direct Redis connections via [`node-redis`](https://github.com/redis/node-redis) (the official Redis client for Node.js). It supports standalone Redis, and through custom client configuration, Redis Sentinel and Cluster deployments.
 
 ## Installation
 

--- a/docs/src/content/en/reference/storage/redis.mdx
+++ b/docs/src/content/en/reference/storage/redis.mdx
@@ -50,7 +50,7 @@ await storage.init()
 
 ### Using Pre-configured Client
 
-For advanced configurations like Sentinel or Cluster, you can pass a pre-configured redis client:
+For advanced configurations like Sentinel or Cluster, you can pass a pre-configured Redis client:
 
 ```typescript
 import { RedisStore } from '@mastra/redis'
@@ -188,7 +188,7 @@ const storage = new RedisStore({
 
 ### Accessing the Underlying Client
 
-You can access the underlying redis client for custom operations:
+You can access the underlying Redis client for custom operations:
 
 ```typescript
 const storage = new RedisStore({

--- a/docs/src/content/en/reference/storage/spanner.mdx
+++ b/docs/src/content/en/reference/storage/spanner.mdx
@@ -179,7 +179,7 @@ Two tables also carry Spanner-specific `STORED` generated columns that the adapt
 
 Both are added via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` during `init()` and skipped under `initMode: 'validate'` (where the schema is owned externally). When the column is absent, the adapter falls back to a `JSON_VALUE` filter at runtime.
 
-The adapter does not create or use named schemas; use a dedicated database for isolation.
+The adapter doesn't create or use named schemas; use a dedicated database for isolation.
 
 ### Initialization
 
@@ -201,7 +201,7 @@ const mastra = new Mastra({
 })
 ```
 
-If you use storage directly, call `init()` once before the first operation. Spanner does not allow concurrent schema changes, so `SpannerStore.init()` runs each domain's setup sequentially.
+If you use storage directly, call `init()` once before the first operation. Spanner doesn't allow concurrent schema changes, so `SpannerStore.init()` runs each domain's setup sequentially.
 
 ```typescript
 const storage = new SpannerStore({
@@ -217,19 +217,19 @@ const thread = await memory?.getThreadById({ threadId: '...' })
 ```
 
 :::warning
-If `init()` is not called and `disableInit` is true, the required tables will not exist and storage operations will fail.
+If `init()` isn't called and `disableInit` is true, the required tables won't exist and storage operations will fail.
 :::
 
 ### GoogleSQL specifics
 
 A few behaviors differ from other relational adapters:
 
-- Upserts use `INSERT OR UPDATE`. Spanner does not provide a `RETURNING` clause for upserts, so callers needing the post-write state must read it back.
-- There is no `TRUNCATE`; `dangerouslyClearAll()` issues `DELETE WHERE TRUE`.
+- Upserts use `INSERT OR UPDATE`. Spanner doesn't provide a `RETURNING` clause for upserts, so callers needing the post-write state must read it back.
+- No `TRUNCATE` exists; `dangerouslyClearAll()` issues `DELETE WHERE TRUE`.
 - Identifiers are quoted with backticks.
 - DDL is applied through `database.updateSchema(...)`, which is asynchronous (long-running operation).
-- `NULLS FIRST/LAST` is not supported. Ordering with NULL handling is emulated through an `IS NULL` ordering key.
-- JSON containment is not supported natively. `listTraces` `metadata` and `scope` filters compile to per-key `JSON_VALUE(...) = @v` equality checks, and `tags` filters compile to `EXISTS` over `JSON_QUERY_ARRAY(...)`. This differs from Postgres' `@>` containment operator (which can match nested structure in a single index scan) — most one-shot lookups still work but deeply nested structural matches are not expressible.
+- `NULLS FIRST/LAST` isn't supported. Ordering with NULL handling is emulated through an `IS NULL` ordering key.
+- JSON containment isn't supported natively. `listTraces` `metadata` and `scope` filters compile to per-key `JSON_VALUE(...) = @v` equality checks, and `tags` filters compile to `EXISTS` over `JSON_QUERY_ARRAY(...)`. This differs from Postgres' `@>` containment operator (which can match nested structure in a single index scan) — most one-shot lookups still work but deeply nested structural matches aren't expressible.
 
 ### Direct database access
 

--- a/docs/src/content/en/reference/streaming/agents/streamUntilIdle.mdx
+++ b/docs/src/content/en/reference/streaming/agents/streamUntilIdle.mdx
@@ -122,7 +122,7 @@ Internally, `streamUntilIdle()`:
 
 1. Runs the initial turn via `agent.stream(...)` and pipes its `fullStream` into the outer stream.
 1. Subscribes to background-task completion events for the resolved memory scope.
-1. Queues each terminal event (`background-task-completed`, `background-task-failed`, `background-task-cancelled`) and, when the outer wrapper is idle between turns, re-invokes `agent.stream([], ...)` with a directive listing the just-completed `toolCallId`s. The continuation turn flows into the same outer stream.
+1. Queues each terminal event (`background-task-completed`, `background-task-failed`, `background-task-cancelled`) and, when the outer wrapper is idle between turns, re-invokes `agent.stream([], ...)` with a directive listing the completed `toolCallId`s. The continuation turn flows into the same outer stream.
 1. Closes the outer stream once no tasks are running and no completions are queued.
 
 ## Extended usage example

--- a/docs/src/content/en/reference/tools/brightdata.mdx
+++ b/docs/src/content/en/reference/tools/brightdata.mdx
@@ -207,7 +207,7 @@ const agent = new Agent({
 
 | Variable | Description |
 | - | - |
-| `BRIGHTDATA_API_TOKEN` | Your Bright Data API token. Used as the default when `apiKey` is not passed to a factory function. |
+| `BRIGHTDATA_API_TOKEN` | Your Bright Data API token. Used as the default when `apiKey` isn't passed to a factory function. |
 
 ## Related
 

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -137,7 +137,7 @@ export const weatherTool = createTool({
 })
 ```
 
-Mastra forwards `strict: true` to model adapters that support strict tool calling. On adapters that do not support strict tool calling, Mastra ignores this option.
+Mastra forwards `strict: true` to model adapters that support strict tool calling. On adapters that don't support strict tool calling, Mastra ignores this option.
 
 ## Example with `toModelOutput`
 

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -257,7 +257,7 @@ const agent = new Agent({
 })
 ```
 
-When `forwardInstructions` is omitted (the default), instructions are still cached and can be inspected via [`getServerInstructions()`](#getserverinstructions), but are not added to any agent's system prompt.
+When `forwardInstructions` is omitted (the default), instructions are still cached and can be inspected via [`getServerInstructions()`](#getserverinstructions), but aren't added to any agent's system prompt.
 
 > **Security note:** server instructions are forwarded verbatim (subject only to length truncation) into the agent's system prompt. A malicious or compromised MCP server can use them to inject instructions the agent will treat as trusted system guidance. Only enable `forwardInstructions` for servers you trust, and prefer reviewing instructions with `getServerInstructions()` before forwarding instructions from third-party servers.
 
@@ -285,7 +285,7 @@ const res = await agent.stream(prompt, {
 
 ### `getServerInstructions()`
 
-Returns the instructions currently known for each configured MCP server. Servers that have not connected yet, or do not advertise instructions, return `undefined`.
+Returns the instructions currently known for each configured MCP server. Servers that haven't connected yet, or don't advertise instructions, return `undefined`.
 
 ```typescript prettier:false
 getServerInstructions(): Record<string, string | undefined>
@@ -1170,9 +1170,9 @@ await agent.generate('Hello!', {
 
 ## Handling auth failures inside custom fetch
 
-A custom `fetch` should not `throw` when authentication is unavailable. The Streamable HTTP transport in the MCP SDK opens a long-lived `GET /mcp` "standalone listener" stream in the background to receive server-pushed notifications. Errors on that stream are retried with exponential backoff, and a thrown `fetch` or a cleanly-closed stream can produce an indefinite reconnect loop at roughly one attempt per second.
+A custom `fetch` shouldn't `throw` when authentication is unavailable. The Streamable HTTP transport in the MCP SDK opens a long-lived `GET /mcp` "standalone listener" stream in the background to receive server-pushed notifications. Errors on that stream are retried with exponential backoff, and a thrown `fetch` or a cleanly-closed stream can produce an indefinite reconnect loop at roughly one attempt per second.
 
-Return a synthetic `Response` instead. The [MCP Streamable HTTP specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports) defines `405 Method Not Allowed` as the signal a server returns when it does not offer the GET SSE stream, and the SDK honors it as a terminal status that stops the listener cleanly. Use this to disable the listener when your server does not push notifications.
+Return a synthetic `Response` instead. The [MCP Streamable HTTP specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports) defines `405 Method Not Allowed` as the signal a server returns when it doesn't offer the GET SSE stream, and the SDK honors it as a terminal status that stops the listener cleanly. Use this to disable the listener when your server doesn't push notifications.
 
 The following pattern waits for an auth token on POST requests, attaches it to outgoing headers, and short-circuits the GET listener with a synthetic 405:
 
@@ -1213,7 +1213,7 @@ const mcpClient = new MCPClient({
 })
 ```
 
-Return `405` for the GET listener only when your server does not push notifications back to the client. If your server uses the standalone GET stream, attach the auth token on `GET` requests as well and let the request through.
+Return `405` for the GET listener only when your server doesn't push notifications back to the client. If your server uses the standalone GET stream, attach the auth token on `GET` requests as well and let the request through.
 
 ## Using SSE request headers
 

--- a/docs/src/content/en/reference/tools/perplexity.mdx
+++ b/docs/src/content/en/reference/tools/perplexity.mdx
@@ -190,7 +190,7 @@ const agent = new Agent({
 
 | Variable | Description |
 | - | - |
-| `PERPLEXITY_API_KEY` | Your Perplexity API key. Used as the default when `apiKey` is not passed to a factory function. |
+| `PERPLEXITY_API_KEY` | Your Perplexity API key. Used as the default when `apiKey` isn't passed to a factory function. |
 | `PPLX_API_KEY` | Fallback used when `PERPLEXITY_API_KEY` is unset. |
 
 ## Related

--- a/docs/src/content/en/reference/tools/tavily.mdx
+++ b/docs/src/content/en/reference/tools/tavily.mdx
@@ -560,7 +560,7 @@ const agent = new Agent({
 
 | Variable | Description |
 | - | - |
-| `TAVILY_API_KEY` | Your Tavily API key. Used as the default when `apiKey` is not passed to a factory function. |
+| `TAVILY_API_KEY` | Your Tavily API key. Used as the default when `apiKey` isn't passed to a factory function. |
 
 ## Related
 

--- a/docs/src/content/en/reference/voice/aws-nova-sonic.mdx
+++ b/docs/src/content/en/reference/voice/aws-nova-sonic.mdx
@@ -284,7 +284,7 @@ Returns: `Promise<void>`
 
 ### `endAudioInput()`
 
-Signals the end of the current audio turn so the model can finalize its response. Call this when the user stops speaking and the provider is not configured for server-side turn detection.
+Signals the end of the current audio turn so the model can finalize its response. Call this when the user stops speaking and the provider isn't configured for server-side turn detection.
 
 Returns: `Promise<void>`
 

--- a/docs/src/content/en/reference/voice/google-gemini-live.mdx
+++ b/docs/src/content/en/reference/voice/google-gemini-live.mdx
@@ -526,7 +526,7 @@ Native-audio Gemini Live models — any model whose ID contains `native-audio`, 
 - The model's spoken reply is delivered as audio plus an `output_audio_transcription` transcript and surfaced as `writing` with `role: 'assistant'`.
 - The model's internal reasoning is delivered as `modelTurn.parts.text` and surfaced as `thinking`.
 
-On non-native-audio models there is no `output_audio_transcription` channel, so `modelTurn.parts.text` is the spoken response itself and is emitted as `writing`; the `thinking` event does not fire.
+On non-native-audio models there is no `output_audio_transcription` channel, so `modelTurn.parts.text` is the spoken response itself and is emitted as `writing`; the `thinking` event doesn't fire.
 
 Input transcription, output transcription, and barge-in detection (`realtime_input_config.activity_handling = 'START_OF_ACTIVITY_INTERRUPTS'`) are enabled automatically in the setup payload — no extra configuration is required.
 

--- a/docs/src/content/en/reference/voice/inworld-realtime.mdx
+++ b/docs/src/content/en/reference/voice/inworld-realtime.mdx
@@ -62,7 +62,7 @@ await voice.send(microphoneStream)
 voice.close()
 ```
 
-> Inworld API keys ship pre-Basic-encoded. Paste them verbatim into `INWORLD_API_KEY`; the package does not re-encode them.
+> Inworld API keys ship pre-Basic-encoded. Paste them verbatim into `INWORLD_API_KEY`; the package doesn't re-encode them.
 
 ## Constructor parameters
 
@@ -256,7 +256,7 @@ Use the typed `session` field for documented Inworld realtime options. Fields co
 
 ### `providerData` (Inworld extensions)
 
-`providerData` is a typed object for Inworld-specific realtime extensions. It is sent under `session.providerData` on every `session.update`, and composes with any `session.providerData` you set via the `session` field — the constructor `providerData` wins on key collisions.
+`providerData` is a typed object for Inworld-specific realtime extensions. It's sent under `session.providerData` on every `session.update`, and composes with any `session.providerData` you set via the `session` field — the constructor `providerData` wins on key collisions.
 
 It has five branches plus two session-level fields:
 
@@ -661,12 +661,12 @@ Any voice ID from [Inworld's voice catalog](https://docs.inworld.ai/quickstart-t
 
 ## Notes
 
-- API keys can be provided via constructor options or the `INWORLD_API_KEY` environment variable. Keys are pre-Basic-encoded; do not re-encode them.
+- API keys can be provided via constructor options or the `INWORLD_API_KEY` environment variable. Keys are pre-Basic-encoded; don't re-encode them.
 - The WebSocket URL appends `?key=<sessionId>&protocol=realtime`. The model is configured via the initial `session.update`, not the URL.
-- Per-call `speak(input, { speaker })` scopes the voice override to a single response (via the flat `response.voice` field) and does NOT mutate the session.
+- Per-call `speak(input, { speaker })` scopes the voice override to a single response (via the flat `response.voice` field) and doesn't mutate the session.
 - Audio output defaults to PCM16 at 24 kHz. Telephony `audio/pcmu` and `audio/pcma` at 8 kHz, and `audio/float32`, are also supported via `session.audio.output.format`.
 - Use `connect()` before any send, speak, or listen call. Events sent before the WebSocket is open are queued and flushed once the server acknowledges `session.updated`.
 - The voice instance must be closed with `close()` or `disconnect()` to release the WebSocket.
-- `audio.input.turn_detection` defaults to semantic VAD when `session` does not supply it. Override with your own object, or pass `null` to disable turn detection entirely.
+- `audio.input.turn_detection` defaults to semantic VAD when `session` doesn't supply it. Override with your own object, or pass `null` to disable turn detection entirely.
 - `audio.input.transcription` defaults to `{ model: 'inworld/inworld-stt-1' }`, so user-side `writing` events fire out of the box. Override with your own object, or pass `null` to disable user-side transcription.
 - `on()` and `off()` are typed against `InworldVoiceEventMap` — known event names yield a typed callback payload, unknown names fall back to `unknown`.

--- a/docs/src/content/en/reference/voice/inworld.mdx
+++ b/docs/src/content/en/reference/voice/inworld.mdx
@@ -293,6 +293,6 @@ const speakers = await voice.getSpeakers()
 ## Notes
 
 - The TTS endpoint uses progressive NDJSON streaming, so audio playback can begin before the full response is received.
-- An API key can be provided via the `speechModel` or `listeningModel` config, or the `INWORLD_API_KEY` environment variable. TTS and STT keys are resolved independently: passing distinct `speechModel.apiKey` and `listeningModel.apiKey` values lets each service use its own credential. If only one is provided, it is reused for both services as a fallback before the env var.
+- An API key can be provided via the `speechModel` or `listeningModel` config, or the `INWORLD_API_KEY` environment variable. TTS and STT keys are resolved independently: passing distinct `speechModel.apiKey` and `listeningModel.apiKey` values lets each service use its own credential. If only one is provided, it's reused for both services as a fallback before the env var.
 - `inworld-tts-2` is the default flagship model. Use `deliveryMode` (`STABLE` | `BALANCED` | `CREATIVE`) to steer delivery style on this model. The `temperature` option is ignored on `inworld-tts-2`.
 - The `inworld-tts-1.5-mini` model offers lower latency at the cost of reduced voice quality compared to `inworld-tts-1.5-max`.

--- a/docs/src/content/en/reference/voice/sarvam.mdx
+++ b/docs/src/content/en/reference/voice/sarvam.mdx
@@ -288,4 +288,4 @@ Returns: `Promise<Array<{voiceId: SarvamVoiceId}>>`
 - Audio is returned as a stream containing binary audio data
 - Speech recognition supports mp3 and wav audio formats
 - `bulbul:v1`, `saarika:v1`, `saarika:v2`, and `saarika:flash` have been deprecated by Sarvam and are no longer supported. Use `bulbul:v3` (or `bulbul:v2`) for TTS and `saarika:v2.5` (or `saaras:v3`) for STT.
-- Speaker names are not interchangeable between `bulbul:v2` and `bulbul:v3` — each model version has its own speaker catalog.
+- Speaker names aren't interchangeable between `bulbul:v2` and `bulbul:v3` — each model version has its own speaker catalog.

--- a/docs/src/content/en/reference/workspace/agentcore-runtime-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/agentcore-runtime-sandbox.mdx
@@ -19,7 +19,7 @@ For interface details, see [WorkspaceSandbox interface](/reference/workspace/san
 
 :::warning
 
-`AgentCoreRuntimeSandbox` only supports one-shot command execution. It does not support background process management, stdin, or filesystem mounts. AgentCore Code Interpreter is a separate AWS service and is not part of this provider.
+`AgentCoreRuntimeSandbox` only supports one-shot command execution. It doesn't support background process management, stdin, or filesystem mounts. AgentCore Code Interpreter is a separate AWS service and isn't part of this provider.
 
 :::
 
@@ -216,7 +216,7 @@ Returns: `Promise<CommandResult>`.
 
 #### `start()`
 
-Runs the sandbox lifecycle start hook. This provider does not create an AgentCore Runtime session during `start()`.
+Runs the sandbox lifecycle start hook. This provider doesn't create an AgentCore Runtime session during `start()`.
 
 ```typescript
 await sandbox.start()
@@ -234,7 +234,7 @@ await sandbox.stop()
 
 Explicitly stops the AgentCore Runtime session used by this sandbox.
 
-Use this when the sandbox owns the runtime session and you want to clean it up directly. `destroy()` does not call this method unless `stopSessionOnLifecycle` is `true`, because AgentCore Runtime sessions can be shared with agent invocations outside the Workspace sandbox lifecycle.
+Use this when the sandbox owns the runtime session and you want to clean it up directly. `destroy()` doesn't call this method unless `stopSessionOnLifecycle` is `true`, because AgentCore Runtime sessions can be shared with agent invocations outside the Workspace sandbox lifecycle.
 
 ```typescript
 await sandbox.stopRuntimeSession()
@@ -265,10 +265,10 @@ Returns: `Promise<SandboxInfo>`.
 `AgentCoreRuntimeSandbox` follows AgentCore Runtime command execution semantics:
 
 - **One-shot commands**: Each command runs to completion or timeout.
-- **No persistent shell**: Shell state does not carry over between commands. Encode state in each command, for example `cd /workspace && npm test`.
-- **Background processes are not supported**: The provider does not expose a `processes` manager.
-- **Interactive stdin is unavailable**: Runtime command execution does not provide an interactive stdin stream through this provider.
-- **Workspace filesystem mounts are unsupported**: Workspace filesystem mounting is not supported by this provider.
+- **No persistent shell**: Shell state doesn't carry over between commands. Encode state in each command, for example `cd /workspace && npm test`.
+- **Background processes aren't supported**: The provider doesn't expose a `processes` manager.
+- **Interactive stdin is unavailable**: Runtime command execution doesn't provide an interactive stdin stream through this provider.
+- **Workspace filesystem mounts are unsupported**: Workspace filesystem mounting isn't supported by this provider.
 - **Container-dependent tools**: Commands can only use tools installed in the AgentCore Runtime container image.
 
 ## Related

--- a/docs/src/content/en/reference/workspace/azure-blob-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/azure-blob-filesystem.mdx
@@ -46,7 +46,7 @@ const agent = new Agent({
 
 ### Account key
 
-Use an account name and account key when you do not want to pass a full connection string:
+Use an account name and account key when you don't want to pass a full connection string:
 
 ```typescript
 import { AzureBlobFilesystem } from '@mastra/azure/blob'
@@ -258,7 +258,7 @@ const config = filesystem.getMountConfig()
 
 :::note
 
-Azure Blob sandbox mounting depends on sandbox support for `azure-blob` mount configs. Use `filesystem` for direct workspace file operations when your sandbox provider does not support Azure Blob mounts.
+Azure Blob sandbox mounting depends on sandbox support for `azure-blob` mount configs. Use `filesystem` for direct workspace file operations when your sandbox provider doesn't support Azure Blob mounts.
 
 :::
 

--- a/docs/src/content/en/reference/workspace/files-sdk-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/files-sdk-filesystem.mdx
@@ -208,10 +208,10 @@ const url = await filesystem.files.url('reports/q3.pdf')
 `FilesSDKFilesystem` treats the configured backend as an object store, even when the underlying adapter is hierarchical (such as `fs`). This keeps behavior consistent across adapters:
 
 - **`mkdir`** is a no-op. Directories exist implicitly when keys with that prefix exist.
-- **`exists`** returns `true` only when an exact key is present as a file, or when the path is a prefix that contains at least one child key. Empty leftover directories on hierarchical adapters do not count.
-- **`deleteFile`** throws `FileNotFoundError` when the key does not exist, unless `{ force: true }` is passed.
+- **`exists`** returns `true` only when an exact key is present as a file, or when the path is a prefix that contains at least one child key. Empty leftover directories on hierarchical adapters don't count.
+- **`deleteFile`** throws `FileNotFoundError` when the key doesn't exist, unless `{ force: true }` is passed.
 - **`deleteFile`** on a directory delegates to `rmdir({ recursive: true })`, matching the [`S3Filesystem`](/reference/workspace/s3-filesystem) and [`GCSFilesystem`](/reference/workspace/gcs-filesystem) behavior.
-- **`moveFile`** is implemented as `copyFile` followed by `deleteFile`. It is **not atomic** — if the source delete fails after a successful copy, the destination remains and the source is not removed.
+- **`moveFile`** is implemented as `copyFile` followed by `deleteFile`. it's **not atomic** — if the source delete fails after a successful copy, the destination remains and the source isn't removed.
 - **`appendFile`** is a read-modify-write operation. Concurrent appends to the same key may overwrite each other; this is inherent to object storage and not specific to FilesSDK.
 - **`readdir({ recursive: true })`** emits intermediate directory entries (for example, `a/b` is emitted alongside `a/b/c.txt`).
 

--- a/docs/src/content/en/reference/workspace/google-drive-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/google-drive-filesystem.mdx
@@ -55,7 +55,7 @@ Supply one of the following authentication options:
 
 #### Service account
 
-Service account auth is the recommended option for backend agents. There is no user consent flow and no token refresh handling. You only need **two values** from the service account JSON key file: `client_email` and `private_key`.
+Service account auth is the recommended option for backend agents. No user consent flow and no token refresh handling is required. You only need **two values** from the service account JSON key file: `client_email` and `private_key`.
 
 ##### Set up the service account
 
@@ -67,21 +67,21 @@ Service account auth is the recommended option for backend agents. There is no u
 
 ##### Share the Drive folder with the service account
 
-The service account is its own Google identity. It cannot see anything in Drive until you share with it explicitly.
+The service account is its own Google identity. It can't see anything in Drive until you share with it explicitly.
 
 1. Open the target folder in [Google Drive](https://drive.google.com/).
 1. Select **Share**.
 1. Paste the service account's `client_email` address.
 1. Set the role to **Editor** (for read and write) or **Viewer** (for read-only access). Select **Send**.
-1. Copy the folder ID from the URL. It is the segment after `/folders/` in `https://drive.google.com/drive/folders/<folderId>`.
+1. Copy the folder ID from the URL. it's the segment after `/folders/` in `https://drive.google.com/drive/folders/<folderId>`.
 
 :::warning
 
-Service accounts cannot create files in standard "My Drive" folders. A service account has no personal Drive storage quota, so any file it creates needs to be owned by a quota-bearing entity. If you only share a personal Drive folder, read operations work but writes fail with a quota error.
+Service accounts can't create files in standard "My Drive" folders. A service account has no personal Drive storage quota, so any file it creates needs to be owned by a quota-bearing entity. If you only share a personal Drive folder, read operations work but writes fail with a quota error.
 
 For write access, place the folder inside a **shared drive** (formerly Team Drive) and add the service account as a member of that shared drive. Shared drives provide the storage quota that service-account-created files need.
 
-Read-only workloads against a personal Drive folder do not have this restriction.
+Read-only workloads against a personal Drive folder don't have this restriction.
 
 :::
 
@@ -108,13 +108,13 @@ const filesystem = new GoogleDriveFilesystem({
 })
 ```
 
-You do **not** need to copy the entire JSON file or pass other fields like `project_id`, `client_id`, `private_key_id`, or `token_uri`. They are not used. Only `clientEmail` and `privateKey` are required. `privateKeyId`, `scopes`, and `subject` are optional. `scopes` defaults to `['https://www.googleapis.com/auth/drive']`, which is the scope required for the service account to see folders shared with it. The narrower `drive.file` scope only grants access to files the application created itself, so a folder shared with the service account would return `404 Not Found`.
+You **don't** need to copy the entire JSON file or pass other fields like `project_id`, `client_id`, `private_key_id`, or `token_uri`. They're not used. Only `clientEmail` and `privateKey` are required. `privateKeyId`, `scopes`, and `subject` are optional. `scopes` defaults to `['https://www.googleapis.com/auth/drive']`, which is the scope required for the service account to see folders shared with it. The narrower `drive.file` scope only grants access to files the application created itself, so a folder shared with the service account would return `404 Not Found`.
 
 `GoogleDriveFilesystem` automatically normalizes the `privateKey` string before signing. It strips surrounding quotes (including escaped quotes from JSON-wrapped values), converts literal `\n` sequences to real newlines, normalizes `\r\n` line endings, and removes a trailing comma. The key works regardless of how your `.env` loader handles the value.
 
 ##### Troubleshoot
 
-- **`404 File not found: <folderId>`**: The service account does not have access to the folder. Confirm the folder is shared with the exact `client_email` address and that the folder ID matches the URL.
+- **`404 File not found: <folderId>`**: The service account doesn't have access to the folder. Confirm the folder is shared with the exact `client_email` address and that the folder ID matches the URL.
 - **`storageQuotaExceeded` on write**: The folder is in a personal "My Drive". Move the folder to a shared drive and add the service account as a member.
 - **`error:1E08010C:DECODER routines::unsupported`**: The `privateKey` value is malformed. Confirm the value contains the full PEM block and that newlines are preserved (literal `\n` is fine).
 

--- a/docs/src/content/en/reference/workspace/modal-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/modal-sandbox.mdx
@@ -233,7 +233,7 @@ await handle.kill()
 
 :::note
 
-`sendStdin()` is not supported — the Modal JS SDK does not expose stdin on `Sandbox.exec()`.
+`sendStdin()` isn't supported — the Modal JS SDK doesn't expose stdin on `Sandbox.exec()`.
 
 :::
 

--- a/docs/src/content/en/reference/workspace/vercel-microvm-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/vercel-microvm-sandbox.mdx
@@ -274,7 +274,7 @@ See the [`SandboxProcessManager` reference](/reference/workspace/process-manager
 
 :::note
 
-The Vercel Sandbox SDK does not expose a stdin channel for running commands, so `handle.sendStdin()` throws. Filesystem mounting (FUSE) is also not supported by this provider.
+The Vercel Sandbox SDK doesn't expose a stdin channel for running commands, so `handle.sendStdin()` throws. Filesystem mounting (FUSE) is also not supported by this provider.
 
 :::
 

--- a/docs/src/content/en/reference/workspace/vercel.mdx
+++ b/docs/src/content/en/reference/workspace/vercel.mdx
@@ -17,7 +17,7 @@ For interface details, see [WorkspaceSandbox interface](/reference/workspace/san
 
 :::warning
 
-VercelSandbox is stateless. There is no persistent filesystem, no interactive shell, and no support for long-running or background processes. Only `/tmp` is writable and is ephemeral between invocations.
+VercelSandbox is stateless. No persistent filesystem, no interactive shell, and no support for long-running or background processes exist. Only `/tmp` is writable and is ephemeral between invocations.
 
 :::
 
@@ -174,7 +174,7 @@ VercelSandbox uses serverless functions under the hood, which means:
 - **No persistent filesystem**: Files written to `/tmp` are ephemeral and cleared between invocations.
 - **No interactive shell**: Commands run via `/bin/sh -c` with no stdin streaming.
 - **No background processes**: No process manager, PIDs, or long-running tasks.
-- **No mounting**: Cloud storage mounting (S3, GCS) is not supported.
+- **No mounting**: Cloud storage mounting (S3, GCS) isn't supported.
 - **Timeout limits**: Maximum execution time is bounded by `maxDuration` (default 60s).
 
 ## Related

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -379,7 +379,7 @@ await workspace.destroy()
 
 Call `destroy()` when your application is done with a workspace. `mastra.shutdown()` calls it for registered workspaces during shutdown. To remove a workspace from the Mastra registry, use [`mastra.removeWorkspace()`](/reference/core/removeWorkspace).
 
-`LocalFilesystem.destroy()` does not delete files on disk. Resolver-backed filesystem and sandbox providers are owned by your application and must be cleaned up by your application.
+`LocalFilesystem.destroy()` doesn't delete files on disk. Resolver-backed filesystem and sandbox providers are owned by your application and must be cleaned up by your application.
 
 ### Search operations
 
@@ -624,9 +624,9 @@ const sandbox = await workspace.resolveSandbox({ requestContext: ctx })
 
 Clear resolver-backed sandboxes cached by `sandboxCacheKey`. Pass a cache key to clear one entry, or omit it to clear all keyed sandbox entries.
 
-This method does not clear the per-`RequestContext` weak cache. Those entries are garbage-collection managed.
+This method doesn't clear the per-`RequestContext` weak cache. Those entries are garbage-collection managed.
 
-The workspace does not own resolver-returned sandboxes. This method only drops workspace references. Destroy the sandbox in your own lifecycle code.
+The workspace doesn't own resolver-returned sandboxes. This method only drops workspace references. Destroy the sandbox in your own lifecycle code.
 
 ```typescript
 workspace.clearSandboxCache('thread-123')
@@ -716,7 +716,7 @@ Added when a sandbox is configured:
 | `mastra_workspace_get_process_output` | Get stdout, stderr, and status of a background process by PID. Accepts `tail` to limit output lines and `wait: true` to block until exit. Only available when the sandbox has a process manager. |
 | `mastra_workspace_kill_process` | Kill a background process by PID. Returns the last 50 lines of output. Only available when the sandbox has a process manager. |
 
-With a static sandbox, capability checks (`executeCommand`, `processes`) decide which tool variants are exposed. With a [dynamic sandbox](/docs/workspace/sandbox#dynamic-sandbox), all sandbox tools are registered and the runtime throws a clear error if the resolved sandbox does not implement a requested capability.
+With a static sandbox, capability checks (`executeCommand`, `processes`) decide which tool variants are exposed. With a [dynamic sandbox](/docs/workspace/sandbox#dynamic-sandbox), all sandbox tools are registered and the runtime throws a clear error if the resolved sandbox doesn't implement a requested capability.
 
 The `execute_command` tool accepts a `backgroundProcesses` option for lifecycle callbacks on background processes:
 

--- a/docs/styles/config/vocabularies/Mastra/accept.txt
+++ b/docs/styles/config/vocabularies/Mastra/accept.txt
@@ -130,7 +130,7 @@ Vercel
 Visual Studio Code
 Vectorize
 (?i)Vitest
-VNext
+(?i)VNext
 WebSocket
 WhatsApp
 (?i)WorkOS

--- a/docs/styles/config/vocabularies/Mastra/accept.txt
+++ b/docs/styles/config/vocabularies/Mastra/accept.txt
@@ -111,7 +111,7 @@ SQL
 SSE
 STS
 STT
-Supabase
+(?i)Supabase
 Svelte
 SvelteKit
 Swagger


### PR DESCRIPTION
## Description

Fixes styleguide issues found by Vale. Also adjusted the `mastra-docs` skill to call out these styling more

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR makes the docs sound more natural and consistent by updating the writing style rules and changing lots of phrases (like "does not" → "doesn't") across the documentation. It's just polishing wording—no code or behavior changes.

## Summary

Updated the Mastra documentation styleguide and applied new writing conventions across the docs. The styleguide now adds four core writing rules: use contractions, remove filler/weak adverbs/weasel words/clichés, avoid starting sentences with "So"/"There is"/"There are", and prefer inclusive, gender-neutral, person-first wording. Many MDX files and reference pages were edited to align with these rules (mostly contraction and phrasing changes).

## Changes

- Styleguide (.claude/skills/mastra-docs/references/STYLEGUIDE.md)
  - Added four core writing rules promoting contractions, removing weak/filler language, avoiding certain sentence-starters, and using inclusive wording.

- Documentation edits (80+ MDX files under docs/src/content/)
  - Widespread, low-risk wording updates: contractions (e.g., "does not" → "doesn't"), rephrasing for clarity, minor punctuation/formatting adjustments.
  - Notable touched areas: agents, browser, editor, observability, storage, server/auth, workspace/sandbox, SDKs, guides, and many reference pages.
  - One content note with slightly higher review effort: docs/src/content/en/docs/editor/overview.mdx (larger wording/structure clarifications).
  - docs/src/content/en/docs/browser/overview.mdx and several medium edits flagged as Medium estimated review effort in the raw summary.

- Vocabulary (docs/styles/config/vocabularies/Mastra/accept.txt)
  - Added case-insensitive matches for "Supabase" and "VNext".

## Impact

- Documentation-only changes; no API, exported symbol, or runtime behavior changes.
- Estimated review effort: Mostly Low; a few files marked Medium where more context/clarity edits occurred.

## Checklist / Notes

- PR description checklist items remain unchecked (link related issues, add documentation notes, add tests, address CodeRabbit comments).
- No tests were added; label: Documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->