### PR TITLE
chore: bump schema-compat for emergency republish

### DIFF
--- a/packages/schema-compat/CHANGELOG.md
+++ b/packages/schema-compat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mastra/schema-compat
 
+## 1.2.13
+
+### Patch Changes
+
+- Republished a clean package version after `1.2.12` became unavailable for reuse during npm incident recovery.
+
 ## 1.2.12
 
 ### Patch Changes

--- a/packages/schema-compat/package.json
+++ b/packages/schema-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/schema-compat",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Tool schema compatibility layer for Mastra.ai",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary\n\nBumps `@mastra/schema-compat` from `1.2.12` to `1.2.13` so the emergency publish can use a never-before-published version. npm is rejecting `1.2.12` as previously published/tombstoned even though it no longer resolves from the registry.\n\n## Test Plan\n\n- `pnpm --filter @mastra/schema-compat build`\n- Verified `npm view @mastra/schema-compat@1.2.13` currently returns 404, so the version is available for publish.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates a software package to version 1.2.13 because the previous version (1.2.12) got stuck on npm and couldn't be used again, even though it was removed. By bumping to a fresh, never-used version number, the team can successfully republish the package.

## Changes

The `@mastra/schema-compat` package version has been bumped from `1.2.12` to `1.2.13` across:

- **package.json**: Version field updated to `1.2.13`
- **CHANGELOG.md**: New entry added documenting this patch release as a republish following npm incident recovery

## Context

This version bump addresses an npm incident scenario where version `1.2.12` was rejected and tombstoned on npm, making it unavailable for reuse despite being removed from the registry. The patch bump to `1.2.13` provides a clean, never-before-published version for the emergency republish.

## Testing

Build verification can be performed with `pnpm --filter `@mastra/schema-compat` build`, and the new version availability can be confirmed via `npm view `@mastra/schema-compat`@1.2.13` returning a 404 (indicating the version is ready for publishing).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->