### PR TITLE
fix(server): move hono to peerDependencies to fix GET_MATCH_RESULT type conflict

### DIFF
--- a/.changeset/heavy-clouds-sneeze.md
+++ b/.changeset/heavy-clouds-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'@mastra/server': patch
+---
+
+hono is now a peer dependency of @mastra/server, eliminating TypeScript type conflicts when the host project uses a different hono version

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -112,7 +112,6 @@
     "esbuild": "^0.27.4",
     "find-workspaces": "^0.3.1",
     "fs-extra": "^11.3.4",
-    "hono": "^4.12.8",
     "local-pkg": "^1.1.2",
     "resolve.exports": "^2.0.3",
     "rollup": "^4.59.0",
@@ -150,7 +149,8 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.34.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.34.0-0 <2.0.0-0",
+    "hono": "^4.0.0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -112,6 +112,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@mastra/core": ">=1.34.0-0 <2.0.0-0",
+    "hono": "^4.0.0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {
@@ -151,7 +152,5 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "dependencies": {
-    "hono": "^4.12.8"
-  }
+  "dependencies": {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3877,7 +3877,7 @@ importers:
         specifier: ^11.3.4
         version: 11.3.4
       hono:
-        specifier: ^4.12.8
+        specifier: ^4.0.0
         version: 4.12.18
       local-pkg:
         specifier: ^1.1.2
@@ -5114,7 +5114,7 @@ importers:
   packages/server:
     dependencies:
       hono:
-        specifier: ^4.12.8
+        specifier: ^4.0.0
         version: 4.12.18
     devDependencies:
       '@ai-sdk/openai':


### PR DESCRIPTION
@
Fixes #17395

## Summary

Apps that install @mastra/server alongside their own hono dependency get TypeScript errors
when typing Hono context objects or route handlers — specifically a GET_MATCH_RESULT unique
symbol incompatibility. This symbol is defined once per hono instance; when @mastra/server
bundles its own copy of hono as a direct dependency, npm/pnpm may resolve it to a separate
installation, producing two non-identical symbols that TypeScript treats as incompatible types.

## Root cause

packages/server/package.json declares hono: ^4.12.8 under dependencies. The server
adapter (packages/server/src/server/server-adapter/index.ts line 9) imports { Hono } at
runtime, and the @mastra/core server types (types.ts) expose Handler and Context from
hono in the public ApiRoute type. When the host project has any other hono version installed,
the package manager may produce two resolution paths. TypeScript's GET_MATCH_RESULT unique
symbol — used internally by hono for type-safe route matching — is created once per module
instance, so the two copies are not assignable to each other.

Making hono a peerDependency (range ^4.0.0) instructs package managers to reuse whatever
hono the host project already has installed, eliminating the duplicate.

packages/deployer/package.json has the same pattern and is fixed in the same PR for
consistency, though the deployer's public API does not surface Hono-typed objects directly.

## Changes

- packages/server/package.json: remove hono: ^4.12.8 from dependencies; add
  hono: ^4.0.0 to peerDependencies (~2 lines)
- packages/deployer/package.json: same move (~2 lines)
- .changeset/heavy-clouds-sneeze.md: combined changeset for @mastra/server and
  @mastra/deployer (patch)

## What is NOT changed

No source files are modified. @mastra/core is unchanged — its hono usage is already
import type only (devDependency). @mastra/mcp is unchanged — hono is in devDependencies
for tests only.

## Out of scope

This PR does not add hono as a peerDependency to the top-level mastra CLI package, which
bundles the server internally and manages its own hono resolution. That is a separate concern.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Linked related issue
- [ ] Added or updated tests
- [ ] Documentation updated (if applicable)
- [x] Addressed all Coderabbit comments

## Test plan

- pnpm --filter ./packages/server test — all passing. Covers: no import resolution errors
  introduced by removing the bundled hono (peer resolution picks up the workspace root's hono).
- pnpm --filter ./packages/deployer test — all passing.
- TypeScript build check: pnpm --filter ./packages/server build succeeds, confirming the
  peer-resolved hono satisfies all type constraints used in the server adapter.
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you use `@mastra/server` alongside your own hono library, you end up with two separate copies of hono that can't talk to each other, causing TypeScript errors. This PR fixes that by making `@mastra/server` use *your* hono instead of bundling its own—so there's only one copy that everyone shares.

## Changes

This PR moves `hono` from dependencies to peerDependencies in two packages:

- **`@mastra/server`**: Removed `hono` from `dependencies` (previously `^4.12.8`) and added it to `peerDependencies` as `^4.0.0`
- **`@mastra/deployer`**: Made the same change for consistency

A changeset was added to mark both packages for patch releases with notes explaining the change.

## Why This Fixes the Problem

The root cause is that Hono uses an internal unique symbol (`GET_MATCH_RESULT`) to identify type compatibility. If `@mastra/server` bundles its own hono instance, package managers may end up installing two separate instances—one from `@mastra` and one from the user's app. Since each instance has its own unique symbol, types become incompatible, and TypeScript throws errors when trying to use Hono-typed handlers and contexts from mastra with the user's own Hono router.

By declaring hono as a peer dependency, the host project is responsible for providing hono, ensuring both `@mastra/server` and the user's code share the same hono instance and its symbols. This eliminates the type conflicts while keeping the version compatibility flexible (`^4.0.0`).

## Verification

- All tests pass for both affected packages
- The build succeeds, confirming that a peer-resolved hono satisfies type requirements
- No source code files were modified; only dependency declarations changed
- `@mastra/core` remains unchanged (it uses `import type` and has hono as a devDependency)

## Scope

This PR addresses only `@mastra/server` and `@mastra/deployer`. The mastra CLI package is out of scope and was not updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->