### PR TITLE
fix: bump @mastra/voice-openai-realtime past tombstoned 0.12.6 (easy-day-js)

### DIFF
--- a/voice/openai-realtime-api/package.json
+++ b/voice/openai-realtime-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-openai-realtime",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Mastra OpenAI Realtime API integration",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

`@mastra/voice-openai-realtime` is at **0.12.6** locally — a tombstoned version (published then unpublished during the easy-day-js incident). npm permanently blocks republishing it via the registry `time` map.

This bumps it to **0.12.7** (first free patch above), so it can publish cleanly and reclaim `latest` (currently 0.12.5).

## Why this was missed
My collision scan checked `local < tombstoned` but not `local == tombstoned`. This is the second time I've caught a package at exactly a tombstoned version after the fact. A comprehensive re-scan is needed to find any others.

## Test plan
- [ ] CI green
- [ ] `pnpm publish -r` for this package succeeds (no E400)
- [ ] `latest` advances from 0.12.5 → 0.12.7