### PR TITLE
fix(server-adapters): don't kill HTTP streams on unserializable chunks

### DIFF
--- a/.changeset/cozy-owls-type.md
+++ b/.changeset/cozy-owls-type.md
@@ -1,0 +1,11 @@
+---
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/nestjs': patch
+'@mastra/hono': patch
+'@mastra/koa': patch
+---
+
+Fixed workflow and agent HTTP streams silently dying when a stream chunk contained values that cannot be serialized to JSON (such as BigInt produced by zod coercions in structuredOutput schemas). In Studio this made workflow step nodes appear stuck in the "running" state even though the run completed successfully on the server.
+
+Unserializable values are now safely converted (BigInt to string, circular references to "[Circular]"). If a chunk still cannot be serialized at all, it is skipped with an error log that includes the route path and reason, instead of killing the stream and dropping all remaining chunks. Fixes [#17821](https://github.com/mastra-ai/mastra/issues/17821)

--- a/.changeset/tricky-banks-nail.md
+++ b/.changeset/tricky-banks-nail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Added a `serializeStreamChunk` helper to `@mastra/server/server-adapter` that server adapters use to safely serialize stream chunks. It converts values that JSON cannot represent (BigInt to string, circular references to "[Circular]") and reports a serialization error instead of throwing, so one bad chunk can no longer terminate an HTTP stream. Part of the fix for [#17821](https://github.com/mastra-ai/mastra/issues/17821)

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -30,6 +30,7 @@ import { getBuiltInRouteFGAConfig } from './routes/fga-manifest';
 
 export * from './routes';
 export { redactStreamChunk } from './redact';
+export { serializeStreamChunk, type SerializedStreamChunk } from './serialize';
 export {
   MASTRA_AUTH_MODE_KEY,
   MASTRA_CLIENT_TYPE_HEADER,

--- a/packages/server/src/server/server-adapter/serialize.test.ts
+++ b/packages/server/src/server/server-adapter/serialize.test.ts
@@ -9,7 +9,9 @@ function expectJson(result: ReturnType<typeof serializeStreamChunk>): string {
 describe('serializeStreamChunk', () => {
   it('serializes plain JSON values', () => {
     const result = serializeStreamChunk({ type: 'workflow-finish', payload: { workflowStatus: 'success' } });
-    expect(expectJson(result)).toBe(JSON.stringify({ type: 'workflow-finish', payload: { workflowStatus: 'success' } }));
+    expect(expectJson(result)).toBe(
+      JSON.stringify({ type: 'workflow-finish', payload: { workflowStatus: 'success' } }),
+    );
   });
 
   it('serializes BigInt values as strings', () => {

--- a/packages/server/src/server/server-adapter/serialize.test.ts
+++ b/packages/server/src/server/server-adapter/serialize.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { serializeStreamChunk } from './serialize';
+
+function expectJson(result: ReturnType<typeof serializeStreamChunk>): string {
+  expect(result.ok).toBe(true);
+  return (result as { ok: true; json: string }).json;
+}
+
+describe('serializeStreamChunk', () => {
+  it('serializes plain JSON values', () => {
+    const result = serializeStreamChunk({ type: 'workflow-finish', payload: { workflowStatus: 'success' } });
+    expect(expectJson(result)).toBe(JSON.stringify({ type: 'workflow-finish', payload: { workflowStatus: 'success' } }));
+  });
+
+  it('serializes BigInt values as strings', () => {
+    const chunk = { type: 'workflow-step-result', payload: { output: { count: 42n } } };
+    const json = expectJson(serializeStreamChunk(chunk));
+    expect(JSON.parse(json)).toEqual({ type: 'workflow-step-result', payload: { output: { count: '42' } } });
+  });
+
+  it('serializes circular references as "[Circular]"', () => {
+    const payload: Record<string, unknown> = { id: 'step' };
+    payload.self = payload;
+    const json = expectJson(serializeStreamChunk({ type: 'workflow-step-result', payload }));
+    expect(JSON.parse(json)).toEqual({ type: 'workflow-step-result', payload: { id: 'step', self: '[Circular]' } });
+  });
+
+  it('returns the error when the chunk cannot be serialized at all', () => {
+    const chunk = {
+      type: 'workflow-step-result',
+      toJSON() {
+        throw new Error('boom from toJSON');
+      },
+    };
+    const result = serializeStreamChunk(chunk);
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; error: Error }).error.message).toBe('boom from toJSON');
+  });
+});

--- a/packages/server/src/server/server-adapter/serialize.ts
+++ b/packages/server/src/server/server-adapter/serialize.ts
@@ -1,0 +1,24 @@
+import { safeStringify } from '@mastra/core/utils';
+
+export type SerializedStreamChunk = { ok: true; json: string } | { ok: false; error: Error };
+
+/**
+ * Serializes a stream chunk to JSON for wire transport.
+ *
+ * Stream chunks can contain values that plain `JSON.stringify` throws on
+ * (e.g. BigInt produced by zod coercions/transforms in structuredOutput
+ * schemas, or circular references) — `safeStringify` handles those. A single
+ * bad chunk must never kill the whole stream — Studio relies on later chunks
+ * (`workflow-step-result`, `workflow-finish`) to render run state.
+ *
+ * Returns `{ ok: false, error }` if the chunk cannot be serialized at all
+ * (e.g. a throwing getter/toJSON) — callers should log the error, skip the
+ * chunk, and keep streaming.
+ */
+export function serializeStreamChunk(chunk: unknown): SerializedStreamChunk {
+  try {
+    return { ok: true, json: safeStringify(chunk) };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
+  }
+}

--- a/server-adapters/_test-utils/src/index.ts
+++ b/server-adapters/_test-utils/src/index.ts
@@ -11,4 +11,10 @@ export { createMCPTransportTestSuite, type MCPTransportTestConfig } from './mcp-
 export { createMultipartTestSuite, type MultipartTestSuiteConfig } from './multipart-test-suite';
 export { createHttpLoggingTestSuite, type HttpLoggingTestSuiteConfig } from './http-logging-test-suite';
 
-export { createDefaultTestContext, createStreamWithSensitiveData, consumeSSEStream } from './test-helpers';
+export {
+  createDefaultTestContext,
+  createStreamWithSensitiveData,
+  createStreamWithUnserializableChunk,
+  expectSerializedStreamChunks,
+  consumeSSEStream,
+} from './test-helpers';

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -1,6 +1,6 @@
 import { Agent, createMessageSignal, createSignal } from '@mastra/core/agent';
 import { Mastra } from '@mastra/core';
-import { Mock, vi } from 'vitest';
+import { expect, Mock, vi } from 'vitest';
 import { Workflow } from '@mastra/core/workflows';
 import { normalizeRoutePath } from './route-test-utils';
 import { createScorer } from '@mastra/core/evals';
@@ -1475,6 +1475,49 @@ export function createStreamWithSensitiveData(format: 'v1' | 'v2' = 'v2'): Reada
       controller.close();
     },
   });
+}
+
+/**
+ * Creates a ReadableStream for testing per-chunk serialization error handling
+ * (https://github.com/mastra-ai/mastra/issues/17821).
+ *
+ * Emits three chunks:
+ * 1. a chunk whose payload contains a BigInt (not JSON-serializable natively — must be coerced to a string)
+ * 2. a chunk that cannot be serialized at all (throwing toJSON — must be skipped without killing the stream)
+ * 3. a final chunk that must still be delivered after the unserializable one
+ *
+ * Use {@link expectSerializedStreamChunks} to assert on the consumed result.
+ */
+export function createStreamWithUnserializableChunk(): ReadableStream {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'workflow-step-result', payload: { output: { count: 42n } } });
+      controller.enqueue({
+        type: 'poison',
+        toJSON() {
+          throw new Error('cannot serialize');
+        },
+      });
+      controller.enqueue({ type: 'workflow-finish', payload: { workflowStatus: 'success' } });
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Asserts the chunks consumed from {@link createStreamWithUnserializableChunk}:
+ * BigInt coerced to a string, the poison chunk skipped, and the final chunk delivered.
+ */
+export function expectSerializedStreamChunks(chunks: any[]): void {
+  const stepResult = chunks.find(c => c.type === 'workflow-step-result');
+  expect(stepResult).toBeDefined();
+  expect(stepResult.payload.output).toEqual({ count: '42' });
+
+  expect(chunks.find(c => c.type === 'poison')).toBeUndefined();
+
+  const finish = chunks.find(c => c.type === 'workflow-finish');
+  expect(finish, 'chunks after an unserializable chunk must still be delivered').toBeDefined();
+  expect(finish.payload.workflowStatus).toBe('success');
 }
 
 /**

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -9,6 +9,8 @@ import {
   createRouteAdapterTestSuite,
   createDefaultTestContext,
   createStreamWithSensitiveData,
+  createStreamWithUnserializableChunk,
+  expectSerializedStreamChunks,
   consumeSSEStream,
   createMultipartTestSuite,
 } from '@internal/server-adapter-test-utils';
@@ -557,6 +559,67 @@ describe('Express Server Adapter', () => {
       const textDelta = chunks.find(c => c.type === 'text-delta');
       expect(textDelta).toBeDefined();
       expect(textDelta.textDelta).toBe('Hello');
+    });
+  });
+
+  // Repro for https://github.com/mastra-ai/mastra/issues/17821 — a chunk that
+  // JSON.stringify can't handle (e.g. a BigInt step output) used to throw inside
+  // the stream loop and silently close the HTTP stream.
+  describe('Stream Chunk Serialization', () => {
+    let context: AdapterTestContext;
+    let server: Server | null = null;
+
+    beforeEach(async () => {
+      context = await createDefaultTestContext();
+    });
+
+    afterEach(async () => {
+      if (server) {
+        await new Promise<void>(resolve => {
+          server!.close(() => resolve());
+        });
+        server = null;
+      }
+    });
+
+    it('serializes BigInt chunks and skips unserializable chunks without killing the stream', async () => {
+      const app = express();
+      app.use(express.json());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/unserializable-stream',
+        responseType: 'stream',
+        streamFormat: 'sse',
+        handler: async () => createStreamWithUnserializableChunk(),
+      };
+
+      app.use(adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      server = await new Promise<Server>(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to get server address');
+      }
+
+      const response = await fetch(`http://localhost:${address.port}/test/unserializable-stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+      const chunks = await consumeSSEStream(response.body);
+      expectSerializedStreamChunks(chunks);
     });
   });
 

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -12,6 +12,7 @@ import {
   isZodError,
   normalizeQueryParams,
   redactStreamChunk,
+  serializeStreamChunk,
 } from '@mastra/server/server-adapter';
 import type { Application, NextFunction, Request, Response } from 'express';
 export { createAuthMiddleware } from './auth-middleware';
@@ -177,10 +178,20 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
           // Optionally redact sensitive data (system prompts, tool definitions, API keys) before sending to the client
           const shouldRedact = this.streamOptions?.redact ?? true;
           const outputValue = shouldRedact ? redactStreamChunk(value) : value;
+          // A chunk that can't be serialized must not kill the stream — skip it and keep streaming
+          const serialized = serializeStreamChunk(outputValue);
+          if (!serialized.ok) {
+            this.mastra.getLogger()?.error('Failed to serialize stream chunk, skipping', {
+              path: route.path,
+              chunkType: (outputValue as { type?: string })?.type,
+              error: serialized.error.message,
+            });
+            continue;
+          }
           if (streamFormat === 'sse') {
-            res.write(`data: ${JSON.stringify(outputValue)}\n\n`);
+            res.write(`data: ${serialized.json}\n\n`);
           } else {
-            res.write(JSON.stringify(outputValue) + '\x1E');
+            res.write(serialized.json + '\x1E');
           }
         }
       }

--- a/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
+++ b/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
@@ -8,6 +8,8 @@ import {
   createRouteAdapterTestSuite,
   createDefaultTestContext,
   createStreamWithSensitiveData,
+  createStreamWithUnserializableChunk,
+  expectSerializedStreamChunks,
   consumeSSEStream,
   createMultipartTestSuite,
 } from '@internal/server-adapter-test-utils';
@@ -480,6 +482,58 @@ describe('Fastify Server Adapter', () => {
       const textDelta = chunks.find(c => c.type === 'text-delta');
       expect(textDelta).toBeDefined();
       expect(textDelta.textDelta).toBe('Hello');
+    });
+  });
+
+  // Repro for https://github.com/mastra-ai/mastra/issues/17821 — a chunk that
+  // JSON.stringify can't handle (e.g. a BigInt step output) used to throw inside
+  // the stream loop and silently close the HTTP stream.
+  describe('Stream Chunk Serialization', () => {
+    let context: AdapterTestContext;
+    let app: FastifyInstance | null = null;
+
+    beforeEach(async () => {
+      context = await createDefaultTestContext();
+    });
+
+    afterEach(async () => {
+      if (app) {
+        app.server.closeAllConnections?.();
+        await app.close();
+        app = null;
+      }
+    });
+
+    it('serializes BigInt chunks and skips unserializable chunks without killing the stream', async () => {
+      app = Fastify();
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/unserializable-stream',
+        responseType: 'stream',
+        streamFormat: 'sse',
+        handler: async () => createStreamWithUnserializableChunk(),
+      };
+
+      app.addHook('preHandler', adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      const address = await app.listen({ port: 0 });
+
+      const response = await fetch(`${address}/test/unserializable-stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+      const chunks = await consumeSSEStream(response.body);
+      expectSerializedStreamChunks(chunks);
     });
   });
 

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -11,6 +11,7 @@ import {
   isZodError,
   normalizeQueryParams,
   redactStreamChunk,
+  serializeStreamChunk,
 } from '@mastra/server/server-adapter';
 import type { FastifyInstance, FastifyReply, FastifyRequest, preHandlerHookHandler, RouteHandlerMethod } from 'fastify';
 export { createAuthMiddleware } from './auth-middleware';
@@ -236,10 +237,20 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
           // Optionally redact sensitive data (system prompts, tool definitions, API keys) before sending to the client
           const shouldRedact = this.streamOptions?.redact ?? true;
           const outputValue = shouldRedact ? redactStreamChunk(value) : value;
+          // A chunk that can't be serialized must not kill the stream — skip it and keep streaming
+          const serialized = serializeStreamChunk(outputValue);
+          if (!serialized.ok) {
+            this.mastra.getLogger()?.error('Failed to serialize stream chunk, skipping', {
+              path: route.path,
+              chunkType: (outputValue as { type?: string })?.type,
+              error: serialized.error.message,
+            });
+            continue;
+          }
           if (streamFormat === 'sse') {
-            reply.raw.write(`data: ${JSON.stringify(outputValue)}\n\n`);
+            reply.raw.write(`data: ${serialized.json}\n\n`);
           } else {
-            reply.raw.write(JSON.stringify(outputValue) + '\x1E');
+            reply.raw.write(serialized.json + '\x1E');
           }
         }
       }

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -10,6 +10,8 @@ import {
   createRouteAdapterTestSuite,
   createDefaultTestContext,
   createStreamWithSensitiveData,
+  createStreamWithUnserializableChunk,
+  expectSerializedStreamChunks,
   consumeSSEStream,
   createMultipartTestSuite,
 } from '@internal/server-adapter-test-utils';
@@ -465,6 +467,50 @@ describe('Hono Server Adapter', () => {
       const textDelta = chunks.find(c => c.type === 'text-delta');
       expect(textDelta).toBeDefined();
       expect(textDelta.textDelta).toBe('Hello');
+    });
+  });
+
+  // Repro for https://github.com/mastra-ai/mastra/issues/17821 — a chunk that
+  // JSON.stringify can't handle (e.g. a BigInt step output) used to throw inside
+  // the stream loop and silently close the HTTP stream, so Studio never received
+  // the remaining chunks and workflow nodes stayed visually "running" forever.
+  describe('Stream Chunk Serialization', () => {
+    let context: AdapterTestContext;
+
+    beforeEach(async () => {
+      context = await createDefaultTestContext();
+    });
+
+    it('serializes BigInt chunks and skips unserializable chunks without killing the stream', async () => {
+      const app = new Hono();
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/unserializable-stream',
+        responseType: 'stream',
+        streamFormat: 'sse',
+        handler: async () => createStreamWithUnserializableChunk(),
+      };
+
+      app.use('*', adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      const response = await app.request(
+        new Request('http://localhost/test/unserializable-stream', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const chunks = await consumeSSEStream(response.body);
+      expectSerializedStreamChunks(chunks);
     });
   });
 

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -11,6 +11,7 @@ import {
   isZodError,
   normalizeQueryParams,
   redactStreamChunk,
+  serializeStreamChunk,
 } from '@mastra/server/server-adapter';
 import { toReqRes, toFetchResponse } from 'fetch-to-node';
 import type { Context, HonoRequest, MiddlewareHandler } from 'hono';
@@ -193,10 +194,20 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
               // Optionally redact sensitive data (system prompts, tool definitions, API keys) before sending to the client
               const shouldRedact = this.streamOptions?.redact ?? true;
               const outputValue = shouldRedact ? redactStreamChunk(value) : value;
+              // A chunk that can't be serialized must not kill the stream — skip it and keep streaming
+              const serialized = serializeStreamChunk(outputValue);
+              if (!serialized.ok) {
+                this.mastra.getLogger()?.error('Failed to serialize stream chunk, skipping', {
+                  path: route.path,
+                  chunkType: (outputValue as { type?: string })?.type,
+                  error: serialized.error.message,
+                });
+                continue;
+              }
               if (streamFormat === 'sse') {
-                await stream.write(`data: ${JSON.stringify(outputValue)}\n\n`);
+                await stream.write(`data: ${serialized.json}\n\n`);
               } else {
-                await stream.write(JSON.stringify(outputValue) + '\x1E');
+                await stream.write(serialized.json + '\x1E');
               }
             }
           }

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -9,6 +9,8 @@ import {
   createRouteAdapterTestSuite,
   createDefaultTestContext,
   createStreamWithSensitiveData,
+  createStreamWithUnserializableChunk,
+  expectSerializedStreamChunks,
   consumeSSEStream,
   createMultipartTestSuite,
 } from '@internal/server-adapter-test-utils';
@@ -886,6 +888,67 @@ describe('Koa Server Adapter', () => {
       const textDelta = chunks.find(c => c.type === 'text-delta');
       expect(textDelta).toBeDefined();
       expect(textDelta.textDelta).toBe('Hello');
+    });
+  });
+
+  // Repro for https://github.com/mastra-ai/mastra/issues/17821 — a chunk that
+  // JSON.stringify can't handle (e.g. a BigInt step output) used to throw inside
+  // the stream loop and silently close the HTTP stream.
+  describe('Stream Chunk Serialization', () => {
+    let context: AdapterTestContext;
+    let server: Server | null = null;
+
+    beforeEach(async () => {
+      context = await createDefaultTestContext();
+    });
+
+    afterEach(async () => {
+      if (server) {
+        await new Promise<void>((resolve, reject) => {
+          server!.close(err => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+        server = null;
+      }
+    });
+
+    it('serializes BigInt chunks and skips unserializable chunks without killing the stream', async () => {
+      const app = new Koa();
+      app.use(bodyParser());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/unserializable-stream',
+        responseType: 'stream',
+        streamFormat: 'sse',
+        handler: async () => createStreamWithUnserializableChunk(),
+      };
+
+      app.use(adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+      const address = server!.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const response = await fetch(`http://localhost:${port}/test/unserializable-stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+      const chunks = await consumeSSEStream(response.body);
+      expectSerializedStreamChunks(chunks);
     });
   });
 

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -12,6 +12,7 @@ import {
   isZodError,
   normalizeQueryParams,
   redactStreamChunk,
+  serializeStreamChunk,
 } from '@mastra/server/server-adapter';
 import type Koa from 'koa';
 import type { Context, Middleware, Next } from 'koa';
@@ -577,10 +578,20 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
           // Optionally redact sensitive data (system prompts, tool definitions, API keys) before sending to the client
           const shouldRedact = this.streamOptions?.redact ?? true;
           const outputValue = shouldRedact ? redactStreamChunk(value) : value;
+          // A chunk that can't be serialized must not kill the stream — skip it and keep streaming
+          const serialized = serializeStreamChunk(outputValue);
+          if (!serialized.ok) {
+            this.mastra.getLogger()?.error('Failed to serialize stream chunk, skipping', {
+              path: route.path,
+              chunkType: (outputValue as { type?: string })?.type,
+              error: serialized.error.message,
+            });
+            continue;
+          }
           if (streamFormat === 'sse') {
-            ctx.res.write(`data: ${JSON.stringify(outputValue)}\n\n`);
+            ctx.res.write(`data: ${serialized.json}\n\n`);
           } else {
-            ctx.res.write(JSON.stringify(outputValue) + '\x1E');
+            ctx.res.write(serialized.json + '\x1E');
           }
         }
       }

--- a/server-adapters/nestjs/src/__tests__/stream-redaction.test.ts
+++ b/server-adapters/nestjs/src/__tests__/stream-redaction.test.ts
@@ -2,6 +2,8 @@ import { Readable } from 'node:stream';
 import {
   createDefaultTestContext,
   createStreamWithSensitiveData,
+  createStreamWithUnserializableChunk,
+  expectSerializedStreamChunks,
   consumeSSEStream,
 } from '@internal/server-adapter-test-utils';
 import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
@@ -208,6 +210,28 @@ describe('NestJS Adapter - Stream Data Redaction', () => {
       expect(text).not.toContain('data: ": heartbeat');
     } finally {
       unregisterRoute(commentRoute);
+    }
+  });
+
+  // Repro for https://github.com/mastra-ai/mastra/issues/17821 — a chunk that
+  // JSON.stringify can't handle (e.g. a BigInt step output) used to throw inside
+  // the stream loop and silently close the HTTP stream.
+  it('serializes BigInt chunks and skips unserializable chunks without killing the stream', async () => {
+    const unserializableRoute: ServerRoute<any, any, any> = {
+      method: 'POST',
+      path: '/test/unserializable-stream',
+      responseType: 'stream',
+      streamFormat: 'sse',
+      handler: async () => createStreamWithUnserializableChunk(),
+    };
+
+    registerRoute(unserializableRoute);
+    try {
+      await setupApp();
+      const chunks = await consumeStream('/test/unserializable-stream');
+      expectSerializedStreamChunks(chunks);
+    } finally {
+      unregisterRoute(unserializableRoute);
     }
   });
 

--- a/server-adapters/nestjs/src/interceptors/streaming.interceptor.ts
+++ b/server-adapters/nestjs/src/interceptors/streaming.interceptor.ts
@@ -1,5 +1,5 @@
 import type { MCPHttpTransportResult, MCPSseTransportResult } from '@mastra/server/handlers/mcp';
-import { redactStreamChunk } from '@mastra/server/server-adapter';
+import { redactStreamChunk, serializeStreamChunk } from '@mastra/server/server-adapter';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
 import type { Request, Response } from 'express';
@@ -164,11 +164,20 @@ export class StreamingInterceptor implements NestInterceptor {
           // Optionally redact sensitive data
           const outputValue = shouldRedact ? redactStreamChunk(value) : value;
 
+          // A chunk that can't be serialized must not kill the stream — skip it and keep streaming
+          const serialized = serializeStreamChunk(outputValue);
+          if (!serialized.ok) {
+            this.logger.error(
+              `Failed to serialize stream chunk, skipping (path: ${response.req?.path}, type: ${(outputValue as { type?: string })?.type}, error: ${serialized.error.message})`,
+            );
+            continue;
+          }
+
           if (streamFormat === 'sse') {
-            response.write(`data: ${JSON.stringify(outputValue)}\n\n`);
+            response.write(`data: ${serialized.json}\n\n`);
           } else {
             // Use record separator (\x1E) for stream format
-            response.write(JSON.stringify(outputValue) + '\x1E');
+            response.write(serialized.json + '\x1E');
           }
         }
       }


### PR DESCRIPTION
Fixes #17821

In Studio, a workflow step node calling `agent.generate(..., { structuredOutput })` could stay visually "running" forever even though the run completed and downstream steps executed. Root cause: if any stream chunk contains a value `JSON.stringify` can't handle (e.g. a `BigInt` from `z.coerce.bigint()` in a structuredOutput schema), the adapter's stream write loop threw and silently closed the HTTP stream — so the client never received `workflow-step-result` / `workflow-finish` and the graph froze, while the server kept running the workflow to completion.

```ts
// before: this schema killed the stream mid-run
const agentStep = createStep({
  // ...
  execute: async () => {
    const res = await agent.generate(prompt, {
      structuredOutput: { schema: z.object({ count: z.coerce.bigint() }) },
    });
    return res.object; // { count: 42n } → JSON.stringify throws → stream dies
  },
});
```

This adds a `serializeStreamChunk` helper to `@mastra/server/server-adapter` and uses it in all 5 adapters (hono, express, fastify, koa, nestjs) with per-chunk error handling. Values JSON can't represent are coerced via `safeStringify` (`BigInt` → string, circular refs → `"[Circular]"`), and if a chunk still can't be serialized it's skipped with an error log (route path + reason) instead of terminating the stream — so all remaining chunks still reach the client and the step node completes normally.

Test plan: new unit tests for `serializeStreamChunk` in `@mastra/server`, plus a shared end-to-end regression test (BigInt chunk + fully unserializable chunk + trailing chunk over a real SSE response) mirrored in every adapter test suite. All 5 adapter suites pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a workflow was sending data back to the browser (called "streaming"), if that data contained special values like `BigInt` that JavaScript's `JSON.stringify` can't handle, the entire data pipeline would suddenly break and close, leaving the user's screen showing the step as "still running" even though the work was done. This PR adds a smart handler that tries to convert those tricky values into something safe to send, and if it really can't, it just skips that one piece of data and keeps the pipeline open so other data gets through.

---

## Summary

This PR fixes issue `#17821`, where workflow step nodes in Studio could appear stuck in a "running" state despite successful server-side completion. The root cause: when HTTP/SSE stream adapters encountered JSON-unserializable values (e.g., `BigInt` from Zod coercions), the serialization would fail and silently close the stream, preventing workflow completion events from reaching the client.

### Core Fix

A new `serializeStreamChunk` helper was added to `@mastra/server/server-adapter` that:
- Converts otherwise-unserializable values safely using `safeStringify` (e.g., `BigInt` → string, circular references → `"[Circular]"`)
- Returns a result object: `{ ok: true; json: string }` on success or `{ ok: false; error: Error }` on failure
- Allows per-chunk error handling without terminating the stream

### Implementation

The fix is applied across all five server adapters (Hono, Express, Fastify, Koa, NestJS):
- Each adapter now calls `serializeStreamChunk` before writing chunks to the HTTP response
- If serialization fails, an error is logged (including route path and reason) and the problematic chunk is skipped
- Remaining chunks continue to stream normally, ensuring workflow-step-result and workflow-finish events reach the client
- Both SSE and non-SSE stream formatting are updated to use serialized output

### Testing

- New unit tests for `serializeStreamChunk` in `@mastra/server` verify: standard JSON serialization, BigInt coercion, circular reference handling, and error-on-toJSON scenarios
- Shared test helpers (`createStreamWithUnserializableChunk` and `expectSerializedStreamChunks`) were added to `server-adapters/_test-utils` and integrated into all five adapter test suites
- Regression tests confirm that streams with unserializable chunks complete successfully without terminating, resolving the Studio visual "stuck running" issue

### Changesets

Patch-level release notes were added for `@mastra/server` and all five adapter packages documenting the serialization fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->