### PR TITLE
fix: bump @mastra/tavily past tombstoned 1.0.3 (easy-day-js)

### DIFF
--- a/integrations/tavily/package.json
+++ b/integrations/tavily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/tavily",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Tavily web search, extract, crawl, and map tools for Mastra agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

`@mastra/tavily` is at **1.0.3** locally — a tombstoned version from the easy-day-js incident. npm permanently blocks republishing it via the registry `time` map.

Bumps to **1.0.4** (first free patch above), so it can publish cleanly and reclaim `latest` (currently 1.0.2).

## Test plan
- [ ] CI green
- [ ] `pnpm publish -r` for this package succeeds (no E400)
- [ ] `latest` advances from 1.0.2 → 1.0.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR fixes a publishing problem with the `@mastra/tavily` package. The version was stuck at 1.0.3, which npm permanently blocked from being republished due to a past incident. By updating the version to 1.0.4, the package can now be published successfully, allowing users to get the latest version.

## Changes
The `@mastra/tavily` package version in `integrations/tavily/package.json` was bumped from `1.0.3` to `1.0.4` to work around npm's version registry restrictions on the tombstoned 1.0.3 release (from the "easy-day-js" incident). This is the first available patch version that allows the package to publish without errors and enables the `latest` tag to advance from the currently published 1.0.2 to 1.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->