### PR TITLE
Fix PR automation app token permissions

### DIFF
--- a/.github/workflows/changed-test-gate-labeler.yml
+++ b/.github/workflows/changed-test-gate-labeler.yml
@@ -33,7 +33,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-issues: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - name: Setup pnpm and node
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -44,7 +44,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-issues: write
-          permission-pull-requests: read
+          permission-pull-requests: write
           permission-members: read
 
       - name: Setup pnpm and node
@@ -95,7 +95,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-issues: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - name: Setup pnpm and node
         uses: ./.github/actions/setup-pnpm-node
@@ -144,6 +144,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-issues: write
+          permission-pull-requests: write
 
       - name: Setup pnpm and node
         uses: ./.github/actions/setup-pnpm-node


### PR DESCRIPTION
## Summary
- grant PR write permission to GitHub App tokens for PR automation jobs that mutate PR labels/comments
- update changed-test-gate labeler and PR triage automation token scopes

## Verification
- parsed all workflow YAML files with Ruby YAML.load_file
- reviewed git diff for workflow-only changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR gives GitHub automation tools special permission to add and remove labels and comments on pull requests. Previously, these tools could only read PR information but not make changes; now they can actually make the updates they're supposed to make.

## Summary of Changes

This PR fixes GitHub App token permissions for PR automation workflows by elevating token access from `read` to `write` for pull request operations.

### Changed Files

**`.github/workflows/changed-test-gate-labeler.yml`**
- Updated the `permission-pull-requests` setting from `read` to `write`, enabling the "Changed Test Gate Labeler" step to perform pull request label modifications.

**`.github/workflows/pr-triage.yml`**
- Updated the `permission-pull-requests` setting from `read` to `write` in the `issue-link-nudge` job
- Updated the `permission-pull-requests` setting from `read` to `write` in the `complexity` job
- Updated the `permission-pull-requests` setting from `read` to `write` in the `summarize` job

## Impact

These changes enable PR automation jobs that mutate PR state (labels, comments) to perform their intended operations with the necessary elevated permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->