### PR TITLE
refactor(core): move Harness mode switching to session.mode.switch

### DIFF
--- a/.changeset/eleven-islands-boil.md
+++ b/.changeset/eleven-islands-boil.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Replaced `Harness.switchModel()` with `harness.session.model.switch()`. Model switching now lives on the session, alongside the active mode/model state it already owns.
+
+**Before**
+
+```typescript
+await harness.switchModel({ modelId: 'openai/gpt-5' });
+```
+
+**After**
+
+```typescript
+await harness.session.model.switch({ modelId: 'openai/gpt-5' });
+```

--- a/.changeset/fancy-sides-brush.md
+++ b/.changeset/fancy-sides-brush.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Replaced `Harness.switchMode()` with `harness.session.mode.switch()`. Switching modes now lives on the session, alongside the active mode/model state it already owns.
+
+**Before**
+
+```typescript
+await harness.switchMode({ modeId: 'build' });
+```
+
+**After**
+
+```typescript
+await harness.session.mode.switch({ modeId: 'build' });
+```

--- a/.changeset/fancy-sides-brush.md
+++ b/.changeset/fancy-sides-brush.md
@@ -16,3 +16,5 @@ await harness.switchMode({ modeId: 'build' });
 ```typescript
 await harness.session.mode.switch({ modeId: 'build' });
 ```
+
+`mastracode` is updated to consume the new API: the TUI and headless callers now invoke `harness.session.mode.switch()` instead of the removed `harness.switchMode()`.

--- a/docs/src/content/en/docs/harness/modes.mdx
+++ b/docs/src/content/en/docs/harness/modes.mdx
@@ -105,10 +105,10 @@ On plan approval, the Harness automatically switches to `build` mode. On rejecti
 
 ## Switching modes
 
-Call `switchMode()` to change the active mode. The Harness aborts any in-progress generation, saves the current model to the outgoing mode, loads the incoming mode's model, and emits `mode_changed` and `model_changed` events:
+The active mode lives on the Session, so call `harness.session.mode.switch()` to change it. The switch aborts any in-progress generation, saves the current model to the outgoing mode, loads the incoming mode's model, and emits `mode_changed` and `model_changed` events:
 
 ```typescript
-await harness.switchMode({ modeId: 'build' })
+await harness.session.mode.switch({ modeId: 'build' })
 ```
 
 ## Querying modes

--- a/docs/src/content/en/docs/harness/modes.mdx
+++ b/docs/src/content/en/docs/harness/modes.mdx
@@ -105,7 +105,7 @@ On plan approval, the Harness automatically switches to `build` mode. On rejecti
 
 ## Switching modes
 
-The active mode lives on the Session, so call `harness.session.mode.switch()` to change it. The switch aborts any in-progress generation, saves the current model to the outgoing mode, loads the incoming mode's model, and emits `mode_changed` and `model_changed` events:
+The active mode lives on the Session, so call `harness.session.mode.switch()` to change it. The switch aborts any in-progress generation, saves the current model to the outgoing mode, and emits a `mode_changed` event. It then resolves the incoming mode's model and, when one resolves, applies it and emits a `model_changed` event:
 
 ```typescript
 await harness.session.mode.switch({ modeId: 'build' })

--- a/docs/src/content/en/docs/harness/overview.mdx
+++ b/docs/src/content/en/docs/harness/overview.mdx
@@ -107,33 +107,31 @@ Visit the [Harness reference](/reference/harness/harness-class) for the full con
 The Harness sits between your application layer and the underlying agent loop:
 
 ```
-┌──────────────────────────┐
-│   Your App (TUI/Web/API) │
-└────────────┬─────────────┘
-             │ commands (sendMessage, switchMode, approve)
-             │ events (message_update, tool_approval_required)
-┌────────────▼─────────────┐
-│  Harness (shared host)   │
-│  Config · Storage        │
-│  Thread lifecycle        │
-│  Permission policy        │
-│  Subagent spawning        │
-│  Event bus               │
-│  ┌─────────────────────┐ │
-│  │ harness.session      │ │
-│  │ identity · thread    │ │
-│  │ mode · model · run   │ │
-│  │ grants · follow-ups  │ │
-│  │ display state        │ │
-│  └─────────────────────┘ │
-└────────────┬─────────────┘
-             │
-┌────────────▼──────────────┐
-│  Agent + Memory + Tools   │
-└───────────────────────────┘
+┌───────────────────────────────────────┐
+│         Your App (TUI/Web/API)        │
+└───────────────────────────────────────┘
+      │  commands              ▲  events
+      ▼                        │
+┌───────────────────────────────────────┐
+│                Harness                │
+│ Config · storage · threads            │
+│ permissions · subagents · events      │
+│                                       │
+│  ┌─────────────────────────────────┐  │
+│  │         harness.session         │  │
+│  │ identity · thread · mode        │  │
+│  │ model · run · grants            │  │
+│  │ display state                   │  │
+│  └─────────────────────────────────┘  │
+└───────────────────────────────────────┘
+                   │
+                   ▼
+┌───────────────────────────────────────┐
+│         Agent + Memory + Tools        │
+└───────────────────────────────────────┘
 ```
 
-Your app sends commands (send a message, switch mode, approve a tool call) and receives typed events. The Harness manages the lifecycle internally: persisting threads, routing to the correct mode agent, enforcing permissions, and emitting events as state changes.
+Your app sends commands — send a message, switch mode, approve a tool call — and receives typed events such as `message_update` and `tool_approval_required`. The Harness manages the lifecycle internally: persisting threads, routing to the correct mode agent, enforcing permissions, and emitting events as state changes.
 
 ## Next steps
 

--- a/docs/src/content/en/docs/harness/session.mdx
+++ b/docs/src/content/en/docs/harness/session.mdx
@@ -55,8 +55,8 @@ See [Threads and state](/docs/harness/threads-and-state) for the full lifecycle.
 The Harness defines the available modes in `config.modes`. The Session tracks which mode and model are _currently_ selected:
 
 ```typescript
