### PR TITLE
docs(harness): sharpen overview and session pages

### DIFF
--- a/docs/src/content/en/docs/harness/modes.mdx
+++ b/docs/src/content/en/docs/harness/modes.mdx
@@ -113,6 +113,8 @@ await harness.switchMode({ modeId: 'build' })
 
 ## Querying modes
 
+The Harness exposes the full mode catalog, while the Session tracks which mode is active. Use `harness.listModes()` to read every configured mode, `harness.session.mode.get()` for the active mode ID, and `harness.session.mode.resolve()` for the active mode's full definition:
+
 ```typescript
 // List all configured modes
 const modes = harness.listModes()

--- a/docs/src/content/en/docs/harness/modes.mdx
+++ b/docs/src/content/en/docs/harness/modes.mdx
@@ -9,7 +9,7 @@ packages:
 
 Modes define the different behaviors a Harness can run. Each mode layers its own instructions and tool overrides on top of a shared backing agent, so the same agent can act as a planner in one mode and an executor in another. The Harness keeps exactly one mode active at a time, carries the thread and state across switches, and handles the transition between them.
 
-Every Harness needs at least one mode — the `modes` array is required, and the Harness throws at construction if it's empty. A single-purpose Harness still defines one mode; multiple modes are how you give a session more than one behavior to switch between. The active mode at startup is the one marked `metadata.default`, the mode named by `defaultModeId`, or the first mode in the array if neither is set.
+Every Harness needs at least one mode — the `modes` array is required, and the Harness throws at construction if it's empty. A single-purpose Harness still defines one mode; multiple modes are how you give a session more than one behavior to switch between.
 
 A mode supplies three things that change how the agent behaves:
 

--- a/docs/src/content/en/docs/harness/modes.mdx
+++ b/docs/src/content/en/docs/harness/modes.mdx
@@ -9,11 +9,9 @@ packages:
 
 Modes define the different behaviors a Harness can run. Each mode layers its own instructions and tool overrides on top of a shared backing agent, so the same agent can act as a planner in one mode and an executor in another. The Harness keeps exactly one mode active at a time, carries the thread and state across switches, and handles the transition between them.
 
-## Modes are required
+Every Harness needs at least one mode — the `modes` array is required, and the Harness throws at construction if it's empty. A single-purpose Harness still defines one mode; multiple modes are how you give a session more than one behavior to switch between. The active mode at startup is the one marked `metadata.default`, the mode named by `defaultModeId`, or the first mode in the array if neither is set.
 
-Every Harness has at least one mode. The `modes` array is required, and the Harness throws at construction if it's empty. A single-purpose Harness still defines one mode; multiple modes are how you give a single session more than one behavior to switch between.
-
-The active mode at startup is the one marked `metadata.default`, the mode named by `defaultModeId`, or the first mode in the array if neither is set. A mode supplies three things that change how the agent behaves:
+A mode supplies three things that change how the agent behaves:
 
 - **Instructions**: layered on top of the backing agent's own instructions while the mode is active.
 - **Tools**: either replacing or adding to the backing agent's tools (see [Mode tool overrides](#mode-tool-overrides)).

--- a/docs/src/content/en/docs/harness/modes.mdx
+++ b/docs/src/content/en/docs/harness/modes.mdx
@@ -7,11 +7,19 @@ packages:
 
 # Modes
 
-Modes define the different personalities or capability sets available within a Harness. Each mode layers its own instructions and tool overrides on top of a shared backing agent. The Harness ensures only one mode is active at a time and handles transitions between them.
+Modes define the different behaviors a Harness can run. Each mode layers its own instructions and tool overrides on top of a shared backing agent, so the same agent can act as a planner in one mode and an executor in another. The Harness keeps exactly one mode active at a time, carries the thread and state across switches, and handles the transition between them.
 
-## When to use modes
+## Modes are required
 
-Use modes when a single conversational session needs to switch between distinct behaviors. For example, a planning mode that reasons about tasks and a build mode that executes them. Modes share the same thread and state, so the agent retains context across switches.
+Every Harness has at least one mode. The `modes` array is required, and the Harness throws at construction if it's empty. A single-purpose Harness still defines one mode; multiple modes are how you give a single session more than one behavior to switch between.
+
+The active mode at startup is the one marked `metadata.default`, the mode named by `defaultModeId`, or the first mode in the array if neither is set. A mode supplies three things that change how the agent behaves:
+
+- **Instructions**: layered on top of the backing agent's own instructions while the mode is active.
+- **Tools**: either replacing or adding to the backing agent's tools (see [Mode tool overrides](#mode-tool-overrides)).
+- **Model**: an optional `defaultModelId` to bootstrap model selection when the session enters the mode.
+
+Because every mode shares the same backing agent, thread, and state, switching modes changes how the agent behaves without losing conversation context.
 
 ## Quickstart
 

--- a/docs/src/content/en/docs/harness/overview.mdx
+++ b/docs/src/content/en/docs/harness/overview.mdx
@@ -13,9 +13,7 @@ The `Harness` feature is in alpha stage and subject to breaking changes in minor
 
 :::
 
-An agent harness is the runtime that wraps a model and governs how it behaves in a real application. The model does the reasoning; the harness gives it the tools, memory, and safety limits it needs to act on that reasoning, and manages the agent's lifecycle, context, and interactions with the outside world.
-
-In practice, the Harness is a session controller for interactive agent applications. It handles the runtime concerns that sit between your UI and the agent loop: managing conversation threads, switching between agent modes, persisting state, gating tool execution with approvals, and coordinating subagents. You can focus on what your agent does rather than how to wire it together.
+The Harness is a session controller for building interactive agent applications. It handles the runtime concerns that sit between your UI and the agent loop: managing conversation threads, switching between agent modes, persisting state, gating tool execution with approvals, and coordinating subagents. You can focus on what your agent does rather than how to wire it together.
 
 A Harness exposes a [`Session`](/docs/harness/session) — the per-conversation runtime state that tracks the active mode, model, thread binding, permission grants, follow-up queue, and token usage. The Harness is the shared host; the Session is the conversation running inside it. In a multi-user host, the same Harness can back many Sessions at once.
 

--- a/docs/src/content/en/docs/harness/overview.mdx
+++ b/docs/src/content/en/docs/harness/overview.mdx
@@ -13,7 +13,7 @@ The `Harness` feature is in alpha stage and subject to breaking changes in minor
 
 :::
 
-An agent harness is the runtime that wraps a model and governs how it behaves in a real application. The model does the reasoning; the harness gives it the tools, memory, and safety limits it needs to act on that reasoning. This is the line between a framework and a harness: the [Agent class](/docs/agents/overview) and the rest of Mastra are the libraries you build an agent from, while the Harness is the running system that manages that agent's lifecycle, context, and interactions with the outside world.
+An agent harness is the runtime that wraps a model and governs how it behaves in a real application. The model does the reasoning; the harness gives it the tools, memory, and safety limits it needs to act on that reasoning, and manages the agent's lifecycle, context, and interactions with the outside world.
 
 In practice, the Harness is a session controller for interactive agent applications. It handles the runtime concerns that sit between your UI and the agent loop: managing conversation threads, switching between agent modes, persisting state, gating tool execution with approvals, and coordinating subagents. You can focus on what your agent does rather than how to wire it together.
 

--- a/docs/src/content/en/docs/harness/overview.mdx
+++ b/docs/src/content/en/docs/harness/overview.mdx
@@ -13,7 +13,9 @@ The `Harness` feature is in alpha stage and subject to breaking changes in minor
 
 :::
 
-The Harness is a session controller for building interactive agent applications. It handles the runtime concerns that sit between your UI and the agent loop: managing conversation threads, switching between agent modes, persisting state, gating tool execution with approvals, and coordinating subagents. You can focus on what your agent does rather than how to wire it together.
+An agent harness is the runtime that wraps a model and governs how it behaves in a real application. The model does the reasoning; the harness gives it the tools, memory, and safety limits it needs to act on that reasoning. This is the line between a framework and a harness: the [Agent class](/docs/agents/overview) and the rest of Mastra are the libraries you build an agent from, while the Harness is the running system that manages that agent's lifecycle, context, and interactions with the outside world.
+
+In practice, the Harness is a session controller for interactive agent applications. It handles the runtime concerns that sit between your UI and the agent loop: managing conversation threads, switching between agent modes, persisting state, gating tool execution with approvals, and coordinating subagents. You can focus on what your agent does rather than how to wire it together.
 
 A Harness exposes a [`Session`](/docs/harness/session) — the per-conversation runtime state that tracks the active mode, model, thread binding, permission grants, follow-up queue, and token usage. The Harness is the shared host; the Session is the conversation running inside it. In a multi-user host, the same Harness can back many Sessions at once.
 
@@ -21,14 +23,15 @@ A Harness exposes a [`Session`](/docs/harness/session) — the per-conversation 
 
 ## What you can build
 
-The Harness is designed for applications where a user has an ongoing, interactive session with one or more AI agents:
+The Harness gives you the runtime pieces to ship interactive agent applications. Each outcome below maps to a capability you can use today:
 
-| Application | How the Harness helps |
-| - | - |
-| **Coding agents** (TUI or IDE) | Plan mode reasons about changes, build mode executes them. Thread persistence resumes conversations across sessions. Tool approvals gate destructive operations like file writes. |
-| **Multi-step assistants** | A research mode gathers information, a drafting mode produces output. Shared state tracks progress. Subagents handle focused subtasks (e.g., web search, code review). |
-| **Copilot UIs** | Model switching lets users pick the right model for the job. Permission policies control which tools run automatically vs. requiring confirmation. Event subscriptions drive real-time UI updates. |
-| **Autonomous task runners** | Background agents with structured task lists, heartbeat handlers for health checks, and observational memory for learning across threads. |
+- **Resume a conversation exactly where the user left off.** Persistent [threads and state](/docs/harness/threads-and-state) reload the active mode, model, and progress across restarts, so a coding agent or assistant picks up mid-task instead of starting over.
+- **Gate destructive actions behind human approval.** [Tool approvals and permission policies](/docs/harness/tool-approvals) let you require confirmation for risky operations like file writes or deployments, while trusted tools run automatically.
+- **Move a task through distinct phases without losing context.** [Modes](/docs/harness/modes) switch the agent's instructions, tools, and model on the same thread, so you can build a plan-then-execute coding agent or a research-then-draft assistant.
+- **Let users pick the right model for each step.** Per-mode [model management](/reference/harness/harness-class) switches models at runtime and tracks usage, which powers copilot UIs where users trade speed for capability.
+- **Delegate focused work to child agents.** [Subagents](/docs/harness/subagents) run subtasks with constrained tools and can fork the parent conversation, so a research mode can spin off web search or code review without polluting the main thread.
+- **Drive a live UI from agent activity.** The [event system](/docs/harness/session) emits typed events and coalesced display snapshots, so your TUI or web app reflects message updates, mode changes, and pending approvals in real time.
+- **Run long-lived autonomous agents.** Structured task lists, heartbeat handlers, and observational memory keep background task runners on track and let them learn across threads.
 
 ## When to use the Harness
 
@@ -40,7 +43,7 @@ Use the Harness when your application needs:
 - Subagent orchestration to delegate focused subtasks with constrained tools
 - Session continuity with persistent threads, state, and observational memory across restarts
 
-For single-shot agent calls or basic request-response patterns, use the [Agent class](/docs/agents/overview) directly. The Harness adds value when you need session state, mode switching, or interactive approval flows.
+You could assemble all of this yourself on top of the [Agent class](/docs/agents/overview), which exposes the full agent loop, tools, and memory. The Harness is an opinionated set of defaults that wires those pieces into one application style: an ongoing session where the agent acts as a collaborator rather than a one-shot endpoint. Reach for the Agent class directly when you want full control or a simple request-response call; reach for the Harness when you want the collaborative-session model without building the runtime around it.
 
 ## Key capabilities
 
@@ -49,10 +52,10 @@ For single-shot agent calls or basic request-response patterns, use the [Agent c
 - **Threads and state**: Persist conversations and structured state across sessions, users, and mode switches. See [Threads and state](/docs/harness/threads-and-state).
 - **Subagents**: Spawn focused child agents with constrained tools for subtasks, optionally forking the parent conversation. See [Subagents](/docs/harness/subagents).
 - **Tool approvals and permissions**: Configure which tools require user confirmation, grant session-wide exceptions, and handle interactive tool suspension. See [Tool approvals](/docs/harness/tool-approvals).
-- **Model management**: Switch models per-mode at runtime, track usage, and resolve gateway-backed models.
-- **Follow-ups and steering**: Queue messages while the agent is running, or inject mid-stream instructions to redirect the agent.
-- **Event system**: Subscribe to typed events (message updates, mode changes, tool approvals) or coalesced `HarnessDisplayState` snapshots to drive your UI.
-- **Observational memory**: Automatic summarization and reflection across threads for long-running agent sessions.
+- **Model management**: Switch models per-mode at runtime, track usage, and resolve gateway-backed models through Mastra's [model router](/models).
+- **Follow-ups and steering**: Queue messages while the agent is running, or inject mid-stream instructions to redirect the agent. Built on [signals](/docs/agents/signals).
+- **Event system**: Subscribe to typed events (message updates, mode changes, tool approvals) or coalesced `HarnessDisplayState` snapshots to drive your UI. See [Events](/reference/harness/harness-class#events).
+- **Observational memory**: Automatic summarization and reflection across threads for long-running agent sessions. See [Observational memory](/docs/memory/observational-memory).
 
 ## Quickstart
 

--- a/docs/src/content/en/docs/harness/session.mdx
+++ b/docs/src/content/en/docs/harness/session.mdx
@@ -117,18 +117,33 @@ See [Threads and state](/docs/harness/threads-and-state) for defining a schema.
 
 ## Display state
 
-`session.displayState` is the coalesced `HarnessDisplayState` snapshot — the single object a UI renders from. It folds run status, streaming messages, active tools, tasks, token usage, and pending approvals into one place:
+A conversation emits many fine-grained events: tokens streaming in, tools starting and finishing, approvals pending, tasks updating, token usage climbing. Subscribing to each event type and reassembling the current picture yourself is tedious and error-prone. `session.displayState` does that work for you.
+
+It's a reducer-maintained snapshot. The Session keeps one `HarnessDisplayState` object and folds every harness event into it as it happens, so the snapshot always reflects the latest state of the whole conversation. A single `HarnessDisplayState` includes:
+
+- `isRunning`: whether an agent operation is in progress
+- `currentMessage`: the message currently streaming in, or `null` when idle
+- `activeTools` and `toolInputBuffers`: tools executing now and their streaming inputs
+- `pendingApproval` and `pendingSuspensions`: tool calls waiting on the user
+- `activeSubagents`: subagents running under the current run
+- `tasks`: the current task list from task tools
+- `tokenUsage`: cumulative token usage for the thread
+- `queuedFollowUps`: how many follow-ups are waiting
+
+Because it's a single object, you can drive an entire UI from one place: read the current snapshot with `get()`, and re-render whenever the Harness emits `display_state_changed` (fired after every other event):
 
 ```typescript
 const snapshot = harness.session.displayState.get()
 
