### PR TITLE
fix(core): use configured ids for signal messages

### DIFF
--- a/.changeset/core-signal-message-id-generator.md
+++ b/.changeset/core-signal-message-id-generator.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Use the configured ID generator for message rows persisted through agent signal APIs.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -50,6 +50,50 @@ function createTextStreamModel(responseText: string) {
   });
 }
 
+function createBlockingFirstTextStreamModel(firstResponseText: string, laterResponseText: string) {
+  let releaseFirst!: () => void;
+  const firstFinished = new Promise<void>(resolve => {
+    releaseFirst = resolve;
+  });
+  let streamCount = 0;
+  const model = new MockLanguageModelV2({
+    doStream: async () => {
+      streamCount += 1;
+      const currentStreamCount = streamCount;
+      const responseText = currentStreamCount === 1 ? firstResponseText : laterResponseText;
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: new ReadableStream({
+          async start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'response-metadata',
+              id: `blocking-stream-${currentStreamCount}`,
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            });
+            controller.enqueue({ type: 'text-start', id: 'text-1' });
+            controller.enqueue({ type: 'text-delta', id: 'text-1', delta: responseText });
+            controller.enqueue({ type: 'text-end', id: 'text-1' });
+            if (currentStreamCount === 1) {
+              await firstFinished;
+            }
+            controller.enqueue({
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  });
+
+  return { model, releaseFirst, getStreamCount: () => streamCount };
+}
+
 function nextTick() {
   return new Promise(resolve => setTimeout(resolve, 0));
 }
@@ -1368,6 +1412,243 @@ describe('Agent signals', () => {
     expect(subscribedRun.value.text).toBe('message response');
 
     subscription.unsubscribe();
+  });
+
+  it('uses the configured message ID generator for persisted sendMessage signal rows', async () => {
+    const memory = new MockMemory();
+    const threadId = 'configured-send-message-thread';
+    const resourceId = 'configured-send-message-user';
+    await memory.createThread({ threadId, resourceId });
+
+    let sequence = 0;
+    const idGenerator = vi.fn((context?: { idType?: string; source?: string; entityId?: string }) => {
+      sequence += 1;
+      return `${context?.idType ?? 'id'}_custom_${sequence}`;
+    });
+
+    const agent = new Agent({
+      id: 'configured-send-message-agent',
+      name: 'Configured Send Message Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('unused'),
+      memory,
+    });
+
+    new Mastra({
+      agents: { configuredSendMessageAgent: agent },
+      idGenerator,
+      logger: false,
+    });
+
+    const result = agent.sendMessage(
+      { contents: 'persist with configured id' },
+      {
+        resourceId,
+        threadId,
+        ifActive: { behavior: 'persist' },
+        ifIdle: { behavior: 'persist' },
+      },
+    );
+
+    await expect(result.persisted).resolves.toBeUndefined();
+
+    expect(result.signal.id).toMatch(/^message_custom_\d+$/);
+    const recalled = await memory.recall({ threadId, resourceId });
+    const persistedSignal = recalled.messages.find(message => message.role === 'signal');
+
+    expect(persistedSignal?.id).toBe(result.signal.id);
+    expect(persistedSignal?.id).toMatch(/^message_custom_\d+$/);
+    expect(idGenerator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idType: 'message',
+        source: 'agent',
+        entityId: 'configured-send-message-agent',
+        threadId,
+        resourceId,
+      }),
+    );
+  });
+
+  it('preserves explicit sendSignal IDs', async () => {
+    const memory = new MockMemory();
+    const threadId = 'explicit-signal-id-thread';
+    const resourceId = 'explicit-signal-id-user';
+    await memory.createThread({ threadId, resourceId });
+
+    const agent = new Agent({
+      id: 'explicit-signal-id-agent',
+      name: 'Explicit Signal ID Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('unused'),
+      memory,
+    });
+
+    new Mastra({
+      agents: { explicitSignalIdAgent: agent },
+      idGenerator: () => 'message_custom_generated',
+      logger: false,
+    });
+
+    const result = agent.sendSignal(
+      { id: 'caller-signal-id', type: 'system-reminder', contents: 'remember this' },
+      {
+        resourceId,
+        threadId,
+        ifIdle: { behavior: 'persist' },
+      },
+    );
+
+    await expect(result.persisted).resolves.toBeUndefined();
+    expect(result.signal.id).toBe('caller-signal-id');
+  });
+
+  it('uses the configured message ID generator for queueMessage signals', async () => {
+    const memory = new MockMemory();
+    const threadId = 'configured-queue-message-thread';
+    const resourceId = 'configured-queue-message-user';
+    await memory.createThread({ threadId, resourceId });
+
+    let sequence = 0;
+    const idGenerator = vi.fn((context?: { idType?: string; source?: string; entityId?: string }) => {
+      sequence += 1;
+      return `${context?.idType ?? 'id'}_custom_${sequence}`;
+    });
+
+    const agent = new Agent({
+      id: 'configured-queue-message-agent',
+      name: 'Configured Queue Message Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('queued response'),
+      memory,
+    });
+
+    new Mastra({
+      agents: { configuredQueueMessageAgent: agent },
+      idGenerator,
+      logger: false,
+    });
+
+    const subscription = await agent.subscribeToThread({ threadId, resourceId });
+    const nextRun = readNextRunWithParts(subscription.stream[Symbol.asyncIterator]());
+
+    const result = agent.queueMessage('queue with configured id', { resourceId, threadId });
+
+    expect(result.signal.id).toMatch(/^message_custom_\d+$/);
+    expect(idGenerator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idType: 'message',
+        source: 'agent',
+        entityId: 'configured-queue-message-agent',
+        threadId,
+        resourceId,
+      }),
+    );
+
+    const queuedRun = await nextRun;
+    expect(queuedRun.value.text).toBe('queued response');
+    subscription.unsubscribe();
+  });
+
+  it('resolves run id context before generating sendMessage signal IDs', async () => {
+    const threadId = 'run-id-send-message-id-thread';
+    const resourceId = 'run-id-send-message-id-user';
+    let sequence = 0;
+    const idGenerator = vi.fn(context => {
+      sequence += 1;
+      if (context?.idType === 'message') return `message_custom_${context.threadId}_${context.resourceId}`;
+      return `${context?.idType ?? 'id'}_custom_${sequence}`;
+    });
+    const { model, releaseFirst } = createBlockingFirstTextStreamModel('first response', 'message response');
+    const agent = new Agent({
+      id: 'run-id-send-message-id-agent',
+      name: 'Run Id Send Message Id Agent',
+      instructions: 'Test',
+      model,
+    });
+
+    new Mastra({
+      agents: { runIdSendMessageIdAgent: agent },
+      idGenerator,
+      logger: false,
+    });
+
+    const subscription = await agent.subscribeToThread({ threadId, resourceId });
+    const stream = await agent.stream('Hello', { memory: { thread: threadId, resource: resourceId } });
+
+    try {
+      await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
+      const result = agent.sendMessage('message by run id', { runId: stream.runId });
+
+      expect(result.signal.id).toBe(`message_custom_${threadId}_${resourceId}`);
+      expect(idGenerator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idType: 'message',
+          source: 'agent',
+          entityId: 'run-id-send-message-id-agent',
+          threadId,
+          resourceId,
+        }),
+      );
+    } finally {
+      releaseFirst();
+      subscription.unsubscribe();
+    }
+
+    await expect(stream.text).resolves.toBe('first responsemessage response');
+  });
+
+  it('resolves run id context before generating queueMessage signal IDs', async () => {
+    const threadId = 'run-id-queue-message-id-thread';
+    const resourceId = 'run-id-queue-message-id-user';
+    let sequence = 0;
+    const idGenerator = vi.fn(context => {
+      sequence += 1;
+      if (context?.idType === 'message') return `message_custom_${context.threadId}_${context.resourceId}`;
+      return `${context?.idType ?? 'id'}_custom_${sequence}`;
+    });
+    const { model, releaseFirst, getStreamCount } = createBlockingFirstTextStreamModel(
+      'first response',
+      'queued response',
+    );
+    const agent = new Agent({
+      id: 'run-id-queue-message-id-agent',
+      name: 'Run Id Queue Message Id Agent',
+      instructions: 'Test',
+      model,
+    });
+
+    new Mastra({
+      agents: { runIdQueueMessageIdAgent: agent },
+      idGenerator,
+      logger: false,
+    });
+
+    const subscription = await agent.subscribeToThread({ threadId, resourceId });
+    const stream = await agent.stream('Hello', { memory: { thread: threadId, resource: resourceId } });
+
+    try {
+      await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
+      const result = agent.queueMessage('queue by run id', { runId: stream.runId });
+
+      expect(result.signal.id).toBe(`message_custom_${threadId}_${resourceId}`);
+      expect(result.runId).not.toBe(stream.runId);
+      expect(idGenerator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idType: 'message',
+          source: 'agent',
+          entityId: 'run-id-queue-message-id-agent',
+          threadId,
+          resourceId,
+        }),
+      );
+      await nextTick();
+      expect(getStreamCount()).toBe(1);
+    } finally {
+      releaseFirst();
+      subscription.unsubscribe();
+    }
+
+    await expect(stream.text).resolves.toBe('first response');
   });
 
   it('persists external state signals with cache-key tracking', async () => {

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -444,6 +444,30 @@ export class AgentThreadStreamRuntime {
     state.approvalSuspendedRunIds.delete(runId);
   }
 
+  #generateSignalMessageId(
+    agent: Agent<any, any, any, any>,
+    target: { threadId?: string; resourceId?: string },
+  ): string {
+    return (
+      agent.getMastraInstance?.()?.generateId({
+        idType: 'message',
+        source: 'agent',
+        entityId: agent.id,
+        threadId: target.threadId,
+        resourceId: target.resourceId,
+      }) ?? randomUUID()
+    );
+  }
+
+  #createMessageSignalInput(message: AgentMessageInput): AgentSignal {
+    const normalizedMessage = typeof message === 'string' || Array.isArray(message) ? { contents: message } : message;
+    return {
+      ...normalizedMessage,
+      type: 'user',
+      tagName: 'user',
+    };
+  }
+
   getThreadState(options: { resourceId?: string; threadId: string }, pubsub?: PubSub): AgentThreadState {
     const state = this.#getState(pubsub);
     const key = this.#threadKey(options.resourceId, options.threadId);
@@ -1755,7 +1779,7 @@ export class AgentThreadStreamRuntime {
     target: SendAgentMessageOptions<OUTPUT>,
     pubsub?: PubSub,
   ): SendAgentMessageResult<OUTPUT> {
-    return this.sendSignal<OUTPUT>(agent, createMessageSignal(message, { acceptedAt: new Date() }), target, pubsub);
+    return this.sendSignal<OUTPUT>(agent, this.#createMessageSignalInput(message), target, pubsub);
   }
 
   queueMessage<OUTPUT = unknown>(
@@ -1765,7 +1789,7 @@ export class AgentThreadStreamRuntime {
     pubsub?: PubSub,
   ): QueueAgentMessageResult<OUTPUT> {
     const state = this.#getState(pubsub);
-    const signal = createMessageSignal(message, { acceptedAt: new Date() });
+    const acceptedAt = new Date();
     let key: string | undefined;
     let runId = target.runId;
     let activeRecord: AgentThreadRunRecord<any> | undefined;
@@ -1795,6 +1819,10 @@ export class AgentThreadStreamRuntime {
     }
 
     key ??= this.#threadKey(resourceId, threadId);
+    const signal = createMessageSignal(message, {
+      id: this.#generateSignalMessageId(agent, { resourceId, threadId }),
+      acceptedAt,
+    });
     const queuedRunId = randomUUID();
     const queuedStreamOptions = target.ifIdle?.streamOptions ?? activeRecord?.streamOptions;
 
@@ -1886,7 +1914,6 @@ export class AgentThreadStreamRuntime {
     pubsub?: PubSub,
   ): SendAgentSignalResult<OUTPUT> {
     const state = this.#getState(pubsub);
-    let signal = createSignal({ ...signalInput, acceptedAt: new Date() });
     let key: string | undefined;
     let runId = target.runId;
     const activeBehavior = target.ifActive?.behavior ?? 'deliver';
@@ -1919,11 +1946,27 @@ export class AgentThreadStreamRuntime {
       }
     }
 
+    if (runId) {
+      activeRecord ??= state.threadRunsById.get(runId);
+      if (activeRecord) {
+        key ??= this.#threadKey(activeRecord.resourceId, activeRecord.threadId);
+      }
+    }
+
+    const resourceId = target.resourceId ?? activeRecord?.resourceId;
+    const threadId = target.threadId ?? activeRecord?.threadId;
+    if (!resourceId || !threadId) {
+      throw new Error('No active agent run found for signal target');
+    }
+
     const isActiveTarget = Boolean(
       runId && (activeRecord?.output.status === 'running' || (key && state.activeThreadRunIds.get(key) === runId)),
     );
-    const resourceId = target.resourceId ?? activeRecord?.resourceId;
-    const threadId = target.threadId ?? activeRecord?.threadId;
+    let signal = createSignal({
+      ...signalInput,
+      id: signalInput.id ?? this.#generateSignalMessageId(agent, { resourceId, threadId }),
+      acceptedAt: new Date(),
+    });
 
     // Resolve conditional delivery attributes now that we know the delivery path.
     signal = resolveDeliveryAttributes(
@@ -1957,7 +2000,6 @@ export class AgentThreadStreamRuntime {
     }
 
     if (runId) {
-      activeRecord ??= state.threadRunsById.get(runId);
       // A run is "blocking" while it is running or suspended awaiting tool approval. Both
       // states mean the run has already made model requests, so a follow-up signal must be
       // queued as a pending (next-turn) signal rather than folded into a not-yet-started
@@ -2017,10 +2059,6 @@ export class AgentThreadStreamRuntime {
           accepted: Promise.resolve({ action: 'deliver' as const, runId }),
         };
       }
-    }
-
-    if (!resourceId || !threadId) {
-      throw new Error('No active agent run found for signal target');
     }
 
     runId = randomUUID();


### PR DESCRIPTION
Fixes #17828

## Summary

Mastra agents can be configured with an `idGenerator`, and normal stream-created message rows already use it. Message rows persisted through the signal path still receive raw UUIDs, so a single `mastra_messages` table can contain both application-generated IDs and UUIDs depending on which public API wrote the row.

## Root cause

`sendMessage()` and `queueMessage()` create message signals without an ID, and `sendSignal()` also lets un-IDed signal inputs fall through to `normalizeSignal`. `normalizeSignal` fills the missing ID with `crypto.randomUUID()`, and `signalToDBMessage` persists that same `signal.id` as the DB message row ID. The runtime already receives the owning `Agent`, but it never calls the agent's registered Mastra instance to mint a configured message ID.

## Changes

- `packages/core/src/agent/thread-stream-runtime.ts`: generate missing signal/message IDs with the owning agent's configured `idGenerator`, using `idType: 'message'`, resolved thread/resource context, and UUID fallback (~60 lines)
- `packages/core/src/agent/__tests__/agent-signals.test.ts`: add regression coverage for persisted `sendMessage` rows, `queueMessage` signals, explicit `sendSignal` IDs, and `runId`-only active-run context resolution (~280 lines)

## What is NOT changed

Signal-originated stored rows still have `role: "signal"` and keep signal metadata. Explicit caller-provided signal IDs are preserved. This PR does not add a new `signal` ID type or change notification/run ID generation.

## Out of scope

The signal API is experimental and there are adjacent open PRs around owner streams and cross-process signal coordination. This PR stays on the ID-generation boundary and does not change delivery semantics, lease ownership, or stream coordination.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Linked related issue
- [x] Added or updated tests
- [ ] Documentation updated (if applicable)
- [x] Addressed all Coderabbit comments

## Test plan

- `pnpm --filter ./packages/core test src/agent/__tests__/agent-signals.test.ts` — 79 passed, 3 skipped. Covers: the agent signal runtime suite, including persisted `sendMessage` rows and `queueMessage` signals using the configured `message` ID generator, explicit `sendSignal` IDs remaining unchanged, and `runId`-only `sendMessage`/`queueMessage` calls resolving active thread/resource context before ID generation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This change gives signal-created messages consistent IDs. It uses the configured ID generator instead of random IDs and preserves IDs supplied by callers.

## Summary
- Routed signal-based message creation through the configured Mastra `idGenerator` with `idType: 'message'`.
- Included resolved thread and resource context in generated IDs.
- Used UUID generation as a fallback.
- Preserved explicitly provided signal IDs.
- Updated `sendMessage`, `queueMessage`, and `sendSignal` without changing delivery or coordination behavior.
- Added tests for persisted messages, queued messages, explicit IDs, and `runId` context resolution.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->