### PR TITLE
docs(smoke-test skill): refresh local-setup and document browser-agent runtime requirement

### DIFF
--- a/.claude/skills/mastra-smoke-test/references/local-setup.md
+++ b/.claude/skills/mastra-smoke-test/references/local-setup.md
@@ -68,16 +68,41 @@ Verify observability is configured before testing traces:
 
 ### 1. Check `src/mastra/index.ts`
 
+`create-mastra` now scaffolds `PinoLogger` + `Observability` (not the older
+`createLogger` / `OtelConfig`), and wires a `MastraCompositeStore` with a
+default LibSQL store plus a DuckDB store for the `observability` domain:
+
 ```typescript
-import { createLogger } from '@mastra/core/logger';
-import { OtelConfig } from '@mastra/core/telemetry';
+import { Mastra } from '@mastra/core/mastra';
+import { PinoLogger } from '@mastra/loggers';
+import { LibSQLStore } from '@mastra/libsql';
+import { DuckDBStore } from '@mastra/duckdb';
+import { MastraCompositeStore } from '@mastra/core/storage';
+import {
+  Observability,
+  MastraStorageExporter,
+  MastraPlatformExporter,
+  SensitiveDataFilter,
+} from '@mastra/observability';
 
 export const mastra = new Mastra({
-  // ... agents, tools, etc.
-  logger: createLogger({ name: 'my-app', level: 'info' }),
-  telemetry: new OtelConfig({
-    serviceName: 'my-app',
-    enabled: true,
+  // ... agents, workflows, scorers
+  storage: new MastraCompositeStore({
+    id: 'composite-storage',
+    default: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db' }),
+    domains: {
+      observability: await new DuckDBStore().getStore('observability'),
+    },
+  }),
+  logger: new PinoLogger({ name: 'Mastra', level: 'info' }),
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [new MastraStorageExporter(), new MastraPlatformExporter()],
+        spanOutputProcessors: [new SensitiveDataFilter()],
+      },
+    },
   }),
 });
 ```