-// React to changes
+// Re-render from the snapshot on every change
 harness.subscribe(event => {
   if (event.type === 'display_state_changed') {
     render(harness.session.displayState.get())
   }
 })
 ```
+
+This is the recommended pattern for most UIs. Subscribe to individual typed events only when you need to react to a specific transition rather than re-render the whole view.
 
 :::note
 

--- a/docs/src/content/en/docs/harness/session.mdx
+++ b/docs/src/content/en/docs/harness/session.mdx
@@ -1,23 +1,23 @@
 ---
 title: "Session | Harness"
-description: "Understand the Session — the per-conversation state object on a Harness — and the identity, thread, mode, grants, run, and display state it tracks."
+description: "Understand the Session — the live state object on a Harness — and the identity, thread, mode, grants, run, and display state it tracks."
 packages:
   - "@mastra/core"
 ---
 
 # Session
 
-A [`Session`](/reference/harness/session) holds the per-conversation state of a Harness: who the conversation is for, which thread is active, the selected mode and model, permission grants, queued follow-ups, token usage, application state, and the display snapshot. You reach it through `harness.session`.
+A [`Session`](/reference/harness/session) holds the live state of a Harness: who the session is for, which thread is active, the selected mode and model, permission grants, queued follow-ups, token usage, application state, and the display snapshot. You reach it through `harness.session`.
 
 ## What the Session tracks
 
-The Session is the live state of one conversation. It answers "what is true about this conversation right now": who the conversation belongs to, which thread is bound, which mode and model are selected, what the user has approved, what's queued or running, the application state, and the snapshot to render. Anything that describes the current conversation lives here; the Harness owns the shared infrastructure that every conversation runs on.
+The Session is the live state of a single user's interaction with the Harness. It answers "what is true right now": who the session belongs to, which thread is currently bound, which mode and model are selected, what the user has approved, what's queued or running, the application state, and the snapshot to render. A session has one active thread at a time but can list, switch between, and clone many threads over its lifetime. Anything that describes the current state lives here; the Harness owns the shared infrastructure every session runs on.
 
-Because the Session is scoped to a single conversation, one Harness can serve many conversations at once — each backed by its own Session — without one conversation's mode, grants, or active thread leaking into another.
+Because each session has its own identity and state, one Harness can serve many users at once — each backed by its own Session — without one session's mode, grants, or active thread leaking into another.
 
-The rest of this page walks through the Session's state in the order a conversation builds it up. Each part is a focused sub-object on `harness.session`:
+The rest of this page walks through the Session's state. Each part is a focused sub-object on `harness.session`:
 
-- **Where the conversation lives**: [Identity](#identity) sets the resource the conversation belongs to, and [Thread](#thread) binds it to a specific conversation thread.
+- **Who and where**: [Identity](#identity) sets the resource the session belongs to, and [Thread](#thread) tracks the currently bound thread.
 - **How the agent behaves**: [Mode and model](#mode-and-model) controls which agent profile and model are active, and [Permission grants](#permission-grants) records what the user has approved to run without prompting.
 - **What's happening right now**: [Run state](#run-state) reflects the in-flight generation, and [Follow-ups](#follow-ups) holds messages queued to send when it finishes.
 - **What you store and render**: [State](#state) holds your application's structured data, and [Display state](#display-state) is the single snapshot your UI renders from.

--- a/docs/src/content/en/docs/harness/session.mdx
+++ b/docs/src/content/en/docs/harness/session.mdx
@@ -33,7 +33,7 @@ const resourceId = harness.session.identity.getResourceId()
 const threadId = harness.session.thread.getId()
 ```
 
