### PR TITLE
chore(docs): Agent builder overview fixes

### DIFF
--- a/docs/src/content/en/docs/agent-builder/model-policy.mdx
+++ b/docs/src/content/en/docs/agent-builder/model-policy.mdx
@@ -26,9 +26,9 @@ new MastraEditor({
       agent: {
         models: {
           allowed: [
-            { provider: 'openai', modelId: '__GATEWAY_OPENAI_MODEL_MINI__' },
-            { provider: 'openai', modelId: '__GATEWAY_OPENAI_MODEL__' },
-            { provider: 'anthropic', modelId: '__GATEWAY_ANTHROPIC_MODEL_OPUS__' },
+            { provider: 'openai', modelId: 'gpt-5.4-mini' },
+            { provider: 'openai', modelId: 'gpt-5.4' },
+            { provider: 'anthropic', modelId: 'claude-opus-4-7' },
           ],
         },
       },

--- a/docs/src/content/en/docs/agent-builder/overview.mdx
+++ b/docs/src/content/en/docs/agent-builder/overview.mdx
@@ -28,15 +28,24 @@ The Agent Builder lets you build, configure, and operate Mastra agents all withi
 
 For building agents entirely in code, see the [Agents overview](/docs/agents/overview). For editing code-defined agents through Studio, see the [Editor overview](/docs/editor/overview).
 
+## Prerequisites
+
+The Agent Builder requires:
+
+- An existing Mastra project (Follow the [installation guide](/guides/getting-started/quickstart) to set up a new project)
+- **Storage**: A `@mastra/core` storage adapter on the `Mastra` instance. Agents, memory, and workspace state all persist through `Mastra.storage`.
+- **A builder agent**: Register a `builderAgent` created with the `createBuilderAgent()` factory from `@mastra/editor/ee` on `Mastra.agents`. The chat-based editor invokes it through the same `Mastra.getAgent(id)` lookup as any other agent. Without this registration, the chat-based editor returns 404.
+- **Model credentials**: `createBuilderAgent()` uses an OpenAI model by default, which requires `OPENAI_API_KEY`. To use a different provider, pass a `model` override to `createBuilderAgent({ model })` and set that provider's credentials instead.
+
 ## Get started
 
-Install `@mastra/editor` alongside a storage adapter:
+Install `@mastra/editor` alongside a storage adapter. This example uses `@mastra/libsql`:
 
 ```bash npm2yarn
 npm install @mastra/editor @mastra/libsql
 ```
 
-Wire the Agent Builder onto a `Mastra` instance:
+The example below defines a storage adapter, registers a builder agent, and enables the editor as explained in the prerequisites:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core/mastra'
@@ -60,21 +69,13 @@ export const mastra = new Mastra({
 })
 ```
 
-Start the dev server:
+Start Mastra's development server:
 
 ```bash
 npx mastra dev
 ```
 
 The Agent Builder is mounted at `http://localhost:4111/agent-builder`.
-
-## Prerequisites
-
-The Agent Builder requires:
-
-- **Storage**: An `@mastra/core` storage adapter on the `Mastra` instance. Agents, memory, and workspace state all persist through `Mastra.storage`.
-- **The Builder agent**: Register a Builder agent created with the `createBuilderAgent()` factory from `@mastra/editor/ee` on `Mastra.agents`. The chat-based editor invokes it through the same `Mastra.getAgent(id)` lookup as any other agent. Without this registration, the chat-based editor returns 404.
-- **Model credentials**: `createBuilderAgent()` uses an OpenAI model by default, which requires `OPENAI_API_KEY`. To use a different provider, pass a `model` override to `createBuilderAgent({ model })` and set that provider's credentials instead.
 
 ## Disabling the Builder
 


### PR DESCRIPTION
## Description

Small follow-up to https://github.com/mastra-ai/mastra/pull/17939

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Summary
This PR improves the Agent builder documentation by fixing examples to use real model names, reorganizing the setup instructions so you know what you need before you start, and adding a clear step to start the development server. It's basically making the docs easier to follow for anyone trying to get started with the Agent builder.

## Changes Made

### Model Policy Documentation
Updated the example code in the Model policy quickstart to use explicit, real model IDs (`openai/gpt-5.4-mini`, `openai/gpt-5.4`, and `anthropic/claude-opus-4-7`) instead of placeholder gateway constants (`__GATEWAY_*__`).

### Agent Builder Overview Reorganization
Restructured the overview documentation for better clarity:
- Added a dedicated **Prerequisites** section early in the page, covering Mastra project setup, storage adapter configuration, builder agent registration, and model credentials
- Reorganized the "Get started" section to follow prerequisites and emphasize installation of `@mastra/editor` with a concrete storage adapter example (`@mastra/libsql`)
- Added an explicit step to start the Mastra dev server with the Builder's mount URL (`http://localhost:4111/agent-builder`)
- Removed duplicate prerequisites content that appeared earlier in the page

## Impact
These changes improve documentation clarity and reduce confusion for new users setting up the Agent builder by establishing clear prerequisites upfront and providing concrete, correct examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->