### PR TITLE
fix(memory): avoid OM activation for provider subnamespaces

### DIFF
--- a/.changeset/fix-om-provider-subnamespace.md
+++ b/.changeset/fix-om-provider-subnamespace.md
@@ -1,0 +1,5 @@
+---
+"@mastra/memory": patch
+---
+
+Avoid observational memory provider-change activation when the same model is attributed through provider subnamespaces such as `openai` and `openai.responses`.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -3305,7 +3305,13 @@ describe('didProviderChange', () => {
 
   it('returns true when both sides are fully-formatted but differ', () => {
     expect(didProviderChange('openai/gpt-4o', 'anthropic/claude-opus-4-7')).toBe(true);
-    expect(didProviderChange('openai.responses/gpt-5.4', 'openai/gpt-5.4')).toBe(true);
+    expect(didProviderChange('openai/gpt-4o', 'openai/gpt-5.4')).toBe(true);
+    expect(didProviderChange('openai.responses/gpt-4o', 'openai/gpt-5.4')).toBe(true);
+  });
+
+  it('returns false when provider subnamespaces differ but base provider and modelId match', () => {
+    expect(didProviderChange('openai.responses/gpt-5.4', 'openai/gpt-5.4')).toBe(false);
+    expect(didProviderChange('openai/gpt-5.4', 'openai.responses/gpt-5.4')).toBe(false);
   });
 
   it('returns false when persisted history has bare modelId that matches actor modelId', () => {

--- a/packages/memory/src/processors/observational-memory/model-context.ts
+++ b/packages/memory/src/processors/observational-memory/model-context.ts
@@ -1,22 +1,34 @@
 /**
  * Compare a model string derived from past messages against the current actor
  * model. Persisted messages from older code paths may carry a bare `modelId`
- * (no `provider/` prefix) while the current actor always formats as
+ * (no `provider/` prefix) while the current actor usually formats as
  * `provider/modelId`. If either side is bare, fall back to comparing just the
  * `modelId` part so a missing provider in history doesn't trigger a spurious
- * provider change.
+ * provider change. Provider subnamespaces are compared by their base provider
+ * (`openai.responses` and `openai` both compare as `openai`) so transport-level
+ * provider attribution differences don't trigger provider-change activation.
  */
+function parseComparableModelContext(model: string): { provider?: string; modelId: string } {
+  const slashIndex = model.indexOf('/');
+  if (slashIndex === -1) return { modelId: model };
+
+  return {
+    provider: model.slice(0, slashIndex).split('.')[0],
+    modelId: model.slice(slashIndex + 1),
+  };
+}
+
 export function didProviderChange(actorModel?: string, lastModel?: string): boolean {
   if (actorModel === undefined || lastModel === undefined) return false;
 
-  const actorHasSlash = actorModel.includes('/');
-  const lastHasSlash = lastModel.includes('/');
+  const actorContext = parseComparableModelContext(actorModel);
+  const lastContext = parseComparableModelContext(lastModel);
 
-  if (actorHasSlash && lastHasSlash) {
-    return actorModel !== lastModel;
+  if (actorContext.modelId !== lastContext.modelId) return true;
+
+  if (actorContext.provider && lastContext.provider) {
+    return actorContext.provider !== lastContext.provider;
   }
 
-  const actorModelId = actorHasSlash ? actorModel.slice(actorModel.indexOf('/') + 1) : actorModel;
-  const lastModelId = lastHasSlash ? lastModel.slice(lastModel.indexOf('/') + 1) : lastModel;
-  return actorModelId !== lastModelId;
+  return false;
 }


### PR DESCRIPTION
This fixes a false observational memory provider-change activation when the same model is recorded through slightly different provider names, like `openai` and `openai.responses`.

Before:

```ts
didProviderChange('openai.responses/gpt-5.4', 'openai/gpt-5.4') // true
```

After:

```ts
didProviderChange('openai.responses/gpt-5.4', 'openai/gpt-5.4') // false
didProviderChange('openai.responses/gpt-4o', 'openai/gpt-5.4') // true
```

Also adds focused regression coverage and a memory changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you have a notebook that tracks which AI service you're talking to. The problem was: if you wrote "OpenAI" one time and "OpenAI (responses)" another time, the notebook thought you switched to a different service—even though you didn't. This PR fixes it so the notebook is smart enough to recognize they're the same service, just written in slightly different ways.

## Summary

This PR fixes a false positive activation in observational memory that occurred when the same model was referenced through different provider namespace formats. Previously, comparing provider identifiers like `openai.responses/gpt-5.4` and `openai/gpt-5.4` would incorrectly trigger a provider-change activation, even though both refer to the same provider and model.

## Changes

**Implementation:**
- Updated `didProviderChange()` function in `model-context.ts` to normalize provider comparisons by extracting and comparing only the base provider segment (before any dot separator). The function now parses `provider/modelId`-style strings and compares base providers separately from model IDs, preventing false positives when the same provider is referenced with different namespace formats.

**Testing:**
- Expanded unit test coverage in `observational-memory.test.ts` with additional test cases for provider/model change detection across fully-qualified and base-model forms
- Added regression test case specifically covering the `openai.responses/gpt-5.4` vs `openai/gpt-5.4` scenario to ensure provider subnamespaces with matching base providers and modelIds are not incorrectly flagged as provider changes
- Verified that genuine provider changes (different providers or different models) are still properly detected

**Release:**
- Added changeset entry for `@mastra/memory` with patch version bump

## Impact

The fix eliminates false provider-change activations caused by namespace variations while maintaining correct detection of actual provider and model changes. Existing functionality for model ID comparison and cross-provider change detection is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->