### PR TITLE
feat(mastracode): pass model instances to subagents and observational memory

### DIFF
--- a/.changeset/curly-stars-cheer.md
+++ b/.changeset/curly-stars-cheer.md
@@ -1,0 +1,29 @@
+---
+'mastracode': minor
+---
+
+Configure subagent and observational-memory models with provider model instances, not just string IDs. This lets you point those models at a provider that needs configuration a string ID can't carry, such as a Vertex AI project, region, or credentials, which is what automated environments like continuous integration (CI) need.
+
+Subagents now accept a `defaultModel` instance, and the new `observationalModel` option sets the observational-memory model (observer and reflector):
+
+```typescript
+import { createMastraCode } from 'mastracode'
+import { createVertex } from '@ai-sdk/google-vertex'
+
+const vertex = createVertex({ project: process.env.GCP_PROJECT_ID, location: 'us-central1' })
+
+await createMastraCode({
+  subagents: [
+    {
+      id: 'explore',
+      name: 'Explore',
+      description: 'Read-only codebase exploration',
+      instructions: 'You are an expert code explorer.',
+      defaultModel: vertex('__AI_SDK_GOOGLE_MODEL__'),
+    },
+  ],
+  observationalModel: vertex('__AI_SDK_GOOGLE_MODEL__'),
+})
+```
+
+`observationalModel` overrides the `observerModelId` and `reflectorModelId` state, so the observational-memory model can no longer be switched at runtime. To use different models for the observer and reflector, pass a custom `memory` instance instead.

--- a/.changeset/curly-stars-cheer.md
+++ b/.changeset/curly-stars-cheer.md
@@ -2,7 +2,7 @@
 'mastracode': minor
 ---
 
-Configure subagent and observational-memory models with provider model instances, not just string IDs. This lets you point those models at a provider that needs configuration a string ID can't carry, such as a Vertex AI project, region, or credentials, which is what automated environments like continuous integration (CI) need.
+Added support for configuring subagent and observational-memory models with provider model instances instead of string IDs, so they work with providers that need extra configuration (for example, a Vertex AI project, region, or credentials) in continuous integration environments.
 
 Subagents now accept a `defaultModel` instance, and the new `observationalModel` option sets the observational-memory model (observer and reflector):
 

--- a/.changeset/quiet-geckos-serve.md
+++ b/.changeset/quiet-geckos-serve.md
@@ -1,0 +1,35 @@
+---
+'@mastra/core': minor
+---
+
+Added `defaultModel` to subagent definitions so a subagent can run on a fully-configured model instance, not just a string model ID. Use this when the model needs provider configuration a string ID can't carry, such as a Vertex AI project, region, or credentials.
+
+`defaultModel` takes precedence over `defaultModelId`, but an explicit model chosen at runtime (a per-invocation model or the model picker) still wins.
+
+Before:
+
+```typescript
+const subagent = {
+  id: 'explore',
+  name: 'Explore',
+  description: 'Read-only codebase exploration',
+  instructions: 'You are an expert code explorer.',
+  defaultModelId: '__GATEWAY_GOOGLE_MODEL__', // string ID only
+}
+```
+
+After:
+
+```typescript
+import { createVertex } from '@ai-sdk/google-vertex'
+
+const vertex = createVertex({ project: process.env.GCP_PROJECT_ID, location: 'us-central1' })
+
+const subagent = {
+  id: 'explore',
+  name: 'Explore',
+  description: 'Read-only codebase exploration',
+  instructions: 'You are an expert code explorer.',
+  defaultModel: vertex('__AI_SDK_GOOGLE_MODEL__'), // configured model instance
+}
+```

