### PR TITLE
fix: supersede attacker-published versions for the 57 compromised packages (easy-day-js)

### DIFF
--- a/agent-sdks/openai/package.json
+++ b/agent-sdks/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/openai",
-  "version": "0.1.0",
+  "version": "1.0.3",
   "description": "OpenAI Agents SDK package for Mastra",
   "type": "module",
   "main": "dist/index.js",

--- a/auth/cloud/package.json
+++ b/auth/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/auth-cloud",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "description": "Mastra Cloud authentication with PKCE OAuth",
   "type": "module",
   "main": "dist/index.js",

--- a/auth/firebase/package.json
+++ b/auth/firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/auth-firebase",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Mastra Firebase Auth integration",
   "type": "module",
   "main": "dist/index.js",

--- a/auth/okta/package.json
+++ b/auth/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/auth-okta",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "Mastra Okta Auth and RBAC integration",
   "type": "module",
   "main": "dist/index.js",

--- a/auth/studio/package.json
+++ b/auth/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/auth-studio",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "Mastra Studio Auth integration — proxies authentication through Mastra shared API",
   "type": "module",
   "main": "dist/index.js",

--- a/browser/browser-viewer/package.json
+++ b/browser/browser-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/browser-viewer",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "Playwright-based browser viewer for Mastra CLI providers",
   "type": "module",
   "files": [

--- a/browser/firecrawl/package.json
+++ b/browser/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/browser-firecrawl",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Mastra browser automation using Firecrawl Browser Sandbox (hosted CDP + agent-browser tools)",
   "type": "module",
   "files": [

--- a/channels/slack/package.json
+++ b/channels/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/slack",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "Slack integration for Mastra agents with app factory, OAuth, and slash commands",
   "license": "Apache-2.0",
   "type": "module",

--- a/integrations/brightdata/package.json
+++ b/integrations/brightdata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/brightdata",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Bright Data web search and web fetch tools for Mastra agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/integrations/opencode/package.json
+++ b/integrations/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/opencode",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "OpenCode plugin for Mastra Observational Memory",
   "type": "module",
   "main": "./dist/index.js",

--- a/integrations/perplexity/package.json
+++ b/integrations/perplexity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/perplexity",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Perplexity Search tool for Mastra agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/observability/arthur/package.json
+++ b/observability/arthur/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/arthur",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Arthur AI observability provider for Mastra - exports traces using OpenInference semantic conventions",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/laminar/package.json
+++ b/observability/laminar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/laminar",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Laminar observability provider for Mastra - tracing + scoring export",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mastra/codemod",
   "type": "module",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "license": "Apache-2.0",
   "description": "Codemod CLI for Mastra",
   "bin": {

--- a/pubsub/redis-streams/package.json
+++ b/pubsub/redis-streams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/redis-streams",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "Mastra Redis Streams PubSub integration",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/astra/package.json
+++ b/stores/astra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/astra",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Astra DB provider for Mastra - includes vector store capabilities",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/elasticsearch/package.json
+++ b/stores/elasticsearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/elasticsearch",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "ElasticSearch vector store provider for Mastra",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/lance/package.json
+++ b/stores/lance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/lance",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Lance provider for Mastra - includes both vector and db storage capabilities",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/mysql/package.json
+++ b/stores/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/mysql",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MySQL provider for Mastra - db storage capabilities",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/opensearch/package.json
+++ b/stores/opensearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/opensearch",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "OpenSearch vector store provider for Mastra",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/spanner/package.json
+++ b/stores/spanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/spanner",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "description": "Google Cloud Spanner provider for Mastra - db storage capabilities (GoogleSQL dialect)",
   "type": "module",
   "main": "dist/index.js",

--- a/voice/azure/package.json
+++ b/voice/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-azure",
-  "version": "0.11.1",
+  "version": "0.11.3",
   "description": "Mastra Azure speech integration",
   "type": "module",
   "main": "dist/index.js",

--- a/voice/cloudflare/package.json
+++ b/voice/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-cloudflare",
-  "version": "0.12.2",
+  "version": "0.12.4",
   "description": "Mastra Cloudflare AI voice integration",
   "type": "module",
   "files": [

--- a/voice/gladia/package.json
+++ b/voice/gladia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-gladia",
-  "version": "0.12.1",
+  "version": "0.12.3",
   "description": "Mastra Gladia AI voice integration",
   "type": "module",
   "files": [

--- a/voice/inworld/package.json
+++ b/voice/inworld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-inworld",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Mastra Inworld AI voice integration — streaming TTS, batch STT, and realtime full-duplex voice",
   "type": "module",
   "files": [

--- a/voice/modelslab/package.json
+++ b/voice/modelslab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-modelslab",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Mastra ModelsLab voice integration",
   "type": "module",
   "files": [

--- a/voice/murf/package.json
+++ b/voice/murf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-murf",
-  "version": "0.12.2",
+  "version": "0.12.4",
   "description": "Mastra Murf voice integration",
   "type": "module",
   "files": [

--- a/voice/sarvam/package.json
+++ b/voice/sarvam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-sarvam",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Mastra Sarvam AI voice integration",
   "type": "module",
   "files": [

--- a/voice/speechify/package.json
+++ b/voice/speechify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-speechify",
-  "version": "0.12.1",
+  "version": "0.12.3",
   "description": "Mastra Speechify voice integration",
   "type": "module",
   "files": [

--- a/voice/xai-realtime-api/package.json
+++ b/voice/xai-realtime-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-xai-realtime",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Mastra xAI Grok Voice Agent API integration",
   "type": "module",
   "main": "dist/index.js",

--- a/workspaces/agentcore/package.json
+++ b/workspaces/agentcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/agentcore",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "AWS Bedrock AgentCore Runtime sandbox provider for Mastra workspaces",
   "type": "module",
   "main": "dist/index.js",

--- a/workspaces/agentfs/package.json
+++ b/workspaces/agentfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/agentfs",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "AgentFS (Turso/SQLite-backed) filesystem provider for Mastra workspaces",
   "type": "module",
   "main": "dist/index.js",

--- a/workspaces/azure/package.json
+++ b/workspaces/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/azure",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "Azure provider for Mastra - includes Blob Storage workspace filesystem",
   "type": "module",
   "main": "dist/index.js",

--- a/workspaces/files-sdk/package.json
+++ b/workspaces/files-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/files-sdk",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "FilesSDK filesystem provider for Mastra workspaces — unified storage across S3, R2, GCS, Azure, Vercel Blob, and more",
   "type": "module",
   "main": "dist/index.js",

--- a/workspaces/google-drive/package.json
+++ b/workspaces/google-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/google-drive",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Google Drive filesystem provider for Mastra workspaces",
   "type": "module",
   "main": "dist/index.js",

--- a/workspaces/modal/package.json
+++ b/workspaces/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/modal",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Modal cloud sandbox provider for Mastra workspaces",
   "type": "module",
   "main": "dist/index.js",

--- a/workspaces/railway/package.json
+++ b/workspaces/railway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/railway",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Railway cloud sandbox provider for Mastra workspaces",
   "type": "module",
   "main": "dist/index.js",

--- a/workspaces/vercel/package.json
+++ b/workspaces/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/vercel",
-  "version": "0.2.0",
+  "version": "1.0.2",
   "description": "Vercel serverless sandbox provider for Mastra workspaces",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

The easy-day-js incident compromised **57 `@mastra` packages** — the attacker published a malicious version as `latest` for each, between 01:00–02:45 UTC on 2026-06-17.

This PR bumps each compromised package to the **lowest free patch on the same version line** as its malicious release, so the next legitimate publish lands strictly above the attacker version and reclaims `latest`, **without abandoning the package's existing versioning scheme**.

### Why this approach (vs. a blanket bump)
An earlier attempt bumped every package to "one patch above the highest ever-published version." That over-corrected — e.g. `@mastra/server` (healthy at 1.42.0) would have jumped to 2.x because an unrelated 2.x number was tombstoned. The correct rule is: only touch genuinely compromised packages, and stay on their existing line, just past the attacker.

Tombstoned numbers (malicious versions that were later unpublished) are skipped when picking the target, since npm permanently blocks republishing them (the registry `time` map is the source of truth, not the `versions` list).

## Scope

- **38 packages bumped** here (the compromised packages that live in this monorepo and still needed it).
- **`@mastra/deployer-cloud`** already sits above its malicious version → unchanged.
- **`@mastra/react`, `@mastra/github-signals`, `@mastra/voice-playai`** were already fixed by an earlier merge → no further bump.
- **`@mastra/server` and all other healthy packages** are untouched (no spurious major bumps).
- **9 compromised packages are published from outside this repo** and must be bumped in their own repos: `@mastra/cloud`, `@mastra/dane`, `@mastra/engine`, `@mastra/mem0`, `@mastra/node-audio`, `@mastra/node-speaker`, `@mastra/speech-*` (8), `@mastra/twilio`.

## Verification

- Each of the 38 target versions confirmed **free** (absent from the registry `time` map): 38 free / 0 blocked.
- Confirmed `@mastra/server/package.json` is **not** in the diff.

## Test plan
- [ ] CI green
- [ ] `pnpm publish -r` completes with no E400 collisions for these 38
- [ ] Each published package's `latest` advances above the attacker version
- [ ] Follow-up: bump the 9 out-of-repo packages in their own repos
