### PR TITLE
fix(ai-sdk): pick most recent approval-responded part in extractV6NativeApproval (closes #17899)

### DIFF
--- a/.changeset/four-ghosts-make.md
+++ b/.changeset/four-ghosts-make.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed extractV6NativeApproval to pick the most recent approval-responded tool part within a trailing assistant message. Earlier, when one message accumulated multiple approval-responded parts across sequential resume cycles, the resume flow used the oldest stale decision instead of the one the user just acted on. Closes #17899.

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
@@ -255,6 +255,37 @@ describe('extractV6NativeApproval', () => {
     expect(extractV6NativeApproval(messages as any)).toBeNull();
   });
 
+  it('picks the most recent approval-responded part when one assistant message has several (issue #17899)', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'old-call',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: `old-run${APPROVAL_ID_SEPARATOR}old-call`, approved: true },
+          },
+          {
+            type: 'tool-myTool',
+            toolCallId: 'new-call',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: `new-run${APPROVAL_ID_SEPARATOR}new-call`, approved: false, reason: 'changed mind' },
+          },
+        ],
+      },
+    ];
+
+    const result = extractV6NativeApproval(messages as any);
+
+    expect(result?.runId).toBe('new-run');
+    expect(result?.resumeData.approved).toBe(false);
+    expect(result?.resumeData.reason).toBe('changed mind');
+  });
+
   it('scans from the end and picks the most recent approval-responded part', () => {
     const messages = [
       {

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -48,7 +48,7 @@ export function extractV6NativeApproval(
 
   const parts = lastAssistantMsg.parts ?? [];
   for (let i = parts.length - 1; i >= 0; i--) {
-    const part = parts[i];
+    const part = parts[i]!;
     if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;
 
     const lastSep = part.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -24,13 +24,16 @@ import type {
 } from './public-types';
 
 /**
- * Scans a v6 UIMessage array for an 'approval-responded' tool part in the
- * last trailing assistant message only. When found, splits the composite
- * approvalId ("${runId}::${toolCallId}") to recover the runId needed for
- * resumeStream.
+ * Scans a v6 UIMessage array for the most recent 'approval-responded' tool
+ * part in the last trailing assistant message only. When found, splits the
+ * composite approvalId ("${runId}::${toolCallId}") to recover the runId
+ * needed for resumeStream.
  *
  * Only the last trailing assistant message is inspected so that approval
- * responses from earlier turns are never re-processed.
+ * responses from earlier turns are never re-processed. Within that message,
+ * parts are scanned in reverse so the decision the user just acted on wins
+ * over any earlier 'approval-responded' parts that have not yet transitioned
+ * to 'output-available'.
  *
  * Returns null when no approval response is present (normal chat turn).
  */
@@ -43,7 +46,9 @@ export function extractV6NativeApproval(
   const lastAssistantMsg = messages.at(-1);
   if (!lastAssistantMsg || lastAssistantMsg.role !== 'assistant') return null;
 
-  for (const part of lastAssistantMsg.parts ?? []) {
+  const parts = lastAssistantMsg.parts ?? [];
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i];
     if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;
 
     const lastSep = part.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);


### PR DESCRIPTION
## Summary

Closes #17899.

`extractV6NativeApproval` scans the trailing assistant message for tool parts with `state: 'approval-responded'`, but the loop returns on the **first** match. When one assistant `UIMessage` accumulates multiple `approval-responded` parts across sequential resume cycles (earlier parts not yet transitioned to `output-available` before the next approval), `handleChatStream` resumes with the **oldest** stale decision, so a later rejection can be silently overridden by an earlier approval.

The function already constrains itself to the last trailing message via `messages.at(-1)`. The fix is to scan the parts array in reverse so the most recent decision wins.

## Repro

The existing test in `tool-call-approval.test.ts` named `'scans from the end and picks the most recent approval-responded part'` covers the **cross-message** case (two separate `assistant` messages, only the trailing one inspected). It does not cover the **within-message** case the issue describes. The new regression test puts two `approval-responded` parts in the same trailing message and asserts the second wins; without the fix, it fails because the first part's `approved: true` is returned instead of the second part's `approved: false`.

## Test commands

Built workspace deps then ran the targeted file:

```
pnpm build:core
pnpm --filter @internal/ai-v6 build
cd client-sdks/ai-sdk && npx vitest run src/__tests__/tool-call-approval.test.ts --reporter=verbose
```

Result: 19 / 19 tests pass, including the new `'picks the most recent approval-responded part when one assistant message has several (issue #17899)'` case.

## Notes

AI assistance was used to identify the fix surface from the issue body and to write the regression test; the diff was reviewed line-by-line and run locally against the reproducer described in the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If an assistant asks for your approval multiple times, the code mistakenly grabbed the *first* (older) approval it saw. This PR makes it use your *latest* approval decision instead.

## Changes Overview

This PR fixes a bug in `extractV6NativeApproval` where, when the trailing assistant message contained multiple `approval-responded` tool parts, the function returned the first (oldest) matching part instead of the most recent one. This could cause sequential resume cycles to reuse a stale approval decision rather than the user’s newest action.

## Key Changes

- **`client-sdks/ai-sdk/src/chat-route.ts`**: Updated `extractV6NativeApproval` to scan the trailing assistant message’s `approval-responded` parts in **reverse order**, so the most recent decision wins. Documentation was updated to reflect the behavior (last trailing assistant message, reverse scan within that message).
- **`client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts`**: Added a regression test for **`#17899`** that puts **two** `approval-responded` parts in the same trailing assistant message (first `approved: true`, second `approved: false`) and asserts the function returns the second (most recent) decision, including the correct `runId` and `resumeData`.
- **Changeset**: Added a patch-level changeset entry for `@mastra/ai-sdk` documenting the fix and closing **`#17899`**.

## Testing

All 19 tests pass locally, including the new regression test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->