### PR TITLE
fix(core): clean up stale agentic-loop snapshot rows on run completion

### DIFF
--- a/.changeset/rare-dingos-dig.md
+++ b/.changeset/rare-dingos-dig.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed workflow snapshot records leaking in storage for every agent run. The agentic loop's nested execution workflow persisted a snapshot row that was never cleaned up, so completed agent runs left behind stale "pending" or "suspended" records in workflow snapshot storage indefinitely. This affected both execution engines: the default engine now deletes the nested row together with the loop's row when a run completes, and the evented engine deletes a nested run's row when it reaches a terminal state its workflow opted not to persist. A "suspended" status in storage now reliably means the run is actually resumable.
+Fixed workflow snapshot records leaking in storage for every agent run. Completed agent runs left behind stale "pending" or "suspended" records indefinitely. These internal records are now removed when an agent run finishes, fails, or is declined. A "suspended" status in workflow snapshot storage now reliably means the run is actually resumable.

--- a/.changeset/rare-dingos-dig.md
+++ b/.changeset/rare-dingos-dig.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow snapshot records leaking in storage for every agent run. The agentic loop's nested execution workflow persisted a snapshot row that was never cleaned up, so completed agent runs left behind stale "pending" or "suspended" records in workflow snapshot storage indefinitely. This affected both execution engines: the default engine now deletes the nested row together with the loop's row when a run completes, and the evented engine deletes a nested run's row when it reaches a terminal state its workflow opted not to persist. A "suspended" status in storage now reliably means the run is actually resumable.

