### PR TITLE
feat(railway): add Railway Sandboxes workspace provider

### DIFF
--- a/.changeset/railway-sandbox-provider.md
+++ b/.changeset/railway-sandbox-provider.md
@@ -11,3 +11,15 @@ configurable idle timeout, `ISOLATED`/`PRIVATE` network isolation, custom base
 images via the Railway template builder, forking a running sandbox into a new
 one, and reattaching to an existing sandbox by ID. Also exports
 `railwaySandboxProvider` for registration with `MastraEditor`.
+
+```typescript
+import { Workspace } from '@mastra/core/workspace';
+import { RailwaySandbox } from '@mastra/railway';
+
+const workspace = new Workspace({
+  sandbox: new RailwaySandbox({
+    idleTimeoutMinutes: 30,
+    networkIsolation: 'PRIVATE',
+  }),
+});
+```

--- a/.changeset/railway-sandbox-provider.md
+++ b/.changeset/railway-sandbox-provider.md
@@ -1,0 +1,13 @@
+---
+"@mastra/railway": minor
+---
+
+Add `@mastra/railway`, a sandbox provider for [Railway Sandboxes](https://docs.railway.com/sandboxes).
+
+Provisions ephemeral, isolated Linux VMs on Railway through the Railway
+TypeScript SDK and exposes them as a Mastra `WorkspaceSandbox`. Supports command
+execution with streaming output and timeouts, background process management,
+configurable idle timeout, `ISOLATED`/`PRIVATE` network isolation, custom base
+images via the Railway template builder, forking a running sandbox into a new
+one, and reattaching to an existing sandbox by ID. Also exports
+`railwaySandboxProvider` for registration with `MastraEditor`.

--- a/docs/src/content/en/docs/workspace/sandbox.mdx
+++ b/docs/src/content/en/docs/workspace/sandbox.mdx
@@ -28,6 +28,7 @@ A sandbox provider executes commands in a controlled environment:
 - [`DaytonaSandbox`](/reference/workspace/daytona-sandbox): Executes commands in isolated Daytona cloud sandboxes
 - [`E2BSandbox`](/reference/workspace/e2b-sandbox): Executes commands in isolated E2B cloud sandboxes
 - [`ModalSandbox`](/reference/workspace/modal-sandbox): Executes commands in isolated Modal cloud sandboxes
+- [`RailwaySandbox`](/reference/workspace/railway-sandbox): Executes commands in ephemeral, isolated Railway cloud sandboxes
 
 ## Basic usage
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -741,6 +741,7 @@ const sidebars = {
         { type: 'doc', id: 'workspace/local-filesystem', label: 'LocalFilesystem' },
         { type: 'doc', id: 'workspace/local-sandbox', label: 'LocalSandbox' },
         { type: 'doc', id: 'workspace/modal-sandbox', label: 'ModalSandbox' },
+        { type: 'doc', id: 'workspace/railway-sandbox', label: 'RailwaySandbox' },
         { type: 'doc', id: 'workspace/s3-filesystem', label: 'S3Filesystem' },
         { type: 'doc', id: 'workspace/process-manager', label: 'SandboxProcessManager' },
         { type: 'doc', id: 'workspace/vercel-microvm-sandbox', label: 'VercelMicroVMSandbox' },

--- a/docs/src/content/en/reference/workspace/railway-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/railway-sandbox.mdx
@@ -1,0 +1,314 @@
+---
+title: "Reference: RailwaySandbox | Workspace"
+description: "Documentation for the RailwaySandbox provider for isolated cloud code execution."
+packages:
+  - "@mastra/railway"
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# RailwaySandbox
+
+Executes commands in ephemeral, isolated [Railway](https://docs.railway.com/sandboxes) sandboxes. Each sandbox is an isolated Debian Linux VM provisioned on demand through the Railway TypeScript SDK. Supports command execution with streaming output, command timeouts, configurable idle timeout, `ISOLATED`/`PRIVATE` network isolation, custom base images via the Railway template builder, forking a running sandbox, and reattaching to an existing sandbox by ID.
+
+:::info
+
+For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
+
+:::
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/railway
+```
+
+Set your Railway credentials in one of three ways.
+
+<Tabs>
+  <TabItem value="shell-export" label="Shell export">
+    ```bash
+    export RAILWAY_API_TOKEN=your-api-token
+    export RAILWAY_ENVIRONMENT_ID=your-environment-id
+    ```
+  </TabItem>
+
+  <TabItem value="env-file" label=".env file">
+    ```bash
+    RAILWAY_API_TOKEN=your-api-token
+    RAILWAY_ENVIRONMENT_ID=your-environment-id
+    ```
+  </TabItem>
+
+  <TabItem value="constructor" label="Constructor">
+    ```typescript
+    new RailwaySandbox({
+      token: 'your-api-token',
+      environmentId: 'your-environment-id',
+    })
+    ```
+  </TabItem>
+</Tabs>
+
+## Usage
+
+Add a `RailwaySandbox` to a workspace and assign it to an agent:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { Workspace } from '@mastra/core/workspace'
+import { RailwaySandbox } from '@mastra/railway'
+
+const workspace = new Workspace({
+  sandbox: new RailwaySandbox({
+    // token + environmentId read from RAILWAY_API_TOKEN / RAILWAY_ENVIRONMENT_ID
+    idleTimeoutMinutes: 30,
+  }),
+})
+
+const agent = new Agent({
+  id: 'code-agent',
+  name: 'Code Agent',
+  instructions: 'You are a coding assistant working in this workspace.',
+  model: '__GATEWAY_ANTHROPIC_MODEL_SONNET__',
+  workspace,
+})
+
+const response = await agent.generate(
+  'Print "Hello, world!" and show the current working directory.',
+)
+
+console.log(response.text)
+```
+
+### Private networking
+
+Join the environment's private network to reach other Railway services (for example `postgres.railway.internal`):
+
+```typescript
+const workspace = new Workspace({
+  sandbox: new RailwaySandbox({
+    networkIsolation: 'PRIVATE',
+    env: { NODE_ENV: 'production' },
+  }),
+})
+```
+
+The default `ISOLATED` mode allows outbound internet access only, with no private network connectivity.
+
+### Custom base image (templates)
+
+Pre-install packages and run setup steps so every sandbox starts ready. Pass a builder callback over the Railway template builder — the template is built once on the first `start()`:
+
+```typescript
+const workspace = new Workspace({
+  sandbox: new RailwaySandbox({
+    template: t => t.withPackages('git', 'curl').run('npm i -g pnpm').workdir('/app'),
+  }),
+})
+```
+
+You can also pass a pre-built `SandboxTemplate` to reuse it across sandboxes without rebuilding. Templates are ignored when `sandboxId` is set, since reattaching uses the existing sandbox's filesystem.
+
+### Forking a running sandbox
+
+Clone a running sandbox's filesystem into a new, independent sandbox — a fresh boot, not live processes. The returned `RailwaySandbox` is already started:
+
+```typescript
+const child = await sandbox.fork({ idleTimeoutMinutes: 15 })
+
+const result = await child.executeCommand('cat', ['/app/state.json'])
+console.log(result.stdout)
+```
+
+The forked sandbox inherits the parent's credentials and defaults unless overridden via the `fork()` options.
+
+### Streaming output
+
+Stream command output in real time via `onStdout` and `onStderr` callbacks:
+
+```typescript
+await sandbox.executeCommand('bash', ['-c', 'for i in 1 2 3; do echo "line $i"; sleep 1; done'], {
+  onStdout: chunk => process.stdout.write(chunk),
+  onStderr: chunk => process.stderr.write(chunk),
+})
+```
+
+Both callbacks are optional and can be used independently.
+
+### Reattaching to an existing sandbox
+
+A Railway sandbox outlives the process that created it. Reconnect by its Railway ID instead of provisioning a new one:
+
+```typescript
+const sandbox = new RailwaySandbox({ sandboxId: 'existing-railway-sandbox-id' })
+await sandbox._start()
+
+const result = await sandbox.executeCommand('cat', ['/tmp/state.txt'])
+```
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Unique identifier for this sandbox instance.',
+    isOptional: true,
+    defaultValue: 'Auto-generated',
+  },
+  {
+    name: 'token',
+    type: 'string',
+    description: 'Railway API token for authentication. Falls back to the RAILWAY_API_TOKEN environment variable.',
+    isOptional: true,
+  },
+  {
+    name: 'environmentId',
+    type: 'string',
+    description: 'Railway environment ID. Falls back to the RAILWAY_ENVIRONMENT_ID environment variable.',
+    isOptional: true,
+  },
+  {
+    name: 'sandboxId',
+    type: 'string',
+    description:
+      'Reattach to an existing Railway sandbox by its Railway ID instead of creating a new one. When set, start() calls Sandbox.connect().',
+    isOptional: true,
+  },
+  {
+    name: 'idleTimeoutMinutes',
+    type: 'number',
+    description:
+      'How long the sandbox can sit idle (no exec interaction) before Railway destroys it automatically. The valid range and default depend on your Railway plan.',
+    isOptional: true,
+  },
+  {
+    name: 'networkIsolation',
+    type: "'ISOLATED' | 'PRIVATE'",
+    description:
+      "Network access mode. 'ISOLATED' allows outbound internet only; 'PRIVATE' joins the environment's private network.",
+    isOptional: true,
+    defaultValue: "'ISOLATED'",
+  },
+  {
+    name: 'env',
+    type: 'Record<string, string>',
+    description: 'Environment variables baked into the sandbox, available to every command.',
+    isOptional: true,
+    defaultValue: '{}',
+  },
+  {
+    name: 'template',
+    type: 'SandboxTemplate | (base: SandboxTemplate) => SandboxTemplate',
+    description:
+      'Provision the sandbox from a custom base image built with the Railway template builder. Accepts a builder callback or a pre-built template. Ignored when sandboxId is set.',
+    isOptional: true,
+  },
+  {
+    name: 'timeout',
+    type: 'number',
+    description:
+      'Default execution timeout in milliseconds applied to commands that do not specify their own timeout. Commands run until they exit when omitted.',
+    isOptional: true,
+  },
+  {
+    name: 'instructions',
+    type: 'string | (opts) => string',
+    description:
+      'Override the default agent instructions. A string replaces them entirely; a function receives the default instructions and returns the final text.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Sandbox instance identifier.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: "Provider name ('RailwaySandbox').",
+  },
+  {
+    name: 'provider',
+    type: 'string',
+    description: "Provider identifier ('railway').",
+  },
+  {
+    name: 'status',
+    type: 'ProviderStatus',
+    description: "'pending' | 'initializing' | 'ready' | 'stopped' | 'destroyed' | 'error'",
+  },
+  {
+    name: 'railway',
+    type: 'Sandbox',
+    description:
+      'The underlying Railway Sandbox instance for direct SDK access. Throws SandboxNotReadyError if the sandbox has not been started.',
+  },
+  {
+    name: 'processes',
+    type: 'RailwayProcessManager',
+    description:
+      'Background process manager. See [SandboxProcessManager reference](/reference/workspace/process-manager).',
+  },
+]}
+/>
+
+## Methods
+
+<PropertiesTable
+  content={[
+  {
+    name: 'fork',
+    type: '(options?) => Promise<RailwaySandbox>',
+    description:
+      'Clone this running sandbox into a new, independent RailwaySandbox. The returned sandbox is already started and reattached to the forked Railway sandbox. Accepts optional id, idleTimeoutMinutes, networkIsolation, and env overrides. Throws SandboxNotReadyError if this sandbox has not been started.',
+  },
+]}
+/>
+
+## Background processes
+
+`RailwaySandbox` includes a built-in process manager for spawning and managing background processes. Each spawned process runs as a Railway `exec` session.
+
+```typescript
+const sandbox = new RailwaySandbox()
+await sandbox.start()
+
+// Spawn a background process
+const handle = await sandbox.processes.spawn('node server.js', {
+  env: { PORT: '3000' },
+  onStdout: data => console.log(data),
+})
+
+// Interact with the process
+console.log(handle.stdout)
+await handle.kill()
+```
+
+Railway's `exec` API does not stream stdin, so `sendStdin()` is not supported.
+
+See [`SandboxProcessManager` reference](/reference/workspace/process-manager) for the full API.
+
+## Editor provider
+
+Register the provider with `MastraEditor` to hydrate stored sandbox configs into runtime instances:
+
+```typescript
+import { railwaySandboxProvider } from '@mastra/railway'
+
+const editor = new MastraEditor({
+  sandboxes: { [railwaySandboxProvider.id]: railwaySandboxProvider },
+})
+```
+
+See the [Sandbox provider reference](/reference/editor/sandbox-provider) for details on registering custom sandbox providers.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,7 +465,7 @@ importers:
     dependencies:
       firebase-admin:
         specifier: ^13.7.0
