### PR TITLE
feat(playground): polish command palette search

### DIFF
--- a/.changeset/heavy-colts-start.md
+++ b/.changeset/heavy-colts-start.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': minor
 ---
 
-Improved command palette keyboard handling, shortcut labels, and inline examples.
+Improved command palette keyboard handling, shortcut labels, overlay behavior, and inline examples.

--- a/.changeset/heavy-colts-start.md
+++ b/.changeset/heavy-colts-start.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Improved command palette keyboard handling, shortcut labels, and inline examples.

--- a/.changeset/heavy-colts-start.md
+++ b/.changeset/heavy-colts-start.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': minor
 ---
 
-Improved command palette keyboard handling, shortcut labels, overlay behavior, and inline examples.
+Improved command palette keyboard handling, input affordance/style slots, scroll-area-backed lists, shortcut labels, overlay behavior, and inline examples.

--- a/packages/playground-ui/src/ds/components/Command/command.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.stories.tsx
@@ -104,7 +104,12 @@ export const InlineVercelStyle: Story = {
             </Kbd>
           }
         />
-        <CommandList className="max-h-[22rem] p-1.5">
+        <CommandList
+          scrollArea
+          scrollAreaClassName="max-h-[22rem]"
+          scrollAreaViewportClassName="rounded-[inherit]"
+          className="p-1.5"
+        >
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Projects">
             <InlineResult

--- a/packages/playground-ui/src/ds/components/Command/command.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Calculator, Calendar, CreditCard, Settings, Smile, User } from 'lucide-react';
+import { Bot, Calculator, Calendar, CreditCard, GitBranch, Rocket, Settings, Shield, Smile, User } from 'lucide-react';
 import * as React from 'react';
 
 import { Button } from '../Button';
