### PR TITLE
feat(upstash): add observational memory support and domain parity

### DIFF
--- a/.changeset/humble-clouds-join.md
+++ b/.changeset/humble-clouds-join.md
@@ -1,0 +1,5 @@
+---
+'@mastra/upstash': patch
+---
+
+Added missing Upstash storage domains and observational memory support.

--- a/.changeset/humble-clouds-join.md
+++ b/.changeset/humble-clouds-join.md
@@ -2,4 +2,18 @@
 '@mastra/upstash': patch
 ---
 
-Added missing Upstash storage domains and observational memory support.
+Added observational memory support and resource-scoped message retrieval to the Upstash storage adapter.
+
+Developers using `@mastra/upstash` can now access observational memory APIs and additional storage domain functionality previously unavailable in the adapter.
+
+Example:
+
+```ts
+const messages = await storage.memory.listMessagesByResourceId({
+  resourceId: "user-123",
+});
+
+const history = await storage.memory.getObservationalMemoryHistory({
+  resourceId: "user-123",
+});
+```

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -24,6 +24,19 @@ import type {
   StorageCloneThreadInput,
   StorageCloneThreadOutput,
   ThreadCloneMetadata,
+  StorageListMessagesByResourceIdInput,
+  ObservationalMemoryRecord,
+  ObservationalMemoryHistoryOptions,
+  BufferedObservationChunk,
+  CreateObservationalMemoryInput,
+  UpdateActiveObservationsInput,
+  UpdateBufferedObservationsInput,
+  UpdateBufferedReflectionInput,
+  SwapBufferedToActiveInput,
+  SwapBufferedToActiveResult,
+  SwapBufferedReflectionToActiveInput,
+  CreateReflectionGenerationInput,
+  UpdateObservationalMemoryConfigInput,
 } from '@mastra/core/storage';
 import type { Redis } from '@upstash/redis';
 import { UpstashDB, resolveUpstashConfig } from '../../db';
@@ -44,7 +57,20 @@ function getMessageIndexKey(messageId: string): string {
   return `msg-idx:${messageId}`;
 }
 
+function getResourceMessagesKey(resourceId: string): string {
+  return `resource:${resourceId}:messages`;
+}
+
+function getObservationalMemoryKey(threadId: string | null, resourceId: string): string {
+  return `observational-memory:${threadId ?? 'resource'}:${resourceId}`;
+}
+
+function getObservationalMemoryIndexKey(id: string): string {
+  return `observational-memory-index:${id}`;
+}
+
 export class StoreMemoryUpstash extends MemoryStorage {
+  readonly supportsObservationalMemory = true;
   private client: Redis;
   #db: UpstashDB;
   constructor(config: UpstashDomainConfig) {
@@ -447,6 +473,11 @@ export class StoreMemoryUpstash extends MemoryStorage {
           // Add to sorted set for this thread
           pipeline.zadd(getThreadMessagesKey(message.threadId!), {
             score,
+            member: message.id,
+          });
+
+          pipeline.zadd(getResourceMessagesKey(message.resourceId!), {
+            score: createdAtScore,
             member: message.id,
           });
         }
@@ -1140,9 +1171,21 @@ export class StoreMemoryUpstash extends MemoryStorage {
                 ? (updatedMessage as any)._index
                 : new Date(updatedMessage.createdAt).getTime();
             pipeline.zadd(newThreadMessagesKey, { score, member: id });
+            if (updatedMessage.resourceId) {
+              pipeline.zadd(getResourceMessagesKey(updatedMessage.resourceId), {
+                score: new Date(updatedMessage.createdAt).getTime(),
+                member: id,
+              });
+            }
           } else {
             // No thread change, just update the existing key
             pipeline.set(key, updatedMessage);
+            if (updatedMessage.resourceId) {
+              pipeline.zadd(getResourceMessagesKey(updatedMessage.resourceId), {
+                score: new Date(updatedMessage.createdAt).getTime(),
+                member: id,
+              });
+            }
           }
         }
       }
@@ -1267,6 +1310,14 @@ export class StoreMemoryUpstash extends MemoryStorage {
         pipeline.del(getMessageIndexKey(messageId));
       }
 
