### PR TITLE
chore(playground): add theme select icons

### DIFF
--- a/.changeset/true-jobs-lose.md
+++ b/.changeset/true-jobs-lose.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added icons to the Studio theme selector.

--- a/.changeset/true-jobs-lose.md
+++ b/.changeset/true-jobs-lose.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/playground-ui': patch
+'@internal/playground': patch
 ---
 
 Added icons to the Studio theme selector.

--- a/packages/playground-ui/src/ds/components/SettingsRow/settings-row.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsRow/settings-row.stories.tsx
@@ -1,8 +1,27 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { LucideIcon } from 'lucide-react';
+import { MonitorIcon, MoonIcon, SunIcon } from 'lucide-react';
 import { SettingsRow } from './settings-row';
 import { Button } from '@/ds/components/Button';
 import { SectionCard } from '@/ds/components/SectionCard';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ds/components/Select';
+
+const THEME_OPTIONS: { value: string; label: string; Icon: LucideIcon }[] = [
+  { value: 'dark', label: 'Dark', Icon: MoonIcon },
+  { value: 'light', label: 'Light', Icon: SunIcon },
+  { value: 'system', label: 'System', Icon: MonitorIcon },
+];
+
+function ThemeOptionLabel({ option }: { option: (typeof THEME_OPTIONS)[number] }) {
+  const { Icon } = option;
+
+  return (
+    <span className="inline-flex min-w-0 max-w-full items-center gap-2">
+      <Icon aria-hidden="true" className="h-4 w-4 shrink-0 opacity-70" />
+      <span className="min-w-0 truncate">{option.label}</span>
+    </span>
+  );
+}
 
 const meta: Meta<typeof SettingsRow> = {
   title: 'Layout/SettingsRow',
@@ -28,12 +47,14 @@ export const WithSelect: Story = {
       <SettingsRow label="Theme mode" htmlFor="theme">
         <Select defaultValue="dark">
           <SelectTrigger id="theme" className="w-full sm:w-48">
-            <SelectValue />
+            <SelectValue className="inline-flex min-w-0 max-w-full items-center" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="dark">Dark</SelectItem>
-            <SelectItem value="light">Light</SelectItem>
-            <SelectItem value="system">System</SelectItem>
+            {THEME_OPTIONS.map(option => (
+              <SelectItem key={option.value} value={option.value}>
+                <ThemeOptionLabel option={option} />
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </SettingsRow>
@@ -51,12 +72,14 @@ export const WithDescription: Story = {
       >
         <Select defaultValue="dark">
           <SelectTrigger id="theme" className="w-full sm:w-48">
-            <SelectValue />
+            <SelectValue className="inline-flex min-w-0 max-w-full items-center" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="dark">Dark</SelectItem>
-            <SelectItem value="light">Light</SelectItem>
-            <SelectItem value="system">System</SelectItem>
+            {THEME_OPTIONS.map(option => (
+              <SelectItem key={option.value} value={option.value}>
+                <ThemeOptionLabel option={option} />
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </SettingsRow>
@@ -81,12 +104,14 @@ export const Stacked: Story = {
         <SettingsRow label="Theme mode" description="Choose how the studio appears." htmlFor="theme">
           <Select defaultValue="dark">
             <SelectTrigger id="theme" className="w-full sm:w-48">
-              <SelectValue />
+              <SelectValue className="inline-flex min-w-0 max-w-full items-center" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="dark">Dark</SelectItem>
-              <SelectItem value="light">Light</SelectItem>
-              <SelectItem value="system">System</SelectItem>
+              {THEME_OPTIONS.map(option => (
+                <SelectItem key={option.value} value={option.value}>
+                  <ThemeOptionLabel option={option} />
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </SettingsRow>

--- a/packages/playground/src/pages/settings/index.tsx
+++ b/packages/playground/src/pages/settings/index.tsx
@@ -10,16 +10,29 @@ import {
 } from '@mastra/playground-ui';
 import type { Theme } from '@mastra/playground-ui';
 import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
+import type { LucideIcon } from 'lucide-react';
+import { MonitorIcon, MoonIcon, SunIcon } from 'lucide-react';
 import { StudioConfigForm } from '@/domains/configuration/components/studio-config-form';
 import { useStudioConfig } from '@/domains/configuration/context/studio-config-state';
 
-const THEME_OPTIONS: { value: Theme; label: string }[] = [
-  { value: 'dark', label: 'Dark' },
-  { value: 'light', label: 'Light' },
-  { value: 'system', label: 'System' },
+const THEME_OPTIONS: { value: Theme; label: string; Icon: LucideIcon }[] = [
+  { value: 'dark', label: 'Dark', Icon: MoonIcon },
+  { value: 'light', label: 'Light', Icon: SunIcon },
+  { value: 'system', label: 'System', Icon: MonitorIcon },
 ];
 
 const isTheme = (value: string): value is Theme => THEME_OPTIONS.some(option => option.value === value);
+
+function ThemeOptionLabel({ option }: { option: (typeof THEME_OPTIONS)[number] }) {
+  const { Icon } = option;
+
+  return (
+    <span className="inline-flex min-w-0 max-w-full items-center gap-2">
+      <Icon aria-hidden="true" className="h-4 w-4 shrink-0 opacity-70" />
+      <span className="min-w-0 truncate">{option.label}</span>
+    </span>
+  );
+}
 
 export const StudioSettingsPage = () => {
   const { baseUrl, headers, apiPrefix } = useStudioConfig();
@@ -37,12 +50,12 @@ export const StudioSettingsPage = () => {
               }}
             >
               <SelectTrigger id="theme" className="w-full sm:w-48">
-                <SelectValue />
+                <SelectValue className="inline-flex min-w-0 max-w-full items-center" />
               </SelectTrigger>
               <SelectContent>
                 {THEME_OPTIONS.map(option => (
                   <SelectItem key={option.value} value={option.value}>
-                    {option.label}
+                    <ThemeOptionLabel option={option} />
                   </SelectItem>
                 ))}
               </SelectContent>


### PR DESCRIPTION
Adds Moon, Sun, and Monitor icons to the Studio theme selector options while keeping the option labels accessible to screen readers.

Also mirrors the same theme option rendering in the SettingsRow stories so the documented example matches Studio.

Validated with targeted ESLint on the changed files, package-level playground-ui lint, and React Doctor on changed files. Full package typecheck is currently blocked by missing workspace declaration outputs for @mastra packages. CodeRabbit CLI is installed locally, but not signed in, so local CodeRabbit review could not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR shows a small icon next to each theme option (light, dark, and system) in the settings, so it’s easier to tell what each choice means. The icons are just visual decoration—your screen reader still reads the actual option text.

## Changes Overview
- **Release note (changeset):** Bumped `@internal/playground` and documented that icons were added to the Studio theme selector.
- **Studio/Storybook docs:** Updated `packages/playground-ui/src/ds/components/SettingsRow/settings-row.stories.tsx` so the “Theme mode” select options are rendered using the same shared `THEME_OPTIONS` (value/label/icon) approach as the real implementation.
- **Settings UI:** Updated `packages/playground/src/pages/settings/index.tsx` so the theme select and its options render icons alongside the theme labels using a new `THEME_OPTIONS` array and a `ThemeOptionLabel` renderer.

## Implementation Details
- Added/used a `THEME_OPTIONS` structure that pairs each theme value with a label and a Lucide icon (`MoonIcon`, `SunIcon`, `MonitorIcon`).
- Introduced a `ThemeOptionLabel` component to display the icon next to the (truncated) label.
- Wired both the select trigger display and the select items to use `ThemeOptionLabel` so the visuals match everywhere.

## Validation
- Targeted ESLint on modified files
- Package-level linting for `playground-ui`
- React Doctor analysis on changed files
- Notes: full package typecheck is blocked by missing workspace declaration outputs for `@mastra` packages; CodeRabbit CLI isn’t signed in locally.

No tests were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->