### PR TITLE
feat(core): add setStudio method for runtime studio configuration

### DIFF
--- a/.changeset/feat-set-studio-method.md
+++ b/.changeset/feat-set-studio-method.md
@@ -1,0 +1,15 @@
+---
+"@mastra/core": minor
+---
+
+Add `setStudio()` method to Mastra class for runtime studio configuration.
+
+This enables deploy wrappers to configure studio auth/RBAC separately from server config, which is required for dual auth patterns where Studio UI uses platform auth while Server API remains open or uses user-configured auth.
+
+```typescript
+// Set studio auth separately from server auth
+mastra.setStudio({
+  auth: new MastraAuthStudio(),
+  rbac: new MastraRBACStudio({ roleMapping: { admin: ['*'] } }),
+});
+```

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -965,6 +965,28 @@ export class Mastra<
   }
 
   /**
+   * Sets the studio configuration for this Mastra instance.
+   *
+   * The studio configuration controls authentication and authorization for Studio UI,
+   * separate from the server configuration. This enables dual auth patterns where
+   * Studio users (e.g., internal team) use different auth than API consumers.
+   *
+   * @param studio - The studio configuration object
+   *
+   * @example
+   * ```typescript
+   * // Set studio auth separately from server auth
+   * mastra.setStudio({
+   *   auth: new MastraAuthStudio(),
+   *   rbac: new MastraRBACStudio({ roleMapping: { admin: ['*'] } }),
+   * });
+   * ```
+   */
+  public setStudio(studio: StudioConfig): void {
+    this.#studio = studio;
+  }
+
+  /**
    * Registers an exporter on the default observability instance.
    *
    * If the current observability is a no-op (user didn't configure any), it is

--- a/packages/core/src/mastra/set-studio.test.ts
+++ b/packages/core/src/mastra/set-studio.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { Mastra } from './index';
+
+describe('Mastra.setStudio()', () => {
+  it('should set studio config on a Mastra instance with no initial studio', () => {
+    const mastra = new Mastra({ logger: false });
+
+    expect(mastra.getStudio()).toBeUndefined();
+
+    const studioConfig = { auth: { name: 'test-auth' } };
+    mastra.setStudio(studioConfig as any);
+
+    expect(mastra.getStudio()).toEqual(studioConfig);
+  });
+
+  it('should replace existing studio config', () => {
+    const initialConfig = { auth: { name: 'initial-auth' } };
+    const mastra = new Mastra({ logger: false, studio: initialConfig as any });
+
+    expect(mastra.getStudio()).toEqual(initialConfig);
+
+    const updatedConfig = { auth: { name: 'updated-auth' } };
+    mastra.setStudio(updatedConfig as any);
+
+    expect(mastra.getStudio()).toEqual(updatedConfig);
+  });
+
+  it('should allow merging with existing studio config via spread', () => {
+    const initialConfig = { auth: { name: 'test-auth' }, rbac: { roleMapping: {} } };
+    const mastra = new Mastra({ logger: false, studio: initialConfig as any });
+
+    mastra.setStudio({ ...mastra.getStudio(), auth: { name: 'new-auth' } } as any);
+
+    expect(mastra.getStudio()).toEqual({ auth: { name: 'new-auth' }, rbac: { roleMapping: {} } });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `setStudio()` method to Mastra class, mirroring the existing `setServer()` method. This enables runtime configuration of studio auth/RBAC separately from server config.

## Why This Is Needed

Platform deploy wrappers need to implement **dual auth**:
- **Studio requests** (via `*.studio.mastra.cloud`): Use platform auth (`MastraAuthStudio`)  
- **Server requests** (via `*.server.mastra.cloud`): Open API access (no auth or user-configured auth)

The dual auth flow:
1. Edge router sets `x-mastra-client-type: studio` header based on domain
2. `@mastra/server`'s `getEffectiveAuthConfig()` routes to `studio.auth` for studio requests
3. **Wrapper calls `setStudio()` to inject platform auth for studio requests**

Without `setStudio()`, wrappers can only modify `server.auth` which applies to **all** requests, breaking the dual auth contract.

## Changes

- Added `setStudio(studio: StudioConfig): void` method to `Mastra` class
- Follows same pattern as `setServer()`

## Usage

```typescript
// In platform deploy wrapper
mastra.setStudio({
  auth: new MastraAuthStudio(),
  rbac: new MastraRBACStudio({ roleMapping: { admin: ['*'] } }),
});
```

## Related

- Complements PR #17722 (dual auth system documentation)
- Enables unified runtime deploys in mastra-ai/platform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR lets Mastra configure “Studio” login/security separately from your API server’s login/security. So the admin dashboard (Studio) can use one auth/RBAC setup while the server API uses another—without mixing them up.

## Summary
This PR adds a new `setStudio(studio: StudioConfig): void` method to the `Mastra` class (`packages/core/src/mastra/index.ts`) to configure Studio authentication and RBAC at runtime, independently from server configuration.

### What changed
- **New API:** `public setStudio(studio: StudioConfig): void`
- The method stores the provided Studio configuration on the instance’s private `#studio` field, mirroring the existing `setServer()` pattern.
- **Dual-auth support (opt-in):**
  - **Studio requests** (`*.studio.mastra.cloud`) can use Studio-specific auth (e.g., `MastraAuthStudio`) and Studio-specific RBAC.
  - **Server requests** (`*.server.mastra.cloud`) can continue using server auth (or open API access) without being affected by Studio settings.
  - An edge router sets `x-mastra-client-type: studio` so the server-side routing logic can apply `studio.auth` for Studio-marked requests.

### Tests & documentation
- Added a `setStudio` test suite verifying:
  - a new `Mastra` instance starts with `getStudio()` unset,
  - `setStudio()` sets/replaces the Studio config,
  - updates can be “merged” by passing an object derived from `...mastra.getStudio()` while changing nested fields (e.g., updating `auth` while preserving `rbac`).
- Added a changeset documenting the new `setStudio()` feature and providing an example usage.

### Example
```ts
mastra.setStudio({
  auth: new MastraAuthStudio(),
  rbac: new MastraRBACStudio({ roleMapping: { admin: ['*'] } }),
});
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->