### PR TITLE
feat(core): move Harness token-usage counter onto Session

### DIFF
--- a/.changeset/harness-session-token-usage.md
+++ b/.changeset/harness-session-token-usage.md
@@ -1,0 +1,9 @@
+---
+"@mastra/core": minor
+---
+
+Move the Harness's live token-usage counter onto the `Session` class. The `Session` now owns the in-memory running tally (`getTokenUsage`, `setTokenUsage`, `resetTokenUsage`, `addUsage`), while the Harness continues to persist usage to (and hydrate it from) thread metadata, since token usage is thread-scoped.
+
+The `harness.getTokenUsage()` method is removed in favor of the `harness.session` accessor:
+
+- `harness.getTokenUsage()` → `harness.session.getTokenUsage()`

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -901,7 +901,7 @@ describe('usage_update', () => {
 
   it('updates tokenUsage from internal token counters', () => {
     // Set internal token counters via the private field
-    (harness as any).tokenUsage = { promptTokens: 100, completionTokens: 50, totalTokens: 150 };
+    harness.session.setTokenUsage({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
     emit(harness, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
 
     const usage = harness.getDisplayState().tokenUsage;
@@ -911,7 +911,7 @@ describe('usage_update', () => {
   });
 
   it('preserves richer token usage fields from internal token counters', () => {
-    (harness as any).tokenUsage = {
+    harness.session.setTokenUsage({
       promptTokens: 100,
       completionTokens: 50,
       totalTokens: 220,
@@ -919,7 +919,7 @@ describe('usage_update', () => {
       cachedInputTokens: 25,
       cacheCreationInputTokens: 5,
       raw: { provider: 'test-provider' },
-    };
+    });
     emit(harness, {
       type: 'usage_update',
       usage: {
@@ -945,10 +945,10 @@ describe('usage_update', () => {
   });
 
   it('accumulates usage across multiple updates', () => {
-    (harness as any).tokenUsage = { promptTokens: 100, completionTokens: 50, totalTokens: 150 };
+    harness.session.setTokenUsage({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
     emit(harness, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
 
-    (harness as any).tokenUsage = { promptTokens: 250, completionTokens: 120, totalTokens: 370 };
+    harness.session.setTokenUsage({ promptTokens: 250, completionTokens: 120, totalTokens: 370 });
     emit(harness, { type: 'usage_update', usage: { promptTokens: 250, completionTokens: 120, totalTokens: 370 } });
 
     const usage = harness.getDisplayState().tokenUsage;
@@ -1391,7 +1391,7 @@ describe('resetThreadDisplayState', () => {
   });
 
   it('resets tokenUsage to zero on thread_created', () => {
-    (harness as any).tokenUsage = { promptTokens: 100, completionTokens: 50, totalTokens: 150 };
+    harness.session.setTokenUsage({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
     emit(harness, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
     expect(harness.getDisplayState().tokenUsage.totalTokens).toBe(150);
 
@@ -1418,7 +1418,7 @@ describe('resetThreadDisplayState', () => {
   });
 
   it('syncs tokenUsage from internal counters on thread_changed', () => {
-    (harness as any).tokenUsage = { promptTokens: 200, completionTokens: 100, totalTokens: 300 };
+    harness.session.setTokenUsage({ promptTokens: 200, completionTokens: 100, totalTokens: 300 });
     emit(harness, { type: 'thread_changed', threadId: 'other', previousThreadId: 'old' });
     expect(harness.getDisplayState().tokenUsage.totalTokens).toBe(300);
   });
@@ -1587,7 +1587,7 @@ describe('full lifecycle integration', () => {
     expect(ds.tasks).toHaveLength(1);
 
     // Usage update
-    (harness as any).tokenUsage = { promptTokens: 1000, completionTokens: 500, totalTokens: 1500 };
+    harness.session.setTokenUsage({ promptTokens: 1000, completionTokens: 500, totalTokens: 1500 });
     emit(harness, { type: 'usage_update', usage: { promptTokens: 1000, completionTokens: 500, totalTokens: 1500 } });
     expect(ds.tokenUsage.totalTokens).toBe(1500);
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -485,7 +485,6 @@ export class Harness<TState = {}> {
     | ((ctx: { requestContext: RequestContext }) => Promise<MastraBrowser | undefined> | MastraBrowser | undefined)
     | undefined = undefined;
   private heartbeatTimers = new Map<string, { timer: NodeJS.Timeout; shutdown?: () => void | Promise<void> }>();
-  private tokenUsage: TokenUsage = createEmptyTokenUsage();
   readonly #session = new Session();
   private displayState: HarnessDisplayState = defaultDisplayState();
   private stateUpdateQueue: Promise<void> = Promise.resolve();
@@ -1225,7 +1224,7 @@ export class Harness<TState = {}> {
       void this.setState({ currentModelId: modelId } as unknown as Partial<TState>);
     }
 
-    this.tokenUsage = createEmptyTokenUsage();
+    this.#session.resetTokenUsage();
     this.emit({ type: 'thread_created', thread });
     await this.ensureCurrentAgentThreadSubscription();
 
@@ -1266,7 +1265,7 @@ export class Harness<TState = {}> {
       }
       this.cleanupAgentThreadSubscription();
       this.currentThreadId = null;
-      this.tokenUsage = createEmptyTokenUsage();
+      this.#session.resetTokenUsage();
     }
 
     this.emit({ type: 'thread_deleted', threadId });
@@ -1341,7 +1340,7 @@ export class Harness<TState = {}> {
     this.cleanupAgentThreadSubscription();
     this.currentThreadId = clonedThread.id;
     await this.loadThreadMetadata();
-    this.tokenUsage = createEmptyTokenUsage();
+    this.#session.resetTokenUsage();
     this.emit({ type: 'thread_created', thread: clonedThread });
     await this.ensureCurrentAgentThreadSubscription();
 
@@ -1457,7 +1456,7 @@ export class Harness<TState = {}> {
 
   private async loadThreadMetadata(): Promise<void> {
     if (!this.currentThreadId || !this.config.storage) {
-      this.tokenUsage = createEmptyTokenUsage();
+      this.#session.resetTokenUsage();
       return;
     }
 
@@ -1466,9 +1465,9 @@ export class Harness<TState = {}> {
       const thread = await memoryStorage.getThreadById({ threadId: this.currentThreadId });
 
       // Load token usage
-      const savedUsage = thread?.metadata?.tokenUsage as typeof this.tokenUsage | undefined;
+      const savedUsage = thread?.metadata?.tokenUsage as TokenUsage | undefined;
       if (savedUsage) {
-        this.tokenUsage = {
+        this.#session.setTokenUsage({
           ...createEmptyTokenUsage(),
           ...savedUsage,
           promptTokens: savedUsage.promptTokens ?? 0,
@@ -1476,9 +1475,9 @@ export class Harness<TState = {}> {
           totalTokens: savedUsage.totalTokens ?? 0,
           cachedInputTokens: savedUsage.cachedInputTokens ?? 0,
           cacheCreationInputTokens: savedUsage.cacheCreationInputTokens ?? 0,
-        };
+        });
       } else {
-        this.tokenUsage = createEmptyTokenUsage();
+        this.#session.resetTokenUsage();
       }
 
       const meta = thread?.metadata as Record<string, unknown> | undefined;
@@ -1556,7 +1555,7 @@ export class Harness<TState = {}> {
         }
       }
     } catch {
-      this.tokenUsage = createEmptyTokenUsage();
+      this.#session.resetTokenUsage();
     }
   }
 
@@ -3005,15 +3004,7 @@ export class Harness<TState = {}> {
             stepUsage.raw = usageRecord.raw;
           }
 
-          this.tokenUsage.promptTokens += promptTokens;
-          this.tokenUsage.completionTokens += completionTokens;
-          this.tokenUsage.totalTokens += totalTokens;
-          addOptionalUsageField(this.tokenUsage, 'reasoningTokens', stepUsage.reasoningTokens);
-          addOptionalUsageField(this.tokenUsage, 'cachedInputTokens', stepUsage.cachedInputTokens);
-          addOptionalUsageField(this.tokenUsage, 'cacheCreationInputTokens', stepUsage.cacheCreationInputTokens);
-          if (stepUsage.raw !== undefined) {
-            this.tokenUsage.raw = stepUsage.raw;
-          }
+          this.#session.addUsage(stepUsage);
 
           this.persistTokenUsage().catch(() => {});
           this.emit({ type: 'usage_update', usage: stepUsage });
@@ -4149,7 +4140,7 @@ export class Harness<TState = {}> {
 
       // ── Token usage ────────────────────────────────────────────────────
       case 'usage_update':
-        ds.tokenUsage = { ...this.tokenUsage };
+        ds.tokenUsage = this.#session.getTokenUsage();
         break;
 
       // ── Tasks ──────────────────────────────────────────────────────────
@@ -4166,7 +4157,7 @@ export class Harness<TState = {}> {
       // ── Thread lifecycle ───────────────────────────────────────────────
       case 'thread_changed':
         this.resetThreadDisplayState();
-        ds.tokenUsage = { ...this.tokenUsage };
+        ds.tokenUsage = this.#session.getTokenUsage();
         break;
 
       case 'thread_created':
@@ -4389,10 +4380,6 @@ export class Harness<TState = {}> {
   // Token Usage
   // ===========================================================================
 
-  getTokenUsage(): TokenUsage {
-    return { ...this.tokenUsage };
-  }
-
   private async persistTokenUsage(): Promise<void> {
     if (!this.currentThreadId || !this.config.storage) return;
 
@@ -4403,7 +4390,7 @@ export class Harness<TState = {}> {
         await memoryStorage.saveThread({
           thread: {
             ...thread,
-            metadata: { ...thread.metadata, tokenUsage: this.tokenUsage },
+            metadata: { ...thread.metadata, tokenUsage: this.#session.getTokenUsage() },
             updatedAt: new Date(),
           },
         });

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -1,4 +1,14 @@
-import type { ToolCategory } from './types';
+import { createEmptyTokenUsage } from './types';
+import type { TokenUsage, ToolCategory } from './types';
+
+/** Usage fields that are summed across steps when present on a step's usage. */
+type OptionalUsageField = 'reasoningTokens' | 'cachedInputTokens' | 'cacheCreationInputTokens';
+
+function addOptionalUsageField(usage: TokenUsage, key: OptionalUsageField, value: number | undefined): void {
+  if (value !== undefined) {
+    usage[key] = (usage[key] ?? 0) + value;
+  }
+}
 
 /**
  * A Harness session owns the per-conversation runtime state that today lives
@@ -6,15 +16,20 @@ import type { ToolCategory } from './types';
  * that state into, one concern at a time, so the Harness can eventually own a
  * `Session` rather than the state itself.
  *
- * Currently owns: session-scoped permission grants — the "allow for this
- * session" approvals a user makes when a tool or tool category is gated behind
- * the permission check.
+ * Currently owns:
+ * - session-scoped permission grants — the "allow for this session" approvals a
+ *   user makes when a tool or tool category is gated behind the permission check.
+ * - the live token-usage counter for the active thread. The Session holds the
+ *   in-memory running tally; the Harness remains responsible for persisting it
+ *   to (and hydrating it from) thread metadata, because usage is thread-scoped.
  */
 export class Session {
   /** Tool categories the user has granted "allow" for the lifetime of this session. */
   readonly #grantedCategories = new Set<string>();
   /** Individual tool names the user has granted "allow" for the lifetime of this session. */
   readonly #grantedTools = new Set<string>();
+  /** Running token-usage tally for the active thread. */
+  #tokenUsage: TokenUsage = createEmptyTokenUsage();
 
   /** Grant a tool category "allow" for the remainder of the session. */
   grantCategory(category: ToolCategory): void {
@@ -42,5 +57,36 @@ export class Session {
       categories: [...this.#grantedCategories] as ToolCategory[],
       tools: [...this.#grantedTools],
     };
+  }
+
+  /** A copy of the running token-usage tally for the active thread. */
+  getTokenUsage(): TokenUsage {
+    return { ...this.#tokenUsage };
+  }
+
+  /**
+   * Replace the running tally, e.g. when hydrating from persisted thread
+   * metadata on thread switch.
+   */
+  setTokenUsage(usage: TokenUsage): void {
+    this.#tokenUsage = { ...usage };
+  }
+
+  /** Reset the running tally to zero, e.g. on a new/empty thread. */
+  resetTokenUsage(): void {
+    this.#tokenUsage = createEmptyTokenUsage();
+  }
+
+  /** Fold a single step's usage into the running tally. */
+  addUsage(stepUsage: TokenUsage): void {
+    this.#tokenUsage.promptTokens += stepUsage.promptTokens;
+    this.#tokenUsage.completionTokens += stepUsage.completionTokens;
+    this.#tokenUsage.totalTokens += stepUsage.totalTokens;
+    addOptionalUsageField(this.#tokenUsage, 'reasoningTokens', stepUsage.reasoningTokens);
+    addOptionalUsageField(this.#tokenUsage, 'cachedInputTokens', stepUsage.cachedInputTokens);
+    addOptionalUsageField(this.#tokenUsage, 'cacheCreationInputTokens', stepUsage.cacheCreationInputTokens);
+    if (stepUsage.raw !== undefined) {
+      this.#tokenUsage.raw = stepUsage.raw;
+    }
   }
 }

--- a/packages/core/src/harness/token-usage.test.ts
+++ b/packages/core/src/harness/token-usage.test.ts
@@ -57,7 +57,7 @@ describe('step-finish token usage extraction', () => {
 
     await (harness as any).processStream({ fullStream: mockStream(usage) });
 
-    const tokenUsage = harness.getTokenUsage();
+    const tokenUsage = harness.session.getTokenUsage();
     expect(tokenUsage.promptTokens).toBe(100);
     expect(tokenUsage.completionTokens).toBe(50);
     expect(tokenUsage.totalTokens).toBe(150);
@@ -68,7 +68,7 @@ describe('step-finish token usage extraction', () => {
 
     await (harness as any).processStream({ fullStream: mockStream(usage) });
 
-    const tokenUsage = harness.getTokenUsage();
+    const tokenUsage = harness.session.getTokenUsage();
     expect(tokenUsage.promptTokens).toBe(200);
     expect(tokenUsage.completionTokens).toBe(80);
     expect(tokenUsage.totalTokens).toBe(280);
@@ -98,7 +98,7 @@ describe('step-finish token usage extraction', () => {
       cacheCreationInputTokens: 5,
       raw: { provider: 'test-provider' },
     };
-    expect(harness.getTokenUsage()).toEqual(expectedUsage);
+    expect(harness.session.getTokenUsage()).toEqual(expectedUsage);
     expect(harness.getDisplayState().tokenUsage).toEqual(expectedUsage);
     expect(events.find(event => event.type === 'usage_update')).toEqual({
       type: 'usage_update',
@@ -179,7 +179,7 @@ describe('step-finish token usage extraction', () => {
 
     await (harness as any).processStream({ fullStream: multiStepStream() });
 
-    const tokenUsage = harness.getTokenUsage();
+    const tokenUsage = harness.session.getTokenUsage();
     expect(tokenUsage.promptTokens).toBe(250);
     expect(tokenUsage.completionTokens).toBe(120);
     expect(tokenUsage.totalTokens).toBe(370);
@@ -238,7 +238,7 @@ describe('step-finish token usage extraction', () => {
 
     await (harness as any).processStream({ fullStream: multiStepStream() });
 
-    expect(harness.getTokenUsage()).toEqual({
+    expect(harness.session.getTokenUsage()).toEqual({
       promptTokens: 250,
       completionTokens: 120,
       totalTokens: 440,
@@ -254,7 +254,7 @@ describe('step-finish token usage extraction', () => {
 
     await (harness as any).processStream({ fullStream: mockStream(usage) });
 
-    const tokenUsage = harness.getTokenUsage();
+    const tokenUsage = harness.session.getTokenUsage();
     expect(tokenUsage.cachedInputTokens).toBe(0);
     expect(tokenUsage.cacheCreationInputTokens).toBe(0);
   });


### PR DESCRIPTION
> **Stacked on #18107** (`harness-session-class`). This PR's base is `harness-session-class`, so its diff is scoped to the token-usage move. Merge #18107 first.

## What

Second slice of the Harness `Session` extraction. Moves the **live token-usage counter** out of the `Harness` and onto the `Session` class.

`Session` gains:
- `getTokenUsage(): TokenUsage` — copy of the running tally
- `setTokenUsage(usage)` — replace the tally (used when hydrating from persisted thread metadata)
- `resetTokenUsage()` — zero the tally (new/empty thread)
- `addUsage(stepUsage)` — fold a step's usage into the tally

The `harness.getTokenUsage()` method is **removed** in favor of the `harness.session` accessor (matching the grants pattern from #18107):

- `harness.getTokenUsage()` → `harness.session.getTokenUsage()`

## Persistence: stays thread-scoped on the Harness

Unlike session grants (transient), token usage **is** durable — but it's a property of the **thread**, not the session. In this Harness one `Session` spans many threads over its lifetime (`currentThreadId` is reassigned on select/create/clone/switch), so token usage cannot live on a single `SessionRecord` without conflating per-thread totals.

So this PR deliberately **keeps persistence on the Harness**: `persistTokenUsage()` still writes `thread.metadata.tokenUsage` via the memory domain, and `loadThreadMetadata()` still hydrates the counter from the thread on switch — it now seeds the session via `setTokenUsage()`. Token usage is **not** moved to `SessionStorage`/`SessionRecord`.

Ownership split:
- **Session** = live in-memory counter + accumulation logic
- **Harness** = thread-scoped persistence + hydration

## Changes

- `packages/core/src/harness/session.ts` — add token-usage API
- `packages/core/src/harness/harness.ts` — remove the `tokenUsage` field and the `getTokenUsage()` method; delegate accumulation, resets, hydration, display-state reads, and persistence to the session
- `packages/core/src/harness/display-state.test.ts` — seed the counter via `harness.session.setTokenUsage()` instead of poking the removed private field
- `packages/core/src/harness/token-usage.test.ts` — read via `harness.session.getTokenUsage()`

## Verification

- `pnpm --filter ./packages/core check` — clean
- prettier `--check` + eslint on changed files — clean
- Harness suite: **34 files, 349 tests pass** (including `token-usage.test.ts` and `display-state.test.ts`)
