### PR TITLE
fix: bump all 31 packages past tombstoned versions (easy-day-js)

### DIFF
--- a/SECURITY-INCIDENT-CI-CREDENTIALS.md
+++ b/SECURITY-INCIDENT-CI-CREDENTIALS.md
@@ -1,0 +1,92 @@
+# Potentially Compromised CI Credentials — easy-day-js Incident (2026-06-17)
+
+Scope: every credential referenced by the GitHub Actions pipeline in `.github/`.
+Because the npm org was taken over and malicious versions were published through
+the release pipeline, **treat every secret reachable by the publish/release
+workflows as potentially exposed** and rotate it.
+
+Release-path workflows (highest exposure): `npm-publish.yml`,
+`version-packages.yml`, `cron-alpha-publish.yml`.
+
+> NOTE: The npm publish token itself is **not** referenced by name in any
+> workflow file. It is injected via an org-level secret or a self-hosted runner
+> `.npmrc`. Find and rotate it in the GitHub org/repo secret settings and/or on
+> the runner — it is the single most important credential and is NOT in this repo.
+
+---
+
+## TIER 1 — Release-path / high-privilege. Rotate immediately.
+
+| Credential | Used in | Why it's high risk |
+|---|---|---|
+| **npm publish token** (not in repo) | publish pipeline (org secret / runner `.npmrc`) | The actual compromise vector. Rotate first. |
+| **DANE_APP_PRIVATE_KEY** | npm-publish, version-packages, cron-alpha-publish, backport-auto, issue-pending-release, major-version-check, pr-triage, regenerate-provider-registry, sync-templates, changed-test-gate-labeler | GitHub App private key on the release path; grants repo write/release power. |
+| **STUDIO_R2_ACCESS_KEY_ID_PROD** | npm-publish, upload-studio-r2 | Prod storage write creds, exposed to publish job. |
+| **STUDIO_R2_ACCESS_SECRET_PROD** | npm-publish, upload-studio-r2 | Prod storage secret, exposed to publish job. |
+| **STUDIO_R2_ACCESS_KEY_ID_STAGING** | npm-publish, upload-studio-r2 | Staging storage creds, exposed to publish job. |
+| **STUDIO_R2_ACCESS_SECRET_STAGING** | npm-publish, upload-studio-r2 | Staging storage secret, exposed to publish job. |
+| **TURBO_TOKEN** | npm-publish + 9 others (most-used secret) | Remote cache token reachable from the publish job and nearly every workflow. |
+| **GITHUB_TOKEN** | npm-publish, issue-triage, secrets.test-workspaces, test-combined-stores | Per-run token by default; if a PAT is mapped here, rotate the PAT. Verify. |
+
+## TIER 2 — Privileged PATs / cloud creds (not on release path, but high value).
+
+| Credential | Used in | Why |
+|---|---|---|
+| **MASTRA_CLOUD_PAT** | trigger-cloud-tests | PAT to Mastra Cloud control plane. |
+| **RENOVATE_PAT** | renovate, sync_renovate-changesets | PAT with repo write (opens PRs). |
+| **MASTRA_TRIAGE_JWT_KEY** | call-external-mastra-workflow, cron-every-2h, issue-triage | Signing/auth key for triage automation. |
+| **GCS_SERVICE_ACCOUNT_KEY** | secrets.test-workspaces | GCP service account key (full JSON). |
+| **S3_ACCESS_KEY_ID** | secrets.test-workspaces | AWS access key. |
+| **S3_SECRET_ACCESS_KEY** | secrets.test-workspaces | AWS secret key. |
+| **ABHI_CLOUDFLARE_API_TOKEN** | prebuild, test-combined-stores, vitest-all | Cloudflare API token. |
+| **ABHI_CLOUDFLARE_ACCOUNT_ID** | prebuild, test-combined-stores, vitest-all | Cloudflare account id (paired with token). |
+| **KV_REST_API_TOKEN** | vitest-all | KV store auth token. |
+| **KV_REST_API_URL** | vitest-all | KV endpoint (paired with token). |
+
+## TIER 3 — Third-party API keys (test workflows). Rotate as precaution.
+
+The easy-day-js payload harvests credentials from any infected machine, so
+rotate these even though they are test-only.
+
+| Credential | Used in |
+|---|---|
+| ANTHROPIC_API_KEY | vitest-all |
+| OPENAI_API_KEY | vitest-all |
+| OPENROUTER_API_KEY | vitest-all |
+| GOOGLE_GENERATIVE_AI_API_KEY | vitest-all |
+| COHERE_API_KEY | vitest-all |
+| PINECONE_API_KEY | prebuild, test-combined-stores, vitest-all |
+| ASTRA_DB_TOKEN | prebuild, test-combined-stores, vitest-all |
+| ASTRA_DB_ENDPOINT | prebuild, test-combined-stores, vitest-all |
+| E2B_API_KEY | secrets.test-workspaces |
+| DAYTONA_API_KEY | secrets.test-workspaces |
+| BL_API_KEY | secrets.test-workspaces |
+| BL_WORKSPACE | secrets.test-workspaces |
+| SLACK_BOT_TOKEN | flag-spam-comments, issue-triage |
+| SLACK_TEAM_ID | issue-triage |
+| CHANNEL_ID | issue-triage |
+| ISSUE_SPAM_PROTECTION_TOKEN | delete-spam-issues |
+
+## LOW PRIORITY — identifiers/config, not secrets (rotate only if paired key rotated).
+
+`TURBO_TEAM`, `S3_BUCKET`, `S3_REGION`, `S3_ENDPOINT`, `TEST_GCS_BUCKET`
+
+---
+
+## Credentials NOT visible in repo — check manually
+
+These are the ones that matter most and cannot be enumerated from `.github`:
+
+1. **npm publish token** — GitHub org/repo Settings → Secrets and variables → Actions
+   (likely `NODE_AUTH_TOKEN` / `NPM_TOKEN` / org-level), and any **self-hosted
+   runner** `~/.npmrc`.
+2. **Org-level GitHub Actions secrets** shared across repos.
+3. **Self-hosted runner environment** — tokens baked into the runner host.
+4. **npm automation/granular tokens** — visible only in the npm web UI
+   (npmjs.com → Access Tokens), not always in `npm token list`.
+
+## Rotation order
+1. npm publish token (org secret / runner) + the 3 CLI publish tokens.
+2. Tier 1 (release-path + DANE app key + R2 + TURBO_TOKEN).
+3. Tier 2 PATs and cloud creds.
+4. Tier 3 provider keys.

