### PR TITLE
feat(core): move Harness run identity onto Session

### DIFF
--- a/.changeset/harness-session-run-state.md
+++ b/.changeset/harness-session-run-state.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': patch
+---
+
+Move Harness run identity onto the Session class.
+
+The transient per-run state — current run id, trace id, and the monotonic
+operation counter — now lives on `session.run` (`SessionRun`) instead of being
+flattened on the Harness:
+
+- `getRunId()` / `setRunId({ runId })`
+- `getTraceId()` / `setTraceId({ traceId })`
+- `reset()` — clears run id and trace id when a run ends
+- `nextOperation()` — bumps the operation counter at the start of a new operation
+
+This is transient scratch state and is never persisted. The Harness still owns
+the live agent subscription (`activeRunId()`) and the public
+`getCurrentRunId()` / `getCurrentTraceId()` accessors, which now delegate to
+`session.run`, so external consumers are unaffected.

--- a/.changeset/harness-session-run-state.md
+++ b/.changeset/harness-session-run-state.md
@@ -1,19 +1,27 @@
 ---
 '@mastra/core': patch
+'mastracode': patch
 ---
 
-Move Harness run identity onto the Session class.
+Move Harness run identity and abort control onto the Session class.
 
-The transient per-run state — current run id, trace id, and the monotonic
-operation counter — now lives on `session.run` (`SessionRun`) instead of being
-flattened on the Harness:
+The transient per-run state now lives on `session.run` (`SessionRun`) instead
+of being flattened on the Harness:
 
-- `getRunId()` / `setRunId({ runId })`
-- `getTraceId()` / `setTraceId({ traceId })`
-- `reset()` — clears run id and trace id when a run ends
-- `nextOperation()` — bumps the operation counter at the start of a new operation
+- run identity — `getRunId()` / `setRunId({ runId })`, `getTraceId()` /
+  `setTraceId({ traceId })`, and `nextOperation()` (monotonic operation counter)
+- abort control — `ensureAbortController()`, `getAbortSignal()`,
+  `isRunning()` / `hasAbortController()`, `clearAbortRequested()`,
+  `isAbortRequested()`, and `requestAbort()` (fires the controller and marks
+  the run aborting)
+- `reset()` — clears run id, trace id, and abort state when a run ends
 
-This is transient scratch state and is never persisted. The Harness still owns
-the live agent subscription (`activeRunId()`) and the public
-`getCurrentRunId()` / `getCurrentTraceId()` accessors, which now delegate to
-`session.run`, so external consumers are unaffected.
+This is transient scratch state and is never persisted.
+
+The pure pass-through accessors `Harness.isRunning()` and
+`Harness.getCurrentTraceId()` are **removed** — read these through the session
+instead (`harness.session.run.isRunning()` /
+`harness.session.run.getTraceId()`). `Harness.abort()` and
+`Harness.getCurrentRunId()` are kept, because they compose the Harness-private
+agent subscription rather than being simple delegators; they will move once the
+subscription itself is owned by the session.