@@ -87,13 +112,15 @@ export const mastra = new Mastra({
 Verify `package.json` includes:
 
 - `@mastra/observability`
+- `@mastra/loggers`
+- `@mastra/libsql` (default store) and `@mastra/duckdb` (observability domain)
 
 ### 3. Check Dev Server Output
 
-When starting the dev server, look for:
-
-- "OpenTelemetry initialized" or similar success message
-- Should NOT see "MASTRA_CLOUD_ACCESS_TOKEN not set" (that's for cloud only)
+When starting the dev server, look for the version banner and Studio URL,
+e.g. `mastra 1.13.0-alpha.4 ready in …` followed by Studio at
+`http://localhost:4111` and the API at `http://localhost:4111/api`.
+Should NOT see `MASTRA_CLOUD_ACCESS_TOKEN not set` (that's for cloud only).
 
 ### Troubleshooting Local Traces
 

--- a/.claude/skills/mastra-smoke-test/references/tests/agents.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/agents.md
@@ -106,3 +106,9 @@ curl -s -X POST "http://localhost:4111/api/agents/<agentKey>/generate" \
 `/generate` — these are silently discarded. Use `memory: { thread, resource }`.
 Top-level `threadId` / `resourceId` are only read by the deprecated
 `/generate-legacy` route.
+
+**Browser agents** (`browser: new StagehandBrowser(...)`) require
+`memory: { thread, resource }` on every call — without it the auto-attached
+`BrowserContextProcessor` throws `computeStateSignal requires Mastra memory
+with an active resourceId and threadId`. See `tests/setup.md` →
+"Runtime requirement".

--- a/.claude/skills/mastra-smoke-test/references/tests/setup.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/setup.md
@@ -177,6 +177,32 @@ export const mastra = new Mastra({
 <pm> exec playwright install chromium
 ```
 
+### 5. Runtime requirement: pass thread + resource on every call
+
+Passing `browser: new StagehandBrowser(...)` to `Agent` auto-attaches the
+`BrowserContextProcessor` input processor. That processor reads/writes
+browser state via Mastra memory, so **every call to the browser agent must
+provide both a thread and a resource id**, or the processor throws:
+
+```
+[Processor:browser-context] computeStateSignal requires Mastra memory with an active resourceId and threadId
+```
+
+Use the `memory: { thread, resource }` payload shape:
+
+```bash
+curl -s -X POST 'http://localhost:4111/api/agents/browser-agent/generate' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "messages":[{"role":"user","content":"Navigate to https://example.com and tell me the page title."}],
+    "memory":{"thread":"<tid>","resource":"<rid>"}
+  }'
+```
+
+Top-level `threadId` / `resourceId` are silently discarded (same as other
+agents). The Studio chat works without explicit IDs because the chat UI
+allocates them for you.
+
 ## Custom API Routes
 
 To add custom API routes:


### PR DESCRIPTION
## Summary

Refreshes the `mastra-smoke-test` skill after a full smoke test of
`mastra@1.13.0-alpha.4` on a fresh `create-mastra@alpha` project.

The smoke run itself was clean — no product bugs were found — but it
surfaced three documentation gaps in the skill that would mislead the
next operator running it.

## What changed

- **`references/local-setup.md`** — The "Local Observability Setup"
  example referenced `createLogger` (from `@mastra/core/logger`) and
  `OtelConfig` (from `@mastra/core/telemetry`). Neither matches what
  `create-mastra` scaffolds today. Replaced with the current shape:
  `PinoLogger` from `@mastra/loggers`, `Observability` from
  `@mastra/observability` with `MastraStorageExporter` +
  `MastraPlatformExporter` + `SensitiveDataFilter`, and a
  `MastraCompositeStore` wiring a default `LibSQLStore` plus a
  `DuckDBStore` for the `observability` domain. Updated the dependency
  list and dev-server banner expectations to match.

- **`references/tests/setup.md`** — Under "Browser Agent" added a
  "Runtime requirement" subsection. Passing
  `browser: new StagehandBrowser(...)` to `Agent` auto-attaches
  `BrowserContextProcessor`, which reads/writes browser state via
  Mastra memory and throws on every call unless the request includes
  `memory: { thread, resource }`:

  ```
  [Processor:browser-context] computeStateSignal requires Mastra memory with an active resourceId and threadId
  ```

  The Studio chat works without explicit IDs because it allocates
  them, so it's easy to miss when driving the agent through REST/SDK.

- **`references/tests/agents.md`** — Added a one-line pointer in the
  existing "Common mistake" callout so an operator testing a browser
  agent sees the requirement and is pointed at the full explanation in
  `tests/setup.md`.

## Test plan

- Re-ran the full smoke flow against `mastra@1.13.0-alpha.4`:
  scaffold → browser agent install → dev server → agents API → Studio
  chat → tools (REST + Studio) → workflow (REST + Studio) → traces
  (REST + Studio + JSON download) → scorers → memory recall → MCP
  empty state → error handling → streaming SSE → tool-call observability
  attributes/metadata → Workspaces empty state → token usage timeline
  on `/metrics` → browser agent E2E via REST with
  `memory: { thread, resource }`.
- Verified the new `local-setup.md` snippet matches the
  `src/mastra/index.ts` emitted by `create-mastra@1.13.0-alpha.4`.
- Verified the new `tests/setup.md` browser-agent note by reproducing
  the error without `memory: { thread, resource }` and confirming
  success when it's added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the documentation for the Mastra smoke test skill to fix three gaps discovered during testing. It shows developers the new way to set up observability tools, and importantly, explains that browser agents need special memory IDs passed with every request or they'll crash—a mistake that's easy to make when using REST instead of the Studio UI.

## Changes

### local-setup.md — Updated observability configuration
Replaced the stale "Local Observability Setup" example with the current scaffold used by `create-mastra@1.13.0-alpha.4`. The new example uses:
- `PinoLogger` from `@mastra/loggers` (replacing `createLogger`)
- `Observability` from `@mastra/observability` configured with `MastraStorageExporter`, `MastraPlatformExporter`, `SensitiveDataFilter`, and a `MastraCompositeStore`
- `MastraCompositeStore` wiring `LibSQLStore` as the default plus a `DuckDBStore` for the observability domain

Updated the "Check Dependencies" section to reflect new packages (`@mastra/loggers`, `@mastra/libsql`, `@mastra/duckdb`) and revised dev-server output checks to match the new startup banner expectations.

### tests/setup.md — Browser agent runtime requirement
Added a new "Runtime requirement" subsection documenting that `StagehandBrowser` auto-attaches `BrowserContextProcessor`, which requires Mastra memory with `{ thread, resource }` on every agent call. Includes example request payload for the `/api/agents/browser-agent/generate` endpoint. Notes that Studio chat automatically allocates these IDs, making the issue easy to miss when using REST/SDK directly.

### tests/agents.md — Cross-reference pointer
Added a one-line note in the existing "Common mistake" callout directing developers to the detailed "Runtime requirement" explanation in tests/setup.md.

## Testing
- Re-ran the full smoke flow against `mastra@1.13.0-alpha.4` including browser agent E2E via REST with memory IDs
- Verified local-setup snippet matches the create-mastra scaffold output
- Reproduced the browser-agent error without memory IDs and confirmed success with proper memory configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->