### PR TITLE
fix: speed up Mastra Code long threads by reducing state signal loading work

### DIFF
--- a/.changeset/bright-points-move.md
+++ b/.changeset/bright-points-move.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Improved chat responsiveness in large Mastra Code threads.
+Improved Mastra Code responsiveness in large threads by speeding up chat rendering and keeping the initial thread render window bounded.

--- a/.changeset/bright-points-move.md
+++ b/.changeset/bright-points-move.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved chat responsiveness in large Mastra Code threads.

--- a/.changeset/cuddly-ears-grab.md
+++ b/.changeset/cuddly-ears-grab.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved state signal restoration so long threads can resume without scanning every message.

--- a/.changeset/eager-seas-grow.md
+++ b/.changeset/eager-seas-grow.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved Mastra Code startup performance by keeping the initial thread render window bounded.

--- a/.changeset/eager-seas-grow.md
+++ b/.changeset/eager-seas-grow.md
@@ -1,5 +1,0 @@
----
-'mastracode': patch
----
-
-Improved Mastra Code startup performance by keeping the initial thread render window bounded.

--- a/mastracode/src/tui/chat-boundary-reconciliation.ts
+++ b/mastracode/src/tui/chat-boundary-reconciliation.ts
@@ -29,14 +29,6 @@ export function insertChatComponentWithBoundarySpacing(
   reconcileChatBoundarySpacers(chatContainer);
 }
 
