### PR TITLE
Show tool provider Connect button in Agent Builder when authentication is disabled

### DIFF
--- a/.changeset/builder-toolkit-connect-no-auth.md
+++ b/.changeset/builder-toolkit-connect-no-auth.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed the Connect button for Composio and other tool provider toolkits not appearing in the Agent Builder tools picker when authentication is turned off. The picker expected a signed-in user that never exists in projects without authentication, so it never finished loading existing connections. Toolkit connections now load and the Connect button appears whether or not authentication is configured.

--- a/packages/playground/src/domains/auth/hooks/use-current-user.ts
+++ b/packages/playground/src/domains/auth/hooks/use-current-user.ts
@@ -4,6 +4,17 @@ import { useQuery } from '@tanstack/react-query';
 import type { CurrentUser } from '../types';
 import { fetchWithRefresh } from './fetch-with-refresh';
 
+export class CurrentUserError extends Error {
+  constructor(public readonly status: number) {
+    super(`Failed to fetch current user: ${status}`);
+    this.name = 'CurrentUserError';
+  }
+}
+
+export function isUnauthenticatedError(error: unknown): boolean {
+  return error instanceof CurrentUserError && error.status === 401;
+}
+
 /**
  * Hook to fetch the current authenticated user.
  *
@@ -47,7 +58,7 @@ export function useCurrentUser() {
       });
 
       if (!response.ok) {
-        throw new Error(`Failed to fetch current user: ${response.status}`);
+        throw new CurrentUserError(response.status);
       }
 
       return response.json();

--- a/packages/playground/src/domains/tool-providers/hooks/__tests__/use-all-connections.test.tsx
+++ b/packages/playground/src/domains/tool-providers/hooks/__tests__/use-all-connections.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import type { PropsWithChildren } from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { useAllConnections } from '../use-all-connections';
 
@@ -84,12 +84,10 @@ describe('useAllConnections — hasConnection', () => {
     await waitFor(() => expect(result.current.hasConnection('composio', 'gmail')).toBe(true));
   });
 
-  // Regression: when auth is disabled `/api/auth/me` has no user, so there is
-  // no caller authorId. The hook must still run the connection queries (server
-  // scopes by request context) instead of stalling on `scopeToSelf`.
-  it('still resolves connections when auth is disabled (no current user)', async () => {
+  it('still resolves connections when auth is disabled (401, no current user)', async () => {
     server.use(
       http.get(`${BASE_URL}/api/auth/me`, () => new HttpResponse(null, { status: 401 })),
+      http.post(`${BASE_URL}/api/auth/refresh`, () => new HttpResponse(null, { status: 401 })),
       http.get(`${BASE_URL}/api/tool-providers`, () =>
         HttpResponse.json({ providers: [{ id: 'composio', name: 'Composio' }] }),
       ),
@@ -105,5 +103,29 @@ describe('useAllConnections — hasConnection', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     await waitFor(() => expect(result.current.hasConnection('composio', 'gmail')).toBe(true));
+  });
+
+  it('stays blocked on a non-401 user lookup failure (fail closed)', async () => {
+    const onConnections = vi.fn<() => void>();
+    server.use(
+      http.get(`${BASE_URL}/api/auth/me`, () => new HttpResponse(null, { status: 500 })),
+      http.get(`${BASE_URL}/api/tool-providers`, () =>
+        HttpResponse.json({ providers: [{ id: 'composio', name: 'Composio' }] }),
+      ),
+      http.get(`${BASE_URL}/api/tool-providers/composio/toolkits`, () =>
+        HttpResponse.json({ data: [{ slug: 'gmail', name: 'Gmail' }] }),
+      ),
+      http.get(`${BASE_URL}/api/tool-providers/composio/connections`, () => {
+        onConnections();
+        return HttpResponse.json({ items: [] });
+      }),
+    );
+
+    const { result } = renderHook(() => useAllConnections({ scopeToSelf: true }), { wrapper });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(onConnections).not.toHaveBeenCalled();
+    expect(result.current.hasConnection('composio', 'gmail')).toBe(false);
   });
 });

--- a/packages/playground/src/domains/tool-providers/hooks/__tests__/use-all-connections.test.tsx
+++ b/packages/playground/src/domains/tool-providers/hooks/__tests__/use-all-connections.test.tsx
@@ -83,4 +83,27 @@ describe('useAllConnections — hasConnection', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     await waitFor(() => expect(result.current.hasConnection('composio', 'gmail')).toBe(true));
   });
+
+  // Regression: when auth is disabled `/api/auth/me` has no user, so there is
+  // no caller authorId. The hook must still run the connection queries (server
+  // scopes by request context) instead of stalling on `scopeToSelf`.
+  it('still resolves connections when auth is disabled (no current user)', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/auth/me`, () => new HttpResponse(null, { status: 401 })),
+      http.get(`${BASE_URL}/api/tool-providers`, () =>
+        HttpResponse.json({ providers: [{ id: 'composio', name: 'Composio' }] }),
+      ),
+      http.get(`${BASE_URL}/api/tool-providers/composio/toolkits`, () =>
+        HttpResponse.json({ data: [{ slug: 'gmail', name: 'Gmail' }] }),
+      ),
+      http.get(`${BASE_URL}/api/tool-providers/composio/connections`, () =>
+        HttpResponse.json({ items: [{ connectionId: 'conn_a', status: 'active', label: 'work' }] }),
+      ),
+    );
+
+    const { result } = renderHook(() => useAllConnections({ scopeToSelf: true }), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.hasConnection('composio', 'gmail')).toBe(true));
+  });
 });

--- a/packages/playground/src/domains/tool-providers/hooks/__tests__/use-existing-connections.test.tsx
+++ b/packages/playground/src/domains/tool-providers/hooks/__tests__/use-existing-connections.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import type { PropsWithChildren } from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { useExistingConnections } from '../use-existing-connections';
 
@@ -38,12 +38,10 @@ describe('useExistingConnections — scopeToSelf', () => {
     expect(result.current.data?.items).toHaveLength(1);
   });
 
-  // Regression: when auth is disabled there is no caller authorId, but the
-  // query must still run (server scopes by request context) rather than
-  // staying pending forever — which would hang the connection control skeleton.
-  it('resolves connections when auth is disabled (no current user)', async () => {
+  it('resolves connections when auth is disabled (401, no current user)', async () => {
     server.use(
       http.get(`${BASE_URL}/api/auth/me`, () => new HttpResponse(null, { status: 401 })),
+      http.post(`${BASE_URL}/api/auth/refresh`, () => new HttpResponse(null, { status: 401 })),
       http.get(`${BASE_URL}/api/tool-providers/composio/connections`, () =>
         HttpResponse.json({ items: [{ connectionId: 'conn_a', status: 'active', label: 'work' }] }),
       ),
@@ -55,5 +53,26 @@ describe('useExistingConnections — scopeToSelf', () => {
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.data?.items).toHaveLength(1);
+  });
+
+  it('stays blocked on a non-401 user lookup failure (fail closed)', async () => {
+    const onConnections = vi.fn<() => void>();
+    server.use(
+      http.get(`${BASE_URL}/api/auth/me`, () => new HttpResponse(null, { status: 500 })),
+      http.get(`${BASE_URL}/api/tool-providers/composio/connections`, () => {
+        onConnections();
+        return HttpResponse.json({ items: [] });
+      }),
+    );
+
+    const { result } = renderHook(() => useExistingConnections('composio', 'gmail', { scopeToSelf: true }), {
+      wrapper,
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(onConnections).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.data).toBeUndefined();
   });
 });

--- a/packages/playground/src/domains/tool-providers/hooks/__tests__/use-existing-connections.test.tsx
+++ b/packages/playground/src/domains/tool-providers/hooks/__tests__/use-existing-connections.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { PropsWithChildren } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { useExistingConnections } from '../use-existing-connections';
+
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const wrapper = ({ children }: PropsWithChildren) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+describe('useExistingConnections — scopeToSelf', () => {
+  it('resolves connections for an authenticated caller', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/auth/me`, () => HttpResponse.json({ id: 'tester', permissions: [] })),
+      http.get(`${BASE_URL}/api/tool-providers/composio/connections`, () =>
+        HttpResponse.json({ items: [{ connectionId: 'conn_a', status: 'active', label: 'work' }] }),
+      ),
+    );
+
+    const { result } = renderHook(() => useExistingConnections('composio', 'gmail', { scopeToSelf: true }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.data?.items).toHaveLength(1);
+  });
+
+  // Regression: when auth is disabled there is no caller authorId, but the
+  // query must still run (server scopes by request context) rather than
+  // staying pending forever — which would hang the connection control skeleton.
+  it('resolves connections when auth is disabled (no current user)', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/auth/me`, () => new HttpResponse(null, { status: 401 })),
+      http.get(`${BASE_URL}/api/tool-providers/composio/connections`, () =>
+        HttpResponse.json({ items: [{ connectionId: 'conn_a', status: 'active', label: 'work' }] }),
+      ),
+    );
+
+    const { result } = renderHook(() => useExistingConnections('composio', 'gmail', { scopeToSelf: true }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.data?.items).toHaveLength(1);
+  });
+});

--- a/packages/playground/src/domains/tool-providers/hooks/use-all-connections.ts
+++ b/packages/playground/src/domains/tool-providers/hooks/use-all-connections.ts
@@ -3,7 +3,7 @@ import { useQueries } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
 import { useToolProviders } from './use-tool-providers';
-import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
+import { isUnauthenticatedError, useCurrentUser } from '@/domains/auth/hooks/use-current-user';
 
 /**
  * Stale time long enough to avoid refetching on every picker re-render but
@@ -45,11 +45,8 @@ export const useAllConnections = (options?: UseAllConnectionsOptions) => {
   const scopeToSelf = options?.scopeToSelf ?? false;
   const currentUserQuery = useCurrentUser();
   const callerAuthorId = currentUserQuery.data?.id;
-  // When self-scoping, wait until the current-user query has settled rather
-  // than requiring an id. If auth is disabled the query settles with no user;
-  // we then omit the `authorId` filter and let the server scope by request
-  // context, so the picker still gates correctly instead of stalling.
-  const callerReady = !scopeToSelf || !currentUserQuery.isPending;
+  const callerReady =
+    !scopeToSelf || currentUserQuery.isSuccess || isUnauthenticatedError(currentUserQuery.error);
 
   // 1. For every provider, list its toolkits.
   const toolkitsQueries = useQueries({

--- a/packages/playground/src/domains/tool-providers/hooks/use-all-connections.ts
+++ b/packages/playground/src/domains/tool-providers/hooks/use-all-connections.ts
@@ -45,8 +45,7 @@ export const useAllConnections = (options?: UseAllConnectionsOptions) => {
   const scopeToSelf = options?.scopeToSelf ?? false;
   const currentUserQuery = useCurrentUser();
   const callerAuthorId = currentUserQuery.data?.id;
-  const callerReady =
-    !scopeToSelf || currentUserQuery.isSuccess || isUnauthenticatedError(currentUserQuery.error);
+  const callerReady = !scopeToSelf || currentUserQuery.isSuccess || isUnauthenticatedError(currentUserQuery.error);
 
   // 1. For every provider, list its toolkits.
   const toolkitsQueries = useQueries({

--- a/packages/playground/src/domains/tool-providers/hooks/use-all-connections.ts
+++ b/packages/playground/src/domains/tool-providers/hooks/use-all-connections.ts
@@ -45,7 +45,11 @@ export const useAllConnections = (options?: UseAllConnectionsOptions) => {
   const scopeToSelf = options?.scopeToSelf ?? false;
   const currentUserQuery = useCurrentUser();
   const callerAuthorId = currentUserQuery.data?.id;
-  const callerReady = !scopeToSelf || Boolean(callerAuthorId);
+  // When self-scoping, wait until the current-user query has settled rather
+  // than requiring an id. If auth is disabled the query settles with no user;
+  // we then omit the `authorId` filter and let the server scope by request
+  // context, so the picker still gates correctly instead of stalling.
+  const callerReady = !scopeToSelf || !currentUserQuery.isPending;
 
   // 1. For every provider, list its toolkits.
   const toolkitsQueries = useQueries({

--- a/packages/playground/src/domains/tool-providers/hooks/use-existing-connections.ts
+++ b/packages/playground/src/domains/tool-providers/hooks/use-existing-connections.ts
@@ -36,8 +36,7 @@ export const useExistingConnections = (
   const currentUserQuery = useCurrentUser();
   const callerAuthorId = currentUserQuery.data?.id;
 
-  const callerReady =
-    !scopeToSelf || currentUserQuery.isSuccess || isUnauthenticatedError(currentUserQuery.error);
+  const callerReady = !scopeToSelf || currentUserQuery.isSuccess || isUnauthenticatedError(currentUserQuery.error);
 
   const enabled = !!providerId && !!toolkit && callerReady;
 

--- a/packages/playground/src/domains/tool-providers/hooks/use-existing-connections.ts
+++ b/packages/playground/src/domains/tool-providers/hooks/use-existing-connections.ts
@@ -1,7 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
-import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
+import { isUnauthenticatedError, useCurrentUser } from '@/domains/auth/hooks/use-current-user';
 
 export interface UseExistingConnectionsOptions {
   /**
@@ -36,12 +36,8 @@ export const useExistingConnections = (
   const currentUserQuery = useCurrentUser();
   const callerAuthorId = currentUserQuery.data?.id;
 
-  // When self-scoping, wait until the current-user query has settled before
-  // firing so admins get the explicit `authorId` filter. If auth is disabled
-  // the query still settles (with no user); we then omit the filter and let
-  // the server scope by request context — otherwise the query would never run
-  // and the connection control would hang on its loading skeleton.
-  const callerReady = !scopeToSelf || !currentUserQuery.isPending;
+  const callerReady =
+    !scopeToSelf || currentUserQuery.isSuccess || isUnauthenticatedError(currentUserQuery.error);
 
   const enabled = !!providerId && !!toolkit && callerReady;
 

--- a/packages/playground/src/domains/tool-providers/hooks/use-existing-connections.ts
+++ b/packages/playground/src/domains/tool-providers/hooks/use-existing-connections.ts
@@ -36,7 +36,14 @@ export const useExistingConnections = (
   const currentUserQuery = useCurrentUser();
   const callerAuthorId = currentUserQuery.data?.id;
 
-  const enabled = !!providerId && !!toolkit && (!scopeToSelf || Boolean(callerAuthorId));
+  // When self-scoping, wait until the current-user query has settled before
+  // firing so admins get the explicit `authorId` filter. If auth is disabled
+  // the query still settles (with no user); we then omit the filter and let
+  // the server scope by request context — otherwise the query would never run
+  // and the connection control would hang on its loading skeleton.
+  const callerReady = !scopeToSelf || !currentUserQuery.isPending;
+
+  const enabled = !!providerId && !!toolkit && callerReady;
 
   return useQuery({
     queryKey: scopeToSelf

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/edit-msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/edit-msw.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/domains/agent-builder', async () => {
 
 vi.mock('@/domains/auth/hooks/use-current-user', () => ({
   useCurrentUser: () => ({ data: { id: 'user-1' }, isLoading: false }),
+  isUnauthenticatedError: () => false,
 }));
 
 vi.mock('@/domains/agent-builder/hooks/use-builder-agent-access', () => ({

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/edit-wizard-tools-gating.msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/edit-wizard-tools-gating.msw.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@mastra/playground-ui', async () => {
 
 vi.mock('@/domains/auth/hooks/use-current-user', () => ({
   useCurrentUser: () => ({ data: { id: 'user-1' }, isLoading: false }),
+  isUnauthenticatedError: () => false,
 }));
 
 vi.mock('@/domains/agent-builder/hooks/use-builder-agent-access', () => ({

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/view-msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/view-msw.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/domains/agent-builder', () => ({
 
 vi.mock('@/domains/auth/hooks/use-current-user', () => ({
   useCurrentUser: () => ({ data: { id: 'user-1' }, isLoading: false }),
+  isUnauthenticatedError: () => false,
 }));
 
 vi.mock('@/domains/agent-builder/hooks/use-builder-agent-access', () => ({

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/view.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/view.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/domains/agent-builder', () => ({
 
 vi.mock('@/domains/auth/hooks/use-current-user', () => ({
   useCurrentUser: () => ({ data: { id: 'user-1' }, isLoading: false }),
+  isUnauthenticatedError: () => false,
 }));
 
 vi.mock('@/domains/agent-builder/hooks/use-builder-agent-access', () => ({

--- a/packages/playground/src/pages/agent-builder/skills/__tests__/create.msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/__tests__/create.msw.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@/domains/auth/hooks/use-permissions', () => ({
 
 vi.mock('@/domains/auth/hooks/use-current-user', () => ({
   useCurrentUser: () => ({ data: { id: 'user-1' }, isLoading: false }),
+  isUnauthenticatedError: () => false,
 }));
 
 // The starter renders a chat-driven builder that boots an SSE stream. Stub it

--- a/packages/playground/src/pages/agent-builder/skills/__tests__/edit-autosave.msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/__tests__/edit-autosave.msw.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/domains/auth/hooks/use-permissions', () => ({
 
 vi.mock('@/domains/auth/hooks/use-current-user', () => ({
   useCurrentUser: () => ({ data: { id: 'user-1' }, isLoading: false }),
+  isUnauthenticatedError: () => false,
 }));
 
 // The chat composer mounts an SSE-driven builder agent which we don't want to

--- a/packages/playground/src/pages/agent-builder/skills/__tests__/view.msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/__tests__/view.msw.test.tsx
@@ -32,6 +32,7 @@ const { currentUserMock } = vi.hoisted(() => ({
 
 vi.mock('@/domains/auth/hooks/use-current-user', () => ({
   useCurrentUser: () => ({ data: { id: currentUserMock.id }, isLoading: false }),
+  isUnauthenticatedError: () => false,
 }));
 
 const renderPage = (skillId: string) => {

--- a/templates/template-agent-builder/src/mastra/index.ts
+++ b/templates/template-agent-builder/src/mastra/index.ts
@@ -26,7 +26,7 @@ const editor = new MastraEditor({
   ...(hasComposio
     ? {
         toolProviders: {
-          composio: new ComposioToolProvider({ apiKey: getEnv('COMPOSIO_API_KEY')! }),
+          composio: new ComposioToolProvider({ apiKey: getEnv('COMPOSIO_API_KEY')!, allowedToolkits: ['gmail'] }),
         },
       }
     : {}),


### PR DESCRIPTION
## Summary

In the Agent Builder tools picker, the **Connect** button for Composio (and other tool provider) toolkits did not appear when a project runs without authentication. The picker showed the toolkit row (e.g. Gmail) but the connection control next to it was stuck on a loading placeholder, so authors could never start the OAuth connect flow.

The root cause is that the picker's connection lookups are "self-scoped": they wait for a signed-in user so that admins only ever see their own connections. In a project with authentication turned off there is no signed-in user, so that wait never resolved and the connection query stayed disabled forever — leaving the control permanently in its loading state.

This change makes the self-scoped lookups wait for the current-user query to **settle** instead of requiring it to return a user. When authentication is off, the query settles with no user, the explicit per-user filter is omitted, and the server scopes results by the request context as it already does. As a result, existing connections load and the Connect button appears whether or not authentication is configured. Behavior for authenticated/admin users is unchanged — they still only see their own connections.

It also defaults the Agent Builder template's Composio provider to the `gmail` toolkit, so a freshly scaffolded template has a connectable toolkit available in the picker out of the box.

## Changes

- `use-existing-connections.ts` / `use-all-connections.ts`: gate self-scoped connection queries on the current-user query having settled rather than on it producing a user id.
- `template-agent-builder`: default the Composio provider to the `gmail` toolkit.
- Added regression tests for both hooks covering the authenticated and auth-disabled paths.
- Added a changeset.

## Test plan

- `pnpm --filter ./packages/playground test run` for the tool-providers + agent-builder suites — 121 passing, including new auth-disabled regression tests for both hooks.
- `pnpm --filter ./packages/playground typecheck` — clean.
- `eslint` on the changed files — clean.
- Manual: run the Agent Builder template/example with authentication disabled and confirm the Connect button appears for the Gmail toolkit and OAuth can be started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The **Connect** button in the tools picker waits for the app to figure out “who is the current user.” If authentication is turned off, that “who am I?” check doesn’t return a user ID—so the picker waits forever and never shows **Connect**. This PR makes the picker wait only until that check is finished, even when there isn’t a signed-in user.

---

## Overview
This PR fixes a bug in Mastra Agent Builder’s tool provider toolkit picker (e.g., **Composio**) where the **Connect** button failed to appear when authentication is disabled.

## Root cause
Connection lookup hooks self-scoped their requests to a signed-in user by gating on a resolved current user / user ID. In auth-disabled projects, there is no signed-in user, so the current-user lookup never provided an ID and the connection query stayed stuck (disabled/loading), preventing **Connect** from appearing.

## Fix
### Wait for the “current user” query to settle (not for a user ID)
- Updated `use-existing-connections.ts` and `use-all-connections.ts` to gate self-scoped connection queries on the **settling** of `useCurrentUser` rather than requiring a truthy `callerAuthorId`.
- When authentication is disabled and `/api/auth/me` indicates **unauthenticated (401)**, the hooks proceed while omitting the per-user `authorId` filter; server/context scoping still ensures the correct connections are returned.
- For authenticated users, behavior remains unchanged: users only see their own connections.

### Typed unauthenticated detection + “fail closed”
- Enhanced `use-current-user.ts` to throw a typed `CurrentUserError` and added `isUnauthenticatedError()` to specifically detect `401` outcomes.
- Added regression coverage to ensure:
  - **401** allows the connection query to complete and `hasConnection('composio', 'gmail')` remains `true` as expected.
  - Non-401 errors (e.g., **500**) are handled **fail-closed** (connections handler not called; hook remains without results).

## Additional changes
- **Template update:** The Agent Builder template’s Composio provider now defaults to the `gmail` toolkit (`allowedToolkits: ['gmail']`) so new scaffolds have a connectable toolkit available.
- **Regression tests:** Added/extended tests for both authenticated and auth-disabled (401) scenarios, plus non-401 “fail closed” behavior.
- **Changeset:** Added a changeset entry documenting the fix.

## Testing
Confirmed passing tests (121 total), including the new regression coverage, with clean type checking and linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->