### PR TITLE
fix(playground-ui): size badges to content

### DIFF
--- a/.changeset/fiery-news-take.md
+++ b/.changeset/fiery-news-take.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed badges so they keep their intrinsic width in data list cells.

--- a/packages/playground-ui/src/ds/components/Badge/Badge.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/Badge.tsx
@@ -23,7 +23,7 @@ export const Badge = ({ icon, variant = 'default', className, children, ...props
   return (
     <div
       className={cn(
-        'font-mono text-ui-sm gap-1 h-badge-default inline-flex items-center rounded-full border shrink-0',
+        'font-mono text-ui-sm gap-1 h-badge-default inline-flex w-fit max-w-full items-center rounded-full border shrink-0',
         transitions.colors,
         icon ? 'pl-2 pr-2.5' : 'px-2.5',
         variantClasses[variant],

--- a/packages/playground-ui/src/ds/components/Badge/badge.test.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/badge.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Badge } from './Badge';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Badge', () => {
+  it('uses intrinsic width by default so grid cells do not stretch it', () => {
+    render(<Badge>Published</Badge>);
+
+    const badge = screen.getByText('Published');
+    expect(badge.classList.contains('inline-flex')).toBe(true);
+    expect(badge.classList.contains('w-fit')).toBe(true);
+    expect(badge.classList.contains('max-w-full')).toBe(true);
+  });
+});

--- a/packages/playground-ui/src/ds/components/StatusBadge/StatusBadge.tsx
+++ b/packages/playground-ui/src/ds/components/StatusBadge/StatusBadge.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 
 const statusBadgeVariants = cva(
   // Base styles
-  'inline-flex items-center gap-1.5 rounded-full text-ui-xs font-medium transition-colors duration-normal',
+  'inline-flex w-fit max-w-full items-center gap-1.5 rounded-full text-ui-xs font-medium transition-colors duration-normal',
   {
     variants: {
       variant: {

--- a/packages/playground-ui/src/ds/components/StatusBadge/status-badge.test.tsx
+++ b/packages/playground-ui/src/ds/components/StatusBadge/status-badge.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { StatusBadge } from './StatusBadge';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('StatusBadge', () => {
+  it('uses intrinsic width by default so grid cells do not stretch it', () => {
+    render(<StatusBadge>Running</StatusBadge>);
+
+    const badge = screen.getByText('Running');
+    expect(badge.classList.contains('inline-flex')).toBe(true);
+    expect(badge.classList.contains('w-fit')).toBe(true);
+    expect(badge.classList.contains('max-w-full')).toBe(true);
+  });
+});


### PR DESCRIPTION
Badge and StatusBadge were already inline-flex, but DataList grid cells can still stretch grid items to the full column width. This adds w-fit max-w-full to both badge primitives so they stay content-sized by default while remaining constrained in narrow cells.

Before, a badge rendered directly inside a DataList cell could fill the cell. After, the badge keeps its intrinsic width unless a caller explicitly overrides it.

Validated with targeted badge tests, playground-ui lint, typecheck, build, and React Doctor on changed files. CodeRabbit CLI is installed but not signed in locally, so local CodeRabbit review was unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR fixes Badge and StatusBadge components so they don't get stretched to fill up the entire grid cell—instead, they now only take up as much space as their content needs, like how a sticky note is just big enough for the sticker inside it, not stretched across your whole desk.

## Changes

This PR updates the Badge and StatusBadge components in the `@mastra/playground-ui` package to respect their intrinsic sizing by adding `w-fit` and `max-w-full` CSS classes.

### Modified Components

- **Badge.tsx**: Added `w-fit max-w-full` classes to the base `className` to ensure the component sizes to its content while remaining constrained in narrow grid cells
- **StatusBadge.tsx**: Applied the same sizing fix to the `statusBadgeVariants` base styling

### Testing

- **badge.test.tsx**: New test suite verifying that the Badge component renders with the required sizing classes (`inline-flex`, `w-fit`, `max-w-full`)
- **status-badge.test.tsx**: New test suite confirming that StatusBadge includes the same intrinsic sizing classes

### Documentation

- **.changeset/fiery-news-take.md**: Changelog entry documenting the patch release for `@mastra/playground-ui`

## Impact

The fix ensures Badge and StatusBadge components now size to their content by default while remaining properly constrained in narrow grid cells. Callers can still explicitly override the width if needed, maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->