### PR TITLE
test: run full Mastra Code e2e suite by default

### DIFF
--- a/.github/workflows/mastracode-e2e.yml
+++ b/.github/workflows/mastracode-e2e.yml
@@ -46,4 +46,4 @@ jobs:
         run: pnpm run build:mastracode
 
       - name: Run Mastra Code E2E
-        run: MC_E2E_VITEST_SCENARIOS=all pnpm --filter ./mastracode run e2e:test -- --reporter=dot
+        run: pnpm --filter ./mastracode run e2e:test -- --reporter=dot

--- a/mastracode/e2e/README.md
+++ b/mastracode/e2e/README.md
@@ -5,12 +5,20 @@ Mastra Code scenarios live in `e2e/scenarios/` and run through the zero-subproce
 ## Run all scenarios
 
 ```bash
-MC_E2E_VITEST_SCENARIOS=all pnpm --filter ./mastracode run e2e:test -- --reporter=dot
+pnpm --filter ./mastracode run e2e:test -- --reporter=dot
 ```
 
 The runner constructs Mastra Code in-process, injects a `pi-tui` terminal backed by `@xterm/headless`, and runs four static Vitest shard files in one CI job. It does not launch the `mastracode` CLI, `tsx` scenario entrypoints, worker threads, or Mastra Code subprocesses.
 
 Failed runs keep their per-scenario temp directories under `mastracode/.tmp-mc-e2e-vitest/` until cleanup runs; inspect that directory when debugging a failed scenario.
+
+## Smoke test
+
+Run the default smoke scenarios (`startup`, `automated-chat`, and `modal-and-shell`):
+
+```bash
+pnpm --filter ./mastracode run e2e:smoke
+```
 
 ## Focused scenario runs
 
@@ -26,4 +34,4 @@ List available scenarios:
 pnpm --filter ./mastracode run e2e:list
 ```
 
-Use focused runs for scenario development, then run `e2e:test` with `MC_E2E_VITEST_SCENARIOS=all` before shipping runner changes.
+Use focused runs for scenario development, then run `e2e:test` before shipping runner changes.

--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -53,8 +53,8 @@
     "test": "vitest",
     "lint": "eslint .",
     "e2e:list": "tsx e2e-list.ts",
-    "e2e:test": "vitest run --config e2e/vitest.shards.config.ts",
-    "e2e:test:vitest": "vitest run --config e2e/vitest.shards.config.ts"
+    "e2e:smoke": "vitest run --config e2e/vitest.shards.config.ts",
+    "e2e:test": "MC_E2E_VITEST_SCENARIOS=all vitest run --config e2e/vitest.shards.config.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- make `mastracode` `e2e:test` run the full scenario suite by default
- add explicit `e2e:smoke` for the short three-scenario local smoke set
- simplify the Mastra Code E2E workflow now that the script owns full-suite selection

## Test plan
- `pnpm prettier --check mastracode/package.json mastracode/e2e/README.md .github/workflows/mastracode-e2e.yml`
- `pnpm --filter ./mastracode exec vitest list --config e2e/vitest.shards.config.ts` lists 3 smoke tests
- `MC_E2E_VITEST_SCENARIOS=all pnpm --filter ./mastracode exec vitest list --config e2e/vitest.shards.config.ts | wc -l` lists 102 runnable full-suite tests

Note: executing the smoke tests locally currently hits an unrelated current-main TUI startup crash in `promptForThreadSelection` (`Cannot read properties of undefined (reading 'thread')`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Now, when you run the main `e2e:test` command, it automatically runs the full set of E2E scenarios—no special environment flag needed. For faster local checks, a new `e2e:smoke` command runs a much smaller three-scenario subset.

## Overview
The Mastra Code E2E workflow was simplified so local test runs behave like CI by moving “full suite vs subset” selection into the `e2e:test` script itself. This removes the need to manually set `MC_E2E_VITEST_SCENARIOS=all`.

## Changes
- **`mastracode/package.json`**
  - Added **`e2e:smoke`** to run `vitest` with the shared shard config (intended for a ~3-scenario smoke run).
  - Updated **`e2e:test`** to run the full scenario suite by default (it sets `MC_E2E_VITEST_SCENARIOS=all` internally before running the shared shard config).
  - Removed **`e2e:test:vitest`**.
- **`.github/workflows/mastracode-e2e.yml`**
  - Removed the `MC_E2E_VITEST_SCENARIOS=all` environment-variable prefix from the E2E step, since `e2e:test` now handles full-suite selection.
- **`mastracode/e2e/README.md`**
  - Updated instructions so users don’t need to set `MC_E2E_VITEST_SCENARIOS=all` when running `e2e:test`.
  - Documented the “smoke test” (`e2e:smoke`) vs “all scenarios” (`e2e:test`) approach.

## Testing
- Formatting/lint compliance verified for: `mastracode/package.json`, `mastracode/e2e/README.md`, and the GitHub workflow file.
- Confirmed **smoke** variant lists **3** scenarios.
- Confirmed **full-suite** variant lists **102** runnable tests (via `MC_E2E_VITEST_SCENARIOS=all`).

## Known Issues
Running smoke tests locally currently hits an unrelated TUI startup crash in `promptForThreadSelection` with: “Cannot read properties of undefined (reading 'thread')”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->