-        version: 13.9.0
+        version: 13.9.0(encoding@0.1.13)
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -1682,16 +1682,16 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: ^2.0.62
-        version: 2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^2.0.99
-        version: 2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: ^2.0.1
         version: 2.0.3
       '@ai-sdk/provider-utils':
         specifier: ^3.0.22
-        version: 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@huggingface/hub':
         specifier: ^0.15.2
         version: 0.15.2
@@ -1764,7 +1764,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   integrations/brightdata:
     devDependencies:
@@ -5607,7 +5607,7 @@ importers:
     devDependencies:
       '@ai-sdk/openai':
         specifier: ^2.0.106
-        version: 2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5(vitest@4.1.5))(@vitest/ui@4.1.5(vitest@4.1.5))(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@internal/lint':
         specifier: workspace:*
         version: link:../../packages/_config
@@ -8352,6 +8352,49 @@ importers:
       modal:
         specifier: ^0.7.3
         version: 0.7.4
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@internal/workspace-test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
+      eslint:
+        specifier: ^10.4.1
+        version: 10.4.1(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.14)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+
+  workspaces/railway:
+    dependencies:
+      railway:
+        specifier: ^3.1.1
+        version: 3.1.1
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -12403,6 +12446,11 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
@@ -25829,6 +25877,11 @@ packages:
   raf-schd@4.0.3:
     resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
 
+  railway@3.1.1:
+    resolution: {integrity: sha512-Oy2F5oIey8KXFJwlka618J/pX0Qi+0kGvfH88eaJNb8C5O0Ba9CcVxguanN6MZEI1sXGMfFp2i3GKvNXQDoM2Q==}
+    engines: {node: '>=22'}
+    hasBin: true
+
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
@@ -29187,10 +29240,10 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -29341,27 +29394,7 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@opentelemetry/api'
-      - '@types/node'
-      - '@vitest/browser-playwright'
-      - '@vitest/browser-preview'
-      - '@vitest/browser-webdriverio'
-      - '@vitest/coverage-istanbul'
-      - '@vitest/coverage-v8'
-      - '@vitest/ui'
-      - happy-dom
-      - jsdom
-      - typescript
-      - vite
-
-  '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5(vitest@4.1.5))(@vitest/ui@4.1.5(vitest@4.1.5))(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+  '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
       '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
@@ -34431,7 +34464,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/firestore@7.11.6':
+  '@google-cloud/firestore@7.11.6(encoding@0.1.13)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       fast-deep-equal: 3.1.3
@@ -34594,6 +34627,10 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.0)':
+    dependencies:
+      graphql: 16.14.0
 
   '@grpc/grpc-js@1.14.4':
     dependencies:
@@ -45569,7 +45606,7 @@ snapshots:
       pkg-types: 1.3.1
       yaml: 2.9.0
 
-  firebase-admin@13.9.0:
+  firebase-admin@13.9.0(encoding@0.1.13):
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0
@@ -45582,7 +45619,7 @@ snapshots:
       node-forge: 1.4.0
       uuid: 11.1.0
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.6
+      '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       '@google-cloud/storage': 7.19.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -50820,6 +50857,12 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   raf-schd@4.0.3: {}
+
+  railway@3.1.1:
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
+      graphql: 16.14.0
+      tsx: 4.22.4
 
   range-parser@1.2.0: {}
 

--- a/workspaces/railway/CHANGELOG.md
+++ b/workspaces/railway/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @mastra/railway

--- a/workspaces/railway/README.md
+++ b/workspaces/railway/README.md
@@ -106,17 +106,17 @@ await handle.kill();
 
 ## Options
 
-| Option               | Type                       | Description                                                                                  |
-| -------------------- | -------------------------- | -------------------------------------------------------------------------------------------- |
-| `token`              | `string`                   | Railway API token. Falls back to `RAILWAY_API_TOKEN`.                                         |
-| `environmentId`      | `string`                   | Railway environment ID. Falls back to `RAILWAY_ENVIRONMENT_ID`.                              |
-| `sandboxId`          | `string`                   | Reattach to an existing Railway sandbox by ID instead of creating one.                        |
-| `idleTimeoutMinutes` | `number`                   | Minutes a sandbox can sit idle before Railway destroys it. Range/default depend on the plan. |
-| `networkIsolation`   | `'ISOLATED' \| 'PRIVATE'`  | Network mode. `ISOLATED` (default) is outbound-only; `PRIVATE` joins the private network.     |
-| `env`                | `Record<string, string>`   | Environment variables baked into the sandbox.                                                 |
+| Option               | Type                                           | Description                                                                                      |
+| -------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `token`              | `string`                                       | Railway API token. Falls back to `RAILWAY_API_TOKEN`.                                            |
+| `environmentId`      | `string`                                       | Railway environment ID. Falls back to `RAILWAY_ENVIRONMENT_ID`.                                  |
+| `sandboxId`          | `string`                                       | Reattach to an existing Railway sandbox by ID instead of creating one.                           |
+| `idleTimeoutMinutes` | `number`                                       | Minutes a sandbox can sit idle before Railway destroys it. Range/default depend on the plan.     |
+| `networkIsolation`   | `'ISOLATED' \| 'PRIVATE'`                      | Network mode. `ISOLATED` (default) is outbound-only; `PRIVATE` joins the private network.        |
+| `env`                | `Record<string, string>`                       | Environment variables baked into the sandbox.                                                    |
 | `template`           | `SandboxTemplate \| (base) => SandboxTemplate` | Provision from a custom base image built with the Railway template builder. Ignored on reattach. |
-| `timeout`            | `number`                   | Default command timeout in milliseconds. Commands run until they exit when omitted.           |
-| `instructions`       | `string \| (opts) => string` | Override the default agent instructions.                                                    |
+| `timeout`            | `number`                                       | Default command timeout in milliseconds. Commands run until they exit when omitted.              |
+| `instructions`       | `string \| (opts) => string`                   | Override the default agent instructions.                                                         |
 
 ## Editor provider
 

