### PR TITLE
Add Table display variants

### DIFF
--- a/.changeset/sweet-beans-visit.md
+++ b/.changeset/sweet-beans-visit.md
@@ -1,0 +1,22 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added visual variants to the semantic `Table` component and reused those table primitives in markdown rendering.
+
+Use `variant="striped"` or `variant="lined"` when a native HTML table should match the denser list treatments.
+
+```tsx
+<Table size="small" variant="striped">
+  <Thead>
+    <Th>Name</Th>
+    <Th>Status</Th>
+  </Thead>
+  <Tbody>
+    <Row>
+      <Cell>Dataset row</Cell>
+      <Cell>Active</Cell>
+    </Row>
+  </Tbody>
+</Table>
+```

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm';
 
 import { Code } from '@/ds/components/Code';
 import { CopyButton } from '@/ds/components/CopyButton';
+import { Cell as TableCell, Row as TableRow, Table, TableBody, TableHeader, Th } from '@/ds/components/Table';
 import { cn } from '@/lib/utils';
 
 export type MarkdownRendererProps = {
@@ -62,6 +63,12 @@ function childrenTakeAllStringContents(element: any): string {
   }
 
   return '';
+}
+
+function getMarkdownTableAlignClass(align?: string) {
+  if (align === 'center') return 'text-center [&>div]:justify-center';
+  if (align === 'right') return 'text-right [&>div]:justify-end';
+  return undefined;
 }
 
 // Create component wrappers with className
@@ -139,32 +146,20 @@ const COMPONENTS: Components = {
       {children}
     </li>
   ),
