### PR TITLE
fix(@mastra/core): forward runId in DurableAgent.prepare() for cold resume

### DIFF
--- a/.changeset/durable-prepare-forwards-runid.md
+++ b/.changeset/durable-prepare-forwards-runid.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `DurableAgent.prepare()` ignoring `options.runId`. `prepare()` did not forward `runId` to `prepareForDurableExecution()` (unlike `stream()`), so it always registered a freshly minted run id. This made `prepare()` unusable for rehydrating a persisted, suspended run in a fresh process (e.g. after a server restart or registry eviction): a follow-up `resume(runId)` couldn't find the registry entry `prepare()` had built and threw `No registry entry found for run … Cannot resume.`. `prepare()` now forwards the caller-provided `runId`, so re-registering a known run id and resuming a durable snapshot across a restart works.

--- a/packages/core/src/agent/durable/__tests__/resume-api.test.ts
+++ b/packages/core/src/agent/durable/__tests__/resume-api.test.ts
@@ -132,6 +132,34 @@ describe('Resume API', () => {
       result.cleanup();
     });
 
+    it('prepare() honors a caller-provided runId so resume(runId) can find the run', async () => {
+      // Regression: prepare() previously dropped options.runId when calling
+      // prepareForDurableExecution (unlike stream()), so it registered a random
+      // id. That breaks rehydrating a persisted, suspended run in a fresh
+      // process: resume(runId) couldn't find the registry entry prepare() built.
+      const mockModel = createTextModel('Prepared!');
+
+      const baseAgent = new Agent({
+        id: 'prepare-runid-agent',
+        name: 'Prepare RunId Agent',
+        instructions: 'Test prepare honors runId',
+        model: mockModel as LanguageModelV2,
+      });
+
+      const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+      const requestedRunId = 'fixed-run-id-aaaaaaaa';
+      const prep = await durableAgent.prepare('Start something', { runId: requestedRunId });
+
+      // prepare() must register the run under the requested id, not a random one.
+      expect(prep.runId).toBe(requestedRunId);
+
+      // ...so a follow-up resume(requestedRunId) finds the registry entry.
+      const result = await durableAgent.resume(requestedRunId, { approved: true });
+      expect(result.runId).toBe(requestedRunId);
+      result.cleanup();
+    });
+
     it('should preserve threadId and resourceId from prepare through resume', async () => {
       const mockModel = createTextModel('Done');
 

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -856,6 +856,12 @@ export class DurableAgent<
       agent: this.#wrappedAgent as Agent<string, any, TOutput>,
       messages,
       options,
+      // Forward the caller-provided runId (mirrors stream()). Without this,
+      // prepareForDurableExecution mints a fresh id, so prepare() registers a
+      // different run than requested and a follow-up resume(runId) — e.g. when
+      // rehydrating a persisted, suspended run in a fresh process — can't find
+      // its registry entry.
+      runId: options?.runId,
       requestContext: options?.requestContext,
       mastra: this.#mastra,
     });


### PR DESCRIPTION
## What

`DurableAgent.prepare()` did not forward `options.runId` to `prepareForDurableExecution()` — unlike `stream()`, which does. Since `prepareForDurableExecution` does `const runId = providedRunId ?? crypto.randomUUID()`, `prepare()` always registered a **freshly minted** run id.

This makes `prepare()` unusable as the rehydration primitive for a persisted, suspended run after the in-memory run registry is gone (process restart or idle eviction): you call `prepare(messages, { runId })` to rebuild the registry for a known run, then `resume(runId)` — but because `prepare()` registered a different id, `resume(runId)` throws:

```
No registry entry found for run <runId>. Cannot resume.
```

## Fix

One line: forward the caller-provided `runId` in `prepare()` (mirrors `stream()`), so re-registering a known run id and resuming a durable snapshot across a restart works.

```ts
const preparation = await prepareForDurableExecution<TOutput>({
  agent: this.#wrappedAgent as Agent<string, any, TOutput>,
  messages,
  options,
  runId: options?.runId,   // <-- added
  requestContext: options?.requestContext,
  mastra: this.#mastra,
});
```

## Test

Adds a regression test in `resume-api.test.ts` asserting `prepare()` honors a caller-provided `runId` and that `resume(runId)` then finds the run. It fails without the fix (`expected '0000…0001' to be 'fixed-run-id-aaaaaaaa'`) and passes with it.

## Context

Closes #18031.

I verified end-to-end against Postgres that, with this single fix, a suspended durable run (tool approval) is resumed correctly across a fresh process — the approved tool executes with its original args restored from the persisted snapshot.

Note: #18031 also described a "Gap 2" (suspended tool args dropped on cold resume). On investigation that turned out to be a **bug in the reproduction's tool**, not in Mastra: the repro tool read `context.note` from its first `execute` argument, but Mastra calls `execute(validatedInput, context)` (input is the first positional arg). The args are in fact persisted and restored correctly on cold resume. So this PR is intentionally just the `prepare()` `runId` fix; I'll update #18031 to retract Gap 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If you tell the system “use this save ID,” but the code accidentally creates a new random one, you can’t find the saved game later. This PR makes `DurableAgent.prepare()` keep the `runId` you provide, so `resume(runId)` can locate and continue the correct persisted run.

## Changes

- **Bug fix:** `DurableAgent.prepare()` now forwards the caller-provided `options?.runId` into `prepareForDurableExecution()` (previously it would generate a new UUID when `runId` was omitted or not forwarded).
- **Why it matters:** This ensures a persisted, suspended durable run is re-registered under the original ID, so a subsequent `resume(runId)` can find the registry entry instead of failing with a “No registry entry found for run” error.
- **Regression test:** Added/updated coverage in `packages/core/src/agent/durable/__tests__/resume-api.test.ts` to verify:
  - `prepare(..., { runId })` returns the same `runId`
  - `resume(runId)` successfully finds and resumes that run.
- **Notes on scope:** The PR intentionally does **not** address Gap 2 from the linked issue (suspended tool args restoration on cold resume); that was determined to be caused by the reproduction’s tooling rather than Mastra.

## Files changed

- `.changeset/durable-prepare-forwards-runid.md`
- `packages/core/src/agent/durable/durable-agent.ts`
- `packages/core/src/agent/durable/__tests__/resume-api.test.ts`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
