### PR TITLE
fix(memory): bound embedding cache and switch to xxhash64 (closes #17900)

### DIFF
--- a/.changeset/violet-cameras-find.md
+++ b/.changeset/violet-cameras-find.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed an unbounded `Map` cache in `Memory.embedMessageContent` that retained every distinct message embedding for the life of the process and could return another message's embeddings on 32-bit hash collisions (~77k distinct contents). The cache is now an LRU (`max: 1000`) keyed by xxhash64, so long-running processes hold a bounded working set and collisions become negligible (closes #17900).

--- a/packages/memory/src/embedding-cache.test.ts
+++ b/packages/memory/src/embedding-cache.test.ts
@@ -1,0 +1,76 @@
+import { InMemoryStore } from '@mastra/core/storage';
+import { describe, it, expect, vi } from 'vitest';
+import { Memory } from './index';
+
+const mocks = vi.hoisted(() => {
+  const embedManyImpl = vi.fn(async ({ values }: { values: string[] }) => ({
+    embeddings: values.map(v => [v.length, v.charCodeAt(0) || 0]),
+    usage: { tokens: 1 },
+  }));
+  return { embedManyImpl };
+});
+
+vi.mock('@internal/ai-v6', () => ({ embedMany: mocks.embedManyImpl }));
+vi.mock('@internal/ai-sdk-v5', () => ({ embedMany: mocks.embedManyImpl }));
+vi.mock('@internal/ai-sdk-v4', () => ({ embedMany: mocks.embedManyImpl }));
+
+class TestableMemory extends Memory {
+  testEmbedMessageContent(content: string) {
+    return (this as any).embedMessageContent(content) as Promise<{
+      chunks: string[];
+      embeddings: number[][];
+    }>;
+  }
+  cacheSize() {
+    return ((this as any).embeddingCache as { size: number }).size;
+  }
+  cacheMax() {
+    return ((this as any).embeddingCache as { max: number }).max;
+  }
+}
+
+function makeMemory() {
+  return new TestableMemory({
+    storage: new InMemoryStore(),
+    vector: {
+      upsert: vi.fn().mockResolvedValue('id'),
+      createIndex: vi.fn().mockResolvedValue({ indexName: 'test-index' }),
+      query: vi.fn().mockResolvedValue([]),
+      describeIndex: vi.fn(),
+    } as any,
+    embedder: {
+      specificationVersion: 'v3',
+      provider: 'test',
+      modelId: 'test-model',
+      doEmbed: vi.fn(),
+    } as any,
+    options: { semanticRecall: true },
+  });
+}
+
+describe('Memory.embedMessageContent cache (#17900)', () => {
+  it("does not return another message's embeddings for h32-colliding contents", async () => {
+    // These two strings collide under xxhash32 (2346541822);
+    // h64ToString must keep them in distinct cache slots.
+    const memory = makeMemory();
+    const first = await memory.testEmbedMessageContent('msg-4246');
+    const second = await memory.testEmbedMessageContent('msg-268273');
+
+    expect(first.chunks).toEqual(['msg-4246']);
+    expect(second.chunks).toEqual(['msg-268273']);
+    expect(second.embeddings).not.toEqual(first.embeddings);
+  });
+
+  it('is bounded so a long-running process cannot retain every embedded message', async () => {
+    const memory = makeMemory();
+    const max = memory.cacheMax();
+    expect(typeof max).toBe('number');
+    expect(max).toBeGreaterThan(0);
+
+    for (let i = 0; i < max + 10; i++) {
+      await memory.testEmbedMessageContent(`unique-content-${i}`);
+    }
+
+    expect(memory.cacheSize()).toBeLessThanOrEqual(max);
+  });
+});

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -43,6 +43,7 @@ import type { VectorFilter } from '@mastra/core/vector';
 import { isStandardSchemaWithJSON, toStandardSchema } from '@mastra/schema-compat/schema';
 import { Mutex } from 'async-mutex';
 import type { JSONSchema7 } from 'json-schema';
+import { LRUCache } from 'lru-cache';
 import xxhash from 'xxhash-wasm';
 import type { ObservationalMemory, ObservationalMemoryConfig } from './processors/observational-memory';
 import { recallTool } from './tools/om-tools';
@@ -970,20 +971,22 @@ ${workingMemory}`;
 
   private hasher = xxhash();
 
-  // embedding is computationally expensive so cache content -> embeddings/chunks
-  private embeddingCache = new Map<
-    number,
+  // embedding is computationally expensive so cache content -> embeddings/chunks.
+  // Bounded via LRU so a long-running process can't accumulate every distinct
+  // message it ever embedded. h64 keeps collision probability negligible at
+  // the cache's max size.
+  private embeddingCache = new LRUCache<
+    string,
     {
       chunks: string[];
       embeddings: Awaited<ReturnType<typeof embedMany>>['embeddings'];
       usage?: { tokens: number };
       dimension: number | undefined;
     }
-  >();
+  >({ max: 1000 });
   private firstEmbed: Promise<any> | undefined;
   protected async embedMessageContent(content: string) {
-    // use fast xxhash for lower memory usage. if we cache by content string we will store all messages in memory for the life of the process
-    const key = (await this.hasher).h32(content);
+    const key = (await this.hasher).h64ToString(content);
     const cached = this.embeddingCache.get(key);
     if (cached) {
       this.logger.debug('Embedding cache hit', { contentHash: key, chunks: cached.chunks.length });


### PR DESCRIPTION
Closes #17900.

`Memory.embedMessageContent` cached embeddings in a plain `Map` with no eviction and a 32-bit `h32` cache key. Two consequences for any long-running process with semantic recall enabled:

- the cache held every distinct embedded message (chunks + full embedding vector) for the life of the process, growing in proportion to traffic
- by the birthday bound, ~77k distinct contents give a >50% chance of an `h32` collision; on collision, `embedMessageContent` returned the other message's cached entry, silently corrupting recall

`"msg-4246"` and `"msg-268273"` collide deterministically under `h32` (both hash to `2346541822`); the regression test pins both behaviors.

## Fix

- Switched the cache from a `Map` to `LRUCache` with `max: 1000`, matching the bound already used by `globalEmbeddingCache` in `packages/core/src/processors/memory/embedding-cache.ts`.
- Switched the key from `h32` (`number`) to `h64ToString` (`string`); a 64-bit hash drops the collision probability at the working-set size to negligible levels.

The cache key shape stays internal and the public `embedMessageContent` signature is unchanged.

## Tests

Added `packages/memory/src/embedding-cache.test.ts`:

- asserts that the `h32`-colliding pair `"msg-4246"` / `"msg-268273"` returns distinct cached entries (would fail before the fix)
- asserts the cache stays at or below its configured `max` after pushing past capacity (would fail before the fix, when growth was unbounded)

Both checks pass against `pnpm --filter @mastra/memory test:unit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a memory leak in how messages are cached for embedding lookups. Previously, the cache kept growing forever and could mix up embeddings from different messages due to using weak hash fingerprints. The fix uses a smart cache that forgets old entries when full and much stronger fingerprints to avoid mix-ups.

---

## Problem Statement

`Memory.embedMessageContent` had two critical issues:

1. **Unbounded memory growth**: The cache used a plain `Map` with no eviction strategy, retaining every distinct embedded message, chunk, and embedding vector for the process lifetime. In long-running servers using semantic recall, this caused steady memory growth (~12–20 KB per embedding).

2. **32-bit hash collisions**: The cache key used a 32-bit xxhash (`h32`); by the birthday paradox, with ~77k distinct contents there was >50% probability of collision. Collisions caused `embedMessageContent` to silently return another message's cached embeddings, corrupting recall results. The issue included a documented collision: "msg-4246" and "msg-268273" both hashed to 2346541822.

---

## Solution

Two concrete fixes were applied:

- **Replace unbounded Map with LRUCache**: Switched to `LRUCache` configured with `max: 1000` (matching the pattern in `globalEmbeddingCache` in packages/core), ensuring cache size stays bounded and old entries are evicted.
- **Replace 32-bit keys with 64-bit string keys**: Replaced the 32-bit `h32` key with a 64-bit hash string produced by `h64ToString`, reducing collision probability to negligible levels.

The external `embedMessageContent` signature and API remain unchanged; the cache key shape remains internal.

---

## Changes Made

**packages/memory/src/index.ts**:
- Imported `LRUCache` from lru-cache
- Replaced the unbounded `Map` cache with an `LRUCache` instance (`max: 1000`)
- Updated cache key generation to use 64-bit hash strings instead of 32-bit numeric hashes

**packages/memory/src/embedding-cache.test.ts** (new file):
- Added Vitest test suite for embedding cache behavior
- Created `TestableMemory` subclass exposing cache internals for testing
- **Test 1**: Verifies that two message strings colliding under `xxhash32` ("msg-4246" and "msg-268273") return distinct cached entries, confirming h64-based keys prevent collisions
- **Test 2**: Verifies that after embedding more unique messages than the configured maximum, cache size remains `<= max`, confirming bounded cache behavior

**.changeset/violet-cameras-find.md** (new):
- Added changeset documenting the patch-level fix for the `@mastra/memory` package

---

## Verification

Both new tests pass with `pnpm --filter `@mastra/memory` test:unit`, confirming:
- The documented h32 collision case now returns distinct entries
- The cache respects its maximum size constraint

Closes issue `#17900`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->