### PR TITLE
fix(memory): prevent circular JSON crash with workflow-composed processors

### DIFF
--- a/.changeset/circular-json-processor-workflow.md
+++ b/.changeset/circular-json-processor-workflow.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed a "Converting circular structure to JSON" crash that happened when Observational Memory was enabled and an input or output processor was composed as a workflow (the documented "run guardrails in parallel" pattern).
+
+Observational Memory tracks each turn with internal runtime objects that reference one another in a cycle. That cycle reached the nested processor workflow's persisted snapshot, where it broke storage two ways: PostgreSQL (and any adapter that uses a plain `JSON.stringify`) threw outright, while LibSQL silently persisted a corrupted snapshot with the cycle rewritten to `"[Circular]"`. Observational Memory now serializes those runtime objects to a compact, acyclic form, so workflow-composed guardrails and Observational Memory work together and snapshots persist intact.

--- a/.changeset/circular-json-processor-workflow.md
+++ b/.changeset/circular-json-processor-workflow.md
@@ -2,6 +2,6 @@
 '@mastra/memory': patch
 ---
 
-Fixed a "Converting circular structure to JSON" crash that happened when Observational Memory was enabled and an input or output processor was composed as a workflow (the documented "run guardrails in parallel" pattern).
+Fixed a "Converting circular structure to JSON" crash when Observational Memory was used with an input or output processor composed as a workflow (the "run guardrails in parallel" pattern).
 
-Observational Memory tracks each turn with internal runtime objects that reference one another in a cycle. That cycle reached the nested processor workflow's persisted snapshot, where it broke storage two ways: PostgreSQL (and any adapter that uses a plain `JSON.stringify`) threw outright, while LibSQL silently persisted a corrupted snapshot with the cycle rewritten to `"[Circular]"`. Observational Memory now serializes those runtime objects to a compact, acyclic form, so workflow-composed guardrails and Observational Memory work together and snapshots persist intact.
+The circular data reached the processor workflow's snapshot and broke storage: PostgreSQL threw, and LibSQL saved a corrupted snapshot. Observational Memory now keeps its runtime data in a serializable form, so workflow-composed processors work with it and snapshots persist correctly.

