### PR TITLE
feat(mcp): request-scoped progress notifications in serverless mode

### DIFF
--- a/.changeset/serverless-mcp-progress-streaming.md
+++ b/.changeset/serverless-mcp-progress-streaming.md
@@ -1,0 +1,9 @@
+---
+"@mastra/mcp": minor
+---
+
+Add `serverlessStreaming` option to `MCPServer.startHTTP()` for request-scoped progress notifications in serverless mode.
+
+Serverless mode (`serverless: true`) buffers each request into a single JSON response, which silently drops any `notifications/progress` a tool emits via `extra.sendNotification()`. Setting `options: { serverless: true, serverlessStreaming: true }` now handles the request with request-scoped SSE streaming (`enableJsonResponse: false` on the transient transport), so progress notifications reach the MCP client's `onprogress` handler before the final result. An explicit `enableJsonResponse` is also honored.
+
+This is still fully stateless — no `mcp-session-id` is required or persisted — and the default behavior is unchanged (`enableJsonResponse: true`), so existing serverless JSON-response users are unaffected. It enables only notifications scoped to the current request, such as progress; elicitation, resource subscriptions, and out-of-request resource/list-change notifications still require session state.

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -517,7 +517,24 @@ Use the default session-based mode (without `serverless: true`) for:
 
 The serverless mode disables session management and creates fresh server instances per request, which is necessary for stateless environments where memory doesn't persist between invocations.
 
-**Note:** The following MCP features require session state or persistent connections and **won't work** in serverless mode:
+By default, serverless mode buffers each request into a single JSON response, so `notifications/progress` sent by a tool never reach the client. Set `serverlessStreaming: true` to handle the request with request-scoped SSE streaming instead, which delivers progress notifications before the final result:
+
+```typescript
+await server.startHTTP({
+  url,
+  httpPath: '/mcp',
+  req: nodeReq,
+  res: nodeRes,
+  options: {
+    serverless: true,
+    serverlessStreaming: true, // ← Stream request-scoped notifications/progress
+  },
+})
+```
+
+This is still stateless: no `mcp-session-id` is required or persisted. It only enables notifications scoped to the current request (such as progress). The session-dependent features below remain unavailable.
+
+**Note:** The following MCP features require session state or persistent connections and **won't work** in serverless mode (including with `serverlessStreaming: true`):
 
 - **Elicitation** - Interactive user input requests during tool execution require session management to route responses back to the correct client
 - **Resource subscriptions** - `resources/subscribe` and `resources/unsubscribe` need persistent connections to maintain subscription state
@@ -570,6 +587,13 @@ The `StreamableHTTPServerTransportOptions` object allows you to customize the be
     type: 'boolean',
     description:
       'If `true`, runs in stateless mode without session management. Each request is handled independently with a fresh server instance. Essential for serverless environments (Cloudflare Workers, Supabase Edge Functions, Vercel Edge, etc.) where sessions cannot persist between invocations. Defaults to `false`.',
