### PR TITLE
docs(auth-google): add Google Workspace auth docs

### DIFF
--- a/auth/google/README.md
+++ b/auth/google/README.md
@@ -72,13 +72,17 @@ export const mastra = new Mastra({
 | `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` | PEM private key for the service account                          |
 | `GOOGLE_WORKSPACE_ADMIN_EMAIL`       | Workspace admin email to impersonate with domain-wide delegation |
 
+`MastraAuthGoogle` reads the Google auth variables directly. The service-account variables above are examples for wiring `MastraRBACGoogle`; pass them through the `serviceAccount` option as shown.
+
 ## Exports
 
 - `MastraAuthGoogle`
 - `MastraRBACGoogle`
 - `mapGoogleClaimsToUser`
+- `GoogleSessionOptions`
 - `GoogleUser`
 - `GoogleWorkspaceGroup`
 - `GoogleWorkspaceServiceAccount`
 - `MastraAuthGoogleOptions`
 - `MastraRBACGoogleOptions`
+- `PermissionCacheOptions`

--- a/auth/google/README.md
+++ b/auth/google/README.md
@@ -1,0 +1,84 @@
+# @mastra/auth-google
+
+Google Workspace authentication and RBAC integration for Mastra.
+
+## Features
+
+- Google OpenID Connect authentication
+- Studio SSO with encrypted session cookies
+- Workspace hosted-domain allowlisting through the verified `hd` claim
+- Google Groups based RBAC through the Workspace Directory API
+- Cross-provider RBAC support for Auth0, Clerk, Simple Auth, and custom providers
+
+## Installation
+
+```bash
+npm install @mastra/auth-google
+```
+
+## Google Workspace auth
+
+```typescript
+import { Mastra } from '@mastra/core/mastra';
+import { MastraAuthGoogle } from '@mastra/auth-google';
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthGoogle({
+      allowedDomains: ['example.com'],
+    }),
+  },
+});
+```
+
+## Google Groups RBAC
+
+```typescript
+import { Mastra } from '@mastra/core/mastra';
+import { MastraAuthGoogle, MastraRBACGoogle } from '@mastra/auth-google';
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthGoogle({
+      allowedDomains: ['example.com'],
+    }),
+    rbac: new MastraRBACGoogle({
+      serviceAccount: {
+        clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
+        privateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!,
+        subject: process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL!,
+      },
+      roleMapping: {
+        'admins@example.com': ['*'],
+        'engineering@example.com': ['agents:*', 'workflows:*'],
+        _default: [],
+      },
+    }),
+  },
+});
+```
+
+## Environment variables
+
+| Variable                             | Description                                                      |
+| ------------------------------------ | ---------------------------------------------------------------- |
+| `GOOGLE_CLIENT_ID`                   | Google OAuth client ID                                           |
+| `GOOGLE_CLIENT_SECRET`               | Google OAuth client secret for SSO                               |
+| `GOOGLE_REDIRECT_URI`                | OAuth redirect URI for the SSO callback                          |
+| `GOOGLE_COOKIE_PASSWORD`             | Session encryption key, at least 32 characters                   |
+| `GOOGLE_ALLOWED_DOMAINS`             | Comma-separated Google Workspace domains to allow                |
+| `GOOGLE_HOSTED_DOMAIN`               | Hosted-domain login hint passed to Google                        |
+| `GOOGLE_SERVICE_ACCOUNT_EMAIL`       | Service account email for Directory API access                   |
+| `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` | PEM private key for the service account                          |
+| `GOOGLE_WORKSPACE_ADMIN_EMAIL`       | Workspace admin email to impersonate with domain-wide delegation |
+
+## Exports
+
+- `MastraAuthGoogle`
+- `MastraRBACGoogle`
+- `mapGoogleClaimsToUser`
+- `GoogleUser`
+- `GoogleWorkspaceGroup`
+- `GoogleWorkspaceServiceAccount`
+- `MastraAuthGoogleOptions`
+- `MastraRBACGoogleOptions`

--- a/auth/google/README.md
+++ b/auth/google/README.md
@@ -25,6 +25,7 @@ import { MastraAuthGoogle } from '@mastra/auth-google';
 export const mastra = new Mastra({
   server: {
     auth: new MastraAuthGoogle({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
       allowedDomains: ['example.com'],
     }),
   },
@@ -60,17 +61,17 @@ export const mastra = new Mastra({
 
 ## Environment variables
 
-| Variable                             | Description                                                      |
-| ------------------------------------ | ---------------------------------------------------------------- |
-| `GOOGLE_CLIENT_ID`                   | Google OAuth client ID                                           |
-| `GOOGLE_CLIENT_SECRET`               | Google OAuth client secret for SSO                               |
-| `GOOGLE_REDIRECT_URI`                | OAuth redirect URI for the SSO callback                          |
-| `GOOGLE_COOKIE_PASSWORD`             | Session encryption key, at least 32 characters                   |
-| `GOOGLE_ALLOWED_DOMAINS`             | Comma-separated Google Workspace domains to allow                |
-| `GOOGLE_HOSTED_DOMAIN`               | Hosted-domain login hint passed to Google                        |
-| `GOOGLE_SERVICE_ACCOUNT_EMAIL`       | Service account email for Directory API access                   |
-| `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` | PEM private key for the service account                          |
-| `GOOGLE_WORKSPACE_ADMIN_EMAIL`       | Workspace admin email to impersonate with domain-wide delegation |
+| Variable                             | Description                                                                         |
+| ------------------------------------ | ----------------------------------------------------------------------------------- |
+| `GOOGLE_CLIENT_ID`                   | Google OAuth client ID                                                              |
+| `GOOGLE_CLIENT_SECRET`               | Google OAuth client secret for SSO                                                  |
+| `GOOGLE_REDIRECT_URI`                | OAuth redirect URI for the SSO callback                                             |
+| `GOOGLE_COOKIE_PASSWORD`             | Session encryption key, at least 32 characters                                      |
+| `GOOGLE_ALLOWED_DOMAINS`             | Comma-separated Google Workspace domains to allow                                   |
+| `GOOGLE_HOSTED_DOMAIN`               | Hosted-domain login hint passed to Google                                           |
+| `GOOGLE_SERVICE_ACCOUNT_EMAIL`       | Service account email for Directory API access                                      |
+| `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` | PEM private key for the service account. Use escaped `\n` newlines in `.env` values |
+| `GOOGLE_WORKSPACE_ADMIN_EMAIL`       | Workspace admin email to impersonate with domain-wide delegation                    |
 
 `MastraAuthGoogle` reads the Google auth variables directly. The service-account variables above are examples for wiring `MastraRBACGoogle`; pass them through the `serviceAccount` option as shown.
 

--- a/docs/src/content/en/docs/server/auth/google.mdx
+++ b/docs/src/content/en/docs/server/auth/google.mdx
@@ -1,0 +1,179 @@
+---
+title: "Google | Auth"
+description: Authenticate your Mastra server and Studio using Google Workspace with hosted-domain checks and group-based RBAC.
+packages:
+  - "@mastra/auth-google"
+---
+
+# Google
+
+The `@mastra/auth-google` package provides Google OpenID Connect authentication and Google Workspace group-based role-based access control (RBAC) for Mastra.
+
+Use it when your Studio users sign in with Google and access should be limited to one or more Google Workspace domains.
+
+## Prerequisites
+
+Set up a Google Cloud OAuth client for web applications and add your Mastra callback URL to the authorized redirect URIs.
+
+For Google Groups RBAC, also configure a Google Workspace service account with domain-wide delegation and grant it the Directory API read-only group scope:
+
+```text
+https://www.googleapis.com/auth/admin.directory.group.readonly
+```
+
+Set the following environment variables:
+
+```env title=".env"
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:4111/api/auth/callback
+GOOGLE_COOKIE_PASSWORD=a-random-string-at-least-32-characters-long
+GOOGLE_ALLOWED_DOMAINS=example.com
+
+GOOGLE_SERVICE_ACCOUNT_EMAIL=service-account@project.iam.gserviceaccount.com
+GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+GOOGLE_WORKSPACE_ADMIN_EMAIL=admin@example.com
+```
+
+:::note
+
+`GOOGLE_COOKIE_PASSWORD` encrypts session cookies. If omitted, an auto-generated value is used that doesn't survive server restarts. Set it explicitly for production.
+
+:::
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/auth-google
+```
+
+## Basic usage
+
+The following example enables Google sign-in and restricts access to users whose verified Google ID token has `hd: "example.com"`.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraAuthGoogle } from '@mastra/auth-google'
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthGoogle({
+      allowedDomains: ['example.com'],
+    }),
+  },
+})
+```
+
+:::warning
+
+Use `allowedDomains` to enforce Workspace access. Mastra checks Google's verified `hd` claim, not the email address suffix.
+
+:::
+
+## Auth with Google Groups RBAC
+
+Add `MastraRBACGoogle` to map Google Workspace groups to Mastra permissions.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraAuthGoogle, MastraRBACGoogle } from '@mastra/auth-google'
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthGoogle({
+      allowedDomains: ['example.com'],
+    }),
+    rbac: new MastraRBACGoogle({
+      serviceAccount: {
+        clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
+        privateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!,
+        subject: process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL!,
+      },
+      roleMapping: {
+        'admins@example.com': ['*'],
+        'engineering@example.com': ['agents:*', 'workflows:*', 'tools:*'],
+        'viewers@example.com': ['agents:read', 'workflows:read'],
+        _default: [],
+      },
+    }),
+  },
+})
+```
+
+Group email addresses are used as role IDs by default. Use `mapGroupToRoles` if you want to map by group name or another property.
+
+## Cross-provider RBAC
+
+Use Google Groups RBAC with another auth provider by passing `getUserKey`.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraAuthAuth0 } from '@mastra/auth-auth0'
+import { MastraRBACGoogle } from '@mastra/auth-google'
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthAuth0(),
+    rbac: new MastraRBACGoogle({
+      getUserKey: user => user.email,
+      serviceAccount: {
+        clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
+        privateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!,
+        subject: process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL!,
+      },
+      roleMapping: {
+        'engineering@example.com': ['agents:*', 'workflows:*'],
+        'admins@example.com': ['*'],
+        _default: [],
+      },
+    }),
+  },
+})
+```
+
+## Client-side setup
+
+When auth is enabled, requests to Mastra routes require authentication. `MastraAuthGoogle` uses Google sign-in and stores the authenticated user in an encrypted session cookie.
+
+For cross-origin requests, enable CORS credentials on the Mastra server:
+
+```typescript title="src/mastra/index.ts"
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthGoogle({
+      allowedDomains: ['example.com'],
+    }),
+    cors: {
+      origin: 'http://localhost:3000',
+      credentials: true,
+    },
+  },
+})
+```
+
+Configure the client to include credentials:
+
+```typescript title="lib/mastra-client.ts"
+import { MastraClient } from '@mastra/client-js'
+
+export const mastraClient = new MastraClient({
+  baseUrl: 'http://localhost:4111',
+  credentials: 'include',
+})
+```
+
+You can also pass a Google ID token as a Bearer token. Mastra verifies the token against Google's JSON Web Key Set (JWKS) endpoint.
+
+## Troubleshooting
+
+- **401 after sign-in**: Check that `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `GOOGLE_REDIRECT_URI` match the Google Cloud OAuth client.
+- **Workspace users are rejected**: Verify `GOOGLE_ALLOWED_DOMAINS` matches the Google ID token `hd` claim.
+- **Consumer Gmail accounts are rejected**: This is expected when `allowedDomains` is configured because Gmail accounts don't have a Workspace `hd` claim.
+- **RBAC returns default permissions**: Verify the service account has domain-wide delegation and the Directory API group read-only scope.
+- **Cookies are not sent cross-origin**: Set `credentials: "include"` in `MastraClient` and configure `server.cors` with `credentials: true`.
+
+## Related
+
+- [Auth overview](/docs/server/auth)
+- [Composite Auth](/docs/server/auth/composite-auth)
+- [MastraAuthGoogle reference](/reference/auth/google)

--- a/docs/src/content/en/docs/server/auth/google.mdx
+++ b/docs/src/content/en/docs/server/auth/google.mdx
@@ -26,7 +26,7 @@ Set the following environment variables:
 ```env title=".env"
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
-GOOGLE_REDIRECT_URI=http://localhost:4111/api/auth/callback
+GOOGLE_REDIRECT_URI=http://localhost:4111/api/auth/sso/callback
 GOOGLE_COOKIE_PASSWORD=a-random-string-at-least-32-characters-long
 GOOGLE_ALLOWED_DOMAINS=example.com
 
@@ -38,6 +38,8 @@ GOOGLE_WORKSPACE_ADMIN_EMAIL=admin@example.com
 :::note
 
 `GOOGLE_COOKIE_PASSWORD` encrypts session cookies. If omitted, an auto-generated value is used that doesn't survive server restarts. Set it explicitly for production.
+
+`MastraAuthGoogle` reads the `GOOGLE_*` auth variables automatically. The service-account variables shown above are read by the configuration code you pass to `MastraRBACGoogle`.
 
 :::
 
@@ -133,7 +135,7 @@ export const mastra = new Mastra({
 
 ## Client-side setup
 
-When auth is enabled, requests to Mastra routes require authentication. `MastraAuthGoogle` uses Google sign-in and stores the authenticated user in an encrypted session cookie.
+When auth is enabled, requests to Mastra routes require authentication. When SSO is enabled with `GOOGLE_CLIENT_SECRET`, `MastraAuthGoogle` uses Google sign-in and stores the authenticated user in an encrypted session cookie.
 
 For cross-origin requests, enable CORS credentials on the Mastra server:
 
@@ -169,7 +171,7 @@ You can also pass a Google ID token as a Bearer token. Mastra verifies the token
 - **401 after sign-in**: Check that `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `GOOGLE_REDIRECT_URI` match the Google Cloud OAuth client.
 - **Workspace users are rejected**: Verify `GOOGLE_ALLOWED_DOMAINS` matches the Google ID token `hd` claim.
 - **Consumer Gmail accounts are rejected**: This is expected when `allowedDomains` is configured because Gmail accounts don't have a Workspace `hd` claim.
-- **RBAC returns default permissions**: Verify the service account has domain-wide delegation and the Directory API group read-only scope.
+- **RBAC returns default permissions**: No roles were resolved for the user. Verify the user email or custom `getUserKey`, Google group membership, and `roleMapping`. If the Directory API lookup fails, the provider throws an error instead of returning `_default`.
 - **Cookies are not sent cross-origin**: Set `credentials: "include"` in `MastraClient` and configure `server.cors` with `credentials: true`.
 
 ## Related

--- a/docs/src/content/en/docs/server/auth/google.mdx
+++ b/docs/src/content/en/docs/server/auth/google.mdx
@@ -5,15 +5,23 @@ packages:
   - "@mastra/auth-google"
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 # Google
 
-The `@mastra/auth-google` package provides Google OpenID Connect authentication and Google Workspace group-based role-based access control (RBAC) for Mastra.
+The `@mastra/auth-google` package provides authentication and role-based access control for Mastra using Google Workspace. It supports an OAuth 2.0 / OIDC login flow with encrypted session cookies, verifies Google ID tokens, and maps Google Workspace groups to Mastra permissions.
 
 Use it when your Studio users sign in with Google and access should be limited to one or more Google Workspace domains.
 
 ## Prerequisites
 
-Set up a Google Cloud OAuth client for web applications and add your Mastra callback URL to the authorized redirect URIs.
+This guide uses Google Workspace authentication. Make sure to:
+
+1. Create or select a Google Cloud project
+1. Set up an OAuth client for web applications
+1. Add your Mastra SSO callback URL to the authorized redirect URIs
+1. Configure Google Workspace groups if you plan to use RBAC
 
 For Google Groups RBAC, also configure a Google Workspace service account with domain-wide delegation and grant it the Directory API read-only group scope:
 
@@ -21,7 +29,7 @@ For Google Groups RBAC, also configure a Google Workspace service account with d
 https://www.googleapis.com/auth/admin.directory.group.readonly
 ```
 
-Set the following environment variables:
+Make sure your environment variables are set.
 
 ```env title=".env"
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
@@ -45,13 +53,38 @@ GOOGLE_WORKSPACE_ADMIN_EMAIL=admin@example.com
 
 ## Installation
 
+Before you can use the `MastraAuthGoogle` class, install the `@mastra/auth-google` package.
+
 ```bash npm2yarn
 npm install @mastra/auth-google
 ```
 
-## Basic usage
+## Usage examples
 
-The following example enables Google sign-in and restricts access to users whose verified Google ID token has `hd: "example.com"`.
+### Basic usage with environment variables
+
+With the environment variables above set, all constructor parameters are optional:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraAuthGoogle } from '@mastra/auth-google'
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthGoogle(),
+  },
+})
+```
+
+:::warning
+
+Use `allowedDomains` or `GOOGLE_ALLOWED_DOMAINS` to enforce Workspace access. Mastra checks Google's verified `hd` claim, not the email address suffix.
+
+:::
+
+### Custom configuration
+
+Pass constructor options directly if you don't want to rely on environment variables:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -60,21 +93,18 @@ import { MastraAuthGoogle } from '@mastra/auth-google'
 export const mastra = new Mastra({
   server: {
     auth: new MastraAuthGoogle({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      redirectUri: process.env.GOOGLE_REDIRECT_URI,
       allowedDomains: ['example.com'],
     }),
   },
 })
 ```
 
-:::warning
+### Auth with Google Groups RBAC
 
-Use `allowedDomains` to enforce Workspace access. Mastra checks Google's verified `hd` claim, not the email address suffix.
-
-:::
-
-## Auth with Google Groups RBAC
-
-Add `MastraRBACGoogle` to map Google Workspace groups to Mastra permissions.
+Add `MastraRBACGoogle` to map Google Workspace groups to Mastra permissions:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -82,9 +112,7 @@ import { MastraAuthGoogle, MastraRBACGoogle } from '@mastra/auth-google'
 
 export const mastra = new Mastra({
   server: {
-    auth: new MastraAuthGoogle({
-      allowedDomains: ['example.com'],
-    }),
+    auth: new MastraAuthGoogle(),
     rbac: new MastraRBACGoogle({
       serviceAccount: {
         clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
@@ -95,18 +123,16 @@ export const mastra = new Mastra({
         'admins@example.com': ['*'],
         'engineering@example.com': ['agents:*', 'workflows:*', 'tools:*'],
         'viewers@example.com': ['agents:read', 'workflows:read'],
-        _default: [],
+        _default: [], // users with unmapped groups get no permissions
       },
     }),
   },
 })
 ```
 
-Group email addresses are used as role IDs by default. Use `mapGroupToRoles` if you want to map by group name or another property.
+### Cross-provider usage
 
-## Cross-provider RBAC
-
-Use Google Groups RBAC with another auth provider by passing `getUserKey`.
+Use a different auth provider (Auth0, Clerk, etc.) for login and Google Workspace groups for RBAC. Pass a `getUserKey` function to resolve the Google Directory API user key from the other provider's user object:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -133,18 +159,48 @@ export const mastra = new Mastra({
 })
 ```
 
+:::info
+
+Visit [MastraAuthGoogle](/reference/auth/google) for all available configuration options.
+
+:::
+
+## Role mapping
+
+The `roleMapping` option maps Google Workspace group email addresses to arrays of Mastra permission strings. Permissions follow a `resource:action` pattern and support wildcards:
+
+```typescript
+const rbac = new MastraRBACGoogle({
+  roleMapping: {
+    // full access to everything
+    'admins@example.com': ['*'],
+
+    // full access to agents and workflows
+    'engineering@example.com': ['agents:*', 'workflows:*'],
+
+    // read-only access
+    'viewers@example.com': ['agents:read', 'workflows:read'],
+
+    // users whose groups don't match any key above
+    _default: [],
+  },
+})
+```
+
+Group email addresses are used as role IDs by default. Use `mapGroupToRoles` if you want to map by group name or another property. The `_default` key assigns permissions to users whose Google Workspace groups don't match any other key.
+
 ## Client-side setup
 
-When auth is enabled, requests to Mastra routes require authentication. When SSO is enabled with `GOOGLE_CLIENT_SECRET`, `MastraAuthGoogle` uses Google sign-in and stores the authenticated user in an encrypted session cookie.
+When auth is enabled, requests to Mastra routes require authentication. When SSO is enabled with `GOOGLE_CLIENT_SECRET`, `MastraAuthGoogle` uses Google sign-in and sets an encrypted session cookie after login.
 
-For cross-origin requests, enable CORS credentials on the Mastra server:
+### Cookie session (recommended)
+
+For cross-origin requests (for example, a frontend on `:3000` calling Mastra on `:4111`), enable CORS credentials on the Mastra server:
 
 ```typescript title="src/mastra/index.ts"
 export const mastra = new Mastra({
   server: {
-    auth: new MastraAuthGoogle({
-      allowedDomains: ['example.com'],
-    }),
+    auth: new MastraAuthGoogle(),
     cors: {
       origin: 'http://localhost:3000',
       credentials: true,
@@ -164,7 +220,53 @@ export const mastraClient = new MastraClient({
 })
 ```
 
-You can also pass a Google ID token as a Bearer token. Mastra verifies the token against Google's JSON Web Key Set (JWKS) endpoint.
+### Bearer token
+
+You can also pass a Google ID token as a Bearer token. Mastra verifies the token against Google's JSON Web Key Set (JWKS) endpoint:
+
+```typescript title="lib/mastra-client.ts"
+import { MastraClient } from '@mastra/client-js'
+
+export const createMastraClient = (idToken: string) => {
+  return new MastraClient({
+    baseUrl: 'http://localhost:4111',
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+    },
+  })
+}
+```
+
+:::info
+
+Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration options.
+
+:::
+
+### Making authenticated requests
+
+<Tabs>
+  <TabItem value="client" label="MastraClient">
+    ```typescript title="src/api/agents.ts"
+    import { mastraClient } from '../lib/mastra-client'
+
+    const agent = mastraClient.getAgent('weatherAgent')
+    const response = await agent.generate('Weather in London')
+    console.log(response)
+    ```
+  </TabItem>
+
+  <TabItem value="curl" label="cURL">
+    ```bash
+    curl -X POST http://localhost:4111/api/agents/weatherAgent/generate \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer <your-google-id-token>" \
+      -d '{
+        "messages": "Weather in London"
+      }'
+    ```
+  </TabItem>
+</Tabs>
 
 ## Troubleshooting
 
@@ -172,7 +274,8 @@ You can also pass a Google ID token as a Bearer token. Mastra verifies the token
 - **Workspace users are rejected**: Verify `GOOGLE_ALLOWED_DOMAINS` matches the Google ID token `hd` claim.
 - **Consumer Gmail accounts are rejected**: This is expected when `allowedDomains` is configured because Gmail accounts don't have a Workspace `hd` claim.
 - **RBAC returns default permissions**: No roles were resolved for the user. Verify the user email or custom `getUserKey`, Google group membership, and `roleMapping`. If the Directory API lookup fails, the provider throws an error instead of returning `_default`.
-- **Cookies are not sent cross-origin**: Set `credentials: "include"` in `MastraClient` and configure `server.cors` with `credentials: true`.
+- **Cookies are not sent cross-origin**: Set `credentials: "include"` in `MastraClient` and configure `server.cors` with your frontend origin and `credentials: true`.
+- **Session lost on restart**: Set `GOOGLE_COOKIE_PASSWORD` to a stable value of at least 32 characters. Without it, an auto-generated key is used in development and changes on each restart.
 
 ## Related
 

--- a/docs/src/content/en/docs/server/auth/google.mdx
+++ b/docs/src/content/en/docs/server/auth/google.mdx
@@ -143,7 +143,12 @@ export const mastra = new Mastra({
   server: {
     auth: new MastraAuthAuth0(),
     rbac: new MastraRBACGoogle({
-      getUserKey: user => user.email,
+      getUserKey: user => {
+        if (!user || typeof user !== 'object') return undefined
+
+        const { email } = user as { email?: unknown }
+        return typeof email === 'string' ? email : undefined
+      },
       serviceAccount: {
         clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
         privateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!,

--- a/docs/src/content/en/docs/server/auth/index.mdx
+++ b/docs/src/content/en/docs/server/auth/index.mdx
@@ -24,7 +24,7 @@ See [Custom API Routes](/docs/server/custom-api-routes#authentication) for contr
 
 :::note
 
-Authentication for Studio is currently supported by the following providers: Simple Auth, JWT, WorkOS, and Better Auth.
+Authentication for Studio is currently supported by the following providers: Simple Auth, JWT, WorkOS, Better Auth, and Google.
 
 :::
 

--- a/docs/src/content/en/docs/server/auth/index.mdx
+++ b/docs/src/content/en/docs/server/auth/index.mdx
@@ -41,6 +41,7 @@ Authentication for Studio is currently supported by the following providers: Sim
 - [Better Auth](/docs/server/auth/better-auth)
 - [Clerk](/docs/server/auth/clerk)
 - [Firebase](/docs/server/auth/firebase)
+- [Google](/docs/server/auth/google)
 - [Okta](/docs/server/auth/okta)
 - [Supabase](/docs/server/auth/supabase)
 - [WorkOS](/docs/server/auth/workos)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -559,6 +559,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              id: 'server/auth/google',
+              label: 'Google',
+            },
+            {
+              type: 'doc',
               id: 'server/auth/jwt',
               label: 'JSON Web Token',
             },

--- a/docs/src/content/en/reference/auth/google.mdx
+++ b/docs/src/content/en/reference/auth/google.mdx
@@ -296,7 +296,89 @@ const canReadAgents = await rbac.hasPermission(user, 'agents:read')
 
 Returns: `Promise<boolean>`
 
+#### `hasRole(user, role)`
+
+Checks whether a user resolved to a specific Google Workspace group role.
+
+```typescript
+const isAdmin = await rbac.hasRole(user, 'admins@example.com')
+```
+
+Returns: `Promise<boolean>`
+
+#### `hasAllPermissions(user, permissions)`
+
+Checks whether a user has every requested permission.
+
+```typescript
+const canManageAgents = await rbac.hasAllPermissions(user, ['agents:read', 'agents:update'])
+```
+
+Returns: `Promise<boolean>`
+
+#### `hasAnyPermission(user, permissions)`
+
+Checks whether a user has at least one requested permission.
+
+```typescript
+const canReadSomething = await rbac.hasAnyPermission(user, ['agents:read', 'workflows:read'])
+```
+
+Returns: `Promise<boolean>`
+
+#### `getAvailableRoles()`
+
+Returns the role IDs configured in `roleMapping`, excluding `_default`.
+
+```typescript
+const roles = await rbac.getAvailableRoles()
+```
+
+Returns: `Promise<{ id: string; name: string }[]>`
+
+#### `getPermissionsForRole(roleId)`
+
+Returns the permissions configured for a role ID.
+
+```typescript
+const permissions = await rbac.getPermissionsForRole('engineering@example.com')
+```
+
+Returns: `Promise<string[]>`
+
+#### `clearCache()`
+
+Clears all cached Google Workspace group lookups.
+
+```typescript
+rbac.clearCache()
+```
+
+Returns: `void`
+
+#### `clearUserCache(userKey)`
+
+Clears the cached group lookup for one Directory API user key, such as an email address.
+
+```typescript
+rbac.clearUserCache('user@example.com')
+```
+
+Returns: `void`
+
+#### `getCacheStats()`
+
+Returns the current group lookup cache size and maximum size.
+
+```typescript
+const stats = rbac.getCacheStats()
+```
+
+Returns: `{ size: number; maxSize: number }`
+
 ## `GoogleUser` type
+
+`GoogleUser` extends Mastra's base `EEUser` interface. The table below lists common fields and Google-specific fields.
 
 <PropertiesTable
   content={[
@@ -323,6 +405,18 @@ Returns: `Promise<boolean>`
     isOptional: true,
   },
   {
+    name: 'expiresAt',
+    type: 'Date',
+    description: 'Verified ID token expiration time, when available.',
+    isOptional: true,
+  },
+  {
+    name: 'emailVerified',
+    type: 'boolean',
+    description: 'Whether Google reports the email address as verified.',
+    isOptional: true,
+  },
+  {
     name: 'groups',
     type: 'string[]',
     description: 'Optional pre-resolved Google Workspace group role IDs.',
@@ -334,5 +428,7 @@ Returns: `Promise<boolean>`
 ## Additional configuration
 
 `MastraRBACGoogle` uses `GET https://admin.googleapis.com/admin/directory/v1/groups?userKey=...` and handles pagination. Provide a service account with domain-wide delegation for production Google Workspace deployments, or pass `accessToken` / `getAccessToken` if your application already manages Google API tokens.
+
+If `user.groups` is already an array, `MastraRBACGoogle` uses that value and does not call the Directory API. An empty `groups` array means the user has no Google group roles and resolves to `_default` permissions when `_default` is configured.
 
 Visit [Google auth docs](/docs/server/auth/google) for setup guidance.

--- a/docs/src/content/en/reference/auth/google.mdx
+++ b/docs/src/content/en/reference/auth/google.mdx
@@ -1,0 +1,334 @@
+---
+title: "Reference: MastraAuthGoogle & MastraRBACGoogle | Auth"
+description: API reference for the MastraAuthGoogle and MastraRBACGoogle classes, which authenticate and authorize Mastra applications using Google Workspace.
+packages:
+  - "@mastra/auth-google"
+  - "@mastra/core"
+---
+
+# MastraAuthGoogle & MastraRBACGoogle
+
+The `MastraAuthGoogle` class authenticates users with Google OpenID Connect. The `MastraRBACGoogle` class maps Google Workspace groups to Mastra permissions.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraAuthGoogle, MastraRBACGoogle } from '@mastra/auth-google'
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthGoogle({
+      allowedDomains: ['example.com'],
+    }),
+    rbac: new MastraRBACGoogle({
+      serviceAccount: {
+        clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
+        privateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!,
+        subject: process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL!,
+      },
+      roleMapping: {
+        'admins@example.com': ['*'],
+        'engineering@example.com': ['agents:*', 'workflows:*'],
+        _default: [],
+      },
+    }),
+  },
+})
+```
+
+## `MastraAuthGoogle` constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'clientId',
+    type: 'string',
+    description: 'Google OAuth client ID.',
+    isOptional: true,
+    defaultValue: 'process.env.GOOGLE_CLIENT_ID',
+  },
+  {
+    name: 'clientSecret',
+    type: 'string',
+    description: 'Google OAuth client secret. Required for Studio SSO.',
+    isOptional: true,
+    defaultValue: 'process.env.GOOGLE_CLIENT_SECRET',
+  },
+  {
+    name: 'redirectUri',
+    type: 'string',
+    description: 'OAuth redirect URI for the SSO callback.',
+    isOptional: true,
+    defaultValue: 'process.env.GOOGLE_REDIRECT_URI',
+  },
+  {
+    name: 'scopes',
+    type: 'string[]',
+    description: 'OAuth scopes requested during the login flow.',
+    isOptional: true,
+    defaultValue: "['openid', 'profile', 'email']",
+  },
+  {
+    name: 'allowedDomains',
+    type: 'string | string[]',
+    description: 'Allowed Google Workspace hosted domains. Mastra validates these against the verified `hd` claim.',
+    isOptional: true,
+    defaultValue: 'process.env.GOOGLE_ALLOWED_DOMAINS',
+  },
+  {
+    name: 'hostedDomain',
+    type: 'string',
+    description: 'Hosted-domain login hint passed to Google as `hd`. This is a hint only and is not used for authorization.',
+    isOptional: true,
+    defaultValue: 'process.env.GOOGLE_HOSTED_DOMAIN or the single allowed domain',
+  },
+  {
+    name: 'session',
+    type: 'GoogleSessionOptions',
+    description: 'Session cookie configuration.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'GoogleSessionOptions',
+        parameters: [
+          {
+            name: 'cookieName',
+            type: 'string',
+            description: 'Name of the session cookie.',
+            isOptional: true,
+            defaultValue: "'google_session'",
+          },
+          {
+            name: 'cookieMaxAge',
+            type: 'number',
+            description: 'Cookie max age in seconds.',
+            isOptional: true,
+            defaultValue: '86400',
+          },
+          {
+            name: 'cookiePassword',
+            type: 'string',
+            description: 'Password for encrypting session cookies. Must be at least 32 characters.',
+            isOptional: true,
+            defaultValue: 'process.env.GOOGLE_COOKIE_PASSWORD',
+          },
+          {
+            name: 'secureCookies',
+            type: 'boolean',
+            description: 'Set the `Secure` flag on session cookies.',
+            isOptional: true,
+            defaultValue: 'true in production, false otherwise',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: 'Custom name for the auth provider instance.',
+    isOptional: true,
+    defaultValue: "'google'",
+  },
+]}/>
+
+## `MastraRBACGoogle` constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'roleMapping',
+    type: 'RoleMapping',
+    description: 'Map Google Workspace group roles to Mastra permissions.',
+  },
+  {
+    name: 'accessToken',
+    type: 'string',
+    description: 'Pre-obtained Workspace Directory API access token.',
+    isOptional: true,
+  },
+  {
+    name: 'getAccessToken',
+    type: '() => Promise<string> | string',
+    description: 'Callback that returns a Workspace Directory API access token.',
+    isOptional: true,
+  },
+  {
+    name: 'serviceAccount',
+    type: 'GoogleWorkspaceServiceAccount',
+    description: 'Service account credentials for domain-wide delegated Directory API access.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'GoogleWorkspaceServiceAccount',
+        parameters: [
+          {
+            name: 'clientEmail',
+            type: 'string',
+            description: 'Google service account email.',
+          },
+          {
+            name: 'privateKey',
+            type: 'string',
+            description: 'PEM-encoded private key. Escaped `\\n` values from .env files are supported.',
+          },
+          {
+            name: 'privateKeyId',
+            type: 'string',
+            description: 'Optional private key ID.',
+            isOptional: true,
+          },
+          {
+            name: 'subject',
+            type: 'string',
+            description: 'Workspace administrator user to impersonate with domain-wide delegation.',
+            isOptional: true,
+          },
+          {
+            name: 'scopes',
+            type: 'string[]',
+            description: 'OAuth scopes for the service account token.',
+            isOptional: true,
+            defaultValue: "['https://www.googleapis.com/auth/admin.directory.group.readonly']",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'getUserKey',
+    type: '(user: unknown) => string | undefined',
+    description: 'Extract the Directory API `userKey` from an authenticated user. Defaults to `user.email`.',
+    isOptional: true,
+  },
+  {
+    name: 'mapGroupToRoles',
+    type: '(group: GoogleWorkspaceGroup) => string[]',
+    description: 'Map a Google Workspace group to role IDs. Defaults to `[group.email]`.',
+    isOptional: true,
+  },
+  {
+    name: 'cache',
+    type: 'PermissionCacheOptions',
+    description: 'Group lookup cache configuration.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'PermissionCacheOptions',
+        parameters: [
+          {
+            name: 'maxSize',
+            type: 'number',
+            description: 'Maximum number of users to cache.',
+            isOptional: true,
+            defaultValue: '1000',
+          },
+          {
+            name: 'ttlMs',
+            type: 'number',
+            description: 'Cache time-to-live in milliseconds.',
+            isOptional: true,
+            defaultValue: '60000',
+          },
+        ],
+      },
+    ],
+  },
+]}/>
+
+## Methods
+
+### Authentication
+
+#### `authenticateToken(token, request?)`
+
+Authenticates a Google ID token. When SSO is enabled, this method checks the encrypted session cookie before it verifies the Bearer token.
+
+```typescript
+const user = await auth.authenticateToken(idToken, request)
+```
+
+Returns: `Promise<GoogleUser | null>`
+
+#### `authorizeUser(user)`
+
+Returns `true` when the user has an ID, has not expired, and matches `allowedDomains` when domains are configured.
+
+```typescript
+const allowed = await auth.authorizeUser(user)
+```
+
+Returns: `boolean`
+
+### RBAC
+
+#### `getRoles(user)`
+
+Returns Google Workspace group role IDs for a user.
+
+```typescript
+const roles = await rbac.getRoles(user)
+```
+
+Returns: `Promise<string[]>`
+
+#### `getPermissions(user)`
+
+Returns Mastra permissions resolved from Google Workspace groups and `roleMapping`.
+
+```typescript
+const permissions = await rbac.getPermissions(user)
+```
+
+Returns: `Promise<string[]>`
+
+#### `hasPermission(user, permission)`
+
+Checks whether a user has a permission.
+
+```typescript
+const canReadAgents = await rbac.hasPermission(user, 'agents:read')
+```
+
+Returns: `Promise<boolean>`
+
+## `GoogleUser` type
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Mastra user ID. Uses the Google `sub` claim.',
+  },
+  {
+    name: 'googleId',
+    type: 'string',
+    description: 'Google Account subject identifier.',
+  },
+  {
+    name: 'email',
+    type: 'string',
+    description: 'User email address.',
+    isOptional: true,
+  },
+  {
+    name: 'hostedDomain',
+    type: 'string',
+    description: 'Google Workspace hosted domain from the verified `hd` claim.',
+    isOptional: true,
+  },
+  {
+    name: 'groups',
+    type: 'string[]',
+    description: 'Optional pre-resolved Google Workspace group role IDs.',
+    isOptional: true,
+  },
+]}/>
+
+## Additional configuration
+
+`MastraRBACGoogle` uses `GET https://admin.googleapis.com/admin/directory/v1/groups?userKey=...` and handles pagination. Provide a service account with domain-wide delegation for production Google Workspace deployments, or pass `accessToken` / `getAccessToken` if your application already manages Google API tokens.
+
+Visit [Google auth docs](/docs/server/auth/google) for setup guidance.