-// Switch mode (Harness orchestration — aborts the run, emits events)
-await harness.switchMode({ modeId: 'build' })
+// Switch mode (aborts the run, emits events)
+await harness.session.mode.switch({ modeId: 'build' })
 
 // Read the current selection (Session state)
 const modeId = harness.session.mode.get()

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -354,7 +354,7 @@ await harness.sendMessage({ content: 'Hello!' })
     name: 'modelUseCountTracker',
     type: 'ModelUseCountTracker',
     description:
-      'Callback invoked when a model is selected via `switchModel()`. Use to track and persist model usage for ranking.',
+      'Callback invoked when a model is selected via `session.model.switch()`. Use to track and persist model usage for ranking.',
     isOptional: true,
   },
   {
@@ -517,18 +517,6 @@ Return the complete model ID string.
 
 ```typescript
 const fullId = harness.getFullModelId()
-```
-
-#### `switchModel({ modelId, scope?, modeId? })`
-
-Switch the active model. When `scope` is `'thread'`, the model ID is persisted to thread metadata so it's restored when switching back. Emits a `model_changed` event.
-
-```typescript
-// Set for current session only
-await harness.switchModel({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
-
-// Persist to the current thread
-await harness.switchModel({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__', scope: 'thread' })
 ```
 
 #### `getCurrentModelAuthStatus()`

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -499,14 +499,6 @@ const modes = harness.listModes()
 
 To read the active mode, use [`session.mode.get()`](/reference/harness/session#mode); to resolve it to a full `HarnessMode`, use [`session.mode.resolve()`](/reference/harness/session#mode).
 
-#### `switchMode({ modeId })`
-
-Switch to a different mode. Aborts any in-progress generation, saves the current model to the outgoing mode, loads the incoming mode's model, and emits `mode_changed` and `model_changed` events.
-
-```typescript
-await harness.switchMode({ modeId: 'build' })
-```
-
 ### Models
 
 To read the active model ID, use [`session.model.get()`](/reference/harness/session#model); to check whether a model is selected, use [`session.model.hasSelection()`](/reference/harness/session#model).

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -270,7 +270,7 @@ await harness.session.thread.deleteSetting({ key: 'omThreshold' })
 
 ## Mode
 
-`session.mode` owns the active mode selection. Switching modes is performed on the [`Harness`](/reference/harness/harness-class#switchmode-modeid-) because it emits events and rebinds the stream.
+`session.mode` owns the active mode selection.
 
 ### `session.mode.get()`
 
@@ -286,6 +286,14 @@ Return the full `HarnessMode` object for the active mode, resolved against the h
 
 ```typescript
 const mode = harness.session.mode.resolve()
+```
+
+### `session.mode.switch({ modeId })`
+
+Switch to a different mode. Aborts any in-progress generation, saves the current model to the outgoing mode, loads the incoming mode's model, and emits `mode_changed` and `model_changed` events.
+
+```typescript
+await harness.session.mode.switch({ modeId: 'build' })
 ```
 
 ## Model

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -298,7 +298,7 @@ await harness.session.mode.switch({ modeId: 'build' })
 
 ## Model
 
-`session.model` owns the active model selection, including per-mode model memory. Switching models is performed on the [`Harness`](/reference/harness/harness-class#switchmodel-modelid-scope-modeid-).
+`session.model` owns the active model selection, including per-mode model memory.
 
 ### `session.model.get()`
 
@@ -316,6 +316,18 @@ Check whether a model is currently selected.
 if (harness.session.model.hasSelection()) {
   // Ready to send messages
 }
+```
+
+### `session.model.switch({ modelId, scope?, modeId? })`
+
+Switch the active model. When `scope` is `'thread'` (the default), the model ID is persisted as the per-mode model so it's restored when switching back. Reports the selection to the harness's `modelUseCountTracker` and emits a `model_changed` event.
+
+```typescript
+// Set for the current session only
+await harness.session.model.switch({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__', scope: 'global' })
+
+// Persist to the current thread (default)
+await harness.session.model.switch({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
 ```
 
 ## Run

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -324,7 +324,10 @@ Switch the active model. When `scope` is `'thread'` (the default), the model ID 
 
 ```typescript
 // Set for the current session only
-await harness.session.model.switch({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__', scope: 'global' })
+await harness.session.model.switch({
+  modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__',
+  scope: 'global',
+})
 
 // Persist to the current thread (default)
 await harness.session.model.switch({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })

--- a/mastracode/VERIFICATION.md
+++ b/mastracode/VERIFICATION.md
@@ -15,7 +15,7 @@ Expected result: each thread restores its own pack selection instead of using on
 ## 2) Model usage ranking
 
 - [ ] Open `/models` and choose a pack that uses a model you can repeatedly select.
-- [ ] Re-select the same model multiple times (through pack switches or model picks that call `switchModel`).
+- [ ] Re-select the same model multiple times (through pack switches or model picks that call `session.model.switch`).
 - [ ] Re-open the model selector.
 - [ ] Confirm frequently selected models appear higher in the sorted list.
 

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -432,7 +432,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
       const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
       return failEarly(`Model "${args.model}" has no API key configured.${keyHint}`);
     }
-    await harness.switchModel({ modelId: args.model });
+    await harness.session.model.switch({ modelId: args.model });
     if (!emit) process.stderr.write(`[model] ${args.model}\n`);
   } else if (args.mode) {
     // --mode flag: look up model from effectiveDefaults (resolved from settings at startup)
@@ -447,7 +447,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
         const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
         return failEarly(`Model "${modelId}" (mode: ${args.mode}) has no API key configured.${keyHint}`);
       }
-      await harness.switchModel({ modelId });
+      await harness.session.model.switch({ modelId });
       if (!emit) process.stderr.write(`[model] ${modelId} (mode: ${args.mode})\n`);
     } else {
       const warnMsg = `--mode ${args.mode} has no configured model, using default`;

--- a/mastracode/src/tui/commands/login.ts
+++ b/mastracode/src/tui/commands/login.ts
@@ -53,7 +53,7 @@ async function performLogin(ctx: SlashCommandContext, providerId: string): Promi
 
         const defaultModel = PROVIDER_DEFAULT_MODELS[providerId as keyof typeof PROVIDER_DEFAULT_MODELS];
         if (defaultModel) {
-          await ctx.state.harness.switchModel({ modelId: defaultModel });
+          await ctx.state.harness.session.model.switch({ modelId: defaultModel });
           ctx.showInfo(`Logged in to ${providerName} - switched to ${defaultModel}`);
         } else {
           ctx.showInfo(`Successfully logged in to ${providerName}`);

--- a/mastracode/src/tui/commands/mode.ts
+++ b/mastracode/src/tui/commands/mode.ts
@@ -18,7 +18,7 @@ export async function handleModeCommand(ctx: SlashCommandContext, args: string[]
   }
   if (args[0]) {
     try {
-      await ctx.harness.switchMode({ modeId: args[0] });
+      await ctx.harness.session.mode.switch({ modeId: args[0] });
       applyCurrentModeColorToRenderedTools(ctx);
     } catch (err) {
       ctx.showError(`Failed to switch mode: ${err instanceof Error ? err.message : String(err)}`);

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -391,7 +391,7 @@ async function applyPack(ctx: SlashCommandContext, pack: ModePack, previousPackI
   const currentModeId = harness.session.mode.get();
   const currentModeModel = (pack.models as Record<string, string>)[currentModeId];
   if (currentModeModel) {
-    await harness.switchModel({ modelId: currentModeModel });
+    await harness.session.model.switch({ modelId: currentModeModel });
   }
 
   const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -286,7 +286,7 @@ export function handleGoalEvaluation(ctx: EventHandlerContext, payload: GoalEval
     if (goal && goal.id === state.planStartedGoalId) {
       const goalId = state.planStartedGoalId;
       state.planStartedGoalId = undefined;
-      state.harness.switchMode({ modeId: 'plan' }).catch(error => {
+      state.harness.session.mode.switch({ modeId: 'plan' }).catch(error => {
         ctx.showError(`Failed to switch to Plan mode: ${error instanceof Error ? error.message : String(error)}`);
         state.planStartedGoalId = goalId;
       });

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -1154,7 +1154,7 @@ export class MastraTUI {
           const { PROVIDER_DEFAULT_MODELS } = await import('../auth/storage.js');
           const defaultModel = PROVIDER_DEFAULT_MODELS[providerId as keyof typeof PROVIDER_DEFAULT_MODELS];
           if (defaultModel) {
-            await this.state.harness.switchModel({ modelId: defaultModel });
+            await this.state.harness.session.model.switch({ modelId: defaultModel });
             showInfo(this.state, `Logged in to ${providerName} - switched to ${defaultModel}`);
           } else {
             showInfo(this.state, `Successfully logged in to ${providerName}`);
@@ -1296,7 +1296,7 @@ export class MastraTUI {
     const currentModeId = harness.session.mode.get();
     const currentModeModel = (modePack.models as Record<string, string>)[currentModeId];
     if (currentModeModel) {
-      await harness.switchModel({ modelId: currentModeModel });
+      await harness.session.model.switch({ modelId: currentModeModel });
     }
 
     const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -156,7 +156,7 @@ export function setupKeyboardShortcuts(
     const currentIndex = modes.findIndex(m => m.id === currentId);
     const nextIndex = (currentIndex + 1) % modes.length;
     const nextMode = modes[nextIndex]!;
-    await state.harness.switchMode({ modeId: nextMode.id });
+    await state.session.mode.switch({ modeId: nextMode.id });
   });
 
   // Ctrl+Y - toggle YOLO mode

--- a/packages/core/src/harness/fork-clone-metadata.test.ts
+++ b/packages/core/src/harness/fork-clone-metadata.test.ts
@@ -236,9 +236,9 @@ describe('Harness fork clone metadata wiring', () => {
 
     // All modes should return the same agent instance — no forking
     const buildAgent = harness.getCurrentAgent();
-    await harness.switchMode({ modeId: 'plan' });
+    await harness.session.mode.switch({ modeId: 'plan' });
     const planAgent = harness.getCurrentAgent();
-    await harness.switchMode({ modeId: 'build' });
+    await harness.session.mode.switch({ modeId: 'build' });
     const buildAgentAgain = harness.getCurrentAgent();
 
     expect(buildAgent).toBe(baseAgent);
@@ -283,9 +283,9 @@ describe('Harness fork clone metadata wiring', () => {
 
     // Switch modes multiple times
     harness.getCurrentAgent();
-    await harness.switchMode({ modeId: 'plan' });
+    await harness.session.mode.switch({ modeId: 'plan' });
     harness.getCurrentAgent();
-    await harness.switchMode({ modeId: 'build' });
+    await harness.session.mode.switch({ modeId: 'build' });
     harness.getCurrentAgent();
 
     // The agent's own instructions should remain unchanged
@@ -333,10 +333,10 @@ describe('Harness fork clone metadata wiring', () => {
     // Default mode is 'build'
     expect(resolve.call(harness)).toBe('Harness global.\nBuild mode.');
 
-    await harness.switchMode({ modeId: 'plan' });
+    await harness.session.mode.switch({ modeId: 'plan' });
     expect(resolve.call(harness)).toBe('Harness global.\nPlan mode.');
 
-    await harness.switchMode({ modeId: 'build' });
+    await harness.session.mode.switch({ modeId: 'build' });
     expect(resolve.call(harness)).toBe('Harness global.\nBuild mode.');
   });
 
@@ -385,7 +385,7 @@ describe('Harness fork clone metadata wiring', () => {
     expect(buildResult.modeTools!.buildTool).toBe(modeTool);
 
     // Switch to 'plan' mode (no mode tools) — modeTools should be absent
-    await harness.switchMode({ modeId: 'plan' });
+    await harness.session.mode.switch({ modeId: 'plan' });
     const planResult = (await buildToolsets.call(harness, new RequestContext())) as {
       modeTools?: Record<string, unknown>;
     };
@@ -438,11 +438,11 @@ describe('Harness fork clone metadata wiring', () => {
     expect(signalProvider.getConnectedAgent()).toBe(baseAgent);
     expect(signalProvider.getConnectedAgent()!.hasOwnMemory()).toBe(true);
 
-    await harness.switchMode({ modeId: 'plan' });
+    await harness.session.mode.switch({ modeId: 'plan' });
     expect(signalProvider.getConnectedAgent()).toBe(baseAgent);
     expect(signalProvider.getConnectedAgent()!.hasOwnMemory()).toBe(true);
 
-    await harness.switchMode({ modeId: 'build' });
+    await harness.session.mode.switch({ modeId: 'build' });
     expect(signalProvider.getConnectedAgent()).toBe(baseAgent);
     expect(signalProvider.getConnectedAgent()!.hasOwnMemory()).toBe(true);
   });
@@ -489,7 +489,7 @@ describe('Harness fork clone metadata wiring', () => {
     const currentBuild = harness.getCurrentAgent();
     expect(currentBuild).toBe(buildAgent);
 
-    await harness.switchMode({ modeId: 'plan' });
+    await harness.session.mode.switch({ modeId: 'plan' });
     const currentPlan = harness.getCurrentAgent();
     expect(currentPlan).toBe(planAgent);
     expect(currentPlan).not.toBe(currentBuild);

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -497,7 +497,10 @@ export class Harness<TState = {}> {
     });
     this.#session.setCategoryResolver(toolName => this.getToolCategory({ toolName }));
     this.#session.setSubagentNameResolver(agentType => this.getSubagentDisplayName(agentType));
-    this.#session.mode.setResolver(modeId => this.config.modes.find(m => m.id === modeId) ?? null);
+    this.#session.mode.setResolver(modeId => this.config.modes.find(m => m.id === modeId) ?? null, {
+      abort: () => this.abort(),
+      emit: event => this.emit(event),
+    });
     this.#session.thread.connect(this.createThreadDataStore());
 
     // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
@@ -885,34 +888,6 @@ export class Harness<TState = {}> {
 
   listModes(): HarnessMode[] {
     return this.config.modes;
-  }
-
-  /**
-   * Switch to a different mode.
-   * Aborts any in-progress generation and switches to the mode's default model.
-   */
-  async switchMode({ modeId }: { modeId: string }): Promise<void> {
-    const mode = this.config.modes.find(m => m.id === modeId);
-    if (!mode) {
-      throw new Error(`Mode not found: ${modeId}`);
-    }
-
-    this.abort();
-
-    const previousModeId = this.#session.mode.get();
-
-    // Emit the mode change immediately so UIs can update without waiting for
-    // the storage round-trips inside session.mode.switch().
-    this.emit({ type: 'mode_changed', modeId, previousModeId });
-
-    // The session owns the version-guarded switch sequence: remember the
-    // outgoing mode's model, persist the new mode, then resolve and apply the
-    // incoming mode's model. It returns the resolved model (or null if a newer
-    // switch superseded this one) so we can emit model_changed.
-    const { modelId } = await this.#session.mode.switch({ modeId, defaultModelId: mode.defaultModelId });
-    if (modelId) {
-      this.emit({ type: 'model_changed', modelId } as HarnessEvent);
-    }
   }
 
   private propagateRuntimeServicesToAgent(agent: Agent): Agent {
@@ -3432,7 +3407,7 @@ export class Harness<TState = {}> {
    * - On **rejection**, the plan-mode run is resumed with the feedback so the agent can
    *   revise and submit again. This is an ordinary tool resume.
    * - On **approval**, the parked plan-mode suspension is abandoned and the Harness
-   *   switches to its default (execution) mode. switchMode aborts the plan-mode run, so
+   *   switches to its default (execution) mode. The mode switch aborts the plan-mode run, so
    *   there is no point resuming it first; the next signal/message drives the fresh
    *   default-mode run. The model still sees the "approved" tool result on the rebuilt
    *   message history when the default-mode run starts.
@@ -3468,8 +3443,8 @@ export class Harness<TState = {}> {
     const transitionMode = this.listModes().find(mode => mode.id === transitionModeId);
     if (transitionMode && transitionMode.id !== this.#session.mode.get()) {
       await new Promise(resolveTimeout => setTimeout(resolveTimeout, 0));
-      await this.switchMode({ modeId: transitionMode.id });
-      // switchMode aborts the in-flight run but does not wait for it to
+      await this.#session.mode.switch({ modeId: transitionMode.id });
+      // The mode switch aborts the in-flight run but does not wait for it to
       // finalize. If the caller (e.g. mastracode's plan-approval handler)
       // immediately fires a system-reminder signal, that signal can land in
       // the dying run's pending queue and later get drained with the run's

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -501,6 +501,11 @@ export class Harness<TState = {}> {
       abort: () => this.abort(),
       emit: event => this.emit(event),
     });
+    this.#session.model.setResolver({
+      getCurrentModeId: () => this.#session.mode.get(),
+      emit: event => this.emit(event),
+      trackModelUse: this.config.modelUseCountTracker,
+    });
     this.#session.thread.connect(this.createThreadDataStore());
 
     // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
@@ -1014,37 +1019,6 @@ export class Harness<TState = {}> {
    */
   getFullModelId(): string {
     return this.#session.model.get();
-  }
-
-  /**
-   * Switch to a different model at runtime.
-   */
-  async switchModel({
-    modelId,
-    scope = 'thread',
-    modeId,
-  }: {
-    modelId: string;
-    scope?: 'global' | 'thread';
-    modeId?: string;
-  }): Promise<void> {
-    const targetModeId = modeId ?? this.#session.mode.get();
-
-    if (targetModeId === this.#session.mode.get()) {
-      this.#session.model.set({ modelId });
-    }
-
-    if (scope === 'thread') {
-      await this.#session.model.saveForMode({ modeId: targetModeId, modelId });
-    }
-
-    try {
-      await Promise.resolve(this.config.modelUseCountTracker?.(modelId));
-    } catch (error) {
-      console.error('Failed to track model usage count', error);
-    }
-
-    this.emit({ type: 'model_changed', modelId, scope, modeId: targetModeId } as HarnessEvent);
   }
 
   /**

--- a/packages/core/src/harness/mode-model-persistence.test.ts
+++ b/packages/core/src/harness/mode-model-persistence.test.ts
@@ -76,7 +76,7 @@ describe('Harness mode-model persistence across restarts', () => {
     const thread = await session1.createThread();
 
     await session1.session.mode.switch({ modeId: 'fast' });
-    await session1.switchModel({ modelId: 'cerebras/qwen-3-coder-480b' });
+    await session1.session.model.switch({ modelId: 'cerebras/qwen-3-coder-480b' });
     expect(session1.session.model.get()).toBe('cerebras/qwen-3-coder-480b');
 
     const session2 = createHarness(storage);
@@ -91,7 +91,7 @@ describe('Harness mode-model persistence across restarts', () => {
     const session1 = createHarness(storage);
     await session1.init();
     const thread = await session1.createThread();
-    await session1.switchModel({ modelId: 'anthropic/claude-opus-4-6' });
+    await session1.session.model.switch({ modelId: 'anthropic/claude-opus-4-6' });
 
     const session2 = createHarness(storage);
     await session2.init();

--- a/packages/core/src/harness/mode-model-persistence.test.ts
+++ b/packages/core/src/harness/mode-model-persistence.test.ts
@@ -57,7 +57,7 @@ describe('Harness mode-model persistence across restarts', () => {
     const thread = await session1.createThread();
     expect(session1.session.mode.get()).toBe('build');
 
-    await session1.switchMode({ modeId: 'fast' });
+    await session1.session.mode.switch({ modeId: 'fast' });
     expect(session1.session.mode.get()).toBe('fast');
     expect(session1.session.model.get()).toBe('cerebras/zai-glm-4.7');
 
@@ -75,7 +75,7 @@ describe('Harness mode-model persistence across restarts', () => {
     await session1.init();
     const thread = await session1.createThread();
 
-    await session1.switchMode({ modeId: 'fast' });
+    await session1.session.mode.switch({ modeId: 'fast' });
     await session1.switchModel({ modelId: 'cerebras/qwen-3-coder-480b' });
     expect(session1.session.model.get()).toBe('cerebras/qwen-3-coder-480b');
 
@@ -105,7 +105,7 @@ describe('Harness mode-model persistence across restarts', () => {
     const session1 = createHarness(storage);
     await session1.init();
     const thread = await session1.createThread();
-    await session1.switchMode({ modeId: 'plan' });
+    await session1.session.mode.switch({ modeId: 'plan' });
 
     const session2 = createHarness(storage);
     await session2.init();
@@ -132,7 +132,7 @@ describe('Harness mode-model persistence across restarts', () => {
     const session = createHarness(storage);
     await session.init();
     await session.createThread();
-    await session.switchMode({ modeId: 'plan' });
+    await session.session.mode.switch({ modeId: 'plan' });
 
     const controller = session.session.run.ensureAbortController();
 

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -14,6 +14,7 @@ import type {
   HarnessRequestState,
   HarnessRequestStateUpdater,
   HarnessThread,
+  ModelUseCountTracker,
   TokenUsage,
   ToolCategory,
 } from './types';
@@ -656,9 +657,33 @@ export class SessionRun {
 export class SessionModel {
   #id = '';
   readonly #store: () => ThreadSettingsStore | undefined;
+  /**
+   * Reads the active mode id. Injected by the Harness via {@link setResolver},
+   * since {@link switch} defaults a model change to the current mode.
+   */
+  #getCurrentModeId: (() => string) | undefined;
+  /** Emits Harness events (`model_changed`). Injected via {@link setResolver}. */
+  #emit: ((event: HarnessEvent) => void) | undefined;
+  /** App hook to track model usage for ranking. Injected via {@link setResolver}. */
+  #trackModelUse: ModelUseCountTracker | undefined;
 
   constructor(store: () => ThreadSettingsStore | undefined) {
     this.#store = store;
+  }
+
+  /**
+   * Attach the Harness-owned dependencies {@link switch} needs: the active-mode
+   * accessor, the event emitter, and the optional model-use tracker. The
+   * Harness injects these once.
+   */
+  setResolver(options: {
+    getCurrentModeId: () => string;
+    emit: (event: HarnessEvent) => void;
+    trackModelUse?: ModelUseCountTracker;
+  }): void {
+    this.#getCurrentModeId = options.getCurrentModeId;
+    this.#emit = options.emit;
+    this.#trackModelUse = options.trackModelUse;
   }
 
   /** The currently-selected model id ('' when none selected yet). */
@@ -695,6 +720,43 @@ export class SessionModel {
     const stored = (await this.#store()?.get(modeModelKey(modeId))) as string | undefined;
     if (stored) return stored;
     return defaultModelId ?? null;
+  }
+
+  /**
+   * Switch to a different model at runtime.
+   *
+   * When `scope` is `'thread'` (the default), the model is persisted as the
+   * per-mode model for `modeId` so it's restored when switching back. The
+   * in-memory selection only updates when the target mode is the active mode.
+   * Reports the selection to the model-use tracker and emits `model_changed`.
+   */
+  async switch({
+    modelId,
+    scope = 'thread',
+    modeId,
+  }: {
+    modelId: string;
+    scope?: 'global' | 'thread';
+    modeId?: string;
+  }): Promise<void> {
+    const currentModeId = this.#getCurrentModeId?.() ?? '';
+    const targetModeId = modeId ?? currentModeId;
+
+    if (targetModeId === currentModeId) {
+      this.set({ modelId });
+    }
+
+    if (scope === 'thread') {
+      await this.saveForMode({ modeId: targetModeId, modelId });
+    }
+
+    try {
+      await Promise.resolve(this.#trackModelUse?.(modelId));
+    } catch (error) {
+      console.error('Failed to track model usage count', error);
+    }
+
+    this.#emit?.({ type: 'model_changed', modelId, scope, modeId: targetModeId });
   }
 }
 

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -720,6 +720,16 @@ export class SessionMode {
    * {@link setResolver}, since the mode *catalog* (`config.modes`) is host config.
    */
   #resolveMode: ((modeId: string) => HarnessMode | null) | undefined;
+  /**
+   * Aborts any in-progress generation before a switch. Injected by the Harness
+   * via {@link setResolver}, since aborting a run is Harness-owned orchestration.
+   */
+  #abort: (() => void) | undefined;
+  /**
+   * Emits Harness events (mode_changed / model_changed) during a switch.
+   * Injected by the Harness via {@link setResolver}.
+   */
+  #emit: ((event: HarnessEvent) => void) | undefined;
 
   constructor(store: () => ThreadSettingsStore | undefined, model: SessionModel) {
     this.#store = store;
@@ -727,11 +737,18 @@ export class SessionMode {
   }
 
   /**
-   * Attach the resolver that maps a mode id to its definition. The Harness owns
-   * the mode catalog (`config.modes`) and injects this once.
+   * Attach the resolver that maps a mode id to its definition, plus the
+   * Harness-owned orchestration callbacks ({@link switch} uses to abort the
+   * in-flight run and emit events). The Harness owns the mode catalog
+   * (`config.modes`) and injects these once.
    */
-  setResolver(resolve: (modeId: string) => HarnessMode | null): void {
+  setResolver(
+    resolve: (modeId: string) => HarnessMode | null,
+    options?: { abort?: () => void; emit?: (event: HarnessEvent) => void },
+  ): void {
     this.#resolveMode = resolve;
+    this.#abort = options?.abort;
+    this.#emit = options?.emit;
   }
 
   /** The currently-selected mode id. */
@@ -757,43 +774,46 @@ export class SessionMode {
   }
 
   /**
-   * Switch to `modeId`, coordinating the selected model and persistence.
+   * Switch to a different mode.
    *
-   * The Harness handles aborting in-flight work and emitting events; this owns
-   * the version-guarded sequence: remember the outgoing mode's model, persist
-   * the new mode, then resolve and apply the incoming mode's model. A newer
-   * switch starting mid-flight supersedes this one, which then bails.
-   *
-   * Returns the resolved model id for the new mode (or null), so the caller can
-   * emit `model_changed` after applying it.
+   * Aborts any in-progress generation, emits `mode_changed`, then runs the
+   * version-guarded sequence: remember the outgoing mode's model, persist the
+   * new mode, then resolve and apply the incoming mode's model — emitting
+   * `model_changed` once applied. A newer switch starting mid-flight supersedes
+   * this one, which then bails before emitting `model_changed`.
    */
-  async switch({
-    modeId,
-    defaultModelId,
-  }: {
-    modeId: string;
-    defaultModelId?: string;
-  }): Promise<{ modelId: string | null }> {
+  async switch({ modeId }: { modeId: string }): Promise<void> {
+    const mode = this.#resolveMode?.(modeId) ?? null;
+    if (!mode) {
+      throw new Error(`Mode not found: ${modeId}`);
+    }
+
+    this.#abort?.();
+
     const previousModeId = this.#id;
     const previousModelId = this.#model.get();
     const version = ++this.#switchVersion;
     this.#id = modeId;
 
+    // Emit the mode change immediately so UIs can update without waiting for
+    // the storage round-trips below.
+    this.#emit?.({ type: 'mode_changed', modeId, previousModeId });
+
     // Remember the outgoing mode's model before moving on.
     if (previousModelId) {
       await this.#model.saveForMode({ modeId: previousModeId, modelId: previousModelId });
     }
-    if (this.#switchVersion !== version) return { modelId: null };
+    if (this.#switchVersion !== version) return;
 
     await this.#store()?.set(MODE_ID_KEY, modeId);
-    if (this.#switchVersion !== version) return { modelId: null };
+    if (this.#switchVersion !== version) return;
 
-    const modelId = await this.#model.resolveForMode({ modeId, defaultModelId });
-    if (this.#switchVersion !== version) return { modelId: null };
+    const modelId = await this.#model.resolveForMode({ modeId, defaultModelId: mode.defaultModelId });
+    if (this.#switchVersion !== version) return;
     if (modelId) {
       this.#model.set({ modelId });
+      this.#emit?.({ type: 'model_changed', modelId } as HarnessEvent);
     }
-    return { modelId };
   }
 }
 

--- a/packages/core/src/harness/switch-model.test.ts
+++ b/packages/core/src/harness/switch-model.test.ts
@@ -19,12 +19,12 @@ function createHarness(onModelUse?: (modelId: string) => void) {
   });
 }
 
-describe('Harness.switchModel', () => {
+describe('session.model.switch', () => {
   it('tracks model selection via modelUseCountTracker', async () => {
     const trackModelUse = vi.fn<(modelId: string) => void>();
     const harness = createHarness(trackModelUse);
 
-    await harness.switchModel({ modelId: 'openai/gpt-5.3-codex' });
+    await harness.session.model.switch({ modelId: 'openai/gpt-5.3-codex' });
 
     expect(trackModelUse).toHaveBeenCalledTimes(1);
     expect(trackModelUse).toHaveBeenCalledWith('openai/gpt-5.3-codex');


### PR DESCRIPTION
Mode switching used to be a method on the Harness (`harness.switchMode()`) that wrapped a lower-level `SessionMode.switch()` primitive. Since the active mode and model already live on the Session, the switching logic belongs there too. This removes `Harness.switchMode()` and consolidates everything into a single `harness.session.mode.switch()` API that handles aborting the in-flight run and emitting `mode_changed` / `model_changed`.

Before:

```typescript
await harness.switchMode({ modeId: 'build' })
```

After:

```typescript
await harness.session.mode.switch({ modeId: 'build' })
```

Updated the MastraCode TUI callers, the harness tests, and the Harness docs (including the architecture diagram). Harness is still under development so this ships as a minor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR moves the “switch mode” button from the top-level Harness into the Session, because the Session already knows what mode/model is currently active. That way, switching can reliably stop anything running, load the right model, and notify the rest of the system.

## Overview
Mode switching is now done via the Session API: `harness.session.mode.switch()`.

**API changes**
- **Before:** `await harness.switchMode({ modeId: 'build' })`
- **After:** `await harness.session.mode.switch({ modeId: 'build' })`

**Event behavior**
- `mode_changed` is emitted **always**
- `model_changed` is emitted **only if a model resolves for the incoming mode**

## Changes made

### Core (`packages/core`)
- Removed `Harness.switchMode()` and the related Harness-level mode/model switching entry points.
- Refactored mode/model switching so the Session owns the full switch flow:
  - `SessionMode.switch({ modeId })` now aborts in-flight generation, persists the new mode id, resolves/applies the incoming mode’s default model, and emits `mode_changed` and (conditionally) `model_changed`.
- Updated relevant internal flows (e.g., plan-approval resume) to switch modes via `this.#session.mode.switch(...)`.

### Tests
- Updated harness tests to call:
  - `harness.session.mode.switch({ modeId })`
  - `harness.session.model.switch({ modelId, scope?, modeId? })` where applicable

### MastraCode (TUI + headless)
- Updated all mode switching call sites to use `harness.session.mode.switch(...)`.
- Updated all model switching call sites to use `harness.session.model.switch(...)` (replacing removed Harness-level APIs), including headless runs and TUI flows (login/onboarding, mode cycling, tool/model packs, etc.).

### Documentation & diagrams
- Updated Harness docs and references to reflect Session-level ownership and the new APIs.
- Revised the architecture diagram to better separate the app layer, `harness.session`, and the underlying “Agent + Memory + Tools” layer.
- Clarified behavioral notes for aborting and event emission (including the conditional `model_changed`).

### Release
- Added changesets to bump `@mastra/core` (minor) and `mastracode` (patch), documenting the API migration for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->