### PR TITLE
chore: improve renovate dependency grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -135,7 +135,8 @@
         "mongodb",
         "mssql",
         "pg",
-        "redis"
+        "redis",
+        "@types/pg"
       ],
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["dependencies", "devDependencies"],
@@ -289,7 +290,15 @@
       "groupName": "Schema",
       "commitMessageTopic": "Schema",
       "matchFileNames": ["+(package.json)", "**/package.json"],
-      "matchPackageNames": ["zod", "json-schema", "zod-to-json-schema"],
+      "matchPackageNames": [
+        "zod",
+        "json-schema",
+        "zod-to-json-schema",
+        "zod-from-json-schema",
+        "zod-from-json-schema-v3",
+        "zod-to-ts",
+        "json-schema-to-zod"
+      ],
       "matchUpdateTypes": ["major", "minor", "patch"],
       "matchDepTypes": ["dependencies", "devDependencies"],
       "dependencyDashboardApproval": false
@@ -350,7 +359,7 @@
       "groupName": "Inngest",
       "commitMessageTopic": "Inngest",
       "matchFileNames": ["+(package.json)", "**/package.json"],
-      "matchPackageNames": ["inngest", "inngest-cli"],
+      "matchPackageNames": ["inngest", "inngest-cli", "@inngest/*"],
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["dependencies", "devDependencies"]
     },
