### PR TITLE
feat(studio): add plugin page registration

### DIFF
--- a/.changeset/lucky-carrots-allow.md
+++ b/.changeset/lucky-carrots-allow.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Added support for loading external Studio plugin module scripts and registering Studio plugin routes and sidebar links.

--- a/packages/cli/src/commands/studio/studio.test.ts
+++ b/packages/cli/src/commands/studio/studio.test.ts
@@ -27,6 +27,7 @@ function createStudioFixture() {
     </script>
   </head>
   <body>studio</body>
+  %%MASTRA_STUDIO_PLUGIN_SCRIPTS%%
 </html>`,
   );
 
@@ -55,6 +56,7 @@ afterEach(() => {
   delete process.env.MASTRA_STUDIO_BASE_PATH;
   delete process.env.MASTRA_TEMPLATES;
   delete process.env.MASTRA_AGENT_SIGNALS;
+  delete process.env.MASTRA_STUDIO_PLUGIN_SCRIPTS;
 
   for (const dir of createdDirs.splice(0, createdDirs.length)) {
     rmSync(dir, { recursive: true, force: true });
@@ -175,6 +177,26 @@ describe('studio base path support', () => {
 
       expect(spaLikeRoute.status).toBe(200);
       expect(spaLikeRoute.body).toContain('<body>studio</body>');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('injects configured Studio plugin module scripts into the HTML shell', async () => {
+    process.env.MASTRA_STUDIO_PLUGIN_SCRIPTS = 'http://127.0.0.1:5174/counter.js,/plugins/local.js';
+    const studioDir = createStudioFixture();
+    const server = createServer(studioDir, {}, '');
+
+    await new Promise<void>(resolve => server.listen(0, resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    try {
+      const htmlResponse = await request(`http://127.0.0.1:${port}/`);
+
+      expect(htmlResponse.status).toBe(200);
+      expect(htmlResponse.body).toContain('<script type="module" src="http://127.0.0.1:5174/counter.js"></script>');
+      expect(htmlResponse.body).toContain('<script type="module" src="/plugins/local.js"></script>');
     } finally {
       await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
     }

--- a/packages/cli/src/commands/studio/studio.ts
+++ b/packages/cli/src/commands/studio/studio.ts
@@ -36,6 +36,20 @@ function normalizeBasePath(basePath: string): string {
   return normalized;
 }
 
