### PR TITLE
fix(stores): advance updatedAt on updateThread in libsql, mongodb, and upstash

### DIFF
--- a/.changeset/wide-crabs-remain.md
+++ b/.changeset/wide-crabs-remain.md
@@ -1,0 +1,7 @@
+---
+'@mastra/mongodb': patch
+'@mastra/upstash': patch
+'@mastra/libsql': patch
+---
+
+Fixed `updateThread` not updating the thread's `updatedAt` timestamp. Renaming a thread or changing its metadata now advances `updatedAt`, so recently-edited threads sort correctly when listing threads by recency and any "changed since" logic sees the new time.

--- a/stores/_test-utils/src/domains/memory/threads.ts
+++ b/stores/_test-utils/src/domains/memory/threads.ts
@@ -4,6 +4,10 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import { randomUUID } from 'node:crypto';
 
+// Normalize a timestamp (Date or ISO string) to epoch millis for comparison across adapters.
+const getTimestamp = (date: Date | string): number =>
+  date instanceof Date ? date.getTime() : new Date(date).getTime();
+
 export function createThreadsTest({ storage }: { storage: MastraStorage }) {
   let memoryStorage: MemoryStorage;
 
@@ -143,6 +147,13 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       const thread = createSampleThread();
       await memoryStorage.saveThread({ thread });
 
+      const createdAt = getTimestamp(thread.createdAt);
+      const beforeUpdate = getTimestamp(thread.updatedAt);
+
+      // Sleep so the new updatedAt is strictly after createdAt even on stores that
+      // store timestamps at coarser-than-microsecond resolution.
+      await new Promise(resolve => setTimeout(resolve, 50));
+
       const newMetadata = { newKey: 'newValue' };
       const updatedThread = await memoryStorage.updateThread({
         id: thread.id,
@@ -156,10 +167,17 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
         ...newMetadata,
       });
 
-      // Verify persistence
+      // updateThread must advance updatedAt past both the original createdAt and the
+      // pre-update updatedAt. (Regression guard: several adapters previously returned
+      // and persisted a stale updatedAt.)
+      expect(getTimestamp(updatedThread.updatedAt)).toBeGreaterThan(createdAt);
+      expect(getTimestamp(updatedThread.updatedAt)).toBeGreaterThan(beforeUpdate);
+
+      // Verify persistence — the read-back must equal what updateThread returned,
+      // including the advanced updatedAt.
       const retrievedThread = await memoryStorage.getThreadById({ threadId: thread.id });
-      console.log('retrievedThread', retrievedThread);
       expect(retrievedThread).toEqual(updatedThread);
+      expect(getTimestamp(retrievedThread!.updatedAt)).toBe(getTimestamp(updatedThread.updatedAt));
     });
 
     it('should return consistent timestamps from getThreadById and listThreads (issue #11496)', async () => {
@@ -192,15 +210,16 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       expect(threadById).toBeDefined();
       expect(threadFromList).toBeDefined();
 
-      // Normalize to timestamps for comparison (handles both Date objects and ISO strings)
-      const getTimestamp = (date: Date | string) => (date instanceof Date ? date.getTime() : new Date(date).getTime());
-
       // The timestamps should be identical between the two retrieval methods
       expect(getTimestamp(threadFromList!.createdAt)).toBe(getTimestamp(threadById!.createdAt));
       expect(getTimestamp(threadFromList!.updatedAt)).toBe(getTimestamp(threadById!.updatedAt));
 
       // Also verify updatedAt from updateThread matches
       expect(getTimestamp(threadFromList!.updatedAt)).toBe(getTimestamp(updatedThread.updatedAt));
+
+      // The update must have actually advanced updatedAt past createdAt (we slept above),
+      // otherwise the "consistency" above could be agreement on a stale value.
+      expect(getTimestamp(threadById!.updatedAt)).toBeGreaterThan(getTimestamp(threadById!.createdAt));
     });
 
     it('should delete thread', async () => {
@@ -1122,8 +1141,6 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
 
       expect(threadById).toBeDefined();
       expect(threadFromList).toBeDefined();
-
-      const getTimestamp = (date: Date | string) => (date instanceof Date ? date.getTime() : new Date(date).getTime());
 
       // Timestamps should be identical
       expect(getTimestamp(threadFromList!.createdAt)).toBe(getTimestamp(threadById!.createdAt));

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -1225,6 +1225,7 @@ export class MemoryLibSQL extends MemoryStorage {
       });
     }
 
