### PR TITLE
feat(core): export ServerConfig and Methods types from server entrypoint

### DIFF
--- a/.changeset/tidy-server-types.md
+++ b/.changeset/tidy-server-types.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': patch
+---
+
+Added the `ServerConfig` and `Methods` type exports to `@mastra/core/server`. Server config and HTTP methods can now be declared in a separate file with full type safety. This complements the `Middleware` export and lets you name the type of `ApiRoute['method']`, which was previously unreachable.
+
+```ts
+import type { ServerConfig, Methods } from '@mastra/core/server';
+
+const protectedMethods: Methods[] = ['POST', 'PUT', 'DELETE'];
+
+export const serverConfig: ServerConfig = {
+  port: 4111,
+  middleware: async (c, next) => {
+    await next();
+  },
+};
+```

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -12,6 +12,8 @@ export type {
   ContextWithMastra,
   CorsOptions,
   ApiRoute,
+  Methods,
+  ServerConfig,
   HttpLoggingConfig,
   ValidationErrorContext,
   ValidationErrorResponse,

--- a/packages/core/src/server/server.test-d.ts
+++ b/packages/core/src/server/server.test-d.ts
@@ -6,6 +6,7 @@ import type { MastraAuthProvider } from './auth';
 import { CompositeAuth } from './composite-auth';
 import { SimpleAuth } from './simple-auth';
 import { registerApiRoute } from './index';
+import type { Methods, ServerConfig } from './index';
 
 /**
  * Type tests for registerApiRoute
@@ -143,5 +144,23 @@ describe('CORS type tests', () => {
         credentials: true,
       },
     });
+  });
+});
+
+describe('server entrypoint type exports', () => {
+  it('allows declaring a server config in a separate module', () => {
+    const server: ServerConfig = {
+      port: 4111,
+      middleware: async (_c, next) => {
+        await next();
+      },
+    };
+
+    new Mastra({ server });
+  });
+
+  it('allows naming the HTTP method union', () => {
+    const protectedMethods: Methods[] = ['POST', 'PUT', 'DELETE'];
+    expectTypeOf(protectedMethods).items.toEqualTypeOf<Methods>();
   });
 });


### PR DESCRIPTION
## Description

Follow-up to #17873 (which re-exports `Middleware`, closing #17868). This one does the same for two related types that have the same gap:

- `ServerConfig` — the shape of the `server` config object, so you can build it in a separate file and annotate it.
- `Methods` — the HTTP method union. `ApiRoute` is already exported and references `Methods`, so right now you can use `ApiRoute` but can't name the type of its `method` field.

Neither of these worked before:

```ts
import type { ServerConfig, Methods } from '@mastra/core/server'
```

Now you can do this:

```ts
import type { ServerConfig, Methods } from '@mastra/core/server'

const protectedMethods: Methods[] = ['POST', 'PUT', 'DELETE']

export const serverConfig: ServerConfig = {
  port: 4111,
  middleware: async (c, next) => {
    await next()
  },
}
```

No runtime changes, this is purely the type exports. I also added a type test for both.

## Related issue(s)

Closes #17874

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
