### PR TITLE
fix(libsql): add write lock and SQLITE_BUSY retry to ThreadState storage

### DIFF
--- a/.changeset/fix-thread-state-sqlite-busy.md
+++ b/.changeset/fix-thread-state-sqlite-busy.md
@@ -2,4 +2,4 @@
 '@mastra/libsql': patch
 ---
 
-ThreadState storage domain now uses write serialization and automatic retry on SQLITE_BUSY errors, preventing lost writes when concurrent agent operations access the same LibSQL database.
+Fixed ThreadState LibSQL writes by adding write serialization and automatic SQLITE_BUSY retries, preventing lost writes when concurrent agent operations access the same LibSQL database.

--- a/.changeset/fix-thread-state-sqlite-busy.md
+++ b/.changeset/fix-thread-state-sqlite-busy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+ThreadState storage domain now uses write serialization and automatic retry on SQLITE_BUSY errors, preventing lost writes when concurrent agent operations access the same LibSQL database.

--- a/stores/libsql/src/storage/domains/thread-state/index.test.ts
+++ b/stores/libsql/src/storage/domains/thread-state/index.test.ts
@@ -1,6 +1,6 @@
 import type { Client } from '@libsql/client';
 import { createClient } from '@libsql/client';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ThreadStateLibSQL } from './index';
 
@@ -72,5 +72,67 @@ describe('ThreadStateLibSQL', () => {
     const reopened = new ThreadStateLibSQL({ client, maxRetries: 1, initialBackoffMs: 10 });
     await reopened.init();
     expect(await reopened.getState({ threadId: 'thread-1', type: 'task' })).toEqual(tasks());
+  });
+
+  it('serializes concurrent writes to the same (threadId, type) without losing data', async () => {
+    // Fire multiple concurrent setState calls for the same key.
+    // The write lock should serialize them so each one sees the prior state.
+    const writes = Array.from({ length: 10 }, (_, i) =>
+      store.setState({ threadId: 'thread-1', type: 'task', value: [{ id: `t${i}`, content: `Task ${i}`, status: 'pending', activeForm: `Doing ${i}` }] }),
+    );
+    await Promise.all(writes);
+
+    // The final read should return one of the written values (last writer wins),
+    // not undefined or corrupted data.
+    const final = await store.getState<Task[]>({ threadId: 'thread-1', type: 'task' });
+    expect(final).toBeDefined();
+    expect(final).toHaveLength(1);
+    expect(final![0].id).toMatch(/^t\d+$/);
+  });
+
+  it('handles concurrent writes to different (threadId, type) keys', async () => {
+    const writes = Array.from({ length: 5 }, (_, i) =>
+      store.setState({ threadId: `thread-${i}`, type: 'task', value: [{ id: `t${i}`, content: `Task ${i}`, status: 'pending', activeForm: `Doing ${i}` }] }),
+    );
+    await Promise.all(writes);
+
+    // Each thread should have its own state
+    for (let i = 0; i < 5; i++) {
+      const state = await store.getState<Task[]>({ threadId: `thread-${i}`, type: 'task' });
+      expect(state).toBeDefined();
+      expect(state![0].id).toBe(`t${i}`);
+    }
+  });
+
+  it('retries setState when the underlying execute throws a SQLITE_BUSY error', async () => {
+    // Use a dedicated client/store with maxRetries: 2 so we get 1 initial attempt + 1 retry.
+    const busyClient = createTestClient();
+    const busyStore = new ThreadStateLibSQL({ client: busyClient, maxRetries: 2, initialBackoffMs: 1 });
+    await busyStore.init();
+
+    // Spy on the client's execute method and simulate SQLITE_BUSY on the first
+    // write call, then let subsequent calls succeed.
+    const originalExecute = busyClient.execute.bind(busyClient);
+    let writeAttempts = 0;
+    const spy = vi.spyOn(busyClient, 'execute').mockImplementation(async (stmt: any) => {
+      const sql = typeof stmt === 'string' ? stmt : stmt.sql;
+      if (sql.includes('INSERT INTO') || sql.includes('ON CONFLICT')) {
+        writeAttempts++;
+        if (writeAttempts === 1) {
+          throw Object.assign(new Error('SQLITE_BUSY: database is locked'), { code: 'SQLITE_BUSY' });
+        }
+      }
+      return originalExecute(stmt);
+    });
+
+    await busyStore.setState({ threadId: 'thread-1', type: 'task', value: tasks() });
+
+    // The first attempt threw SQLITE_BUSY, the retry succeeded — so 2 write attempts total.
+    expect(writeAttempts).toBe(2);
+    const result = await busyStore.getState<Task[]>({ threadId: 'thread-1', type: 'task' });
+    expect(result).toEqual(tasks());
+
+    spy.mockRestore();
+    busyClient.close();
   });
 });