--- a/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
+++ b/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Workflow snapshot lifecycle for the agentic loop.
+ *
+ * Suspended runs must keep their snapshot rows (both `agentic-loop` and the
+ * nested `executionWorkflow`) so `resumeStream()` can restore them — including
+ * after a server restart. Once a run completes, all of its snapshot rows must
+ * be deleted; previously the nested `executionWorkflow` row leaked as a stale
+ * "pending"/"suspended" record for every completed agent run.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { createTool } from '../../tools';
+import type { WorkflowRunState } from '../../workflows';
+import { Agent } from '../agent';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from './mock-model';
+
+const mockFindUser = vi.fn().mockImplementation(async (data: { name: string }) => {
+  return { name: data.name, email: 'dero@mail.com' };
+});
+
+function createFindUserTool() {
+  return createTool({
+    id: 'Find user tool',
+    description: 'Returns the name and email of a user',
+    inputSchema: z.object({ name: z.string() }),
+    requireApproval: true,
+    execute: async input => {
+      return mockFindUser(input) as Promise<Record<string, any>>;
+    },
+  });
+}
+
+function createMockModel() {
+  let callCount = 0;
+  return new MockLanguageModelV2({
+    doStream: async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'findUserTool',
+              input: '{"name":"Dero Israel"}',
+              providerExecuted: false,
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      }
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'User found' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+      };
+    },
+  });
+}
+
+function summarizeRuns(runs: { workflowName: string; runId: string; snapshot: string | WorkflowRunState }[]) {
+  return runs
+    .map(r => ({
+      workflowName: r.workflowName,
+      runId: r.runId,
+      status: typeof r.snapshot === 'string' ? r.snapshot : r.snapshot?.status,
+    }))
+    .sort((a, b) => a.workflowName.localeCompare(b.workflowName));
+}
+
+// The loop workflows pick their engine from MASTRA_EVENTED_EXECUTION at
+// creation time (per stream call), so the whole lifecycle runs against both
+// the default (direct) engine and the evented engine. The evented engine
+// persists snapshots asynchronously via its event processor, so cleanup on
+// terminal state must hold there too.
+describe.each([
+  { engine: 'default', evented: false },
+  { engine: 'evented', evented: true },
+])('agentic-loop snapshot lifecycle ($engine engine)', ({ evented }) => {
+  beforeAll(() => {
+    if (evented) vi.stubEnv('MASTRA_EVENTED_EXECUTION', 'true');
+  });
+
+  afterAll(() => {
+    if (evented) vi.unstubAllEnvs();
+  });
+  it('keeps snapshot rows while suspended and deletes all rows after resume completes', async () => {
+    const agent = new Agent({
+      id: 'user-agent',
+      name: 'User Agent',
+      instructions: 'You find users.',
+      model: createMockModel(),
+      tools: { findUserTool: createFindUserTool() },
+    });
+
+    const mastra = new Mastra({
+      agents: { agent },
+      logger: false,
+      storage: new InMemoryStore(),
+    });
+
+    const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
+
+    const stream = await agent.stream('Find the user with name - Dero Israel', {
+      requireToolApproval: true,
+    });
+
+    let toolCallId = '';
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'tool-call-approval') {
+        toolCallId = chunk.payload.toolCallId;
+      }
+    }
+    expect(toolCallId).toBeTruthy();
+
+    // While suspended, both the loop row and the nested execution row must
+    // exist so resumeStream() can restore the run (e.g. after a restart).
+    // The default engine persists the nested row under the parent's runId;
+    // the evented engine assigns nested runs their own random runId.
+    const afterSuspend = summarizeRuns((await workflowsStore.listWorkflowRuns({})).runs);
+    expect(afterSuspend).toEqual([
+      { workflowName: 'agentic-loop', runId: stream.runId, status: 'suspended' },
+      { workflowName: 'executionWorkflow', runId: evented ? expect.any(String) : stream.runId, status: 'suspended' },
+    ]);
+
+    const resumeStream = await agent.approveToolCall({ runId: stream.runId, toolCallId });
+    for await (const _chunk of resumeStream.fullStream) {
+      // consume
+    }
+
+    // After the resumed run completes, no stale rows may remain — neither a
+    // "suspended" agentic-loop row nor the nested executionWorkflow row.
+    const afterResume = (await workflowsStore.listWorkflowRuns({})).runs;
+    expect(afterResume).toHaveLength(0);
+  }, 30000);
+
+  it('deletes all snapshot rows after both supervisor and subagent approval runs complete', async () => {
+    const subAgent = new Agent({
+      id: 'billing-agent',
+      name: 'Billing Agent',
+      instructions: 'You handle billing.',
+      model: createMockModel(),
+      tools: { findUserTool: createFindUserTool() },
+    });
+
+    let supCallCount = 0;
+    const supervisorModel = new MockLanguageModelV2({
+      doStream: async () => {
+        supCallCount++;
+        if (supCallCount === 1) {
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'sup-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'sup-call-1',
+                toolName: 'agent-billing-agent',
+                input: '{"message":"Find Dero Israel"}',
+                providerExecuted: false,
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              },
+            ]),
+          };
+        }
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'sup-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Done' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ]),
+        };
+      },
+    });
+
+    const supervisor = new Agent({
+      id: 'support-agent',
+      name: 'Support Agent',
+      instructions: 'You delegate to billing.',
+      model: supervisorModel,
+      agents: { 'billing-agent': subAgent },
+    });
+
+    const mastra = new Mastra({
+      agents: { supervisor, subAgent },
+      logger: false,
+      storage: new InMemoryStore(),
+    });
+    const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
+
+    const stream = await supervisor.stream('Find the user Dero Israel via billing');
+
+    let toolCallId = '';
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'tool-call-approval') {
+        toolCallId = chunk.payload.toolCallId;
+      }
+    }
+    expect(toolCallId).toBeTruthy();
+
+    // Both the supervisor's run and the subagent's inner run persist
+    // suspended rows (loop + nested execution row each).
+    const afterSuspend = summarizeRuns((await workflowsStore.listWorkflowRuns({})).runs);
+    expect(afterSuspend.filter(r => r.workflowName === 'agentic-loop')).toHaveLength(2);
+    expect(afterSuspend.filter(r => r.workflowName === 'executionWorkflow')).toHaveLength(2);
+    expect(afterSuspend.every(r => r.status === 'suspended')).toBe(true);
+
+    const resumeStream = await supervisor.approveToolCall({ runId: stream.runId, toolCallId });
+    for await (const _chunk of resumeStream.fullStream) {
+      // consume
+    }
+
+    const afterResume = (await workflowsStore.listWorkflowRuns({})).runs;
+    expect(afterResume).toHaveLength(0);
+  }, 30000);
+
+  it('leaves no snapshot rows behind for a run that never suspends', async () => {
+    const agent = new Agent({
+      id: 'plain-agent',
+      name: 'Plain Agent',
+      instructions: 'You answer.',
+      model: new MockLanguageModelV2({
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'hello' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ]),
+        }),
+      }),
+    });
+
+    const mastra = new Mastra({
+      agents: { agent },
+      logger: false,
+      storage: new InMemoryStore(),
+    });
+    const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
+
+    const stream = await agent.stream('hi');
+    for await (const _chunk of stream.fullStream) {
+      // consume
+    }
+
+    // Previously the nested executionWorkflow row leaked as a permanent
+    // "pending" record for every completed agent run.
+    const rows = (await workflowsStore.listWorkflowRuns({})).runs;
+    expect(rows).toHaveLength(0);
+  }, 30000);
+
+  it('deletes all snapshot rows after a declined tool call completes the run', async () => {
+    const agent = new Agent({
+      id: 'decline-agent',
+      name: 'Decline Agent',
+      instructions: 'You find users.',
+      model: createMockModel(),
+      tools: { findUserTool: createFindUserTool() },
+    });
+
+    const mastra = new Mastra({
+      agents: { agent },
+      logger: false,
+      storage: new InMemoryStore(),
+    });
+    const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
+
+    const stream = await agent.stream('Find the user with name - Dero Israel', {
+      requireToolApproval: true,
+    });
+
+    let toolCallId = '';
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'tool-call-approval') {
+        toolCallId = chunk.payload.toolCallId;
+      }
+    }
+    expect(toolCallId).toBeTruthy();
+
+    const resumeStream = await agent.declineToolCall({ runId: stream.runId, toolCallId });
+    for await (const _chunk of resumeStream.fullStream) {
+      // consume
+    }
+
+    const afterDecline = (await workflowsStore.listWorkflowRuns({})).runs;
+    expect(afterDecline).toHaveLength(0);
+  }, 30000);
+
+  it('deletes all snapshot rows after a run fails', async () => {
+    const agent = new Agent({
+      id: 'failing-agent',
+      name: 'Failing Agent',
+      instructions: 'You answer.',
+      model: new MockLanguageModelV2({
+        doStream: async () => {
+          throw new Error('model exploded');
+        },
+      }),
+    });
+
+    const mastra = new Mastra({
+      agents: { agent },
+      logger: false,
+      storage: new InMemoryStore(),
+    });
+    const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
+
+    const stream = await agent.stream('hi');
+    let sawError = false;
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'error') sawError = true;
+    }
+    expect(sawError).toBe(true);
+
+    // The failure path must clean up the same way the success path does —
+    // in the evented engine a step failure ends the run via endWorkflow with
+    // status 'failed' (processWorkflowFail covers processor-internal errors).
+    const rows = (await workflowsStore.listWorkflowRuns({})).runs;
+    expect(rows).toHaveLength(0);
+  }, 30000);
+
+  // Default engine only: the evented processor shares the same storage call,
+  // and rejecting it there would break the event-processor flow unrelated to
+  // what this test asserts (the stream-side cleanup being best-effort).
+  it.skipIf(evented)('still finishes the stream when snapshot cleanup fails', async () => {
+    const agent = new Agent({
+      id: 'cleanup-fail-agent',
+      name: 'Cleanup Fail Agent',
+      instructions: 'You answer.',
+      model: new MockLanguageModelV2({
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'hello' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ]),
+        }),
+      }),
+    });
+
+    const mastra = new Mastra({
+      agents: { agent },
+      logger: false,
+      storage: new InMemoryStore(),
+    });
+    const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
+    const deleteSpy = vi
+      .spyOn(workflowsStore, 'deleteWorkflowRunById')
+      .mockRejectedValue(new Error('storage offline'));
+
+    try {
+      const stream = await agent.stream('hi');
+      let sawFinish = false;
+      for await (const chunk of stream.fullStream) {
+        if (chunk.type === 'finish') sawFinish = true;
+      }
+      // Cleanup is best-effort: a storage failure must not turn a successful
+      // run into a stream error or swallow the finish chunk.
+      expect(sawFinish).toBe(true);
+      expect(deleteSpy).toHaveBeenCalled();
+    } finally {
+      deleteSpy.mockRestore();
+    }
+  }, 30000);
+});

