### PR TITLE
fix(harness,libsql): keep agent loop alive after tool suspension

### DIFF
--- a/.changeset/keep-agent-loop-alive-after-suspension.md
+++ b/.changeset/keep-agent-loop-alive-after-suspension.md
@@ -1,0 +1,11 @@
+---
+"@mastra/core": patch
+"@mastra/libsql": patch
+---
+
+Keep the agent loop alive after a tool suspension (e.g. `ask_user`, `request_access`).
+
+Two related fixes that stop the agent from appearing to quit mid-task right after a suspended tool resumes:
+
+- **Harness resume step budget**: `resumeStream()` was called without a step budget, so a resumed run merged over the agent's small default `maxSteps` and stopped after a single step. The harness now threads a shared set of run options (`maxSteps`, `savePerStep`, `modelSettings`, etc.) into both the initial stream and the resume via one helper, so the two paths can no longer drift.
+- **LibSQL `busy_timeout` survival**: bump `@libsql/client` to `^0.17.4` and add a configurable connection timeout so `PRAGMA busy_timeout` survives connections created after `transaction()` (libsql-client-ts#288/#345). This reduces `SQLITE_BUSY` retry-exhaustion stalls under the evented engine's concurrent writes.

--- a/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
+++ b/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
@@ -348,4 +348,72 @@ describe('Harness: tool suspension and resumption', () => {
     // Yolo mode should disable tool approval gating on resume, matching sendMessage's behavior
     expect(resumeOptions.requireToolApproval).toBe(false);
   });
+
+  it('should forward the full run budget (maxSteps) to resumeStream so the resumed run does not stop mid-task', async () => {
+    // Regression: resumeStream previously omitted maxSteps, so the resumed run
+    // merged over the agent's small default budget and ended with reason
+    // "complete" after a few steps — the agent stopped mid-task after ask_user.
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        // Resume-aware: continue instead of re-suspending once resumeData arrives,
+        // so the resumed run can actually complete.
+        const resumeData = context?.agent?.resumeData ?? context?.workflow?.resumeData ?? context?.resumeData;
+        if (resumeData) {
+          return { result: `Action "${input.action}" confirmed`, resumed: resumeData };
+        }
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-budget-resume',
+      name: 'Test Agent Budget Resume',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: (() => {
+          let callCount = 0;
+          return async () => {
+            callCount++;
+            return { stream: callCount === 1 ? createToolCallStream() : createTextStream() };
+          };
+        })(),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-budget-resume': agent },
+      logger: false,
+      storage,
+    });
+
+    const registeredAgent = mastra.getAgent('test-agent-budget-resume');
+    const resumeStreamSpy = vi.spyOn(registeredAgent, 'resumeStream');
+
+    const harness = new Harness({
+      id: 'test-harness-budget-resume',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+
+    await harness.init();
+    await harness.createThread();
+
+    await harness.sendMessage({ content: 'Deploy to production' });
+    await harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+
+    expect(resumeStreamSpy).toHaveBeenCalled();
+    const [, resumeOptions] = resumeStreamSpy.mock.calls[0] as [any, any];
+    // Must match the budget used for the initial stream, not the agent default.
+    expect(resumeOptions.maxSteps).toBe(1000);
+    expect(resumeOptions.savePerStep).toBe(false);
+  });
 });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -154,6 +154,18 @@ export function describeNonSuccessFinishReason(reason: string, providerMetadata:
 const FABLE_FALLBACK_MODEL = 'claude-opus-4-8';
 
 /**
+ * Step budget applied to every harness-driven agent run.
+ *
+ * This MUST be passed to both the initial stream and `resumeStream`: when a run
+ * suspends on an interactive tool (e.g. `ask_user`) and then resumes, the
+ * resumed call merges over the agent's *default* options, whose `maxSteps` is
+ * small (~5). Without re-supplying this budget the resumed run is silently
+ * capped and ends with `reason:"complete"` after a few steps — the agent stops
+ * mid-task even though it promised to continue. See {@link buildSharedRunOptions}.
+ */
+const HARNESS_MAX_STEPS = 1000;
+
+/**
  * Returns Anthropic `providerOptions` that enable a server-side fallback to
  * {@link FABLE_FALLBACK_MODEL} when the active model is `claude-fable-5`, and
  * `undefined` otherwise.
@@ -1881,33 +1893,42 @@ export class Harness<TState = {}> {
     this.abortRequested = false;
     this.abortController ??= new AbortController();
     const requestContext = await this.buildRequestContext(requestContextInput);
-    const isYolo = (this.state as Record<string, unknown>).yolo === true;
     const streamOptions: Record<string, unknown> = {
+      ...this.buildSharedRunOptions(),
       memory: { thread: this.currentThreadId, resource: this.resourceId },
       abortSignal: this.abortController.signal,
       requestContext,
-      maxSteps: 1000,
-      savePerStep: false,
-      requireToolApproval: !isYolo,
-      modelSettings: { temperature: 1 },
       ...(tracingContext && { tracingContext }),
       ...(tracingOptions && { tracingOptions }),
     };
     streamOptions.toolsets = await this.buildToolsets(requestContext);
 
+    return streamOptions;
+  }
+
+  /**
+   * Options that every harness-driven agent run must carry — the initial stream
+   * AND every `resumeStream`. Centralized so the two paths can't drift: a
+   * missing `maxSteps` on resume silently caps the resumed run at the agent's
+   * small default and ends it mid-task (see {@link HARNESS_MAX_STEPS}).
+   */
+  private buildSharedRunOptions(): Record<string, unknown> {
+    const isYolo = (this.state as Record<string, unknown>).yolo === true;
+    const shared: Record<string, unknown> = {
+      maxSteps: HARNESS_MAX_STEPS,
+      savePerStep: false,
+      requireToolApproval: !isYolo,
+      modelSettings: { temperature: 1 },
+    };
+
     // Auto-enable Anthropic server-side fallbacks for fable-5 so a classifier
     // block is transparently retried on the fallback model instead of failing.
     const fableFallback = buildFableFallbackProviderOptions(this.getCurrentModelId());
     if (fableFallback) {
-      const existing = streamOptions.providerOptions as Record<string, unknown> | undefined;
-      const existingAnthropic = (existing?.anthropic as Record<string, unknown> | undefined) ?? {};
-      streamOptions.providerOptions = {
-        ...existing,
-        anthropic: { ...existingAnthropic, ...fableFallback.anthropic },
-      };
+      shared.providerOptions = { anthropic: { ...fableFallback.anthropic } };
     }
 
-    return streamOptions;
+    return shared;
   }
 
   private async drainFollowUpQueue(options?: {
@@ -3683,16 +3704,19 @@ export class Harness<TState = {}> {
     this.displayState.pendingSuspensions.delete(toolCallId);
 
     const requestContext = await this.buildRequestContext(requestContextInput);
-    const isYolo = (this.state as Record<string, unknown>).yolo === true;
+
     const output = await agent.resumeStream(resumeData, {
+      // Re-supply the shared run budget (maxSteps, etc). Without it the resumed
+      // run merges over the agent's small default maxSteps and stops mid-task.
+      ...this.buildSharedRunOptions(),
       runId: suspension.runId,
       toolCallId,
-      requireToolApproval: !isYolo,
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
       abortSignal: this.abortController.signal,
       requestContext,
       toolsets: await this.buildToolsets(requestContext),
     });
+
     await this.processStream(output, requestContext);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6322,8 +6322,8 @@ importers:
   stores/libsql:
     dependencies:
       '@libsql/client':
-        specifier: ^0.17.3
-        version: 0.17.3(bufferutil@4.1.0)
+        specifier: ^0.17.4
+        version: 0.17.4(bufferutil@4.1.0)
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -13119,11 +13119,11 @@ packages:
   '@lezer/markdown@1.5.1':
     resolution: {integrity: sha512-F3ZFnIfNAOy/jPSk6Q0e3bs7e9grfK/n5zerkKoc5COH6Guy3Zb0vrJwXzdck79K16goBhYBRAvhf+ksqe0cMg==}
 
-  '@libsql/client@0.17.3':
-    resolution: {integrity: sha512-HXk9wiAoJbKFbyBH4O+aEhN6ir5ERXuXvwE5OD2eR4/5RUa3Pw/8L9zrnVdU+iNJitRvisPWaIwmhkO3bH7giA==}
+  '@libsql/client@0.17.4':
+    resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
 
-  '@libsql/core@0.17.3':
-    resolution: {integrity: sha512-2UjK1i7JBkMduJo4WdvvBxMMvVJ31pArBZNONyz/GCJJAH+1UHat2X6vn10S/WpY5fKzIT98WqYFl2vzWRLOfg==}
+  '@libsql/core@0.17.4':
+    resolution: {integrity: sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==}
 
   '@libsql/darwin-arm64@0.5.29':
     resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
@@ -34646,9 +34646,9 @@ snapshots:
       '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
 
-  '@libsql/client@0.17.3(bufferutil@4.1.0)':
+  '@libsql/client@0.17.4(bufferutil@4.1.0)':
     dependencies:
-      '@libsql/core': 0.17.3
+      '@libsql/core': 0.17.4
       '@libsql/hrana-client': 0.10.0(bufferutil@4.1.0)
       js-base64: 3.7.8
       libsql: 0.5.29
@@ -34657,7 +34657,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@libsql/core@0.17.3':
+  '@libsql/core@0.17.4':
     dependencies:
       js-base64: 3.7.8
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,6 +80,11 @@ minimumReleaseAgeExclude:
   - 'mastracode'
   - '@earendil-works/pi-tui'
   - railway@3.3.1
+  # Turso-recommended busy_timeout fix (libsql-client-ts#288/#345). Adopted
+  # immediately on their guidance; pinned so the release-age gate still applies
+  # to any later @libsql/client versions.
+  - '@libsql/client@0.17.4'
+  - '@libsql/core@0.17.4'
 trustPolicyExclude:
   # Security fix for GHSA middleware-based route protection bypass (CVE).
   # 3.47.4 is published with provenance attestation rather than trusted publisher,

--- a/stores/libsql/package.json
+++ b/stores/libsql/package.json
@@ -27,7 +27,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@libsql/client": "^0.17.3"
+    "@libsql/client": "^0.17.4"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/stores/libsql/src/storage/busy-timeout.test.ts
+++ b/stores/libsql/src/storage/busy-timeout.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { createClient } from '@libsql/client';
+import type { createClient } from '@libsql/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { resolveClient, DEFAULT_CONNECTION_TIMEOUT_MS } from './db';
@@ -29,11 +29,13 @@ describe('LibSQL busy_timeout configuration', () => {
 
   it('applies the default busy_timeout to a local file store', async () => {
     const store = new LibSQLStore({ id: 'busy-default', url: `file:${path.join(tmpDir, 'default.db')}` });
-    await store.init();
+    try {
+      await store.init();
 
-    expect(await readBusyTimeout(getClient(store))).toBe(DEFAULT_CONNECTION_TIMEOUT_MS);
-
-    await store.close();
+      expect(await readBusyTimeout(getClient(store))).toBe(DEFAULT_CONNECTION_TIMEOUT_MS);
+    } finally {
+      await store.close();
+    }
   });
 
   it('honors a custom connectionTimeoutMs', async () => {
@@ -42,32 +44,38 @@ describe('LibSQL busy_timeout configuration', () => {
       url: `file:${path.join(tmpDir, 'custom.db')}`,
       connectionTimeoutMs: 1234,
     });
-    await store.init();
+    try {
+      await store.init();
 
-    expect(await readBusyTimeout(getClient(store))).toBe(1234);
-
-    await store.close();
+      expect(await readBusyTimeout(getClient(store))).toBe(1234);
+    } finally {
+      await store.close();
+    }
   });
 
   it('keeps the busy_timeout after a transaction() opens a new connection (libsql-client-ts#288)', async () => {
     const client = resolveClient({ url: `file:${path.join(tmpDir, 'txn.db')}`, connectionTimeoutMs: 4321 });
 
-    const txn = await client.transaction('write');
-    await txn.execute('CREATE TABLE t (a)');
-    await txn.commit();
+    try {
+      const txn = await client.transaction('write');
+      await txn.execute('CREATE TABLE t (a)');
+      await txn.commit();
 
-    // transaction() hands the client's connection to the transaction and lazily
-    // opens a new one; the timeout must apply to that new connection too.
-    expect(await readBusyTimeout(client)).toBe(4321);
-
-    client.close();
+      // transaction() hands the client's connection to the transaction and lazily
+      // opens a new one; the timeout must apply to that new connection too.
+      expect(await readBusyTimeout(client)).toBe(4321);
+    } finally {
+      client.close();
+    }
   });
 
   it('resolveClient defaults the busy_timeout for local urls', async () => {
     const client = resolveClient({ url: `file:${path.join(tmpDir, 'resolve.db')}` });
 
-    expect(await readBusyTimeout(client)).toBe(DEFAULT_CONNECTION_TIMEOUT_MS);
-
-    client.close();
+    try {
+      expect(await readBusyTimeout(client)).toBe(DEFAULT_CONNECTION_TIMEOUT_MS);
+    } finally {
+      client.close();
+    }
   });
 });

--- a/stores/libsql/src/storage/busy-timeout.test.ts
+++ b/stores/libsql/src/storage/busy-timeout.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createClient } from '@libsql/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveClient, DEFAULT_CONNECTION_TIMEOUT_MS } from './db';
+import { LibSQLStore } from './index';
+
+type TestClient = ReturnType<typeof createClient>;
+
+const getClient = (store: LibSQLStore): TestClient => (store as unknown as { client: TestClient }).client;
+
+const readBusyTimeout = async (client: TestClient): Promise<number> => {
+  const rs = await client.execute('PRAGMA busy_timeout');
+  return Number(rs.rows[0]!['timeout']);
+};
+
+describe('LibSQL busy_timeout configuration', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'libsql-busy-timeout-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('applies the default busy_timeout to a local file store', async () => {
+    const store = new LibSQLStore({ id: 'busy-default', url: `file:${path.join(tmpDir, 'default.db')}` });
+    await store.init();
+
+    expect(await readBusyTimeout(getClient(store))).toBe(DEFAULT_CONNECTION_TIMEOUT_MS);
+
+    await store.close();
+  });
+
+  it('honors a custom connectionTimeoutMs', async () => {
+    const store = new LibSQLStore({
+      id: 'busy-custom',
+      url: `file:${path.join(tmpDir, 'custom.db')}`,
+      connectionTimeoutMs: 1234,
+    });
+    await store.init();
+
+    expect(await readBusyTimeout(getClient(store))).toBe(1234);
+
+    await store.close();
+  });
+
+  it('keeps the busy_timeout after a transaction() opens a new connection (libsql-client-ts#288)', async () => {
+    const client = resolveClient({ url: `file:${path.join(tmpDir, 'txn.db')}`, connectionTimeoutMs: 4321 });
+
+    const txn = await client.transaction('write');
+    await txn.execute('CREATE TABLE t (a)');
+    await txn.commit();
+
+    // transaction() hands the client's connection to the transaction and lazily
+    // opens a new one; the timeout must apply to that new connection too.
+    expect(await readBusyTimeout(client)).toBe(4321);
+
+    client.close();
+  });
+
+  it('resolveClient defaults the busy_timeout for local urls', async () => {
+    const client = resolveClient({ url: `file:${path.join(tmpDir, 'resolve.db')}` });
+
+    expect(await readBusyTimeout(client)).toBe(DEFAULT_CONNECTION_TIMEOUT_MS);
+
+    client.close();
+  });
+});