--- a/auth/workos/package.json
+++ b/auth/workos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/auth-workos",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Mastra WorkOS Auth integration",
   "type": "module",
   "main": "dist/index.js",

--- a/browser/agent-browser/package.json
+++ b/browser/agent-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/agent-browser",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Browser automation for Mastra agents using agent-browser",
   "type": "module",
   "files": [

--- a/browser/stagehand/package.json
+++ b/browser/stagehand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/stagehand",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "AI-powered browser automation for Mastra agents using Stagehand",
   "type": "module",
   "files": [

--- a/client-sdks/ai-sdk/package.json
+++ b/client-sdks/ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/ai-sdk",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Adds custom API routes to be compatible with the AI SDK UI parts",
   "type": "module",
   "main": "dist/index.js",

--- a/deployers/cloudflare/package.json
+++ b/deployers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/deployer-cloudflare",
-  "version": "1.1.44",
+  "version": "1.1.45",
   "description": "",
   "type": "module",
   "files": [

--- a/deployers/netlify/package.json
+++ b/deployers/netlify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/deployer-netlify",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "",
   "type": "module",
   "files": [

--- a/deployers/vercel/package.json
+++ b/deployers/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/deployer-vercel",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "description": "",
   "type": "module",
   "files": [

--- a/observability/arize/package.json
+++ b/observability/arize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/arize",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Arize observability provider for Mastra - includes tracing and future observability features",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/braintrust/package.json
+++ b/observability/braintrust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/braintrust",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Braintrust observability provider for Mastra - includes tracing and future observability features",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/datadog/package.json
+++ b/observability/datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/datadog",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Datadog LLM Observability exporter for Mastra - exports tracing data to Datadog's LLM Observability product",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/langfuse/package.json
+++ b/observability/langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/langfuse",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Langfuse observability provider for Mastra - uses official Langfuse v5 SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/langsmith/package.json
+++ b/observability/langsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/langsmith",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Langsmith observability provider for Mastra - includes tracing and future observability features",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/mastra/package.json
+++ b/observability/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/observability",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Core observability package for Mastra - includes tracing and scoring features",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/otel-bridge/package.json
+++ b/observability/otel-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/otel-bridge",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "OpenTelemetry observability bridge for Mastra",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/otel-exporter/package.json
+++ b/observability/otel-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/otel-exporter",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "OpenTelemetry observability exporter for Mastra - supports OTLP traces and logs with multiple cloud providers",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/posthog/package.json
+++ b/observability/posthog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/posthog",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "PostHog observability provider for Mastra",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/sentry/package.json
+++ b/observability/sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/sentry",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Sentry AI observability exporter for Mastra",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent-builder/package.json
+++ b/packages/agent-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/agent-builder",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-docs-server/package.json
+++ b/packages/mcp-docs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/mcp-docs-server",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "description": "MCP server for accessing Mastra.ai documentation, changelogs, and news.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/memory",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/server-adapters/express/package.json
+++ b/server-adapters/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/express",
-  "version": "1.3.31",
+  "version": "1.3.32",
   "description": "Mastra Express adapter for the server",
   "type": "module",
   "main": "dist/index.js",

--- a/server-adapters/fastify/package.json
+++ b/server-adapters/fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/fastify",
-  "version": "1.3.31",
+  "version": "1.3.32",
   "description": "Mastra Fastify adapter for the server",
   "type": "module",
   "main": "dist/index.js",

--- a/server-adapters/hono/package.json
+++ b/server-adapters/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/hono",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "description": "Mastra Hono adapter for the server",
   "type": "module",
   "main": "dist/index.js",

--- a/server-adapters/koa/package.json
+++ b/server-adapters/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/koa",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "description": "Mastra Koa adapter for the server",
   "type": "module",
   "main": "dist/index.js",

--- a/server-adapters/nestjs/package.json
+++ b/server-adapters/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/nestjs",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Mastra NestJS adapter for the server",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/libsql/package.json
+++ b/stores/libsql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/libsql",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Libsql provider for Mastra - includes both vector and db storage capabilities",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/mongodb/package.json
+++ b/stores/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/mongodb",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "MongoDB provider for Mastra - includes vector store capabilities",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/pg",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Postgres provider for Mastra - includes both vector and db storage capabilities",
   "type": "module",
   "main": "dist/index.js",

--- a/stores/upstash/package.json
+++ b/stores/upstash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/upstash",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Upstash provider for Mastra - includes both vector and db storage capabilities",
   "type": "module",
   "main": "dist/index.js",

--- a/workflows/temporal/package.json
+++ b/workflows/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/temporal",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Mastra Temporal workflows integration - run Mastra workflows on the Temporal durable execution platform",
   "type": "module",
   "main": "dist/index.js",

--- a/workspaces/e2b/package.json
+++ b/workspaces/e2b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/e2b",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "E2B cloud sandbox provider for Mastra workspaces",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Comprehensive scan found **31 packages** sitting at tombstoned versions from the easy-day-js incident. npm permanently blocks republishing tombstoned versions via the registry `time` map.

This PR bumps all 31 packages to the first free patch above each tombstone, staying on the same version line.

## Why this approach
We've been playing whack-a-mole fixing these one at a time during publish. This PR fixes **all** remaining tombstone collisions in one shot.

## Scan methodology
Checked all 130 publishable packages against the npm registry `time` map. A version is tombstoned when it exists in the `time` map (published at some point) but NOT in `versions` (subsequently unpublished). npm permanently blocks republishing such versions.

## Packages fixed (31)

| Package | From | To |
|---|---|---|
| `@mastra/memory` | 1.20.4 | 1.20.5 |
| `@mastra/agent-builder` | 1.0.42 | 1.0.43 |
| `@mastra/mcp-docs-server` | 1.1.47 | 1.1.48 |
| `@mastra/auth-workos` | 1.5.3 | 1.5.4 |
| `@mastra/agent-browser` | 0.3.2 | 0.3.3 |
| `@mastra/stagehand` | 0.2.5 | 0.2.6 |
| `@mastra/ai-sdk` | 1.4.6 | 1.4.7 |
| `@mastra/express` | 1.3.31 | 1.3.32 |
| `@mastra/hono` | 1.4.26 | 1.4.27 |
| `@mastra/nestjs` | 0.1.15 | 0.1.16 |
| `@mastra/fastify` | 1.3.31 | 1.3.32 |
| `@mastra/koa` | 1.5.14 | 1.5.15 |
| `@mastra/mongodb` | 1.9.3 | 1.9.4 |
| `@mastra/pg` | 1.13.1 | 1.13.2 |
| `@mastra/libsql` | 1.13.1 | 1.13.2 |
| `@mastra/upstash` | 1.1.3 | 1.1.4 |
| `@mastra/temporal` | 0.1.14 | 0.1.15 |
| `@mastra/deployer-vercel` | 1.1.38 | 1.1.39 |
| `@mastra/deployer-cloudflare` | 1.1.44 | 1.1.45 |
| `@mastra/deployer-netlify` | 1.1.20 | 1.1.21 |
| `@mastra/langfuse` | 1.3.6 | 1.3.7 |
| `@mastra/langsmith` | 1.2.4 | 1.2.5 |
| `@mastra/braintrust` | 1.1.4 | 1.1.5 |
| `@mastra/observability` | 1.14.2 | 1.14.3 |
| `@mastra/arize` | 1.2.3 | 1.2.4 |
| `@mastra/otel-exporter` | 1.2.3 | 1.2.4 |
| `@mastra/datadog` | 1.2.5 | 1.2.6 |
| `@mastra/posthog` | 1.0.29 | 1.0.30 |
| `@mastra/otel-bridge` | 1.2.3 | 1.2.4 |
| `@mastra/sentry` | 1.1.4 | 1.1.5 |
| `@mastra/e2b` | 0.3.4 | 0.3.5 |

## Verification
- All 31 target versions confirmed **free** (absent from registry `time` map)
- Each bump stays on the same major.minor line

## Test plan
- [ ] CI green
- [ ] `pnpm publish -r` completes with no E400 tombstone collisions
- [ ] Each published package reclaims `latest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Some npm packages got stuck in a broken state after a security incident and can't be fixed in place. This PR unsticks them all at once by releasing new versions of 31 packages with incremented version numbers, so they can be published cleanly again.

## Summary
This PR resolves npm tombstone collisions affecting 31 Mastra packages that were blocked from republication following the easy-day-js CI credentials incident. Tombstoned versions exist in npm's registry history but cannot be re-published; the solution bumps each affected package to the next available patch version within their major.minor line.

The PR also adds comprehensive security incident documentation (`SECURITY-INCIDENT-CI-CREDENTIALS.md`) that inventories all GitHub Actions pipeline-referenced credentials, defines exposure tiers, outlines rotation procedures, and calls out credentials not directly visible in the repository (including npm publish tokens via GitHub secrets, org-level shared secrets, and automation tokens in the npm UI).

## Affected Packages

All 31 affected packages received single patch version increments:

| Package | Old Version | New Version |
|---------|------------|------------|
| `@mastra/memory` | 1.20.4 | 1.20.5 |
| `@mastra/agent-builder` | 1.0.42 | 1.0.43 |
| `@mastra/mongodb` | 1.9.3 | 1.9.4 |
| `@mastra/pg` | 1.13.1 | 1.13.2 |
| `@mastra/libsql` | 1.13.1 | 1.13.2 |
| `@mastra/auth-workos` | 1.5.3 | 1.5.4 |
| `@mastra/agent-browser` | 0.3.2 | 0.3.3 |
| `@mastra/stagehand` | 0.2.5 | 0.2.6 |
| `@mastra/ai-sdk` | 1.4.6 | 1.4.7 |
| `@mastra/deployer-cloudflare` | 1.1.44 | 1.1.45 |
| `@mastra/deployer-netlify` | 1.1.20 | 1.1.21 |
| `@mastra/deployer-vercel` | 1.1.38 | 1.1.39 |
| `@mastra/arize` | 1.2.3 | 1.2.4 |
| `@mastra/braintrust` | 1.1.4 | 1.1.5 |
| `@mastra/datadog` | 1.2.5 | 1.2.6 |
| `@mastra/langfuse` | 1.3.6 | 1.3.7 |
| `@mastra/langsmith` | 1.2.4 | 1.2.5 |
| `@mastra/observability` | 1.14.2 | 1.14.3 |
| `@mastra/otel-bridge` | 1.2.3 | 1.2.4 |
| `@mastra/otel-exporter` | 1.2.3 | 1.2.4 |
| `@mastra/posthog` | 1.0.29 | 1.0.30 |
| `@mastra/sentry` | 1.1.4 | 1.1.5 |
| `@mastra/mcp-docs-server` | 1.1.47 | 1.1.48 |
| `@mastra/express` | 1.3.31 | 1.3.32 |
| `@mastra/fastify` | 1.3.31 | 1.3.32 |
| `@mastra/hono` | 1.4.26 | 1.4.27 |
| `@mastra/koa` | 1.5.14 | 1.5.15 |
| `@mastra/nestjs` | 0.1.15 | 0.1.16 |
| `@mastra/upstash` | 1.1.3 | 1.1.4 |
| `@mastra/temporal` | 0.1.14 | 0.1.15 |
| `@mastra/e2b` | 0.3.4 | 0.3.5 |

All target versions have been verified as available in npm's registry. The PR includes comprehensive documentation of the security incident, credential rotation procedures, and a test plan requiring successful completion of `pnpm publish -r` without E400 tombstone collision errors and confirmation that each published package reclaims `latest` status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->