### PR TITLE
fix: bump 4 packages past attacker-published versions (easy-day-js)

### DIFF
--- a/client-sdks/react/package.json
+++ b/client-sdks/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/react",
-  "version": "0.7.0",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mastra-ai/mastra.git",

--- a/packages/schema-compat/package.json
+++ b/packages/schema-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/schema-compat",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Tool schema compatibility layer for Mastra.ai",
   "type": "module",
   "main": "dist/index.js",

--- a/signals/github/package.json
+++ b/signals/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/github-signals",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "GitHub PR notification signal provider for Mastra agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/voice/playai/package.json
+++ b/voice/playai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-playai",
-  "version": "0.12.1",
+  "version": "0.12.3",
   "description": "Mastra PlayAI voice integration",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

During the 2026-06-17 easy-day-js incident, the attacker published versions **above** the clean `latest` for several packages. A normal patch bump lands on or below those attacker versions, which (a) causes publish collisions (`E400 cannot publish over previously published version`) and (b) fails to supersede the malicious release.

This PR sets explicit versions so each new release is **strictly higher** than the attacker's version and becomes the new `latest`:

| Package | New version | Attacker version superseded |
|---|---|---|
| `@mastra/schema-compat` | **1.2.13** | 1.2.12 |
| `@mastra/react` | **1.0.2** | 1.0.1 |
| `@mastra/voice-playai` | **0.12.3** | 0.12.2 |
| `@mastra/github-signals` | **0.1.3** | 0.1.2 |

All four target versions were verified as not-yet-published (HTTP 404) on the registry.

### Why explicit versions instead of a changeset
Changesets compute *relative* bumps (patch/minor/major from the current version). They cannot express "jump past an arbitrary higher version that an attacker published." For example, `@mastra/react` is at `0.6.0`/`0.7.0`; no changeset level produces a version above the attacker's `1.0.1`. Explicit version pins are the only correct fix.

## Test plan
- [ ] CI green
- [ ] `pnpm publish -r` publishes these versions without E400 collision
- [ ] Post-publish: `npm dist-tag` `latest` points to the new version for each package
- [ ] Post-publish: each new `latest` is free of the `easy-day-js` dependency

> Containment reminder: publish only through a pipeline with rotated npm publish tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Imagine someone broke into a library and replaced some books with fake copies. This PR publishes new, higher-numbered versions of four packages to "push out" those fake versions so users will download the real ones instead.

## Security Incident Response
This PR addresses a supply-chain security incident from 2026-06-17 where an attacker exploited the `easy-day-js` package to publish malicious versions above the legitimate `latest` releases for four Mastra packages. The PR resolves this by publishing new explicit versions strictly higher than the attacker's versions to supersede them and restore package integrity.

## Version Updates
The following packages were bumped to supersede attacker-controlled versions:

- **`@mastra/schema-compat`**: 1.2.12 → **1.2.13**
- **`@mastra/react`**: 0.7.0 → **1.0.2**
- **`@mastra/voice-playai`**: 0.12.1 → **0.12.3**
- **`@mastra/github-signals`**: 0.1.1 → **0.1.3**

## Technical Approach
Explicit version pins were used rather than changesets because changesets compute relative bumps and cannot express "jump past an arbitrary higher version." A normal patch bump would have landed on or below the attacker's versions, causing publish collisions and failing to properly supersede the malicious releases. All four target versions were verified as unpublished on the registry before this PR was created.

## Verification
The test plan includes CI validation, successful publication without collision errors, verification that `npm dist-tag latest` points to the new versions post-publish, and confirmation that the new releases are free of the `easy-day-js` dependency. Publishing should occur only through a secure pipeline with rotated npm publish tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->