--- a/workspaces/railway/README.md
+++ b/workspaces/railway/README.md
@@ -1,0 +1,135 @@
+# @mastra/railway
+
+Railway cloud sandbox provider for [Mastra](https://mastra.ai) workspaces.
+
+Implements the `WorkspaceSandbox` interface using [Railway Sandboxes](https://docs.railway.com/sandboxes) — ephemeral, isolated Linux VMs provisioned on demand through Railway's TypeScript SDK. Supports command execution with streaming output, command timeouts, configurable idle timeout, network isolation, and reattaching to an existing sandbox.
+
+> Railway Sandboxes are available through Priority Boarding and the SDK may change in breaking ways between releases.
+
+## Install
+
+```bash
+pnpm add @mastra/railway @mastra/core
+```
+
+## Configuration
+
+The provider reads credentials from the environment by default:
+
+| Option          | Environment variable     |
+| --------------- | ------------------------ |
+| `token`         | `RAILWAY_API_TOKEN`      |
+| `environmentId` | `RAILWAY_ENVIRONMENT_ID` |
+
+Pass them explicitly to override the environment values.
+
+## Usage
+
+### Basic
+
+```typescript
+import { Workspace } from '@mastra/core/workspace';
+import { RailwaySandbox } from '@mastra/railway';
+
+const sandbox = new RailwaySandbox({
+  // token + environmentId read from RAILWAY_API_TOKEN / RAILWAY_ENVIRONMENT_ID
+  idleTimeoutMinutes: 30,
+});
+
+const workspace = new Workspace({ sandbox });
+await workspace.init();
+
+const result = await workspace.sandbox.executeCommand('echo', ['Hello!']);
+console.log(result.stdout); // "Hello!"
+
+await workspace.destroy();
+```
+
+### Private networking
+
+Join the environment's private network to reach other services (for example
+`postgres.railway.internal`):
+
+```typescript
+const sandbox = new RailwaySandbox({
+  networkIsolation: 'PRIVATE',
+  env: { NODE_ENV: 'production' },
+});
+```
+
+### Reattach to an existing sandbox
+
+A Railway sandbox outlives the process that created it. Reconnect by its
+Railway ID instead of provisioning a new one:
+
+```typescript
+const sandbox = new RailwaySandbox({ sandboxId: 'existing-railway-sandbox-id' });
+```
+
+### Custom base image (templates)
+
+Pre-install packages and run setup steps so every sandbox starts ready. Pass a
+builder callback over the Railway template builder — it's built once on the
+first `start()`:
+
+```typescript
+const sandbox = new RailwaySandbox({
+  template: t => t.withPackages('git', 'curl').run('npm i -g pnpm').workdir('/app'),
+});
+```
+
+You can also pass a pre-built `SandboxTemplate` to reuse it across sandboxes
+without rebuilding. Templates are ignored when `sandboxId` is set (reattach).
+
+### Fork a running sandbox
+
+Clone a running sandbox's filesystem into a new, independent sandbox (a fresh
+boot, not live processes). The returned `RailwaySandbox` is already started:
+
+```typescript
+const child = await sandbox.fork({ idleTimeoutMinutes: 15 });
+const result = await child.executeCommand('cat', ['/app/state.json']);
+```
+
+### Long-running processes
+
+Use the process manager to spawn background commands and stream their output:
+
+```typescript
+const handle = await sandbox.processes.spawn('npm run dev', {
+  onStdout: chunk => process.stdout.write(chunk),
+});
+
+// Later
+await handle.kill();
+```
+
+## Options
+
+| Option               | Type                       | Description                                                                                  |
+| -------------------- | -------------------------- | -------------------------------------------------------------------------------------------- |
+| `token`              | `string`                   | Railway API token. Falls back to `RAILWAY_API_TOKEN`.                                         |
+| `environmentId`      | `string`                   | Railway environment ID. Falls back to `RAILWAY_ENVIRONMENT_ID`.                              |
+| `sandboxId`          | `string`                   | Reattach to an existing Railway sandbox by ID instead of creating one.                        |
+| `idleTimeoutMinutes` | `number`                   | Minutes a sandbox can sit idle before Railway destroys it. Range/default depend on the plan. |
+| `networkIsolation`   | `'ISOLATED' \| 'PRIVATE'`  | Network mode. `ISOLATED` (default) is outbound-only; `PRIVATE` joins the private network.     |
+| `env`                | `Record<string, string>`   | Environment variables baked into the sandbox.                                                 |
+| `template`           | `SandboxTemplate \| (base) => SandboxTemplate` | Provision from a custom base image built with the Railway template builder. Ignored on reattach. |
+| `timeout`            | `number`                   | Default command timeout in milliseconds. Commands run until they exit when omitted.           |
+| `instructions`       | `string \| (opts) => string` | Override the default agent instructions.                                                    |
+
+## Editor provider
+
+Register the provider with `MastraEditor` to hydrate stored sandbox configs:
+
+```typescript
+import { railwaySandboxProvider } from '@mastra/railway';
+
+const editor = new MastraEditor({
+  sandboxes: { [railwaySandboxProvider.id]: railwaySandboxProvider },
+});
+```
+
+## License
+
+Apache-2.0

--- a/workspaces/railway/eslint.config.js
+++ b/workspaces/railway/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/workspaces/railway/lint-staged.config.js
+++ b/workspaces/railway/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/workspaces/railway/package.json
+++ b/workspaces/railway/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@mastra/railway",
+  "version": "0.0.1",
+  "description": "Railway cloud sandbox provider for Mastra workspaces",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "build:lib": "pnpm build",
+    "build:watch": "pnpm build --watch",
+    "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
+    "test:watch": "vitest watch",
+    "test": "vitest run ./src/**/*.integration.test.ts",
+    "test:cloud": "pnpm test",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "railway": "^3.1.1"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@internal/workspace-test-utils": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.19.15",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "dotenv": "^17.3.1",
+    "eslint": "^10.4.1",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.12.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "workspaces/railway"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/workspaces/railway/src/index.ts
+++ b/workspaces/railway/src/index.ts
@@ -1,0 +1,3 @@
+export { RailwaySandbox, type RailwaySandboxOptions } from './sandbox';
+export { RailwayProcessManager, type RailwayProcessManagerOptions } from './sandbox/process-manager';
+export { railwaySandboxProvider } from './provider';

--- a/workspaces/railway/src/provider.ts
+++ b/workspaces/railway/src/provider.ts
@@ -1,0 +1,61 @@
+/**
+ * Railway sandbox provider descriptor for MastraEditor.
+ *
+ * @example
+ * ```typescript
+ * import { railwaySandboxProvider } from '@mastra/railway';
+ *
+ * const editor = new MastraEditor({
+ *   sandboxes: { [railwaySandboxProvider.id]: railwaySandboxProvider },
+ * });
+ * ```
+ */
+import type { SandboxProvider } from '@mastra/core/editor';
+import { RailwaySandbox } from './sandbox';
+
+/**
+ * Serializable subset of RailwaySandboxOptions for editor storage.
+ */
+interface RailwayProviderConfig {
+  token?: string;
+  environmentId?: string;
+  sandboxId?: string;
+  idleTimeoutMinutes?: number;
+  networkIsolation?: 'ISOLATED' | 'PRIVATE';
+  env?: Record<string, string>;
+  timeout?: number;
+}
+
+export const railwaySandboxProvider: SandboxProvider<RailwayProviderConfig> = {
+  id: 'railway',
+  name: 'Railway Sandbox',
+  description: 'Ephemeral, isolated Linux VM powered by Railway',
+  configSchema: {
+    type: 'object',
+    properties: {
+      token: { type: 'string', description: 'Railway API token (falls back to RAILWAY_API_TOKEN)' },
+      environmentId: {
+        type: 'string',
+        description: 'Railway environment ID (falls back to RAILWAY_ENVIRONMENT_ID)',
+      },
+      sandboxId: { type: 'string', description: 'Reattach to an existing Railway sandbox by ID' },
+      idleTimeoutMinutes: {
+        type: 'number',
+        description: 'Minutes a sandbox can sit idle before Railway destroys it',
+      },
+      networkIsolation: {
+        type: 'string',
+        description: 'Network isolation mode',
+        enum: ['ISOLATED', 'PRIVATE'],
+        default: 'ISOLATED',
+      },
+      env: {
+        type: 'object',
+        description: 'Environment variables',
+        additionalProperties: { type: 'string' },
+      },
+      timeout: { type: 'number', description: 'Default command timeout in ms' },
+    },
+  },
+  createSandbox: config => new RailwaySandbox(config),
+};