+      for (const messageId of foundMessageIds) {
+        const message = await this.listMessagesById({ messageIds: [messageId] });
+        const resourceId = message.messages[0]?.resourceId;
+        if (resourceId) {
+          pipeline.zrem(getResourceMessagesKey(resourceId), messageId);
+        }
+      }
+
       // Update thread timestamps
       if (threadIds.size > 0) {
         for (const threadId of threadIds) {
@@ -1297,6 +1348,401 @@ export class StoreMemoryUpstash extends MemoryStorage {
         error,
       );
     }
+  }
+
+  async listMessagesByResourceId({
+    resourceId,
+    filter,
+    perPage: perPageInput,
+    page = 0,
+    orderBy,
+  }: StorageListMessagesByResourceIdInput): Promise<StorageListMessagesOutput> {
+    const { field, direction } = this.parseOrderBy(orderBy, 'ASC');
+    const perPage = normalizePerPage(perPageInput, 40);
+    this.validatePaginationInput(page, perPageInput ?? 40);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const indexedIds = await this.client.zrange(getResourceMessagesKey(resourceId), 0, -1);
+      let messages: MastraDBMessage[] = [];
+
+      if (indexedIds.length > 0) {
+        const indexPipeline = this.client.pipeline();
+        indexedIds.forEach(id => indexPipeline.get(getMessageIndexKey(id as string)));
+        const threadIds = (await indexPipeline.exec()) as (string | null)[];
+
+        const messagePipeline = this.client.pipeline();
+        indexedIds.forEach((id, index) => {
+          const threadId = threadIds[index];
+          if (threadId) {
+            messagePipeline.get(getMessageKey(threadId, id as string));
+          }
+        });
+        messages = ((await messagePipeline.exec()) as (MastraDBMessage | null)[]).filter(
+          (message): message is MastraDBMessage => !!message && message.resourceId === resourceId,
+        );
+      } else {
+        const keys = await this.#db.scanKeys(`${TABLE_MESSAGES}:*`);
+        if (keys.length > 0) {
+          const pipeline = this.client.pipeline();
+          keys.forEach(key => pipeline.get(key));
+          messages = ((await pipeline.exec()) as (MastraDBMessage | null)[]).filter(
+            (message): message is MastraDBMessage => !!message && message.resourceId === resourceId,
+          );
+        }
+      }
+
+      messages = filterByDateRange(messages, message => new Date(message.createdAt), filter?.dateRange);
+      messages = this._sortMessages(messages, field, direction);
+
+      const total = messages.length;
+      const paginated = perPageInput === false ? messages : messages.slice(offset, offset + perPage);
+      const list = new MessageList().add(paginated, 'memory');
+
+      return {
+        messages: list.get.all.db(),
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('UPSTASH', 'LIST_MESSAGES_BY_RESOURCE_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { resourceId },
+        },
+        error,
+      );
+    }
+  }
+
+  private async getObservationalMemoryRecords(
+    threadId: string | null,
+    resourceId: string,
+  ): Promise<ObservationalMemoryRecord[]> {
+    const records = await this.client.get<ObservationalMemoryRecord[]>(getObservationalMemoryKey(threadId, resourceId));
+    return (records ?? []).map(record => this.reviveObservationalMemoryRecord(record));
+  }
+
+  private async saveObservationalMemoryRecords(
+    threadId: string | null,
+    resourceId: string,
+    records: ObservationalMemoryRecord[],
+  ): Promise<void> {
+    await this.client.set(getObservationalMemoryKey(threadId, resourceId), records);
+    const pipeline = this.client.pipeline();
+    records.forEach(record => pipeline.set(getObservationalMemoryIndexKey(record.id), getObservationalMemoryKey(threadId, resourceId)));
+    await pipeline.exec();
+  }
+
+  private reviveObservationalMemoryRecord(record: ObservationalMemoryRecord): ObservationalMemoryRecord {
+    return {
+      ...record,
+      createdAt: ensureDate(record.createdAt)!,
+      updatedAt: ensureDate(record.updatedAt)!,
+      lastObservedAt: record.lastObservedAt ? ensureDate(record.lastObservedAt) : undefined,
+      lastBufferedAtTime: record.lastBufferedAtTime ? ensureDate(record.lastBufferedAtTime)! : null,
+      bufferedObservationChunks: record.bufferedObservationChunks?.map(chunk => ({
+        ...chunk,
+        createdAt: ensureDate(chunk.createdAt)!,
+        lastObservedAt: chunk.lastObservedAt ? ensureDate(chunk.lastObservedAt)! : new Date(0),
+      })),
+    };
+  }
+
+  private async updateObservationalMemoryRecord(
+    id: string,
+    updater: (record: ObservationalMemoryRecord) => void,
+  ): Promise<ObservationalMemoryRecord> {
+    const key = await this.client.get<string>(getObservationalMemoryIndexKey(id));
+    if (!key) {
+      throw new Error(`Observational memory record not found: ${id}`);
+    }
+
+    const records = ((await this.client.get<ObservationalMemoryRecord[]>(key)) ?? []).map(record =>
+      this.reviveObservationalMemoryRecord(record),
+    );
+    const record = records.find(item => item.id === id);
+    if (!record) {
+      throw new Error(`Observational memory record not found: ${id}`);
+    }
+
+    updater(record);
+    record.updatedAt = new Date();
+    await this.client.set(key, records);
+    return record;
+  }
+
+  async getObservationalMemory(
+    threadId: string | null,
+    resourceId: string,
+  ): Promise<ObservationalMemoryRecord | null> {
+    const records = await this.getObservationalMemoryRecords(threadId, resourceId);
+    return records[0] ?? null;
+  }
+
+  async getObservationalMemoryHistory(
+    threadId: string | null,
+    resourceId: string,
+    limit?: number,
+    options?: ObservationalMemoryHistoryOptions,
+  ): Promise<ObservationalMemoryRecord[]> {
+    let records = await this.getObservationalMemoryRecords(threadId, resourceId);
+    if (options?.from) records = records.filter(record => record.createdAt >= options.from!);
+    if (options?.to) records = records.filter(record => record.createdAt <= options.to!);
+    if (options?.offset != null) records = records.slice(options.offset);
+    return limit != null ? records.slice(0, limit) : records;
+  }
+
+  async initializeObservationalMemory(input: CreateObservationalMemoryInput): Promise<ObservationalMemoryRecord> {
+    const now = new Date();
+    const record: ObservationalMemoryRecord = {
+      id: crypto.randomUUID(),
+      scope: input.scope,
+      threadId: input.threadId,
+      resourceId: input.resourceId,
+      createdAt: now,
+      updatedAt: now,
+      lastObservedAt: undefined,
+      originType: 'initial',
+      generationCount: 0,
+      activeObservations: '',
+      bufferedObservations: undefined,
+      bufferedReflection: undefined,
+      totalTokensObserved: 0,
+      observationTokenCount: 0,
+      pendingMessageTokens: 0,
+      isReflecting: false,
+      isObserving: false,
+      isBufferingObservation: false,
+      isBufferingReflection: false,
+      lastBufferedAtTokens: 0,
+      lastBufferedAtTime: null,
+      config: input.config,
+      observedTimezone: input.observedTimezone,
+      metadata: {},
+    };
+    const records = await this.getObservationalMemoryRecords(input.threadId, input.resourceId);
+    await this.saveObservationalMemoryRecords(input.threadId, input.resourceId, [record, ...records]);
+    return record;
+  }
+
+  async insertObservationalMemoryRecord(record: ObservationalMemoryRecord): Promise<void> {
+    const records = await this.getObservationalMemoryRecords(record.threadId, record.resourceId);
+    records.push(record);
+    records.sort((a, b) => b.generationCount - a.generationCount);
+    await this.saveObservationalMemoryRecords(record.threadId, record.resourceId, records);
+  }
+
+  async updateActiveObservations(input: UpdateActiveObservationsInput): Promise<void> {
+    await this.updateObservationalMemoryRecord(input.id, record => {
+      record.activeObservations = input.observations;
+      record.observationTokenCount = input.tokenCount;
+      record.totalTokensObserved += input.tokenCount;
+      record.pendingMessageTokens = 0;
+      record.lastObservedAt = input.lastObservedAt;
+      if (input.observedMessageIds) record.observedMessageIds = input.observedMessageIds;
+    });
+  }
+
+  async updateBufferedObservations(input: UpdateBufferedObservationsInput): Promise<void> {
+    await this.updateObservationalMemoryRecord(input.id, record => {
+      const chunk: BufferedObservationChunk = {
+        id: `ombuf-${crypto.randomUUID()}`,
+        cycleId: input.chunk.cycleId,
+        observations: input.chunk.observations,
+        tokenCount: input.chunk.tokenCount,
+        messageIds: input.chunk.messageIds,
+        messageTokens: input.chunk.messageTokens,
+        lastObservedAt: input.chunk.lastObservedAt,
+        createdAt: new Date(),
+        suggestedContinuation: input.chunk.suggestedContinuation,
+        currentTask: input.chunk.currentTask,
+        threadTitle: input.chunk.threadTitle,
+      };
+      record.bufferedObservationChunks = [...(record.bufferedObservationChunks ?? []), chunk];
+      if (input.lastBufferedAtTime) record.lastBufferedAtTime = input.lastBufferedAtTime;
+    });
+  }
+
+  async swapBufferedToActive(input: SwapBufferedToActiveInput): Promise<SwapBufferedToActiveResult> {
+    let result: SwapBufferedToActiveResult | undefined;
+    await this.updateObservationalMemoryRecord(input.id, record => {
+      const chunks = input.bufferedChunks ?? record.bufferedObservationChunks ?? [];
+      if (chunks.length === 0) {
+        result = {
+          chunksActivated: 0,
+          messageTokensActivated: 0,
+          observationTokensActivated: 0,
+          messagesActivated: 0,
+          activatedCycleIds: [],
+          activatedMessageIds: [],
+        };
+        return;
+      }
+
+      const targetMessageTokens = Math.max(0, input.currentPendingTokens - input.messageTokensThreshold * (1 - input.activationRatio));
+      let cumulative = 0;
+      let chunksToActivate = chunks.length;
+      for (let index = 0; index < chunks.length; index++) {
+        cumulative += chunks[index]!.messageTokens ?? 0;
+        if (cumulative >= targetMessageTokens) {
+          chunksToActivate = index + 1;
+          break;
+        }
+      }
+
+      const activated = chunks.slice(0, chunksToActivate);
+      const remaining = chunks.slice(chunksToActivate);
+      const observations = activated.map(chunk => chunk.observations).join('\n\n');
+      const observationTokensActivated = activated.reduce((sum, chunk) => sum + chunk.tokenCount, 0);
+      const messageTokensActivated = activated.reduce((sum, chunk) => sum + (chunk.messageTokens ?? 0), 0);
+      const activatedMessageIds = activated.flatMap(chunk => chunk.messageIds);
+      const lastObservedAt = input.lastObservedAt ?? activated[activated.length - 1]?.lastObservedAt ?? new Date();
+
+      record.activeObservations = record.activeObservations
+        ? `${record.activeObservations}\n\n--- message boundary (${new Date(lastObservedAt).toISOString()}) ---\n\n${observations}`
+        : observations;
+      record.observationTokenCount = (record.observationTokenCount ?? 0) + observationTokensActivated;
+      record.pendingMessageTokens = Math.max(0, (record.pendingMessageTokens ?? 0) - messageTokensActivated);
+      record.bufferedObservationChunks = remaining.length > 0 ? remaining : undefined;
+      record.lastObservedAt = new Date(lastObservedAt);
+
+      result = {
+        chunksActivated: activated.length,
+        messageTokensActivated,
+        observationTokensActivated,
+        messagesActivated: activatedMessageIds.length,
+        activatedCycleIds: activated.map(chunk => chunk.cycleId).filter((id): id is string => !!id),
+        activatedMessageIds,
+        observations,
+        perChunk: activated.map(chunk => ({
+          cycleId: chunk.cycleId ?? '',
+          messageTokens: chunk.messageTokens ?? 0,
+          observationTokens: chunk.tokenCount,
+          messageCount: chunk.messageIds.length,
+          observations: chunk.observations,
+        })),
+        suggestedContinuation: activated[activated.length - 1]?.suggestedContinuation,
+        currentTask: activated[activated.length - 1]?.currentTask,
+      };
+    });
+    return result!;
+  }
+
+  async createReflectionGeneration(input: CreateReflectionGenerationInput): Promise<ObservationalMemoryRecord> {
+    const now = new Date();
+    const newRecord: ObservationalMemoryRecord = {
+      id: crypto.randomUUID(),
+      scope: input.currentRecord.scope,
+      threadId: input.currentRecord.threadId,
+      resourceId: input.currentRecord.resourceId,
+      createdAt: now,
+      updatedAt: now,
+      lastObservedAt: input.currentRecord.lastObservedAt ?? now,
+      originType: 'reflection',
+      generationCount: input.currentRecord.generationCount + 1,
+      activeObservations: input.reflection,
+      config: input.currentRecord.config,
+      totalTokensObserved: input.currentRecord.totalTokensObserved,
+      observationTokenCount: input.tokenCount,
+      pendingMessageTokens: 0,
+      isReflecting: false,
+      isObserving: false,
+      isBufferingObservation: false,
+      isBufferingReflection: false,
+      lastBufferedAtTokens: 0,
+      lastBufferedAtTime: null,
+      observedTimezone: input.currentRecord.observedTimezone,
+      metadata: {},
+    };
+    const records = await this.getObservationalMemoryRecords(input.currentRecord.threadId, input.currentRecord.resourceId);
+    await this.saveObservationalMemoryRecords(input.currentRecord.threadId, input.currentRecord.resourceId, [
+      newRecord,
+      ...records,
+    ]);
+    return newRecord;
+  }
+
+  async updateBufferedReflection(input: UpdateBufferedReflectionInput): Promise<void> {
+    await this.updateObservationalMemoryRecord(input.id, record => {
+      record.bufferedReflection = record.bufferedReflection
+        ? `${record.bufferedReflection}\n\n${input.reflection}`
+        : input.reflection;
+      record.bufferedReflectionTokens = (record.bufferedReflectionTokens ?? 0) + input.tokenCount;
+      record.bufferedReflectionInputTokens = (record.bufferedReflectionInputTokens ?? 0) + input.inputTokenCount;
+      record.reflectedObservationLineCount = input.reflectedObservationLineCount;
+    });
+  }
+
+  async swapBufferedReflectionToActive(input: SwapBufferedReflectionToActiveInput): Promise<ObservationalMemoryRecord> {
+    const record = await this.updateObservationalMemoryRecord(input.currentRecord.id, current => {
+      if (!current.bufferedReflection) throw new Error('No buffered reflection to swap');
+    });
+    const reflectedLineCount = record.reflectedObservationLineCount ?? 0;
+    const unreflected = (record.activeObservations ?? '').split('\n').slice(reflectedLineCount).join('\n').trim();
+    const reflection = unreflected ? `${record.bufferedReflection}\n\n${unreflected}` : record.bufferedReflection!;
+    const newRecord = await this.createReflectionGeneration({
+      currentRecord: record,
+      reflection,
+      tokenCount: input.tokenCount,
+    });
+    await this.updateObservationalMemoryRecord(record.id, current => {
+      current.bufferedReflection = undefined;
+      current.bufferedReflectionTokens = undefined;
+      current.bufferedReflectionInputTokens = undefined;
+      current.reflectedObservationLineCount = undefined;
+    });
+    return newRecord;
+  }
+
+  async setReflectingFlag(id: string, isReflecting: boolean): Promise<void> {
+    await this.updateObservationalMemoryRecord(id, record => {
+      record.isReflecting = isReflecting;
+    });
+  }
+
+  async setObservingFlag(id: string, isObserving: boolean): Promise<void> {
+    await this.updateObservationalMemoryRecord(id, record => {
+      record.isObserving = isObserving;
+    });
+  }
+
+  async setBufferingObservationFlag(id: string, isBuffering: boolean, lastBufferedAtTokens?: number): Promise<void> {
+    await this.updateObservationalMemoryRecord(id, record => {
+      record.isBufferingObservation = isBuffering;
+      if (lastBufferedAtTokens !== undefined) record.lastBufferedAtTokens = lastBufferedAtTokens;
+    });
+  }
+
+  async setBufferingReflectionFlag(id: string, isBuffering: boolean): Promise<void> {
+    await this.updateObservationalMemoryRecord(id, record => {
+      record.isBufferingReflection = isBuffering;
+    });
+  }
+
+  async clearObservationalMemory(threadId: string | null, resourceId: string): Promise<void> {
+    const key = getObservationalMemoryKey(threadId, resourceId);
+    const records = (await this.client.get<ObservationalMemoryRecord[]>(key)) ?? [];
+    const pipeline = this.client.pipeline();
+    pipeline.del(key);
+    records.forEach(record => pipeline.del(getObservationalMemoryIndexKey(record.id)));
+    await pipeline.exec();
+  }
+
+  async setPendingMessageTokens(id: string, tokenCount: number): Promise<void> {
+    await this.updateObservationalMemoryRecord(id, record => {
+      record.pendingMessageTokens = tokenCount;
+    });
+  }
+
+  async updateObservationalMemoryConfig(input: UpdateObservationalMemoryConfigInput): Promise<void> {
+    await this.updateObservationalMemoryRecord(input.id, record => {
+      record.config = this.deepMergeConfig(record.config as Record<string, unknown>, input.config);
+    });
   }
 
   private sortThreads(

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -459,9 +459,18 @@ export class StoreMemoryUpstash extends MemoryStorage {
           // Check if this message id exists in another thread (index lookup, no scan)
           const existingThreadId = batchExistingThreadIds[batchIndex];
           if (existingThreadId && existingThreadId !== message.threadId) {
+            const existingMessage = await this.client.get<MastraDBMessage>(getMessageKey(existingThreadId, message.id));
             pipeline.del(getMessageKey(existingThreadId, message.id));
             pipeline.zrem(getThreadMessagesKey(existingThreadId), message.id);
+            if (existingMessage?.resourceId && existingMessage.resourceId !== message.resourceId) {
+              pipeline.zrem(getResourceMessagesKey(existingMessage.resourceId), message.id);
+            }
             batchTouchedThreadIds.add(existingThreadId);
+          } else if (existingThreadId) {
+            const existingMessage = await this.client.get<MastraDBMessage>(getMessageKey(existingThreadId, message.id));
+            if (existingMessage?.resourceId && existingMessage.resourceId !== message.resourceId) {
+              pipeline.zrem(getResourceMessagesKey(existingMessage.resourceId), message.id);
+            }
           }
 
           // Store the message data
@@ -1154,6 +1163,9 @@ export class StoreMemoryUpstash extends MemoryStorage {
             // Remove from old thread's sorted set
             const oldThreadMessagesKey = getThreadMessagesKey(existingMessage.threadId!);
             pipeline.zrem(oldThreadMessagesKey, id);
+            if (existingMessage.resourceId && existingMessage.resourceId !== updatedMessage.resourceId) {
+              pipeline.zrem(getResourceMessagesKey(existingMessage.resourceId), id);
+            }
 
             // Delete the old message key
             pipeline.del(key);
@@ -1180,6 +1192,9 @@ export class StoreMemoryUpstash extends MemoryStorage {
           } else {
             // No thread change, just update the existing key
             pipeline.set(key, updatedMessage);
+            if (existingMessage.resourceId && existingMessage.resourceId !== updatedMessage.resourceId) {
+              pipeline.zrem(getResourceMessagesKey(existingMessage.resourceId), id);
+            }
             if (updatedMessage.resourceId) {
               pipeline.zadd(getResourceMessagesKey(updatedMessage.resourceId), {
                 score: new Date(updatedMessage.createdAt).getTime(),
@@ -1363,35 +1378,20 @@ export class StoreMemoryUpstash extends MemoryStorage {
     const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
 
     try {
-      const indexedIds = await this.client.zrange(getResourceMessagesKey(resourceId), 0, -1);
-      let messages: MastraDBMessage[] = [];
+      const messagesById = new Map<string, MastraDBMessage>();
+      const indexedMessages = await this.getMessagesFromResourceIndex(resourceId);
+      const scannedMessages = await this.scanMessagesByResourceId(resourceId);
 
-      if (indexedIds.length > 0) {
-        const indexPipeline = this.client.pipeline();
-        indexedIds.forEach(id => indexPipeline.get(getMessageIndexKey(id as string)));
-        const threadIds = (await indexPipeline.exec()) as (string | null)[];
-
-        const messagePipeline = this.client.pipeline();
-        indexedIds.forEach((id, index) => {
-          const threadId = threadIds[index];
-          if (threadId) {
-            messagePipeline.get(getMessageKey(threadId, id as string));
-          }
-        });
-        messages = ((await messagePipeline.exec()) as (MastraDBMessage | null)[]).filter(
-          (message): message is MastraDBMessage => !!message && message.resourceId === resourceId,
-        );
-      } else {
-        const keys = await this.#db.scanKeys(`${TABLE_MESSAGES}:*`);
-        if (keys.length > 0) {
-          const pipeline = this.client.pipeline();
-          keys.forEach(key => pipeline.get(key));
-          messages = ((await pipeline.exec()) as (MastraDBMessage | null)[]).filter(
-            (message): message is MastraDBMessage => !!message && message.resourceId === resourceId,
-          );
-        }
+      for (const message of indexedMessages) {
+        messagesById.set(message.id, message);
+      }
+      for (const message of scannedMessages) {
+        messagesById.set(message.id, message);
       }
 
+      await this.backfillResourceMessageIndex(resourceId, scannedMessages);
+
+      let messages = Array.from(messagesById.values());
       messages = filterByDateRange(messages, message => new Date(message.createdAt), filter?.dateRange);
       messages = this._sortMessages(messages, field, direction);
 
@@ -1417,6 +1417,56 @@ export class StoreMemoryUpstash extends MemoryStorage {
         error,
       );
     }
+  }
+
+  private async getMessagesFromResourceIndex(resourceId: string): Promise<MastraDBMessage[]> {
+    const indexedIds = await this.client.zrange(getResourceMessagesKey(resourceId), 0, -1);
+    if (indexedIds.length === 0) return [];
+
+    const indexPipeline = this.client.pipeline();
+    indexedIds.forEach(id => indexPipeline.get(getMessageIndexKey(id as string)));
+    const threadIds = (await indexPipeline.exec()) as (string | null)[];
+    const lookups = indexedIds.flatMap((id, index) => {
+      const threadId = threadIds[index];
+      return threadId ? [{ messageId: id as string, threadId }] : [];
+    });
+    if (lookups.length === 0) return [];
+
+    const messagePipeline = this.client.pipeline();
+    lookups.forEach(({ messageId, threadId }) => {
+      messagePipeline.get(getMessageKey(threadId, messageId));
+    });
+
+    return ((await messagePipeline.exec()) as (MastraDBMessage | null)[]).filter(
+      (message): message is MastraDBMessage => !!message && message.resourceId === resourceId,
+    );
+  }
+
+  private async scanMessagesByResourceId(resourceId: string): Promise<MastraDBMessage[]> {
+    const keys = await this.#db.scanKeys(`${TABLE_MESSAGES}:*`);
+    if (keys.length === 0) return [];
+
+    const pipeline = this.client.pipeline();
+    keys.forEach(key => pipeline.get(key));
+
+    return ((await pipeline.exec()) as (MastraDBMessage | null)[]).filter(
+      (message): message is MastraDBMessage => !!message && message.resourceId === resourceId,
+    );
+  }
+
+  private async backfillResourceMessageIndex(resourceId: string, messages: MastraDBMessage[]): Promise<void> {
+    if (messages.length === 0) return;
+
+    const pipeline = this.client.pipeline();
+    for (const message of messages) {
+      if (!message.threadId) continue;
+      pipeline.set(getMessageIndexKey(message.id), message.threadId);
+      pipeline.zadd(getResourceMessagesKey(resourceId), {
+        score: new Date(message.createdAt).getTime(),
+        member: message.id,
+      });
+    }
+    await pipeline.exec();
   }
 
   private async getObservationalMemoryRecords(
@@ -1895,6 +1945,10 @@ export class StoreMemoryUpstash extends MemoryStorage {
         // Add to sorted set for this thread (use index for ordering)
         writePipeline.zadd(newThreadMessagesKey, {
           score: i,
+          member: newMessageId,
+        });
+        writePipeline.zadd(getResourceMessagesKey(targetResourceId), {
+          score: new Date(newMessage.createdAt).getTime(),
           member: newMessageId,
         });
 

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -1398,9 +1398,10 @@ export class StoreMemoryUpstash extends MemoryStorage {
       const total = messages.length;
       const paginated = perPageInput === false ? messages : messages.slice(offset, offset + perPage);
       const list = new MessageList().add(paginated, 'memory');
+      const finalMessages = this._sortMessages(list.get.all.db(), field, direction);
 
       return {
-        messages: list.get.all.db(),
+        messages: finalMessages,
         total,
         page,
         perPage: perPageForResponse,

--- a/stores/upstash/src/storage/domains/persisted-inmemory.ts
+++ b/stores/upstash/src/storage/domains/persisted-inmemory.ts
@@ -1,0 +1,738 @@
+import { NotificationsStorage } from '@mastra/core/notifications';
+import type {
+  CreateNotificationInput,
+  ListDueNotificationsInput,
+  ListNotificationsInput,
+  NotificationRecord,
+  NotificationStatus,
+  UpdateNotificationInput,
+} from '@mastra/core/notifications';
+import {
+  BlobStore,
+  ChannelsStorage,
+  InMemoryDB,
+  InMemoryAgentsStorage,
+  DatasetsInMemory,
+  ExperimentsInMemory,
+  InMemoryFavoritesStorage,
+  InMemoryMCPClientsStorage,
+  InMemoryMCPServersStorage,
+  ObservabilityInMemory,
+  InMemoryPromptBlocksStorage,
+  InMemorySchedulesStorage,
+  InMemoryScorerDefinitionsStorage,
+  InMemorySkillsStorage,
+  InMemoryWorkspacesStorage,
+} from '@mastra/core/storage';
+import type {
+  StorageDeleteToolProviderConnectionInput,
+  StorageListToolProviderConnectionsInput,
+  StorageToolProviderConnection,
+  StorageToolProviderConnectionKey,
+  StorageUpsertToolProviderConnectionInput,
+  StorageBlobEntry,
+  ChannelConfig,
+  ChannelInstallation,
+} from '@mastra/core/storage';
+import type { Redis } from '@upstash/redis';
+import { resolveUpstashConfig } from '../db';
+import type { UpstashDomainConfig } from '../db';
+
+type PersistedConfig = UpstashDomainConfig & {
+  namespace?: string;
+  db?: InMemoryDB;
+};
+
+const MAP_FIELDS = [
+  'threads',
+  'messages',
+  'resources',
+  'workflows',
+  'scores',
+  'traces',
+  'traceCursorIds',
+  'branchCursorIds',
+  'agents',
+  'agentVersions',
+  'promptBlocks',
+  'promptBlockVersions',
+  'scorerDefinitions',
+  'scorerDefinitionVersions',
+  'mcpClients',
+  'mcpClientVersions',
+  'mcpServers',
+  'mcpServerVersions',
+  'workspaces',
+  'workspaceVersions',
+  'skills',
+  'skillVersions',
+  'favorites',
+  'observationalMemory',
+  'datasets',
+  'datasetItems',
+  'datasetVersions',
+  'experiments',
+  'experimentResults',
+  'backgroundTasks',
+  'schedules',
+] as const;
+
+const ARRAY_FIELDS = [
+  'metricRecords',
+  'logRecords',
+  'scoreRecords',
+  'feedbackRecords',
+  'scheduleTriggers',
+] as const;
+
+type Snapshot = {
+  maps?: Partial<Record<(typeof MAP_FIELDS)[number], [string, unknown][]>>;
+  arrays?: Partial<Record<(typeof ARRAY_FIELDS)[number], unknown[]>>;
+  observabilityNextCursorId?: number;
+};
+
+function isIsoDateString(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value);
+}
+
+function reviveDates<T>(value: T): T {
+  if (typeof value === 'string' && isIsoDateString(value)) {
+    return new Date(value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => reviveDates(item)) as T;
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      out[key] = reviveDates(item);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+async function scanKeys(client: Redis, pattern: string): Promise<string[]> {
+  let cursor = '0';
+  const keys: string[] = [];
+  do {
+    const [nextCursor, batch] = await client.scan(cursor, { match: pattern, count: 1000 });
+    keys.push(...batch);
+    cursor = nextCursor;
+  } while (cursor !== '0');
+  return keys;
+}
+
+async function deleteByPattern(client: Redis, pattern: string): Promise<void> {
+  const keys = await scanKeys(client, pattern);
+  if (keys.length > 0) await client.del(...keys);
+}
+
+function reviveChannelInstallation(installation: ChannelInstallation): ChannelInstallation {
+  return {
+    ...installation,
+    createdAt: new Date(installation.createdAt),
+    updatedAt: new Date(installation.updatedAt),
+  };
+}
+
+function reviveNotification(record: NotificationRecord): NotificationRecord {
+  return {
+    ...record,
+    createdAt: new Date(record.createdAt),
+    updatedAt: new Date(record.updatedAt),
+    deliveredAt: record.deliveredAt ? new Date(record.deliveredAt) : undefined,
+    seenAt: record.seenAt ? new Date(record.seenAt) : undefined,
+    dismissedAt: record.dismissedAt ? new Date(record.dismissedAt) : undefined,
+    archivedAt: record.archivedAt ? new Date(record.archivedAt) : undefined,
+    discardedAt: record.discardedAt ? new Date(record.discardedAt) : undefined,
+    deliverAt: record.deliverAt ? new Date(record.deliverAt) : undefined,
+    summaryAt: record.summaryAt ? new Date(record.summaryAt) : undefined,
+    lastDeliveryAttemptAt: record.lastDeliveryAttemptAt ? new Date(record.lastDeliveryAttemptAt) : undefined,
+  };
+}
+
+function matchesValue<T extends string>(value: T, filter?: T | T[]): boolean {
+  if (!filter) return true;
+  return Array.isArray(filter) ? filter.includes(value) : value === filter;
+}
+
+function notificationDueTime(record: NotificationRecord): number {
+  const deliverAt = record.deliverAt?.getTime();
+  const summaryAt = record.summaryAt?.getTime();
+  if (deliverAt !== undefined && summaryAt !== undefined) return Math.min(deliverAt, summaryAt);
+  return deliverAt ?? summaryAt ?? Number.POSITIVE_INFINITY;
+}
+
+function notificationStatusTimestamp(status: NotificationStatus, now: Date) {
+  if (status === 'delivered') return { deliveredAt: now };
+  if (status === 'seen') return { seenAt: now };
+  if (status === 'dismissed') return { dismissedAt: now };
+  if (status === 'archived') return { archivedAt: now };
+  if (status === 'discarded') return { discardedAt: now };
+  return {};
+}
+
+class UpstashInMemoryPersister {
+  readonly client: Redis;
+  readonly db: InMemoryDB;
+  readonly key: string;
+
+  constructor(config: PersistedConfig, defaultNamespace: string) {
+    this.client = resolveUpstashConfig(config);
+    this.db = config.db ?? new InMemoryDB();
+    this.key = `mastra:upstash:domain-snapshot:${config.namespace ?? defaultNamespace}`;
+  }
+
+  async load(): Promise<void> {
+    const snapshot = await this.client.get<Snapshot>(this.key);
+    if (!snapshot) return;
+
+    this.db.clear();
+
+    for (const field of MAP_FIELDS) {
+      const map = (this.db as any)[field] as Map<string, unknown>;
+      for (const [key, value] of snapshot.maps?.[field] ?? []) {
+        map.set(key, reviveDates(value));
+      }
+    }
+
+    for (const field of ARRAY_FIELDS) {
+      const target = this.db[field] as unknown[];
+      target.length = 0;
+      target.push(...(snapshot.arrays?.[field] ?? []).map(item => reviveDates(item)));
+    }
+
+    this.db.observabilityNextCursorId = snapshot.observabilityNextCursorId ?? 1;
+  }
+
+  async save(): Promise<void> {
+    const maps: Snapshot['maps'] = {};
+    const arrays: Snapshot['arrays'] = {};
+
+    for (const field of MAP_FIELDS) {
+      maps[field] = Array.from(((this.db as any)[field] as Map<string, unknown>).entries());
+    }
+    for (const field of ARRAY_FIELDS) {
+      arrays[field] = [...(this.db[field] as unknown[])];
+    }
+
+    await this.client.set(this.key, {
+      maps,
+      arrays,
+      observabilityNextCursorId: this.db.observabilityNextCursorId,
+    } satisfies Snapshot);
+  }
+
+  async clear(): Promise<void> {
+    this.db.clear();
+    await this.client.del(this.key);
+  }
+}
+
+function persisted<T extends object>(domain: T, persister: UpstashInMemoryPersister): T {
+  return new Proxy(domain, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== 'function' || prop === '__registerMastra') {
+        return value;
+      }
+
+      return async (...args: unknown[]) => {
+        await persister.load();
+        const result = await value.apply(target, args);
+        if (prop === 'dangerouslyClearAll') {
+          await persister.clear();
+        } else if (prop !== 'init') {
+          await persister.save();
+        }
+        return result;
+      };
+    },
+  });
+}
+
+export class AgentsUpstash extends InMemoryAgentsStorage {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'agents');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class BlobsUpstash extends BlobStore {
+  private client: Redis;
+  private namespace: string;
+
+  constructor(config: PersistedConfig) {
+    super();
+    this.client = resolveUpstashConfig(config);
+    this.namespace = config.namespace ?? 'blobs';
+  }
+
+  async init(): Promise<void> {}
+
+  async put(entry: StorageBlobEntry): Promise<void> {
+    await this.client.set(this.key(entry.hash), entry);
+  }
+
+  async get(hash: string): Promise<StorageBlobEntry | null> {
+    return (await this.client.get<StorageBlobEntry>(this.key(hash))) ?? null;
+  }
+
+  async has(hash: string): Promise<boolean> {
+    return (await this.get(hash)) !== null;
+  }
+
+  async delete(hash: string): Promise<boolean> {
+    const existed = await this.has(hash);
+    if (existed) await this.client.del(this.key(hash));
+    return existed;
+  }
+
+  async putMany(entries: StorageBlobEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    const pipeline = this.client.pipeline();
+    entries.forEach(entry => pipeline.set(this.key(entry.hash), entry));
+    await pipeline.exec();
+  }
+
+  async getMany(hashes: string[]): Promise<Map<string, StorageBlobEntry>> {
+    const result = new Map<string, StorageBlobEntry>();
+    if (hashes.length === 0) return result;
+    const pipeline = this.client.pipeline();
+    hashes.forEach(hash => pipeline.get(this.key(hash)));
+    const entries = (await pipeline.exec()) as (StorageBlobEntry | null)[];
+    hashes.forEach((hash, index) => {
+      const entry = entries[index];
+      if (entry) result.set(hash, entry);
+    });
+    return result;
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.deleteByPattern(this.key('*'));
+  }
+
+  private key(hash: string): string {
+    return `mastra:upstash:blobs:${this.namespace}:${hash}`;
+  }
+
+  private async deleteByPattern(pattern: string): Promise<void> {
+    const keys = await scanKeys(this.client, pattern);
+    if (keys.length > 0) await this.client.del(...keys);
+  }
+}
+
+export class ChannelsUpstash extends ChannelsStorage {
+  private client: Redis;
+  private namespace: string;
+
+  constructor(config: PersistedConfig) {
+    super();
+    this.client = resolveUpstashConfig(config);
+    this.namespace = config.namespace ?? 'channels';
+  }
+
+  async saveInstallation(installation: ChannelInstallation): Promise<void> {
+    await this.client.set(this.installationKey(installation.id), installation);
+  }
+
+  async getInstallation(id: string): Promise<ChannelInstallation | null> {
+    const installation = await this.client.get<ChannelInstallation>(this.installationKey(id));
+    return installation ? reviveChannelInstallation(installation) : null;
+  }
+
+  async getInstallationByAgent(platform: string, agentId: string): Promise<ChannelInstallation | null> {
+    const installations = await this.listInstallations(platform);
+    const statusPriority = { active: 0, pending: 1, error: 2 } as const;
+    return (
+      installations
+        .filter(installation => installation.agentId === agentId)
+        .sort((a, b) => (statusPriority[a.status] ?? 3) - (statusPriority[b.status] ?? 3))[0] ?? null
+    );
+  }
+
+  async getInstallationByWebhookId(webhookId: string): Promise<ChannelInstallation | null> {
+    const installations = await this.allInstallations();
+    return installations.find(installation => installation.webhookId === webhookId) ?? null;
+  }
+
+  async listInstallations(platform: string): Promise<ChannelInstallation[]> {
+    return (await this.allInstallations()).filter(installation => installation.platform === platform);
+  }
+
+  async deleteInstallation(id: string): Promise<void> {
+    await this.client.del(this.installationKey(id));
+  }
+
+  async saveConfig(config: ChannelConfig): Promise<void> {
+    await this.client.set(this.configKey(config.platform), config);
+  }
+
+  async getConfig(platform: string): Promise<ChannelConfig | null> {
+    const config = await this.client.get<ChannelConfig>(this.configKey(platform));
+    return config ? { ...config, updatedAt: new Date(config.updatedAt) } : null;
+  }
+
+  async deleteConfig(platform: string): Promise<void> {
+    await this.client.del(this.configKey(platform));
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await deleteByPattern(this.client, `mastra:upstash:channels:${this.namespace}:*`);
+  }
+
+  private async allInstallations(): Promise<ChannelInstallation[]> {
+    const keys = await scanKeys(this.client, this.installationKey('*'));
+    if (keys.length === 0) return [];
+    const pipeline = this.client.pipeline();
+    keys.forEach(key => pipeline.get(key));
+    return ((await pipeline.exec()) as (ChannelInstallation | null)[])
+      .filter((installation): installation is ChannelInstallation => !!installation)
+      .map(reviveChannelInstallation);
+  }
+
+  private installationKey(id: string): string {
+    return `mastra:upstash:channels:${this.namespace}:installations:${id}`;
+  }
+
+  private configKey(platform: string): string {
+    return `mastra:upstash:channels:${this.namespace}:configs:${platform}`;
+  }
+}
+
+export class DatasetsUpstash extends DatasetsInMemory {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'datasets');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class ExperimentsUpstash extends ExperimentsInMemory {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'experiments');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class FavoritesUpstash extends InMemoryFavoritesStorage {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'favorites');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class MCPClientsUpstash extends InMemoryMCPClientsStorage {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'mcp-clients');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class MCPServersUpstash extends InMemoryMCPServersStorage {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'mcp-servers');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class NotificationsUpstash extends NotificationsStorage {
+  private client: Redis;
+  private namespace: string;
+
+  constructor(config: PersistedConfig) {
+    super();
+    this.client = resolveUpstashConfig(config);
+    this.namespace = config.namespace ?? 'notifications';
+  }
+
+  async createNotification(input: CreateNotificationInput): Promise<NotificationRecord> {
+    const existing = await this.findCoalescable(input);
+    if (existing) {
+      const now = new Date();
+      const next: NotificationRecord = {
+        ...existing,
+        summary: input.summary,
+        payload: input.payload ?? existing.payload,
+        priority: input.priority ?? existing.priority,
+        attributes: input.attributes ? { ...existing.attributes, ...input.attributes } : existing.attributes,
+        updatedAt: now,
+        deliverAt: input.deliverAt ?? existing.deliverAt,
+        summaryAt: input.summaryAt ?? existing.summaryAt,
+        deliveryReason: input.deliveryReason ?? existing.deliveryReason,
+        coalescedCount: (existing.coalescedCount ?? 1) + 1,
+        metadata: input.metadata ? { ...existing.metadata, ...input.metadata } : existing.metadata,
+      };
+      await this.client.set(this.notificationKey(next.threadId, next.id), next);
+      return next;
+    }
+
+    const now = input.createdAt ?? new Date();
+    const record: NotificationRecord = {
+      id: input.id ?? crypto.randomUUID(),
+      threadId: input.threadId,
+      source: input.source,
+      kind: input.kind,
+      priority: input.priority ?? 'medium',
+      status: 'pending',
+      summary: input.summary,
+      payload: input.payload,
+      resourceId: input.resourceId,
+      agentId: input.agentId,
+      sourceId: input.sourceId,
+      dedupeKey: input.dedupeKey,
+      coalesceKey: input.coalesceKey,
+      coalescedCount: 1,
+      attributes: input.attributes,
+      createdAt: now,
+      updatedAt: now,
+      deliverAt: input.deliverAt,
+      summaryAt: input.summaryAt,
+      deliveryReason: input.deliveryReason,
+      deliveryAttempts: 0,
+      metadata: input.metadata,
+    };
+    await this.client.set(this.notificationKey(record.threadId, record.id), record);
+    return record;
+  }
+
+  async listNotifications(input: ListNotificationsInput): Promise<NotificationRecord[]> {
+    const search = input.search?.toLowerCase();
+    const records = await this.allNotifications();
+    return records
+      .filter(record => record.threadId === input.threadId)
+      .filter(record => matchesValue(record.status, input.status))
+      .filter(record => matchesValue(record.priority, input.priority))
+      .filter(record => !input.source || record.source === input.source)
+      .filter(record => !input.resourceId || record.resourceId === input.resourceId)
+      .filter(record => !input.agentId || record.agentId === input.agentId)
+      .filter(
+        record =>
+          !search ||
+          record.summary.toLowerCase().includes(search) ||
+          record.kind.toLowerCase().includes(search) ||
+          record.source.toLowerCase().includes(search),
+      )
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+      .slice(0, input.limit ?? records.length);
+  }
+
+  async listDueNotifications(input: ListDueNotificationsInput): Promise<NotificationRecord[]> {
+    const now = input.now.getTime();
+    const records = await this.allNotifications();
+    return records
+      .filter(record => record.status === 'pending')
+      .filter(record => !input.agentId || record.agentId === input.agentId)
+      .filter(record => !input.resourceId || record.resourceId === input.resourceId)
+      .filter(record => notificationDueTime(record) <= now)
+      .sort((a, b) => notificationDueTime(a) - notificationDueTime(b) || a.updatedAt.getTime() - b.updatedAt.getTime())
+      .slice(0, input.limit ?? records.length);
+  }
+
+  async getNotification(input: { threadId: string; id: string }): Promise<NotificationRecord | null> {
+    const record = await this.client.get<NotificationRecord>(this.notificationKey(input.threadId, input.id));
+    return record ? reviveNotification(record) : null;
+  }
+
+  async updateNotification(input: UpdateNotificationInput): Promise<NotificationRecord> {
+    const existing = await this.getNotification(input);
+    if (!existing) throw new Error(`Notification ${input.id} was not found for thread ${input.threadId}`);
+    const now = new Date();
+    const next: NotificationRecord = {
+      ...existing,
+      ...(input.status ? { status: input.status, ...notificationStatusTimestamp(input.status, now) } : {}),
+      ...(input.summary !== undefined ? { summary: input.summary } : {}),
+      ...(input.payload !== undefined ? { payload: input.payload } : {}),
+      ...(input.attributes !== undefined ? { attributes: input.attributes } : {}),
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+      ...(input.deliverAt !== undefined ? { deliverAt: input.deliverAt ?? undefined } : {}),
+      ...(input.summaryAt !== undefined ? { summaryAt: input.summaryAt ?? undefined } : {}),
+      ...(input.deliveryReason !== undefined ? { deliveryReason: input.deliveryReason } : {}),
+      ...(input.deliveryAttempts !== undefined ? { deliveryAttempts: input.deliveryAttempts } : {}),
+      ...(input.lastDeliveryAttemptAt !== undefined ? { lastDeliveryAttemptAt: input.lastDeliveryAttemptAt } : {}),
+      ...(input.lastDeliveryError !== undefined ? { lastDeliveryError: input.lastDeliveryError } : {}),
+      ...(input.deliveredSignalId !== undefined ? { deliveredSignalId: input.deliveredSignalId } : {}),
+      ...(input.summarySignalId !== undefined ? { summarySignalId: input.summarySignalId } : {}),
+      updatedAt: now,
+    };
+    await this.client.set(this.notificationKey(next.threadId, next.id), next);
+    return next;
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await deleteByPattern(this.client, `mastra:upstash:notifications:${this.namespace}:*`);
+  }
+
+  private async allNotifications(): Promise<NotificationRecord[]> {
+    const keys = await scanKeys(this.client, this.notificationKey('*', '*'));
+    if (keys.length === 0) return [];
+    const pipeline = this.client.pipeline();
+    keys.forEach(key => pipeline.get(key));
+    return ((await pipeline.exec()) as (NotificationRecord | null)[])
+      .filter((record): record is NotificationRecord => !!record)
+      .map(reviveNotification);
+  }
+
+  private async findCoalescable(input: CreateNotificationInput): Promise<NotificationRecord | undefined> {
+    if (!input.dedupeKey && !input.coalesceKey) return undefined;
+    const records = await this.allNotifications();
+    return records.find(record => {
+      if (
+        record.threadId !== input.threadId ||
+        record.source !== input.source ||
+        record.kind !== input.kind ||
+        record.status !== 'pending'
+      ) {
+        return false;
+      }
+      if (record.agentId !== input.agentId || record.resourceId !== input.resourceId) return false;
+      return Boolean(
+        (input.dedupeKey && record.dedupeKey === input.dedupeKey) ||
+          (input.coalesceKey && record.coalesceKey === input.coalesceKey),
+      );
+    });
+  }
+
+  private notificationKey(threadId: string, id: string): string {
+    return `mastra:upstash:notifications:${this.namespace}:${threadId}:${id}`;
+  }
+}
+
+export class ObservabilityUpstash extends ObservabilityInMemory {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'observability');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class PromptBlocksUpstash extends InMemoryPromptBlocksStorage {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'prompt-blocks');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class SchedulesUpstash extends InMemorySchedulesStorage {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'schedules');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class ScorerDefinitionsUpstash extends InMemoryScorerDefinitionsStorage {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'scorer-definitions');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class SkillsUpstash extends InMemorySkillsStorage {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'skills');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}
+
+export class ToolProviderConnectionsUpstash {
+  private client: Redis;
+  private namespace: string;
+
+  constructor(config: PersistedConfig) {
+    this.client = resolveUpstashConfig(config);
+    this.namespace = config.namespace ?? 'tool-provider-connections';
+  }
+
+  async init(): Promise<void> {}
+
+  async dangerouslyClearAll(): Promise<void> {
+    const keys = await this.scanKeys(this.key('*', '*', '*'));
+    if (keys.length > 0) await this.client.del(...keys);
+  }
+
+  async getConnectionById({
+    authorId,
+    providerId,
+    connectionId,
+  }: StorageToolProviderConnectionKey): Promise<StorageToolProviderConnection | null> {
+    return (await this.client.get<StorageToolProviderConnection>(this.key(authorId, providerId, connectionId))) ?? null;
+  }
+
+  async upsertConnection(input: StorageUpsertToolProviderConnectionInput): Promise<StorageToolProviderConnection> {
+    const existing = await this.getConnectionById(input);
+    const now = new Date();
+    const row: StorageToolProviderConnection = {
+      authorId: input.authorId,
+      providerId: input.providerId,
+      toolkit: input.toolkit,
+      connectionId: input.connectionId,
+      label: input.label,
+      scope: input.scope ?? existing?.scope ?? 'per-author',
+      createdAt: existing?.createdAt ? new Date(existing.createdAt) : now,
+      updatedAt: now,
+    };
+    await this.client.set(this.key(input.authorId, input.providerId, input.connectionId), row);
+    return row;
+  }
+
+  async listConnectionsByAuthor({
+    authorId,
+    providerId,
+    toolkit,
+    scope,
+  }: StorageListToolProviderConnectionsInput): Promise<StorageToolProviderConnection[]> {
+    const keys = await this.scanKeys(this.key(authorId ?? '*', providerId ?? '*', '*'));
+    if (keys.length === 0) return [];
+
+    const pipeline = this.client.pipeline();
+    keys.forEach(key => pipeline.get(key));
+    const rows = (await pipeline.exec()) as (StorageToolProviderConnection | null)[];
+
+    return rows
+      .filter((row): row is StorageToolProviderConnection => !!row)
+      .map(row => ({
+        ...row,
+        createdAt: new Date(row.createdAt),
+        updatedAt: new Date(row.updatedAt),
+      }))
+      .filter(row => (toolkit ? row.toolkit === toolkit : true))
+      .filter(row => (scope ? row.scope === scope : true));
+  }
+
+  async deleteConnection({ authorId, providerId, connectionId }: StorageDeleteToolProviderConnectionInput): Promise<void> {
+    await this.client.del(this.key(authorId, providerId, connectionId));
+  }
+
+  private key(authorId: string, providerId: string, connectionId: string): string {
+    return `mastra:upstash:tool-provider-connections:${this.namespace}:${authorId}:${providerId}:${connectionId}`;
+  }
+
+  private async scanKeys(pattern: string): Promise<string[]> {
+    let cursor = '0';
+    const keys: string[] = [];
+    do {
+      const [nextCursor, batch] = await this.client.scan(cursor, { match: pattern, count: 1000 });
+      keys.push(...batch);
+      cursor = nextCursor;
+    } while (cursor !== '0');
+    return keys;
+  }
+}
+
+export class WorkspacesUpstash extends InMemoryWorkspacesStorage {
+  constructor(config: PersistedConfig) {
+    const persister = new UpstashInMemoryPersister(config, 'workspaces');
+    super({ db: persister.db });
+    return persisted(this, persister);
+  }
+}

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -307,3 +307,79 @@ describe('updateMessages keeps msg-idx index in sync', () => {
     expect(messages[0]!.threadId).toBe(sourceThread.id);
   });
 });
+
+describe('pg parity storage domains', () => {
+  it('wires every persistent domain exposed by PostgresStore', () => {
+    const store = new UpstashStore({
+      id: `upstash-domain-parity-${randomUUID()}`,
+      client: createTestClient(),
+    });
+
+    const domains = store.stores as Record<string, unknown>;
+    expect(domains.agents).toBeDefined();
+    expect(domains.blobs).toBeDefined();
+    expect(domains.channels).toBeDefined();
+    expect(domains.datasets).toBeDefined();
+    expect(domains.experiments).toBeDefined();
+    expect(domains.favorites).toBeDefined();
+    expect(domains.mcpClients).toBeDefined();
+    expect(domains.mcpServers).toBeDefined();
+    expect(domains.notifications).toBeDefined();
+    expect(domains.observability).toBeDefined();
+    expect(domains.promptBlocks).toBeDefined();
+    expect(domains.schedules).toBeDefined();
+    expect(domains.scorerDefinitions).toBeDefined();
+    expect(domains.skills).toBeDefined();
+    expect(domains.toolProviderConnections).toBeDefined();
+    expect(domains.workspaces).toBeDefined();
+  });
+});
+
+describe('observational memory support', () => {
+  it('lists messages by resource id and persists observational memory history', async () => {
+    const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
+    await memoryDomain.init();
+
+    const resourceId = `resource-${randomUUID()}`;
+    const thread = createThread(resourceId);
+    await memoryDomain.saveThread({ thread });
+
+    const firstMessage = createMessage(thread, {
+      id: `msg-${randomUUID()}`,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    });
+    const secondMessage = createMessage(thread, {
+      id: `msg-${randomUUID()}`,
+      createdAt: new Date('2024-01-02T00:00:00.000Z'),
+    });
+    await memoryDomain.saveMessages({ messages: [firstMessage, secondMessage] });
+
+    const listed = await memoryDomain.listMessagesByResourceId({
+      resourceId,
+      orderBy: { field: 'createdAt', direction: 'ASC' },
+    });
+    expect(listed.messages.map(message => message.id)).toEqual([firstMessage.id, secondMessage.id]);
+
+    const record = await memoryDomain.initializeObservationalMemory({
+      threadId: null,
+      resourceId,
+      scope: 'resource',
+      config: { enabled: true },
+    });
+    await memoryDomain.updateActiveObservations({
+      id: record.id,
+      observations: 'User likes concise answers.',
+      tokenCount: 5,
+      lastObservedAt: secondMessage.createdAt,
+      observedMessageIds: [firstMessage.id, secondMessage.id],
+    });
+
+    const current = await memoryDomain.getObservationalMemory(null, resourceId);
+    expect(current?.activeObservations).toBe('User likes concise answers.');
+    expect(current?.observedMessageIds).toEqual([firstMessage.id, secondMessage.id]);
+
+    const history = await memoryDomain.getObservationalMemoryHistory(null, resourceId, 10);
+    expect(history).toHaveLength(1);
+    expect(history[0]?.id).toBe(record.id);
+  });
+});

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -368,6 +368,32 @@ describe('observational memory support', () => {
     expect(listed.messages.map(message => message.id)).toEqual([unindexedMessage.id, indexedMessage.id]);
   });
 
+  it('preserves DESC ordering after MessageList processing when listing messages by resource id', async () => {
+    const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
+    await memoryDomain.init();
+
+    const resourceId = `resource-${randomUUID()}`;
+    const thread = createThread(resourceId);
+    await memoryDomain.saveThread({ thread });
+
+    const olderMessage = createMessage(thread, {
+      id: `older-msg-${randomUUID()}`,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    });
+    const newerMessage = createMessage(thread, {
+      id: `newer-msg-${randomUUID()}`,
+      createdAt: new Date('2024-01-02T00:00:00.000Z'),
+    });
+    await memoryDomain.saveMessages({ messages: [olderMessage, newerMessage] });
+
+    const listed = await memoryDomain.listMessagesByResourceId({
+      resourceId,
+      orderBy: { field: 'createdAt', direction: 'DESC' },
+    });
+
+    expect(listed.messages.map(message => message.id)).toEqual([newerMessage.id, olderMessage.id]);
+  });
+
   it('lists messages by resource id and persists observational memory history', async () => {
     const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
     await memoryDomain.init();

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -6,11 +6,13 @@ import {
   createDomainDirectTests,
 } from '@internal/storage-test-utils';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
+import { TABLE_MESSAGES } from '@mastra/core/storage';
 import { Redis } from '@upstash/redis';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { StoreMemoryUpstash } from './domains/memory';
 import { ScoresUpstash } from './domains/scores';
+import { getKey } from './domains/utils';
 import { WorkflowsUpstash } from './domains/workflows';
 import { UpstashStore } from './index';
 
@@ -336,6 +338,36 @@ describe('pg parity storage domains', () => {
 });
 
 describe('observational memory support', () => {
+  it('returns resource messages from both indexed and unindexed storage rows', async () => {
+    const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
+    await memoryDomain.init();
+
+    const resourceId = `resource-${randomUUID()}`;
+    const thread = createThread(resourceId);
+    await memoryDomain.saveThread({ thread });
+
+    const unindexedMessage = createMessage(thread, {
+      id: `legacy-msg-${randomUUID()}`,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    });
+    const indexedMessage = createMessage(thread, {
+      id: `indexed-msg-${randomUUID()}`,
+      createdAt: new Date('2024-01-02T00:00:00.000Z'),
+    });
+
+    const client = (memoryDomain as any).client as Redis;
+    await client.set(getKey(TABLE_MESSAGES, { threadId: thread.id, id: unindexedMessage.id }), unindexedMessage);
+
+    await memoryDomain.saveMessages({ messages: [indexedMessage] });
+
+    const listed = await memoryDomain.listMessagesByResourceId({
+      resourceId,
+      orderBy: { field: 'createdAt', direction: 'ASC' },
+    });
+
+    expect(listed.messages.map(message => message.id)).toEqual([unindexedMessage.id, indexedMessage.id]);
+  });
+
   it('lists messages by resource id and persists observational memory history', async () => {
     const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
     await memoryDomain.init();

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -1,13 +1,52 @@
-import { MastraCompositeStore } from '@mastra/core/storage';
+import { InMemoryDB, MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
 import { Redis } from '@upstash/redis';
 import { BackgroundTasksUpstash } from './domains/background-tasks';
 import { StoreMemoryUpstash } from './domains/memory';
+import {
+  AgentsUpstash,
+  BlobsUpstash,
+  ChannelsUpstash,
+  DatasetsUpstash,
+  ExperimentsUpstash,
+  FavoritesUpstash,
+  MCPClientsUpstash,
+  MCPServersUpstash,
+  NotificationsUpstash,
+  ObservabilityUpstash,
+  PromptBlocksUpstash,
+  SchedulesUpstash,
+  ScorerDefinitionsUpstash,
+  SkillsUpstash,
+  ToolProviderConnectionsUpstash,
+  WorkspacesUpstash,
+} from './domains/persisted-inmemory';
 import { ScoresUpstash } from './domains/scores';
 import { WorkflowsUpstash } from './domains/workflows';
 
 // Export domain classes for direct use with MastraStorage composition
-export { BackgroundTasksUpstash, StoreMemoryUpstash, ScoresUpstash, WorkflowsUpstash };
+export {
+  AgentsUpstash,
+  BackgroundTasksUpstash,
+  BlobsUpstash,
+  ChannelsUpstash,
+  DatasetsUpstash,
+  ExperimentsUpstash,
+  FavoritesUpstash,
+  MCPClientsUpstash,
+  MCPServersUpstash,
+  StoreMemoryUpstash,
+  NotificationsUpstash,
+  ObservabilityUpstash,
+  PromptBlocksUpstash,
+  ScorerDefinitionsUpstash,
+  ScoresUpstash,
+  SchedulesUpstash,
+  SkillsUpstash,
+  ToolProviderConnectionsUpstash,
+  WorkflowsUpstash,
+  WorkspacesUpstash,
+};
 export type { UpstashDomainConfig } from './db';
 
 /**
@@ -123,13 +162,31 @@ export class UpstashStore extends MastraCompositeStore {
     const workflows = new WorkflowsUpstash({ client: this.redis });
     const memory = new StoreMemoryUpstash({ client: this.redis });
     const backgroundTasks = new BackgroundTasksUpstash({ client: this.redis });
+    const persistedDb = new InMemoryDB();
+    const persistedConfig = { client: this.redis, namespace: config.id, db: persistedDb };
 
     this.stores = {
       scores,
       workflows,
       memory,
       backgroundTasks,
-    };
+      agents: new AgentsUpstash(persistedConfig),
+      blobs: new BlobsUpstash(persistedConfig),
+      channels: new ChannelsUpstash(persistedConfig),
+      datasets: new DatasetsUpstash(persistedConfig),
+      experiments: new ExperimentsUpstash(persistedConfig),
+      favorites: new FavoritesUpstash(persistedConfig),
+      mcpClients: new MCPClientsUpstash(persistedConfig),
+      mcpServers: new MCPServersUpstash(persistedConfig),
+      notifications: new NotificationsUpstash(persistedConfig),
+      observability: new ObservabilityUpstash(persistedConfig),
+      promptBlocks: new PromptBlocksUpstash(persistedConfig),
+      schedules: new SchedulesUpstash(persistedConfig),
+      scorerDefinitions: new ScorerDefinitionsUpstash(persistedConfig),
+      skills: new SkillsUpstash(persistedConfig),
+      toolProviderConnections: new ToolProviderConnectionsUpstash(persistedConfig),
+      workspaces: new WorkspacesUpstash(persistedConfig),
+    } as unknown as StorageDomains;
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
## Description

Adds observational memory support and storage domain parity improvements to `@mastra/upstash`.

### Changes

* Added observational memory methods
* Added resource-scoped message retrieval
* Added missing Upstash storage domain wiring
* Added tests
* Added changeset

## Related issue(s)

Closes #17871

## Type of change

* [x] New feature (non-breaking change that adds functionality)
* [x] Test update

## Checklist

* [x] I have linked the related issue(s) in the description above
* [ ] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR fills missing features in the Upstash storage adapter so it can be used like the other storage backends: it adds a "watch-and-remember" memory feature (observational memory) and brings many other domain stores into parity so Upstash supports the same tooling as other adapters.

## Changes Overview

### Observational Memory Support
- Full observational memory implementation in the Upstash memory domain (StoreMemoryUpstash).
- Adds supportsObservationalMemory = true.
- Lifecycle and operational APIs: initialize/insert/get/history, update active/buffered observations, swap buffered→active, create/update/swap reflection generations, set flags (reflecting/observing/buffering), clear, set pending tokens, and config updates (deep-merge).
- History retrieval and record persistence keyed per record.

### Resource-Scoped Message Retrieval
- Resource-scoped indexing via Redis sorted sets: resource:{resourceId}:messages scored by createdAt.
- New public API listMessagesByResourceId({resourceId,...}) with filtering, pagination, and ordering.
- saveMessages/updateMessages/deleteMessages/cloneThread updated to maintain resource indices, including handling messages moved between threads/resources.
- Backfill logic: scans message table entries for resource when index is partial.

### Domain Parity (persisted in-memory)
- Adds persisted-inmemory Upstash-backed implementations for many in-memory domains so Upstash exposes the same domains as other adapters:
  - In-memory-backed domains: Agents, Datasets, Experiments, Favorites, MCP Clients, MCP Servers, Observability, Prompt Blocks, Schedules, Scorer Definitions, Skills, Workspaces.
  - Redis-backed domains: Blobs (KV), Channels (installations/configs), Notifications (with dedupe/coalesce and due-time listing), Tool Provider Connections.
- Introduces UpstashInMemoryPersister to serialize/restore InMemoryDB state (with ISO date revival).
- persisted() proxy wrapper auto-loads and auto-saves state around method calls (except init and dangerouslyClearAll).
- UpstashStore now composes these persisted-inmemory domains using a shared persistedDb and config.

### Tests & Changeset
- New/updated tests:
  - Domain-parity test asserting presence of the expanded set of domains.
  - Observational memory tests: resource-scoped listing (including legacy/unindexed items), DESC ordering preservation, initialize + updateActiveObservations + history retrieval.
- Changeset added with release notes for `@mastra/upstash`.
- Commits include fixes for partial resource indexes and preserving DESC ordering.

### Notable Implementation Details
- listMessagesByResourceId uses resource index primarily and scans/backfills when needed.
- Message index updates handle thread/resource moves and conditional removal from previous indices.
- Date/time revival logic applied across persisted domains and notification timestamps.
- Utility helpers for SCAN-based key operations and pattern deletion included.

### Remaining Items / Maintainer Questions
- Documentation updates and addressing all Coderabbit comments are not complete.
- Author requests maintainer guidance on whether to continue with the current persisted-inmemory approach (improving persisted-inmemory design) or prefer Redis-native implementations for certain domains before further work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->