### PR TITLE
feat(playground-ui): redesign resize handles with shared gradient indicator

### DIFF
--- a/.changeset/petite-needles-find.md
+++ b/.changeset/petite-needles-find.md
@@ -1,0 +1,10 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Redesigned resize handles across the studio. The sidebar and panel separators now show a subtle gradient line that fades in on hover and stays visible for the whole drag — including when the sidebar is collapsed to icons and the cursor moves away from the handle (the handle now captures the pointer during the gesture). `PanelSeparator` accepts a new `variant` prop: `line` (default) fits panels with a visible container edge, `pill` shows a floating pill for panels without one.
+
+```tsx
+<PanelSeparator />            // gradient line (default)
+<PanelSeparator variant="pill" />  // floating pill
+```

--- a/.changeset/rare-squids-create.md
+++ b/.changeset/rare-squids-create.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Removed the right padding on the agent memory sidebar so it sits flush against the panel resize handle.

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.test.tsx
@@ -5,12 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MainSidebar } from './main-sidebar';
 import { MainSidebarProvider } from './main-sidebar-context';
 
-beforeEach(() => {
+const mockMatchMedia = (matches: boolean) => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     configurable: true,
     value: vi.fn().mockImplementation((query: string) => ({
-      matches: true,
+      matches,
       media: query,
       onchange: null,
       addEventListener: vi.fn(),
@@ -20,12 +20,90 @@ beforeEach(() => {
       dispatchEvent: vi.fn(),
     })),
   });
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
 });
 
 afterEach(() => cleanup());
 