--- a/stores/libsql/src/storage/db/index.ts
+++ b/stores/libsql/src/storage/db/index.ts
@@ -35,7 +35,23 @@ export type LibSQLDomainBaseConfig = {
    * @default 100
    */
   initialBackoffMs?: number;
+  /**
+   * SQLite `busy_timeout` (in milliseconds) applied to the underlying connection
+   * for local (`file:`/`:memory:`) databases. Lets a write wait for a lock to
+   * clear instead of failing immediately with `SQLITE_BUSY`. Requires
+   * `@libsql/client` >= 0.17.4 (see libsql-client-ts#288/#345). Ignored when an
+   * existing `client` is supplied.
+   * @default 5000
+   */
+  connectionTimeoutMs?: number;
 };
+
+/**
+ * Default SQLite `busy_timeout` (ms) for local LibSQL connections. Chosen to
+ * comfortably exceed the write-retry backoff window so contended writes block
+ * briefly rather than surfacing as `SQLITE_BUSY` errors.
+ */
+export const DEFAULT_CONNECTION_TIMEOUT_MS = 5000;
 
 /**
  * Configuration for LibSQL domains - accepts either credentials or an existing client
@@ -63,9 +79,14 @@ export function resolveClient(config: LibSQLDomainConfig): Client {
   if ('client' in config) {
     return config.client;
   }
+  const isLocal = config.url.startsWith('file:') || config.url.includes(':memory:');
+  const timeout = config.connectionTimeoutMs ?? DEFAULT_CONNECTION_TIMEOUT_MS;
   return createClient({
     url: config.url,
     ...(config.authToken ? { authToken: config.authToken } : {}),
+    // Only local sqlite3 connections honor `busy_timeout`; remote contention is
+    // resolved server-side, so passing it there is meaningless.
+    ...(isLocal ? { timeout } : {}),
   });
 }
 

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -3,6 +3,7 @@ import type { Client } from '@libsql/client';
 import type { StorageDomains } from '@mastra/core/storage';
 import { MastraCompositeStore } from '@mastra/core/storage';
 
+import { DEFAULT_CONNECTION_TIMEOUT_MS } from './db';
 import { AgentsLibSQL } from './domains/agents';
 import { BackgroundTasksLibSQL } from './domains/background-tasks';
 import { BlobsLibSQL } from './domains/blobs';
@@ -89,6 +90,19 @@ export type LibSQLBaseConfig = {
    */
   initialBackoffMs?: number;
   /**
+   * SQLite `busy_timeout` (in milliseconds) applied to the underlying connection
+   * for local (`file:`/`:memory:`) databases. When a write hits a locked
+   * database, the driver waits up to this long for the lock to clear instead of
+   * failing immediately with `SQLITE_BUSY`. Requires `@libsql/client` >= 0.17.4,
+   * which also ensures the timeout survives connections created after
+   * `transaction()` (see libsql-client-ts#288/#345).
+   *
+   * Has no effect for remote (`libsql://`/`https://`) clients or when an existing
+   * `client` is supplied.
+   * @default 5000
+   */
+  connectionTimeoutMs?: number;
+  /**
    * Overrides local SQLite PRAGMA values used for startup/read performance.
    * Only applies to local file and in-memory databases.
    */
