### PR TITLE
chore(docs): Clarify agent builder prerequisites

### DIFF
--- a/docs/src/content/en/docs/agent-builder/access-control.mdx
+++ b/docs/src/content/en/docs/agent-builder/access-control.mdx
@@ -28,7 +28,7 @@ The Builder UI calls several resources on load, so a usable `member` role needs 
 
 | Permission | Used for |
 | - | - |
-| `agent-builder:*` | Load Builder actions, runs, and stream Builder workflows |
+| `agent-builder:*` | Load Builder actions and run Builder workflows. The derived Builder actions are `agent-builder:read` and `agent-builder:execute`; the wildcard grants both. |
 | `agents:read`, `agents:execute` | List registered agents and chat with the Builder agent |
 | `stored-agents:*` | List, view, create, and edit agents |
 | `stored-skills:*` | List, view, create, and edit stored skills |

--- a/docs/src/content/en/docs/agent-builder/access-control.mdx
+++ b/docs/src/content/en/docs/agent-builder/access-control.mdx
@@ -96,13 +96,13 @@ export const mastra = new Mastra({
 
 Permission patterns follow `resource:action`. Wildcards are supported on either side:
 
-- `*` — full access (every resource, every action). Used by `admin`.
-- `agent-builder:*` — every action on the `agent-builder` resource.
-- `*:read` — `read` across every resource.
+- `*`: Full access (every resource, every action). Used by `admin`.
+- `agent-builder:*`: Every action on the `agent-builder` resource.
+- `*:read`: `read` Across every resource.
 
 Patterns resolve through `matchesPermission()`. The first matching role permission grants the action.
 
 ## Related
 
-- [Configuration](/docs/agent-builder/configuration) — wire RBAC alongside the rest of the Builder config.
-- [Deploying](/docs/agent-builder/deploying) — auth, RBAC, and EE license setup for production.
+- [Configuration](/docs/agent-builder/configuration): Wire RBAC alongside the rest of the Builder config.
+- [Deploying](/docs/agent-builder/deploying): Auth, RBAC, and EE license setup for production.

--- a/docs/src/content/en/docs/agent-builder/browser.mdx
+++ b/docs/src/content/en/docs/agent-builder/browser.mdx
@@ -12,7 +12,7 @@ packages:
 The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
 :::
 
-The Agent Builder can give end-user agents a browser tool driven by a registered provider. Unlike filesystems and sandboxes, **there are no built-in browser providers** — you must register one through `MastraEditor.browsers`.
+The Agent Builder can give end-user agents a browser tool driven by a registered provider. Unlike filesystems and sandboxes, **there are no built-in browser providers** and you must register one through `MastraEditor.browsers`.
 
 ## Quickstart
 
@@ -54,9 +54,9 @@ new MastraEditor({
 
 `MastraEditor.browsers` accepts a `Record<string, BrowserProvider>`. Each provider exposes:
 
-- `id` — provider identifier, matched against `StorageBrowserConfig.provider` (e.g., `'stagehand'`).
-- `name` — display name shown in the Builder UI.
-- `createBrowser(config)` — hydrates a stored browser config into a runtime `MastraBrowser`. This is where you inject runtime-only credentials (API keys, project IDs) that aren't stored in the agent snapshot.
+- `id`: Provider identifier, matched against `StorageBrowserConfig.provider` (e.g., `'stagehand'`).
+- `name`: Display name shown in the Builder UI.
+- `createBrowser(config)`: Hydrates a stored browser config into a runtime `MastraBrowser`. This is where you inject runtime-only credentials (API keys, project IDs) that aren't stored in the agent snapshot.
 
 Browser classes ship as separate packages (e.g., `@mastra/stagehand`, `@mastra/agent-browser`). The provider entry is a plain object wrapping the class — register one entry per browser you want the Builder to expose to end users. See the [StorageBrowserRef reference](/reference/editor/storage-browser-ref) for the full `browser` field schema, including all `StorageBrowserConfig` options.
 
@@ -66,6 +66,6 @@ The `features.agent.browser` toggle controls whether end users can enable browse
 
 ## Related
 
-- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) — the full `browser` field schema.
-- [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) — the full Builder config surface, including `features.agent.browser`.
-- [Configuration](/docs/agent-builder/configuration) — wire `browser` alongside the rest of the Builder config.
+- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults): The full `browser` field schema.
+- [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options): The full Builder config surface, including `features.agent.browser`.
+- [Configuration](/docs/agent-builder/configuration): Wire `browser` alongside the rest of the Builder config.

--- a/docs/src/content/en/docs/agent-builder/channels.mdx
+++ b/docs/src/content/en/docs/agent-builder/channels.mdx
@@ -54,8 +54,8 @@ The Slack provider handles app creation, OAuth, slash commands, and message rout
 
 `SlackProvider` requires one environment variable and accepts one optional override:
 
-- `SLACK_APP_CONFIG_REFRESH_TOKEN` (required): the refresh token from your Slack app configuration tokens, available under **Your App Configuration Tokens** on [api.slack.com/apps](https://api.slack.com/apps). The refresh token doesn't expire, but the access tokens it issues rotate every 12 hours and are auto-persisted to `Mastra.storage`.
-- `baseUrl` (optional): the public URL Slack should send events and OAuth callbacks to. Defaults to the running Mastra server's host and port (for example, `http://localhost:4111` in local development). Pass `baseUrl` explicitly when the public URL differs from the server's resolved address — typically a tunnel for local development (`cloudflared tunnel --url http://localhost:4111`) or a deployed URL in production.
+- `SLACK_APP_CONFIG_REFRESH_TOKEN` (required): The refresh token from your Slack app configuration tokens, available under **Your App Configuration Tokens** on [api.slack.com/apps](https://api.slack.com/apps). The refresh token doesn't expire, but the access tokens it issues rotate every 12 hours and are auto-persisted to `Mastra.storage`.
+- `baseUrl` (optional): The public URL Slack should send events and OAuth callbacks to. Defaults to the running Mastra server's host and port (for example, `http://localhost:4111` in local development). Pass `baseUrl` explicitly when the public URL differs from the server's resolved address — typically a tunnel for local development (`cloudflared tunnel --url http://localhost:4111`) or a deployed URL in production.
 
 ## Storage requirement
 
@@ -63,5 +63,5 @@ The Slack provider handles app creation, OAuth, slash commands, and message rout
 
 ## Related
 
-- [Deploying](/docs/agent-builder/deploying) — set a public `baseUrl` for production deployments.
-- [Configuration](/docs/agent-builder/configuration) — wire channel toggles into the Builder UI.
+- [Deploying](/docs/agent-builder/deploying): Set a public `baseUrl` for production deployments.
+- [Configuration](/docs/agent-builder/configuration): Wire channel toggles into the Builder UI.

--- a/docs/src/content/en/docs/agent-builder/configuration.mdx
+++ b/docs/src/content/en/docs/agent-builder/configuration.mdx
@@ -77,9 +77,9 @@ new MastraEditor({
       agent: {
         models: {
           allowed: [
-            { provider: 'openai', modelId: 'gpt-5.4-mini' },
-            { provider: 'openai', modelId: 'gpt-5.4' },
-            { provider: 'anthropic', modelId: 'claude-opus-4-7' },
+            { provider: 'openai', modelId: '__GATEWAY_OPENAI_MODEL_MINI__' },
+            { provider: 'openai', modelId: '__GATEWAY_OPENAI_MODEL__' },
+            { provider: 'anthropic', modelId: '__GATEWAY_ANTHROPIC_MODEL_OPUS__' },
           ],
         },
       },
@@ -130,9 +130,9 @@ MCP tools work the same way: load them via `MCPClient.getTools()` and spread the
 
 `configuration.agent.tools`, `configuration.agent.agents`, and `configuration.agent.workflows` constrain which registered entries appear in the Builder's pickers. Allowlist semantics are the same for all three:
 
-- **Omitted**: unrestricted. The picker shows every registered entry.
-- **`allowed: []`**: explicit lockdown. The picker is empty.
-- **`allowed: [...ids]`**: the picker shows only the listed IDs.
+- **Omitted**: Unrestricted. The picker shows every registered entry.
+- **`allowed: []`**: Explicit lockdown. The picker is empty.
+- **`allowed: [...ids]`**: The picker shows only the listed IDs.
 
 Unknown IDs are dropped and surfaced as warnings through `getModelPolicyWarnings()` and the server logs.
 
@@ -153,7 +153,7 @@ new MastraEditor({
 
 ## Related
 
-- [Model policy](/docs/agent-builder/model-policy) — pin the allowed models and default model.
-- [Memory](/docs/agent-builder/memory) — set the default memory shape for new agents.
-- [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) — full property list.
-- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) — every field on `configuration.agent`.
+- [Model policy](/docs/agent-builder/model-policy): Pin the allowed models and default model.
+- [Memory](/docs/agent-builder/memory): Set the default memory shape for new agents.
+- [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options): Full property list.
+- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults): Every field on `configuration.agent`.

--- a/docs/src/content/en/docs/agent-builder/configuration.mdx
+++ b/docs/src/content/en/docs/agent-builder/configuration.mdx
@@ -49,19 +49,21 @@ new MastraEditor({
         tools: true,
         agents: true,
         workflows: true,
+        scorers: true,
         skills: true,
         memory: true,
+        variables: true,
+        favorites: true,
+        avatarUpload: true,
         model: true,
         browser: true,
-        avatarUpload: true,
-        favorites: true,
       },
     },
   },
 })
 ```
 
-The shipping UI consumes these `AgentFeatures` keys: `tools`, `agents`, `workflows`, `skills`, `memory`, `model`, `browser`, `avatarUpload`, and `favorites`. See the [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) for the full schema.
+The shipping UI consumes these `AgentFeatures` keys: `tools`, `agents`, `workflows`, `scorers`, `skills`, `memory`, `variables`, `favorites`, `avatarUpload`, `model`, and `browser`. See the [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) for the full schema.
 
 ## Admin defaults
 

--- a/docs/src/content/en/docs/agent-builder/configuration.mdx
+++ b/docs/src/content/en/docs/agent-builder/configuration.mdx
@@ -69,25 +69,6 @@ The shipping UI consumes these `AgentFeatures` keys: `tools`, `agents`, `workflo
 
 `builder.configuration.agent` pins admin-controlled defaults onto every agent the Builder produces.
 
-```typescript title="src/mastra/index.ts"
-new MastraEditor({
-  builder: {
-    enabled: true,
-    configuration: {
-      agent: {
-        models: {
-          allowed: [
-            { provider: 'openai', modelId: '__GATEWAY_OPENAI_MODEL_MINI__' },
-            { provider: 'openai', modelId: '__GATEWAY_OPENAI_MODEL__' },
-            { provider: 'anthropic', modelId: '__GATEWAY_ANTHROPIC_MODEL_OPUS__' },
-          ],
-        },
-      },
-    },
-  },
-})
-```
-
 `configuration.agent` accepts `models`, `memory`, `workspace`, `browser`, `tools`, `agents`, and `workflows`. See the [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) for the full shape.
 
 ## Making tools, agents, and workflows available

--- a/docs/src/content/en/docs/agent-builder/deploying.mdx
+++ b/docs/src/content/en/docs/agent-builder/deploying.mdx
@@ -15,16 +15,16 @@ packages:
 The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
 :::
 
-Production deployments swap the local primitives in the Quickstart for cloud-backed equivalents. The shape of the `Mastra` and `MastraEditor` config doesn't change — only the providers behind it.
+Production deployments swap the local primitives in the Quickstart for cloud-backed equivalents. The shape of the `Mastra` and `MastraEditor` config doesn't change, only the providers behind it.
 
 ## What a production deployment needs
 
-1. **EE license** — a valid `MASTRA_EE_LICENSE` so the server will start with the Builder enabled.
-1. **Hosted storage** — a shared store for agents, skills, runs, and memory.
-1. **Shared workspace filesystem** — survives across instances; `local` is single-node only.
-1. **Cloud sandbox** — runs agent commands safely; `local` is unsafe in shared environments.
-1. **Auth and RBAC** — gates the Builder UI and `/agent-builder/*` routes.
-1. **Public base URL for channels** — Slack and other channel providers need a reachable URL.
+1. **EE license**: A valid `MASTRA_EE_LICENSE` so the server will start with the Builder enabled.
+1. **Hosted storage**: A shared store for agents, skills, runs, and memory.
+1. **Shared workspace filesystem**: Survives across instances; `local` is single-node only.
+1. **Cloud sandbox**: Runs agent commands safely; `local` is unsafe in shared environments.
+1. **Auth and RBAC**: Gates the Builder UI and `/agent-builder/*` routes.
+1. **Public base URL for channels**: Slack and other channel providers need a reachable URL.
 
 ## EE license
 
@@ -94,7 +94,7 @@ new Mastra({
 
 `S3Filesystem` uses the default AWS credential chain (environment variables, `~/.aws` config, IAM roles, EC2 instance profile). For long-running deployments, use a credential provider function so credentials refresh automatically.
 
-`DockerSandbox` and `VercelSandbox` are alternative cloud sandbox providers — pick whichever matches your runtime.
+`DockerSandbox` and `VercelSandbox` are alternative cloud sandbox providers, pick whichever matches your runtime.
 
 :::warning
 
@@ -114,5 +114,5 @@ Slack needs to reach your server through a public URL. Pass `baseUrl` to `SlackP
 
 ## Related
 
-- [Access control](/docs/agent-builder/access-control) — auth and RBAC setup.
-- [Channels](/docs/agent-builder/channels) — Slack `baseUrl` and channel-specific setup.
+- [Access control](/docs/agent-builder/access-control): Auth and RBAC setup.
+- [Channels](/docs/agent-builder/channels): Slack `baseUrl` and channel-specific setup.

--- a/docs/src/content/en/docs/agent-builder/memory.mdx
+++ b/docs/src/content/en/docs/agent-builder/memory.mdx
@@ -70,6 +70,6 @@ If a required adapter is missing, Mastra throws a descriptive error at agent run
 
 ## Related
 
-- [Memory overview](/docs/memory/overview) — concepts and core configuration.
-- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) — the full `memory` field schema.
-- [Configuration](/docs/agent-builder/configuration) — wire `memory` alongside the rest of the Builder config.
+- [Memory overview](/docs/memory/overview): Concepts and core configuration.
+- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults): The full `memory` field schema.
+- [Configuration](/docs/agent-builder/configuration): Wire `memory` alongside the rest of the Builder config.

--- a/docs/src/content/en/docs/agent-builder/model-policy.mdx
+++ b/docs/src/content/en/docs/agent-builder/model-policy.mdx
@@ -26,9 +26,9 @@ new MastraEditor({
       agent: {
         models: {
           allowed: [
-            { provider: 'openai', modelId: 'gpt-5.4-mini' },
-            { provider: 'openai', modelId: 'gpt-5.4' },
-            { provider: 'anthropic', modelId: 'claude-opus-4-7' },
+            { provider: 'openai', modelId: '__GATEWAY_OPENAI_MODEL_MINI__' },
+            { provider: 'openai', modelId: '__GATEWAY_OPENAI_MODEL__' },
+            { provider: 'anthropic', modelId: '__GATEWAY_ANTHROPIC_MODEL_OPUS__' },
           ],
         },
       },
@@ -53,6 +53,6 @@ See the [`builder.configuration.agent.models`](/reference/editor/agent-builder/b
 
 ## Related
 
-- [Configuration](/docs/agent-builder/configuration) — wire the model policy into the broader Builder config.
-- [`builder.configuration.agent.models`](/reference/editor/agent-builder/builder-models) — full property list.
-- [Provider registry](https://github.com/mastra-ai/mastra/blob/main/packages/core/src/llm/model/provider-registry.json) — every model ID Mastra recognizes out of the box.
+- [Configuration](/docs/agent-builder/configuration): Wire the model policy into the broader Builder config.
+- [`builder.configuration.agent.models`](/reference/editor/agent-builder/builder-models): Full property list.
+- [Provider registry](https://github.com/mastra-ai/mastra/blob/main/packages/core/src/llm/model/provider-registry.json): Every model ID Mastra recognizes out of the box.

--- a/docs/src/content/en/docs/agent-builder/overview.mdx
+++ b/docs/src/content/en/docs/agent-builder/overview.mdx
@@ -72,7 +72,7 @@ The Agent Builder requires:
 
 - **Storage**: An `@mastra/core` storage adapter on the `Mastra` instance. Agents, memory, and workspace state all persist through `Mastra.storage`.
 - **The Builder agent**: Register a Builder agent created with the `createBuilderAgent()` factory from `@mastra/editor/ee` on `Mastra.agents`. The chat-based editor invokes it through the same `Mastra.getAgent(id)` lookup as any other agent. Without this registration, the chat-based editor returns 404.
-- **`OPENAI_API_KEY`**: The Builder agent created by `createBuilderAgent()` runs on an OpenAI model, so an `OPENAI_API_KEY` environment variable is required.
+- **Model credentials**: `createBuilderAgent()` uses `openai/gpt-5.5` by default, which requires `OPENAI_API_KEY`. To use a different provider, pass a `model` override to `createBuilderAgent({ model })` and set that provider's credentials instead.
 
 ## Disabling the Builder
 

--- a/docs/src/content/en/docs/agent-builder/overview.mdx
+++ b/docs/src/content/en/docs/agent-builder/overview.mdx
@@ -18,6 +18,8 @@ The Agent Builder lets you build, configure, and operate Mastra agents all withi
 - [**Configuration**](/docs/agent-builder/configuration): Toggle UI sections and pin admin-controlled defaults for every new agent.
 - [**Model policy**](/docs/agent-builder/model-policy): Restrict which providers and models the Builder exposes, and pin a default.
 - [**Memory**](/docs/agent-builder/memory): Configure the default memory shape for every Builder-created agent.
+- [**Workspace**](/docs/agent-builder/workspace): Configure the default filesystem, sandbox, and skills workspace for Builder-created agents.
+- [**Browser**](/docs/agent-builder/browser): Register browser providers and pin a default browser configuration.
 - [**Access control**](/docs/agent-builder/access-control): Gate the Builder behind Mastra RBAC roles and permissions.
 - [**Channels**](/docs/agent-builder/channels): Connect Builder-created agents to Slack and other channels.
 - [**Tool providers**](/docs/agent-builder/integrations): Connect Builder-created agents to third-party apps through OAuth-backed tool providers.
@@ -87,3 +89,9 @@ new MastraEditor({
 ```
 
 Omitting the `builder` field has the same effect.
+
+## Next steps
+
+- [Configuration](/docs/agent-builder/configuration): Toggle Builder surfaces and pin defaults for new agents.
+- [Access control](/docs/agent-builder/access-control): Gate the Builder with authentication and role-based access control.
+- [Deploying](/docs/agent-builder/deploying): Replace local development primitives with production-ready storage, filesystems, and sandboxes.

--- a/docs/src/content/en/docs/agent-builder/overview.mdx
+++ b/docs/src/content/en/docs/agent-builder/overview.mdx
@@ -72,7 +72,7 @@ The Agent Builder requires:
 
 - **Storage**: An `@mastra/core` storage adapter on the `Mastra` instance. Agents, memory, and workspace state all persist through `Mastra.storage`.
 - **The Builder agent**: Register a Builder agent created with the `createBuilderAgent()` factory from `@mastra/editor/ee` on `Mastra.agents`. The chat-based editor invokes it through the same `Mastra.getAgent(id)` lookup as any other agent. Without this registration, the chat-based editor returns 404.
-- **Model credentials**: `createBuilderAgent()` uses `openai/gpt-5.5` by default, which requires `OPENAI_API_KEY`. To use a different provider, pass a `model` override to `createBuilderAgent({ model })` and set that provider's credentials instead.
+- **Model credentials**: `createBuilderAgent()` uses an OpenAI model by default, which requires `OPENAI_API_KEY`. To use a different provider, pass a `model` override to `createBuilderAgent({ model })` and set that provider's credentials instead.
 
 ## Disabling the Builder
 

--- a/docs/src/content/en/docs/agent-builder/skill-registries.mdx
+++ b/docs/src/content/en/docs/agent-builder/skill-registries.mdx
@@ -41,5 +41,5 @@ See the [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-bu
 
 ## Related
 
-- [Configuration](/docs/agent-builder/configuration) — wire registries alongside the rest of the Builder config.
-- [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) — every field on `builder`.
+- [Configuration](/docs/agent-builder/configuration): Wire registries alongside the rest of the Builder config.
+- [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options): Every field on `builder`.

--- a/docs/src/content/en/docs/agent-builder/workspace.mdx
+++ b/docs/src/content/en/docs/agent-builder/workspace.mdx
@@ -51,8 +51,8 @@ The Builder derives a deterministic id from the inline config and persists the s
 
 `configuration.agent.workspace` accepts a `StorageWorkspaceRef`:
 
-- **`{ type: 'inline', config }`** — embeds a serialized workspace snapshot directly on the agent. Useful for per-agent, ad-hoc configurations.
-- **`{ type: 'id', workspaceId }`** — references a workspace already registered on the `Mastra` instance via `new Mastra({ workspace })` or `mastra.addWorkspace(...)`. Use this for shared, named workspaces.
+- **`{ type: 'inline', config }`**: Embeds a serialized workspace snapshot directly on the agent. Useful for per-agent, ad-hoc configurations.
+- **`{ type: 'id', workspaceId }`**: References a workspace already registered on the `Mastra` instance via `new Mastra({ workspace })` or `mastra.addWorkspace(...)`. Use this for shared, named workspaces.
 
 See the [StorageWorkspaceRef reference](/reference/editor/storage-workspace-ref) for both variants.
 
@@ -64,7 +64,7 @@ For cloud deployments, swap `LocalFilesystem` / `LocalSandbox` for managed provi
 
 ## Related
 
-- [Workspace overview](/docs/workspace/overview) — the underlying workspace model.
-- [Filesystem](/docs/workspace/filesystem) and [Sandbox](/docs/workspace/sandbox) — the building blocks.
-- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) — the full `workspace` field schema.
-- [Configuration](/docs/agent-builder/configuration) — wire `workspace` alongside the rest of the Builder config.
+- [Workspace overview](/docs/workspace/overview): The underlying workspace model.
+- [Filesystem](/docs/workspace/filesystem) and [Sandbox](/docs/workspace/sandbox): The building blocks.
+- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults): The full `workspace` field schema.
+- [Configuration](/docs/agent-builder/configuration): Wire `workspace` alongside the rest of the Builder config.


### PR DESCRIPTION
## Description

Fix styleguide issues in agent builder docs + fix incorrect prerequisite

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This pull request updates the Agent Builder docs to be easier to understand and follow. It fixes confusing wording/style issues in several guides and corrects the “what you need first” explanation so it matches how the builder actually works.

## Changes Summary

This documentation-only PR refreshes and clarifies 10 Agent Builder MDX files:

- **Prerequisites & setup clarity**
  - **overview.mdx**: Clarifies credential/prerequisite guidance for `createBuilderAgent()` (defaults to OpenAI, requires `OPENAI_API_KEY`, and can use another provider via a `model` override). Adds “Workspace” and “Browser” configuration bullets and updates the “Next steps” links.

- **Access control accuracy & readability**
  - **access-control.mdx**: Expands the “Minimum permissions” / `agent-builder:*` guidance to explicitly state the wildcard covers **both** `agent-builder:read` and `agent-builder:execute`. Reformats the permission grammar and related links.

- **Configuration example & guidance formatting**
  - **configuration.mdx**: Updates the `builder.features.agent` example to include **`scorers`** and **`variables`**. Reworks allowlist semantics presentation for consistency and cleans up related links formatting.

- **Deployment guidance polish**
  - **deploying.mdx**: Reformats and reflows the “What a production deployment needs” list to emphasize the providers change, and cleans up related links styling.

- **Example accuracy**
  - **model-policy.mdx**: Replaces concrete model IDs with gateway placeholder IDs.

- **Styleguide/link formatting standardization across docs**
  - **browser.mdx, channels.mdx, memory.mdx, skill-registries.mdx, workspace.mdx**: Adjusts wording, capitalization/punctuation, and “Related” link list formatting (moving away from em-dash style to cleaner bullet/colon formatting) without changing described behavior.

**Total lines changed:** +65 / -74
<!-- end of auto-generated comment: release notes by coderabbit.ai -->