-To change the resource a conversation operates under, use `harness.setResourceId()` — it lives on the Harness because it also clears the active thread and releases the shared lock.
+The resource ID is set on the Harness constructor and defaults to the harness `id`. See [Resource IDs](/docs/harness/threads-and-state#resource-ids) for how it scopes threads.
 
 ## Thread
 

--- a/docs/src/content/en/docs/harness/session.mdx
+++ b/docs/src/content/en/docs/harness/session.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Session | Harness"
-description: "Understand the Session — the per-conversation state object on a Harness — and how it divides responsibility with the shared host."
+description: "Understand the Session — the per-conversation state object on a Harness — and the identity, thread, mode, grants, run, and display state it tracks."
 packages:
   - "@mastra/core"
 ---
@@ -14,6 +14,15 @@ A [`Session`](/reference/harness/session) holds the per-conversation state of a 
 The Session is the live state of one conversation. It answers "what is true about this conversation right now": who the conversation belongs to, which thread is bound, which mode and model are selected, what the user has approved, what's queued or running, the application state, and the snapshot to render. Anything that describes the current conversation lives here; the Harness owns the shared infrastructure that every conversation runs on.
 
 Because the Session is scoped to a single conversation, one Harness can serve many conversations at once — each backed by its own Session — without one conversation's mode, grants, or active thread leaking into another.
+
+The rest of this page walks through the Session's state in the order a conversation builds it up. Each part is a focused sub-object on `harness.session`:
+
+- **Where the conversation lives**: [Identity](#identity) sets the resource the conversation belongs to, and [Thread](#thread) binds it to a specific conversation thread.
+- **How the agent behaves**: [Mode and model](#mode-and-model) controls which agent profile and model are active, and [Permission grants](#permission-grants) records what the user has approved to run without prompting.
+- **What's happening right now**: [Run state](#run-state) reflects the in-flight generation, and [Follow-ups](#follow-ups) holds messages queued to send when it finishes.
+- **What you store and render**: [State](#state) holds your application's structured data, and [Display state](#display-state) is the single snapshot your UI renders from.
+
+The Harness performs actions that change this state — switching threads, modes, or models — because those operations coordinate shared infrastructure and emit events. The Session is where you read the result. The sections below note this split where it matters.
 
 ## Identity
 
@@ -87,11 +96,13 @@ harness.abort()
 
 ## Follow-ups
 
-While a run is in progress, queued follow-up messages live on `session.followUps`. They are sent when the current run finishes:
+A user may want to add to the conversation while the agent is still working. Instead of dropping or interrupting those messages, the Session queues them on `session.followUps` and sends them when the current run finishes:
 
 ```typescript
 const queued = harness.session.followUps.count()
 ```
+
+Queue a follow-up with `harness.followUp({ content })`. To redirect the agent mid-run instead of waiting, use `harness.steer({ content })`. Both build on [signals](/docs/agents/signals).
 
 ## State
 

--- a/docs/src/content/en/docs/harness/session.mdx
+++ b/docs/src/content/en/docs/harness/session.mdx
@@ -119,16 +119,7 @@ See [Threads and state](/docs/harness/threads-and-state) for defining a schema.
 
 A conversation emits many fine-grained events: tokens streaming in, tools starting and finishing, approvals pending, tasks updating, token usage climbing. Subscribing to each event type and reassembling the current picture yourself is tedious and error-prone. `session.displayState` does that work for you.
 
-It's a reducer-maintained snapshot. The Session keeps one `HarnessDisplayState` object and folds every harness event into it as it happens, so the snapshot always reflects the latest state of the whole conversation. A single `HarnessDisplayState` includes:
-
-- `isRunning`: whether an agent operation is in progress
-- `currentMessage`: the message currently streaming in, or `null` when idle
-- `activeTools` and `toolInputBuffers`: tools executing now and their streaming inputs
-- `pendingApproval` and `pendingSuspensions`: tool calls waiting on the user
-- `activeSubagents`: subagents running under the current run
-- `tasks`: the current task list from task tools
-- `tokenUsage`: cumulative token usage for the thread
-- `queuedFollowUps`: how many follow-ups are waiting
+It's a reducer-maintained snapshot. The Session keeps one `HarnessDisplayState` object and folds every harness event into it as it happens, so the snapshot always reflects the latest state. It captures everything a UI needs to render: whether the agent is running and what it's streaming, which tools and subagents are active, anything waiting on the user such as approvals, the current task list, and running totals like token usage and queued follow-ups.
 
 Because it's a single object, you can drive an entire UI from one place: read the current snapshot with `get()`, and re-render whenever the Harness emits `display_state_changed` (fired after every other event):
 

--- a/docs/src/content/en/docs/harness/session.mdx
+++ b/docs/src/content/en/docs/harness/session.mdx
@@ -7,27 +7,13 @@ packages:
 
 # Session
 
-A `Session` holds the per-conversation state of a Harness: who the conversation is for, which thread is active, the selected mode and model, permission grants, queued follow-ups, token usage, application state, and the display snapshot. You reach it through `harness.session`.
+A [`Session`](/reference/harness/session) holds the per-conversation state of a Harness: who the conversation is for, which thread is active, the selected mode and model, permission grants, queued follow-ups, token usage, application state, and the display snapshot. You reach it through `harness.session`.
 
-## Harness vs. Session
+## What the Session tracks
 
-The Harness is the shared host. It owns the machinery that doesn't change from one conversation to the next: configuration, storage, the agent registry, the thread lock, the event bus, and permission _policy_. The Session is the per-conversation state that sits on top of that machinery.
+The Session is the live state of one conversation. It answers "what is true about this conversation right now": who the conversation belongs to, which thread is bound, which mode and model are selected, what the user has approved, what's queued or running, the application state, and the snapshot to render. Anything that describes the current conversation lives here; the Harness owns the shared infrastructure that every conversation runs on.
 
-A useful way to remember the split: the **Harness** is the application, and the **Session** is the current conversation running inside it. Operations that mutate shared infrastructure or coordinate the event bus stay on the Harness; everything that describes "this conversation right now" lives on the Session.
-
-| Lives on the Harness (shared host) | Lives on the Session (per-conversation) |
-| - | - |
-| Configuration, storage, and memory | Resource ID and active thread binding ([`session.identity`](#identity), [`session.thread`](#thread)) |
-| Thread lifecycle: `createThread`, `switchThread`, `cloneThread`, `renameThread`, `deleteThread` | Thread and message reads ([`session.thread.list()`](#thread)) |
-| The event bus (`subscribe`, event emission) | Selected mode and model ([`session.mode`](#mode-and-model), [`session.model`](#mode-and-model)) |
-| Permission _policy_ (`setPermissionForCategory`, `getToolCategory`) | Permission _grants_ ([`session.grantCategory`](#permission-grants)) |
-| Mode and model _definitions_ (`config.modes`) | Run state, abort, follow-ups, suspensions ([`session.run`](#run-state), [`session.followUps`](#follow-ups)) |
-| The `stateSchema` definition | Application state and its updates ([`session.state`](#state)) |
-| The shared agent loop and subagent spawning | Token usage and the display snapshot ([`session.displayState`](#display-state)) |
-
-This is why thread _creation_ is `harness.createThread()` (it acquires the shared lock and emits an event) while thread _reads_ are `harness.session.thread.list()` (they describe the current conversation's view).
-
-In single-player apps there is one Harness and one Session, so the split is mostly organizational. In a multi-user host, the same Harness can serve many conversations — each backed by its own Session — without one conversation's mode, grants, or active thread leaking into another.
+Because the Session is scoped to a single conversation, one Harness can serve many conversations at once — each backed by its own Session — without one conversation's mode, grants, or active thread leaking into another.
 
 ## Identity
 

--- a/docs/src/content/en/docs/harness/subagents.mdx
+++ b/docs/src/content/en/docs/harness/subagents.mdx
@@ -7,15 +7,7 @@ packages:
 
 # Subagents
 
-Subagents let a parent agent delegate focused tasks to child agents with constrained tools and instructions. The Harness auto-generates a `subagent` built-in tool that the parent model can call to spawn any configured subagent type.
-
-## When to use subagents
-
-Use subagents when:
-
-- A task needs a different toolset or instruction set than the parent agent
-- You want to isolate a subtask's messages from the parent thread
-- The parent agent needs to delegate to a cheaper or faster model for specific work
+Subagents let a parent agent delegate focused tasks to child agents with constrained tools and instructions. The Harness auto-generates a `subagent` built-in tool that the parent model can call to spawn any configured subagent type. Reach for a subagent when a task needs a different toolset or instruction set than the parent agent, when you want to isolate a subtask's messages from the parent thread, or when the parent should delegate to a cheaper or faster model for specific work.
 
 ## Quickstart
 

--- a/docs/src/content/en/docs/harness/subagents.mdx
+++ b/docs/src/content/en/docs/harness/subagents.mdx
@@ -51,6 +51,8 @@ const harness = new Harness({
 
 The parent agent can then call the auto-generated `subagent` tool with a `task` description and optional `agentType`.
 
+When you define a subagent, write its `description` and `instructions` to be clear and narrow. The `description` is what the parent model reads to decide _when_ to delegate, so state the single job the subagent is for and, by implication, what it's not for — "Reads files and gathers context without making changes" tells the parent to reach for it during exploration and to handle edits elsewhere. The `instructions` then keep the child agent inside that job. A subagent scoped to one task with a focused toolset stays predictable and is easier for the parent to route to; a broadly described subagent invites the parent to over-delegate and blurs the boundary between types. Pair the narrow scope with `allowedWorkspaceTools` so the subagent can only do what its description promises.
+
 For the full list of subagent configuration options, see [`Harness` reference](/reference/harness/harness-class#subagents).
 
 ## Forked subagents

--- a/docs/src/content/en/docs/harness/subagents.mdx
+++ b/docs/src/content/en/docs/harness/subagents.mdx
@@ -66,7 +66,6 @@ const collaborator = {
   id: 'collaborator',
   name: 'Collaborator',
   description: 'Continues the conversation in a fork.',
-  instructions: '...', // Ignored in forked mode
   // highlight-next-line
   forked: true,
 }

--- a/docs/src/content/en/docs/harness/subagents.mdx
+++ b/docs/src/content/en/docs/harness/subagents.mdx
@@ -57,7 +57,11 @@ For the full list of subagent configuration options, see [`Harness` reference](/
 
 ## Forked subagents
 
-By default, a subagent runs with a fresh context and doesn't see the parent conversation. **Forked subagents** run on a clone of the parent thread and reuse the parent agent's configuration. This preserves prompt-cache prefixes and gives the subagent full conversation context.
+A default subagent starts with a fresh context: it can't see the parent conversation, so you pass everything it needs in the `task` description. That's the right model for self-contained work, but it has two costs. The subagent has no access to what's already happened, and it builds a brand-new request prefix — a different system prompt and tool schemas — so it can't reuse the parent's prompt cache.
+
+**Forked subagents** solve both. Instead of a fresh agent, a fork clones the parent thread and runs the parent agent itself, so it sees the full conversation history and keeps the same system prompt and tool schemas as the parent. The identical prefix means the model's prompt cache still hits, which makes context-heavy delegation cheaper and faster.
+
+Use a fork when the subtask depends on the conversation so far — prior messages, earlier tool results, or the parent's tool environment — and you want to run it without paying to rebuild that context. Use a default subagent when the task is self-contained and benefits from a narrower toolset, a tighter system prompt, or a cheaper model.
 
 Enable forked mode per-type:
 
@@ -71,19 +75,17 @@ const collaborator = {
 }
 ```
 
-Or per-invocation via the `subagent` tool's `forked` input parameter.
+Or per-invocation via the `subagent` tool's `forked` input parameter, which overrides the type's default.
 
 ### Forked mode semantics
 
-- Memory must be configured on the Harness (forking clones the thread)
-- The parent agent's instructions, tools, model, and `maxSteps` apply
-- The subagent definition's own `instructions`, `tools`, and `defaultModelId` are ignored
-- Fork threads are tagged with `metadata.forkedSubagent === true` and hidden from `session.thread.list()` by default
-- Recursive forks are blocked at runtime to prevent infinite nesting
+Because a fork reuses the parent agent to keep the prompt prefix stable, the subagent's own definition is mostly set aside:
 
-### When to prefer non-forked mode
-
-Use non-forked subagents when the child needs a strictly smaller toolset, a different system prompt, or a cheaper model. Pass any required context explicitly in the `task` description.
+- Memory must be configured on the Harness, since forking clones the parent thread. Without it, the fork call returns an error.
+- The fork runs with the parent agent's instructions, tools, and model. The subagent definition's own `instructions`, `tools`, and `defaultModelId` are ignored, and a per-invocation `modelId` is ignored too.
+- Only the subagent definition's `description` still matters — it's what the parent model reads to decide when to delegate.
+- Fork threads are tagged with `metadata.forkedSubagent === true` and hidden from `session.thread.list()` by default.
+- Recursive forks are blocked at runtime: the inherited `subagent` tool is disabled inside a fork to prevent infinite nesting.
 
 ## Subagent model management
 

--- a/docs/src/content/en/docs/harness/threads-and-state.mdx
+++ b/docs/src/content/en/docs/harness/threads-and-state.mdx
@@ -7,13 +7,15 @@ packages:
 
 # Threads and state
 
-The Harness manages conversation threads and shared state that persist across mode switches, model changes, and sessions. Threads hold messages while state holds structured data that agents and the UI can read and write.
+Threads and state are how a Harness conversation survives beyond a single exchange. A **thread** is the persistent record of a conversation — its messages and metadata, saved to storage so a user can close the app and resume the same conversation later, or switch between several conversations. **State** is structured data attached to the conversation — values like model preferences, feature flags, or progress — that agents and your UI read and write as the conversation runs.
 
-Thread _lifecycle_ transitions (create, switch, clone, delete) live on the Harness because they coordinate the shared thread lock and emit events. The active thread binding and thread/message _reads_ live on the [`Session`](/docs/harness/session) as `harness.session.thread`.
+The two work together: the thread is the message history, and state is the shared scratchpad alongside it. Both persist across mode switches, model changes, and restarts, so nothing is lost when a user switches from plan mode to build mode or reopens the app the next day.
 
-Threads hold persistent conversation history and let users resume or switch between conversations. State holds structured values — model preferences, feature flags, UI settings — that agents and the UI layer share across those conversations.
+Thread _lifecycle_ transitions — create, switch, clone, delete — live on the Harness because they coordinate the shared thread lock and emit events. The active thread binding and thread/message _reads_ live on the [`Session`](/docs/harness/session) as `harness.session.thread`.
 
 ## Threads
+
+A thread holds one conversation's full message history. The Harness binds the Session to one active thread at a time; messages you send and the agent's replies are appended to that thread and saved to storage. Threads let users resume a past conversation, keep several conversations side by side, or branch one into alternatives.
 
 ### Creating and selecting threads
 
@@ -119,16 +121,19 @@ State changes emit a `state_changed` event with the new state and the set of cha
 
 ## Resource IDs
 
-Threads are scoped to a resource ID. The resource ID defaults to the harness `id` but can be set explicitly to group threads by project, user, or workspace:
+Threads are scoped to a resource ID, which groups a conversation's threads by project, user, or workspace. Set it on the Harness constructor; it defaults to the harness `id` when omitted:
 
 ```typescript
 const harness = new Harness({
   id: 'my-agent',
   resourceId: 'project-xyz',
 })
+```
 
-// Change resource ID at runtime (clears the current thread)
-harness.setResourceId({ resourceId: 'project-abc' })
+The resource ID is part of a conversation's identity, so you read it from the Session:
+
+```typescript
+const resourceId = harness.session.identity.getResourceId()
 ```
 
 ## Related

--- a/docs/src/content/en/docs/harness/threads-and-state.mdx
+++ b/docs/src/content/en/docs/harness/threads-and-state.mdx
@@ -79,6 +79,8 @@ const harness = new Harness({
 
 ## State
 
+Where a thread stores the conversation's messages, state stores structured values that describe the conversation but aren't messages — model preferences, feature flags, UI settings, or progress markers. Agents can read and update state during a run, and your UI can react to changes, so state is how the agent and the interface stay in sync on shared facts. You define its shape with a schema, and every update is validated against that schema before it's applied.
+
 ### Defining a state schema
 
 Pass a `stateSchema` (Standard JSON Schema) to validate state and extract defaults:

--- a/docs/src/content/en/docs/harness/threads-and-state.mdx
+++ b/docs/src/content/en/docs/harness/threads-and-state.mdx
@@ -11,9 +11,7 @@ The Harness manages conversation threads and shared state that persist across mo
 
 Thread _lifecycle_ transitions (create, switch, clone, delete) live on the Harness because they coordinate the shared thread lock and emit events. The active thread binding and thread/message _reads_ live on the [`Session`](/docs/harness/session) as `harness.session.thread`.
 
-## When to use threads and state
-
-Use threads when your application needs persistent conversation history, multi-session continuity, or when users switch between threads. Use state for structured values (model preferences, feature flags, UI settings) that agents and the UI layer share.
+Threads hold persistent conversation history and let users resume or switch between conversations. State holds structured values — model preferences, feature flags, UI settings — that agents and the UI layer share across those conversations.
 
 ## Threads
 

--- a/docs/src/content/en/docs/harness/tool-approvals.mdx
+++ b/docs/src/content/en/docs/harness/tool-approvals.mdx
@@ -7,11 +7,7 @@ packages:
 
 # Tool approvals and permissions
 
-The Harness provides a permission system that controls which tools require user approval before execution. You can configure policies at the category level or per-tool, and grant session-wide exceptions for trusted tools.
-
-## When to use tool approvals
-
-Use tool approvals when agents have access to destructive or sensitive tools (file writes, command execution, API calls) and you want a human-in-the-loop checkpoint before those tools run.
+The Harness provides a permission system that controls which tools require user approval before execution. You can configure policies at the category level or per-tool, and grant session-wide exceptions for trusted tools. This gives agents with access to destructive or sensitive tools — file writes, command execution, API calls — a human-in-the-loop checkpoint before those tools run.
 
 ## Permission policies
 


### PR DESCRIPTION
## Summary

Improves the Harness documentation so it explains what a harness is and what it's for before diving into APIs.

### Harness overview
- Lead with a clear definition of an agent harness: the runtime that wraps a model and governs its behavior, distinct from the framework you build an agent from.
- Rewrite the "What you can build" section to be outcome-driven — each item maps a concrete result to the capability and doc page that delivers it.
- Reframe "When to use the Harness" so it no longer implies the Agent class is only for one-shot calls; the Harness is positioned as an opinionated default for collaborative-session apps.
- Add missing reference links: model router, signals, the events reference, and observational memory.

### Session page
- Link the first mention of `Session` to the Session reference page.
- Replace the Harness-vs-Session comparison table with a high-level description of the Session's scope of responsibilities.

## Test plan
- Docs-only change. Verified every internal link resolves to an existing page or in-page anchor, and confirmed the Harness Quickstart code matches the current `Harness` API (constructor config, mode shape, and the `init` / `selectOrCreateThread` / `sendMessage` / `subscribe` methods) in `packages/core/src/harness`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

This PR makes the Harness docs easier to understand by first explaining, in plain terms, what the Harness is (a runtime that controls how a model behaves) and what you can build with it. It also rewrites the Session and Modes pages so readers know exactly what each thing tracks/controls, and it adds missing links to related references.

## Overview Changes

**docs/src/content/en/docs/harness/overview.mdx**
- **Sharper definition up front:** Replaces earlier wording with a clear explanation that the Harness is a **runtime** that wraps a model and governs its behavior (separate from the agent/framework used to build an agent).
- **Outcome-driven “What you can build”:** Rewrites the section to map concrete results to capabilities, including:
  - Persistent threads/state management
  - Tool-approval gating
  - Modes on a single thread
  - Runtime model switching
  - Subagents
  - Live UI/event driving
  - Long-lived autonomous agents
- **Reframed “When to use the Harness”:** Positions the Harness as an opinionated default for **collaborative-session** apps, clarifying that `Agent` is better suited for full control or one-shot calls.
- **Reference link gaps filled:** Adds missing links for the **model router**, **signals**, the **events reference** (including `HarnessDisplayState`), and **observational memory**.

## Session Page Changes

**docs/src/content/en/docs/harness/session.mdx**
- **Removed “Harness vs. Session” comparison:** Replaces it with a clearer, high-level description of the Session’s scope.
- **Better Session framing:** Adds “What the Session tracks,” describing Session as per-conversation live state and breaking down Session sub-objects in conversation-building order.
- **Follow-ups clarified:** Explains that follow-ups added during an active run are queued on `session.followUps`, and introduces mid-run redirection via `harness.steer({ content })` (signals-based).
- **Display state rewritten and concretized:** Updates `session.displayState` to a **reducer-maintained snapshot** that folds harness events into a single `HarnessDisplayState` object, including guidance to **subscribe and render** when `display_state_changed` fires.
- **First `Session` mention linked:** The initial use of `Session` on the page now links to the Session reference.

## Modes Page Changes

**docs/src/content/en/docs/harness/modes.mdx**
- **What a mode is (and that it’s required):** Adds a clear explanation that modes must be provided and what they consist of (e.g., instructions, tools, model).
- **Startup/selection behavior clarified:** Documents what happens when modes are empty and how the default mode is chosen (via metadata like `default` / `defaultModeId`, or the first mode).
- **Querying modes clarified:** Expands guidance that the Harness owns the mode catalog while the Session tracks the active mode, referencing `harness.listModes()`, `harness.session.mode.get()`, and `harness.session.mode.resolve()`.

## Testing / Validation Notes

- Internal links were verified to resolve correctly.
- Harness Quickstart code was confirmed to match the current Harness API in `packages/core/src/harness` (constructor config, mode shape, and `init`, `selectOrCreateThread`, `sendMessage`, `subscribe`).
- Changes are documentation-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->