### PR TITLE
ci: skip scheduled community-automation jobs on forks

### DIFF
--- a/.github/workflows/cron-every-2h.yml
+++ b/.github/workflows/cron-every-2h.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   discord-github-sync:
     name: Discord to GitHub Sync
+    # Only run on the main repository, not on forks
+    if: ${{ github.repository == 'mastra-ai/mastra' }}
     uses: ./.github/workflows/call-external-mastra-workflow.yml
     with:
       workflow_name: discordSyncWorkflow
@@ -25,6 +27,8 @@ jobs:
 
   discord-triage:
     name: Discord Triage
+    # Only run on the main repository, not on forks
+    if: ${{ github.repository == 'mastra-ai/mastra' }}
     uses: ./.github/workflows/call-external-mastra-workflow.yml
     with:
       workflow_name: discordToGithubWorkflow
@@ -35,6 +39,8 @@ jobs:
 
   github-issues-follow-up:
     name: GitHub Issues Follow-Up
+    # Only run on the main repository, not on forks
+    if: ${{ github.repository == 'mastra-ai/mastra' }}
     uses: ./.github/workflows/call-external-mastra-workflow.yml
     with:
       workflow_name: githubIssueManagerWorkflow


### PR DESCRIPTION
## Description

`cron-every-2h.yml` (Discord to GitHub Sync, Discord Triage, GitHub Issues Follow-Up) is the only scheduled workflow **without** the fork guard that the other scheduled workflows already use:

- `delete-spam-issues.yml` → `if: ${{ github.repository == 'mastra-ai/mastra' }}`
- `cron-alpha-publish.yml` → `if: ${{ github.repository == 'mastra-ai/mastra' && github.ref == 'refs/heads/main' }}`

On any fork with Actions enabled, its three jobs actually execute every two hours, call Mastra Cloud with empty `vars.MASTRA_CLOUD_BASE_URL` / `secrets.MASTRA_TRIAGE_JWT_KEY`, and fail with exit code 3 — ~36 red job runs and failure-notification emails per day, per fork (example: [a fork run failing exactly this way](https://github.com/BeamusWayne/mastra/actions/runs/27313554827)).

This PR adds the same job-level guard (comment + condition copied verbatim from `delete-spam-issues.yml`) to the three jobs, so forks skip silently in ~1s the way the sibling crons already do. Zero behavior change in `mastra-ai/mastra` — the condition is always true here.

## Related issue(s)

Fixes #17815

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Validation

- YAML parses; all three jobs keep `uses:` with the added job-level `if:` (job-level `if` is valid on reusable-workflow-call jobs).
- Pattern is identical to the guards already running in `delete-spam-issues.yml` (skips in ~1s on forks, runs normally upstream).
- CI-only change: no code, no changeset needed.

## Checklist

- [x] I have made corresponding changes to the documentation (N/A — CI only)
- [x] I have added tests that prove my fix is effective (N/A — workflow config; validated by YAML parse + sibling-pattern equivalence)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR prevents scheduled automation tasks from running on repository forks (copies). Without this change, when someone forks the repository, these automated tasks still try to run every 2 hours but fail because they can't access the necessary credentials and information that only exist in the main repository.

## Changes

Modified `.github/workflows/cron-every-2h.yml` to add repository guards to three scheduled jobs:

- `discord-github-sync`
- `discord-triage`
- `github-issues-follow-up`

Each job now includes a condition (`if: github.repository == 'mastra-ai/mastra'`) that prevents execution on forks while preserving the original behavior in the main repository.

## Impact

- Eliminates repeated job failures on forks caused by missing environment variables and secrets
- Aligns `cron-every-2h.yml` with the fork-guard pattern already implemented in other scheduled workflows (`delete-spam-issues.yml`, `cron-alpha-publish.yml`)
- Workflow configuration change only; no impact on production code

## Type

Bug fix

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