--- a/docs/src/mastra-code/customization.mdx
+++ b/docs/src/mastra-code/customization.mdx
@@ -131,6 +131,52 @@ const { harness } = await createMastraCode({
 })
 ```
 
+By default a subagent picks up the model from its mode, or you can set a `defaultModelId` string. When the model needs provider configuration a string ID can't carry, such as a Vertex AI project, region, or credentials, pass a configured model instance through `defaultModel` instead. This is the way to wire subagents to a specific provider in automated environments like continuous integration (CI), where there's no interactive model picker.
+
+```typescript title="src/subagent-model-instance.ts"
+import { createMastraCode } from 'mastracode'
+import { createVertex } from '@ai-sdk/google-vertex'
+
+const vertex = createVertex({
+  project: process.env.GCP_PROJECT_ID,
+  location: 'us-central1',
+})
+
+const { harness } = await createMastraCode({
+  subagents: [
+    {
+      id: 'explore',
+      name: 'Explore',
+      description: 'Read-only codebase exploration',
+      instructions: 'You are an expert code explorer.',
+      defaultModel: vertex('__AI_SDK_GOOGLE_MODEL__'),
+    },
+  ],
+})
+```
+
+`defaultModel` takes precedence over `defaultModelId`, but an explicit model chosen at runtime through the model picker still wins.
+
+## Observational memory model
+
+Observational memory uses a background model to write and condense notes about each session. Set its model with a string ID through the `observerModelId` and `reflectorModelId` state fields. When that model needs provider configuration a string ID can't carry, pass a configured instance through `observationalModel`:
+
+```typescript title="src/observational-model-instance.ts"
+import { createMastraCode } from 'mastracode'
+import { createVertex } from '@ai-sdk/google-vertex'
+
+const vertex = createVertex({
+  project: process.env.GCP_PROJECT_ID,
+  location: 'us-central1',
+})
+
+const { harness } = await createMastraCode({
+  observationalModel: vertex('__AI_SDK_GOOGLE_MODEL__'),
+})
+```
+
+`observationalModel` applies to both the observer and reflector roles, and overrides the `observerModelId` and `reflectorModelId` state, so the observational-memory model can no longer be switched at runtime. To use different models for the observer and reflector, pass a custom `memory` instance instead.
+
 ## Custom storage
 
 Connect to a remote database instead of the default local SQLite:

--- a/docs/src/mastra-code/reference.mdx
+++ b/docs/src/mastra-code/reference.mdx
@@ -55,6 +55,7 @@ const {
 | `subagents` | `HarnessSubagent[]` | Explore, Plan, Execute | Custom subagent definitions |
 | `storage` | `StorageConfig` | Local LibSQL | Database configuration |
 | `initialState` | `Partial<MastraCodeState>` | Default state | Initial harness state values |
+| `observationalModel` | `LanguageModel` | Resolved from state | Model instance for observational memory (observer and reflector). Overrides `observerModelId` and `reflectorModelId`. Ignored when `memory` is set |
 | `heartbeatHandlers` | `HeartbeatHandler[]` | Default handlers | Background task definitions |
 | `resolveModel` | `(modelId: string, options?: { thinkingLevel?: ThinkingLevel; remapForCodexOAuth?: boolean; requestContext?: RequestContext }) => ResolvedModel` | Default resolver | Custom model resolution function |
 
@@ -83,7 +84,8 @@ Subagent definitions for spawning focused child agents.
 | `instructions` | `string` | Yes | System prompt for the subagent |
 | `tools` | `ToolsInput` | No | Tools available to this subagent |
 | `allowedHarnessTools` | `string[]` | No | Tool IDs from harness tools this subagent can use |
-| `defaultModelId` | `string` | No | Default model for this subagent type |
+| `defaultModelId` | `string` | No | Default model ID for this subagent type |
+| `defaultModel` | `MastraLanguageModel` | No | Default model instance for this subagent type. Takes precedence over `defaultModelId`; a runtime model override still wins |
 | `maxSteps` | `number` | No | Optional maximum number of steps for the spawned subagent; defaults to `50` |
 | `stopWhen` | `LoopOptions['stopWhen']` | No | Optional stop condition for the spawned subagent loop |
 

--- a/docs/src/plugins/remark-model-tokens/models.ts
+++ b/docs/src/plugins/remark-model-tokens/models.ts
@@ -28,6 +28,7 @@ export const MODEL_TOKENS: Record<string, string> = {
 
   // Google
   __GATEWAY_GOOGLE_MODEL__: 'google/gemini-2.5-flash',
+  __AI_SDK_GOOGLE_MODEL__: 'gemini-2.5-flash',
 
   // Alibaba
   __GATEWAY_ALIBABA_MODEL__: 'alibaba/qwen-max',

--- a/mastracode/src/agents/__tests__/memory.test.ts
+++ b/mastracode/src/agents/__tests__/memory.test.ts
@@ -1,0 +1,68 @@
+import type { RequestContext } from '@mastra/core/request-context';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture the options passed to the Memory constructor so we can assert which
+// model each observational-memory role is wired to.
+const { memoryOpts } = vi.hoisted(() => {
+  const memoryOpts: { last: any } = { last: null };
+  return { memoryOpts };
+});
+
+vi.mock('@mastra/memory', () => ({
+  Memory: class {
+    constructor(opts: any) {
+      memoryOpts.last = opts;
+    }
+  },
+}));
+
+vi.mock('@mastra/fastembed', () => ({
+  fastembed: { small: { id: 'fastembed-small' } },
+}));
+
+vi.mock('../../utils/project', () => ({
+  getOmScope: () => 'thread',
+}));
+
+// Avoid pulling in the model resolver's AuthStorage (filesystem access at import).
+vi.mock('../model', () => ({
+  resolveModel: vi.fn(),
+}));
+
+import { getDynamicMemory } from '../memory';
+
+const storage = { id: 'store' } as any;
+
+function callFactory(observationalModel?: any) {
+  const factory = getDynamicMemory(storage, undefined, observationalModel);
+  // No harness state set — the factory falls back to defaults.
+  factory({ requestContext: { get: () => undefined } as unknown as RequestContext });
+  return memoryOpts.last.options.observationalMemory;
+}
+
+describe('getDynamicMemory observationalModel override', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memoryOpts.last = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the provided instance for both observer and reflector', () => {
+    const model = { modelId: 'vertex-gemini' } as any;
+    const om = callFactory(model);
+
+    expect(om.observation.model).toBe(model);
+    expect(om.reflection.model).toBe(model);
+  });
+
+  it('falls back to the dynamic model resolvers when no instance is provided', () => {
+    const om = callFactory();
+
+    // Without an override, each role keeps its state-driven resolver function.
+    expect(typeof om.observation.model).toBe('function');
+    expect(typeof om.reflection.model).toBe('function');
+  });
+});

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -1,4 +1,5 @@
 import type { HarnessRequestContext } from '@mastra/core/harness';
+import type { LanguageModel } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { MastraCompositeStore } from '@mastra/core/storage';
 import type { MastraVector } from '@mastra/core/vector';
@@ -11,6 +12,7 @@ import { resolveModel } from './model';
 
 let cachedMemory: Memory | null = null;
 let cachedMemoryKey: string | null = null;
+let cachedMemoryOverride: LanguageModel | undefined;
 
 /**
  * Read harness state from requestContext.
@@ -75,8 +77,17 @@ Drop caveman for: security warnings, irreversible action confirmations, multi-st
  * Dynamic memory factory function.
  * Reads OM thresholds from harness state via requestContext.
  * Model functions also read from requestContext (no mutable bridge needed).
+ *
+ * When `observationalModel` is provided, it is used for both the observer and reflector
+ * roles instead of resolving the model from `observerModelId` / `reflectorModelId` state.
+ * This lets callers pass a provider-configured model instance (e.g. Vertex AI) that a
+ * string model ID can't represent.
  */
-export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraVector) {
+export function getDynamicMemory(
+  storage: MastraCompositeStore,
+  vector?: MastraVector,
+  observationalModel?: LanguageModel,
+) {
   return ({ requestContext }: { requestContext: RequestContext }) => {
     const state = getHarnessState(requestContext);
     const omScope = state?.omScope ?? getOmScope(state?.projectPath);
@@ -88,7 +99,7 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
     const observerPreviousObservationTokens = 1000;
     const observeAttachments = state?.observeAttachments;
     const cacheKey = `${obsThreshold}:${refThreshold}:${omScope}:${observerPreviousObservationTokens}:${caveman ? 1 : 0}:${observeAttachments}`;
-    if (cachedMemory && cachedMemoryKey === cacheKey) {
+    if (cachedMemory && cachedMemoryKey === cacheKey && cachedMemoryOverride === observationalModel) {
       return cachedMemory;
     }
 
@@ -115,7 +126,7 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
           observation: {
             bufferTokens: isResourceScope ? false : 1 / 5,
             bufferActivation: isResourceScope ? undefined : 2000,
-            model: getObserverModel,
+            model: observationalModel ?? getObserverModel,
             messageTokens: obsThreshold,
             blockAfter: 2,
             previousObserverTokens: observerPreviousObservationTokens,
@@ -126,7 +137,7 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
           reflection: {
             bufferActivation: isResourceScope ? undefined : 1 / 2,
             blockAfter: 1.1,
-            model: getReflectorModel,
+            model: observationalModel ?? getReflectorModel,
             observationTokens: refThreshold,
             instruction: reflectionInstruction,
           },
@@ -134,6 +145,7 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
       },
     });
     cachedMemoryKey = cacheKey;
+    cachedMemoryOverride = observationalModel;
 
     return cachedMemory;
   };

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -10,10 +10,6 @@ import type { MastraCodeState } from '../schema';
 import { getOmScope } from '../utils/project';
 import { resolveModel } from './model';
 
-let cachedMemory: Memory | null = null;
-let cachedMemoryKey: string | null = null;
-let cachedMemoryOverride: LanguageModel | undefined;
-
 /**
  * Read harness state from requestContext.
  * Used by both the memory factory and the OM model functions.
@@ -88,6 +84,8 @@ export function getDynamicMemory(
   vector?: MastraVector,
   observationalModel?: LanguageModel,
 ) {
+  let cachedMemory: Memory | null = null;
+  let cachedMemoryKey: string | null = null;
   return ({ requestContext }: { requestContext: RequestContext }) => {
     const state = getHarnessState(requestContext);
     const omScope = state?.omScope ?? getOmScope(state?.projectPath);
@@ -99,7 +97,7 @@ export function getDynamicMemory(
     const observerPreviousObservationTokens = 1000;
     const observeAttachments = state?.observeAttachments;
     const cacheKey = `${obsThreshold}:${refThreshold}:${omScope}:${observerPreviousObservationTokens}:${caveman ? 1 : 0}:${observeAttachments}`;
-    if (cachedMemory && cachedMemoryKey === cacheKey && cachedMemoryOverride === observationalModel) {
+    if (cachedMemory && cachedMemoryKey === cacheKey) {
       return cachedMemory;
     }
 
@@ -145,7 +143,6 @@ export function getDynamicMemory(
       },
     });
     cachedMemoryKey = cacheKey;
-    cachedMemoryOverride = observationalModel;
 
     return cachedMemory;
   };

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -184,6 +184,15 @@ export interface MastraCodeConfig {
    * that mastracode's `resolveModel` cannot resolve.
    */
   memory?: HarnessConfig<MastraCodeState>['memory'];
+  /**
+   * Model instance for observational memory (used for both the observer and reflector roles).
+   * Use this when the observational-memory model needs provider configuration a string ID can't
+   * carry (e.g. a Vertex AI project, region, or credentials in CI/CD). When set, it overrides the
+   * `observerModelId` / `reflectorModelId` state, so the observational-memory model can no longer be
+   * switched at runtime. To use different models for the observer and reflector, pass a custom
+   * `memory` instance instead. Ignored when `memory` is also provided.
+   */
+  observationalModel?: LanguageModel;
   /** Browser provider for browser automation tools. When set, the agent gains access to browser tools. */
   browser?: HarnessConfig<MastraCodeState>['browser'];
   /** PubSub for signal routing. When crossProcessPubSub is true, thread locks are disabled. */
@@ -398,7 +407,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   // Vector store for recall search (separate DB file to avoid bloating main storage)
   const vectorStore = await createVectorStore(storageConfig, storageResult.backend);
 
-  const memory = config?.memory ?? getDynamicMemory(storage, vectorStore);
+  const memory = config?.memory ?? getDynamicMemory(storage, vectorStore, config?.observationalModel);
 
   // MCP
   const mcpManager = config?.disableMcp ? undefined : createMcpManager(project.rootPath, configDir, config?.mcpServers);
@@ -612,7 +621,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
         };
       }
     }
-    return model ? { ...filtered, defaultModelId: model } : filtered;
+    // Don't inject a mode-default model ID over a subagent that supplies its own model instance.
+    return model && !sa.defaultModel ? { ...filtered, defaultModelId: model } : filtered;
   });
 
   // Build initial state with global preferences

--- a/packages/core/src/harness/subagent-tool.test.ts
+++ b/packages/core/src/harness/subagent-tool.test.ts
@@ -1132,7 +1132,14 @@ describe('createSubagentTool model resolution', () => {
 
     const tool = createSubagentTool({
       subagents: [
-        { id: 'explore', name: 'Explore', description: 'd', instructions: 'i', defaultModel, defaultModelId: 'openai/gpt-5.5' },
+        {
+          id: 'explore',
+          name: 'Explore',
+          description: 'd',
+          instructions: 'i',
+          defaultModel,
+          defaultModelId: 'openai/gpt-5.5',
+        },
       ],
       resolveModel,
     });

--- a/packages/core/src/harness/subagent-tool.test.ts
+++ b/packages/core/src/harness/subagent-tool.test.ts
@@ -1094,3 +1094,120 @@ describe('createSubagentTool forked subagent behavior', () => {
     expect(streamOpts.memory).toBeUndefined();
   });
 });
+
+describe('createSubagentTool model resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // The instance must reach the Agent verbatim so provider config (e.g. Vertex AI) is preserved.
+  it('uses a subagent `defaultModel` instance directly without calling resolveModel', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('ok'));
+    const defaultModel = { modelId: 'vertex-gemini', specificationVersion: 'v2' } as any;
+    const resolveModel = vi.fn().mockReturnValue({ modelId: 'gateway-model' });
+
+    const tool = createSubagentTool({
+      subagents: [{ id: 'explore', name: 'Explore', description: 'd', instructions: 'i', defaultModel }],
+      resolveModel,
+    });
+
+    const result = await (tool as any).execute(
+      { agentType: 'explore', task: 'task' },
+      { requestContext: new RequestContext(), agent: { toolCallId: 'tc-1' } },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(resolveModel).not.toHaveBeenCalled();
+    expect(MockAgent.lastConstructorOpts.model).toBe(defaultModel);
+  });
+
+  it('prefers a `defaultModel` instance over a `defaultModelId` string', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('ok'));
+    const defaultModel = { modelId: 'vertex-gemini', specificationVersion: 'v2' } as any;
+    const resolveModel = vi.fn().mockReturnValue({ modelId: 'gateway-model' });
+
+    const tool = createSubagentTool({
+      subagents: [
+        { id: 'explore', name: 'Explore', description: 'd', instructions: 'i', defaultModel, defaultModelId: 'openai/gpt-5.5' },
+      ],
+      resolveModel,
+    });
+
+    await (tool as any).execute(
+      { agentType: 'explore', task: 'task' },
+      { requestContext: new RequestContext(), agent: { toolCallId: 'tc-2' } },
+    );
+
+    expect(resolveModel).not.toHaveBeenCalled();
+    expect(MockAgent.lastConstructorOpts.model).toBe(defaultModel);
+  });
+
+  it('lets an explicit per-invocation model override the `defaultModel` instance', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('ok'));
+    const defaultModel = { modelId: 'vertex-gemini', specificationVersion: 'v2' } as any;
+    const resolved = { modelId: 'gateway-model' };
+    const resolveModel = vi.fn().mockReturnValue(resolved);
+
+    const tool = createSubagentTool({
+      subagents: [{ id: 'explore', name: 'Explore', description: 'd', instructions: 'i', defaultModel }],
+      resolveModel,
+    });
+
+    await (tool as any).execute(
+      { agentType: 'explore', task: 'task', modelId: 'openai/gpt-5.5' },
+      { requestContext: new RequestContext(), agent: { toolCallId: 'tc-3' } },
+    );
+
+    expect(resolveModel).toHaveBeenCalledWith('openai/gpt-5.5');
+    expect(MockAgent.lastConstructorOpts.model).toBe(resolved);
+  });
+
+  it('lets the model picker (getSubagentModelId) override the `defaultModel` instance', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('ok'));
+    const defaultModel = { modelId: 'vertex-gemini', specificationVersion: 'v2' } as any;
+    const resolved = { modelId: 'gateway-model' };
+    const resolveModel = vi.fn().mockReturnValue(resolved);
+
+    const tool = createSubagentTool({
+      subagents: [{ id: 'explore', name: 'Explore', description: 'd', instructions: 'i', defaultModel }],
+      resolveModel,
+    });
+
+    const requestContext = new RequestContext();
+    const harnessCtx: Partial<HarnessRequestContext> = {
+      emitEvent: vi.fn(),
+      getSubagentModelId: () => 'anthropic/claude-sonnet-4-6',
+    };
+    requestContext.set('harness', harnessCtx);
+
+    await (tool as any).execute(
+      { agentType: 'explore', task: 'task' },
+      { requestContext, agent: { toolCallId: 'tc-4' } },
+    );
+
+    expect(resolveModel).toHaveBeenCalledWith('anthropic/claude-sonnet-4-6');
+    expect(MockAgent.lastConstructorOpts.model).toBe(resolved);
+  });
+
+  it('errors when a subagent has neither a model instance, a model ID, nor a fallback', async () => {
+    const resolveModel = vi.fn();
+
+    const tool = createSubagentTool({
+      subagents: [{ id: 'explore', name: 'Explore', description: 'd', instructions: 'i' }],
+      resolveModel,
+    });
+
+    const result = await (tool as any).execute(
+      { agentType: 'explore', task: 'task' },
+      { requestContext: new RequestContext(), agent: { toolCallId: 'tc-5' } },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No model available for subagent');
+    expect(resolveModel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -799,7 +799,7 @@ export interface CreateSubagentToolOptions {
   resolveModel: (modelId: string) => MastraLanguageModel;
   /** Resolved harness tools (already evaluated from DynamicArgument) */
   harnessTools?: ToolsInput;
-  /** Fallback model ID when subagent definition has no defaultModelId */
+  /** Fallback model ID when a subagent definition has no `defaultModel` instance or `defaultModelId` */
   fallbackModelId?: string;
   /** Returns the parent model ID for display when a subagent call is forked. */
   getParentModelId?: () => string;
@@ -1015,22 +1015,41 @@ Use this tool when:
           }
         }
 
-        // Resolve model: explicit arg → harness setting → subagent default → fallback
+        // Resolve model: explicit arg / picker → subagent defaultModel instance → defaultModelId string → fallback
         const harnessModelId = harnessCtx?.getSubagentModelId?.({ agentType }) ?? undefined;
-        const maybeModelId = modelId ?? harnessModelId ?? definition.defaultModelId ?? fallbackModelId;
-        if (!maybeModelId) {
-          return { content: 'No model ID available for subagent. Configure defaultModelId.', isError: true };
-        }
-        resolvedModelId = maybeModelId;
+        const explicitModelId = modelId ?? harnessModelId;
 
         let model: MastraLanguageModel;
-        try {
-          model = resolveModel(resolvedModelId);
-        } catch (err) {
-          return {
-            content: `Failed to resolve model "${resolvedModelId}": ${err instanceof Error ? err.message : String(err)}`,
-            isError: true,
-          };
+        if (explicitModelId) {
+          resolvedModelId = explicitModelId;
+          try {
+            model = resolveModel(explicitModelId);
+          } catch (err) {
+            return {
+              content: `Failed to resolve model "${explicitModelId}": ${err instanceof Error ? err.message : String(err)}`,
+              isError: true,
+            };
+          }
+        } else if (definition.defaultModel) {
+          model = definition.defaultModel;
+          resolvedModelId = definition.defaultModel.modelId ?? `${definition.id}-model`; // display only
+        } else {
+          const fallbackId = definition.defaultModelId ?? fallbackModelId;
+          if (!fallbackId) {
+            return {
+              content: 'No model available for subagent. Configure `defaultModel` or `defaultModelId`.',
+              isError: true,
+            };
+          }
+          resolvedModelId = fallbackId;
+          try {
+            model = resolveModel(fallbackId);
+          } catch (err) {
+            return {
+              content: `Failed to resolve model "${fallbackId}": ${err instanceof Error ? err.message : String(err)}`,
+              isError: true,
+            };
+          }
         }
 
         subagentToRun = new Agent({

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -103,6 +103,14 @@ export interface HarnessSubagent {
   /** Default model ID for this subagent type (e.g., "anthropic/claude-sonnet-4-20250514") */
   defaultModelId?: string;
 
+  /**
+   * Default model instance for this subagent type. Use this when the model needs
+   * provider configuration a string ID can't carry (e.g. a Vertex AI project,
+   * region, or credentials). Takes precedence over `defaultModelId`, but an
+   * explicit runtime override (a per-invocation model or the model picker) still wins.
+   */
+  defaultModel?: MastraLanguageModel;
+
   /** Optional maximum number of steps for this subagent's execution loop */
   maxSteps?: number;
 

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -132,8 +132,8 @@ export interface HarnessSubagent {
    * instructions and tools, preserving prompt-cache prefix.
    *
    * The parent's `instructions`, `tools`, `allowedHarnessTools`,
-   * `allowedWorkspaceTools`, and `defaultModelId` fields on the definition
-   * are ignored when a run is forked — the parent agent is used as-is.
+   * `allowedWorkspaceTools`, `defaultModelId`, and `defaultModel` fields on the
+   * definition are ignored when a run is forked — the parent agent is used as-is.
    *
    * Callers can override per-invocation by passing `forked` in the tool
    * input. Forked subagents require memory to be configured on the Harness.


### PR DESCRIPTION
## Description

Lets `createMastraCode()` configure subagent and observational-memory models with fully-configured model **instances**, not just string model IDs. A string ID can't carry provider configuration such as a Vertex AI project, region, or credentials — which is required to run Mastra Code headless in CI/CD, where there is no interactive model picker. The main agent already accepts a model instance; this brings subagents and the observational model to parity.

- Added `defaultModel?: MastraLanguageModel` to `HarnessSubagent` (`@mastra/core`); the subagent tool uses the instance directly, with precedence: explicit per-invocation model / picker → `defaultModel` instance → `defaultModelId` string → fallback.
- Added `observationalModel?: LanguageModel` to `MastraCodeConfig`; `getDynamicMemory` uses it for both the observer and reflector roles, overriding the `observerModelId` / `reflectorModelId` state. (`initialState` can't hold an instance because harness state is serialized to storage — hence a top-level config field.)
- Made the observational-memory cache override-aware so it can't return a memory built with a different model.
- Guarded mastracode's mode-map injection so a subagent's own `defaultModel` instance isn't shadowed by a mode-default string ID.
- Added an `__AI_SDK_GOOGLE_MODEL__` docs model token for examples.
- Documented both options in `docs/src/mastra-code/customization.mdx` and `reference.mdx`; added `@mastra/core` and `mastracode` changesets (minor).

All changes are additive and backward-compatible: setting none of the new fields preserves existing behavior.

## Related Issue(s)

Fixes #15610

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

You can now give subagents and the observational memory the actual, fully-configured model objects (including provider credentials and region) instead of only model names, so automated workflows (like CI/CD) and per-subagent configurations work without manual setup.

## Summary

This PR lets Mastra Code accept fully-configured model instances (not just string model IDs) for subagents and for observational memory so provider configuration (project, region, credentials) can be carried programmatically for headless CI/CD and per-subagent/provider setups.

## Key Changes

### Implementation
- Subagents
  - Added optional defaultModel?: MastraLanguageModel to HarnessSubagent.
  - Resolution precedence: explicit per-invocation model / model picker → defaultModel (instance) → defaultModelId (string) → fallback.
  - createSubagentTool uses a provided defaultModel instance directly (no resolveModel call) and sets resolvedModelId for display when applicable.
  - Mode-map injection guarded so a mode-default string ID does not override a subagent’s defaultModel instance.
- Observational memory
  - MastraCodeConfig gains observationalModel?: LanguageModel.
  - getDynamicMemory(storage, vector, observationalModel?) accepts an observationalModel instance and, when provided, wires that instance to both observer and reflector roles (overriding observerModelId/reflectorModelId state).
  - Memory caching scoped per getDynamicMemory invocation: module-level cache variables removed and replaced with per-factory cachedMemory/cachedMemoryKey so returned memories respect the observationalModel passed in.

### Tests
- Added unit tests verifying:
  - getDynamicMemory uses an observationalModel instance for both observation and reflection and preserves resolver functions when no instance is given.
  - createSubagentTool model precedence: uses defaultModel instances directly, allows explicit modelId or model-picker to override (and trigger resolveModel), and errors when no model is available.

### Documentation & Tooling
- Docs updated (customization.mdx, reference.mdx) to document defaultModel and observationalModel, precedence rules, and guidance (e.g., use custom memory for separate observer/reflector models).
- Added docs model token __AI_SDK_GOOGLE_MODEL__ → 'gemini-2.5-flash'.
- Changesets added for `@mastra/core` and `mastracode` (minor).

## Behavior Notes
- Backward-compatible: new fields are optional and preserve previous behavior when unset.
- observationalModel must be supplied at top-level config (not in serialized initialState); setting it fixes the observational-memory model (cannot be switched at runtime). Provide a custom memory instance if separate observer/reflector models are required.
- Caching and mode-injection logic updated so instance-based models are respected and not shadowed by string IDs.

## Related
Fixes `#15610`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->