### PR TITLE
fix/workflow-cancel-interrupt-sleep

### DIFF
--- a/.changeset/fix-workflow-cancel-interrupts-sleep.md
+++ b/.changeset/fix-workflow-cancel-interrupts-sleep.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `Run.cancel()` so it interrupts an in-flight `.sleep()` / `.sleepUntil()` immediately instead of waiting for the full duration.
+
+Previously the default execution engine's sleep used a plain `setTimeout` that ignored the run's abort signal. A run canceled during a long sleep would keep a timer alive for the whole duration (e.g. `.sleepUntil(+24h)` held the run in memory for 24 hours), then wake up and overwrite the `'canceled'` status with `'running'` and publish a sleep-step `success` — so observers saw the run flip from `canceled` → `running` → `canceled`.
+
+Now the sleep races against the abort signal: the timer is cleared on cancel (and `unref`'d so a long sleep never keeps the process alive on its own), the downstream step never runs, and the run settles as `canceled` right away without persisting `running` or a sleep-step `success`.
+
+```ts
+const run = await workflow.createRun();
+const result = run.start({ inputData: {} });
+setTimeout(() => run.cancel(), 1000); // during .sleep(60_000)
+
+// Before: resolves after ~60s, status briefly flips back to running
+// After:  resolves promptly with status 'canceled'
+await result;
+```

--- a/packages/core/src/workflows/cancel-sleep.test.ts
+++ b/packages/core/src/workflows/cancel-sleep.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+import { createWorkflow } from './create';
+import { createStep } from './workflow';
+
+/**
+ * Regression tests for issue-02:
+ *
+ *   Workflow cancel() did not interrupt sleep()/sleepUntil() — the run kept
+ *   executing for the full duration and then overwrote the canceled status
+ *   with 'running' and published a sleep-step 'success'.
+ *
+ * Expected behaviour:
+ *   - cancel() interrupts an in-flight sleep immediately (no full-duration wait),
+ *   - the downstream step never runs,
+ *   - the result settles as 'canceled', and
+ *   - the persisted status is 'canceled' and is NOT flipped back to 'running' /
+ *     'success' after cancellation.
+ */
+describe('workflow cancel interrupts sleep (issue-02)', () => {
+  const noopStep = (id: string, fn = vi.fn().mockResolvedValue({})) =>
+    createStep({
+      id,
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      execute: fn,
+    });
+
+  it('cancel() during .sleep() interrupts immediately and the run stays canceled', async () => {
+    const SLEEP_MS = 60_000;
+    const afterSleep = vi.fn().mockResolvedValue({});
+
+    const workflow = createWorkflow({
+      id: 'cancel-sleep-wf',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      options: { validateInputs: false },
+    })
+      .then(noopStep('a'))
+      .sleep(SLEEP_MS)
+      .then(noopStep('b', afterSleep))
+      .commit();
+
+    const storage = new MockStore();
+    new Mastra({ logger: false, storage, workflows: { 'cancel-sleep-wf': workflow } });
+
+    const run = await workflow.createRun();
+
+    const startedAt = Date.now();
+    const resultPromise = run.start({ inputData: {} });
+    setTimeout(() => void run.cancel(), 200);
+
+    const result = await resultPromise;
+    const elapsed = Date.now() - startedAt;
+
+    // The wait is interrupted — we settle far sooner than the 60s duration.
+    expect(elapsed).toBeLessThan(5_000);
+    // The step after the sleep never runs.
+    expect(afterSleep).not.toHaveBeenCalled();
+    // The result settles as canceled, not success.
+    expect(result.status).toBe('canceled');
+
+    // Storage reflects 'canceled' and was not overwritten back to 'running'/'success'.
+    const store = await storage.getStore('workflows');
+    const snapshot = await store?.loadWorkflowSnapshot({
+      workflowName: 'cancel-sleep-wf',
+      runId: run.runId,
+    });
+    expect(snapshot?.status).toBe('canceled');
+  }, 15_000);
+
+  it('cancel() during .sleepUntil() interrupts immediately and the run stays canceled', async () => {
+    const afterSleep = vi.fn().mockResolvedValue({});
+
+    const workflow = createWorkflow({
+      id: 'cancel-sleep-until-wf',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      options: { validateInputs: false },
+    })
+      .then(noopStep('a'))
+      .sleepUntil(new Date(Date.now() + 60_000))
+      .then(noopStep('b', afterSleep))
+      .commit();
+
+    const storage = new MockStore();
+    new Mastra({ logger: false, storage, workflows: { 'cancel-sleep-until-wf': workflow } });
+
+    const run = await workflow.createRun();
+
+    const startedAt = Date.now();
+    const resultPromise = run.start({ inputData: {} });
+    setTimeout(() => void run.cancel(), 200);
+
+    const result = await resultPromise;
+    const elapsed = Date.now() - startedAt;
+
+    expect(elapsed).toBeLessThan(5_000);
+    expect(afterSleep).not.toHaveBeenCalled();
+    expect(result.status).toBe('canceled');
+
+    const store = await storage.getStore('workflows');
+    const snapshot = await store?.loadWorkflowSnapshot({
+      workflowName: 'cancel-sleep-until-wf',
+      runId: run.runId,
+    });
+    expect(snapshot?.status).toBe('canceled');
+  }, 15_000);
+});

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -45,6 +45,8 @@ import type {
   TimeTravelExecutionParams,
 } from './types';
 
+import { abortableSleep } from './utils';
+
 // Re-export ExecutionContext for backwards compatibility
 export type { ExecutionContext } from './types';
 
@@ -105,9 +107,15 @@ export class DefaultExecutionEngine extends ExecutionEngine {
    * @param duration - The duration to sleep in milliseconds
    * @param _sleepId - Unique identifier for this sleep operation
    * @param _workflowId - The workflow ID (for constructing platform-specific IDs)
+   * @param signal - Optional abort signal; the sleep resolves early when the run is canceled
    */
-  async executeSleepDuration(duration: number, _sleepId: string, _workflowId: string): Promise<void> {
-    await new Promise(resolve => setTimeout(resolve, duration < 0 ? 0 : duration));
+  async executeSleepDuration(
+    duration: number,
+    _sleepId: string,
+    _workflowId: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await abortableSleep(duration < 0 ? 0 : duration, signal);
   }
 
   /**
@@ -116,10 +124,16 @@ export class DefaultExecutionEngine extends ExecutionEngine {
    * @param date - The date to sleep until
    * @param _sleepUntilId - Unique identifier for this sleep operation
    * @param _workflowId - The workflow ID (for constructing platform-specific IDs)
+   * @param signal - Optional abort signal; the sleep resolves early when the run is canceled
    */
-  async executeSleepUntilDate(date: Date, _sleepUntilId: string, _workflowId: string): Promise<void> {
+  async executeSleepUntilDate(
+    date: Date,
+    _sleepUntilId: string,
+    _workflowId: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
     const time = date.getTime() - Date.now();
-    await new Promise(resolve => setTimeout(resolve, time < 0 ? 0 : time));
+    await abortableSleep(time < 0 ? 0 : time, signal);
   }
 
   /**

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -575,17 +575,6 @@ export async function executeEntry(
 
     delete executionContext.activeStepsPath[entry.id];
 
-    await engine.persistStepUpdate({
-      workflowId,
-      runId,
-      resourceId,
-      serializedStepGraph,
-      stepResults,
-      executionContext,
-      workflowStatus: 'running',
-      requestContext,
-    });
-
     const endedAt = Date.now();
     const stepInfo = {
       payload: prevOutput,
@@ -593,36 +582,55 @@ export async function executeEntry(
       endedAt,
     };
 
-    execResults = { ...stepInfo, status: 'success', output: prevOutput };
-    stepResults[entry.id] = { ...stepInfo, status: 'success', output: prevOutput };
-    const sleepResultOperationId = `workflow.${workflowId}.run.${runId}.sleep.${entry.id}.result_ev`;
-    await engine.wrapDurableOperation(sleepResultOperationId, async () => {
-      await pubsub.publish(`workflow.events.v2.${runId}`, {
-        type: 'watch',
+    if (abortController?.signal?.aborted) {
+      // The run was canceled while parked in the sleep. Settle as canceled and
+      // skip the 'running' persist + success events so we don't overwrite the
+      // canceled status that cancel() just wrote. The step result is left as the
+      // 'waiting' value recorded before the sleep — it never completed.
+      execResults = { ...stepInfo, status: 'canceled', output: prevOutput };
+    } else {
+      await engine.persistStepUpdate({
+        workflowId,
         runId,
-        data: {
-          type: 'workflow-step-result',
-          payload: {
-            id: entry.id,
-            endedAt,
-            status: 'success',
-            output: prevOutput,
-          },
-        },
+        resourceId,
+        serializedStepGraph,
+        stepResults,
+        executionContext,
+        workflowStatus: 'running',
+        requestContext,
       });
 
-      await pubsub.publish(`workflow.events.v2.${runId}`, {
-        type: 'watch',
-        runId,
-        data: {
-          type: 'workflow-step-finish',
-          payload: {
-            id: entry.id,
-            metadata: {},
+      execResults = { ...stepInfo, status: 'success', output: prevOutput };
+      stepResults[entry.id] = { ...stepInfo, status: 'success', output: prevOutput };
+      const sleepResultOperationId = `workflow.${workflowId}.run.${runId}.sleep.${entry.id}.result_ev`;
+      await engine.wrapDurableOperation(sleepResultOperationId, async () => {
+        await pubsub.publish(`workflow.events.v2.${runId}`, {
+          type: 'watch',
+          runId,
+          data: {
+            type: 'workflow-step-result',
+            payload: {
+              id: entry.id,
+              endedAt,
+              status: 'success',
+              output: prevOutput,
+            },
           },
-        },
+        });
+
+        await pubsub.publish(`workflow.events.v2.${runId}`, {
+          type: 'watch',
+          runId,
+          data: {
+            type: 'workflow-step-finish',
+            payload: {
+              id: entry.id,
+              metadata: {},
+            },
+          },
+        });
       });
-    });
+    }
   } else if (entry.type === 'sleepUntil') {
     executionContext.stepExecutionPath?.push(entry.id);
     const startedAt = Date.now();
@@ -680,17 +688,6 @@ export async function executeEntry(
 
     delete executionContext.activeStepsPath[entry.id];
 
-    await engine.persistStepUpdate({
-      workflowId,
-      runId,
-      resourceId,
-      serializedStepGraph,
-      stepResults,
-      executionContext,
-      workflowStatus: 'running',
-      requestContext,
-    });
-
     const endedAt = Date.now();
     const stepInfo = {
       payload: prevOutput,
@@ -698,37 +695,56 @@ export async function executeEntry(
       endedAt,
     };
 
-    execResults = { ...stepInfo, status: 'success', output: prevOutput };
-    stepResults[entry.id] = { ...stepInfo, status: 'success', output: prevOutput };
-
-    const sleepUntilResultOperationId = `workflow.${workflowId}.run.${runId}.sleepUntil.${entry.id}.result_ev`;
-    await engine.wrapDurableOperation(sleepUntilResultOperationId, async () => {
-      await pubsub.publish(`workflow.events.v2.${runId}`, {
-        type: 'watch',
+    if (abortController?.signal?.aborted) {
+      // The run was canceled while parked in the sleepUntil. Settle as canceled
+      // and skip the 'running' persist + success events so we don't overwrite the
+      // canceled status that cancel() just wrote. The step result is left as the
+      // 'waiting' value recorded before the sleep — it never completed.
+      execResults = { ...stepInfo, status: 'canceled', output: prevOutput };
+    } else {
+      await engine.persistStepUpdate({
+        workflowId,
         runId,
-        data: {
-          type: 'workflow-step-result',
-          payload: {
-            id: entry.id,
-            endedAt,
-            status: 'success',
-            output: prevOutput,
-          },
-        },
+        resourceId,
+        serializedStepGraph,
+        stepResults,
+        executionContext,
+        workflowStatus: 'running',
+        requestContext,
       });
 
-      await pubsub.publish(`workflow.events.v2.${runId}`, {
-        type: 'watch',
-        runId,
-        data: {
-          type: 'workflow-step-finish',
-          payload: {
-            id: entry.id,
-            metadata: {},
+      execResults = { ...stepInfo, status: 'success', output: prevOutput };
+      stepResults[entry.id] = { ...stepInfo, status: 'success', output: prevOutput };
+
+      const sleepUntilResultOperationId = `workflow.${workflowId}.run.${runId}.sleepUntil.${entry.id}.result_ev`;
+      await engine.wrapDurableOperation(sleepUntilResultOperationId, async () => {
+        await pubsub.publish(`workflow.events.v2.${runId}`, {
+          type: 'watch',
+          runId,
+          data: {
+            type: 'workflow-step-result',
+            payload: {
+              id: entry.id,
+              endedAt,
+              status: 'success',
+              output: prevOutput,
+            },
           },
-        },
+        });
+
+        await pubsub.publish(`workflow.events.v2.${runId}`, {
+          type: 'watch',
+          runId,
+          data: {
+            type: 'workflow-step-finish',
+            payload: {
+              id: entry.id,
+              metadata: {},
+            },
+          },
+        });
       });
-    });
+    }
   }
 
   if (entry.type === 'step' || entry.type === 'loop' || entry.type === 'foreach') {

--- a/packages/core/src/workflows/handlers/sleep.ts
+++ b/packages/core/src/workflows/handlers/sleep.ts
@@ -124,7 +124,12 @@ export async function executeSleep(engine: DefaultExecutionEngine, params: Execu
   }
 
   try {
-    await engine.executeSleepDuration(!duration || duration < 0 ? 0 : duration, entry.id, workflowId);
+    await engine.executeSleepDuration(
+      !duration || duration < 0 ? 0 : duration,
+      entry.id,
+      workflowId,
+      abortController?.signal,
+    );
     await engine.endChildSpan({
       span: sleepSpan,
       operationId: `workflow.${workflowId}.run.${runId}.sleep.${entry.id}.span.end`,
@@ -261,7 +266,7 @@ export async function executeSleepUntil(
   }
 
   try {
-    await engine.executeSleepUntilDate(date, entry.id, workflowId);
+    await engine.executeSleepUntilDate(date, entry.id, workflowId, abortController?.signal);
     await engine.endChildSpan({
       span: sleepUntilSpan,
       operationId: `workflow.${workflowId}.run.${runId}.sleepUntil.${entry.id}.span.end`,

--- a/packages/core/src/workflows/utils.test.ts
+++ b/packages/core/src/workflows/utils.test.ts
@@ -11,6 +11,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  abortableSleep,
   cleanStepResult,
   createDeprecationProxy,
   getResumeLabelsByStepId,
@@ -332,5 +333,41 @@ describe('createDeprecationProxy', () => {
     });
 
     expect(proxy.retryCount).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// abortableSleep
+// ---------------------------------------------------------------------------
+
+describe('abortableSleep', () => {
+  it('resolves after the given duration when not aborted', async () => {
+    const start = Date.now();
+    await abortableSleep(50);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(40);
+  });
+
+  it('resolves immediately when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const start = Date.now();
+    await abortableSleep(60_000, controller.signal);
+    expect(Date.now() - start).toBeLessThan(1_000);
+  });
+
+  it('resolves early and clears the timer when aborted mid-sleep', async () => {
+    const controller = new AbortController();
+    const start = Date.now();
+    const p = abortableSleep(60_000, controller.signal);
+    setTimeout(() => controller.abort(), 50);
+    await p;
+    expect(Date.now() - start).toBeLessThan(1_000);
+  });
+
+  it('resolves immediately for a non-positive duration', async () => {
+    const start = Date.now();
+    await abortableSleep(0);
+    await abortableSleep(-100);
+    expect(Date.now() - start).toBeLessThan(1_000);
   });
 });

--- a/packages/core/src/workflows/utils.ts
+++ b/packages/core/src/workflows/utils.ts
@@ -216,6 +216,36 @@ export function getResumeLabelsByStepId(
     );
 }
 
+/**
+ * Sleep for `ms` milliseconds, resolving early if `signal` aborts.
+ *
+ * The underlying timer is cleared on abort (so a canceled run does not hold the
+ * process open for the full sleep duration) and is `unref`'d so a long sleep
+ * never keeps the Node event loop alive on its own.
+ */
+export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>(resolve => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    // Don't keep the event loop alive solely for a pending sleep timer.
+    (timer as unknown as { unref?: () => void }).unref?.();
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 export const runCountDeprecationMessage =
   "Warning: 'runCount' is deprecated and will be removed on November 4th, 2025. Please use 'retryCount' instead.";
 


### PR DESCRIPTION
Makes `Run.cancel()` interrupt an in-flight `.sleep(ms)` / `.sleepUntil(date)` immediately, instead of waiting for the full duration and then overwriting the canceled status.

Fixes the workflow-cancel-during-sleep bug #17908 .

## Why

The default execution engine's sleep primitives were plain `setTimeout` promises that never observed the run's abort signal. A run canceled mid-sleep would:

1. keep the Node timer alive for the full duration (`.sleepUntil(+24h)` held the run for 24h after cancel);
2. wake up and overwrite the persisted `'canceled'` status with `'running'`; and
3. publish a sleep-step `success` event.

So observers saw the run flip `canceled` → `running` → `canceled`, and cancellation didn't actually take effect until the timer fired.

## How

- **`workflows/utils.ts`** — new `abortableSleep(ms, signal)` helper. It races the timer against the abort signal, clears the timer on abort, and `unref`s it so a long sleep never keeps the Node event loop alive on its own.
- **`workflows/default.ts`** — `executeSleepDuration` / `executeSleepUntilDate` now accept an optional `AbortSignal` and use `abortableSleep`. The parameter is optional, so existing engine overrides (e.g. Inngest) remain source-compatible.
- **`workflows/handlers/sleep.ts`** — threads `abortController?.signal` into those engine calls.
- **`workflows/handlers/entry.ts`** — after the wait, if the signal is aborted, the handler skips the `'running'` persist and the sleep-step `success` / `finish` events and settles the result as `canceled`. The existing tail handler then persists `canceled` and publishes `workflow-canceled`. (The per-step result is left as its prior `'waiting'` value, since `'canceled'` is not a valid `StepResult` status — cancellation is tracked on the run, matching existing behavior.)

### Before / After

```ts
const run = await workflow.createRun();
const result = run.start({ inputData: {} });
setTimeout(() => run.cancel(), 1000); // during .sleep(60_000)

await result;
// Before: resolves after ~60s; status briefly flips canceled → running → canceled
// After:  resolves promptly with status 'canceled'; sleep step never reports success
```

## Tests

- `packages/core/src/workflows/cancel-sleep.test.ts` — new regression test covering both `.sleep()` and `.sleepUntil()`: asserts the wait is interrupted (<5s), the downstream step never runs, the result is `canceled`, and storage stays `canceled` (not flipped to `running`/`success`). Fails on `main` (times out), passes with this fix.
- `packages/core/src/workflows/utils.test.ts` — unit tests for `abortableSleep` (resolves on duration, resolves early on abort / already-aborted signal, handles non-positive durations).

### Checks run

- `vitest run` for the new/affected suites (regression + unit + `default.test.ts` + evented sleep tests): all pass.
- `tsc --noEmit -p tsconfig.build.json`: clean.
- `eslint` on changed files: clean.
- Changeset added: `.changeset/fix-workflow-cancel-interrupts-sleep.md` (`@mastra/core`: patch).

## Affected package

`@mastra/core`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you tell a workflow to cancel, it should stop sleeping right away instead of waiting for the sleep timer to finish. This PR fixes that—now when you cancel a run, any in-flight `.sleep()` or `.sleepUntil()` calls get interrupted immediately, so the workflow stops cleanly and doesn't accidentally flip back to "running" status after the timer expires.

## Overview

This PR fixes bug `#17908` where canceling a workflow run didn't interrupt in-flight `.sleep()` and `.sleepUntil()` operations immediately. Previously, the default execution engine's sleep calls ignored cancellation signals, leading to:
- Node timers staying alive for the full sleep duration
- Run status being overwritten from `canceled` back to `running` after the sleep completed
- Sleep-step success events being published even though the run was canceled

## Changes

**New utilities:**
- Added `abortableSleep(ms, signal?)` in `workflows/utils.ts` that races a timer against an `AbortSignal`, clears the timer on abort, and unrefs the timer to prevent keeping the Node event loop alive for long sleeps

**Engine updates:**
- `DefaultExecutionEngine.executeSleepDuration()` and `executeSleepUntilDate()` now accept an optional `AbortSignal` parameter and use `abortableSleep` instead of `setTimeout`

**Handler updates:**
- `workflows/handlers/sleep.ts` threads the abort controller's signal into engine sleep calls
- `workflows/handlers/entry.ts` checks if the signal is aborted after the waiting phase completes; if aborted, it records the step result as `canceled`, skips persisting the `running` status, skips success/finish events, and settles the run as `canceled`

## Testing

- New regression test file `cancel-sleep.test.ts` covers both `.sleep()` and `.sleepUntil()` scenarios, verifying that cancellation resolves quickly, downstream steps don't run, and persisted status remains `canceled`
- New unit tests in `utils.test.ts` for `abortableSleep` covering normal resolution, pre-aborted signals, mid-sleep abort, and non-positive durations
- Changeset added documenting the fix

## Compatibility

Method signatures are backward compatible—the `signal` parameter is optional on both engine sleep methods, preserving compatibility with engine overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->