### PR TITLE
Revert "fix(core): require approval by default for execute_command on a local sandbox"

### DIFF
--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -90,21 +90,6 @@ function hasSandboxConfig(workspace: Workspace): boolean {
 }
 
 /**
- * Whether a sandbox executes commands directly on the host without OS-level
- * isolation. The built-in LocalSandbox exposes `isolation` and reports `'none'`
- * when no seatbelt/bwrap backend is active; container/cloud sandboxes (E2B,
- * Docker, Modal, …) don't expose this field and are isolated by construction.
- *
- * Used to make `execute_command` fail-safe (require approval by default) when a
- * model tool call would otherwise reach an un-isolated host shell. Detection is
- * duck-typed (no import of the Node-only LocalSandbox) so this stays
- * browser-safe and applies to any provider that reports `isolation: 'none'`.
- */
-function sandboxRunsUnisolatedOnHost(sandbox: WorkspaceSandbox | undefined): boolean {
-  return (sandbox as { isolation?: unknown } | undefined)?.isolation === 'none';
-}
-
-/**
  * Normalize a requestContext value to a plain Record.
  * Callers may pass a Map-like RequestContext (with `.entries()`) or a plain
  * object.  Dynamic config functions always receive a plain object so that
@@ -129,25 +114,10 @@ export interface ResolvedToolConfig {
 }
 
 /**
- * Per-tool built-in defaults that override the global fail-open defaults.
- * Used to make individual tools fail-safe based on the runtime environment
- * (e.g. requiring approval for command execution on an un-isolated sandbox).
- */
-export interface ToolConfigDefaults {
-  /**
-   * Built-in default for `requireApproval` when the host hasn't configured it
-   * (neither top-level nor per-tool). Host config always takes precedence, so
-   * this only raises the floor — it never overrides an explicit setting.
-   */
-  requireApproval?: DynamicToolConfigValue<ToolConfigWithArgsContext>;
-}
-
-/**
  * Resolves the effective configuration for a specific tool.
  *
  * Resolution order (later overrides earlier):
- * 1. Built-in defaults (enabled: true, requireApproval: false unless `defaults`
- *    raises it for this tool/environment)
+ * 1. Built-in defaults (enabled: true, requireApproval: false)
  * 2. Top-level config (tools.enabled, tools.requireApproval)
  * 3. Per-tool config (tools[toolName].enabled, tools[toolName].requireApproval)
  *
@@ -159,10 +129,9 @@ export async function resolveToolConfig(
   toolsConfig: WorkspaceToolsConfig | undefined,
   toolName: WorkspaceToolName,
   context?: ToolConfigContext,
-  defaults?: ToolConfigDefaults,
 ): Promise<ResolvedToolConfig> {
   let enabled: DynamicToolConfigValue = true;
-  let requireApproval: DynamicToolConfigValue<ToolConfigWithArgsContext> = defaults?.requireApproval ?? false;
+  let requireApproval: DynamicToolConfigValue<ToolConfigWithArgsContext> = false;
   let requireReadBeforeWrite: DynamicToolConfigValue<ToolConfigWithArgsContext> | undefined;
   let maxOutputTokens: number | undefined;
   let name: string | undefined;
@@ -435,10 +404,9 @@ export async function createWorkspaceTools(
       readTrackerMode?: 'read' | 'write';
       useWriteLock?: boolean;
       targets?: ResolveTargets;
-      defaults?: ToolConfigDefaults;
     },
   ) => {
-    const config = await resolveToolConfig(toolsConfig, name, effectiveConfigContext, opts?.defaults);
+    const config = await resolveToolConfig(toolsConfig, name, effectiveConfigContext);
     if (!config.enabled) return;
     if (opts?.requireWrite && isReadOnly) return;
 
@@ -561,23 +529,11 @@ export async function createWorkspaceTools(
     await addTool(WORKSPACE_TOOLS.SEARCH.INDEX, indexContentTool, { requireWrite: true });
   }
 
-  // When the sandbox runs commands directly on the host with no OS isolation,
-  // a single model/tool call (e.g. from prompt injection) can execute arbitrary
-  // shell commands. Default execute_command to requiring approval in that case;
-  // host config (top-level or per-tool requireApproval) still overrides this.
-  const sandboxIsUnisolated = sandboxRunsUnisolatedOnHost(workspace.sandbox);
-  const executeCommandDefaults: ToolConfigDefaults | undefined = sandboxIsUnisolated
-    ? { requireApproval: true }
-    : undefined;
-
   if (workspace.sandbox) {
     if (workspace.sandbox.executeCommand) {
       // Pick the right tool variant based on whether processes are available
       const baseTool = workspace.sandbox.processes ? executeCommandWithBackgroundTool : executeCommandTool;
-      await addTool(WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND, baseTool, {
-        targets: { sandbox: true },
-        defaults: executeCommandDefaults,
-      });
+      await addTool(WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND, baseTool, { targets: { sandbox: true } });
     }
 
     // Background process tools (only when process manager is available)

--- a/packages/core/src/workspace/workspace-safety.test.ts
+++ b/packages/core/src/workspace/workspace-safety.test.ts
@@ -363,7 +363,7 @@ describe('Workspace Safety Features', () => {
       await workspace.destroy();
     });
 
-    it('should default to all tools enabled and no approval required (except un-isolated execute_command)', async () => {
+    it('should default to all tools enabled and no approval required', async () => {
       const workspace = new Workspace({
         filesystem: new LocalFilesystem({ basePath: tempDir }),
         sandbox: new LocalSandbox({ workingDirectory: tempDir }),
@@ -384,14 +384,10 @@ describe('Workspace Safety Features', () => {
       expect(tools[WORKSPACE_TOOLS.SEARCH.INDEX]).toBeDefined();
       expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
 
-      // No approval required by default for non-command tools
+      // No approval required by default
       expect(tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].requireApproval).toBe(false);
       expect(tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].requireApproval).toBe(false);
-
-      // execute_command on an un-isolated LocalSandbox (isolation: 'none', the
-      // default) runs on the host shell with no OS isolation, so it is gated
-      // behind approval by default. Hosts can opt out via tools.requireApproval.
-      expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND].requireApproval).toBe(true);
+      expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND].requireApproval).toBe(false);
 
       await workspace.destroy();
     });
@@ -519,109 +515,6 @@ describe('Workspace Safety Features', () => {
       const tools = await createWorkspaceTools(workspace);
 
       expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND].requireApproval).toBe(true);
-
-      await workspace.destroy();
-    });
-  });
-
-  // ===========================================================================
-  // execute_command approval default for un-isolated sandboxes
-  //
-  // A model/tool call (e.g. from prompt injection) that reaches an un-isolated
-  // LocalSandbox runs arbitrary shell commands on the host. execute_command must
-  // therefore default to requiring approval when isolation is 'none', while
-  // staying backward-compatible: hosts can opt out, and isolated/cloud sandboxes
-  // are unaffected.
-  // ===========================================================================
-  describe('execute_command host-isolation approval default', () => {
-    it('requires approval by default for an un-isolated LocalSandbox (isolation: none)', async () => {
-      const sandbox = new LocalSandbox({ workingDirectory: tempDir });
-      expect(sandbox.isolation).toBe('none');
-
-      const workspace = new Workspace({
-        filesystem: new LocalFilesystem({ basePath: tempDir }),
-        sandbox,
-      });
-      await workspace.init();
-
-      const tools = await createWorkspaceTools(workspace);
-
-      expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
-      // Without this default, a model tool call would reach LocalProcessManager
-      // .spawn/execa on the host shell with no human-in-the-loop gate.
-      expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND].requireApproval).toBe(true);
-
-      await workspace.destroy();
-    });
-
-    it('preserves the host opt-out (tools.requireApproval: false) for an un-isolated LocalSandbox', async () => {
-      const workspace = new Workspace({
-        filesystem: new LocalFilesystem({ basePath: tempDir }),
-        sandbox: new LocalSandbox({ workingDirectory: tempDir }),
-        tools: {
-          requireApproval: false,
-        },
-      });
-      await workspace.init();
-
-      const tools = await createWorkspaceTools(workspace);
-
-      // Explicit host config wins over the safe default (backward compatible).
-      expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND].requireApproval).toBe(false);
-
-      await workspace.destroy();
-    });
-
-    it('preserves the per-tool opt-out for an un-isolated LocalSandbox', async () => {
-      const workspace = new Workspace({
-        filesystem: new LocalFilesystem({ basePath: tempDir }),
-        sandbox: new LocalSandbox({ workingDirectory: tempDir }),
-        tools: {
-          [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: {
-            requireApproval: false,
-          },
-        },
-      });
-      await workspace.init();
-
-      const tools = await createWorkspaceTools(workspace);
-
-      expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND].requireApproval).toBe(false);
-
-      await workspace.destroy();
-    });
-
-    it('does NOT change the default for an isolated sandbox (isolation !== none)', async () => {
-      // A sandbox that reports OS-level isolation (e.g. seatbelt/bwrap, or a
-      // cloud/container provider) is safe by construction, so the command tool
-      // keeps its original non-gated default. Modelled here with a duck-typed
-      // sandbox so the test doesn't depend on a host seatbelt/bwrap backend.
-      const isolatedSandbox: any = {
-        id: 'isolated-test',
-        name: 'IsolatedTestSandbox',
-        provider: 'test',
-        status: 'pending',
-        isolation: 'seatbelt',
-        async start() {
-          this.status = 'running';
-        },
-        async stop() {},
-        async destroy() {},
-        async executeCommand() {
-          return { exitCode: 0, stdout: '', stderr: '', success: true, executionTimeMs: 0, command: '' };
-        },
-      };
-
-      const workspace = new Workspace({
-        filesystem: new LocalFilesystem({ basePath: tempDir }),
-        sandbox: isolatedSandbox,
-      });
-      await workspace.init();
-
-      const tools = await createWorkspaceTools(workspace);
-
-      expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
-      expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND].requireApproval).toBe(false);
 
       await workspace.destroy();
     });


### PR DESCRIPTION
Reverts mastra-ai/mastra#18129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This pull request removes a safety requirement that was added before, which forced users to approve commands before they could be run in a local sandbox environment. Now, users won't need to give that approval by default anymore.

## Overview

This PR reverts the changes from PR `#18129`, which had introduced mandatory approval requirements for executing commands on local sandboxes. The revert removes sandbox isolation detection logic and simplifies tool configuration by eliminating unnecessary approval defaults that were previously tied to whether a sandbox ran directly on the host.

## Changes

### `packages/core/src/workspace/tools/tools.ts`
Removed the unisolated host detection helper and the associated logic that automatically set `requireApproval: true` for `execute_command` when running on an isolated sandbox. The changes include:
- Removed exported interface `ToolConfigDefaults`
- Updated `resolveToolConfig` function signature to remove the `defaults` parameter
- Tool configuration resolution now relies solely on global/configured tool settings and built-in defaults
- `execute_command` tool registration no longer attaches the host isolation-based approval defaults

### `packages/core/src/workspace/workspace-safety.test.ts`
Updated test expectations to reflect the removal of mandatory approval requirements:
- Modified the "default tools enabled and no approval required" test to expect `requireApproval: false` for both filesystem write tools and the `SANDBOX.EXECUTE_COMMAND` tool
- Removed the entire `execute_command host-isolation approval default` test suite that previously verified approval behavior based on sandbox isolation status

## Impact

After this change, executing commands via `execute_command` will no longer require approval by default, regardless of whether the sandbox runs in isolation or directly on the host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->