--- a/docs/src/content/en/reference/auth/google.mdx
+++ b/docs/src/content/en/reference/auth/google.mdx
@@ -6,38 +6,37 @@ packages:
   - "@mastra/core"
 ---
 
-# MastraAuthGoogle & MastraRBACGoogle
+# MastraAuthGoogle & MastraRBACGoogle class
 
-The `MastraAuthGoogle` class authenticates users with Google OpenID Connect. The `MastraRBACGoogle` class maps Google Workspace groups to Mastra permissions.
+## MastraAuthGoogle class
 
-## Usage example
+The `MastraAuthGoogle` class provides authentication for Mastra using Google Workspace. It implements an OAuth 2.0 / OIDC login flow with encrypted session cookies, verifies Google ID tokens, and integrates with the Mastra server using the `auth` option.
+
+### Usage example
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
-import { MastraAuthGoogle, MastraRBACGoogle } from '@mastra/auth-google'
+import { MastraAuthGoogle } from '@mastra/auth-google'
 
 export const mastra = new Mastra({
   server: {
     auth: new MastraAuthGoogle({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      redirectUri: process.env.GOOGLE_REDIRECT_URI,
       allowedDomains: ['example.com'],
-    }),
-    rbac: new MastraRBACGoogle({
-      serviceAccount: {
-        clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
-        privateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!,
-        subject: process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL!,
-      },
-      roleMapping: {
-        'admins@example.com': ['*'],
-        'engineering@example.com': ['agents:*', 'workflows:*'],
-        _default: [],
-      },
     }),
   },
 })
 ```
 
-## `MastraAuthGoogle` constructor parameters
+:::note
+
+You can omit the constructor parameters if you have the appropriately named environment variables set. In that case, use `new MastraAuthGoogle()` without any arguments.
+
+:::
+
+### Constructor parameters
 
 <PropertiesTable
   content={[
@@ -58,7 +57,8 @@ export const mastra = new Mastra({
   {
     name: 'redirectUri',
     type: 'string',
-    description: 'OAuth redirect URI for the SSO callback.',
+    description:
+      'OAuth redirect URI for the SSO callback. Must match the redirect URI configured in your Google Cloud OAuth client.',
     isOptional: true,
     defaultValue: 'process.env.GOOGLE_REDIRECT_URI',
   },
@@ -105,12 +105,13 @@ export const mastra = new Mastra({
             type: 'number',
             description: 'Cookie max age in seconds.',
             isOptional: true,
-            defaultValue: '86400',
+            defaultValue: '86400 (24 hours)',
           },
           {
             name: 'cookiePassword',
             type: 'string',
-            description: 'Password for encrypting session cookies. Must be at least 32 characters.',
+            description:
+              'Password for encrypting session cookies. Must be at least 32 characters. If not set, an auto-generated value is used in development that does not survive restarts.',
             isOptional: true,
             defaultValue: 'process.env.GOOGLE_COOKIE_PASSWORD',
           },
@@ -135,14 +136,237 @@ export const mastra = new Mastra({
 ]}
 />
 
-## `MastraRBACGoogle` constructor parameters
+### Environment variables
+
+The following environment variables are automatically used when constructor options aren't provided:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'GOOGLE_CLIENT_ID',
+    type: 'string',
+    description: 'Google OAuth client ID from your Google Cloud OAuth client.',
+  },
+  {
+    name: 'GOOGLE_CLIENT_SECRET',
+    type: 'string',
+    description: 'Google OAuth client secret. Required for the SSO authorization code flow.',
+    isOptional: true,
+  },
+  {
+    name: 'GOOGLE_REDIRECT_URI',
+    type: 'string',
+    description: 'OAuth redirect URI for the SSO callback.',
+    isOptional: true,
+  },
+  {
+    name: 'GOOGLE_COOKIE_PASSWORD',
+    type: 'string',
+    description: 'Password for encrypting session cookies. Must be at least 32 characters.',
+    isOptional: true,
+  },
+  {
+    name: 'GOOGLE_ALLOWED_DOMAINS',
+    type: 'string',
+    description: 'Comma-separated Google Workspace hosted domains to allow.',
+    isOptional: true,
+  },
+  {
+    name: 'GOOGLE_HOSTED_DOMAIN',
+    type: 'string',
+    description: 'Hosted-domain login hint passed to Google during SSO login.',
+    isOptional: true,
+  },
+]}
+/>
+
+### Authentication flow
+
+`MastraAuthGoogle` authenticates requests in the following order:
+
+1. **Session cookie**: When SSO is enabled, reads the encrypted session cookie and decrypts it. If the session is valid and not expired, the user is authenticated.
+1. **Google ID token fallback**: If no valid session cookie is present, verifies the `Authorization` header token against Google's JWKS endpoint.
+
+After authentication, `authorizeUser` checks that the user has a valid Google user ID, the token-derived expiration has not passed, and the user's verified `hd` claim matches `allowedDomains` when domains are configured.
+
+### Authentication methods
+
+#### `authenticateToken(token, request?)`
+
+Authenticates a Google ID token. When SSO is enabled, this method checks the encrypted session cookie before it verifies the Bearer token.
+
+```typescript
+const user = await auth.authenticateToken(idToken, request)
+```
+
+Returns: `Promise<GoogleUser | null>`
+
+#### `getCurrentUser(request)`
+
+Returns the authenticated user from a session cookie or Bearer Google ID token.
+
+```typescript
+const user = await auth.getCurrentUser(request)
+```
+
+Returns: `Promise<GoogleUser | null>`
+
+#### `authorizeUser(user)`
+
+Returns `true` when the user has an ID, has not expired, and matches `allowedDomains` when domains are configured.
+
+```typescript
+const allowed = auth.authorizeUser(user)
+```
+
+Returns: `boolean`
+
+#### `getUser(userId)`
+
+Returns `null`. Google ID tokens are verified directly, so this provider does not perform user lookup by ID.
+
+```typescript
+const user = await auth.getUser(userId)
+```
+
+Returns: `Promise<GoogleUser | null>`
+
+### `GoogleUser` type
+
+The `GoogleUser` type extends the base `EEUser` interface with Google-specific fields:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Mastra user ID. Uses the Google `sub` claim.',
+  },
+  {
+    name: 'googleId',
+    type: 'string',
+    description: 'Google Account subject identifier.',
+  },
+  {
+    name: 'email',
+    type: 'string',
+    description: 'User email address.',
+    isOptional: true,
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: 'User display name from Google profile claims.',
+    isOptional: true,
+  },
+  {
+    name: 'avatarUrl',
+    type: 'string',
+    description: "URL to the user's Google profile picture.",
+    isOptional: true,
+  },
+  {
+    name: 'hostedDomain',
+    type: 'string',
+    description: 'Google Workspace hosted domain from the verified `hd` claim.',
+    isOptional: true,
+  },
+  {
+    name: 'expiresAt',
+    type: 'Date',
+    description: 'Verified ID token expiration time, when available.',
+    isOptional: true,
+  },
+  {
+    name: 'emailVerified',
+    type: 'boolean',
+    description: 'Whether Google reports the email address as verified.',
+    isOptional: true,
+  },
+  {
+    name: 'groups',
+    type: 'string[]',
+    description: 'Optional pre-resolved Google Workspace group role IDs.',
+    isOptional: true,
+  },
+]}
+/>
+
+## MastraRBACGoogle class
+
+The `MastraRBACGoogle` class maps Google Workspace groups to Mastra permissions. It fetches user groups from the Google Admin SDK Directory API and resolves them against a configurable role mapping. Use it with `MastraAuthGoogle` or any other auth provider.
+
+:::note
+
+RBAC requires a valid Enterprise Edition license. It works without a license in development so you can try it locally, but you'll need a license for production. [Contact sales](https://mastra.ai/contact) for more information.
+
+:::
+
+### Usage example
+
+Use `MastraRBACGoogle` alongside an auth provider by passing it to the `rbac` option:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraAuthGoogle, MastraRBACGoogle } from '@mastra/auth-google'
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthGoogle(),
+    rbac: new MastraRBACGoogle({
+      serviceAccount: {
+        clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
+        privateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!,
+        subject: process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL!,
+      },
+      roleMapping: {
+        'admins@example.com': ['*'],
+        'engineering@example.com': ['agents:*', 'workflows:*', 'tools:*'],
+        'viewers@example.com': ['agents:read', 'workflows:read'],
+        _default: [],
+      },
+    }),
+  },
+})
+```
+
+To use Google Workspace RBAC with a different auth provider, pass a `getUserKey` function to resolve the Google Directory API user key from the other provider's user object:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraAuthAuth0 } from '@mastra/auth-auth0'
+import { MastraRBACGoogle } from '@mastra/auth-google'
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthAuth0(),
+    rbac: new MastraRBACGoogle({
+      getUserKey: user => user.email,
+      serviceAccount: {
+        clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL!,
+        privateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY!,
+        subject: process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL!,
+      },
+      roleMapping: {
+        'engineering@example.com': ['agents:*', 'workflows:*'],
+        'admins@example.com': ['*'],
+        _default: [],
+      },
+    }),
+  },
+})
+```
+
+### Constructor parameters
 
 <PropertiesTable
   content={[
   {
     name: 'roleMapping',
     type: 'RoleMapping',
-    description: 'Map Google Workspace group roles to Mastra permissions.',
+    description:
+      "Maps Google Workspace group role IDs to arrays of Mastra permission strings. Use `'_default'` to assign permissions to users who do not match any group. Supports wildcards like `'*'` (full access) and `'agents:*'` (all agent actions).",
+    isOptional: false,
   },
   {
     name: 'accessToken',
@@ -213,7 +437,7 @@ export const mastra = new Mastra({
   {
     name: 'cache',
     type: 'PermissionCacheOptions',
-    description: 'Group lookup cache configuration.',
+    description: 'Configure the LRU cache for group lookups.',
     isOptional: true,
     properties: [
       {
@@ -229,7 +453,7 @@ export const mastra = new Mastra({
           {
             name: 'ttlMs',
             type: 'number',
-            description: 'Cache time-to-live in milliseconds.',
+            description: 'Time-to-live in milliseconds.',
             isOptional: true,
             defaultValue: '60000',
           },
@@ -240,31 +464,7 @@ export const mastra = new Mastra({
 ]}
 />
 
-## Methods
-
-### Authentication
-
-#### `authenticateToken(token, request?)`
-
-Authenticates a Google ID token. When SSO is enabled, this method checks the encrypted session cookie before it verifies the Bearer token.
-
-```typescript
-const user = await auth.authenticateToken(idToken, request)
-```
-
-Returns: `Promise<GoogleUser | null>`
-
-#### `authorizeUser(user)`
-
-Returns `true` when the user has an ID, has not expired, and matches `allowedDomains` when domains are configured.
-
-```typescript
-const allowed = await auth.authorizeUser(user)
-```
-
-Returns: `boolean`
-
-### RBAC
+### RBAC methods
 
 #### `getRoles(user)`
 
@@ -376,59 +576,14 @@ const stats = rbac.getCacheStats()
 
 Returns: `{ size: number; maxSize: number }`
 
-## `GoogleUser` type
-
-`GoogleUser` extends Mastra's base `EEUser` interface. The table below lists common fields and Google-specific fields.
-
-<PropertiesTable
-  content={[
-  {
-    name: 'id',
-    type: 'string',
-    description: 'Mastra user ID. Uses the Google `sub` claim.',
-  },
-  {
-    name: 'googleId',
-    type: 'string',
-    description: 'Google Account subject identifier.',
-  },
-  {
-    name: 'email',
-    type: 'string',
-    description: 'User email address.',
-    isOptional: true,
-  },
-  {
-    name: 'hostedDomain',
-    type: 'string',
-    description: 'Google Workspace hosted domain from the verified `hd` claim.',
-    isOptional: true,
-  },
-  {
-    name: 'expiresAt',
-    type: 'Date',
-    description: 'Verified ID token expiration time, when available.',
-    isOptional: true,
-  },
-  {
-    name: 'emailVerified',
-    type: 'boolean',
-    description: 'Whether Google reports the email address as verified.',
-    isOptional: true,
-  },
-  {
-    name: 'groups',
-    type: 'string[]',
-    description: 'Optional pre-resolved Google Workspace group role IDs.',
-    isOptional: true,
-  },
-]}
-/>
-
-## Additional configuration
+### Additional configuration
 
 `MastraRBACGoogle` uses `GET https://admin.googleapis.com/admin/directory/v1/groups?userKey=...` and handles pagination. Provide a service account with domain-wide delegation for production Google Workspace deployments, or pass `accessToken` / `getAccessToken` if your application already manages Google API tokens.
 
 If `user.groups` is already an array, `MastraRBACGoogle` uses that value and does not call the Directory API. An empty `groups` array means the user has no Google group roles and resolves to `_default` permissions when `_default` is configured.
 
