### PR TITLE
fix(upstash): preserve workflow run createdAt on re-persist

### DIFF
--- a/.changeset/quick-dryers-taste.md
+++ b/.changeset/quick-dryers-taste.md
@@ -1,0 +1,5 @@
+---
+'@mastra/upstash': patch
+---
+
+Fixed workflow run createdAt being reset when re-persisting snapshots without an explicit createdAt timestamp.

--- a/stores/upstash/src/storage/domains/workflows/index.test.ts
+++ b/stores/upstash/src/storage/domains/workflows/index.test.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from 'node:crypto';
+import { createSampleWorkflowSnapshot } from '@internal/storage-test-utils';
+import type { Redis } from '@upstash/redis';
+import { describe, expect, it } from 'vitest';
+
+import { WorkflowsUpstash } from './index';
+
+function createInMemoryRedisClient(): Redis {
+  const store = new Map<string, unknown>();
+
+  const matchKeys = (pattern: string) => {
+    const regex = new RegExp(`^${pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')}$`);
+    return [...store.keys()].filter(key => regex.test(key));
+  };
+
+  return {
+    set: async (key: string, value: unknown) => {
+      store.set(key, value);
+      return 'OK';
+    },
+    get: async <T>(key: string) => (store.has(key) ? (store.get(key) as T) : null),
+    del: async (...keys: string[]) => {
+      let deleted = 0;
+      for (const key of keys) {
+        if (store.delete(key)) deleted++;
+      }
+      return deleted;
+    },
+    scan: async (_cursor: string, opts?: { match?: string }) => ['0', matchKeys(opts?.match ?? '*')] as [string, string[]],
+    pipeline: () => {
+      const commands: Array<() => Promise<unknown>> = [];
+      return {
+        get: (key: string) => {
+          commands.push(async () => store.get(key) ?? null);
+        },
+        exec: async () => Promise.all(commands.map(command => command())),
+      };
+    },
+    eval: async () => null,
+  } as unknown as Redis;
+}
+
+describe('WorkflowsUpstash.persistWorkflowSnapshot', () => {
+  it('preserves createdAt across subsequent upserts when caller omits it', async () => {
+    const workflows = new WorkflowsUpstash({ client: createInMemoryRedisClient() });
+    const { snapshot, runId } = createSampleWorkflowSnapshot('running');
+    const workflowName = `wf-${randomUUID()}`;
+    const originalCreatedAt = new Date('2024-01-15T10:00:00.000Z');
+
+    await workflows.persistWorkflowSnapshot({
+      workflowName,
+      runId,
+      snapshot,
+      createdAt: originalCreatedAt,
+      updatedAt: originalCreatedAt,
+    });
+
+    await workflows.persistWorkflowSnapshot({
+      workflowName,
+      runId,
+      snapshot: { ...snapshot, status: 'success' },
+      updatedAt: new Date('2024-06-01T12:00:00.000Z'),
+    });
+
+    const fetched = await workflows.getWorkflowRunById({ runId, workflowName });
+    expect(fetched?.createdAt.getTime()).toBe(originalCreatedAt.getTime());
+    expect(fetched?.updatedAt.getTime()).toBe(new Date('2024-06-01T12:00:00.000Z').getTime());
+  });
+});

--- a/stores/upstash/src/storage/domains/workflows/index.ts
+++ b/stores/upstash/src/storage/domains/workflows/index.ts
@@ -298,6 +298,26 @@ export class WorkflowsUpstash extends WorkflowsStorage {
   }): Promise<void> {
     const { namespace = 'workflows', workflowName, runId, resourceId, snapshot, createdAt, updatedAt } = params;
     try {
+      let finalCreatedAt = createdAt;
+      if (!finalCreatedAt) {
+        const existing = await this.#db.get<{
+          namespace: string;
+          workflow_name: string;
+          run_id: string;
+          snapshot: WorkflowRunState;
+          createdAt: string | Date;
+          updatedAt: string | Date;
+        }>({
+          tableName: TABLE_WORKFLOW_SNAPSHOT,
+          keys: {
+            namespace,
+            workflow_name: workflowName,
+            run_id: runId,
+          },
+        });
+        finalCreatedAt = existing?.createdAt ? ensureDate(existing.createdAt) : new Date();
+      }
+
       await this.#db.insert({
         tableName: TABLE_WORKFLOW_SNAPSHOT,
         record: {
@@ -306,7 +326,7 @@ export class WorkflowsUpstash extends WorkflowsStorage {
           run_id: runId,
           resourceId,
           snapshot,
-          createdAt: createdAt ?? new Date(),
+          createdAt: finalCreatedAt,
           updatedAt: updatedAt ?? new Date(),
         },
       });


### PR DESCRIPTION
## Description

`WorkflowsUpstash.persistWorkflowSnapshot` was doing a blind Redis `SET` with `createdAt: createdAt ?? new Date()`, so re-persisting a snapshot without an explicit `createdAt` reset the run's creation timestamp.

Core calls `persistWorkflowSnapshot` without `createdAt` on step updates and on evented engine start/resume, so this affected real workflow runs stored in Upstash.

This PR reads the existing record before insert when `createdAt` is omitted, matching `@mastra/redis` behavior, and adds a regression test.

## Related issue(s)

Fixes #18091

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test plan

- [x] `pnpm --filter ./stores/upstash exec vitest run src/storage/domains/workflows/index.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When saving a workflow's progress to Redis, the system was accidentally overwriting the original "creation time" with the current time every time it saved. This PR fixes that by checking what the original creation time was before saving, and keeping that original time instead of replacing it.

## Changes

### Bug Fix
Fixed a critical bug in `WorkflowsUpstash.persistWorkflowSnapshot` where re-persisting a workflow snapshot without an explicit `createdAt` parameter was resetting the run's creation timestamp. The method now implements a read-before-insert pattern: when `createdAt` is omitted, it reads the existing record to preserve the original timestamp, ensuring `createdAt` is maintained across multiple persist calls while `updatedAt` correctly reflects the latest update time.

### Impact
This bug was affecting real workflow runs because the core engine calls `persistWorkflowSnapshot` without the `createdAt` parameter during:
- Step updates via `persistStepUpdate` in the default engine
- Engine start/resume operations in the evented engine

The timestamp drift was breaking critical functionality including:
- Date-range filtering via `listWorkflowRuns({ fromDate, toDate })`
- Sorting by creation timestamp
- Displaying run start times in Studio

### Implementation Details
The fix reads from `TABLE_WORKFLOW_SNAPSHOT` by `namespace`, `workflow_name`, and `run_id` to retrieve the existing record, then derives `finalCreatedAt` from the stored value. If no existing record is found, it defaults to `new Date()`. This aligns with the existing behavior in `@mastra/redis` and matches the pattern already used in the Lua script for `updateWorkflowResults`.

### Testing
Added a regression test suite that verifies when persisting a workflow snapshot with an explicit `createdAt`, then re-persisting with the same `runId`/`workflowName` while omitting `createdAt`, the stored `createdAt` remains unchanged while `updatedAt` is updated to the new timestamp.

### Files Changed
- `.changeset/quick-dryers-taste.md` - Changesets entry marking a patch release
- `stores/upstash/src/storage/domains/workflows/index.ts` - Implementation fix with read-before-insert pattern
- `stores/upstash/src/storage/domains/workflows/index.test.ts` - New regression test with in-memory Redis mock

<!-- end of auto-generated comment: release notes by coderabbit.ai -->