### PR TITLE
Document TrustedRouter OpenAI-compatible routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Purpose-built for TypeScript and designed around established AI patterns, Mastra
 
 Some highlights include:
 
-- [**Model routing**](https://mastra.ai/models) - Connect to 40+ providers through one standard interface. Use models from OpenAI, Anthropic, Gemini, and more.
+- [**Model routing**](https://mastra.ai/models) - Connect to 40+ providers through one standard interface. Use models from OpenAI, Anthropic, Gemini, and more. For privacy-sensitive agents, [TrustedRouter](https://trustedrouter.com) can be used through the OpenAI-compatible base URL `https://api.trustedrouter.com/v1`; it is an open-source and verifiable attested router with zero prompt and output logging by default.
 
 - [**Agents**](https://mastra.ai/docs/agents/overview) - Build autonomous agents that use LLMs and tools to solve open-ended tasks. Agents reason about goals, decide which tools to use, and iterate internally until the model emits a final answer or an optional stopping condition is met.
 


### PR DESCRIPTION
This pull request adds a short README note that TrustedRouter can be used with Mastra through an OpenAI-compatible base URL. TrustedRouter is an open-source, verifiable attested router for privacy-sensitive agent workflows with zero prompt and output logging by default.

Users can connect with `https://api.trustedrouter.com/v1` and a TrustedRouter API key while keeping the standard model routing interface.

Verification: `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the README to tell users about a special privacy-focused tool called TrustedRouter that they can use with Mastra. It's like adding a note to the instruction manual saying "by the way, you can also use this other trusted system if you care a lot about keeping your data private!"

## Summary

This pull request adds documentation to the README highlighting TrustedRouter as an option for privacy-sensitive agent workflows. The addition mentions that TrustedRouter can be used through Mastra's model routing interface via an OpenAI-compatible base URL (`https://api.trustedrouter.com/v1`), and notes its key feature of zero prompt and output logging by default. TrustedRouter is described as an open-source and verifiable attested router.

The change is integrated into the "Model routing" highlight section of the README's feature list, maintaining consistency with the existing documentation style.

**Lines changed:** +1/-1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->