### PR TITLE
feat(harness): support gateway model resolution

### DIFF
--- a/.changeset/kind-friends-appear.md
+++ b/.changeset/kind-friends-appear.md
@@ -3,4 +3,4 @@
 'mastracode': patch
 ---
 
-Moved MastraCode model catalog and gateway-backed model resolution out of the core harness.
+Moved MastraCode model catalog and gateway-backed model resolution out of the core harness and into a class-backed MastraCode gateway, with model IDs resolving directly to gateway-created provider instances.

--- a/.changeset/kind-friends-appear.md
+++ b/.changeset/kind-friends-appear.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastracode': patch
+---
+
+Moved MastraCode model catalog and gateway-backed model resolution out of the core harness.

--- a/.changeset/proud-lemons-find.md
+++ b/.changeset/proud-lemons-find.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added gateway support to harness v0 model resolution, auth checks, and model discovery.

--- a/.changeset/quiet-carrots-swim.md
+++ b/.changeset/quiet-carrots-swim.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Moved Mastra Code model discovery and resolution onto its gateway configuration.

--- a/mastracode/src/HarnessCompat.ts
+++ b/mastracode/src/HarnessCompat.ts
@@ -19,14 +19,14 @@ type SessionStateFields = {
   modeId?: string;
 };
 
-export function v1ModeToLegacy<TState = {}>(mode: HarnessMode, agent: Agent): HarnessModeLegacy<TState> {
+export function v1ModeToLegacy(mode: HarnessMode, agent: Agent): HarnessModeLegacy {
   const meta = mode.metadata ?? {};
   return {
     id: mode.id,
     name: mode.description,
     default: meta.default === true,
     defaultModelId: mode.defaultModelId,
-    color: typeof meta.color === 'string' ? meta.color : undefined,
+    metadata: meta,
     agent,
   };
 }
@@ -207,7 +207,7 @@ export class HarnessCompat<TState = {}> extends HarnessLegacy<TState> {
     };
   }
 