--- a/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
+++ b/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
@@ -358,49 +358,53 @@ describe.each([
   // Default engine only: the evented processor shares the same storage call,
   // and rejecting it there would break the event-processor flow unrelated to
   // what this test asserts (the stream-side cleanup being best-effort).
-  it.skipIf(evented)('still finishes the stream when snapshot cleanup fails', async () => {
-    const agent = new Agent({
-      id: 'cleanup-fail-agent',
-      name: 'Cleanup Fail Agent',
-      instructions: 'You answer.',
-      model: new MockLanguageModelV2({
-        doStream: async () => ({
-          rawCall: { rawPrompt: null, rawSettings: {} },
-          warnings: [],
-          stream: convertArrayToReadableStream([
-            { type: 'stream-start', warnings: [] },
-            { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
-            { type: 'text-start', id: 'text-1' },
-            { type: 'text-delta', id: 'text-1', delta: 'hello' },
-            { type: 'text-end', id: 'text-1' },
-            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
-          ]),
+  it.skipIf(evented)(
+    'still finishes the stream when snapshot cleanup fails',
+    async () => {
+      const agent = new Agent({
+        id: 'cleanup-fail-agent',
+        name: 'Cleanup Fail Agent',
+        instructions: 'You answer.',
+        model: new MockLanguageModelV2({
+          doStream: async () => ({
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'hello' },
+              { type: 'text-end', id: 'text-1' },
+              { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+            ]),
+          }),
         }),
-      }),
-    });
+      });
 
-    const mastra = new Mastra({
-      agents: { agent },
-      logger: false,
-      storage: new InMemoryStore(),
-    });
-    const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
-    const deleteSpy = vi
-      .spyOn(workflowsStore, 'deleteWorkflowRunById')
-      .mockRejectedValue(new Error('storage offline'));
+      const mastra = new Mastra({
+        agents: { agent },
+        logger: false,
+        storage: new InMemoryStore(),
+      });
+      const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
+      const deleteSpy = vi
+        .spyOn(workflowsStore, 'deleteWorkflowRunById')
+        .mockRejectedValue(new Error('storage offline'));
 
-    try {
-      const stream = await agent.stream('hi');
-      let sawFinish = false;
-      for await (const chunk of stream.fullStream) {
-        if (chunk.type === 'finish') sawFinish = true;
+      try {
+        const stream = await agent.stream('hi');
+        let sawFinish = false;
+        for await (const chunk of stream.fullStream) {
+          if (chunk.type === 'finish') sawFinish = true;
+        }
+        // Cleanup is best-effort: a storage failure must not turn a successful
+        // run into a stream error or swallow the finish chunk.
+        expect(sawFinish).toBe(true);
+        expect(deleteSpy).toHaveBeenCalled();
+      } finally {
+        deleteSpy.mockRestore();
       }
-      // Cleanup is best-effort: a storage failure must not turn a successful
-      // run into a stream error or swallow the finish chunk.
-      expect(sawFinish).toBe(true);
-      expect(deleteSpy).toHaveBeenCalled();
-    } finally {
-      deleteSpy.mockRestore();
-    }
-  }, 30000);
+    },
+    30000,
+  );
 });

--- a/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
+++ b/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
@@ -27,7 +27,7 @@ function createFindUserTool() {
     inputSchema: z.object({ name: z.string() }),
     requireApproval: true,
     execute: async input => {
-      return mockFindUser(input) as Promise<Record<string, any>>;
+      return mockFindUser(input);
     },
   });
 }

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -13,6 +13,8 @@ import { resolveConfiguredToolCallConcurrency, resolveToolCallConcurrency } from
 import type { ToolCallForeachOptions } from './tool-call-concurrency';
 import { createToolCallStep } from './tool-call-step';
 