+    const updatedAt = new Date();
     const updatedThread = {
       ...thread,
       title,
@@ -1232,12 +1233,13 @@ export class MemoryLibSQL extends MemoryStorage {
         ...thread.metadata,
         ...metadata,
       },
+      updatedAt,
     };
 
     try {
       await this.#client.execute({
-        sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?) WHERE id = ?`,
-        args: [title, JSON.stringify(updatedThread.metadata), id],
+        sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?), "updatedAt" = ? WHERE id = ?`,
+        args: [title, JSON.stringify(updatedThread.metadata), updatedAt.toISOString(), id],
       });
 
       return updatedThread;

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -1084,6 +1084,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         ...thread.metadata,
         ...metadata,
       },
+      updatedAt: new Date(),
     };
 
     try {
@@ -1094,6 +1095,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
           $set: {
             title,
             metadata: updatedThread.metadata,
+            updatedAt: updatedThread.updatedAt,
           },
         },
       );

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -276,6 +276,7 @@ export class StoreMemoryUpstash extends MemoryStorage {
         ...thread.metadata,
         ...metadata,
       },
+      updatedAt: new Date(),
     };
 
     try {


### PR DESCRIPTION
## Description

`updateThread` did not advance `updatedAt` in the `@mastra/libsql`, `@mastra/mongodb`, and `@mastra/upstash` adapters. When you updated a thread's title or metadata, these three wrote the new title and metadata but left `updatedAt` at its old value, and they returned a thread object that still carried the stale timestamp. The canonical in-memory store and the other adapters all set a fresh `updatedAt` on update, so these three were the odd ones out. They shared the same root cause: building the updated thread as `{ ...thread, title, metadata }` without touching `updatedAt`.

This PR makes the three adapters advance `updatedAt` to the current time on update, so both the returned thread and the persisted row carry the new timestamp. After an update, `updatedAt` is strictly greater than `createdAt`, and thread recency ordering (`listThreads` sorts by `updatedAt`) plus any "changed since" logic now reflect the edit. `redis` already did this correctly and was used as the template.

It also tightens the shared conformance suite, which is the reason the bug shipped green. The existing tests only checked that the read methods agreed with the value returned by `updateThread`, so they passed even when that value was stale. The "update thread title and metadata" test ended in `expect(retrieved).toEqual(updated)`, a tautology for the timestamp, and the "consistent timestamps" test only checked agreement across reads. Both now assert that `updatedAt` strictly advances past `createdAt` and the pre-update value.

To keep CI green, all three adapter fixes land together with the test change. Tightening the shared test on its own would turn libsql, mongodb, and upstash red, since they all run the same suite.

Changes:
- libsql: write `updatedAt` in the `UPDATE` statement and return it on the thread object
- mongodb: set `updatedAt` in the `$set` and on the returned object
- upstash: set `updatedAt` on the merged thread before saving
- _test-utils: assert `updatedAt` strictly advances in both thread timestamp tests, and hoist the shared `getTimestamp` helper to module scope

I checked the timestamp column precision for every adapter that runs the shared suite (DATETIME(3)/(6) on mysql, DATETIME2(7) on mssql, timestamptz on pg and dsql, DateTime64(3) on clickhouse, ISO strings and Date objects elsewhere). They all keep sub-second precision, so the 50ms sleep in the tests is safe and will not flake the adapters that were already correct.

## Related issue(s)

Fixes #18000

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you change a thread's title or other information, the system is supposed to update a timestamp saying "this was just changed." Three storage systems (libsql, mongodb, and upstash) had a bug where they weren't doing this—they'd update the information but leave the timestamp unchanged. This PR fixes those three systems so they properly update the timestamp, and also improves the tests that check this behavior works correctly.

## Changes

**Bug fixes in three storage adapters:**

- **libsql**: Added `updatedAt` to the SQL `UPDATE` statement, now persisting and returning the new timestamp when a thread is updated
- **mongodb**: Included `updatedAt` in the MongoDB `$set` operation, ensuring the timestamp is persisted and returned
- **upstash**: Sets a new `updatedAt` timestamp on the thread object before persisting updates

**Test suite improvements:**

- Created a shared `getTimestamp` helper in the test utilities to normalize timestamp comparisons across storage adapters
- Tightened the "update thread title and metadata" test to verify that `updatedAt` strictly advances past both `createdAt` and the pre-update value, and that the updated timestamp persists when retrieving the thread
- Enhanced the "consistent timestamps" test to explicitly assert that `updatedAt` is greater than `createdAt`
- These changes close a test coverage gap where the original assertions only verified agreement between read methods without confirming that timestamps actually advance

**Release updates:**

- Marked patch releases for `@mastra/mongodb`, `@mastra/libsql`, and `@mastra/upstash` packages to include these fixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->