@@ -146,6 +160,7 @@ export class LibSQLStore extends MastraCompositeStore {
   private client: Client;
   private readonly maxRetries: number;
   private readonly initialBackoffMs: number;
+  private readonly connectionTimeoutMs: number;
   private readonly pragmasReady: Promise<void>;
   private readonly isLocalDb: boolean;
   private readonly localPragmas: Required<LibSQLLocalPragmaOptions>;
@@ -160,6 +175,7 @@ export class LibSQLStore extends MastraCompositeStore {
 
     this.maxRetries = config.maxRetries ?? 5;
     this.initialBackoffMs = config.initialBackoffMs ?? 100;
+    this.connectionTimeoutMs = config.connectionTimeoutMs ?? DEFAULT_CONNECTION_TIMEOUT_MS;
     this.localPragmas = {
       cacheSize: config.localPragmas?.cacheSize ?? DEFAULT_LOCAL_CACHE_SIZE,
       mmapSize: config.localPragmas?.mmapSize ?? DEFAULT_LOCAL_MMAP_SIZE,
@@ -171,12 +187,15 @@ export class LibSQLStore extends MastraCompositeStore {
         this.shouldCacheInit = false;
       }
 
+      this.isLocalDb = config.url.startsWith('file:') || config.url.includes(':memory:');
+
       this.client = createClient({
         url: config.url,
         ...(config.authToken ? { authToken: config.authToken } : {}),
+        // `busy_timeout` only applies to local sqlite3 connections; remote
+        // contention is handled server-side. See libsql-client-ts#288/#345.
+        ...(this.isLocalDb ? { timeout: this.connectionTimeoutMs } : {}),
       });
-
-      this.isLocalDb = config.url.startsWith('file:') || config.url.includes(':memory:');
       this.pragmasReady = this.isLocalDb ? this.applyLocalPragmas() : Promise.resolve();
     } else {
       this.client = config.client;
@@ -242,7 +261,9 @@ export class LibSQLStore extends MastraCompositeStore {
   private async applyLocalPragmas(): Promise<void> {
     const pragmas = [
       ['journal_mode=WAL', 'PRAGMA journal_mode=WAL;'],
-      ['busy_timeout=5000', 'PRAGMA busy_timeout=5000;'],
+      // Keep in sync with the connection-level `timeout` passed to createClient
+      // so a custom connectionTimeoutMs isn't clobbered back to a hardcoded value.
+      [`busy_timeout=${this.connectionTimeoutMs}`, `PRAGMA busy_timeout=${this.connectionTimeoutMs};`],
       ['synchronous=NORMAL', 'PRAGMA synchronous=NORMAL;'],
       ['temp_store=MEMORY', 'PRAGMA temp_store=MEMORY;'],
       [`cache_size=${this.localPragmas.cacheSize}`, `PRAGMA cache_size=${this.localPragmas.cacheSize};`],


### PR DESCRIPTION
## Summary

Two fixes for the reported bug where **MastraCode stops mid-task right after an `ask_user` (or other interactive-tool) suspension**, even though the agent says it will keep working.

### 1. `harness`: resume was capped at the agent's default step budget
`handleToolResume` called `agent.resumeStream()` **without `maxSteps`**. `resumeStream` merges per-call options over the agent's `getDefaultOptions()`, whose `maxSteps` is small (~5). So a resumed run took only a few LLM steps and ended with `reason:"complete"` — looking like the agent quit mid-task.

The initial stream sets `maxSteps: 1000`; the resume didn't. The fix extracts a single `buildSharedRunOptions()` helper (`maxSteps`, `savePerStep`, `modelSettings`, fable-5 fallback `providerOptions`, `requireToolApproval`) used by **both** the initial stream and `resumeStream`, so the two paths can't drift again. A `HARNESS_MAX_STEPS` constant documents why.

### 2. `libsql`: SQLITE_BUSY storms under the evented engine
Concurrent writers on a single-connection LibSQL client triggered `SQLITE_BUSY` retry-exhaustion that could stall runs. Bump `@libsql/client` to `^0.17.4` and thread a configurable connection timeout into `createClient` so `PRAGMA busy_timeout` **survives connections created after `transaction()`** (Turso `libsql-client-ts` #288/#345). SQLite now waits for locks instead of immediately throwing.

## Tests
- `harness-tool-suspension.test.ts`: new regression test asserting the resume forwards the full step budget (`maxSteps: 1000`, `savePerStep: false`); existing yolo-mode resume assertion still holds.
- `stores/libsql/.../busy-timeout.test.ts`: covers default/custom timeout and post-`transaction()` survival.

## Verification
- `pnpm --filter ./packages/core check` — clean
- harness suspension + ask-user suites: 12 passed
- libsql busy-timeout + write-lock suites: 8 passed

## Notes
All `[suspend-trace]` debug instrumentation used during investigation was stripped from this branch; only the two fixes + tests + dep bumps remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes two ways an AI agent could “get stuck.” After the agent pauses to ask the user something, it was restarting with too few “work steps” left—so it could look like it quit early. Also, the database layer could error when multiple writes happened at once; the fix makes SQLite wait for locks instead of failing immediately.

---

## Issue 1: Harness step budget lost during tool resume

**Problem:**  
When a MastraCode agent hit an interactive tool suspension (e.g., `ask_user`), it resumed with the wrong (too-small) step budget. That made the resumed run stop after only a handful of LLM steps, appearing like the agent quit prematurely.

**Solution:**  
- Added `HARNESS_MAX_STEPS` to document the intended 1000-step budget.
- Introduced `buildSharedRunOptions()` to centralize shared harness run configuration (including `maxSteps`, `savePerStep`, `modelSettings`, provider option fallback, and `requireToolApproval`).
- Refactored initial streaming option construction and tool-resume handling to both use the exact same shared run options when calling `agent.resumeStream()`.

**Tests:**  
- Added `harness-tool-suspension.test.ts` to verify that after a tool suspension, the harness resumes with `resumeOptions.maxSteps === 1000` (and `resumeOptions.savePerStep === false`), preventing early termination.

---

## Issue 2: LibSQL `SQLITE_BUSY` contention under concurrent writes

**Problem:**  
Concurrent writes using a single-connection LibSQL client could hit `SQLITE_BUSY` retry-exhaustion errors, stalling execution.

**Solution:**  
- Bumped `@libsql/client` to `^0.17.4`.
- Added optional `connectionTimeoutMs` configuration (with exported `DEFAULT_CONNECTION_TIMEOUT_MS = 5000`) to apply SQLite `busy_timeout`.
- Updated `resolveClient()` to pass `{ timeout }` to `createClient()` for local `file:` / `:memory:` URLs so the setting applies to connections created after `transaction()`.
- Updated local initialization pragmas to set `busy_timeout` from `connectionTimeoutMs` (instead of a hardcoded value).

**Tests:**  
- Added `stores/libsql/.../busy-timeout.test.ts` to cover default vs custom timeout and that `busy_timeout` persists for connections created after `client.transaction()`.

---

## Files modified

| File | Changes |
|---|---|
| `packages/core/src/harness/harness.ts` | Added `HARNESS_MAX_STEPS`; added `buildSharedRunOptions()`; ensured both initial streaming and `resumeStream` use identical shared run options |
| `packages/core/src/harness/__tests__/harness-tool-suspension.test.ts` | New regression test asserting resumed runs keep `maxSteps: 1000` and `savePerStep: false` |
| `stores/libsql/package.json` | Updated `@libsql/client` to `^0.17.4` |
| `stores/libsql/src/storage/db/index.ts` | Added `connectionTimeoutMs`, exported `DEFAULT_CONNECTION_TIMEOUT_MS`, and applied `{ timeout }` for local connections |
| `stores/libsql/src/storage/index.ts` | Added `connectionTimeoutMs` to store config and updated `busy_timeout` pragmas |
| `stores/libsql/src/storage/busy-timeout.test.ts` | New tests for default/custom timeout and post-`transaction()` persistence |
| `pnpm-workspace.yaml` | Added release-gate exclusions for pinned `@libsql/client@0.17.4` and `@libsql/core@0.17.4` |
| `.changeset/keep-agent-loop-alive-after-suspension.md` | Documented the harness resume + LibSQL `busy_timeout` fixes |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->