### PR TITLE
fix(ai-sdk): use latest v6 approval response

### DIFF
--- a/.changeset/curly-states-brake.md
+++ b/.changeset/curly-states-brake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed AI SDK v6 approval resumes to use the latest response when a message contains multiple approval updates.

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
@@ -291,6 +291,38 @@ describe('extractV6NativeApproval', () => {
     expect(result?.resumeData.approved).toBe(false);
   });
 
+  it('uses the most recent approval-responded part in the trailing assistant message', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'old-call',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: `old-run${APPROVAL_ID_SEPARATOR}old-call`, approved: true },
+          },
+          {
+            type: 'tool-myTool',
+            toolCallId: 'new-call',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: `new-run${APPROVAL_ID_SEPARATOR}new-call`, approved: false, reason: 'Denied' },
+          },
+        ],
+      },
+    ];
+
+    const result = extractV6NativeApproval(messages as any);
+
+    expect(result).toEqual({
+      resumeData: { approved: false, reason: 'Denied' },
+      runId: 'new-run',
+    });
+  });
+
   it('ignores earlier approval responses once a later user follow-up exists', () => {
     const messages = [
       {

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -43,7 +43,9 @@ export function extractV6NativeApproval(
   const lastAssistantMsg = messages.at(-1);
   if (!lastAssistantMsg || lastAssistantMsg.role !== 'assistant') return null;
 
-  for (const part of lastAssistantMsg.parts ?? []) {
+  const parts = lastAssistantMsg.parts ?? [];
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i];
     if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;
 
     const lastSep = part.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);


### PR DESCRIPTION
## Description

Fixes AI SDK v6 native approval extraction so it uses the most recent `approval-responded` tool part within the trailing assistant message.

Previously, `extractV6NativeApproval` only inspected the trailing assistant message, but it iterated that message's parts from the beginning. If the same message contained multiple approval response updates, an older response could be resumed instead of the latest response. This changes the scan to walk the trailing assistant message parts from the end.

## Related issue(s)

Fixes #17899

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Verification

- `npx -y pnpm@11.5.1 --filter @mastra/ai-sdk test src/__tests__/tool-call-approval.test.ts`
- `npx -y pnpm@11.5.1 exec eslint client-sdks/ai-sdk/src/chat-route.ts client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts`
- `npx -y pnpm@11.5.1 exec prettier --check client-sdks/ai-sdk/src/chat-route.ts client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts .changeset/curly-states-brake.md`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

Imagine you asked someone to approve or reject something multiple times, and they kept adding their answers to the same list. The bug was that the code always read the first answer instead of the most recent one. This PR fixes it to read from the end of the list backwards, so it always gets the newest answer.

---

## Summary

This PR fixes a critical bug in the AI SDK v6 native approval extraction functionality where the `extractV6NativeApproval` function was incorrectly using the first `approval-responded` tool part instead of the most recent one.

### The Problem

When a single assistant message contains multiple `approval-responded` tool parts across sequential resume cycles, the function was iterating from the beginning and returning on the first match. This could cause the system to use an older, stale approval decision instead of the user's latest action.

### The Fix

The `extractV6NativeApproval` function in `chat-route.ts` was updated to iterate through the trailing assistant message's `parts` in reverse order (from end to beginning) instead of using a forward loop. This ensures the most recent `approval-responded` part is always selected, preventing scenarios where older approval decisions are incorrectly prioritized.

### Changes

- **client-sdks/ai-sdk/src/chat-route.ts**: Modified `extractV6NativeApproval` to scan message parts in reverse order (3 lines changed)
- **client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts**: Added a new test case verifying the function correctly uses the most recent `approval-responded` part when multiple approval responses exist in the same message (32 lines added)
- **.changeset/curly-states-brake.md**: Updated changeset metadata documenting the patch fix

<!-- end of auto-generated comment: release notes by coderabbit.ai -->