### PR TITLE
 fix(playground): overlay update badges on the version footer

### DIFF
--- a/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
@@ -88,12 +88,18 @@ export const MastraVersionFooter = ({ collapsed }: MastraVersionFooterProps) => 
         <DialogTrigger asChild>
           <button
             type="button"
-            className="flex flex-col items-end gap-1 rounded-lg p-1 hover:bg-sidebar-nav-hover transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:shadow-focus-ring"
+            className="flex rounded-lg p-1 hover:bg-sidebar-nav-hover transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:shadow-focus-ring"
           >
-            {isLoadingUpdates && <Spinner className="size-3 text-neutral3" />}
-            {outdatedCount > 0 && <CountBadge count={outdatedCount} variant="warning" />}
-            {deprecatedCount > 0 && <CountBadge count={deprecatedCount} variant="error" />}
-            <span className={versionBadgeClassName}>v{mainVersion}</span>
+            <span className="relative inline-flex">
+              {(isLoadingUpdates || outdatedCount > 0 || deprecatedCount > 0) && (
+                <span className="absolute -right-1.5 -top-1.5 flex items-center gap-1">
+                  {isLoadingUpdates && <Spinner className="size-3 text-neutral3" />}
+                  {outdatedCount > 0 && <CountBadge count={outdatedCount} variant="warning" />}
+                  {deprecatedCount > 0 && <CountBadge count={deprecatedCount} variant="error" />}
+                </span>
+              )}
+              <span className={versionBadgeClassName}>v{mainVersion}</span>
+            </span>
           </button>
         </DialogTrigger>
       </div>


### PR DESCRIPTION
The spinner and the outdated/deprecated count badges were stacked in a column above the `v{version}` badge in the sidebar footer, so the footer grew taller whenever updates were detected.

They now float as a small cluster anchored to the top-right corner of the version badge, notification-style — the footer keeps a stable height and the badges still show loading, outdated and deprecated states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

Imagine you have a sticker on your desk that shows your app's version number. Before, when you got update notifications, they would stack up in a tall column above the sticker, making your desk take up more space. Now, those notifications are tiny dots that float in the corner of the sticker instead, keeping your desk neat and tidy while still showing you when updates are available.

## Changes Overview

The PR restructures the layout of the Mastra version footer in the sidebar to improve visual stability and space efficiency.

### What Changed

The version badge footer component was refactored to change how status indicators (loading spinner, outdated package count, and deprecated package count) are displayed:

**Previous layout**: Status badges were displayed inline/stacked vertically, causing the footer container to expand in height when updates were detected.

**New layout**: Status indicators now use CSS absolute positioning to create a notification-style overlay anchored to the top-right corner of the version badge. The version badge (`v{version}`) is relatively-positioned to serve as the anchor point for the overlaid indicators.

This change preserves the footer's vertical height consistency while maintaining clear visibility of:
- Loading state (spinner icon)
- Number of outdated packages
- Number of deprecated packages

**File modified**: `packages/playground/src/domains/configuration/components/mastra-version-footer.tsx`
- 11 lines added
- 5 lines removed

The implementation uses Tailwind classes (`relative inline-flex`, `absolute -right-1.5 -top-1.5`) to position the indicators as a small cluster overlay rather than expanding the layout vertically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->