+import { Kbd } from '../Kbd';
 import {
   Command,
   CommandDialog,
@@ -25,6 +26,28 @@ const meta: Meta<typeof Command> = {
 
 export default meta;
 type Story = StoryObj<typeof Command>;
+
+const InlineResult = ({
+  icon,
+  title,
+  subtitle,
+  value,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  value: string;
+}) => (
+  <CommandItem value={value} className="h-auto items-start gap-3 px-2.5 py-2">
+    <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-md bg-surface5 text-neutral4">
+      {icon}
+    </span>
+    <span className="flex min-w-0 flex-col gap-0.5">
+      <span className="truncate text-ui-sm font-medium leading-ui-sm text-neutral6">{title}</span>
+      <span className="truncate text-ui-xs leading-ui-xs text-neutral3">{subtitle}</span>
+    </span>
+  </CommandItem>
+);
 
 export const Default: Story = {
   render: () => (
@@ -66,6 +89,67 @@ export const Default: Story = {
         </CommandGroup>
       </CommandList>
     </Command>
+  ),
+};
+
+export const InlineVercelStyle: Story = {
+  render: () => (
+    <div className="w-[24rem] overflow-hidden rounded-xl border border-border1 bg-surface2 shadow-dialog">
+      <Command className="rounded-none bg-surface2">
+        <CommandInput
+          placeholder="Find..."
+          rightSlot={
+            <Kbd className="min-w-0 rounded border-border1 bg-surface4 px-1.5 py-0 text-[10px] leading-4 text-neutral4">
+              Esc
+            </Kbd>
+          }
+        />
+        <CommandList className="max-h-[22rem] p-1.5">
+          <CommandEmpty>No results found.</CommandEmpty>
+          <CommandGroup heading="Projects">
+            <InlineResult
+              icon={<Settings className="size-3.5" />}
+              title="Settings"
+              subtitle="Mastra"
+              value="settings mastra account billing"
+            />
+            <InlineResult
+              icon={<Rocket className="size-3.5" />}
+              title="mastra-cloud-admin"
+              subtitle="Project"
+              value="mastra cloud admin project"
+            />
+            <InlineResult
+              icon={<GitBranch className="size-3.5" />}
+              title="codex/eu-residency-ux-plan"
+              subtitle="platform-admin-portal"
+              value="codex eu residency ux plan platform admin portal"
+            />
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Commands">
+            <InlineResult
+              icon={<Shield className="size-3.5" />}
+              title="Deployments"
+              subtitle="mastra-docs-1.x"
+              value="deployments mastra docs"
+            />
+            <InlineResult
+              icon={<Settings className="size-3.5" />}
+              title="On-Demand Concurrent Builds"
+              subtitle="Mastra / Build and Deployment / Settings"
+              value="on demand concurrent builds mastra build deployment settings"
+            />
+            <InlineResult
+              icon={<Bot className="size-3.5" />}
+              title="Navigation Assistant"
+              subtitle="Search projects, routes, and commands"
+              value="navigation assistant search projects routes commands"
+            />
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </div>
   ),
 };
 

--- a/packages/playground-ui/src/ds/components/Command/command.test.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.test.tsx
@@ -71,6 +71,17 @@ describe('Command', () => {
     expect(onParentKeyDown).not.toHaveBeenCalled();
   });
 
+  it('renders CommandDialog without the standard dialog overlay', () => {
+    render(
+      <CommandDialog open onOpenChange={() => {}}>
+        <CommandInput placeholder="Search commands" />
+      </CommandDialog>,
+    );
+
+    expect(screen.getByPlaceholderText('Search commands')).toBeDefined();
+    expect(document.querySelector('.dialog-overlay-anim')).toBeNull();
+  });
+
   it('renders CommandInput rightSlot without replacing the input', () => {
     render(
       <Command>

--- a/packages/playground-ui/src/ds/components/Command/command.test.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from './command';
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class ResizeObserverPolyfill {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  globalThis.ResizeObserver = ResizeObserverPolyfill as unknown as typeof ResizeObserver;
+}
+
+if (typeof globalThis.Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Command', () => {
+  it('closes CommandDialog when Escape is pressed inside the input', async () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <CommandDialog open onOpenChange={onOpenChange}>
+        <CommandInput placeholder="Search commands" />
+        <CommandList>
+          <CommandGroup heading="Navigation">
+            <CommandItem value="settings">Settings</CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>,
+    );
+
+    fireEvent.keyDown(screen.getByPlaceholderText('Search commands'), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false, expect.anything());
+    });
+  });
+
+  it('stops non-Escape key events from leaving CommandDialog', () => {
+    const onParentKeyDown = vi.fn();
+
+    render(
+      <div onKeyDown={onParentKeyDown}>
+        <CommandDialog open onOpenChange={() => {}}>
+          <CommandInput placeholder="Search commands" />
+          <CommandList>
+            <CommandGroup heading="Navigation">
+              <CommandItem value="settings">Settings</CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </CommandDialog>
+      </div>,
+    );
+
+    fireEvent.keyDown(screen.getByPlaceholderText('Search commands'), {
+      key: 'ArrowDown',
+      code: 'ArrowDown',
+    });
+
+    expect(onParentKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('renders CommandInput rightSlot without replacing the input', () => {
+    render(
+      <Command>
+        <CommandInput placeholder="Search commands" rightSlot={<span>Esc</span>} />
+      </Command>,
+    );
+
+    expect(screen.getByPlaceholderText('Search commands')).toBeDefined();
+    expect(screen.getByText('Esc')).toBeDefined();
+  });
+
+  it('preserves DOM order while filtering matching items', async () => {
+    render(
+      <CommandDialog open onOpenChange={() => {}}>
+        <CommandInput placeholder="Search commands" />
+        <CommandList>
+          <CommandEmpty>No results found.</CommandEmpty>
+          <CommandGroup heading="Navigation">
+            <CommandItem value="beta weather agent">Beta Weather</CommandItem>
+            <CommandItem value="alpha weather agent">Alpha Weather</CommandItem>
+            <CommandItem value="weather workflow">Weather Workflow</CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search commands'), {
+      target: { value: 'weather agent' },
+    });
+
+    const beta = screen.getByText('Beta Weather').closest('[cmdk-item]');
+    const alpha = screen.getByText('Alpha Weather').closest('[cmdk-item]');
+
+    await waitFor(() => {
+      expect(beta?.hasAttribute('hidden')).toBe(false);
+      expect(alpha?.hasAttribute('hidden')).toBe(false);
+      expect(screen.queryByText('Weather Workflow')).toBeNull();
+    });
+
+    expect(Boolean(beta?.compareDocumentPosition(alpha!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+  });
+});

--- a/packages/playground-ui/src/ds/components/Command/command.test.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.test.tsx
@@ -82,6 +82,19 @@ describe('Command', () => {
     expect(document.querySelector('.dialog-overlay-anim')).toBeNull();
   });
 
+  it('renders a custom CommandDialog overlay when requested', () => {
+    render(
+      <CommandDialog open onOpenChange={() => {}} showOverlay overlayClassName="bg-surface1/40 backdrop-blur-none">
+        <CommandInput placeholder="Search commands" />
+      </CommandDialog>,
+    );
+
+    const overlay = document.querySelector('.dialog-overlay-anim');
+    expect(overlay?.className).toContain('bg-surface1/40');
+    expect(overlay?.className).toContain('backdrop-blur-none');
+    expect(overlay?.className).not.toContain('backdrop-blur-xs');
+  });
+
   it('renders CommandInput rightSlot without replacing the input', () => {
     render(
       <Command>
@@ -91,6 +104,57 @@ describe('Command', () => {
 
     expect(screen.getByPlaceholderText('Search commands')).toBeDefined();
     expect(screen.getByText('Esc')).toBeDefined();
+  });
+
+  it('applies CommandInput wrapperClassName to the input wrapper', () => {
+    render(
+      <Command>
+        <CommandInput placeholder="Search commands" wrapperClassName="custom-wrapper" />
+      </Command>,
+    );
+
+    expect(screen.getByPlaceholderText('Search commands').parentElement?.classList.contains('custom-wrapper')).toBe(
+      true,
+    );
+  });
+
+  it('renders CommandList inside ScrollArea when requested', () => {
+    render(
+      <Command>
+        <CommandList
+          scrollArea
+          scrollAreaClassName="scroll-root"
+          scrollAreaViewportClassName="scroll-viewport"
+          className="custom-list"
+        >
+          <CommandGroup heading="Navigation">
+            <CommandItem value="settings">Settings</CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>,
+    );
+
+    const list = screen.getByRole('listbox', { name: 'Suggestions' });
+    const viewport = document.querySelector('.scroll-viewport');
+
+    expect(list.classList.contains('custom-list')).toBe(true);
+    expect(document.querySelector('.scroll-root')?.contains(list)).toBe(true);
+    expect(viewport?.contains(list)).toBe(true);
+  });
+
+  it('removes the browser focus outline from CommandList', () => {
+    render(
+      <Command>
+        <CommandList>
+          <CommandGroup heading="Navigation">
+            <CommandItem value="settings">Settings</CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>,
+    );
+
+    const list = screen.getByRole('listbox', { name: 'Suggestions' });
+    expect(list.classList.contains('focus-visible:outline-none')).toBe(true);
   });
 
   it('preserves DOM order while filtering matching items', async () => {

--- a/packages/playground-ui/src/ds/components/Command/command.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.tsx
@@ -52,7 +52,7 @@ const CommandDialog = ({
 
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0">
+      <DialogContent showOverlay={false} className="overflow-hidden p-0">
         <DialogTitle className="sr-only">{title}</DialogTitle>
         <DialogDescription className="sr-only">{description}</DialogDescription>
         <Command

--- a/packages/playground-ui/src/ds/components/Command/command.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.tsx
@@ -45,6 +45,8 @@ const CommandDialog = ({
   // Stop propagation to prevent keyboard events from reaching
   // global document-level listeners (e.g., table keyboard nav)
   const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') return;
+
     e.stopPropagation();
   }, []);
 
@@ -59,7 +61,7 @@ const CommandDialog = ({
           className={cn(
             '**:[[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-neutral3',
             '[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 **:[[cmdk-group]]:px-2',
-            '[&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5',
+            '[&_[data-slot=command-input-wrapper]_svg]:h-5 [&_[data-slot=command-input-wrapper]_svg]:w-5',
             '**:[[cmdk-input]]:h-12',
             '**:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3',
             '[&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5',
@@ -72,25 +74,36 @@ const CommandDialog = ({
   );
 };
 
-const CommandInput = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
-  <div className={cn('flex items-center border-b border-border1 px-3', transitions.colors)} cmdk-input-wrapper="">
-    <Search className={cn('mr-2 h-4 w-4 shrink-0 text-neutral3', transitions.colors)} />
-    <CommandPrimitive.Input
-      ref={ref}
-      className={cn(
-        'flex h-10 w-full rounded-md bg-transparent py-3 text-ui-smd leading-ui-sm text-neutral6',
-        'placeholder:text-neutral3 disabled:cursor-not-allowed disabled:opacity-50',
-        'outline-none focus:outline-none focus-visible:outline-none',
-        transitions.colors,
-        className,
+type CommandInputProps = React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & {
+  rightSlot?: React.ReactNode;
+};
+
+const CommandInput = React.forwardRef<React.ElementRef<typeof CommandPrimitive.Input>, CommandInputProps>(
+  ({ className, rightSlot, ...props }, ref) => (
+    <div
+      data-slot="command-input-wrapper"
+      className={cn('flex items-center border-b border-border1 px-3', transitions.colors)}
+    >
+      <Search className={cn('mr-2 h-4 w-4 shrink-0 text-neutral3', transitions.colors)} />
+      <CommandPrimitive.Input
+        ref={ref}
+        className={cn(
+          'flex h-10 min-w-0 flex-1 rounded-md bg-transparent py-3 text-ui-smd leading-ui-sm text-neutral6',
+          'placeholder:text-neutral3 disabled:cursor-not-allowed disabled:opacity-50',
+          'outline-none focus:outline-none focus-visible:outline-none',
+          transitions.colors,
+          className,
+        )}
+        {...props}
+      />
+      {rightSlot && (
+        <div data-slot="command-input-right-slot" className="ml-2 flex shrink-0 items-center text-neutral3">
+          {rightSlot}
+        </div>
       )}
-      {...props}
-    />
-  </div>
-));
+    </div>
+  ),
+);
 CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 const CommandList = React.forwardRef<

--- a/packages/playground-ui/src/ds/components/Command/command.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.tsx
@@ -3,6 +3,8 @@ import { Search } from 'lucide-react';
 import * as React from 'react';
 
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/ds/components/Dialog';
+import { ScrollArea } from '@/ds/components/ScrollArea';
+import type { ScrollAreaMask } from '@/ds/components/ScrollArea';
 import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
@@ -22,12 +24,20 @@ type CommandDialogProps = Omit<React.ComponentPropsWithoutRef<typeof Dialog>, 'c
   children?: React.ReactNode;
   title?: string;
   description?: string;
+  contentClassName?: string;
+  commandClassName?: string;
+  showOverlay?: boolean;
+  overlayClassName?: string;
 };
 
 const CommandDialog = ({
   children,
   title = 'Command Palette',
   description = 'Search for commands and actions',
+  contentClassName,
+  commandClassName,
+  showOverlay = false,
+  overlayClassName,
   ...props
 }: CommandDialogProps) => {
   // Custom filter that preserves DOM order by returning 1 for all matches
@@ -52,7 +62,11 @@ const CommandDialog = ({
 
   return (
     <Dialog {...props}>
-      <DialogContent showOverlay={false} className="overflow-hidden p-0">
+      <DialogContent
+        showOverlay={showOverlay}
+        overlayClassName={overlayClassName}
+        className={cn('overflow-hidden p-0', contentClassName)}
+      >
         <DialogTitle className="sr-only">{title}</DialogTitle>
         <DialogDescription className="sr-only">{description}</DialogDescription>
         <Command
@@ -65,6 +79,7 @@ const CommandDialog = ({
             '**:[[cmdk-input]]:h-12',
             '**:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3',
             '[&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5',
+            commandClassName,
           )}
         >
           {children}
@@ -76,13 +91,14 @@ const CommandDialog = ({
 
 type CommandInputProps = React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & {
   rightSlot?: React.ReactNode;
+  wrapperClassName?: string;
 };
 
 const CommandInput = React.forwardRef<React.ElementRef<typeof CommandPrimitive.Input>, CommandInputProps>(
-  ({ className, rightSlot, ...props }, ref) => (
+  ({ className, rightSlot, wrapperClassName, ...props }, ref) => (
     <div
       data-slot="command-input-wrapper"
-      className={cn('flex items-center border-b border-border1 px-3', transitions.colors)}
+      className={cn('flex items-center border-b border-border1 px-3', transitions.colors, wrapperClassName)}
     >
       <Search className={cn('mr-2 h-4 w-4 shrink-0 text-neutral3', transitions.colors)} />
       <CommandPrimitive.Input
@@ -106,16 +122,43 @@ const CommandInput = React.forwardRef<React.ElementRef<typeof CommandPrimitive.I
 );
 CommandInput.displayName = CommandPrimitive.Input.displayName;
 
-const CommandList = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.List
-    ref={ref}
-    className={cn('max-h-dropdown-max-height overflow-y-auto overflow-x-hidden', className)}
-    {...props}
-  />
-));
+type CommandListProps = React.ComponentPropsWithoutRef<typeof CommandPrimitive.List> & {
+  scrollArea?: boolean;
+  scrollAreaClassName?: string;
+  scrollAreaViewportClassName?: string;
+  scrollAreaMask?: ScrollAreaMask;
+};
+
+const CommandList = React.forwardRef<React.ElementRef<typeof CommandPrimitive.List>, CommandListProps>(
+  (
+    { className, scrollArea = false, scrollAreaClassName, scrollAreaViewportClassName, scrollAreaMask, ...props },
+    ref,
+  ) => {
+    const list = (
+      <CommandPrimitive.List
+        ref={ref}
+        className={cn(
+          'outline-none focus:outline-none focus-visible:outline-none',
+          scrollArea ? 'overflow-visible' : 'max-h-dropdown-max-height overflow-y-auto overflow-x-hidden',
+          className,
+        )}
+        {...props}
+      />
+    );
+
+    if (!scrollArea) return list;
+
+    return (
+      <ScrollArea
+        className={cn('min-h-0', scrollAreaClassName)}
+        viewPortClassName={scrollAreaViewportClassName}
+        mask={scrollAreaMask}
+      >
+        {list}
+      </ScrollArea>
+    );
+  },
+);
 CommandList.displayName = CommandPrimitive.List.displayName;
 
 const CommandEmpty = React.forwardRef<

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.css
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.css
@@ -51,12 +51,12 @@
 
 .dialog-overlay-anim[data-state='open'],
 .dialog-overlay-anim[data-open] {
-  animation: dialog-overlay-in 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  animation: dialog-overlay-in 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .dialog-overlay-anim[data-state='closed'],
 .dialog-overlay-anim[data-closed] {
-  animation: dialog-overlay-out 240ms cubic-bezier(0.32, 0, 0.67, 0);
+  animation: dialog-overlay-out 240ms cubic-bezier(0.32, 0, 0.67, 0) both;
 }
 
 .dialog-content-anim[data-state='open'],

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.test.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.test.tsx
@@ -45,6 +45,28 @@ describe('Dialog', () => {
     expect(screen.getByText('Body content')).toBeDefined();
   });
 
+  it('renders the overlay by default and allows it to be disabled', () => {
+    const { rerender } = render(
+      <Dialog defaultOpen>
+        <DialogContent>
+          <DialogTitle>With overlay</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(document.querySelector('.dialog-overlay-anim')).not.toBeNull();
+
+    rerender(
+      <Dialog defaultOpen>
+        <DialogContent showOverlay={false}>
+          <DialogTitle>No overlay</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(document.querySelector('.dialog-overlay-anim')).toBeNull();
+  });
+
   it('renders an asChild Trigger as the child element without nesting buttons', () => {
     render(
       <Dialog>

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.test.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.test.tsx
@@ -67,6 +67,22 @@ describe('Dialog', () => {
     expect(document.querySelector('.dialog-overlay-anim')).toBeNull();
   });
 
+  it('applies custom classes to the overlay', () => {
+    render(
+      <Dialog defaultOpen>
+        <DialogContent overlayClassName="custom-overlay bg-surface1/40 backdrop-blur-none">
+          <DialogTitle>Custom overlay</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const overlay = document.querySelector('.dialog-overlay-anim');
+    expect(overlay?.className).toContain('custom-overlay');
+    expect(overlay?.className).toContain('bg-surface1/40');
+    expect(overlay?.className).toContain('backdrop-blur-none');
+    expect(overlay?.className).not.toContain('backdrop-blur-xs');
+  });
+
   it('renders an asChild Trigger as the child element without nesting buttons', () => {
     render(
       <Dialog>

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -58,12 +58,13 @@ DialogOverlay.displayName = 'DialogOverlay';
 type DialogContentProps = Omit<DialogPrimitive.Popup.Props, 'className'> & {
   className?: string;
   showOverlay?: boolean;
+  overlayClassName?: string;
 };
 
 const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
-  ({ className, children, showOverlay = true, ...props }, ref) => (
+  ({ className, children, showOverlay = true, overlayClassName, ...props }, ref) => (
     <DialogPortal>
-      {showOverlay && <DialogOverlay />}
+      {showOverlay && <DialogOverlay className={overlayClassName} />}
       <DialogPrimitive.Popup
         ref={ref}
         data-slot="dialog-content"

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -57,35 +57,38 @@ DialogOverlay.displayName = 'DialogOverlay';
 
 type DialogContentProps = Omit<DialogPrimitive.Popup.Props, 'className'> & {
   className?: string;
+  showOverlay?: boolean;
 };
 
-const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Popup
-      ref={ref}
-      data-slot="dialog-content"
-      className={cn(
-        'dialog-content-anim',
-        'fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%]',
-        'w-full max-w-[calc(100%-2rem)] sm:max-w-lg',
-        'rounded-xl border border-border1/40 bg-surface2/96 backdrop-blur-md shadow-dialog',
-        'focus-visible:outline-hidden',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close
-        render={
-          <Button variant="ghost" size="sm" className="absolute top-3 right-3" aria-label="Close">
-            <X />
-          </Button>
-        }
-      />
-    </DialogPrimitive.Popup>
-  </DialogPortal>
-));
+const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
+  ({ className, children, showOverlay = true, ...props }, ref) => (
+    <DialogPortal>
+      {showOverlay && <DialogOverlay />}
+      <DialogPrimitive.Popup
+        ref={ref}
+        data-slot="dialog-content"
+        className={cn(
+          'dialog-content-anim',
+          'fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%]',
+          'w-full max-w-[calc(100%-2rem)] sm:max-w-lg',
+          'rounded-xl border border-border1/40 bg-surface2/96 backdrop-blur-md shadow-dialog',
+          'focus-visible:outline-hidden',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close
+          render={
+            <Button variant="ghost" size="sm" className="absolute top-3 right-3" aria-label="Close">
+              <X />
+            </Button>
+          }
+        />
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  ),
+);
 DialogContent.displayName = 'DialogContent';
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-item-classes.ts
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-item-classes.ts
@@ -1,0 +1,31 @@
+import { cn } from '@/lib/utils';
+
+type ItemStyleOptions = {
+  isActive?: boolean;
+  isCollapsed?: boolean;
+  isFeatured?: boolean;
+};
+
+/**
+ * Shared classes for any sidebar nav row element (anchor, button, custom).
+ * Apply directly to the interactive element so `asChild` and custom slotted
+ * elements all receive the same styling.
+ */
+export const navItemClasses = ({ isActive, isCollapsed, isFeatured }: ItemStyleOptions = {}) =>
+  cn(
+    'flex cursor-pointer items-center text-ui-md text-neutral3 rounded-lg h-9 min-w-0 whitespace-nowrap',
+    'transition-all duration-normal ease-out-custom motion-reduce:transition-none',
+    '[&_svg]:w-4 [&_svg]:h-4 [&_svg]:shrink-0 [&_svg]:text-neutral3/70 [&_svg]:transition-colors [&_svg]:duration-normal motion-reduce:[&_svg]:transition-none',
+    'hover:bg-sidebar-nav-hover hover:text-neutral6 [&:hover_svg]:text-neutral5',
+    'focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:shadow-focus-ring',
+    !isCollapsed && 'w-full gap-2 py-1 px-3 justify-start',
+    isCollapsed && 'w-full p-0 justify-center',
+    isActive &&
+      'text-neutral6 bg-sidebar-nav-active hover:bg-sidebar-nav-active hover:text-neutral6 [&_svg]:text-neutral6 [&:hover_svg]:text-neutral6',
+    isCollapsed && !isActive && '[&_svg]:text-neutral3',
+    isFeatured && 'my-2 bg-accent1Dark hover:bg-accent1Darker text-accent1 hover:text-accent1 border border-accent1/30',
+    isFeatured &&
+      'dark:bg-accent1 dark:hover:bg-accent1/90 dark:text-black dark:hover:text-black dark:border-transparent',
+    isFeatured &&
+      '[&_svg]:text-accent1 [&:hover_svg]:text-accent1 dark:[&_svg]:text-black/75 dark:[&:hover_svg]:text-black',
+  );

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
@@ -43,6 +43,16 @@ afterEach(() => cleanup());
 //     producing an arrow stranded in the middle of empty space.
 
 describe('MainSidebarNavLink (collapsed) — tooltip regression', () => {
+  it('applies a pointer cursor to sidebar nav items', () => {
+    render(
+      <ul>
+        <MainSidebarNavLink state="default" link={{ name: 'Agents', url: '/agents' }} />
+      </ul>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Agents' }).className).toContain('cursor-pointer');
+  });
+
   it('renders the trigger as a real <a> so Floating UI can anchor to it', () => {
     render(
       <MainSidebarProvider defaultState="collapsed">
@@ -132,7 +142,7 @@ describe('MainSidebarNavLink (collapsed) — tooltip regression', () => {
       <TooltipProvider delay={0}>
         <TooltipPrimitive.Root open>
           <TooltipTrigger asChild>
-            <span tabIndex={0}>Traces</span>
+            <button type="button">Traces</button>
           </TooltipTrigger>
           <TooltipContent side="bottom">Add @mastra/observability to enable this tab.</TooltipContent>
         </TooltipPrimitive.Root>

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
 import type { SidebarState } from './main-sidebar-context';
 import { useMaybeSidebar } from './main-sidebar-context';
+import { navItemClasses } from './main-sidebar-nav-item-classes';
 import { MainSidebarNavLabel } from './main-sidebar-nav-label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import type { LinkComponent } from '@/ds/types/link-component';
@@ -17,37 +18,6 @@ export type NavLink = {
   /** @deprecated Sidebar nav items now render flush; this option is accepted but ignored. */
   indent?: boolean;
 };
-
-type ItemStyleOptions = {
-  isActive?: boolean;
-  isCollapsed?: boolean;
-  isFeatured?: boolean;
-};
-
-/**
- * Shared classes for any sidebar nav row element (anchor, button, custom).
- * Apply directly to the interactive element so `asChild` and custom slotted
- * elements (e.g. router Links) all receive the same styling without relying
- * on `[&>a]:` child selectors.
- */
-export const navItemClasses = ({ isActive, isCollapsed, isFeatured }: ItemStyleOptions = {}) =>
-  cn(
-    'flex items-center text-ui-md text-neutral3 rounded-lg h-9 min-w-0 whitespace-nowrap',
-    'transition-all duration-normal ease-out-custom motion-reduce:transition-none',
-    '[&_svg]:w-4 [&_svg]:h-4 [&_svg]:shrink-0 [&_svg]:text-neutral3/70 [&_svg]:transition-colors [&_svg]:duration-normal motion-reduce:[&_svg]:transition-none',
-    'hover:bg-sidebar-nav-hover hover:text-neutral6 [&:hover_svg]:text-neutral5',
-    'focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:shadow-focus-ring',
-    !isCollapsed && 'w-full gap-2.5 py-1 px-3 justify-start',
-    isCollapsed && 'w-full p-0 justify-center',
-    isActive &&
-      'text-neutral6 bg-sidebar-nav-active hover:bg-sidebar-nav-active hover:text-neutral6 [&_svg]:text-neutral6 [&:hover_svg]:text-neutral6',
-    isCollapsed && !isActive && '[&_svg]:text-neutral3',
-    isFeatured && 'my-2 bg-accent1Dark hover:bg-accent1Darker text-accent1 hover:text-accent1 border border-accent1/30',
-    isFeatured &&
-      'dark:bg-accent1 dark:hover:bg-accent1/90 dark:text-black dark:hover:text-black dark:border-transparent',
-    isFeatured &&
-      '[&_svg]:text-accent1 [&:hover_svg]:text-accent1 dark:[&_svg]:text-black/75 dark:[&:hover_svg]:text-black',
-  );
 
 export type MainSidebarNavLinkProps = Omit<ComponentPropsWithoutRef<'li'>, 'children'> & {
   link?: NavLink;

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-list.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-list.tsx
@@ -5,7 +5,7 @@ export type MainSidebarNavListProps = ComponentPropsWithoutRef<'ul'>;
 
 export function MainSidebarNavList({ className, children, ...props }: MainSidebarNavListProps) {
   return (
-    <ul className={cn('grid grid-cols-[minmax(0,1fr)] gap-1 items-start content-center', className)} {...props}>
+    <ul className={cn('grid grid-cols-[minmax(0,1fr)] gap-0.5 items-start content-center', className)} {...props}>
       {children}
     </ul>
   );

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.tsx
@@ -13,7 +13,8 @@ import { MainSidebarTrigger } from './main-sidebar-trigger';
 
 export { MainSidebarProvider, type SidebarState, type MainSidebarProviderProps } from './main-sidebar-context';
 export { useMainSidebar, useMaybeSidebar } from './main-sidebar-context';
-export { type NavLink, navItemClasses } from './main-sidebar-nav-link';
+export { navItemClasses } from './main-sidebar-nav-item-classes';
+export { type NavLink } from './main-sidebar-nav-link';
 export { type NavSection } from './main-sidebar-nav-section';
 export { MainSidebarTrigger } from './main-sidebar-trigger';
 export { MainSidebarMobileTrigger } from './main-sidebar-mobile-trigger';

--- a/packages/playground-ui/src/hooks/use-keyboard-shortcut-label.test.tsx
+++ b/packages/playground-ui/src/hooks/use-keyboard-shortcut-label.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useKeyboardShortcutLabel } from './use-keyboard-shortcut-label';
+
+const setNavigatorValue = <T,>(property: keyof Navigator | 'userAgentData', value: T) => {
+  Object.defineProperty(window.navigator, property, {
+    configurable: true,
+    value,
+  });
+};
+
+describe('useKeyboardShortcutLabel', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window.navigator, 'platform');
+    Reflect.deleteProperty(window.navigator, 'userAgent');
+    Reflect.deleteProperty(window.navigator, 'userAgentData');
+  });
+
+  it('uses the Command symbol on Apple platforms', () => {
+    setNavigatorValue('platform', 'MacIntel');
+    setNavigatorValue('userAgent', '');
+
+    const { result } = renderHook(() => useKeyboardShortcutLabel('k'));
+
+    expect(result.current).toBe('⌘ K');
+  });
+
+  it('uses Ctrl on Windows platforms', () => {
+    setNavigatorValue('platform', 'Win32');
+    setNavigatorValue('userAgent', 'Windows');
+
+    const { result } = renderHook(() => useKeyboardShortcutLabel('K'));
+
+    expect(result.current).toBe('Ctrl K');
+  });
+
+  it('prefers userAgentData platform when available', () => {
+    setNavigatorValue('platform', 'Win32');
+    setNavigatorValue('userAgentData', { platform: 'macOS' });
+
+    const { result } = renderHook(() => useKeyboardShortcutLabel('p'));
+
+    expect(result.current).toBe('⌘ P');
+  });
+});

--- a/packages/playground-ui/src/hooks/use-keyboard-shortcut-label.ts
+++ b/packages/playground-ui/src/hooks/use-keyboard-shortcut-label.ts
@@ -1,0 +1,34 @@
+import { useMemo, useState } from 'react';
+
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: {
+    platform?: string;
+  };
+};
+
+const APPLE_PLATFORM_PATTERN = /mac|iphone|ipad|ipod/i;
+
+function getIsApplePlatform() {
+  if (typeof navigator === 'undefined') return false;
+
+  const nav = navigator as NavigatorWithUserAgentData;
+  const platform = nav.userAgentData?.platform || nav.platform || '';
+  const userAgent = nav.userAgent || '';
+
+  return APPLE_PLATFORM_PATTERN.test(platform) || APPLE_PLATFORM_PATTERN.test(userAgent);
+}
+
+export function useIsApplePlatform() {
+  const [isApplePlatform] = useState(getIsApplePlatform);
+
+  return isApplePlatform;
+}
+
+export function useKeyboardShortcutLabel(key: string) {
+  const isApplePlatform = useIsApplePlatform();
+
+  return useMemo(() => {
+    const normalizedKey = key.trim().toUpperCase();
+    return `${isApplePlatform ? '⌘' : 'Ctrl'} ${normalizedKey}`;
+  }, [isApplePlatform, key]);
+}

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -119,6 +119,7 @@ export * from './hooks/use-copy-to-clipboard';
 export * from './hooks/use-in-view';
 export * from './hooks/use-autoscroll';
 export * from './hooks/use-is-mobile';
+export * from './hooks/use-keyboard-shortcut-label';
 
 // Pure lib utilities
 export { cn } from './lib/utils';

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -1,6 +1,6 @@
-import { LogoWithoutText, MainSidebar, cn, useMainSidebar } from '@mastra/playground-ui';
+import { LogoWithoutText, MainSidebar, cn, useKeyboardShortcutLabel, useMainSidebar } from '@mastra/playground-ui';
 import type { NavLink } from '@mastra/playground-ui';
-import { Wrench } from 'lucide-react';
+import { Search, Wrench } from 'lucide-react';
 import { useLocation } from 'react-router';
 import { useAgentBuilderSidebarVisibility } from '@/domains/agent-builder/hooks/use-agent-builder-sidebar-visibility';
 import { AuthStatus } from '@/domains/auth/components/auth-status';
@@ -11,6 +11,7 @@ import { getPermissionForRoute, hasRoutePermission } from '@/domains/auth/route-
 import { isAuthenticated } from '@/domains/auth/types';
 import { useIsCmsAvailable } from '@/domains/cms/hooks/use-is-cms-available';
 import { MastraVersionFooter } from '@/domains/configuration/components/mastra-version-footer';
+import { useNavigationCommand } from '@/lib/command';
 import { useLinkComponent } from '@/lib/framework';
 import { useMastraPlatform } from '@/lib/mastra-platform/hooks/use-mastra-platform';
 import { bottomNav, mainNav } from '@/lib/nav/nav-items';
@@ -37,7 +38,9 @@ function getIsLinkActive(item: NavItem, pathname: string): boolean {
 
 export function AppSidebar() {
   const { Link } = useLinkComponent();
-  const { state, isMobile } = useMainSidebar();
+  const { state, isMobile, setOpenMobile } = useMainSidebar();
+  const { setOpen: setNavigationCommandOpen } = useNavigationCommand({ enableShortcut: false });
+  const commandShortcutLabel = useKeyboardShortcutLabel('K');
 
   const location = useLocation();
   const pathname = location.pathname;
@@ -51,6 +54,11 @@ export function AppSidebar() {
   const cmsOnlyLinks = new Set(['/prompts']);
   const { isVisible: isAgentBuilderVisible } = useAgentBuilderSidebarVisibility();
   const isAgentBuilderActive = pathname === '/agent-builder' || pathname.startsWith('/agent-builder/');
+
+  const openNavigationCommand = () => {
+    if (isMobile) setOpenMobile(false);
+    setNavigationCommandOpen(true);
+  };
 
   const filterItem = (item: NavItem) => {
     if (cmsOnlyLinks.has(item.url) && !isCmsAvailable && !isCmsLoading) return false;
@@ -78,9 +86,9 @@ export function AppSidebar() {
 
   return (
     <MainSidebar>
-      <div className="pt-3 mb-4">
+      <div className="pt-2 mb-2">
         {state === 'collapsed' ? (
-          <div className="flex flex-col gap-3 items-center">
+          <div className="flex flex-col gap-2 items-center">
             <div className="relative grid place-items-center size-9">
               <LogoWithoutText
                 className={cn(
@@ -118,8 +126,40 @@ export function AppSidebar() {
         )}
       </div>
 
+      <div className="mb-2">
+        <MainSidebar.NavList>
+          <MainSidebar.NavLink
+            asChild
+            state={state}
+            link={{
+              name: 'Search',
+              url: '#',
+              icon: <Search />,
+            }}
+          >
+            <button
+              type="button"
+              onClick={openNavigationCommand}
+              aria-label="Search and navigate"
+              className="border border-border1 bg-surface3 text-neutral5 hover:bg-surface4 hover:text-neutral6 active:bg-surface5 [&_svg]:text-neutral4 [&:hover_svg]:text-neutral5"
+            >
+              <Search />
+              <MainSidebar.NavLabel state={state}>Search</MainSidebar.NavLabel>
+              {state !== 'collapsed' && (
+                <kbd
+                  aria-hidden="true"
+                  className="ml-auto rounded border border-border1 bg-surface4 px-1.5 py-0.5 font-mono text-[10px] leading-none text-neutral3"
+                >
+                  {commandShortcutLabel}
+                </kbd>
+              )}
+            </button>
+          </MainSidebar.NavLink>
+        </MainSidebar.NavList>
+      </div>
+
       {isAgentBuilderVisible && (
-        <div className="mb-2">
+        <div className="mb-1">
           <MainSidebar.NavList>
             <MainSidebar.NavLink
               LinkComponent={Link}
@@ -182,7 +222,7 @@ export function AppSidebar() {
         )}
         {state !== 'collapsed' && (
           <>
-            <div role="separator" aria-orientation="horizontal" className="mx-6 my-2 h-px bg-border1" />
+            <hr className="mx-6 my-2 h-px border-0 bg-border1" />
             <MastraVersionFooter collapsed={false} />
           </>
         )}

--- a/packages/playground/src/lib/command/navigation-command.css
+++ b/packages/playground/src/lib/command/navigation-command.css
@@ -1,0 +1,126 @@
+.navigation-command-popup[data-open] {
+  animation: none !important;
+}
+
+.navigation-command-popup[data-closed] {
+  animation: navigation-command-popup-hold 260ms linear both !important;
+}
+
+.navigation-command-surface {
+  --navigation-command-enter-delay: 0ms;
+  --navigation-command-exit-delay: 0ms;
+  transform-origin: center;
+  will-change: opacity, transform;
+}
+
+.navigation-command-surface-input {
+  --navigation-command-enter-delay: 20ms;
+  --navigation-command-exit-delay: 80ms;
+}
+
+.navigation-command-surface-rail {
+  --navigation-command-enter-delay: 60ms;
+  --navigation-command-exit-delay: 40ms;
+}
+
+.navigation-command-surface-results {
+  --navigation-command-enter-delay: 100ms;
+  --navigation-command-exit-delay: 0ms;
+}
+
+.navigation-command-results-panel {
+  --navigation-command-footer-height: 4.75rem;
+  isolation: isolate;
+}
+
+.navigation-command-results-panel::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 10;
+  height: var(--navigation-command-footer-height);
+  pointer-events: none;
+  content: '';
+  background: linear-gradient(
+    to top,
+    var(--surface2) 0%,
+    var(--surface2) 28%,
+    color-mix(in oklab, var(--surface2) 94%, transparent) 68%,
+    transparent 100%
+  );
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.navigation-command-list {
+  padding: 0.5rem 0.5rem var(--navigation-command-footer-height);
+}
+
+.navigation-command-scroll-viewport {
+  scroll-padding-bottom: var(--navigation-command-footer-height);
+}
+
+.navigation-command-footer {
+  min-height: calc(var(--navigation-command-footer-height) - 1.25rem);
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.navigation-command-popup[data-open] .navigation-command-surface {
+  animation: navigation-command-surface-in 320ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: var(--navigation-command-enter-delay);
+}
+
+.navigation-command-popup[data-closed] .navigation-command-surface {
+  animation: navigation-command-surface-out 180ms cubic-bezier(0.5, 0, 0.75, 0) both;
+  animation-delay: var(--navigation-command-exit-delay);
+}
+
+@keyframes navigation-command-surface-in {
+  from {
+    opacity: 0;
+    transform: scale(1.02);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes navigation-command-surface-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: scale(1.01);
+  }
+}
+
+@keyframes navigation-command-popup-hold {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navigation-command-popup[data-open],
+  .navigation-command-popup[data-closed],
+  .navigation-command-popup[data-open] .navigation-command-surface,
+  .navigation-command-popup[data-closed] .navigation-command-surface {
+    animation: none !important;
+  }
+
+  .navigation-command-surface {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/packages/playground/src/lib/command/navigation-command.tsx
+++ b/packages/playground/src/lib/command/navigation-command.tsx
@@ -26,6 +26,36 @@ import { useTools } from '@/domains/tools/hooks/use-all-tools';
 import { useWorkflows } from '@/domains/workflows/hooks/use-workflows';
 import { useLinkComponent } from '@/lib/framework';
 import { useMastraPlatform } from '@/lib/mastra-platform';
+import { cn } from '@/lib/utils';
+
+type NavigationCommandItemProps = Omit<React.ComponentProps<typeof CommandItem>, 'children'> & {
+  icon: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  shortcut?: React.ReactNode;
+};
+
+const NavigationCommandItem = ({
+  icon,
+  title,
+  subtitle,
+  shortcut,
+  className,
+  ...props
+}: NavigationCommandItemProps) => {
+  return (
+    <CommandItem className={cn('h-auto items-start gap-3 py-2', className)} {...props}>
+      <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center text-neutral3 [&>svg]:size-4">
+        {icon}
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="truncate text-ui-sm font-medium leading-ui-sm text-neutral6">{title}</span>
+        {subtitle && <span className="truncate text-ui-xs leading-ui-xs text-neutral3">{subtitle}</span>}
+      </span>
+      {shortcut}
+    </CommandItem>
+  );
+};
 
 export const NavigationCommand = () => {
   const { open, setOpen } = useNavigationCommand();
@@ -64,56 +94,83 @@ export const NavigationCommand = () => {
 
         <CommandGroup heading="Navigation">
           {sidebar && (
-            <CommandItem
-              value="toggle sidebar collapse expand"
+            <NavigationCommandItem
+              value="toggle sidebar collapse expand layout panel"
               onSelect={() => {
                 sidebar.toggleSidebar();
                 setOpen(false);
               }}
-            >
-              <PanelLeftIcon className="text-neutral3" />
-              <span>Toggle Sidebar</span>
-              <CommandShortcut>Ctrl+B</CommandShortcut>
-            </CommandItem>
+              icon={<PanelLeftIcon />}
+              title="Toggle Sidebar"
+              subtitle="Layout"
+              shortcut={<CommandShortcut>Ctrl+B</CommandShortcut>}
+            />
           )}
-          <CommandItem value="all agents" onSelect={() => handleSelect('/agents')}>
-            <AgentIcon className="text-neutral3" />
-            <span>All Agents</span>
-          </CommandItem>
-          <CommandItem value="all workflows" onSelect={() => handleSelect('/workflows')}>
-            <WorkflowIcon className="text-neutral3" />
-            <span>All Workflows</span>
-          </CommandItem>
-          <CommandItem value="all tools" onSelect={() => handleSelect('/tools')}>
-            <ToolsIcon className="text-neutral3" />
-            <span>All Tools</span>
-          </CommandItem>
-          <CommandItem value="all scorers" onSelect={() => handleSelect('/scorers')}>
-            <GaugeIcon className="text-neutral3" />
-            <span>All Scorers</span>
-          </CommandItem>
-          <CommandItem value="all processors" onSelect={() => handleSelect('/processors')}>
-            <Cpu className="text-neutral3" />
-            <span>All Processors</span>
-          </CommandItem>
-          <CommandItem value="all mcp servers" onSelect={() => handleSelect('/mcps')}>
-            <McpServerIcon className="text-neutral3" />
-            <span>All MCP Servers</span>
-          </CommandItem>
-          <CommandItem value="observability traces" onSelect={() => handleSelect('/observability')}>
-            <EyeIcon className="text-neutral3" />
-            <span>Observability</span>
-          </CommandItem>
+          <NavigationCommandItem
+            value="all agents agents chat /agents"
+            onSelect={() => handleSelect('/agents')}
+            icon={<AgentIcon />}
+            title="All Agents"
+            subtitle="Browse and chat with agents"
+          />
+          <NavigationCommandItem
+            value="all workflows workflows graph /workflows"
+            onSelect={() => handleSelect('/workflows')}
+            icon={<WorkflowIcon />}
+            title="All Workflows"
+            subtitle="Browse workflow graphs"
+          />
+          <NavigationCommandItem
+            value="all tools tools /tools"
+            onSelect={() => handleSelect('/tools')}
+            icon={<ToolsIcon />}
+            title="All Tools"
+            subtitle="Inspect available tools"
+          />
+          <NavigationCommandItem
+            value="all scorers scores evaluation /scorers"
+            onSelect={() => handleSelect('/scorers')}
+            icon={<GaugeIcon />}
+            title="All Scorers"
+            subtitle="Manage evaluation scorers"
+          />
+          <NavigationCommandItem
+            value="all processors processors /processors"
+            onSelect={() => handleSelect('/processors')}
+            icon={<Cpu />}
+            title="All Processors"
+            subtitle="Review input and output processors"
+          />
+          <NavigationCommandItem
+            value="all mcp servers mcp /mcps"
+            onSelect={() => handleSelect('/mcps')}
+            icon={<McpServerIcon />}
+            title="All MCP Servers"
+            subtitle="Browse connected MCP servers"
+          />
+          <NavigationCommandItem
+            value="observability traces telemetry /observability"
+            onSelect={() => handleSelect('/observability')}
+            icon={<EyeIcon />}
+            title="Observability"
+            subtitle="Inspect traces and telemetry"
+          />
           {!isMastraPlatform && (
             <>
-              <CommandItem value="settings" onSelect={() => handleSelect('/settings')}>
-                <SettingsIcon className="text-neutral3" />
-                <span>Settings</span>
-              </CommandItem>
-              <CommandItem value="templates" onSelect={() => handleSelect('/templates')}>
-                <PackageIcon className="text-neutral3" />
-                <span>Templates</span>
-              </CommandItem>
+              <NavigationCommandItem
+                value="settings configuration studio /settings"
+                onSelect={() => handleSelect('/settings')}
+                icon={<SettingsIcon />}
+                title="Settings"
+                subtitle="Configure Studio"
+              />
+              <NavigationCommandItem
+                value="templates starter projects examples /templates"
+                onSelect={() => handleSelect('/templates')}
+                icon={<PackageIcon />}
+                title="Templates"
+                subtitle="Create from a starter"
+              />
             </>
           )}
         </CommandGroup>
@@ -124,17 +181,20 @@ export const NavigationCommand = () => {
             <CommandGroup heading="Agents">
               {agentEntries.map(([id, agent]) => (
                 <React.Fragment key={id}>
-                  <CommandItem value={`${agent.name} chat agent`} onSelect={() => handleSelect(paths.agentLink(id))}>
-                    <AgentIcon className="text-neutral3" />
-                    <span>{agent.name}: Chat</span>
-                  </CommandItem>
-                  <CommandItem
-                    value={`${agent.name} traces agent observability`}
+                  <NavigationCommandItem
+                    value={`${agent.name} ${id} chat agent conversation ${paths.agentLink(id)}`}
+                    onSelect={() => handleSelect(paths.agentLink(id))}
+                    icon={<AgentIcon />}
+                    title={`${agent.name}: Chat`}
+                    subtitle="Agent conversation"
+                  />
+                  <NavigationCommandItem
+                    value={`${agent.name} ${id} traces agent observability telemetry`}
                     onSelect={() => handleSelect(`/observability?entity=${id}`)}
-                  >
-                    <EyeIcon className="text-neutral3" />
-                    <span>{agent.name}: Traces</span>
-                  </CommandItem>
+                    icon={<EyeIcon />}
+                    title={`${agent.name}: Traces`}
+                    subtitle="Agent observability"
+                  />
                 </React.Fragment>
               ))}
             </CommandGroup>
@@ -147,20 +207,20 @@ export const NavigationCommand = () => {
             <CommandGroup heading="Workflows">
               {workflowEntries.map(([id, workflow]) => (
                 <React.Fragment key={id}>
-                  <CommandItem
-                    value={`${workflow.name} graph workflow view`}
+                  <NavigationCommandItem
+                    value={`${workflow.name} ${id} graph workflow view ${paths.workflowLink(id)}`}
                     onSelect={() => handleSelect(paths.workflowLink(id))}
-                  >
-                    <WorkflowIcon className="text-neutral3" />
-                    <span>{workflow.name}: Graph</span>
-                  </CommandItem>
-                  <CommandItem
-                    value={`${workflow.name} traces workflow observability`}
+                    icon={<WorkflowIcon />}
+                    title={`${workflow.name}: Graph`}
+                    subtitle="Workflow view"
+                  />
+                  <NavigationCommandItem
+                    value={`${workflow.name} ${id} traces workflow observability telemetry`}
                     onSelect={() => handleSelect(`/observability?entity=${workflow.name}`)}
-                  >
-                    <EyeIcon className="text-neutral3" />
-                    <span>{workflow.name}: Traces</span>
-                  </CommandItem>
+                    icon={<EyeIcon />}
+                    title={`${workflow.name}: Traces`}
+                    subtitle="Workflow observability"
+                  />
                 </React.Fragment>
               ))}
             </CommandGroup>
@@ -172,10 +232,14 @@ export const NavigationCommand = () => {
             <CommandSeparator />
             <CommandGroup heading="Tools">
               {toolEntries.map(([id, tool]) => (
-                <CommandItem key={id} value={`tool ${tool.id}`} onSelect={() => handleSelect(paths.toolLink(id))}>
-                  <ToolsIcon className="text-neutral3" />
-                  <span>{tool.id}</span>
-                </CommandItem>
+                <NavigationCommandItem
+                  key={id}
+                  value={`tool ${tool.id} ${id} ${paths.toolLink(id)}`}
+                  onSelect={() => handleSelect(paths.toolLink(id))}
+                  icon={<ToolsIcon />}
+                  title={tool.id}
+                  subtitle="Tool"
+                />
               ))}
             </CommandGroup>
           </>
@@ -188,10 +252,14 @@ export const NavigationCommand = () => {
               {scorerEntries.map(([id, scorer]) => {
                 const name = scorer.scorer?.config?.name || scorer.scorer?.config?.id || id;
                 return (
-                  <CommandItem key={id} value={`scorer ${name}`} onSelect={() => handleSelect(paths.scorerLink(id))}>
-                    <GaugeIcon className="text-neutral3" />
-                    <span>{name}</span>
-                  </CommandItem>
+                  <NavigationCommandItem
+                    key={id}
+                    value={`scorer score evaluation ${name} ${id} ${paths.scorerLink(id)}`}
+                    onSelect={() => handleSelect(paths.scorerLink(id))}
+                    icon={<GaugeIcon />}
+                    title={name}
+                    subtitle="Scorer"
+                  />
                 );
               })}
             </CommandGroup>
@@ -208,14 +276,14 @@ export const NavigationCommand = () => {
                   ? paths.workflowLink(processor.id) + '/graph'
                   : paths.processorLink(processor.id);
                 return (
-                  <CommandItem
+                  <NavigationCommandItem
                     key={processor.id}
-                    value={`processor ${displayName}`}
+                    value={`processor ${displayName} ${processor.id} ${targetPath}`}
                     onSelect={() => handleSelect(targetPath)}
-                  >
-                    <Cpu className="text-neutral3" />
-                    <span>{displayName}</span>
-                  </CommandItem>
+                    icon={<Cpu />}
+                    title={displayName}
+                    subtitle={processor.isWorkflow ? 'Workflow processor' : 'Processor'}
+                  />
                 );
               })}
             </CommandGroup>
@@ -227,14 +295,14 @@ export const NavigationCommand = () => {
             <CommandSeparator />
             <CommandGroup heading="MCP Servers">
               {mcpServers.map(server => (
-                <CommandItem
+                <NavigationCommandItem
                   key={server.id}
-                  value={`mcp server ${server.name}`}
+                  value={`mcp server ${server.name} ${server.id} ${paths.mcpServerLink(server.id)}`}
                   onSelect={() => handleSelect(paths.mcpServerLink(server.id))}
-                >
-                  <McpServerIcon className="text-neutral3" />
-                  <span>{server.name}</span>
-                </CommandItem>
+                  icon={<McpServerIcon />}
+                  title={server.name}
+                  subtitle="MCP server"
+                />
               ))}
             </CommandGroup>
           </>

--- a/packages/playground/src/lib/command/navigation-command.tsx
+++ b/packages/playground/src/lib/command/navigation-command.tsx
@@ -1,24 +1,38 @@
 import {
   useMaybeSidebar,
   AgentIcon,
-  McpServerIcon,
-  SettingsIcon,
-  ToolsIcon,
-  WorkflowIcon,
   CommandDialog,
   CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
   CommandShortcut,
+  Kbd,
+  McpServerIcon,
+  ScrollArea,
+  ToolsIcon,
+  WorkflowIcon,
+  useKeyboardShortcutLabel,
 } from '@mastra/playground-ui';
-import { Cpu, EyeIcon, GaugeIcon, PackageIcon, PanelLeftIcon } from 'lucide-react';
+import {
+  Cpu,
+  EyeIcon,
+  GaugeIcon,
+  Layers3Icon,
+  PackageIcon,
+  PanelLeftIcon,
+  RouteIcon,
+  SearchIcon,
+  SlidersHorizontalIcon,
+} from 'lucide-react';
 import React from 'react';
 
 import { useNavigationCommand } from './use-navigation-command';
 import { useAgents } from '@/domains/agents/hooks/use-agents';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+import { getPermissionForRoute, hasRoutePermission } from '@/domains/auth/route-permissions';
+import { useIsCmsAvailable } from '@/domains/cms/hooks/use-is-cms-available';
 import { useMCPServers } from '@/domains/mcps/hooks/use-mcp-servers';
 import { useProcessors } from '@/domains/processors/hooks/use-processors';
 import { useScorers } from '@/domains/scores/hooks/use-scorers';
@@ -26,42 +40,541 @@ import { useTools } from '@/domains/tools/hooks/use-all-tools';
 import { useWorkflows } from '@/domains/workflows/hooks/use-workflows';
 import { useLinkComponent } from '@/lib/framework';
 import { useMastraPlatform } from '@/lib/mastra-platform';
+import { bottomNav, mainNav } from '@/lib/nav/nav-items';
+import type { NavItem } from '@/lib/nav/nav-items';
 import { cn } from '@/lib/utils';
+
+import './navigation-command.css';
+
+type CommandScope = 'all' | 'paths' | 'agents' | 'workflows' | 'tooling' | 'evaluation' | 'observability' | 'settings';
+
+type ScopeOption = {
+  id: CommandScope;
+  label: string;
+  icon: React.ReactNode;
+  count: number;
+};
 
 type NavigationCommandItemProps = Omit<React.ComponentProps<typeof CommandItem>, 'children'> & {
   icon: React.ReactNode;
   title: string;
   subtitle?: string;
+  path?: string;
+  badge?: string;
   shortcut?: React.ReactNode;
 };
+
+const scopeButtonClassName =
+  'flex h-9 w-full cursor-pointer items-center gap-2 rounded-lg border border-transparent px-2.5 text-left text-ui-smd leading-ui-sm text-neutral3 transition-[background-color,border-color,color,transform] duration-150 ease-out hover:border-border1 hover:bg-surface4 hover:text-neutral6 active:scale-[0.99] data-[active=true]:border-border1 data-[active=true]:bg-surface4 data-[active=true]:text-neutral6';
+
+const resultIconClassName =
+  'mt-0.5 flex size-4 min-w-4 max-w-4 basis-4 shrink-0 items-center justify-center text-neutral3 transition-colors duration-150 ease-out group-data-[selected=true]:text-neutral6 [&>svg]:!size-4 [&>svg]:shrink-0';
+
+const CommandPath = ({ children }: { children: React.ReactNode }) => (
+  <span className="max-w-[13rem] truncate rounded-md border border-border1 bg-surface4/70 px-1.5 py-0.5 font-mono text-[10px] leading-none text-neutral3">
+    {children}
+  </span>
+);
 
 const NavigationCommandItem = ({
   icon,
   title,
   subtitle,
+  path,
+  badge,
   shortcut,
   className,
   ...props
 }: NavigationCommandItemProps) => {
   return (
-    <CommandItem className={cn('h-auto items-start gap-3 py-2', className)} {...props}>
-      <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center text-neutral3 [&>svg]:size-4">
-        {icon}
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-ui-sm font-medium leading-ui-sm text-neutral6">{title}</span>
-        {subtitle && <span className="truncate text-ui-xs leading-ui-xs text-neutral3">{subtitle}</span>}
+    <CommandItem
+      className={cn(
+        'group h-auto items-start gap-3 rounded-xl border border-transparent px-3 py-2.5 data-[selected=true]:border-border1 data-[selected=true]:bg-surface4/80',
+        'transition-[background-color,border-color] duration-150 ease-out',
+        className,
+      )}
+      {...props}
+    >
+      <span className={resultIconClassName}>{icon}</span>
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-ui-smd font-medium leading-ui-sm text-neutral6">{title}</span>
+          {badge && (
+            <span className="shrink-0 rounded-md border border-border1 bg-surface4/60 px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none text-neutral3">
+              {badge}
+            </span>
+          )}
+        </span>
+        {(subtitle || path) && (
+          <span className="flex min-w-0 items-center gap-2 text-ui-xs leading-ui-xs text-neutral3">
+            {subtitle && <span className="truncate">{subtitle}</span>}
+            {path && <CommandPath>{path}</CommandPath>}
+          </span>
+        )}
       </span>
       {shortcut}
     </CommandItem>
   );
 };
 
+const ScopeButton = ({
+  option,
+  activeScope,
+  onSelect,
+}: {
+  option: ScopeOption;
+  activeScope: CommandScope;
+  onSelect: () => void;
+}) => (
+  <button type="button" className={scopeButtonClassName} data-active={activeScope === option.id} onClick={onSelect}>
+    <span className="flex size-4 shrink-0 items-center justify-center [&>svg]:size-4">{option.icon}</span>
+    <span className="min-w-0 flex-1 truncate">{option.label}</span>
+    <span className="rounded-md border border-border1 bg-surface4/70 px-1.5 py-0.5 text-[10px] leading-none text-neutral3">
+      {option.count}
+    </span>
+  </button>
+);
+
+function getRouteValue(item: NavItem, sectionTitle?: string) {
+  return [item.name, item.url, sectionTitle, item.docs?.label, 'path route navigate'].filter(Boolean).join(' ');
+}
+
+function getRouteBadge(sectionTitle?: string) {
+  if (!sectionTitle || sectionTitle === 'Studio') return 'Path';
+  return sectionTitle;
+}
+
+function getObservabilityEntityPath(entity: string) {
+  return `/observability?entity=${encodeURIComponent(entity)}`;
+}
+
+type NavigationSection = {
+  key: string;
+  title: string;
+  items: NavItem[];
+};
+
+type NavigationPaths = ReturnType<typeof useLinkComponent>['paths'];
+type SidebarContextValue = NonNullable<ReturnType<typeof useMaybeSidebar>>;
+type HandleSelect = (path: string) => void;
+type AgentEntry = [string, { name: string }];
+type WorkflowEntry = [string, { name: string }];
+type ToolEntry = [string, { id: string }];
+type ProcessorEntry = {
+  id: string;
+  name?: string;
+  isWorkflow?: boolean;
+};
+type McpServerEntry = {
+  id: string;
+  name: string;
+};
+type ScorerEntry = [
+  string,
+  {
+    scorer?: {
+      config?: {
+        id?: string;
+        name?: string;
+      };
+    };
+  },
+];
+
+const CommandRail = ({
+  scopeOptions,
+  activeScope,
+  onScopeChange,
+}: {
+  scopeOptions: ScopeOption[];
+  activeScope: CommandScope;
+  onScopeChange: (scope: CommandScope) => void;
+}) => (
+  <aside className="navigation-command-surface navigation-command-surface-rail flex min-h-0 max-h-[min(14rem,32dvh)] flex-col overflow-hidden rounded-2xl border border-border1 bg-surface2 p-3 shadow-[0_8px_24px_-20px_rgb(0_0_0_/_0.55)] md:h-full md:max-h-none">
+    <ScrollArea className="-m-1 min-h-0 flex-1 p-1" viewPortClassName="pr-1">
+      <div className="flex flex-col gap-1">
+        {scopeOptions.map(option => (
+          <ScopeButton
+            key={option.id}
+            option={option}
+            activeScope={activeScope}
+            onSelect={() => onScopeChange(option.id)}
+          />
+        ))}
+      </div>
+    </ScrollArea>
+  </aside>
+);
+
+const ShortcutResults = ({
+  sidebar,
+  activeScope,
+  sidebarShortcutLabel,
+  setOpen,
+}: {
+  sidebar: SidebarContextValue | null;
+  activeScope: CommandScope;
+  sidebarShortcutLabel: string;
+  setOpen: (open: boolean) => void;
+}) => {
+  if (!sidebar || (activeScope !== 'all' && activeScope !== 'settings')) return null;
+
+  return (
+    <CommandGroup heading="Shortcuts">
+      <NavigationCommandItem
+        value="toggle sidebar collapse expand layout panel shortcut command b ctrl b"
+        onSelect={() => {
+          sidebar.toggleSidebar();
+          setOpen(false);
+        }}
+        icon={<PanelLeftIcon />}
+        title="Toggle Sidebar"
+        subtitle="Studio layout"
+        badge="Shortcut"
+        shortcut={
+          <CommandShortcut className="flex items-center">
+            <Kbd className="text-[10px]">{sidebarShortcutLabel}</Kbd>
+          </CommandShortcut>
+        }
+      />
+    </CommandGroup>
+  );
+};
+
+const PathSectionResults = ({
+  sections,
+  handleSelect,
+}: {
+  sections: NavigationSection[];
+  handleSelect: HandleSelect;
+}) => (
+  <>
+    {sections.map(section => (
+      <CommandGroup key={section.key} heading={section.title}>
+        {section.items.map(item => {
+          const Icon = item.Icon;
+          return (
+            <NavigationCommandItem
+              key={item.url}
+              value={getRouteValue(item, section.title)}
+              onSelect={() => handleSelect(item.url)}
+              icon={<Icon />}
+              title={item.name}
+              subtitle="Studio path"
+              path={item.url}
+              badge={getRouteBadge(section.title)}
+            />
+          );
+        })}
+      </CommandGroup>
+    ))}
+  </>
+);
+
+const AgentResults = ({
+  visible,
+  entries,
+  paths,
+  handleSelect,
+}: {
+  visible: boolean;
+  entries: AgentEntry[];
+  paths: NavigationPaths;
+  handleSelect: HandleSelect;
+}) => {
+  if (!visible || entries.length === 0) return null;
+
+  return (
+    <CommandGroup heading="Agents">
+      {entries.map(([id, agent]) => (
+        <NavigationCommandItem
+          key={id}
+          value={`${agent.name} ${id} chat agent conversation thread ${paths.agentLink(id)}`}
+          onSelect={() => handleSelect(paths.agentLink(id))}
+          icon={<AgentIcon />}
+          title={agent.name}
+          subtitle="Agent chat"
+          path={paths.agentLink(id)}
+          badge="Agent"
+        />
+      ))}
+    </CommandGroup>
+  );
+};
+
+const WorkflowResults = ({
+  visible,
+  entries,
+  paths,
+  handleSelect,
+}: {
+  visible: boolean;
+  entries: WorkflowEntry[];
+  paths: NavigationPaths;
+  handleSelect: HandleSelect;
+}) => {
+  if (!visible || entries.length === 0) return null;
+
+  return (
+    <CommandGroup heading="Workflows">
+      {entries.map(([id, workflow]) => (
+        <NavigationCommandItem
+          key={id}
+          value={`${workflow.name} ${id} graph workflow view ${paths.workflowLink(id)}`}
+          onSelect={() => handleSelect(paths.workflowLink(id))}
+          icon={<WorkflowIcon />}
+          title={workflow.name}
+          subtitle="Workflow graph"
+          path={paths.workflowLink(id)}
+          badge="Workflow"
+        />
+      ))}
+    </CommandGroup>
+  );
+};
+
+const ToolResults = ({
+  visible,
+  entries,
+  paths,
+  handleSelect,
+}: {
+  visible: boolean;
+  entries: ToolEntry[];
+  paths: NavigationPaths;
+  handleSelect: HandleSelect;
+}) => {
+  if (!visible || entries.length === 0) return null;
+
+  return (
+    <CommandGroup heading="Tools">
+      {entries.map(([id, tool]) => (
+        <NavigationCommandItem
+          key={id}
+          value={`tool ${tool.id} ${id} ${paths.toolLink(id)}`}
+          onSelect={() => handleSelect(paths.toolLink(id))}
+          icon={<ToolsIcon />}
+          title={tool.id}
+          subtitle="Tool definition"
+          path={paths.toolLink(id)}
+          badge="Tool"
+        />
+      ))}
+    </CommandGroup>
+  );
+};
+
+const ProcessorResults = ({
+  visible,
+  entries,
+  paths,
+  handleSelect,
+}: {
+  visible: boolean;
+  entries: ProcessorEntry[];
+  paths: NavigationPaths;
+  handleSelect: HandleSelect;
+}) => {
+  if (!visible || entries.length === 0) return null;
+
+  return (
+    <CommandGroup heading="Processors">
+      {entries.map(processor => {
+        const displayName = processor.name || processor.id;
+        const targetPath = processor.isWorkflow
+          ? paths.workflowLink(processor.id) + '/graph'
+          : paths.processorLink(processor.id);
+        return (
+          <NavigationCommandItem
+            key={processor.id}
+            value={`processor ${displayName} ${processor.id} ${targetPath}`}
+            onSelect={() => handleSelect(targetPath)}
+            icon={<Cpu />}
+            title={displayName}
+            subtitle={processor.isWorkflow ? 'Workflow processor' : 'Processor'}
+            path={targetPath}
+            badge="Processor"
+          />
+        );
+      })}
+    </CommandGroup>
+  );
+};
+
+const McpServerResults = ({
+  visible,
+  entries,
+  paths,
+  handleSelect,
+}: {
+  visible: boolean;
+  entries: McpServerEntry[];
+  paths: NavigationPaths;
+  handleSelect: HandleSelect;
+}) => {
+  if (!visible || entries.length === 0) return null;
+
+  return (
+    <CommandGroup heading="MCP Servers">
+      {entries.map(server => (
+        <NavigationCommandItem
+          key={server.id}
+          value={`mcp server ${server.name} ${server.id} ${paths.mcpServerLink(server.id)}`}
+          onSelect={() => handleSelect(paths.mcpServerLink(server.id))}
+          icon={<McpServerIcon />}
+          title={server.name}
+          subtitle="MCP server"
+          path={paths.mcpServerLink(server.id)}
+          badge="MCP"
+        />
+      ))}
+    </CommandGroup>
+  );
+};
+
+const ObservabilityResults = ({
+  visible,
+  agentEntries,
+  workflowEntries,
+  handleSelect,
+}: {
+  visible: boolean;
+  agentEntries: AgentEntry[];
+  workflowEntries: WorkflowEntry[];
+  handleSelect: HandleSelect;
+}) => {
+  if (!visible) return null;
+
+  return (
+    <>
+      <CommandGroup heading="Observability">
+        <NavigationCommandItem
+          value="observability traces telemetry signals /observability"
+          onSelect={() => handleSelect('/observability')}
+          icon={<EyeIcon />}
+          title="Traces"
+          subtitle="Runtime traces"
+          path="/observability"
+          badge="Signal"
+        />
+        <NavigationCommandItem
+          value="metrics usage latency performance tokens /metrics"
+          onSelect={() => handleSelect('/metrics')}
+          icon={<GaugeIcon />}
+          title="Metrics"
+          subtitle="Runtime metrics"
+          path="/metrics"
+          badge="Signal"
+        />
+        <NavigationCommandItem
+          value="logs events runtime /logs"
+          onSelect={() => handleSelect('/logs')}
+          icon={<EyeIcon />}
+          title="Logs"
+          subtitle="Runtime logs"
+          path="/logs"
+          badge="Signal"
+        />
+      </CommandGroup>
+
+      {agentEntries.length > 0 && (
+        <CommandGroup heading="Agent Traces">
+          {agentEntries.map(([id, agent]) => {
+            const path = getObservabilityEntityPath(id);
+
+            return (
+              <NavigationCommandItem
+                key={id}
+                value={`${agent.name} ${id} traces agent observability telemetry`}
+                onSelect={() => handleSelect(path)}
+                icon={<EyeIcon />}
+                title={agent.name}
+                subtitle="Agent traces"
+                path={path}
+                badge="Trace"
+              />
+            );
+          })}
+        </CommandGroup>
+      )}
+
+      {workflowEntries.length > 0 && (
+        <CommandGroup heading="Workflow Traces">
+          {workflowEntries.map(([id, workflow]) => {
+            const path = getObservabilityEntityPath(workflow.name);
+
+            return (
+              <NavigationCommandItem
+                key={id}
+                value={`${workflow.name} ${id} traces workflow observability telemetry`}
+                onSelect={() => handleSelect(path)}
+                icon={<EyeIcon />}
+                title={workflow.name}
+                subtitle="Workflow traces"
+                path={path}
+                badge="Trace"
+              />
+            );
+          })}
+        </CommandGroup>
+      )}
+    </>
+  );
+};
+
+const EvaluationResults = ({
+  visible,
+  entries,
+  paths,
+  handleSelect,
+}: {
+  visible: boolean;
+  entries: ScorerEntry[];
+  paths: NavigationPaths;
+  handleSelect: HandleSelect;
+}) => {
+  if (!visible || entries.length === 0) return null;
+
+  return (
+    <CommandGroup heading="Scorers">
+      {entries.map(([id, scorer]) => {
+        const name = scorer.scorer?.config?.name || scorer.scorer?.config?.id || id;
+        return (
+          <NavigationCommandItem
+            key={id}
+            value={`scorer score evaluation ${name} ${id} ${paths.scorerLink(id)}`}
+            onSelect={() => handleSelect(paths.scorerLink(id))}
+            icon={<GaugeIcon />}
+            title={name}
+            subtitle="Evaluation scorer"
+            path={paths.scorerLink(id)}
+            badge="Scorer"
+          />
+        );
+      })}
+    </CommandGroup>
+  );
+};
+
+const CommandFooter = () => (
+  <div className="navigation-command-footer pointer-events-none absolute inset-x-0 bottom-0 z-20 flex items-end justify-between gap-3 px-4 pb-2 pt-5 text-ui-xs text-neutral3">
+    <span className="truncate">Studio search</span>
+    <span className="flex shrink-0 items-center gap-1.5">
+      <Kbd className="min-w-5 px-1 text-[10px]">↑</Kbd>
+      <Kbd className="min-w-5 px-1 text-[10px]">↓</Kbd>
+      <Kbd className="min-w-5 px-1 text-[10px]">↵</Kbd>
+      <Kbd className="min-w-5 px-1 text-[10px]">Esc</Kbd>
+    </span>
+  </div>
+);
+
 export const NavigationCommand = () => {
   const { open, setOpen } = useNavigationCommand();
   const { navigate, paths } = useLinkComponent();
   const { isMastraPlatform } = useMastraPlatform();
   const sidebar = useMaybeSidebar();
+  const sidebarShortcutLabel = useKeyboardShortcutLabel('B');
+  const [activeScope, setActiveScope] = React.useState<CommandScope>('all');
 
   const { data: agents = {} } = useAgents();
   const { data: workflows = {} } = useWorkflows();
@@ -69,11 +582,30 @@ export const NavigationCommand = () => {
   const { data: processors = {} } = useProcessors();
   const { data: mcpServers = [] } = useMCPServers();
   const { data: scorers = {} } = useScorers();
+  const { isCmsAvailable, isLoading: isCmsLoading } = useIsCmsAvailable();
+  const { hasPermission, hasAnyPermission, isLoading: isPermissionsLoading } = usePermissions();
+
+  React.useEffect(() => {
+    if (!open) setActiveScope('all');
+  }, [open]);
 
   const handleSelect = (path: string) => {
     navigate(path);
     setOpen(false);
   };
+
+  const filterNavItem = React.useCallback(
+    (item: NavItem) => {
+      if (item.url === '/prompts' && !isCmsAvailable && !isCmsLoading) return false;
+      if (isMastraPlatform && !item.isOnMastraPlatform) return false;
+
+      const requiredPermission = getPermissionForRoute(item.url);
+      if (isPermissionsLoading && requiredPermission && requiredPermission !== 'public') return false;
+
+      return hasRoutePermission(requiredPermission, hasPermission, hasAnyPermission);
+    },
+    [hasAnyPermission, hasPermission, isCmsAvailable, isCmsLoading, isMastraPlatform, isPermissionsLoading],
+  );
 
   const agentEntries = Object.entries(agents);
   const workflowEntries = Object.entries(workflows);
@@ -81,233 +613,150 @@ export const NavigationCommand = () => {
   const processorEntries = Object.values(processors).filter(p => p.phases && p.phases.length > 0);
   const scorerEntries = Object.entries(scorers);
 
+  const navigationSections = React.useMemo(() => {
+    const sections: NavigationSection[] = [];
+    for (const section of mainNav) {
+      const items = section.items.filter(filterNavItem);
+      if (items.length > 0) sections.push({ key: section.key, title: section.title, items });
+    }
+
+    const studioItems: NavItem[] = [
+      ...bottomNav.filter(filterNavItem),
+      ...(!isMastraPlatform
+        ? [
+            {
+              name: 'Templates',
+              url: '/templates',
+              Icon: PackageIcon,
+              isOnMastraPlatform: false,
+            },
+          ]
+        : []),
+    ];
+
+    if (studioItems.length === 0) return sections;
+    return [...sections, { key: 'studio', title: 'Studio', items: studioItems }];
+  }, [filterNavItem, isMastraPlatform]);
+
+  const pathCount = navigationSections.reduce((count, section) => count + section.items.length, 0);
+  const toolingCount = toolEntries.length + processorEntries.length + mcpServers.length;
+  const evaluationCount = scorerEntries.length;
+  const observabilityCount = agentEntries.length + workflowEntries.length + 3;
+  const settingsCount = navigationSections.find(section => section.key === 'studio')?.items.length ?? 0;
+  const allCount =
+    pathCount + agentEntries.length + workflowEntries.length + toolingCount + evaluationCount + observabilityCount;
+
+  const scopeOptions: ScopeOption[] = [
+    { id: 'all', label: 'All', icon: <SearchIcon />, count: allCount },
+    { id: 'paths', label: 'Paths', icon: <RouteIcon />, count: pathCount },
+    { id: 'agents', label: 'Agents', icon: <AgentIcon />, count: agentEntries.length },
+    { id: 'workflows', label: 'Workflows', icon: <WorkflowIcon />, count: workflowEntries.length },
+    { id: 'tooling', label: 'Tooling', icon: <Layers3Icon />, count: toolingCount },
+    { id: 'evaluation', label: 'Evaluation', icon: <GaugeIcon />, count: evaluationCount },
+    { id: 'observability', label: 'Signals', icon: <EyeIcon />, count: observabilityCount },
+    { id: 'settings', label: 'Studio', icon: <SlidersHorizontalIcon />, count: settingsCount },
+  ];
+
+  const showPaths = activeScope === 'all' || activeScope === 'paths';
+  const showAgents = activeScope === 'all' || activeScope === 'agents';
+  const showWorkflows = activeScope === 'all' || activeScope === 'workflows';
+  const showTooling = activeScope === 'all' || activeScope === 'tooling';
+  const showEvaluation = activeScope === 'all' || activeScope === 'evaluation';
+  const showObservability = activeScope === 'all' || activeScope === 'observability';
+  const showSettings = activeScope === 'settings';
+
+  const visiblePathSections = React.useMemo(() => {
+    const sections: NavigationSection[] = [];
+    for (const section of navigationSections) {
+      if (showSettings) {
+        if (section.key === 'studio') sections.push(section);
+        continue;
+      }
+
+      const isVisible =
+        (activeScope === 'evaluation' && section.key === 'evaluation') ||
+        (activeScope === 'observability' && section.key === 'observability') ||
+        (showPaths && (activeScope === 'all' || section.key !== 'studio'));
+
+      if (isVisible) sections.push(section);
+    }
+    return sections;
+  }, [activeScope, navigationSections, showPaths, showSettings]);
+
   return (
     <CommandDialog
       open={open}
       onOpenChange={setOpen}
-      title="Navigation"
-      description="Search and navigate to any entity"
+      title="Mastra Studio Search"
+      description="Search Studio routes and runtime entities"
+      showOverlay
+      overlayClassName="bg-surface1/40 backdrop-blur-none"
+      contentClassName="navigation-command-popup max-w-[min(56rem,calc(100vw-2rem))] overflow-visible border-none bg-transparent p-0 shadow-none backdrop-blur-none sm:max-w-[min(56rem,calc(100vw-2rem))]"
+      commandClassName={cn(
+        'h-[min(42rem,calc(100dvh-2rem))] min-h-[min(30rem,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] gap-2 overflow-visible rounded-none bg-transparent text-neutral4 shadow-none backdrop-blur-none',
+        '[&_[data-slot=command-input-wrapper]]:h-14 [&_[data-slot=command-input-wrapper]]:shrink-0 [&_[data-slot=command-input-wrapper]]:rounded-xl [&_[data-slot=command-input-wrapper]]:border [&_[data-slot=command-input-wrapper]]:border-border1 [&_[data-slot=command-input-wrapper]]:bg-surface3 [&_[data-slot=command-input-wrapper]]:px-4 [&_[data-slot=command-input-wrapper]]:shadow-[0_6px_18px_-16px_rgb(0_0_0_/_0.55)]',
+        '[&_[data-slot=command-input-wrapper]]:pr-11 [&_[data-slot=command-input-wrapper]]:transition-[border-color,box-shadow] [&_[data-slot=command-input-wrapper]]:duration-150 [&_[data-slot=command-input-wrapper]]:ease-out [&_[data-slot=command-input-wrapper]:focus-within]:border-border1 [&_[data-slot=command-input-wrapper]:focus-within]:bg-surface3 [&_[data-slot=command-input-wrapper]:focus-within]:shadow-[0_8px_22px_-18px_rgb(0_0_0_/_0.6)] [&_[data-slot=command-input-wrapper]_svg]:text-neutral4',
+        '**:[[cmdk-input]]:h-full **:[[cmdk-input]]:text-ui-md',
+        '**:[[cmdk-group]]:p-0 **:[[cmdk-group-heading]]:px-3 **:[[cmdk-group-heading]]:pb-2 **:[[cmdk-group-heading]]:pt-3',
+        '**:[[cmdk-item]]:px-3 **:[[cmdk-item]]:py-2.5',
+      )}
     >
-      <CommandInput placeholder="Search or navigate..." />
-      <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
+      <CommandInput
+        placeholder="Search Studio, agents, workflows, tools, paths..."
+        wrapperClassName="navigation-command-surface navigation-command-surface-input"
+      />
 
-        <CommandGroup heading="Navigation">
-          {sidebar && (
-            <NavigationCommandItem
-              value="toggle sidebar collapse expand layout panel"
-              onSelect={() => {
-                sidebar.toggleSidebar();
-                setOpen(false);
-              }}
-              icon={<PanelLeftIcon />}
-              title="Toggle Sidebar"
-              subtitle="Layout"
-              shortcut={<CommandShortcut>Ctrl+B</CommandShortcut>}
-            />
-          )}
-          <NavigationCommandItem
-            value="all agents agents chat /agents"
-            onSelect={() => handleSelect('/agents')}
-            icon={<AgentIcon />}
-            title="All Agents"
-            subtitle="Browse and chat with agents"
-          />
-          <NavigationCommandItem
-            value="all workflows workflows graph /workflows"
-            onSelect={() => handleSelect('/workflows')}
-            icon={<WorkflowIcon />}
-            title="All Workflows"
-            subtitle="Browse workflow graphs"
-          />
-          <NavigationCommandItem
-            value="all tools tools /tools"
-            onSelect={() => handleSelect('/tools')}
-            icon={<ToolsIcon />}
-            title="All Tools"
-            subtitle="Inspect available tools"
-          />
-          <NavigationCommandItem
-            value="all scorers scores evaluation /scorers"
-            onSelect={() => handleSelect('/scorers')}
-            icon={<GaugeIcon />}
-            title="All Scorers"
-            subtitle="Manage evaluation scorers"
-          />
-          <NavigationCommandItem
-            value="all processors processors /processors"
-            onSelect={() => handleSelect('/processors')}
-            icon={<Cpu />}
-            title="All Processors"
-            subtitle="Review input and output processors"
-          />
-          <NavigationCommandItem
-            value="all mcp servers mcp /mcps"
-            onSelect={() => handleSelect('/mcps')}
-            icon={<McpServerIcon />}
-            title="All MCP Servers"
-            subtitle="Browse connected MCP servers"
-          />
-          <NavigationCommandItem
-            value="observability traces telemetry /observability"
-            onSelect={() => handleSelect('/observability')}
-            icon={<EyeIcon />}
-            title="Observability"
-            subtitle="Inspect traces and telemetry"
-          />
-          {!isMastraPlatform && (
-            <>
-              <NavigationCommandItem
-                value="settings configuration studio /settings"
-                onSelect={() => handleSelect('/settings')}
-                icon={<SettingsIcon />}
-                title="Settings"
-                subtitle="Configure Studio"
+      <div className="min-h-0 flex-1 rounded-2xl">
+        <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-2 md:grid-cols-[13rem_minmax(0,1fr)] md:grid-rows-none">
+          <CommandRail scopeOptions={scopeOptions} activeScope={activeScope} onScopeChange={setActiveScope} />
+
+          <div className="navigation-command-surface navigation-command-surface-results navigation-command-results-panel relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-border1 bg-surface2 shadow-[0_10px_28px_-22px_rgb(0_0_0_/_0.6)]">
+            <CommandList
+              scrollArea
+              scrollAreaClassName="min-h-0 flex-1 rounded-none"
+              scrollAreaViewportClassName="navigation-command-scroll-viewport"
+              className="navigation-command-list max-h-none rounded-none border-none bg-transparent shadow-none"
+            >
+              <CommandEmpty>No matching results.</CommandEmpty>
+              <ShortcutResults
+                sidebar={sidebar}
+                activeScope={activeScope}
+                sidebarShortcutLabel={sidebarShortcutLabel}
+                setOpen={setOpen}
               />
-              <NavigationCommandItem
-                value="templates starter projects examples /templates"
-                onSelect={() => handleSelect('/templates')}
-                icon={<PackageIcon />}
-                title="Templates"
-                subtitle="Create from a starter"
+              <PathSectionResults sections={visiblePathSections} handleSelect={handleSelect} />
+              <AgentResults visible={showAgents} entries={agentEntries} paths={paths} handleSelect={handleSelect} />
+              <WorkflowResults
+                visible={showWorkflows}
+                entries={workflowEntries}
+                paths={paths}
+                handleSelect={handleSelect}
               />
-            </>
-          )}
-        </CommandGroup>
-
-        {agentEntries.length > 0 && (
-          <>
-            <CommandSeparator />
-            <CommandGroup heading="Agents">
-              {agentEntries.map(([id, agent]) => (
-                <React.Fragment key={id}>
-                  <NavigationCommandItem
-                    value={`${agent.name} ${id} chat agent conversation ${paths.agentLink(id)}`}
-                    onSelect={() => handleSelect(paths.agentLink(id))}
-                    icon={<AgentIcon />}
-                    title={`${agent.name}: Chat`}
-                    subtitle="Agent conversation"
-                  />
-                  <NavigationCommandItem
-                    value={`${agent.name} ${id} traces agent observability telemetry`}
-                    onSelect={() => handleSelect(`/observability?entity=${id}`)}
-                    icon={<EyeIcon />}
-                    title={`${agent.name}: Traces`}
-                    subtitle="Agent observability"
-                  />
-                </React.Fragment>
-              ))}
-            </CommandGroup>
-          </>
-        )}
-
-        {workflowEntries.length > 0 && (
-          <>
-            <CommandSeparator />
-            <CommandGroup heading="Workflows">
-              {workflowEntries.map(([id, workflow]) => (
-                <React.Fragment key={id}>
-                  <NavigationCommandItem
-                    value={`${workflow.name} ${id} graph workflow view ${paths.workflowLink(id)}`}
-                    onSelect={() => handleSelect(paths.workflowLink(id))}
-                    icon={<WorkflowIcon />}
-                    title={`${workflow.name}: Graph`}
-                    subtitle="Workflow view"
-                  />
-                  <NavigationCommandItem
-                    value={`${workflow.name} ${id} traces workflow observability telemetry`}
-                    onSelect={() => handleSelect(`/observability?entity=${workflow.name}`)}
-                    icon={<EyeIcon />}
-                    title={`${workflow.name}: Traces`}
-                    subtitle="Workflow observability"
-                  />
-                </React.Fragment>
-              ))}
-            </CommandGroup>
-          </>
-        )}
-
-        {toolEntries.length > 0 && (
-          <>
-            <CommandSeparator />
-            <CommandGroup heading="Tools">
-              {toolEntries.map(([id, tool]) => (
-                <NavigationCommandItem
-                  key={id}
-                  value={`tool ${tool.id} ${id} ${paths.toolLink(id)}`}
-                  onSelect={() => handleSelect(paths.toolLink(id))}
-                  icon={<ToolsIcon />}
-                  title={tool.id}
-                  subtitle="Tool"
-                />
-              ))}
-            </CommandGroup>
-          </>
-        )}
-
-        {scorerEntries.length > 0 && (
-          <>
-            <CommandSeparator />
-            <CommandGroup heading="Scorers">
-              {scorerEntries.map(([id, scorer]) => {
-                const name = scorer.scorer?.config?.name || scorer.scorer?.config?.id || id;
-                return (
-                  <NavigationCommandItem
-                    key={id}
-                    value={`scorer score evaluation ${name} ${id} ${paths.scorerLink(id)}`}
-                    onSelect={() => handleSelect(paths.scorerLink(id))}
-                    icon={<GaugeIcon />}
-                    title={name}
-                    subtitle="Scorer"
-                  />
-                );
-              })}
-            </CommandGroup>
-          </>
-        )}
-
-        {processorEntries.length > 0 && (
-          <>
-            <CommandSeparator />
-            <CommandGroup heading="Processors">
-              {processorEntries.map(processor => {
-                const displayName = processor.name || processor.id;
-                const targetPath = processor.isWorkflow
-                  ? paths.workflowLink(processor.id) + '/graph'
-                  : paths.processorLink(processor.id);
-                return (
-                  <NavigationCommandItem
-                    key={processor.id}
-                    value={`processor ${displayName} ${processor.id} ${targetPath}`}
-                    onSelect={() => handleSelect(targetPath)}
-                    icon={<Cpu />}
-                    title={displayName}
-                    subtitle={processor.isWorkflow ? 'Workflow processor' : 'Processor'}
-                  />
-                );
-              })}
-            </CommandGroup>
-          </>
-        )}
-
-        {mcpServers.length > 0 && (
-          <>
-            <CommandSeparator />
-            <CommandGroup heading="MCP Servers">
-              {mcpServers.map(server => (
-                <NavigationCommandItem
-                  key={server.id}
-                  value={`mcp server ${server.name} ${server.id} ${paths.mcpServerLink(server.id)}`}
-                  onSelect={() => handleSelect(paths.mcpServerLink(server.id))}
-                  icon={<McpServerIcon />}
-                  title={server.name}
-                  subtitle="MCP server"
-                />
-              ))}
-            </CommandGroup>
-          </>
-        )}
-      </CommandList>
+              <ToolResults visible={showTooling} entries={toolEntries} paths={paths} handleSelect={handleSelect} />
+              <ProcessorResults
+                visible={showTooling}
+                entries={processorEntries}
+                paths={paths}
+                handleSelect={handleSelect}
+              />
+              <McpServerResults visible={showTooling} entries={mcpServers} paths={paths} handleSelect={handleSelect} />
+              <ObservabilityResults
+                visible={showObservability}
+                agentEntries={agentEntries}
+                workflowEntries={workflowEntries}
+                handleSelect={handleSelect}
+              />
+              <EvaluationResults
+                visible={showEvaluation}
+                entries={scorerEntries}
+                paths={paths}
+                handleSelect={handleSelect}
+              />
+            </CommandList>
+            <CommandFooter />
+          </div>
+        </div>
+      </div>
     </CommandDialog>
   );
 };

--- a/packages/playground/src/lib/command/use-navigation-command.ts
+++ b/packages/playground/src/lib/command/use-navigation-command.ts
@@ -1,13 +1,47 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 
-export const useNavigationCommand = () => {
-  const [open, setOpen] = useState(false);
+type NavigationCommandOpen = boolean | ((open: boolean) => boolean);
+
+type UseNavigationCommandOptions = {
+  enableShortcut?: boolean;
+};
+
+let navigationCommandOpen = false;
+const listeners = new Set<() => void>();
+
+const emit = () => {
+  listeners.forEach(listener => listener());
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getSnapshot = () => navigationCommandOpen;
+
+const setNavigationCommandOpen = (nextOpen: NavigationCommandOpen) => {
+  const resolved = typeof nextOpen === 'function' ? nextOpen(navigationCommandOpen) : nextOpen;
+  if (resolved === navigationCommandOpen) return;
+
+  navigationCommandOpen = resolved;
+  emit();
+};
+
+export const useNavigationCommand = ({ enableShortcut = true }: UseNavigationCommandOptions = {}) => {
+  const open = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const setOpen = useCallback((nextOpen: NavigationCommandOpen) => {
+    setNavigationCommandOpen(nextOpen);
+  }, []);
 
   const toggle = useCallback(() => {
-    setOpen(prev => !prev);
+    setNavigationCommandOpen(prev => !prev);
   }, []);
 
   useEffect(() => {
+    if (!enableShortcut) return;
+
     const down = (e: KeyboardEvent) => {
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
@@ -17,7 +51,7 @@ export const useNavigationCommand = () => {
 
     document.addEventListener('keydown', down);
     return () => document.removeEventListener('keydown', down);
-  }, [toggle]);
+  }, [enableShortcut, toggle]);
 
   return { open, setOpen, toggle };
 };


### PR DESCRIPTION
Polishes the shared command palette primitives and the current Studio navigation command. CommandDialog now lets Escape reach the dialog close handler while still stopping non-Escape keys, does not render the standard page-dimming overlay, and CommandInput supports a rightSlot for inline hints. DialogContent also has an opt-out for the standard overlay while preserving the default overlay for normal dialogs.

The playground sidebar now has a filled Search row that opens the shared command state, uses platform-aware shortcut labels, removes the redundant expanded tooltip, tightens spacing, and applies pointer cursor treatment to sidebar nav rows.

Validated with pnpm --filter ./packages/playground-ui test -- Command, pnpm --filter ./packages/playground-ui exec vitest run src/ds/components/Command/command.test.tsx src/ds/components/Dialog/dialog.test.tsx, pnpm --filter ./packages/playground-ui exec vitest run src/hooks/use-keyboard-shortcut-label.test.tsx, pnpm --filter ./packages/playground-ui exec vitest run src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx, pnpm --filter ./packages/playground-ui typecheck, pnpm --filter ./packages/playground typecheck, pnpm build:playground-ui, targeted ESLint/Prettier, and React Doctor. React Doctor still reports maintainability warnings around changed forwardRef patterns and the MainSidebar aggregate export file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes the playground’s command palette feel smoother and cleaner: pressing **Escape** works properly, the palette no longer adds an extra dark overlay, and it shows small keyboard hints. It also upgrades the sidebar “Search” row to open the same command palette state, with shortcut labels that automatically use **⌘ on Mac** and **Ctrl** elsewhere.

## Overview
Polishes the playground command palette and related UI components (keyboard handling, overlay behavior, inline input hints, styling), and improves the playground sidebar “Search” entry by wiring it into a shared navigation-command store with platform-aware shortcut labels. Adds substantial component test coverage and updates Storybook stories.

## Command Dialog + Command input improvements
- **Escape key behavior:** Updated `CommandDialog` keyboard handling so **Escape can reach the close handler** while preventing other keys from propagating.
- **Overlay behavior:** `CommandDialog` no longer renders the standard page-dimming overlay.
- **More customization props:** `CommandDialog` supports `contentClassName`, `commandClassName`, `showOverlay`, and `overlayClassName`.
- **Inline hint support:** `CommandInput` gains a **`rightSlot`** prop (used for inline hints like “Esc”) and supports `wrapperClassName`.
- **Scroll-enabled command lists:** `CommandList` adds optional `scrollArea` support (wrapped in `ScrollArea` with related class hooks).
- **Data-slot selector tweaks:** Styling selectors were updated to target the input wrapper via `data-slot="command-input-wrapper"`.

## Dialog overlay opt-out (shared component)
- `DialogContent` now supports:
  - **`showOverlay?: boolean`** (default `true`) to suppress `DialogOverlay`
  - **`overlayClassName?: string`** to customize overlay classes when shown
- Added tests to confirm default overlay rendering and correct opt-out/custom overlay class application.

## Playground sidebar + navigation command enhancements
- **Filled “Search” row:** `AppSidebar`’s Search entry is now a button-based nav link that opens the navigation command and closes the mobile sidebar first; includes an inline shortcut hint when appropriate.
- **Shared command state:** `useNavigationCommand` was refactored to use a **module-level external store** (`useSyncExternalStore`) to keep sidebar and dialog state in sync, with an `enableShortcut` option.
- **Navigation command rewrite:** `NavigationCommand` is now **data-driven** with:
  - sectioned results built from main/bottom nav + CMS/platform/permission gating
  - an optional **left rail / scope filtering** UX that resets on close
  - dynamic command entries for entities (agents, workflows, tools, processors, MCP servers, observability paths, scorers/evaluation)
  - updated metadata and command input UI text/styling
- **Shortcut labels are platform-aware:** Added `useIsApplePlatform` + `useKeyboardShortcutLabel` (⌘ vs Ctrl) and tests that mock navigator fields.
- **UI polish:**
  - tighter spacing in the sidebar
  - pointer cursor styling for navigation rows
  - removed redundant expanded tooltip usage
  - updated sidebar nav list spacing (`gap-0.5`)
- **Styling organization:** Sidebar nav-row class generation was extracted into `main-sidebar-nav-item-classes`, with re-export updates.

## Stories + testing/validation
- **Storybook:** Added a compact “Inline Vercel style” command palette story variant.
- **Tests added/expanded:**
  - command/dialog keyboard behavior (Escape handling and key propagation)
  - confirm **no standard overlay** for `CommandDialog`
  - `rightSlot` rendering and `wrapperClassName` behavior
  - overlay class behavior when `showOverlay`/`overlayClassName` are provided
  - `CommandList` scroll-area structure rendering and focus outline class removal
  - shortcut label hook correctness across Apple/Windows detection
  - sidebar nav link cursor-pointer + tooltip trigger changes
- **Validation mentioned:** component tests, keyboard shortcut label tests, type checking, ESLint/Prettier, and React Doctor analysis (including maintainability warnings around `forwardRef` pattern changes and sidebar export aggregation).

## Packaging
- Added a changeset for `@mastra/playground-ui` to publish a minor release documenting the UI/command-palette improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->