### PR TITLE
fix(stores): updateThread now bumps the thread's updatedAt

### DIFF
--- a/.changeset/heavy-paws-smoke.md
+++ b/.changeset/heavy-paws-smoke.md
@@ -1,0 +1,7 @@
+---
+'@mastra/mongodb': patch
+'@mastra/upstash': patch
+'@mastra/libsql': patch
+---
+
+Fixed updateThread not refreshing a thread's updatedAt timestamp. Editing a thread's title or metadata now bumps updatedAt, so edited threads correctly resurface when listing threads sorted by most recently updated.

--- a/stores/_test-utils/src/domains/memory/threads.ts
+++ b/stores/_test-utils/src/domains/memory/threads.ts
@@ -143,6 +143,11 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       const thread = createSampleThread();
       await memoryStorage.saveThread({ thread });
 
+      const originalUpdatedAtTime = new Date(thread.updatedAt).getTime();
+
+      // Wait a small amount to ensure a different timestamp
+      await new Promise(resolve => setTimeout(resolve, 10));
+
       const newMetadata = { newKey: 'newValue' };
       const updatedThread = await memoryStorage.updateThread({
         id: thread.id,
@@ -155,11 +160,12 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
         ...thread.metadata,
         ...newMetadata,
       });
+      expect(new Date(updatedThread.updatedAt).getTime()).toBeGreaterThan(originalUpdatedAtTime);
 
       // Verify persistence
       const retrievedThread = await memoryStorage.getThreadById({ threadId: thread.id });
-      console.log('retrievedThread', retrievedThread);
       expect(retrievedThread).toEqual(updatedThread);
+      expect(new Date(retrievedThread!.updatedAt).getTime()).toBeGreaterThan(originalUpdatedAtTime);
     });
 
     it('should return consistent timestamps from getThreadById and listThreads (issue #11496)', async () => {

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -1225,6 +1225,7 @@ export class MemoryLibSQL extends MemoryStorage {
       });
     }
 
+    const now = new Date();
     const updatedThread = {
       ...thread,
       title,
@@ -1232,12 +1233,13 @@ export class MemoryLibSQL extends MemoryStorage {
         ...thread.metadata,
         ...metadata,
       },
+      updatedAt: now,
     };
 
     try {
       await this.#client.execute({
-        sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?) WHERE id = ?`,
-        args: [title, JSON.stringify(updatedThread.metadata), id],
+        sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?), updatedAt = ? WHERE id = ?`,
+        args: [title, JSON.stringify(updatedThread.metadata), now.toISOString(), id],
       });
 
       return updatedThread;

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -1077,6 +1077,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
       });
     }
 
+    const now = new Date();
     const updatedThread = {
       ...thread,
       title,
@@ -1084,6 +1085,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         ...thread.metadata,
         ...metadata,
       },
+      updatedAt: now,
     };
 
     try {
@@ -1094,6 +1096,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
           $set: {
             title,
             metadata: updatedThread.metadata,
+            updatedAt: now,
           },
         },
       );

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -269,6 +269,7 @@ export class StoreMemoryUpstash extends MemoryStorage {
       });
     }
 
+    const now = new Date();
     const updatedThread = {
       ...thread,
       title,
@@ -276,6 +277,7 @@ export class StoreMemoryUpstash extends MemoryStorage {
         ...thread.metadata,
         ...metadata,
       },
+      updatedAt: now,
     };
 
     try {


### PR DESCRIPTION
## Description

The libsql `updateThread` only updated a thread's title and metadata and left `updatedAt` alone. It was missing from the SQL SET clause, and the returned object just carried over the old value from the thread that was read in. mongodb and upstash had the same miss.

The effect was that editing a thread never moved its `updatedAt`, so edited threads did not resurface when listing threads sorted by most recently updated (the default), and callers got back a stale timestamp.

This was already the expected behavior everywhere else. The in-memory reference bumps `updatedAt` on update, the siblings in the same files (`saveMessages`, `updateMessages`) bump it, and the pg and cloudflare-d1 adapters already do it in their own `updateThread`. So this just brings libsql, mongodb and upstash in line.

What changed:

- libsql: added `updatedAt` to the SQL SET clause and set it on the returned object, using the same ISO string format the rest of the file uses.
- mongodb: added `updatedAt` to the `$set` and the returned object.
- upstash: set `updatedAt` before saving the thread.
- Strengthened the shared `updateThread` test. It was tautological before (it compared two objects that were both equally stale, so it passed on broken code). It now asserts that `updatedAt` actually moves forward, both on the returned object and after reading the thread back. Also removed a stray `console.log`.

I verified the before and after against libsql on Node 22: the strengthened test fails on the old code (`expected X to be greater than X`) and passes with the fix, and the full Threads suite stays green. mongodb and upstash were typechecked and formatted but not run locally since they need live services. The shared test covers them in CI.

## Related issue(s)

Fixes #17932

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you edit a thread (change its title or details), the system should remember when you did that so it can show you the edited thread first when you ask for your most recently updated threads. This PR fixes a bug where three of the storage systems (libsql, mongodb, and upstash) weren't actually updating that "last edited time" when threads were modified, so edited threads would stay stuck at the bottom of the list.

## Changes

### Changeset
- Bumped patch versions for `@mastra/mongodb`, `@mastra/upstash`, and `@mastra/libsql`
- Records fix where `updateThread` now refreshes a thread's `updatedAt` timestamp when thread title or metadata is edited, ensuring edited threads resurface correctly when listing threads sorted by most recently updated

### Test Improvements
The shared `updateThread` test in `stores/_test-utils/src/domains/memory/threads.ts` was strengthened:
- Now captures the original `updatedAt` timestamp before calling `updateThread`
- Asserts that the returned thread's `updatedAt` is later than the original
- After retrieving the thread from storage to verify persistence, confirms the retrieved thread's `updatedAt` also advanced
- Removed a stray `console.log` statement

### libsql Adapter
In `stores/libsql/src/storage/domains/memory/index.ts`, `updateThread` now:
- Creates a single `now` timestamp once
- Sets `updatedAt` on the returned `updatedThread` object
- Updates the database with `updatedAt = ?` in the SQL SET clause, passing the ISO string formatted timestamp as a parameter

### MongoDB Adapter
In `stores/mongodb/src/storage/domains/memory/index.ts`, `updateThread` now:
- Creates a single `now = new Date()` value
- Uses it for both the returned `updatedThread.updatedAt` field and the MongoDB `$set.updatedAt` update operation

### Upstash Adapter
In `stores/upstash/src/storage/domains/memory/index.ts`, `updateThread` now:
- Captures a single `now` timestamp at the start
- Sets `updatedAt` on the returned `updatedThread` object using this timestamp

These changes bring libsql, mongodb, and upstash in line with the in-memory reference implementation and the pg and cloudflare-d1 adapters, which were already correctly updating `updatedAt` on thread modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->