### PR TITLE
fix(core): preserve modelId empty-string fallback in step-finish response

### DIFF
--- a/.changeset/quiet-pumpkins-wave.md
+++ b/.changeset/quiet-pumpkins-wave.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fix `response.modelId` being overwritten with `undefined` in `step-finish` chunks when the upstream model stream omits `modelId` from `response-metadata`. The explicit empty-string fallback was placed before a `...otherMetadata` spread that could overwrite it with `undefined`. Moved the `modelId` assignment after the spread so the fallback always wins.
+
+This restores consistent `response.modelId === ''` behavior across both the direct and evented agentic-loop workflow paths.

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -704,9 +704,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 response: {
                   id: chunk.payload.id || '',
                   timestamp: (chunk.payload.metadata?.timestamp as Date) || new Date(),
+                  ...otherMetadata,
                   modelId:
                     (chunk.payload.metadata?.modelId as string) || (chunk.payload.metadata?.model as string) || '',
-                  ...otherMetadata,
                   messages: chunk.payload.messages?.nonUser || [],
                   dbMessages: self.messageList.get.response.db(),
                   // We have to cast this until messageList can take generics also and type metadata, it was too


### PR DESCRIPTION
The two failing integration-test snapshots in `observability/mastra` (`Expected: "" / Actual: undefined` on `model_generation.span.attributes.responseModel`) were a symptom of an ordering bug in `packages/core/src/stream/base/output.ts`. Fixing the bug at the source restores the intended `""` behavior across both workflow paths.

### Initial approach (rejected)

The first version of this PR simply removed `"responseModel": ""` from the two affected snapshot files. That worked locally and unblocked CI, but on closer inspection it was masking the real bug:

- Setting `MASTRA_EVENTED_EXECUTION=true` would have flipped the snapshots back to failing (the evented path *does* emit `""`).
- 34 other snapshots in the same package already expect `"responseModel": "mock-model-id"` or `""` — those work because their mocks supply `modelId`. The two "fixed" snapshots would have become the odd ones out, hiding a latent runtime inconsistency.

So we dug into why the two paths produced different values for the same input and found a fixable runtime bug instead.

### Root cause

In the `step-finish` chunk handler, the response object was constructed as:

```ts
response: {
  id: chunk.payload.id || '',
  timestamp: ...,
  modelId: (chunk.payload.metadata?.modelId as string)
    || (chunk.payload.metadata?.model as string)
    || '',
  ...otherMetadata,  // ← spread AFTER, overwrites modelId
  messages: ...,
}
```

`otherMetadata` (`chunk.payload.metadata` minus `providerMetadata`/`request`) carries `modelId: undefined` (key present, value undefined) when the model stream's `response-metadata` chunk omits `modelId`. The spread then overwrites the explicit `''` fallback with `undefined`.

### Why this surfaced now

- `#16796` (Jun 9) forced the agentic-loop to use `createEventedWorkflow` unconditionally. The evented path parses step input through `llmIterationOutputSchema` (Zod), which strips `undefined` optional keys. As a side effect, `otherMetadata` had no `modelId` key → the explicit `''` fallback survived → snapshots were updated to expect `"responseModel": ""`.
- `#17727` (Jun 10) reverted that to env-gated: `createDirectWorkflow` by default, `createEventedWorkflow` only when `MASTRA_EVENTED_EXECUTION === 'true'`. The direct path skips the Zod parse, so the `modelId: undefined` key reaches the spread and overwrites the fallback. Snapshots not updated → CI failure.

The underlying ordering bug existed in both paths; the evented path masked it via Zod's strip-undefined behavior.

### Fix

Move the `modelId` assignment after `...otherMetadata` so the explicit `''` fallback wins regardless of which workflow path produced the metadata. Leave `id` and `timestamp` before the spread (existing behavior — they're intentionally allowed to be overridden by metadata values).

### Verification

- `observability/mastra`: 917 passed, 2 skipped (was 2 failed).
- `packages/core` loop tests: 321 passed, 15 skipped, 19 todo.
- `packages/core` agent tests: 2164 passed, 75 skipped.
- Both `MASTRA_EVENTED_EXECUTION=true` and default (direct) paths produce `response.modelId === ""` when upstream omits `modelId`.

Reproduce the original failure: `cd observability/mastra && pnpm vitest run src/integration-tests.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're putting stickers on a notebook. You first put a blank sticker (empty string) in a special spot, but then you dump a bag of other stickers on top, and one of those has a "nothing" sticker that covers up your blank one. This PR fixes it by putting your blank sticker on *after* dumping the bag, so it stays visible.

## Overview

This PR fixes a bug in the `step-finish` response metadata handler where the fallback value for `modelId` (an empty string `""`) was being overwritten with `undefined`. This caused snapshot test failures in the observability/mastra integration tests that expected `response.modelId` to be `""`.

## Root Cause

In `packages/core/src/stream/base/output.ts`, the response object was being constructed with an explicit `modelId` fallback *before* spreading `otherMetadata`. When `otherMetadata` contained a key for `modelId` with an `undefined` value, the spread operation would overwrite the intentional `""` fallback with `undefined`.

The bug was masked previously by Zod parsing (which strips `undefined` keys), but became visible when the workflow execution path was reverted to direct execution that skips Zod parsing.

## Changes

**packages/core/src/stream/base/output.ts:**
- Reordered the response object construction to assign `modelId` *after* spreading `otherMetadata`, ensuring the explicit fallback cannot be overwritten
- `id` and `timestamp` remain before the spread (intentionally designed to be overridable)

**.changeset/quiet-pumpkins-wave.md:**
- Added changeset documenting the patch for `@mastra/core`

## Verification

- Observability/mastra integration tests: 917 passed, 2 skipped (previously 2 failed)
- Both evented and direct execution paths now produce consistent `response.modelId === ""` when upstream omits `modelId`
- Core loop and agent tests reported passing counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->