### PR TITLE
feat(workspaces): add Upstash Box sandbox provider

### DIFF
--- a/.changeset/upstash-box-sandbox-provider.md
+++ b/.changeset/upstash-box-sandbox-provider.md
@@ -1,0 +1,5 @@
+---
+"@mastra/upstash-box": minor
+---
+
+Add Upstash Box cloud sandbox provider for Mastra workspaces. `UpstashBoxSandbox` runs shell commands in an isolated Box, with reconnect-by-id, pause/resume lifecycle, runtime/size selection, env vars, network policy, and skill installation.

--- a/docs/src/content/en/docs/workspace/sandbox.mdx
+++ b/docs/src/content/en/docs/workspace/sandbox.mdx
@@ -29,6 +29,7 @@ A sandbox provider executes commands in a controlled environment:
 - [`E2BSandbox`](/reference/workspace/e2b-sandbox): Executes commands in isolated E2B cloud sandboxes
 - [`ModalSandbox`](/reference/workspace/modal-sandbox): Executes commands in isolated Modal cloud sandboxes
 - [`RailwaySandbox`](/reference/workspace/railway-sandbox): Executes commands in ephemeral, isolated Railway cloud sandboxes
+- [`UpstashBoxSandbox`](/reference/workspace/upstash-box-sandbox): Executes commands in isolated Upstash Box cloud sandboxes
 
 ## Basic usage
 
