### PR TITLE
fix: Add execCommand fallback for clipboard copy in strict-permission browsers

### DIFF
--- a/.changeset/soft-kind-clear.md
+++ b/.changeset/soft-kind-clear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed copy button silently failing in browsers with strict clipboard permissions (Arc, Firefox). Adds a document.execCommand fallback so copy works without needing the Clipboard API permission.

--- a/packages/playground-ui/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/playground-ui/src/hooks/use-copy-to-clipboard.ts
@@ -6,28 +6,56 @@ type UseCopyToClipboardProps = {
   copyMessage?: string;
 };
 
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  // Keep the textarea off-screen so it doesn't flash visible
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try {
+    return document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
 export function useCopyToClipboard({ text, copyMessage = 'Copied to clipboard!' }: UseCopyToClipboardProps) {
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  const onSuccess = useCallback(() => {
+    toast.success(copyMessage);
+    setIsCopied(true);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    timeoutRef.current = setTimeout(() => {
+      setIsCopied(false);
+    }, 2000);
+  }, [copyMessage]);
+
   const handleCopy = useCallback(() => {
     navigator.clipboard
       .writeText(text)
-      .then(() => {
-        toast.success(copyMessage);
-        setIsCopied(true);
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current);
-          timeoutRef.current = null;
-        }
-        timeoutRef.current = setTimeout(() => {
-          setIsCopied(false);
-        }, 2000);
-      })
+      .then(onSuccess)
       .catch(() => {
-        toast.error('Failed to copy to clipboard.');
+        // navigator.clipboard requires the Clipboard permission, which browsers
+        // like Arc or Firefox in strict mode may deny. Fall back to the older
+        // execCommand approach which works without explicit permission.
+        const ok = copyViaExecCommand(text);
+        if (ok) {
+          onSuccess();
+        } else {
+          toast.error('Failed to copy to clipboard.');
+        }
       });
-  }, [text, copyMessage]);
+  }, [text, onSuccess]);
 
   return { isCopied, handleCopy };
 }


### PR DESCRIPTION
Copy button on assistant messages silently failed in Arc and browsers with strict clipboard permissions. `navigator.clipboard.writeText` rejects when `clipboard-write` isn't granted — the catch only showed a toast, nothing ended up in the clipboard.

Added a `copyViaExecCommand` fallback: on permission rejection, it creates an off-screen textarea, selects the content, calls `document.execCommand('copy')`, and cleans up. Error toast only shows if both paths fail.

Closes #18112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The copy button on chat messages was broken in some stricter browsers like Arc. The fix tries the modern way to copy first, and if the browser says "no," it switches to an older backup method that still works. Now users can copy messages no matter which browser they're using.

## Changes

### Changeset
Added a new changeset entry for `@mastra/playground-ui` documenting a `patch` version bump for fixing the copy button in browsers with strict clipboard permissions.

### Hook Refactoring (`useCopyToClipboard`)
Refactored the clipboard functionality to implement a two-tier copy strategy:

**Primary mechanism:** Uses the modern `navigator.clipboard.writeText()` API as the first approach.

**Fallback mechanism:** Added a new `copyViaExecCommand` helper function that:
- Creates an off-screen textarea element
- Populates it with the text to copy
- Selects the text and invokes `document.execCommand('copy')`
- Cleans up the temporary element via a `finally` block

**Improved error handling:** Centralized success behavior (toast notification, `isCopied` state toggle, and 2-second timeout reset) into a reusable `onSuccess` callback. Error toast notifications now only display when both the Clipboard API and the `execCommand` fallback fail, eliminating unnecessary error messages when the fallback succeeds.

The exported function signature remains unchanged, maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->