### PR TITLE
docs(processors): warn that workflow processors fail on circular run state

### DIFF
--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -820,6 +820,10 @@ If a branch uses a mutating strategy like `redact`, map to that branch so its tr
 
 When an agent is registered with Mastra, processor workflows are automatically registered as workflows, allowing you to view and debug them in the [Studio](/docs/studio/overview).
 
+:::warning
+A workflow processor runs as a nested workflow, and its run state — which includes the agent's message list — is persisted by serializing it to JSON. If the message list contains circular references, serialization fails with `Converting circular structure to JSON` and the processor workflow errors. This happens, for example, when the agent has [Observational Memory](/docs/memory/observational-memory) enabled, whose `ObservationTurn` and `ObservationStep` objects reference each other. The same processors used directly (as a flat `inputProcessors` / `outputProcessors` list, not wrapped in a workflow) are unaffected, since they do not go through nested-workflow persistence. See [issue #17933](https://github.com/mastra-ai/mastra/issues/17933).
+:::
+
 ### Retry mechanism
 
 Processors can request that the LLM retry its response with feedback. This is useful for implementing quality checks, output validation, or iterative refinement:


### PR DESCRIPTION
Closes #17945

## What

Adds a warning to the "Use workflows as processors" section of the processors docs: a workflow processor runs as a nested workflow whose run state — including the agent's message list — is persisted by serializing it to JSON. If the message list contains circular references, serialization throws `Converting circular structure to JSON` and the processor workflow errors.

The most common trigger is an agent with [Observational Memory](https://mastra.ai/docs/memory/observational-memory) enabled, whose `ObservationTurn` and `ObservationStep` objects reference each other. The same processors used directly (as a flat `inputProcessors` / `outputProcessors` list) are unaffected, since they don't go through nested-workflow persistence.

## Why

Both "run guardrails in parallel as a workflow processor" and "Observational Memory" are recommended in the docs, but combining them currently crashes, and the interaction was undocumented (#17945). The underlying crash was reported as a production issue in #17933. This doc note gives users the workaround (use a flat processor list) until the underlying serialization is made circular-safe.

## Notes

- Docs-only change; no code touched and (per the docs contributing guide and recent docs PRs) no changeset needed.
- Single internal link to the Observational Memory page (verified to exist), plus references to #17945 (docs gap) and #17933 (underlying code fix).
