### PR TITLE
docs: clarify notification signal examples

### DIFF
--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -130,7 +130,7 @@ Visit [`Agent.sendSignal()` reference](/reference/agents/agent#sendsignalsignal-
 
 Signals have a semantic `type` and an LLM-facing `tagName`. Use `type` to describe the signal category. Use `tagName` to control the XML tag the model sees.
 
-For external events, use `type: 'notification'`. Reactive signals are reserved for processor- or runtime-generated context, such as policy guidance, background task results, and auto-loaded instructions.
+For external events, use `type: 'notification'`. Notification signals fit events such as GitHub review activity, issue updates, CI results, or deployment status changes. Reactive signals are reserved for processor- or runtime-generated context, such as policy guidance, background task results, and auto-loaded instructions.
 
 ```typescript title="src/mastra/signals.ts"
 agent.sendSignal(


### PR DESCRIPTION
## Summary
- Clarifies that notification signals fit GitHub review activity, issue updates, CI results, and deployment status changes.

## Test plan
- Verified the docs-only diff.
- Ran `pnpm --dir docs exec prettier --check src/content/en/docs/agents/signals.mdx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This pull request updates the documentation to make it clearer when to use different types of signals in Mastra agents. It explains that notification signals should be used for external events (like GitHub updates and CI results), while reactive signals are for internal system-generated messages.

## Summary

This documentation-only PR clarifies the use cases for notification signals in the Agents signals guide (`docs/src/content/en/docs/agents/signals.mdx`).

### Changes Made

The "Send notification context" section was updated to provide explicit guidance distinguishing between two signal types:

- **Notification signals** (`type: 'notification'`): For external events such as GitHub review activity, issue updates, CI results, and deployment status changes
- **Reactive signals**: Reserved for processor- or runtime-generated context, such as policy guidance, background task results, and auto-loaded instructions

This clarification helps developers understand which signal type is appropriate for different scenarios when implementing agent signal handling.

### Testing

The documentation file has been formatted with Prettier to ensure code style consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->