### PR TITLE
fix: build the monorepo on native Windows (path separators)

### DIFF
--- a/.changeset/afraid-icons-teach.md
+++ b/.changeset/afraid-icons-teach.md
@@ -1,0 +1,6 @@
+---
+'@mastra/editor': patch
+'@mastra/core': patch
+---
+
+Fixed the @mastra/editor build failing on native Windows by using POSIX separators for tsup entry globs.

--- a/packages/_types-builder/src/replace-types.js
+++ b/packages/_types-builder/src/replace-types.js
@@ -1,6 +1,6 @@
 // Typescript tooling really sucks so we are going to do some transfomrations ourselves
 import { readFile, mkdir, copyFile, stat } from 'node:fs/promises';
-import { join, dirname, relative, resolve, extname } from 'node:path';
+import { join, dirname, relative, resolve, extname, sep } from 'node:path';
 import { Project, SyntaxKind } from 'ts-morph';
 import { getPackageInfo } from 'local-pkg';
 import { pathToFileURL } from 'node:url';
@@ -242,7 +242,11 @@ async function replaceBundledReferences(file, rootDir, bundledPackages, visited,
 
     await copyDeclarationGraph(sourceTypesPath, sourcePkgRootPath, destTypesRoot, rootDir, bundledPackages, visited);
 
-    let relativeImport = relative(fileDirname, destTypesPath);
+    // Module specifiers must always use POSIX separators ('/'), but path.relative()
+    // returns OS-native separators (backslashes on Windows). Without this normalization,
+    // generated .d.ts files contain unresolvable specifiers like '..\_types\...' that
+    // break `moduleResolution: "bundler"` on Windows. On POSIX, sep === '/' so this is a no-op.
+    let relativeImport = relative(fileDirname, destTypesPath).split(sep).join('/');
     if (!relativeImport.startsWith('.')) {
       relativeImport = './' + relativeImport;
     }

--- a/packages/editor/tsup.config.ts
+++ b/packages/editor/tsup.config.ts
@@ -3,13 +3,10 @@ import { join } from 'node:path';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: [
-    join('src', 'index.ts'),
-    join('src', 'composio.ts'),
-    join('src', 'arcade.ts'),
-    join('src', 'storage', 'index.ts'),
-    join('src', 'ee', 'index.ts'),
-  ],
+  // tsup entry values are globs, which must use POSIX separators ('/'). Using path.join()
+  // here produced backslash paths on Windows (e.g. 'src\\index.ts'), which glob treats as
+  // escape sequences rather than separators, so no entry matched and the build failed.
+  entry: ['src/index.ts', 'src/composio.ts', 'src/arcade.ts', 'src/storage/index.ts', 'src/ee/index.ts'],
   format: ['cjs', 'esm'],
   dts: true,
   clean: true,


### PR DESCRIPTION
## Description

The Mastra monorepo is developed on macOS/Linux, and two build-tooling spots used OS-native path separators where forward-slash globs / module specifiers are required. On native Windows this produced backslashes that broke the build from source. On POSIX the same code already emits `/`, so **both changes are byte-for-byte no-ops on macOS/Linux** — CI/Linux output is unchanged.

The full type/build pipeline is only exercised at publish time: CI type-checks via Vitest (esbuild transpile, no `tsc` emit), so the generated `.d.ts` and tsup entry globs are never validated by the normal test run. That masked two latent Windows-only failures.

**1. `@internal/types-builder` — generated `.d.ts` specifiers** (`packages/_types-builder/src/replace-types.js`)

`path.relative()` returns OS-native separators, so on Windows the generated `.d.ts` module specifiers were written with backslashes, e.g.

```
import('..\_types\@standard-schema_spec\dist\index.d.ts')
```

which is unresolvable under `moduleResolution: "bundler"`. External generics (e.g. `StandardSchemaV1`) collapsed to `unknown`, cascading **73 type errors** in `@mastra/core` on Windows.

```js
// before
let relativeImport = relative(fileDirname, destTypesPath);
// after  (sep imported from 'node:path')
let relativeImport = relative(fileDirname, destTypesPath).split(sep).join('/');
```

**2. `@mastra/editor` — tsup entry globs** (`packages/editor/tsup.config.ts`)

tsup `entry` values are globs and must use `/`. `join('src', 'index.ts')` produced `src\index.ts` on Windows, which glob treats as an escape sequence — no entry matched and the build emitted nothing.

```ts
// before
entry: [join('src', 'index.ts'), join('src', 'composio.ts'), /* ... */],
// after
entry: ['src/index.ts', 'src/composio.ts', /* ... */],
```

(The `join` import stays — still used by `onSuccess` for the real filesystem copy, where native separators are correct.)

### Cross-platform safety (no-op on macOS/Linux)

On POSIX `path.sep === '/'`, so `relative(...).split(sep).join('/')` is the string identity and `join('src', 'index.ts') === 'src/index.ts'`. `path.relative` already emits `/` on POSIX, so the generated `.d.ts` specifiers and the tsup entry array are **byte-for-byte identical pre/post fix**. Only Windows `\`→`/` is rewritten.

### Verification (native Windows)

- `@mastra/core` typecheck: **73 → 4** errors. (The 4 remaining are a separate, pre-existing all-platform `harness/v1/tools.ts` type bug fixed in a companion PR; both are needed for a fully green `tsc` build.)
- `pnpm build:core` → exit 0; `pnpm build:cli` → 36 tasks green (with the harness fix applied).
- `mastra dev` → served Studio (HTTP 200) and the Node inspector on port 9229.

### Changesets

- `@mastra/editor` — patch (published package whose build was broken on Windows).
- `@internal/types-builder` — none; private build tooling consumed as `workspace:*` source, with identical published output on Linux.

## Related issue(s)

Fixes #16251. A companion PR (#18125) fixes the separate `harness/v1/tools.ts` type errors that also block a fully green `tsc` build.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

On Windows computers, file path separators (the slashes between folder names) are different than on Mac/Linux. This PR fixes two places in the code where Windows path separators were breaking the build process—the fix is to use the same forward slashes everywhere, which works correctly on all systems.

---

## Overview

This PR fixes Windows build failures in the Mastra monorepo caused by OS-native path separators. The build breaks in two distinct locations where forward-slash separators are required by build tooling, but Windows uses backslashes instead.

### Issue 1: `@internal/types-builder` Generated Module Specifiers

The `path.relative()` function returns OS-native separators, which on Windows produces backslash paths in generated `.d.ts` files (e.g., `import('..\_types\`@standard-schema_spec`\dist\index.d.ts')`). These fail to resolve under `moduleResolution: "bundler"`, cascading into 73 type errors when building `@mastra/core` on Windows.

**Fix**: Normalize the path output to forward slashes by calling `.split(sep).join('/')` on the relative path result in `packages/_types-builder/src/replace-types.js`.

### Issue 2: `@mastra/editor` tsup Entry Globs

The tsup `entry` configuration accepts globs that require forward slashes. Using `path.join()` produced backslash paths on Windows (e.g., `src\index.ts`), which glob parsers treat as escape sequences rather than separators, causing no entries to match and the build to fail.

**Fix**: Replace dynamic path construction with hardcoded forward-slash paths in the `packages/editor/tsup.config.ts` entry array.

## Changes

- **`packages/_types-builder/src/replace-types.js`**: Added `sep` import from `node:path` and modified `relativeImport` computation to normalize paths to forward slashes
- **`packages/editor/tsup.config.ts`**: Updated tsup `entry` configuration to use explicit POSIX-style forward-slash paths instead of `path.join()`
- **`.changeset/afraid-icons-teach.md`**: Added changeset documenting patch release for `@mastra/editor`

## Cross-Platform Compatibility

Both changes are byte-for-byte no-ops on macOS/Linux. On POSIX systems, `path.sep === '/'`, and `path.relative()` already emits forward slashes, so the generated output remains identical.

## Verification

**Before**: `@mastra/core` had 73 type errors on Windows
**After**: Type errors reduced to 4, builds succeeded with `pnpm build:core` and `pnpm build:cli`, and the Studio was successfully served with `mastra dev`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