-  getCurrentMode(): HarnessModeLegacy<TState> {
+  getCurrentMode(): HarnessModeLegacy {
     if (!this.#session) {
       return super.getCurrentMode();
     }

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -1,17 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const gatewayRegistrySyncGateways = vi.fn();
-const gatewayRegistryGetProviders = vi.fn(() => ({}));
-const gatewayRegistryGetInstance = vi.fn(() => ({
-  syncGateways: gatewayRegistrySyncGateways,
-  getProviders: gatewayRegistryGetProviders,
-}));
 const providerRegistryMock: Record<string, unknown> = {};
+const mastraCodeGatewayMock = {
+  id: 'mastracode',
+  name: 'MastraCode Gateway',
+  fetchProviders: vi.fn(async () => ({})),
+  buildUrl: vi.fn((modelId: string) => modelId),
+  getApiKey: vi.fn(async () => ''),
+  resolveLanguageModel: vi.fn(),
+};
+const createMastraCodeGatewayMock = vi.fn(() => mastraCodeGatewayMock);
 
 vi.mock('@mastra/core/llm', () => ({
-  GatewayRegistry: {
-    getInstance: gatewayRegistryGetInstance,
-  },
   PROVIDER_REGISTRY: providerRegistryMock,
 }));
 
@@ -147,45 +147,50 @@ vi.mock('@mastra/core/processors', () => ({
   },
 }));
 
-vi.mock('./agents/instructions.js', () => ({
+vi.mock('../agents/instructions.js', () => ({
   getDynamicInstructions: vi.fn(),
 }));
 
 const getDynamicMemoryMock = vi.fn();
 
-vi.mock('./agents/memory.js', () => ({
+vi.mock('../agents/memory.js', () => ({
   getDynamicMemory: getDynamicMemoryMock,
 }));
 
-vi.mock('./agents/model.js', () => ({
+vi.mock('../agents/model.js', () => ({
+  createMastraCodeGateway: createMastraCodeGatewayMock,
   getDynamicModel: vi.fn(),
+  getGoalJudgeModel: vi.fn(),
   resolveModel: vi.fn(),
 }));
 
-vi.mock('./agents/subagents/execute.js', () => ({
+vi.mock('../agents/subagents/execute.js', () => ({
   executeSubagent: {},
 }));
 
-vi.mock('./agents/subagents/explore.js', () => ({
+vi.mock('../agents/subagents/explore.js', () => ({
   exploreSubagent: {},
 }));
 
-vi.mock('./agents/subagents/plan.js', () => ({
+vi.mock('../agents/subagents/plan.js', () => ({
   planSubagent: {},
 }));
 
-vi.mock('./agents/tools.js', () => ({
+vi.mock('../agents/tools.js', () => ({
   createDynamicTools: vi.fn(),
   createToolHooks: vi.fn(),
 }));
 
-vi.mock('./agents/workspace.js', () => ({
+vi.mock('../agents/workspace.js', () => ({
   getDynamicWorkspace: getDynamicWorkspaceMock,
 }));
 
-vi.mock('./auth/storage.js', () => ({
+vi.mock('../auth/storage.js', () => ({
   AuthStorage: class {
     get() {
+      return undefined;
+    }
+    getStoredApiKey() {
       return undefined;
     }
     loadStoredApiKeysIntoEnv() {}
@@ -220,35 +225,35 @@ vi.mock('../onboarding/settings.js', () => ({
   toCustomProviderModelId: vi.fn(),
 }));
 
-vi.mock('./permissions.js', () => ({
+vi.mock('../permissions.js', () => ({
   getToolCategory: vi.fn(),
 }));
 
-vi.mock('./providers/claude-max.js', () => ({
+vi.mock('../providers/claude-max.js', () => ({
   setAuthStorage: vi.fn(),
 }));
 
-vi.mock('./providers/openai-codex.js', () => ({
+vi.mock('../providers/openai-codex.js', () => ({
   setAuthStorage: vi.fn(),
 }));
 
-vi.mock('./providers/github-copilot.js', () => ({
+vi.mock('../providers/github-copilot.js', () => ({
   setAuthStorage: vi.fn(),
 }));
 
-vi.mock('./tools/index.js', () => ({
+vi.mock('../tools/index.js', () => ({
   defaultTools: {},
 }));
 
-vi.mock('./schema.js', () => ({
+vi.mock('../schema.js', () => ({
   stateSchema: {},
 }));
 
-vi.mock('./tui/theme.js', () => ({
+vi.mock('../tui/theme.js', () => ({
   mastra: {},
 }));
 
-vi.mock('./utils/gateway-sync.js', () => ({
+vi.mock('../utils/gateway-sync.js', () => ({
   syncGateways: vi.fn(),
 }));
 
@@ -275,7 +280,7 @@ vi.mock('../utils/storage-factory.js', () => ({
   createVectorStore: createVectorStoreMock,
 }));
 
-vi.mock('./utils/thread-lock.js', () => ({
+vi.mock('../utils/thread-lock.js', () => ({
   acquireThreadLock: vi.fn(),
   releaseThreadLock: vi.fn(),
 }));
@@ -283,15 +288,17 @@ vi.mock('./utils/thread-lock.js', () => ({
 describe('createMastraCode', () => {
   beforeEach(() => {
     vi.resetModules();
-    gatewayRegistrySyncGateways.mockReset();
-    gatewayRegistryGetProviders.mockReset();
-    gatewayRegistryGetProviders.mockReturnValue({});
-    gatewayRegistryGetInstance.mockClear();
+    createMastraCodeGatewayMock.mockClear();
+    mastraCodeGatewayMock.fetchProviders.mockClear();
+    mastraCodeGatewayMock.buildUrl.mockClear();
+    mastraCodeGatewayMock.getApiKey.mockClear();
+    mastraCodeGatewayMock.resolveLanguageModel.mockClear();
     createStorageMock.mockReset();
     createStorageMock.mockReturnValue({ storage: {}, backend: 'memory' });
     createVectorStoreMock.mockReset();
     createVectorStoreMock.mockReturnValue({});
     getDynamicMemoryMock.mockReset();
+    getDynamicMemoryMock.mockReturnValue(() => undefined);
     harnessSubscribeMock.mockReset();
     harnessGetCurrentThreadIdMock.mockReset();
     harnessGetCurrentThreadIdMock.mockReturnValue(undefined);
@@ -322,10 +329,6 @@ describe('createMastraCode', () => {
     loadSettingsMock.mockReturnValue(createMockSettings());
     agentConstructorMock.mockReset();
     harnessConstructorMock.mockReset();
-    gatewayRegistryGetInstance.mockImplementation(() => ({
-      syncGateways: gatewayRegistrySyncGateways,
-      getProviders: gatewayRegistryGetProviders,
-    }));
     getAvailableModePacksMock.mockClear();
     getAvailableOmPacksMock.mockClear();
     for (const key of Object.keys(providerRegistryMock)) {
@@ -333,29 +336,44 @@ describe('createMastraCode', () => {
     }
     delete process.env.MC_E2E_PRIMARY_KEY;
     delete process.env.MC_E2E_SECONDARY_KEY;
+    delete process.env.MASTRA_GATEWAY_API_KEY;
   });
 
-  it('enables dynamic provider registry loading before bootstrapping auth and models', async () => {
+  it('registers the MastraCode gateway on Harness instead of a legacy model resolver', async () => {
     const { createMastraCode } = await import('../index.js');
 
     await createMastraCode();
 
-    expect(gatewayRegistryGetInstance).toHaveBeenCalledWith({ useDynamicLoading: true });
+    expect(createMastraCodeGatewayMock).toHaveBeenCalledWith({
+      mastraGatewayBaseUrl: 'https://gateway-api.mastra.ai',
+      mastraGatewayApiKey: undefined,
+      routeThroughMastraGateway: false,
+      settingsPath: undefined,
+    });
+
+    const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as
+      | { gateways?: unknown[]; resolveModel?: unknown; modelAuthChecker?: unknown; customModelCatalogProvider?: unknown }
+      | undefined;
+    expect(harnessConfig?.gateways).toEqual([mastraCodeGatewayMock]);
+    expect(harnessConfig?.resolveModel).toBeUndefined();
+    expect(harnessConfig?.modelAuthChecker).toBeUndefined();
+    expect(harnessConfig?.customModelCatalogProvider).toBeUndefined();
   }, 10_000);
 
-  it('starts gateway sync in the background after loading stored API keys', async () => {
-    let resolveSync: (() => void) | undefined;
-    gatewayRegistrySyncGateways.mockReturnValue(
-      new Promise<void>(resolve => {
-        resolveSync = resolve;
-      }),
-    );
+  it('uses configured memory gateway settings when creating the MastraCode gateway', async () => {
+    const settings = createMockSettings();
+    settings.memoryGateway = { baseUrl: 'https://gateway.example.com/v1' };
+    loadSettingsMock.mockReturnValue(settings);
     const { createMastraCode } = await import('../index.js');
 
-    await expect(createMastraCode()).resolves.toBeTruthy();
+    await createMastraCode({ settingsPath: '/tmp/settings.json' });
 
-    expect(gatewayRegistrySyncGateways).toHaveBeenCalledWith(true);
-    resolveSync?.();
+    expect(createMastraCodeGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mastraGatewayBaseUrl: 'https://gateway.example.com',
+        settingsPath: '/tmp/settings.json',
+      }),
+    );
   });
 
   it('treats registry providers with any configured API-key env var as startup provider access', async () => {

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -348,8 +348,9 @@ describe('createMastraCode', () => {
 
   it('registers the MastraCode gateway and app-provided model hooks on Harness', async () => {
     const { createMastraCode } = await import('../index.js');
+    const subagent = { id: 'review', name: 'Review', instructions: 'Review changes' };
 
-    await createMastraCode();
+    await createMastraCode({ subagents: [subagent as any] });
 
     expect(createMastraCodeGatewayMock).toHaveBeenCalledWith({
       mastraGatewayBaseUrl: 'https://gateway-api.mastra.ai',
@@ -364,9 +365,11 @@ describe('createMastraCode', () => {
           resolveModel?: unknown;
           modelAuthChecker?: unknown;
           customModelCatalogProvider?: unknown;
+          subagents?: unknown[];
         }
       | undefined;
     expect(harnessConfig?.gateways).toEqual([mastraCodeGatewayMock]);
+    expect(harnessConfig?.subagents).toEqual([subagent]);
     expect(harnessConfig?.resolveModel).toBe(resolveModelMock);
     expect(createMastraCodeModelCatalogProviderMock).toHaveBeenCalledWith(mastraCodeGatewayMock);
     expect(harnessConfig?.modelAuthChecker).toBeUndefined();

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -359,7 +359,12 @@ describe('createMastraCode', () => {
     });
 
     const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as
-      | { gateways?: unknown[]; resolveModel?: unknown; modelAuthChecker?: unknown; customModelCatalogProvider?: unknown }
+      | {
+          gateways?: unknown[];
+          resolveModel?: unknown;
+          modelAuthChecker?: unknown;
+          customModelCatalogProvider?: unknown;
+        }
       | undefined;
     expect(harnessConfig?.gateways).toEqual([mastraCodeGatewayMock]);
     expect(harnessConfig?.resolveModel).toBe(resolveModelMock);

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -10,6 +10,9 @@ const mastraCodeGatewayMock = {
   resolveLanguageModel: vi.fn(),
 };
 const createMastraCodeGatewayMock = vi.fn(() => mastraCodeGatewayMock);
+const mastraCodeCatalogProviderMock = vi.fn();
+const createMastraCodeModelCatalogProviderMock = vi.fn(() => mastraCodeCatalogProviderMock);
+const resolveModelMock = vi.fn();
 
 vi.mock('@mastra/core/llm', () => ({
   PROVIDER_REGISTRY: providerRegistryMock,
@@ -159,9 +162,10 @@ vi.mock('../agents/memory.js', () => ({
 
 vi.mock('../agents/model.js', () => ({
   createMastraCodeGateway: createMastraCodeGatewayMock,
+  createMastraCodeModelCatalogProvider: createMastraCodeModelCatalogProviderMock,
   getDynamicModel: vi.fn(),
   getGoalJudgeModel: vi.fn(),
-  resolveModel: vi.fn(),
+  resolveModel: resolveModelMock,
 }));
 
 vi.mock('../agents/subagents/execute.js', () => ({
@@ -289,6 +293,9 @@ describe('createMastraCode', () => {
   beforeEach(() => {
     vi.resetModules();
     createMastraCodeGatewayMock.mockClear();
+    createMastraCodeModelCatalogProviderMock.mockClear();
+    mastraCodeCatalogProviderMock.mockClear();
+    resolveModelMock.mockClear();
     mastraCodeGatewayMock.fetchProviders.mockClear();
     mastraCodeGatewayMock.buildUrl.mockClear();
     mastraCodeGatewayMock.getApiKey.mockClear();
@@ -339,7 +346,7 @@ describe('createMastraCode', () => {
     delete process.env.MASTRA_GATEWAY_API_KEY;
   });
 
-  it('registers the MastraCode gateway on Harness instead of a legacy model resolver', async () => {
+  it('registers the MastraCode gateway and app-provided model hooks on Harness', async () => {
     const { createMastraCode } = await import('../index.js');
 
     await createMastraCode();
@@ -355,9 +362,10 @@ describe('createMastraCode', () => {
       | { gateways?: unknown[]; resolveModel?: unknown; modelAuthChecker?: unknown; customModelCatalogProvider?: unknown }
       | undefined;
     expect(harnessConfig?.gateways).toEqual([mastraCodeGatewayMock]);
-    expect(harnessConfig?.resolveModel).toBeUndefined();
+    expect(harnessConfig?.resolveModel).toBe(resolveModelMock);
+    expect(createMastraCodeModelCatalogProviderMock).toHaveBeenCalledWith(mastraCodeGatewayMock);
     expect(harnessConfig?.modelAuthChecker).toBeUndefined();
-    expect(harnessConfig?.customModelCatalogProvider).toBeUndefined();
+    expect(harnessConfig?.customModelCatalogProvider).toBe(mastraCodeCatalogProviderMock);
   }, 10_000);
 
   it('uses configured memory gateway settings when creating the MastraCode gateway', async () => {

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -46,8 +46,10 @@ vi.mock('../../providers/openai-codex.js', () => ({
   },
 }));
 
+const mockGetCopilotModelCatalog = vi.hoisted(() => vi.fn(async () => []));
 vi.mock('../../providers/github-copilot.js', () => ({
   githubCopilotProvider: vi.fn(() => ({ __provider: 'github-copilot' })),
+  getCopilotModelCatalog: mockGetCopilotModelCatalog,
 }));
 
 // Mock @ai-sdk/anthropic
@@ -163,7 +165,14 @@ import { wrapLanguageModel } from 'ai';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { opencodeClaudeMaxProvider, buildAnthropicOAuthFetch } from '../../providers/claude-max.js';
 import { openaiCodexProvider, buildOpenAICodexOAuthFetch } from '../../providers/openai-codex.js';
-import { resolveModel, getDynamicModel, getAnthropicApiKey, getOpenAIApiKey, resolveAuth } from '../model.js';
+import {
+  createMastraCodeGateway,
+  resolveModel,
+  getDynamicModel,
+  getAnthropicApiKey,
+  getOpenAIApiKey,
+  resolveAuth,
+} from '../model.js';
 
 function makeRequestContext({ threadId, resourceId }: { threadId?: string; resourceId?: string } = {}) {
   const values = new Map<string, unknown>();
@@ -196,6 +205,41 @@ describe('resolveModel', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
+  });
+
+  it('discovers custom and Copilot providers through the MastraCode gateway', async () => {
+    mockLoadSettings.mockReturnValue({
+      customProviders: [
+        {
+          name: 'Acme Models',
+          url: 'https://llm.acme.dev/v1',
+          apiKey: 'acme-secret',
+          models: ['reasoner-v1'],
+        } as any,
+      ],
+      memoryGateway: {},
+    });
+    mockGetCopilotModelCatalog.mockResolvedValueOnce([{ id: 'gpt-4.1' }] as any);
+
+    const gateway = createMastraCodeGateway({
+      mastraGatewayBaseUrl: 'https://gateway-api.mastra.ai',
+      routeThroughMastraGateway: false,
+    });
+
+    await expect(gateway.fetchProviders()).resolves.toMatchObject({
+      'acme-models': {
+        name: 'Acme Models',
+        url: 'https://llm.acme.dev/v1',
+        gateway: 'mastracode',
+        models: ['reasoner-v1'],
+      },
+      'github-copilot': {
+        name: 'GitHub Copilot',
+        gateway: 'mastracode',
+        models: ['gpt-4.1'],
+      },
+    });
+    expect(mockGetCopilotModelCatalog).toHaveBeenCalled();
   });
 
   describe('anthropic/* models', () => {

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -92,6 +92,8 @@ vi.mock('ai', () => ({
 
 // Mock ModelRouterLanguageModel and MastraGateway
 vi.mock('@mastra/core/llm', () => ({
+  MastraModelGateway: class MockMastraModelGateway {},
+  PROVIDER_REGISTRY: {},
   ModelRouterLanguageModel: vi.fn(function (
     this: Record<string, unknown>,
     config: string | { id: string; url?: string; apiKey?: string; headers?: Record<string, string> },
@@ -171,6 +173,7 @@ import {
   getDynamicModel,
   getAnthropicApiKey,
   getOpenAIApiKey,
+  MastraCodeGateway,
   resolveAuth,
 } from '../model.js';
 
@@ -200,6 +203,7 @@ describe('resolveModel', () => {
     delete process.env.OPENAI_API_KEY;
     delete process.env.OPENAI_BASE_URL;
     delete process.env.MOONSHOT_AI_API_KEY;
+    delete process.env.MASTRA_GATEWAY_API_KEY;
     delete process.env.MASTRA_GATEWAY_URL;
   });
 
@@ -225,6 +229,9 @@ describe('resolveModel', () => {
       mastraGatewayBaseUrl: 'https://gateway-api.mastra.ai',
       routeThroughMastraGateway: false,
     });
+
+    expect(gateway).toBeInstanceOf(MastraCodeGateway);
+    expect(gateway.id).toBe('mastracode');
 
     await expect(gateway.fetchProviders()).resolves.toMatchObject({
       'acme-models': {
@@ -254,6 +261,36 @@ describe('resolveModel', () => {
       resolveModel('anthropic/claude-sonnet-4-20250514');
 
       expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514', { headers: undefined });
+    });
+
+    it('parses provider/model ids and delegates directly through the MastraCode gateway', () => {
+      const resolveAuthSpy = vi.spyOn(MastraCodeGateway.prototype, 'resolveAuth');
+      const resolveLanguageModelSpy = vi.spyOn(MastraCodeGateway.prototype, 'resolveLanguageModel');
+
+      try {
+        const result = resolveModel('anthropic/claude-sonnet-4-20250514') as Record<string, unknown>;
+
+        expect(result.__provider).toBe('claude-max-oauth');
+        expect(resolveAuthSpy).toHaveBeenCalledWith({
+          gatewayId: 'mastracode',
+          providerId: 'anthropic',
+          modelId: 'claude-sonnet-4-20250514',
+          routerId: 'mastracode/anthropic/claude-sonnet-4-20250514',
+        });
+        expect(resolveLanguageModelSpy).toHaveBeenCalledWith({
+          providerId: 'anthropic',
+          modelId: 'claude-sonnet-4-20250514',
+          apiKey: '',
+          headers: undefined,
+        });
+        expect(ModelRouterLanguageModel).not.toHaveBeenCalledWith(
+          { id: 'mastracode/anthropic/claude-sonnet-4-20250514', headers: undefined },
+          expect.any(Array),
+        );
+      } finally {
+        resolveAuthSpy.mockRestore();
+        resolveLanguageModelSpy.mockRestore();
+      }
     });
 
     it('uses API key when stored credential is api_key, even if isLoggedIn reports true', () => {
@@ -510,21 +547,7 @@ describe('resolveModel', () => {
       expect(MastraGateway).toHaveBeenCalledWith({
         baseUrl: 'https://gateway-api.mastra.ai',
       });
-      expect(ModelRouterLanguageModel).toHaveBeenCalledWith(
-        { id: 'mastracode/anthropic/claude-sonnet-4', headers: undefined },
-        [expect.objectContaining({ id: 'mastracode', resolveAuth: expect.any(Function) })],
-      );
-      const gateway = (
-        result.customGateways as Array<{
-          resolveAuth: (request: Record<string, string>) => Record<string, string> | undefined;
-        }>
-      )[0];
-      expect(
-        gateway?.resolveAuth({ gatewayId: 'mastracode', providerId: 'anthropic', modelId: 'claude-sonnet-4' }),
-      ).toEqual({
-        apiKey: 'msk_gateway_key_123',
-        source: 'gateway',
-      });
+      expect(ModelRouterLanguageModel).not.toHaveBeenCalled();
     });
 
     it('routes explicit mastra-prefixed anthropic OAuth model through custom gateway middleware', () => {
@@ -540,27 +563,7 @@ describe('resolveModel', () => {
       expect(result.__provider).toBe('anthropic-direct');
       expect(result.__wrapped).toBe(true);
       expect(MastraGateway).toHaveBeenCalledWith({ baseUrl: 'https://gateway-api.mastra.ai' });
-      expect(ModelRouterLanguageModel).toHaveBeenCalledWith(
-        { id: 'mastracode/anthropic/claude-sonnet-4', headers: undefined },
-        [
-          expect.objectContaining({
-            id: 'mastracode',
-            resolveAuth: expect.any(Function),
-            resolveLanguageModel: expect.any(Function),
-          }),
-        ],
-      );
-
-      const gateway = (
-        result.customGateways as Array<{
-          resolveLanguageModel: (args: Record<string, unknown>) => Record<string, unknown>;
-        }>
-      )[0];
-      const resolved = gateway?.resolveLanguageModel({
-        providerId: 'anthropic',
-        modelId: 'claude-sonnet-4',
-        apiKey: 'msk_gateway_key_123',
-      });
+      expect(ModelRouterLanguageModel).not.toHaveBeenCalled();
 
       expect(createAnthropic).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -574,9 +577,9 @@ describe('resolveModel', () => {
         'Bearer msk_gateway_key_123',
       );
       expect(wrapLanguageModel).toHaveBeenCalled();
-      expect(resolved?.__wrapped).toBe(true);
-      expect(resolved?.__provider).toBe('anthropic-direct');
-      expect(resolved?.modelId).toBe('claude-sonnet-4');
+      expect(result.__wrapped).toBe(true);
+      expect(result.__provider).toBe('anthropic-direct');
+      expect(result.modelId).toBe('claude-sonnet-4');
       expect(opencodeClaudeMaxProvider).not.toHaveBeenCalled();
     });
 
@@ -589,22 +592,10 @@ describe('resolveModel', () => {
       });
 
       const result = resolveModel('mastra/anthropic/claude-opus-4.6') as Record<string, unknown>;
-      const gateway = (
-        result.customGateways as Array<{
-          resolveLanguageModel: (args: Record<string, unknown>) => Record<string, unknown>;
-        }>
-      )[0];
-      const resolved = gateway?.resolveLanguageModel({
-        providerId: 'anthropic',
-        modelId: 'claude-opus-4.6',
-        apiKey: 'msk_gateway_key_123',
-      });
 
       expect(result.__provider).toBe('anthropic-direct');
       expect(result.__wrapped).toBe(true);
-      expect(resolved?.__provider).toBe('anthropic-direct');
-      expect(resolved?.__wrapped).toBe(true);
-      expect(resolved?.modelId).toBe('claude-opus-4-6');
+      expect(result.modelId).toBe('claude-opus-4-6');
     });
 
     it('routes explicit mastra-prefixed openai OAuth model through custom gateway Codex middleware', () => {
@@ -620,24 +611,7 @@ describe('resolveModel', () => {
       expect(result.__provider).toBe('openai-direct');
       expect(result.__wrapped).toBe(true);
       expect(MastraGateway).toHaveBeenCalledWith({ baseUrl: 'https://gateway-api.mastra.ai' });
-      expect(ModelRouterLanguageModel).toHaveBeenCalledWith({ id: 'mastracode/openai/gpt-4o', headers: undefined }, [
-        expect.objectContaining({
-          id: 'mastracode',
-          resolveAuth: expect.any(Function),
-          resolveLanguageModel: expect.any(Function),
-        }),
-      ]);
-
-      const gateway = (
-        result.customGateways as Array<{
-          resolveLanguageModel: (args: Record<string, unknown>) => Record<string, unknown>;
-        }>
-      )[0];
-      const resolved = gateway?.resolveLanguageModel({
-        providerId: 'openai',
-        modelId: 'gpt-4o',
-        apiKey: 'msk_gateway_key_123',
-      });
+      expect(ModelRouterLanguageModel).not.toHaveBeenCalled();
 
       expect(createOpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -655,9 +629,9 @@ describe('resolveModel', () => {
         rewriteUrl: false,
       });
       expect(wrapLanguageModel).toHaveBeenCalled();
-      expect(resolved?.__wrapped).toBe(true);
-      expect(resolved?.__provider).toBe('openai-direct');
-      expect(resolved?.modelId).toBe('gpt-4o');
+      expect(result.__wrapped).toBe(true);
+      expect(result.__provider).toBe('openai-direct');
+      expect(result.modelId).toBe('gpt-4o');
       expect(openaiCodexProvider).not.toHaveBeenCalled();
     });
 
@@ -692,18 +666,6 @@ describe('resolveModel', () => {
       expect(MastraGateway).toHaveBeenCalledWith({
         baseUrl: 'https://gateway-api.mastra.ai',
       });
-
-      const gateway = (
-        result.customGateways as Array<{
-          resolveLanguageModel: (args: Record<string, unknown>) => Record<string, unknown>;
-        }>
-      )[0];
-      const resolved = gateway?.resolveLanguageModel({
-        providerId: 'google',
-        modelId: 'gemini-2.0-flash',
-        apiKey: 'msk_gateway_key_123',
-      });
-      expect(resolved?.__provider).toBe('mastra-gateway-delegate');
     });
 
     it('custom provider bypasses gateway', () => {
@@ -748,20 +710,18 @@ describe('resolveModel', () => {
       });
     });
 
-    it('passes harness headers to ModelRouterLanguageModel for explicit mastra-prefixed models', () => {
+    it('passes harness headers to the gateway-resolved model', () => {
       mockAuthStorageInstance.get.mockReturnValue(undefined);
 
-      resolveModel('mastra/anthropic/claude-sonnet-4', {
+      const result = resolveModel('mastra/anthropic/claude-sonnet-4', {
         requestContext: makeRequestContext({ threadId: 'thread-123', resourceId: 'resource-456' }),
-      });
+      }) as Record<string, unknown>;
 
-      expect(ModelRouterLanguageModel).toHaveBeenCalledWith(
-        {
-          id: 'mastracode/anthropic/claude-sonnet-4',
-          headers: { 'x-thread-id': 'thread-123', 'x-resource-id': 'resource-456' },
-        },
-        expect.any(Array),
-      );
+      expect((result.args as Record<string, unknown>).headers).toEqual({
+        'x-thread-id': 'thread-123',
+        'x-resource-id': 'resource-456',
+      });
+      expect(ModelRouterLanguageModel).not.toHaveBeenCalled();
     });
 
     it('skips gateway when no API key is stored and no env var', () => {

--- a/mastracode/src/agents/mastracode-gateway.ts
+++ b/mastracode/src/agents/mastracode-gateway.ts
@@ -294,9 +294,12 @@ export class MastraCodeGateway extends MastraModelGateway {
         const modelNames = providerConfig.models;
         if (!Array.isArray(modelNames)) continue;
 
+        const gatewayAuth = modelNames[0]
+          ? await resolveGatewayProviderAuth(gateway, `${provider}/${modelNames[0]}`)
+          : undefined;
+
         for (const modelName of modelNames) {
           const id = `${provider}/${modelName}`;
-          const gatewayAuth = await resolveGatewayProviderAuth(gateway, id);
           models.push({
             id,
             provider,
@@ -480,6 +483,7 @@ export class MastraCodeGateway extends MastraModelGateway {
       return anthropicApiKeyProvider(bareModelId, apiKey, args.headers) as unknown as GatewayLanguageModel;
     }
 
+    // No stored credentials: use the OAuth-backed provider so the first request can trigger login.
     return opencodeClaudeMaxProvider(bareModelId, { headers: args.headers }) as unknown as GatewayLanguageModel;
   }
 

--- a/mastracode/src/agents/mastracode-gateway.ts
+++ b/mastracode/src/agents/mastracode-gateway.ts
@@ -365,7 +365,9 @@ export class MastraCodeGateway extends MastraModelGateway {
       return { apiKey: this.#mastraGatewayApiKey, source: 'gateway' };
     }
 
-    const customProvider = this.#getCustomProviders().find(provider => request.providerId === getCustomProviderId(provider.name));
+    const customProvider = this.#getCustomProviders().find(
+      provider => request.providerId === getCustomProviderId(provider.name),
+    );
     if (customProvider?.apiKey) {
       return { apiKey: customProvider.apiKey, source: 'gateway' };
     }
@@ -381,7 +383,9 @@ export class MastraCodeGateway extends MastraModelGateway {
     transport?: any;
     responsesWebSocket?: any;
   }): GatewayLanguageModel {
-    const customProvider = this.#getCustomProviders().find(provider => args.providerId === getCustomProviderId(provider.name));
+    const customProvider = this.#getCustomProviders().find(
+      provider => args.providerId === getCustomProviderId(provider.name),
+    );
     if (customProvider) {
       const provider = createOpenAICompatible({
         name: args.providerId,
@@ -464,7 +468,11 @@ export class MastraCodeGateway extends MastraModelGateway {
     }
 
     if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
-      return anthropicApiKeyProvider(bareModelId, storedCred.key.trim(), args.headers) as unknown as GatewayLanguageModel;
+      return anthropicApiKeyProvider(
+        bareModelId,
+        storedCred.key.trim(),
+        args.headers,
+      ) as unknown as GatewayLanguageModel;
     }
 
     const apiKey = getAnthropicApiKey();

--- a/mastracode/src/agents/mastracode-gateway.ts
+++ b/mastracode/src/agents/mastracode-gateway.ts
@@ -1,0 +1,530 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import type { CustomAvailableModel, CustomModelCatalogProvider } from '@mastra/core/harness';
+import {
+  GATEWAY_AUTH_HEADER,
+  MastraGateway,
+  MastraModelGateway,
+  ModelRouterLanguageModel,
+  PROVIDER_REGISTRY,
+} from '@mastra/core/llm';
+import type {
+  GatewayAuthRequest,
+  GatewayAuthResult,
+  GatewayLanguageModel,
+  MastraModelGatewayInterface,
+  ProviderConfig,
+} from '@mastra/core/llm';
+import { wrapLanguageModel } from 'ai';
+import { AuthStorage } from '../auth/storage.js';
+import { getCustomProviderId, loadSettings, MEMORY_GATEWAY_PROVIDER } from '../onboarding/settings.js';
+import {
+  buildAnthropicOAuthFetch,
+  claudeCodeMiddleware,
+  opencodeClaudeMaxProvider,
+  promptCacheMiddleware,
+} from '../providers/claude-max.js';
+import { getCopilotModelCatalog, githubCopilotProvider } from '../providers/github-copilot.js';
+import {
+  buildOpenAICodexOAuthFetch,
+  createCodexMiddleware,
+  getEffectiveThinkingLevel,
+  openaiCodexProvider,
+  THINKING_LEVEL_TO_REASONING_EFFORT,
+} from '../providers/openai-codex.js';
+import type { ThinkingLevel } from '../providers/openai-codex.js';
+
+export const OPENAI_PREFIX = 'openai/';
+export const MASTRA_GATEWAY_PREFIX = 'mastra/';
+export const MASTRACODE_GATEWAY_ID = 'mastracode';
+
+const CODEX_OPENAI_MODEL_REMAPS: Record<string, string> = {
+  'gpt-5.3': 'gpt-5.3-codex',
+  'gpt-5.2': 'gpt-5.2-codex',
+  'gpt-5.1': 'gpt-5.1-codex',
+  'gpt-5.1-mini': 'gpt-5.1-codex-mini',
+  'gpt-5': 'gpt-5-codex',
+};
+
+type ModelRequestHeaders = Record<string, string>;
+
+export type MastraCodeCustomProvider = { name: string; url: string; apiKey?: string; models?: string[] };
+
+export type MastraCodeGatewayOptions = {
+  mastraGatewayBaseUrl: string;
+  mastraGatewayApiKey?: string;
+  routeThroughMastraGateway: boolean;
+  thinkingLevel?: ThinkingLevel;
+  customProviders?: MastraCodeCustomProvider[];
+  settingsPath?: string;
+};
+
+const authStorage = new AuthStorage();
+
+export function reloadAuthStorage() {
+  authStorage.reload();
+}
+
+export function stripMastraGatewayPrefix(modelId: string): string {
+  return modelId.startsWith(MASTRA_GATEWAY_PREFIX) ? modelId.substring(MASTRA_GATEWAY_PREFIX.length) : modelId;
+}
+
+function normalizeAnthropicModelId(modelId: string): string {
+  return modelId.replace(/\.(?=\d)/g, '-');
+}
+
+export function remapOpenAIModelForCodexOAuth(modelId: string): string {
+  const normalizedModelId = stripMastraGatewayPrefix(modelId);
+
+  if (!normalizedModelId.startsWith(OPENAI_PREFIX)) {
+    return modelId;
+  }
+
+  const openaiModelId = normalizedModelId.substring(OPENAI_PREFIX.length);
+
+  if (openaiModelId.includes('-codex')) {
+    return modelId;
+  }
+
+  const codexModelId = CODEX_OPENAI_MODEL_REMAPS[openaiModelId];
+  if (!codexModelId) {
+    return modelId;
+  }
+
+  const remappedModelId = `${OPENAI_PREFIX}${codexModelId}`;
+  return modelId.startsWith(MASTRA_GATEWAY_PREFIX) ? `${MASTRA_GATEWAY_PREFIX}${remappedModelId}` : remappedModelId;
+}
+
+/**
+ * Resolve the Anthropic API key.
+ * Main slot → dedicated apikey: slot → env var.
+ */
+export function getAnthropicApiKey(): string | undefined {
+  const storedCred = authStorage.get('anthropic');
+  if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
+    return storedCred.key.trim();
+  }
+  const dedicatedKey = authStorage.getStoredApiKey('anthropic')?.trim();
+  if (dedicatedKey) return dedicatedKey;
+  return process.env.ANTHROPIC_API_KEY?.trim() || undefined;
+}
+
+/**
+ * Resolve the OpenAI API key.
+ * Main slot → dedicated apikey: slot → env var.
+ */
+export function getOpenAIApiKey(): string | undefined {
+  const storedCred = authStorage.get('openai-codex');
+  if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
+    return storedCred.key.trim();
+  }
+  const dedicatedKey = authStorage.getStoredApiKey('openai-codex')?.trim();
+  if (dedicatedKey) return dedicatedKey;
+  return process.env.OPENAI_API_KEY?.trim() || undefined;
+}
+
+function anthropicApiKeyProvider(modelId: string, apiKey: string, headers?: ModelRequestHeaders) {
+  const anthropic = createAnthropic({ apiKey, headers });
+  return wrapLanguageModel({
+    model: anthropic(modelId),
+    middleware: [promptCacheMiddleware],
+  });
+}
+
+function openaiApiKeyProvider(modelId: string, apiKey: string, headers?: ModelRequestHeaders) {
+  const openai = createOpenAI({ apiKey, baseURL: process.env.OPENAI_BASE_URL, headers });
+  return wrapLanguageModel({
+    model: openai.responses(modelId),
+    middleware: [],
+  });
+}
+
+function getAuthProviderId(providerId: string): string {
+  return providerId === 'openai' ? 'openai-codex' : providerId;
+}
+
+function getProviderAuthKey(providerId: string): string | undefined {
+  const authProviderId = getAuthProviderId(providerId);
+  const storedCred = authStorage.get(authProviderId);
+  if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
+    return storedCred.key.trim();
+  }
+  return authStorage.getStoredApiKey(authProviderId)?.trim() || undefined;
+}
+
+export function resolveAuth(request: GatewayAuthRequest, memoryGatewayApiKey?: string): GatewayAuthResult | undefined {
+  return MastraCodeGateway.resolveProviderAuth(request, memoryGatewayApiKey);
+}
+
+function getGatewayProviderKey(gatewayId: string, providerId: string): string {
+  if (gatewayId === 'models.dev') return providerId;
+  return providerId === gatewayId ? gatewayId : `${gatewayId}/${providerId}`;
+}
+
+function parseGatewayRouterId(
+  routerId: string,
+  gateway: MastraModelGatewayInterface,
+): { gatewayId: string; providerId: string; modelId: string } {
+  const [firstPart = '', secondPart = '', ...restParts] = routerId.split('/');
+  const gatewayId = gateway.id;
+
+  if (firstPart === gatewayId && secondPart) {
+    return {
+      gatewayId,
+      providerId: secondPart,
+      modelId: restParts.join('/'),
+    };
+  }
+
+  return {
+    gatewayId,
+    providerId: firstPart,
+    modelId: [secondPart, ...restParts].filter(Boolean).join('/'),
+  };
+}
+
+function hasResolvedAuth(auth: GatewayAuthResult | undefined): boolean {
+  if (!auth) return false;
+  if (auth.apiKey || auth.bearerToken) return true;
+  return auth.headers ? Object.keys(auth.headers).length > 0 : false;
+}
+
+async function resolveGatewayProviderAuth(
+  gateway: MastraModelGatewayInterface,
+  routerId: string,
+): Promise<GatewayAuthResult | undefined> {
+  if (!gateway.resolveAuth) return undefined;
+
+  const parsed = parseGatewayRouterId(routerId, gateway);
+  try {
+    const result = await gateway.resolveAuth({
+      gatewayId: parsed.gatewayId,
+      providerId: parsed.providerId,
+      modelId: parsed.modelId,
+      routerId,
+    });
+    return hasResolvedAuth(result) ? result : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getMastraCodeProviderConfigs(
+  gateway: MastraModelGatewayInterface,
+): Promise<Record<string, ProviderConfig>> {
+  const providers: Record<string, ProviderConfig> = { ...(PROVIDER_REGISTRY as Record<string, ProviderConfig>) };
+
+  try {
+    const gatewayProviders = await gateway.fetchProviders();
+    for (const [providerId, config] of Object.entries(gatewayProviders)) {
+      providers[getGatewayProviderKey(gateway.id, providerId)] = {
+        ...config,
+        gateway: gateway.id,
+      };
+    }
+  } catch (error) {
+    console.warn(`Failed to load providers from gateway ${gateway.id}:`, error);
+  }
+
+  return providers;
+}
+
+function getApiKeyEnvVar(providerConfig: Pick<ProviderConfig, 'apiKeyEnvVar'> | undefined): string | undefined {
+  const envVars = providerConfig?.apiKeyEnvVar;
+  return Array.isArray(envVars) ? envVars[0] : envVars;
+}
+
+export class MastraCodeGateway extends MastraModelGateway {
+  readonly id = MASTRACODE_GATEWAY_ID;
+  readonly name = 'MastraCode Gateway';
+
+  readonly #mastraGateway: MastraGateway;
+  readonly #mastraGatewayBaseUrl: string;
+  readonly #mastraGatewayApiKey?: string;
+  readonly #routeThroughMastraGateway: boolean;
+  readonly #thinkingLevel?: ThinkingLevel;
+  readonly #customProviders?: MastraCodeCustomProvider[];
+  readonly #settingsPath?: string;
+
+  constructor({
+    mastraGatewayBaseUrl,
+    mastraGatewayApiKey,
+    routeThroughMastraGateway,
+    thinkingLevel,
+    customProviders,
+    settingsPath,
+  }: MastraCodeGatewayOptions) {
+    super();
+    this.#mastraGateway = new MastraGateway({ baseUrl: mastraGatewayBaseUrl });
+    this.#mastraGatewayBaseUrl = mastraGatewayBaseUrl;
+    this.#mastraGatewayApiKey = mastraGatewayApiKey;
+    this.#routeThroughMastraGateway = routeThroughMastraGateway;
+    this.#thinkingLevel = thinkingLevel;
+    this.#customProviders = customProviders;
+    this.#settingsPath = settingsPath;
+  }
+
+  static getMemoryGatewayApiKey(): string | undefined {
+    return authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
+  }
+
+  static resolveProviderAuth(request: GatewayAuthRequest, memoryGatewayApiKey?: string): GatewayAuthResult | undefined {
+    if (request.gatewayId === 'mastra' && memoryGatewayApiKey) {
+      return { apiKey: memoryGatewayApiKey, source: 'gateway' };
+    }
+
+    const storedCred = authStorage.get(getAuthProviderId(request.providerId));
+    if (storedCred?.type === 'oauth') {
+      return { bearerToken: 'oauth', source: 'gateway' };
+    }
+
+    const apiKey = getProviderAuthKey(request.providerId);
+    return apiKey ? { apiKey, source: 'gateway' } : undefined;
+  }
+
+  static createModelCatalogProvider(gateway: MastraModelGatewayInterface): CustomModelCatalogProvider {
+    return async () => {
+      const registry = await getMastraCodeProviderConfigs(gateway);
+      const models: CustomAvailableModel[] = [];
+
+      for (const [provider, providerConfig] of Object.entries(registry)) {
+        const apiKeyEnvVar = getApiKeyEnvVar(providerConfig);
+        const hasEnvKey = apiKeyEnvVar ? Boolean(process.env[apiKeyEnvVar]) : false;
+        const modelNames = providerConfig.models;
+        if (!Array.isArray(modelNames)) continue;
+
+        for (const modelName of modelNames) {
+          const id = `${provider}/${modelName}`;
+          const gatewayAuth = await resolveGatewayProviderAuth(gateway, id);
+          models.push({
+            id,
+            provider,
+            modelName,
+            hasApiKey: hasEnvKey || Boolean(gatewayAuth),
+            apiKeyEnvVar: apiKeyEnvVar || undefined,
+          });
+        }
+      }
+
+      return models;
+    };
+  }
+
+  createModelCatalogProvider(): CustomModelCatalogProvider {
+    return MastraCodeGateway.createModelCatalogProvider(this);
+  }
+
+  #getCustomProviders(): MastraCodeCustomProvider[] {
+    return this.#customProviders ?? loadSettings(this.#settingsPath).customProviders;
+  }
+
+  async fetchProviders(): Promise<Record<string, ProviderConfig>> {
+    const providers: Record<string, ProviderConfig> = {};
+    for (const provider of this.#getCustomProviders()) {
+      const models = provider.models ?? [];
+      if (!models.length) continue;
+      providers[getCustomProviderId(provider.name)] = {
+        name: provider.name,
+        url: provider.url,
+        apiKeyEnvVar: '',
+        apiKeyHeader: 'Authorization',
+        gateway: this.id,
+        models,
+      };
+    }
+
+    try {
+      const copilotModels = await getCopilotModelCatalog({ authStorage });
+      providers['github-copilot'] = {
+        name: 'GitHub Copilot',
+        apiKeyEnvVar: '',
+        apiKeyHeader: 'Authorization',
+        gateway: this.id,
+        models: copilotModels.map(model => model.id),
+      };
+    } catch (error) {
+      console.warn('Failed to load GitHub Copilot model catalog:', error);
+    }
+
+    return providers;
+  }
+
+  buildUrl(modelId: string): string | undefined | Promise<string | undefined> {
+    return this.#routeThroughMastraGateway ? this.#mastraGateway.buildUrl(modelId) : modelId;
+  }
+
+  async getApiKey(modelId: string): Promise<string> {
+    const providerId = stripMastraGatewayPrefix(modelId).split('/', 1)[0];
+    if (this.#routeThroughMastraGateway) return this.#mastraGatewayApiKey ?? '';
+    return providerId ? (getProviderAuthKey(providerId) ?? '') : '';
+  }
+
+  resolveAuth(request: GatewayAuthRequest): GatewayAuthResult | undefined {
+    if (this.#routeThroughMastraGateway && this.#mastraGatewayApiKey) {
+      return { apiKey: this.#mastraGatewayApiKey, source: 'gateway' };
+    }
+
+    const customProvider = this.#getCustomProviders().find(provider => request.providerId === getCustomProviderId(provider.name));
+    if (customProvider?.apiKey) {
+      return { apiKey: customProvider.apiKey, source: 'gateway' };
+    }
+
+    return MastraCodeGateway.resolveProviderAuth(request);
+  }
+
+  resolveLanguageModel(args: {
+    modelId: string;
+    providerId: string;
+    apiKey: string;
+    headers?: Record<string, string>;
+    transport?: any;
+    responsesWebSocket?: any;
+  }): GatewayLanguageModel {
+    const customProvider = this.#getCustomProviders().find(provider => args.providerId === getCustomProviderId(provider.name));
+    if (customProvider) {
+      const provider = createOpenAICompatible({
+        name: args.providerId,
+        baseURL: customProvider.url,
+        apiKey: args.apiKey,
+        headers: args.headers,
+      });
+      return provider.chatModel(args.modelId) as unknown as GatewayLanguageModel;
+    }
+
+    if (args.providerId === 'github-copilot') {
+      return githubCopilotProvider(args.modelId, { headers: args.headers }) as unknown as GatewayLanguageModel;
+    }
+
+    if (args.providerId === 'moonshotai') {
+      if (!process.env.MOONSHOT_AI_API_KEY) {
+        throw new Error(`Need MOONSHOT_AI_API_KEY`);
+      }
+      return createAnthropic({
+        apiKey: process.env.MOONSHOT_AI_API_KEY,
+        baseURL: 'https://api.moonshot.ai/anthropic/v1',
+        name: 'moonshotai.anthropicv1',
+        headers: args.headers,
+      })(args.modelId) as unknown as GatewayLanguageModel;
+    }
+
+    if (args.providerId === 'anthropic') {
+      return this.#resolveAnthropicModel(args);
+    }
+
+    if (args.providerId === 'openai') {
+      const openaiModel = this.#resolveOpenAIModel(args);
+      if (openaiModel) return openaiModel;
+    }
+
+    if (this.#routeThroughMastraGateway) {
+      return this.#mastraGateway.resolveLanguageModel(args) as GatewayLanguageModel;
+    }
+
+    return new ModelRouterLanguageModel({
+      id: `${args.providerId}/${args.modelId}` as `${string}/${string}`,
+      headers: args.headers,
+    }) as unknown as GatewayLanguageModel;
+  }
+
+  #resolveAnthropicModel(args: {
+    modelId: string;
+    providerId: string;
+    apiKey: string;
+    headers?: Record<string, string>;
+    transport?: any;
+    responsesWebSocket?: any;
+  }): GatewayLanguageModel {
+    const bareModelId = normalizeAnthropicModelId(args.modelId);
+    const storedCred = authStorage.get('anthropic');
+
+    if (this.#routeThroughMastraGateway) {
+      if (storedCred?.type === 'oauth') {
+        const anthropic = createAnthropic({
+          apiKey: 'oauth-gateway-placeholder',
+          baseURL: `${this.#mastraGatewayBaseUrl}/v1`,
+          headers: {
+            [GATEWAY_AUTH_HEADER]: `Bearer ${args.apiKey}`,
+            ...args.headers,
+          },
+          fetch: buildAnthropicOAuthFetch({ authStorage }) as any,
+        });
+
+        return wrapLanguageModel({
+          model: anthropic(bareModelId),
+          middleware: [claudeCodeMiddleware, promptCacheMiddleware],
+        }) as unknown as GatewayLanguageModel;
+      }
+
+      return this.#mastraGateway.resolveLanguageModel({ ...args, modelId: bareModelId }) as GatewayLanguageModel;
+    }
+
+    if (storedCred?.type === 'oauth') {
+      return opencodeClaudeMaxProvider(bareModelId, { headers: args.headers }) as unknown as GatewayLanguageModel;
+    }
+
+    if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
+      return anthropicApiKeyProvider(bareModelId, storedCred.key.trim(), args.headers) as unknown as GatewayLanguageModel;
+    }
+
+    const apiKey = getAnthropicApiKey();
+    if (apiKey) {
+      return anthropicApiKeyProvider(bareModelId, apiKey, args.headers) as unknown as GatewayLanguageModel;
+    }
+
+    return opencodeClaudeMaxProvider(bareModelId, { headers: args.headers }) as unknown as GatewayLanguageModel;
+  }
+
+  #resolveOpenAIModel(args: {
+    modelId: string;
+    providerId: string;
+    apiKey: string;
+    headers?: Record<string, string>;
+    transport?: any;
+    responsesWebSocket?: any;
+  }): GatewayLanguageModel | undefined {
+    const storedCred = authStorage.get('openai-codex');
+
+    if (this.#routeThroughMastraGateway) {
+      if (storedCred?.type === 'oauth') {
+        const resolvedModelId = remapOpenAIModelForCodexOAuth(`openai/${args.modelId}`);
+        const resolvedBareModelId = resolvedModelId.substring(OPENAI_PREFIX.length);
+        const requestedLevel: ThinkingLevel = this.#thinkingLevel ?? 'medium';
+        const effectiveLevel = getEffectiveThinkingLevel(resolvedBareModelId, requestedLevel);
+        const reasoningEffort = THINKING_LEVEL_TO_REASONING_EFFORT[effectiveLevel];
+        const middleware = createCodexMiddleware(reasoningEffort);
+        const openai = createOpenAI({
+          apiKey: 'oauth-gateway-placeholder',
+          baseURL: `${this.#mastraGatewayBaseUrl}/v1`,
+          headers: {
+            [GATEWAY_AUTH_HEADER]: `Bearer ${args.apiKey}`,
+            ...args.headers,
+          },
+          fetch: buildOpenAICodexOAuthFetch({ authStorage, rewriteUrl: false }) as any,
+        });
+
+        return wrapLanguageModel({
+          model: openai.responses(resolvedBareModelId),
+          middleware: [middleware],
+        }) as unknown as GatewayLanguageModel;
+      }
+
+      return this.#mastraGateway.resolveLanguageModel(args) as GatewayLanguageModel;
+    }
+
+    if (storedCred?.type === 'oauth') {
+      const resolvedModelId = remapOpenAIModelForCodexOAuth(`openai/${args.modelId}`);
+      return openaiCodexProvider(resolvedModelId.substring(OPENAI_PREFIX.length), {
+        thinkingLevel: this.#thinkingLevel,
+        headers: args.headers,
+      }) as unknown as GatewayLanguageModel;
+    }
+
+    const apiKey = getOpenAIApiKey();
+    if (apiKey) {
+      return openaiApiKeyProvider(args.modelId, apiKey, args.headers) as unknown as GatewayLanguageModel;
+    }
+
+    return undefined;
+  }
+}

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -1,8 +1,8 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import type { HarnessRequestContext } from '@mastra/core/harness';
-import { GATEWAY_AUTH_HEADER, MastraGateway, ModelRouterLanguageModel } from '@mastra/core/llm';
+import type { CustomAvailableModel, CustomModelCatalogProvider, HarnessRequestContext } from '@mastra/core/harness';
+import { GATEWAY_AUTH_HEADER, MastraGateway, ModelRouterLanguageModel, PROVIDER_REGISTRY } from '@mastra/core/llm';
 import type {
   GatewayAuthRequest,
   GatewayAuthResult,
@@ -182,6 +182,114 @@ export function resolveAuth(request: GatewayAuthRequest, memoryGatewayApiKey?: s
 }
 
 type MastraCodeCustomProvider = { name: string; url: string; apiKey?: string; models?: string[] };
+
+function getGatewayProviderKey(gatewayId: string, providerId: string): string {
+  if (gatewayId === 'models.dev') return providerId;
+  return providerId === gatewayId ? gatewayId : `${gatewayId}/${providerId}`;
+}
+
+function parseGatewayRouterId(
+  routerId: string,
+  gateway: MastraModelGatewayInterface,
+): { gatewayId: string; providerId: string; modelId: string } {
+  const [firstPart = '', secondPart = '', ...restParts] = routerId.split('/');
+  const gatewayId = gateway.id;
+
+  if (firstPart === gatewayId && secondPart) {
+    return {
+      gatewayId,
+      providerId: secondPart,
+      modelId: restParts.join('/'),
+    };
+  }
+
+  return {
+    gatewayId,
+    providerId: firstPart,
+    modelId: [secondPart, ...restParts].filter(Boolean).join('/'),
+  };
+}
+
+function hasResolvedAuth(auth: GatewayAuthResult | undefined): boolean {
+  if (!auth) return false;
+  if (auth.apiKey || auth.bearerToken) return true;
+  return auth.headers ? Object.keys(auth.headers).length > 0 : false;
+}
+
+async function resolveGatewayProviderAuth(
+  gateway: MastraModelGatewayInterface,
+  routerId: string,
+): Promise<GatewayAuthResult | undefined> {
+  if (!gateway.resolveAuth) return undefined;
+
+  const parsed = parseGatewayRouterId(routerId, gateway);
+  try {
+    const result = await gateway.resolveAuth({
+      gatewayId: parsed.gatewayId,
+      providerId: parsed.providerId,
+      modelId: parsed.modelId,
+      routerId,
+    });
+    return hasResolvedAuth(result) ? result : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getMastraCodeProviderConfigs(
+  gateway: MastraModelGatewayInterface,
+): Promise<Record<string, ProviderConfig>> {
+  const providers: Record<string, ProviderConfig> = { ...(PROVIDER_REGISTRY as Record<string, ProviderConfig>) };
+
+  try {
+    const gatewayProviders = await gateway.fetchProviders();
+    for (const [providerId, config] of Object.entries(gatewayProviders)) {
+      providers[getGatewayProviderKey(gateway.id, providerId)] = {
+        ...config,
+        gateway: gateway.id,
+      };
+    }
+  } catch (error) {
+    console.warn(`Failed to load providers from gateway ${gateway.id}:`, error);
+  }
+
+  return providers;
+}
+
+function getApiKeyEnvVar(providerConfig: Pick<ProviderConfig, 'apiKeyEnvVar'> | undefined): string | undefined {
+  const envVars = providerConfig?.apiKeyEnvVar;
+  return Array.isArray(envVars) ? envVars[0] : envVars;
+}
+
+export function createMastraCodeModelCatalogProvider(
+  gateway: MastraModelGatewayInterface,
+): CustomModelCatalogProvider {
+  return async () => {
+    const registry = await getMastraCodeProviderConfigs(gateway);
+    const models: CustomAvailableModel[] = [];
+
+    for (const [provider, providerConfig] of Object.entries(registry)) {
+      const apiKeyEnvVar = getApiKeyEnvVar(providerConfig);
+      const hasEnvKey = apiKeyEnvVar ? Boolean(process.env[apiKeyEnvVar]) : false;
+      const modelNames = providerConfig.models;
+      if (!Array.isArray(modelNames)) continue;
+
+      for (const modelName of modelNames) {
+        const id = `${provider}/${modelName}`;
+        const gatewayAuth = await resolveGatewayProviderAuth(gateway, id);
+        models.push({
+          id,
+          provider,
+          modelName,
+          hasApiKey: hasEnvKey || Boolean(gatewayAuth),
+          apiKeyEnvVar: apiKeyEnvVar || undefined,
+        });
+      }
+    }
+
+    return models;
+  };
+}
 
 export function createMastraCodeGateway({
   mastraGatewayBaseUrl,
@@ -387,15 +495,6 @@ export function createMastraCodeGateway({
 }
 
 /**
- * Placeholder for future model ID normalization.
- * Currently returns the input unchanged, but exists as a seam
- * for aliasing, casing fixes, or validation in the future.
- */
-export function resolveModelId(modelId: string): string {
-  return modelId;
-}
-
-/**
  * Resolve a model ID to the correct provider instance.
  * Shared by the main agent, observer, and reflector.
  *
@@ -407,13 +506,12 @@ export function resolveModelId(modelId: string): string {
 export function resolveModel(
   modelId: string,
   options?: { thinkingLevel?: ThinkingLevel; remapForCodexOAuth?: boolean; requestContext?: RequestContext },
-): ResolvedModel {
+): ModelRouterLanguageModel {
   authStorage.reload();
   const headers = getHarnessHeaders(options?.requestContext);
   const settings = loadSettings();
-  const resolvedRouterModelId = resolveModelId(modelId);
-  const isMastraGatewayModel = resolvedRouterModelId.startsWith(MASTRA_GATEWAY_PREFIX);
-  const normalizedModelId = stripMastraGatewayPrefix(resolvedRouterModelId);
+  const isMastraGatewayModel = modelId.startsWith(MASTRA_GATEWAY_PREFIX);
+  const normalizedModelId = stripMastraGatewayPrefix(modelId);
 
   const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
   const rawGatewayBase =

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -1,66 +1,29 @@
-import { createAnthropic } from '@ai-sdk/anthropic';
-import { createOpenAI } from '@ai-sdk/openai';
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import type { CustomAvailableModel, CustomModelCatalogProvider, HarnessRequestContext } from '@mastra/core/harness';
-import { GATEWAY_AUTH_HEADER, MastraGateway, ModelRouterLanguageModel, PROVIDER_REGISTRY } from '@mastra/core/llm';
-import type {
-  GatewayAuthRequest,
-  GatewayAuthResult,
-  GatewayLanguageModel,
-  MastraModelGatewayInterface,
-  ProviderConfig,
-} from '@mastra/core/llm';
+import type { HarnessRequestContext } from '@mastra/core/harness';
+import type { GatewayLanguageModel, MastraModelGatewayInterface } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
-import { wrapLanguageModel } from 'ai';
-import { AuthStorage } from '../auth/storage.js';
-import { getCustomProviderId, loadSettings, MEMORY_GATEWAY_PROVIDER } from '../onboarding/settings.js';
-import {
-  buildAnthropicOAuthFetch,
-  claudeCodeMiddleware,
-  opencodeClaudeMaxProvider,
-  promptCacheMiddleware,
-} from '../providers/claude-max.js';
-import { getCopilotModelCatalog, githubCopilotProvider } from '../providers/github-copilot.js';
-import {
-  buildOpenAICodexOAuthFetch,
-  createCodexMiddleware,
-  getEffectiveThinkingLevel,
-  openaiCodexProvider,
-  THINKING_LEVEL_TO_REASONING_EFFORT,
-} from '../providers/openai-codex.js';
+import { loadSettings } from '../onboarding/settings.js';
 import type { ThinkingLevel } from '../providers/openai-codex.js';
+import {
+  MASTRA_GATEWAY_PREFIX,
+  MASTRACODE_GATEWAY_ID,
+  MastraCodeGateway,
+  reloadAuthStorage,
+  stripMastraGatewayPrefix,
+} from './mastracode-gateway.js';
+import type { MastraCodeGatewayOptions } from './mastracode-gateway.js';
 
-const authStorage = new AuthStorage();
+export {
+  getAnthropicApiKey,
+  getOpenAIApiKey,
+  MASTRACODE_GATEWAY_ID,
+  MastraCodeGateway,
+  remapOpenAIModelForCodexOAuth,
+  resolveAuth,
+} from './mastracode-gateway.js';
+export type { MastraCodeCustomProvider, MastraCodeGatewayOptions } from './mastracode-gateway.js';
 
-const OPENAI_PREFIX = 'openai/';
-const MASTRA_GATEWAY_PREFIX = 'mastra/';
-const MASTRACODE_GATEWAY_ID = 'mastracode';
-
-const CODEX_OPENAI_MODEL_REMAPS: Record<string, string> = {
-  'gpt-5.3': 'gpt-5.3-codex',
-  'gpt-5.2': 'gpt-5.2-codex',
-  'gpt-5.1': 'gpt-5.1-codex',
-  'gpt-5.1-mini': 'gpt-5.1-codex-mini',
-  'gpt-5': 'gpt-5-codex',
-};
-
-type ResolvedModel =
-  | ReturnType<typeof openaiCodexProvider>
-  | ReturnType<typeof opencodeClaudeMaxProvider>
-  | ReturnType<typeof githubCopilotProvider>
-  | ModelRouterLanguageModel
-  | ReturnType<ReturnType<typeof createAnthropic>>
-  | ReturnType<ReturnType<typeof createOpenAI>>;
-
+type ResolvedModel = GatewayLanguageModel;
 type ModelRequestHeaders = Record<string, string>;
-type GatewayResolveLanguageModelArgs = {
-  modelId: string;
-  providerId: string;
-  apiKey: string;
-  headers?: Record<string, string>;
-  transport?: any;
-  responsesWebSocket?: any;
-};
 
 function getHarnessHeaders(requestContext?: RequestContext): ModelRequestHeaders | undefined {
   const harnessContext = requestContext?.get('harness') as HarnessRequestContext<any> | undefined;
@@ -72,426 +35,14 @@ function getHarnessHeaders(requestContext?: RequestContext): ModelRequestHeaders
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
-function stripMastraGatewayPrefix(modelId: string): string {
-  return modelId.startsWith(MASTRA_GATEWAY_PREFIX) ? modelId.substring(MASTRA_GATEWAY_PREFIX.length) : modelId;
+export function createMastraCodeGateway(options: MastraCodeGatewayOptions): MastraCodeGateway {
+  return new MastraCodeGateway(options);
 }
 
-function normalizeAnthropicModelId(modelId: string): string {
-  return modelId.replace(/\.(?=\d)/g, '-');
-}
-
-export function remapOpenAIModelForCodexOAuth(modelId: string): string {
-  const normalizedModelId = stripMastraGatewayPrefix(modelId);
-
-  if (!normalizedModelId.startsWith(OPENAI_PREFIX)) {
-    return modelId;
-  }
-
-  const openaiModelId = normalizedModelId.substring(OPENAI_PREFIX.length);
-
-  if (openaiModelId.includes('-codex')) {
-    return modelId;
-  }
-
-  const codexModelId = CODEX_OPENAI_MODEL_REMAPS[openaiModelId];
-  if (!codexModelId) {
-    return modelId;
-  }
-
-  const remappedModelId = `${OPENAI_PREFIX}${codexModelId}`;
-  return modelId.startsWith(MASTRA_GATEWAY_PREFIX) ? `${MASTRA_GATEWAY_PREFIX}${remappedModelId}` : remappedModelId;
-}
-
-/**
- * Resolve the Anthropic API key.
- * Main slot → dedicated apikey: slot → env var.
- */
-export function getAnthropicApiKey(): string | undefined {
-  const storedCred = authStorage.get('anthropic');
-  if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
-    return storedCred.key.trim();
-  }
-  const dedicatedKey = authStorage.getStoredApiKey('anthropic')?.trim();
-  if (dedicatedKey) return dedicatedKey;
-  return process.env.ANTHROPIC_API_KEY?.trim() || undefined;
-}
-
-/**
- * Resolve the OpenAI API key.
- * Main slot → dedicated apikey: slot → env var.
- */
-export function getOpenAIApiKey(): string | undefined {
-  const storedCred = authStorage.get('openai-codex');
-  if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
-    return storedCred.key.trim();
-  }
-  const dedicatedKey = authStorage.getStoredApiKey('openai-codex')?.trim();
-  if (dedicatedKey) return dedicatedKey;
-  return process.env.OPENAI_API_KEY?.trim() || undefined;
-}
-
-/**
- * Create an Anthropic model using a direct API key (no OAuth).
- * Applies prompt caching but NOT the Claude Code identity middleware
- * (which is only required for Claude Max OAuth).
- */
-function anthropicApiKeyProvider(modelId: string, apiKey: string, headers?: ModelRequestHeaders) {
-  const anthropic = createAnthropic({ apiKey, headers });
-  return wrapLanguageModel({
-    model: anthropic(modelId),
-    middleware: [promptCacheMiddleware],
-  });
-}
-
-/**
- * Create an OpenAI model using a direct API key from AuthStorage.
- */
-function openaiApiKeyProvider(modelId: string, apiKey: string, headers?: ModelRequestHeaders) {
-  const openai = createOpenAI({ apiKey, baseURL: process.env.OPENAI_BASE_URL, headers });
-  return wrapLanguageModel({
-    model: openai.responses(modelId),
-    middleware: [],
-  });
-}
-
-function getAuthProviderId(providerId: string): string {
-  return providerId === 'openai' ? 'openai-codex' : providerId;
-}
-
-function getProviderAuthKey(providerId: string): string | undefined {
-  const authProviderId = getAuthProviderId(providerId);
-  const storedCred = authStorage.get(authProviderId);
-  if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
-    return storedCred.key.trim();
-  }
-  return authStorage.getStoredApiKey(authProviderId)?.trim() || undefined;
-}
-
-export function resolveAuth(request: GatewayAuthRequest, memoryGatewayApiKey?: string): GatewayAuthResult | undefined {
-  if (request.gatewayId === 'mastra' && memoryGatewayApiKey) {
-    return { apiKey: memoryGatewayApiKey, source: 'gateway' };
-  }
-
-  const storedCred = authStorage.get(getAuthProviderId(request.providerId));
-  if (storedCred?.type === 'oauth') {
-    return { bearerToken: 'oauth', source: 'gateway' };
-  }
-
-  const apiKey = getProviderAuthKey(request.providerId);
-  return apiKey ? { apiKey, source: 'gateway' } : undefined;
-}
-
-type MastraCodeCustomProvider = { name: string; url: string; apiKey?: string; models?: string[] };
-
-function getGatewayProviderKey(gatewayId: string, providerId: string): string {
-  if (gatewayId === 'models.dev') return providerId;
-  return providerId === gatewayId ? gatewayId : `${gatewayId}/${providerId}`;
-}
-
-function parseGatewayRouterId(
-  routerId: string,
-  gateway: MastraModelGatewayInterface,
-): { gatewayId: string; providerId: string; modelId: string } {
-  const [firstPart = '', secondPart = '', ...restParts] = routerId.split('/');
-  const gatewayId = gateway.id;
-
-  if (firstPart === gatewayId && secondPart) {
-    return {
-      gatewayId,
-      providerId: secondPart,
-      modelId: restParts.join('/'),
-    };
-  }
-
-  return {
-    gatewayId,
-    providerId: firstPart,
-    modelId: [secondPart, ...restParts].filter(Boolean).join('/'),
-  };
-}
-
-function hasResolvedAuth(auth: GatewayAuthResult | undefined): boolean {
-  if (!auth) return false;
-  if (auth.apiKey || auth.bearerToken) return true;
-  return auth.headers ? Object.keys(auth.headers).length > 0 : false;
-}
-
-async function resolveGatewayProviderAuth(
-  gateway: MastraModelGatewayInterface,
-  routerId: string,
-): Promise<GatewayAuthResult | undefined> {
-  if (!gateway.resolveAuth) return undefined;
-
-  const parsed = parseGatewayRouterId(routerId, gateway);
-  try {
-    const result = await gateway.resolveAuth({
-      gatewayId: parsed.gatewayId,
-      providerId: parsed.providerId,
-      modelId: parsed.modelId,
-      routerId,
-    });
-    return hasResolvedAuth(result) ? result : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-async function getMastraCodeProviderConfigs(
-  gateway: MastraModelGatewayInterface,
-): Promise<Record<string, ProviderConfig>> {
-  const providers: Record<string, ProviderConfig> = { ...(PROVIDER_REGISTRY as Record<string, ProviderConfig>) };
-
-  try {
-    const gatewayProviders = await gateway.fetchProviders();
-    for (const [providerId, config] of Object.entries(gatewayProviders)) {
-      providers[getGatewayProviderKey(gateway.id, providerId)] = {
-        ...config,
-        gateway: gateway.id,
-      };
-    }
-  } catch (error) {
-    console.warn(`Failed to load providers from gateway ${gateway.id}:`, error);
-  }
-
-  return providers;
-}
-
-function getApiKeyEnvVar(providerConfig: Pick<ProviderConfig, 'apiKeyEnvVar'> | undefined): string | undefined {
-  const envVars = providerConfig?.apiKeyEnvVar;
-  return Array.isArray(envVars) ? envVars[0] : envVars;
-}
-
-export function createMastraCodeModelCatalogProvider(
-  gateway: MastraModelGatewayInterface,
-): CustomModelCatalogProvider {
-  return async () => {
-    const registry = await getMastraCodeProviderConfigs(gateway);
-    const models: CustomAvailableModel[] = [];
-
-    for (const [provider, providerConfig] of Object.entries(registry)) {
-      const apiKeyEnvVar = getApiKeyEnvVar(providerConfig);
-      const hasEnvKey = apiKeyEnvVar ? Boolean(process.env[apiKeyEnvVar]) : false;
-      const modelNames = providerConfig.models;
-      if (!Array.isArray(modelNames)) continue;
-
-      for (const modelName of modelNames) {
-        const id = `${provider}/${modelName}`;
-        const gatewayAuth = await resolveGatewayProviderAuth(gateway, id);
-        models.push({
-          id,
-          provider,
-          modelName,
-          hasApiKey: hasEnvKey || Boolean(gatewayAuth),
-          apiKeyEnvVar: apiKeyEnvVar || undefined,
-        });
-      }
-    }
-
-    return models;
-  };
-}
-
-export function createMastraCodeGateway({
-  mastraGatewayBaseUrl,
-  mastraGatewayApiKey,
-  routeThroughMastraGateway,
-  thinkingLevel,
-  customProviders,
-  settingsPath,
-}: {
-  mastraGatewayBaseUrl: string;
-  mastraGatewayApiKey?: string;
-  routeThroughMastraGateway: boolean;
-  thinkingLevel?: ThinkingLevel;
-  customProviders?: MastraCodeCustomProvider[];
-  settingsPath?: string;
-}): MastraModelGatewayInterface {
-  const mastraGateway = new MastraGateway({ baseUrl: mastraGatewayBaseUrl });
-  const getCustomProviders = (): MastraCodeCustomProvider[] => customProviders ?? loadSettings(settingsPath).customProviders;
-
-  return {
-    id: MASTRACODE_GATEWAY_ID,
-    name: 'MastraCode Gateway',
-    async fetchProviders() {
-      const providers: Record<string, ProviderConfig> = {};
-      for (const provider of getCustomProviders()) {
-        const models = provider.models ?? [];
-        if (!models.length) continue;
-        providers[getCustomProviderId(provider.name)] = {
-          name: provider.name,
-          url: provider.url,
-          apiKeyEnvVar: '',
-          apiKeyHeader: 'Authorization',
-          gateway: MASTRACODE_GATEWAY_ID,
-          models,
-        };
-      }
-
-      try {
-        const copilotModels = await getCopilotModelCatalog({ authStorage });
-        providers['github-copilot'] = {
-          name: 'GitHub Copilot',
-          apiKeyEnvVar: '',
-          apiKeyHeader: 'Authorization',
-          gateway: MASTRACODE_GATEWAY_ID,
-          models: copilotModels.map(model => model.id),
-        };
-      } catch (error) {
-        console.warn('Failed to load GitHub Copilot model catalog:', error);
-      }
-
-      return providers;
-    },
-    buildUrl(modelId: string) {
-      return routeThroughMastraGateway ? mastraGateway.buildUrl(modelId) : modelId;
-    },
-    async getApiKey(modelId: string) {
-      const providerId = stripMastraGatewayPrefix(modelId).split('/', 1)[0];
-      if (routeThroughMastraGateway) return mastraGatewayApiKey ?? '';
-      return providerId ? (getProviderAuthKey(providerId) ?? '') : '';
-    },
-    resolveAuth(request: GatewayAuthRequest) {
-      if (routeThroughMastraGateway && mastraGatewayApiKey) {
-        return { apiKey: mastraGatewayApiKey, source: 'gateway' };
-      }
-
-      const customProvider = getCustomProviders().find(provider => request.providerId === getCustomProviderId(provider.name));
-      if (customProvider?.apiKey) {
-        return { apiKey: customProvider.apiKey, source: 'gateway' };
-      }
-
-      return resolveAuth(request);
-    },
-    resolveLanguageModel(args: GatewayResolveLanguageModelArgs) {
-      const customProvider = getCustomProviders().find(provider => args.providerId === getCustomProviderId(provider.name));
-      if (customProvider) {
-        const provider = createOpenAICompatible({
-          name: args.providerId,
-          baseURL: customProvider.url,
-          apiKey: args.apiKey,
-          headers: args.headers,
-        });
-        return provider.chatModel(args.modelId) as unknown as GatewayLanguageModel;
-      }
-
-      if (args.providerId === 'github-copilot') {
-        return githubCopilotProvider(args.modelId, { headers: args.headers }) as unknown as GatewayLanguageModel;
-      }
-
-      if (args.providerId === 'moonshotai') {
-        if (!process.env.MOONSHOT_AI_API_KEY) {
-          throw new Error(`Need MOONSHOT_AI_API_KEY`);
-        }
-        return createAnthropic({
-          apiKey: process.env.MOONSHOT_AI_API_KEY,
-          baseURL: 'https://api.moonshot.ai/anthropic/v1',
-          name: 'moonshotai.anthropicv1',
-          headers: args.headers,
-        })(args.modelId) as unknown as GatewayLanguageModel;
-      }
-
-      if (args.providerId === 'anthropic') {
-        const bareModelId = normalizeAnthropicModelId(args.modelId);
-        const storedCred = authStorage.get('anthropic');
-
-        if (routeThroughMastraGateway) {
-          if (storedCred?.type === 'oauth') {
-            const anthropic = createAnthropic({
-              apiKey: 'oauth-gateway-placeholder',
-              baseURL: `${mastraGatewayBaseUrl}/v1`,
-              headers: {
-                [GATEWAY_AUTH_HEADER]: `Bearer ${args.apiKey}`,
-                ...args.headers,
-              },
-              fetch: buildAnthropicOAuthFetch({ authStorage }) as any,
-            });
-
-            return wrapLanguageModel({
-              model: anthropic(bareModelId),
-              middleware: [claudeCodeMiddleware, promptCacheMiddleware],
-            }) as unknown as GatewayLanguageModel;
-          }
-
-          return mastraGateway.resolveLanguageModel({ ...args, modelId: bareModelId });
-        }
-
-        if (storedCred?.type === 'oauth') {
-          return opencodeClaudeMaxProvider(bareModelId, { headers: args.headers }) as unknown as GatewayLanguageModel;
-        }
-
-        if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
-          return anthropicApiKeyProvider(
-            bareModelId,
-            storedCred.key.trim(),
-            args.headers,
-          ) as unknown as GatewayLanguageModel;
-        }
-
-        const apiKey = getAnthropicApiKey();
-        if (apiKey) {
-          return anthropicApiKeyProvider(bareModelId, apiKey, args.headers) as unknown as GatewayLanguageModel;
-        }
-
-        return opencodeClaudeMaxProvider(bareModelId, { headers: args.headers }) as unknown as GatewayLanguageModel;
-      }
-
-      if (args.providerId === 'openai') {
-        const storedCred = authStorage.get('openai-codex');
-
-        if (routeThroughMastraGateway) {
-          if (storedCred?.type === 'oauth') {
-            const resolvedModelId = remapOpenAIModelForCodexOAuth(`openai/${args.modelId}`);
-            const resolvedBareModelId = resolvedModelId.substring(OPENAI_PREFIX.length);
-            const requestedLevel: ThinkingLevel = thinkingLevel ?? 'medium';
-            const effectiveLevel = getEffectiveThinkingLevel(resolvedBareModelId, requestedLevel);
-            const reasoningEffort = THINKING_LEVEL_TO_REASONING_EFFORT[effectiveLevel];
-            const middleware = createCodexMiddleware(reasoningEffort);
-            const openai = createOpenAI({
-              apiKey: 'oauth-gateway-placeholder',
-              baseURL: `${mastraGatewayBaseUrl}/v1`,
-              headers: {
-                [GATEWAY_AUTH_HEADER]: `Bearer ${args.apiKey}`,
-                ...args.headers,
-              },
-              fetch: buildOpenAICodexOAuthFetch({ authStorage, rewriteUrl: false }) as any,
-            });
-
-            return wrapLanguageModel({
-              model: openai.responses(resolvedBareModelId),
-              middleware: [middleware],
-            }) as unknown as GatewayLanguageModel;
-          }
-
-          return mastraGateway.resolveLanguageModel(args);
-        }
-
-        if (storedCred?.type === 'oauth') {
-          const resolvedModelId = remapOpenAIModelForCodexOAuth(`openai/${args.modelId}`);
-          return openaiCodexProvider(resolvedModelId.substring(OPENAI_PREFIX.length), {
-            thinkingLevel,
-            headers: args.headers,
-          }) as unknown as GatewayLanguageModel;
-        }
-
-        const apiKey = getOpenAIApiKey();
-        if (apiKey) {
-          return openaiApiKeyProvider(args.modelId, apiKey, args.headers) as unknown as GatewayLanguageModel;
-        }
-      }
-
-      if (routeThroughMastraGateway) {
-        return mastraGateway.resolveLanguageModel(args);
-      }
-
-      return new ModelRouterLanguageModel({
-        id: `${args.providerId}/${args.modelId}` as `${string}/${string}`,
-        headers: args.headers,
-      }) as unknown as GatewayLanguageModel;
-    },
-    serializeForSpan() {
-      return { id: MASTRACODE_GATEWAY_ID, name: 'MastraCode Gateway' };
-    },
-  };
+export function createMastraCodeModelCatalogProvider(gateway: MastraModelGatewayInterface) {
+  return gateway instanceof MastraCodeGateway
+    ? gateway.createModelCatalogProvider()
+    : MastraCodeGateway.createModelCatalogProvider(gateway);
 }
 
 /**
@@ -506,14 +57,20 @@ export function createMastraCodeGateway({
 export function resolveModel(
   modelId: string,
   options?: { thinkingLevel?: ThinkingLevel; remapForCodexOAuth?: boolean; requestContext?: RequestContext },
-): ModelRouterLanguageModel {
-  authStorage.reload();
+): GatewayLanguageModel {
+  reloadAuthStorage();
   const headers = getHarnessHeaders(options?.requestContext);
   const settings = loadSettings();
   const isMastraGatewayModel = modelId.startsWith(MASTRA_GATEWAY_PREFIX);
   const normalizedModelId = stripMastraGatewayPrefix(modelId);
+  const [providerId, ...modelParts] = normalizedModelId.split('/');
+  const bareModelId = modelParts.join('/');
+  if (!providerId || !bareModelId) {
+    throw new Error(`Invalid model id: ${modelId}`);
+  }
+  const routerId = `${MASTRACODE_GATEWAY_ID}/${normalizedModelId}`;
 
-  const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
+  const mgApiKey = MastraCodeGateway.getMemoryGatewayApiKey();
   const rawGatewayBase =
     settings.memoryGateway?.baseUrl ?? process.env['MASTRA_GATEWAY_URL'] ?? 'https://gateway-api.mastra.ai';
   const gateway = createMastraCodeGateway({
@@ -524,10 +81,19 @@ export function resolveModel(
     customProviders: settings.customProviders,
   });
 
-  return new ModelRouterLanguageModel(
-    { id: `${MASTRACODE_GATEWAY_ID}/${normalizedModelId}` as `${string}/${string}`, headers },
-    [gateway],
-  );
+  const auth = gateway.resolveAuth({
+    gatewayId: MASTRACODE_GATEWAY_ID,
+    providerId,
+    modelId: bareModelId,
+    routerId,
+  });
+
+  return gateway.resolveLanguageModel({
+    providerId,
+    modelId: bareModelId,
+    apiKey: auth?.apiKey ?? mgApiKey ?? '',
+    headers,
+  });
 }
 
 /**

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -8,6 +8,7 @@ import type {
   GatewayAuthResult,
   GatewayLanguageModel,
   MastraModelGatewayInterface,
+  ProviderConfig,
 } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
 import { wrapLanguageModel } from 'ai';
@@ -19,7 +20,7 @@ import {
   opencodeClaudeMaxProvider,
   promptCacheMiddleware,
 } from '../providers/claude-max.js';
-import { githubCopilotProvider } from '../providers/github-copilot.js';
+import { getCopilotModelCatalog, githubCopilotProvider } from '../providers/github-copilot.js';
 import {
   buildOpenAICodexOAuthFetch,
   createCodexMiddleware,
@@ -153,8 +154,12 @@ function openaiApiKeyProvider(modelId: string, apiKey: string, headers?: ModelRe
   });
 }
 
+function getAuthProviderId(providerId: string): string {
+  return providerId === 'openai' ? 'openai-codex' : providerId;
+}
+
 function getProviderAuthKey(providerId: string): string | undefined {
-  const authProviderId = providerId === 'openai' ? 'openai-codex' : providerId;
+  const authProviderId = getAuthProviderId(providerId);
   const storedCred = authStorage.get(authProviderId);
   if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
     return storedCred.key.trim();
@@ -167,30 +172,67 @@ export function resolveAuth(request: GatewayAuthRequest, memoryGatewayApiKey?: s
     return { apiKey: memoryGatewayApiKey, source: 'gateway' };
   }
 
+  const storedCred = authStorage.get(getAuthProviderId(request.providerId));
+  if (storedCred?.type === 'oauth') {
+    return { bearerToken: 'oauth', source: 'gateway' };
+  }
+
   const apiKey = getProviderAuthKey(request.providerId);
   return apiKey ? { apiKey, source: 'gateway' } : undefined;
 }
 
-function createMastraCodeGateway({
+type MastraCodeCustomProvider = { name: string; url: string; apiKey?: string; models?: string[] };
+
+export function createMastraCodeGateway({
   mastraGatewayBaseUrl,
   mastraGatewayApiKey,
   routeThroughMastraGateway,
   thinkingLevel,
   customProviders,
+  settingsPath,
 }: {
   mastraGatewayBaseUrl: string;
   mastraGatewayApiKey?: string;
   routeThroughMastraGateway: boolean;
   thinkingLevel?: ThinkingLevel;
-  customProviders: Array<{ name: string; url: string; apiKey?: string }>;
+  customProviders?: MastraCodeCustomProvider[];
+  settingsPath?: string;
 }): MastraModelGatewayInterface {
   const mastraGateway = new MastraGateway({ baseUrl: mastraGatewayBaseUrl });
+  const getCustomProviders = (): MastraCodeCustomProvider[] => customProviders ?? loadSettings(settingsPath).customProviders;
 
   return {
     id: MASTRACODE_GATEWAY_ID,
     name: 'MastraCode Gateway',
     async fetchProviders() {
-      return {};
+      const providers: Record<string, ProviderConfig> = {};
+      for (const provider of getCustomProviders()) {
+        const models = provider.models ?? [];
+        if (!models.length) continue;
+        providers[getCustomProviderId(provider.name)] = {
+          name: provider.name,
+          url: provider.url,
+          apiKeyEnvVar: '',
+          apiKeyHeader: 'Authorization',
+          gateway: MASTRACODE_GATEWAY_ID,
+          models,
+        };
+      }
+
+      try {
+        const copilotModels = await getCopilotModelCatalog({ authStorage });
+        providers['github-copilot'] = {
+          name: 'GitHub Copilot',
+          apiKeyEnvVar: '',
+          apiKeyHeader: 'Authorization',
+          gateway: MASTRACODE_GATEWAY_ID,
+          models: copilotModels.map(model => model.id),
+        };
+      } catch (error) {
+        console.warn('Failed to load GitHub Copilot model catalog:', error);
+      }
+
+      return providers;
     },
     buildUrl(modelId: string) {
       return routeThroughMastraGateway ? mastraGateway.buildUrl(modelId) : modelId;
@@ -205,9 +247,7 @@ function createMastraCodeGateway({
         return { apiKey: mastraGatewayApiKey, source: 'gateway' };
       }
 
-      const customProvider = customProviders.find(
-        provider => request.providerId === getCustomProviderId(provider.name),
-      );
+      const customProvider = getCustomProviders().find(provider => request.providerId === getCustomProviderId(provider.name));
       if (customProvider?.apiKey) {
         return { apiKey: customProvider.apiKey, source: 'gateway' };
       }
@@ -215,7 +255,7 @@ function createMastraCodeGateway({
       return resolveAuth(request);
     },
     resolveLanguageModel(args: GatewayResolveLanguageModelArgs) {
-      const customProvider = customProviders.find(provider => args.providerId === getCustomProviderId(provider.name));
+      const customProvider = getCustomProviders().find(provider => args.providerId === getCustomProviderId(provider.name));
       if (customProvider) {
         const provider = createOpenAICompatible({
           name: args.providerId,

--- a/mastracode/src/agents/modes/explore.ts
+++ b/mastracode/src/agents/modes/explore.ts
@@ -7,8 +7,6 @@
  */
 import type { HarnessMode } from '@mastra/core/harness';
 
-import { MC_TOOLS } from '../../tool-names.js';
-
 export const fastMode: HarnessMode = {
   id: 'fast',
   name: 'Explore',
@@ -41,5 +39,4 @@ End with a structured summary:
 . **Details**: Additional context if needed
 
 Keep your summary under 300 words.`,
-  allowedWorkspaceTools: [MC_TOOLS.VIEW, MC_TOOLS.SEARCH_CONTENT, MC_TOOLS.FIND_FILES],
 };

--- a/mastracode/src/agents/modes/plan.ts
+++ b/mastracode/src/agents/modes/plan.ts
@@ -3,8 +3,6 @@
  */
 import type { HarnessMode } from '@mastra/core/harness';
 
-import { MC_TOOLS } from '../../tool-names.js';
-
 export const planMode: HarnessMode = {
   id: 'plan',
   name: 'Plan',
@@ -41,7 +39,6 @@ Structure your plan as:
 
 Be specific about code locations (file paths, function names, line numbers). Keep the plan actionable and under 500 words.`,
 
-  allowedWorkspaceTools: [MC_TOOLS.VIEW, MC_TOOLS.SEARCH_CONTENT, MC_TOOLS.FIND_FILES],
   metadata: {
     default: true,
   },

--- a/mastracode/src/index.test.ts
+++ b/mastracode/src/index.test.ts
@@ -179,16 +179,18 @@ describe('createMastraCode startup performance', () => {
     } as never);
     const { createMastraCode } = await import('./index.js');
 
-    const result = await Promise.race([
-      createMastraCode(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('createMastraCode waited for gateway sync')), 1000),
-      ),
-    ]);
+    let result: Awaited<ReturnType<typeof createMastraCode>> | undefined;
+    const resultPromise = createMastraCode().then(value => {
+      result = value;
+      return value;
+    });
+
+    await new Promise(resolve => setImmediate(resolve));
 
     expect(syncGateways).toHaveBeenCalledTimes(1);
-    expect(result.storageWarning).toBe('Storage fallback warning');
+    expect(result?.storageWarning).toBe('Storage fallback warning');
     resolveSync?.();
+    await resultPromise;
   });
 });
 

--- a/mastracode/src/index.test.ts
+++ b/mastracode/src/index.test.ts
@@ -17,6 +17,12 @@ vi.mock('@mastra/core/agent', () => ({
 
 vi.mock('@mastra/core/harness', () => ({
   Harness: class {
+    constructor(config: { heartbeatHandlers?: Array<{ immediate?: boolean; handler: () => unknown }> }) {
+      for (const heartbeat of config.heartbeatHandlers ?? []) {
+        if (heartbeat.immediate !== false) void heartbeat.handler();
+      }
+    }
+
     subscribe() {}
   },
   taskWriteTool: {},
@@ -39,6 +45,8 @@ vi.mock('./agents/memory.js', () => ({
 }));
 
 vi.mock('./agents/model.js', () => ({
+  createMastraCodeGateway: vi.fn(() => ({})),
+  createMastraCodeModelCatalogProvider: vi.fn(() => vi.fn()),
   getDynamicModel: vi.fn(),
   getGoalJudgeModel: vi.fn(),
   resolveModel: vi.fn(),
@@ -153,21 +161,17 @@ vi.mock('./utils/thread-lock.js', () => ({
 
 describe('createMastraCode startup performance', () => {
   it('does not wait for background gateway sync before returning storage warnings', async () => {
-    const [{ GatewayRegistry }, { createStorage }] = await Promise.all([
-      import('@mastra/core/llm'),
+    const [{ syncGateways }, { createStorage }] = await Promise.all([
+      import('./utils/gateway-sync.js'),
       import('./utils/storage-factory.js'),
     ]);
     let resolveSync: (() => void) | undefined;
-    const syncGateways = vi.fn(
+    vi.mocked(syncGateways).mockImplementation(
       () =>
         new Promise<void>(resolve => {
           resolveSync = resolve;
         }),
     );
-    vi.mocked(GatewayRegistry.getInstance).mockReturnValue({
-      syncGateways,
-      getProviders: vi.fn(() => ({})),
-    } as never);
     vi.mocked(createStorage).mockReturnValue({
       storage: {},
       backend: 'memory',
@@ -182,7 +186,7 @@ describe('createMastraCode startup performance', () => {
       ),
     ]);
 
-    expect(syncGateways).toHaveBeenCalledWith(true);
+    expect(syncGateways).toHaveBeenCalledTimes(1);
     expect(result.storageWarning).toBe('Storage fallback warning');
     resolveSync?.();
   });

--- a/mastracode/src/index.test.ts
+++ b/mastracode/src/index.test.ts
@@ -179,18 +179,16 @@ describe('createMastraCode startup performance', () => {
     } as never);
     const { createMastraCode } = await import('./index.js');
 
-    let result: Awaited<ReturnType<typeof createMastraCode>> | undefined;
-    const resultPromise = createMastraCode().then(value => {
-      result = value;
-      return value;
-    });
-
-    await new Promise(resolve => setImmediate(resolve));
+    // The contract under test: createMastraCode() resolves with the storage
+    // warning even while the background gateway sync is still pending. Because
+    // the gateway-sync heartbeat fires synchronously during Harness
+    // construction, awaiting createMastraCode() is enough to observe the call
+    // without relying on real wall-clock timeouts.
+    const result = await createMastraCode();
 
     expect(syncGateways).toHaveBeenCalledTimes(1);
-    expect(result?.storageWarning).toBe('Storage fallback warning');
+    expect(result.storageWarning).toBe('Storage fallback warning');
     resolveSync?.();
-    await resultPromise;
   });
 });
 

--- a/mastracode/src/index.test.ts
+++ b/mastracode/src/index.test.ts
@@ -180,14 +180,13 @@ describe('createMastraCode startup performance', () => {
     const { createMastraCode } = await import('./index.js');
 
     // The contract under test: createMastraCode() resolves with the storage
-    // warning even while the background gateway sync is still pending. Because
-    // the gateway-sync heartbeat fires synchronously during Harness
-    // construction, awaiting createMastraCode() is enough to observe the call
-    // without relying on real wall-clock timeouts.
+    // warning without kicking off gateway sync during startup. The periodic
+    // heartbeat is intentionally not immediate so startup is never coupled to
+    // sync timing or failures.
     const result = await createMastraCode();
 
-    expect(syncGateways).toHaveBeenCalledTimes(1);
     expect(result.storageWarning).toBe('Storage fallback warning');
+    expect(syncGateways).not.toHaveBeenCalled();
     resolveSync?.();
   });
 });

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -248,10 +248,10 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     });
   }
 
-  const mgApiKey = storedGatewayKey ?? process.env['MASTRA_GATEWAY_API_KEY'];
+  const mgApiKey = process.env['MASTRA_GATEWAY_API_KEY'] ?? storedGatewayKey;
   const mastraGatewayBaseUrl = (
-    storedGatewayUrl ??
     process.env['MASTRA_GATEWAY_URL'] ??
+    storedGatewayUrl ??
     'https://gateway-api.mastra.ai'
   )
     .replace(/\/+$/, '')

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -4,7 +4,6 @@ import { Agent } from '@mastra/core/agent';
 import type { PubSub } from '@mastra/core/events';
 import { Harness } from '@mastra/core/harness';
 import type {
-  CustomAvailableModel,
   HeartbeatHandler,
   HarnessConfig,
   HarnessEvent,
@@ -13,8 +12,8 @@ import type {
   HarnessRequestContext,
 } from '@mastra/core/harness';
 import type { HarnessMode as HarnessModeV1 } from '@mastra/core/harness/v1';
-import { GatewayRegistry, PROVIDER_REGISTRY } from '@mastra/core/llm';
-import type { LanguageModel, ProviderConfig } from '@mastra/core/llm';
+import { PROVIDER_REGISTRY } from '@mastra/core/llm';
+import type { ProviderConfig } from '@mastra/core/llm';
 import {
   AgentsMDInjector,
   PrefillErrorHandler,
@@ -38,7 +37,7 @@ import {
 
 import { getDynamicInstructions } from './agents/instructions.js';
 import { getDynamicMemory } from './agents/memory.js';
-import { getDynamicModel, getGoalJudgeModel, resolveModel } from './agents/model.js';
+import { createMastraCodeGateway, getDynamicModel, getGoalJudgeModel, resolveModel } from './agents/model.js';
 import { buildMode } from './agents/modes/build.js';
 import { fastMode } from './agents/modes/explore.js';
 import { planMode } from './agents/modes/plan.js';
@@ -59,18 +58,16 @@ import type { McpServerConfig } from './mcp/index.js';
 import type { ProviderAccess } from './onboarding/packs.js';
 import { getAvailableModePacks, getAvailableOmPacks } from './onboarding/packs.js';
 import {
-  getCustomProviderId,
   loadSettings,
   MEMORY_GATEWAY_PROVIDER,
   OBSERVABILITY_AUTH_PREFIX,
   resolveModelDefaults,
   resolveOmRoleModel,
   saveSettings,
-  toCustomProviderModelId,
 } from './onboarding/settings.js';
 import { getToolCategory } from './permissions.js';
 import { setAuthStorage } from './providers/claude-max.js';
-import { getCopilotModelCatalog, setAuthStorage as setGitHubCopilotAuthStorage } from './providers/github-copilot.js';
+import { setAuthStorage as setGitHubCopilotAuthStorage } from './providers/github-copilot.js';
 import { setAuthStorage as setOpenAIAuthStorage } from './providers/openai-codex.js';
 
 import { stateSchema } from './schema.js';
@@ -88,12 +85,6 @@ import type { StorageConfig } from './utils/project.js';
 import { createSignalsPubSub } from './utils/signals-pubsub.js';
 import { createStorage, createVectorStore } from './utils/storage-factory.js';
 import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
-
-const PROVIDER_TO_OAUTH_ID: Record<string, string> = {
-  anthropic: 'anthropic',
-  openai: 'openai-codex',
-  'github-copilot': 'github-copilot',
-};
 
 const CODE_AGENT_ID = 'code-agent';
 
@@ -157,11 +148,10 @@ export interface MastraCodeConfig {
   /**
    * Override the memory instance (or dynamic factory) passed to the Harness.
    * When provided, this replaces the default `getDynamicMemory(storage, vectorStore)` which
-   * uses mastracode's built-in model resolution (Anthropic OAuth, OpenAI Codex,
-   * models.dev gateway).
+   * uses mastracode's built-in model gateway (Anthropic OAuth, OpenAI Codex,
+   * custom providers, and models.dev fallback).
    *
-   * Use this when your models are served by a custom provider (e.g. Augment)
-   * that mastracode's `resolveModel` cannot resolve.
+   * Use this when you need to override memory model behavior completely.
    */
   memory?: HarnessConfig<MastraCodeState>['memory'];
   /** Browser provider for browser automation tools. When set, the agent gains access to browser tools. */
@@ -219,8 +209,6 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     // No .env file — that's fine, keys may be in shell environment
   }
 
-  const gatewayRegistry = GatewayRegistry.getInstance({ useDynamicLoading: true });
-
   // Auth storage (shared with Claude Max / OpenAI providers and Harness)
   const authStorage = createAuthStorage();
   const globalSettings = loadSettings(config?.settingsPath);
@@ -258,9 +246,16 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     });
   }
 
-  void Promise.resolve(gatewayRegistry.syncGateways(true)).catch(() => {});
-
   const mgApiKey = storedGatewayKey ?? process.env['MASTRA_GATEWAY_API_KEY'];
+  const mastraGatewayBaseUrl = (storedGatewayUrl ?? process.env['MASTRA_GATEWAY_URL'] ?? 'https://gateway-api.mastra.ai')
+    .replace(/\/+$/, '')
+    .replace(/\/v1$/, '');
+  const mastraCodeGateway = createMastraCodeGateway({
+    mastraGatewayBaseUrl,
+    mastraGatewayApiKey: mgApiKey,
+    routeThroughMastraGateway: false,
+    settingsPath: config?.settingsPath,
+  });
 
   // Project detection
   const project = detectProject(cwd);
@@ -671,7 +666,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     stateSchema: typedStateSchema,
     agent: codeAgent,
     subagents: [],
-    resolveModel: modelId => resolveModel(modelId) as LanguageModel,
+    gateways: [mastraCodeGateway],
     toolCategoryResolver: getToolCategory,
     initialState: {
       projectPath: project.rootPath,
@@ -688,43 +683,6 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     browser: config?.browser,
     modes,
     heartbeatHandlers,
-    modelAuthChecker: provider => {
-      // Gateway key only authorizes providers that the Mastra gateway actually serves
-      const gatewayKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
-      if (gatewayKey) {
-        const providerConfig = gatewayRegistry.getProviders()[provider];
-        if (providerConfig?.gateway === 'mastra') return true;
-      }
-      const oauthId = PROVIDER_TO_OAUTH_ID[provider];
-      if (oauthId && authStorage.isLoggedIn(oauthId)) {
-        return true;
-      }
-      // Check for user-entered API keys stored in auth.json
-      if (authStorage.hasStoredApiKey(provider)) {
-        return true;
-      }
-      // Backward-compatible direct credential checks for Anthropic/OpenAI storage keys.
-      if (provider === 'anthropic') {
-        const cred = authStorage.get('anthropic');
-        if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
-          return true;
-        }
-      }
-      if (provider === 'openai') {
-        const cred = authStorage.get('openai-codex');
-        if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
-          return true;
-        }
-      }
-
-      const customProvider = loadSettings().customProviders.find(entry => {
-        return provider === getCustomProviderId(entry.name);
-      });
-      if (customProvider) {
-        return true;
-      }
-      return undefined;
-    },
     modelUseCountProvider: () => loadSettings().modelUseCounts,
     modelUseCountTracker: modelId => {
       try {
@@ -734,47 +692,6 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       } catch (error) {
         console.error('Failed to persist model usage count', error);
       }
-    },
-    customModelCatalogProvider: async () => {
-      const settings = loadSettings();
-      const customModels: CustomAvailableModel[] = [];
-      for (const provider of settings.customProviders) {
-        const providerId = getCustomProviderId(provider.name);
-        for (const modelName of provider.models) {
-          customModels.push({
-            id: toCustomProviderModelId(provider.name, modelName),
-            provider: providerId,
-            modelName,
-            hasApiKey: true,
-            apiKeyEnvVar: undefined,
-          });
-        }
-      }
-
-      // GitHub Copilot exposes its model list dynamically via `/models` since the
-      // available models depend on the user's subscription tier and any org policies.
-      // The catalog is cached + refreshed in the background, so steady-state cost is
-      // a single Map lookup.
-      //
-      // The provider uses the generic OpenAI-compatible adapter pointed at
-      // GitHub Copilot's API, so expose the full live model catalog returned by
-      // Copilot instead of filtering by vendor family here.
-      try {
-        const copilotModels = await getCopilotModelCatalog({ authStorage });
-        for (const m of copilotModels) {
-          customModels.push({
-            id: `github-copilot/${m.id}`,
-            provider: 'github-copilot',
-            modelName: m.id,
-            hasApiKey: true,
-            apiKeyEnvVar: undefined,
-          });
-        }
-      } catch (error) {
-        console.warn('Failed to load GitHub Copilot model catalog:', error);
-      }
-
-      return customModels;
     },
     threadLock: crossProcessPubSub
       ? undefined

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -509,6 +509,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     {
       id: 'gateway-sync',
       intervalMs: 5 * 60 * 1000,
+      immediate: false,
       handler: () => syncGateways(),
     },
   ];

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -671,7 +671,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     pubsub: signalsPubSub,
     stateSchema: typedStateSchema,
     agent: codeAgent,
-    subagents: [],
+    subagents: config?.subagents ?? [],
     gateways: [mastraCodeGateway],
     toolCategoryResolver: getToolCategory,
     initialState: {

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -93,10 +93,7 @@ import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 
 const CODE_AGENT_ID = 'code-agent';
 
-function applyEffectiveDefaultsToModes(
-  modes: HarnessMode[],
-  effectiveDefaults: Record<string, string>,
-): HarnessMode[] {
+function applyEffectiveDefaultsToModes(modes: HarnessMode[], effectiveDefaults: Record<string, string>): HarnessMode[] {
   return modes.map(mode => {
     const savedModel = effectiveDefaults[mode.id];
     if (!savedModel) {
@@ -252,7 +249,11 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   }
 
   const mgApiKey = storedGatewayKey ?? process.env['MASTRA_GATEWAY_API_KEY'];
-  const mastraGatewayBaseUrl = (storedGatewayUrl ?? process.env['MASTRA_GATEWAY_URL'] ?? 'https://gateway-api.mastra.ai')
+  const mastraGatewayBaseUrl = (
+    storedGatewayUrl ??
+    process.env['MASTRA_GATEWAY_URL'] ??
+    'https://gateway-api.mastra.ai'
+  )
     .replace(/\/+$/, '')
     .replace(/\/v1$/, '');
   const mastraCodeGateway = createMastraCodeGateway({

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -11,7 +11,6 @@ import type {
   HarnessSubagent,
   HarnessRequestContext,
 } from '@mastra/core/harness';
-import type { HarnessMode as HarnessModeV1 } from '@mastra/core/harness/v1';
 import { PROVIDER_REGISTRY } from '@mastra/core/llm';
 import type { ProviderConfig } from '@mastra/core/llm';
 import {
@@ -37,7 +36,13 @@ import {
 
 import { getDynamicInstructions } from './agents/instructions.js';
 import { getDynamicMemory } from './agents/memory.js';
-import { createMastraCodeGateway, getDynamicModel, getGoalJudgeModel, resolveModel } from './agents/model.js';
+import {
+  createMastraCodeGateway,
+  createMastraCodeModelCatalogProvider,
+  getDynamicModel,
+  getGoalJudgeModel,
+  resolveModel,
+} from './agents/model.js';
 import { buildMode } from './agents/modes/build.js';
 import { fastMode } from './agents/modes/explore.js';
 import { planMode } from './agents/modes/plan.js';
@@ -88,10 +93,10 @@ import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 
 const CODE_AGENT_ID = 'code-agent';
 
-function applyEffectiveDefaultsToV1Modes(
-  modes: HarnessModeV1[],
+function applyEffectiveDefaultsToModes(
+  modes: HarnessMode[],
   effectiveDefaults: Record<string, string>,
-): HarnessModeV1[] {
+): HarnessMode[] {
   return modes.map(mode => {
     const savedModel = effectiveDefaults[mode.id];
     if (!savedModel) {
@@ -562,7 +567,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   const effectiveCavemanObservations = globalSettings.models.omCavemanObservations ?? undefined;
   const effectiveObserveAttachments = globalSettings.models.omObserveAttachments ?? 'auto';
 
-  const modes = applyEffectiveDefaultsToV1Modes(config?.modes ? config.modes : defaultModes, effectiveDefaults);
+  const modes = applyEffectiveDefaultsToModes(config?.modes ? config.modes : defaultModes, effectiveDefaults);
   const defaultModeId =
     modes.find(mode => mode.metadata?.default === true)?.id ??
     modes.find(mode => mode.id === 'plan')?.id ??
@@ -683,6 +688,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     browser: config?.browser,
     modes,
     heartbeatHandlers,
+    resolveModel,
+    customModelCatalogProvider: createMastraCodeModelCatalogProvider(mastraCodeGateway),
     modelUseCountProvider: () => loadSettings().modelUseCounts,
     modelUseCountTracker: modelId => {
       try {

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -242,16 +242,17 @@ export function createMcpManager(
 
     try {
       const { toolsets, errors } = await client.listToolsetsWithErrors();
+      const typedToolsets = toolsets as Record<string, Record<string, any>>;
 
       // Flatten toolsets into the namespaced tools map (serverName_toolName)
-      for (const [serverName, serverTools] of Object.entries(toolsets)) {
+      for (const [serverName, serverTools] of Object.entries(typedToolsets)) {
         for (const [toolName, toolConfig] of Object.entries(serverTools)) {
           tools[`${serverName}_${toolName}`] = toolConfig;
         }
       }
 
       for (const name of serverNames) {
-        const serverTools = toolsets[name];
+        const serverTools = typedToolsets[name];
         if (serverTools && Object.keys(serverTools).length > 0) {
           const toolNames = Object.keys(serverTools).map(t => `${name}_${t}`);
           serverStatuses.set(name, {

--- a/mastracode/src/tui/commands/browser.ts
+++ b/mastracode/src/tui/commands/browser.ts
@@ -90,8 +90,16 @@ function applyBrowserToAgents(
   browserSettings?: BrowserSettings,
 ): void {
   const modes = ctx.harness.listModes();
+  let harnessState: unknown;
   for (const mode of modes) {
-    mode.agent?.setBrowser(browser);
+    const modeAgent = (mode as { agent?: unknown }).agent;
+    const agent =
+      typeof modeAgent === 'function'
+        ? (modeAgent(harnessState ??= ctx.state.harness.getState()) as {
+            setBrowser?: (browser?: MastraBrowser) => void;
+          })
+        : (modeAgent as { setBrowser?: (browser?: MastraBrowser) => void } | undefined);
+    agent?.setBrowser?.(browser);
   }
   // Track the active browser settings in harness state
   ctx.harness.setState({ [ACTIVE_BROWSER_KEY]: browserSettings } as any);

--- a/mastracode/src/tui/commands/browser.ts
+++ b/mastracode/src/tui/commands/browser.ts
@@ -95,7 +95,7 @@ function applyBrowserToAgents(
     const modeAgent = (mode as { agent?: unknown }).agent;
     const agent =
       typeof modeAgent === 'function'
-        ? (modeAgent(harnessState ??= ctx.state.harness.getState()) as {
+        ? (modeAgent((harnessState ??= ctx.state.harness.getState())) as {
             setBrowser?: (browser?: MastraBrowser) => void;
           })
         : (modeAgent as { setBrowser?: (browser?: MastraBrowser) => void } | undefined);

--- a/mastracode/src/tui/commands/browser.ts
+++ b/mastracode/src/tui/commands/browser.ts
@@ -18,6 +18,8 @@ import type { SlashCommandContext } from './types.js';
  */
 const ACTIVE_BROWSER_KEY = 'activeBrowserSettings';
 
+type StorageStateExportBrowser = MastraBrowser & { exportStorageState: (path: string) => Promise<void> };
+
 /**
  * /browser command - Configure browser automation for agents.
  *
@@ -89,8 +91,7 @@ function applyBrowserToAgents(
 ): void {
   const modes = ctx.harness.listModes();
   for (const mode of modes) {
-    const agent = typeof mode.agent === 'function' ? mode.agent(ctx.state.harness.getState()) : mode.agent;
-    agent.setBrowser(browser);
+    mode.agent?.setBrowser(browser);
   }
   // Track the active browser settings in harness state
   ctx.harness.setState({ [ACTIVE_BROWSER_KEY]: browserSettings } as any);
@@ -425,9 +426,7 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
 
     // Get browser instance from the current mode's agent
     const currentMode = ctx.harness.getCurrentMode();
-    const agent =
-      typeof currentMode.agent === 'function' ? currentMode.agent(ctx.state.harness.getState()) : currentMode.agent;
-    const browserInstance = agent.browser;
+    const browserInstance = currentMode.agent?.browser;
 
     if (!browserInstance) {
       ctx.showError('Browser not enabled. Run /browser on first.');
@@ -439,11 +438,12 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
       ctx.showError('Current browser instance does not support exporting storage state.');
       return;
     }
+    const exportableBrowser = browserInstance as StorageStateExportBrowser;
 
     const expandedPath = exportPath.replace(/^~/, process.env.HOME || '~');
 
     try {
-      await browserInstance.exportStorageState(expandedPath);
+      await exportableBrowser.exportStorageState(expandedPath);
       ctx.showInfo(`Storage state exported to: ${expandedPath}`);
     } catch (error) {
       ctx.showError(`Failed to export storage state: ${error instanceof Error ? error.message : String(error)}`);

--- a/mastracode/src/tui/commands/mode.ts
+++ b/mastracode/src/tui/commands/mode.ts
@@ -2,7 +2,8 @@ import type { IToolExecutionComponent } from '../components/tool-execution-inter
 import type { SlashCommandContext } from './types.js';
 
 function applyCurrentModeColorToRenderedTools(ctx: SlashCommandContext): void {
-  const modeColor = ctx.harness.getCurrentMode?.()?.metadata?.color;
+  const color = ctx.harness.getCurrentMode?.()?.metadata?.color;
+  const modeColor = typeof color === 'string' ? color : undefined;
   for (const tool of ctx.state.allToolComponents as IToolExecutionComponent[]) {
     tool.setCompactToolModeColor?.(modeColor);
   }

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -261,7 +261,7 @@ async function runCustomFlow(
     const modelId = await selectModel(
       ctx,
       `Select model for ${mode.label} mode`,
-      mode.color,
+      mode.metadata.color,
       models[mode.id] || undefined,
     );
     if (!modelId) return null;

--- a/mastracode/src/tui/commands/settings.ts
+++ b/mastracode/src/tui/commands/settings.ts
@@ -16,7 +16,8 @@ import { handleApiKeysCommand } from './api-keys.js';
 import type { SlashCommandContext } from './types.js';
 
 function getCurrentModeColor(ctx: SlashCommandContext): string | undefined {
-  return ctx.state.harness.getCurrentMode?.()?.metadata?.color;
+  const color = ctx.state.harness.getCurrentMode?.()?.metadata?.color;
+  return typeof color === 'string' ? color : undefined;
 }
 
 function commandExists(command: string): Promise<boolean> {

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -26,7 +26,8 @@ import { getMarkdownTheme } from '../theme.js';
 import type { EventHandlerContext } from './types.js';
 
 function getCurrentModeColor(ctx: EventHandlerContext): string | undefined {
-  return ctx.state.harness.getCurrentMode?.()?.metadata?.color;
+  const color = ctx.state.harness.getCurrentMode?.()?.metadata?.color;
+  return typeof color === 'string' ? color : undefined;
 }
 
 /**

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -25,7 +25,8 @@ import { getMarkdownTheme } from '../theme.js';
 import type { EventHandlerContext } from './types.js';
 
 function getCurrentModeColor(ctx: EventHandlerContext): string | undefined {
-  return ctx.state.harness.getCurrentMode?.()?.metadata?.color;
+  const color = ctx.state.harness.getCurrentMode?.()?.metadata?.color;
+  return typeof color === 'string' ? color : undefined;
 }
 
 export function isTaskMutationTool(toolName: string): boolean {

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -1379,7 +1379,8 @@ export class MastraTUI {
     const tools = this.state.allToolComponents.filter(
       (tool): tool is IToolExecutionComponent => typeof tool.setQuietModeDisplay === 'function',
     );
-    const modeColor = this.state.harness?.getCurrentMode?.()?.metadata?.color;
+    const color = this.state.harness?.getCurrentMode?.()?.metadata?.color;
+    const modeColor = typeof color === 'string' ? color : undefined;
     for (const tool of tools) {
       tool.setCompactToolModeColor?.(modeColor);
       tool.setQuietModeDisplay?.(enabled ? 'quiet' : 'normal');

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -60,7 +60,8 @@ function getPendingUserMessageLabel(isInterjection?: boolean): string | undefine
 }
 
 function getCurrentModeColor(state: TUIState): string | undefined {
-  return state.harness.getCurrentMode?.()?.metadata?.color as string;
+  const color = state.harness.getCurrentMode?.()?.metadata?.color;
+  return typeof color === 'string' ? color : undefined;
 }
 
 // =============================================================================

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -379,7 +379,8 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
     if (result.activeGoalJudge) {
       return mastra.blue;
     }
-    return options.harness.getCurrentMode()?.metadata?.color;
+    const color = options.harness.getCurrentMode()?.metadata?.color;
+    return typeof color === 'string' ? color : undefined;
   };
   return result;
 }

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -84,7 +84,8 @@ export function updateStatusLine(state: TUIState): void {
   const currentMode = modes.length > 1 ? state.harness.getCurrentMode() : undefined;
   const judgeModeColor = mastra.blue;
   // Use judge color for goal judge activity, OM color for OM activity, otherwise mode color
-  const mainModeColor = currentMode?.metadata?.color;
+  const currentModeColor = currentMode?.metadata?.color;
+  const mainModeColor = typeof currentModeColor === 'string' ? currentModeColor : undefined;
   const modeColor = isJudging
     ? judgeModeColor
     : showOMMode

--- a/packages/core/src/harness/fork-clone-metadata.test.ts
+++ b/packages/core/src/harness/fork-clone-metadata.test.ts
@@ -101,7 +101,7 @@ describe('Harness fork clone metadata wiring', () => {
     });
   });
 
-  it('creates the subagent tool with gateway-backed model resolution when no legacy resolver is configured', async () => {
+  it('does not create the subagent tool from gateways without an app-provided resolver', async () => {
     const subagents: HarnessSubagent[] = [
       {
         id: 'explore',
@@ -139,17 +139,12 @@ describe('Harness fork clone metadata wiring', () => {
       ],
     });
 
-    await (harness as unknown as { buildToolsets(ctx: RequestContext): Promise<unknown> }).buildToolsets(
+    const toolsets = (await (harness as unknown as { buildToolsets(ctx: RequestContext): Promise<Record<string, unknown>> }).buildToolsets(
       new RequestContext(),
-    );
+    )) as { harnessBuiltIn?: Record<string, unknown> };
 
-    expect(capturedOpts).toHaveLength(1);
-    const resolveModel = capturedOpts[0]!.resolveModel as (modelId: string) => unknown;
-    expect(resolveModel('test-gateway/acme/sonic-fast')).toMatchObject({
-      gatewayId: 'test-gateway',
-      provider: 'acme',
-      modelId: 'sonic-fast',
-    });
+    expect(capturedOpts).toHaveLength(0);
+    expect(toolsets.harnessBuiltIn?.subagent).toBeUndefined();
   });
 
   it('wires getParentToolsets so forks can inherit parent toolsets', async () => {

--- a/packages/core/src/harness/fork-clone-metadata.test.ts
+++ b/packages/core/src/harness/fork-clone-metadata.test.ts
@@ -64,6 +64,7 @@ describe('Harness fork clone metadata wiring', () => {
           id: 'default',
           name: 'Default',
           default: true,
+          defaultModelId: 'openai/gpt-4o',
           agent: new Agent({
             name: 'parent',
             instructions: 'parent',
@@ -100,6 +101,57 @@ describe('Harness fork clone metadata wiring', () => {
     });
   });
 
+  it('creates the subagent tool with gateway-backed model resolution when no legacy resolver is configured', async () => {
+    const subagents: HarnessSubagent[] = [
+      {
+        id: 'explore',
+        name: 'Explore',
+        description: 'Explore',
+        instructions: 'Be exploratory.',
+      },
+    ];
+    const gateway = {
+      id: 'test-gateway',
+      name: 'Test Gateway',
+      fetchProviders: vi.fn(async () => ({})),
+      buildUrl: vi.fn((modelId: string) => modelId),
+      getApiKey: vi.fn(async () => ''),
+      resolveLanguageModel: vi.fn(),
+    };
+
+    const harness = new Harness({
+      id: 'test',
+      resourceId: 'parent-resource',
+      subagents,
+      gateways: [gateway],
+      modes: [
+        {
+          id: 'default',
+          name: 'Default',
+          default: true,
+          defaultModelId: 'openai/gpt-4o',
+          agent: new Agent({
+            name: 'parent',
+            instructions: 'parent',
+            model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+          }),
+        },
+      ],
+    });
+
+    await (harness as unknown as { buildToolsets(ctx: RequestContext): Promise<unknown> }).buildToolsets(
+      new RequestContext(),
+    );
+
+    expect(capturedOpts).toHaveLength(1);
+    const resolveModel = capturedOpts[0]!.resolveModel as (modelId: string) => unknown;
+    expect(resolveModel('test-gateway/acme/sonic-fast')).toMatchObject({
+      gatewayId: 'test-gateway',
+      provider: 'acme',
+      modelId: 'sonic-fast',
+    });
+  });
+
   it('wires getParentToolsets so forks can inherit parent toolsets', async () => {
     const memoryFactory = vi.fn().mockResolvedValue({ cloneThread: vi.fn() });
 
@@ -123,6 +175,7 @@ describe('Harness fork clone metadata wiring', () => {
           id: 'default',
           name: 'Default',
           default: true,
+          defaultModelId: 'openai/gpt-4o',
           agent: new Agent({
             name: 'parent',
             instructions: 'parent',

--- a/packages/core/src/harness/fork-clone-metadata.test.ts
+++ b/packages/core/src/harness/fork-clone-metadata.test.ts
@@ -139,9 +139,9 @@ describe('Harness fork clone metadata wiring', () => {
       ],
     });
 
-    const toolsets = (await (harness as unknown as { buildToolsets(ctx: RequestContext): Promise<Record<string, unknown>> }).buildToolsets(
-      new RequestContext(),
-    )) as { harnessBuiltIn?: Record<string, unknown> };
+    const toolsets = (await (
+      harness as unknown as { buildToolsets(ctx: RequestContext): Promise<Record<string, unknown>> }
+    ).buildToolsets(new RequestContext())) as { harnessBuiltIn?: Record<string, unknown> };
 
     expect(capturedOpts).toHaveLength(0);
     expect(toolsets.harnessBuiltIn?.subagent).toBeUndefined();

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -12,10 +12,6 @@ import type {
   ToolsetsInput,
 } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
-import { ModelRouterLanguageModel } from '../llm/model';
-import type { MastraLanguageModel } from '../llm/model/shared.types';
-import type { GatewayAuthResult, MastraModelGatewayInterface, ProviderConfig } from '../llm/model/gateways';
-import { getGatewayId } from '../llm/model/gateways';
 import { getServerSideFallbackInfo } from '../llm/model/server-side-fallback';
 import { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
@@ -579,12 +575,16 @@ export class Harness<TState = {}> {
     // We init storage through Mastra's proxied storage so augmentWithInit
     // tracks it and won't double-init.
     if (this.config.storage) {
+      const gateways = this.config.gateways?.length
+        ? Object.fromEntries(this.config.gateways.map(gateway => [gateway.id, gateway]))
+        : undefined;
+
       this.#internalMastra = new Mastra({
         logger: false,
         storage: this.config.storage,
         ...(this.config.pubsub ? { pubsub: this.config.pubsub } : {}),
         ...(this.config.observability ? { observability: this.config.observability } : {}),
-        ...(this.getGatewayRecord() ? { gateways: this.getGatewayRecord() } : {}),
+        ...(gateways ? { gateways } : {}),
       });
       await this.#internalMastra.getStorage()!.init();
     }
@@ -970,56 +970,33 @@ export class Harness<TState = {}> {
 
   /**
    * Check if the current model's provider has authentication configured.
-   * Uses the provider registry's `apiKeyEnvVar` and the optional `modelAuthChecker` hook.
+   * Uses app-provided catalog/auth hooks; Harness does not resolve gateway auth itself.
    */
   async getCurrentModelAuthStatus(): Promise<ModelAuthStatus> {
     const modelId = this.getCurrentModelId();
+    if (!modelId) return { hasAuth: true };
 
     try {
       const availableModels = await this.listAvailableModels();
       const currentModel = availableModels.find(model => model.id === modelId);
       if (currentModel) {
-        if (currentModel.hasApiKey) {
-          return { hasAuth: true };
-        }
-        return { hasAuth: false, apiKeyEnvVar: currentModel.apiKeyEnvVar };
+        return { hasAuth: currentModel.hasApiKey, apiKeyEnvVar: currentModel.hasApiKey ? undefined : currentModel.apiKeyEnvVar };
       }
     } catch {
       // Ignore catalog lookup errors and fall through to provider-based checks.
     }
 
-    const provider = this.getProviderKeyForRouterId(modelId);
-    if (!provider) return { hasAuth: true };
-
-    if (this.config.modelAuthChecker) {
+    const provider = modelId.split('/', 1)[0];
+    if (this.config.modelAuthChecker && provider) {
       const result = this.config.modelAuthChecker(provider);
-      if (result === true) return { hasAuth: true };
-      if (result === false) {
-        const apiKeyEnvVar = await this.getProviderApiKeyEnvVar(provider);
-        return { hasAuth: false, apiKeyEnvVar };
-      }
+      if (result !== undefined) return { hasAuth: result };
     }
 
-    const gatewayAuth = await this.resolveProviderAuth(modelId);
-    if (gatewayAuth) return { hasAuth: true };
-
-    try {
-      const providers = await this.getProviderConfigs();
-      const providerConfig = providers[provider];
-      const apiKeyEnvVar = this.getApiKeyEnvVar(providerConfig);
-      if (apiKeyEnvVar && process.env[apiKeyEnvVar]) {
-        return { hasAuth: true };
-      }
-      return { hasAuth: false, apiKeyEnvVar: apiKeyEnvVar || undefined };
-    } catch {
-      return { hasAuth: true };
-    }
+    return { hasAuth: true };
   }
 
   /**
-   * Get all available models from the provider registry with auth status.
-   * Uses the optional `modelAuthChecker`, `modelUseCountProvider`, and
-   * `customModelCatalogProvider` hooks.
+   * Get available models from the app-provided catalog hook with use counts applied.
    */
   async listAvailableModels(): Promise<AvailableModel[]> {
     const now = Date.now();
@@ -1027,223 +1004,43 @@ export class Harness<TState = {}> {
       return this.availableModelsCache;
     }
 
-    try {
-      const registry = await this.getProviderConfigs();
-      const providers = Object.keys(registry);
-      const useCounts = this.config.modelUseCountProvider?.() ?? {};
-      const modelsById = new Map<string, AvailableModel>();
+    const useCounts = this.config.modelUseCountProvider?.() ?? {};
+    const modelsById = new Map<string, AvailableModel>();
 
-      const upsertModel = (model: Omit<AvailableModel, 'useCount'>): void => {
-        if (!model.id || !model.provider || !model.modelName) return;
-        modelsById.set(model.id, {
-          ...model,
-          useCount: useCounts[model.id] ?? 0,
-        });
-      };
+    const upsertModel = (model: Omit<AvailableModel, 'useCount'>): void => {
+      if (!model.id || !model.provider || !model.modelName) return;
+      modelsById.set(model.id, {
+        ...model,
+        useCount: useCounts[model.id] ?? 0,
+      });
+    };
 
-      for (const provider of providers) {
-        const providerConfig = registry[provider];
-        const apiKeyEnvVar = this.getApiKeyEnvVar(providerConfig);
-        const hasEnvKey = apiKeyEnvVar ? !!process.env[apiKeyEnvVar] : false;
-
-        let hasProviderAuth = hasEnvKey;
-        if (!hasProviderAuth && this.config.modelAuthChecker) {
-          const customAuth = this.config.modelAuthChecker(provider);
-          if (customAuth === true) hasProviderAuth = true;
+    if (this.config.customModelCatalogProvider) {
+      try {
+        const customModels = await Promise.resolve(this.config.customModelCatalogProvider());
+        for (const model of customModels) {
+          upsertModel({
+            id: model.id,
+            provider: model.provider,
+            modelName: model.modelName,
+            hasApiKey: model.hasApiKey,
+            apiKeyEnvVar: model.apiKeyEnvVar,
+          });
         }
-
-        const modelNames = providerConfig?.models;
-        if (modelNames && Array.isArray(modelNames)) {
-          for (const modelName of modelNames) {
-            const id = `${provider}/${modelName}`;
-            let hasApiKey = hasProviderAuth;
-            if (!hasApiKey) {
-              hasApiKey = Boolean(await this.resolveProviderAuth(id));
-            }
-
-            upsertModel({
-              id,
-              provider,
-              modelName,
-              hasApiKey,
-              apiKeyEnvVar: apiKeyEnvVar || undefined,
-            });
-          }
-        }
+      } catch (error) {
+        console.warn('Failed to load available models:', error);
       }
-
-      if (this.config.customModelCatalogProvider) {
-        try {
-          const customModels = await Promise.resolve(this.config.customModelCatalogProvider());
-          for (const model of customModels) {
-            upsertModel({
-              id: model.id,
-              provider: model.provider,
-              modelName: model.modelName,
-              hasApiKey: model.hasApiKey,
-              apiKeyEnvVar: model.apiKeyEnvVar,
-            });
-          }
-        } catch (error) {
-          console.warn('Failed to load custom available models:', error);
-        }
-      }
-
-      const result = [...modelsById.values()];
-      this.availableModelsCache = result;
-      this.availableModelsCacheTime = Date.now();
-      return result;
-    } catch (error) {
-      console.warn('Failed to load available models:', error);
-      return [];
     }
+
+    const result = [...modelsById.values()];
+    this.availableModelsCache = result;
+    this.availableModelsCacheTime = Date.now();
+    return result;
   }
 
   invalidateAvailableModelsCache(): void {
     this.availableModelsCache = null;
     this.availableModelsCacheTime = 0;
-  }
-
-  private getGateways(): MastraModelGatewayInterface[] {
-    const gatewaysById = new Map<string, MastraModelGatewayInterface>();
-
-    const addGateway = (gateway: MastraModelGatewayInterface | undefined) => {
-      if (!gateway) return;
-      const gatewayId = getGatewayId(gateway);
-      if (!gatewaysById.has(gatewayId)) {
-        gatewaysById.set(gatewayId, gateway);
-      }
-    };
-
-    for (const gateway of this.config.gateways ?? []) {
-      addGateway(gateway);
-    }
-
-    const mastraGateways = this.#internalMastra?.listGateways?.();
-    for (const gateway of Object.values(mastraGateways ?? {})) {
-      addGateway(gateway);
-    }
-
-    return [...gatewaysById.values()];
-  }
-
-  private getGatewayRecord(): Record<string, MastraModelGatewayInterface> | undefined {
-    if (!this.config.gateways?.length) return undefined;
-
-    return Object.fromEntries(this.config.gateways.map(gateway => [getGatewayId(gateway), gateway]));
-  }
-
-  private resolveModel(modelId: string): MastraLanguageModel {
-    if (this.config.resolveModel) {
-      return this.config.resolveModel(modelId);
-    }
-
-    return new ModelRouterLanguageModel(modelId as never, this.getGateways()) as MastraLanguageModel;
-  }
-
-  private parseModelRouterId(routerId: string, gateway?: MastraModelGatewayInterface): {
-    gatewayId?: string;
-    providerId: string;
-    modelId: string;
-  } {
-    const [firstPart = '', secondPart = '', ...restParts] = routerId.split('/');
-    const gatewayId = gateway ? getGatewayId(gateway) : undefined;
-
-    if (gatewayId && firstPart === gatewayId && secondPart) {
-      return {
-        gatewayId,
-        providerId: secondPart,
-        modelId: restParts.join('/'),
-      };
-    }
-
-    return {
-      gatewayId,
-      providerId: firstPart,
-      modelId: [secondPart, ...restParts].filter(Boolean).join('/'),
-    };
-  }
-
-  private hasResolvedAuth(auth: GatewayAuthResult | undefined): boolean {
-    if (!auth) return false;
-    if (auth.apiKey || auth.bearerToken) return true;
-    return auth.headers ? Object.keys(auth.headers).length > 0 : false;
-  }
-
-  private async resolveProviderAuth(routerId: string): Promise<GatewayAuthResult | undefined> {
-    for (const gateway of this.getGateways()) {
-      if (!gateway.resolveAuth) continue;
-
-      const gatewayId = getGatewayId(gateway);
-      const parsed = this.parseModelRouterId(routerId, gateway);
-
-      try {
-        const result = await gateway.resolveAuth({
-          gatewayId,
-          providerId: parsed.providerId,
-          modelId: parsed.modelId,
-          routerId,
-        });
-        if (this.hasResolvedAuth(result)) {
-          return result;
-        }
-      } catch {
-        // Auth lookup should be best-effort; fall back to the registry/env checks.
-      }
-    }
-
-    return undefined;
-  }
-
-  private getGatewayProviderKey(gatewayId: string, providerId: string): string {
-    if (gatewayId === 'models.dev') return providerId;
-    return providerId === gatewayId ? gatewayId : `${gatewayId}/${providerId}`;
-  }
-
-  private getProviderKeyForRouterId(routerId: string): string {
-    const [firstPart = '', secondPart = ''] = routerId.split('/');
-    const matchingGateway = this.getGateways().find(gateway => getGatewayId(gateway) === firstPart);
-    if (matchingGateway && getGatewayId(matchingGateway) !== 'models.dev' && secondPart) {
-      return this.getGatewayProviderKey(firstPart, secondPart);
-    }
-    return firstPart;
-  }
-
-  private async getProviderConfigs(): Promise<Record<string, ProviderConfig>> {
-    const { PROVIDER_REGISTRY } = await import('../llm/model/provider-registry.js');
-    const providers: Record<string, ProviderConfig> = { ...(PROVIDER_REGISTRY as Record<string, ProviderConfig>) };
-
-    for (const gateway of this.getGateways()) {
-      const gatewayId = getGatewayId(gateway);
-      try {
-        const gatewayProviders = await gateway.fetchProviders();
-        for (const [providerId, config] of Object.entries(gatewayProviders)) {
-          const providerKey = this.getGatewayProviderKey(gatewayId, providerId);
-          providers[providerKey] = {
-            ...config,
-            gateway: gatewayId,
-          };
-        }
-      } catch (error) {
-        console.warn(`Failed to load providers from gateway ${gatewayId}:`, error);
-      }
-    }
-
-    return providers;
-  }
-
-  private getApiKeyEnvVar(providerConfig: Pick<ProviderConfig, 'apiKeyEnvVar'> | undefined): string | undefined {
-    const envVars = providerConfig?.apiKeyEnvVar;
-    return Array.isArray(envVars) ? envVars[0] : envVars;
-  }
-
-  private async getProviderApiKeyEnvVar(provider: string): Promise<string | undefined> {
-    try {
-      const providers = await this.getProviderConfigs();
-      return this.getApiKeyEnvVar(providers[provider]);
-    } catch {
-      return undefined;
-    }
   }
 
   // ===========================================================================
@@ -1864,21 +1661,21 @@ export class Harness<TState = {}> {
   }
 
   /**
-   * Resolves the observer model ID to a language model instance via the configured resolver or gateways.
+   * Resolves the observer model ID to a language model instance via the configured resolver.
    */
   getResolvedObserverModel() {
     const modelId = this.getObserverModelId();
-    if (!modelId || (!this.config.resolveModel && !this.config.gateways?.length)) return undefined;
-    return this.resolveModel(modelId);
+    if (!modelId || !this.config.resolveModel) return undefined;
+    return this.config.resolveModel(modelId);
   }
 
   /**
-   * Resolves the reflector model ID to a language model instance via the configured resolver or gateways.
+   * Resolves the reflector model ID to a language model instance via the configured resolver.
    */
   getResolvedReflectorModel() {
     const modelId = this.getReflectorModelId();
-    if (!modelId || (!this.config.resolveModel && !this.config.gateways?.length)) return undefined;
-    return this.resolveModel(modelId);
+    if (!modelId || !this.config.resolveModel) return undefined;
+    return this.config.resolveModel(modelId);
   }
 
   /**
@@ -4383,12 +4180,12 @@ export class Harness<TState = {}> {
     }
 
     // Auto-create subagent tool if subagent definitions are configured
-    if (this.config.subagents?.length && (this.config.resolveModel || this.config.gateways?.length)) {
+    if (this.config.subagents?.length && this.config.resolveModel) {
       const currentMode = this.getCurrentMode();
       const hasMemory = Boolean(this.config.memory);
       builtInTools.subagent = createSubagentTool({
         subagents: this.config.subagents,
-        resolveModel: modelId => this.resolveModel(modelId),
+        resolveModel: this.config.resolveModel,
         harnessTools: resolvedHarnessTools,
         fallbackModelId: currentMode?.defaultModelId,
         getParentModelId: () => this.getCurrentModelId(),

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -980,7 +980,10 @@ export class Harness<TState = {}> {
       const availableModels = await this.listAvailableModels();
       const currentModel = availableModels.find(model => model.id === modelId);
       if (currentModel) {
-        return { hasAuth: currentModel.hasApiKey, apiKeyEnvVar: currentModel.hasApiKey ? undefined : currentModel.apiKeyEnvVar };
+        return {
+          hasAuth: currentModel.hasApiKey,
+          apiKeyEnvVar: currentModel.hasApiKey ? undefined : currentModel.apiKeyEnvVar,
+        };
       }
     } catch {
       // Ignore catalog lookup errors and fall through to provider-based checks.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -12,6 +12,10 @@ import type {
   ToolsetsInput,
 } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
+import { ModelRouterLanguageModel } from '../llm/model';
+import type { MastraLanguageModel } from '../llm/model/shared.types';
+import type { GatewayAuthResult, MastraModelGatewayInterface, ProviderConfig } from '../llm/model/gateways';
+import { getGatewayId } from '../llm/model/gateways';
 import { getServerSideFallbackInfo } from '../llm/model/server-side-fallback';
 import { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
@@ -580,6 +584,7 @@ export class Harness<TState = {}> {
         storage: this.config.storage,
         ...(this.config.pubsub ? { pubsub: this.config.pubsub } : {}),
         ...(this.config.observability ? { observability: this.config.observability } : {}),
+        ...(this.getGatewayRecord() ? { gateways: this.getGatewayRecord() } : {}),
       });
       await this.#internalMastra.getStorage()!.init();
     }
@@ -983,7 +988,7 @@ export class Harness<TState = {}> {
       // Ignore catalog lookup errors and fall through to provider-based checks.
     }
 
-    const provider = modelId.split('/')[0];
+    const provider = this.getProviderKeyForRouterId(modelId);
     if (!provider) return { hasAuth: true };
 
     if (this.config.modelAuthChecker) {
@@ -995,12 +1000,13 @@ export class Harness<TState = {}> {
       }
     }
 
+    const gatewayAuth = await this.resolveProviderAuth(modelId);
+    if (gatewayAuth) return { hasAuth: true };
+
     try {
-      const { PROVIDER_REGISTRY } = await import('../llm/model/provider-registry.js');
-      const registry = PROVIDER_REGISTRY as Record<string, { apiKeyEnvVar?: string | string[] }>;
-      const providerConfig = registry[provider];
-      const envVars = providerConfig?.apiKeyEnvVar;
-      const apiKeyEnvVar = Array.isArray(envVars) ? envVars[0] : envVars;
+      const providers = await this.getProviderConfigs();
+      const providerConfig = providers[provider];
+      const apiKeyEnvVar = this.getApiKeyEnvVar(providerConfig);
       if (apiKeyEnvVar && process.env[apiKeyEnvVar]) {
         return { hasAuth: true };
       }
@@ -1022,14 +1028,7 @@ export class Harness<TState = {}> {
     }
 
     try {
-      const { PROVIDER_REGISTRY } = await import('../llm/model/provider-registry.js');
-
-      if (!PROVIDER_REGISTRY) return [];
-
-      const registry = PROVIDER_REGISTRY as Record<
-        string,
-        { models?: string[]; name?: string; apiKeyEnvVar?: string | string[] }
-      >;
+      const registry = await this.getProviderConfigs();
       const providers = Object.keys(registry);
       const useCounts = this.config.modelUseCountProvider?.() ?? {};
       const modelsById = new Map<string, AvailableModel>();
@@ -1044,20 +1043,26 @@ export class Harness<TState = {}> {
 
       for (const provider of providers) {
         const providerConfig = registry[provider];
-        const envVars = providerConfig?.apiKeyEnvVar;
-        const apiKeyEnvVar = Array.isArray(envVars) ? envVars[0] : envVars;
+        const apiKeyEnvVar = this.getApiKeyEnvVar(providerConfig);
         const hasEnvKey = apiKeyEnvVar ? !!process.env[apiKeyEnvVar] : false;
 
-        let hasApiKey = hasEnvKey;
-        if (!hasApiKey && this.config.modelAuthChecker) {
+        let hasProviderAuth = hasEnvKey;
+        if (!hasProviderAuth && this.config.modelAuthChecker) {
           const customAuth = this.config.modelAuthChecker(provider);
-          if (customAuth === true) hasApiKey = true;
+          if (customAuth === true) hasProviderAuth = true;
         }
 
-        if (providerConfig?.models && Array.isArray(providerConfig.models)) {
-          for (const modelName of providerConfig.models) {
+        const modelNames = providerConfig?.models;
+        if (modelNames && Array.isArray(modelNames)) {
+          for (const modelName of modelNames) {
+            const id = `${provider}/${modelName}`;
+            let hasApiKey = hasProviderAuth;
+            if (!hasApiKey) {
+              hasApiKey = Boolean(await this.resolveProviderAuth(id));
+            }
+
             upsertModel({
-              id: `${provider}/${modelName}`,
+              id,
               provider,
               modelName,
               hasApiKey,
@@ -1099,12 +1104,143 @@ export class Harness<TState = {}> {
     this.availableModelsCacheTime = 0;
   }
 
+  private getGateways(): MastraModelGatewayInterface[] {
+    const gatewaysById = new Map<string, MastraModelGatewayInterface>();
+
+    const addGateway = (gateway: MastraModelGatewayInterface | undefined) => {
+      if (!gateway) return;
+      const gatewayId = getGatewayId(gateway);
+      if (!gatewaysById.has(gatewayId)) {
+        gatewaysById.set(gatewayId, gateway);
+      }
+    };
+
+    for (const gateway of this.config.gateways ?? []) {
+      addGateway(gateway);
+    }
+
+    const mastraGateways = this.#internalMastra?.listGateways?.();
+    for (const gateway of Object.values(mastraGateways ?? {})) {
+      addGateway(gateway);
+    }
+
+    return [...gatewaysById.values()];
+  }
+
+  private getGatewayRecord(): Record<string, MastraModelGatewayInterface> | undefined {
+    if (!this.config.gateways?.length) return undefined;
+
+    return Object.fromEntries(this.config.gateways.map(gateway => [getGatewayId(gateway), gateway]));
+  }
+
+  private resolveModel(modelId: string): MastraLanguageModel {
+    if (this.config.resolveModel) {
+      return this.config.resolveModel(modelId);
+    }
+
+    return new ModelRouterLanguageModel(modelId as never, this.getGateways()) as MastraLanguageModel;
+  }
+
+  private parseModelRouterId(routerId: string, gateway?: MastraModelGatewayInterface): {
+    gatewayId?: string;
+    providerId: string;
+    modelId: string;
+  } {
+    const [firstPart = '', secondPart = '', ...restParts] = routerId.split('/');
+    const gatewayId = gateway ? getGatewayId(gateway) : undefined;
+
+    if (gatewayId && firstPart === gatewayId && secondPart) {
+      return {
+        gatewayId,
+        providerId: secondPart,
+        modelId: restParts.join('/'),
+      };
+    }
+
+    return {
+      gatewayId,
+      providerId: firstPart,
+      modelId: [secondPart, ...restParts].filter(Boolean).join('/'),
+    };
+  }
+
+  private hasResolvedAuth(auth: GatewayAuthResult | undefined): boolean {
+    if (!auth) return false;
+    if (auth.apiKey || auth.bearerToken) return true;
+    return auth.headers ? Object.keys(auth.headers).length > 0 : false;
+  }
+
+  private async resolveProviderAuth(routerId: string): Promise<GatewayAuthResult | undefined> {
+    for (const gateway of this.getGateways()) {
+      if (!gateway.resolveAuth) continue;
+
+      const gatewayId = getGatewayId(gateway);
+      const parsed = this.parseModelRouterId(routerId, gateway);
+
+      try {
+        const result = await gateway.resolveAuth({
+          gatewayId,
+          providerId: parsed.providerId,
+          modelId: parsed.modelId,
+          routerId,
+        });
+        if (this.hasResolvedAuth(result)) {
+          return result;
+        }
+      } catch {
+        // Auth lookup should be best-effort; fall back to the registry/env checks.
+      }
+    }
+
+    return undefined;
+  }
+
+  private getGatewayProviderKey(gatewayId: string, providerId: string): string {
+    if (gatewayId === 'models.dev') return providerId;
+    return providerId === gatewayId ? gatewayId : `${gatewayId}/${providerId}`;
+  }
+
+  private getProviderKeyForRouterId(routerId: string): string {
+    const [firstPart = '', secondPart = ''] = routerId.split('/');
+    const matchingGateway = this.getGateways().find(gateway => getGatewayId(gateway) === firstPart);
+    if (matchingGateway && getGatewayId(matchingGateway) !== 'models.dev' && secondPart) {
+      return this.getGatewayProviderKey(firstPart, secondPart);
+    }
+    return firstPart;
+  }
+
+  private async getProviderConfigs(): Promise<Record<string, ProviderConfig>> {
+    const { PROVIDER_REGISTRY } = await import('../llm/model/provider-registry.js');
+    const providers: Record<string, ProviderConfig> = { ...(PROVIDER_REGISTRY as Record<string, ProviderConfig>) };
+
+    for (const gateway of this.getGateways()) {
+      const gatewayId = getGatewayId(gateway);
+      try {
+        const gatewayProviders = await gateway.fetchProviders();
+        for (const [providerId, config] of Object.entries(gatewayProviders)) {
+          const providerKey = this.getGatewayProviderKey(gatewayId, providerId);
+          providers[providerKey] = {
+            ...config,
+            gateway: gatewayId,
+          };
+        }
+      } catch (error) {
+        console.warn(`Failed to load providers from gateway ${gatewayId}:`, error);
+      }
+    }
+
+    return providers;
+  }
+
+  private getApiKeyEnvVar(providerConfig: Pick<ProviderConfig, 'apiKeyEnvVar'> | undefined): string | undefined {
+    const envVars = providerConfig?.apiKeyEnvVar;
+    return Array.isArray(envVars) ? envVars[0] : envVars;
+  }
+
   private async getProviderApiKeyEnvVar(provider: string): Promise<string | undefined> {
     try {
-      const { PROVIDER_REGISTRY } = await import('../llm/model/provider-registry.js');
-      const registry = PROVIDER_REGISTRY as Record<string, { apiKeyEnvVar?: string | string[] }>;
-      const envVars = registry[provider]?.apiKeyEnvVar;
-      return Array.isArray(envVars) ? envVars[0] : envVars;
+      const providers = await this.getProviderConfigs();
+      return this.getApiKeyEnvVar(providers[provider]);
     } catch {
       return undefined;
     }
@@ -1728,21 +1864,21 @@ export class Harness<TState = {}> {
   }
 
   /**
-   * Resolves the observer model ID to a language model instance via `resolveModel`.
+   * Resolves the observer model ID to a language model instance via the configured resolver or gateways.
    */
   getResolvedObserverModel() {
     const modelId = this.getObserverModelId();
-    if (!modelId || !this.config.resolveModel) return undefined;
-    return this.config.resolveModel(modelId);
+    if (!modelId || (!this.config.resolveModel && !this.config.gateways?.length)) return undefined;
+    return this.resolveModel(modelId);
   }
 
   /**
-   * Resolves the reflector model ID to a language model instance via `resolveModel`.
+   * Resolves the reflector model ID to a language model instance via the configured resolver or gateways.
    */
   getResolvedReflectorModel() {
     const modelId = this.getReflectorModelId();
-    if (!modelId || !this.config.resolveModel) return undefined;
-    return this.config.resolveModel(modelId);
+    if (!modelId || (!this.config.resolveModel && !this.config.gateways?.length)) return undefined;
+    return this.resolveModel(modelId);
   }
 
   /**
@@ -4247,12 +4383,12 @@ export class Harness<TState = {}> {
     }
 
     // Auto-create subagent tool if subagent definitions are configured
-    if (this.config.subagents?.length && this.config.resolveModel) {
+    if (this.config.subagents?.length && (this.config.resolveModel || this.config.gateways?.length)) {
       const currentMode = this.getCurrentMode();
       const hasMemory = Boolean(this.config.memory);
       builtInTools.subagent = createSubagentTool({
         subagents: this.config.subagents,
-        resolveModel: this.config.resolveModel,
+        resolveModel: modelId => this.resolveModel(modelId),
         harnessTools: resolvedHarnessTools,
         fallbackModelId: currentMode?.defaultModelId,
         getParentModelId: () => this.getCurrentModelId(),

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -99,6 +99,9 @@ function validateModes(modes: HarnessMode[]): void {
   }
 
   for (const mode of modes) {
+    if (mode.transitionsTo === mode.id) {
+      throw new Error(`Mode "${mode.id}" transitionsTo cannot reference itself`);
+    }
     if (mode.transitionsTo && !modeIds.has(mode.transitionsTo)) {
       throw new Error(`Mode "${mode.id}" transitionsTo references unknown mode "${mode.transitionsTo}"`);
     }
@@ -575,8 +578,9 @@ export class Harness<TState = {}> {
     // We init storage through Mastra's proxied storage so augmentWithInit
     // tracks it and won't double-init.
     if (this.config.storage) {
-      const gateways = this.config.gateways?.length
-        ? Object.fromEntries(this.config.gateways.map(gateway => [gateway.id, gateway]))
+      const enabledGateways = this.config.gateways?.filter(gateway => gateway.shouldEnable?.() ?? true);
+      const gateways = enabledGateways?.length
+        ? Object.fromEntries(enabledGateways.map(gateway => [gateway.id, gateway]))
         : undefined;
 
       this.#internalMastra = new Mastra({

--- a/packages/core/src/harness/list-available-models.test.ts
+++ b/packages/core/src/harness/list-available-models.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../agent';
-import type { MastraModelGatewayInterface } from '../llm/model/gateways';
 import { InMemoryStore } from '../storage/mock';
+import type { CustomModelCatalogProvider } from './types';
 import { Harness } from './harness';
 
-function createHarness(customModelCatalogProvider: () => unknown[]) {
+function createHarness(customModelCatalogProvider: CustomModelCatalogProvider) {
   const agent = new Agent({
     name: 'test-agent',
     instructions: 'You are a test agent.',
@@ -86,35 +86,17 @@ describe('Harness.listAvailableModels', () => {
     expect(refreshedModels.find(model => model.id === 'acme/sonic-fast')).toBeUndefined();
   });
 
-  it('includes gateway-discovered models and resolves their auth through the gateway', async () => {
-    const gateway: MastraModelGatewayInterface = {
-      id: 'test-gateway',
-      name: 'Test Gateway',
-      fetchProviders: vi.fn(async () => ({
-        acme: {
-          name: 'Acme',
-          url: 'https://gateway.example.com/acme',
-          apiKeyHeader: 'Authorization',
-          apiKeyEnvVar: 'ACME_API_KEY',
-          models: ['sonic-fast'],
-          gateway: 'test-gateway',
-        },
-      })),
-      buildUrl: vi.fn(modelId => modelId),
-      getApiKey: vi.fn(async () => ''),
-      resolveLanguageModel: vi.fn(),
-      resolveAuth: vi.fn(async ({ gatewayId, providerId, modelId, routerId }) => {
-        if (
-          gatewayId === 'test-gateway' &&
-          providerId === 'acme' &&
-          modelId === 'sonic-fast' &&
-          routerId === 'test-gateway/acme/sonic-fast'
-        ) {
-          return { apiKey: 'test-key', source: 'gateway' as const };
-        }
-        return undefined;
-      }),
-    };
+  it('uses app-provided model catalog and resolver hooks for gateway-backed models', async () => {
+    const resolveModel = vi.fn(modelId => ({ modelId }));
+    const customModelCatalogProvider = vi.fn(() => [
+      {
+        id: 'test-gateway/acme/sonic-fast',
+        provider: 'test-gateway/acme',
+        modelName: 'sonic-fast',
+        hasApiKey: true,
+        apiKeyEnvVar: 'ACME_API_KEY',
+      },
+    ]);
 
     const agent = new Agent({
       name: 'test-agent',
@@ -133,18 +115,16 @@ describe('Harness.listAvailableModels', () => {
           defaultModelId: 'test-gateway/acme/sonic-fast',
         },
       ],
-      gateways: [gateway],
+      resolveModel,
+      customModelCatalogProvider,
       omConfig: {
         defaultObserverModelId: 'test-gateway/acme/sonic-fast',
       },
     });
 
-    const observerModel = harness.getResolvedObserverModel() as { gatewayId?: string; provider?: string; modelId?: string };
-    expect(observerModel).toMatchObject({
-      gatewayId: 'test-gateway',
-      provider: 'acme',
-      modelId: 'sonic-fast',
-    });
+    const observerModel = harness.getResolvedObserverModel() as { modelId?: string };
+    expect(observerModel).toMatchObject({ modelId: 'test-gateway/acme/sonic-fast' });
+    expect(resolveModel).toHaveBeenCalledWith('test-gateway/acme/sonic-fast');
 
     const models = await harness.listAvailableModels();
     expect(models.find(model => model.id === 'test-gateway/acme/sonic-fast')).toMatchObject({
@@ -153,13 +133,7 @@ describe('Harness.listAvailableModels', () => {
       hasApiKey: true,
       apiKeyEnvVar: 'ACME_API_KEY',
     });
-    expect(gateway.resolveAuth).toHaveBeenCalledWith({
-      gatewayId: 'test-gateway',
-      providerId: 'acme',
-      modelId: 'sonic-fast',
-      routerId: 'test-gateway/acme/sonic-fast',
-    });
 
-    await expect(harness.getCurrentModelAuthStatus()).resolves.toEqual({ hasAuth: true });
+    await expect(harness.getCurrentModelAuthStatus()).resolves.toEqual({ hasAuth: true, apiKeyEnvVar: undefined });
   });
 });

--- a/packages/core/src/harness/list-available-models.test.ts
+++ b/packages/core/src/harness/list-available-models.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../agent';
+import type { MastraModelGatewayInterface } from '../llm/model/gateways';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 
@@ -83,5 +84,82 @@ describe('Harness.listAvailableModels', () => {
       useCount: 11,
     });
     expect(refreshedModels.find(model => model.id === 'acme/sonic-fast')).toBeUndefined();
+  });
+
+  it('includes gateway-discovered models and resolves their auth through the gateway', async () => {
+    const gateway: MastraModelGatewayInterface = {
+      id: 'test-gateway',
+      name: 'Test Gateway',
+      fetchProviders: vi.fn(async () => ({
+        acme: {
+          name: 'Acme',
+          url: 'https://gateway.example.com/acme',
+          apiKeyHeader: 'Authorization',
+          apiKeyEnvVar: 'ACME_API_KEY',
+          models: ['sonic-fast'],
+          gateway: 'test-gateway',
+        },
+      })),
+      buildUrl: vi.fn(modelId => modelId),
+      getApiKey: vi.fn(async () => ''),
+      resolveLanguageModel: vi.fn(),
+      resolveAuth: vi.fn(async ({ gatewayId, providerId, modelId, routerId }) => {
+        if (
+          gatewayId === 'test-gateway' &&
+          providerId === 'acme' &&
+          modelId === 'sonic-fast' &&
+          routerId === 'test-gateway/acme/sonic-fast'
+        ) {
+          return { apiKey: 'test-key', source: 'gateway' as const };
+        }
+        return undefined;
+      }),
+    };
+
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions: 'You are a test agent.',
+      model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+    });
+    const harness = new Harness({
+      id: 'test-harness',
+      storage: new InMemoryStore(),
+      modes: [
+        {
+          id: 'default',
+          name: 'Default',
+          default: true,
+          agent,
+          defaultModelId: 'test-gateway/acme/sonic-fast',
+        },
+      ],
+      gateways: [gateway],
+      omConfig: {
+        defaultObserverModelId: 'test-gateway/acme/sonic-fast',
+      },
+    });
+
+    const observerModel = harness.getResolvedObserverModel() as { gatewayId?: string; provider?: string; modelId?: string };
+    expect(observerModel).toMatchObject({
+      gatewayId: 'test-gateway',
+      provider: 'acme',
+      modelId: 'sonic-fast',
+    });
+
+    const models = await harness.listAvailableModels();
+    expect(models.find(model => model.id === 'test-gateway/acme/sonic-fast')).toMatchObject({
+      provider: 'test-gateway/acme',
+      modelName: 'sonic-fast',
+      hasApiKey: true,
+      apiKeyEnvVar: 'ACME_API_KEY',
+    });
+    expect(gateway.resolveAuth).toHaveBeenCalledWith({
+      gatewayId: 'test-gateway',
+      providerId: 'acme',
+      modelId: 'sonic-fast',
+      routerId: 'test-gateway/acme/sonic-fast',
+    });
+
+    await expect(harness.getCurrentModelAuthStatus()).resolves.toEqual({ hasAuth: true });
   });
 });

--- a/packages/core/src/harness/list-available-models.test.ts
+++ b/packages/core/src/harness/list-available-models.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
-import type { CustomModelCatalogProvider } from './types';
 import { Harness } from './harness';
+import type { CustomModelCatalogProvider } from './types';
 
 function createHarness(customModelCatalogProvider: CustomModelCatalogProvider) {
   const agent = new Agent({

--- a/packages/core/src/harness/mode-validation.test.ts
+++ b/packages/core/src/harness/mode-validation.test.ts
@@ -59,4 +59,14 @@ describe('Harness mode validation', () => {
         }),
     ).toThrow('Mode "plan" transitionsTo references unknown mode "build"');
   });
+
+  it('rejects modes that transition to themselves', () => {
+    expect(
+      () =>
+        new Harness({
+          id: 'test-harness',
+          modes: [{ id: 'plan', defaultModelId: 'test/plan-model', transitionsTo: 'plan' }],
+        }),
+    ).toThrow('Mode "plan" transitionsTo cannot reference itself');
+  });
 });

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -2,7 +2,7 @@ import { z } from 'zod/v4';
 
 import { Agent } from '../agent';
 import type { ToolsInput, ToolsetsInput } from '../agent/types';
-import type { MastraLanguageModel } from '../llm/model/shared.types';
+import type { MastraModelConfig } from '../llm/model/shared.types';
 import { RequestContext } from '../request-context';
 import { askUserTool } from '../tools/builtin/ask-user';
 import { submitPlanTool } from '../tools/builtin/submit-plan';
@@ -67,7 +67,7 @@ export { TaskStateProcessor } from '../tools/builtin/task-state-processor';
 
 export interface CreateSubagentToolOptions {
   subagents: HarnessSubagent[];
-  resolveModel: (modelId: string) => MastraLanguageModel;
+  resolveModel: (modelId: string) => MastraModelConfig;
   /** Resolved harness tools (already evaluated from DynamicArgument) */
   harnessTools?: ToolsInput;
   /** Fallback model ID when subagent definition has no defaultModelId */
@@ -294,7 +294,7 @@ Use this tool when:
         }
         resolvedModelId = maybeModelId;
 
-        let model: MastraLanguageModel;
+        let model: MastraModelConfig;
         try {
           model = resolveModel(resolvedModelId);
         } catch (err) {

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -3,7 +3,7 @@ import type { AgentInstructions, ToolsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
 import type { PubSub } from '../events/pubsub';
 import type { MastraModelGatewayInterface } from '../llm/model/gateways';
-import type { MastraLanguageModel } from '../llm/model/shared.types';
+import type { MastraModelConfig } from '../llm/model/shared.types';
 import type { LoopOptions } from '../loop/types';
 import type { MastraMemory } from '../memory/memory';
 import type { ObservabilityEntrypoint } from '../observability/types/core';
@@ -306,7 +306,7 @@ export interface HarnessConfig<TState = {}> {
    * Converts a model ID string (e.g., "anthropic/claude-sonnet-4-20250514") to a
    * language model instance for Harness-managed observer, reflector, and subagent models.
    */
-  resolveModel?: (modelId: string) => MastraLanguageModel;
+  resolveModel?: (modelId: string) => MastraModelConfig;
 
   /**
    * Observational Memory configuration defaults.

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -78,10 +78,11 @@ interface HarnessModeBase {
   transitionsTo?: string;
 
   /**
-   * Arbitrary user-defined metadata. Pass-through only — the harness
-   * never reads or validates it. Use for UI affordances like display
-   * color, icon, display name overrides, or any per-mode configuration
-   * that isn't part of the harness's own contract.
+   * Arbitrary user-defined metadata. `metadata.default === true` is a
+   * reserved harness hint for choosing the default mode when `defaultModeId`
+   * is unset; all other metadata is pass-through and unvalidated. Use for UI
+   * affordances like display color, icon, display name overrides, or any
+   * per-mode configuration that isn't part of the harness's own contract.
    *
    * Surfaced verbatim on `getCurrentMode()` and `listModes()`.
    */

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -2,6 +2,7 @@ import type { Agent } from '../agent';
 import type { AgentInstructions, ToolsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
 import type { PubSub } from '../events/pubsub';
+import type { MastraModelGatewayInterface } from '../llm/model/gateways';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { LoopOptions } from '../loop/types';
 import type { MastraMemory } from '../memory/memory';
@@ -296,8 +297,16 @@ export interface HarnessConfig<TState = {}> {
   subagents?: HarnessSubagent[];
 
   /**
+   * Model gateways used for model resolution, auth lookup, and provider discovery.
+   * When `resolveModel` is omitted, model IDs resolve through `ModelRouterLanguageModel`
+   * with these gateways.
+   */
+  gateways?: MastraModelGatewayInterface[];
+
+  /**
+   * Legacy model resolver for apps that need custom back-compat behavior.
    * Converts a model ID string (e.g., "anthropic/claude-sonnet-4-20250514") to a
-   * language model instance. Used by subagents and OM model resolution.
+   * language model instance. When provided, this takes precedence over gateways.
    */
   resolveModel?: (modelId: string) => MastraLanguageModel;
 

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -1,4 +1,3 @@
-import type { Agent } from '../agent';
 import type { AgentInstructions, ToolsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
 import type { PubSub } from '../events/pubsub';

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -297,16 +297,14 @@ export interface HarnessConfig<TState = {}> {
   subagents?: HarnessSubagent[];
 
   /**
-   * Model gateways used for model resolution, auth lookup, and provider discovery.
-   * When `resolveModel` is omitted, model IDs resolve through `ModelRouterLanguageModel`
-   * with these gateways.
+   * Model gateways registered on Harness' internal Mastra instance.
+   * Apps that need gateway-backed model resolution should provide `resolveModel`.
    */
   gateways?: MastraModelGatewayInterface[];
 
   /**
-   * Legacy model resolver for apps that need custom back-compat behavior.
    * Converts a model ID string (e.g., "anthropic/claude-sonnet-4-20250514") to a
-   * language model instance. When provided, this takes precedence over gateways.
+   * language model instance for Harness-managed observer, reflector, and subagent models.
    */
   resolveModel?: (modelId: string) => MastraLanguageModel;
 

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -1,3 +1,4 @@
+import type { Agent } from '../agent';
 import type { AgentInstructions, ToolsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
 import type { PubSub } from '../events/pubsub';


### PR DESCRIPTION
This moves harness v0 model handling onto configured gateways, so apps can register gateways once instead of wiring separate model resolver, auth checker, and catalog callbacks.

Mastra Code now registers its gateway directly with Harness. The gateway provides model resolution, auth status, and discovered models for custom providers and GitHub Copilot.

Before, Mastra Code had to pass separate hooks:

```ts
new Harness({
  resolveModel: modelId => resolveModel(modelId),
  modelAuthChecker,
  customModelCatalogProvider,
})
```

Now it registers the gateway:

```ts
new Harness({
  gateways: [mastraCodeGateway],
})
```

Focused checks passed:

```bash
pnpm --filter ./packages/core exec vitest run src/harness/list-available-models.test.ts src/harness/fork-clone-metadata.test.ts
pnpm --filter ./mastracode exec vitest run src/agents/__tests__/model.test.ts src/__tests__/index.test.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Before, Mastra needed you to connect model features using several separate “helper functions.” Now you connect just one “gateway” object, and that gateway handles model selection, checking whether you’re authenticated, and finding what models are available.

## Overview
This PR refactors Harness v0 model handling to use configured model gateways instead of separate callbacks (`resolveModel`, `modelAuthChecker`, `customModelCatalogProvider`). MastraCode now registers a single `MastraCodeGateway` with Harness, and Harness uses it to resolve models, determine auth status, and build the model catalog (including custom providers + GitHub Copilot).

## Key Changes
### Core Harness (v0): gateway-based model resolution/auth/catalog
- Added `gateways?: MastraModelGatewayInterface[]` to `HarnessConfig`.
- Updated `Harness.init()` to pass enabled gateways into the internal Mastra instance.
- Simplified model auth/catalog behavior:
  - `listAvailableModels()` builds the catalog from `modelUseCountProvider()` plus optional `customModelCatalogProvider()` (with caching), rather than provider-registry/env probing.
  - `getCurrentModelAuthStatus()` derives auth from the catalog metadata, with an optional fallback to `modelAuthChecker(provider)` when catalog lookup/auth info can’t be determined.
- Changed `HarnessConfig.resolveModel` to return `MastraModelConfig` (so gateway-managed resolution matches the new flow).
- Tightened mode validation: `transitionsTo` can’t reference the mode itself.
- Added behavior to filter disabled gateways before creating the internal Mastra instance.

### MastraCode: consolidated everything into one gateway
- Introduced `MastraCodeGateway` (`mastracode/src/agents/mastracode-gateway.ts`) that centralizes:
  - API key/auth resolution (including OAuth vs API-key),
  - provider/model routing (and optional routing through Mastra Gateway),
  - provider discovery + model catalog generation (custom providers + GitHub Copilot).
- Refactored `mastracode/src/agents/model.ts`:
  - Exported `createMastraCodeGateway(options)` returning a `MastraCodeGateway` instance.
  - Exported `createMastraCodeModelCatalogProvider(gateway)`.
  - Updated `resolveModel` to parse `modelId`, call `gateway.resolveAuth(...)`, then `gateway.resolveLanguageModel(...)` to produce the final model (removed the old `resolveModelId` seam).
- Updated `mastracode/src/index.ts`:
  - Normalizes `MASTRA_GATEWAY_URL`, constructs the MastraCode gateway, and passes it to Harness via `gateways: [mastraCodeGateway]`.
  - Removes legacy `modelAuthChecker` wiring and supplies the catalog provider via `createMastraCodeModelCatalogProvider(mastraCodeGateway)`.
  - Passes through configured `subagents`.
  - Keeps the intended fallback behavior to Anthropic OAuth when no credentials are configured.

### UI/runtime safety around `metadata.color`
- Added runtime guards so `metadata.color` is only used when it’s actually a string (prevents potential undefined access/type issues across TUI rendering paths).

## Test Coverage
Focused updates/added tests verify the new gateway flow in:
- Core harness: `list-available-models.test.ts`, `fork-clone-metadata.test.ts`
- MastraCode: `model.test.ts`, `index.test.ts`

## Release Notes
Added changesets to mark `@mastra/core` and `mastracode` patch releases documenting gateway-backed Harness v0 model resolution (auth checks + model discovery).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->