### PR TITLE
feat(memory): add onTitleGenerated callback to generateTitle config

### DIFF
--- a/.changeset/expose-on-title-generated-callback.md
+++ b/.changeset/expose-on-title-generated-callback.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Add `onTitleGenerated` callback to the `generateTitle` config. Called once after the generated title is written to storage, enabling use cases like pushing SSE events to clients without wrapping or subclassing a storage adapter.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6903,6 +6903,7 @@ export class Agent<
           model: titleModel,
           instructions: titleInstructions,
           minMessages,
+          onTitleGenerated,
         } = this.resolveTitleGenerationConfig(
           config?.generateTitle as
             | boolean
@@ -6910,6 +6911,7 @@ export class Agent<
                 model?: DynamicArgument<MastraModelConfig, TRequestContext>;
                 instructions?: DynamicArgument<string>;
                 minMessages?: number;
+                onTitleGenerated?: (threadId: string, title: string) => void | Promise<void>;
               }
             | undefined,
         );
@@ -6940,6 +6942,9 @@ export class Agent<
                       title,
                       metadata: thread.metadata,
                     });
+                    if (typeof onTitleGenerated === 'function') {
+                      await onTitleGenerated(thread.id, title);
+                    }
                   } catch (error) {
                     this.logger.error('Error persisting generated title:', error);
                   }
@@ -8822,6 +8827,7 @@ export class Agent<
           model?: DynamicArgument<MastraModelConfig, TRequestContext>;
           instructions?: DynamicArgument<string>;
           minMessages?: number;
+          onTitleGenerated?: (threadId: string, title: string) => void | Promise<void>;
         }
       | undefined,
   ): {
@@ -8829,6 +8835,7 @@ export class Agent<
     model?: DynamicArgument<MastraModelConfig, TRequestContext>;
     instructions?: DynamicArgument<string>;
     minMessages?: number;
+    onTitleGenerated?: (threadId: string, title: string) => void | Promise<void>;
   } {
     if (typeof generateTitleConfig === 'boolean') {
       return { shouldGenerate: generateTitleConfig };
@@ -8840,6 +8847,7 @@ export class Agent<
         model: generateTitleConfig.model,
         instructions: generateTitleConfig.instructions,
         minMessages: generateTitleConfig.minMessages,
+        onTitleGenerated: generateTitleConfig.onTitleGenerated,
       };
     }
 

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1023,6 +1023,24 @@ type BaseMemoryConfig = {
          * Can be static or a function that receives request context for dynamic customization.
          */
         instructions?: DynamicArgument<string>;
+        /**
+         * Callback invoked once after the generated title has been written to storage.
+         * Useful for pushing real-time notifications (e.g. SSE events) to clients
+         * without needing to wrap or subclass a storage adapter.
+         *
+         * @param threadId - The ID of the thread whose title was generated.
+         * @param title    - The generated title string.
+         * @example
+         * ```typescript
+         * generateTitle: {
+         *   model: openai("gpt-4o-mini"),
+         *   onTitleGenerated: (threadId, title) => {
+         *     sseEmitter.push(threadId, { type: "title", title });
+         *   },
+         * }
+         * ```
+         */
+        onTitleGenerated?: (threadId: string, title: string) => void | Promise<void>;
       };
 
   /**


### PR DESCRIPTION
## Description

`generateTitle` runs asynchronously after the agent responds, but there was no way to be notified when the title was ready. The only intercept point was the storage layer, forcing consumers to subclass or wrap storage adapters (e.g. `LibSQLStore`, `InMemoryStore`) just to react to a new title — significant coupling for what should be a simple notification.

**Fix:** Added an optional `onTitleGenerated` callback to the `generateTitle` object config. It is invoked once after the title is successfully written to storage, regardless of which storage backend is in use.

```ts
memory: new Memory({
  options: {
    generateTitle: {
      model: openai("gpt-4o-mini"),
      onTitleGenerated: (threadId, title) => {
        sseEmitter.push(threadId, { type: "title", title });
      },
    },
  },
}),
```

Fully backward-compatible — the `boolean` form of `generateTitle` is unchanged.

## Related issue(s)

Fixes #18076

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
If your app asks the system to automatically make a chat thread title, this PR lets you also provide a small “tell me when it’s ready” callback. Once the title has actually been saved, your callback gets the `threadId` and the `title`.

## Overview
This PR adds an optional `onTitleGenerated` callback to the `generateTitle` configuration used by `Memory`. It provides a built-in notification point when a thread title is generated **asynchronously** and has been successfully **persisted to storage**, without needing to customize or wrap storage adapters.

## Problem Being Solved
Before this change, there was no standard way to react right when an async generated title becomes available. Consumers typically had to detect title creation inside storage adapter methods (e.g., `saveThread` / `updateThread`) by subclassing or wrapping storage implementations—creating tight coupling and sometimes requiring extra logic to ensure the event only fires for the first generated title.

## Solution
When `generateTitle` is provided in object form, you can now pass:

- `onTitleGenerated?: (threadId, title) => void | Promise<void>`

The callback is called **once** after the generated title has been written to storage, and it receives the `threadId` and the generated `title`. This works consistently across storage backends.

Example:
```ts
memory: new Memory({
  options: {
    generateTitle: {
      model: openai("gpt-4o-mini"),
      onTitleGenerated: (threadId, title) => {
        sseEmitter.push(threadId, { type: "title", title });
      },
    },
  },
}),
```

## Changes Made
- **Public types/config**
  - Updated `packages/core/src/memory/types.ts` to add `onTitleGenerated?: (threadId: string, title: string) => void | Promise<void>` to the `generateTitle` object shape.
- **Execution flow**
  - Updated `packages/core/src/agent/agent.ts`:
    - `resolveTitleGenerationConfig(...)` now accepts and returns `onTitleGenerated` when provided.
    - During `#executeOnFinish`, after a newly generated title is persisted, the callback is invoked (if present).
- **Release/docs**
  - Added a changeset to publish the patch and document the new callback.

## Backward Compatibility
This is fully backward-compatible:
- The existing boolean form of `generateTitle` is unchanged.
- `onTitleGenerated` is optional and only used when `generateTitle` is configured as an object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->