@@ -243,5 +244,6 @@ For the full `SandboxProcessManager` API (spawning processes programmatically, r
 - [`E2BSandbox` reference](/reference/workspace/e2b-sandbox)
 - [`LocalSandbox` reference](/reference/workspace/local-sandbox)
 - [`ModalSandbox` reference](/reference/workspace/modal-sandbox)
+- [`UpstashBoxSandbox` reference](/reference/workspace/upstash-box-sandbox)
 - [Workspace overview](/docs/workspace/overview)
 - [Filesystem](/docs/workspace/filesystem)

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -750,6 +750,7 @@ const sidebars = {
         { type: 'doc', id: 'workspace/railway-sandbox', label: 'RailwaySandbox' },
         { type: 'doc', id: 'workspace/s3-filesystem', label: 'S3Filesystem' },
         { type: 'doc', id: 'workspace/process-manager', label: 'SandboxProcessManager' },
+        { type: 'doc', id: 'workspace/upstash-box-sandbox', label: 'UpstashBoxSandbox' },
         { type: 'doc', id: 'workspace/vercel-microvm-sandbox', label: 'VercelMicroVMSandbox' },
         { type: 'doc', id: 'workspace/vercel', label: 'VercelSandbox' },
         { type: 'doc', id: 'workspace/workspace-class', label: 'Workspace Class' },

--- a/docs/src/content/en/reference/workspace/upstash-box-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/upstash-box-sandbox.mdx
@@ -1,0 +1,285 @@
+---
+title: "Reference: UpstashBoxSandbox | Workspace"
+description: "Documentation for the UpstashBoxSandbox provider for isolated cloud code execution via Upstash Box."
+packages:
+  - "@mastra/upstash-box"
+---
+
+# UpstashBoxSandbox
+
+Executes commands in isolated [Upstash Box](https://upstash.com/docs/box) cloud sandboxes. Box provides managed, disposable environments for AI coding agents backed by Upstash's infrastructure.
+
+:::info
+
+For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
+
+:::
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/upstash-box
+```
+
+## Usage
+
+Add an `UpstashBoxSandbox` to a workspace and assign it to an agent:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { Workspace } from '@mastra/core/workspace'
+import { UpstashBoxSandbox } from '@mastra/upstash-box'
+
+const workspace = new Workspace({
+  sandbox: new UpstashBoxSandbox({
+    id: 'dev-sandbox',
+    runtime: 'node',
+    size: 'small',
+  }),
+})
+
+const agent = new Agent({
+  id: 'dev-agent',
+  model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
+  workspace,
+})
+```
+
+## Authentication
+
+Set your Box API key via environment variable or constructor option:
+
+```bash
+UPSTASH_BOX_API_KEY=...
+# Optional — defaults to the Box SDK's base URL
+UPSTASH_BOX_BASE_URL=https://us-east-1.box.upstash.com
+```
+
+Or pass it directly:
+
+```typescript
+const sandbox = new UpstashBoxSandbox({
+  apiKey: process.env.UPSTASH_BOX_API_KEY,
+})
+```
+
+Get your API key from the [Upstash console](https://console.upstash.com).
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description:
+      'Logical identifier for this sandbox instance. Used as the box name on create; it is not the server-side box id.',
+    isOptional: true,
+    defaultValue: 'Auto-generated',
+  },
+  {
+    name: 'boxId',
+    type: 'string',
+    description:
+      'Reconnect to an existing box by its server-side id instead of creating a new one. Also set automatically after the first start() so a stop() then start() reuses the same box.',
+    isOptional: true,
+  },
+  {
+    name: 'apiKey',
+    type: 'string',
+    description: 'Box API key. Falls back to the UPSTASH_BOX_API_KEY environment variable.',
+    isOptional: true,
+  },
+  {
+    name: 'baseUrl',
+    type: 'string',
+    description: 'Box API base URL. Falls back to UPSTASH_BOX_BASE_URL or the SDK default.',
+    isOptional: true,
+  },
+  {
+    name: 'runtime',
+    type: "'node' | 'python' | 'golang' | 'ruby' | 'rust'",
+    description: 'Runtime preinstalled in the box.',
+    isOptional: true,
+    defaultValue: "'node'",
+  },
+  {
+    name: 'size',
+    type: "'small' | 'medium' | 'large'",
+    description: 'Resource size of the box.',
+    isOptional: true,
+    defaultValue: "'small'",
+  },
+  {
+    name: 'keepAlive',
+    type: 'boolean',
+    description:
+      'Keep the box alive instead of letting it idle-pause. Keep-alive boxes cannot be paused, so stop() becomes a no-op for them.',
+    isOptional: true,
+    defaultValue: 'false',
+  },
+  {
+    name: 'env',
+    type: 'Record<string, string>',
+    description: 'Environment variables baked into the box at create time.',
+    isOptional: true,
+  },
+  {
+    name: 'workdir',
+    type: 'string',
+    description: 'Default working directory for spawned commands.',
+    isOptional: true,
+  },
+  {
+    name: 'networkPolicy',
+    type: 'NetworkPolicy',
+    description: 'Outbound network access policy for the box.',
+    isOptional: true,
+  },
+  {
+    name: 'skills',
+    type: 'string[]',
+    description: "GitHub 'owner/repo' skills to install on the box.",
+    isOptional: true,
+  },
+  {
+    name: 'timeout',
+    type: 'number',
+    description:
+      "Default command timeout in milliseconds, applied to spawned commands that don't specify their own. When omitted, commands run until they exit (matches Daytona/Railway/E2B).",
+    isOptional: true,
+  },
+  {
+    name: 'requestTimeout',
+    type: 'number',
+    description: 'Request timeout in milliseconds for Box API calls (create/get/exec).',
+    isOptional: true,
+    defaultValue: '600000 (10 minutes)',
+  },
+  {
+    name: 'instructions',
+    type: 'string | function',
+    description:
+      'Custom instructions returned by getInstructions(). Pass a string to fully replace the default, or a function to extend it.',
+    isOptional: true,
+  },
+  {
+    name: 'onStart',
+    type: 'function',
+    description: 'Lifecycle hook called after the sandbox reaches running status.',
+    isOptional: true,
+  },
+  {
+    name: 'onStop',
+    type: 'function',
+    description: 'Lifecycle hook called before the sandbox stops.',
+    isOptional: true,
+  },
+  {
+    name: 'onDestroy',
+    type: 'function',
+    description: 'Lifecycle hook called before the sandbox is destroyed.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Sandbox instance identifier.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: "Provider name ('UpstashBoxSandbox')",
+  },
+  {
+    name: 'provider',
+    type: 'string',
+    description: "Provider identifier ('upstash-box')",
+  },
+  {
+    name: 'status',
+    type: 'ProviderStatus',
+    description: "'pending' | 'starting' | 'running' | 'stopping' | 'stopped' | 'destroying' | 'destroyed' | 'error'",
+  },
+  {
+    name: 'box',
+    type: 'Box',
+    description:
+      'The underlying Upstash Box instance, for direct access to files, git, and snapshot APIs. Throws SandboxNotReadyError if the sandbox has not been started.',
+  },
+  {
+    name: 'remoteId',
+    type: 'string | undefined',
+    description: 'The server-side box id, available once the sandbox has started.',
+  },
+  {
+    name: 'processes',
+    type: 'UpstashBoxProcessManager',
+    description:
+      'Background process manager. See [SandboxProcessManager reference](/reference/workspace/process-manager).',
+  },
+]}
+/>
+
+## Sandbox lifecycle
+
+- **`_start()`**: Reconnects to a known box (when a `boxId` is set from an option or a previous start) and resumes it if it was paused, otherwise creates a new box.
+- **`_stop()`**: Pauses the box, releasing compute while preserving state. No-op for keep-alive boxes. The box id is retained so the next `_start()` reconnects.
+- **`_destroy()`**: Permanently deletes the box and clears all state.
+
+```typescript
+const sandbox = new UpstashBoxSandbox({
+  id: 'dev-sandbox',
+  runtime: 'node',
+})
+
+await sandbox._start()
+await sandbox.processes.spawn('npm install')
+await sandbox._stop()
+await sandbox._start() // reconnects and resumes the same box
+```
+
+## Background processes
+
+`UpstashBoxSandbox` includes a built-in process manager for spawning and managing background processes. Box's `exec` API is request/response and blocks until a command finishes, so each `spawn()` launches the command **detached** on the box (a small shell harness started via `nohup`). `spawn()` returns immediately with the process's OS pid; `wait()` polls the box, streaming new output to the handle and resolving on exit; `kill()` signals the pid.
+
+```typescript
+const sandbox = new UpstashBoxSandbox({ id: 'dev-sandbox' })
+await sandbox._start()
+
+// Spawn a background process — returns immediately, even for long-running commands
+const handle = await sandbox.processes.spawn('node script.js', {
+  env: { PORT: '3000' },
+  onStdout: data => console.log(data),
+})
+
+// Wait for the process to complete
+const result = await handle.wait()
+console.log(result.exitCode)
+
+// Kill the process
+await handle.kill()
+```
+
+:::note
+
+stdout and stderr are captured separately (`result.stdout` / `result.stderr`). Output streaming is **poll-based** (default 400ms), so `onStdout`/`onStderr` callbacks fire in near-real-time rather than as a true byte stream. `sendStdin()` isn't supported — Box doesn't expose a stdin channel on exec.
+
+:::
+
+See [`SandboxProcessManager` reference](/reference/workspace/process-manager) for the full API.
+
+## Related
+
+- [SandboxProcessManager reference](/reference/workspace/process-manager)
+- [WorkspaceSandbox interface](/reference/workspace/sandbox)
+- [ModalSandbox reference](/reference/workspace/modal-sandbox)
+- [DaytonaSandbox reference](/reference/workspace/daytona-sandbox)
+- [Workspace overview](/docs/workspace/overview)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8510,6 +8510,49 @@ importers:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  workspaces/upstash-box:
+    dependencies:
+      '@upstash/box':
+        specifier: ^0.5.0
+        version: 0.5.0(zod@4.4.3)
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@internal/workspace-test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(vitest@4.1.8)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.8(vitest@4.1.8)
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
+      eslint:
+        specifier: ^10.4.1
+        version: 10.4.1(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.14)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+
   workspaces/vercel:
     dependencies:
       '@vercel/sandbox':
@@ -17937,6 +17980,12 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/box@0.5.0':
+    resolution: {integrity: sha512-0Cm1xU0390zHdbhjjw09jXxAz7bEwf66FYVimBqa0ZgeENyT3+TMal7zeatu9VANq1DJ9PJZl4LJMvHN+GKXiQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@upstash/redis@1.38.0':
     resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
@@ -40412,6 +40461,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@upstash/box@0.5.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
 
   '@upstash/redis@1.38.0':
     dependencies:

--- a/workspaces/upstash-box/.env.example
+++ b/workspaces/upstash-box/.env.example
@@ -1,0 +1,7 @@
+# Upstash Box API key for sandbox operations.
+# Get one at https://console.upstash.com — falls back to this env var when
+# `apiKey` is not passed to UpstashBoxSandbox.
+UPSTASH_BOX_API_KEY=your-api-key-here
+
+# Optional: Box API base URL (defaults to https://us-east-1.box.upstash.com)
+# UPSTASH_BOX_BASE_URL=https://us-east-1.box.upstash.com

--- a/workspaces/upstash-box/.gitignore
+++ b/workspaces/upstash-box/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+.env
+.turbo

--- a/workspaces/upstash-box/CHANGELOG.md
+++ b/workspaces/upstash-box/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @mastra/upstash-box

--- a/workspaces/upstash-box/README.md
+++ b/workspaces/upstash-box/README.md
@@ -1,0 +1,111 @@
+# @mastra/upstash-box
+
+[Upstash Box](https://upstash.com/docs/box) cloud sandbox provider for [Mastra](https://mastra.ai) workspaces.
+
+Box is a managed cloud sandbox for AI coding agents. This package adapts it to
+the Mastra `WorkspaceSandbox` interface so agents can run shell commands in an
+isolated, disposable cloud environment.
+
+## Installation
+
+```bash
+npm install @mastra/upstash-box
+```
+
+## Usage
+
+```typescript
+import { Workspace } from '@mastra/core/workspace';
+import { UpstashBoxSandbox } from '@mastra/upstash-box';
+
+const sandbox = new UpstashBoxSandbox({
+  runtime: 'node',
+  size: 'small',
+  // apiKey defaults to the UPSTASH_BOX_API_KEY env var
+});
+
+const workspace = new Workspace({ sandbox });
+await workspace.init();
+
+const result = await workspace.sandbox.executeCommand('echo', ['hello']);
+console.log(result.stdout); // "hello"
+
+await workspace.destroy();
+```
+
+### Reconnecting to an existing box
+
+```typescript
+const sandbox = new UpstashBoxSandbox({ boxId: 'box_abc123' });
+```
+
+After the first `start()`, the server-side box id is stored, so a `stop()`
+(which pauses the box) followed by `start()` reconnects to the same box and
+resumes it.
+
+## Configuration
+
+| Option          | Type                                | Default                  | Description                                                                |
+| --------------- | ----------------------------------- | ------------------------ | -------------------------------------------------------------------------- |
+| `id`            | `string`                            | auto-generated           | Logical id for this sandbox instance (used as the box name on create).     |
+| `boxId`         | `string`                            | —                        | Reconnect to an existing box by its server-side id.                        |
+| `apiKey`        | `string`                            | `UPSTASH_BOX_API_KEY`    | Box API key.                                                               |
+| `baseUrl`       | `string`                            | SDK default              | Box API base URL (`UPSTASH_BOX_BASE_URL` env var also honored by the SDK). |
+| `runtime`       | `'node' \| 'python' \| ...`         | `'node'`                 | Runtime preinstalled in the box.                                           |
+| `size`          | `'small' \| 'medium' \| 'large'`    | `'small'`                | Resource size of the box.                                                  |
+| `keepAlive`     | `boolean`                           | `false`                  | Keep the box alive instead of idle-pausing. Keep-alive boxes can't pause.  |
+| `env`           | `Record<string, string>`            | `{}`                     | Environment variables baked in at create time.                             |
+| `workdir`       | `string`                            | —                        | Default working directory for spawned commands.                            |
+| `networkPolicy` | `NetworkPolicy`                     | allow-all                | Outbound network access policy.                                            |
+| `skills`        | `string[]`                          | —                        | GitHub `owner/repo` skills to install on the box.                          |
+| `timeout`       | `number`                            | —                        | Default command timeout (ms) for spawns without their own; omit = unbounded (matches Daytona/Railway/E2B). |
+| `requestTimeout`| `number`                            | `600_000`                | Request timeout (ms) for Box API calls.                                    |
+| `instructions`  | `string \| (ctx) => string`         | —                        | Override `getInstructions()` output for agents.                            |
+
+## Lifecycle
+
+- **`start()`** — reconnects to a known box (`boxId`) and resumes it, or creates a new box.
+- **`stop()`** — pauses the box (releases compute, preserves state). No-op for keep-alive boxes. The box id is retained for reconnect.
+- **`destroy()`** — permanently deletes the box.
+
+## Background processes
+
+Box's `exec` API is request/response and blocks until a command finishes, so the
+process manager runs each spawned process **detached** on the box (a small shell
+harness started via `nohup`). `spawn()` returns immediately with the process's
+OS pid; `wait()` polls the box, streaming new stdout/stderr to the handle and
+resolving when the process exits; `kill()` signals the pid.
+
+```typescript
+await sandbox._start()
+
+const handle = await sandbox.processes.spawn('npm run dev', {
+  onStdout: data => process.stdout.write(data),
+})
+// ... do other work while it runs ...
+await handle.kill()
+```
+
+## Notes
+
+- Background processes are supported via the detached-harness model above, so
+  `spawn()` is non-blocking and long-running processes can be killed.
+- stdout and stderr are captured separately (`result.stdout` / `result.stderr`).
+- Output streaming is **poll-based** (default 400ms), so `onStdout`/`onStderr`
+  callbacks fire in near-real-time rather than as a true byte stream.
+- `sendStdin()` is not supported — Box does not expose a stdin channel on exec.
+
+## Direct SDK access
+
+Use the `box` accessor to reach Box features not surfaced through the
+`WorkspaceSandbox` interface (files, git, snapshots, agents):
+
+```typescript
+await sandbox._start();
+await sandbox.box.files.write({ path: 'hello.txt', content: 'hi' });
+await sandbox.box.git.clone({ repo: 'owner/repo' });
+```
+
+## License
+
+Apache-2.0

--- a/workspaces/upstash-box/eslint.config.js
+++ b/workspaces/upstash-box/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/workspaces/upstash-box/lint-staged.config.js
+++ b/workspaces/upstash-box/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/workspaces/upstash-box/package.json
+++ b/workspaces/upstash-box/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@mastra/upstash-box",
+  "version": "0.0.1",
+  "description": "Upstash Box cloud sandbox provider for Mastra workspaces",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "build:lib": "pnpm build",
+    "build:watch": "pnpm build --watch",
+    "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
+    "test:watch": "vitest watch",
+    "test": "vitest run ./src/**/*.integration.test.ts",
+    "test:cloud": "pnpm test",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@upstash/box": "^0.5.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@internal/workspace-test-utils": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.19.15",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "dotenv": "^17.3.1",
+    "eslint": "^10.4.1",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.12.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "workspaces/upstash-box"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/workspaces/upstash-box/src/index.ts
+++ b/workspaces/upstash-box/src/index.ts
@@ -1,0 +1,3 @@
+export { UpstashBoxSandbox, type UpstashBoxSandboxOptions } from './sandbox';
+export { UpstashBoxProcessManager, type UpstashBoxProcessManagerOptions } from './sandbox/process-manager';
+export { upstashBoxSandboxProvider } from './provider';

--- a/workspaces/upstash-box/src/provider.ts
+++ b/workspaces/upstash-box/src/provider.ts
@@ -1,0 +1,78 @@
+/**
+ * Upstash Box sandbox provider descriptor for MastraEditor.
+ *
+ * @example
+ * ```typescript
+ * import { upstashBoxSandboxProvider } from '@mastra/upstash-box';
+ *
+ * const editor = new MastraEditor({
+ *   sandboxes: { [upstashBoxSandboxProvider.id]: upstashBoxSandboxProvider },
+ * });
+ * ```
+ */
+import type { SandboxProvider } from '@mastra/core/editor';
+import type { NetworkPolicy } from '@upstash/box';
+import { UpstashBoxSandbox } from './sandbox';
+
+/**
+ * Serializable subset of UpstashBoxSandboxOptions for editor storage.
+ * (`instructions` is omitted because its function form isn't JSON-serializable.)
+ */
+interface UpstashBoxProviderConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  boxId?: string;
+  runtime?: 'node' | 'python' | 'golang' | 'ruby' | 'rust';
+  size?: 'small' | 'medium' | 'large';
+  keepAlive?: boolean;
+  env?: Record<string, string>;
+  workdir?: string;
+  networkPolicy?: NetworkPolicy;
+  skills?: string[];
+  timeout?: number;
+  requestTimeout?: number;
+  debug?: boolean;
+}
+
+export const upstashBoxSandboxProvider: SandboxProvider<UpstashBoxProviderConfig> = {
+  id: 'upstash-box',
+  name: 'Upstash Box Sandbox',
+  description: 'Managed, disposable cloud sandbox for AI coding agents powered by Upstash Box',
+  configSchema: {
+    type: 'object',
+    properties: {
+      apiKey: { type: 'string', description: 'Box API key (falls back to UPSTASH_BOX_API_KEY)' },
+      baseUrl: { type: 'string', description: 'Box API base URL (falls back to UPSTASH_BOX_BASE_URL)' },
+      boxId: { type: 'string', description: 'Reconnect to an existing box by its server-side id' },
+      runtime: {
+        type: 'string',
+        description: 'Runtime preinstalled in the box',
+        enum: ['node', 'python', 'golang', 'ruby', 'rust'],
+        default: 'node',
+      },
+      size: {
+        type: 'string',
+        description: 'Resource size of the box',
+        enum: ['small', 'medium', 'large'],
+        default: 'small',
+      },
+      keepAlive: { type: 'boolean', description: 'Keep the box alive instead of letting it idle-pause' },
+      env: {
+        type: 'object',
+        description: 'Environment variables',
+        additionalProperties: { type: 'string' },
+      },
+      workdir: { type: 'string', description: 'Default working directory for spawned commands' },
+      networkPolicy: { type: 'object', description: 'Outbound network access policy' },
+      skills: {
+        type: 'array',
+        description: "GitHub 'owner/repo' skills to install on the box",
+        items: { type: 'string' },
+      },
+      timeout: { type: 'number', description: 'Default command timeout in ms (commands without their own)' },
+      requestTimeout: { type: 'number', description: 'Request timeout in ms for Box API calls' },
+      debug: { type: 'boolean', description: 'Enable Box SDK debug logging' },
+    },
+  },
+  createSandbox: config => new UpstashBoxSandbox(config),
+};

--- a/workspaces/upstash-box/src/sandbox/index.ts
+++ b/workspaces/upstash-box/src/sandbox/index.ts
@@ -1,0 +1,483 @@
+/**
+ * Upstash Box Sandbox Provider
+ *
+ * An Upstash Box implementation for Mastra workspaces. Box is a managed cloud
+ * sandbox for AI coding agents with streaming command execution, file I/O, git,
+ * and snapshots.
+ *
+ * @see https://upstash.com/docs/box
+ */
+
+import type { MastraSandboxOptions, ProviderStatus, SandboxInfo } from '@mastra/core/workspace';
+import { MastraSandbox, SandboxNotReadyError } from '@mastra/core/workspace';
+import { Box, BoxError } from '@upstash/box';
+import type { BoxSize, NetworkPolicy, Runtime } from '@upstash/box';
+import { UpstashBoxProcessManager } from './process-manager';
+
+const LOG_PREFIX = '[UpstashBoxSandbox]';
+
+/** Max time to wait for a reconnected box to leave a transitional state. */
+const RECONNECT_MAX_WAIT_MS = 120_000;
+/** Poll interval while waiting for a reconnected box to become usable. */
+const RECONNECT_POLL_MS = 2_000;
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+type InstructionsOption = string | ((opts: { defaultInstructions: string }) => string);
+
+// =============================================================================
+// Options
+// =============================================================================
+
+/**
+ * Upstash Box sandbox provider configuration.
+ */
+export interface UpstashBoxSandboxOptions extends Omit<MastraSandboxOptions, 'processes'> {
+  /** Logical identifier for this sandbox instance (local; not the Box id). */
+  id?: string;
+  /**
+   * Reconnect to an existing Box by its server-side id instead of creating a
+   * new one. Also set after the first `start()` so stop→start reuses the box.
+   */
+  boxId?: string;
+  /** API key for authentication. Falls back to the `UPSTASH_BOX_API_KEY` env var. */
+  apiKey?: string;
+  /** API base URL. Falls back to `UPSTASH_BOX_BASE_URL` or the SDK default. */
+  baseUrl?: string;
+  /**
+   * Runtime preinstalled in the box.
+   * @default 'node'
+   */
+  runtime?: Runtime;
+  /**
+   * Resource size of the box.
+   * @default 'small'
+   */
+  size?: BoxSize;
+  /**
+   * Keep the box alive instead of letting it idle-pause. Keep-alive boxes
+   * cannot be paused, so `stop()` becomes a no-op for them.
+   * @default false
+   */
+  keepAlive?: boolean;
+  /** Environment variables baked into the box at create time. */
+  env?: Record<string, string>;
+  /** Default working directory for spawned commands. */
+  workdir?: string;
+  /** Network access policy controlling outbound connectivity. */
+  networkPolicy?: NetworkPolicy;
+  /** GitHub `owner/repo` skills to install on the box. */
+  skills?: string[];
+  /**
+   * Default command timeout in milliseconds, applied to spawned commands that
+   * don't specify their own. When omitted, commands run until they exit. Matches
+   * the `timeout` semantics of the Daytona/Railway/E2B providers.
+   */
+  timeout?: number;
+  /**
+   * Request timeout in milliseconds for Box API calls (create/get/exec).
+   * @default 600_000 // 10 minutes
+   */
+  requestTimeout?: number;
+  /** Enable Box SDK debug logging. */
+  debug?: boolean;
+  /** Custom instructions for getInstructions(). String replaces the default; function receives it. */
+  instructions?: InstructionsOption;
+}
+
+// =============================================================================
+// UpstashBoxSandbox
+// =============================================================================
+
+/**
+ * Upstash Box cloud sandbox provider for Mastra workspaces.
+ *
+ * Features:
+ * - Isolated cloud sandbox via the Upstash Box SDK
+ * - Streaming shell command execution
+ * - Resource sizing (small / medium / large) and runtime selection
+ * - Network policy and skill installation
+ * - Reconnect-by-id with pause/resume lifecycle
+ *
+ * @example Basic usage
+ * ```typescript
+ * import { Workspace } from '@mastra/core/workspace';
+ * import { UpstashBoxSandbox } from '@mastra/upstash-box';
+ *
+ * const sandbox = new UpstashBoxSandbox({
+ *   runtime: 'node',
+ *   size: 'small',
+ * });
+ *
+ * const workspace = new Workspace({ sandbox });
+ * await workspace.init();
+ * const result = await workspace.sandbox.executeCommand('echo', ['hello']);
+ * ```
+ *
+ * @example Reconnecting to an existing box
+ * ```typescript
+ * const sandbox = new UpstashBoxSandbox({ boxId: 'box_abc123' });
+ * ```
+ */
+export class UpstashBoxSandbox extends MastraSandbox {
+  readonly id: string;
+  readonly name = 'UpstashBoxSandbox';
+  readonly provider = 'upstash-box';
+  status: ProviderStatus = 'pending';
+
+  declare readonly processes: UpstashBoxProcessManager;
+
+  private _box: Box | null = null;
+  private _boxId?: string;
+  private _createdAt: Date | null = null;
+  private _isRetrying = false;
+
+  private readonly apiKey?: string;
+  private readonly baseUrl?: string;
+  private readonly runtime: Runtime;
+  private readonly size: BoxSize;
+  private readonly keepAlive: boolean;
+  private readonly env: Record<string, string>;
+  private readonly workdir?: string;
+  private readonly networkPolicy?: NetworkPolicy;
+  private readonly skills?: string[];
+  private readonly requestTimeout: number;
+  private readonly debug: boolean;
+  private readonly _instructionsOverride?: InstructionsOption;
+  /** Whether `id` was auto-generated (and thus unique) vs. user-supplied. */
+  private readonly _idWasGenerated: boolean;
+
+  constructor(options: UpstashBoxSandboxOptions = {}) {
+    super({
+      ...options,
+      name: 'UpstashBoxSandbox',
+      processes: new UpstashBoxProcessManager({
+        env: options.env ?? {},
+        workdir: options.workdir,
+        defaultTimeout: options.timeout,
+      }),
+    });
+
+    this._idWasGenerated = options.id === undefined;
+    this.id = options.id ?? this._generateId();
+    this._boxId = options.boxId;
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl;
+    this.runtime = options.runtime ?? 'node';
+    this.size = options.size ?? 'small';
+    this.keepAlive = options.keepAlive ?? false;
+    this.env = options.env ?? {};
+    this.workdir = options.workdir;
+    this.networkPolicy = options.networkPolicy;
+    this.skills = options.skills;
+    this.requestTimeout = options.requestTimeout ?? 600_000;
+    this.debug = options.debug ?? false;
+    this._instructionsOverride = options.instructions;
+  }
+
+  /**
+   * The underlying Box instance, for direct access to Box APIs not surfaced
+   * through the WorkspaceSandbox interface (files, git, snapshots, etc.).
+   *
+   * @throws {SandboxNotReadyError} If the sandbox has not been started.
+   */
+  get box(): Box {
+    if (!this._box) {
+      throw new SandboxNotReadyError(this.id);
+    }
+    return this._box;
+  }
+
+  /** The server-side Box id, available once the sandbox has started. */
+  get remoteId(): string | undefined {
+    return this._boxId;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Start the box. Reconnects to an existing box when a `boxId` is known
+   * (option or a prior start), otherwise creates a fresh one.
+   */
+  async start(): Promise<void> {
+    if (this._box) {
+      return;
+    }
+
+    const connOpts = {
+      ...(this.apiKey !== undefined && { apiKey: this.apiKey }),
+      ...(this.baseUrl !== undefined && { baseUrl: this.baseUrl }),
+    };
+
+    // Try to reconnect to a known box first.
+    if (this._boxId) {
+      try {
+        const existing = await Box.get(this._boxId, {
+          ...connOpts,
+          timeout: this.requestTimeout,
+          debug: this.debug,
+        });
+
+        if (await this.waitForUsableBox(existing)) {
+          this._box = existing;
+          this._createdAt = new Date();
+          this.logger.debug(`${LOG_PREFIX} Reconnected to box ${this._boxId} for: ${this.id}`);
+          return;
+        }
+
+        // Box is gone/unusable — fall through to create a fresh one.
+        this.logger.debug(`${LOG_PREFIX} Box ${this._boxId} is not usable, creating a fresh one`);
+        this._boxId = undefined;
+      } catch (error) {
+        if (!this.isBoxGoneError(error)) {
+          throw error;
+        }
+        this.logger.debug(`${LOG_PREFIX} Box ${this._boxId} no longer exists, creating a fresh one`);
+        this._boxId = undefined;
+      }
+    }
+
+    this.logger.debug(`${LOG_PREFIX} Creating box for: ${this.id}`);
+    try {
+      this._box = await Box.create({
+        ...connOpts,
+        name: this.id,
+        runtime: this.runtime,
+        size: this.size,
+        keepAlive: this.keepAlive,
+        ...(Object.keys(this.env).length > 0 && { env: this.env }),
+        ...(this.networkPolicy && { networkPolicy: this.networkPolicy }),
+        ...(this.skills?.length && { skills: this.skills }),
+        timeout: this.requestTimeout,
+        debug: this.debug,
+      });
+    } catch (error) {
+      // The server may have provisioned the box before the failure surfaced
+      // (e.g. readiness polling threw) without returning its id. We can only
+      // identify it by name — which is safe to delete ONLY when the id was
+      // auto-generated (and therefore unique to this instance). A user-supplied
+      // id may be shared by concurrent instances, so deleting by name could nuke
+      // a sibling's live box — warn instead.
+      if (this._idWasGenerated) {
+        await this.cleanupOrphanByName(connOpts).catch(() => {});
+      } else {
+        this.logger.warn(
+          `${LOG_PREFIX} Box.create failed; a box named "${this.id}" may have been orphaned. Not auto-deleting because the id was user-supplied (it may be shared by other instances) — remove it manually if needed.`,
+        );
+      }
+      throw error;
+    }
+    this._boxId = this._box.id;
+    this._createdAt = new Date();
+    this.logger.debug(`${LOG_PREFIX} Created box ${this._box.id} for logical id: ${this.id}`);
+  }
+
+  /**
+   * Stop the box, releasing compute while preserving state so a later `start()`
+   * can resume it. Keep-alive boxes cannot be paused, so this becomes a no-op
+   * that just drops the local reference.
+   */
+  async stop(): Promise<void> {
+    if (!this._box) return;
+
+    if (!this.keepAlive) {
+      try {
+        await this._box.pause();
+        this.logger.debug(`${LOG_PREFIX} Paused box ${this._box.id}`);
+      } catch (error) {
+        // Best-effort — box may already be paused or gone.
+        this.logger.debug(`${LOG_PREFIX} Pause failed (non-fatal):`, error);
+      }
+    }
+
+    // Keep `_boxId` so start() can reconnect.
+    this._box = null;
+  }
+
+  /**
+   * Destroy the box permanently and clear all state.
+   */
+  async destroy(): Promise<void> {
+    const box = this._box;
+    if (box) {
+      try {
+        await box.delete();
+        this.logger.debug(`${LOG_PREFIX} Deleted box ${box.id}`);
+      } catch {
+        // Ignore errors during cleanup.
+      }
+    } else if (this._boxId) {
+      // Orphan cleanup: start() may have stored a box id then failed; delete it
+      // so it doesn't leak.
+      try {
+        await Box.delete({
+          boxIds: this._boxId,
+          ...(this.apiKey !== undefined && { apiKey: this.apiKey }),
+          ...(this.baseUrl !== undefined && { baseUrl: this.baseUrl }),
+        });
+      } catch {
+        // Best-effort — box may not exist or may already be gone.
+      }
+    }
+
+    this._box = null;
+    this._boxId = undefined;
+  }
+
+  /** Whether the sandbox is ready for operations. */
+  async isReady(): Promise<boolean> {
+    return this.status === 'running' && this._box !== null;
+  }
+
+  /** Information about the current state of the sandbox. */
+  async getInfo(): Promise<SandboxInfo> {
+    return {
+      id: this.id,
+      name: this.name,
+      provider: this.provider,
+      status: this.status,
+      createdAt: this._createdAt ?? new Date(),
+      metadata: {
+        runtime: this.runtime,
+        size: this.size,
+        keepAlive: this.keepAlive,
+        ...(this._boxId && { boxId: this._boxId }),
+      },
+    };
+  }
+
+  /**
+   * Instructions describing this sandbox. Used by agents to understand the
+   * execution environment.
+   */
+  getInstructions(): string {
+    const defaultInstructions = this._getDefaultInstructions();
+    if (this._instructionsOverride === undefined) return defaultInstructions;
+    if (typeof this._instructionsOverride === 'string') return this._instructionsOverride;
+    return this._instructionsOverride({ defaultInstructions });
+  }
+
+  private _getDefaultInstructions(): string {
+    const parts = [
+      `Upstash Box cloud sandbox (${this.runtime} runtime, ${this.size} size).`,
+      'Use executeCommand() to run shell commands.',
+    ];
+    if (this.workdir) {
+      parts.push(`Default working directory: ${this.workdir}.`);
+    }
+    return parts.join(' ');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dead-box Retry
+  // ---------------------------------------------------------------------------
+
+  /** True when an error indicates the box no longer exists / is gone. */
+  private isBoxGoneError(error: unknown): boolean {
+    if (!error) return false;
+    if (error instanceof BoxError && error.statusCode === 404) return true;
+    const errorStr = String(error);
+    return (
+      errorStr.includes('not found') ||
+      errorStr.includes('does not exist') ||
+      errorStr.includes('has been deleted')
+    );
+  }
+
+  private handleBoxDead(): void {
+    this._box = null;
+    this.status = 'stopped';
+  }
+
+  /**
+   * Execute a function, retrying once if the box is found to be gone.
+   * Used by the process manager to handle stale boxes transparently.
+   * @internal
+   */
+  async retryOnDead<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (error) {
+      if (this.isBoxGoneError(error) && !this._isRetrying) {
+        // The stored box is gone — drop the id so we create a fresh one.
+        this._boxId = undefined;
+        this.handleBoxDead();
+        this._isRetrying = true;
+        try {
+          await this.ensureRunning();
+          return await fn();
+        } finally {
+          this._isRetrying = false;
+        }
+      }
+      throw error;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal Helpers
+  // ---------------------------------------------------------------------------
+
+  private _generateId(): string {
+    return `box-sandbox-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  /**
+   * Wait for a reconnected box to reach a usable state before handing it back,
+   * so commands don't fire against a box that's still provisioning.
+   *
+   * - `running` / `idle` → usable
+   * - `paused` → resume once, then keep polling until it settles
+   * - `creating` → poll until it settles
+   * - `deleted` / `error` → not usable (caller creates a fresh box)
+   *
+   * @returns true if the box is usable, false if it's gone and should be recreated.
+   */
+  private async waitForUsableBox(box: Box): Promise<boolean> {
+    const deadline = Date.now() + RECONNECT_MAX_WAIT_MS;
+    let resumed = false;
+
+    while (true) {
+      const { status } = await box.getStatus();
+
+      if (status === 'deleted' || status === 'error') {
+        return false;
+      }
+      if (status === 'running' || status === 'idle') {
+        return true;
+      }
+      // Resuming a paused box may fail for a real reason (auth, quota, backend) —
+      // let that propagate rather than silently treating the box as usable.
+      if (status === 'paused' && !resumed) {
+        await box.resume();
+        resumed = true;
+        continue; // re-check immediately
+      }
+
+      // Still 'creating' (or transitioning out of 'paused') — wait for it to settle.
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `${LOG_PREFIX} Timed out waiting for box ${box.id} to become usable (still "${status}" after ${RECONNECT_MAX_WAIT_MS}ms)`,
+        );
+      }
+      await sleep(RECONNECT_POLL_MS);
+    }
+  }
+
+  /**
+   * Best-effort cleanup of an orphaned box left by a failed Box.create().
+   * Deletes boxes named for this sandbox. Only called when the id was
+   * auto-generated (hence unique to this instance), so this can't collide with
+   * another instance's box.
+   */
+  private async cleanupOrphanByName(conn: { apiKey?: string; baseUrl?: string }): Promise<void> {
+    const boxes = await Box.list(conn);
+    const orphanIds = boxes.filter(b => b.name === this.id).map(b => b.id);
+    if (orphanIds.length > 0) {
+      this.logger.debug(`${LOG_PREFIX} Cleaning up ${orphanIds.length} orphaned box(es) named "${this.id}"`);
+      await Box.delete({ ...conn, boxIds: orphanIds });
+    }
+  }
+}

--- a/workspaces/upstash-box/src/sandbox/process-manager.ts
+++ b/workspaces/upstash-box/src/sandbox/process-manager.ts
@@ -171,7 +171,8 @@ class UpstashBoxProcessHandle extends ProcessHandle {
 
         if (this._exitCode === undefined) {
           if (code !== null && code !== '') {
-            this._exitCode = parseInt(code, 10) || 0;
+            const parsed = Number.parseInt(code, 10);
+            this._exitCode = Number.isNaN(parsed) ? 1 : parsed;
           } else if (this._killed) {
             this._exitCode = 137;
           } else {
@@ -193,7 +194,7 @@ class UpstashBoxProcessHandle extends ProcessHandle {
   }
 
   private async _doWait(): Promise<CommandResult> {
-    if (this._timeout) {
+    if (this._timeout !== undefined) {
       const remaining = this._startTime + this._timeout - Date.now();
       let timer: ReturnType<typeof setTimeout> | undefined;
       const timedOut = new Promise<'timeout'>(resolve => {

--- a/workspaces/upstash-box/src/sandbox/process-manager.ts
+++ b/workspaces/upstash-box/src/sandbox/process-manager.ts
@@ -1,0 +1,398 @@
+/**
+ * Upstash Box Process Manager
+ *
+ * Implements SandboxProcessManager for Upstash Box cloud sandboxes.
+ *
+ * Box's `exec` API is request/response and blocks until a command finishes, so
+ * it can't model long-running background processes directly. Instead, each
+ * spawn() launches the command **detached** on the box (`nohup` + a small shell
+ * harness delivered as a base64 blob over `exec.command`), capturing:
+ *
+ *   <dir>/out   — stdout
+ *   <dir>/err   — stderr
+ *   <dir>/pid   — the command's OS pid (for kill)
+ *   <dir>/code  — exit code, written once the command exits
+ *
+ * spawn() returns immediately with the OS pid. wait() polls the box: it streams
+ * new stdout/stderr bytes to the handle (base64-framed so binary/newlines never
+ * collide with the poll markers) and resolves when the process is gone. kill()
+ * signals the pid directly.
+ *
+ * Box exposes no stdin channel, so sendStdin() is unsupported.
+ */
+
+import { ProcessHandle, SandboxProcessManager } from '@mastra/core/workspace';
+import type { CommandResult, ProcessInfo, SpawnProcessOptions } from '@mastra/core/workspace';
+import { shellQuote } from '../utils/shell-quote';
+import type { UpstashBoxSandbox } from './index';
+
+/** Root directory on the box for per-process bookkeeping files. */
+const PROC_ROOT = '/tmp/.mastra-box';
+/** How often wait() polls the box for output/exit status. */
+const POLL_INTERVAL_MS = 400;
+/** Grace window to let the harness write the exit-code file after the process exits. */
+const CODE_GRACE_MS = 2_000;
+/** Poll interval while waiting for the exit-code file within the grace window. */
+const CODE_POLL_MS = 150;
+
+const SHELL_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/** Runs a shell command on the box, returning stdout. */
+type RunFn = (command: string) => Promise<string>;
+
+// =============================================================================
+// Upstash Box Process Handle
+// =============================================================================
+
+/**
+ * Wraps a detached Box process to conform to Mastra's ProcessHandle.
+ * Not exported — internal to this module.
+ */
+class UpstashBoxProcessHandle extends ProcessHandle {
+  readonly pid: string;
+
+  private readonly _dir: string;
+  private readonly _osPid: string;
+  private readonly _run: RunFn;
+  private readonly _startTime: number;
+  private readonly _timeout?: number;
+
+  private _exitCode: number | undefined;
+  private _killed = false;
+  private _waitPromise: Promise<CommandResult> | null = null;
+  private readonly _pollingPromise: Promise<void>;
+  /** 1-based byte offsets for `tail -c +N` incremental reads. */
+  private _outOff = 1;
+  private _errOff = 1;
+
+  constructor(
+    pid: string,
+    dir: string,
+    osPid: string,
+    run: RunFn,
+    startTime: number,
+    options?: SpawnProcessOptions,
+  ) {
+    super(options);
+    this.pid = pid;
+    this._dir = dir;
+    this._osPid = osPid;
+    this._run = run;
+    this._startTime = startTime;
+    this._timeout = options?.timeout;
+
+    // Poll in the background from spawn time so output accumulates and the exit
+    // code resolves even if the caller only ever calls get() (never wait()).
+    this._pollingPromise = this._pollLoop();
+  }
+
+  get exitCode(): number | undefined {
+    return this._exitCode;
+  }
+
+  /**
+   * One poll round-trip: emit any new stdout/stderr to the handle and report
+   * whether the process is still running plus its exit code (if written).
+   */
+  private async _poll(): Promise<{ running: boolean; code: string | null }> {
+    const stdout = await this._run(pollCommand(this._osPid, this._dir, this._outOff, this._errOff));
+
+    let running = true;
+    let code: string | null = null;
+
+    for (const line of stdout.split('\n')) {
+      if (line.startsWith('R:')) {
+        running = line.slice(2).trim() === '1';
+      } else if (line.startsWith('C:')) {
+        const c = line.slice(2).trim();
+        code = c === '' ? null : c;
+      } else if (line.startsWith('O:')) {
+        const b = line.slice(2).trim();
+        if (b) {
+          const data = Buffer.from(b, 'base64').toString('utf8');
+          this.emitStdout(data);
+          this._outOff += Buffer.byteLength(data);
+        }
+      } else if (line.startsWith('E:')) {
+        const b = line.slice(2).trim();
+        if (b) {
+          const data = Buffer.from(b, 'base64').toString('utf8');
+          this.emitStderr(data);
+          this._errOff += Buffer.byteLength(data);
+        }
+      }
+    }
+
+    return { running, code };
+  }
+
+  async wait(): Promise<CommandResult> {
+    // Idempotent — cache the promise so repeated calls return the same result.
+    if (!this._waitPromise) {
+      this._waitPromise = this._doWait();
+    }
+    return this._waitPromise;
+  }
+
+  /**
+   * Background poll loop: drains output and resolves the exit code. Runs until
+   * the process exits or is killed; never rejects (errors resolve to a code).
+   */
+  private async _pollLoop(): Promise<void> {
+    while (true) {
+      let res: { running: boolean; code: string | null };
+      try {
+        res = await this._poll();
+      } catch {
+        // Box gone or transient error — treat as terminal.
+        this._exitCode ??= this._killed ? 137 : 1;
+        return;
+      }
+
+      if (!res.running) {
+        // The harness writes the exit-code file just *after* the process exits
+        // (`wait "$cpid"; echo "$?" > code`), so there's a brief window where the
+        // process is gone but the code isn't visible yet. Poll a little longer
+        // for it rather than defaulting a real non-zero exit to success.
+        let code = res.code;
+        const graceDeadline = Date.now() + CODE_GRACE_MS;
+        while (code === null && Date.now() < graceDeadline) {
+          await sleep(CODE_POLL_MS);
+          try {
+            code = (await this._poll()).code;
+          } catch {
+            // Box gone / transient — stop grace-polling and fall through to the
+            // fallback below. _pollLoop must never reject.
+            break;
+          }
+        }
+
+        if (this._exitCode === undefined) {
+          if (code !== null && code !== '') {
+            this._exitCode = parseInt(code, 10) || 0;
+          } else if (this._killed) {
+            this._exitCode = 137;
+          } else {
+            // Process is gone but no exit code was ever recorded (e.g. the harness
+            // itself died). Treat as a failure rather than a phantom success.
+            this._exitCode = 1;
+          }
+        }
+        return;
+      }
+
+      if (this._killed) {
+        this._exitCode ??= 137;
+        return;
+      }
+
+      await sleep(POLL_INTERVAL_MS);
+    }
+  }
+
+  private async _doWait(): Promise<CommandResult> {
+    if (this._timeout) {
+      const remaining = this._startTime + this._timeout - Date.now();
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timedOut = new Promise<'timeout'>(resolve => {
+        timer = setTimeout(() => resolve('timeout'), Math.max(0, remaining));
+      });
+      const outcome = await Promise.race([this._pollingPromise.then(() => 'done' as const), timedOut]);
+      clearTimeout(timer);
+
+      if (outcome === 'timeout') {
+        await this.kill();
+        this._exitCode = 124; // conventional timeout exit code
+        return {
+          success: false,
+          exitCode: 124,
+          stdout: this.stdout,
+          stderr: this.stderr || `Command timed out after ${this._timeout}ms`,
+          executionTimeMs: Date.now() - this._startTime,
+          killed: true,
+          timedOut: true,
+        };
+      }
+    } else {
+      await this._pollingPromise;
+    }
+
+    return {
+      success: this._exitCode === 0,
+      exitCode: this._exitCode ?? 1,
+      stdout: this.stdout,
+      stderr: this.stderr,
+      executionTimeMs: Date.now() - this._startTime,
+      ...(this._killed && { killed: true, timedOut: false }),
+    };
+  }
+
+  async kill(): Promise<boolean> {
+    if (this._exitCode !== undefined) return false;
+    this._killed = true;
+    // Signal the command directly. The harness records the resulting exit code
+    // (143 for SIGTERM) to the code file, which wait() reads.
+    try {
+      await this._run(`kill -TERM ${this._osPid} 2>/dev/null; kill -KILL ${this._osPid} 2>/dev/null; true`);
+    } catch {
+      // Box may be gone; wait() falls back to exit 137.
+    }
+    return true;
+  }
+
+  async sendStdin(_data: string): Promise<void> {
+    throw new Error('Upstash Box does not expose stdin on exec — sendStdin() is not supported');
+  }
+}
+
+// =============================================================================
+// Upstash Box Process Manager
+// =============================================================================
+
+export interface UpstashBoxProcessManagerOptions {
+  env?: Record<string, string | undefined>;
+  /** Default working directory baked into spawned commands when none is given. */
+  workdir?: string;
+  /** Default command timeout (ms) for spawns that don't specify their own. */
+  defaultTimeout?: number;
+}
+
+/**
+ * Upstash Box implementation of SandboxProcessManager.
+ * Launches each process detached on the box and tracks it by OS pid.
+ */
+export class UpstashBoxProcessManager extends SandboxProcessManager<UpstashBoxSandbox> {
+  private _spawnCounter = 0;
+  private readonly _workdir?: string;
+  private readonly _defaultTimeout?: number;
+
+  constructor(opts: UpstashBoxProcessManagerOptions = {}) {
+    super({ env: opts.env });
+    this._workdir = opts.workdir;
+    this._defaultTimeout = opts.defaultTimeout;
+  }
+
+  /** Run a shell command on the box and return its stdout. */
+  private run: RunFn = async command => {
+    const result = await this.sandbox.box.exec.command(command);
+    return result.result;
+  };
+
+  async spawn(command: string, options: SpawnProcessOptions = {}): Promise<ProcessHandle> {
+    // Apply the manager-level default timeout when the caller didn't specify one.
+    const effectiveOptions: SpawnProcessOptions = {
+      ...options,
+      timeout: options.timeout ?? this._defaultTimeout,
+    };
+
+    const mergedEnv = { ...this.env, ...effectiveOptions.env };
+    const envs = Object.fromEntries(
+      Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
+    );
+
+    // Build before retryOnDead so user-controlled validation errors cannot be
+    // mistaken for Box dead-box errors.
+    const token = `box-proc-${Date.now().toString(36)}-${++this._spawnCounter}`;
+    const dir = `${PROC_ROOT}/${token}`;
+    const script = buildChildScript(dir, command, envs, effectiveOptions.cwd ?? this._workdir);
+    const launch = buildLaunchCommand(dir, script);
+
+    return this.sandbox.retryOnDead(async () => {
+      const osPid = (await this.run(launch)).trim().split('\n').pop()?.trim() ?? '';
+      if (!osPid) {
+        throw new Error(`Failed to launch process for command: ${command}`);
+      }
+
+      const handle = new UpstashBoxProcessHandle(token, dir, osPid, this.run, Date.now(), effectiveOptions);
+      this._tracked.set(token, handle);
+      return handle;
+    });
+  }
+
+  async list(): Promise<ProcessInfo[]> {
+    const result: ProcessInfo[] = [];
+    for (const [pid, handle] of this._tracked) {
+      result.push({
+        pid,
+        command: handle.command,
+        running: handle.exitCode === undefined,
+        exitCode: handle.exitCode,
+      });
+    }
+    return result;
+  }
+}
+
+// =============================================================================
+// Shell Building
+// =============================================================================
+
+/**
+ * Build the detached harness script. The user command is wrapped in a subshell
+ * so compound commands, `exit N`, and heredocs behave; its pid is captured for
+ * kill, and the exit code is recorded once it finishes.
+ */
+function buildChildScript(
+  dir: string,
+  command: string,
+  envs: Record<string, string>,
+  cwd: string | undefined,
+): string {
+  const lines = ['#!/bin/sh', `DIR='${dir}'`, 'mkdir -p "$DIR"'];
+
+  for (const [k, v] of Object.entries(envs)) {
+    if (!SHELL_IDENTIFIER_PATTERN.test(k)) {
+      throw new Error(`Invalid environment variable name: ${JSON.stringify(k)}`);
+    }
+    lines.push(`export ${k}=${shellQuote(v)}`);
+  }
+
+  // cd runs inside the redirected subshell so a bad cwd fails the command
+  // (non-zero exit + the cd error on stderr) rather than silently running in
+  // the box's default directory.
+  const cdPrefix = cwd ? `cd ${shellQuote(cwd)} || exit 1; ` : '';
+
+  lines.push(
+    `( ${cdPrefix}${command} ) > "$DIR/out" 2> "$DIR/err" &`,
+    'cpid=$!',
+    'echo "$cpid" > "$DIR/pid"',
+    'wait "$cpid"',
+    'echo "$?" > "$DIR/code"',
+  );
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Build the launch command run via `exec.command`. Delivers the harness script
+ * as a base64 blob (no shell-quoting of user content), starts it detached, then
+ * blocks only until the pid file appears and echoes the pid.
+ */
+function buildLaunchCommand(dir: string, script: string): string {
+  const b64 = Buffer.from(script, 'utf8').toString('base64');
+  const childPath = `${dir}.sh`;
+  // Joined with newlines, not '; ' — a backgrounding '&' followed by ';' is a
+  // shell syntax error ("';' unexpected"), but '&' followed by a newline is fine.
+  return [
+    `mkdir -p '${PROC_ROOT}'`,
+    `echo '${b64}' | base64 -d > '${childPath}'`,
+    `nohup sh '${childPath}' >/dev/null 2>&1 &`,
+    `i=0; while [ ! -s '${dir}/pid' ] && [ $i -lt 250 ]; do sleep 0.02; i=$((i+1)); done`,
+    `cat '${dir}/pid' 2>/dev/null`,
+  ].join('\n');
+}
+
+/**
+ * Build a single poll round-trip: running flag, exit code, and base64-framed
+ * new stdout/stderr from the given byte offsets.
+ */
+function pollCommand(osPid: string, dir: string, outOff: number, errOff: number): string {
+  return [
+    `if kill -0 ${osPid} 2>/dev/null; then echo R:1; else echo R:0; fi`,
+    `echo "C:$(cat '${dir}/code' 2>/dev/null)"`,
+    `echo "O:$(tail -c +${outOff} '${dir}/out' 2>/dev/null | base64 | tr -d '\\n')"`,
+    `echo "E:$(tail -c +${errOff} '${dir}/err' 2>/dev/null | base64 | tr -d '\\n')"`,
+  ].join('; ');
+}

--- a/workspaces/upstash-box/src/sandbox/sandbox.integration.test.ts
+++ b/workspaces/upstash-box/src/sandbox/sandbox.integration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Upstash Box Sandbox Integration Tests
+ *
+ * These tests require a valid Upstash Box API key and run against the real Box
+ * API. They are separated from unit tests to avoid mock conflicts.
+ *
+ * Required environment variables:
+ * - UPSTASH_BOX_API_KEY: Box API key
+ * - UPSTASH_BOX_BASE_URL: (optional) Box API base URL
+ */
+
+import { createSandboxTestSuite } from '@internal/workspace-test-utils';
+import { describe, expect, it } from 'vitest';
+
+import { UpstashBoxSandbox } from './index';
+
+const hasCredentials = !!process.env.UPSTASH_BOX_API_KEY;
+
+/**
+ * Placeholder suite so the file always registers at least one suite. Without it,
+ * vitest fails the file when credentials are missing and the conformance suite
+ * is skipped.
+ */
+describe.skipIf(hasCredentials)('UpstashBoxSandbox Integration (skipped without credentials)', () => {
+  it('requires UPSTASH_BOX_API_KEY', () => {});
+});
+
+/**
+ * Shared Sandbox Conformance Tests
+ *
+ * Verify UpstashBoxSandbox conforms to the WorkspaceSandbox interface using the
+ * shared suite from @internal/workspace-test-utils.
+ */
+if (hasCredentials) {
+  createSandboxTestSuite({
+    suiteName: 'UpstashBoxSandbox Conformance',
+    createSandbox: options => {
+      return new UpstashBoxSandbox({
+        id: `conformance-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        timeout: 120000,
+        ...(options?.env && { env: options.env }),
+      });
+    },
+    cleanupSandbox: async sandbox => {
+      try {
+        await sandbox._destroy();
+      } catch {
+        // Ignore cleanup errors
+      }
+    },
+    killSandboxExternally: async sb => {
+      // Delete the box out-of-band so the next operation hits a 404 and the
+      // provider's retry-on-dead path has to recreate it.
+      await (sb as UpstashBoxSandbox).box.delete();
+    },
+    capabilities: {
+      supportsMounting: false,
+      supportsReconnection: true,
+      supportsConcurrency: true,
+      supportsEnvVars: true,
+      supportsWorkingDirectory: true,
+      supportsTimeout: true,
+      supportsStreaming: true,
+      supportsStdin: false, // Box exec does not expose stdin
+      defaultCommandTimeout: 30000,
+    },
+    testTimeout: 120000,
+  });
+}
+
+/**
+ * Box-specific behaviors not covered by the shared conformance suite.
+ */
+describe.skipIf(!hasCredentials)('UpstashBoxSandbox box-specific', () => {
+  it('fails the command when cwd does not exist (no silent fallback)', async () => {
+    const sandbox = new UpstashBoxSandbox({ id: `cwd-test-${Date.now().toString(36)}`, runtime: 'node' });
+    try {
+      await sandbox._start();
+      const handle = await sandbox.processes.spawn('pwd', { cwd: '/no/such/dir' });
+      const result = await handle.wait();
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).not.toBe(0);
+      // The cd error is surfaced on stderr rather than running in the default dir.
+      expect(result.stderr.toLowerCase()).toMatch(/no such|can't cd|cannot/);
+    } finally {
+      await sandbox._destroy().catch(() => {});
+    }
+  }, 120000);
+});

--- a/workspaces/upstash-box/src/sandbox/sandbox.test.ts
+++ b/workspaces/upstash-box/src/sandbox/sandbox.test.ts
@@ -1,0 +1,689 @@
+/**
+ * UpstashBoxSandbox unit tests — the @upstash/box SDK is mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be defined before any imports that use '@upstash/box'
+// ---------------------------------------------------------------------------
+
+const mockBox = {
+  id: 'box-test-123',
+  exec: { command: vi.fn() },
+  getStatus: vi.fn().mockResolvedValue({ status: 'running' }),
+  pause: vi.fn().mockResolvedValue(undefined),
+  resume: vi.fn().mockResolvedValue(undefined),
+  delete: vi.fn().mockResolvedValue(undefined),
+};
+
+const BoxCtor = {
+  create: vi.fn().mockResolvedValue(mockBox),
+  get: vi.fn().mockResolvedValue(mockBox),
+  delete: vi.fn().mockResolvedValue(undefined),
+  list: vi.fn().mockResolvedValue([]),
+};
+
+vi.mock('@upstash/box', () => {
+  class BoxError extends Error {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.name = 'BoxError';
+      this.statusCode = statusCode;
+    }
+  }
+  const Box = {
+    create: (...args: unknown[]) => BoxCtor.create(...args),
+    get: (...args: unknown[]) => BoxCtor.get(...args),
+    delete: (...args: unknown[]) => BoxCtor.delete(...args),
+    list: (...args: unknown[]) => BoxCtor.list(...args),
+  };
+  return { Box, BoxError };
+});
+
+// Import after mock registration
+// eslint-disable-next-line import/order
+import { BoxError } from '@upstash/box';
+import { upstashBoxSandboxProvider } from '../provider';
+import { UpstashBoxSandbox } from './index';
+
+type UpstashBoxSandboxOptions = ConstructorParameters<typeof UpstashBoxSandbox>[0];
+
+// ---------------------------------------------------------------------------
+// exec.command simulator
+//
+// The process manager launches detached processes and then polls the box. The
+// simulator interprets the three command shapes the manager issues — launch
+// (base64 harness + `cat <dir>/pid`), poll (`kill -0 <pid>` → R:/C:/O:/E:), and
+// kill (`kill -TERM <pid>`) — against a tiny in-memory process model.
+// ---------------------------------------------------------------------------
+
+interface ProcSpec {
+  /** stdout the process emits (delivered on first poll). */
+  out?: string;
+  /** stderr the process emits (delivered on first poll). */
+  err?: string;
+  /** exit code string once finished. */
+  code?: string;
+  /** number of polls to report RUNNING before reporting DONE (Infinity = forever). */
+  runningPolls?: number;
+  /** number of DONE polls that report an empty code before the real one (simulates the write race). */
+  codeDelayPolls?: number;
+}
+
+interface ProcState extends Required<ProcSpec> {
+  pollIndex: number;
+  delivered: boolean;
+  codeDelay: number;
+}
+
+const procRegistry = new Map<string, ProcState>();
+let nextSpec: ProcSpec | null = null;
+let pidSeq = 1000;
+
+/** Queue the behavior for the next spawn(). */
+function queueProc(spec: ProcSpec): void {
+  nextSpec = spec;
+}
+
+const b64 = (s: string) => Buffer.from(s, 'utf8').toString('base64');
+
+/** Install the simulator as mockBox.exec.command. */
+function installExecSim(): void {
+  procRegistry.clear();
+  nextSpec = null;
+  pidSeq = 1000;
+
+  mockBox.exec.command = vi.fn(async (cmd: string) => {
+    // Launch: deliver a pid and register the process.
+    if (cmd.includes('base64 -d') && cmd.includes("/pid'")) {
+      const pid = String(++pidSeq);
+      const spec = nextSpec ?? {};
+      nextSpec = null;
+      procRegistry.set(pid, {
+        out: spec.out ?? '',
+        err: spec.err ?? '',
+        code: spec.code ?? '0',
+        runningPolls: spec.runningPolls ?? 0,
+        codeDelayPolls: spec.codeDelayPolls ?? 0,
+        codeDelay: spec.codeDelayPolls ?? 0,
+        pollIndex: 0,
+        delivered: false,
+      });
+      return { result: `${pid}\n`, output: `${pid}\n`, exit_code: 0 };
+    }
+
+    // Kill: mark the process finished with a SIGTERM exit code.
+    let m = cmd.match(/kill -TERM (\d+)/);
+    if (m && !cmd.includes('kill -0')) {
+      const p = procRegistry.get(m[1]!);
+      if (p) {
+        p.code = '143'; // SIGTERM
+        p.runningPolls = 0;
+      }
+      return { result: '', output: '', exit_code: 0 };
+    }
+
+    // Poll: report running flag, exit code, and base64-framed new output.
+    m = cmd.match(/kill -0 (\d+)/);
+    if (m) {
+      const p = procRegistry.get(m[1]!);
+      if (!p) {
+        return { result: 'R:0\nC:0\nO:\nE:\n', output: '', exit_code: 0 };
+      }
+      const running = p.pollIndex < p.runningPolls;
+      p.pollIndex++;
+      let o = '';
+      let e = '';
+      if (!p.delivered) {
+        o = b64(p.out);
+        e = b64(p.err);
+        p.delivered = true;
+      }
+      let code = '';
+      if (!running) {
+        if (p.codeDelay > 0) {
+          p.codeDelay--; // process gone, but the code file isn't visible yet
+        } else {
+          code = p.code;
+        }
+      }
+      return { result: `R:${running ? 1 : 0}\nC:${code}\nO:${o}\nE:${e}\n`, output: '', exit_code: 0 };
+    }
+
+    return { result: '', output: '', exit_code: 0 };
+  });
+}
+
+/** Decode the harness script embedded in a captured launch command. */
+function decodeLaunchedScript(cmd: string): string {
+  const m = cmd.match(/echo '([A-Za-z0-9+/=]+)' \| base64 -d/);
+  return m ? Buffer.from(m[1]!, 'base64').toString('utf8') : '';
+}
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  BoxCtor.create.mockResolvedValue(mockBox);
+  BoxCtor.get.mockResolvedValue(mockBox);
+  BoxCtor.delete.mockResolvedValue(undefined);
+  BoxCtor.list.mockResolvedValue([]);
+  mockBox.getStatus.mockResolvedValue({ status: 'running' });
+  mockBox.pause.mockResolvedValue(undefined);
+  mockBox.resume.mockResolvedValue(undefined);
+  mockBox.delete.mockResolvedValue(undefined);
+  installExecSim();
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+describe('UpstashBoxSandbox lifecycle', () => {
+  it('creates a new box when none exists', async () => {
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', runtime: 'node' });
+    await sandbox._start();
+
+    expect(BoxCtor.get).not.toHaveBeenCalled();
+    expect(BoxCtor.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'test-sb', runtime: 'node', size: 'small' }),
+    );
+    expect(sandbox.status).toBe('running');
+    expect(sandbox.remoteId).toBe('box-test-123');
+  });
+
+  it('reconnects to a running box by boxId without resuming', async () => {
+    mockBox.getStatus.mockResolvedValue({ status: 'running' });
+
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', boxId: 'box-existing' });
+    await sandbox._start();
+
+    expect(BoxCtor.get).toHaveBeenCalledWith('box-existing', expect.anything());
+    expect(BoxCtor.create).not.toHaveBeenCalled();
+    expect(mockBox.resume).not.toHaveBeenCalled();
+    expect(sandbox.status).toBe('running');
+  });
+
+  it('resumes a paused box on reconnect, then waits until it is usable', async () => {
+    // paused → (resume) → running
+    mockBox.getStatus.mockResolvedValueOnce({ status: 'paused' }).mockResolvedValue({ status: 'running' });
+
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', boxId: 'box-existing' });
+    await sandbox._start();
+
+    expect(mockBox.resume).toHaveBeenCalledTimes(1);
+    expect(sandbox.status).toBe('running');
+  });
+
+  it('waits out a "creating" box on reconnect before using it', async () => {
+    // creating → creating → running
+    mockBox.getStatus
+      .mockResolvedValueOnce({ status: 'creating' })
+      .mockResolvedValueOnce({ status: 'creating' })
+      .mockResolvedValue({ status: 'running' });
+
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', boxId: 'box-existing' });
+    await sandbox._start();
+
+    expect(mockBox.resume).not.toHaveBeenCalled();
+    expect(sandbox.status).toBe('running');
+  }, 10_000);
+
+  it('fails start() if a reconnected box never becomes usable before timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      mockBox.getStatus.mockResolvedValue({ status: 'creating' });
+      const sandbox = new UpstashBoxSandbox({ id: 'test-sb', boxId: 'box-existing' });
+
+      const startPromise = sandbox._start();
+      const rejection = expect(startPromise).rejects.toThrow(/timed out waiting for box/i);
+      await vi.advanceTimersByTimeAsync(130_000);
+
+      await rejection;
+      expect(BoxCtor.create).not.toHaveBeenCalled();
+      expect(sandbox.status).toBe('error');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('propagates resume failures for a paused box', async () => {
+    mockBox.getStatus.mockResolvedValue({ status: 'paused' });
+    mockBox.resume.mockRejectedValue(new BoxError('quota exceeded', 402));
+
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', boxId: 'box-existing' });
+    await expect(sandbox._start()).rejects.toThrow('quota exceeded');
+    expect(sandbox.status).toBe('error');
+  });
+
+  it('creates a fresh box when the existing one is in a "deleted"/"error" status', async () => {
+    mockBox.getStatus.mockResolvedValue({ status: 'deleted' });
+
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', boxId: 'box-existing' });
+    await sandbox._start();
+
+    expect(BoxCtor.create).toHaveBeenCalled();
+    expect(mockBox.resume).not.toHaveBeenCalled();
+    expect(sandbox.status).toBe('running');
+  });
+
+  it('creates a fresh box when the stored boxId is gone (404)', async () => {
+    BoxCtor.get.mockRejectedValue(new BoxError('not found', 404));
+
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', boxId: 'box-gone' });
+    await sandbox._start();
+
+    expect(BoxCtor.get).toHaveBeenCalled();
+    expect(BoxCtor.create).toHaveBeenCalled();
+    expect(sandbox.status).toBe('running');
+  });
+
+  it('propagates unexpected errors from get()', async () => {
+    BoxCtor.get.mockRejectedValue(new BoxError('rate limited', 429));
+
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', boxId: 'box-x' });
+    await expect(sandbox._start()).rejects.toThrow('rate limited');
+  });
+
+  it('cleans up the orphaned box when create() fails and the id was auto-generated', async () => {
+    BoxCtor.create.mockRejectedValue(new BoxError('creation timed out', 504));
+
+    const sandbox = new UpstashBoxSandbox({}); // auto-generated (unique) id
+    BoxCtor.list.mockResolvedValue([
+      { id: 'orphan-1', name: sandbox.id },
+      { id: 'unrelated', name: 'someone-else' },
+    ]);
+
+    await expect(sandbox._start()).rejects.toThrow('creation timed out');
+
+    expect(BoxCtor.delete).toHaveBeenCalledWith(expect.objectContaining({ boxIds: ['orphan-1'] }));
+  });
+
+  it('does NOT auto-delete on create() failure when the id was user-supplied (may be shared)', async () => {
+    BoxCtor.create.mockRejectedValue(new BoxError('creation timed out', 504));
+    // A box with this (possibly shared) name exists — must not be deleted, since
+    // it could belong to a concurrent instance using the same id.
+    BoxCtor.list.mockResolvedValue([{ id: 'maybe-siblings', name: 'shared-id' }]);
+
+    const sandbox = new UpstashBoxSandbox({ id: 'shared-id' });
+    await expect(sandbox._start()).rejects.toThrow('creation timed out');
+
+    expect(BoxCtor.delete).not.toHaveBeenCalled();
+  });
+
+  it('stop() pauses the box and keeps boxId for reconnect', async () => {
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb' });
+    await sandbox._start();
+    await sandbox._stop();
+
+    expect(mockBox.pause).toHaveBeenCalled();
+    expect(sandbox.status).toBe('stopped');
+    expect(sandbox.remoteId).toBe('box-test-123');
+  });
+
+  it('stop() does not pause keep-alive boxes', async () => {
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', keepAlive: true });
+    await sandbox._start();
+    await sandbox._stop();
+
+    expect(mockBox.pause).not.toHaveBeenCalled();
+    expect(sandbox.status).toBe('stopped');
+  });
+
+  it('start() after stop() reconnects to the same box', async () => {
+    const sandbox = new UpstashBoxSandbox({ id: 'resume-test' });
+    await sandbox._start();
+    expect(BoxCtor.create).toHaveBeenCalledTimes(1);
+
+    await sandbox._stop();
+    await sandbox._start();
+
+    expect(BoxCtor.get).toHaveBeenCalledWith('box-test-123', expect.anything());
+    expect(BoxCtor.create).toHaveBeenCalledTimes(1);
+    expect(sandbox.status).toBe('running');
+  });
+
+  it('destroy() deletes the box', async () => {
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb' });
+    await sandbox._start();
+    await sandbox._destroy();
+
+    expect(mockBox.delete).toHaveBeenCalled();
+    expect(sandbox.status).toBe('destroyed');
+    expect(sandbox.remoteId).toBeUndefined();
+  });
+
+  it('destroy() on a pending sandbox transitions directly to destroyed', async () => {
+    const sandbox = new UpstashBoxSandbox();
+    expect(sandbox.status).toBe('pending');
+    await sandbox._destroy();
+    expect(sandbox.status).toBe('destroyed');
+    expect(BoxCtor.create).not.toHaveBeenCalled();
+  });
+
+  it('start() is idempotent when already running', async () => {
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb' });
+    await sandbox._start();
+    await sandbox._start();
+
+    expect(BoxCtor.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes env, size, networkPolicy, and skills to create()', async () => {
+    const sandbox = new UpstashBoxSandbox({
+      env: { NODE_ENV: 'test' },
+      size: 'large',
+      networkPolicy: { mode: 'deny-all' },
+      skills: ['upstash/workflow-js'],
+    });
+    await sandbox._start();
+
+    expect(BoxCtor.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { NODE_ENV: 'test' },
+        size: 'large',
+        networkPolicy: { mode: 'deny-all' },
+        skills: ['upstash/workflow-js'],
+      }),
+    );
+  });
+
+  it('omits env when empty', async () => {
+    const sandbox = new UpstashBoxSandbox({});
+    await sandbox._start();
+
+    const params = BoxCtor.create.mock.calls[0]![0] as Record<string, unknown>;
+    expect(params.env).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getInfo / getInstructions
+// ---------------------------------------------------------------------------
+
+describe('UpstashBoxSandbox metadata', () => {
+  it('getInfo() returns sandbox metadata', async () => {
+    const sandbox = new UpstashBoxSandbox({ id: 'test-sb', runtime: 'python', size: 'medium' });
+    await sandbox._start();
+
+    const info = await sandbox.getInfo();
+    expect(info.id).toBe('test-sb');
+    expect(info.provider).toBe('upstash-box');
+    expect(info.status).toBe('running');
+    expect(info.metadata?.runtime).toBe('python');
+    expect(info.metadata?.size).toBe('medium');
+    expect(info.metadata?.boxId).toBe('box-test-123');
+  });
+
+  it('getInstructions() includes runtime and size', () => {
+    const sandbox = new UpstashBoxSandbox({ runtime: 'python', size: 'large' });
+    const instructions = sandbox.getInstructions();
+    expect(instructions).toContain('python');
+    expect(instructions).toContain('large');
+  });
+
+  it('getInstructions() respects string override', () => {
+    const sandbox = new UpstashBoxSandbox({ instructions: 'custom instructions' });
+    expect(sandbox.getInstructions()).toBe('custom instructions');
+  });
+
+  it('getInstructions() respects function override receiving default', () => {
+    const sandbox = new UpstashBoxSandbox({
+      instructions: ({ defaultInstructions }) => `${defaultInstructions} Extra.`,
+    });
+    expect(sandbox.getInstructions()).toContain('Extra.');
+  });
+
+  it('box getter throws when not started', () => {
+    const sandbox = new UpstashBoxSandbox();
+    expect(() => sandbox.box).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Process management
+// ---------------------------------------------------------------------------
+
+describe('UpstashBoxProcessManager', () => {
+  async function startedSandbox(opts?: UpstashBoxSandboxOptions) {
+    const sandbox = new UpstashBoxSandbox(opts);
+    await sandbox._start();
+    return sandbox;
+  }
+
+  it('spawn() launches a detached process and returns a handle with a pid', async () => {
+    queueProc({ out: 'hello\n', code: '0' });
+
+    const sandbox = await startedSandbox({ id: 'proc-test' });
+    const handle = await sandbox.processes.spawn('echo hello');
+
+    expect(handle.pid).toMatch(/^box-proc-/);
+    // First call is the launch command carrying the base64 harness.
+    expect(mockBox.exec.command.mock.calls[0]![0]).toContain('base64 -d');
+  });
+
+  it('wait() returns accumulated stdout and exit code', async () => {
+    queueProc({ out: 'hello\nworld\n', code: '0' });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('echo hello');
+    const result = await handle.wait();
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('hello\nworld\n');
+    expect(result.killed).toBeUndefined();
+    expect(result.timedOut).toBeUndefined();
+  });
+
+  it('does not report success when the exit code is briefly unobservable after exit', async () => {
+    // Process is gone but the harness hasn't written the code file yet on the
+    // first DONE poll; the grace poll should still pick up the real non-zero code.
+    queueProc({ code: '7', codeDelayPolls: 2 });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('cmd');
+    const result = await handle.wait();
+
+    expect(result.exitCode).toBe(7);
+    expect(result.success).toBe(false);
+  });
+
+  it('captures stderr separately from stdout', async () => {
+    queueProc({ out: 'out\n', err: 'err\n', code: '0' });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('cmd');
+    const result = await handle.wait();
+
+    expect(result.stdout).toBe('out\n');
+    expect(result.stderr).toBe('err\n');
+  });
+
+  it('wait() returns failure for non-zero exit code', async () => {
+    queueProc({ out: 'boom\n', code: '2' });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('false');
+    const result = await handle.wait();
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('wait() is idempotent — returns the same result on repeated calls', async () => {
+    queueProc({ out: 'out\n', code: '0' });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('cmd');
+    const r1 = await handle.wait();
+    const r2 = await handle.wait();
+
+    expect(r1).toEqual(r2);
+  });
+
+  it('exitCode is undefined while the process is still running', async () => {
+    queueProc({ runningPolls: Infinity });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('sleep 60');
+
+    expect(handle.exitCode).toBeUndefined();
+  });
+
+  it('spawn() bakes env exports into the harness script', async () => {
+    queueProc({ code: '0' });
+
+    const sandbox = await startedSandbox({ env: { BASE: 'base' } });
+    await sandbox.processes.spawn('true', { env: { EXTRA: 'extra' } });
+
+    const script = decodeLaunchedScript(mockBox.exec.command.mock.calls[0]![0] as string);
+    expect(script).toContain('export BASE=base');
+    expect(script).toContain('export EXTRA=extra');
+  });
+
+  it('spawn() bakes cwd into the harness script and fails the command if cd fails', async () => {
+    queueProc({ code: '0' });
+
+    const sandbox = await startedSandbox();
+    await sandbox.processes.spawn('pwd', { cwd: '/app' });
+
+    const script = decodeLaunchedScript(mockBox.exec.command.mock.calls[0]![0] as string);
+    // cd runs inside the subshell with `|| exit 1` so a bad cwd is a hard failure.
+    expect(script).toContain('cd /app || exit 1;');
+  });
+
+  it('spawn() rejects invalid env var names', async () => {
+    const sandbox = await startedSandbox();
+    await expect(sandbox.processes.spawn('true', { env: { 'BAD-NAME': 'x' } })).rejects.toThrow(
+      /environment variable name/i,
+    );
+  });
+
+  it('kill() signals the process and returns true; wait() reports the kill', async () => {
+    queueProc({ runningPolls: Infinity });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('sleep 100');
+
+    const killed = await handle.kill();
+    expect(killed).toBe(true);
+
+    const result = await handle.wait();
+    expect(result.success).toBe(false);
+    expect(result.killed).toBe(true);
+    expect(result.timedOut).toBe(false);
+    // SIGTERM exit code recorded by the harness.
+    expect(result.exitCode).toBe(143);
+  });
+
+  it('wait() with a per-spawn timeout returns exitCode 124', async () => {
+    queueProc({ runningPolls: Infinity });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('sleep 100', { timeout: 50 });
+    const result = await handle.wait();
+
+    expect(result.exitCode).toBe(124);
+    expect(result.success).toBe(false);
+    expect(result.killed).toBe(true);
+    expect(result.timedOut).toBe(true);
+  }, 5000);
+
+  it('sandbox-level timeout applies as the default command timeout', async () => {
+    queueProc({ runningPolls: Infinity });
+
+    // No per-spawn timeout — the sandbox `timeout` option should bound it.
+    const sandbox = await startedSandbox({ timeout: 50 });
+    const handle = await sandbox.processes.spawn('sleep 100');
+    const result = await handle.wait();
+
+    expect(result.exitCode).toBe(124);
+    expect(result.timedOut).toBe(true);
+  }, 5000);
+
+  it('sendStdin() throws not supported', async () => {
+    queueProc({ runningPolls: Infinity });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('cat');
+    await expect(handle.sendStdin('hi')).rejects.toThrow(/stdin/i);
+  });
+
+  it('list() returns tracked processes', async () => {
+    queueProc({ runningPolls: Infinity });
+    const sandbox = await startedSandbox();
+    await sandbox.processes.spawn('cmd1');
+    queueProc({ runningPolls: Infinity });
+    await sandbox.processes.spawn('cmd2');
+
+    const list = await sandbox.processes.list();
+    expect(list.map(p => p.command)).toContain('cmd1');
+    expect(list.map(p => p.command)).toContain('cmd2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dead-box retry
+// ---------------------------------------------------------------------------
+
+describe('UpstashBoxSandbox.retryOnDead()', () => {
+  it('retries once on a 404 and succeeds against a fresh box', async () => {
+    const sim = mockBox.exec.command;
+    let launchCount = 0;
+    mockBox.exec.command = vi.fn(async (cmd: string) => {
+      if (cmd.includes('base64 -d') && launchCount++ === 0) {
+        throw new BoxError('box not found', 404);
+      }
+      return sim(cmd);
+    });
+    queueProc({ out: 'ok\n', code: '0' });
+
+    const sandbox = new UpstashBoxSandbox({ id: 'retry-test' });
+    await sandbox._start();
+
+    const handle = await sandbox.processes.spawn('echo ok');
+    const result = await handle.wait();
+
+    expect(result.stdout).toBe('ok\n');
+    // A fresh box is created after the dead one is dropped.
+    expect(BoxCtor.create).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry on non-dead errors', async () => {
+    let calls = 0;
+    mockBox.exec.command = vi.fn(async () => {
+      calls++;
+      throw new BoxError('permission denied', 403);
+    });
+
+    const sandbox = new UpstashBoxSandbox({ id: 'non-dead' });
+    await sandbox._start();
+
+    await expect(sandbox.processes.spawn('cmd')).rejects.toThrow('permission denied');
+    expect(calls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Editor provider descriptor
+// ---------------------------------------------------------------------------
+
+describe('upstashBoxSandboxProvider', () => {
+  it('exposes the expected descriptor', () => {
+    expect(upstashBoxSandboxProvider.id).toBe('upstash-box');
+    expect(upstashBoxSandboxProvider.name).toBeTruthy();
+    expect(upstashBoxSandboxProvider.configSchema).toBeTypeOf('object');
+  });
+
+  it('createSandbox() returns an UpstashBoxSandbox with the given config', () => {
+    const sandbox = upstashBoxSandboxProvider.createSandbox({ boxId: 'box-from-editor', runtime: 'python' });
+    expect(sandbox).toBeInstanceOf(UpstashBoxSandbox);
+    expect((sandbox as UpstashBoxSandbox).provider).toBe('upstash-box');
+    expect((sandbox as UpstashBoxSandbox).remoteId).toBe('box-from-editor');
+  });
+});

--- a/workspaces/upstash-box/src/sandbox/sandbox.test.ts
+++ b/workspaces/upstash-box/src/sandbox/sandbox.test.ts
@@ -515,6 +515,17 @@ describe('UpstashBoxProcessManager', () => {
     expect(result.exitCode).toBe(2);
   });
 
+  it('treats malformed exit code content as failure (never coerces to success)', async () => {
+    queueProc({ code: 'not-a-number' });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('cmd');
+    const result = await handle.wait();
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+
   it('wait() is idempotent — returns the same result on repeated calls', async () => {
     queueProc({ out: 'out\n', code: '0' });
 
@@ -591,6 +602,18 @@ describe('UpstashBoxProcessManager', () => {
     expect(result.exitCode).toBe(124);
     expect(result.success).toBe(false);
     expect(result.killed).toBe(true);
+    expect(result.timedOut).toBe(true);
+  }, 5000);
+
+  it('timeout: 0 triggers immediate timeout handling', async () => {
+    queueProc({ runningPolls: Infinity });
+
+    const sandbox = await startedSandbox();
+    const handle = await sandbox.processes.spawn('sleep 100', { timeout: 0 });
+    const result = await handle.wait();
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(124);
     expect(result.timedOut).toBe(true);
   }, 5000);
 

--- a/workspaces/upstash-box/src/utils/shell-quote.ts
+++ b/workspaces/upstash-box/src/utils/shell-quote.ts
@@ -1,0 +1,12 @@
+/**
+ * Shell-quote a single argument for safe use in a command string.
+ *
+ * Arguments containing only safe characters are returned as-is.
+ * All others are wrapped in single quotes with embedded single quotes escaped.
+ */
+export function shellQuote(arg: string): string {
+  // Safe characters that don't need quoting
+  if (/^[a-zA-Z0-9._\-/@:=]+$/.test(arg)) return arg;
+  // Wrap in single quotes, escaping any embedded single quotes
+  return "'" + arg.replace(/'/g, "'\\''") + "'";
+}

--- a/workspaces/upstash-box/tsconfig.build.json
+++ b/workspaces/upstash-box/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/upstash-box/tsconfig.json
+++ b/workspaces/upstash-box/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/upstash-box/tsup.config.ts
+++ b/workspaces/upstash-box/tsup.config.ts
@@ -1,0 +1,18 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  external: ['@mastra/core'],
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/workspaces/upstash-box/vitest.config.ts
+++ b/workspaces/upstash-box/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+    setupFiles: ['dotenv/config'],
+    testTimeout: 60000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a new `@mastra/upstash-box` workspace package that implements `UpstashBoxSandbox` and editor provider metadata
- include detached-process management, reconnect/retry handling, and comprehensive unit/integration tests for command execution semantics
- add docs + reference pages and sidebar/workspace docs updates, plus a changeset and lockfile updates for release wiring

## Test plan
- [x] `./node_modules/.bin/vitest run --root \"/Users/alitarik/Desktop/mastra/workspaces/upstash-box\" src/sandbox/sandbox.test.ts`
- [x] `eslint` run for `workspaces/upstash-box/src`
- [x] credentialed integration tests for Upstash Box (`sandbox.integration.test.ts`)

Fixes [#17947](https://github.com/mastra-ai/mastra/issues/17947#issue-4665719558)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR adds a new “Upstash Box sandbox” option so your Mastra AI agents can run commands in a safe cloud sandbox. It also helps things keep working if the connection drops—by reconnecting and retrying—and it manages the agent command as a background, detached process.

## Overview

This PR introduces the new `@mastra/upstash-box` workspace package, which implements an Upstash Box sandbox provider for Mastra workspaces. It enables agent workloads to run inside Upstash Box sandboxes with robust lifecycle handling (start/stop/destroy, reconnect-by-id, retry/recovery) and detached background process execution.

## Core Implementation

### `UpstashBoxSandbox` (workspaces/upstash-box/src/sandbox/index.ts)
- Implements sandbox lifecycle: `_start`, `_stop`, `_destroy`
- Supports reconnecting to an existing sandbox using `boxId`, including correct handling for paused/creating states
- Adds dead-box retry logic to recover from “box gone” scenarios by dropping stale state and recreating the box
- Provides status/info/instructions methods and exposes the underlying Upstash SDK via a `box` getter
- Generates/customizes sandbox “instructions” (default or user-provided)

### `UpstashBoxProcessManager` (workspaces/upstash-box/src/sandbox/process-manager.ts)
- Implements detached/background process execution semantics compatible with Mastra’s sandbox process interface
- Builds a per-command harness that runs the user command and captures:
  - exit code via a remote `code` file
  - stdout/stderr via remote `out`/`err` files with byte-offset polling
- Polls for completion and streams incremental output
- Hardened exit-code handling so malformed exit-code content won’t be incorrectly treated as success
- Timeout handling that correctly treats `timeout=0` as an explicit immediate timeout (not a truthiness edge case)
- `wait()` is idempotent; on timeout it kills the process and returns exit code `124`
- `sendStdin()` is explicitly unsupported (throws)
- Validates environment variable names before exporting them into the harness

### `upstashBoxSandboxProvider` (workspaces/upstash-box/src/provider.ts)
- Adds the editor/workspace provider descriptor for `id: "upstash-box"`
- Defines a config schema for credentials and sandbox options (e.g., `apiKey`, `baseUrl`, `boxId`, `runtime`, `size`, `keepAlive`, `env`, `workdir`, `networkPolicy`, `skills`, `timeout`, `requestTimeout`, `debug`)
- Wires sandbox creation via `createSandbox` to instantiate `UpstashBoxSandbox`

### Utilities
- Adds `shellQuote()` (workspaces/upstash-box/src/utils/shell-quote.ts) for safe shell argument quoting

## Testing

- **Unit tests** (workspaces/upstash-box/src/sandbox/sandbox.test.ts, Vitest)
  - Covers sandbox lifecycle, reconnect/retry behavior, and error-state transitions
  - Validates detached process semantics: spawn/wait/kill, streaming output polling, idempotent `wait()`
  - Verifies hardened exit parsing and correct timeout behavior, including `timeout: 0`
  - Confirms env var export safety and `sendStdin()` rejection
  - Checks provider descriptor + `createSandbox()` wiring

- **Integration tests** (workspaces/upstash-box/src/sandbox/sandbox.integration.test.ts)
  - Conditionally runs real Upstash Box command conformance tests when `UPSTASH_BOX_API_KEY` is set
  - Includes cleanup logic and credential-missing handling via skipped suites/placeholders

## Documentation / Release Wiring

- Adds docs for the new provider:
  - New reference page: `docs/src/content/en/reference/workspace/upstash-box-sandbox.mdx`
  - Updates sandbox provider listings: `docs/src/content/en/docs/workspace/sandbox.mdx`
  - Adds sidebar entry: `docs/src/content/en/reference/sidebars.js`
- Adds workspace package docs/README and `.env.example`, plus standard workspace config files (lint/build/test configs, changelog)
- Adds a changeset for releasing `@mastra/upstash-box` as a minor update

## Package Characteristics
- New ESM/CJS dual export package (`workspaces/upstash-box/package.json`) targeting Node `>=22.13.0`
- Depends on `@upstash/box` and peers `@mastra/core`
- Includes `UpstashBoxSandbox` and `UpstashBoxProcessManager` exports from `workspaces/upstash-box/src/index.ts`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->