+    optional: true,
+  },
+  {
+    name: 'serverlessStreaming',
+    type: 'boolean',
+    description:
+      'If `true`, serverless requests use request-scoped SSE streaming instead of a buffered JSON response, allowing in-request `notifications/progress` to reach the client before the final result. Only takes effect together with `serverless: true`. Defaults to `false` (buffered JSON responses), which preserves backward-compatible behavior. This enables only request-scoped notifications such as progress; elicitation, subscriptions, and out-of-request notifications still require session state.',
     optional: true,
   },
   {

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -9,6 +9,8 @@ import type { InternalCoreTool, Tool } from '@mastra/core/tools';
 import { createTool } from '@mastra/core/tools';
 import { createStep, Workflow } from '@mastra/core/workflows';
 import { isStandardSchemaWithJSON, standardSchemaToJSONSchema } from '@mastra/schema-compat/schema';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type {
   Resource,
@@ -1436,6 +1438,147 @@ describe('MCPServer', () => {
       expect(Object.keys(tools).length).toBeGreaterThan(0);
 
       await client.disconnect();
+    });
+
+    it('should still return final tool results in serverless JSON response mode (default)', async () => {
+      sessionServer = new MCPServer({
+        name: 'ServerlessJsonServer',
+        version: '1.0.0',
+        tools: {
+          echoTool: {
+            description: 'Echoes the provided message',
+            parameters: z.object({ message: z.string() }),
+            execute: async ({ message }: { message: string }) => ({ echoed: message }),
+          },
+        },
+      });
+
+      sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = new URL(req.url || '', `http://localhost:${currentTestPort}`);
+        await sessionServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          // Default serverless mode: enableJsonResponse stays true (no streaming opt-in)
+          options: { serverless: true },
+        });
+      });
+
+      await new Promise<void>(resolve => sessionHttpServer.listen(currentTestPort, () => resolve()));
+
+      const client = new Client({ name: 'serverless-json-client', version: '1.0.0' });
+      const transport = new StreamableHTTPClientTransport(new URL(`http://localhost:${currentTestPort}/http`));
+      await client.connect(transport);
+
+      const result = await client.callTool({ name: 'echoTool', arguments: { message: 'hello' } });
+
+      // Final tool result is still delivered in JSON response mode
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(JSON.parse(content[0].text)).toEqual({ echoed: 'hello' });
+
+      await client.close();
+      await transport.close();
+    });
+
+    it('should deliver notifications/progress to an MCP client onprogress handler in serverless streaming mode', async () => {
+      sessionServer = new MCPServer({
+        name: 'ServerlessStreamingServer',
+        version: '1.0.0',
+        tools: {
+          progressTool: {
+            description: 'Reports progress while working',
+            parameters: z.object({}),
+            execute: async (_args: unknown, context: any) => {
+              const extra = context?.mcp?.extra;
+              const progressToken = extra?._meta?.progressToken;
+              if (progressToken !== undefined && extra?.sendNotification) {
+                await extra.sendNotification({
+                  method: 'notifications/progress',
+                  params: { progressToken, progress: 1, total: 2 },
+                });
+                await extra.sendNotification({
+                  method: 'notifications/progress',
+                  params: { progressToken, progress: 2, total: 2 },
+                });
+              }
+              return { result: 'done' };
+            },
+          },
+        },
+      });
+
+      sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = new URL(req.url || '', `http://localhost:${currentTestPort}`);
+        await sessionServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          // Opt into request-scoped SSE streaming for serverless requests
+          options: { serverless: true, serverlessStreaming: true },
+        });
+      });
+
+      await new Promise<void>(resolve => sessionHttpServer.listen(currentTestPort, () => resolve()));
+
+      const client = new Client({ name: 'serverless-streaming-client', version: '1.0.0' });
+      const transport = new StreamableHTTPClientTransport(new URL(`http://localhost:${currentTestPort}/http`));
+      await client.connect(transport);
+
+      const progressUpdates: Array<{ progress: number; total?: number }> = [];
+      const result = await client.callTool({ name: 'progressTool', arguments: {} }, undefined, {
+        onprogress: notification =>
+          progressUpdates.push({ progress: notification.progress, total: notification.total }),
+      });
+
+      // The client received the request-scoped progress notifications
+      expect(progressUpdates).toEqual([
+        { progress: 1, total: 2 },
+        { progress: 2, total: 2 },
+      ]);
+
+      // The final tool result is still delivered after the stream completes
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(JSON.parse(content[0].text)).toEqual({ result: 'done' });
+
+      await client.close();
+      await transport.close();
+    });
+
+    it('should not require or persist an mcp-session-id in serverless streaming mode', async () => {
+      sessionServer = new MCPServer({
+        name: 'ServerlessNoSessionServer',
+        version: '1.0.0',
+        tools: minimalTestTool,
+      });
+
+      sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = new URL(req.url || '', `http://localhost:${currentTestPort}`);
+        await sessionServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          options: { serverless: true, serverlessStreaming: true },
+        });
+      });
+
+      await new Promise<void>(resolve => sessionHttpServer.listen(currentTestPort, () => resolve()));
+
+      const client = new Client({ name: 'serverless-no-session-client', version: '1.0.0' });
+      const transport = new StreamableHTTPClientTransport(new URL(`http://localhost:${currentTestPort}/http`));
+      await client.connect(transport);
+
+      // Stateless mode: the server assigns no session, so the client transport has no session ID
+      expect(transport.sessionId).toBeUndefined();
+
+      // Subsequent requests still work without an mcp-session-id
+      const tools = await client.listTools();
+      expect(tools.tools.length).toBeGreaterThan(0);
+
+      await client.close();
+      await transport.close();
     });
   });
 });

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1341,7 +1341,22 @@ export class MCPServer extends MCPServerBase {
     httpPath: string;
     req: http.IncomingMessage;
     res: http.ServerResponse<http.IncomingMessage>;
-    options?: Partial<StreamableHTTPServerTransportOptions> & { serverless?: boolean };
+    options?: Partial<StreamableHTTPServerTransportOptions> & {
+      serverless?: boolean;
+      /**
+       * Opt into request-scoped SSE streaming for serverless requests.
+       *
+       * When `true`, the transient serverless transport is created with
+       * `enableJsonResponse: false`, which allows in-request `notifications/progress`
+       * to stream back to the client before the final result. Defaults to `false`,
+       * preserving the JSON-response behavior that buffers only the final result.
+       *
+       * This only enables notifications scoped to the current request (e.g. progress).
+       * Elicitation, subscriptions, and out-of-request resource/list-change
+       * notifications still require a stateful session or another protocol model.
+       */
+      serverlessStreaming?: boolean;
+    };
   }) {
     this.logger.debug(`startHTTP: Received ${req.method} request to ${url.pathname}`);
 
@@ -1358,7 +1373,11 @@ export class MCPServer extends MCPServerBase {
 
     if (isStatelessMode) {
       this.logger.debug('startHTTP: Running in stateless mode (serverless or sessionIdGenerator: undefined)');
-      await this.handleServerlessRequest(req, res);
+      // Default to JSON responses for backward compatibility. Opt into request-scoped
+      // SSE streaming (e.g. notifications/progress) via serverlessStreaming or an explicit
+      // enableJsonResponse: false.
+      const enableJsonResponse = options?.serverlessStreaming === true ? false : (options?.enableJsonResponse ?? true);
+      await this.handleServerlessRequest(req, res, { enableJsonResponse });
       return;
     }
 
@@ -1520,9 +1539,17 @@ export class MCPServer extends MCPServerBase {
    *
    * @param req - Incoming HTTP request
    * @param res - HTTP response object
+   * @param options - Transport options for this request
+   * @param options.enableJsonResponse - When `true` (default), buffers and returns a single
+   *   JSON-RPC response. When `false`, the request is handled with request-scoped SSE streaming,
+   *   so in-request `notifications/progress` reach the client before the final result.
    * @private
    */
-  private async handleServerlessRequest(req: http.IncomingMessage, res: http.ServerResponse<http.IncomingMessage>) {
+  private async handleServerlessRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse<http.IncomingMessage>,
+    { enableJsonResponse = true }: { enableJsonResponse?: boolean } = {},
+  ) {
     try {
       this.logger.debug(`handleServerlessRequest: Received ${req.method} request`);
 
@@ -1533,17 +1560,19 @@ export class MCPServer extends MCPServerBase {
       this.logger.debug(`handleServerlessRequest: Processing ${req.method} request`, {
         method: body?.method,
         id: body?.id,
+        enableJsonResponse,
       });
 
       // Create a transient server instance for this single request
       const transientServer = this.createServerInstance();
 
-      // Create a one-time transport that handles this single request
-      // sessionIdGenerator: undefined disables session management entirely
-      // enableJsonResponse: true forces JSON-RPC responses instead of SSE streaming
+      // Create a one-time transport that handles this single request.
+      // sessionIdGenerator: undefined disables session management entirely.
+      // enableJsonResponse: true (default) buffers a single JSON-RPC response; false enables
+      // request-scoped SSE streaming so notifications/progress can reach the client.
       const tempTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
-        enableJsonResponse: true,
+        enableJsonResponse,
       });
 
       // Connect the transient server to the temporary transport


### PR DESCRIPTION
Closes #17926

## Summary

`MCPServer.handleServerlessRequest()` creates a transient `StreamableHTTPServerTransport` with `enableJsonResponse: true` hard-coded. That buffers each request into a single JSON-RPC response and silently drops any `notifications/progress` a tool emits via `extra.sendNotification()`. As a result, serverless MCP tools can call `sendNotification()` but the client's `onprogress` handler never fires.

This adds an opt-in `serverlessStreaming: true` flag that handles the request with **request-scoped SSE streaming** (`enableJsonResponse: false`) instead, so progress notifications reach the client before the final result — while staying fully stateless.

```ts
await server.startHTTP({
  url, httpPath: '/mcp', req, res,
  options: { serverless: true, serverlessStreaming: true },
});
```

## Why

This reconciles two existing capabilities that were mutually exclusive in serverless mode:

- #9585 added serverless mode by disabling streaming (`enableJsonResponse: true`, `sessionIdGenerator: undefined`).
- #10637 added progress-notification support, which serverless mode then dropped.

The MCP SDK already supports stateless per-request SSE when `sessionIdGenerator: undefined` and `enableJsonResponse: false` — Mastra just needed to stop forcing JSON-response mode for every serverless request. This also aligns with the direction in modelcontextprotocol/modelcontextprotocol#2575.

## Changes

- `startHTTP()` options gain `serverlessStreaming?: boolean` (defaults to `false`).
- `startHTTP()` computes `enableJsonResponse` (`serverlessStreaming === true` → `false`; otherwise honors an explicit `enableJsonResponse`, defaulting to `true`) and passes it through.
- `handleServerlessRequest()` now receives and applies `enableJsonResponse` instead of hard-coding `true`.
- Reference docs (`reference/tools/mcp-server.mdx`) document the flag and its scope.
- Changeset added (`@mastra/mcp` minor).

## Behavior & compatibility

- **Default unchanged.** Without the flag, serverless still returns buffered JSON responses, so existing serverless users are unaffected.
- **Still stateless.** No `mcp-session-id` is required or persisted in either mode.
- **Scope.** This enables only request-scoped notifications such as **progress**. Elicitation, resource subscriptions, and out-of-request resource/list-change notifications still require session state or a different protocol model, and remain unavailable in serverless mode.

## Tests

Added to `packages/mcp/src/server/server.test.ts`:

1. Serverless JSON-response mode (default) still returns final tool results.
2. Serverless streaming mode delivers `notifications/progress` to a real MCP SDK `Client.callTool(..., { onprogress })` handler, and still returns the final result.
3. Serverless mode does not require or persist an `mcp-session-id`.

All 83 server tests pass; `eslint` and `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Before this change, when using MCP Server in serverless mode, progress updates (like "tool is 50% done") were discarded and never reached the client—only the final result arrived. This PR adds an optional `serverlessStreaming` flag that lets progress notifications stream to clients in real-time while the request is still being processed, without requiring session state.

---

## Overview

This PR introduces request-scoped SSE streaming for serverless MCP deployments, enabling progress notifications to be delivered to clients before the final result. It adds a new `serverlessStreaming` option to `MCPServer.startHTTP()` that, when enabled alongside `serverless: true`, changes how responses are handled from buffered JSON to streaming without requiring server-side session state.

## Key Changes

- **New Option**: `serverlessStreaming?: boolean` added to `MCPServer.startHTTP()` options (default: `false`)
- **Transport Configuration**: `startHTTP()` now computes `enableJsonResponse` based on the `serverlessStreaming` flag:
  - When `serverlessStreaming: true` → `enableJsonResponse: false` (enables SSE streaming)
  - When `serverlessStreaming: false` (or absent) → `enableJsonResponse: true` (buffered JSON, default behavior preserved)
  - Explicit `enableJsonResponse` values are honored if provided
- **Server Logic**: `handleServerlessRequest()` now accepts `enableJsonResponse` parameter and passes it to the per-request transport instead of hard-coding it to `true`

## Compatibility

- **Backward Compatible**: Default serverless behavior remains unchanged (buffered JSON responses)
- **Request-Scoped Only**: Only request-scoped progress notifications are enabled by this flag; session-dependent MCP features (elicitation, resource subscriptions, resource notifications, prompt list changes) remain unavailable in serverless mode
- **No Session State**: Streaming mode remains stateless—no `mcp-session-id` is required or persisted

## Testing

Three new test cases cover:
1. Default serverless JSON response mode still delivers final tool results
2. Streaming mode delivers progress/progressToken updates via client `onprogress` handler followed by final result
3. Streaming mode does not require or persist `mcp-session-id` while supporting subsequent tool calls

All 83 server tests pass; code follows project style guidelines.

## Files Modified

- `packages/mcp/src/server/server.ts` — Core implementation with `startHTTP()` and `handleServerlessRequest()` updates
- `packages/mcp/src/server/server.test.ts` — New test coverage for serverless progress streaming
- `docs/src/content/en/reference/tools/mcp-server.mdx` — Updated documentation with usage examples and option details
- `.changeset/serverless-mcp-progress-streaming.md` — Release note for the new feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->