### PR TITLE
docs(mastra-platform): document GitHub integration

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-platform/configuration.mdx
@@ -11,7 +11,7 @@ This page explains both mechanisms and how they differ between Studio and Server
 
 ## Project config
 
-The `.mastra-project.json` file is auto-generated on your first Studio or Server deploy. It links your local project to a platform project.
+The `.mastra-project.json` file is auto-generated on your first Studio or Server deploy. It links your local project to a platform project. The [GitHub integration](/docs/mastra-platform/github) writes the same file into linked repositories.
 
 Commit it to your version control so that subsequent deploys (including from CI) target the correct project.
 

--- a/docs/src/content/en/docs/mastra-platform/github.mdx
+++ b/docs/src/content/en/docs/mastra-platform/github.mdx
@@ -137,7 +137,7 @@ After a repository is linked, every push to a configured branch triggers a deplo
 
 Each deploy carries the commit SHA, branch, and (when available) the pull request number that introduced the commit. Builds run inside the platform and report status back to GitHub as check runs on the commit.
 
-Only one build per project runs at a time. If a new push arrives while a build is in progress, the platform cancels older queued builds for the same target and runs the latest.
+Only one build per deploy target runs at a time. If a new push arrives while a build is in progress, the platform cancels older queued builds for that same target and runs the latest. Studio and Server builds are tracked independently, so they can run in parallel when both targets are configured.
 
 ### Manual GitHub deploys
 

