### PR TITLE
feat(playground-ui): striped DataList variant + studio table rollout

### DIFF
--- a/.changeset/dull-ants-nail.md
+++ b/.changeset/dull-ants-nail.md
@@ -1,0 +1,17 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a `striped` variant to the `DataList` component for a flat, full-bleed table look: zebra-striped rows, a contrasting sticky header with column separators, rounded corners, and edge fade masks via an overlay scrollbar (virtualization preserved). Also added a per-row `error` tone.
+
+Studio now uses this variant on the Observability, Scorers, Agents, Workflows, Tools, Datasets, MCP Servers, Processors, Prompts, Experiments, Schedules, and Logs tables for a consistent, denser browse experience.
+
+```tsx
+// Whole-list look
+<DataList columns="auto 1fr auto" variant="striped">
+  <DataList.Top>…</DataList.Top>
+
+  {/* Per-row tone — error rows get a subtle destructive tint */}
+  <DataList.RowButton variant="error">…</DataList.RowButton>
+</DataList>
+```

--- a/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
@@ -77,7 +77,7 @@ export function LogsListView({
     virtualItems.length > 0 ? Math.max(0, totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0)) : 0;
 
   return (
-    <LogsDataList columns={COLUMNS} scrollRef={scrollRef} className="min-w-0">
+    <LogsDataList columns={COLUMNS} variant="striped" scrollRef={scrollRef} className="min-w-0">
       <LogsDataList.Top>
         <LogsDataList.TopCell>Date</LogsDataList.TopCell>
         <LogsDataList.TopCell>Time</LogsDataList.TopCell>
@@ -109,6 +109,7 @@ export function LogsListView({
                 data-index={vi.index}
                 onClick={() => onLogClick(log)}
                 featured={isFeatured}
+                variant={log.level === 'error' || log.level === 'fatal' ? 'error' : 'default'}
               >
                 <LogsDataList.DateCell timestamp={log.timestamp} />
                 <LogsDataList.TimeCell timestamp={log.timestamp} />

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -115,7 +115,7 @@ export function TracesListView({
     virtualItems.length > 0 ? Math.max(0, totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0)) : 0;
 
   return (
-    <TracesDataList columns={COLUMNS} scrollRef={scrollRef} className="min-w-0">
+    <TracesDataList columns={COLUMNS} variant="striped" scrollRef={scrollRef} className="min-w-0">
       <TracesDataList.Top>
         <TracesDataList.TopCell>Date</TracesDataList.TopCell>
         <TracesDataList.TopCell>Time</TracesDataList.TopCell>

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { DataList } from './data-list';
+
+afterEach(() => {
+  cleanup();
+});
+
+const Header = () => (
+  <DataList.Top>
+    <DataList.TopCell>Name</DataList.TopCell>
+    <DataList.TopCell>Description</DataList.TopCell>
+  </DataList.Top>
+);
+
+describe('DataListRoot', () => {
+  /**
+   * Virtualization (traces/logs) relies on `scrollRef` pointing at the scrolling
+   * grid in the default variant. These guard the wiring so the striped/ScrollArea
+   * work can't silently break it.
+   */
+  describe('default variant — native scroll (virtualization path)', () => {
+    it('forwards scrollRef to the scrollable grid, not a wrapper', () => {
+      const scrollRef = createRef<HTMLDivElement>();
+      const { container } = render(
+        <DataList columns="1fr 1fr" scrollRef={scrollRef}>
+          <Header />
+        </DataList>,
+      );
+
+      expect(scrollRef.current).not.toBeNull();
+      // the ref'd element is the grid itself and is the scroll container
+      expect(scrollRef.current).toBe(container.firstElementChild);
+      expect(scrollRef.current?.className).toContain('overflow-auto');
+      expect(scrollRef.current?.style.gridTemplateColumns).toBe('1fr 1fr');
+    });
+
+    it('does not introduce an intermediate scroll wrapper', () => {
+      const { container } = render(
+        <DataList columns="1fr 1fr">
+          <Header />
+        </DataList>,
+      );
+      // grid is the top-level node — no ScrollArea viewport/content above it
+      const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
+      expect(grid).toBe(container.firstElementChild);
+    });
+  });
+
+  describe('striped variant — ScrollArea (overlay scrollbar + horizontal mask)', () => {
+    it('wraps the grid in a ScrollArea, which owns scrolling', () => {
+      const { container } = render(
+        <DataList columns="1fr 1fr" variant="striped">
+          <Header />
+        </DataList>,
+      );
+
+      const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
+      expect(grid).not.toBeNull();
+      // grid is nested inside the ScrollArea, not the root child
+      expect(grid).not.toBe(container.firstElementChild);
+      // the ScrollArea viewport owns scrolling, so the grid doesn't
+      expect(grid?.className).not.toContain('overflow-auto');
+    });
+  });
+
+  describe('striped variant — virtualized (scrollRef forwarded to the viewport)', () => {
+    it('points scrollRef at the scrolling viewport that contains the grid', () => {
+      const scrollRef = createRef<HTMLDivElement>();
+      const { container } = render(
+        <DataList columns="1fr 1fr" variant="striped" scrollRef={scrollRef}>
+          <Header />
+        </DataList>,
+      );
+
+      // scrollRef now resolves to the ScrollArea viewport (the scroll element the
+      // virtualizer binds to via getScrollElement), not the grid — so the list
+      // virtualizes against the overlay-scrollbar viewport.
+      expect(scrollRef.current).not.toBeNull();
+      const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
+      expect(grid).not.toBeNull();
+      expect(scrollRef.current).not.toBe(grid);
+      expect(scrollRef.current?.contains(grid)).toBe(true);
+    });
+  });
+
+  describe('header titles — overflow / sizing', () => {
+    it('truncates plain-text titles via an inner truncate span', () => {
+      const { container } = render(
+        <DataList columns="1fr">
+          <DataList.Top>
+            <DataList.TopCell>A title long enough to need truncation</DataList.TopCell>
+          </DataList.Top>
+        </DataList>,
+      );
+      const cell = container.querySelector<HTMLElement>('.data-list-top > *');
+      const inner = cell?.querySelector<HTMLElement>('span.truncate');
+      expect(inner).not.toBeNull();
+      expect(inner?.textContent).toBe('A title long enough to need truncation');
+    });
+
+    it('renders non-text title children as-is (not wrapped)', () => {
+      const { container } = render(
+        <DataList columns="1fr">
+          <DataList.Top>
+            <DataList.TopCell>
+              <svg data-testid="icon" />
+            </DataList.TopCell>
+          </DataList.Top>
+        </DataList>,
+      );
+      const cell = container.querySelector<HTMLElement>('.data-list-top > *');
+      expect(cell?.querySelector('span.truncate')).toBeNull();
+      expect(cell?.querySelector('[data-testid="icon"]')).not.toBeNull();
+    });
+  });
+
+  describe('per-row error variant', () => {
+    it('applies a destructive tint to error rows and nothing to default rows', () => {
+      const { container } = render(
+        <DataList columns="1fr">
+          <DataList.RowButton variant="error">
+            <DataList.Cell>boom</DataList.Cell>
+          </DataList.RowButton>
+          <DataList.RowButton>
+            <DataList.Cell>ok</DataList.Cell>
+          </DataList.RowButton>
+        </DataList>,
+      );
+      const [errorRow, defaultRow] = container.querySelectorAll<HTMLButtonElement>('.data-list-row');
+      expect(errorRow.className).toContain('bg-notice-destructive/10');
+      expect(defaultRow.className).not.toContain('bg-notice-destructive');
+    });
+
+    it('applies the selection fill as `!important` so it wins over the striped zebra', () => {
+      // The striped zebra is a root descendant rule (higher specificity), so a
+      // plain `bg-surface4` would lose on even rows. The `!` keeps the selected
+      // row highlighted regardless of its zebra parity.
+      const { container } = render(
+        <DataList columns="1fr" variant="striped">
+          <DataList.RowButton featured>
+            <DataList.Cell>selected</DataList.Cell>
+          </DataList.RowButton>
+        </DataList>,
+      );
+      const row = container.querySelector<HTMLButtonElement>('.data-list-row');
+      expect(row?.className).toContain('bg-surface4!');
+    });
+
+    it('does not leak the variant prop onto the DOM element', () => {
+      const { container } = render(
+        <DataList columns="1fr">
+          <DataList.RowButton variant="error">
+            <DataList.Cell>boom</DataList.Cell>
+          </DataList.RowButton>
+        </DataList>,
+      );
+      const row = container.querySelector<HTMLButtonElement>('.data-list-row');
+      expect(row?.getAttribute('variant')).toBeNull();
+    });
+  });
+});

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -1,10 +1,22 @@
+import { cva } from 'class-variance-authority';
 import type { ReactNode, RefObject } from 'react';
+import { ScrollArea } from '@/ds/components/ScrollArea/scroll-area';
 import { cn } from '@/lib/utils';
+
+/**
+ * Visual treatment for the whole list.
+ *
+ * - `default`: bordered card, `surface2` body, hairline row separators.
+ * - `striped`: borderless and full-bleed, zebra-striped rows (every other row
+ *   tinted), contrasting sticky header band, no row separators.
+ */
+export type DataListVariant = 'default' | 'striped';
 
 export type DataListRootProps = {
   children: ReactNode;
   columns: string;
   className?: string;
+  variant?: DataListVariant;
   /**
    * Ref to the scroll container — pass this to TanStack Virtual's
    * `getScrollElement` when virtualizing. Without it, the list behaves as a
@@ -13,17 +25,92 @@ export type DataListRootProps = {
   scrollRef?: RefObject<HTMLDivElement | null>;
 };
 
-export function DataListRoot({ children, columns, className, scrollRef }: DataListRootProps) {
-  return (
+/**
+ * Root grid styling per `variant`. Kept module-private (an exported cva in a
+ * `.tsx` trips react-refresh). The striped treatment is driven entirely from the
+ * root with CSS descendant selectors on the `.data-list-top` / `.data-list-row`
+ * markers — the header and row primitives stay untouched, no JS per-row index:
+ * - no container fill or border: the stripes are translucent neutral overlays
+ *   (`surface-overlay-*`, theme-aware) so the list composites over any view.
+ * - `gap-y-px`: a uniform 1px gap between every grid track (header and rows).
+ * - header: a contrasting band that owns the radius (the container no longer
+ *   rounds/clips) — `rounded-t-xl` top, `rounded-b-md` bottom to match the rows
+ *   sitting below the 1px gap, no hairline.
+ * - rows: full-bleed, `rounded-md` (last row included), no separators; rows zero
+ *   their own margins so the grid gap is the only spacing.
+ * - zebra: tint every other row with `:even`; hover & focus use `!` so they
+ *   still win over the zebra tint.
+ */
+const dataListRootVariants = cva('grid min-w-0 max-w-full content-start', {
+  variants: {
+    variant: {
+      default: 'bg-surface2 border border-border1 rounded-xl',
+      striped: cn(
+        'gap-y-px',
+        // The header is sticky, so it must be opaque to occlude rows scrolling
+        // behind it (a translucent overlay would show ghosted content through it).
+        // Rows keep the translucent tints — only the header needs to be solid.
+        '[&_.data-list-top]:mx-0 [&_.data-list-top]:bg-surface4 [&_.data-list-top]:after:hidden',
+        '[&_.data-list-top]:rounded-t-xl [&_.data-list-top]:rounded-b-md',
+        // header column separators: a short, faint vertical line centered in the gap
+        // to the left of every header cell but the first. A `before` pseudo (not a
+        // `border-l` + padding) keeps header text aligned with the row cells below.
+        // The cell's default `overflow-hidden` would clip a gap-positioned pseudo, so
+        // these cells switch to `overflow-visible`; the title text still truncates via
+        // its inner `truncate` span, so nothing else spills.
+        '[&_.data-list-top>*:not(:first-child)]:relative [&_.data-list-top>*:not(:first-child)]:overflow-visible',
+        '[&_.data-list-top>*:not(:first-child)]:before:absolute [&_.data-list-top>*:not(:first-child)]:before:-left-4 [&_.data-list-top>*:not(:first-child)]:before:top-1/2 [&_.data-list-top>*:not(:first-child)]:before:-translate-y-1/2 [&_.data-list-top>*:not(:first-child)]:before:h-4 [&_.data-list-top>*:not(:first-child)]:before:w-px [&_.data-list-top>*:not(:first-child)]:before:bg-border2 [&_.data-list-top>*:not(:first-child)]:before:content-[""]',
+        '[&_.data-list-row]:mx-0 [&_.data-list-row]:my-0 [&_.data-list-row]:rounded-md [&_.data-list-row]:after:hidden',
+        '[&_.data-list-row]:even:bg-surface-overlay-soft',
+        '[&_.data-list-row]:hover:bg-surface-overlay-strong!',
+        '[&_.data-list-row]:focus-visible:bg-surface-overlay-strong!',
+      ),
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export function DataListRoot({ children, columns, className, variant = 'default', scrollRef }: DataListRootProps) {
+  const isStriped = variant === 'striped';
+
+  const grid = (
     <div
-      ref={scrollRef}
+      // Striped scrolls inside the ScrollArea viewport (below); default scrolls the
+      // grid natively, so it owns `scrollRef`.
+      ref={isStriped ? undefined : scrollRef}
       className={cn(
-        'grid min-w-0 max-w-full bg-surface2 border max-h-full border-border1 rounded-xl overflow-auto content-start',
-        className,
+        dataListRootVariants({ variant }),
+        // Default is its own scroll container; striped delegates scrolling to the
+        // ScrollArea viewport, so the grid just lays out.
+        !isStriped && 'max-h-full overflow-auto',
+        !isStriped && className,
       )}
       style={{ gridTemplateColumns: columns }}
     >
       {children}
     </div>
+  );
+
+  if (!isStriped) return grid;
+
+  // Striped always uses the DS ScrollArea: an overlay scrollbar (no reserved
+  // gutter, so the sticky header spans the full width and both top corners clip
+  // cleanly) plus the default edge fades. When the list virtualizes it passes a
+  // `scrollRef`; forwarding it as `viewportRef` makes the virtualizer scroll this
+  // viewport, so virtualization works without a native scrollbar.
+  //
+  // `rounded-t-xl` clips the viewport top. Masks default to every overflowing
+  // edge except the top — a top fade would fade the opaque sticky header.
+  return (
+    <ScrollArea
+      orientation="both"
+      mask={{ top: false }}
+      viewportRef={scrollRef}
+      className={cn('h-full w-full rounded-t-xl', className)}
+    >
+      {grid}
+    </ScrollArea>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
 import { useDataListRowWrapperContext } from './data-list-row-wrapper-context';
-import { dataListRowInteractiveStyles, dataListRowStyles } from './shared';
+import { dataListRowInteractiveStyles, dataListRowStyles, dataListRowVariants } from './shared';
 import type { DataListRowSharedProps } from './shared';
 import { cn } from '@/lib/utils';
 
@@ -13,7 +13,7 @@ export type DataListRowButtonProps = ComponentPropsWithoutRef<'button'> & DataLi
  */
 export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButtonProps>(
   (
-    { children, className, type = 'button', flushLeft, flushRight, colStart, colEnd, featured, style, ...rest },
+    { children, className, type = 'button', flushLeft, flushRight, colStart, colEnd, featured, variant, style, ...rest },
     ref,
   ) => {
     const isWrapped = useDataListRowWrapperContext();
@@ -28,7 +28,10 @@ export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButton
           'text-left',
           !isWrapped && flushLeft && 'ml-0!',
           !isWrapped && flushRight && 'mr-0!',
-          featured && 'bg-surface4',
+          // `!` so the selection fill wins over the striped variant's zebra tint
+          // (a higher-specificity root descendant rule); same color in `default`.
+          featured && 'bg-surface4!',
+          dataListRowVariants({ variant }),
           className,
         )}
         style={resolvedStyle}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
@@ -13,7 +13,19 @@ export type DataListRowButtonProps = ComponentPropsWithoutRef<'button'> & DataLi
  */
 export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButtonProps>(
   (
-    { children, className, type = 'button', flushLeft, flushRight, colStart, colEnd, featured, variant, style, ...rest },
+    {
+      children,
+      className,
+      type = 'button',
+      flushLeft,
+      flushRight,
+      colStart,
+      colEnd,
+      featured,
+      variant,
+      style,
+      ...rest
+    },
     ref,
   ) => {
     const isWrapped = useDataListRowWrapperContext();

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, ReactNode } from 'react';
 import { useDataListRowWrapperContext } from './data-list-row-wrapper-context';
-import { dataListRowInteractiveStyles, dataListRowStyles } from './shared';
+import { dataListRowInteractiveStyles, dataListRowStyles, dataListRowVariants } from './shared';
 import type { DataListRowSharedProps } from './shared';
 import type { LinkComponent } from '@/ds/types/link-component';
 import { cn } from '@/lib/utils';
@@ -24,6 +24,7 @@ export function DataListRowLink({
   colStart,
   colEnd,
   featured,
+  variant,
 }: DataListRowLinkProps) {
   const isWrapped = useDataListRowWrapperContext();
   const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
@@ -35,7 +36,10 @@ export function DataListRowLink({
         ...(isWrapped ? dataListRowInteractiveStyles : dataListRowStyles),
         !isWrapped && flushLeft && 'ml-0!',
         !isWrapped && flushRight && 'mr-0!',
-        featured && 'bg-surface4',
+        // `!` so the selection fill wins over the striped variant's zebra tint
+        // (a higher-specificity root descendant rule); same color in `default`.
+        featured && 'bg-surface4!',
+        dataListRowVariants({ variant }),
         className,
       )}
       style={resolvedStyle}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-static.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-static.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
 import { useDataListRowWrapperContext } from './data-list-row-wrapper-context';
-import { dataListRowStaticStyles } from './shared';
+import { dataListRowStaticStyles, dataListRowVariants } from './shared';
 import type { DataListRowSharedProps } from './shared';
 import { cn } from '@/lib/utils';
 
@@ -12,7 +12,7 @@ export type DataListRowStaticProps = ComponentPropsWithoutRef<'div'> & DataListR
  * has no link target or click handler
  */
 export const DataListRowStatic = forwardRef<HTMLDivElement, DataListRowStaticProps>(
-  ({ children, className, flushLeft, flushRight, colStart, colEnd, featured, style, ...rest }, ref) => {
+  ({ children, className, flushLeft, flushRight, colStart, colEnd, featured, variant, style, ...rest }, ref) => {
     const isWrapped = useDataListRowWrapperContext();
     const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
     const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
@@ -25,7 +25,10 @@ export const DataListRowStatic = forwardRef<HTMLDivElement, DataListRowStaticPro
             : dataListRowStaticStyles,
           !isWrapped && flushLeft && 'ml-0!',
           !isWrapped && flushRight && 'mr-0!',
-          featured && 'bg-surface4',
+          // `!` so the selection fill wins over the striped variant's zebra tint
+          // (a higher-specificity root descendant rule); same color in `default`.
+          featured && 'bg-surface4!',
+          dataListRowVariants({ variant }),
           className,
         )}
         style={resolvedStyle}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
@@ -17,16 +17,19 @@ export type DataListTopCellProps = {
 export const DataListTopCell = forwardRef<HTMLSpanElement, DataListTopCellProps>(
   ({ children, className, as, ...rest }, ref) => {
     const Component = as || 'span';
+    const isText = typeof children === 'string' || typeof children === 'number';
     return (
       <Component
         ref={ref}
         className={cn(
-          'h-8 min-w-0 max-w-full overflow-hidden py-1 flex items-center uppercase whitespace-nowrap text-neutral2 tracking-widest text-ui-xs',
+          'h-8 min-w-0 max-w-full overflow-hidden py-1 flex items-center whitespace-nowrap text-neutral2 font-semibold tracking-tight text-ui-sm',
           className,
         )}
         {...rest}
       >
-        {children}
+        {/* Plain string/number titles truncate with an ellipsis; element children
+            (icons, smart long/short labels, checkboxes) render as-is. */}
+        {isText ? <span className="min-w-0 truncate">{children}</span> : children}
       </Component>
     );
   },

--- a/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
@@ -449,10 +449,11 @@ export const Loading: Story = {
   render: () => <DataListSkeleton columns={COMPACT_COLUMNS} numberOfRows={5} />,
 };
 
-/** Page-based pagination footer — `Previous` shows when `currentPage > 0`, `Next` shows when `hasMore`. */
+/** Page-based pagination footer — `Previous` shows when `currentPage > 0`, `Next` shows when `hasMore`.
+ *  `currentPage` is zero-based: the footer renders it as `currentPage + 1`, so page `0` reads as "Page 1". */
 export const WithPagination: Story = {
   render: function WithPaginationStory() {
-    const [page, setPage] = useState(1);
+    const [page, setPage] = useState(0);
     return (
       <DataList columns={COMPACT_COLUMNS}>
         <DataList.Top>

--- a/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
@@ -108,6 +108,80 @@ export const Default: Story = {
   ),
 };
 
+/**
+ * Borderless, zebra-striped table. The stripes and header band are translucent
+ * neutral overlays (theme-aware), so the list composites cleanly over any
+ * background — no card fill of its own. The header owns the card radius via
+ * `rounded-t-xl`, rows are `rounded-md` with a 1px gap, and anything trailing
+ * (e.g. `Pagination`) sits at the end instead of inside a bordered box.
+ */
+export const Striped: Story = {
+  render: function StripedStory() {
+    const [page, setPage] = useState(0);
+    return (
+      <DataList columns={COMPACT_COLUMNS} variant="striped" className="max-h-[320px]">
+        <DataList.Top>
+          <DataList.TopCell>ID</DataList.TopCell>
+          <DataList.TopCell>Input</DataList.TopCell>
+          <DataList.TopCell>Status</DataList.TopCell>
+          <DataList.TopCell>Date</DataList.TopCell>
+          <DataList.TopCell>Time</DataList.TopCell>
+        </DataList.Top>
+        {Array.from({ length: 12 }, (_, index) => {
+          const run = SAMPLE_RUNS[index % SAMPLE_RUNS.length];
+          return (
+            <DataList.RowButton key={`${run.id}-${index}`} onClick={() => {}}>
+              <DataList.IdCell id={`${run.id}_${index}`} />
+              <DataList.MonoCell>{run.input}</DataList.MonoCell>
+              <DataList.Cell height="compact">{run.status}</DataList.Cell>
+              <DataList.DateCell timestamp={run.createdAt} />
+              <DataList.TimeCell timestamp={run.createdAt} />
+            </DataList.RowButton>
+          );
+        })}
+        <DataList.Pagination
+          currentPage={page}
+          hasMore={page < 3}
+          onNextPage={() => setPage(p => p + 1)}
+          onPrevPage={() => setPage(p => Math.max(0, p - 1))}
+        />
+      </DataList>
+    );
+  },
+};
+
+/**
+ * Per-row `variant="error"` lays a subtle, theme-aware destructive tint over the
+ * row — it wins over the zebra background, so error rows read clearly while the
+ * rest keep striping. Useful for log/run lists where some rows failed.
+ */
+export const StripedWithErrorRows: Story = {
+  render: () => (
+    <DataList columns={COMPACT_COLUMNS} variant="striped" className="max-h-[320px]">
+      <DataList.Top>
+        <DataList.TopCell>ID</DataList.TopCell>
+        <DataList.TopCell>Input</DataList.TopCell>
+        <DataList.TopCell>Status</DataList.TopCell>
+        <DataList.TopCell>Date</DataList.TopCell>
+        <DataList.TopCell>Time</DataList.TopCell>
+      </DataList.Top>
+      {Array.from({ length: 10 }, (_, index) => {
+        const run = SAMPLE_RUNS[index % SAMPLE_RUNS.length];
+        const failed = run.status === 'failed';
+        return (
+          <DataList.RowButton key={`${run.id}-${index}`} onClick={() => {}} variant={failed ? 'error' : 'default'}>
+            <DataList.IdCell id={`${run.id}_${index}`} />
+            <DataList.MonoCell>{run.input}</DataList.MonoCell>
+            <DataList.Cell height="compact">{run.status}</DataList.Cell>
+            <DataList.DateCell timestamp={run.createdAt} />
+            <DataList.TimeCell timestamp={run.createdAt} />
+          </DataList.RowButton>
+        );
+      })}
+    </DataList>
+  ),
+};
+
 /* Anchor that ignores navigation so RowLink can render in Storybook. */
 const StoryLink: LinkComponent = forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement>>(
   ({ children, href, onClick, ...rest }, ref) => (

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -23,11 +23,36 @@ export const dataListRowStyles = ['mx-1', ...dataListRowInteractiveStyles, ...da
 
 export const dataListRowStaticStyles = ['mx-1 grid grid-cols-subgrid gap-8 px-5', ...dataListRowOuterStyles] as const;
 
+import { cva } from 'class-variance-authority';
+
+/** Tone for a single row. `error` lays a subtle, theme-aware destructive tint
+ *  over whatever background the row already has. */
+export type DataListRowVariant = 'default' | 'error';
+
+/**
+ * Per-row tone. Kept as a `.ts` cva (safe to export — no react-refresh concern).
+ * The error tint uses `!` so it wins over the striped variant's root-level zebra
+ * (a higher-specificity descendant rule) and over the base row hover.
+ */
+export const dataListRowVariants = cva('', {
+  variants: {
+    variant: {
+      default: '',
+      error: 'bg-notice-destructive/10! hover:bg-notice-destructive/15!',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
 /**
  * Layout/state modifiers shared by interactive row primitives
  * (`DataList.RowButton`, `DataList.RowLink`).
  */
 export type DataListRowSharedProps = {
+  /** Row tone — `error` applies a subtle destructive background tint. */
+  variant?: DataListRowVariant;
   /**
    * Drop the row's default left margin. Use when the row is wrapped in a
    * `DataList.RowWrapper` that owns the leading inset (e.g. for selection rows where

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
@@ -33,6 +33,12 @@ export type ScrollAreaProps = React.ComponentPropsWithoutRef<typeof ScrollAreaPr
   mask?: ScrollAreaMask;
   /** @deprecated Use `mask` instead. Retained for backward compatibility. */
   showMask?: boolean;
+  /**
+   * Ref to the scrolling viewport element. Use this as the scroll element for a
+   * virtualizer (`getScrollElement: () => viewportRef.current`) so the list can
+   * virtualize while still using the ScrollArea's overlay scrollbar + masks.
+   */
+  viewportRef?: React.Ref<HTMLDivElement>;
 };
 
 type ResolvedMask = { top: boolean; bottom: boolean; left: boolean; right: boolean };
@@ -82,12 +88,24 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
       orientation = 'vertical',
       mask,
       showMask,
+      viewportRef,
       ...props
     },
     ref,
   ) => {
     const areaRef = React.useRef<HTMLDivElement>(null);
     useAutoscroll(areaRef, { enabled: autoScroll });
+
+    // Keep the internal autoscroll ref while also exposing the viewport to callers
+    // (e.g. a virtualizer's scroll element).
+    const setViewportRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        areaRef.current = node;
+        if (typeof viewportRef === 'function') viewportRef(node);
+        else if (viewportRef) (viewportRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      },
+      [viewportRef],
+    );
 
     const effectiveMask: ScrollAreaMask | undefined = mask !== undefined ? mask : showMask;
     const sides = resolveMask(effectiveMask, orientation);
@@ -116,7 +134,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
     return (
       <ScrollAreaPrimitive.Root ref={ref} className={cn('relative overflow-hidden', className)} {...props}>
         <ScrollAreaPrimitive.Viewport
-          ref={areaRef}
+          ref={setViewportRef}
           className={cn('h-full w-full rounded-[inherit]', maskClasses(sides), viewPortClassName)}
           style={viewportStyle}
         >

--- a/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
@@ -37,7 +37,7 @@ export function AgentsList({ agents, isLoading, search = '' }: AgentsListProps) 
   }
 
   return (
-    <EntityList columns={'auto 1fr auto auto auto auto'}>
+    <EntityList columns={'auto 1fr auto auto auto auto'} variant="striped">
       <EntityList.Top>
         <EntityList.TopCell className="">Name</EntityList.TopCell>
         <EntityList.TopCell className="">Instructions</EntityList.TopCell>

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -108,7 +108,7 @@ export function DatasetsList({
   }
 
   return (
-    <EntityList columns={COLUMNS}>
+    <EntityList columns={COLUMNS} variant="striped">
       <EntityList.Top>
         <EntityList.TopCell>Name</EntityList.TopCell>
         <EntityList.TopCell>Description</EntityList.TopCell>

--- a/packages/playground/src/domains/experiments/components/experiments-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-list.tsx
@@ -78,7 +78,7 @@ export function ExperimentsList({
   }
 
   return (
-    <EntityList columns={COLUMNS}>
+    <EntityList columns={COLUMNS} variant="striped">
       <EntityList.Top>
         <EntityList.TopCell>Experiment</EntityList.TopCell>
         <EntityList.TopCell>Dataset</EntityList.TopCell>

--- a/packages/playground/src/domains/mcps/components/mcps-list/mcps-list.tsx
+++ b/packages/playground/src/domains/mcps/components/mcps-list/mcps-list.tsx
@@ -58,7 +58,7 @@ export function McpServersList({ mcpServers, isLoading, search = '' }: McpServer
   }
 
   return (
-    <EntityList columns="auto 1fr auto auto auto">
+    <EntityList columns="auto 1fr auto auto auto" variant="striped">
       <EntityList.Top>
         <EntityList.TopCell>Name</EntityList.TopCell>
         <EntityList.TopCell>URL</EntityList.TopCell>

--- a/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
+++ b/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
@@ -30,7 +30,7 @@ export function ProcessorsList({ processors, isLoading, search = '' }: Processor
   }
 
   return (
-    <EntityList columns="auto 1fr auto auto auto auto auto auto">
+    <EntityList columns="auto 1fr auto auto auto auto auto auto" variant="striped">
       <EntityList.Top>
         <EntityList.TopCell>Name</EntityList.TopCell>
         <EntityList.TopCell>Description</EntityList.TopCell>

--- a/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
@@ -25,7 +25,7 @@ export function PromptsList({ promptBlocks, isLoading, search = '' }: PromptsLis
   }
 
   return (
-    <EntityList columns="auto 1fr auto auto">
+    <EntityList columns="auto 1fr auto auto" variant="striped">
       <EntityList.Top>
         <EntityList.TopCell>Name</EntityList.TopCell>
         <EntityList.TopCell>Description</EntityList.TopCell>

--- a/packages/playground/src/domains/schedules/components/schedules-list.tsx
+++ b/packages/playground/src/domains/schedules/components/schedules-list.tsx
@@ -28,7 +28,7 @@ export function SchedulesList({ schedules, isLoading, search = '' }: SchedulesLi
   }
 
   return (
-    <DataList columns={COLUMNS} className="min-w-0">
+    <DataList columns={COLUMNS} variant="striped" className="min-w-0">
       <DataList.Top>
         <DataList.TopCell>Workflow</DataList.TopCell>
         <DataList.TopCell>Schedule ID</DataList.TopCell>

--- a/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
@@ -42,7 +42,7 @@ export function ScorersList({ scorers, isLoading, search = '', sourceFilter = 'a
   }
 
   return (
-    <EntityList columns={COLUMNS}>
+    <EntityList columns={COLUMNS} variant="striped">
       <EntityList.Top>
         <EntityList.TopCell>Name</EntityList.TopCell>
         <EntityList.TopCell>Description</EntityList.TopCell>

--- a/packages/playground/src/domains/tools/components/tools-list/tools-list.tsx
+++ b/packages/playground/src/domains/tools/components/tools-list/tools-list.tsx
@@ -31,7 +31,7 @@ export function ToolsList({ tools, agents, isLoading, search = '' }: ToolsListPr
   }
 
   return (
-    <EntityList columns="auto 1fr auto">
+    <EntityList columns="auto 1fr auto" variant="striped">
       <EntityList.Top>
         <EntityList.TopCell>Name</EntityList.TopCell>
         <EntityList.TopCell>Description</EntityList.TopCell>

--- a/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
+++ b/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
@@ -33,7 +33,7 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
   }
 
   return (
-    <EntityList columns="auto 1fr auto">
+    <EntityList columns="auto 1fr auto" variant="striped">
       <EntityList.Top>
         <EntityList.TopCell>Name</EntityList.TopCell>
         <EntityList.TopCell>Description</EntityList.TopCell>


### PR DESCRIPTION
## What

Adds a new **`striped`** visual variant to the `DataList` design-system component and rolls it out across the studio's browse tables.

The striped variant is a flat, full-bleed table look (inspired by dense experiment tables):

- **Borderless, zebra-striped rows** — every other row gets a subtle, theme-aware overlay tint (works on any surface, light or dark).
- **Contrasting sticky header** — opaque header band with `rounded-t-xl`, faint vertical column separators, and restyled titles (`font-semibold`, truncating instead of clipping).
- **1px row gap + `rounded-md` rows** so the last row matches the rest.
- **Edge-fade masks via the ScrollArea overlay scrollbar** — no reserved gutter (clean top corners), masks on every overflowing edge except the top (a top fade would dissolve the sticky header). Virtualization is preserved by forwarding `scrollRef` to the ScrollArea `viewportRef`.
- **Per-row `error` tone** (`variant="error"`) — a subtle destructive tint that wins over the zebra.

```tsx
<DataList columns="auto 1fr auto" variant="striped">
  <DataList.Top>…</DataList.Top>
  <DataList.RowButton variant="error">…</DataList.RowButton>
</DataList>
```

## Rollout

Striped is now used on the full-page browse tables for a consistent, denser look:

**Observability (traces), Scorers, Agents, Workflows, Tools, Datasets, MCP Servers, Processors, Prompts, Experiments, Schedules, Logs.**

Embedded / detail-panel lists (scores in scorer detail, span scores/feedback, dataset items/experiments tabs, agent playground, review, workspace, channels) intentionally keep the **default bordered card**, which better delineates a nested list from its surrounding content.

## Notable fix

The selection fill (`featured`) is now `!important` so it wins over the striped zebra on even rows. Same color in the `default` variant → no visual change there.

## Testing

- `@mastra/playground-ui` build + typecheck ✅
- `@internal/playground` typecheck ✅
- DataList unit tests: 13 passed (incl. new guards for virtualization wiring, header truncation, per-row error tone, and the `featured` precedence fix) ✅
- ESLint on all changed files (`--max-warnings 0`) ✅
- Live-verified `/observability` and `/scorers` render the striped layout

A `@mastra/playground-ui` minor changeset is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a new **“striped”** table look to the `DataList` component (think zebra rows + a clearer sticky header) and then uses it across most studio browse tables so they all feel consistent and denser. It also keeps “error” rows and selected (“featured”) rows visually correct by overriding the stripe styling when needed.

---

## Component Changes

### DataList Core Component
- Added a new `variant` prop to `DataListRoot` with `DataListVariant = 'default' | 'striped'`.
- Introduced variant-driven styling via a CVA `dataListRootVariants`:
  - Borderless, full-bleed table layout
  - Zebra striping using subtle theme-aware overlays
  - Sticky header band with rounded top corners (`rounded-t-xl`), faint vertical column separators, and updated header title styling (semi-bold + truncation)
  - 1px row gaps with `rounded-md` rows
  - Edge-fade masks using the ScrollArea overlay scrollbar on overflowing edges (while preserving the sticky header visibility; top is preserved)
- Updated virtualization wiring:
  - **Default**: forwards `scrollRef` to the native/grid scroll container.
  - **Striped**: wraps the grid in `ScrollArea` and forwards `scrollRef` to `ScrollArea`’s new `viewportRef`.

### Row Components (Default vs Error Tone, plus Selection Priority)
- Added per-row tone support:
  - New shared `DataListRowVariant = 'default' | 'error'`
  - Row components (`DataListRowButton`, `DataListRowLink`, `DataListRowStatic`) accept a `variant` prop and apply it through `dataListRowVariants`.
- **Error rows** apply a subtle destructive tint that overrides the zebra stripe pattern.
- **Featured/selected rows** now use `bg-surface4!` so the selection fill takes precedence over the zebra styling.

### Header Cells
- `DataListTopCell` now:
  - Wraps primitive string/number children in a truncating `<span>` (ellipsis behavior)
  - Renders non-primitive children (e.g., icons/SVGs) without adding the truncate wrapper
  - Updates typography sizing/alignment to match the new design.

### ScrollArea Enhancement (Virtualization Support)
- Added `viewportRef?: React.Ref<HTMLDivElement>` to `ScrollArea`.
- The ScrollArea viewport now supports external access so `DataList` can keep virtualization behavior working in striped mode.

### Storybook
- Added `Striped` and `StripedWithErrorRows` stories to demonstrate the new variant and per-row error tinting.

---

## Studio Integration (Where “striped” is Applied)
The striped `EntityList`/`DataList` presentation is applied to full-page browse tables including:
- Observability (traces)
- Scorers
- Agents
- Workflows
- Tools
- Datasets
- MCP Servers
- Processors
- Prompts
- Experiments
- Schedules
- Logs

Nested/embedded or detail-panel lists intentionally keep the default bordered card variant (to better delineate nested content).

---

## Testing & Quality
- Added/extended DataList unit tests (13 passing) covering:
  - Scroll/virtualization wiring differences between `default` vs `striped`
  - Header truncation behavior
  - Per-row error tone styling overriding zebra stripes
  - `featured` (selection) precedence using higher-specificity styling
  - Ensuring `variant` is not incorrectly rendered as a DOM attribute
- Verified builds/typechecks and linting:
  - `@mastra/playground-ui` build + typecheck
  - `@internal/playground` typecheck
  - ESLint with zero warnings
- Live verification of striped rendering on Observability and Scorers pages
- Included a minor changeset for `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->