### PR TITLE
fix(core): stop harness default temperature

### DIFF
--- a/.changeset/harness-omit-default-temperature.md
+++ b/.changeset/harness-omit-default-temperature.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed Harness runs so they no longer send a default temperature when the caller did not configure model settings.

--- a/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
+++ b/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
@@ -70,6 +70,42 @@ function createTextStream() {
 }
 
 describe('Harness: tool suspension and resumption', () => {
+  it('should not inject default model settings when sending a message', async () => {
+    const agent = new Agent({
+      id: 'test-agent-default-model-settings',
+      name: 'Test Agent Default Model Settings',
+      instructions: 'You answer directly.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-default-model-settings': agent },
+      logger: false,
+      storage,
+    });
+
+    const registeredAgent = mastra.getAgent('test-agent-default-model-settings');
+    const streamSpy = vi.spyOn(registeredAgent, 'stream');
+
+    const harness = new Harness({
+      id: 'test-harness-default-model-settings',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+    });
+
+    await harness.init();
+    await harness.createThread();
+
+    await harness.sendMessage({ content: 'Hello' });
+
+    expect(streamSpy).toHaveBeenCalled();
+    const [, streamOptions] = streamSpy.mock.calls[0] as [any, any];
+    expect(streamOptions.modelSettings).toBeUndefined();
+  });
+
   it('should emit a suspension-related event when a tool calls suspend(), not silently complete', async () => {
     // Tool that suspends mid-execution waiting for external input
     const confirmTool = createTool({
@@ -415,5 +451,6 @@ describe('Harness: tool suspension and resumption', () => {
     // Must match the budget used for the initial stream, not the agent default.
     expect(resumeOptions.maxSteps).toBe(1000);
     expect(resumeOptions.savePerStep).toBe(false);
+    expect(resumeOptions.modelSettings).toBeUndefined();
   });
 });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1932,7 +1932,6 @@ export class Harness<TState = {}> {
       maxSteps: HARNESS_MAX_STEPS,
       savePerStep: false,
       requireToolApproval: !isYolo,
-      modelSettings: { temperature: 1 },
     };
 
     // Auto-enable Anthropic server-side fallbacks for fable-5 so a classifier


### PR DESCRIPTION
## Summary
- Stop Harness runs from injecting `modelSettings.temperature = 1` when the caller did not configure model settings.
- Add regression coverage for initial Harness streams and resumed runs so default model settings stay omitted while the shared run budget is preserved.
- This supersedes #18101 by removing the default sampling param instead of maintaining a reasoning-model allowlist/denylist.

Fixes #18074

## Testing
- `git diff --check`
- Not run: focused Vitest suite. This environment does not have `node`, `pnpm`, or `node_modules` available on PATH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Harness component was automatically adding a temperature setting to all model requests, but some advanced AI models (like reasoning models) reject this setting and return an error. This PR stops automatically adding that temperature setting, allowing each application to only include it when needed.

## Changes Made

### Removed Default Temperature Injection

The Harness component no longer injects a default `modelSettings` override (`{ temperature: 1 }`) when building shared run options. This resolves the `[400] Unsupported parameter: temperature` errors that users experienced when selecting reasoning models (GPT-5.5 at high/xhigh reasoning effort or o-series models) through an OpenAI-compatible provider.

### Test Coverage Added

Added regression test coverage to verify the fix:

- **Initial Harness Streams**: New test case verifies that `sendMessage()` does not inject `modelSettings` into the underlying agent `stream()` call when using default mode
- **Resumed Runs**: Extended existing test to assert that `resumeStream()` calls also omit `modelSettings` 

These tests ensure that default model settings remain omitted while preserving other shared run budget functionality (`maxSteps`, `savePerStep`, `requireToolApproval`).

### Changeset Entry

Added a new changeset entry documenting a patch version bump for `@mastra/core`.

## Impact

This change allows callers to explicitly configure temperature only when needed, rather than having the Harness inject unsupported parameters into model requests. The fix is implemented at the core model-request building level in `@mastra/core`, eliminating the need for conditional logic based on model capability flags or downstream application-level workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->