+function escapeHtmlAttribute(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function getStudioPluginScriptTags(): string {
+  const scripts = process.env.MASTRA_STUDIO_PLUGIN_SCRIPTS ?? '';
+  const srcs = scripts
+    .split(',')
+    .map(src => src.trim())
+    .filter(Boolean);
+
+  return srcs.map(src => `<script type="module" src="${escapeHtmlAttribute(src)}"></script>`).join('\n    ');
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -117,7 +131,8 @@ export const createServer = (builtStudioPath: string, options: StudioOptions, re
     .replaceAll('%%MASTRA_TELEMETRY_DISABLED%%', process.env.MASTRA_TELEMETRY_DISABLED ?? '')
     .replaceAll('%%MASTRA_REQUEST_CONTEXT_PRESETS%%', escapeJsonForHtml(requestContextPresetsJson))
     .replaceAll('%%MASTRA_EXPERIMENTAL_UI%%', experimentalUI)
-    .replaceAll('%%MASTRA_AGENT_SIGNALS%%', agentSignals);
+    .replaceAll('%%MASTRA_AGENT_SIGNALS%%', agentSignals)
+    .replaceAll('%%MASTRA_STUDIO_PLUGIN_SCRIPTS%%', getStudioPluginScriptTags());
 
   // Pre-compress the HTML shell since it's served for every non-asset request
   const compressedHtml = gzipSync(Buffer.from(html));

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -21,6 +21,13 @@
       window.MASTRA_REQUEST_CONTEXT_PRESETS = '%%MASTRA_REQUEST_CONTEXT_PRESETS%%';
       window.MASTRA_EXPERIMENTAL_UI = '%%MASTRA_EXPERIMENTAL_UI%%';
       window.MASTRA_AGENT_SIGNALS = '%%MASTRA_AGENT_SIGNALS%%';
+      window.MASTRA_STUDIO = window.MASTRA_STUDIO || {};
+      window.MASTRA_STUDIO.plugins = window.MASTRA_STUDIO.plugins || [];
+      window.MASTRA_STUDIO.registerPlugin =
+        window.MASTRA_STUDIO.registerPlugin ||
+        function registerPlugin(plugin) {
+          window.MASTRA_STUDIO.plugins.push(plugin);
+        };
 
       try {
         const storageValue = window.localStorage.getItem('mastra-playground-store');
@@ -89,6 +96,7 @@
 
   <body class="overflow-hidden">
     <div id="root"></div>
+    %%MASTRA_STUDIO_PLUGIN_SCRIPTS%%
     <script type="module" src="./src/bootstrap.ts"></script>
   </body>
 </html>

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -109,6 +109,7 @@ import type { CrumbDef, RouteHeaderHandle } from '@/lib/route-header';
 import { PlaygroundQueryClient } from '@/lib/tanstack-query';
 import { Processors } from '@/pages/processors';
 import { Processor } from '@/pages/processors/processor';
+import { getStudioPluginRoutes } from '@/plugins';
 import Tools from '@/pages/tools';
 
 // Extend window type for Mastra config
@@ -655,6 +656,21 @@ export const routes: RouteObject[] = [
   },
 ];
 
+// eslint-disable-next-line react-refresh/only-export-components -- route metadata is covered by regression tests.
+export function getStudioRoutes(): RouteObject[] {
+  const pluginRoutes = getStudioPluginRoutes();
+  if (pluginRoutes.length === 0) return routes;
+
+  return routes.map(route => {
+    if (!route.children?.some(child => child.path === '/agents')) return route;
+
+    return {
+      ...route,
+      children: [...pluginRoutes, ...route.children],
+    };
+  });
+}
+
 function App() {
   const studioBasePath = window.MASTRA_STUDIO_BASE_PATH || '';
   const { baseUrl, headers, apiPrefix, isLoading } = useStudioConfig();
@@ -665,7 +681,7 @@ function App() {
     [baseUrl, apiPrefix],
   );
   const studioHeaders = useMemo(() => ({ ...headers, 'x-mastra-client-type': 'studio' }), [headers]);
-  const router = useMemo(() => createBrowserRouter(routes, { basename: studioBasePath }), [studioBasePath]);
+  const router = useMemo(() => createBrowserRouter(getStudioRoutes(), { basename: studioBasePath }), [studioBasePath]);
 
   if (isLoading) {
     // Config is loaded from localStorage. However, there might be a race condition

--- a/packages/playground/src/components/ui/__tests__/app-sidebar-plugin-link.test.tsx
+++ b/packages/playground/src/components/ui/__tests__/app-sidebar-plugin-link.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import type { BuilderSettingsResponse } from '@mastra/client-js';
+import { MainSidebarProvider, TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// jsdom doesn't provide ResizeObserver, which ScrollArea expects.
+globalThis.ResizeObserver ??= class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof globalThis.ResizeObserver;
+
+if (typeof Element !== 'undefined' && typeof Element.prototype.getAnimations !== 'function') {
+  Element.prototype.getAnimations = function getAnimations() {
+    return [] as Animation[];
+  };
+}
+
+import { AppSidebar } from '../app-sidebar';
+import { RoleImpersonationProvider } from '@/domains/auth/context/role-impersonation-context';
+import type { AuthCapabilities } from '@/domains/auth/types';
+import { LinkComponentProvider } from '@/lib/framework';
+import { registerStudioPlugin, resetStudioPluginsForTests } from '@/plugins';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const authDisabledCapabilities = {
+  enabled: false,
+  login: { type: 'credentials' as const },
+} satisfies AuthCapabilities;
+
+const builderDisabled: BuilderSettingsResponse = {
+  enabled: false,
+};
+
+function authHandler(capabilities: AuthCapabilities) {
+  return http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(capabilities));
+}
+
+function builderHandler(settings: BuilderSettingsResponse) {
+  return http.get(`${BASE_URL}/api/editor/builder/settings`, () => HttpResponse.json(settings));
+}
+
+function systemPackagesHandler() {
+  return http.get(`${BASE_URL}/api/system/packages`, () =>
+    HttpResponse.json({ packages: [], cmsEnabled: false, observabilityEnabled: false }),
+  );
+}
+
+function CounterIcon() {
+  return <svg aria-hidden="true" />;
+}
+
+const StubLink = ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a {...props}>{children}</a>
+);
+
+const noopPaths = {
+  agentLink: () => '',
+  agentMessageLink: () => '',
+  workflowLink: () => '',
+  toolLink: () => '',
+  scoreLink: () => '',
+  scorerLink: () => '',
+  toolByAgentLink: () => '',
+  toolByWorkflowLink: () => '',
+  promptLink: () => '',
+  legacyWorkflowLink: () => '',
+  policyLink: () => '',
+  vNextNetworkLink: () => '',
+  agentBuilderLink: () => '',
+  mcpServerLink: () => '',
+  mcpServerToolLink: () => '',
+  workflowRunLink: () => '',
+  datasetLink: () => '',
+  datasetItemLink: () => '',
+  datasetExperimentLink: () => '',
+  experimentLink: () => '',
+} as never;
+
+function renderSidebar(initialPath = '/agents') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <RoleImpersonationProvider>
+          <LinkComponentProvider Link={StubLink as never} navigate={() => {}} paths={noopPaths}>
+            <MemoryRouter initialEntries={[initialPath]}>
+              <TooltipProvider>
+                <MainSidebarProvider>
+                  <AppSidebar />
+                </MainSidebarProvider>
+              </TooltipProvider>
+            </MemoryRouter>
+          </LinkComponentProvider>
+        </RoleImpersonationProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+}
+
+beforeEach(() => {
+  (window as unknown as Record<string, unknown>).MASTRA_CLOUD_API_ENDPOINT = '';
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  resetStudioPluginsForTests();
+  cleanup();
+});
+
+describe('AppSidebar — Studio plugin links', () => {
+  it('renders registered plugin nav items in the sidebar', async () => {
+    registerStudioPlugin({
+      id: 'counter',
+      name: 'Counter tools',
+      navItems: [{ name: 'Counter', url: '/counter', Icon: CounterIcon }],
+    });
+
+    server.use(authHandler(authDisabledCapabilities), builderHandler(builderDisabled), systemPackagesHandler());
+
+    renderSidebar();
+
+    const link = await screen.findByRole('link', { name: /counter/i });
+    expect(link.getAttribute('href')).toBe('/counter');
+  });
+});

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -15,6 +15,7 @@ import { useLinkComponent } from '@/lib/framework';
 import { useMastraPlatform } from '@/lib/mastra-platform/hooks/use-mastra-platform';
 import { bottomNav, mainNav } from '@/lib/nav/nav-items';
 import type { NavItem } from '@/lib/nav/nav-items';
+import { getStudioPluginNavSections } from '@/plugins';
 
 declare global {
   interface Window {
@@ -138,7 +139,7 @@ export function AppSidebar() {
       <ImpersonationBanner />
 
       <MainSidebar.Nav>
-        {mainNav.map(section => {
+        {[...mainNav, ...getStudioPluginNavSections()].map(section => {
           const filtered = section.items.filter(filterItem);
           const anySubActive = filtered.some(item => getIsLinkActive(item, pathname));
           const isHeaderActive = !!(section.href && pathname === section.href && !anySubActive);

--- a/packages/playground/src/exports.ts
+++ b/packages/playground/src/exports.ts
@@ -11,6 +11,14 @@ export {
 
 export { PlaygroundQueryClient } from './lib/tanstack-query';
 
+export {
+  getStudioPlugins,
+  registerStudioPlugin,
+  type StudioPlugin,
+  type StudioPluginNavItem,
+  type StudioPluginRoute,
+} from './plugins';
+
 export { usePlaygroundStore, useTheme, type Theme, type ResolvedTheme } from '@mastra/playground-ui';
 
 export { isWorkspaceV1Supported } from '@mastra/playground-ui/utils';

--- a/packages/playground/src/plugins.test.tsx
+++ b/packages/playground/src/plugins.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  getStudioPluginNavSections,
+  getStudioPluginRoutes,
+  registerStudioPlugin,
+  resetStudioPluginsForTests,
+} from './plugins';
+
+function CounterPage() {
+  return <p>Counter plugin</p>;
+}
+
+function CounterIcon() {
+  return <svg aria-hidden="true" />;
+}
+
+afterEach(() => {
+  resetStudioPluginsForTests();
+});
+
+describe('Studio plugin registry', () => {
+  it('exposes registered plugin routes as React Router route objects', () => {
+    registerStudioPlugin({
+      id: 'counter',
+      name: 'Counter tools',
+      routes: [{ path: '/counter', component: CounterPage }],
+    });
+
+    const [route] = getStudioPluginRoutes();
+
+    expect(route.path).toBe('/counter');
+    expect(renderToStaticMarkup(route.element)).toContain('Counter plugin');
+  });
+
+  it('exposes registered plugin nav items under a Studio plugins section', () => {
+    registerStudioPlugin({
+      id: 'counter',
+      name: 'Counter tools',
+      navItems: [{ name: 'Counter', url: '/counter', Icon: CounterIcon }],
+    });
+
+    expect(getStudioPluginNavSections()).toEqual([
+      {
+        key: 'studio-plugins',
+        title: 'Plugins',
+        items: [{ name: 'Counter', url: '/counter', Icon: CounterIcon, isOnMastraPlatform: true }],
+      },
+    ]);
+  });
+});

--- a/packages/playground/src/plugins.tsx
+++ b/packages/playground/src/plugins.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import type { ComponentType, ReactElement, ReactNode, SVGProps } from 'react';
+import type { RouteObject } from 'react-router';
+import { PuzzleIcon } from 'lucide-react';
+
+import type { RouteHeaderHandle } from '@/lib/route-header';
+
+export type StudioPluginIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+export interface StudioPluginRoute {
+  path: `/${string}`;
+  component?: ComponentType;
+  element?: ReactNode;
+  handle?: RouteHeaderHandle;
+}
+
+export interface StudioPluginNavItem {
+  name: string;
+  url: `/${string}`;
+  Icon?: StudioPluginIcon;
+  activePaths?: string[];
+  isOnMastraPlatform?: boolean;
+}
+
+export interface StudioPlugin {
+  id: string;
+  name?: string;
+  routes?: StudioPluginRoute[];
+  navItems?: StudioPluginNavItem[];
+}
+
+export interface StudioPluginNavSection {
+  key: string;
+  title: string;
+  href?: string;
+  items: Array<
+    Required<Pick<StudioPluginNavItem, 'name' | 'url' | 'Icon' | 'isOnMastraPlatform'>> &
+      Pick<StudioPluginNavItem, 'activePaths'>
+  >;
+}
+
+interface StudioPluginHost {
+  React: typeof React;
+  plugins: StudioPlugin[];
+  registerPlugin: (plugin: StudioPlugin) => void;
+}
+
+declare global {
+  interface Window {
+    MASTRA_STUDIO?: Partial<StudioPluginHost>;
+  }
+}
+
+function ensureStudioPluginHost(): StudioPluginHost {
+  const existingHost = window.MASTRA_STUDIO ?? {};
+  const plugins = existingHost.plugins ?? [];
+  const host: StudioPluginHost = {
+    React,
+    plugins,
+    registerPlugin: registerStudioPlugin,
+  };
+
+  window.MASTRA_STUDIO = host;
+
+  return host;
+}
+
+function pluginRouteElement(route: StudioPluginRoute): ReactNode {
+  if (route.element) return route.element;
+  if (!route.component) return null;
+
+  const Component = route.component;
+  return <Component />;
+}
+
+function pluginRouteHandle(plugin: StudioPlugin, route: StudioPluginRoute): RouteHeaderHandle {
+  if (route.handle) return route.handle;
+
+  const matchingNavItem = plugin.navItems?.find(item => item.url === route.path);
+  const label = matchingNavItem?.name ?? plugin.name ?? plugin.id;
+  const Icon = matchingNavItem?.Icon ?? PuzzleIcon;
+
+  return {
+    crumbs: [{ id: `plugin:${plugin.id}:${route.path}`, label, icon: Icon }],
+  };
+}
+
+/**
+ * Registers an external Studio plugin before the Studio router is created.
+ */
+export function registerStudioPlugin(plugin: StudioPlugin): void {
+  const host = ensureStudioPluginHost();
+  const existingIndex = host.plugins.findIndex(registeredPlugin => registeredPlugin.id === plugin.id);
+
+  if (existingIndex >= 0) {
+    host.plugins[existingIndex] = plugin;
+    return;
+  }
+
+  host.plugins.push(plugin);
+}
+
+/**
+ * Returns the Studio plugins registered on the current browser window.
+ */
+export function getStudioPlugins(): readonly StudioPlugin[] {
+  return ensureStudioPluginHost().plugins;
+}
+
+/**
+ * Returns registered plugin routes in the shape expected by React Router.
+ */
+export function getStudioPluginRoutes(): RouteObject[] {
+  return getStudioPlugins().flatMap(plugin =>
+    (plugin.routes ?? []).map(route => ({
+      path: route.path,
+      element: pluginRouteElement(route) as ReactElement,
+      handle: pluginRouteHandle(plugin, route),
+    })),
+  );
+}
+
+/**
+ * Returns a sidebar section containing all registered plugin navigation items.
+ */
+export function getStudioPluginNavSections(): StudioPluginNavSection[] {
+  const items = getStudioPlugins().flatMap(plugin => plugin.navItems ?? []);
+
+  if (items.length === 0) return [];
+
+  return [
+    {
+      key: 'studio-plugins',
+      title: 'Plugins',
+      items: items.map(item => ({
+        ...item,
+        Icon: item.Icon ?? PuzzleIcon,
+        isOnMastraPlatform: item.isOnMastraPlatform ?? true,
+      })),
+    },
+  ];
+}
+
+/**
+ * Clears registered plugins between tests.
+ */
+export function resetStudioPluginsForTests(): void {
+  ensureStudioPluginHost().plugins.splice(0);
+}

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -21,7 +21,8 @@ const studioStandalonePlugin = (targetPort: string, targetHost: string): PluginO
       .replace(/%%MASTRA_AUTO_DETECT_URL%%/g, 'true')
       .replace(/%%MASTRA_EXPERIMENTAL_FEATURES%%/g, process.env.EXPERIMENTAL_FEATURES || 'false')
       .replace(/%%MASTRA_EXPERIMENTAL_UI%%/g, process.env.MASTRA_EXPERIMENTAL_UI || 'false')
-      .replace(/%%MASTRA_AGENT_SIGNALS%%/g, process.env.MASTRA_AGENT_SIGNALS ?? 'true');
+      .replace(/%%MASTRA_AGENT_SIGNALS%%/g, process.env.MASTRA_AGENT_SIGNALS ?? 'true')
+      .replace(/%%MASTRA_STUDIO_PLUGIN_SCRIPTS%%/g, '');
   },
 });
 


### PR DESCRIPTION
## Summary
- Add a Studio plugin registry that external modules can use to register routes and sidebar navigation.
- Inject configured plugin module scripts into the Studio HTML shell through `MASTRA_STUDIO_PLUGIN_SCRIPTS`.
- Export the registration API from the playground package and cover route/sidebar/script injection with focused tests.

## External example
- Kept the sample counter plugin outside this repo at `/private/tmp/mastra-studio-counter-plugin` so it remains an encapsulated installable-style example.

## Verification
- `pnpm --filter ./packages/playground test:run src/plugins.test.tsx src/components/ui/__tests__/app-sidebar-plugin-link.test.tsx`
- `pnpm --filter ./packages/playground test:run src/lib/route-header/__tests__/route-header-handles.test.tsx`
- `pnpm --filter ./packages/cli exec vitest run src/commands/studio/studio.test.ts`
- `node --check /private/tmp/mastra-studio-counter-plugin/counter-plugin.js`
- `pnpm --filter ./packages/playground build`

## Notes
- `pnpm --filter ./packages/playground typecheck` is blocked by existing missing/unbuilt `@mastra/playground-ui` declarations in this fresh worktree.
- `pnpm --filter ./packages/cli typecheck` is blocked by existing missing/unbuilt `@mastra/deployer` declarations and related existing type errors.