### PR TITLE
fix(core): source harness v1 runId/traceId from the session

### DIFF
--- a/.changeset/crisp-squids-sleep.md
+++ b/.changeset/crisp-squids-sleep.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Harness v1 `ask_user` and `submit_plan` tools reading `runId` and `traceId` from fields that do not exist on the tool execution context, which broke the type build. They now read the current run and trace IDs from the harness session.

--- a/packages/core/src/harness/v1/tools.ts
+++ b/packages/core/src/harness/v1/tools.ts
@@ -216,8 +216,8 @@ export function buildHarnessBuiltInTools(session: AnySession): ToolsInput {
             id: randomUUID(),
             kind: 'question',
             status: 'pending',
-            runId: context.agent?.runId ?? context.workflow?.runId ?? null,
-            traceId: context.traceId ?? null,
+            runId: session.getCurrentRunId(),
+            traceId: session.getCurrentTraceId(),
             payload: input,
           });
           return { isError: false, pendingItemId: pending.id, status: pending.status };
@@ -237,8 +237,8 @@ export function buildHarnessBuiltInTools(session: AnySession): ToolsInput {
             id: randomUUID(),
             kind: 'plan-approval',
             status: 'pending',
-            runId: context.agent?.runId ?? context.workflow?.runId ?? null,
-            traceId: context.traceId ?? null,
+            runId: session.getCurrentRunId(),
+            traceId: session.getCurrentTraceId(),
             payload: { ...input, transitionModeId: session.getMode().transitionsTo },
           });
           return { isError: false, pendingItemId: pending.id, status: pending.status };


### PR DESCRIPTION
## Description

A pre-existing, platform-independent structural type bug in the Harness v1 built-in tools. It was surfaced while getting the monorepo to build on native Windows (#16251), but it fails the `tsc` type-emit on **all** platforms — only undetected because CI type-checks via Vitest (no `tsc`).

`packages/core/src/harness/v1/tools.ts` (the `ask_user` and `submit_plan` tools) read:

```ts
runId: context.agent?.runId ?? context.workflow?.runId ?? null,
traceId: context.traceId ?? null,
```

But `AgentToolExecutionContext` has no `runId` and `ToolExecutionContext` has no top-level `traceId`, so this is a real type error (4× TS2339). At runtime (esbuild strips types) `context.agent?.runId` and `context.traceId` were always `undefined`, so `runId`/`traceId` were **never populated** — both resolved to `null`.

```ts
// after
runId: session.getCurrentRunId(),
traceId: session.getCurrentTraceId(),
```

The harness session already tracks the active run (`#markRunning(runId)`), exposed via the public `getCurrentRunId()` / `getCurrentTraceId()` (both `string | null`, matching `HarnessPendingItemRecord.runId?` / `traceId?`).

### Behavior & safety (all platforms)

- These tools fire only inside `session.signal()` (the agent path), where `#markRunning` has already set the active run **before** the tools are built. So `getCurrentRunId()` now returns the **real active runId** — previously always lost as `null`. `getCurrentTraceId()` returns `null` today (identical to the old value), now correctly wired.
- Worst case (tool fires while not running): the getters return `null` — exactly the old value. **No regression on any platform.**
- The values are write-only metadata for the `question` / `plan-approval` item kinds these tools create; the only `item.runId` consumer is gated to `kind === 'tool-approval'`, and `item.traceId` is read nowhere.

### Verification

- `@mastra/core` typecheck: removes the final 4 errors (→ **0**) on top of the Windows path-separator fixes (#16251 companion PR).
- Harness v1 test suite green (34 files / 349 tests); no test asserts these values.

### Changeset

`@mastra/core` — patch.

## Related issue(s)

Fixes #18126. Surfaced while fixing #16251 (the Windows build). This is a separate, all-platform `tsc` type error; both this and the path-separator PR (#18124) are required for a fully green build.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes some tools in the Harness system that were accidentally looking for information (`runId` and `traceId`) in the wrong place - like looking for your keys in a drawer when they're actually on the table. The fix tells them to look in the session object instead, where that information actually exists.

## Summary

This PR fixes structural type errors in the Harness v1 built-in tools (`ask_user` and `submit_plan`) in `packages/core/src/harness/v1/tools.ts`. The tools were attempting to access `runId` and `traceId` properties from the tool execution context, but these properties don't exist at those locations (`AgentToolExecutionContext` lacks `runId` and `ToolExecutionContext` lacks a top-level `traceId`).

### Changes

- Updated the tools to retrieve `runId` via `session.getCurrentRunId()` and `traceId` via `session.getCurrentTraceId()` instead of attempting to read them from the context object
- The session object already has access to these values through its `#markRunning(runId)` method, which is called before the tools are constructed

### Impact

- **Type safety**: Resolves four TS2339 type-check errors that were previously undetected in CI
- **Runtime behavior**: No functional changes when tools execute within the agent path; the tools now provide the actual `runId` instead of `null`. When firing outside an active run, the methods return `null`, matching previous behavior
- **Build**: Marked as a patch-level fix for `@mastra/core` and resolves all remaining type-check errors in the core package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
