### PR TITLE
fix(playground-ui): expand embedded JSON strings in trace/log panels and improve log message rendering

### DIFF
--- a/.changeset/breezy-kings-clean.md
+++ b/.changeset/breezy-kings-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Expand embedded JSON strings in trace and log code panels, and improve log message rendering

--- a/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 import { ArrowDownIcon, ArrowRightIcon, ArrowUpIcon, ChevronsDownUpIcon, ChevronsUpDownIcon } from 'lucide-react';
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import type { LogRecord } from '../types';
 import { Button } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
@@ -69,6 +69,9 @@ export function LogDetailsView({
 }: LogDetailsViewProps) {
   const [internalCollapsed, setInternalCollapsed] = useState(false);
   const [messageExpanded, setMessageExpanded] = useState(false);
+  useEffect(() => {
+    setMessageExpanded(false);
+  }, [log.message, log.timestamp]);
   const collapsed = controlledCollapsed ?? internalCollapsed;
   const setCollapsed = onCollapsedChange ?? setInternalCollapsed;
   const date = toDate(log.timestamp);

--- a/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
@@ -10,6 +10,38 @@ import { cn } from '@/lib/utils';
 
 const KV = DataDetailsPanel.KeyValueList;
 
+const MESSAGE_TRUNCATE_LENGTH = 300;
+
+function isValidJson(s: string): boolean {
+  const trimmed = s.trimStart();
+  if (trimmed[0] !== '{' && trimmed[0] !== '[') return false;
+  try {
+    JSON.parse(s);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSimpleMetadataValue(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  if (value.length > MESSAGE_TRUNCATE_LENGTH) return false;
+  const trimmed = value.trimStart();
+  if (trimmed[0] === '{' || trimmed[0] === '[') {
+    try {
+      JSON.parse(value);
+      return false;
+    } catch {
+      // not JSON, falls through to true
+    }
+  }
+  return true;
+}
+
+function metadataCodeStr(value: unknown): string {
+  return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+}
+
 function toDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
 }
@@ -36,9 +68,11 @@ export function LogDetailsView({
   onCollapsedChange,
 }: LogDetailsViewProps) {
   const [internalCollapsed, setInternalCollapsed] = useState(false);
+  const [messageExpanded, setMessageExpanded] = useState(false);
   const collapsed = controlledCollapsed ?? internalCollapsed;
   const setCollapsed = onCollapsedChange ?? setInternalCollapsed;
   const date = toDate(log.timestamp);
+  const isJsonMsg = isValidJson(log.message);
 
   return (
     <DataDetailsPanel collapsed={collapsed}>
@@ -72,7 +106,24 @@ export function LogDetailsView({
 
       {!collapsed && (
         <DataDetailsPanel.Content>
-          <p className="text-ui-md text-neutral4 font-mono wrap-break-word whitespace-pre-wrap">{log.message}</p>
+          {isJsonMsg ? (
+            <DataDetailsPanel.CodeSection title="Message" codeStr={log.message} className="mb-6" />
+          ) : (
+            <div className="mb-6">
+              <p className="text-ui-md text-neutral4 font-mono wrap-break-word whitespace-pre-wrap">
+                {messageExpanded ? log.message : log.message.slice(0, MESSAGE_TRUNCATE_LENGTH)}
+              </p>
+              {log.message.length > MESSAGE_TRUNCATE_LENGTH && (
+                <button
+                  type="button"
+                  className="mt-1 text-ui-sm text-accent1 hover:underline"
+                  onClick={() => setMessageExpanded(v => !v)}
+                >
+                  {messageExpanded ? 'Show less' : 'Show more'}
+                </button>
+              )}
+            </div>
+          )}
 
           {(log.traceId || log.spanId) && (
             <div className={cn('grid gap-2 my-8', '[&>button]:justify-between [&>button]:overflow-hidden')}>
@@ -139,17 +190,28 @@ export function LogDetailsView({
                 <KV.Value>{log.source}</KV.Value>
               </>
             )}
-            {log.metadata && Object.keys(log.metadata).length > 0 && (
-              <>
-                {Object.entries(log.metadata).map(([key, value]) => (
+            {log.metadata &&
+              Object.entries(log.metadata)
+                .filter(([, v]) => isSimpleMetadataValue(v))
+                .map(([key, value]) => (
                   <Fragment key={key}>
                     <KV.Key>{key}</KV.Key>
                     <KV.Value>{String(value)}</KV.Value>
                   </Fragment>
                 ))}
-              </>
-            )}
           </KV>
+
+          {log.metadata &&
+            Object.entries(log.metadata)
+              .filter(([, v]) => !isSimpleMetadataValue(v))
+              .map(([key, value]) => (
+                <DataDetailsPanel.CodeSection
+                  key={key}
+                  title={key}
+                  codeStr={metadataCodeStr(value)}
+                  className="mt-3"
+                />
+              ))}
 
           {log.data && Object.keys(log.data).length > 0 && (
             <DataDetailsPanel.CodeSection title="Data" codeStr={JSON.stringify(log.data, null, 2)} className="mt-6" />

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
@@ -99,6 +99,30 @@ export const LargeContent: Story = {
   },
 };
 
+export const WithMarkdownPretty: Story = {
+  args: {
+    title: 'Tool Result',
+    icon: <CodeIcon />,
+    codeStr: JSON.stringify({
+      type: 'text',
+      text: '### Ran Playwright code\n```js\nawait page.goto(\'https://linear.app\');\n```\n## Page\n- Page URL: https://linear.app\n- Page Title: Linear\n### Snapshot\n- [Snapshot](.playwright-mcp/page-2026-06-15.yml)',
+    }),
+  },
+};
+
+export const WithEmbeddedJson: Story = {
+  args: {
+    title: 'Tool Result',
+    icon: <CodeIcon />,
+    codeStr: JSON.stringify({
+      status: 'ok',
+      result: JSON.stringify({ key: 'value', nested: [1, 2, 3] }),
+      meta: JSON.stringify({ agent: 'playwright', step: 4 }),
+      plain: 'just a plain string',
+    }),
+  },
+};
+
 export const NullContent: Story = {
   args: {
     title: 'Empty',

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.tsx
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.tsx
@@ -9,7 +9,7 @@ import { tags as t } from '@lezer/highlight';
 import { draculaInit } from '@uiw/codemirror-theme-dracula';
 import type { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import ReactCodeMirror from '@uiw/react-codemirror';
-import { AlignJustifyIcon, AlignLeftIcon, ExpandIcon, XIcon } from 'lucide-react';
+import { AlignJustifyIcon, AlignLeftIcon, ExpandIcon, SparklesIcon, XIcon } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { Button } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
@@ -25,8 +25,9 @@ import {
 } from '@/ds/components/Dialog';
 import { SearchFieldBlock } from '@/ds/components/FormFieldBlocks/fields/search-field-block';
 import { useTheme } from '@/ds/components/ThemeProvider';
-import { expandEmbeddedJsonStrings } from '@/lib/json-utils';
+import { expandEmbeddedJsonStrings, hasMarkdownStrings } from '@/lib/json-utils';
 import { cn } from '@/lib/utils';
+import { JsonPrettyRenderer } from './json-pretty-renderer';
 
 // -- Search highlight extension -----------------------------------------------
 
@@ -156,6 +157,7 @@ export function DataCodeSection({
 }: DataCodeSectionProps) {
   const theme = useCodemirrorTheme();
   const [showAsMultilineText, setShowAsMultilineText] = useState(false);
+  const [showPretty, setShowPretty] = useState(false);
   const [searchMinimized, setSearchMinimized] = useState(true);
   const [searchQuery, setSearchQueryState] = useState('');
   const [expandedOpen, setExpandedOpen] = useState(false);
@@ -165,6 +167,12 @@ export function DataCodeSection({
   const expandedEditorRef = useRef<ReactCodeMirrorRef>(null);
 
   const processedCodeStr = useMemo(() => expandEmbeddedJsonStrings(codeStr), [codeStr]);
+
+  const parsedValue = useMemo(() => {
+    try { return JSON.parse(processedCodeStr); } catch { return null; }
+  }, [processedCodeStr]);
+
+  const hasPrettyContent = useMemo(() => parsedValue !== null && hasMarkdownStrings(parsedValue), [parsedValue]);
 
   const hasMultilineText = useMemo(() => {
     try {
@@ -266,7 +274,17 @@ export function DataCodeSection({
           )}
           <ButtonsGroup>
             <CopyButton content={codeStr || 'No content'} size="sm" />
-            {hasMultilineText && (
+            {hasPrettyContent && (
+              <Button
+                size="sm"
+                aria-label={showPretty ? 'Show raw JSON' : 'Show pretty view'}
+                tooltip={showPretty ? 'Show raw JSON' : 'Show pretty view'}
+                onClick={() => setShowPretty(v => !v)}
+              >
+                <SparklesIcon />
+              </Button>
+            )}
+            {!showPretty && hasMultilineText && (
               <Button
                 size="sm"
                 aria-label={showAsMultilineText ? 'Show escaped newlines' : 'Show multiline text'}
@@ -284,7 +302,9 @@ export function DataCodeSection({
       </div>
 
       <div className="dark:bg-black/20 bg-surface3 p-3 overflow-hidden rounded-lg border dark:border-white/10 border-border1 text-neutral4 text-ui-sm break-all max-h-[30vh] overflow-y-auto">
-        {usePlainTextView ? (
+        {showPretty && parsedValue !== null ? (
+          <JsonPrettyRenderer value={parsedValue} />
+        ) : usePlainTextView ? (
           <div className="text-neutral4 font-mono break-all">
             <pre className="text-wrap">{finalCodeStr}</pre>
           </div>
@@ -345,7 +365,11 @@ export function DataCodeSection({
             </div>
           </DialogHeader>
           <div className="overflow-auto px-6 pb-6">
-            {expandedMultiline ? (
+            {showPretty && parsedValue !== null ? (
+              <div className="dark:bg-black/20 bg-surface3 p-3 rounded-lg border dark:border-white/10 border-border1">
+                <JsonPrettyRenderer value={parsedValue} />
+              </div>
+            ) : expandedMultiline ? (
               <div className="dark:bg-black/20 bg-surface3 p-3 overflow-hidden rounded-lg border dark:border-white/10 border-border1 text-neutral4 text-ui-sm break-all overflow-y-auto">
                 <div className="text-neutral4 font-mono break-all">
                   <pre className="text-wrap">{expandedFinalCodeStr}</pre>

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.tsx
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/ds/components/Dialog';
 import { SearchFieldBlock } from '@/ds/components/FormFieldBlocks/fields/search-field-block';
 import { useTheme } from '@/ds/components/ThemeProvider';
+import { expandEmbeddedJsonStrings } from '@/lib/json-utils';
 import { cn } from '@/lib/utils';
 
 // -- Search highlight extension -----------------------------------------------
@@ -163,14 +164,16 @@ export function DataCodeSection({
   const editorRef = useRef<ReactCodeMirrorRef>(null);
   const expandedEditorRef = useRef<ReactCodeMirrorRef>(null);
 
+  const processedCodeStr = useMemo(() => expandEmbeddedJsonStrings(codeStr), [codeStr]);
+
   const hasMultilineText = useMemo(() => {
     try {
-      const parsed = JSON.parse(codeStr);
+      const parsed = JSON.parse(processedCodeStr);
       return containsInnerNewline(parsed || '');
     } catch {
       return false;
     }
-  }, [codeStr]);
+  }, [processedCodeStr]);
 
   const dispatchSearch = useCallback((query: string) => {
     const view = editorRef.current?.view;
@@ -236,8 +239,8 @@ export function DataCodeSection({
     dispatchExpandedSearch('');
   }, [dispatchExpandedSearch]);
 
-  const finalCodeStr = showAsMultilineText ? codeStr?.replace(/\\n/g, '\n') : codeStr;
-  const expandedFinalCodeStr = expandedMultiline ? codeStr?.replace(/\\n/g, '\n') : codeStr;
+  const finalCodeStr = showAsMultilineText ? processedCodeStr?.replace(/\\n/g, '\n') : processedCodeStr;
+  const expandedFinalCodeStr = expandedMultiline ? processedCodeStr?.replace(/\\n/g, '\n') : processedCodeStr;
   const usePlainTextView = simplified || showAsMultilineText;
 
   if (!codeStr || codeStr === 'null') return null;
@@ -290,7 +293,7 @@ export function DataCodeSection({
             ref={editorRef}
             extensions={[json(), EditorView.lineWrapping, searchHighlightExtension()]}
             theme={theme}
-            value={codeStr}
+            value={processedCodeStr}
             editable={false}
           />
         )}
@@ -353,7 +356,7 @@ export function DataCodeSection({
                 ref={expandedEditorRef}
                 extensions={[json(), EditorView.lineWrapping, searchHighlightExtension()]}
                 theme={theme}
-                value={codeStr}
+                value={processedCodeStr}
                 editable={false}
               />
             )}

--- a/packages/playground-ui/src/ds/components/DataCodeSection/json-pretty-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/json-pretty-renderer.tsx
@@ -1,0 +1,77 @@
+import { Fragment } from 'react';
+import { MarkdownRenderer } from '@/ds/components/MarkdownRenderer';
+import { looksLikeMarkdown } from '@/lib/json-utils';
+import { cn } from '@/lib/utils';
+
+function StringValue({ value }: { value: string }) {
+  if (looksLikeMarkdown(value)) {
+    return (
+      <div className="mt-1 text-ui-sm text-neutral4">
+        <MarkdownRenderer>{value}</MarkdownRenderer>
+      </div>
+    );
+  }
+  return (
+    <span className="font-mono text-ui-sm text-accent1 break-all whitespace-pre-wrap">
+      {value.replace(/\\n/g, '\n')}
+    </span>
+  );
+}
+
+function PrimitiveValue({ value }: { value: string | number | boolean | null }) {
+  if (value === null) return <span className="font-mono text-ui-sm text-accent6">null</span>;
+  if (typeof value === 'boolean') return <span className="font-mono text-ui-sm text-accent6">{String(value)}</span>;
+  if (typeof value === 'number') return <span className="font-mono text-ui-sm text-accent5">{value}</span>;
+  return <StringValue value={value} />;
+}
+
+function JsonNode({ value, depth }: { value: unknown; depth: number }) {
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return <PrimitiveValue value={value as string | number | boolean | null} />;
+  }
+
+  if (Array.isArray(value)) {
+    if (!value.length) return <span className="font-mono text-ui-sm text-neutral2">[]</span>;
+    return (
+      <div className={cn('flex flex-col gap-2', depth > 0 && 'pl-4 border-l border-border1 ml-1')}>
+        {value.map((item, i) => (
+          <div key={i} className="flex gap-2">
+            <span className="font-mono text-ui-sm text-neutral2 shrink-0">{i}</span>
+            <JsonNode value={item} depth={depth + 1} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (!entries.length) return <span className="font-mono text-ui-sm text-neutral2">{'{}'}</span>;
+    return (
+      <div className={cn('flex flex-col gap-3', depth > 0 && 'pl-4 border-l border-border1 ml-1')}>
+        {entries.map(([k, v]) => (
+          <Fragment key={k}>
+            <div className="flex flex-col gap-0.5">
+              <span className="font-mono text-ui-xs uppercase tracking-wider text-neutral2">{k}</span>
+              <JsonNode value={v} depth={depth + 1} />
+            </div>
+          </Fragment>
+        ))}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export interface JsonPrettyRendererProps {
+  value: unknown;
+}
+
+export function JsonPrettyRenderer({ value }: JsonPrettyRendererProps) {
+  return (
+    <div className="text-neutral4 text-ui-sm">
+      <JsonNode value={value} depth={0} />
+    </div>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel-code-section.tsx
+++ b/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel-code-section.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { CopyButton } from '@/ds/components/CopyButton';
 import { useTheme } from '@/ds/components/ThemeProvider';
+import { expandEmbeddedJsonStrings } from '@/lib/json-utils';
 import { cn } from '@/lib/utils';
 
 function buildDarkTheme(): Extension {
@@ -96,16 +97,19 @@ export function DataDetailsPanelCodeSection({
 }: DataDetailsPanelCodeSectionProps) {
   const theme = useCodemirrorTheme();
   const [showAsMultilineText, setShowAsMultilineText] = useState(false);
+
+  const processedCodeStr = useMemo(() => expandEmbeddedJsonStrings(codeStr), [codeStr]);
+
   const hasMultilineText = useMemo(() => {
     try {
-      const parsed = JSON.parse(codeStr);
+      const parsed = JSON.parse(processedCodeStr);
       return containsInnerNewline(parsed || '');
     } catch {
       return false;
     }
-  }, [codeStr]);
+  }, [processedCodeStr]);
 
-  const finalCodeStr = showAsMultilineText ? codeStr?.replace(/\\n/g, '\n') : codeStr;
+  const finalCodeStr = showAsMultilineText ? processedCodeStr?.replace(/\\n/g, '\n') : processedCodeStr;
   const usePlainTextView = simplified || showAsMultilineText;
 
   if (!codeStr || codeStr === 'null') return null;
@@ -144,7 +148,7 @@ export function DataDetailsPanelCodeSection({
           <ReactCodeMirror
             extensions={[json(), EditorView.lineWrapping]}
             theme={theme}
-            value={codeStr}
+            value={processedCodeStr}
             editable={false}
           />
         )}

--- a/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel-code-section.tsx
+++ b/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel-code-section.tsx
@@ -5,14 +5,15 @@ import { EditorView } from '@codemirror/view';
 import { tags as t } from '@lezer/highlight';
 import { draculaInit } from '@uiw/codemirror-theme-dracula';
 import ReactCodeMirror from '@uiw/react-codemirror';
-import { AlignJustifyIcon, AlignLeftIcon } from 'lucide-react';
+import { AlignJustifyIcon, AlignLeftIcon, SparklesIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Button } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { CopyButton } from '@/ds/components/CopyButton';
 import { useTheme } from '@/ds/components/ThemeProvider';
-import { expandEmbeddedJsonStrings } from '@/lib/json-utils';
+import { expandEmbeddedJsonStrings, hasMarkdownStrings } from '@/lib/json-utils';
 import { cn } from '@/lib/utils';
+import { JsonPrettyRenderer } from '@/ds/components/DataCodeSection/json-pretty-renderer';
 
 function buildDarkTheme(): Extension {
   return draculaInit({
@@ -97,8 +98,15 @@ export function DataDetailsPanelCodeSection({
 }: DataDetailsPanelCodeSectionProps) {
   const theme = useCodemirrorTheme();
   const [showAsMultilineText, setShowAsMultilineText] = useState(false);
+  const [showPretty, setShowPretty] = useState(false);
 
   const processedCodeStr = useMemo(() => expandEmbeddedJsonStrings(codeStr), [codeStr]);
+
+  const parsedValue = useMemo(() => {
+    try { return JSON.parse(processedCodeStr); } catch { return null; }
+  }, [processedCodeStr]);
+
+  const hasPrettyContent = useMemo(() => parsedValue !== null && hasMarkdownStrings(parsedValue), [parsedValue]);
 
   const hasMultilineText = useMemo(() => {
     try {
@@ -128,7 +136,17 @@ export function DataDetailsPanelCodeSection({
         </div>
         <ButtonsGroup>
           <CopyButton content={codeStr || 'No content'} size="sm" />
-          {hasMultilineText && (
+          {hasPrettyContent && (
+            <Button
+              size="sm"
+              aria-label={showPretty ? 'Show raw JSON' : 'Show pretty view'}
+              tooltip={showPretty ? 'Show raw JSON' : 'Show pretty view'}
+              onClick={() => setShowPretty(v => !v)}
+            >
+              <SparklesIcon />
+            </Button>
+          )}
+          {!showPretty && hasMultilineText && (
             <Button
               size="sm"
               aria-label={showAsMultilineText ? 'Show escaped newlines' : 'Show multiline text'}
@@ -140,7 +158,9 @@ export function DataDetailsPanelCodeSection({
         </ButtonsGroup>
       </div>
       <div className="dark:bg-black/20 bg-surface3 p-3 overflow-hidden rounded-lg border dark:border-white/10 border-border1 text-neutral4 text-ui-sm break-all max-h-[30vh] overflow-y-auto">
-        {usePlainTextView ? (
+        {showPretty && parsedValue !== null ? (
+          <JsonPrettyRenderer value={parsedValue} />
+        ) : usePlainTextView ? (
           <div className="text-neutral4 font-mono break-all">
             <pre className="text-wrap">{finalCodeStr}</pre>
           </div>

--- a/packages/playground-ui/src/lib/json-utils.ts
+++ b/packages/playground-ui/src/lib/json-utils.ts
@@ -1,0 +1,50 @@
+const MAX_EXPAND_DEPTH = 5;
+
+function expandNode(value: unknown, depth: number): unknown {
+  if (depth >= MAX_EXPAND_DEPTH) return value;
+
+  if (typeof value === 'string') {
+    const trimmed = value.trimStart();
+    if (trimmed[0] !== '{' && trimmed[0] !== '[') return value;
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (typeof parsed === 'object' && parsed !== null) {
+        return expandNode(parsed, depth + 1);
+      }
+    } catch {
+      // not valid JSON — leave as-is
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => expandNode(item, depth + 1));
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = expandNode(v, depth + 1);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Walks a JSON string, replacing any string value whose content is valid JSON
+ * with the parsed structure (up to MAX_EXPAND_DEPTH levels deep), then
+ * re-serialises the whole thing. Returns the original string unchanged if the
+ * top-level parse fails.
+ */
+export function expandEmbeddedJsonStrings(codeStr: string): string {
+  if (!codeStr) return codeStr;
+  try {
+    const parsed: unknown = JSON.parse(codeStr);
+    const expanded = expandNode(parsed, 0);
+    return JSON.stringify(expanded, null, 2);
+  } catch {
+    return codeStr;
+  }
+}

--- a/packages/playground-ui/src/lib/json-utils.ts
+++ b/packages/playground-ui/src/lib/json-utils.ts
@@ -32,6 +32,24 @@ function expandNode(value: unknown, depth: number): unknown {
   return value;
 }
 
+const MARKDOWN_PATTERN = /(?:^|\n)(?:#{1,6} |```|\*\*|__|- |\* |\d+\. |> )/;
+
+/** True when a string value (after unescaping \n) looks like Markdown prose. */
+export function looksLikeMarkdown(s: string): boolean {
+  const unescaped = s.replace(/\\n/g, '\n');
+  return unescaped.includes('\n') && MARKDOWN_PATTERN.test(unescaped);
+}
+
+/** True when any string value anywhere in the parsed JSON tree looks like Markdown. */
+export function hasMarkdownStrings(value: unknown): boolean {
+  if (typeof value === 'string') return looksLikeMarkdown(value);
+  if (Array.isArray(value)) return value.some(hasMarkdownStrings);
+  if (typeof value === 'object' && value !== null) {
+    return Object.values(value as Record<string, unknown>).some(hasMarkdownStrings);
+  }
+  return false;
+}
+
 /**
  * Walks a JSON string, replacing any string value whose content is valid JSON
  * with the parsed structure (up to MAX_EXPAND_DEPTH levels deep), then


### PR DESCRIPTION
## Summary

- Adds `src/lib/json-utils.ts` with `expandEmbeddedJsonStrings(codeStr)`: walks a JSON tree recursively (depth cap: 5) replacing any string value whose content is valid JSON with the parsed object/array, then re-serialises. Falls back to the original string on top-level parse failure.
- `DataCodeSection` (Traces panel — Input/Output/Metadata/Attributes) now pre-processes `codeStr` through `expandEmbeddedJsonStrings` before passing to CodeMirror. Embedded JSON strings (e.g. a Playwright tool result containing a nested JSON payload) are rendered as structured, syntax-highlighted JSON instead of a quoted escaped string.
- `DataDetailsPanelCodeSection` (Logs panel — Data section) receives the same treatment.
- `log-details-view.tsx`:
  - `log.message`: if the message is valid JSON it is routed to `DataDetailsPanel.CodeSection` (syntax-highlighted, expandable); if it is plain text longer than 300 characters a "Show more / Show less" toggle is added.
  - Log metadata values: short scalar strings (≤ 300 chars, not valid JSON) remain inline in the key-value grid; objects, arrays, JSON strings, and long strings are rendered as individual `DataDetailsPanel.CodeSection` blocks below the grid.

## Motivation

String values in tool call results and log entries frequently contain embedded JSON payloads (e.g. Playwright MCP results, LLM outputs). CodeMirror renders these as opaque quoted strings, making them hard to inspect. Long log messages also had no truncation mechanism, pushing content off-screen.

The `expandEmbeddedJsonStrings` pre-processing step is the minimal, zero-new-dependency change that unlocks structured display while keeping all existing CodeMirror features (search, expand-to-dialog, multiline toggle, copy button) intact.

## Test plan

- [ ] Run `pnpm test` in `packages/playground-ui` — all existing tests pass
- [ ] Run `pnpm storybook` in `packages/playground-ui` and verify `DataCodeSection` renders expanded nested JSON for a `codeStr` containing embedded JSON strings
- [ ] Open Mastra Studio → Traces tab → click a tool call span that returns a JSON payload containing embedded JSON strings — confirm they expand inline
- [ ] Open Mastra Studio → Logs tab → click a log entry whose `message` is a JSON string — confirm it renders as syntax-highlighted code
- [ ] Click a log entry whose `message` is plain text > 300 chars — confirm truncation + "Show more" toggle
- [ ] Click a log entry with object/array metadata values — confirm they render as CodeSection blocks, not truncated inline text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I’m 5)

Sometimes logs and tool results include JSON “inside text,” and it looked like a messy blob of escaped quotes. This PR teaches the UI to recognize embedded JSON inside those strings and show it as clean, readable, syntax-highlighted JSON instead.

## Technical Summary

### New utility: `expandEmbeddedJsonStrings`
- Added `packages/playground-ui/src/lib/json-utils.ts` with `expandEmbeddedJsonStrings(codeStr: string): string`.
- It:
  - Tries to parse the input as top-level JSON
  - Recursively scans strings inside the structure (up to a depth limit of 5)
  - If a string contains valid JSON (object/array starting with `{`/`[`), it parses and replaces that string with the corresponding object/array
  - Re-serializes the expanded structure with `JSON.stringify(..., null, 2)`
  - Falls back to the original input when top-level parsing fails
- Also adds Markdown-detection helpers used to drive “pretty” rendering.

### `DataCodeSection` (Traces panel)
- Updated `packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.tsx` to preprocess `codeStr` with `expandEmbeddedJsonStrings()` before:
  - multiline/newline detection
  - the CodeMirror `value` used for inline rendering + the expanded dialog
- Introduced/used a “pretty” mode that can render JSON via a pretty renderer when markdown-like content is detected, and hides the multiline toggle while pretty view is active.

### `DataDetailsPanelCodeSection` (Logs panel)
- Updated `packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel-code-section.tsx` to preprocess `codeStr` with `expandEmbeddedJsonStrings()` for all downstream parsing/rendering.
- Added a `showPretty` state and a pretty-view toggle that uses a `JsonPrettyRenderer` when markdown-like content is present.

### `LogDetailsView` message + metadata routing
- Updated `packages/playground-ui/src/domains/logs/components/log-details-view.tsx` so rendering depends on content type:
  - Valid JSON messages → rendered in `DataDetailsPanel.CodeSection` (inspectable/expandable JSON)
  - Non-JSON plain text messages longer than 300 chars → truncated with a “Show more / Show less” toggle
  - Metadata values are handled contextually:
    - Short non-JSON scalar strings (≤300 chars) stay as inline key/value grid entries
    - Objects/arrays/JSON strings and longer strings render as `DataDetailsPanel.CodeSection` blocks below the grid

### Pretty JSON renderer + stories
- Added `packages/playground-ui/src/ds/components/DataCodeSection/json-pretty-renderer.tsx` (`JsonPrettyRenderer`) to render JSON nodes with styled primitives/structure and markdown-aware string handling.
- Added Storybook stories in `data-code-section.stories.tsx`:
  - `WithMarkdownPretty`
  - `WithEmbeddedJson`

### Release metadata
- Added a changeset bump for `@mastra/playground-ui` documenting the embedded JSON rendering improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->