### PR TITLE
fix(server): allow workflows:execute to start a workflow run

### DIFF
--- a/.changeset/workflows-create-run-execute-perm.md
+++ b/.changeset/workflows-create-run-execute-perm.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Allow `workflows:execute` to authorize `POST /workflows/:workflowId/create-run` and `POST /workflows/events`. Both routes previously required `workflows:write` (which is intended for editing workflow definitions); they now accept either `workflows:write` or `workflows:execute`. This unblocks Studio's "Run workflow" flow for roles that only have `*:execute` (e.g. WorkOS `member`) and aligns the broker push endpoint's permission with what it actually does (advance runtime state).

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -346,6 +346,10 @@ export const CREATE_WORKFLOW_RUN_ROUTE = createRoute({
   description: 'Creates a new workflow execution instance with an optional custom run ID',
   tags: ['Workflows'],
   requiresAuth: true,
+  // Creating a run is part of the execute flow (Studio/UI calls this before
+  // starting/streaming a workflow), so allow either permission. `write` is kept
+  // for back-compat with roles that already grant it.
+  requiresPermission: ['workflows:write', 'workflows:execute'],
   handler: async ({ mastra, workflowId, runId, resourceId, disableScorers, requestContext }) => {
     try {
       // Use effective resourceId (context key takes precedence over client-provided value)
@@ -1407,6 +1411,10 @@ export const RECEIVE_WORKFLOW_EVENT_ROUTE = createRoute({
     'Push-mode entry point for workflow events. Brokers (GCP Pub/Sub push, SNS, EventBridge) POST each event here; Mastra processes it through the same pipeline as pull-mode workers.',
   tags: ['Workflows', 'Worker'],
   requiresAuth: true,
+  // Broker push endpoint: it advances runtime state rather than editing
+  // definitions, so `workflows:execute` is the more accurate fit. `write` is
+  // kept for back-compat with service principals that already grant it.
+  requiresPermission: ['workflows:write', 'workflows:execute'],
   handler: (async ({ mastra, event }: ReceiveWorkflowEventHandlerArgs) => {
     try {
       // The wire schema carries `createdAt` as a string; coerce to Date here


### PR DESCRIPTION
## Summary

Two workflow routes were gated on `workflows:write` by convention:

- `POST /workflows/:workflowId/create-run` — called by Studio (and `@mastra/react`'s `useCreateWorkflowRun`) immediately before starting or streaming a workflow.
- `POST /workflows/events` — the broker push entry point used by GCP Pub/Sub push, SNS, and EventBridge.

`workflows:write` is intended for editing workflow definitions, not for advancing or kicking off runs, so roles that grant `*:execute` (e.g. the WorkOS `member` role, which resolves to `['*:read', '*:execute']`) could not start workflows from Studio even though they're allowed to execute them.

Both routes now use the existing array form of `requiresPermission` to accept **either** `workflows:write` **or** `workflows:execute`:

```ts
requiresPermission: ['workflows:write', 'workflows:execute']
```

Array semantics are already implemented in `server-adapter/index.ts` — the user needs ANY ONE of the listed permissions (`permissions.some(...)`). `workflows:write` is kept alongside `workflows:execute` for back-compat with roles already configured to grant it.

## Why two routes

- **`/create-run`** is part of the normal user-initiated execute flow; treating it as `write` blocks Studio for `*:execute`-only roles.
- **`/workflows/events`** is a broker → server callback that advances runtime state. `execute` is semantically more accurate than `write`; the change also lets operators wire broker service principals with a narrower role.

## Test plan

- `pnpm --filter ./packages/server generate:permissions` — no drift in `permissions.generated.ts`
- `pnpm --filter ./packages/server check:permissions` — ✓ generator matches `getEffectivePermission` for all routes
- `pnpm --filter ./packages/server test` — 60 files / 1771 tests passing
- `pnpm build:server` — green

## Changeset

`@mastra/server`: patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Summary

This PR fixes a permission issue where people with the ability to "execute workflows" (like WorkOS members) couldn't actually start or run workflows because the system was only checking for "write permissions." The fix simply allows both permissions to work for starting workflows, unblocking users who have execute-only access.

---

## Overview

This PR updates two workflow-related API endpoints to accept either `workflows:write` or `workflows:execute` permissions, whereas they previously required only `workflows:write`.

## Changes

### Routes Updated
- **POST /workflows/:workflowId/create-run** — used by Studio and `@mastra/react`'s `useCreateWorkflowRun` to start or stream workflows
- **POST /workflows/events** — broker push entry point for GCP Pub/Sub, SNS, and EventBridge

### Implementation
Both routes now declare:
```
requiresPermission: ['workflows:write', 'workflows:execute']
```

The array syntax (OR logic) is already supported by the server-adapter, so users need only one of these permissions.

## Rationale

- **Backward Compatibility**: `workflows:write` is retained so existing roles continue to work
- **Unblocks Execute-Only Roles**: Roles that grant `*:execute` but not `*:write` (e.g., WorkOS members) can now start workflows and have broker events advance runtime state
- **Aligns with Studio Workflow**: Unblocks Studio's "Run workflow" flow for execute-only users

## Testing

All verification checks passed:
- Permissions generation check (no drift in `permissions.generated.ts`)
- Permission checks validation (generator matches `getEffectivePermission` for all routes)
- Server tests: 60 files, 1,771 tests passing
- Build: green

## Version Bump

- `@mastra/server`: patch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->