### PR TITLE
ci: harden dependency lockfile update script

### DIFF
--- a/.github/scripts/install-deps.bash
+++ b/.github/scripts/install-deps.bash
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
 # Get the base SHA from the first argument
-BASE_SHA=$1
+BASE_SHA=${1:-}
 
 if [ -z "$BASE_SHA" ]; then
   echo "Error: Base SHA not provided"
@@ -10,9 +11,8 @@ fi
 
 echo "Using base SHA: $BASE_SHA"
 
-
 # Get list of changed package.json files in examples and e2e-tests directories
-changed_files=$(git diff --name-only $BASE_SHA HEAD | grep -E "(examples|e2e-tests|integration-tests)/.*package.json" | grep -v "e2e-tests/.*/templates/")
+changed_files=$(git diff --name-only "$BASE_SHA" HEAD | grep -E "(examples|e2e-tests|integration-tests)/.*package.json" | grep -v -E "e2e-tests/.*/templates?/" || true)
 
 echo "changed_files: $changed_files"
 
@@ -27,9 +27,17 @@ for package_json in $changed_files; do
   fi
 done
 
-# Commit the changes if any were made
-if [ -n "$(git status --porcelain)" ]; then
-  git add .
+workspace_changes=$(git status --porcelain -- ':(glob)**/pnpm-workspace.yaml')
+if [ -n "$workspace_changes" ]; then
+  echo "Error: pnpm install unexpectedly modified pnpm-workspace.yaml files"
+  echo "$workspace_changes"
+  git diff -- ':(glob)**/pnpm-workspace.yaml'
+  exit 1
+fi
+
+lockfile_changes=$(git status --porcelain -- ':(glob)**/pnpm-lock.yaml')
+if [ -n "$lockfile_changes" ]; then
+  git add -- ':(glob)**/pnpm-lock.yaml'
   git commit -m "chore: update pnpm-lock.yaml files"
   git push
 fi


### PR DESCRIPTION
This hardens the CI dependency install helper so it handles a missing base SHA safely, quotes the diff base, tolerates no matching package changes, and only commits pnpm lockfile changes. It now fails if pnpm install mutates pnpm-workspace.yaml files instead of committing broad workspace changes.

Tested with `bash -n .github/scripts/install-deps.bash` and `bash .github/scripts/install-deps.bash HEAD`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes a CI helper script safer and more careful. The script updates dependency lockfiles in test/example folders when they change. The improvements ensure the script fails gracefully if given bad input, prevents it from accidentally modifying important workspace configuration files, and makes sure it only commits changes that actually exist.

## What Changed

The `.github/scripts/install-deps.bash` script was hardened with several safety improvements:

### Error Handling & Input Validation
- Added strict bash error handling with `set -euo pipefail` to catch failures immediately
- Made base SHA handling safer by using parameter expansion with a default value (`${1:-}`)
- Script now exits with a clear error message if the required base SHA argument is missing

### Improved File Discovery
- Updated the `git diff` invocation to properly quote the base SHA: `git diff --name-only "$BASE_SHA" HEAD`
- Refined the filter for changed `package.json` files to explicitly exclude template directories: `grep -v -E "e2e-tests/.*/templates?/"`
- This targets only relevant package files in `examples/`, `e2e-tests/`, and `integration-tests/` directories

### Workspace Mutation Guards
- Added a check that fails the script if `pnpm install` unexpectedly modifies `pnpm-workspace.yaml` files
- When workspace files are mutated, the script logs an error message, displays the diff, and exits with failure
- This prevents the script from committing broad workspace configuration changes that should be intentional

### Selective Lockfile Commits
- Replaced a blanket "commit if dirty" approach with targeted lockfile-only logic
- Only stages, commits, and pushes changes if `pnpm-lock.yaml` files were actually modified
- Skips the commit/push steps entirely if there are no lockfile changes, avoiding empty commits

## Impact

The script is now more robust for CI automation:
- Safer to run with automated inputs due to proper error handling
- Fails fast and clearly on problems rather than silently continuing
- Guards against unintended workspace mutations that could break builds
- More predictable commit behavior (no empty commits)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->