### PR TITLE
fix(core): add AGENT_RUN root span to DurableAgent.stream() for observability traces

### DIFF
--- a/.changeset/giant-cars-smoke.md
+++ b/.changeset/giant-cars-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Durable agents now produce complete observability traces matching the non-durable path — AGENT_RUN root span, MODEL_GENERATION per iteration, MODEL_STEP/MODEL_INFERENCE closing correctly, and TOOL_CALL spans nested under model_step

--- a/.changeset/quick-bags-buy.md
+++ b/.changeset/quick-bags-buy.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Add AGENT_RUN root span to DurableAgent.stream() and propagate tracingContext into workflow execution so durable agent runs produce observability traces
+Durable agents now produce observability traces. Previously, createDurableAgent runs were invisible to trace exporters because no root span was created. Traces now appear for durable agent runs just like regular agent runs.

--- a/.changeset/quick-bags-buy.md
+++ b/.changeset/quick-bags-buy.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-Durable agents now produce observability traces. Previously, createDurableAgent runs were invisible to trace exporters because no root span was created. Traces now appear for durable agent runs just like regular agent runs.

--- a/.changeset/quick-bags-buy.md
+++ b/.changeset/quick-bags-buy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add AGENT_RUN root span to DurableAgent.stream() and propagate tracingContext into workflow execution so durable agent runs produce observability traces

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -392,7 +392,9 @@ export class DurableAgent<
     const workflow = this.getWorkflow();
     const registryEntry = globalRunRegistry.get(runId);
     const requestContext = registryEntry?.requestContext;
-    const spanTracingContext = (registryEntry?.agentSpan as any)?.getTracingContext?.();
+    const spanTracingContext = registryEntry?.agentSpan
+      ? { currentSpan: registryEntry.agentSpan }
+      : undefined;
     const run = await workflow.createRun({ runId, pubsub: this.pubsub });
     const result = await run.start({ inputData: workflowInput, requestContext, tracingContext: spanTracingContext });
 

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -12,6 +12,7 @@ import type { MessageListInput } from '../message-list';
 import type { ToolsInput } from '../types';
 
 import { AGENT_STREAM_TOPIC } from './constants';
+import { EntityType, SpanType, getOrCreateSpan } from '../../observability';
 import { runDurableStreamUntilIdle } from './durable-stream-until-idle';
 import { prepareForDurableExecution } from './preparation';
 import { ExtendedRunRegistry, globalRunRegistry } from './run-registry';
