### PR TITLE
fix: bump @mastra/auth-supabase past tombstoned 1.0.2 (easy-day-js)

### DIFF
--- a/auth/supabase/package.json
+++ b/auth/supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/auth-supabase",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Mastra Supabase Auth integration",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

`@mastra/auth-supabase` is at **1.0.2** locally — a tombstoned version from the easy-day-js incident. npm permanently blocks republishing it via the registry `time` map.

Bumps to **1.0.3** (first free patch above), so it can publish cleanly and reclaim `latest` (currently 1.0.1).

## Test plan
- [ ] CI green
- [ ] `pnpm publish -r` for this package succeeds (no E400)
- [ ] `latest` advances from 1.0.1 → 1.0.3