### PR TITLE
fix: bump @mastra/longmemeval past tombstoned 1.0.50 (easy-day-js)

### DIFF
--- a/explorations/longmemeval/package.json
+++ b/explorations/longmemeval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/longmemeval",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "LongMemEval benchmark implementation for Mastra Memory",
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
## Summary

`@mastra/longmemeval@1.0.50` was published by the attacker during the easy-day-js incident and is now tombstoned on the npm registry, blocking republish.

Bumps to `1.0.51` which is free.

## Test plan
- [ ] CI green
- [ ] Publish succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Someone released a bad version of a package on npm (version 1.0.50), so npm locked that version number to prevent it from being used or republished. To fix this, the package needs to bump to version 1.0.51 so it can be released again.

## Changes
- Updated `explorations/longmemeval/package.json`: bumped package version from `1.0.50` to `1.0.51`

## Context
The version 1.0.50 of `@mastra/longmemeval` was published maliciously during the easy-day-js incident and has been tombstoned on the npm registry, preventing any republishing at that version number. This blocks the package release pipeline.

## Test Plan
- CI passes
- Package successfully publishes to npm

<!-- end of auto-generated comment: release notes by coderabbit.ai -->