+export const AGENTIC_EXECUTION_WORKFLOW_ID = 'executionWorkflow';
+
 export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
   models,
   _internal,
@@ -73,7 +75,7 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
   const createWorkflow = process.env.MASTRA_EVENTED_EXECUTION === 'true' ? createEventedWorkflow : createDirectWorkflow;
 
   return createWorkflow({
-    id: 'executionWorkflow',
+    id: AGENTIC_EXECUTION_WORKFLOW_ID,
     inputSchema: llmIterationOutputSchema,
     outputSchema: llmIterationOutputSchema,
     options: {

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -11,6 +11,7 @@ import { safeClose, safeEnqueue } from '../../stream/base';
 import type { ChunkType } from '../../stream/types';
 import { ChunkFrom } from '../../stream/types';
 import type { LoopRun } from '../types';
+import { AGENTIC_EXECUTION_WORKFLOW_ID } from './agentic-execution';
 import { createAgenticLoopWorkflow } from './agentic-loop';
 
 export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
@@ -210,6 +211,23 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
         rest.mastra.__registerInternalWorkflow(agenticLoopWorkflow, runId);
       }
 
+      // Once the run reaches a terminal state its snapshot rows are no longer
+      // needed for resume. Delete both the agentic-loop row and the nested
+      // execution workflow's row (persisted under the same runId) — otherwise
+      // the nested row leaks as a stale "pending"/"suspended" record in
+      // workflow snapshot storage for every completed agent run.
+      // Best-effort: a cleanup failure must never turn a finished run into a
+      // stream error (a stale row is preferable to a broken stream).
+      const deleteRunSnapshots = async () => {
+        try {
+          await agenticLoopWorkflow.deleteWorkflowRunById(runId);
+          const workflowsStore = await rest.mastra?.getStorage()?.getStore('workflows');
+          await workflowsStore?.deleteWorkflowRunById({ runId, workflowName: AGENTIC_EXECUTION_WORKFLOW_ID });
+        } catch (error) {
+          rest.logger?.warn('Failed to delete agentic-loop snapshot rows after terminal state', { runId, error });
+        }
+      };
+
       // Keep the run-scoped registration alive only when the run suspends — a
       // later resume on the same runId must still resolve this instance. Every
       // other exit (success, failure, or a throw before completion) must drop
@@ -299,7 +317,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
           }
 
           if (executionResult.status !== 'suspended') {
-            await agenticLoopWorkflow.deleteWorkflowRunById(runId);
+            await deleteRunSnapshots();
           } else {
             keepRegisteredForResume = true;
           }
@@ -308,7 +326,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
           return;
         }
 