--- a/stores/libsql/src/storage/domains/thread-state/index.test.ts
+++ b/stores/libsql/src/storage/domains/thread-state/index.test.ts
@@ -125,14 +125,16 @@ describe('ThreadStateLibSQL', () => {
       return originalExecute(stmt);
     });
 
-    await busyStore.setState({ threadId: 'thread-1', type: 'task', value: tasks() });
+    try {
+      await busyStore.setState({ threadId: 'thread-1', type: 'task', value: tasks() });
 
-    // The first attempt threw SQLITE_BUSY, the retry succeeded — so 2 write attempts total.
-    expect(writeAttempts).toBe(2);
-    const result = await busyStore.getState<Task[]>({ threadId: 'thread-1', type: 'task' });
-    expect(result).toEqual(tasks());
-
-    spy.mockRestore();
-    busyClient.close();
+      // The first attempt threw SQLITE_BUSY, the retry succeeded — so 2 write attempts total.
+      expect(writeAttempts).toBe(2);
+      const result = await busyStore.getState<Task[]>({ threadId: 'thread-1', type: 'task' });
+      expect(result).toEqual(tasks());
+    } finally {
+      spy.mockRestore();
+      busyClient.close();
+    }
   });
 });

--- a/stores/libsql/src/storage/domains/thread-state/index.ts
+++ b/stores/libsql/src/storage/domains/thread-state/index.ts
@@ -9,6 +9,8 @@ import {
 
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
+import { createExecuteWriteOperationWithRetry } from '../../db/utils';
+import { withClientWriteLock } from '../../db/write-lock';
 
 /**
  * LibSQL implementation of {@link ThreadStateStorage}.
@@ -20,12 +22,57 @@ import type { LibSQLDomainConfig } from '../../db';
 export class ThreadStateLibSQL extends ThreadStateStorage {
   #db: LibSQLDB;
   #client: Client;
+  private readonly executeWithRetry: <T>(operationFn: () => Promise<T>, operationDescription: string) => Promise<T>;
 
   constructor(config: LibSQLDomainConfig) {
     super();
     const client = resolveClient(config);
+    const maxRetries = config.maxRetries ?? 5;
+    const initialBackoffMs = config.initialBackoffMs ?? 100;
+
     this.#client = client;
-    this.#db = new LibSQLDB({ client, maxRetries: config.maxRetries, initialBackoffMs: config.initialBackoffMs });
+    this.#db = new LibSQLDB({ client, maxRetries, initialBackoffMs });
+    this.executeWithRetry = createExecuteWriteOperationWithRetry({
+      logger: this.logger,
+      maxRetries,
+      initialBackoffMs,
+    });
+
+    // Set PRAGMA settings to help with database locks
+    // Note: This is async but we can't await in constructor, so we'll handle it as a fire-and-forget
+    this.setupPragmaSettings().catch(err =>
+      this.logger.warn('LibSQL ThreadState: Failed to setup PRAGMA settings.', err),
+    );
+  }
+
+  supportsConcurrentUpdates(): boolean {
+    return true;
+  }
+
+  private async setupPragmaSettings() {
+    try {
+      // Set busy timeout to wait longer before returning busy errors
+      await this.#client.execute('PRAGMA busy_timeout = 10000;');
+      this.logger.debug('LibSQL ThreadState: PRAGMA busy_timeout=10000 set.');
+
+      // Enable WAL mode for better concurrency (if supported)
+      try {
+        await this.#client.execute('PRAGMA journal_mode = WAL;');
+        this.logger.debug('LibSQL ThreadState: PRAGMA journal_mode=WAL set.');
+      } catch {
+        this.logger.debug('LibSQL ThreadState: WAL mode not supported, using default journal mode.');
+      }
+
+      // Set synchronous mode for better durability vs performance trade-off
+      try {
+        await this.#client.execute('PRAGMA synchronous = NORMAL;');
+        this.logger.debug('LibSQL ThreadState: PRAGMA synchronous=NORMAL set.');
+      } catch {
+        this.logger.debug('LibSQL ThreadState: Failed to set synchronous mode.');
+      }
+    } catch (err) {
+      this.logger.warn('LibSQL ThreadState: Failed to set PRAGMA settings.', err);
+    }
   }
 
   async init(): Promise<void> {
@@ -38,7 +85,7 @@ export class ThreadStateLibSQL extends ThreadStateStorage {
 
   async dangerouslyClearAll(): Promise<void> {
     try {
-      await this.#client.execute(`DELETE FROM "${TABLE_THREAD_STATE}"`);
+      await this.#db.deleteData({ tableName: TABLE_THREAD_STATE });
     } catch (error) {
       throw new MastraError(
         {
@@ -77,13 +124,19 @@ export class ThreadStateLibSQL extends ThreadStateStorage {
     const now = new Date().toISOString();
     const serialized = JSON.stringify(value ?? null);
     try {
-      await this.#client.execute({
-        sql: `INSERT INTO "${TABLE_THREAD_STATE}" ("threadId", "type", "value", "createdAt", "updatedAt")
-              VALUES (?, ?, ?, ?, ?)
-              ON CONFLICT ("threadId", "type")
-              DO UPDATE SET "value" = excluded."value", "updatedAt" = excluded."updatedAt"`,
-        args: [threadId, type, serialized, now, now],
-      });
+      await this.executeWithRetry(
+        () =>
+          withClientWriteLock(this.#client, () =>
+            this.#client.execute({
+              sql: `INSERT INTO "${TABLE_THREAD_STATE}" ("threadId", "type", "value", "createdAt", "updatedAt")
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT ("threadId", "type")
+                    DO UPDATE SET "value" = excluded."value", "updatedAt" = excluded."updatedAt"`,
+              args: [threadId, type, serialized, now, now],
+            }),
+          ),
+        'setState',
+      );
     } catch (error) {
       throw new MastraError(
         {
@@ -99,10 +152,16 @@ export class ThreadStateLibSQL extends ThreadStateStorage {
 
   async deleteState({ threadId, type }: { threadId: string; type: string }): Promise<void> {
     try {
-      await this.#client.execute({
-        sql: `DELETE FROM "${TABLE_THREAD_STATE}" WHERE "threadId" = ? AND "type" = ?`,
-        args: [threadId, type],
-      });
+      await this.executeWithRetry(
+        () =>
+          withClientWriteLock(this.#client, () =>
+            this.#client.execute({
+              sql: `DELETE FROM "${TABLE_THREAD_STATE}" WHERE "threadId" = ? AND "type" = ?`,
+              args: [threadId, type],
+            }),
+          ),
+        'deleteState',
+      );
     } catch (error) {
       throw new MastraError(
         {

--- a/stores/libsql/src/storage/domains/thread-state/index.ts
+++ b/stores/libsql/src/storage/domains/thread-state/index.ts
@@ -45,10 +45,6 @@ export class ThreadStateLibSQL extends ThreadStateStorage {
     );
   }
 
-  supportsConcurrentUpdates(): boolean {
-    return true;
-  }
-
   private async setupPragmaSettings() {
     try {
       // Set busy timeout to wait longer before returning busy errors


### PR DESCRIPTION
## Summary

The ThreadState LibSQL storage domain was performing writes directly via `client.execute()` without write serialization or retry logic. This left it vulnerable to `SQLITE_BUSY` errors and silent lost writes when concurrent agent operations (task tools, goal scorer, workflow snapshots) hit the same LibSQL database — a scenario that arises frequently with the evented workflow engine.

Every other LibSQL domain (workflows, notifications, experiments, etc.) already wraps writes with `withClientWriteLock` + `executeWithRetry`. The thread-state domain was the outlier.

## Changes

- **`stores/libsql/src/storage/domains/thread-state/index.ts`**
  - `setState` and `deleteState` now go through `withClientWriteLock` (serializes writes on the shared connection) wrapped in `executeWithRetry` (automatic exponential-backoff retry on `SQLITE_BUSY` / `SQLITE_LOCKED`).
  - `dangerouslyClearAll` delegates to `LibSQLDB.deleteData`, which already handles write locking internally.
  - Added `setupPragmaSettings` (fire-and-forget in constructor) that sets `busy_timeout=10000`, `journal_mode=WAL`, and `synchronous=NORMAL` — matching the workflow domain's pattern.

- **`stores/libsql/src/storage/domains/thread-state/index.test.ts`**
  - New test: concurrent writes to the same `(threadId, type)` key are serialized without data loss.
  - New test: concurrent writes to different keys all persist correctly.
  - New test: `SQLITE_BUSY` on the first write attempt is retried and the value is persisted.

- **`.changeset/fix-thread-state-sqlite-busy.md`** — patch changeset for `@mastra/libsql`.

## Test Plan

- All 9 thread-state tests pass (including 3 new concurrency/retry tests).
- Full `stores/libsql` suite: 793 passed, 17 skipped.
- `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If several agents try to save thread state at the same time, the database can get “too busy” and either reject writes (`SQLITE_BUSY`) or risk overwriting each other. This PR makes those writes happen one-at-a-time and automatically retries when the database says it can’t accept the write yet.

---

## Summary

This PR fixes `SQLITE_BUSY` errors and potential lost writes in the `ThreadState` LibSQL storage domain during concurrent agent operations (e.g., task tools, goal scorer, workflow snapshots). Previously, `ThreadState` wrote directly without the same write-locking and retry protections used by the other LibSQL domains.

### Changes Made
- Updated `setState` and `deleteState` to:
  - serialize writes via `withClientWriteLock`
  - retry automatically on transient contention using `executeWithRetry` for `SQLITE_BUSY` / `SQLITE_LOCKED` (exponential backoff)
- Updated `dangerouslyClearAll` to delegate to `LibSQLDB.deleteData`, ensuring it follows the same internal write-locking approach
- Added `setupPragmaSettings` (run in the constructor) to configure:
  - `busy_timeout=10000`
  - `journal_mode=WAL` (with fallback logging if unsupported)
  - `synchronous=NORMAL`
- Declared concurrent update support via `supportsConcurrentUpdates(): boolean { return true }`

### Test Coverage
- Added concurrency/retry tests to verify:
  1. Concurrent writes to the same `(threadId, type)` key are serialized and don’t corrupt results
  2. Concurrent writes to different keys persist correctly
  3. A `SQLITE_BUSY` on the first attempt is retried successfully (asserting exactly two write attempts total and correct final persisted value)

### Results
All 9 thread-state tests pass. The full `stores/libsql` suite passes with 793 total tests and 17 skipped. TypeScript compilation is clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->