--- a/packages/memory/src/processors/observational-memory/__tests__/processor-workflow-circular.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/processor-workflow-circular.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Reproduction + fix verification for issue #17933:
+ * "Converting circular structure to JSON" when an input processor is composed as a
+ * workflow while Observational Memory is enabled.
+ *
+ * Real path (no synthetic circular objects):
+ *  - An agent has Observational Memory enabled. OM's processor builds a real
+ *    `ObservationTurn`, and `turn.step(n)` wires up an `ObservationStep`, creating the
+ *    `ObservationTurn._currentStep -> ObservationStep.turn -> ObservationTurn` cycle.
+ *  - OM stashes the live turn in the shared processor-state map (`state.__omTurn`) so the
+ *    input and output OM processor instances can share it within one request.
+ *  - A second input processor is composed as a workflow (the documented "run guardrails in
+ *    parallel" pattern). The agent runs all input processors as a combined
+ *    `${id}-input-processor` workflow; the guardrails workflow becomes a nested workflow
+ *    whose pending snapshot carries the processor state in `context.input`.
+ *  - Serializing that snapshot reaches the OM cycle and used to throw.
+ *
+ * The fix is at the source: `ObservationTurn`/`ObservationStep` project to a minimal, acyclic
+ * representation via `toJSON()`, so any `JSON.stringify` of a snapshot that happens to carry a
+ * turn produces a correct, lossless value instead of crashing.
+ */
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import type { InputProcessorOrWorkflow } from '@mastra/core/processors';
+import { ProcessorStepSchema } from '@mastra/core/processors';
+import { InMemoryStore } from '@mastra/core/storage';
+import { createWorkflow, createStep } from '@mastra/core/workflows';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { Memory } from '../../../index';
+import { ObservationStep } from '../observation-turn/step';
+import { ObservationTurn } from '../observation-turn/turn';
+
+function createMockAgentModel(responseText: string) {
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      text: responseText,
+      content: [{ type: 'text' as const, text: responseText }],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start' as const, warnings: [] },
+        { type: 'response-metadata' as const, id: 'mock-response', modelId: 'mock-model', timestamp: new Date(0) },
+        { type: 'text-start' as const, id: 'text-1' },
+        { type: 'text-delta' as const, id: 'text-1', delta: responseText },
+        { type: 'text-end' as const, id: 'text-1' },
+        {
+          type: 'finish' as const,
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        },
+      ]),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
+function createMockObserverModel() {
+  const text = `<observations>
+## January 28, 2026
+### Thread: test
+- 🔴 User asked for help
+</observations>
+<current-task>Help</current-task>`;
+  return new MockLanguageModelV2({
+    doGenerate: async () => {
+      throw new Error('Unexpected doGenerate call — OM should use the stream path');
+    },
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'obs-1', modelId: 'mock-observer-model', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: text },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 50, outputTokens: 100, totalTokens: 150 } },
+      ]),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
+const longResponseText =
+  `I understand your request completely. Let me provide you with a comprehensive and detailed ` +
+  `response that covers all the important aspects of what you asked about. Here are my thoughts ` +
+  `and recommendations based on the information you provided.`;
+
+// A trivial input processor composed as a workflow — the documented guardrails-in-parallel
+// pattern, minimised to a single pass-through step. It is detected as a ProcessorWorkflow.
+function createGuardrailWorkflow(): InputProcessorOrWorkflow {
+  return createWorkflow({
+    id: 'input-guardrails',
+    inputSchema: ProcessorStepSchema,
+    outputSchema: ProcessorStepSchema,
+  })
+    .then(createStep({ id: 'guard', processInput: async ({ messages }) => messages }))
+    .commit() as unknown as InputProcessorOrWorkflow;
+}
+
+// Recursively look for the ObservationTurn projection produced by `ObservationTurn.toJSON()`.
+function findTurnProjection(value: unknown, seen = new Set<unknown>()): Record<string, unknown> | undefined {
+  if (value === null || typeof value !== 'object' || seen.has(value)) return undefined;
+  seen.add(value);
+  const obj = value as Record<string, unknown>;
+  if (obj.threadId === 'thread-1' && typeof obj.started === 'boolean' && typeof obj.ended === 'boolean') {
+    return obj;
+  }
+  for (const child of Object.values(obj)) {
+    const found = findTurnProjection(child, seen);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+describe('processor workflow + observational memory (issue #17933)', () => {
+  let store: InMemoryStore;
+  let memory: Memory;
+
+  beforeEach(() => {
+    store = new InMemoryStore();
+    memory = new Memory({
+      storage: store,
+      options: {
+        observationalMemory: {
+          enabled: true,
+          observation: {
+            model: createMockObserverModel() as any,
+            messageTokens: 20,
+            bufferTokens: false,
+          },
+          reflection: {
+            observationTokens: 50000,
+          },
+        },
+      },
+    });
+  });
+
+  // Make the workflows store serialize the snapshot the way a standard SQL adapter (e.g. pg) does:
+  // a plain JSON.stringify with no circular-safe replacer. libsql's safeStringify hides the bug by
+  // silently rewriting cycles to "[Circular]" — that lossy behaviour is exactly what we must NOT
+  // rely on. Capture every snapshot so the test can prove they round-trip losslessly. If a snapshot
+  // is unserializable, report which top-level field still holds the cycle.
+  async function captureSnapshotSerialization(storage: InMemoryStore) {
+    // Capture the serialized string at persist time — the live snapshot objects are mutated
+    // later in the run (e.g. the turn is cleared on end()), so a post-run reference is stale.
+    const captured: string[] = [];
+    const workflowsStore: any = await storage.getStore('workflows');
+    const original = workflowsStore.persistWorkflowSnapshot.bind(workflowsStore);
+    vi.spyOn(workflowsStore, 'persistWorkflowSnapshot').mockImplementation(async (args: any) => {
+      try {
+        captured.push(JSON.stringify(args.snapshot));
+      } catch (error) {
+        const circularFields = Object.keys(args.snapshot ?? {}).filter(field => {
+          try {
+            JSON.stringify(args.snapshot[field]);
+            return false;
+          } catch {
+            return true;
+          }
+        });
+        throw new Error(
+          `Snapshot for "${args.workflowName}" (status: ${args.snapshot?.status}) is not JSON-serializable. ` +
+            `Circular field(s): [${circularFields.join(', ')}]. Cause: ${(error as Error).message}`,
+        );
+      }
+      return original(args);
+    });
+    return captured;
+  }
+
+  it('serializes the workflow snapshot losslessly with a workflow-composed input processor', async () => {
+    const agent = new Agent({
+      id: 'om-guardrails-agent',
+      name: 'om-guardrails-agent',
+      instructions: 'You are a helpful assistant.',
+      model: createMockAgentModel(longResponseText) as any,
+      memory,
+      inputProcessors: [createGuardrailWorkflow()],
+    });
+    const mastra = new Mastra({
+      agents: { 'om-guardrails-agent': agent },
+      storage: store,
+      logger: false,
+    });
+    const snapshots = await captureSnapshotSerialization(store);
+
+    // Before the fix this rejects with "Converting circular structure to JSON".
+    const result = await mastra
+      .getAgent('om-guardrails-agent')
+      .generate('Hello, I need help with something important.', {
+        memory: { thread: 'thread-1', resource: 'resource-1' },
+      });
+    expect(result.text).toBeTruthy();
+
+    // Losslessness: the turn rode into at least one persisted snapshot, and that snapshot
+    // round-trips to a CORRECT, acyclic projection of the turn — not a "[Circular]" stub.
+    const turnProjection = snapshots.map(s => findTurnProjection(JSON.parse(s))).find(Boolean);
+    expect(turnProjection).toBeDefined();
+    expect(turnProjection).toMatchObject({ threadId: 'thread-1', resourceId: 'resource-1', started: true });
+    // No mangled circular markers leaked into any snapshot.
+    for (const snapshot of snapshots) {
+      expect(snapshot).not.toContain('[Circular]');
+    }
+
+    // The real Observational Memory record persisted correctly through the run.
+    const memoryStore = await store.getStore('memory');
+    const record = await memoryStore!.getObservationalMemory('thread-1', 'resource-1');
+    expect(record).toBeTruthy();
+  });
+});
+
+describe('ObservationTurn/ObservationStep serialization contract', () => {
+  it('projects the turn<->step cycle to a minimal acyclic value without mutating the live objects', () => {
+    const turn = new ObservationTurn({
+      om: { scope: 'thread' } as any,
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      messageList: {} as any,
+    });
+    // Reproduce the real cycle: turn._currentStep -> step.turn -> turn.
+    const step = new ObservationStep(turn, 2);
+    (turn as unknown as { _currentStep: ObservationStep })._currentStep = step;
+
+    // Sanity: the raw cycle is what JSON.stringify chokes on without toJSON.
+    expect(turn.currentStep).toBe(step);
+
+    // toJSON breaks the cycle and yields a correct, acyclic projection.
+    expect(() => JSON.stringify(turn)).not.toThrow();
+    expect(JSON.parse(JSON.stringify(turn))).toEqual({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      started: false,
+      ended: false,
+      currentStepNumber: 2,
+    });
+
+    expect(() => JSON.stringify(step)).not.toThrow();
+    expect(JSON.parse(JSON.stringify(step))).toEqual({ stepNumber: 2, prepared: false });
+
+    // The live objects are untouched — toJSON only changes the JSON projection.
+    expect(turn.currentStep).toBe(step);
+    expect(step.stepNumber).toBe(2);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -29,6 +29,19 @@ export class ObservationStep {
     return this._prepared;
   }
 
+  /**
+   * Serialize to a minimal, acyclic snapshot.
+   *
+   * The `turn` back-reference exists only so a step can read context off its parent turn at
+   * runtime. It closes the `ObservationTurn._currentStep -> ObservationStep.turn` cycle, so
+   * serializing it throws "Converting circular structure to JSON" (e.g. when a turn is stashed
+   * in processor state that flows into a processor-workflow snapshot). The parent turn fully
+   * owns the step, so omitting the back-reference is lossless.
+   */
+  toJSON() {
+    return { stepNumber: this.stepNumber, prepared: this._prepared };
+  }
+
   /** Step context from prepare(). Throws if prepare() hasn't been called. */
   get context(): StepContext {
     if (!this._context) throw new Error('Step not prepared yet — call prepare() first');

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -244,4 +244,32 @@ export class ObservationTurn {
     }
     return this._context?.otherThreadsContext;
   }
+
+  /**
+   * Serialize to a minimal, acyclic snapshot of the turn's identity and lifecycle.
+   *
+   * `ObservationTurn` is a request-scoped runtime orchestration object: it holds live
+   * references (the `ObservationalMemory` engine, the `MessageList`, the stream writer, the
+   * memory provider, lifecycle hooks) and a back-reference to its current `ObservationStep`,
+   * which points back at the turn — a cycle. None of that is persistable state. The turn is
+   * stashed in the shared processor-state map (`state.__omTurn`) only so the input and output
+   * OM processor instances can reach the *live* object within a single request; that map is
+   * also threaded into processor workflows, whose snapshots the storage layer serializes with
+   * `JSON.stringify`. Without this projection, that serialization throws "Converting circular
+   * structure to JSON" via `_currentStep` <-> `turn`.
+   *
+   * The projection is lossless: the dropped fields are live runtime objects that cannot and
+   * should not round-trip through storage, and OM never reads the turn back from a snapshot —
+   * it always reads the live `__omTurn` from the in-memory map and re-establishes a fresh turn
+   * when a deserialized `MessageList` no longer matches (see the processor's turn handling).
+   */
+  toJSON() {
+    return {
+      threadId: this.threadId,
+      resourceId: this.resourceId,
+      started: this._started,
+      ended: this._ended,
+      currentStepNumber: this._currentStep?.stepNumber,
+    };
+  }
 }

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -13,6 +13,20 @@ import { isOmReproCaptureEnabled, safeCaptureJson, writeProcessInputStepReproCap
 import { insertTemporalGapMarkers } from './temporal-markers';
 import type { TokenCounterModelContext } from './token-counter';
 
+/**
+ * Coerce a shared `state.__omTurn` value to a usable live turn.
+ *
+ * The turn is stashed in the shared processor-state map as a live `ObservationTurn`, but it
+ * serializes (via `ObservationTurn.toJSON`) to a plain, method-less projection. If such a snapshot
+ * were ever resumed back through here, `__omTurn` would be that plain object and calling `.end()`
+ * on it would throw a synchronous TypeError the surrounding `.catch()` could not trap. Only treat a
+ * value with a callable `end()` as a turn, so OM falls through to creating a fresh one. In practice
+ * OM reads the live turn from the in-memory map, so this is defensive.
+ */
+function asLiveTurn(value: unknown): ObservationTurn | undefined {
+  return value && typeof (value as ObservationTurn).end === 'function' ? (value as ObservationTurn) : undefined;
+}
+
 /** Subset of Memory that the processor needs — avoids circular imports. */
 export interface MemoryContextProvider {
   getContext(opts: { threadId: string; resourceId?: string }): Promise<{
@@ -214,7 +228,7 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
       // processOutputResult. In production, getInputProcessors() and
       // getOutputProcessors() each call createOMProcessor(), producing two
       // different instances that share only the processorStates map.
-      const activeTurn = (state.__omTurn as ObservationTurn | undefined) ?? this.turn;
+      const activeTurn = asLiveTurn(state.__omTurn) ?? this.turn;
       if (activeTurn && activeTurn.messageList !== messageList) {
         // Durable runs may deserialize a fresh MessageList between loop iterations. End the
         // old turn first so any messages tracked on that list are flushed before OM moves on.
@@ -365,7 +379,7 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
 
         // Retrieve the turn from shared processor state — in production, the input
         // and output processors are separate instances (see comment in processInputStep).
-        const turn = (state.__omTurn as ObservationTurn | undefined) ?? this.turn;
+        const turn = asLiveTurn(state.__omTurn) ?? this.turn;
         if (turn) {
           await turn.end();
           this.turn = undefined;


### PR DESCRIPTION
## Description

When an agent has Observational Memory turned on and you compose an input or output processor as a workflow (the "run guardrails in parallel" pattern from the docs), every request crashed with "Converting circular structure to JSON".

Here is what was happening. Observational Memory keeps a live `ObservationTurn` for the request and stashes it in the shared processor state map so the separate input and output processor instances can find it. The turn and its current step hold references to each other, which is a cycle. The agent runs all of its input processors as one combined workflow, so a processor that is itself a workflow becomes a nested workflow. That nested workflow persists a snapshot, and the snapshot carries the processor state, so the live turn (and its cycle) ends up being serialized. Postgres, and any adapter that uses a plain `JSON.stringify`, threw outright. LibSQL did not throw but quietly wrote a corrupted snapshot with the cycle rewritten to "[Circular]".

The same processors used directly, as a flat list rather than wrapped in a workflow, were never affected, because that path does not serialize the processor state. That is the difference between the two setups.

The fix is at the source. `ObservationTurn` and `ObservationStep` now have a `toJSON` that returns a small, acyclic projection of the turn's identity and lifecycle. The fields it drops are live runtime objects (the memory engine, the message list, the stream writer, the step back reference) that should never round trip through storage, and Observational Memory always reads the live turn from the in-memory map rather than from a snapshot, so nothing real is lost. As a small bit of defense, the two spots that read the shared turn now coerce it to a live instance, so a projected object coming back from a resumed snapshot cannot throw on `end()`.

### Testing

Added a test that reproduces the real path: an agent with Observational Memory plus a workflow-composed input processor. It fails with the exact original error when the fix is reverted, and it asserts the persisted snapshot round trips to a correct acyclic value rather than a "[Circular]" stub. There is also a focused unit test for the `toJSON` contract. The full Observational Memory suite (898 tests), the core workflows suite, and the agent processor suite all pass.

## Related issue(s)

Fixes #17933

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Observational Memory keeps track of an “observation turn” while the agent runs. When you combine it with workflow-composed processors, that in-memory object accidentally included a circular reference, so database snapshot saving crashed. This PR makes the observation turn/step objects serialize safely (no circles) and adds a small defensive check so deserialized snapshots don’t break finalization.

## Overview

Fixes a production crash when **Observational Memory** is enabled alongside a **workflow-composed input/output processor** (e.g., “run guardrails in parallel”): requests failed with **“Converting circular structure to JSON”** because live `ObservationTurn`/`ObservationStep` objects were getting stored in workflow snapshots with a circular reference (`turn ↔ current step`). This could crash PostgreSQL and corrupt the stored “[Circular]” snapshot in LibSQL.

## Changes

### Core fix: acyclic `toJSON()` projections
- **`ObservationTurn.toJSON()`** now serializes only a minimal, acyclic identity/lifecycle projection:
  - `threadId`, `resourceId`
  - `started`, `ended`
  - `currentStepNumber` (from the current step when available)
- **`ObservationStep.toJSON()`** now serializes only:
  - `stepNumber`
  - `prepared`
- Both implementations intentionally omit live runtime references (including the step↔turn back-reference cycle) so `JSON.stringify` of workflow snapshot state no longer throws.

### Defensive coercion when reading shared processor state
- **Added `asLiveTurn()` helper** in the Observational Memory processor:
  - Treats `state.__omTurn` as a real live `ObservationTurn` only if it has a callable `end()` method.
  - Updated input/output processing paths to use `asLiveTurn(state.__omTurn) ?? this.turn`, preventing synchronous errors if a stored projection is encountered.

## Testing

- **Integration test** `processor-workflow-circular.test.ts`: reproduces issue `#17933` by running an agent with Observational Memory plus a nested workflow input processor, and verifies workflow persistence snapshots serialize correctly (no circular/`[Circular]` artifacts) and that observational memory data persists.
- **Unit coverage** for the `toJSON()` contract: asserts the `ObservationTurn`/`ObservationStep` cycle is projected into an acyclic form and that `JSON.stringify` does not throw.
- Verified that existing test suites continue to pass (including the full Observational Memory suite and workflow/agent processor suites).

## Changeset

- Added a **patch changeset** for `@mastra/memory` documenting the crash fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->