-        await agenticLoopWorkflow.deleteWorkflowRunById(runId);
+        await deleteRunSnapshots();
 
         // Always emit finish chunk, even for abort (tripwire) cases
         // This ensures the stream properly completes and all promises are resolved

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -410,8 +410,13 @@ export class WorkflowEventProcessor extends EventProcessor {
       // A row may still exist from an earlier persisted phase — 'pending' at
       // nested-run start or 'suspended' before a resume — and without the
       // terminal update it would leak as a stale, resumable-looking record.
-      // Terminal runs can't be resumed, so drop the row entirely.
-      await workflowsStore?.deleteWorkflowRunById({ runId, workflowName: workflowId });
+      // Terminal runs can't be resumed, so drop the row entirely. Best-effort:
+      // a storage failure here must not abort run completion.
+      try {
+        await workflowsStore?.deleteWorkflowRunById({ runId, workflowName: workflowId });
+      } catch (e) {
+        this.mastra.getLogger()?.warn('Failed to clean up nested workflow snapshot', { workflowId, runId, error: e });
+      }
     }
 
     if (perStep) {
@@ -675,7 +680,12 @@ export class WorkflowEventProcessor extends EventProcessor {
       // Mirrors endWorkflow: a nested run whose workflow opted out of
       // persisting the terminal 'failed' status would otherwise leak its
       // earlier-phase ('pending'/'suspended') snapshot row forever.
-      await workflowsStore?.deleteWorkflowRunById({ runId, workflowName: workflowId });
+      // Best-effort: a storage failure here must not abort run completion.
+      try {
+        await workflowsStore?.deleteWorkflowRunById({ runId, workflowName: workflowId });
+      } catch (e) {
+        this.mastra.getLogger()?.warn('Failed to clean up nested workflow snapshot', { workflowId, runId, error: e });
+      }
     }
 
     // handle nested workflow

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -372,7 +372,17 @@ export class WorkflowEventProcessor extends EventProcessor {
   }
 
   protected async endWorkflow(args: ProcessorArgs, status: 'success' | 'failed' | 'canceled' | 'paused' = 'success') {
-    const { workflowId, runId, prevResult, perStep, workflow, stepResults, activeStepsPath, executionPath } = args;
+    const {
+      workflowId,
+      runId,
+      prevResult,
+      perStep,
+      workflow,
+      stepResults,
+      activeStepsPath,
+      executionPath,
+      parentWorkflow,
+    } = args;
     const workflowsStore = await this.mastra.getStorage()?.getStore('workflows');
 
     // Check shouldPersistSnapshot option - default to true if not specified
@@ -394,6 +404,14 @@ export class WorkflowEventProcessor extends EventProcessor {
           activeStepsPath: activeStepsPath,
         },
       });