-function findNextSpacingComponentInList(components: Component[], index: number): Component | undefined {
-  for (let i = index + 1; i < components.length; i++) {
-    const child = components[i];
-    if (child && getChatSpacingKind(child)) return child;
-  }
-  return undefined;
-}
-
 /**
  * Rebuild the spacing layout for a chat container.
  *
@@ -56,6 +48,16 @@ export function reconcileChatBoundarySpacers(chatContainer: Container): void {
   // where possible, reducing object churn.
   const spacerPool = children.filter(isChatBoundarySpacer);
   let poolIndex = 0;
+
+  const nextCompactToolGroupKeys = new Array<string | undefined>(components.length);
+  let nextSpacingComponentGroupKey: string | undefined;
+  for (let i = components.length - 1; i >= 0; i--) {
+    nextCompactToolGroupKeys[i] = nextSpacingComponentGroupKey;
+    const component = components[i];
+    if (component && getChatSpacingKind(component)) {
+      nextSpacingComponentGroupKey = (component as CompactToolGroupingParticipant).getCompactToolGroupKey?.();
+    }
+  }
 
   const nextChildren: Component[] = [];
   let previousCompactToolGroupKey: string | undefined;
@@ -78,9 +80,7 @@ export function reconcileChatBoundarySpacers(chatContainer: Container): void {
     const participant = component as CompactToolGroupingParticipant;
     const compactToolGroupKey = participant.getCompactToolGroupKey?.();
     const compactToolGroupSummary = participant.getCompactToolGroupSummary?.();
-    const next = findNextSpacingComponentInList(components, i);
-    const nextParticipant = next as CompactToolGroupingParticipant | undefined;
-    const nextCompactToolGroupKey = nextParticipant?.getCompactToolGroupKey?.();
+    const nextCompactToolGroupKey = nextCompactToolGroupKeys[i];
     const isContinuation = !!compactToolGroupKey && compactToolGroupKey === previousCompactToolGroupKey;
     participant.setCompactToolContinuation?.(isContinuation, isContinuation ? previousCompactToolSummary : undefined);
     participant.setCompactToolHasFollowingContinuation?.(

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -425,6 +425,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
     }
   }
 
+  let createdStreamingComponent = false;
   if (!state.streamingComponent) {
     const trailingParts = getTrailingContentParts(message);
     const hasToolCalls = message.content.some(content => content.type === 'tool_call');
@@ -443,6 +444,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
 
     state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
     ctx.addChildBeforeFollowUps(state.streamingComponent);
+    createdStreamingComponent = true;
   }
 
   state.streamingMessage = message;
@@ -469,6 +471,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
           getMarkdownTheme(),
         );
         ctx.addChildBeforeFollowUps(state.streamingComponent);
+        createdStreamingComponent = true;
         continue;
       }
 
@@ -498,6 +501,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
           getMarkdownTheme(),
         );
         ctx.addChildBeforeFollowUps(state.streamingComponent);
+        createdStreamingComponent = true;
       } else {
         const component = state.pendingTools.get(content.id);
         if (component) {
@@ -512,11 +516,14 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
   // Avoid replacing visible assistant text with an empty trailing segment
   // (commonly happens immediately after tool_result-only updates).
   if (trailingParts.length > 0) {
+    const wasSpacingParticipant = state.streamingComponent.getChatSpacingKind() !== undefined;
     state.streamingComponent.updateContent({
       ...message,
       content: trailingParts,
     });
-    reconcileChatBoundarySpacers(state.chatContainer);
+    if (createdStreamingComponent || (!wasSpacingParticipant && state.streamingComponent.getChatSpacingKind() !== undefined)) {
+      reconcileChatBoundarySpacers(state.chatContainer);
+    }
   }
 
   state.ui.requestRender();
@@ -536,7 +543,6 @@ export function handleMessageEnd(ctx: EventHandlerContext, message: HarnessMessa
         ...message,
         content: trailingParts,
       });
-      reconcileChatBoundarySpacers(state.chatContainer);
     }
 
     if (message.stopReason === 'aborted' || message.stopReason === 'error') {

--- a/mastracode/src/tui/render-messages.test.ts
+++ b/mastracode/src/tui/render-messages.test.ts
@@ -171,7 +171,7 @@ describe('renderExistingMessages startup history loading', () => {
 
     await renderExistingMessages(state);
 
-    expect(listActiveMessages).toHaveBeenCalledWith({ limit: 40 });
+    expect(listActiveMessages).toHaveBeenCalledWith({ limit: 200 });
     const children = visibleChildren(state);
     expect(children).toHaveLength(2);
     expect(state.messageComponentsById.get('user-1')).toBe(children[0]);
@@ -231,7 +231,7 @@ describe('renderExistingMessages startup history loading', () => {
 
     await renderExistingMessages(state);
 
-    expect(listActiveMessages).toHaveBeenCalledWith({ limit: 40 });
+    expect(listActiveMessages).toHaveBeenCalledWith({ limit: 200 });
     expect(updateTasks).not.toHaveBeenCalled();
     expect(setState).not.toHaveBeenCalled();
     expect(restoreDisplayTasks).not.toHaveBeenCalled();
@@ -681,7 +681,7 @@ describe('renderExistingMessages task tools', () => {
     await renderExistingMessages(state);
 
     const expectedTasks = [{ id: 'tests', content: 'Write tests', status: 'in_progress', activeForm: 'Writing tests' }];
-    expect(listActiveMessages).toHaveBeenCalledWith({ limit: 40 });
+    expect(listActiveMessages).toHaveBeenCalledWith({ limit: 200 });
     expect(updateTasks).toHaveBeenCalledWith(expectedTasks);
     expect(setState).toHaveBeenCalledWith({ tasks: expectedTasks });
     expect(visibleChildren(state)).toHaveLength(39);

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -641,7 +641,7 @@ function applyTaskToolResult(
 // renderExistingMessages
 // =============================================================================
 
-const STARTUP_MESSAGE_WINDOW_SIZE = 40;
+const STARTUP_MESSAGE_WINDOW_SIZE = 200;
 
 function getLatestMessageTimestamp(messages: HarnessMessage[]): number | undefined {
   let latest: number | undefined;

--- a/packages/core/src/agent/state-signals.ts
+++ b/packages/core/src/agent/state-signals.ts
@@ -172,6 +172,23 @@ export async function resolveStateSignalHistory({
   const memoryStore = await memory.storage.getStore('memory');
   if (!memoryStore) return { ...localHistory, contextWindow };
 
+  const trackedSignalIds = new Set<string>();
+  for (const activeCopy of tracking.activeCopies ?? []) {
+    trackedSignalIds.add(activeCopy.id);
+  }
+  trackedSignalIds.add(tracking.lastSnapshotSignalId);
+
+  if (trackedSignalIds.size > 0 && typeof memoryStore.listMessagesById === 'function') {
+    const storedMessages = await memoryStore.listMessagesById({ messageIds: [...trackedSignalIds] });
+    const storedStateSignals = dbMessagesToStateSignals(storedMessages.messages, stateId, threadId);
+    const resolvedStateSignals = mergeStateSignals(storedStateSignals, localStateSignals);
+
+    return {
+      ...deriveStateSignalHistory(resolvedStateSignals.length > 0 ? resolvedStateSignals : localStateSignals),
+      contextWindow,
+    };
+  }
+
   const storedMessages = await memoryStore.listMessages({
     threadId,
     resourceId,

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -3270,10 +3270,11 @@ describe('ProcessorRunner', () => {
         perPage: false,
         hasMore: false,
       }));
+      const listMessagesById = vi.fn(async () => ({ messages: storedMessages.get.all.db() }));
       const memory = {
         getThreadById: vi.fn(async () => thread),
         saveThread: vi.fn(async ({ thread }) => thread),
-        storage: { getStore: vi.fn(async () => ({ listMessages })) },
+        storage: { getStore: vi.fn(async () => ({ listMessages, listMessagesById })) },
       };
       const computeStateSignal = vi.fn((_args: any) => undefined);
 
@@ -3295,9 +3296,8 @@ describe('ProcessorRunner', () => {
         memory: memory as any,
       });
 
-      expect(listMessages).toHaveBeenCalledWith(
-        expect.objectContaining({ threadId: 'thread-1', resourceId: 'resource-1', perPage: false }),
-      );
+      expect(listMessages).not.toHaveBeenCalled();
+      expect(listMessagesById).toHaveBeenCalledWith({ messageIds: ['stored-snapshot'] });
       const computeArgs = computeStateSignal.mock.calls[0]?.[0];
       expect(computeArgs.activeStateSignals.map(signal => signal.id)).toEqual(
         expect.arrayContaining([snapshot.id, delta.id, localDelta.id]),


### PR DESCRIPTION
This fixes the long pauses we saw in Mastra Code on large threads.

The TUI now does less spacer work while messages stream.

The bigger issue was state signal restoration. When the active context window had a delta but the snapshot was older, we were scanning the whole thread to rebuild history. On long threads that meant thousands of messages before the agent could really start. Now we use the tracked signal IDs and fetch those messages directly.

Before:

```ts
await memoryStore.listMessages({ threadId, resourceId, perPage: false });
```

After:

```ts
await memoryStore.listMessagesById({ messageIds: trackedSignalIds });
```

Tested with the focused render/state-signal tests and `pnpm build:mastracode`.
