### PR TITLE
fix: use drawer for mobile sidebar menu

### DIFF
--- a/.changeset/fine-mugs-train.md
+++ b/.changeset/fine-mugs-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved the mobile sidebar menu to use native drawer interactions.

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.test.tsx
@@ -120,6 +120,7 @@ describe('MainSidebar mobile drawer', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open navigation menu' }));
 
     expect(screen.getByRole('dialog', { name: 'Navigation' })).toBeDefined();
+    expect(document.querySelector('[data-slot="drawer-popup"]')?.getAttribute('data-swipe-direction')).toBe('left');
     expect(screen.getByRole('link', { name: 'Agents' })).toBeDefined();
   });
 });

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.tsx
@@ -1,7 +1,7 @@
-import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { useCallback, useEffect, useRef } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { useMainSidebar } from './main-sidebar-context';
+import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from '@/ds/components/Drawer';
 import { ResizeHandleIndicator } from '@/ds/primitives/resize-handle-indicator';
 import { VisuallyHidden } from '@/ds/primitives/visually-hidden';
 import { cn } from '@/lib/utils';
@@ -172,7 +172,7 @@ export function MainSidebarRoot({ children, className }: MainSidebarRootProps) {
     [isCollapsed, width, minWidth, maxWidth, setWidth, expand, commit, toggleSidebar],
   );
 
-  // Mobile: render as an off-canvas drawer via Base UI Dialog.
+  // Mobile: render as an off-canvas drawer via Base UI Drawer.
   // Auto-close on link navigation (standard drawer UX). Don't gate on
   // `defaultPrevented` — client-side router links call `preventDefault()` for
   // SPA navigation, and we still want to close the drawer when they do.
@@ -191,38 +191,24 @@ export function MainSidebarRoot({ children, className }: MainSidebarRootProps) {
 
   if (isMobile) {
     return (
-      <DialogPrimitive.Root open={openMobile} onOpenChange={setOpenMobile}>
-        <DialogPrimitive.Portal>
-          <DialogPrimitive.Backdrop
-            className={cn(
-              'fixed inset-0 z-40 bg-overlay backdrop-blur-sm',
-              'opacity-100 transition-opacity duration-200 ease-out motion-reduce:transition-none',
-              'data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 data-[ending-style]:duration-150 data-[ending-style]:ease-in',
-            )}
-          />
-          <DialogPrimitive.Popup
-            className={cn(
-              'fixed inset-y-0 left-0 z-50 flex h-full flex-col',
-              'w-3/4 max-w-(--sidebar-width-mobile)',
-              'bg-surface2 shadow-xl',
-              'data-[open]:animate-in data-[closed]:animate-out',
-              'data-[open]:slide-in-from-left data-[closed]:slide-out-to-left',
-              'duration-200',
-              className,
-            )}
-          >
-            <VisuallyHidden asChild>
-              <DialogPrimitive.Title>Navigation</DialogPrimitive.Title>
-            </VisuallyHidden>
-            <VisuallyHidden asChild>
-              <DialogPrimitive.Description>Primary site navigation drawer</DialogPrimitive.Description>
-            </VisuallyHidden>
-            <div onClick={closeOnAnchor} className="flex flex-col h-full min-h-0 px-4 py-2 overflow-hidden">
-              {children}
-            </div>
-          </DialogPrimitive.Popup>
-        </DialogPrimitive.Portal>
-      </DialogPrimitive.Root>
+      <Drawer side="left" open={openMobile} onOpenChange={setOpenMobile}>
+        <DrawerContent
+          className={cn(
+            'w-3/4 max-w-(--sidebar-width-mobile) rounded-none border-0 bg-surface2 shadow-xl overflow-hidden',
+            className,
+          )}
+        >
+          <VisuallyHidden asChild>
+            <DrawerTitle>Navigation</DrawerTitle>
+          </VisuallyHidden>
+          <VisuallyHidden asChild>
+            <DrawerDescription>Primary site navigation drawer</DrawerDescription>
+          </VisuallyHidden>
+          <div onClick={closeOnAnchor} className="flex flex-col h-full min-h-0 px-4 py-2 overflow-hidden">
+            {children}
+          </div>
+        </DrawerContent>
+      </Drawer>
     );
   }
 


### PR DESCRIPTION
## Summary

- Switch `MainSidebar` mobile rendering from Base UI Dialog to the shared Playground UI Drawer primitive.
- Preserve the existing accessible `Navigation` dialog title/description and close-on-link behavior.
- Add a regression assertion that the mobile menu opens as a left-side Drawer popup.
- Add a patch changeset for `@mastra/playground-ui`.

## Storybook coverage

Confirmed existing stories already show this design:

- `MainSidebar / Mobile` documents that below `mobileBreakpoint`, `MainSidebar` renders as an off-canvas drawer and should be opened through `MainSidebar.MobileTrigger`.
- `Drawer / Left` demonstrates a left-edge navigation drawer with swipe dismissal.
- `Drawer / MobileNavigation` demonstrates the mobile menu drawer pattern.

## Validation

- `pnpm --filter ./packages/playground-ui exec vitest run src/ds/components/MainSidebar/main-sidebar-root.test.tsx`
- `pnpm --filter ./packages/playground-ui exec eslint src/ds/components/MainSidebar/main-sidebar-root.tsx src/ds/components/MainSidebar/main-sidebar-root.test.tsx`
- `pnpm --filter ./packages/playground-ui exec prettier --check src/ds/components/MainSidebar/main-sidebar-root.tsx src/ds/components/MainSidebar/main-sidebar-root.test.tsx .changeset/fine-mugs-train.md`
- `pnpm build:playground-ui`
- `pnpm --filter ./packages/playground-ui typecheck`

Note: `react-doctor --scope changed` currently falls back to a full repo scan and reports existing unrelated project-wide issues, so it is not a clean signal for this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the mobile menu in the sidebar work better by switching it to use a special "drawer" component that slides in from the left side of the screen, instead of the old popup dialog. It's like using a better-designed drawer to organize your mobile menu.

## Changes

### Component Implementation
Updated `MainSidebar` component to replace the Base UI `Dialog` primitive with the project's shared `Drawer` primitive for mobile rendering. The mobile sidebar now uses `Drawer`, `DrawerContent`, `DrawerTitle`, and `DrawerDescription` components instead of Dialog components. The implementation preserves:
- Navigation dialog title and description (rendered as `VisuallyHidden`)
- Close-on-link behavior via the existing `closeOnAnchor` click handler
- State management through `openMobile`/`setOpenMobile`

### Test Updates
Added regression assertion in the mobile drawer test to verify the drawer popup has a `data-swipe-direction="left"` attribute, confirming the left-edge drawer rendering behavior on mobile.

### Changeset
Added patch version declaration for `@mastra/playground-ui` documenting improved mobile sidebar menu behavior using native drawer interactions.

### Validation
Changes are covered by existing Storybook stories:
- `MainSidebar / Mobile` - off-canvas drawer rendering below mobile breakpoint
- `Drawer / Left` - left-edge navigation drawer with swipe dismissal
- `Drawer / MobileNavigation` - mobile menu drawer pattern

<!-- end of auto-generated comment: release notes by coderabbit.ai -->