### PR TITLE
fix(core): declare hono as a peer dependency

### DIFF
--- a/.changeset/mastra-core-hono-peer-dependency.md
+++ b/.changeset/mastra-core-hono-peer-dependency.md
@@ -1,0 +1,17 @@
+---
+"@mastra/core": patch
+---
+
+Declare `hono` as a peer dependency of `@mastra/core`.
+
+`@mastra/core` re-exports `hono`'s `Handler`, `MiddlewareHandler` and `Context`
+types in its public server API (`ApiRoute`, `Middleware`, `ContextWithMastra`,
+`ServerConfig.onError`), but only listed `hono` under `devDependencies`. When a
+consumer registers a Mastra-produced handler (e.g. `chatRoute()`) on their own
+`Hono` instance, the package manager can resolve a separate `hono` install for
+the consumer than the one `@mastra/core`'s published types were built against.
+The `GET_MATCH_RESULT` unique symbol then differs between the two `hono`
+instances, producing a `No overload matches this call` type error.
+
+Adding `hono` to `peerDependencies` makes the consumer's single `hono` instance
+the one that satisfies `@mastra/core`'s type surface, resolving the mismatch.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -829,6 +829,7 @@
     "xxhash-wasm": "^1.1.0"
   },
   "peerDependencies": {
+    "hono": "^4.12.8",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #17395

## Problem

`@mastra/core` re-exports `hono`'s `Handler`, `MiddlewareHandler` and `Context` types in its public server API — `ApiRoute.handler`, `Middleware`, `ContextWithMastra`, and `ServerConfig.onError(err, c: Context)` in `packages/core/src/server/types.ts`. These types flow into the return type of helpers like `chatRoute()`.

However `hono` was only listed under `@mastra/core`'s `devDependencies`, not `peerDependencies`. When a consumer registers a Mastra-produced handler on their own `Hono` instance:

\`\`\`ts
const chatRouteConfig = chatRoute({ path: '/chat/:agentId' });
const router = new Hono<{ Bindings: HonoBindings; Variables: HonoVariables }>();
router.post('/chat/:agentId', chatRouteConfig.handler); // type error
\`\`\`

the package manager can resolve a separate `hono` install for the consumer than the one `@mastra/core`'s published types were built against. `hono`'s `GET_MATCH_RESULT` unique symbol then differs between the two instances, producing:

\`\`\`
No overload matches this call.
  ... Property '[GET_MATCH_RESULT]' is missing in type 'HonoRequest<...>' but required in type 'HonoRequest<...>'.
\`\`\`

## Fix

Add `hono` to `@mastra/core`'s `peerDependencies` (it remains in `devDependencies` so core still builds and tests itself). This makes the consumer's single `hono` instance the one that satisfies core's type surface, resolving the symbol mismatch.

This mirrors the existing convention in `server-adapters/hono`, which already declares `hono: "^4.12.8"` as a peer dependency for the same reason.

## Note on the issue title

The issue is titled "move hono from dependencies to peerDependencies", but in current `main` `@mastra/core` lists `hono` under `devDependencies` (not `dependencies`). The effective fix is therefore to *add* it to `peerDependencies` rather than move it from `dependencies`. The user-facing symptom and root cause are exactly as described in the issue.

I declared the peer as required (no `peerDependenciesMeta` optional entry) to match `server-adapters/hono`. If you'd prefer it optional — so consumers who never touch the server types aren't prompted to install `hono` — I'm happy to add `peerDependenciesMeta: { hono: { optional: true } }`.

`hono-openapi` is leaked the same way (via `DescribeRouteOptions` in the same file) and is also dev-only; I scoped this PR to `hono` to match the issue and can follow up on `hono-openapi` separately if you'd like.

## Verification

Single-line manifest change plus a changeset; `hono` stays in `devDependencies`, so `@mastra/core`'s own build is unaffected. CI will run the full typecheck/build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a problem where TypeScript users were getting confusing error messages when trying to use Mastra's server functions with their own Hono web server. The issue happened because Mastra used Hono's types but didn't tell the package manager that consumers needed Hono too, so different versions could end up being installed. By declaring Hono as a peer dependency (rather than just an internal dev dependency), the package manager now ensures everyone uses the same version of Hono, fixing the type errors.

---

## Changes

### Package Dependencies
- **packages/core/package.json**: Added `hono` (`^4.12.8`) to `peerDependencies`

### Documentation
- **Created**: `.changeset/mastra-core-hono-peer-dependency.md` – Changeset documenting the peer dependency declaration for `@mastra/core`

---

## Rationale

`@mastra/core` re-exports types from `hono` (`Handler`, `MiddlewareHandler`, and `Context`) as part of its public server API, including in helpers like `chatRoute()`. However, `hono` was previously listed only as a `devDependency`. This caused a version mismatch when consumers registered Mastra-produced handlers on their own Hono instances—package managers could install different `hono` versions for the consumer and `@mastra/core`, leading to incompatible internal type symbols (`GET_MATCH_RESULT`) and TypeScript compilation errors.

Adding `hono` to `peerDependencies` ensures the consumer's single `hono` installation satisfies `@mastra/core`'s type surface and prevents symbol mismatches. This approach aligns with the existing convention in `server-adapters/hono`, which already declares `hono` as a peer dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->