### PR TITLE
fix(schema-compat): publish json-schema type dependency

### DIFF
--- a/.changeset/kind-lobsters-drum.md
+++ b/.changeset/kind-lobsters-drum.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed a packaging issue where `JSONSchema7` type imports could resolve to `any` for consumers without `@types/json-schema`, breaking type inference in `createTool` and other schema utilities.

--- a/packages/schema-compat/package.json
+++ b/packages/schema-compat/package.json
@@ -98,6 +98,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "@types/json-schema": "^7.0.15",
     "json-schema-to-zod": "^2.7.0",
     "zod-from-json-schema": "^0.5.2",
     "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5",
@@ -118,7 +119,6 @@
     "@internal/test-utils": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@standard-schema/spec": "^1.1.0",
-    "@types/json-schema": "^7.0.15",
     "@types/node": "22.19.15",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",

--- a/packages/schema-compat/src/schema.types.test.ts
+++ b/packages/schema-compat/src/schema.types.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+describe('schema-compat package metadata', () => {
+  it('publishes @types/json-schema for consumers', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+    ) as PackageJson;
+
+    expect(packageJson.dependencies?.['@types/json-schema']).toBe('^7.0.15');
+    expect(packageJson.devDependencies?.['@types/json-schema']).toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5016,6 +5016,9 @@ importers:
 
   packages/schema-compat:
     dependencies:
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
       json-schema-to-zod:
         specifier: ^2.7.0
         version: 2.7.0
@@ -5062,9 +5065,6 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
-      '@types/json-schema':
-        specifier: ^7.0.15
-        version: 7.0.15
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15


### PR DESCRIPTION
title: fix(schema-compat): publish json-schema type dependency

Fixes #17826

## Summary

`@mastra/schema-compat` publishes public declaration files that import `JSONSchema7` from `json-schema`, but the package only declares `@types/json-schema` as a development dependency. Consumers without that type package elsewhere in their tree can see `createTool` input inference collapse to `any`.

## Root cause

`PublicSchema` includes `JSONSchema7`, and that type comes from `@types/json-schema`, not from the runtime `json-schema` package itself. Because the declaration provider is dev-only, downstream installs can load the public `.d.ts` through an implicit-any import; that `any` member poisons the schema union and makes `InferPublicSchema` infer `any` for tool input schemas.

## Changes

- `packages/schema-compat/package.json`: move `@types/json-schema` into published dependencies (~2 lines)
- `pnpm-lock.yaml`: reflect the dependency-scope change
- `packages/schema-compat/src/schema.types.test.ts`: add a dependency-scope regression for the public `JSONSchema7` type import (~15 lines)
- `packages/core/src/tools/createtool-input-types.test-d.ts`: keep existing inference coverage unchanged and rerun it as a smoke check (~0 lines expected)

## What is NOT changed

`PublicSchema`, `InferPublicSchema`, and JSON Schema runtime conversion behavior are unchanged. This PR only fixes the package metadata that makes the existing public types safe for consumers.

## Out of scope

The issue also suggests auditing other generated declaration surfaces that mention `json-schema`. This PR stays on the confirmed `@mastra/schema-compat` package boundary that causes the `createTool` inference regression.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Linked related issue
- [x] Added or updated tests
- [ ] Documentation updated (if applicable)
- [x] Addressed all Coderabbit comments

## Test plan

- `pnpm --filter ./packages/schema-compat test src/schema.types.test.ts` — passed, `2/2` tests. Covers: the new package-metadata regression that asserts `@types/json-schema` is published in `dependencies` and absent from `devDependencies`, plus the package's existing colocated `schema.types` test file included by the Vitest run.
- `pnpm --filter ./packages/core test src/tools/createtool-input-types.test-d.ts` — failed before reaching a change-specific regression signal. Covers: existing `createTool` input inference smoke coverage when the package type-test suite is healthy. Current blocker: unrelated pre-existing `packages/core` type-test failures in workflow and workspace files, including missing `@internal/ai-sdk-v4`, missing `logger` properties, and unrelated `InferPublicSchema`/`workflow-schema-types.test-d.ts` errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR ensures the package that provides schema types actually ships the JSON Schema type definitions it references so TypeScript won't treat those types as "any" for people who install the package.

## Problem Statement

Published declaration files in `@mastra/schema-compat` import JSONSchema7 from 'json-schema', but `@types/json-schema` was only a devDependency. Consumers without that types package could have JSONSchema7 resolve to any, collapsing type inference (e.g., createTool input types) to any.

## Changes Made

1. Moved `@types/json-schema` from devDependencies to dependencies in packages/schema-compat/package.json (now at "^7.0.15").
2. Updated pnpm-lock.yaml to reflect the dependency scope change (included in the PR).
3. Added a Vitest regression test at packages/schema-compat/src/schema.types.test.ts that asserts:
   - package.json lists `@types/json-schema` in dependencies with version '^7.0.15'
   - `@types/json-schema` is absent from devDependencies
4. Added a changeset patch (.changeset/kind-lobsters-drum.md) documenting the fix.
5. Re-ran an existing createtool input inference type-test in packages/core as a smoke check (noting unrelated pre-existing failures in packages/core remain).

## Impact

- No runtime or exported API changes (PublicSchema, InferPublicSchema, and JSON Schema runtime conversion unchanged).
- Packaging fix ensures consumers receive proper JSONSchema7 types, restoring TypeScript inference for createTool and preventing InferPublicSchema from collapsing to any.
- Tests: schema-compat type tests pass locally (2/2); new regression test included to prevent future regressions.

## Notes / Alternatives

- Alternatives considered: vendor a local JSONSchema7 type or audit other declaration surfaces referencing 'json-schema' for similar scoping errors; chosen fix is minimal and low-risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->