+    } else if (parentWorkflow && finalStatus !== 'paused') {
+      // The nested run reached a terminal state its workflow opted not to
+      // persist (e.g. the internal `executionWorkflow` inside `agentic-loop`).
+      // A row may still exist from an earlier persisted phase — 'pending' at
+      // nested-run start or 'suspended' before a resume — and without the
+      // terminal update it would leak as a stale, resumable-looking record.
+      // Terminal runs can't be resumed, so drop the row entirely.
+      await workflowsStore?.deleteWorkflowRunById({ runId, workflowName: workflowId });
     }
 
     if (perStep) {
@@ -653,6 +671,11 @@ export class WorkflowEventProcessor extends EventProcessor {
           activeStepsPath: activeStepsPath,
         },
       });
+    } else if (parentWorkflow) {
+      // Mirrors endWorkflow: a nested run whose workflow opted out of
+      // persisting the terminal 'failed' status would otherwise leak its
+      // earlier-phase ('pending'/'suspended') snapshot row forever.
+      await workflowsStore?.deleteWorkflowRunById({ runId, workflowName: workflowId });
     }
 
     // handle nested workflow


### PR DESCRIPTION
Every completed agent run was leaking a workflow snapshot row in storage. The agentic loop runs a nested `executionWorkflow` internally, and while the `agentic-loop` row got deleted when a run finished, the nested row never did — it stuck around forever as `"pending"` (plain runs) or `"suspended"` (runs that suspended for tool approval and were then resumed). That made the snapshot table grow unboundedly and made `status: 'suspended'` useless for telling which runs are actually resumable.

