### PR TITLE
fix(ci): restore hosted runners for npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,7 +43,7 @@ jobs:
         (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: version packages') && github.event.head_commit.author.username == 'dane-ai-mastra[bot]') ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_type == 'prerelease')
       )
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
@@ -157,7 +157,7 @@ jobs:
       github.repository == 'mastra-ai/mastra' && 
       github.event_name == 'workflow_dispatch' && 
       github.event.inputs.publish_type == 'stable'
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -315,7 +315,7 @@ jobs:
         (github.event.inputs.publish_type == 'stable' && !inputs.dry_run && needs.stable.result == 'success') ||
         github.event.inputs.publish_type == 'enter-prerelease'
       )
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -386,7 +386,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && 
       github.event.inputs.publish_type == 'snapshot' &&
       github.ref != 'refs/heads/main'
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
This restores the npm publish workflow to GitHub-hosted runners so prerelease, stable, post-release, and snapshot publish jobs can run without relying on the Starsling runner label.

Before:
```yaml
runs-on: starsling-ubuntu-24.04
```

After:
```yaml
runs-on: ubuntu-latest
```

I did not add a changeset because this only changes GitHub Actions workflow configuration and does not affect a published package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR moves the publishing process from a special custom computer back to GitHub's regular computers. It's like moving a task from a dedicated server in someone's basement to a reliable standard cloud service—it makes the process more flexible and easier to manage without changing what actually gets published.

## Overview

This pull request restores npm publish workflow operations to GitHub-hosted runners instead of custom Starsling runners. The `runs-on` configuration for all four publish jobs (`prerelease`, `stable`, `enter_prerelease`, and `snapshot`) is updated from `starsling-ubuntu-24.04` to `ubuntu-latest`, enabling these jobs to run independently on standard GitHub infrastructure without dependency on a custom runner label.

## Changes

- **File modified**: `.github/workflows/npm-publish.yml`
- **Runner updates**: Changed `runs-on` from `starsling-ubuntu-24.04` to `ubuntu-latest` for:
  - `prerelease` job
  - `stable` job  
  - `enter_prerelease` job (post-release)
  - `snapshot` job
- No changes to job steps, conditions, triggers, or publish logic
- No changeset added (configuration-only change)

## Impact

- **Publishing behavior**: No functional changes to publishing workflows
- **Job independence**: Each publish job can now run without constraint to Starsling infrastructure
- **Infrastructure simplification**: Reduces reliance on custom runner setup for standard publishing tasks
- **Review effort**: Low (configuration-only)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->