### PR TITLE
fix(deployer): default dev server bind to localhost (closes #17906)

### DIFF
--- a/.changeset/thirty-knives-worry.md
+++ b/.changeset/thirty-knives-worry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed Mastra dev server defaulting to bind on `0.0.0.0` (all network interfaces) while logging that it was running on `localhost`. The dev server now defaults the bind address to `localhost`, matching the log message and avoiding silent network exposure. Set `serverOptions.host` or `MASTRA_HOST=0.0.0.0` when the server needs to be reachable beyond the loopback adapter. Closes #17906.

--- a/packages/deployer/src/server/__tests__/node-server-host.test.ts
+++ b/packages/deployer/src/server/__tests__/node-server-host.test.ts
@@ -102,13 +102,16 @@ describe('createNodeServer host binding', () => {
     delete process.env.MASTRA_HTTPS_CERT;
   });
 
-  it('leaves hostname undefined when no host is configured', async () => {
+  it('defaults hostname to localhost when no host is configured (closes #17906)', async () => {
     await createNodeServer(mockMastra, { tools: {} });
 
     expect(serveMock).toHaveBeenCalledOnce();
+    // Previously the bind was left undefined, which Node interprets as the
+    // unspecified address (binds to every interface) while the log claimed
+    // localhost. Default explicitly so the bind matches what we log.
     expect(serveMock.mock.calls[0]?.[0]).toMatchObject({
       port: 4111,
-      hostname: undefined,
+      hostname: 'localhost',
     });
     expect(logger.info).toHaveBeenCalledWith('Mastra API running', { url: 'http://localhost:4111/api' });
   });

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -450,8 +450,8 @@ export async function createHonoServer(
       // Inject the server configuration into index.html placeholders
       const port = serverOptions?.port ?? (Number(process.env.PORT) || 4111);
       const hideCloudCta = process.env.MASTRA_HIDE_CLOUD_CTA === 'true';
-      const bindHost = serverOptions?.host ?? process.env.MASTRA_HOST;
-      const host = bindHost ?? 'localhost';
+      const bindHost = serverOptions?.host ?? process.env.MASTRA_HOST ?? 'localhost';
+      const host = bindHost;
       const key =
         serverOptions?.https?.key ??
         (process.env.MASTRA_HTTPS_KEY ? Buffer.from(process.env.MASTRA_HTTPS_KEY, 'base64') : undefined);
@@ -550,8 +550,12 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
     (process.env.MASTRA_HTTPS_CERT ? Buffer.from(process.env.MASTRA_HTTPS_CERT, 'base64') : undefined);
   const isHttpsEnabled = Boolean(key && cert);
 
-  const bindHost = serverOptions?.host ?? process.env.MASTRA_HOST;
-  const host = bindHost ?? 'localhost';
+  // Default to `localhost` so the bind matches what the log message reports
+  // and so the dev server doesn't silently expose to every network interface
+  // reachable by the host. Set `serverOptions.host` (or MASTRA_HOST=0.0.0.0)
+  // when the server needs to be reachable beyond the loopback adapter.
+  const bindHost = serverOptions?.host ?? process.env.MASTRA_HOST ?? 'localhost';
+  const host = bindHost;
   const port = serverOptions?.port ?? (Number(process.env.PORT) || 4111);
   const protocol = isHttpsEnabled ? 'https' : 'http';
   const studioHost = serverOptions?.studioHost ?? host;


### PR DESCRIPTION
## Summary

Closes #17906.

When neither `serverOptions.host` nor `MASTRA_HOST` was set, `bindHost` was `undefined`. Hono's `serve()` passes that through to Node's `http.Server.listen`, which treats `undefined` as the unspecified address and binds to every reachable IPv4 interface on the host (LAN, VPN, container bridge, etc.). At the same time the "Mastra API running" log substituted `'localhost'` for that case, so the running server silently exposed every interface while telling the operator it was bound to loopback. That's both a log-vs-bind mismatch and a security default issue, which the reporter laid out clearly.

Fix is to fall back to `'localhost'` explicitly when nothing else is set, so the bind matches the log and `mastra dev` doesn't default to a network-reachable surface. Folks who want all-interfaces binding can still opt in via `serverOptions.host` or `MASTRA_HOST=0.0.0.0` (the existing "uses MASTRA_HOST when it is set" test continues to cover that path).

## Test commands

```
pnpm build:core
pnpm --filter @mastra/server build
cd packages/deployer && npx vitest run src/server/__tests__/node-server-host.test.ts
```

The `node-server-host.test.ts` suite has two cases for this code path:

- `defaults hostname to localhost when no host is configured (closes #17906)` — new contract, asserts `hostname: 'localhost'` (was `hostname: undefined`).
- `uses MASTRA_HOST when it is set` — unchanged, asserts `hostname: '0.0.0.0'` when env is `0.0.0.0`.

The opt-in path (`MASTRA_HOST=0.0.0.0` or `serverOptions.host = '0.0.0.0'`) keeps the previous behavior verbatim.

## Notes

The reporter pinpointed the exact mismatch between `bindHost` (line 553) and `host` (line 554) in `packages/deployer/src/server/index.ts`, and the studio-injection block at line 453 had the same pattern; both are corrected. Changeset added at `.changeset/thirty-knives-worry.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine a security guard who tells people the front door is locked, but actually forgets to lock it—letting anyone nearby walk in. This PR fixes that: the Mastra dev server was saying it's only available locally (localhost) but was actually open to everyone on the network. Now it actually stays locked locally unless you explicitly ask to open it to the network.

## Overview

This PR fixes a host binding mismatch in the Mastra deployer where the dev server would advertise binding to `localhost` in logs but actually bind to `0.0.0.0` (all network interfaces), unintentionally exposing the development server to external networks. The fix ensures the server explicitly defaults to binding on `localhost` when neither `serverOptions.host` nor the `MASTRA_HOST` environment variable is configured, making the actual bind behavior match what is logged and preventing accidental exposure.

## Changes

### Core Logic (`packages/deployer/src/server/index.ts`)
- Updated host resolution logic to explicitly default `bindHost` to `'localhost'` when both `serverOptions.host` and `MASTRA_HOST` are unset
- This ensures the value passed to the Node.js `serve()` function and the Studio HTML injection logic (host/protocol/port placeholders) consistently use `localhost` rather than `undefined`

### Tests (`packages/deployer/src/server/__tests__/node-server-host.test.ts`)
- Updated test assertions to expect `hostname: 'localhost'` when no explicit host configuration is provided
- Added clarifying comments explaining the expected default behavior
- Preserved existing tests for explicit configuration (e.g., `MASTRA_HOST=0.0.0.0`) to ensure opt-in all-interfaces binding still works

### Documentation (`.changeset/thirty-knives-worry.md`)
- Added changeset documenting the patch-level fix to the `@mastra/deployer` package
- Noted the default bind address change and instructions for explicitly enabling external access

## Behavior
- **Before**: No explicit host configured → server binds to `0.0.0.0` while logs report `localhost` (mismatch)
- **After**: No explicit host configured → server binds to `localhost` (matches logs)
- **Opt-in unchanged**: `serverOptions.host='0.0.0.0'` or `MASTRA_HOST=0.0.0.0` still allows external access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