+// jsdom has no PointerEvent constructor; the handlers only read MouseEvent
+// fields plus `pointerId`, so a MouseEvent with `pointerId` patched on works.
+const pointerEvent = (type: string, init: MouseEventInit & { pointerId: number }) => {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true, ...init });
+  Object.assign(event, { pointerId: init.pointerId });
+  return event;
+};
+
+describe('MainSidebar resize handle gesture', () => {
+  const renderCollapsedSidebar = () => {
+    mockMatchMedia(false);
+    render(
+      <MainSidebarProvider defaultState="collapsed">
+        <MainSidebar>
+          <MainSidebar.Nav>
+            <MainSidebar.NavList>
+              <MainSidebar.NavLink link={{ name: 'Agents', url: '/agents' }} />
+            </MainSidebar.NavList>
+          </MainSidebar.Nav>
+        </MainSidebar>
+      </MainSidebarProvider>,
+    );
+    const scope = document.querySelector('[data-sidebar-scope]');
+    if (!scope) throw new Error('sidebar scope not rendered');
+    return { scope, separator: screen.getByRole('separator') };
+  };
+
+  it('engages gesture-active on press, before any movement', () => {
+    const { scope, separator } = renderCollapsedSidebar();
+
+    fireEvent(separator, pointerEvent('pointerdown', { button: 0, pointerId: 1, clientX: 64 }));
+    expect(scope.getAttribute('data-sidebar-gesture')).toBe('active');
+
+    // Sub-threshold wiggle (≤ 5px) is still a held gesture, not a hover state.
+    fireEvent(window, pointerEvent('pointermove', { pointerId: 1, clientX: 67 }));
+    expect(scope.getAttribute('data-sidebar-gesture')).toBe('active');
+
+    fireEvent(window, pointerEvent('pointerup', { pointerId: 1 }));
+    expect(scope.getAttribute('data-sidebar-gesture')).toBeNull();
+  });
+
+  it('captures the pointer so the handle keeps its hover styles for the whole drag', () => {
+    const { separator } = renderCollapsedSidebar();
+    const setPointerCapture = vi.fn();
+    separator.setPointerCapture = setPointerCapture;
+
+    fireEvent(separator, pointerEvent('pointerdown', { button: 0, pointerId: 1, clientX: 64 }));
+    expect(setPointerCapture).toHaveBeenCalledWith(1);
+  });
+
+  it('keeps gesture-active for the whole collapsed drag, even far from the handle', () => {
+    const { scope, separator } = renderCollapsedSidebar();
+
+    fireEvent(separator, pointerEvent('pointerdown', { button: 0, pointerId: 1, clientX: 64 }));
+
+    // Past the drag threshold but still inside the snap zone (< collapseBelow):
+    // pointer is way off the 8px handle, sidebar stays collapsed.
+    fireEvent(window, pointerEvent('pointermove', { pointerId: 1, clientX: 100 }));
+    expect(scope.getAttribute('data-sidebar-gesture')).toBe('active');
+
+    // Crossing collapseBelow expands the sidebar (state change + re-render).
+    fireEvent(window, pointerEvent('pointermove', { pointerId: 1, clientX: 250 }));
+    expect(scope.getAttribute('data-sidebar-gesture')).toBe('active');
+
+    // Back into the snap zone: collapses again mid-drag.
+    fireEvent(window, pointerEvent('pointermove', { pointerId: 1, clientX: 120 }));
+    expect(scope.getAttribute('data-sidebar-gesture')).toBe('active');
+
+    fireEvent(window, pointerEvent('pointerup', { pointerId: 1 }));
+    expect(scope.getAttribute('data-sidebar-gesture')).toBeNull();
+  });
+});
+
 describe('MainSidebar mobile drawer', () => {
   it('opens as an accessible dialog on mobile', () => {
+    mockMatchMedia(true);
     render(
       <MainSidebarProvider>
         <MainSidebar.MobileTrigger />

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.tsx
@@ -2,6 +2,7 @@ import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { useCallback, useEffect, useRef } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { useMainSidebar } from './main-sidebar-context';
+import { ResizeHandleIndicator } from '@/ds/primitives/resize-handle-indicator';
 import { VisuallyHidden } from '@/ds/primitives/visually-hidden';
 import { cn } from '@/lib/utils';
 
@@ -52,11 +53,21 @@ export function MainSidebarRoot({ children, className }: MainSidebarRootProps) {
       event.preventDefault();
 
       draggedRef.current = false;
+      // Active styles on press, not after drag threshold.
+      setGestureActive(true);
 
       const startX = event.clientX;
 
       const handle = event.currentTarget;
       const pointerId = event.pointerId;
+
+      // Capture pointer: keeps :hover + col-resize cursor on handle for the
+      // whole drag, even when cursor leaves the hotzone (collapsed snap-zone).
+      try {
+        handle.setPointerCapture(pointerId);
+      } catch {
+        // Pointer already gone.
+      }
 
       // WYSIWYG resize: sidebar width = cursor X relative to sidebar's left edge.
       // Captured once — sidebar is `shrink-0`, left edge is stable during the gesture.
@@ -74,7 +85,6 @@ export function MainSidebarRoot({ children, className }: MainSidebarRootProps) {
           draggedRef.current = true;
           document.body.style.cursor = 'col-resize';
           document.body.style.userSelect = 'none';
-          setGestureActive(true);
         }
 
         // Single rule, no started-state branch: cursor position alone defines state.
@@ -265,14 +275,11 @@ export function MainSidebarRoot({ children, className }: MainSidebarRootProps) {
           'focus-visible:outline-hidden',
         )}
       >
-        <span
-          aria-hidden
+        <ResizeHandleIndicator
           className={cn(
-            'block h-10 w-0.5 translate-x-0 group-hover:translate-x-1.5 rounded-full bg-transparent scale-50 group-hover:scale-100',
-            'transition duration-150 ease-out motion-reduce:transition-none pointer-events-none',
-            'group-hover:bg-surface5',
-            'group-focus-visible:bg-accent1',
-            'in-data-[sidebar-gesture=active]:bg-accent1',
+            'group-hover:opacity-100',
+            'group-focus-visible:opacity-100 group-focus-visible:via-accent1',
+            'in-data-[sidebar-gesture=active]:opacity-100 in-data-[sidebar-gesture=active]:via-neutral6/45',
           )}
         />
       </div>

--- a/packages/playground-ui/src/ds/primitives/resize-handle-indicator.tsx
+++ b/packages/playground-ui/src/ds/primitives/resize-handle-indicator.tsx
@@ -1,0 +1,30 @@
+import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+// line: gradient hairline, fits a visible container edge.
+// pill: small floating pill, for handles with no container around.
+const indicatorVariants = cva(
+  'block pointer-events-none transition-all duration-150 ease-out motion-reduce:transition-none',
+  {
+    variants: {
+      variant: {
+        line: 'h-3/4 w-px bg-linear-to-b from-transparent via-neutral6/25 to-transparent opacity-0',
+        pill: 'h-10 w-0.5 rounded-full bg-surface5',
+      },
+    },
+    defaultVariants: {
+      variant: 'line',
+    },
+  },
+);
+
+export type ResizeHandleIndicatorProps = VariantProps<typeof indicatorVariants> & {
+  className?: string;
+};
+
+// Shared visual for resize handles (sidebar, panel separators).
+// Consumers reveal/emphasize it via their own state variant classes.
+export const ResizeHandleIndicator = ({ variant, className }: ResizeHandleIndicatorProps) => (
+  <span aria-hidden className={cn(indicatorVariants({ variant }), className)} />
+);

--- a/packages/playground-ui/src/lib/resize/separator.tsx
+++ b/packages/playground-ui/src/lib/resize/separator.tsx
@@ -1,7 +1,28 @@
 import { Separator } from 'react-resizable-panels';
+import { ResizeHandleIndicator } from '@/ds/primitives/resize-handle-indicator';
 import { cn } from '@/lib/utils';
 
-export const PanelSeparator = () => {
+export type PanelSeparatorProps = {
+  /** `line` fits a visible container edge; `pill` floats when there is none. */
+  variant?: 'line' | 'pill';
+};
+
+const stateClasses = {
+  line: cn(
+    'group-hover/separator:opacity-100',
+    "group-data-[separator='hover']/separator:opacity-100",
+    "group-data-[separator='active']/separator:opacity-100 group-data-[separator='active']/separator:via-neutral6/45",
+    'group-focus-visible/separator:opacity-100 group-focus-visible/separator:via-accent1',
+  ),
+  pill: cn(
+    'group-hover/separator:h-12 group-hover/separator:w-1',
+    "group-data-[separator='hover']/separator:h-12 group-data-[separator='hover']/separator:w-1",
+    "group-data-[separator='active']/separator:h-12 group-data-[separator='active']/separator:w-1 group-data-[separator='active']/separator:bg-accent1",
+    'group-focus-visible/separator:bg-accent1',
+  ),
+};
+
+export const PanelSeparator = ({ variant = 'line' }: PanelSeparatorProps) => {
   return (
     <Separator
       className={cn(
@@ -9,18 +30,12 @@ export const PanelSeparator = () => {
         'focus:outline-hidden focus-visible:outline-hidden',
       )}
     >
-      <span aria-hidden className={cn('absolute inset-y-0 -left-1 -right-1', 'cursor-col-resize touch-none')}>
-        <span
-          className={cn(
-            'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
-            'h-10 w-0.5 bg-surface5 pointer-events-none rounded-full',
-            'transition-all duration-150 ease-out motion-reduce:transition-none',
-            'group-hover/separator:h-12 group-hover/separator:w-1 group-hover/separator:bg-surface5',
-            "group-data-[separator='hover']/separator:h-12 group-data-[separator='hover']/separator:w-1 group-data-[separator='hover']/separator:bg-surface5",
-            "group-data-[separator='active']/separator:h-12 group-data-[separator='active']/separator:w-1 group-data-[separator='active']/separator:bg-accent1",
-            'group-focus-visible/separator:h-12 group-focus-visible/separator:w-1 group-focus-visible/separator:bg-accent1',
-          )}
-        />
+      {/* Hit zone wider than the 0px separator; indicator centered inside. */}
+      <span
+        aria-hidden
+        className="absolute inset-y-0 -left-1 -right-1 flex items-center justify-center cursor-col-resize touch-none"
+      >
+        <ResizeHandleIndicator variant={variant} className={stateClasses[variant]} />
       </span>
     </Separator>
   );

--- a/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
@@ -26,7 +26,7 @@ export function MemorySidebar({
   const { selectedTab, handleTabChange } = useMemorySidebarTab();
 
   return (
-    <div className="h-full w-full min-w-0 p-2">
+    <div className="h-full w-full min-w-0 p-2 pr-0">
       <div className="bg-surface3 rounded-studio-panel border border-border1/50 flex h-full min-h-0 flex-col overflow-hidden">
         {hasMemory ? (
           <Tabs


### PR DESCRIPTION
The sidebar resize handle and the panel separators now share one visual: a `ResizeHandleIndicator` primitive that renders a subtle gradient hairline, hidden at rest and fading in on hover.

Two real fixes came out of this. The sidebar handle now captures the pointer on press, so `:hover` and the `col-resize` cursor stick to the handle for the whole drag — before, dragging the collapsed (icon-only) sidebar through the snap-zone dropped all hover styles while you were still dragging. And the gesture-active styles now engage on press instead of after the 5px drag threshold. Both are covered by unit tests on the `data-sidebar-gesture` contract.

`PanelSeparator` also gets a `variant` prop since the hairline only reads well against a visible container edge:

```tsx
<PanelSeparator />                 // gradient line (default)
<PanelSeparator variant="pill" />  // floating pill, for panels without a container
```

Side note: the old separator hover/active state classes were never actually generated into the app CSS, so its grow-on-hover effect silently never worked — works now. Also removed the right padding on the agent memory sidebar so it sits flush against the separator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR redesigns the draggable resize handles that let you resize sidebar and panel sections in the UI. The main change is creating a reusable "indicator" (a subtle glowing line) that shows up when you hover over or drag the resize handles, and making sure the drag cursor stays visible and consistent even when you're dragging the sidebar all the way to collapse it.

## Overview

This PR introduces a new `ResizeHandleIndicator` primitive component that provides a shared, reusable design for resize handle indicators. It updates the sidebar and panel separator implementations to use this primitive, improves pointer event handling during resize gestures, and makes minor layout adjustments to the agent memory sidebar.

## New Primitive Component

**ResizeHandleIndicator** (`packages/playground-ui/src/ds/primitives/resize-handle-indicator.tsx`)
- A new UI primitive that renders a subtle, aria-hidden indicator for resize handles
- Supports two visual variants via `class-variance-authority`:
  - `line`: A vertical gradient hairline (default)
  - `pill`: A small floating pill style for panels without container edges
- Provides `ResizeHandleIndicatorProps` type combining variant configuration with optional custom className

## Sidebar Resize Handle Improvements

**MainSidebar** (`packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.tsx`)
- Refactored desktop resize handle to use the new `ResizeHandleIndicator` component
- Gesture-active styling (`data-sidebar-gesture` attribute) now applies immediately on pointer down, rather than waiting for a 5px drag threshold
- Added pointer capture via `setPointerCapture()` (with fallback error handling) to ensure the col-resize cursor and hover styles persist throughout the entire drag, even when dragging the collapsed snap-zone
- Removes duplicate gesture-active state changes from threshold-crossing logic

## Panel Separator Updates

**PanelSeparator** (`packages/playground-ui/src/lib/resize/separator.tsx`)
- Refactored from a static implementation to a prop-driven component
- Now accepts optional `variant` prop (`'line' | 'pill'`, defaults to `'line'`)
- Renders `ResizeHandleIndicator` with variant-specific styling
- Restores grow-on-hover behavior with proper CSS class application

## Layout Adjustments

**MemorySidebar** (`packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx`)
- Removed right padding (`pr-0`) so the sidebar sits flush against the panel resize separator

## Testing Enhancements

**MainSidebar Tests** (`packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.test.tsx`)
- Added reusable `mockMatchMedia(matches)` helper for environment setup
- Added `pointerEvent()` helper to simulate pointer events (bridges jsdom's lack of native `PointerEvent` support)
- Introduced new test suite "MainSidebar resize handle gesture" that validates:
  - `data-sidebar-gesture` state transitions on pointer press/move/release
  - Pointer capture behavior and gesture continuity across drag movements
- Updated mobile drawer test to explicitly configure media query mocking

## Version Bumps

- Minor version bump for `@mastra/playground-ui` documenting the new `ResizeHandleIndicator` primitive and `PanelSeparator` variant prop
- Patch version bump for layout adjustments to the agent memory sidebar

<!-- end of auto-generated comment: release notes by coderabbit.ai -->