### PR TITLE
fix(harness): omit temperature for reasoning models to prevent 400 errors

### DIFF
--- a/.changeset/fix-harness-reasoning-temperature.md
+++ b/.changeset/fix-harness-reasoning-temperature.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fix [400] Unsupported parameter: temperature error when using reasoning models (o1, o3, o4-mini, gpt-5, sonar-reasoning, grok-4-reasoning). The harness now omits temperature and top_p for reasoning models instead of sending unsupported sampling parameters.

--- a/.changeset/fix-harness-reasoning-temperature.md
+++ b/.changeset/fix-harness-reasoning-temperature.md
@@ -2,4 +2,4 @@
 "@mastra/core": patch
 ---
 
-Fix [400] Unsupported parameter: temperature error when using reasoning models (o1, o3, o4-mini, gpt-5, sonar-reasoning, grok-4-reasoning). The harness now omits temperature and top_p for reasoning models instead of sending unsupported sampling parameters.
+Fix [400] Unsupported parameter: temperature error when using reasoning models (o1, o3, o4-mini, gpt-5, sonar-reasoning, grok-4-reasoning). The harness now omits temperature for reasoning models instead of sending an unsupported sampling parameter.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1946,7 +1946,7 @@ export class Harness<TState = {}> {
   private buildSharedRunOptions(): Record<string, unknown> {
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
     const modelName = this.getCurrentModelId().split('/').pop() ?? '';
-    const isReasoningModel = /^(o1|o3|o4|o1-mini|o3-mini|o3-pro|o4-mini|gpt-5|sonar-reasoning|sonar-reasoning-pro|grok-4-fast-reasoning|grok-4-1-fast-reasoning)/.test(modelName);
+    const isReasoningModel = /^(o1|o3|o4|o1-mini|o3-mini|o3-pro|o4-mini|gpt-5|sonar-reasoning|sonar-reasoning-pro|grok-4-fast-reasoning|grok-4-1-fast-reasoning|grok-4-reasoning)/.test(modelName);
     const shared: Record<string, unknown> = {
       maxSteps: HARNESS_MAX_STEPS,
       savePerStep: false,

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1945,11 +1945,13 @@ export class Harness<TState = {}> {
    */
   private buildSharedRunOptions(): Record<string, unknown> {
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
+    const modelName = this.getCurrentModelId().split('/').pop() ?? '';
+    const isReasoningModel = /^(o1|o3|o4|o1-mini|o3-mini|o3-pro|o4-mini|gpt-5|sonar-reasoning|sonar-reasoning-pro|grok-4-fast-reasoning|grok-4-1-fast-reasoning)/.test(modelName);
     const shared: Record<string, unknown> = {
       maxSteps: HARNESS_MAX_STEPS,
       savePerStep: false,
       requireToolApproval: !isYolo,
-      modelSettings: { temperature: 1 },
+      ...(isReasoningModel ? {} : { modelSettings: { temperature: 1 } }),
     };
 
     // Auto-enable Anthropic server-side fallbacks for fable-5 so a classifier


### PR DESCRIPTION
## Description

The harness hardcodes `temperature: 1` in `buildSharedRunOptions()` for every generate call. Reasoning models (o1, o3, o4-mini, gpt-5.x, sonar-reasoning, grok-4-reasoning) reject this parameter with `[400] Unsupported parameter: temperature`, and there was no way to suppress it from the public `HarnessConfig` or `switchModel` surface.

The fix detects reasoning models by matching the model name against a known pattern before building shared run options. If the active model is a reasoning model, `modelSettings.temperature` is omitted entirely. Non-reasoning models continue to receive `temperature: 1` as before. Both call sites (`buildAgentMessageStreamOptions` and `resumeStream`) are covered since both spread `buildSharedRunOptions()`.

## Related issue(s)

Fixes #18074

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The Harness was always telling every AI model to use `temperature: 1`. But some “reasoning” models (like o1/o3/o4-mini and other reasoning-tuned models) don’t support that setting and crash with a `400 Unsupported parameter: temperature` error—so this PR skips `temperature` only for those models.

---

## Summary

This PR fixes a `[400] Unsupported parameter: temperature` error when using reasoning models (o1, o3, o4-mini, gpt-5.x, sonar-reasoning, grok-4-reasoning) with the Harness.

### Root Cause
`buildSharedRunOptions()` unconditionally included `modelSettings: { temperature: 1 }` in generate calls. Reasoning models reject this parameter.

### Solution
`buildSharedRunOptions()` now:
1. Reads the active model id via `getCurrentModelId()`
2. Detects “reasoning models” by matching the model name against a known regex pattern
3. Applies `modelSettings.temperature: 1` only for **non-reasoning** models
4. Omits the `temperature` field entirely for **reasoning** models

The regex pattern detects: `o1`, `o3`, `o4`, `o1-mini`, `o3-mini`, `o3-pro`, `o4-mini`, `gpt-5`, `sonar-reasoning`, `sonar-reasoning-pro`, `grok-4-fast-reasoning`, and `grok-4-1-fast-reasoning`.

### Changes Made
- **packages/core/src/harness/harness.ts**: Updated `buildSharedRunOptions()` to conditionally exclude `modelSettings.temperature` for reasoning models (affects both `buildAgentMessageStreamOptions` and `resumeStream`)
- **.changeset/fix-harness-reasoning-temperature.md**: Added a patch changeset for `@mastra/core` documenting the fix

### Impact
- **Non-breaking** for existing non-reasoning models (they still receive `temperature: 1`)
- **Unblocks** reasoning model usage by preventing unsupported `temperature` from being sent
<!-- end of auto-generated comment: release notes by coderabbit.ai -->