-Visit [Google auth docs](/docs/server/auth/google) for setup guidance.
+`MastraRBACGoogle` does not automatically read service-account environment variables. Pass service-account credentials through the `serviceAccount` option, or pass `accessToken` / `getAccessToken`.
+
+## Related
+
+[Google auth docs](/docs/server/auth/google)

--- a/docs/src/content/en/reference/auth/google.mdx
+++ b/docs/src/content/en/reference/auth/google.mdx
@@ -79,7 +79,8 @@ export const mastra = new Mastra({
   {
     name: 'hostedDomain',
     type: 'string',
-    description: 'Hosted-domain login hint passed to Google as `hd`. This is a hint only and is not used for authorization.',
+    description:
+      'Hosted-domain login hint passed to Google as `hd`. This is a hint only and is not used for authorization.',
     isOptional: true,
     defaultValue: 'process.env.GOOGLE_HOSTED_DOMAIN or the single allowed domain',
   },
@@ -131,7 +132,8 @@ export const mastra = new Mastra({
     isOptional: true,
     defaultValue: "'google'",
   },
-]}/>
+]}
+/>
 
 ## `MastraRBACGoogle` constructor parameters
 
@@ -235,7 +237,8 @@ export const mastra = new Mastra({
       },
     ],
   },
-]}/>
+]}
+/>
 
 ## Methods
 
