### PR TITLE
feat(core): add persistPartialOnAbort option to preserve partial stream output on abort

### DIFF
--- a/.changeset/thick-baths-open.md
+++ b/.changeset/thick-baths-open.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added `persistPartialOnAbort` option to `agent.stream()` to save partial output when a stream is aborted. When a stream is aborted, any text already received by the client is now optionally saved to thread history. Pass `persistPartialOnAbort: true` to opt in — default behavior is unchanged (partial output is discarded on abort).

--- a/packages/core/src/agent/__tests__/persist-partial-on-abort.test.ts
+++ b/packages/core/src/agent/__tests__/persist-partial-on-abort.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
 import type { MastraDBMessage } from '../message-list';
-import { MockLanguageModelV2, convertArrayToReadableStream } from './mock-model';
+import { MockLanguageModelV2 } from './mock-model';
 
 function buildAbortingStreamModel(opts: { chunks: string[]; abortAfterChunk: number }) {
   const { chunks, abortAfterChunk } = opts;
@@ -45,6 +45,20 @@ function buildAbortingStreamModel(opts: { chunks: string[]; abortAfterChunk: num
   });
 
   return { model, abortController };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  opts: { timeout?: number; interval?: number } = {},
+): Promise<void> {
+  const { timeout = 1000, interval = 10 } = opts;
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start >= timeout) {
+      return;
+    }
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
 }
 
 function extractAssistantText(messages: MastraDBMessage[]): string {
@@ -93,8 +107,8 @@ describe('persistPartialOnAbort', () => {
       await stream.consumeStream();
     } catch {}
 
-    // Wait a tick for any async persistence to settle
-    await new Promise(resolve => setTimeout(resolve, 100));
+    // Wait for any async persistence to settle (none expected in this case)
+    await waitFor(() => savedMessages.length > 0, { timeout: 200 });
 
     const assistantText = extractAssistantText(savedMessages);
     // By default, partial output should NOT be saved
@@ -131,8 +145,8 @@ describe('persistPartialOnAbort', () => {
       await stream.consumeStream();
     } catch {}
 
-    // Wait for async persistence
-    await new Promise(resolve => setTimeout(resolve, 200));
+    // Wait for async persistence to complete
+    await waitFor(() => extractAssistantText(savedMessages).length > 0);
 
     const assistantText = extractAssistantText(savedMessages);
     // With persistPartialOnAbort: true, the partial text received before abort should be saved
@@ -190,7 +204,8 @@ describe('persistPartialOnAbort', () => {
       await stream.consumeStream();
     } catch {}
 
-    await new Promise(resolve => setTimeout(resolve, 100));
+    // Give any (unexpected) async persistence a chance to settle before asserting
+    await waitFor(() => savedMessages.some(m => m.role === 'assistant'), { timeout: 200 });
 
     const assistantMessages = savedMessages.filter(m => m.role === 'assistant');
     // Empty partial output should not be persisted

--- a/packages/core/src/agent/__tests__/persist-partial-on-abort.test.ts
+++ b/packages/core/src/agent/__tests__/persist-partial-on-abort.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import { MockMemory } from '../../memory/mock';
+import { Agent } from '../agent';
+import type { MastraDBMessage } from '../message-list';
+import { MockLanguageModelV2, convertArrayToReadableStream } from './mock-model';
+
+function buildAbortingStreamModel(opts: { chunks: string[]; abortAfterChunk: number }) {
+  const { chunks, abortAfterChunk } = opts;
+  const abortController = new AbortController();
+  let index = 0;
+
+  const allChunks = [
+    { type: 'stream-start' as const, warnings: [] },
+    { type: 'response-metadata' as const, id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+    { type: 'text-start' as const, id: 'text-1' },
+    ...chunks.map(delta => ({ type: 'text-delta' as const, id: 'text-1', delta })),
+    { type: 'text-end' as const, id: 'text-1' },
+    {
+      type: 'finish' as const,
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 10, outputTokens: chunks.length, totalTokens: 10 + chunks.length },
+    },
+  ];
+
+  const model = new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: new ReadableStream({
+        pull(controller) {
+          if (index < allChunks.length) {
+            const chunk = allChunks[index++]!;
+            // Abort after the specified number of text-delta chunks have been enqueued
+            const textDeltasSoFar = allChunks.slice(0, index).filter(c => c.type === 'text-delta').length;
+            if (chunk.type === 'text-delta' && textDeltasSoFar === abortAfterChunk) {
+              abortController.abort();
+            }
+            controller.enqueue(chunk);
+          } else {
+            controller.close();
+          }
+        },
+      }),
+    }),
+  });
+
+  return { model, abortController };
+}
+
+function extractAssistantText(messages: MastraDBMessage[]): string {
+  return messages
+    .filter(m => m.role === 'assistant')
+    .map(m => {
+      if (typeof m.content === 'string') return m.content;
+      if (m.content && typeof m.content === 'object' && 'parts' in m.content && Array.isArray(m.content.parts)) {
+        return m.content.parts
+          .filter((p: any) => p.type === 'text')
+          .map((p: any) => p.text)
+          .join('');
+      }
+      return '';
+    })
+    .join('');
+}
+
+describe('persistPartialOnAbort', () => {
+  it('does NOT persist partial output on abort by default', async () => {
+    const chunks = ['hello', ' world', ' partial'];
+    const { model, abortController } = buildAbortingStreamModel({ chunks, abortAfterChunk: 2 });
+
+    const mockMemory = new MockMemory();
+    const savedMessages: MastraDBMessage[] = [];
+    const orig = mockMemory.saveMessages.bind(mockMemory);
+    mockMemory.saveMessages = async args => {
+      savedMessages.push(...args.messages);
+      return orig(args);
+    };
+
+    const agent = new Agent({
+      id: 'test-no-persist-default',
+      name: 'Test No Persist Default',
+      model,
+      instructions: 'Test agent',
+      memory: mockMemory,
+    });
+
+    const stream = await agent.stream('Hello', {
+      abortSignal: abortController.signal,
+      memory: { thread: 'no-persist-thread', resource: 'no-persist-resource' },
+    });
+
+    try {
+      await stream.consumeStream();
+    } catch {}
+
+    // Wait a tick for any async persistence to settle
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const assistantText = extractAssistantText(savedMessages);
+    // By default, partial output should NOT be saved
+    expect(assistantText).toBe('');
+  });
+
+  it('persists partial output on abort when persistPartialOnAbort is true', async () => {
+    const chunks = ['hello', ' world', ' partial'];
+    const { model, abortController } = buildAbortingStreamModel({ chunks, abortAfterChunk: 2 });
+
+    const mockMemory = new MockMemory();
+    const savedMessages: MastraDBMessage[] = [];
+    const orig = mockMemory.saveMessages.bind(mockMemory);
+    mockMemory.saveMessages = async args => {
+      savedMessages.push(...args.messages);
+      return orig(args);
+    };
+
+    const agent = new Agent({
+      id: 'test-persist-on-abort',
+      name: 'Test Persist On Abort',
+      model,
+      instructions: 'Test agent',
+      memory: mockMemory,
+    });
+
+    const stream = await agent.stream('Hello', {
+      persistPartialOnAbort: true,
+      abortSignal: abortController.signal,
+      memory: { thread: 'persist-abort-thread', resource: 'persist-abort-resource' },
+    });
+
+    try {
+      await stream.consumeStream();
+    } catch {}
+
+    // Wait for async persistence
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    const assistantText = extractAssistantText(savedMessages);
+    // With persistPartialOnAbort: true, the partial text received before abort should be saved
+    expect(assistantText.length).toBeGreaterThan(0);
+    // The partial text should include at least the first chunk
+    expect(assistantText).toContain('hello');
+  });
+
+  it('does not save empty text even when persistPartialOnAbort is true', async () => {
+    const abortController = new AbortController();
+    let pulled = 0;
+
+    // Model that aborts immediately, before emitting any text
+    const model = new MockLanguageModelV2({
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: new ReadableStream({
+          pull(controller) {
+            pulled++;
+            if (pulled === 1) {
+              abortController.abort();
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+            } else {
+              controller.error(new DOMException('The user aborted a request.', 'AbortError'));
+            }
+          },
+        }),
+      }),
+    });
+
+    const mockMemory = new MockMemory();
+    const savedMessages: MastraDBMessage[] = [];
+    const orig = mockMemory.saveMessages.bind(mockMemory);
+    mockMemory.saveMessages = async args => {
+      savedMessages.push(...args.messages);
+      return orig(args);
+    };
+
+    const agent = new Agent({
+      id: 'test-no-save-empty',
+      name: 'Test No Save Empty',
+      model,
+      instructions: 'Test agent',
+      memory: mockMemory,
+    });
+
+    const stream = await agent.stream('Hello', {
+      persistPartialOnAbort: true,
+      abortSignal: abortController.signal,
+      memory: { thread: 'no-save-empty-thread', resource: 'no-save-empty-resource' },
+    });
+
+    try {
+      await stream.consumeStream();
+    } catch {}
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const assistantMessages = savedMessages.filter(m => m.role === 'assistant');
+    // Empty partial output should not be persisted
+    expect(assistantMessages.length).toBe(0);
+  });
+
+  it('streams without memory do not throw when persistPartialOnAbort is true', async () => {
+    const chunks = ['hello', ' world'];
+    const { model, abortController } = buildAbortingStreamModel({ chunks, abortAfterChunk: 1 });
+
+    const agent = new Agent({
+      id: 'test-persist-abort-no-memory',
+      name: 'Test Persist Abort No Memory',
+      model,
+      instructions: 'Test agent',
+    });
+
+    const stream = await agent.stream('Hello', {
+      persistPartialOnAbort: true,
+      abortSignal: abortController.signal,
+    });
+
+    // Should not throw even without memory configured
+    await expect(stream.consumeStream().catch(() => {})).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -689,8 +689,7 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
    * @example
    * ```typescript
    * const stream = await agent.stream("Hello", {
-   *   threadId: "my-thread",
-   *   resourceId: "user-123",
+   *   memory: { thread: "my-thread", resource: "user-123" },
    *   persistPartialOnAbort: true,
    * });
    * ```

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -680,6 +680,22 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
    * continuation from outside the loop.
    */
   _skipBgTaskWait?: boolean;
+
+  /**
+   * When true, any text already streamed to the client is persisted to thread
+   * history even if the stream is aborted before the model finishes. Defaults
+   * to false (partial output is discarded on abort).
+   *
+   * @example
+   * ```typescript
+   * const stream = await agent.stream("Hello", {
+   *   threadId: "my-thread",
+   *   resourceId: "user-123",
+   *   persistPartialOnAbort: true,
+   * });
+   * ```
+   */
+  persistPartialOnAbort?: boolean;
 } & Partial<ObservabilityContext>;
 
 /**

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -299,6 +299,32 @@ export function createMapResultsStep<OUTPUT = undefined>({
           }
 
           if (payload.finishReason === 'aborted') {
+            if (options.persistPartialOnAbort && payload.text) {
+              try {
+                await capabilities.executeOnFinish({
+                  result: payload,
+                  outputText: payload.text,
+                  thread: result.thread,
+                  threadId: result.threadId,
+                  readOnlyMemory: memoryConfig?.readOnly,
+                  resourceId,
+                  memoryConfig,
+                  requestContext,
+                  agentSpan: agentSpan,
+                  runId,
+                  messageList,
+                  threadExists: memoryData.threadExists,
+                  structuredOutput: false,
+                  overrideScorers: options.scorers,
+                });
+              } catch (e) {
+                capabilities.logger.error('Error saving partial memory on abort', {
+                  error: e,
+                  runId,
+                });
+              }
+            }
+
             agentSpan?.end({
               output: {
                 status: 'aborted',
@@ -356,6 +382,32 @@ export function createMapResultsStep<OUTPUT = undefined>({
                     );
 
               agentSpan?.error({ error: spanError, endSpan: true });
+            }
+          } else if (options.persistPartialOnAbort && payload.text) {
+            try {
+              await capabilities.executeOnFinish({
+                result: payload,
+                outputText: payload.text,
+                thread: result.thread,
+                threadId: result.threadId,
+                readOnlyMemory: memoryConfig?.readOnly,
+                resourceId,
+                memoryConfig,
+                requestContext,
+                agentSpan: agentSpan,
+                runId,
+                messageList,
+                threadExists: memoryData.threadExists,
+                structuredOutput: false,
+                overrideScorers: options.scorers,
+              });
+            } catch (e) {
+              capabilities.logger.error('Error saving partial memory on abort', {
+                error: e,
+                runId,
+              });
+
+              agentSpan?.end();
             }
           } else {
             agentSpan?.end();


### PR DESCRIPTION
## Summary

Closes #17510

When an agent stream is aborted, any text already streamed to the client is currently discarded and not persisted to thread history. This adds an opt-in `persistPartialOnAbort` option that, when enabled, saves the partial response to memory before the stream exits.

**Usage:**
\`\`\`ts
const stream = await agent.stream("Hello", {
  threadId: "my-thread",
  resourceId: "user-123",
  persistPartialOnAbort: true, // save partial output if stream is aborted
});
\`\`\`

By default, behavior is unchanged (partial output is discarded on abort).

## Changes

- Added `persistPartialOnAbort?: boolean` to `AgentExecutionOptionsBase` (shared by all stream/generate options)
- When `persistPartialOnAbort: true` and the stream is aborted with non-empty text, `executeOnFinish` is called to persist the partial response
- Handles both abort paths: `finishReason === 'aborted'` and `abortSignal?.aborted === true`

## Test Plan

- [ ] Unit tests added covering the new flag (`persist-partial-on-abort.test.ts`)
- [ ] Existing tests pass
- [ ] Behavior is unchanged when `persistPartialOnAbort` is not set (default `false`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When you stop an AI chat stream mid-sentence, the app currently throws away whatever text was already generated. This change adds an optional switch so the “already-generated” part can still be saved to your chat history even after you abort.

## Summary by CodeRabbit
* **New Features**
  - Added a `persistPartialOnAbort?: boolean` option to the agent streaming execution options.
  - When `persistPartialOnAbort` is `true` and a stream aborts after receiving some text, the partial assistant output is persisted via `executeOnFinish` before the stream ends.
  - Ensures the same behavior for both abort styles (`finishReason === 'aborted'` and `abortSignal?.aborted === true`).
* **Tests**
  - Added unit tests (`persist-partial-on-abort.test.ts`) covering default behavior, opt-in persistence, no empty message persistence when no text was emitted, and safety when `memory` is omitted.
* **Behavior Preservation**
  - Defaults to `false`, keeping existing behavior where partial output is discarded on abort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->