### PR TITLE
docs(agents): document DurableAgent behavior differences from Agent

### DIFF
--- a/docs/src/content/en/reference/agents/durable-agent.mdx
+++ b/docs/src/content/en/reference/agents/durable-agent.mdx
@@ -488,19 +488,11 @@ const { output, cleanup } = await durableAgent.stream('Hello!', {
 
 ### `providerOptions` and `defaultOptions` are not inherited
 
-The wrapped agent's `providerOptions` (model-level provider settings such as Anthropic extended thinking or OpenAI reasoning effort) and `defaultOptions` (default generation options) are not forwarded to the durable workflow. These values are serialized as part of the per-call workflow input, so they must be passed on each `stream()` call rather than configured once on the inner agent:
-
-```typescript
-const { output, cleanup } = await durableAgent.stream('Hello!', {
-  providerOptions: {
-    anthropic: { thinking: { type: 'enabled', budgetTokens: 5000 } },
-  },
-})
-```
+The wrapped agent's `providerOptions` (model-level provider settings such as Anthropic extended thinking or OpenAI reasoning effort) and `defaultOptions` (default generation options) are not forwarded to the durable workflow. `DurableAgentStreamOptions` does not expose a `providerOptions` field, so there is currently no supported way to set these for a `DurableAgent`, either per call on `stream()` or at construction time via the `DurableAgent` constructor or `createDurableAgent`. If your use case depends on `providerOptions` or `defaultOptions`, use a regular `Agent` instead until `DurableAgent` adds support for them.
 
 :::note
 
-These differences exist because `DurableAgent` serializes its execution input into a durable workflow. Settings that exist only on the `Agent` instance are not automatically included in that serialized input. Passing the options directly to the `DurableAgent` constructor or `stream()` call is the correct workaround.
+These differences exist because `DurableAgent` serializes its execution input into a durable workflow. Settings that exist only on the `Agent` instance are not automatically included in that serialized input.
 
 :::
 

--- a/docs/src/content/en/reference/agents/durable-agent.mdx
+++ b/docs/src/content/en/reference/agents/durable-agent.mdx
@@ -461,6 +461,49 @@ interface DurableAgentStreamResult<OUTPUT = undefined> {
 ]}
 />
 
+## Behavior differences from Agent
+
+`DurableAgent` wraps a regular `Agent` but does not inherit all of its settings. The differences below apply regardless of what the wrapped agent has configured.
+
+### `maxSteps` defaults to 5
+
+The wrapped agent's `maxSteps` setting is **not** inherited. `DurableAgent` runs the agentic loop through a durable workflow, and that workflow defaults `maxSteps` to `5` when no value is provided explicitly.
+
+To use a different limit, pass `maxSteps` to the `DurableAgent` constructor (or `createDurableAgent`) rather than on the inner agent:
+
+```typescript
+const durableAgent = createDurableAgent({
+  agent,
+  maxSteps: 20, // set here, not on the inner agent
+})
+```
+
+You can also pass `maxSteps` per call in the `stream()` options:
+
+```typescript
+const { output, cleanup } = await durableAgent.stream('Hello!', {
+  maxSteps: 20,
+})
+```
+
+### `providerOptions` and `defaultOptions` are not inherited
+
+The wrapped agent's `providerOptions` (model-level provider settings such as Anthropic extended thinking or OpenAI reasoning effort) and `defaultOptions` (default generation options) are not forwarded to the durable workflow. These values are serialized as part of the per-call workflow input, so they must be passed on each `stream()` call rather than configured once on the inner agent:
+
+```typescript
+const { output, cleanup } = await durableAgent.stream('Hello!', {
+  providerOptions: {
+    anthropic: { thinking: { type: 'enabled', budgetTokens: 5000 } },
+  },
+})
+```
+
+:::note
+
+These differences exist because `DurableAgent` serializes its execution input into a durable workflow. Settings that exist only on the `Agent` instance are not automatically included in that serialized input. Passing the options directly to the `DurableAgent` constructor or `stream()` call is the correct workaround.
+
+:::
+
 ## Related
 
 - [Agent class](/reference/agents/agent)


### PR DESCRIPTION
﻿## Summary

- Documents that DurableAgent defaults maxSteps to 5 and does not inherit the wrapped agent maxSteps setting
- Documents that providerOptions and defaultOptions from the wrapped agent are not forwarded to the durable workflow
- Provides concrete workarounds showing how to pass these options directly on the DurableAgent constructor and per-stream call

Closes #18021

## What was added

A new "Behavior differences from Agent" section was added to docs/src/content/en/reference/agents/durable-agent.mdx, placed just before the existing "Related" section. The section covers:

1. maxSteps defaulting to 5 (not inherited from the wrapped agent), with examples showing where to set it correctly
2. providerOptions and defaultOptions not being inherited, with an example showing per-call usage

## Related issues

Surfaced by users in #17790 and #17789.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

DurableAgent helps runs keep going even if your connection drops, but it doesn’t automatically copy every setting from the Agent you wrapped. This PR updates the DurableAgent docs to clearly explain which settings change and how to set the right values on DurableAgent instead.

## Summary

Added a new **“Behavior differences from Agent”** section to `docs/src/content/en/reference/agents/durable-agent.mdx` (placed before **Related**) documenting two cases where DurableAgent silently diverges from the wrapped Agent:

1. **`maxSteps` defaults to 5 (not inherited)**  
   The wrapped Agent’s `maxSteps` is ignored. The docs show setting `maxSteps` on the `DurableAgent`/`createDurableAgent` constructor and overriding it per call via `durableAgent.stream(..., { maxSteps })`.

2. **`providerOptions` and `defaultOptions` are not inherited**  
   The wrapped Agent’s `providerOptions` and `defaultOptions` are not forwarded into the durable workflow (and `DurableAgentStreamOptions` does not expose `providerOptions`). The docs include guidance to use a regular `Agent` if you rely on those settings, and note this limitation is due to serializing execution input for the durable workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->