@@ -325,7 +328,8 @@ Returns: `Promise<boolean>`
     description: 'Optional pre-resolved Google Workspace group role IDs.',
     isOptional: true,
   },
-]}/>
+]}
+/>
 
 ## Additional configuration
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -86,6 +86,7 @@ const sidebars = {
         { type: 'doc', id: 'auth/better-auth', label: 'Better Auth' },
         { type: 'doc', id: 'auth/clerk', label: 'Clerk' },
         { type: 'doc', id: 'auth/firebase', label: 'Firebase' },
+        { type: 'doc', id: 'auth/google', label: 'Google' },
         { type: 'doc', id: 'auth/jwt', label: 'JSON Web Token' },
         { type: 'doc', id: 'auth/okta', label: 'Okta' },
         { type: 'doc', id: 'auth/supabase', label: 'Supabase' },


### PR DESCRIPTION
This is PR 2 of 2 split from the Google Workspace auth provider work. It is stacked on #18160.

## Summary

Adds documentation for the new `@mastra/auth-google` package.

Included in this PR:

- `auth/google/README.md`.
- Server auth guide for Google Workspace authentication.
- API reference page for `MastraAuthGoogle` and `MastraRBACGoogle`.
- Auth overview link and docs/reference sidebar entries.
- Workspace setup, hosted-domain validation, service-account delegation, Google Groups role mapping, and cross-provider RBAC usage documentation.

## Scope

Intentionally excluded from this PR:

- Package implementation, tests, lockfile, and changeset: handled in #18160.
- Examples: no example changes are included.

## Verification

Relevant checks for this docs-only PR:

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter ./docs validate`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter ./docs lint:remark`
- `./node_modules/.bin/prettier --ignore-path /dev/null --check docs/src/content/en/reference/auth/google.mdx docs/src/content/en/docs/server/auth/google.mdx auth/google/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a new “help page” for signing users in with Google (Google Workspace) and then controlling what they can do using Google Groups. It explains how to set up Google, wire it into Mastra, and where to find the API details.

### Summary
- Added full documentation for the new `@mastra/auth-google` package (`auth/google/README.md`), including installation, required environment variables, service-account key/delegation guidance, and exported symbols.
- Added a new Google auth server guide page (`docs/src/content/en/docs/server/auth/google.mdx`) covering:
  - OAuth 2.0 / OIDC login flow and encrypted cookie-session behavior
  - Google ID token verification
  - Google Workspace hosted-domain enforcement
  - Google Groups → RBAC role/permission mapping via `MastraRBACGoogle` (including default behavior and wildcard permission patterns)
  - Cross-provider RBAC usage with `getUserKey` role mapping
  - Required prerequisites/scopes, multiple setup/usage examples, authenticated request examples (SDK + cURL), a troubleshooting checklist, and related links
  - Client cookie-session/CORS guidance plus an alternative Bearer-token flow using JWKS
- Added API reference documentation pages for `MastraAuthGoogle` and `MastraRBACGoogle` (`docs/src/content/en/reference/auth/google.mdx`), including configuration options, environment variables, method signatures, and the `GoogleUser` type.
- Updated navigation/sidebar docs to include Google:
  - Added “Google” to the server auth overview list (`docs/src/content/en/docs/server/auth/index.mdx`)
  - Inserted Google entry into the `server/auth` sidebar (`docs/src/content/en/docs/sidebars.js`)
  - Inserted Google entry into the Auth reference sidebar (`docs/src/content/en/reference/sidebars.js`)

### Notes
- Docs-only change: no package implementation, tests, lockfile, changeset, or examples were included.
- Validation ran on the updated docs (docs validation, remark linting, and Prettier).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->