### PR TITLE
fix(temporal): discover factory-created workflow steps

### DIFF
--- a/.changeset/fuzzy-waves-share.md
+++ b/.changeset/fuzzy-waves-share.md
@@ -1,0 +1,5 @@
+---
+'@mastra/temporal': patch
+---
+
+Fixed Temporal prebuild activity discovery for workflow steps created by local factory functions.

--- a/workflows/temporal/src/index.test.ts
+++ b/workflows/temporal/src/index.test.ts
@@ -117,6 +117,64 @@ describe('@mastra/temporal transform exports', () => {
     expect(output).toContain('.then("fetch-weather")');
   });
 
+  it('supports factory-created steps in workflow chains', async () => {
+    const output = await transform(`
+      import { createStep, createWorkflow } from '@mastra/core/workflows';
+
+      function makeFetchWeather() {
+        return createStep({ id: 'fetch-weather', execute: async () => ({}) });
+      }
+
+      const fetchWeather = makeFetchWeather();
+      export const weatherWorkflow = createWorkflow({ id: 'weather-workflow' }).then(fetchWeather);
+    `);
+
+    expect(output).toContain('.then("fetch-weather")');
+    expect(output).not.toContain('fetchWeather =');
+  });
+
+  it('supports multiple factory-created steps in workflow chains', async () => {
+    const output = await transform(`
+      import { createStep, createWorkflow } from '@mastra/core/workflows';
+
+      function makeFetchWeather() {
+        return createStep({ id: 'fetch-weather', execute: async () => ({}) });
+      }
+
+      function makePlanActivities() {
+        return createStep({ id: 'plan-activities', execute: async () => ({}) });
+      }
+
+      const fetchWeather = makeFetchWeather();
+      const planActivities = makePlanActivities();
+      export const weatherWorkflow = createWorkflow({ id: 'weather-workflow' }).parallel([
+        fetchWeather,
+        planActivities,
+      ]);
+    `);
+
+    expect(output).toContain('.parallel(["fetch-weather", "plan-activities"])');
+  });
+
+  it('supports nested factory-created steps in workflow chains', async () => {
+    const output = await transform(`
+      import { createStep, createWorkflow } from '@mastra/core/workflows';
+
+      function makeFetchWeather() {
+        return createStep({ id: 'fetch-weather', execute: async () => ({}) });
+      }
+
+      function wrapFetchWeather() {
+        return makeFetchWeather();
+      }
+
+      const fetchWeather = wrapFetchWeather();
+      export const weatherWorkflow = createWorkflow({ id: 'weather-workflow' }).then(fetchWeather);
+    `);
+
+    expect(output).toContain('.then("fetch-weather")');
+  });
+
   it('supports inline createStep calls in parallel', async () => {
     const output = await transform(`
       import { createStep, createWorkflow } from '@mastra/core/workflows';
@@ -197,6 +255,26 @@ describe('@mastra/temporal activities module transform', () => {
 
     expect(output).toContain('function createStep(args)');
     expect(output).toContain('const fetchWeather = createStep({');
+    expect(output).toMatch(/export\s*(const\s+fetchWeather\s*=|\{\s*fetchWeather\s*\})/);
+  });
+
+  it('extracts factory-created createStep declarations as named exports', async () => {
+    const output = await transformActivities(`
+      import { createStep } from '@mastra/core/workflows';
+
+      function makeFetchWeather() {
+        return createStep({
+          id: 'fetch-weather',
+          execute: async () => ({ ok: true }),
+        });
+      }
+
+      const fetchWeather = makeFetchWeather();
+    `);
+
+    expect(output).toContain('function createStep(args)');
+    expect(output).toContain('function makeFetchWeather()');
+    expect(output).toContain('const fetchWeather = makeFetchWeather();');
     expect(output).toMatch(/export\s*(const\s+fetchWeather\s*=|\{\s*fetchWeather\s*\})/);
   });
 
@@ -415,6 +493,45 @@ describe('@mastra/temporal configureWorker activities', () => {
     await expect(
       readFile(path.resolve(process.cwd(), 'node_modules/.mastra/activities.mjs'), 'utf8'),
     ).resolves.not.toContain('./output/index.mjs');
+  });
+
+  it('generates activity bindings and worker activities for factory-created steps', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'mastra-temporal-factory-worker-'));
+    const entryPath = path.join(tempDir, 'src', 'index.ts');
+    const compiledEntrySource = `
+      import { createWorkflow, createStep } from '@mastra/core/workflows';
+
+      function makeEchoStep() {
+        return createStep({
+          id: 'echo',
+          execute: async ({ inputData }) => inputData,
+        });
+      }
+
+      const echoStep = makeEchoStep();
+      export const echoWorkflow = createWorkflow({ id: 'echo-workflow' }).then(echoStep);
+    `;
+    const compiledWorkflowSource = `export const unused = true;`;
+    mockCompiledBundle({ compiledEntrySource, compiledWorkflowSource });
+
+    const workerPlugin = new MastraPlugin({});
+    await workerPlugin.prebuild({ entryFile: entryPath });
+
+    const activityBindingsSource = await readFile(
+      path.resolve(process.cwd(), 'node_modules/.mastra/activity-bindings.json'),
+      'utf8',
+    );
+    const activityBindings = JSON.parse(activityBindingsSource) as { exportName: string; stepId: string }[];
+    expect(activityBindings).toEqual([{ exportName: 'echoStep', stepId: 'echo' }]);
+
+    const workerOptions = workerPlugin.configureWorker({ taskQueue: 'mastra' } as any);
+    const echo = (workerOptions.activities as Record<string, (...args: any[]) => Promise<unknown>>).echo;
+
+    expect(echo).toBeTypeOf('function');
+    await expect(echo({ inputData: 'hello' })).resolves.toBe('hello');
+    await expect(
+      readFile(path.resolve(process.cwd(), 'node_modules/.mastra/activities.mjs'), 'utf8'),
+    ).resolves.toContain('const echoStep = makeEchoStep();');
   });
 
   it('bundles local mastra bindings into the generated activities module', async () => {

--- a/workflows/temporal/src/plugin.ts
+++ b/workflows/temporal/src/plugin.ts
@@ -11,6 +11,7 @@ const CACHE_PATH = 'node_modules/.mastra';
 const WORKFLOW_FILE_NAME = 'workflow.mjs';
 const ACTIVITIES_FILE_NAME = 'activities.mjs';
 const ACTIVITY_BINDINGS_FILE_NAME = 'activity-bindings.json';
+const EXECUTABLE_WORKFLOW_STEP_PATTERN = /\.(?:then|parallel|branch|dowhile|dountil|foreach)\(/;
 
 function getGeneratedWorkflowModulePath(outputDir: string): string {
   return path.join(outputDir, WORKFLOW_FILE_NAME);
@@ -54,13 +55,24 @@ export class MastraPlugin implements WorkerPlugin {
     const temporalOutputDir = path.resolve(projectRoot, CACHE_PATH);
     const compiledEntryPath = await this.#bundleMastra(entryFile, projectRoot, temporalOutputDir);
 
-    await buildTemporalWorkflowModule(compiledEntryPath, temporalOutputDir, WORKFLOW_FILE_NAME);
+    const { outputPath: workflowOutputPath } = await buildTemporalWorkflowModule(
+      compiledEntryPath,
+      temporalOutputDir,
+      WORKFLOW_FILE_NAME,
+    );
 
     const { activityBindings } = await buildTemporalActivitiesModule(
       compiledEntryPath,
       temporalOutputDir,
       ACTIVITIES_FILE_NAME,
     );
+
+    const workflowSource = readFileSync(workflowOutputPath, 'utf8');
+    if (activityBindings.length === 0 && EXECUTABLE_WORKFLOW_STEP_PATTERN.test(workflowSource)) {
+      throw new Error(
+        'MastraPlugin.prebuild() found workflow steps but generated zero Temporal activities. Ensure every workflow step is created with createStep() or a local factory that returns createStep().',
+      );
+    }
 
     await writeFile(getActivityBindingsPath(temporalOutputDir), JSON.stringify(activityBindings, null, 2), 'utf8');
 

--- a/workflows/temporal/src/plugin.ts
+++ b/workflows/temporal/src/plugin.ts
@@ -11,7 +11,6 @@ const CACHE_PATH = 'node_modules/.mastra';
 const WORKFLOW_FILE_NAME = 'workflow.mjs';
 const ACTIVITIES_FILE_NAME = 'activities.mjs';
 const ACTIVITY_BINDINGS_FILE_NAME = 'activity-bindings.json';
-const EXECUTABLE_WORKFLOW_STEP_PATTERN = /\.(?:then|parallel|branch|dowhile|dountil|foreach)\(/;
 
 function getGeneratedWorkflowModulePath(outputDir: string): string {
   return path.join(outputDir, WORKFLOW_FILE_NAME);
@@ -55,24 +54,13 @@ export class MastraPlugin implements WorkerPlugin {
     const temporalOutputDir = path.resolve(projectRoot, CACHE_PATH);
     const compiledEntryPath = await this.#bundleMastra(entryFile, projectRoot, temporalOutputDir);
 
-    const { outputPath: workflowOutputPath } = await buildTemporalWorkflowModule(
-      compiledEntryPath,
-      temporalOutputDir,
-      WORKFLOW_FILE_NAME,
-    );
+    await buildTemporalWorkflowModule(compiledEntryPath, temporalOutputDir, WORKFLOW_FILE_NAME);
 
     const { activityBindings } = await buildTemporalActivitiesModule(
       compiledEntryPath,
       temporalOutputDir,
       ACTIVITIES_FILE_NAME,
     );
-
-    const workflowSource = readFileSync(workflowOutputPath, 'utf8');
-    if (activityBindings.length === 0 && EXECUTABLE_WORKFLOW_STEP_PATTERN.test(workflowSource)) {
-      throw new Error(
-        'MastraPlugin.prebuild() found workflow steps but generated zero Temporal activities. Ensure every workflow step is created with createStep() or a local factory that returns createStep().',
-      );
-    }
 
     await writeFile(getActivityBindingsPath(temporalOutputDir), JSON.stringify(activityBindings, null, 2), 'utf8');
 

--- a/workflows/temporal/src/transforms/activities.test.ts
+++ b/workflows/temporal/src/transforms/activities.test.ts
@@ -50,6 +50,59 @@ describe('activity transform', () => {
     ]);
   });
 
+  it('collects factory-created activity bindings by declaration export name and step id', () => {
+    const bindings = collectTemporalActivityBindings(
+      `
+        import { createStep, createWorkflow } from '@mastra/core/workflows';
+
+        function makeFetchWeather() {
+          return createStep({ id: 'fetch-weather', execute: async () => ({}) });
+        }
+
+        const fetchWeather = makeFetchWeather();
+        export const weatherWorkflow = createWorkflow({ id: 'weather-workflow' }).then(fetchWeather);
+      `,
+      '/virtual/weather-workflow.mjs',
+    );
+
+    expect(bindings).toEqual([{ exportName: 'fetchWeather', stepId: 'fetch-weather' }]);
+  });
+
+  it('collects exported factory-created activity bindings', () => {
+    const bindings = collectTemporalActivityBindings(
+      `
+        import { createStep } from '@mastra/core/workflows';
+
+        const makeFetchWeather = () => createStep({ id: 'fetch-weather', execute: async () => ({}) });
+        export const fetchWeather = makeFetchWeather();
+      `,
+      '/virtual/weather-workflow.mjs',
+    );
+
+    expect(bindings).toEqual([{ exportName: 'fetchWeather', stepId: 'fetch-weather' }]);
+  });
+
+  it('collects nested factory-created activity bindings', () => {
+    const bindings = collectTemporalActivityBindings(
+      `
+        import { createStep } from '@mastra/core/workflows';
+
+        function makeFetchWeather() {
+          return createStep({ id: 'fetch-weather', execute: async () => ({}) });
+        }
+
+        function wrapFetchWeather() {
+          return makeFetchWeather();
+        }
+
+        const fetchWeather = wrapFetchWeather();
+      `,
+      '/virtual/weather-workflow.mjs',
+    );
+
+    expect(bindings).toEqual([{ exportName: 'fetchWeather', stepId: 'fetch-weather' }]);
+  });
+
   it('uses a local mastra binding in the injected helper', async () => {
     const output = await transform(`
       import { createStep } from '@mastra/core/workflows';
@@ -61,6 +114,25 @@ describe('activity transform', () => {
     expect(output).toMatch(/args\.execute\(\{[\s\S]*\.\.\.params,[\s\S]*mastra[\s\S]*\}\)/);
     expect(output).not.toMatch(/await import\(/);
     expect(output).toContain('const fetchWeather = createStep({');
+  });
+
+  it('extracts factory-created createStep declarations as named exports', async () => {
+    const output = await transform(`
+      import { createStep } from '@mastra/core/workflows';
+
+      function makeFetchWeather() {
+        return createStep({
+          id: 'fetch-weather',
+          execute: async () => ({ ok: true }),
+        });
+      }
+
+      const fetchWeather = makeFetchWeather();
+    `);
+
+    expect(output).toContain('function makeFetchWeather()');
+    expect(output).toContain('const fetchWeather = makeFetchWeather();');
+    expect(output).toMatch(/export\s*(const\s+fetchWeather\s*=|\{\s*fetchWeather\s*\})/);
   });
 
   it('keeps supporting declarations needed by extracted activities while stripping workflow setup', async () => {

--- a/workflows/temporal/src/transforms/activities.ts
+++ b/workflows/temporal/src/transforms/activities.ts
@@ -6,6 +6,7 @@ import { rollup } from 'rollup';
 import {
   collectImportedNames,
   collectInlineCreateSteps,
+  collectStepFactoryReturns,
   createExportedStepStatement,
   getCreateStepId,
   getStepNameFromCall,
@@ -17,6 +18,7 @@ import {
   nodeReferencesName,
   parserPlugins,
   pruneUnusedTopLevelBindings,
+  resolveCreateStepCall,
   walk,
 } from './shared';
 
@@ -39,9 +41,9 @@ export function collectTemporalActivityBindings(sourceText: string, filePath: st
 
   const bindings: TemporalActivityBinding[] = [];
   const seenNames = new Set<string>();
+  const factoryReturns = collectStepFactoryReturns(ast.program);
 
-  const addBinding = (call: t.CallExpression): void => {
-    const exportName = getStepNameFromCall(call);
+  const addBinding = (call: t.CallExpression, exportName = getStepNameFromCall(call)): void => {
     const stepId = getCreateStepId(call);
 
     if (!exportName || !stepId || seenNames.has(exportName)) {
@@ -78,7 +80,13 @@ export function collectTemporalActivityBindings(sourceText: string, filePath: st
         }
 
         if (isCreateStepCall(declaration.init)) {
-          addBinding(declaration.init);
+          addBinding(declaration.init, t.isIdentifier(declaration.id) ? declaration.id.name : undefined);
+          continue;
+        }
+
+        const resolvedStepCall = resolveCreateStepCall(declaration.init, factoryReturns);
+        if (resolvedStepCall) {
+          addBinding(resolvedStepCall, t.isIdentifier(declaration.id) ? declaration.id.name : undefined);
           continue;
         }
 
@@ -259,6 +267,7 @@ export async function buildTemporalActivitiesModule(
           const workflowBindingNames = collectWorkflowBindingNames(ast);
           const sourceFilePath = id;
           const hasMastraBinding = hasLocalMastraBinding(ast);
+          const factoryReturns = collectStepFactoryReturns(ast.program);
           let helperInserted = false;
 
           const ensureHelperInserted = () => {
@@ -358,6 +367,14 @@ export async function buildTemporalActivitiesModule(
                   continue;
                 }
 
+                const resolvedStepCall = resolveCreateStepCall(declaration.init, factoryReturns);
+                if (resolvedStepCall) {
+                  seenNames.add(declaration.id.name);
+                  addActivityBinding(declaration.id.name, resolvedStepCall);
+                  statements.push(createExportedStepStatement(declaration.id.name, declaration.init));
+                  continue;
+                }
+
                 if (hasCreateWorkflowCall(declaration.init)) {
                   workflowBindingNames.add(declaration.id.name);
                   strippedNames.add(declaration.id.name);
@@ -407,6 +424,14 @@ export async function buildTemporalActivitiesModule(
                 if (isCreateStepCall(declaration.init)) {
                   seenNames.add(declaration.id.name);
                   addActivityBinding(declaration.id.name, declaration.init);
+                  statements.push(createExportedStepStatement(declaration.id.name, declaration.init));
+                  continue;
+                }
+
+                const resolvedStepCall = resolveCreateStepCall(declaration.init, factoryReturns);
+                if (resolvedStepCall) {
+                  seenNames.add(declaration.id.name);
+                  addActivityBinding(declaration.id.name, resolvedStepCall);
                   statements.push(createExportedStepStatement(declaration.id.name, declaration.init));
                   continue;
                 }

--- a/workflows/temporal/src/transforms/shared.ts
+++ b/workflows/temporal/src/transforms/shared.ts
@@ -91,6 +91,105 @@ export function isCreateStepCall(node: t.Node): node is t.CallExpression {
   return t.isCallExpression(node) && isIdentifierNamed(node.callee, 'createStep');
 }
 
+function getFunctionReturnExpression(node: t.FunctionDeclaration | t.FunctionExpression | t.ArrowFunctionExpression): t.Expression | null {
+  if (t.isArrowFunctionExpression(node) && t.isExpression(node.body)) {
+    return node.body;
+  }
+
+  if (!t.isBlockStatement(node.body)) {
+    return null;
+  }
+
+  for (const statement of node.body.body) {
+    if (t.isReturnStatement(statement) && t.isExpression(statement.argument)) {
+      return statement.argument;
+    }
+  }
+
+  return null;
+}
+
+function getVariableFunction(
+  declaration: t.VariableDeclarator,
+): t.FunctionExpression | t.ArrowFunctionExpression | null {
+  if (!t.isIdentifier(declaration.id) || !declaration.init) {
+    return null;
+  }
+
+  return t.isFunctionExpression(declaration.init) || t.isArrowFunctionExpression(declaration.init)
+    ? declaration.init
+    : null;
+}
+
+export function collectStepFactoryReturns(program: t.Program): Map<string, t.Expression> {
+  const factoryReturns = new Map<string, t.Expression>();
+
+  for (const statement of program.body) {
+    const declarationStatement = t.isExportNamedDeclaration(statement) ? statement.declaration : statement;
+
+    if (t.isFunctionDeclaration(declarationStatement) && declarationStatement.id) {
+      const returnExpression = getFunctionReturnExpression(declarationStatement);
+      if (returnExpression) {
+        factoryReturns.set(declarationStatement.id.name, returnExpression);
+      }
+      continue;
+    }
+
+    if (!t.isVariableDeclaration(declarationStatement)) {
+      continue;
+    }
+
+    for (const declaration of declarationStatement.declarations) {
+      if (!t.isIdentifier(declaration.id)) {
+        continue;
+      }
+
+      const functionExpression = getVariableFunction(declaration);
+      const returnExpression = functionExpression ? getFunctionReturnExpression(functionExpression) : null;
+      if (returnExpression) {
+        factoryReturns.set(declaration.id.name, returnExpression);
+      }
+    }
+  }
+
+  return factoryReturns;
+}
+
+export function resolveCreateStepCall(
+  node: t.Node | null | undefined,
+  factoryReturns: Map<string, t.Expression>,
+  seenFactories = new Set<string>(),
+): t.CallExpression | null {
+  if (!node) {
+    return null;
+  }
+
+  if (!t.isCallExpression(node)) {
+    return null;
+  }
+
+  if (isIdentifierNamed(node.callee, 'createStep')) {
+    return node;
+  }
+
+  if (!t.isIdentifier(node.callee)) {
+    return null;
+  }
+
+  const factoryName = node.callee.name;
+  if (seenFactories.has(factoryName)) {
+    return null;
+  }
+
+  const returnExpression = factoryReturns.get(factoryName);
+  if (!returnExpression) {
+    return null;
+  }
+
+  seenFactories.add(factoryName);
+  return resolveCreateStepCall(returnExpression, factoryReturns, seenFactories);
+}
+
 export function getObjectPropertyName(property: t.ObjectProperty | t.ObjectMethod): string | null {
   if (property.computed) {
     return null;

--- a/workflows/temporal/src/transforms/workflows.test.ts
+++ b/workflows/temporal/src/transforms/workflows.test.ts
@@ -76,6 +76,64 @@ describe('workflow transform', () => {
     expect(result).not.toContain('.then("subWorkflow")');
   });
 
+  it('rewrites factory-created step references to step ids', async () => {
+    const result = await transform(`
+      import { createStep, createWorkflow } from '@mastra/core/workflows';
+
+      function makeFetchWeather() {
+        return createStep({ id: 'fetch-weather', execute: async () => ({}) });
+      }
+
+      const fetchWeather = makeFetchWeather();
+      export const weatherWorkflow = createWorkflow({ id: 'weather-workflow' }).then(fetchWeather);
+    `);
+
+    expect(result).toContain('.then("fetch-weather")');
+    expect(result).not.toContain('fetchWeather =');
+  });
+
+  it('rewrites multiple factory-created step references to step ids', async () => {
+    const result = await transform(`
+      import { createStep, createWorkflow } from '@mastra/core/workflows';
+
+      function makeFetchWeather() {
+        return createStep({ id: 'fetch-weather', execute: async () => ({}) });
+      }
+
+      function makePlanActivities() {
+        return createStep({ id: 'plan-activities', execute: async () => ({}) });
+      }
+
+      const fetchWeather = makeFetchWeather();
+      const planActivities = makePlanActivities();
+      export const weatherWorkflow = createWorkflow({ id: 'weather-workflow' }).parallel([
+        fetchWeather,
+        planActivities,
+      ]);
+    `);
+
+    expect(result).toContain('.parallel(["fetch-weather", "plan-activities"])');
+  });
+
+  it('rewrites nested factory-created step references to step ids', async () => {
+    const result = await transform(`
+      import { createStep, createWorkflow } from '@mastra/core/workflows';
+
+      function makeFetchWeather() {
+        return createStep({ id: 'fetch-weather', execute: async () => ({}) });
+      }
+
+      function wrapFetchWeather() {
+        return makeFetchWeather();
+      }
+
+      const fetchWeather = wrapFetchWeather();
+      export const weatherWorkflow = createWorkflow({ id: 'weather-workflow' }).then(fetchWeather);
+    `);
+
+    expect(result).toContain('.then("fetch-weather")');
+  });
+
   it('injects the helper runtime from the dedicated module into transformed output', async () => {
     const output = await transform(`
       import { createWorkflow } from '@mastra/core/workflows';

--- a/workflows/temporal/src/transforms/workflows.ts
+++ b/workflows/temporal/src/transforms/workflows.ts
@@ -7,6 +7,7 @@ import { rollup } from 'rollup';
 import { toWorkflowType } from '../utils';
 import {
   collectImportedNames,
+  collectStepFactoryReturns,
   getCreateStepId,
   getObjectPropertyName,
   isCreateWorkflowCall,
@@ -18,6 +19,7 @@ import {
   parseModule,
   parserPlugins,
   pruneUnusedTopLevelBindings,
+  resolveCreateStepCall,
 } from './shared';
 
 /**
@@ -125,6 +127,7 @@ function parseWorkflowChain(
  */
 function collectStepBindings(program: t.Program): Map<string, string> {
   const stepBindings = new Map<string, string>();
+  const factoryReturns = collectStepFactoryReturns(program);
 
   for (const statement of program.body) {
     if (
@@ -143,7 +146,7 @@ function collectStepBindings(program: t.Program): Map<string, string> {
         continue;
       }
 
-      const stepId = getCreateStepId(declaration.init);
+      const stepId = getCreateStepId(resolveCreateStepCall(declaration.init, factoryReturns));
       if (stepId) {
         stepBindings.set(declaration.id.name, stepId);
       }


### PR DESCRIPTION
## Description

Fixes activity discovery for Temporal workflows that use factory-created steps.

Previously, Temporal prebuild only detected activities when `createStep()` was used directly in a top-level variable initializer. Steps created through local factory functions were not added to `activity-bindings.json`, causing workers to start without registered activities and workflows to fail at runtime.

This change:

* Adds support for resolving local factory functions that return `createStep(...)`
* Supports nested local factory wrappers
* Updates workflow transformation to rewrite factory-created step references to step IDs
* Adds regression tests covering activity discovery and workflow transformation
* Adds a prebuild validation error when workflow steps are detected but zero Temporal activities are generated

## Related issue(s)

Fixes #17980

## Type of change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [x] Test update

## Checklist

* [x] I have linked the related issue(s) in the description above
* [ ] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a problem where Temporal workflows didn't work when developers created workflow steps inside helper functions (factories). Instead of ignoring these helper functions and causing silent failures at runtime, the code now finds them, registers the steps properly, and shows a clear error message during the build if something goes wrong.

---

## Changes Overview

The PR adds support for discovering and transforming Temporal workflow steps that are created through local factory functions in the `@mastra/temporal` package. Previously, the prebuild process only detected `createStep()` calls made directly in top-level variable initializers, causing workflows to fail silently at runtime when steps were created via factory functions.

## Key Changes

### Core Logic Additions

**New AST utilities** (`workflows/temporal/src/transforms/shared.ts`):
- `collectStepFactoryReturns()`: Scans the program for factory functions and maps factory names to their return expressions, supporting both direct `createStep()` returns and nested factory returns
- `resolveCreateStepCall()`: Resolves step creation through factory indirection by following factory function calls back to the actual `createStep()` invocation, with cycle detection to prevent infinite recursion

### Transform Updates

**Activities module generation** (`workflows/temporal/src/transforms/activities.ts`):
- Now computes factory metadata once per transform
- When processing variable declarations, resolves `createStep()` calls through factories before extracting step IDs
- Maintains original initializer expressions for step wrapper generation while using resolved calls for activity binding collection

**Workflow transformation** (`workflows/temporal/src/transforms/workflows.ts`):
- Integrates factory resolution into `collectStepBindings()` 
- Steps created via factories are now properly converted to step-ID string references in workflow chains

### Build Validation

**Plugin prebuild process** (`workflows/temporal/src/plugin.ts`):
- Adds a new validation check that throws a clear error if workflow steps are detected in the generated source but zero activity bindings were created
- Prevents silent failures by catching the mismatch between detected steps and registered activities at build time

### Test Coverage

Added comprehensive regression tests across three files:
- **Factory detection tests** (`workflows/temporal/src/transforms/activities.test.ts`): Verifies activity binding collection from directly declared factories, factory-created exports, and nested factory calls
- **Workflow transformation tests** (`workflows/temporal/src/transforms/workflows.test.ts`): Validates that factory-created steps are correctly rewritten to step-ID references in workflow chains and parallel constructs
- **End-to-end tests** (`workflows/temporal/src/index.test.ts`): Tests the full prebuild flow with factory-created steps, verifying `activity-bindings.json` generation and worker configuration

## Files Modified

- `.changeset/fuzzy-waves-share.md`: Changesets entry (patch level)
- `workflows/temporal/src/plugin.ts`: Validation logic
- `workflows/temporal/src/transforms/shared.ts`: New factory resolution utilities
- `workflows/temporal/src/transforms/activities.ts`: Factory-aware activity binding collection
- `workflows/temporal/src/transforms/workflows.ts`: Factory-aware step binding resolution
- `workflows/temporal/src/transforms/activities.test.ts`: New test cases (+72 lines)
- `workflows/temporal/src/transforms/workflows.test.ts`: New test cases (+58 lines)
- `workflows/temporal/src/index.test.ts`: New test cases (+117 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->