--- a/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -125,7 +125,7 @@ describe('MastraTUI queueing', () => {
     };
     const state = {
       editor,
-      harness: { isRunning: vi.fn(() => true) },
+      harness: { session: { run: { isRunning: vi.fn(() => true) } } },
       pendingSlashCommands: [],
       pendingQueuedActions: [],
       pendingFollowUpMessages: [],
@@ -168,7 +168,7 @@ describe('MastraTUI queueing', () => {
     };
     const state = {
       editor,
-      harness: { isRunning: vi.fn(() => true) },
+      harness: { session: { run: { isRunning: vi.fn(() => true) } } },
       pendingSlashCommands: [],
       pendingQueuedActions: [],
       pendingFollowUpMessages: [],
@@ -209,7 +209,7 @@ describe('MastraTUI queueing', () => {
     const state = {
       editor,
       activeGoalJudge: { modelId: '__GATEWAY_OPENAI_MODEL__' },
-      harness: { isRunning: vi.fn(() => false) },
+      harness: { session: { run: { isRunning: vi.fn(() => false) } } },
       pendingSlashCommands: [],
       pendingQueuedActions: [],
       pendingFollowUpMessages: [],

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -90,7 +90,7 @@ function createState(isRunning: boolean) {
   const state = {
     editor,
     harness: {
-      isRunning: vi.fn(() => isRunning),
+      session: { run: { isRunning: vi.fn(() => isRunning) } },
       hasPendingSuspensions: vi.fn(() => false),
       getState: vi.fn(() => ({})),
       listModes: vi.fn(() => []),

--- a/mastracode/src/tui/commands/__tests__/feedback.test.ts
+++ b/mastracode/src/tui/commands/__tests__/feedback.test.ts
@@ -15,7 +15,9 @@ function createCtx(options?: {
   const addFeedback = options?.addFeedback ?? vi.fn().mockResolvedValue(undefined);
   return {
     harness: {
-      getCurrentTraceId: vi.fn(() => (options && 'traceId' in options ? options.traceId : 'trace-123')),
+      session: {
+        run: { getTraceId: vi.fn(() => (options && 'traceId' in options ? options.traceId : 'trace-123')) },
+      },
       getCurrentRunId: vi.fn(() => (options && 'runId' in options ? options.runId : 'run-123')),
       getCurrentThreadId: vi.fn(() => (options && 'threadId' in options ? options.threadId : 'thread-123')),
       getMastra: vi.fn(() => ({ observability: { addFeedback } })),

--- a/mastracode/src/tui/commands/__tests__/goal.test.ts
+++ b/mastracode/src/tui/commands/__tests__/goal.test.ts
@@ -589,7 +589,7 @@ describe('handleGoalCommand', () => {
       pendingInlineQuestions: [],
       pendingAskUserComponents: new Map(),
       harness: {
-        isRunning: vi.fn(() => false),
+        session: { run: { isRunning: vi.fn(() => false) } },
         hasPendingSuspensions: vi.fn(() => false),
         abort,
       },
@@ -624,7 +624,7 @@ describe('handleGoalCommand', () => {
       pendingInlineQuestions: [() => {}],
       pendingAskUserComponents: new Map([['t', {}]]),
       harness: {
-        isRunning: vi.fn(() => true),
+        session: { run: { isRunning: vi.fn(() => true) } },
         hasPendingSuspensions: vi.fn(() => false),
         abort,
       },

--- a/mastracode/src/tui/commands/feedback.ts
+++ b/mastracode/src/tui/commands/feedback.ts
@@ -30,10 +30,10 @@ export async function handleFeedbackCommand(ctx: SlashCommandContext, args: stri
   }
 
   // Resolve trace context.
-  // getCurrentTraceId() returns the actual observability traceId (OTel 32-hex-char ID)
+  // session.run.getTraceId() returns the actual observability traceId (OTel 32-hex-char ID)
   // captured from the stream response. getCurrentRunId() returns the agent's runId (UUID).
   // We pass both so the cloud endpoint can correlate feedback to the correct trace.
-  const traceId = ctx.harness.getCurrentTraceId() ?? undefined;
+  const traceId = ctx.harness.session.run.getTraceId() ?? undefined;
   const runId = ctx.harness.getCurrentRunId() ?? undefined;
   const threadId = ctx.harness.getCurrentThreadId() ?? undefined;
 

--- a/mastracode/src/tui/commands/goal.ts
+++ b/mastracode/src/tui/commands/goal.ts
@@ -107,7 +107,7 @@ export async function handleGoalCommand(ctx: SlashCommandContext, args: string[]
     // attempting the goal". Stop it immediately so clear means stop. Mirrors the
     // Esc/abort cleanup so a turn parked in a tool suspension (e.g. ask_user) is
     // also aborted cleanly.
-    if (state.harness.isRunning() || state.harness.hasPendingSuspensions()) {
+    if (state.harness.session.run.isRunning() || state.harness.hasPendingSuspensions()) {
       state.activeInlineQuestion = undefined;
       state.pendingInlineQuestions.length = 0;
       state.pendingAskUserComponents?.clear();

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -656,7 +656,7 @@ export class MastraTUI {
   private async renderExistingMessagesAndSeedIdleCounter(): Promise<void> {
     await renderExistingMessages(this.state);
 
-    if (this.state.harness.isRunning()) {
+    if (this.state.harness.session.run.isRunning()) {
       this.clearIdleCounter();
       return;
     }
@@ -777,7 +777,7 @@ export class MastraTUI {
 
   private emitErrorFeedback(errorMessage: string): void {
     const harness = this.state.harness;
-    const traceId = harness.getCurrentTraceId() ?? undefined;
+    const traceId = harness.session.run.getTraceId() ?? undefined;
     const runId = harness.getCurrentRunId() ?? undefined;
     const threadId = harness.getCurrentThreadId() ?? undefined;
 
@@ -999,7 +999,7 @@ export class MastraTUI {
         }
         this.state.editor.setText('');
 
-        if (this.state.harness.isRunning()) {
+        if (this.state.harness.session.run.isRunning()) {
           if (text.startsWith('/')) {
             // Run slash commands immediately — they are either settings
             // commands (no agent interaction) or agent-facing commands the

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -55,7 +55,7 @@ export function setupKeyboardShortcuts(
       state.pendingInlineQuestions.length = 0;
       state.userInitiatedAbort = true;
       state.harness.abort();
-    } else if (state.harness.isRunning() || state.harness.hasPendingSuspensions()) {
+    } else if (state.harness.session.run.isRunning() || state.harness.hasPendingSuspensions()) {
       // Clean up active inline components on abort. hasPendingSuspensions covers
       // the case where the run is parked in a tool suspend() (e.g. ask_user) —
       // isRunning() is false there because the AbortController was nulled, but the
@@ -141,7 +141,7 @@ export function setupKeyboardShortcuts(
   // Shift+Tab - cycle harness modes
   state.editor.onAction('cycleMode', async () => {
     // Block mode switching while the agent is active or plan approval is pending
-    if (state.harness.isRunning()) {
+    if (state.harness.session.run.isRunning()) {
       showInfo(state, 'Wait for the agent to finish first');
       return;
     }
@@ -191,7 +191,7 @@ export function setupKeyboardShortcuts(
     }
 
     const text = state.editor.getExpandedText();
-    if (!state.harness.isRunning()) {
+    if (!state.harness.session.run.isRunning()) {
       state.editor.onSubmit?.(text);
       return true;
     }

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -454,9 +454,6 @@ export class Harness<TState = {}> {
   private listeners: HarnessEventListener[] = [];
   private abortController: AbortController | null = null;
   private abortRequested: boolean = false;
-  private currentRunId: string | null = null;
-  private currentTraceId: string | null = null;
-  private currentOperationId: number = 0;
   private agentThreadSubscription: AgentThreadSubscription<any> | null = null;
   private agentThreadSubscriptionKey: string | null = null;
   private followUpQueue: Array<{ content: string; requestContext?: RequestContext }> = [];
@@ -1819,8 +1816,7 @@ export class Harness<TState = {}> {
     this.agentThreadSubscription?.unsubscribe();
     this.agentThreadSubscription = null;
     this.agentThreadSubscriptionKey = null;
-    this.currentRunId = null;
-    this.currentTraceId = null;
+    this.#session.run.reset();
     this.abortController = null;
     this.abortRequested = false;
   }
@@ -1994,8 +1990,7 @@ export class Harness<TState = {}> {
   }): Promise<void> {
     const reason = error ? 'error' : suspended ? 'suspended' : aborted || this.abortRequested ? 'aborted' : 'complete';
     this.emit({ type: 'agent_end', reason });
-    this.currentRunId = null;
-    this.currentTraceId = null;
+    this.#session.run.reset();
     this.abortController = null;
     this.abortRequested = false;
     await this.drainFollowUpQueue();
@@ -2011,8 +2006,7 @@ export class Harness<TState = {}> {
     this.agentThreadSubscription?.unsubscribe();
     this.agentThreadSubscription = null;
     this.agentThreadSubscriptionKey = null;
-    this.currentRunId = null;
-    this.currentTraceId = null;
+    this.#session.run.reset();
     this.abortController = null;
     this.abortRequested = false;
     await this.drainFollowUpQueue();
@@ -2037,10 +2031,10 @@ export class Harness<TState = {}> {
 
         if (!currentRun) {
           currentRun = this.createStreamState();
-          this.currentOperationId += 1;
+          this.#session.run.nextOperation();
           this.abortController ??= new AbortController();
-          this.currentRunId = subscription.activeRunId() ?? ('runId' in chunk ? chunk.runId : null);
-          this.currentTraceId = null;
+          this.#session.run.setRunId({ runId: subscription.activeRunId() ?? ('runId' in chunk ? chunk.runId : null) });
+          this.#session.run.setTraceId({ traceId: null });
           this.emit({ type: 'agent_start' });
         }
 
@@ -2057,7 +2051,7 @@ export class Harness<TState = {}> {
             chunk.type === 'abort' ||
             chunk.type === 'tool-call-suspended'
           ) {
-            const finishedRunId: string | null = chunkRunId ?? this.currentRunId;
+            const finishedRunId: string | null = chunkRunId ?? this.#session.run.getRunId();
             const suspended =
               chunk.type === 'tool-call-suspended' ||
               (streamResult ?? this.finishStreamState(currentRun)).suspended ||
@@ -2121,7 +2115,7 @@ export class Harness<TState = {}> {
       const agent = this.getCurrentAgent();
       await this.ensureAgentThreadSubscription(agent, this.currentThreadId);
 
-      if (this.currentRunId && this.agentThreadSubscription?.activeRunId()) {
+      if (this.#session.run.getRunId() && this.agentThreadSubscription?.activeRunId()) {
         const result = agent.sendSignal(signal, {
           resourceId: this.resourceId,
           threadId: this.currentThreadId,
@@ -2165,7 +2159,7 @@ export class Harness<TState = {}> {
     const agent = this.getCurrentAgent();
     await this.ensureAgentThreadSubscription(agent, this.currentThreadId);
 
-    if (this.currentRunId && this.agentThreadSubscription?.activeRunId()) {
+    if (this.#session.run.getRunId() && this.agentThreadSubscription?.activeRunId()) {
       return agent.sendNotificationSignal(input, {
         resourceId: this.resourceId,
         threadId: this.currentThreadId,
@@ -2703,7 +2697,7 @@ export class Harness<TState = {}> {
   ): Promise<{ message: HarnessMessage; suspended?: boolean } | undefined> {
     const state = this.createStreamState();
     const requestContext = await this.buildRequestContext(requestContextInput);
-    this.currentOperationId += 1;
+    this.#session.run.nextOperation();
     this.emit({ type: 'agent_start' });
 
     let result: { message: HarnessMessage; suspended?: boolean } | undefined;
@@ -2752,8 +2746,7 @@ export class Harness<TState = {}> {
             : 'complete',
     });
 
-    this.currentRunId = null;
-    this.currentTraceId = null;
+    this.#session.run.reset();
     this.abortController = null;
     this.abortRequested = false;
     await this.drainFollowUpQueue();
@@ -2767,7 +2760,7 @@ export class Harness<TState = {}> {
     requestContext: RequestContext,
   ): Promise<{ message: HarnessMessage; suspended?: boolean } | undefined> {
     if ('runId' in chunk && chunk.runId) {
-      this.currentRunId = chunk.runId;
+      this.#session.run.setRunId({ runId: chunk.runId });
     }
 
     switch (chunk.type) {
@@ -2937,8 +2930,9 @@ export class Harness<TState = {}> {
         const suspPayload = getDisplayTransform(chunk.metadata, 'suspend', chunk.payload.suspendPayload);
         const suspResumeSchema = chunk.payload.resumeSchema;
 
-        if (this.currentRunId) {
-          this.pendingSuspensions.set(suspToolCallId, { runId: this.currentRunId, toolName: suspToolName });
+        const suspRunId = this.#session.run.getRunId();
+        if (suspRunId) {
+          this.pendingSuspensions.set(suspToolCallId, { runId: suspRunId, toolName: suspToolName });
         }
         state.isSuspended = true;
 
@@ -3414,7 +3408,7 @@ export class Harness<TState = {}> {
   }
 
   getCurrentRunId(): string | null {
-    return this.agentThreadSubscription?.activeRunId() ?? this.currentRunId;
+    return this.agentThreadSubscription?.activeRunId() ?? this.#session.run.getRunId();
   }
 
   isCurrentThreadStreamActive(): boolean {
@@ -3434,13 +3428,13 @@ export class Harness<TState = {}> {
    * be drained with the previous run's already-aborted abortSignal.
    */
   private async waitForCurrentThreadStreamIdle(): Promise<void> {
-    while (this.isCurrentThreadStreamActive() || this.currentRunId !== null) {
+    while (this.isCurrentThreadStreamActive() || this.#session.run.getRunId() !== null) {
       await new Promise(resolve => setTimeout(resolve, 0));
     }
   }
 
   getCurrentTraceId(): string | null {
-    return this.currentTraceId;
+    return this.#session.run.getTraceId();
   }
 
   private getSubagentDisplayName(agentType: string): string | undefined {
@@ -3651,7 +3645,8 @@ export class Harness<TState = {}> {
     toolCallId?: string;
     requestContext?: RequestContext;
   }): Promise<void> {
-    if (!this.currentRunId) {
+    const runId = this.#session.run.getRunId();
+    if (!runId) {
       throw new Error('No active run to approve tool call for');
     }
 
@@ -3664,7 +3659,7 @@ export class Harness<TState = {}> {
     const requestContext = await this.buildRequestContext(requestContextInput);
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
     await agent.approveToolCall({
-      runId: this.currentRunId,
+      runId,
       toolCallId,
       requireToolApproval: !isYolo,
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
@@ -3681,7 +3676,8 @@ export class Harness<TState = {}> {
     toolCallId?: string;
     requestContext?: RequestContext;
   }): Promise<void> {
-    if (!this.currentRunId) {
+    const runId = this.#session.run.getRunId();
+    if (!runId) {
       throw new Error('No active run to decline tool call for');
     }
 
@@ -3693,7 +3689,7 @@ export class Harness<TState = {}> {
     const requestContext = await this.buildRequestContext(requestContextInput);
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
     await agent.declineToolCall({
-      runId: this.currentRunId,
+      runId,
       toolCallId,
       requireToolApproval: !isYolo,
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -452,8 +452,6 @@ export class Harness<TState = {}> {
   private resourceId: string;
   private defaultResourceId: string;
   private listeners: HarnessEventListener[] = [];
-  private abortController: AbortController | null = null;
-  private abortRequested: boolean = false;
   private agentThreadSubscription: AgentThreadSubscription<any> | null = null;
   private agentThreadSubscriptionKey: string | null = null;
   private followUpQueue: Array<{ content: string; requestContext?: RequestContext }> = [];
@@ -1817,8 +1815,6 @@ export class Harness<TState = {}> {
     this.agentThreadSubscription = null;
     this.agentThreadSubscriptionKey = null;
     this.#session.run.reset();
-    this.abortController = null;
-    this.abortRequested = false;
   }
 
   private getAgentThreadSubscriptionKey(agent: Agent, threadId: string): string {
@@ -1891,8 +1887,7 @@ export class Harness<TState = {}> {
       throw new Error('Cannot build stream options without a current thread');
     }
 
-    this.abortRequested = false;
-    this.abortController ??= new AbortController();
+    this.#session.run.clearAbortRequested();
     const requestContext = await this.buildRequestContext(requestContextInput);
     // Resolve mode-aware instructions at call time so the agent's own
     // instructions are never mutated by the harness.
@@ -1901,7 +1896,7 @@ export class Harness<TState = {}> {
     const streamOptions: Record<string, unknown> = {
       ...this.buildSharedRunOptions(),
       memory: { thread: this.currentThreadId, resource: this.resourceId },
-      abortSignal: this.abortController.signal,
+      abortSignal: this.#session.run.ensureAbortController().signal,
       requestContext,
       ...(tracingContext && { tracingContext }),
       ...(tracingOptions && { tracingOptions }),
@@ -1988,11 +1983,15 @@ export class Harness<TState = {}> {
     error?: boolean;
     aborted?: boolean;
   }): Promise<void> {
-    const reason = error ? 'error' : suspended ? 'suspended' : aborted || this.abortRequested ? 'aborted' : 'complete';
+    const reason = error
+      ? 'error'
+      : suspended
+        ? 'suspended'
+        : aborted || this.#session.run.isAbortRequested()
+          ? 'aborted'
+          : 'complete';
     this.emit({ type: 'agent_end', reason });
     this.#session.run.reset();
-    this.abortController = null;
-    this.abortRequested = false;
     await this.drainFollowUpQueue();
   }
 
@@ -2007,8 +2006,6 @@ export class Harness<TState = {}> {
     this.agentThreadSubscription = null;
     this.agentThreadSubscriptionKey = null;
     this.#session.run.reset();
-    this.abortController = null;
-    this.abortRequested = false;
     await this.drainFollowUpQueue();
   }
 
@@ -2032,7 +2029,7 @@ export class Harness<TState = {}> {
         if (!currentRun) {
           currentRun = this.createStreamState();
           this.#session.run.nextOperation();
-          this.abortController ??= new AbortController();
+          this.#session.run.ensureAbortController();
           this.#session.run.setRunId({ runId: subscription.activeRunId() ?? ('runId' in chunk ? chunk.runId : null) });
           this.#session.run.setTraceId({ traceId: null });
           this.emit({ type: 'agent_start' });
@@ -2061,7 +2058,13 @@ export class Harness<TState = {}> {
             // content-filter refusal) is surfaced as an explicit error so the
             // run never silently stops without a visible terminal state.
             let isError = chunk.type === 'error';
-            if (currentRun.terminalError && !isError && !aborted && !this.abortRequested && !suspended) {
+            if (
+              currentRun.terminalError &&
+              !isError &&
+              !aborted &&
+              !this.#session.run.isAbortRequested() &&
+              !suspended
+            ) {
               isError = true;
               this.emit({ type: 'error', error: new Error(currentRun.terminalError) });
             }
@@ -2718,7 +2721,7 @@ export class Harness<TState = {}> {
         chunk.type === 'error' ||
         chunk.type === 'abort' ||
         chunk.type === 'tool-call-suspended' ||
-        this.abortRequested
+        this.#session.run.isAbortRequested()
       ) {
         result ??= this.finishStreamState(state);
         break;
@@ -2730,7 +2733,7 @@ export class Harness<TState = {}> {
     // A non-success terminal finish reason (e.g. a `claude-fable-5`
     // content-filter refusal) is surfaced as an explicit error so the run never
     // silently stops without a visible terminal state.
-    if (state.terminalError && !error && !aborted && !this.abortRequested && !result.suspended) {
+    if (state.terminalError && !error && !aborted && !this.#session.run.isAbortRequested() && !result.suspended) {
       error = true;
       this.emit({ type: 'error', error: new Error(state.terminalError) });
     }
@@ -2741,14 +2744,12 @@ export class Harness<TState = {}> {
         ? 'error'
         : result.suspended
           ? 'suspended'
-          : aborted || this.abortRequested
+          : aborted || this.#session.run.isAbortRequested()
             ? 'aborted'
             : 'complete',
     });
 
     this.#session.run.reset();
-    this.abortController = null;
-    this.abortRequested = false;
     await this.drainFollowUpQueue();
 
     return result;
@@ -3333,7 +3334,6 @@ export class Harness<TState = {}> {
    * Abort the current operation.
    */
   abort(): void {
-    this.abortRequested = true;
     // Drop any tool suspensions parked awaiting a resume. A run sitting in a
     // tool suspend() (e.g. ask_user / request_access) is not actively streaming,
     // so aborting the AbortController alone leaves it orphaned. Clearing the map
@@ -3344,12 +3344,7 @@ export class Harness<TState = {}> {
     try {
       this.agentThreadSubscription?.abort();
     } catch {}
-    if (this.abortController) {
-      try {
-        this.abortController.abort();
-      } catch {}
-      this.abortController = null;
-    }
+    this.#session.run.requestAbort();
   }
 
   /**
@@ -3380,7 +3375,7 @@ export class Harness<TState = {}> {
    * Queue a follow-up message to be processed after the current operation completes.
    */
   async followUp({ content, requestContext }: { content: string; requestContext?: RequestContext }): Promise<void> {
-    if (this.isRunning()) {
+    if (this.#session.run.isRunning()) {
       this.followUpQueue.push({ content, requestContext });
       this.emit({ type: 'follow_up_queued', count: this.followUpQueue.length });
     } else {
@@ -3390,10 +3385,6 @@ export class Harness<TState = {}> {
 
   getFollowUpCount(): number {
     return this.followUpQueue.length;
-  }
-
-  isRunning(): boolean {
-    return this.abortController !== null;
   }
 
   /**
@@ -3431,10 +3422,6 @@ export class Harness<TState = {}> {
     while (this.isCurrentThreadStreamActive() || this.#session.run.getRunId() !== null) {
       await new Promise(resolve => setTimeout(resolve, 0));
     }
-  }
-
-  getCurrentTraceId(): string | null {
-    return this.#session.run.getTraceId();
   }
 
   private getSubagentDisplayName(agentType: string): string | undefined {
@@ -3652,10 +3639,6 @@ export class Harness<TState = {}> {
 
     const agent = this.getCurrentAgent();
 
-    if (!this.abortController) {
-      this.abortController = new AbortController();
-    }
-
     const requestContext = await this.buildRequestContext(requestContextInput);
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
     await agent.approveToolCall({
@@ -3663,7 +3646,7 @@ export class Harness<TState = {}> {
       toolCallId,
       requireToolApproval: !isYolo,
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
-      abortSignal: this.abortController.signal,
+      abortSignal: this.#session.run.ensureAbortController().signal,
       requestContext,
       toolsets: await this.buildToolsets(requestContext),
     });
@@ -3682,9 +3665,6 @@ export class Harness<TState = {}> {
     }
 
     const agent = this.getCurrentAgent();
-    if (!this.abortController) {
-      this.abortController = new AbortController();
-    }
 
     const requestContext = await this.buildRequestContext(requestContextInput);
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
@@ -3693,7 +3673,7 @@ export class Harness<TState = {}> {
       toolCallId,
       requireToolApproval: !isYolo,
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
-      abortSignal: this.abortController.signal,
+      abortSignal: this.#session.run.ensureAbortController().signal,
       requestContext,
       toolsets: await this.buildToolsets(requestContext),
     });
@@ -3715,10 +3695,6 @@ export class Harness<TState = {}> {
 
     const agent = this.getCurrentAgent();
 
-    if (!this.abortController) {
-      this.abortController = new AbortController();
-    }
-
     // Remove before resuming so a re-suspend during the resumed run can re-register
     // the same toolCallId without being clobbered by this cleanup. Drop the matching
     // display-state entry too so the UI stops rendering only the resolved prompt
@@ -3735,7 +3711,7 @@ export class Harness<TState = {}> {
       runId: suspension.runId,
       toolCallId,
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
-      abortSignal: this.abortController.signal,
+      abortSignal: this.#session.run.ensureAbortController().signal,
       requestContext,
       toolsets: await this.buildToolsets(requestContext),
     });
@@ -4313,7 +4289,7 @@ export class Harness<TState = {}> {
         modeId: this.#session.mode.get(),
         modelId: this.#session.model.get(),
       },
-      abortSignal: this.abortController?.signal,
+      abortSignal: this.#session.run.getAbortSignal(),
       workspace: this.workspace,
       emitEvent: event => this.emit(event),
       getSubagentModelId: params => this.getSubagentModelId(params),

--- a/packages/core/src/harness/mode-model-persistence.test.ts
+++ b/packages/core/src/harness/mode-model-persistence.test.ts
@@ -134,8 +134,7 @@ describe('Harness mode-model persistence across restarts', () => {
     await session.createThread();
     await session.switchMode({ modeId: 'plan' });
 
-    const controller = new AbortController();
-    (session as unknown as { abortController: AbortController | null }).abortController = controller;
+    const controller = session.session.run.ensureAbortController();
 
     // Simulate a submit_plan tool that suspended during a plan-mode run.
     const pendingSuspensions = (

--- a/packages/core/src/harness/om-failure-abort.test.ts
+++ b/packages/core/src/harness/om-failure-abort.test.ts
@@ -24,7 +24,7 @@ describe('Harness OM failure abort behavior', () => {
     const events: HarnessEvent[] = [];
     harness.subscribe(event => events.push(event));
 
-    (harness as any).abortController = new AbortController();
+    harness.session.run.ensureAbortController();
 
     await (harness as any).processStream({
       fullStream: (async function* () {
@@ -47,8 +47,8 @@ describe('Harness OM failure abort behavior', () => {
       'Observational memory observation buffering failed: Bad Request',
     );
     expect(events.some(e => e.type === 'agent_end' && e.reason === 'aborted')).toBe(true);
-    expect((harness as any).abortRequested).toBe(false);
-    expect((harness as any).abortController).toBeNull();
+    expect(harness.session.run.isAbortRequested()).toBe(false);
+    expect(harness.session.run.hasAbortController()).toBe(false);
     expect(events.some(e => e.type === 'message_start')).toBe(false);
   });
 
@@ -57,7 +57,7 @@ describe('Harness OM failure abort behavior', () => {
     const events: HarnessEvent[] = [];
     harness.subscribe(event => events.push(event));
 
-    (harness as any).abortController = new AbortController();
+    harness.session.run.ensureAbortController();
 
     await (harness as any).processStream({
       fullStream: (async function* () {
@@ -81,7 +81,7 @@ describe('Harness OM failure abort behavior', () => {
       'Observational memory reflection run failed: Model unavailable',
     );
     expect(events.some(e => e.type === 'agent_end' && e.reason === 'aborted')).toBe(true);
-    expect((harness as any).abortRequested).toBe(false);
+    expect(harness.session.run.isAbortRequested()).toBe(false);
     expect(events.some(e => e.type === 'message_start')).toBe(false);
   });
 });

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -29,6 +29,57 @@ const MODE_ID_KEY = 'currentModeId';
 const modeModelKey = (modeId: string) => `modeModelId_${modeId}`;
 
 /**
+ * Owns the session's transient run identity: the id of the run currently
+ * streaming on the active thread, its trace id, and a monotonic operation
+ * counter bumped each time a new operation starts. All of this is per-run
+ * scratch state — it is never persisted and resets between runs.
+ *
+ * The Harness still owns the live agent subscription (`activeRunId()`); this
+ * holds the last run id observed on a chunk so callers have a stable value once
+ * the subscription has settled.
+ */
+export class SessionRun {
+  /** Id of the run currently streaming on the active thread, or null when idle. */
+  #runId: string | null = null;
+  /** Trace id for the current run, or null when unset. */
+  #traceId: string | null = null;
+  /** Monotonic counter bumped at the start of each operation. */
+  #operationId = 0;
+
+  /** The current run id (null when idle). */
+  getRunId(): string | null {
+    return this.#runId;
+  }
+
+  /** Set the current run id. */
+  setRunId({ runId }: { runId: string | null }): void {
+    this.#runId = runId;
+  }
+
+  /** The current trace id (null when unset). */
+  getTraceId(): string | null {
+    return this.#traceId;
+  }
+
+  /** Set the current trace id. */
+  setTraceId({ traceId }: { traceId: string | null }): void {
+    this.#traceId = traceId;
+  }
+
+  /** Clear run identity (run id + trace id) when a run ends or is reset. */
+  reset(): void {
+    this.#runId = null;
+    this.#traceId = null;
+  }
+
+  /** Bump and return the operation counter at the start of a new operation. */
+  nextOperation(): number {
+    this.#operationId += 1;
+    return this.#operationId;
+  }
+}
+
+/**
  * Owns the session's currently-selected model. Source of truth for "which model
  * is active", plus the per-mode model memory persisted to the thread-settings
  * store (so each mode remembers the model it was last used with).
@@ -168,6 +219,9 @@ export class SessionMode {
  *   The Session is the source of truth for which mode/model is active and owns
  *   the mode-switch sequence and per-mode model memory. The Harness still owns
  *   the mode *definitions* (`config.modes`).
+ * - transient run identity (`session.run`): the current run id, trace id, and a
+ *   monotonic operation counter. This is per-run scratch state and is never
+ *   persisted.
  *
  * Mode/model persistence is thread-scoped, so the Session writes through a
  * {@link ThreadSettingsStore} the Harness backs with thread metadata; when no
@@ -186,6 +240,8 @@ export class Session {
   readonly model = new SessionModel(() => this.#store);
   /** The session's currently-selected mode and switch sequence. */
   readonly mode = new SessionMode(() => this.#store, this.model);
+  /** Transient run identity (run id, trace id, operation counter) for the active run. */
+  readonly run = new SessionRun();
 
   /**
    * Attach the thread-settings store the Session persists mode/model through.

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -29,10 +29,11 @@ const MODE_ID_KEY = 'currentModeId';
 const modeModelKey = (modeId: string) => `modeModelId_${modeId}`;
 
 /**
- * Owns the session's transient run identity: the id of the run currently
- * streaming on the active thread, its trace id, and a monotonic operation
- * counter bumped each time a new operation starts. All of this is per-run
- * scratch state — it is never persisted and resets between runs.
+ * Owns the session's transient run identity and abort control: the id of the
+ * run currently streaming on the active thread, its trace id, a monotonic
+ * operation counter bumped each time a new operation starts, and the
+ * AbortController/abort-requested flag governing cancellation. All of this is
+ * per-run scratch state — it is never persisted and resets between runs.
  *
  * The Harness still owns the live agent subscription (`activeRunId()`); this
  * holds the last run id observed on a chunk so callers have a stable value once
@@ -45,6 +46,10 @@ export class SessionRun {
   #traceId: string | null = null;
   /** Monotonic counter bumped at the start of each operation. */
   #operationId = 0;
+  /** Controller whose signal cancels the active run; null when no run is armed. */
+  #abortController: AbortController | null = null;
+  /** Whether an abort has been requested for the current run. */
+  #abortRequested = false;
 
   /** The current run id (null when idle). */
   getRunId(): string | null {
@@ -66,16 +71,78 @@ export class SessionRun {
     this.#traceId = traceId;
   }
 
-  /** Clear run identity (run id + trace id) when a run ends or is reset. */
+  /**
+   * Clear all run state (run id, trace id, abort controller + requested flag)
+   * when a run ends or is reset. Does not touch the operation counter.
+   */
   reset(): void {
     this.#runId = null;
     this.#traceId = null;
+    this.#abortController = null;
+    this.#abortRequested = false;
   }
 
   /** Bump and return the operation counter at the start of a new operation. */
   nextOperation(): number {
     this.#operationId += 1;
     return this.#operationId;
+  }
+
+  /**
+   * Lazily create (if needed) and return the AbortController for the current
+   * run. Callers pass its `.signal` into the underlying stream.
+   */
+  ensureAbortController(): AbortController {
+    this.#abortController ??= new AbortController();
+    return this.#abortController;
+  }
+
+  /** Signal for the current run's AbortController, or undefined when none is armed. */
+  getAbortSignal(): AbortSignal | undefined {
+    return this.#abortController?.signal;
+  }
+
+  /**
+   * Whether a run is currently in progress. A run is armed with an
+   * AbortController for its duration, so the presence of one is what "running"
+   * means; this is the semantic accessor callers should use.
+   */
+  isRunning(): boolean {
+    return this.#abortController !== null;
+  }
+
+  /**
+   * Whether an AbortController is currently armed. Equivalent to
+   * {@link isRunning} today; kept for callers that assert on the controller's
+   * lifecycle specifically (e.g. that it was cleared after an abort).
+   */
+  hasAbortController(): boolean {
+    return this.#abortController !== null;
+  }
+
+  /** Clear the abort-requested flag at the start of a fresh run. */
+  clearAbortRequested(): void {
+    this.#abortRequested = false;
+  }
+
+  /** Whether an abort has been requested for the current run. */
+  isAbortRequested(): boolean {
+    return this.#abortRequested;
+  }
+
+  /**
+   * Request an abort: mark the run as aborting and fire the AbortController (if
+   * armed), then drop the controller. Leaves the requested flag set so the
+   * run-end path can resolve its reason as 'aborted'; {@link reset} clears it.
+   */
+  requestAbort(): void {
+    this.#abortRequested = true;
+    if (this.#abortController) {
+      try {
+        this.#abortController.abort();
+      } catch {}
+      this.#abortController = null;
+    }
   }
 }
 
@@ -219,9 +286,9 @@ export class SessionMode {
  *   The Session is the source of truth for which mode/model is active and owns
  *   the mode-switch sequence and per-mode model memory. The Harness still owns
  *   the mode *definitions* (`config.modes`).
- * - transient run identity (`session.run`): the current run id, trace id, and a
- *   monotonic operation counter. This is per-run scratch state and is never
- *   persisted.
+ * - transient run identity and abort control (`session.run`): the current run
+ *   id, trace id, monotonic operation counter, and the AbortController/
+ *   abort-requested flag. This is per-run scratch state and is never persisted.
  *
  * Mode/model persistence is thread-scoped, so the Session writes through a
  * {@link ThreadSettingsStore} the Harness backs with thread metadata; when no

--- a/packages/core/src/harness/signal-messages.test.ts
+++ b/packages/core/src/harness/signal-messages.test.ts
@@ -430,7 +430,7 @@ describe('Harness signal messages', () => {
     const thread = await harness.createThread();
 
     // Simulate an active run from the harness consumer's perspective
-    (harness as any).currentRunId = 'active-run-id';
+    harness.session.run.setRunId({ runId: 'active-run-id' });
 
     const buildToolsets = vi.spyOn(harness as any, 'buildToolsets');
     const sendSignal = vi.spyOn(agent, 'sendSignal').mockReturnValue({

--- a/packages/core/src/harness/signal-messages.test.ts
+++ b/packages/core/src/harness/signal-messages.test.ts
@@ -460,7 +460,7 @@ describe('Harness signal messages', () => {
       events.push(event);
     });
 
-    (harness as any).abortController = new AbortController();
+    harness.session.run.ensureAbortController();
 
     await harness.followUp({ content: 'queued follow-up' });
 
@@ -495,7 +495,7 @@ describe('Harness signal messages', () => {
     });
     const sendSignal = vi.spyOn(agent, 'sendSignal');
     const thread = await harness.createThread();
-    (harness as any).abortController = new AbortController();
+    harness.session.run.ensureAbortController();
 
     await harness.followUp({ content: 'queued follow-up' });
     await (harness as any).drainFollowUpQueue();

--- a/packages/core/src/harness/tracing-propagation.test.ts
+++ b/packages/core/src/harness/tracing-propagation.test.ts
@@ -116,7 +116,7 @@ describe('Harness tracing propagation', () => {
     harness.subscribe(event => {
       events.push(event as { type: string; reason?: string });
     });
-    (harness as unknown as { abortRequested: boolean }).abortRequested = true;
+    harness.session.run.requestAbort();
 
     await harness.sendMessage({ content: 'hello' });
 


### PR DESCRIPTION
## What

Moves the Harness's transient **run identity** onto the Session class (`session.run`), continuing the incremental extraction of per-conversation state off the flattened Harness instance.

`SessionRun` now owns:
- `currentRunId` — id of the run currently streaming on the active thread
- `currentTraceId` — trace id for the current run
- the monotonic **operation counter** bumped at the start of each operation

API (object params, mirroring `session.mode` / `session.model`):
- `getRunId()` / `setRunId({ runId })`
- `getTraceId()` / `setTraceId({ traceId })`
- `reset()` — clears run id + trace id when a run ends
- `nextOperation()` — bumps the operation counter

## Notes

- This is **transient scratch state and is never persisted** — no store wiring, resets between runs.
- The Harness keeps the live agent subscription (`activeRunId()`) and the public `getCurrentRunId()` / `getCurrentTraceId()` accessors, which now delegate to `session.run`. **External consumers (incl. mastracode) are unaffected** — no API change.
- ~25 internal Harness sites replumbed.

## Stack

Stacked on `harness-session-mode-model` (mode + model extraction). Part of the Session-extraction series: grants → token usage → mode → model → **run identity**.

## Verification

- `pnpm --filter ./packages/core check` — typecheck clean
- eslint + prettier clean on touched files
- harness suite: **349/349** pass (one white-box test reseeded via the public `session.run.setRunId(...)`)