@@ -363,10 +372,88 @@
       "matchDepTypes": ["dependencies", "devDependencies"]
     },
     {
+      "groupName": "Browser automation",
+      "commitMessageTopic": "Browser automation",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["@browserbasehq/stagehand", "agent-browser", "firecrawl"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
+      "groupName": "Chat adapter",
+      "commitMessageTopic": "Chat adapter",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["@chat-adapter/slack", "chat"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
+      "groupName": "Composio",
+      "commitMessageTopic": "Composio",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["@composio/core", "@composio/mastra"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
+      "groupName": "MCP",
+      "commitMessageTopic": "MCP",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["@modelcontextprotocol/*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
+      "groupName": "OpenCode",
+      "commitMessageTopic": "OpenCode",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["@opencode-ai/*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
+      "groupName": "React Hook Form",
+      "commitMessageTopic": "React Hook Form",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["react-hook-form", "@hookform/resolvers"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
+      "groupName": "Smithy",
+      "commitMessageTopic": "Smithy",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["@smithy/*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
+      "groupName": "Tailwind ecosystem",
+      "commitMessageTopic": "Tailwind ecosystem",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["@tailwindcss/typography", "prettier-plugin-tailwindcss", "tailwind-merge"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
       "groupName": "Vector Databases",
       "commitMessageTopic": "Vector Databases",
       "matchFileNames": ["+(package.json)", "**/package.json"],
-      "matchPackageNames": ["@qdrant/js-client-rest", "chromadb", "lancedb", "turbopuffer"],
+      "matchPackageNames": [
+        "@lancedb/lancedb",
+        "@pinecone-database/pinecone",
+        "@qdrant/js-client-rest",
+        "@turbopuffer/turbopuffer",
+        "chromadb"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
+      "groupName": "WorkOS",
+      "commitMessageTopic": "WorkOS",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["@workos-inc/node", "@workos/authkit-session"],
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["dependencies", "devDependencies"]
     },
@@ -374,7 +461,15 @@
       "groupName": "Workflow Platforms",
       "commitMessageTopic": "Workflow Platforms",
       "matchFileNames": ["+(package.json)", "**/package.json"],
-      "matchPackageNames": ["convex", "@daytona-io/sdk", "electrodb"],
+      "matchPackageNames": ["convex", "electrodb"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
+    },
+    {
+      "groupName": "Workspace providers",
+      "commitMessageTopic": "Workspace providers",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": ["@blaxel/core", "@daytonaio/sdk", "agentfs-sdk", "e2b", "files-sdk", "modal", "@vercel/sandbox"],
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["dependencies", "devDependencies"]
     }

--- a/renovate.json
+++ b/renovate.json
@@ -125,18 +125,24 @@
         "@datastax/astra-db-ts",
         "@duckdb/node-api",
         "@elastic/elasticsearch",
+        "@lancedb/lancedb",
         "@libsql/client",
         "@opensearch-project/opensearch",
         "@pinecone-database/pinecone",
+        "@qdrant/js-client-rest",
         "@supabase/supabase-js",
         "@turbopuffer/turbopuffer",
+        "@types/mssql",
+        "@types/pg",
+        "chromadb",
+        "convex",
         "couchbase",
+        "electrodb",
         "ioredis",
         "mongodb",
         "mssql",
         "pg",
-        "redis",
-        "@types/pg"
+        "redis"
       ],
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["dependencies", "devDependencies"],
@@ -391,7 +397,7 @@
       "groupName": "Composio",
       "commitMessageTopic": "Composio",
       "matchFileNames": ["+(package.json)", "**/package.json"],
-      "matchPackageNames": ["@composio/core", "@composio/mastra"],
+      "matchPackageNames": ["@composio/*"],
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["dependencies", "devDependencies"]
     },
@@ -436,20 +442,6 @@
       "matchDepTypes": ["dependencies", "devDependencies"]
     },
     {
-      "groupName": "Vector Databases",
-      "commitMessageTopic": "Vector Databases",
-      "matchFileNames": ["+(package.json)", "**/package.json"],
-      "matchPackageNames": [
-        "@lancedb/lancedb",
-        "@pinecone-database/pinecone",
-        "@qdrant/js-client-rest",
-        "@turbopuffer/turbopuffer",
-        "chromadb"
-      ],
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchDepTypes": ["dependencies", "devDependencies"]
-    },
-    {
       "groupName": "WorkOS",
       "commitMessageTopic": "WorkOS",
       "matchFileNames": ["+(package.json)", "**/package.json"],
@@ -458,18 +450,18 @@
       "matchDepTypes": ["dependencies", "devDependencies"]
     },
     {
-      "groupName": "Workflow Platforms",
-      "commitMessageTopic": "Workflow Platforms",
-      "matchFileNames": ["+(package.json)", "**/package.json"],
-      "matchPackageNames": ["convex", "electrodb"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchDepTypes": ["dependencies", "devDependencies"]
-    },
-    {
       "groupName": "Workspace providers",
       "commitMessageTopic": "Workspace providers",
       "matchFileNames": ["+(package.json)", "**/package.json"],
-      "matchPackageNames": ["@blaxel/core", "@daytonaio/sdk", "agentfs-sdk", "e2b", "files-sdk", "modal", "@vercel/sandbox"],
+      "matchPackageNames": [
+        "@blaxel/core",
+        "@daytonaio/sdk",
+        "agentfs-sdk",
+        "e2b",
+        "files-sdk",
+        "modal",
+        "@vercel/sandbox"
+      ],
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["dependencies", "devDependencies"]
     }


### PR DESCRIPTION
This tightens up Renovate grouping so related dependency updates land together instead of as scattered PRs.

It adds groups for a few shared ecosystems like MCP, browser automation, Composio, OpenCode, React Hook Form, Smithy, Tailwind, WorkOS, and workspace providers. It also fixes vector DB package names and expands existing database, schema, and Inngest groups.

Validated with `pnpm dlx --package renovate renovate-config-validator renovate.json`.

No changeset because this only changes repo automation config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Renovate is the bot that updates your dependencies. This change tells it to collect “similar” updates together (by ecosystem) so it opens fewer, more organized upgrade pull requests instead of many small ones.

## Technical Details

**What changed in `renovate.json`:**
- **Expanded existing dependency grouping rules:**
  - **Database clients**: added additional TypeScript DB type packages (e.g., `@types/pg`, `@types/mssql`).
  - **Schema tools**: widened the match list to include more Zod / JSON-schema conversion helpers (e.g., `zod-from-json-schema*`, `zod-to-ts`, `json-schema-to-zod` variants).
  - **Inngest**: broadened matches to include the `@inngest/*` scoped packages.
- **Added new dependency groups** so Renovate consolidates related updates:
  - **Browser automation**, **Chat adapter**, **Composio**, **MCP (Model Context Protocol)**, **OpenCode**, **React Hook Form**, **Smithy**.
- **Refined other grouping rules:**
  - **Tailwind ecosystem**, **WorkOS**, and **Workspace providers** were updated/expanded (including additional `@vercel/sandbox`-ending provider matches in the visible section).
  - **Vector database package naming** was adjusted so the grouping matches the correct package names.
  - Some prior rule placement for groups like **Vector Databases** and **Workflow Platforms** was reorganized within the `packageRules` array.
- **Validation:** ran `renovate-config-validator` via `pnpm dlx --package renovate renovate-config-validator renovate.json` to confirm the config is valid.
- **No changeset added** because this is a repository automation configuration change.

Lines changed in `renovate.json`: **+95 / -8**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->