--- a/docs/src/content/en/docs/mastra-platform/github.mdx
+++ b/docs/src/content/en/docs/mastra-platform/github.mdx
@@ -1,0 +1,194 @@
+---
+title: "GitHub integration | Mastra platform"
+description: Connect a GitHub repository to a Mastra platform project to deploy Studio and Server on every push.
+---
+
+import Steps from "@site/src/components/Steps";
+import StepItem from "@site/src/components/StepItem";
+
+# GitHub integration
+
+The GitHub integration links a Mastra platform project to a GitHub repository so that pushes to a branch deploy Studio and Server automatically. Use it when you want push-to-deploy instead of running `mastra studio deploy` or `mastra server deploy` from your terminal or CI.
+
+Once a repository is linked, the platform:
+
+- Builds and deploys Studio and Server on every push to the configured branches.
+- Provisions managed databases and the Mastra gateway API key for projects created from a template.
+- Surfaces commit, branch, and pull request context on each deploy.
+- Reports build status back to GitHub as check runs and to the project dashboard with live status badges and inline logs.
+
+## When to use the GitHub integration
+
+Choose the GitHub integration when you want one of the following:
+
+- Push-to-deploy from `main` or any other branch, including separate branches for Studio and Server.
+- A managed onboarding flow that scaffolds a project from a Mastra template, including a fresh repository, managed database, and gateway API key.
+- Pull-request and commit context inside the platform dashboard for triage.
+
+The CLI flow (`mastra studio deploy` and `mastra server deploy`) is still available for ad-hoc deploys and CI providers other than GitHub. See [Studio](/docs/mastra-platform/studio) and [Server](/docs/mastra-platform/server) for the CLI-only path.
+
+## Install the Mastra GitHub App
+
+The integration is powered by the Mastra GitHub App. The App reads repository contents, listens for `push` events on the configured branches, and writes deploy status back as check runs.
+
+<Steps>
+  <StepItem>
+    In the [Mastra platform dashboard](https://projects.mastra.ai), open your organization settings and select **GitHub**.
+  </StepItem>
+
+  <StepItem>
+    Select **Install GitHub App** and choose the GitHub account or organization to install on.
+
+    If you don't own the GitHub organization, GitHub creates a pending **installation request** that an admin must approve. The dashboard tracks pending requests alongside completed installations.
+  </StepItem>
+
+  <StepItem>
+    Select the repositories the App can access. You can scope to specific repositories or grant access to all repositories on the account.
+
+    Mastra requests only the permissions needed for push-to-deploy and check runs. You can revoke or change repository access at any time from GitHub's App settings.
+  </StepItem>
+</Steps>
+
+:::note
+If GitHub later updates the App's required permissions, the dashboard surfaces an **outdated permissions** warning with a one-click approval link. Repository operations return a `403` until an admin re-approves.
+:::
+
+### Pending installation requests
+
+When a non-admin requests the App on an organization, the request stays pending until an organization admin approves it on github.com. The dashboard:
+
+- Lists pending requests next to active installations.
+- Lets the same user request access to multiple GitHub accounts at once.
+- Reconciles pending state against GitHub when you open the page, removing requests an admin has declined or the requester has withdrawn.
+
+There's no API to cancel a pending request from Mastra. Withdraw it from github.com if you no longer need it.
+
+## Create a project from a template
+
+Templates are the fastest way to start. The platform creates a new repository from a Mastra template, links it to a fresh project, provisions any managed databases the template declares, and runs the first deploy.
+
+<Steps>
+  <StepItem>
+    In the dashboard, select **Create project** and choose **Start from a template**.
+  </StepItem>
+
+  <StepItem>
+    Pick a template and select the GitHub account that owns the new repository. Name the repository and choose whether it should be private.
+  </StepItem>
+
+  <StepItem>
+    Configure the template's managed database requirements. Templates can declare required databases (such as Turso or Neon) and you pick the provider and region per requirement.
+  </StepItem>
+
+  <StepItem>
+    Add any template-specific environment variables (for example, AI provider API keys). The platform seeds `MASTRA_GATEWAY_API_KEY` and `MASTRA_PLATFORM_ACCESS_TOKEN` automatically so that template code that talks to the Mastra gateway works on the first deploy.
+  </StepItem>
+
+  <StepItem>
+    Select **Create project**. The platform creates the repository, writes a `.mastra-project.json` config file into it, provisions the managed databases, and triggers the initial Studio and Server deploys.
+  </StepItem>
+</Steps>
+
+The initial deploy waits for managed databases to finish provisioning before it starts, so the template's first build sees the database connection environment variables.
+
+## Link an existing repository
+
+Use this flow when you already have a Mastra project in a GitHub repository.
+
+<Steps>
+  <StepItem>
+    In the dashboard, select **Create project** and choose **Connect an existing repository**, or open an existing project and select **Link repository** from the project settings.
+  </StepItem>
+
+  <StepItem>
+    Pick an installation, then choose the repository. Repository search works across every repository the App has access to on that installation.
+  </StepItem>
+
+  <StepItem>
+    Choose the Studio and Server deploy branches. Both targets default to the repository's default branch, and they can share a branch or use different branches.
+
+    You can disable Studio or Server for the project. The dashboard always selects both by default when you open the deploy drawer.
+  </StepItem>
+
+  <StepItem>
+    Select **Link repository**. The platform validates that the repository doesn't already have a `.mastra-project.json` file pointing at a different project. If it does, the dashboard warns you and offers an **Overwrite** option that replaces the file on link.
+  </StepItem>
+</Steps>
+
+After linking, the next push to the configured branch triggers a deploy.
+
+### `.mastra-project.json` conflicts
+
+The platform writes a `.mastra-project.json` file into every linked repository to identify the project. When you link a repository that already has one of these files, the dashboard checks its contents before submitting:
+
+- **Missing**: the platform creates the file on link.
+- **Matching**: the file already points at the project you're linking, so no change is needed.
+- **Conflicting**: the file points at a different project. You can cancel or explicitly overwrite the file.
+
+See [Configuration](/docs/mastra-platform/configuration) for the file's schema.
+
+## Push-to-deploy
+
+After a repository is linked, every push to a configured branch triggers a deploy:
+
+- A push to the **Studio branch** triggers a Studio deploy.
+- A push to the **Server branch** triggers a Server deploy.
+- If both targets share a branch, one push triggers both deploys in parallel.
+
+Each deploy carries the commit SHA, branch, and (when available) the pull request number that introduced the commit. Builds run inside the platform and report status back to GitHub as check runs on the commit.
+
+Only one build per project runs at a time. If a new push arrives while a build is in progress, the platform cancels older queued builds for the same target and runs the latest.
+
+### Manual GitHub deploys
+
+You can also trigger a deploy from the dashboard without pushing. Open the project, select **Deploy from GitHub**, pick the target (Studio, Server, or both) and a branch, and submit. The platform runs the deploy against the head commit of that branch and records the trigger as a **GitHub Workflow** deploy.
+
+## Track deploys
+
+### Project setup page
+
+After a project is created from a template or linked to a repository, the **Setup** page shows one row per deploy target. Each row:
+
+- Displays a live status badge that polls the deploy until it finishes.
+- Links to the deploy detail page via the deploy ID.
+- Exposes a **Show logs** toggle that streams build and runtime logs inline. Server logs poll every three seconds while the deploy is active.
+
+### Deploy detail page
+
+The deploy detail header shows the commit SHA and, when the deploy is linked to a pull request, a colored pull-request button that links to the PR on GitHub. The button reflects the PR's current state:
+
+| State    | Color  |
+| -------- | ------ |
+| Draft    | Grey   |
+| Open     | Green  |
+| Closed   | Red    |
+| Merged   | Purple |
+
+The platform resolves PR status through the GitHub App so the badge works for private repositories.
+
+### Deploy source
+
+Every deploy records how it was triggered:
+
+- **CLI**: `mastra studio deploy` or `mastra server deploy`.
+- **GitHub Push**: a push to a configured branch.
+- **GitHub Workflow**: a manual deploy from the dashboard.
+
+The deploy list and detail pages show the source as a badge and you can filter the list by source.
+
+## Permissions and revocation
+
+To stop deploys from a repository, do one of the following:
+
+- **Unlink the repository** from the project in **Project settings → Repository**. The project keeps its history and you can re-link a different repository later.
+- **Remove repository access** for the Mastra GitHub App on github.com. Existing deploys keep running, but no new push triggers a deploy.
+- **Uninstall the GitHub App** from the GitHub account. This removes access to every repository on that account.
+
+If GitHub revokes or rotates the App's installation token, repository reads return a `github_app_permissions_outdated` error and the dashboard prompts an admin to re-approve permissions.
+
+## Related
+
+- [Mastra platform overview](/docs/mastra-platform/overview)
+- [Studio on Mastra platform](/docs/mastra-platform/studio)
+- [Server on Mastra platform](/docs/mastra-platform/server)
+- [Configuration](/docs/mastra-platform/configuration)

--- a/docs/src/content/en/docs/mastra-platform/github.mdx
+++ b/docs/src/content/en/docs/mastra-platform/github.mdx
@@ -33,7 +33,7 @@ The integration is powered by the Mastra GitHub App. The App reads repository co
 
 <Steps>
   <StepItem>
-    In the [Mastra platform dashboard](https://projects.mastra.ai), open your organization settings and select **GitHub**.
+    In the [Mastra platform dashboard](https://projects.mastra.ai), open your organization settings. The page includes a **GitHub App** section.
   </StepItem>
 
   <StepItem>
@@ -45,7 +45,7 @@ The integration is powered by the Mastra GitHub App. The App reads repository co
   <StepItem>
     Select the repositories the App can access. You can scope to specific repositories or grant access to all repositories on the account.
 
-    Mastra requests only the permissions needed for push-to-deploy and check runs. You can revoke or change repository access at any time from GitHub's App settings.
+    You can revoke or change repository access at any time from GitHub's App settings.
   </StepItem>
 </Steps>
 
@@ -61,11 +61,11 @@ When a non-admin requests the App on an organization, the request stays pending 
 - Lets the same user request access to multiple GitHub accounts at once.
 - Reconciles pending state against GitHub when you open the page, removing requests an admin has declined or the requester has withdrawn.
 
-Mastra has no API to cancel a pending request. Withdraw it from GitHub.com if you no longer need it.
+To cancel a pending request, select **Cancel** next to it in the dashboard.
 
 ## Create a project from a template
 
-Templates are the fastest way to start. The platform creates a new repository from a Mastra template, links it to a fresh project, provisions any managed databases the template declares, and runs the first deploy.
+Templates are the fastest way to get started. The platform creates a new repository from a Mastra template, links it to a fresh project, provisions any managed databases the template declares, and runs the first deploy.
 
 <Steps>
   <StepItem>
@@ -145,36 +145,11 @@ You can also trigger a deploy from the dashboard without pushing. Open the proje
 
 ## Track deploys
 
-### Project setup page
-
 After a project is created from a template or linked to a repository, the **Setup** page shows one row per deploy target. Each row:
 
 - Displays a live status badge that polls the deploy until it finishes.
 - Links to the deploy detail page via the deploy ID.
 - Exposes a **Show logs** toggle that streams build and runtime logs inline. Server logs poll every three seconds while the deploy is active.
-
-### Deploy detail page
-
-The deploy detail header shows the commit SHA and, when the deploy is linked to a pull request, a colored pull-request button that links to the PR on GitHub. The button reflects the PR's current state:
-
-| State | Color |
-| - | - |
-| Draft | Grey |
-| Open | Green |
-| Closed | Red |
-| Merged | Purple |
-
-The platform resolves PR status through the GitHub App so the badge works for private repositories.
-
-### Deploy source
-
-Every deploy records how it was triggered:
-
-- **CLI**: `mastra studio deploy` or `mastra server deploy`
-- **GitHub Push**: A push to a configured branch
-- **GitHub Workflow**: A manual deploy from the dashboard
-
-The deploy list and detail pages show the source as a badge and you can filter the list by source.
 
 ## Permissions and revocation
 

--- a/docs/src/content/en/docs/mastra-platform/github.mdx
+++ b/docs/src/content/en/docs/mastra-platform/github.mdx
@@ -157,12 +157,12 @@ After a project is created from a template or linked to a repository, the **Setu
 
 The deploy detail header shows the commit SHA and, when the deploy is linked to a pull request, a colored pull-request button that links to the PR on GitHub. The button reflects the PR's current state:
 
-| State    | Color  |
-| -------- | ------ |
-| Draft    | Grey   |
-| Open     | Green  |
-| Closed   | Red    |
-| Merged   | Purple |
+| State | Color |
+| - | - |
+| Draft | Grey |
+| Open | Green |
+| Closed | Red |
+| Merged | Purple |
 
 The platform resolves PR status through the GitHub App so the badge works for private repositories.
 

--- a/docs/src/content/en/docs/mastra-platform/github.mdx
+++ b/docs/src/content/en/docs/mastra-platform/github.mdx
@@ -6,11 +6,11 @@ description: Connect a GitHub repository to a Mastra platform project to deploy 
 import Steps from "@site/src/components/Steps";
 import StepItem from "@site/src/components/StepItem";
 
-# GitHub integration
+# GitHub integration on Mastra platform
 
 The GitHub integration links a Mastra platform project to a GitHub repository so that pushes to a branch deploy Studio and Server automatically. Use it when you want push-to-deploy instead of running `mastra studio deploy` or `mastra server deploy` from your terminal or CI.
 
-Once a repository is linked, the platform:
+After a repository is linked, the platform:
 
 - Builds and deploys Studio and Server on every push to the configured branches.
 - Provisions managed databases and the Mastra gateway API key for projects created from a template.
@@ -50,18 +50,18 @@ The integration is powered by the Mastra GitHub App. The App reads repository co
 </Steps>
 
 :::note
-If GitHub later updates the App's required permissions, the dashboard surfaces an **outdated permissions** warning with a one-click approval link. Repository operations return a `403` until an admin re-approves.
+If GitHub later updates the App's required permissions, the dashboard surfaces an **outdated permissions** warning with an approval link. Repository operations return a `403` until an admin re-approves.
 :::
 
 ### Pending installation requests
 
-When a non-admin requests the App on an organization, the request stays pending until an organization admin approves it on github.com. The dashboard:
+When a non-admin requests the App on an organization, the request stays pending until an organization admin approves it on GitHub.com. The dashboard:
 
 - Lists pending requests next to active installations.
 - Lets the same user request access to multiple GitHub accounts at once.
 - Reconciles pending state against GitHub when you open the page, removing requests an admin has declined or the requester has withdrawn.
 
-There's no API to cancel a pending request from Mastra. Withdraw it from github.com if you no longer need it.
+Mastra has no API to cancel a pending request. Withdraw it from GitHub.com if you no longer need it.
 
 ## Create a project from a template
 
@@ -107,7 +107,7 @@ Use this flow when you already have a Mastra project in a GitHub repository.
   <StepItem>
     Choose the Studio and Server deploy branches. Both targets default to the repository's default branch, and they can share a branch or use different branches.
 
-    You can disable Studio or Server for the project. The dashboard always selects both by default when you open the deploy drawer.
+    You can disable Studio or Server for the project. The manual **Deploy from GitHub** drawer selects both targets by default when both are configured.
   </StepItem>
 
   <StepItem>
@@ -121,9 +121,9 @@ After linking, the next push to the configured branch triggers a deploy.
 
 The platform writes a `.mastra-project.json` file into every linked repository to identify the project. When you link a repository that already has one of these files, the dashboard checks its contents before submitting:
 
-- **Missing**: the platform creates the file on link.
-- **Matching**: the file already points at the project you're linking, so no change is needed.
-- **Conflicting**: the file points at a different project. You can cancel or explicitly overwrite the file.
+- **Missing**: The platform creates the file on link.
+- **Matching**: The file already points at the project you're linking, so no change is needed.
+- **Conflicting**: The file points at a different project. You can cancel or explicitly overwrite the file.
 
 See [Configuration](/docs/mastra-platform/configuration) for the file's schema.
 
@@ -170,9 +170,9 @@ The platform resolves PR status through the GitHub App so the badge works for pr
 
 Every deploy records how it was triggered:
 
-- **CLI**: `mastra studio deploy` or `mastra server deploy`.
-- **GitHub Push**: a push to a configured branch.
-- **GitHub Workflow**: a manual deploy from the dashboard.
+- **CLI**: `mastra studio deploy` or `mastra server deploy`
+- **GitHub Push**: A push to a configured branch
+- **GitHub Workflow**: A manual deploy from the dashboard
 
 The deploy list and detail pages show the source as a badge and you can filter the list by source.
 
@@ -181,7 +181,7 @@ The deploy list and detail pages show the source as a badge and you can filter t
 To stop deploys from a repository, do one of the following:
 
 - **Unlink the repository** from the project in **Project settings → Repository**. The project keeps its history and you can re-link a different repository later.
-- **Remove repository access** for the Mastra GitHub App on github.com. Existing deploys keep running, but no new push triggers a deploy.
+- **Remove repository access** for the Mastra GitHub App on GitHub.com. Existing deploys keep running, but no new push triggers a deploy.
 - **Uninstall the GitHub App** from the GitHub account. This removes access to every repository on that account.
 
 If GitHub revokes or rotates the App's installation token, repository reads return a `github_app_permissions_outdated` error and the dashboard prompts an admin to re-approve permissions.

--- a/docs/src/content/en/docs/mastra-platform/github.mdx
+++ b/docs/src/content/en/docs/mastra-platform/github.mdx
@@ -8,7 +8,11 @@ import StepItem from "@site/src/components/StepItem";
 
 # GitHub integration on Mastra platform
 
-The GitHub integration links a Mastra platform project to a GitHub repository so that pushes to a branch deploy Studio and Server automatically. Use it when you want push-to-deploy instead of running `mastra studio deploy` or `mastra server deploy` from your terminal or CI.
+The GitHub integration links a Mastra platform project to a GitHub repository. When you push changes to your repository Studio and Server will automatically be deployed.
+
+:::note
+The integration only works with repositories hosted on GitHub.com. Self-hosted GitHub Enterprise instances are not currently supported.
+:::
 
 After a repository is linked, the platform:
 

--- a/docs/src/content/en/docs/mastra-platform/overview.mdx
+++ b/docs/src/content/en/docs/mastra-platform/overview.mdx
@@ -11,6 +11,8 @@ The [Mastra platform](https://projects.mastra.ai) provides three products for de
 - [**Studio**](/docs/mastra-platform/studio): A hosted visual environment for testing agents, running workflows, and inspecting traces. Starting with Studio also gives you Observability.
 - [**Server**](/docs/mastra-platform/server): A production deployment target that runs your Mastra application as an API server. Starting with Server also gives you Observability.
 
+You can deploy Studio and Server from the CLI or connect a GitHub repository for push-to-deploy. See the [GitHub integration](/docs/mastra-platform/github) for the repository-linked flow.
+
 ## Get started
 
 Choose the path that matches what you want to do:

--- a/docs/src/content/en/docs/mastra-platform/server.mdx
+++ b/docs/src/content/en/docs/mastra-platform/server.mdx
@@ -69,6 +69,10 @@ A deploy transitions through **queued → uploading → building → deploying �
 
 Automate deployments from GitHub Actions, GitLab CI, or any CI provider. After your first interactive deploy, CI/CD needs two things: an API token and the `.mastra-project.json` file committed to your repository.
 
+:::tip
+If your code lives on GitHub, the [GitHub integration](/docs/mastra-platform/github) gives you push-to-deploy without writing a workflow file. Use the CLI-based CI/CD flow below when you need GitLab, another CI provider, or custom build steps before deploy.
+:::
+
 ### Create an API token
 
 <Steps>

--- a/docs/src/content/en/docs/mastra-platform/studio.mdx
+++ b/docs/src/content/en/docs/mastra-platform/studio.mdx
@@ -10,6 +10,8 @@ import StepItem from "@site/src/components/StepItem";
 
 Studio on Mastra platform is a hosted visual environment for testing agents, running workflows, and inspecting traces. Use it when you want to share Studio with your team without hosting the Studio UI yourself.
 
+You can deploy Studio from the CLI as shown below, or link a GitHub repository for push-to-deploy. See the [GitHub integration](/docs/mastra-platform/github) for the repository-linked flow.
+
 ## Quickstart
 
 <Steps>

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -857,6 +857,14 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'mastra-platform/github',
+          label: 'GitHub integration',
+          customProps: {
+            tags: ['new'],
+          },
+        },
+        {
+          type: 'doc',
           id: 'mastra-platform/configuration',
           label: 'Configuration',
         },


### PR DESCRIPTION
## Summary

Adds a dedicated documentation page for the Mastra Platform's GitHub integration and links it from the surrounding platform docs.

The new page walks readers through the full flow:

- Installing the Mastra GitHub App and handling org-admin approval / install requests
- Creating a project from a template (managed database attach + provisioned `MASTRA_GATEWAY_API_KEY`)
- Linking an existing repo, including `.mastra-project.json` preflight validation and overwrite behavior
- Push-to-deploy from configurable Studio and Server branches, plus manual deploys via the floating target drawer
- The project Setup page: live deploy status badges and inline expandable logs
- Pull request status on the deploy detail page (`draft`, `open`, `closed`, `merged`)
- Deploy trigger source metadata (CLI, GitHub push, manual)
- Managing or revoking the installation

Also wires the new page into the Mastra platform sidebar and cross-links it from `overview.mdx`, `configuration.mdx`, `server.mdx`, and `studio.mdx` so the GitHub flow is discoverable next to the CLI deploy docs.

## Test plan

- `cd docs && pnpm build` — succeeds, generates the new `/docs/mastra-platform/github` page; only broken-anchor warning is a pre-existing unrelated one on `/reference/agents/agent`.
- `pnpm remark` lint clean on the new and modified MDX files.
- Verified the sidebar entry and cross-links render in the built HTML.

Opening as draft for review of accuracy and scope before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a step-by-step guide showing how to connect a GitHub repo to Mastra so that pushing to specific branches automatically deploys your Studio and/or Server. It also makes this GitHub “push-to-deploy” path easy to discover from the rest of the Mastra docs.

## Changes

### New GitHub integration documentation
Added `docs/src/content/en/docs/mastra-platform/github.mdx`, covering the full GitHub push-to-deploy workflow:
- Install Mastra’s GitHub App, including handling pending install requests and the “outdated permissions” state that blocks repo operations until re-approval
- Create projects from Mastra templates, including managed database provisioning and provisioning of `MASTRA_GATEWAY_API_KEY` / `MASTRA_PLATFORM_ACCESS_TOKEN` for the first deploy
- Link existing repositories with `.mastra-project.json` preflight validation, documented conflict detection, and overwrite behavior
- Configure push-to-deploy separately for Studio vs Server branches (including parallel deploys when both share a branch), with per-target build scheduling where newer pushes cancel older queued builds
- Manual deploys from the dashboard using the floating target drawer, recorded as “GitHub Workflow”
- Deploy UX on the project Setup page: live deploy status badges and expandable inline logs
- Pull request status display (`draft`, `open`, `closed`, `merged`)
- Deploy trigger source metadata (CLI, GitHub push, manual)
- Manage and revoke the GitHub App installation (including dashboard behavior when GitHub revokes/rotates tokens via `github_app_permissions_outdated`)

### Updates to related Mastra docs
- `docs/src/content/en/docs/mastra-platform/overview.mdx`: added a pointer to the GitHub integration docs for push-to-deploy alongside CLI deployment
- `docs/src/content/en/docs/mastra-platform/configuration.mdx`: clarified that the auto-generated `.mastra-project.json` is written into linked repositories via the GitHub integration (not only during the first deploy)
- `docs/src/content/en/docs/mastra-platform/server.mdx`: added a CI/CD tip contrasting GitHub integration push-to-deploy (no workflow file) vs CLI/custom CI providers
- `docs/src/content/en/docs/mastra-platform/studio.mdx`: added guidance pointing to the GitHub integration page

### Sidebar navigation
- `docs/src/content/en/docs/sidebars.js`: added a new “GitHub integration” sidebar entry (`mastra-platform/github`, tagged as `new`)

### Validation
Confirmed the build generates the new `/docs/mastra-platform/github` page and that remark lint passes on both new and modified MDX files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->