--- a/workspaces/railway/src/sandbox/index.integration.test.ts
+++ b/workspaces/railway/src/sandbox/index.integration.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Railway Sandbox Integration Tests
+ *
+ * These tests require real Railway API access and run against actual Railway sandboxes.
+ * They are separated from unit tests to avoid mock conflicts.
+ *
+ * Required environment variables:
+ * - RAILWAY_API_TOKEN: Railway API token
+ * - RAILWAY_ENVIRONMENT_ID: Railway environment ID
+ */
+
+import { createSandboxTestSuite } from '@internal/workspace-test-utils';
+import { describe, it } from 'vitest';
+
+import { RailwaySandbox } from './index';
+
+const hasRailwayCredentials = !!(process.env.RAILWAY_API_TOKEN && process.env.RAILWAY_ENVIRONMENT_ID);
+
+/**
+ * Placeholder suite so the file always registers at least one suite. Without it,
+ * vitest fails the file when credentials are missing and every other suite is skipped.
+ */
+describe.skipIf(hasRailwayCredentials)('RailwaySandbox Integration (skipped without credentials)', () => {
+  it('requires RAILWAY_API_TOKEN and RAILWAY_ENVIRONMENT_ID', () => {});
+});
+
+/**
+ * Shared Sandbox Conformance Tests
+ *
+ * These tests verify RailwaySandbox conforms to the WorkspaceSandbox interface.
+ * They use the shared test suite from @internal/workspace-test-utils.
+ */
+if (hasRailwayCredentials) {
+  createSandboxTestSuite({
+    suiteName: 'RailwaySandbox Conformance',
+    createSandbox: options => {
+      return new RailwaySandbox({
+        id: `conformance-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        timeout: 120000,
+        ...(options?.env && { env: options.env }),
+      });
+    },
+    cleanupSandbox: async sandbox => {
+      try {
+        await sandbox._destroy();
+      } catch {
+        // Ignore cleanup errors
+      }
+    },
+    killSandboxExternally: async sb => {
+      await (sb as RailwaySandbox).railway.destroy();
+    },
+    capabilities: {
+      supportsMounting: false,
+      supportsReconnection: true,
+      supportsConcurrency: true,
+      supportsEnvVars: true,
+      supportsWorkingDirectory: true,
+      supportsTimeout: true,
+      supportsStdin: false, // Railway SDK does not support stdin
+      defaultCommandTimeout: 30000,
+    },
+    testTimeout: 120000,
+  });
+}

--- a/workspaces/railway/src/sandbox/index.test.ts
+++ b/workspaces/railway/src/sandbox/index.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Railway Sandbox Provider Tests
+ *
+ * Tests Railway-specific functionality:
+ * - Constructor options and ID generation
+ * - Lifecycle (create, connect, destroy)
+ * - Command execution and result mapping
+ * - Process spawning, env/cwd command building, and kill
+ */
+
+import { SandboxNotReadyError } from '@mastra/core/workspace';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { buildSpawnCommand } from './process-manager';
+import { RailwaySandbox } from './index';
+
+// =============================================================================
+// Mock the Railway SDK
+// =============================================================================
+
+const {
+  mockSandbox,
+  mockForkedSandbox,
+  mockTemplate,
+  mockCreate,
+  mockConnect,
+  mockTemplateFactory,
+  makeExecHandle,
+} = vi.hoisted(() => {
+  /**
+   * Build a fake ExecHandle: a Promise that resolves to an ExecResult and
+   * exposes `kill`. Invokes onStdout/onStderr asynchronously to mimic the
+   * real SDK, which streams chunks after the handle is returned.
+   */
+  const makeExecHandle = (
+    result: { exitCode: number | null; stdout?: string; stderr?: string; timedOut?: boolean; truncated?: boolean },
+    opts?: { onStdout?: (c: string) => void; onStderr?: (c: string) => void },
+  ) => {
+    queueMicrotask(() => {
+      if (result.stdout) opts?.onStdout?.(result.stdout);
+      if (result.stderr) opts?.onStderr?.(result.stderr);
+    });
+    const execResult = {
+      exitCode: result.exitCode,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      truncated: result.truncated ?? false,
+      timedOut: result.timedOut ?? false,
+    };
+    const promise = Promise.resolve(execResult) as Promise<typeof execResult> & {
+      kill: ReturnType<typeof vi.fn>;
+    };
+    promise.kill = vi.fn().mockResolvedValue(true);
+    return promise;
+  };
+
+  const mockForkedSandbox = {
+    id: 'rw-forked-456',
+    status: 'RUNNING',
+    environmentId: 'env-1',
+    region: 'us-west',
+    networkIsolation: 'ISOLATED',
+    idleTimeoutMinutes: 30,
+    createdAt: '2026-01-02T00:00:00.000Z',
+    exec: vi.fn((_command: string, options?: { onStdout?: (c: string) => void; onStderr?: (c: string) => void }) =>
+      makeExecHandle({ exitCode: 0, stdout: 'ok' }, options),
+    ),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const mockSandbox = {
+    id: 'rw-sandbox-123',
+    status: 'RUNNING',
+    environmentId: 'env-1',
+    region: 'us-west',
+    networkIsolation: 'ISOLATED',
+    idleTimeoutMinutes: 30,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    exec: vi.fn((_command: string, options?: { onStdout?: (c: string) => void; onStderr?: (c: string) => void }) =>
+      makeExecHandle({ exitCode: 0, stdout: 'ok' }, options),
+    ),
+    fork: vi.fn().mockResolvedValue(mockForkedSandbox),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  };
+
+  // Chainable template builder mock.
+  const mockTemplate = {
+    run: vi.fn(() => mockTemplate),
+    withPackages: vi.fn(() => mockTemplate),
+    withEnv: vi.fn(() => mockTemplate),
+    workdir: vi.fn(() => mockTemplate),
+    build: vi.fn(() => Promise.resolve(mockTemplate)),
+  };
+
+  const mockCreate = vi.fn().mockResolvedValue(mockSandbox);
+  const mockConnect = vi.fn().mockResolvedValue(mockSandbox);
+  const mockTemplateFactory = vi.fn(() => mockTemplate);
+
+  return {
+    mockSandbox,
+    mockForkedSandbox,
+    mockTemplate,
+    mockCreate,
+    mockConnect,
+    mockTemplateFactory,
+    makeExecHandle,
+  };
+});
+
+vi.mock('railway', () => ({
+  Sandbox: {
+    create: mockCreate,
+    connect: mockConnect,
+    template: mockTemplateFactory,
+  },
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('RailwaySandbox', () => {
+  beforeEach(() => {
+    mockCreate.mockClear().mockResolvedValue(mockSandbox);
+    mockConnect.mockClear().mockResolvedValue(mockSandbox);
+    mockTemplateFactory.mockClear().mockReturnValue(mockTemplate);
+    mockTemplate.run.mockClear().mockReturnValue(mockTemplate);
+    mockTemplate.withPackages.mockClear().mockReturnValue(mockTemplate);
+    mockTemplate.withEnv.mockClear().mockReturnValue(mockTemplate);
+    mockTemplate.workdir.mockClear().mockReturnValue(mockTemplate);
+    mockTemplate.build.mockClear().mockResolvedValue(mockTemplate);
+    mockSandbox.exec.mockClear();
+    mockSandbox.fork.mockClear().mockResolvedValue(mockForkedSandbox);
+    mockSandbox.destroy.mockClear().mockResolvedValue(undefined);
+    mockSandbox.exec.mockImplementation((_command: string, options?: { onStdout?: (c: string) => void }) =>
+      makeExecHandle({ exitCode: 0, stdout: 'ok' }, options),
+    );
+  });
+
+  describe('constructor', () => {
+    it('creates an instance with defaults', () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      expect(sandbox.name).toBe('RailwaySandbox');
+      expect(sandbox.provider).toBe('railway');
+      expect(sandbox.status).toBe('pending');
+      expect(sandbox.id).toMatch(/^railway-sandbox-/);
+    });
+
+    it('honors a custom id', () => {
+      const sandbox = new RailwaySandbox({ id: 'custom-id' });
+      expect(sandbox.id).toBe('custom-id');
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('creates a Railway sandbox on start with configured options', async () => {
+      const sandbox = new RailwaySandbox({
+        token: 'tok',
+        environmentId: 'env-1',
+        idleTimeoutMinutes: 45,
+        networkIsolation: 'PRIVATE',
+        env: { FOO: 'bar' },
+      });
+      await sandbox._start();
+
+      expect(sandbox.status).toBe('running');
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'tok',
+          environmentId: 'env-1',
+          idleTimeoutMinutes: 45,
+          networkIsolation: 'PRIVATE',
+          env: { FOO: 'bar' },
+        }),
+      );
+    });
+
+    it('reconnects to an existing sandbox when sandboxId is set', async () => {
+      const sandbox = new RailwaySandbox({ token: 'tok', sandboxId: 'rw-existing' });
+      await sandbox._start();
+
+      expect(mockConnect).toHaveBeenCalledWith('rw-existing', expect.objectContaining({ token: 'tok' }));
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('throws SandboxNotReadyError when accessing railway before start', () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      expect(() => sandbox.railway).toThrow(SandboxNotReadyError);
+    });
+
+    it('destroys the underlying sandbox', async () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      await sandbox._start();
+      await sandbox._destroy();
+
+      expect(mockSandbox.destroy).toHaveBeenCalledTimes(1);
+      expect(sandbox.status).toBe('destroyed');
+    });
+  });
+
+  describe('template', () => {
+    it('builds a template from a builder callback and creates from it', async () => {
+      const sandbox = new RailwaySandbox({
+        token: 'tok',
+        template: t => t.withPackages('git', 'curl').run('npm i -g pnpm'),
+      });
+      await sandbox._start();
+
+      expect(mockTemplateFactory).toHaveBeenCalledTimes(1);
+      expect(mockTemplate.withPackages).toHaveBeenCalledWith('git', 'curl');
+      expect(mockTemplate.run).toHaveBeenCalledWith('npm i -g pnpm');
+      expect(mockTemplate.build).toHaveBeenCalledTimes(1);
+      // create(template, options)
+      expect(mockCreate).toHaveBeenCalledWith(mockTemplate, expect.objectContaining({ token: 'tok' }));
+    });
+
+    it('accepts a pre-built template instance without calling the factory', async () => {
+      const sandbox = new RailwaySandbox({ token: 'tok', template: mockTemplate as never });
+      await sandbox._start();
+
+      expect(mockTemplateFactory).not.toHaveBeenCalled();
+      expect(mockTemplate.build).toHaveBeenCalledTimes(1);
+      expect(mockCreate).toHaveBeenCalledWith(mockTemplate, expect.objectContaining({ token: 'tok' }));
+    });
+
+    it('ignores the template when reattaching by sandboxId', async () => {
+      const sandbox = new RailwaySandbox({
+        token: 'tok',
+        sandboxId: 'rw-existing',
+        template: t => t.run('echo hi'),
+      });
+      await sandbox._start();
+
+      expect(mockConnect).toHaveBeenCalledWith('rw-existing', expect.anything());
+      expect(mockTemplate.build).not.toHaveBeenCalled();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fork', () => {
+    it('forks a running sandbox into a new started RailwaySandbox', async () => {
+      const sandbox = new RailwaySandbox({ token: 'tok', environmentId: 'env-1' });
+      await sandbox._start();
+
+      const child = await sandbox.fork({ idleTimeoutMinutes: 15 });
+
+      expect(mockSandbox.fork).toHaveBeenCalledWith(expect.objectContaining({ idleTimeoutMinutes: 15 }));
+      // The child reattaches to the forked sandbox id via connect().
+      expect(mockConnect).toHaveBeenCalledWith('rw-forked-456', expect.objectContaining({ token: 'tok' }));
+      expect(child).toBeInstanceOf(RailwaySandbox);
+      expect(child.status).toBe('running');
+      expect(child).not.toBe(sandbox);
+    });
+
+    it('throws SandboxNotReadyError when forking before start', async () => {
+      const sandbox = new RailwaySandbox({ token: 'tok' });
+      await expect(sandbox.fork()).rejects.toBeInstanceOf(SandboxNotReadyError);
+    });
+  });
+
+  describe('executeCommand', () => {
+    it('runs a command and maps a successful result', async () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      const result = await sandbox.executeCommand!('echo hello');
+
+      expect(result.success).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('ok');
+      expect(result.command).toBe('echo hello');
+    });
+
+    it('maps a non-zero exit code to failure', async () => {
+      mockSandbox.exec.mockImplementationOnce((_command: string, options?: { onStderr?: (c: string) => void }) =>
+        makeExecHandle({ exitCode: 2, stderr: 'boom' }, options),
+      );
+      const sandbox = new RailwaySandbox({ token: 't' });
+      const result = await sandbox.executeCommand!('false');
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toBe('boom');
+    });
+
+    it('quotes args into the command', async () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      await sandbox.executeCommand!('echo', ['a b']);
+
+      const sentCommand = mockSandbox.exec.mock.calls[0]![0] as string;
+      expect(sentCommand).toContain("'a b'");
+    });
+
+    it('passes timeoutSec derived from the timeout option', async () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      await sandbox.executeCommand!('sleep 1', [], { timeout: 5000 });
+
+      const sentOptions = mockSandbox.exec.mock.calls[0]![1] as { timeoutSec?: number };
+      expect(sentOptions.timeoutSec).toBe(5);
+    });
+  });
+
+  describe('process manager', () => {
+    it('spawns and waits on a process', async () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      await sandbox._start();
+      const handle = await sandbox.processes.spawn('node server.js');
+      const result = await handle.wait();
+
+      expect(result.exitCode).toBe(0);
+      expect(handle.pid).toMatch(/^railway-proc-/);
+    });
+
+    it('lists tracked processes', async () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      await sandbox._start();
+      const handle = await sandbox.processes.spawn('node server.js');
+      await handle.wait();
+
+      const list = await sandbox.processes.list();
+      expect(list.some(p => p.pid === handle.pid)).toBe(true);
+    });
+
+    it('kills a running process via signal', async () => {
+      let killable: ReturnType<typeof makeExecHandle>;
+      mockSandbox.exec.mockImplementationOnce(() => {
+        // A handle that never resolves on its own, only via kill.
+        type ExecResultShape = { exitCode: number | null; stdout: string; stderr: string; truncated: boolean; timedOut: boolean };
+        const promise = new Promise<ExecResultShape>(() => {}) as Promise<ExecResultShape> & {
+          kill: ReturnType<typeof vi.fn>;
+        };
+        promise.kill = vi.fn().mockResolvedValue(true);
+        killable = promise;
+        return promise;
+      });
+
+      const sandbox = new RailwaySandbox({ token: 't' });
+      await sandbox._start();
+      const handle = await sandbox.processes.spawn('sleep 1000');
+      const killed = await handle.kill();
+
+      expect(killed).toBe(true);
+      expect(killable!.kill).toHaveBeenCalledWith('TERM');
+    });
+  });
+
+  describe('getInfo / getInstructions', () => {
+    it('returns sandbox info with railway metadata after start', async () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      await sandbox._start();
+      const info = await sandbox.getInfo();
+
+      expect(info.provider).toBe('railway');
+      expect(info.metadata).toMatchObject({
+        railwaySandboxId: 'rw-sandbox-123',
+        environmentId: 'env-1',
+        region: 'us-west',
+        networkIsolation: 'ISOLATED',
+      });
+    });
+
+    it('builds default instructions and honors overrides', () => {
+      const sandbox = new RailwaySandbox({ token: 't', networkIsolation: 'PRIVATE' });
+      expect(sandbox.getInstructions()).toContain('private network');
+
+      const overridden = new RailwaySandbox({ token: 't', instructions: 'custom' });
+      expect(overridden.getInstructions()).toBe('custom');
+
+      const fn = new RailwaySandbox({
+        token: 't',
+        instructions: ({ defaultInstructions }) => `${defaultInstructions} extra`,
+      });
+      expect(fn.getInstructions()).toContain('extra');
+    });
+  });
+});
+
+describe('buildSpawnCommand', () => {
+  it('returns the bare command wrapped in sh -c', () => {
+    expect(buildSpawnCommand('echo hi')).toBe("sh -c 'echo hi'");
+  });
+
+  it('prepends a cd for the working directory', () => {
+    expect(buildSpawnCommand('ls', '/app')).toBe("sh -c 'cd /app && ls'");
+  });
+
+  it('exports environment variables via env', () => {
+    const cmd = buildSpawnCommand('printenv FOO', undefined, { FOO: 'bar baz' });
+    expect(cmd).toBe("env FOO='bar baz' sh -c 'printenv FOO'");
+  });
+});

--- a/workspaces/railway/src/sandbox/index.test.ts
+++ b/workspaces/railway/src/sandbox/index.test.ts
@@ -18,94 +18,87 @@ import { RailwaySandbox } from './index';
 // Mock the Railway SDK
 // =============================================================================
 
-const {
-  mockSandbox,
-  mockForkedSandbox,
-  mockTemplate,
-  mockCreate,
-  mockConnect,
-  mockTemplateFactory,
-  makeExecHandle,
-} = vi.hoisted(() => {
-  /**
-   * Build a fake ExecHandle: a Promise that resolves to an ExecResult and
-   * exposes `kill`. Invokes onStdout/onStderr asynchronously to mimic the
-   * real SDK, which streams chunks after the handle is returned.
-   */
-  const makeExecHandle = (
-    result: { exitCode: number | null; stdout?: string; stderr?: string; timedOut?: boolean; truncated?: boolean },
-    opts?: { onStdout?: (c: string) => void; onStderr?: (c: string) => void },
-  ) => {
-    queueMicrotask(() => {
-      if (result.stdout) opts?.onStdout?.(result.stdout);
-      if (result.stderr) opts?.onStderr?.(result.stderr);
-    });
-    const execResult = {
-      exitCode: result.exitCode,
-      stdout: result.stdout ?? '',
-      stderr: result.stderr ?? '',
-      truncated: result.truncated ?? false,
-      timedOut: result.timedOut ?? false,
+const { mockSandbox, mockForkedSandbox, mockTemplate, mockCreate, mockConnect, mockTemplateFactory, makeExecHandle } =
+  vi.hoisted(() => {
+    /**
+     * Build a fake ExecHandle: a Promise that resolves to an ExecResult and
+     * exposes `kill`. Invokes onStdout/onStderr asynchronously to mimic the
+     * real SDK, which streams chunks after the handle is returned.
+     */
+    const makeExecHandle = (
+      result: { exitCode: number | null; stdout?: string; stderr?: string; timedOut?: boolean; truncated?: boolean },
+      opts?: { onStdout?: (c: string) => void; onStderr?: (c: string) => void },
+    ) => {
+      queueMicrotask(() => {
+        if (result.stdout) opts?.onStdout?.(result.stdout);
+        if (result.stderr) opts?.onStderr?.(result.stderr);
+      });
+      const execResult = {
+        exitCode: result.exitCode,
+        stdout: result.stdout ?? '',
+        stderr: result.stderr ?? '',
+        truncated: result.truncated ?? false,
+        timedOut: result.timedOut ?? false,
+      };
+      const promise = Promise.resolve(execResult) as Promise<typeof execResult> & {
+        kill: ReturnType<typeof vi.fn>;
+      };
+      promise.kill = vi.fn().mockResolvedValue(true);
+      return promise;
     };
-    const promise = Promise.resolve(execResult) as Promise<typeof execResult> & {
-      kill: ReturnType<typeof vi.fn>;
+
+    const mockForkedSandbox = {
+      id: 'rw-forked-456',
+      status: 'RUNNING',
+      environmentId: 'env-1',
+      region: 'us-west',
+      networkIsolation: 'ISOLATED',
+      idleTimeoutMinutes: 30,
+      createdAt: '2026-01-02T00:00:00.000Z',
+      exec: vi.fn((_command: string, options?: { onStdout?: (c: string) => void; onStderr?: (c: string) => void }) =>
+        makeExecHandle({ exitCode: 0, stdout: 'ok' }, options),
+      ),
+      destroy: vi.fn().mockResolvedValue(undefined),
     };
-    promise.kill = vi.fn().mockResolvedValue(true);
-    return promise;
-  };
 
-  const mockForkedSandbox = {
-    id: 'rw-forked-456',
-    status: 'RUNNING',
-    environmentId: 'env-1',
-    region: 'us-west',
-    networkIsolation: 'ISOLATED',
-    idleTimeoutMinutes: 30,
-    createdAt: '2026-01-02T00:00:00.000Z',
-    exec: vi.fn((_command: string, options?: { onStdout?: (c: string) => void; onStderr?: (c: string) => void }) =>
-      makeExecHandle({ exitCode: 0, stdout: 'ok' }, options),
-    ),
-    destroy: vi.fn().mockResolvedValue(undefined),
-  };
+    const mockSandbox = {
+      id: 'rw-sandbox-123',
+      status: 'RUNNING',
+      environmentId: 'env-1',
+      region: 'us-west',
+      networkIsolation: 'ISOLATED',
+      idleTimeoutMinutes: 30,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      exec: vi.fn((_command: string, options?: { onStdout?: (c: string) => void; onStderr?: (c: string) => void }) =>
+        makeExecHandle({ exitCode: 0, stdout: 'ok' }, options),
+      ),
+      fork: vi.fn().mockResolvedValue(mockForkedSandbox),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
 
-  const mockSandbox = {
-    id: 'rw-sandbox-123',
-    status: 'RUNNING',
-    environmentId: 'env-1',
-    region: 'us-west',
-    networkIsolation: 'ISOLATED',
-    idleTimeoutMinutes: 30,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    exec: vi.fn((_command: string, options?: { onStdout?: (c: string) => void; onStderr?: (c: string) => void }) =>
-      makeExecHandle({ exitCode: 0, stdout: 'ok' }, options),
-    ),
-    fork: vi.fn().mockResolvedValue(mockForkedSandbox),
-    destroy: vi.fn().mockResolvedValue(undefined),
-  };
+    // Chainable template builder mock.
+    const mockTemplate = {
+      run: vi.fn(() => mockTemplate),
+      withPackages: vi.fn(() => mockTemplate),
+      withEnv: vi.fn(() => mockTemplate),
+      workdir: vi.fn(() => mockTemplate),
+      build: vi.fn(() => Promise.resolve(mockTemplate)),
+    };
 
-  // Chainable template builder mock.
-  const mockTemplate = {
-    run: vi.fn(() => mockTemplate),
-    withPackages: vi.fn(() => mockTemplate),
-    withEnv: vi.fn(() => mockTemplate),
-    workdir: vi.fn(() => mockTemplate),
-    build: vi.fn(() => Promise.resolve(mockTemplate)),
-  };
+    const mockCreate = vi.fn().mockResolvedValue(mockSandbox);
+    const mockConnect = vi.fn().mockResolvedValue(mockSandbox);
+    const mockTemplateFactory = vi.fn(() => mockTemplate);
 
-  const mockCreate = vi.fn().mockResolvedValue(mockSandbox);
-  const mockConnect = vi.fn().mockResolvedValue(mockSandbox);
-  const mockTemplateFactory = vi.fn(() => mockTemplate);
-
-  return {
-    mockSandbox,
-    mockForkedSandbox,
-    mockTemplate,
-    mockCreate,
-    mockConnect,
-    mockTemplateFactory,
-    makeExecHandle,
-  };
-});
+    return {
+      mockSandbox,
+      mockForkedSandbox,
+      mockTemplate,
+      mockCreate,
+      mockConnect,
+      mockTemplateFactory,
+      makeExecHandle,
+    };
+  });
 
 vi.mock('railway', () => ({
   Sandbox: {
@@ -324,7 +317,13 @@ describe('RailwaySandbox', () => {
       let killable: ReturnType<typeof makeExecHandle>;
       mockSandbox.exec.mockImplementationOnce(() => {
         // A handle that never resolves on its own, only via kill.
-        type ExecResultShape = { exitCode: number | null; stdout: string; stderr: string; truncated: boolean; timedOut: boolean };
+        type ExecResultShape = {
+          exitCode: number | null;
+          stdout: string;
+          stderr: string;
+          truncated: boolean;
+          timedOut: boolean;
+        };
         const promise = new Promise<ExecResultShape>(() => {}) as Promise<ExecResultShape> & {
           kill: ReturnType<typeof vi.fn>;
         };

--- a/workspaces/railway/src/sandbox/index.ts
+++ b/workspaces/railway/src/sandbox/index.ts
@@ -258,10 +258,7 @@ export class RailwaySandbox extends MastraSandbox {
    * pre-built `SandboxTemplate` or a builder callback over `Sandbox.template()`.
    * Calls `.build()` so the recipe is materialised before `Sandbox.create()`.
    */
-  private async _resolveTemplate(buildOptions: {
-    token?: string;
-    environmentId?: string;
-  }): Promise<SandboxTemplate> {
+  private async _resolveTemplate(buildOptions: { token?: string; environmentId?: string }): Promise<SandboxTemplate> {
     const option = this._templateOption!;
     const template = typeof option === 'function' ? option(Sandbox.template()) : option;
     this.logger.debug(`${LOG_PREFIX} Building Railway sandbox template for: ${this.id}`);

--- a/workspaces/railway/src/sandbox/index.ts
+++ b/workspaces/railway/src/sandbox/index.ts
@@ -1,0 +1,385 @@
+/**
+ * Railway Sandbox Provider
+ *
+ * A Railway sandbox implementation for Mastra workspaces. Provisions an
+ * ephemeral, isolated Linux VM on Railway, runs commands in it via the
+ * Railway TypeScript SDK, and destroys it on teardown.
+ *
+ * @see https://docs.railway.com/sandboxes
+ */
+
+import type {
+  CommandResult,
+  ExecuteCommandOptions,
+  InstructionsOption,
+  MastraSandboxOptions,
+  ProviderStatus,
+  SandboxInfo,
+} from '@mastra/core/workspace';
+import { MastraSandbox, SandboxNotReadyError } from '@mastra/core/workspace';
+import { Sandbox } from 'railway';
+import type { SandboxNetworkIsolation, SandboxTemplate } from 'railway';
+import { shellQuote } from '../utils/shell-quote';
+import { LOG_PREFIX, RailwayProcessManager } from './process-manager';
+
+// =============================================================================
+// Railway Sandbox Options
+// =============================================================================
+
+/**
+ * Railway sandbox provider configuration.
+ */
+export interface RailwaySandboxOptions extends Omit<MastraSandboxOptions, 'processes'> {
+  /** Unique identifier for this sandbox instance. */
+  id?: string;
+  /** Railway API token. Falls back to the RAILWAY_API_TOKEN env var. */
+  token?: string;
+  /** Railway environment ID. Falls back to the RAILWAY_ENVIRONMENT_ID env var. */
+  environmentId?: string;
+  /**
+   * Reattach to an existing Railway sandbox by its Railway ID instead of
+   * creating a new one. When set, `start()` calls `Sandbox.connect()`.
+   */
+  sandboxId?: string;
+  /**
+   * How long the sandbox can sit idle (no `exec` interaction) before Railway
+   * destroys it automatically. Range depends on plan (1–120 minutes on
+   * Hobby/Pro, 1–5 on Trial/Free). Defaults to the plan default when omitted.
+   */
+  idleTimeoutMinutes?: number;
+  /**
+   * Network isolation mode.
+   * - `ISOLATED` (default): outbound internet only, no private network access.
+   * - `PRIVATE`: joins the environment's private network.
+   */
+  networkIsolation?: SandboxNetworkIsolation;
+  /** Environment variables baked into the sandbox, available to every command. */
+  env?: Record<string, string>;
+  /**
+   * Provision the sandbox from a custom base image built with the Railway
+   * template builder. Use this to pre-install packages or run setup steps so
+   * every sandbox created from it starts ready.
+   *
+   * - Builder callback — receives the base `Sandbox.template()` and returns the
+   *   configured template. The template is built (`.build()`) on first
+   *   `start()` if not already built.
+   *   ```ts
+   *   template: t => t.withPackages('git', 'curl').run('npm i -g pnpm')
+   *   ```
+   * - Pre-built `SandboxTemplate` — pass a template you built yourself to reuse
+   *   it across sandboxes without rebuilding.
+   *
+   * Ignored when `sandboxId` is set (reattach) or when forking.
+   */
+  template?: SandboxTemplate | ((base: SandboxTemplate) => SandboxTemplate);
+  /**
+   * Default execution timeout in milliseconds applied to commands that don't
+   * specify their own timeout. When omitted, commands run until they exit.
+   */
+  timeout?: number;
+  /**
+   * Custom instructions that override the default instructions returned by
+   * `getInstructions()`.
+   *
+   * - `string` — Fully replaces the default instructions. Pass an empty string
+   *   to suppress instructions entirely.
+   * - `(opts) => string` — Receives the default instructions and optional
+   *   request context so you can extend or customise per-request.
+   */
+  instructions?: InstructionsOption;
+}
+
+// =============================================================================
+// Railway Sandbox Implementation
+// =============================================================================
+
+/**
+ * Railway sandbox provider for Mastra workspaces.
+ *
+ * Features:
+ * - Ephemeral, isolated Linux VM via the Railway TypeScript SDK
+ * - Command execution with streaming output and timeouts
+ * - Configurable idle timeout and network isolation
+ * - Reattach to an existing sandbox by Railway ID
+ *
+ * @example Basic usage
+ * ```typescript
+ * import { Workspace } from '@mastra/core/workspace';
+ * import { RailwaySandbox } from '@mastra/railway';
+ *
+ * const sandbox = new RailwaySandbox({
+ *   // token + environmentId read from RAILWAY_API_TOKEN / RAILWAY_ENVIRONMENT_ID
+ *   idleTimeoutMinutes: 30,
+ * });
+ *
+ * const workspace = new Workspace({ sandbox });
+ * const result = await workspace.executeCode('console.log("Hello!")');
+ * ```
+ *
+ * @example Private networking
+ * ```typescript
+ * const sandbox = new RailwaySandbox({
+ *   networkIsolation: 'PRIVATE',
+ *   env: { NODE_ENV: 'production' },
+ * });
+ * ```
+ */
+export class RailwaySandbox extends MastraSandbox {
+  readonly id: string;
+  readonly name = 'RailwaySandbox';
+  readonly provider = 'railway';
+  status: ProviderStatus = 'pending';
+
+  declare readonly processes: RailwayProcessManager;
+
+  private _sandbox: Sandbox | null = null;
+  private _createdAt: Date | null = null;
+
+  private readonly _token?: string;
+  private readonly _environmentId?: string;
+  private readonly _sandboxId?: string;
+  private readonly _idleTimeoutMinutes?: number;
+  private readonly _networkIsolation?: SandboxNetworkIsolation;
+  private readonly _env: Record<string, string>;
+  private readonly _timeout?: number;
+  private readonly _instructionsOverride?: InstructionsOption;
+  private readonly _templateOption?: RailwaySandboxOptions['template'];
+
+  constructor(options: RailwaySandboxOptions = {}) {
+    super({
+      ...options,
+      name: 'RailwaySandbox',
+      processes: new RailwayProcessManager({ env: options.env }),
+    });
+
+    this.id = options.id ?? this.generateId();
+    this._token = options.token ?? process.env.RAILWAY_API_TOKEN;
+    this._environmentId = options.environmentId ?? process.env.RAILWAY_ENVIRONMENT_ID;
+    this._sandboxId = options.sandboxId;
+    this._idleTimeoutMinutes = options.idleTimeoutMinutes;
+    this._networkIsolation = options.networkIsolation;
+    this._env = options.env ?? {};
+    this._timeout = options.timeout;
+    this._instructionsOverride = options.instructions;
+    this._templateOption = options.template;
+  }
+
+  private generateId(): string {
+    return `railway-sandbox-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  /**
+   * Get the underlying Railway Sandbox instance for direct SDK access.
+   *
+   * @throws {SandboxNotReadyError} If the sandbox has not been started.
+   */
+  get railway(): Sandbox {
+    if (!this._sandbox) {
+      throw new SandboxNotReadyError(this.id);
+    }
+    return this._sandbox;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Start the Railway sandbox.
+   *
+   * Reattaches to an existing sandbox when `sandboxId` is configured,
+   * otherwise provisions a new one. Resolves once the sandbox is RUNNING.
+   */
+  async start(): Promise<void> {
+    if (this._sandbox) {
+      return;
+    }
+
+    const clientConfig = {
+      ...(this._token !== undefined && { token: this._token }),
+      ...(this._environmentId !== undefined && { environmentId: this._environmentId }),
+    };
+
+    const createOptions = {
+      ...clientConfig,
+      ...(this._idleTimeoutMinutes !== undefined && { idleTimeoutMinutes: this._idleTimeoutMinutes }),
+      ...(this._networkIsolation !== undefined && { networkIsolation: this._networkIsolation }),
+      ...(Object.keys(this._env).length > 0 && { env: this._env }),
+    };
+
+    if (this._sandboxId) {
+      this.logger.debug(`${LOG_PREFIX} Reconnecting to Railway sandbox ${this._sandboxId}...`);
+      this._sandbox = await Sandbox.connect(this._sandboxId, clientConfig);
+    } else if (this._templateOption) {
+      const template = await this._resolveTemplate(clientConfig);
+      this.logger.debug(`${LOG_PREFIX} Creating Railway sandbox from template for: ${this.id}`);
+      this._sandbox = await Sandbox.create(template, createOptions);
+    } else {
+      this.logger.debug(`${LOG_PREFIX} Creating Railway sandbox for: ${this.id}`);
+      this._sandbox = await Sandbox.create(createOptions);
+    }
+
+    this._createdAt = this._sandbox.createdAt ? new Date(this._sandbox.createdAt) : new Date();
+    this.logger.debug(`${LOG_PREFIX} Railway sandbox ${this._sandbox.id} ready for logical ID: ${this.id}`);
+  }
+
+  /**
+   * Stop the Railway sandbox.
+   *
+   * Railway sandboxes have no separate "stopped" state — they're either
+   * running or destroyed — so stopping destroys the sandbox.
+   */
+  async stop(): Promise<void> {
+    await this._teardown();
+  }
+
+  /**
+   * Destroy the Railway sandbox and release its resources.
+   */
+  async destroy(): Promise<void> {
+    await this._teardown();
+  }
+
+  private async _teardown(): Promise<void> {
+    if (!this._sandbox) {
+      return;
+    }
+    const sandbox = this._sandbox;
+    this._sandbox = null;
+    try {
+      await sandbox.destroy();
+    } catch (error) {
+      this.logger.warn(`${LOG_PREFIX} Failed to destroy Railway sandbox ${sandbox.id}:`, error);
+    }
+  }
+
+  /**
+   * Build the configured template into a ready-to-use base. Accepts either a
+   * pre-built `SandboxTemplate` or a builder callback over `Sandbox.template()`.
+   * Calls `.build()` so the recipe is materialised before `Sandbox.create()`.
+   */
+  private async _resolveTemplate(buildOptions: {
+    token?: string;
+    environmentId?: string;
+  }): Promise<SandboxTemplate> {
+    const option = this._templateOption!;
+    const template = typeof option === 'function' ? option(Sandbox.template()) : option;
+    this.logger.debug(`${LOG_PREFIX} Building Railway sandbox template for: ${this.id}`);
+    return template.build(buildOptions);
+  }
+
+  /**
+   * Fork this running sandbox into a new, independent `RailwaySandbox`.
+   *
+   * Clones the filesystem (a fresh boot, not live processes) into the same
+   * environment. The returned sandbox is already started and reattached to the
+   * forked Railway sandbox; it inherits this sandbox's credentials and defaults
+   * unless overridden via `options`.
+   *
+   * @throws {SandboxNotReadyError} If this sandbox has not been started.
+   */
+  async fork(
+    options: Pick<RailwaySandboxOptions, 'id' | 'idleTimeoutMinutes' | 'networkIsolation' | 'env'> = {},
+  ): Promise<RailwaySandbox> {
+    const source = this.railway;
+    const forked = await source.fork({
+      ...(options.idleTimeoutMinutes !== undefined && { idleTimeoutMinutes: options.idleTimeoutMinutes }),
+      ...(options.networkIsolation !== undefined && { networkIsolation: options.networkIsolation }),
+      ...(options.env !== undefined && { env: options.env }),
+    });
+
+    const child = new RailwaySandbox({
+      ...(options.id !== undefined && { id: options.id }),
+      ...(this._token !== undefined && { token: this._token }),
+      ...(this._environmentId !== undefined && { environmentId: this._environmentId }),
+      sandboxId: forked.id,
+      idleTimeoutMinutes: options.idleTimeoutMinutes ?? this._idleTimeoutMinutes,
+      networkIsolation: options.networkIsolation ?? this._networkIsolation,
+      env: options.env ?? this._env,
+      timeout: this._timeout,
+    });
+    await child._start();
+    return child;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Info & Instructions
+  // ---------------------------------------------------------------------------
+
+  async getInfo(): Promise<SandboxInfo> {
+    return {
+      id: this.id,
+      name: this.name,
+      provider: this.provider,
+      status: this.status,
+      createdAt: this._createdAt ?? new Date(),
+      metadata: {
+        ...(this._sandbox && {
+          railwaySandboxId: this._sandbox.id,
+          environmentId: this._sandbox.environmentId,
+          region: this._sandbox.region,
+          networkIsolation: this._sandbox.networkIsolation,
+          ...(this._sandbox.idleTimeoutMinutes != null && {
+            idleTimeoutMinutes: this._sandbox.idleTimeoutMinutes,
+          }),
+        }),
+      },
+    };
+  }
+
+  getInstructions(): string {
+    const defaultInstructions = this._buildDefaultInstructions();
+
+    if (typeof this._instructionsOverride === 'string') {
+      return this._instructionsOverride;
+    }
+    if (typeof this._instructionsOverride === 'function') {
+      return this._instructionsOverride({ defaultInstructions });
+    }
+    return defaultInstructions;
+  }
+
+  private _buildDefaultInstructions(): string {
+    const parts: string[] = [];
+    parts.push('Railway cloud sandbox: an isolated Debian Linux VM with outbound internet access.');
+
+    if (this._networkIsolation === 'PRIVATE') {
+      parts.push('Joined to the environment private network.');
+    }
+
+    if (this._timeout !== undefined) {
+      parts.push(`Default command timeout: ${Math.ceil(this._timeout / 1000)}s.`);
+    } else {
+      parts.push('Commands run until they exit unless a timeout is set.');
+    }
+
+    if (this._idleTimeoutMinutes !== undefined) {
+      parts.push(`Idle timeout: ${this._idleTimeoutMinutes} minute(s).`);
+    }
+
+    return parts.join(' ');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Command Execution
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Execute a command in the sandbox and return the result.
+   */
+  async executeCommand(
+    command: string,
+    args: string[] = [],
+    options: ExecuteCommandOptions = {},
+  ): Promise<CommandResult> {
+    await this.ensureRunning();
+    const fullCommand = args.length > 0 ? `${command} ${args.map(shellQuote).join(' ')}` : command;
+    const effectiveOptions: ExecuteCommandOptions = {
+      ...options,
+      timeout: options.timeout ?? this._timeout,
+    };
+    const handle = await this.processes.spawn(fullCommand, effectiveOptions);
+    const result = await handle.wait();
+    return { ...result, command, args };
+  }
+}

--- a/workspaces/railway/src/sandbox/process-manager.ts
+++ b/workspaces/railway/src/sandbox/process-manager.ts
@@ -24,11 +24,7 @@ export const LOG_PREFIX = '[RailwaySandbox]';
  * variables, since Railway's `exec` takes neither per-call. Env vars are
  * exported via `env` so they apply to the command's process group.
  */
-export function buildSpawnCommand(
-  command: string,
-  cwd?: string,
-  env: Record<string, string> = {},
-): string {
+export function buildSpawnCommand(command: string, cwd?: string, env: Record<string, string> = {}): string {
   const envAssignments = Object.entries(env)
     .map(([key, value]) => `${key}=${shellQuote(value)}`)
     .join(' ');

--- a/workspaces/railway/src/sandbox/process-manager.ts
+++ b/workspaces/railway/src/sandbox/process-manager.ts
@@ -1,0 +1,203 @@
+/**
+ * Railway Process Manager
+ *
+ * Implements SandboxProcessManager for Railway sandboxes.
+ * Wraps the Railway SDK's `Sandbox.exec()` API.
+ *
+ * Railway's `exec(command)` returns an `ExecHandle` that runs the command
+ * server-side, independently of the client. Each spawn() starts one exec.
+ * The handle streams output via `onStdout`/`onStderr` callbacks wired to
+ * `emitStdout`/`emitStderr`, exposes a durable `sessionName`, and can be
+ * terminated with `kill(signal)`.
+ */
+
+import { ProcessHandle, SandboxProcessManager } from '@mastra/core/workspace';
+import type { CommandResult, ProcessInfo, SpawnProcessOptions } from '@mastra/core/workspace';
+import type { ExecHandle, ExecResult } from 'railway';
+import { shellQuote } from '../utils/shell-quote';
+import type { RailwaySandbox } from './index';
+
+export const LOG_PREFIX = '[RailwaySandbox]';
+
+/**
+ * Build a shell command that applies a working directory and environment
+ * variables, since Railway's `exec` takes neither per-call. Env vars are
+ * exported via `env` so they apply to the command's process group.
+ */
+export function buildSpawnCommand(
+  command: string,
+  cwd?: string,
+  env: Record<string, string> = {},
+): string {
+  const envAssignments = Object.entries(env)
+    .map(([key, value]) => `${key}=${shellQuote(value)}`)
+    .join(' ');
+
+  const envPrefix = envAssignments ? `env ${envAssignments} ` : '';
+  // Wrap in a subshell so a `cd` and the user command compose cleanly.
+  const inner = cwd ? `cd ${shellQuote(cwd)} && ${command}` : command;
+  return `${envPrefix}sh -c ${shellQuote(inner)}`;
+}
+
+// =============================================================================
+// Railway Process Handle
+// =============================================================================
+
+/**
+ * Wraps a Railway ExecHandle to conform to Mastra's ProcessHandle.
+ * Not exported — internal to this module.
+ */
+class RailwayProcessHandle extends ProcessHandle {
+  readonly pid: string;
+
+  private readonly _execHandle: ExecHandle;
+  private readonly _startTime: number;
+  private _exitCode: number | undefined;
+  private _waitPromise: Promise<CommandResult> | null = null;
+  private _killed = false;
+
+  constructor(pid: string, execHandle: ExecHandle, startTime: number, options?: SpawnProcessOptions) {
+    super(options);
+    this.pid = pid;
+    this._execHandle = execHandle;
+    this._startTime = startTime;
+
+    // Resolve exit code once the command completes so exitCode is available
+    // without an explicit wait().
+    void this._execHandle.then(
+      (result: ExecResult) => {
+        // -1 means terminated by a signal (e.g. after kill()).
+        this._exitCode = result.exitCode ?? (this._killed ? 137 : -1);
+      },
+      () => {
+        if (this._exitCode === undefined) {
+          this._exitCode = 1;
+        }
+      },
+    );
+  }
+
+  get exitCode(): number | undefined {
+    return this._exitCode;
+  }
+
+  async wait(): Promise<CommandResult> {
+    // Idempotent — cache the promise so repeated calls return the same result.
+    if (!this._waitPromise) {
+      this._waitPromise = this._doWait();
+    }
+    return this._waitPromise;
+  }
+
+  private async _doWait(): Promise<CommandResult> {
+    try {
+      const result = await this._execHandle;
+      const exitCode = result.exitCode ?? (this._killed ? 137 : -1);
+      this._exitCode = exitCode;
+
+      // Railway captures output server-side; surface it through the base buffers
+      // if streaming callbacks didn't already populate them.
+      if (result.stdout && !this.stdout) this.emitStdout(result.stdout);
+      if (result.stderr && !this.stderr) this.emitStderr(result.stderr);
+
+      return {
+        success: exitCode === 0,
+        exitCode,
+        stdout: this.stdout,
+        stderr: this.stderr,
+        executionTimeMs: Date.now() - this._startTime,
+        killed: this._killed,
+        timedOut: result.timedOut,
+      };
+    } catch (error) {
+      const exitCode = this._exitCode ?? 1;
+      this._exitCode = exitCode;
+      return {
+        success: false,
+        exitCode,
+        stdout: this.stdout,
+        stderr: this.stderr || (error instanceof Error ? error.message : String(error)),
+        executionTimeMs: Date.now() - this._startTime,
+        killed: this._killed,
+      };
+    }
+  }
+
+  async kill(): Promise<boolean> {
+    if (this._exitCode !== undefined) return false;
+    this._killed = true;
+    try {
+      return await this._execHandle.kill('TERM');
+    } catch {
+      // Command may already be gone.
+      return false;
+    }
+  }
+
+  async sendStdin(_data: string): Promise<void> {
+    // Railway's exec API does not expose stdin streaming.
+    throw new Error(`${LOG_PREFIX} sending stdin is not supported by the Railway sandbox provider`);
+  }
+}
+
+// =============================================================================
+// Railway Process Manager
+// =============================================================================
+
+export interface RailwayProcessManagerOptions {
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Railway implementation of SandboxProcessManager.
+ * Uses the Railway SDK's `Sandbox.exec()` with one exec per spawned process.
+ */
+export class RailwayProcessManager extends SandboxProcessManager<RailwaySandbox> {
+  private _spawnCounter = 0;
+
+  constructor(opts: RailwayProcessManagerOptions = {}) {
+    super({ env: opts.env });
+  }
+
+  async spawn(command: string, options: SpawnProcessOptions = {}): Promise<ProcessHandle> {
+    const railway = this.sandbox.railway;
+
+    // Merge default env with per-spawn env.
+    const mergedEnv = { ...this.env, ...options.env };
+    const envs = Object.fromEntries(
+      Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
+    );
+
+    const fullCommand = buildSpawnCommand(command, options.cwd, envs);
+    const pid = `railway-proc-${Date.now().toString(36)}-${(this._spawnCounter++).toString(36)}`;
+
+    // Deferred reference — callbacks fire asynchronously after the handle is
+    // assigned, so `handle` is always defined by the time they run.
+    let handle: RailwayProcessHandle;
+
+    const execHandle = railway.exec(fullCommand, {
+      ...(options.timeout !== undefined && { timeoutSec: Math.ceil(options.timeout / 1000) }),
+      onStdout: (chunk: string) => handle.emitStdout(chunk),
+      onStderr: (chunk: string) => handle.emitStderr(chunk),
+    });
+
+    handle = new RailwayProcessHandle(pid, execHandle, Date.now(), options);
+    this._tracked.set(handle.pid, handle);
+    return handle;
+  }
+
+  /**
+   * List tracked processes.
+   *
+   * Railway has no API to enumerate running exec sessions by sandbox, so this
+   * reports the processes this manager spawned.
+   */
+  async list(): Promise<ProcessInfo[]> {
+    return Array.from(this._tracked.values()).map(handle => ({
+      pid: handle.pid,
+      command: handle.command,
+      running: handle.exitCode === undefined,
+      ...(handle.exitCode !== undefined && { exitCode: handle.exitCode }),
+    }));
+  }
+}

--- a/workspaces/railway/src/utils/shell-quote.ts
+++ b/workspaces/railway/src/utils/shell-quote.ts
@@ -1,0 +1,12 @@
+/**
+ * Shell-quote a single argument for safe use in a command string.
+ *
+ * Arguments containing only safe characters are returned as-is.
+ * All others are wrapped in single quotes with embedded single quotes escaped.
+ */
+export function shellQuote(arg: string): string {
+  // Safe characters that don't need quoting
+  if (/^[a-zA-Z0-9._\-/@:=]+$/.test(arg)) return arg;
+  // Wrap in single quotes, escaping any embedded single quotes
+  return "'" + arg.replace(/'/g, "'\\''") + "'";
+}

--- a/workspaces/railway/tsconfig.build.json
+++ b/workspaces/railway/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/railway/tsconfig.json
+++ b/workspaces/railway/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/railway/tsup.config.ts
+++ b/workspaces/railway/tsup.config.ts
@@ -1,0 +1,18 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  external: ['@mastra/core'],
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/workspaces/railway/vitest.config.ts
+++ b/workspaces/railway/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+    setupFiles: ['dotenv/config'],
+    testTimeout: 60000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
Adds `@mastra/railway`, a new sandbox provider that lets agents run shell commands in Railway's ephemeral, isolated Linux VMs. It plugs into a Workspace the same way the other sandbox providers do, and supports streaming command output, background processes, command timeouts, a configurable idle timeout, `ISOLATED`/`PRIVATE` network isolation, custom base images via the Railway template builder, forking a running sandbox, and reattaching to an existing sandbox by ID.

Using it looks like this:

```typescript
import { Workspace } from '@mastra/core/workspace'
import { RailwaySandbox } from '@mastra/railway'

const workspace = new Workspace({
  sandbox: new RailwaySandbox({
    idleTimeoutMinutes: 30,
    networkIsolation: 'PRIVATE',
  }),
})
```

It also exports `railwaySandboxProvider` for registering with `MastraEditor`. Includes unit tests, a README, reference docs under the workspace section, and a changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a new package that lets Mastra run commands inside temporary, isolated Linux VMs on Railway—so you can run code in a disposable cloud "sandbox" and manage it from Mastra.

## Overview

Adds a new `@mastra/railway` package implementing a Workspace sandbox provider backed by Railway Sandboxes. It integrates with Mastra's Workspace sandbox APIs and supports streaming command output, background processes, per-command and default timeouts, configurable idle timeout, network isolation modes (ISOLATED / PRIVATE), custom base images via Railway templates, forking running sandboxes, and reattaching to an existing sandbox by ID. It exports RailwaySandbox and railwaySandboxProvider for direct use and editor registration.

## Key Features

- Execute shell commands with streaming stdout/stderr and proper argument quoting
- Per-command timeouts and provider-level default timeout; configurable idleTimeoutMinutes for automatic cleanup
- Background process management with kill support and process listing
- Network isolation modes (ISOLATED / PRIVATE)
- Custom base-image/template support via Railway template builder or prebuilt template
- Fork an existing sandbox and obtain a RailwaySandbox already attached to the fork; reattach by sandboxId
- Exposes getInfo(), getInstructions(), and other standard Mastra Sandbox lifecycle APIs

## Implementation Notes

- RailwaySandbox extends MastraSandbox (uses the _start() lifecycle wrapper pattern). start() builds templates (if provided) and either creates or reconnects to a Railway sandbox; stop()/destroy() share teardown logic; railway getter throws if accessed before start.
- RailwayProcessManager implements spawn/list and returns ProcessHandles that wrap Railway ExecHandles, converting timeouts (ms → timeoutSec), routing stdout/stderr streams into buffers, and exposing wait()/kill().
- Utilities include shellQuote() and buildSpawnCommand() to produce a single sh -c invocation that injects cwd and environment safely.
- fork() calls Railway to fork the underlying sandbox and returns a new RailwaySandbox reattached to the forked sandbox.
- Tests include unit coverage for lifecycle, execution, process management, template handling, forking, reattachment, and instruction generation; an integration test suite is added (gated on RAILWAY_API_TOKEN / RAILWAY_ENVIRONMENT_ID) with a skipped placeholder when creds are absent so CI discovery is stable.

## Public API Exports

- RailwaySandbox, RailwaySandboxOptions
- RailwayProcessManager, RailwayProcessManagerOptions
- railwaySandboxProvider (SandboxProvider<RailwayProviderConfig>)
- buildSpawnCommand, shellQuote (utilities)

## Docs, Packaging & Tooling

- New README, reference doc (workspace/railway-sandbox), sidebar entry, and changeset for a minor release bump
- Package config (workspaces/railway/package.json) with ESM/CJS exports, tsup build config, TypeScript configs, Vitest config, ESLint and lint-staged configs, and a changelog entry
- CI-friendly integration test gating and a placeholder suite to avoid empty-suite failures

## Review / Discussion Highlights

- Contributor ran Prettier and added a public-API usage example to the changeset to address lint/CI feedback.
- A flagged "critical" about calling child._start() was discussed: maintainers clarified this is intentional and consistent with MastraSandbox semantics (_start() is the race-safe lifecycle wrapper and subclasses implement start()); the implementation and tests ensure forked children are initialized via _start().
<!-- end of auto-generated comment: release notes by coderabbit.ai -->