### PR TITLE
chore: restore hosted runners for npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,7 +43,7 @@ jobs:
         (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: version packages') && github.event.head_commit.author.username == 'dane-ai-mastra[bot]') ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_type == 'prerelease')
       )
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
@@ -157,7 +157,7 @@ jobs:
       github.repository == 'mastra-ai/mastra' && 
       github.event_name == 'workflow_dispatch' && 
       github.event.inputs.publish_type == 'stable'
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -315,7 +315,7 @@ jobs:
         (github.event.inputs.publish_type == 'stable' && !inputs.dry_run && needs.stable.result == 'success') ||
         github.event.inputs.publish_type == 'enter-prerelease'
       )
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -386,7 +386,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && 
       github.event.inputs.publish_type == 'snapshot' &&
       github.ref != 'refs/heads/main'
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary\n- switch npm publish workflow jobs back to GitHub-hosted runners\n\n## Testing\n- not run (workflow YAML only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This pull request switches the npm publish workflow back to using GitHub's standard computers to run jobs instead of custom computers. It's like going back to using a regular tool instead of a specialized one - it's simpler and easier for everyone to understand and manage.

## Summary of Changes

Updated the npm publish workflow configuration (`.github/workflows/npm-publish.yml`) to restore GitHub-hosted runners across four jobs:
- `prerelease`
- `stable`
- `enter_prerelease`
- `snapshot`

Each job's `runs-on` value was changed from `starsling-ubuntu-24.04` (custom runner) to `ubuntu-latest` (GitHub-hosted runner). No other workflow logic, steps, inputs, or publish commands were modified.

**Lines changed:** 4 additions, 4 deletions

**Note:** This change has not been tested in a live environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->