```ts
const stream = await agent.stream('Find the user', { requireToolApproval: true });
// ...approve, resume, run completes...

// before: stale rows linger forever
await workflowsStore.listWorkflowRuns({});
// [{ workflowName: 'executionWorkflow', status: 'suspended' }, ...]

// after: completed runs leave nothing behind
await workflowsStore.listWorkflowRuns({});
// []
```

Both execution engines needed their own fix. In the default engine the nested row shares the parent's runId, so it's now deleted together with the loop's row on any terminal exit. In the evented engine nested runs get their own random runId, so the event processor now deletes a nested run's row when it ends in a terminal state its workflow opted not to persist via `shouldPersistSnapshot` — only nested runs with an explicit opt-out are affected, so user-defined workflows behave exactly as before. Suspended rows are never touched, so resuming (including after a server restart) keeps working. Cleanup is best-effort: if the storage delete fails, the run still finishes normally instead of erroring the stream.

Test plan: new lifecycle tests run against both engines (suspend → resume, supervisor + subagent approval, plain run, declined approval, failed run, cleanup-failure resilience). Verified the evented assertions actually exercise the new deletion by mutation-testing the branch. Full `pnpm test:core` passes (9500+ tests), plus the evented workflow and background-task suites, tsc, and lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When agent runs finished, a small helper record in the database was left behind, making the database grow and making "suspended" unreliable. This PR makes sure all related helper records are removed when a run finishes so storage stays clean and suspended meaning stays correct.

## What was broken

Completed agent runs deleted the top-level "agentic-loop" snapshot but left a nested "executionWorkflow" snapshot row in storage with "pending" or "suspended" status. Consequences:
- Unbounded growth of the snapshot table
- `status: 'suspended'` became an unreliable indicator for resumable runs
- Database bloat from leaked snapshot rows

## The fix

- Default engine: the nested executionWorkflow now shares the parent runId so its snapshot row is deleted together with the agentic-loop row on terminal exit.
- Evented engine: when a nested run (has parentWorkflow) opts out of persistence (`shouldPersistSnapshot === false`) and reaches a terminal state (except paused/suspended), the event processor attempts to delete the nested run's snapshot row. Suspended rows are preserved so resume behavior remains intact. Cleanup is best-effort: storage deletion failures are logged and do not block run completion or cause retries.

## Changes made

- .changeset/rare-dingos-dig.md
  - Release note documenting the patch fixing snapshot storage leaks.

- packages/core/src/loop/workflows/agentic-execution/index.ts
  - Exported constant AGENTIC_EXECUTION_WORKFLOW_ID = 'executionWorkflow' to identify nested workflow snapshots.

- packages/core/src/loop/workflows/stream.ts
  - Added deleteRunSnapshots helper to best-effort delete both the agentic-loop and nested executionWorkflow snapshot rows in non-suspended terminal paths; logs warning on failure.

- packages/core/src/workflows/evented/workflow-event-processor/index.ts
  - In endWorkflow: when a nested run opted not to persist and reached a terminal state (not paused), delete the workflow run row to avoid leaving stale terminal-looking records.
  - In processWorkflowFail: same deletion behavior for opted-out nested runs on failure.
  - Made nested-run snapshot cleanup non-fatal so storage errors don't interrupt run completion.

- packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
  - New Vitest suite validating lifecycle across default and evented engines:
    - suspend→resume cleans up snapshots
    - supervisor + subagent approval flows clean up after completion
    - plain runs (no suspend) do not leave orphaned executionWorkflow rows
    - declined approvals and failed runs clean up correctly
    - cleanup-failure resilience: deletion errors don't prevent stream finish (skipped for evented engine where behavior differs)

## Testing

- New lifecycle tests added and passing for both engines.
- Full test suite and tooling checks passed: pnpm test:core, evented workflow and background-task suites, tsc, lint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->