### PR TITLE
chore: add emergency clean publish changeset

### DIFF
--- a/.changeset/emergency-npm-compromise-clean-patches.md
+++ b/.changeset/emergency-npm-compromise-clean-patches.md
@@ -1,0 +1,15 @@
+---
+"@mastra/core": patch
+"@mastra/server": patch
+"@mastra/memory": patch
+"@mastra/observability": patch
+"@mastra/deployer": patch
+"@mastra/playground-ui": patch
+"@mastra/client-js": patch
+"create-mastra": patch
+"mastra": patch
+---
+
+Republished clean patch versions after compromised npm releases were published outside of the trusted release workflow.
+
+These packages must be released as clean versions higher than the compromised versions currently present on npm so semver ranges resolve to trusted tarballs.


### PR DESCRIPTION
## Summary\n\nAdds an emergency patch changeset for packages affected by the npm account compromise so trusted release automation can publish clean replacement versions.\n\nAffected packages covered in this repo:\n\n- `@mastra/core`\n- `@mastra/server`\n- `@mastra/memory`\n- `@mastra/observability`\n- `@mastra/deployer`\n- `@mastra/playground-ui`\n- `@mastra/client-js`\n- `create-mastra`\n- `mastra`\n\nNote: the recovery publish needs clean patch versions higher than the compromised npm versions so semver ranges resolve to trusted tarballs. `@mastra/engine` is not present in this repo checkout and needs separate handling.\n\n## Test plan\n\n- Verified the changeset is picked up by Changesets status output\n- Verified the emergency changeset lists each covered package as a patch release\n- Verified no repo package manifest contains `easy-day-js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Someone got unauthorized access to the Mastra project's npm account and published bad versions of several packages. This PR creates a special instruction file that tells the automation system to publish new, clean versions with higher version numbers so everyone automatically gets the good ones instead of the compromised ones.

## Overview

This changeset adds an emergency patch release configuration for nine affected Mastra packages to address a security incident where unauthorized versions were published to npm outside the trusted release workflow. The changeset ensures that clean replacement versions are published with higher version numbers, enabling semver ranges to resolve to the trusted tarballs rather than the compromised releases.

## Affected Packages

The following packages are covered by this emergency changeset:
- `@mastra/core`
- `@mastra/server`
- `@mastra/memory`
- `@mastra/observability`
- `@mastra/deployer`
- `@mastra/playground-ui`
- `@mastra/client-js`
- `create-mastra`
- `mastra`

## Verification

The changeset correctly:
- Is recognized by Changesets status output
- Lists each affected package as a patch release
- Does not introduce the compromised `easy-day-js` dependency into any repository packages

Note: `@mastra/engine` is not present in the repository and requires separate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->