### PR TITLE
fix(cli): replace @expo/devcert with selfsigned for Node 22 HTTPS support

### DIFF
--- a/.changeset/eighty-experts-flash.md
+++ b/.changeset/eighty-experts-flash.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra dev --https` crashing on Node.js 22 by replacing unmaintained `@expo/devcert` with `selfsigned` for development certificate generation

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "@babel/parser": "^7.29.7",
     "@babel/types": "^7.29.7",
     "@clack/prompts": "^1.1.0",
-    "@expo/devcert": "^1.2.1",
+    "selfsigned": "^2.4.1",
     "@mastra/deployer": "workspace:^",
     "@mastra/loggers": "workspace:^",
     "archiver": "^7.0.1",

--- a/packages/cli/src/commands/dev/dev.test.ts
+++ b/packages/cli/src/commands/dev/dev.test.ts
@@ -10,11 +10,12 @@ vi.mock('execa', () => ({
   execa: vi.fn(),
 }));
 
-vi.mock('@expo/devcert', () => ({
+vi.mock('selfsigned', () => ({
   default: {
-    certificateFor: vi.fn().mockResolvedValue({
-      key: Buffer.from('mock-key'),
-      cert: Buffer.from('mock-cert'),
+    generate: vi.fn().mockReturnValue({
+      private: '-----BEGIN RSA PRIVATE KEY-----\nmock-key\n-----END RSA PRIVATE KEY-----',
+      cert: '-----BEGIN CERTIFICATE-----\nmock-cert\n-----END CERTIFICATE-----',
+      public: '-----BEGIN PUBLIC KEY-----\nmock-pub\n-----END PUBLIC KEY-----',
     }),
   },
 }));
@@ -475,5 +476,165 @@ describe('dev command - inspect flag behavior', () => {
       expect(commands).toContain('--inspect-brk');
       expect(commands.some(cmd => cmd.startsWith('--inspect-brk='))).toBe(false);
     });
+  });
+});
+
+describe('dev command - certificate generation with selfsigned', () => {
+  let execaMock: any;
+  let mockChildProcess: MockChildProcess;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockChildProcess = new MockChildProcess();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('server unavailable')));
+
+    const { execa } = await import('execa');
+    execaMock = vi.mocked(execa);
+    execaMock.mockReturnValue(mockChildProcess as unknown as ChildProcess);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should generate self-signed certificate with correct hostname when --https flag is passed', async () => {
+    const { getServerOptions } = await import('@mastra/deployer/build');
+    vi.mocked(getServerOptions).mockResolvedValue({
+      port: 4111,
+      host: 'localhost',
+    } as any);
+
+    const { dev } = await import('./dev');
+
+    await dev({
+      dir: undefined,
+      root: process.cwd(),
+      tools: undefined,
+      env: undefined,
+      inspect: false,
+      inspectBrk: false,
+      customArgs: undefined,
+      https: true,
+      debug: false,
+    });
+
+    const selfsignedModule = await import('selfsigned');
+    const generateMock = vi.mocked(selfsignedModule.default.generate);
+
+    expect(generateMock).toHaveBeenCalledWith(
+      [{ name: 'commonName', value: 'localhost' }],
+      expect.objectContaining({
+        days: 365,
+        keySize: 2048,
+        algorithm: 'sha256',
+      })
+    );
+  });
+
+  it('should include localhost IP addresses in Subject Alternative Names', async () => {
+    const { getServerOptions } = await import('@mastra/deployer/build');
+    vi.mocked(getServerOptions).mockResolvedValue({
+      port: 4111,
+      host: 'localhost',
+    } as any);
+
+    const { dev } = await import('./dev');
+
+    await dev({
+      dir: undefined,
+      root: process.cwd(),
+      tools: undefined,
+      env: undefined,
+      inspect: false,
+      inspectBrk: false,
+      customArgs: undefined,
+      https: true,
+      debug: false,
+    });
+
+    const selfsignedModule = await import('selfsigned');
+    const generateMock = vi.mocked(selfsignedModule.default.generate);
+    const callArgs = generateMock.mock.calls[0];
+    const extensions = callArgs[1]?.extensions;
+
+    expect(extensions).toContainEqual(
+      expect.objectContaining({
+        name: 'subjectAltName',
+        altNames: expect.arrayContaining([
+          expect.objectContaining({ type: 2, value: 'localhost' }),
+          expect.objectContaining({ type: 7, ip: '127.0.0.1' }),
+          expect.objectContaining({ type: 7, ip: '::1' }),
+        ]),
+      })
+    );
+  });
+
+  it('should pass generated certificate to server process', async () => {
+    const { getServerOptions } = await import('@mastra/deployer/build');
+    vi.mocked(getServerOptions).mockResolvedValue({
+      port: 4111,
+      host: 'localhost',
+    } as any);
+
+    const { dev } = await import('./dev');
+
+    await dev({
+      dir: undefined,
+      root: process.cwd(),
+      tools: undefined,
+      env: undefined,
+      inspect: false,
+      inspectBrk: false,
+      customArgs: undefined,
+      https: true,
+      debug: false,
+    });
+
+    expect(execaMock).toHaveBeenCalled();
+    const callArgs = execaMock.mock.calls[0];
+    const env = callArgs[2]?.env;
+
+    expect(env).toBeDefined();
+    expect(env.MASTRA_HTTPS_KEY).toBeDefined();
+    expect(env.MASTRA_HTTPS_CERT).toBeDefined();
+  });
+
+  it('should use IP SAN type when host is an IP address', async () => {
+    const { getServerOptions } = await import('@mastra/deployer/build');
+    vi.mocked(getServerOptions).mockResolvedValue({
+      port: 4111,
+      host: '192.168.1.100',
+    } as any);
+
+    const { dev } = await import('./dev');
+
+    await dev({
+      dir: undefined,
+      root: process.cwd(),
+      tools: undefined,
+      env: undefined,
+      inspect: false,
+      inspectBrk: false,
+      customArgs: undefined,
+      https: true,
+      debug: false,
+    });
+
+    const selfsignedModule = await import('selfsigned');
+    const generateMock = vi.mocked(selfsignedModule.default.generate);
+    const callArgs = generateMock.mock.calls[0];
+    const extensions = callArgs[1]?.extensions;
+    const sanExt = extensions?.find((e: any) => e.name === 'subjectAltName');
+
+    expect(sanExt?.altNames).toContainEqual(
+      expect.objectContaining({ type: 7, ip: '192.168.1.100' })
+    );
+    expect(sanExt?.altNames).not.toContainEqual(
+      expect.objectContaining({ type: 2, value: '192.168.1.100' })
+    );
   });
 });

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -1,13 +1,14 @@
 import type { ChildProcess } from 'node:child_process';
 import { mkdir, writeFile } from 'node:fs/promises';
+import { isIP } from 'node:net';
 import { join } from 'node:path';
 import process from 'node:process';
-import devcert from '@expo/devcert';
 import { FileService } from '@mastra/deployer';
 import { getServerOptions, normalizeStudioBase } from '@mastra/deployer/build';
 import { execa } from 'execa';
 import getPort from 'get-port';
 import pc from 'picocolors';
+import selfsigned from 'selfsigned';
 import { getAnalytics } from '../../analytics/index.js';
 import { checkMastraPeerDeps, getUpdateCommand, logPeerDepWarnings } from '../../utils/check-peer-deps.js';
 import type { PeerDepMismatch } from '../../utils/check-peer-deps.js';
@@ -498,8 +499,20 @@ export async function dev({
   if (serverOptions?.https) {
     httpsOptions = serverOptions.https;
   } else if (https) {
-    const { key, cert } = await devcert.certificateFor(serverOptions?.host ?? 'localhost');
-    httpsOptions = { key, cert };
+    const hostname = hostToUse;
+    const attrs = [{ name: 'commonName', value: hostname }];
+    const pems = selfsigned.generate(attrs, {
+      days: 365,
+      keySize: 2048,
+      algorithm: 'sha256',
+      extensions: [
+        { name: 'subjectAltName', altNames: [
+          ...(isIP(hostname) ? [{ type: 7, ip: hostname }] : [{ type: 2, value: hostname }]),
+          ...(hostname === 'localhost' ? [{ type: 7, ip: '127.0.0.1' }, { type: 7, ip: '::1' }] : []),
+        ]},
+      ],
+    });
+    httpsOptions = { key: Buffer.from(pems.private), cert: Buffer.from(pems.cert) };
   }
 
   // Extract mastra packages from the project's package.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3326,9 +3326,6 @@ importers:
       '@clack/prompts':
         specifier: ^1.1.0
         version: 1.3.0
-      '@expo/devcert':
-        specifier: ^1.2.1
-        version: 1.2.1
       '@mastra/deployer':
         specifier: workspace:^
         version: link:../deployer
@@ -3365,6 +3362,9 @@ importers:
       posthog-node:
         specifier: ^5.30.6
         version: 5.33.4(rxjs@7.8.1)
+      selfsigned:
+        specifier: ^2.4.1
+        version: 2.4.1
       semver:
         specifier: ^7.7.4
         version: 7.8.0
@@ -12187,12 +12187,6 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
-
-  '@expo/devcert@1.2.1':
-    resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
-
-  '@expo/sudo-prompt@9.3.2':
-    resolution: {integrity: sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==}
 
   '@fastify/accept-negotiator@2.0.1':
     resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
@@ -26621,6 +26615,10 @@ packages:
   select-hose@2.0.0:
     resolution: {integrity: sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==}
 
+  selfsigned@2.4.1:
+    resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
+    engines: {node: '>=10'}
+
   selfsigned@5.5.0:
     resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
     engines: {node: '>=18'}
@@ -34229,15 +34227,6 @@ snapshots:
   '@exodus/bytes@1.15.1(@noble/hashes@2.0.1)':
     optionalDependencies:
       '@noble/hashes': 2.0.1
-
-  '@expo/devcert@1.2.1':
-    dependencies:
-      '@expo/sudo-prompt': 9.3.2
-      debug: 3.2.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@expo/sudo-prompt@9.3.2': {}
 
   '@fastify/accept-negotiator@2.0.1': {}
 
@@ -52126,6 +52115,11 @@ snapshots:
   secure-json-parse@4.1.0: {}
 
   select-hose@2.0.0: {}
+
+  selfsigned@2.4.1:
+    dependencies:
+      '@types/node-forge': 1.3.14
+      node-forge: 1.4.0
 
   selfsigned@5.5.0:
     dependencies:


### PR DESCRIPTION
Fixes #9571

## Summary

`mastra dev --https` crashes on Node.js 22 because `@expo/devcert` calls `crypto.createCipher()`, which was removed in Node 22. The upstream package is unmaintained at v1.2.1 with no fix available.

## Root cause

`@expo/devcert@1.2.1` encrypts its local CA store using `crypto.createCipher()`, a function deprecated since Node 10 and removed in Node 22. When `dev.ts:501` calls `devcert.certificateFor('localhost')`, the internal encryption path throws `crypto_1.default.createCipher is not a function`. This affects all platforms (confirmed on Windows 11 and macOS) running Node 22+.

## Changes

- `packages/cli/package.json`: replace `@expo/devcert` dependency with `selfsigned@^2.4.1` (~+1 line)
- `packages/cli/src/commands/dev/dev.ts`: swap the import and cert generation call to use `selfsigned.generate()` with SAN extensions for Chrome compatibility; uses `net.isIP()` to emit correct SAN type (IP vs DNS) for IP-literal hosts (~+12 lines)
- `packages/cli/src/commands/dev/dev.test.ts`: update the mock from `@expo/devcert` to `selfsigned`, add cert generation regression tests including IP-host SAN type correctness (~+30 lines)

## What is NOT changed

- The `server.https` config-based path (user-provided certs via `serverOptions.https`) is completely untouched and still takes precedence over `--https`
- The CLI flag interface (`--https`) is unchanged
- No behavioral change for users who already provide their own certs via config

## Out of scope

- System CA trust store installation: `@expo/devcert` installed a local CA so browsers trusted the cert without warnings. `selfsigned` generates a self-signed cert, so browsers will show a one-time certificate warning in dev. Users who want trusted certs can generate them with `mkcert` and pass them via `server.https` config, as documented at https://mastra.ai/docs/getting-started/studio#local-https. A follow-up could add optional `mkcert` integration.
- Updating the docs page to note the self-signed cert behavior change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Linked related issue
- [x] Added or updated tests
- [ ] Documentation updated (if applicable)
- [x] Addressed all Coderabbit comments

## Test plan

- `pnpm --filter ./packages/cli test src/commands/dev/dev.test.ts` â€” covers: HTTPS cert generation with `--https` flag triggers `selfsigned.generate()` with correct hostname and SAN config, SAN includes localhost IPv4/IPv6 loopback addresses, IP-literal hosts get `type: 7` (IP) SANs instead of `type: 2` (DNS), generated cert is passed through to the server process via env vars. Existing tests for http/https scheme selection and inspect flag passthrough are updated to use the new mock.
