### PR TITLE
fix(mastracode): claude-fable-5 failing with "fallbacks: Extra inputs are not permitted" on Claude Max OAuth

### DIFF
--- a/.changeset/moody-feet-thank.md
+++ b/.changeset/moody-feet-thank.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed claude-fable-5 requests failing with "Invalid request: fallbacks: Extra inputs are not permitted" when logged in with Claude Max OAuth. The OAuth fetch wrapper was overwriting the anthropic-beta header, dropping the server-side-fallback beta that the automatic fable-5 fallback configuration requires. Request betas are now merged with the OAuth-required betas instead of being replaced.

--- a/mastracode/src/providers/__tests__/oauth-fetches.test.ts
+++ b/mastracode/src/providers/__tests__/oauth-fetches.test.ts
@@ -52,6 +52,30 @@ describe('gateway oauth fetch wrappers', () => {
     });
   });
 
+  it('merges SDK-provided anthropic-beta values with the OAuth-required betas', async () => {
+    anthropicStorage.get.mockReturnValue({ type: 'oauth' });
+    anthropicStorage.getApiKey.mockResolvedValue('oauth-token');
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    const { buildAnthropicOAuthFetch } = await import('../claude-max.js');
+    const fetchWithOAuth = buildAnthropicOAuthFetch({ authStorage: anthropicStorage as any });
+
+    // The AI SDK sets this beta when providerOptions.anthropic.fallbacks is
+    // configured; overwriting it makes the API reject the `fallbacks` body
+    // field with "Extra inputs are not permitted".
+    await fetchWithOAuth('https://api.anthropic.com/v1/messages', {
+      headers: { 'anthropic-beta': 'server-side-fallback-2026-06-01' },
+    });
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    const betas = headers.get('anthropic-beta')!.split(',');
+    expect(betas).toContain('server-side-fallback-2026-06-01');
+    expect(betas).toContain('oauth-2025-04-20');
+    expect(betas).toContain('claude-code-20250219');
+    // No duplicates when a required beta is also present on the request.
+    expect(new Set(betas).size).toBe(betas.length);
+  });
+
   it('annotates OpenAI gateway fetch errors with the request URL', async () => {
     openAIStorage.get.mockReturnValue({ type: 'oauth', access: 'oauth-token', expires: Date.now() + 60_000 });
     fetchMock.mockRejectedValueOnce(new Error('fetch failed'));

--- a/mastracode/src/providers/claude-max.ts
+++ b/mastracode/src/providers/claude-max.ts
@@ -14,6 +14,18 @@ import { AuthStorage } from '../auth/storage.js';
 // Required for Claude Max plan OAuth - the endpoint checks for this system message
 const claudeCodeIdentity = "You are Claude Code, Anthropic's official CLI for Claude.";
 
+// Betas required for Claude Max plan OAuth. Merged with (not replacing) any
+// betas the AI SDK already set on the request — e.g. the SDK adds
+// `server-side-fallback-2026-06-01` when `providerOptions.anthropic.fallbacks`
+// is configured; dropping it makes the API reject the `fallbacks` body field
+// with "Extra inputs are not permitted".
+const OAUTH_REQUIRED_BETAS = [
+  'oauth-2025-04-20',
+  'claude-code-20250219',
+  'interleaved-thinking-2025-05-14',
+  'fine-grained-tool-streaming-2025-05-14',
+];
+
 // Singleton auth storage instance
 let authStorageInstance: AuthStorage | null = null;
 
@@ -168,10 +180,11 @@ export function buildAnthropicOAuthFetch(opts: { authStorage?: AuthStorage } = {
     }
 
     headers.set('Authorization', `Bearer ${accessToken}`);
-    headers.set(
-      'anthropic-beta',
-      'oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14',
-    );
+    const requestBetas = (headers.get('anthropic-beta') ?? '')
+      .split(',')
+      .map(beta => beta.trim())
+      .filter(Boolean);
+    headers.set('anthropic-beta', Array.from(new Set([...OAUTH_REQUIRED_BETAS, ...requestBetas])).join(','));
     headers.set('anthropic-version', '2023-06-01');
 
     try {


### PR DESCRIPTION
Since #17893 auto-enables `providerOptions.anthropic.fallbacks` for claude-fable-5, every turn on a Claude Max OAuth login failed with `Invalid request: fallbacks: Extra inputs are not permitted`.

The AI SDK puts `fallbacks` in the request body and adds the required `server-side-fallback-2026-06-01` beta to the `anthropic-beta` header, but the OAuth fetch wrapper replaced that header with a fixed list of OAuth betas — so the API saw `fallbacks` without the beta enabled and rejected the request. This hit both the direct Anthropic path and the Mastra gateway path, since both use `buildAnthropicOAuthFetch`.

Before:
```ts
headers.set('anthropic-beta', 'oauth-2025-04-20,claude-code-20250219,...');
```

After:
```ts
const requestBetas = (headers.get('anthropic-beta') ?? '').split(',').map(b => b.trim()).filter(Boolean);
headers.set('anthropic-beta', Array.from(new Set([...OAUTH_REQUIRED_BETAS, ...requestBetas])).join(','));
```

Added a test asserting SDK-provided betas survive the wrapper without duplicates. Verified with the provider/model test suites (56 passing) and a clean typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're sending a request to an AI service with two special instructions: one from the app itself and one required for authentication. Previously, the authentication step was ignoring the app's instruction and only keeping the authentication instruction. This broke things when the app needed both. The fix is simple: keep both instructions instead of throwing one away.

## Overview

This PR fixes Claude Fable-5 requests failing with "Invalid request: fallbacks: Extra inputs are not permitted" when using Claude Max OAuth authentication. The root cause was that the OAuth fetch wrapper was overwriting the `anthropic-beta` header, removing the `server-side-fallback-2026-06-01` beta that the AI SDK automatically adds for fallback support.

## Changes

**mastracode/src/providers/claude-max.ts** (+17/-4)
- Introduced a centralized `OAUTH_REQUIRED_BETAS` constant listing the required betas for Claude Max OAuth: `oauth-2025-04-20` and `claude-code-20250219`
- Modified `buildAnthropicOAuthFetch` to merge existing `anthropic-beta` header values with the required betas instead of overwriting
- Implementation reads the existing header (if present), combines it with `OAUTH_REQUIRED_BETAS`, deduplicates entries, and writes the merged comma-separated result back

**mastracode/src/providers/__tests__/oauth-fetches.test.ts** (+24/-0)
- Added a new test case verifying that the Anthropic OAuth fetch wrapper preserves SDK-provided `anthropic-beta` values
- Test sets an initial `anthropic-beta` header on the request, invokes `buildAnthropicOAuthFetch`, and asserts that:
  - The resulting header includes the server-side fallback beta plus both required OAuth betas
  - No duplicate beta entries exist

**.changeset/moody-feet-thank.md** (+5/-0)
- Documentation entry for the patch release describing the fix for Claude Fable-5 OAuth authentication

## Testing

- New test case validates that SDK-provided betas survive the OAuth wrapper without duplicates
- Provider/model test suite: 56 passing tests
- Typecheck: passing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->