### PR TITLE
ci: pin workflow actions and use app auth

### DIFF
--- a/.github/actions/app-auth/action.yaml
+++ b/.github/actions/app-auth/action.yaml
@@ -4,9 +4,6 @@ inputs:
   client-id:
     description: 'GitHub App Client ID'
     required: false
-  app-id:
-    description: 'GitHub App ID fallback when client-id is unavailable'
-    required: false
   private-key:
     description: 'GitHub App private key'
     required: true
@@ -39,7 +36,6 @@ runs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
       with:
         client-id: ${{ inputs.client-id }}
-        app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repositories }}

--- a/.github/actions/app-auth/action.yaml
+++ b/.github/actions/app-auth/action.yaml
@@ -17,6 +17,27 @@ inputs:
     description: 'Do not revoke token at job end (optional)'
     required: false
     default: 'false'
+  permission-contents:
+    description: "Optional token permission for repository contents. Can be 'read' or 'write'."
+    required: false
+  permission-issues:
+    description: "Optional token permission for issues. Can be 'read' or 'write'."
+    required: false
+  permission-pull-requests:
+    description: "Optional token permission for pull requests. Can be 'read' or 'write'."
+    required: false
+  permission-checks:
+    description: "Optional token permission for checks. Can be 'read' or 'write'."
+    required: false
+  permission-statuses:
+    description: "Optional token permission for commit statuses. Can be 'read' or 'write'."
+    required: false
+  permission-members:
+    description: "Optional token permission for organization members. Can be 'read' or 'write'."
+    required: false
+  permission-administration:
+    description: "Optional token permission for repository administration. Can be 'read' or 'write'."
+    required: false
 
 outputs:
   token:
@@ -40,6 +61,13 @@ runs:
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repositories }}
         skip-token-revoke: ${{ inputs['skip-token-revoke'] }}
+        permission-contents: ${{ inputs['permission-contents'] }}
+        permission-issues: ${{ inputs['permission-issues'] }}
+        permission-pull-requests: ${{ inputs['permission-pull-requests'] }}
+        permission-checks: ${{ inputs['permission-checks'] }}
+        permission-statuses: ${{ inputs['permission-statuses'] }}
+        permission-members: ${{ inputs['permission-members'] }}
+        permission-administration: ${{ inputs['permission-administration'] }}
 
     - name: Get GitHub App User ID
       id: get-user-id

--- a/.github/actions/app-auth/action.yaml
+++ b/.github/actions/app-auth/action.yaml
@@ -38,6 +38,9 @@ inputs:
   permission-administration:
     description: "Optional token permission for repository administration. Can be 'read' or 'write'."
     required: false
+  permission-organization-administration:
+    description: "Optional token permission for organization administration. Can be 'read' or 'write'."
+    required: false
 
 outputs:
   token:
@@ -68,6 +71,7 @@ runs:
         permission-statuses: ${{ inputs['permission-statuses'] }}
         permission-members: ${{ inputs['permission-members'] }}
         permission-administration: ${{ inputs['permission-administration'] }}
+        permission-organization-administration: ${{ inputs['permission-organization-administration'] }}
 
     - name: Get GitHub App User ID
       id: get-user-id

--- a/.github/actions/app-auth/action.yaml
+++ b/.github/actions/app-auth/action.yaml
@@ -36,7 +36,7 @@ runs:
   using: 'composite'
   steps:
     - id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
       with:
         client-id: ${{ inputs.client-id }}
         app-id: ${{ inputs.app-id }}

--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js 22.x
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         node-version: 22.13.0
 

--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -35,7 +35,7 @@ runs:
     # setup-node's cache: 'pnpm' runs `pnpm store path --silent` which returns
     # a bogus path on self-hosted runners where pnpm is installed into
     # ~/setup-pnpm/node_modules/.bin/.
-    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
       name: Install pnpm
       with:
         version: ${{ inputs.version || '' }}

--- a/.github/workflows/backport-auto.yml
+++ b/.github/workflows/backport-auto.yml
@@ -1,8 +1,7 @@
 name: Backport PRs
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 on:
   pull_request_target:
@@ -32,6 +31,10 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Re-checkout with app token
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/backport-auto.yml
+++ b/.github/workflows/backport-auto.yml
@@ -16,7 +16,7 @@ jobs:
       github.repository == 'mastra-ai/mastra' && 
       github.event.pull_request.merged == true && 
       contains(github.event.pull_request.labels.*.name, 'cherry')
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     steps:
       - name: Initial checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/backport-auto.yml
+++ b/.github/workflows/backport-auto.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -34,7 +34,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ steps.app-auth.outputs.token }}
           persist-credentials: true

--- a/.github/workflows/call-external-mastra-workflow.yml
+++ b/.github/workflows/call-external-mastra-workflow.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   execute-workflow:
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     steps:
       - name: Create and execute workflow run
         run: |

--- a/.github/workflows/changed-test-gate-labeler.yml
+++ b/.github/workflows/changed-test-gate-labeler.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout automation scripts
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/changed-test-gate-labeler.yml
+++ b/.github/workflows/changed-test-gate-labeler.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
 
 jobs:
   label:
@@ -33,6 +31,9 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: read
 
       - name: Setup pnpm and node
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/changed-test-gate-labeler.yml
+++ b/.github/workflows/changed-test-gate-labeler.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   label:
     if: ${{ github.repository == 'mastra-ai/mastra' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].number != null }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout automation scripts

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout base
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Setup Node.js
         if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22.13.0
 

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -20,7 +20,7 @@ jobs:
     # This workflow runs PR code in the unprivileged pull_request sandbox, without
     # secrets or write permissions. Keep PR Triage on pull_request_target for labels.
     if: ${{ github.repository == 'mastra-ai/mastra' && github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Checkout base

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Setup pnpm
         if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
         with:
           run_install: false
           cache: true

--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -31,7 +31,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -1,7 +1,7 @@
 name: Cron Alpha Version
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   schedule:
@@ -29,6 +29,8 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
       - name: Re-checkout with app token
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   alpha-version:
     if: ${{ github.repository == 'mastra-ai/mastra' && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     steps:
       - name: Initial checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/delete-spam-issues.yml
+++ b/.github/workflows/delete-spam-issues.yml
@@ -11,7 +11,7 @@ jobs:
   delete-spam:
     # Only run on the main repository, not on forks
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/delete-spam-issues.yml
+++ b/.github/workflows/delete-spam-issues.yml
@@ -17,10 +17,22 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Dane App Auth
+        id: app-auth
+        uses: ./.github/actions/app-auth
+        with:
+          client-id: ${{ vars.DANE_CLIENT_ID }}
+          private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+
       - name: Delete spam issues with GraphQL
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
-          github-token: ${{ secrets.ISSUE_SPAM_PROTECTION_TOKEN }}
+          github-token: ${{ steps.app-auth.outputs.token }}
           script: |
             // Helper function to add delay between operations
             const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));

--- a/.github/workflows/delete-spam-issues.yml
+++ b/.github/workflows/delete-spam-issues.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Delete spam issues with GraphQL
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           github-token: ${{ secrets.ISSUE_SPAM_PROTECTION_TOKEN }}
           script: |

--- a/.github/workflows/delete-spam-issues.yml
+++ b/.github/workflows/delete-spam-issues.yml
@@ -13,7 +13,6 @@ jobs:
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     runs-on: starsling-ubuntu-24.04
     permissions:
-      issues: write
       contents: read
 
     steps:
@@ -28,6 +27,8 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
 
       - name: Delete spam issues with GraphQL
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3

--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   e2e-docs:
     name: Docs E2E tests
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -158,7 +158,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -191,7 +191,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -226,7 +226,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -258,7 +258,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
 

--- a/.github/workflows/flag-spam-comments.yml
+++ b/.github/workflows/flag-spam-comments.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-comment:
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     permissions:
       issues: read
       pull-requests: read

--- a/.github/workflows/flag-spam-comments.yml
+++ b/.github/workflows/flag-spam-comments.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check for spam and notify via Slack DM
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_USER_ID: 'U086EV0DN8H'

--- a/.github/workflows/issue-pending-release.yml
+++ b/.github/workflows/issue-pending-release.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
 
 jobs:
   label-linked-issues:
@@ -33,6 +31,9 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: read
 
       - name: Setup pnpm and node
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/issue-pending-release.yml
+++ b/.github/workflows/issue-pending-release.yml
@@ -15,7 +15,7 @@ jobs:
       github.repository == 'mastra-ai/mastra' &&
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main'
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout automation scripts

--- a/.github/workflows/issue-pending-release.yml
+++ b/.github/workflows/issue-pending-release.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout automation scripts
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/issue-pending-release.yml
+++ b/.github/workflows/issue-pending-release.yml
@@ -32,7 +32,6 @@ jobs:
         uses: ./.github/actions/app-auth
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
-          app-id: ${{ vars.DANE_APP_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Setup pnpm and node

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -7,7 +7,7 @@ jobs:
   issue_created:
     # Only run on the main repository, not on forks
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     permissions:
       issues: write
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -10,13 +10,21 @@ jobs:
     runs-on: starsling-ubuntu-24.04
     permissions:
       contents: read
-      issues: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
+
+      - name: Dane App Auth
+        id: app-auth
+        uses: ./.github/actions/app-auth
+        with:
+          client-id: ${{ vars.DANE_CLIENT_ID }}
+          private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: read
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -32,7 +40,7 @@ jobs:
         run: npx tsx index.ts
         working-directory: scripts/gh-issue-triage
         env:
-          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ steps.app-auth.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -9,6 +9,7 @@ jobs:
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     runs-on: starsling-ubuntu-24.04
     permissions:
+      contents: read
       issues: write
 
     steps:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v5

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22.13.0
           package-manager-cache: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 1
           fetch-tags: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   labeler:
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Comment on PR if redirects are missing
         if: failure()
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const logsUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
@@ -133,7 +133,7 @@ jobs:
 
       - name: Comment on PR if redirect issues found
         if: failure()
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const logsUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   changes:
     name: Detect docs changes
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     permissions:
       contents: read
     outputs:
@@ -38,7 +38,7 @@ jobs:
     name: Check for deleted pages without redirects
     needs: changes
     if: needs.changes.outputs.docs == 'true'
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -119,7 +119,7 @@ jobs:
     name: Validate redirects
     needs: changes
     if: needs.changes.outputs.docs == 'true'
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -181,7 +181,7 @@ jobs:
     name: Lint docs
     needs: changes
     if: needs.changes.outputs.docs == 'true'
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -21,7 +21,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -185,7 +185,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.mdx-changes.outputs.has_changes == 'true'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '22.13.0'
           package-manager-cache: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -213,7 +213,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22.13.0
           package-manager-cache: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       has_examples: ${{ steps.filter.outputs.has_examples }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           # Fetch entire git history so Changesets can generate changelogs
           # with the correct commits
@@ -210,7 +210,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   changes:
     name: Detect code changes
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     permissions:
       contents: read
     outputs:
@@ -48,7 +48,7 @@ jobs:
   lint:
     name: Lint
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     if: needs.changes.outputs.has_code == 'true' && github.repository == 'mastra-ai/mastra'
     env:
@@ -73,7 +73,7 @@ jobs:
   check-bundle:
     name: Validate build outputs
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     if: needs.changes.outputs.has_code == 'true' && github.repository == 'mastra-ai/mastra'
     env:
@@ -107,7 +107,7 @@ jobs:
   validator:
     name: Validate examples packages.json
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     if: needs.changes.outputs.has_examples == 'true' && github.repository == 'mastra-ai/mastra'
     permissions:
@@ -132,7 +132,7 @@ jobs:
   agents-md-check:
     name: Validate AGENTS.md files
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     if: github.repository == 'mastra-ai/mastra'
     permissions:
@@ -152,7 +152,7 @@ jobs:
 
   peerdeps-check:
     name: Validate peer dependencies
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     # Run on main repository or for trusted bot PRs
     if: ${{ github.repository == 'mastra-ai/mastra' }}
@@ -202,7 +202,7 @@ jobs:
   validate-pkg-json:
     name: Validate package.json files
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     if: needs.changes.outputs.has_code == 'true' && github.repository == 'mastra-ai/mastra'
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:rw
     permissions:
+      contents: read
       pull-requests: read
 
     steps:
@@ -81,6 +82,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
     permissions:
+      contents: read
       pull-requests: read
 
     steps:
@@ -111,6 +113,7 @@ jobs:
     timeout-minutes: 30
     if: needs.changes.outputs.has_examples == 'true' && github.repository == 'mastra-ai/mastra'
     permissions:
+      contents: read
       pull-requests: read
 
     steps:
@@ -136,6 +139,7 @@ jobs:
     timeout-minutes: 10
     if: github.repository == 'mastra-ai/mastra'
     permissions:
+      contents: read
       pull-requests: read
 
     steps:
@@ -157,6 +161,7 @@ jobs:
     # Run on main repository or for trusted bot PRs
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     permissions:
+      contents: read
       pull-requests: read
 
     steps:
@@ -206,6 +211,7 @@ jobs:
     timeout-minutes: 10
     if: needs.changes.outputs.has_code == 'true' && github.repository == 'mastra-ai/mastra'
     permissions:
+      contents: read
       pull-requests: read
 
     steps:

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -8,9 +8,7 @@ on:
 
 permissions:
   contents: read
-  issues: read
   pull-requests: read
-  checks: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -108,6 +106,10 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-checks: write
+          permission-issues: read
+          permission-members: read
 
       - name: Check if major version bump is allowed
         if: steps.check_major.outputs.has_major_changeset == 'true'

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Check for major changesets
         id: check_major
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const prNumber = context.payload?.pull_request?.number || context.payload?.issue?.number;
@@ -112,7 +112,7 @@ jobs:
       - name: Check if major version bump is allowed
         if: steps.check_major.outputs.has_major_changeset == 'true'
         id: check_approval
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   check-major-bump:
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     # Only run on canonical repo (secrets unavailable for forks) and for PR events or PR comments
     if: |
       github.repository == 'mastra-ai/mastra' &&

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Checkout for local action
         if: steps.check_major.outputs.has_major_changeset == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           # Pin to PR base SHA to prevent malicious PRs from modifying the local action
           ref: ${{ steps.check_major.outputs.base_sha }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,7 +43,7 @@ jobs:
         (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: version packages') && github.event.head_commit.author.username == 'dane-ai-mastra[bot]') ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_type == 'prerelease')
       )
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     permissions:
       contents: write
       issues: write
@@ -157,7 +157,7 @@ jobs:
       github.repository == 'mastra-ai/mastra' && 
       github.event_name == 'workflow_dispatch' && 
       github.event.inputs.publish_type == 'stable'
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     permissions:
       contents: write
       issues: write
@@ -314,7 +314,7 @@ jobs:
         (github.event.inputs.publish_type == 'stable' && !inputs.dry_run && needs.stable.result == 'success') ||
         github.event.inputs.publish_type == 'enter-prerelease'
       )
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write
@@ -384,7 +384,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && 
       github.event.inputs.publish_type == 'snapshot' &&
       github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,7 +61,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -200,7 +200,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -345,7 +345,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -420,7 +420,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
         name: Install pnpm
         with:
           run_install: false
@@ -194,7 +194,7 @@ jobs:
             echo "files_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
         name: Install pnpm
         with:
           run_install: false
@@ -339,7 +339,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
         name: Install pnpm
         with:
           run_install: false
@@ -414,7 +414,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
         name: Install pnpm

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,7 +51,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -165,7 +165,7 @@ jobs:
       id-token: write
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -178,7 +178,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0
@@ -320,7 +320,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -333,7 +333,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0
@@ -395,7 +395,7 @@ jobs:
       TURBO_CACHE: remote:r
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -408,7 +408,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,9 +45,8 @@ jobs:
       )
     runs-on: starsling-ubuntu-24.04
     permissions:
-      contents: write
+      contents: read
       issues: write
-      pull-requests: write
       id-token: write
     steps:
       - name: Checkout repo
@@ -160,9 +159,7 @@ jobs:
       github.event.inputs.publish_type == 'stable'
     runs-on: starsling-ubuntu-24.04
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
       id-token: write
     steps:
       - name: Initial checkout
@@ -177,6 +174,9 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
 
       - name: Re-checkout with app token
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -317,8 +317,7 @@ jobs:
       )
     runs-on: starsling-ubuntu-24.04
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Initial checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -332,6 +331,8 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
       - name: Re-checkout with app token
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -387,8 +388,7 @@ jobs:
       github.ref != 'refs/heads/main'
     runs-on: starsling-ubuntu-24.04
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       id-token: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -407,6 +407,8 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: read
 
       - name: Re-checkout with app token
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -30,7 +30,7 @@ jobs:
       summary: ${{ steps.issue_link.outputs.summary }}
     steps:
       - name: Checkout automation scripts
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -77,7 +77,7 @@ jobs:
       summary: ${{ steps.complexity.outputs.summary }}
     steps:
       - name: Checkout automation scripts
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -123,7 +123,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout automation scripts
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -166,7 +166,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout automation scripts
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   issue-link-nudge:
     if: ${{ github.repository == 'mastra-ai/mastra' && github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     outputs:
       needs_issue: ${{ steps.issue_link.outputs.needs_issue }}
@@ -71,7 +71,7 @@ jobs:
   complexity:
     needs: issue-link-nudge
     if: ${{ needs['issue-link-nudge'].outputs.needs_issue == 'false' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     outputs:
       summary: ${{ steps.complexity.outputs.summary }}
@@ -119,7 +119,7 @@ jobs:
       - issue-link-nudge
       - complexity
     if: ${{ always() && github.repository == 'mastra-ai/mastra' && github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout automation scripts
@@ -162,7 +162,7 @@ jobs:
 
   close-stale-unlinked:
     if: ${{ github.repository == 'mastra-ai/mastra' && github.event_name == 'schedule' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout automation scripts

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -13,8 +13,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.run_id }}
@@ -44,6 +42,10 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: read
+          permission-members: read
 
       - name: Setup pnpm and node
         uses: ./.github/actions/setup-pnpm-node
@@ -91,6 +93,9 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: read
 
       - name: Setup pnpm and node
         uses: ./.github/actions/setup-pnpm-node
@@ -137,6 +142,8 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
 
       - name: Setup pnpm and node
         uses: ./.github/actions/setup-pnpm-node
@@ -180,6 +187,10 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+          permission-members: read
 
       - name: Setup pnpm and node
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -21,7 +21,7 @@ jobs:
       has_code: ${{ steps.filter.outputs.has_code }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
@@ -99,7 +99,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -144,7 +144,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -202,7 +202,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -262,7 +262,7 @@ jobs:
       TURBO_CACHE: remote:r
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -18,7 +18,7 @@ jobs:
   regenerate:
     # Only run on the main repository, not on forks
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     env:
       HUSKY: 0

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -1,7 +1,7 @@
 name: Regenerate Providers & Docs
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   # Run every 6 hours to keep provider registry and documentation up-to-date
@@ -39,6 +39,8 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
       - name: Re-checkout with app token
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -41,7 +41,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: main
           token: ${{ steps.app-auth.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -40,7 +40,7 @@ jobs:
     if: github.repository == 'mastra-ai/mastra'
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     if: github.repository == 'mastra-ai/mastra'
     steps:
       - name: Initial checkout

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Set pending status
@@ -51,7 +51,7 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set success status for unchanged workspaces
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
@@ -71,7 +71,7 @@ jobs:
     outputs:
       packages: ${{ steps.set-packages.outputs.packages }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - id: set-packages
@@ -99,7 +99,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
@@ -135,7 +135,7 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set success status for completed tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
@@ -153,7 +153,7 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set failure status for failed tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
@@ -171,7 +171,7 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set status for skipped tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha }
+          persist-credentials: false
       - name: Set pending status
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          ref: ${{ github.event.workflow_run.head_sha }
+          ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
       - name: Set pending status
         uses: ./.github/workflows/shared-actions/set-pr-status

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -50,6 +50,7 @@ jobs:
     if: needs.check-changes.outputs.workspaces-changed == 'false'
     runs-on: starsling-ubuntu-24.04
     permissions:
+      contents: read
       statuses: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -134,6 +135,7 @@ jobs:
     if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && needs.test-cloud.result == 'success' }}
     runs-on: starsling-ubuntu-24.04
     permissions:
+      contents: read
       statuses: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -152,6 +154,7 @@ jobs:
     if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && (needs.setup.result == 'failure' || needs.test-cloud.result == 'failure') }}
     runs-on: starsling-ubuntu-24.04
     permissions:
+      contents: read
       statuses: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -170,6 +173,7 @@ jobs:
     if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && needs.setup.result != 'failure' && needs.test-cloud.result == 'skipped' }}
     runs-on: starsling-ubuntu-24.04
     permissions:
+      contents: read
       statuses: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -13,6 +13,8 @@ jobs:
     name: Sync Template Repositories
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - name: Initial checkout

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -32,8 +32,8 @@ jobs:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
           owner: mastra-ai
-          permission-administration: write
           permission-contents: write
+          permission-organization-administration: write
 
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -12,7 +12,7 @@ jobs:
   sync-templates:
     name: Sync Template Repositories
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
 
     steps:
       - name: Initial checkout

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -32,6 +32,8 @@ jobs:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
           owner: mastra-ai
+          permission-administration: write
+          permission-contents: write
 
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -32,7 +32,7 @@ jobs:
           owner: mastra-ai
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   changeset:
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     if: startsWith(github.head_ref, 'renovate/') && github.repository == 'mastra-ai/mastra'
     permissions:
       pull-requests: write

--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Re-checkout with app token
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           token: ${{ secrets.RENOVATE_PAT  }}

--- a/.github/workflows/test-combined-stores.yml
+++ b/.github/workflows/test-combined-stores.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       stores: ${{ steps.set-stores.outputs.stores }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -85,7 +85,7 @@ jobs:
       TURBO_CACHE: remote:r
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
           fetch-depth: 2
@@ -98,7 +98,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 2
           ref: ${{ inputs.head_sha }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Checkout repo
         if: inputs.has_code == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 1
           ref: ${{ inputs.head_sha }}

--- a/.github/workflows/test-workspaces.yml
+++ b/.github/workflows/test-workspaces.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       packages: ${{ steps.set-packages.outputs.packages }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -48,7 +48,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.setup.outputs.packages) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -77,7 +77,7 @@ jobs:
       matrix:
         package: [s3, gcs, azure]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false

--- a/.github/workflows/test-workspaces.yml
+++ b/.github/workflows/test-workspaces.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   setup:
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     outputs:
       packages: ${{ steps.set-packages.outputs.packages }}
     steps:
@@ -38,7 +38,7 @@ jobs:
   test-unit:
     needs: setup
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -67,7 +67,7 @@ jobs:
 
   test-docker:
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/trigger-cloud-tests.yml
+++ b/.github/workflows/trigger-cloud-tests.yml
@@ -14,7 +14,7 @@ jobs:
   trigger:
     # Only run on the main repository, not on forks
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     steps:
       - name: Trigger mastra-cloud integration tests
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/upload-studio-r2.yml
+++ b/.github/workflows/upload-studio-r2.yml
@@ -17,7 +17,7 @@ jobs:
   upload-studio:
     name: Build and Upload Studio
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/upload-studio-r2.yml
+++ b/.github/workflows/upload-studio-r2.yml
@@ -24,7 +24,7 @@ jobs:
       TURBO_CACHE: remote:r
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 1
           ref: mastra@${{ inputs.version }}

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -1,8 +1,7 @@
 name: Version Packages
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 on:
   push:
@@ -29,6 +28,9 @@ jobs:
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Re-checkout with app token
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initial checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -31,7 +31,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ steps.app-auth.outputs.token }}
           # Fetch entire git history so Changesets can generate changelogs

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -13,7 +13,7 @@ jobs:
   version:
     # Only run on the main repository, not on forks
     if: ${{ github.repository == 'mastra-ai/mastra' }}
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     steps:
       - name: Initial checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/vitest-all.yml
+++ b/.github/workflows/vitest-all.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   test:
     name: UNIT Test (Shard ${{ matrix.shard }})
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     timeout-minutes: 30
     strategy:
@@ -66,7 +66,7 @@ jobs:
 
   e2e-test:
     name: E2E Test (${{ matrix.project }})
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     timeout-minutes: 30
     strategy:
@@ -147,7 +147,7 @@ jobs:
 
   merge-reports:
     name: Merge Test Reports
-    runs-on: ubuntu-latest
+    runs-on: starsling-ubuntu-24.04
     needs: [test, e2e-test]
     if: always()
     # Minimal permissions - read-only access

--- a/.github/workflows/vitest-all.yml
+++ b/.github/workflows/vitest-all.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -156,7 +156,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node


### PR DESCRIPTION
Pins our GitHub Actions to commit SHAs and moves workflows onto the starsling runner. It also switches spam issue cleanup from the dedicated secret token to the shared GitHub App auth action.

This should make CI dependencies more reproducible while keeping workflow auth consistent with the rest of the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes your CI runs more consistent by replacing “latest/moving” GitHub Action references with exact pinned versions, and by standardizing workflows to run on the same `starsling-ubuntu-24.04` runner. It also updates the spam-issue cleanup to authenticate the same way as the rest of the repo, using the shared GitHub App auth action instead of a dedicated secret token.

## Overview
### Pin GitHub Actions to exact commit SHAs
Across many workflows and composite actions, the PR replaces floating action tags (e.g., `@v5/@v6/@v8`) with pinned commit SHAs for better reproducibility and supply-chain safety. Examples include:
- `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10`
- `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`
- `pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271`
- `actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3`

### Switch workflows to `starsling-ubuntu-24.04`
A large set of workflows were updated from `ubuntu-latest` to the dedicated `starsling-ubuntu-24.04` runner, while keeping their existing job logic intact.

### Standardize spam cleanup authentication via shared GitHub App auth
The spam issue cleanup workflow now uses the shared local composite action `./.github/actions/app-auth` (a GitHub App installation token) rather than a dedicated secret token.

Concretely, in `.github/workflows/delete-spam-issues.yml`:
- `runs-on: starsling-ubuntu-24.04`
- workflow permissions tightened to `contents: read`
- `actions/checkout` pinned, with `persist-credentials: false`
- “Dane App Auth” uses `./.github/actions/app-auth` and requests `permission-issues: write`
- “Delete spam issues with GraphQL” (`actions/github-script`) pinned and authenticates using `github-token: ${{ steps.app-auth.outputs.token }}`

## Notable files updated
### Composite actions
- `.github/actions/app-auth/action.yaml`
  - Pinned `actions/create-github-app-token` to `bcd2ba49218906704ab6c1aa796996da409d3eb1`
  - Removed the `app-id` input
  - Added optional permission inputs to drive GitHub App token scopes:
    - `permission-contents`, `permission-issues`, `permission-pull-requests`, `permission-checks`, `permission-statuses`, `permission-members`, `permission-administration`, `permission-organization-administration`
  - Wired these inputs through to `actions/create-github-app-token` and kept the existing outputs (`token`, `app-slug`, `user-id`).

- `.github/actions/setup-pnpm-node/action.yaml`
  - Pinned `actions/setup-node` and `pnpm/action-setup` to exact commit SHAs.

### Workflows
- Runner + action pinning updates across many workflows (e.g., backport, lint, test/e2e, publish, triage, and version checks).
- Authentication migration specifically impacts the spam cleanup workflow (`delete-spam-issues.yml`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->