-  table: ({ children, ...props }) => (
-    <table className="w-full border-collapse overflow-y-auto rounded-md border border-neutral6/20" {...props}>
+  table: ({ children }) => <Table size="small">{children}</Table>,
+  thead: ({ children, node: _node, ...props }: any) => <TableHeader {...props}>{children}</TableHeader>,
+  tbody: ({ children, node: _node, ...props }: any) => <TableBody {...props}>{children}</TableBody>,
+  th: ({ children, align, node: _node, ...props }: any) => (
+    <Th className={cn('px-4 py-2 font-bold', getMarkdownTableAlignClass(align))} align={align} {...props}>
       {children}
-    </table>
+    </Th>
   ),
-  th: ({ children, ...props }) => (
-    <th
-      className="border border-neutral6/20 px-4 py-2 text-left font-bold [[align=center]]:text-center [[align=right]]:text-right"
-      {...props}
-    >
+  td: ({ children, align, node: _node, ...props }: any) => (
+    <TableCell className={cn('px-4 py-2', getMarkdownTableAlignClass(align))} align={align} {...props}>
       {children}
-    </th>
+    </TableCell>
   ),
-  td: ({ children, ...props }) => (
-    <td
-      className="border border-neutral6/20 px-4 py-2 text-left [[align=center]]:text-center [[align=right]]:text-right"
-      {...props}
-    >
-      {children}
-    </td>
-  ),
-  tr: ({ children, ...props }) => (
-    <tr className="m-0 border-t p-0 even:bg-surface4" {...props}>
-      {children}
-    </tr>
-  ),
+  tr: ({ children, node: _node, ...props }: any) => <TableRow {...props}>{children}</TableRow>,
   p: ({ children, ...props }) => (
     <p className="whitespace-pre-wrap leading-relaxed" {...props}>
       {children}

--- a/packages/playground-ui/src/ds/components/Table/Cells.tsx
+++ b/packages/playground-ui/src/ds/components/Table/Cells.tsx
@@ -18,6 +18,8 @@ export const Cell = ({ className, children, ...props }: CellProps) => {
   );
 };
 
+export const TableCell = Cell;
+
 export const TxtCell = ({ className, children }: CellProps) => {
   return (
     <Cell className={className}>

--- a/packages/playground-ui/src/ds/components/Table/Table.tsx
+++ b/packages/playground-ui/src/ds/components/Table/Table.tsx
@@ -1,11 +1,16 @@
-import type { CSSProperties, HTMLAttributes, ReactNode, ThHTMLAttributes } from 'react';
-import { forwardRef, useEffect, useRef } from 'react';
+import type { CSSProperties, HTMLAttributes, KeyboardEvent, ReactNode, ThHTMLAttributes } from 'react';
+import { createContext, forwardRef, useContext, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
+
+export type TableVariant = 'default' | 'striped' | 'lined';
+export type TableSize = 'default' | 'small';
 
 export interface TableProps {
   className?: string;
+  containerClassName?: string;
   children: ReactNode;
-  size?: 'default' | 'small';
+  size?: TableSize;
+  variant?: TableVariant;
   style?: CSSProperties;
 }
 
@@ -14,11 +19,64 @@ const rowSize = {
   small: '[&>tbody>tr]:h-table-row-small',
 };
 
-export const Table = ({ className, children, size = 'default', style }: TableProps) => {
+const tableContainerStyles: Record<TableVariant, string> = {
+  default: 'max-w-full overflow-x-auto rounded-lg border border-border1 bg-surface2',
+  striped: 'max-w-full overflow-x-auto rounded-t-xl',
+  lined: 'max-w-full overflow-x-auto rounded-t-xl',
+};
+
+type TableContextValue = {
+  variant: TableVariant;
+};
+
+const tableContextValues = {
+  default: { variant: 'default' },
+  striped: { variant: 'striped' },
+  lined: { variant: 'lined' },
+} satisfies Record<TableVariant, TableContextValue>;
+
+const TableContext = createContext<TableContextValue>(tableContextValues.default);
+const TableSectionContext = createContext<'head' | 'body'>('body');
+
+function useTableContext() {
+  return useContext(TableContext);
+}
+
+function useTableSectionContext() {
+  return useContext(TableSectionContext);
+}
+
+export const Table = ({
+  className,
+  containerClassName,
+  children,
+  size = 'default',
+  variant = 'default',
+  style,
+}: TableProps) => {
   return (
-    <table className={cn('w-full', rowSize[size], className)} style={style}>
-      {children}
-    </table>
+    <TableContext.Provider value={tableContextValues[variant]}>
+      <div className={cn(tableContainerStyles[variant], containerClassName)}>
+        <table className={cn('w-full border-collapse', rowSize[size], className)} style={style}>
+          {children}
+        </table>
+      </div>
+    </TableContext.Provider>
+  );
+};
+
+export interface TableHeaderProps extends HTMLAttributes<HTMLTableSectionElement> {
+  className?: string;
+  children: ReactNode;
+}
+
+export const TableHeader = ({ className, children, ...props }: TableHeaderProps) => {
+  return (
+    <TableSectionContext.Provider value="head">
+      <thead className={className} {...props}>
+        {children}
+      </thead>
+    </TableSectionContext.Provider>
   );
 };
 
@@ -29,46 +87,51 @@ export interface TheadProps {
 
 export const Thead = ({ className, children }: TheadProps) => {
   return (
-    <thead>
-      <tr className={cn('h-table-header border-b border-border1 bg-surface2/80', className)}>{children}</tr>
-    </thead>
+    <TableHeader>
+      <Row className={className}>{children}</Row>
+    </TableHeader>
   );
 };
 
-export interface ThProps extends ThHTMLAttributes<HTMLTableCellElement> {
+export interface TableBodyProps extends HTMLAttributes<HTMLTableSectionElement> {
   className?: string;
-  style?: CSSProperties;
   children: ReactNode;
 }
 
-export const Th = ({ className, children, ...props }: ThProps) => {
+export const TableBody = ({ className, children, ...props }: TableBodyProps) => {
   return (
-    <th
-      className={cn(
-        'text-neutral2 text-ui-xs h-full whitespace-nowrap text-left font-medium uppercase tracking-wide first:pl-3 last:pr-3',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </th>
+    <TableSectionContext.Provider value="body">
+      <tbody className={className} {...props}>
+        {children}
+      </tbody>
+    </TableSectionContext.Provider>
   );
 };
 
-export interface TbodyProps extends HTMLAttributes<HTMLTableSectionElement> {
-  className?: string;
-  children: ReactNode;
-}
+export interface TbodyProps extends TableBodyProps {}
 
 export const Tbody = ({ className, children, ...props }: TbodyProps) => {
   return (
-    <tbody className={cn('', className)} {...props}>
+    <TableBody className={className} {...props}>
       {children}
-    </tbody>
+    </TableBody>
   );
 };
 
-export interface RowProps {
+const headerRowStyles: Record<TableVariant, string> = {
+  default: 'h-table-header border-b border-border1 bg-surface2/80',
+  striped: 'h-table-header border-b border-transparent bg-surface4',
+  lined: 'h-table-header border-b border-border1 bg-surface4',
+};
+
+const bodyRowStyles: Record<TableVariant, string> = {
+  default: 'border-b border-border1 hover:bg-surface3 focus:bg-surface3',
+  striped:
+    'border-b border-transparent even:bg-surface-overlay-soft hover:bg-surface-overlay-strong focus:bg-surface-overlay-strong',
+  lined: 'border-b border-neutral6/10 hover:bg-surface-overlay-strong focus:bg-surface-overlay-strong',
+};
+
+export interface RowProps extends Omit<HTMLAttributes<HTMLTableRowElement>, 'onClick'> {
   className?: string;
   children: ReactNode;
   selected?: boolean;
@@ -80,7 +143,9 @@ export interface RowProps {
 }
 
 export const Row = forwardRef<HTMLTableRowElement, RowProps>(
-  ({ className, children, selected = false, style, onClick, isActive = false, ...props }, ref) => {
+  ({ className, children, selected = false, style, onClick, isActive = false, onKeyDown, ...props }, ref) => {
+    const { variant } = useTableContext();
+    const section = useTableSectionContext();
     const internalRef = useRef<HTMLTableRowElement>(null);
 
     // Merge forwarded ref with internal ref
@@ -101,21 +166,30 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(
       }
     }, [isActive]);
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLTableRowElement>) => {
-      if (event.key === 'Enter' && onClick) {
+    const handleKeyDown = (event: KeyboardEvent<HTMLTableRowElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented) return;
+
+      if ((event.key === 'Enter' || event.key === ' ') && onClick) {
+        event.preventDefault();
         onClick();
       }
     };
 
+    if (section === 'head') {
+      return (
+        <tr ref={internalRef} className={cn(headerRowStyles[variant], className)} style={style} {...props}>
+          {children}
+        </tr>
+      );
+    }
+
     return (
       <tr
         className={cn(
-          'border-b border-border1',
-          // Smooth hover transition
+          bodyRowStyles[variant],
           'transition-colors duration-normal ease-out-custom',
-          'hover:bg-surface3',
-          // Focus state
-          'focus:bg-surface3 focus:outline-hidden focus:ring-1 focus:ring-inset focus:ring-accent1/50',
+          'focus:outline-hidden focus:ring-1 focus:ring-inset focus:ring-accent1/50',
           selected && 'bg-surface4',
           onClick && 'cursor-pointer',
           className,
@@ -125,6 +199,7 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(
         ref={internalRef}
         tabIndex={onClick ? 0 : undefined}
         onKeyDown={handleKeyDown}
+        aria-selected={selected || undefined}
         data-active={isActive || undefined}
         {...props}
       >
@@ -133,3 +208,28 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(
     );
   },
 );
+
+export const TableRow = Row;
+
+export interface ThProps extends ThHTMLAttributes<HTMLTableCellElement> {
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}
+
+export const Th = ({ className, children, scope = 'col', ...props }: ThProps) => {
+  return (
+    <th
+      scope={scope}
+      className={cn(
+        'text-neutral2 text-ui-xs h-full whitespace-nowrap text-left font-medium uppercase tracking-wide first:pl-3 last:pr-3',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </th>
+  );
+};
+
+export const TableHead = Th;

--- a/packages/playground-ui/src/ds/components/Table/table.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Table/table.stories.tsx
@@ -15,6 +15,10 @@ const meta: Meta<typeof Table> = {
       control: { type: 'select' },
       options: ['default', 'small'],
     },
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'striped', 'lined'],
+    },
   },
 };
 
@@ -78,6 +82,80 @@ export const SmallSize: Story = {
             <Cell>
               <Badge variant="success">Active</Badge>
             </Cell>
+          </Row>
+        </Tbody>
+      </Table>
+    </div>
+  ),
+};
+
+export const Striped: Story = {
+  render: () => (
+    <div className="w-[600px]">
+      <Table variant="striped">
+        <Thead>
+          <Th>Name</Th>
+          <Th>Status</Th>
+          <Th>Created</Th>
+        </Thead>
+        <Tbody>
+          <Row>
+            <TxtCell>Item One</TxtCell>
+            <Cell>
+              <Badge variant="success">Active</Badge>
+            </Cell>
+            <TxtCell>Jan 14, 2026</TxtCell>
+          </Row>
+          <Row>
+            <TxtCell>Item Two</TxtCell>
+            <Cell>
+              <Badge variant="default">Pending</Badge>
+            </Cell>
+            <TxtCell>Jan 13, 2026</TxtCell>
+          </Row>
+          <Row>
+            <TxtCell>Item Three</TxtCell>
+            <Cell>
+              <Badge variant="error">Error</Badge>
+            </Cell>
+            <TxtCell>Jan 12, 2026</TxtCell>
+          </Row>
+        </Tbody>
+      </Table>
+    </div>
+  ),
+};
+
+export const Lined: Story = {
+  render: () => (
+    <div className="w-[600px]">
+      <Table variant="lined">
+        <Thead>
+          <Th>Name</Th>
+          <Th>Status</Th>
+          <Th>Created</Th>
+        </Thead>
+        <Tbody>
+          <Row>
+            <TxtCell>Item One</TxtCell>
+            <Cell>
+              <Badge variant="success">Active</Badge>
+            </Cell>
+            <TxtCell>Jan 14, 2026</TxtCell>
+          </Row>
+          <Row>
+            <TxtCell>Item Two</TxtCell>
+            <Cell>
+              <Badge variant="default">Pending</Badge>
+            </Cell>
+            <TxtCell>Jan 13, 2026</TxtCell>
+          </Row>
+          <Row>
+            <TxtCell>Item Three</TxtCell>
+            <Cell>
+              <Badge variant="error">Error</Badge>
+            </Cell>
+            <TxtCell>Jan 12, 2026</TxtCell>
           </Row>
         </Tbody>
       </Table>

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-preview-table.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-preview-table.tsx
@@ -26,26 +26,24 @@ export function CSVPreviewTable({ headers, data, maxRows = 5 }: CSVPreviewTableP
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="overflow-x-auto rounded-lg border border-border1">
-        <Table size="small">
-          <Thead>
-            {headers.map((header: string) => (
-              <Th key={header}>{header}</Th>
-            ))}
-          </Thead>
-          <Tbody>
-            {displayData.map((row: Record<string, unknown>, rowIndex: number) => (
-              <Row key={rowIndex}>
-                {headers.map((header: string) => (
-                  <Cell key={header} className="text-sm max-w-[200px]">
-                    <span className="truncate block">{truncateValue(row[header])}</span>
-                  </Cell>
-                ))}
-              </Row>
-            ))}
-          </Tbody>
-        </Table>
-      </div>
+      <Table size="small">
+        <Thead>
+          {headers.map((header: string) => (
+            <Th key={header}>{header}</Th>
+          ))}
+        </Thead>
+        <Tbody>
+          {displayData.map((row: Record<string, unknown>, rowIndex: number) => (
+            <Row key={rowIndex}>
+              {headers.map((header: string) => (
+                <Cell key={header} className="text-sm max-w-[200px]">
+                  <span className="truncate block">{truncateValue(row[header])}</span>
+                </Cell>
+              ))}
+            </Row>
+          ))}
+        </Tbody>
+      </Table>
 
       {/* Row count indicator */}
       <div className="text-xs text-neutral4">


### PR DESCRIPTION
## Summary
- Kept `Table` as the semantic HTML table primitive instead of moving table semantics into `DataList`.
- Added `variant="striped"` and `variant="lined"` display treatments to `Table`, plus Storybook coverage.
- Updated markdown-rendered tables to use the shared `Table` primitives.
- Kept the CSV preview on `Table`, now relying on the table component for its scroll/border container.

## Notes
- `DataList` is unchanged semantically and remains the list/resource-log primitive for clickable rows, links, wrappers, virtual spacers, empty states, and loading states.
- `ExperimentScorerSummary` uses `ItemList`, not `DataList mode="table"`. `ItemList` and `MetricsDataTable` are separate consolidation targets and are intentionally left out of this PR.

## Validation
- `pnpm --filter ./packages/playground-ui exec vitest run src/components-exports.test.ts src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx src/ds/components/DataList/data-list-root.test.tsx`
- `npx -y react-doctor@latest . --verbose --scope changed`
- `pnpm --filter ./packages/playground-ui typecheck` fails in this worktree because workspace packages such as `@mastra/core`, `@mastra/react`, and `@mastra/client-js` are not resolved.
- `pnpm --filter ./packages/playground typecheck` fails in this worktree because workspace packages such as `@mastra/playground-ui`, `@mastra/core`, `@mastra/react`, and `@mastra/client-js` are not resolved.