@@ -64,6 +65,10 @@ export interface DurableAgentStreamOptions<OUTPUT = undefined> {
   structuredOutput?: AgentExecutionOptions<OUTPUT>['structuredOutput'];
   /** Version overrides for sub-agent delegation */
   versions?: AgentExecutionOptions<OUTPUT>['versions'];
+  /** Tracing options for observability */
+  tracingOptions?: AgentExecutionOptions<OUTPUT>['tracingOptions'];
+  /** Tracing context for span propagation */
+  tracingContext?: AgentExecutionOptions<OUTPUT>['tracingContext'];
   /** Callback when chunk is received */
   onChunk?: (chunk: ChunkType<OUTPUT>) => void | Promise<void>;
   /** Callback when step finishes */
@@ -385,10 +390,11 @@ export class DurableAgent<
    */
   protected async executeWorkflow(runId: string, workflowInput: DurableAgenticWorkflowInput): Promise<void> {
     const workflow = this.getWorkflow();
-    const requestContext = globalRunRegistry.get(runId)?.requestContext;
-
+    const registryEntry = globalRunRegistry.get(runId);
+    const requestContext = registryEntry?.requestContext;
+    const spanTracingContext = (registryEntry?.agentSpan as any)?.getTracingContext?.();
     const run = await workflow.createRun({ runId, pubsub: this.pubsub });
-    const result = await run.start({ inputData: workflowInput, requestContext });
+    const result = await run.start({ inputData: workflowInput, requestContext, tracingContext: spanTracingContext });
 
     if (result?.status === 'failed') {
       const error = new Error((result as any).error?.message || 'Workflow execution failed');
@@ -434,7 +440,22 @@ export class DurableAgent<
     messages: MessageListInput,
     options?: DurableAgentStreamOptions<TOutput>,
   ): Promise<DurableAgentStreamResult<TOutput>> {
-    // 1. Prepare for durable execution (non-durable phase)
+    // 1. Create AGENT_RUN root span so durable traces have an exportable root,
+    //    matching the non-durable Agent.stream() path.
+    const agentSpan = getOrCreateSpan({
+      type: SpanType.AGENT_RUN,
+      name: `agent run: '${this.#wrappedAgent.id}'`,
+      entityType: EntityType.AGENT,
+      entityId: this.#wrappedAgent.id,
+      entityName: this.#wrappedAgent.name,
+      input: messages,
+      tracingOptions: options?.tracingOptions,
+      tracingContext: options?.tracingContext,
+      requestContext: options?.requestContext,
+      mastra: this.#mastra,
+    });
+
+    // 2. Prepare for durable execution (non-durable phase)
     const preparation = await prepareForDurableExecution<TOutput>({
       agent: this.#wrappedAgent as Agent<string, any, TOutput>,
       messages,
@@ -448,7 +469,7 @@ export class DurableAgent<
 
     // 2. Register non-serializable state (both local and global registries)
     this.#runRegistry.registerWithMessageList(runId, registryEntry, messageList, { threadId, resourceId });
-    globalRunRegistry.set(runId, { ...registryEntry, messageList });
+    globalRunRegistry.set(runId, { ...registryEntry, messageList, agentSpan });
 
     // Track cleanup state to avoid double cleanup
     let cleanedUp = false;
@@ -487,10 +508,13 @@ export class DurableAgent<
       onStepFinish: options?.onStepFinish,
       onFinish: async result => {
         await options?.onFinish?.(result);
+        agentSpan?.end?.({ output: result.output });
         scheduleAutoCleanup();
       },
       onError: async error => {
         await options?.onError?.(error);
+        agentSpan?.error?.({ error });
+        agentSpan?.end?.({});
         scheduleAutoCleanup();
       },
       onSuspended: options?.onSuspended,

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -595,6 +595,19 @@ export class DurableAgent<
     };
 
     const globalEntry = globalRunRegistry.get(runId);
+    // Create a new AGENT_RUN span for the resumed run.
+    // The original span is gone (globalRunRegistry is in-memory and doesn't
+    // survive suspensions), so we open a fresh root span marked as a resume.
+    const resumeAgentSpan = getOrCreateSpan({
+      type: SpanType.AGENT_RUN,
+      name: `agent run: '${this.#wrappedAgent.id}' (resumed)`,
+      entityType: EntityType.AGENT,
+      entityId: this.#wrappedAgent.id,
+      entityName: this.#wrappedAgent.name,
+      metadata: { runId, resumed: true },
+      requestContext: globalEntry?.requestContext,
+      mastra: this.#mastra,
+    });
     const resumeModel = globalEntry?.model as any;
 
     const {
@@ -616,10 +629,13 @@ export class DurableAgent<
       onStepFinish: options?.onStepFinish,
       onFinish: async result => {
         await options?.onFinish?.(result);
+        resumeAgentSpan?.end?.({ output: result.output });
         scheduleAutoCleanup();
       },
       onError: async error => {
         await options?.onError?.(error);
+        resumeAgentSpan?.error?.({ error });
+        resumeAgentSpan?.end?.({});
         scheduleAutoCleanup();
       },
       onSuspended: options?.onSuspended,
@@ -631,7 +647,10 @@ export class DurableAgent<
     ready
       .then(async () => {
         const run = await workflow.createRun({ runId, pubsub: this.pubsub });
-        const result = await run.resume({ resumeData, requestContext });
+        const spanTracingContext = resumeAgentSpan
+          ? { currentSpan: resumeAgentSpan }
+          : undefined;
+        const result = await run.resume({ resumeData, requestContext, tracingContext: spanTracingContext });
         if (result?.status === 'failed') {
           const error = new Error((result as any).error?.message || 'Workflow resume failed');
           void this.emitError(runId, error);

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -17,6 +17,8 @@ import type { MemoryConfig } from '../../memory/types';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow, ErrorProcessorOrWorkflow } from '../../processors';
 import type { ProcessorState } from '../../processors/runner';
 import type { RequestContext } from '../../request-context';
+import type { Span } from '../../observability';
+import { SpanType } from '../../observability';
 import type { ChunkType } from '../../stream/types';
 import type { CoreTool } from '../../tools/types';
 import type { Workspace } from '../../workspace';
@@ -436,7 +438,7 @@ export interface RunRegistryEntry {
   /** Agent background tasks configuration */
   backgroundTasksConfig?: AgentBackgroundConfig;
   /** AGENT_RUN span for trace propagation into workflow steps (non-serializable) */
-  agentSpan?: any;
+  agentSpan?: Span<SpanType.AGENT_RUN>;
 }
 
 /**

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -268,6 +268,8 @@ export interface DurableToolCallInput {
   output?: unknown;
   /** Tool names enabled for the step that produced this call, or null if a processor cleared the restriction */
   activeTools?: string[] | null;
+  /** Exported model_step span data for parenting tool call spans under model_step */
+  stepSpanData?: unknown;
 }
 
 /**

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -435,6 +435,8 @@ export interface RunRegistryEntry {
   backgroundTaskManager?: BackgroundTaskManager;
   /** Agent background tasks configuration */
   backgroundTasksConfig?: AgentBackgroundConfig;
+  /** AGENT_RUN span for trace propagation into workflow steps (non-serializable) */
+  agentSpan?: any;
 }
 
 /**

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -81,6 +81,7 @@ const durableLLMOutputSchema = z.object({
       args: z.record(z.string(), z.any()),
       providerMetadata: z.record(z.string(), z.any()).optional(),
       activeTools: z.array(z.string()).nullable().optional(),
+      stepSpanData: z.any().optional(),
     }),
   ),
   stepResult: z.object({

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -5,12 +5,13 @@ import type { PubSub } from '../../../../events/pubsub';
 import { mergeProviderOptions } from '../../../../llm/model/provider-options';
 import type { SharedProviderOptions } from '../../../../llm/model/shared.types';
 import type { Mastra } from '../../../../mastra';
-import type { SpanType, AIModelGenerationSpan, ExportedSpan, IModelSpanTracker } from '../../../../observability';
+import { SpanType } from '../../../../observability';
+import type { AIModelGenerationSpan, ExportedSpan, IModelSpanTracker } from '../../../../observability';
 import { getStepAvailableToolNames } from '../../../../observability/utils';
 import { ProcessorRunner } from '../../../../processors/runner';
 import { execute } from '../../../../stream/aisdk/v5/execute';
 import { MastraModelOutput } from '../../../../stream/base/output';
-import type { TextDeltaPayload, ToolCallPayload } from '../../../../stream/types';
+import type { ChunkType, TextDeltaPayload, ToolCallPayload } from '../../../../stream/types';
 import { createStep } from '../../../../workflows';
 import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
 import { MessageList } from '../../../message-list';
@@ -204,18 +205,27 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               modelEntry.config.providerOptions,
             ) as SharedProviderOptions | undefined;
 
-            // 6. Rebuild MODEL_GENERATION span from passed data
-            // For durable execution, ONE model_generation span is created BEFORE the workflow starts
-            // and passed through each iteration. This ensures all steps are children of the same span.
+            // 6. Rebuild or create MODEL_GENERATION span.
+            // If modelSpanData was passed from a prior iteration (tool-calling path), rebuild it.
+            // Otherwise create a fresh child span under the AGENT_RUN root so the first
+            // iteration also gets a model_generation span.
             const observability = mastra?.observability?.getSelectedInstance({ requestContext });
-
-            // modelSpanData is passed through from the workflow input (created in create-inngest-agent.ts)
             const inputModelSpanData = (inputData as any).modelSpanData as
               | ExportedSpan<SpanType.MODEL_GENERATION>
               | undefined;
             const modelSpan = inputModelSpanData
               ? (observability?.rebuildSpan(inputModelSpanData) as AIModelGenerationSpan | undefined)
-              : undefined;
+              : (tracingContext?.currentSpan?.createChildSpan({
+                  name: `llm: '${currentModel.modelId}'`,
+                  type: SpanType.MODEL_GENERATION,
+                  attributes: {
+                    model: currentModel.modelId,
+                    provider: currentModel.provider,
+                    streaming: true,
+                  },
+                  metadata: { runId },
+                  requestContext,
+                }) as AIModelGenerationSpan | undefined);
 
             // Create model span tracker for MODEL_STEP and MODEL_CHUNK spans
             const modelSpanTracker: IModelSpanTracker | undefined = modelSpan?.createTracker();
@@ -383,8 +393,25 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             // 11. Process the stream and emit chunks via pubsub
             // Wrap the base stream with ModelSpanTracker to create MODEL_STEP and MODEL_CHUNK spans
             const baseStream = outputStream._getBaseStream();
-            const trackedStream = modelSpanTracker?.wrapStream(baseStream) ?? baseStream;
-
+            // Convert finish → step-finish before wrapStream so the ModelSpanTracker
+            // sees step-finish and correctly closes MODEL_STEP/MODEL_INFERENCE spans.
+            // The durable LLM stream emits finish but never step-finish; wrapStream
+            // only closes spans on step-finish, so without this transform the spans
+            // are never ended and never exported.
+            const stepFinishStream = modelSpanTracker
+              ? (baseStream as any).pipeThrough(
+                  new TransformStream<any, any>({
+                    transform(chunk, controller) {
+                      if ((chunk as any).type === 'finish') {
+                        controller.enqueue({ ...(chunk as any), type: 'step-finish' } as ChunkType<undefined>);
+                      } else {
+                        controller.enqueue(chunk);
+                      }
+                    },
+                  }),
+                )
+              : baseStream;
+            const trackedStream = modelSpanTracker?.wrapStream(stepFinishStream) ?? stepFinishStream;
             try {
               for await (const chunk of trackedStream) {
                 if (!chunk) continue;
@@ -408,11 +435,6 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 //   sees the same shape it would in the non-durable path.
                 if (pubsub && chunk.type !== 'finish') {
                   await emitChunkEvent(pubsub, runId, chunk);
-                } else if (pubsub && chunk.type === 'finish') {
-                  await emitChunkEvent(pubsub, runId, {
-                    ...chunk,
-                    type: 'step-finish',
-                  } as any);
                 }
 
                 // Process different chunk types
@@ -437,11 +459,10 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                     break;
                   }
 
+                  case 'step-finish':
                   case 'finish': {
                     const payload = chunk.payload as any;
-                    // The finish chunk from MastraModelOutput has finishReason in stepResult.reason
                     finishReason = payload.stepResult?.reason || payload.finishReason || 'stop';
-                    // Usage can be in output.usage or directly in payload.usage
                     usage = payload.output?.usage || payload.usage || usage;
                     break;
                   }
@@ -547,7 +568,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             const output: DurableLLMStepOutput = {
               messageListState: messageList.serialize(),
               text: textDeltas.join(''),
-              toolCalls,
+              toolCalls: toolCalls.map(tc => ({ ...tc, stepSpanData })),
               stepResult: {
                 reason: finishReason as any,
                 warnings,
@@ -579,7 +600,6 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               // Close the step span with usage/finish info
               const pendingPayload = modelSpanTracker?.getPendingStepFinishPayload() as any;
               if (pendingPayload) {
-                // End step span using the pending payload
                 const stepSpan = modelSpanTracker?.exportCurrentStep();
                 if (stepSpan && observability) {
                   const rebuiltStepSpan = observability.rebuildSpan(stepSpan);
@@ -596,6 +616,18 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   });
                 }
               }
+              // End model_generation span — no tool calls means this is the final iteration
+              modelSpan?.end({
+                output: { text: textDeltas.join('') },
+                attributes: { usage },
+              });
+            } else {
+              // Has tool calls — end model_generation now so this iteration's span exports.
+              // The next iteration will create a fresh model_generation span.
+              modelSpan?.end({
+                output: { toolCalls: toolCalls.map(tc => tc.toolName) },
+                attributes: { usage },
+              });
             }
 
             // Success - return the output

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -7,6 +7,8 @@ import type { Mastra } from '../../../../mastra';
 import type { MastraMemory } from '../../../../memory/memory';
 import type { MemoryConfig } from '../../../../memory/types';
 import { ChunkFrom } from '../../../../stream/types';
+import { SpanType } from '../../../../observability';
+import type { ExportedSpan } from '../../../../observability';
 import { createStep } from '../../../../workflows';
 import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
 import type { SuspendOptions } from '../../../../workflows/step';
@@ -31,6 +33,7 @@ const durableToolCallInputSchema = z.object({
   providerExecuted: z.boolean().optional(),
   output: z.any().optional(),
   activeTools: z.array(z.string()).nullable().optional(),
+  stepSpanData: z.any().optional(),
 });
 
 /**
@@ -640,8 +643,23 @@ export function createDurableToolCallStep() {
         }
       }
 
+      // Rebuild model_step span so the tool call spans nest under it
+      const observability = (mastra as any)?.observability?.getSelectedInstance({ requestContext });
+      const stepSpanData = (typedInput as any).stepSpanData as ExportedSpan<SpanType.MODEL_STEP> | undefined;
+      const stepSpan = stepSpanData && observability
+        ? observability.rebuildSpan(stepSpanData)
+        : undefined;
+      const toolSpan = stepSpan?.createChildSpan({
+        name: `tool: '${toolName}'`,
+        type: SpanType.TOOL_CALL,
+        input: { args: cleanedArgs },
+        metadata: { runId, toolCallId },
+        requestContext,
+      }) ?? undefined;
+
       try {
         const result = await tool.execute(cleanedArgs, toolOptions);
+        toolSpan?.end({ output: { result } });
 
         // Emit tool-result chunk (non-fatal — result is returned regardless)
         if (pubsub) {
@@ -662,6 +680,8 @@ export function createDurableToolCallStep() {
           result,
         };
       } catch (error) {
+        toolSpan?.error({ error: error instanceof Error ? error : new Error(String(error)) });
+        toolSpan?.end({});
         const toolError = serializeError(error);
 
         // Emit tool-error chunk (non-fatal — error result is returned regardless)

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -681,7 +681,6 @@ export function createDurableToolCallStep() {
         };
       } catch (error) {
         toolSpan?.error({ error: error instanceof Error ? error : new Error(String(error)) });
-        toolSpan?.end({});
         const toolError = serializeError(error);
 
         // Emit tool-error chunk (non-fatal — error result is returned regardless)

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -310,7 +310,7 @@ export function createDurableToolCallStep() {
       // Build tracingContext from stepSpanData so builder's TOOL_CALL span
       // nests under model_step instead of floating at AGENT_RUN root.
       const observability = (mastra as any)?.observability?.getSelectedInstance({ requestContext });
-      const stepSpanData = (typedInput as any).stepSpanData as ExportedSpan<SpanType.MODEL_STEP> | undefined;
+      const stepSpanData = typedInput.stepSpanData as ExportedSpan<SpanType.MODEL_STEP> | undefined;
       const stepSpan = stepSpanData && observability
         ? observability.rebuildSpan(stepSpanData)
         : undefined;

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -307,13 +307,22 @@ export function createDurableToolCallStep() {
         };
       }
 
+      // Build tracingContext from stepSpanData so builder's TOOL_CALL span
+      // nests under model_step instead of floating at AGENT_RUN root.
+      const observability = (mastra as any)?.observability?.getSelectedInstance({ requestContext });
+      const stepSpanData = (typedInput as any).stepSpanData as ExportedSpan<SpanType.MODEL_STEP> | undefined;
+      const stepSpan = stepSpanData && observability
+        ? observability.rebuildSpan(stepSpanData)
+        : undefined;
+      const toolTracingContext = stepSpan ? { currentSpan: stepSpan } : undefined;
+
       const toolOptions = {
         toolCallId,
         messages: [],
         workspace,
         requestContext,
         resumeData: isResumingFromSuspension ? resumeData : undefined,
-
+        tracingContext: toolTracingContext,
         // In-execution suspend callback — allows tools to suspend mid-execution
         suspend: async (suspendPayload: any, suspendOptions?: SuspendOptions) => {
           if (suspendOptions?.requireToolApproval) {
@@ -643,23 +652,8 @@ export function createDurableToolCallStep() {
         }
       }
 
-      // Rebuild model_step span so the tool call spans nest under it
-      const observability = (mastra as any)?.observability?.getSelectedInstance({ requestContext });
-      const stepSpanData = (typedInput as any).stepSpanData as ExportedSpan<SpanType.MODEL_STEP> | undefined;
-      const stepSpan = stepSpanData && observability
-        ? observability.rebuildSpan(stepSpanData)
-        : undefined;
-      const toolSpan = stepSpan?.createChildSpan({
-        name: `tool: '${toolName}'`,
-        type: SpanType.TOOL_CALL,
-        input: { args: cleanedArgs },
-        metadata: { runId, toolCallId },
-        requestContext,
-      }) ?? undefined;
-
       try {
         const result = await tool.execute(cleanedArgs, toolOptions);
-        toolSpan?.end({ output: { result } });
 
         // Emit tool-result chunk (non-fatal — result is returned regardless)
         if (pubsub) {
@@ -680,7 +674,6 @@ export function createDurableToolCallStep() {
           result,
         };
       } catch (error) {
-        toolSpan?.error({ error: error instanceof Error ? error : new Error(String(error)) });
         const toolError = serializeError(error);
 
         // Emit tool-error chunk (non-fatal — error result is returned regardless)


### PR DESCRIPTION
## Summary
Fixes #17863

DurableAgent.stream() never created an AGENT_RUN root span, so all
durable workflow spans had no non-internal ancestor and were dropped
by getRootExportSpan(). Plain Agent.stream() correctly creates this span.

## Changes
- Added getOrCreateSpan(AGENT_RUN) in DurableAgent.stream() matching the non-durable path
- Stored agentSpan in globalRunRegistry so executeWorkflow() can access it
- Pass agentSpan.getTracingContext() into run.start() so LLM/tool/processor
  child spans are correctly parented under the AGENT_RUN root
- End/error the span in onFinish/onError callbacks
- Added tracingOptions and tracingContext to DurableAgentStreamOptions
- Added agentSpan field to RunRegistryEntry

## Trace chain
stream() → agentSpan (AGENT_RUN, non-internal) → run.start(tracingContext)
→ workflow steps → llm-execution params.tracingContext → child spans

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Before this, durable agents didn’t create the “top” trace span that monitoring tools look for, so their runs were often invisible. This PR makes durable agents create the same `AGENT_RUN` root span as regular agents and then hangs the rest of the model/tool spans under it so exporters can export complete traces.

## Overview

Updates the durable execution path to create an exportable, non-internal `AGENT_RUN` root span and to consistently propagate tracing context through `run.start()`, model execution, and tool calls—matching the trace shape of non-durable `Agent.stream()`.

## Changes

- **`packages/core/src/agent/durable/durable-agent.ts`**
  - **`DurableAgent.stream()`** now creates an **`AGENT_RUN` root span** via `getOrCreateSpan({ type: SpanType.AGENT_RUN, tracingContext: options?.tracingContext })`.
  - Stores the created **`agentSpan`** in `globalRunRegistry` (alongside `messageList`) so workflow steps can parent to it.
  - Ensures the span is **ended/errored** in the `onFinish`/`onError` lifecycle callbacks.
  - **`executeWorkflow()`** reads `registryEntry.agentSpan` and passes it as `tracingContext` into `run.start(...)` so durable workflow spans attach under the `AGENT_RUN` root.

- **`packages/core/src/agent/durable/types.ts`**
  - `RunRegistryEntry` adds `agentSpan?: Span<SpanType.AGENT_RUN>` for trace propagation into workflow steps.
  - `DurableToolCallInput` adds `stepSpanData?: unknown` so tool calls can be parented under the correct model step span.

- **`packages/core/src/agent/durable/workflows/steps/llm-execution.ts`**
  - Improves span creation/closing across iterations (e.g., creating the first `MODEL_GENERATION` child span when missing, and ending `MODEL_GENERATION` appropriately when tool calls exist so the next iteration can start cleanly).
  - Ensures streaming finish handling results in correct `MODEL_STEP`/`MODEL_INFERENCE` closure.
  - Produces per-tool-call output that includes optional `stepSpanData` for correct tool-call parenting.

- **`packages/core/src/agent/durable/workflows/steps/tool-call.ts`**
  - When `stepSpanData` is present, reconstructs the parent span (via observability span rebuilding) and passes the derived `tracingContext` into `toolOptions`, so `TOOL_CALL` spans nest under the intended `model_step` span rather than incorrectly rooting elsewhere.

- **`.changeset/giant-cars-smoke.md`**
  - Documents that durable agents now emit complete observability traces consistent with the non-durable path.

## Observability Outcome

Durable trace structure becomes:

`stream()` → **`AGENT_RUN` (root, non-internal)** → `run.start(tracingContext)` → workflow/model/tool spans (with tool calls correctly nested under the relevant `model_step`), ensuring exporters can find/export the trace root.

## Impact

- Durable agent runs now produce **exportable, `AGENT_RUN`-rooted traces** like non-durable agents.
- Caller-provided tracing context is preserved through the durable execution pipeline.
- Model/tool step span hierarchy and closing behavior are corrected so traces are complete across tool-calling iterations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->