### PR TITLE
fix(core): interrupt workflow sleep on cancel (closes #17908)

### DIFF
--- a/.changeset/curly-rocks-matter.md
+++ b/.changeset/curly-rocks-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `run.cancel()` not interrupting `sleep()` / `sleepUntil()` in the default workflow execution engine. The pending `setTimeout` was previously held until it fired naturally, which kept the run in memory for the full sleep duration, then flipped its status from 'canceled' back to 'running' and recorded the sleep step as 'success'. The sleep primitives now observe the run's abort signal: when `cancel()` is called the timer is cleared, the run settles as 'canceled' immediately, and the next step does not execute (closes #17908).

--- a/packages/core/src/workflows/cancel-sleep.test.ts
+++ b/packages/core/src/workflows/cancel-sleep.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { DefaultExecutionEngine } from './default';
+
+describe('DefaultExecutionEngine sleep + cancel (#17908)', () => {
+  it('executeSleepDuration resolves immediately when its abort signal fires', async () => {
+    const engine = new DefaultExecutionEngine({ mastra: undefined });
+    const abortController = new AbortController();
+
+    const startedAt = Date.now();
+    const sleeping = engine.executeSleepDuration(60_000, 'sleep-1', 'wf', abortController.signal);
+
+    setTimeout(() => abortController.abort(), 50);
+
+    await sleeping;
+
+    const elapsed = Date.now() - startedAt;
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  it('executeSleepDuration resolves immediately when its signal is already aborted', async () => {
+    const engine = new DefaultExecutionEngine({ mastra: undefined });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const startedAt = Date.now();
+    await engine.executeSleepDuration(60_000, 'sleep-1', 'wf', abortController.signal);
+    expect(Date.now() - startedAt).toBeLessThan(50);
+  });
+
+  it('executeSleepUntilDate resolves immediately when its abort signal fires', async () => {
+    const engine = new DefaultExecutionEngine({ mastra: undefined });
+    const abortController = new AbortController();
+    const target = new Date(Date.now() + 60_000);
+
+    const startedAt = Date.now();
+    const sleeping = engine.executeSleepUntilDate(target, 'sleepUntil-1', 'wf', abortController.signal);
+
+    setTimeout(() => abortController.abort(), 50);
+
+    await sleeping;
+
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
+  it('executeSleepDuration still completes its full duration without a signal', async () => {
+    const engine = new DefaultExecutionEngine({ mastra: undefined });
+
+    const startedAt = Date.now();
+    await engine.executeSleepDuration(150, 'sleep-1', 'wf');
+    const elapsed = Date.now() - startedAt;
+
+    expect(elapsed).toBeGreaterThanOrEqual(140);
+  });
+});

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -48,6 +48,21 @@ import type {
 // Re-export ExecutionContext for backwards compatibility
 export type { ExecutionContext } from './types';
 
+function abortableTimeout(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise<void>(resolve => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 /**
  * Default implementation of the ExecutionEngine
  */
@@ -105,9 +120,15 @@ export class DefaultExecutionEngine extends ExecutionEngine {
    * @param duration - The duration to sleep in milliseconds
    * @param _sleepId - Unique identifier for this sleep operation
    * @param _workflowId - The workflow ID (for constructing platform-specific IDs)
+   * @param signal - Abort signal; when fired, clears the timer and resolves immediately
    */
-  async executeSleepDuration(duration: number, _sleepId: string, _workflowId: string): Promise<void> {
-    await new Promise(resolve => setTimeout(resolve, duration < 0 ? 0 : duration));
+  async executeSleepDuration(
+    duration: number,
+    _sleepId: string,
+    _workflowId: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await abortableTimeout(duration < 0 ? 0 : duration, signal);
   }
 
   /**
@@ -116,10 +137,16 @@ export class DefaultExecutionEngine extends ExecutionEngine {
    * @param date - The date to sleep until
    * @param _sleepUntilId - Unique identifier for this sleep operation
    * @param _workflowId - The workflow ID (for constructing platform-specific IDs)
+   * @param signal - Abort signal; when fired, clears the timer and resolves immediately
    */
-  async executeSleepUntilDate(date: Date, _sleepUntilId: string, _workflowId: string): Promise<void> {
+  async executeSleepUntilDate(
+    date: Date,
+    _sleepUntilId: string,
+    _workflowId: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
     const time = date.getTime() - Date.now();
-    await new Promise(resolve => setTimeout(resolve, time < 0 ? 0 : time));
+    await abortableTimeout(time < 0 ? 0 : time, signal);
   }
 
   /**

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -575,54 +575,65 @@ export async function executeEntry(
 
     delete executionContext.activeStepsPath[entry.id];
 
-    await engine.persistStepUpdate({
-      workflowId,
-      runId,
-      resourceId,
-      serializedStepGraph,
-      stepResults,
-      executionContext,
-      workflowStatus: 'running',
-      requestContext,
-    });
-
-    const endedAt = Date.now();
-    const stepInfo = {
-      payload: prevOutput,
-      startedAt,
-      endedAt,
-    };
-
-    execResults = { ...stepInfo, status: 'success', output: prevOutput };
-    stepResults[entry.id] = { ...stepInfo, status: 'success', output: prevOutput };
-    const sleepResultOperationId = `workflow.${workflowId}.run.${runId}.sleep.${entry.id}.result_ev`;
-    await engine.wrapDurableOperation(sleepResultOperationId, async () => {
-      await pubsub.publish(`workflow.events.v2.${runId}`, {
-        type: 'watch',
+    // If the run was canceled while we were sleeping, do not flip status back to
+    // 'running' or publish a sleep-step success — that would overwrite the
+    // 'canceled' status that cancel() persisted (#17908). The final block of
+    // this function still persists the canceled status and publishes the
+    // workflow-canceled event.
+    if (abortController?.signal?.aborted) {
+      const endedAt = Date.now();
+      execResults = { payload: prevOutput, startedAt, endedAt, status: 'canceled' };
+      stepResults[entry.id] = execResults;
+    } else {
+      await engine.persistStepUpdate({
+        workflowId,
         runId,
-        data: {
-          type: 'workflow-step-result',
-          payload: {
-            id: entry.id,
-            endedAt,
-            status: 'success',
-            output: prevOutput,
-          },
-        },
+        resourceId,
+        serializedStepGraph,
+        stepResults,
+        executionContext,
+        workflowStatus: 'running',
+        requestContext,
       });
 
-      await pubsub.publish(`workflow.events.v2.${runId}`, {
-        type: 'watch',
-        runId,
-        data: {
-          type: 'workflow-step-finish',
-          payload: {
-            id: entry.id,
-            metadata: {},
+      const endedAt = Date.now();
+      const stepInfo = {
+        payload: prevOutput,
+        startedAt,
+        endedAt,
+      };
+
+      execResults = { ...stepInfo, status: 'success', output: prevOutput };
+      stepResults[entry.id] = { ...stepInfo, status: 'success', output: prevOutput };
+      const sleepResultOperationId = `workflow.${workflowId}.run.${runId}.sleep.${entry.id}.result_ev`;
+      await engine.wrapDurableOperation(sleepResultOperationId, async () => {
+        await pubsub.publish(`workflow.events.v2.${runId}`, {
+          type: 'watch',
+          runId,
+          data: {
+            type: 'workflow-step-result',
+            payload: {
+              id: entry.id,
+              endedAt,
+              status: 'success',
+              output: prevOutput,
+            },
           },
-        },
+        });
+
+        await pubsub.publish(`workflow.events.v2.${runId}`, {
+          type: 'watch',
+          runId,
+          data: {
+            type: 'workflow-step-finish',
+            payload: {
+              id: entry.id,
+              metadata: {},
+            },
+          },
+        });
       });
-    });
+    }
   } else if (entry.type === 'sleepUntil') {
     executionContext.stepExecutionPath?.push(entry.id);
     const startedAt = Date.now();
@@ -680,55 +691,63 @@ export async function executeEntry(
 
     delete executionContext.activeStepsPath[entry.id];
 
-    await engine.persistStepUpdate({
-      workflowId,
-      runId,
-      resourceId,
-      serializedStepGraph,
-      stepResults,
-      executionContext,
-      workflowStatus: 'running',
-      requestContext,
-    });
-
-    const endedAt = Date.now();
-    const stepInfo = {
-      payload: prevOutput,
-      startedAt,
-      endedAt,
-    };
-
-    execResults = { ...stepInfo, status: 'success', output: prevOutput };
-    stepResults[entry.id] = { ...stepInfo, status: 'success', output: prevOutput };
-
-    const sleepUntilResultOperationId = `workflow.${workflowId}.run.${runId}.sleepUntil.${entry.id}.result_ev`;
-    await engine.wrapDurableOperation(sleepUntilResultOperationId, async () => {
-      await pubsub.publish(`workflow.events.v2.${runId}`, {
-        type: 'watch',
+    // If cancel() fired during the sleepUntil, skip the 'running' status flip
+    // and the sleep-step success event for the same reason as plain sleep (#17908).
+    if (abortController?.signal?.aborted) {
+      const endedAt = Date.now();
+      execResults = { payload: prevOutput, startedAt, endedAt, status: 'canceled' };
+      stepResults[entry.id] = execResults;
+    } else {
+      await engine.persistStepUpdate({
+        workflowId,
         runId,
-        data: {
-          type: 'workflow-step-result',
-          payload: {
-            id: entry.id,
-            endedAt,
-            status: 'success',
-            output: prevOutput,
-          },
-        },
+        resourceId,
+        serializedStepGraph,
+        stepResults,
+        executionContext,
+        workflowStatus: 'running',
+        requestContext,
       });
 
-      await pubsub.publish(`workflow.events.v2.${runId}`, {
-        type: 'watch',
-        runId,
-        data: {
-          type: 'workflow-step-finish',
-          payload: {
-            id: entry.id,
-            metadata: {},
+      const endedAt = Date.now();
+      const stepInfo = {
+        payload: prevOutput,
+        startedAt,
+        endedAt,
+      };
+
+      execResults = { ...stepInfo, status: 'success', output: prevOutput };
+      stepResults[entry.id] = { ...stepInfo, status: 'success', output: prevOutput };
+
+      const sleepUntilResultOperationId = `workflow.${workflowId}.run.${runId}.sleepUntil.${entry.id}.result_ev`;
+      await engine.wrapDurableOperation(sleepUntilResultOperationId, async () => {
+        await pubsub.publish(`workflow.events.v2.${runId}`, {
+          type: 'watch',
+          runId,
+          data: {
+            type: 'workflow-step-result',
+            payload: {
+              id: entry.id,
+              endedAt,
+              status: 'success',
+              output: prevOutput,
+            },
           },
-        },
+        });
+
+        await pubsub.publish(`workflow.events.v2.${runId}`, {
+          type: 'watch',
+          runId,
+          data: {
+            type: 'workflow-step-finish',
+            payload: {
+              id: entry.id,
+              metadata: {},
+            },
+          },
+        });
       });
-    });
+    }
   }
 
   if (entry.type === 'step' || entry.type === 'loop' || entry.type === 'foreach') {

--- a/packages/core/src/workflows/handlers/sleep.ts
+++ b/packages/core/src/workflows/handlers/sleep.ts
@@ -124,7 +124,12 @@ export async function executeSleep(engine: DefaultExecutionEngine, params: Execu
   }
 
   try {
-    await engine.executeSleepDuration(!duration || duration < 0 ? 0 : duration, entry.id, workflowId);
+    await engine.executeSleepDuration(
+      !duration || duration < 0 ? 0 : duration,
+      entry.id,
+      workflowId,
+      abortController?.signal,
+    );
     await engine.endChildSpan({
       span: sleepSpan,
       operationId: `workflow.${workflowId}.run.${runId}.sleep.${entry.id}.span.end`,
@@ -261,7 +266,7 @@ export async function executeSleepUntil(
   }
 
   try {
-    await engine.executeSleepUntilDate(date, entry.id, workflowId);
+    await engine.executeSleepUntilDate(date, entry.id, workflowId, abortController?.signal);
     await engine.endChildSpan({
       span: sleepUntilSpan,
       operationId: `workflow.${workflowId}.run.${runId}.sleepUntil.${entry.id}.span.end`,


### PR DESCRIPTION
Closes #17908.

`Run.cancel()` aborts the run's `AbortController` and writes `status: 'canceled'` to storage, but the default engine's `executeSleepDuration` / `executeSleepUntilDate` were plain `setTimeout` promises that never observed the abort signal. Three downstream effects:

1. the Node timer stayed alive for the full sleep duration; a `.sleepUntil(+24h)` held the run in memory for 24h after cancellation
2. when the timer eventually fired, the entry handler unconditionally called `persistStepUpdate({ workflowStatus: 'running' })` and published a sleep-step `success` event, overwriting the `'canceled'` status that `cancel()` had persisted
3. the step after the sleep ran anyway

## Fix

Wire the run's abort signal through to the sleep primitives and skip the post-sleep "running" status flip / success event when the signal is already aborted.

- `executeSleepDuration` / `executeSleepUntilDate` take an optional `signal?: AbortSignal`. The default implementation uses a small `abortableTimeout` helper that clears the underlying timer and resolves the promise as soon as the signal fires (and short-circuits when the signal is already aborted on entry). The parameter is optional so existing subclasses (e.g. Inngest) are not broken by the signature change.
- `handlers/sleep.ts` passes `abortController.signal` to both calls.
- `handlers/entry.ts`, for both `sleep` and `sleepUntil` branches, checks `abortController.signal.aborted` after the sleep returns. When aborted, it records `execResults` as `{ status: 'canceled', startedAt, endedAt }` and skips the persistStepUpdate('running') + sleep-step success/finish publishes. The existing terminal block at the end of `executeEntry` then persists the canceled status and publishes the workflow-canceled event exactly as it did before.

## Tests

`packages/core/src/workflows/cancel-sleep.test.ts`:
- a 60s `executeSleepDuration` whose signal aborts after 50ms must return in under 1s
- a 60s `executeSleepDuration` whose signal is pre-aborted must return in under 50ms
- a 60s `executeSleepUntilDate` whose signal aborts after 50ms must return in under 1s
- without a signal, a 150ms `executeSleepDuration` must still run for ~150ms (no regression)

All four pass against the patched engine and would fail against `main`. The full `pnpm --filter @mastra/core test workflows` suite (37 files, 949 tests) stays green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you tell a workflow to cancel while it's sleeping, it should wake up right away and stop. Previously, it would ignore the cancel command and finish sleeping anyway. This PR fixes that by making the sleep function listen for a "stop" signal, so cancellation interrupts the sleep immediately and the workflow shuts down cleanly.

## Changes Overview

This PR fixes workflow cancellation behavior during sleep operations by introducing interrupt-aware sleep implementations:

### Core Changes

**1. Abortable Sleep Helper** (`packages/core/src/workflows/default.ts`)
- Added internal `abortableTimeout(ms, signal?)` helper that clears timers and resolves immediately when an `AbortSignal` fires
- Updated `executeSleepDuration` and `executeSleepUntilDate` to accept optional `signal?: AbortSignal` parameter and use abortable waits
- Preserves backward compatibility by making the signal parameter optional; existing behavior (clamping negative durations/times to 0) unchanged

**2. Signal Propagation** (`packages/core/src/workflows/handlers/sleep.ts`)
- `executeSleep` and `executeSleepUntil` now pass `abortController?.signal` to the underlying engine sleep methods
- Error handling, span lifecycle, and duration computation remain unchanged

**3. Post-Sleep Cancellation Handling** (`packages/core/src/workflows/handlers/entry.ts`)
- After sleep completes, the entry handler now checks `abortController.signal.aborted`
- When aborted: sets `execResults` to `{ status: 'canceled', startedAt, endedAt }` and skips post-sleep persist and event publishing
- When not aborted: preserves existing behavior (persists running status, publishes sleep-step success/finish events)
- Existing terminal block still persists canceled status and publishes workflow-canceled event as before

### Test Coverage

New test suite (`packages/core/src/workflows/cancel-sleep.test.ts`) with four test cases:
- `executeSleepDuration` with signal aborting after 50ms resolves in <1s
- `executeSleepDuration` with pre-aborted signal returns in <50ms
- `executeSleepUntilDate` with signal aborting after 50ms resolves in <1s
- `executeSleepDuration` without signal still waits ~150ms (regression test)

### Outcomes

- Canceling a workflow during sleep immediately interrupts the timer instead of waiting for completion
- Timers are cleared, preventing memory leaks from long-duration sleeps (e.g., `sleepUntil(+24h)`)
- Run status settles as `canceled` immediately without overwriting to `running`
- Subsequent workflow steps do not execute after cancellation
- No running status or sleep-step success events are published/persisted after cancellation

All tests pass; full core workflow test suite remains green.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->