### PR TITLE
fix(core): sync harness session events

### DIFF
--- a/.changeset/wide-games-sink.md
+++ b/.changeset/wide-games-sink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed harness sessions so state events notify subscribers and keep display state in sync.

--- a/mastracode/src/evals/context-builder.ts
+++ b/mastracode/src/evals/context-builder.ts
@@ -220,7 +220,7 @@ function buildRequestContext(harness: Harness<any>, threadId: string): Record<st
   return {
     threadId,
     mode: state.currentMode ?? state.mode,
-    modelId: harness.session.model.get(),
+    modelId: harness.session.model,
     projectPath: state.projectPath,
     projectName: state.projectName,
     gitBranch: state.gitBranch,

--- a/mastracode/src/headless-integration.test.ts
+++ b/mastracode/src/headless-integration.test.ts
@@ -666,7 +666,7 @@ describe('headless mode — --model flag', () => {
     expect(modelChanged.modelId).toBe('anthropic/claude-haiku-4-5');
 
     // Verify the harness state was updated
-    expect(harness.session.model.get()).toBe('anthropic/claude-haiku-4-5');
+    expect(harness.session.model).toBe('anthropic/claude-haiku-4-5');
   });
 
   it('returns exit code 1 for an unknown model', async () => {
@@ -847,7 +847,7 @@ describe('headless mode — --model flag', () => {
 
     expect(exitCode).toBe(0);
     expect(stderrCalls.join('')).toContain('--model overrides --mode');
-    expect(harness.session.model.get()).toBe('anthropic/claude-haiku-4-5');
+    expect(harness.session.model).toBe('anthropic/claude-haiku-4-5');
   });
 
   it('emits structured warning in JSON mode when --model and --mode are both provided', async () => {
@@ -930,7 +930,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(harness.session.model.get()).toBe('cerebras/zai-glm-4.7');
+    expect(harness.session.model).toBe('cerebras/zai-glm-4.7');
   });
 
   it('--model still overrides effectiveDefaults', async () => {
@@ -959,7 +959,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
 
     expect(exitCode).toBe(0);
     // --model should win over effectiveDefaults
-    expect(harness.session.model.get()).toBe('anthropic/claude-haiku-4-5');
+    expect(harness.session.model).toBe('anthropic/claude-haiku-4-5');
   });
 
   it('--mode returns exit code 1 when resolved model is not available', async () => {

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -432,7 +432,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
       const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
       return failEarly(`Model "${args.model}" has no API key configured.${keyHint}`);
     }
-    await harness.session.model.switch({ modelId: args.model });
+    await harness.session.switchModel({ modelId: args.model });
     if (!emit) process.stderr.write(`[model] ${args.model}\n`);
   } else if (args.mode) {
     // --mode flag: look up model from effectiveDefaults (resolved from settings at startup)
@@ -447,7 +447,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
         const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
         return failEarly(`Model "${modelId}" (mode: ${args.mode}) has no API key configured.${keyHint}`);
       }
-      await harness.session.model.switch({ modelId });
+      await harness.session.switchModel({ modelId });
       if (!emit) process.stderr.write(`[model] ${modelId} (mode: ${args.mode})\n`);
     } else {
       const warnMsg = `--mode ${args.mode} has no configured model, using default`;

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -423,8 +423,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
             threadId,
             resourceId,
             session: {
-              modeId: harness.session.mode.get(),
-              modelId: harness.session.model.get(),
+              modeId: harness.session.mode,
+              modelId: harness.session.model,
               state: {
                 get: () => harness.session.state.get(),
                 set: updates => harness.session.state.set(updates),

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -105,7 +105,7 @@ async function tuiMain(pipedInput?: string | null) {
 
   analytics = createMastraCodeAnalytics({ version: getCurrentVersion() });
   analytics.capture('mastracode_session_started', {
-    mode: harness.session.mode.get(),
+    mode: harness.session.mode,
     resourceId: harness.session.identity.getResourceId(),
     hasAuthStorage: Boolean(authStorage),
     hasMcp: Boolean(mcpManager),

--- a/mastracode/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/src/tui/__tests__/command-dispatch.test.ts
@@ -100,7 +100,7 @@ describe('dispatchSlashCommand models routing', () => {
       session: {
         identity: { getResourceId: vi.fn(() => 'resource-1') },
         thread: { getId: vi.fn(() => 'thread-1') },
-        mode: { get: vi.fn(() => 'build') },
+        mode: 'build',
       },
     } as any;
     const ctx = { analytics: { trackCommand: mocks.trackCommand } } as any;
@@ -124,7 +124,7 @@ describe('dispatchSlashCommand models routing', () => {
       session: {
         identity: { getResourceId: vi.fn(() => 'resource-1') },
         thread: { getId: vi.fn(() => 'thread-1') },
-        mode: { get: vi.fn(() => 'build') },
+        mode: 'build',
       },
     } as any;
     const ctx = { analytics: { trackCommand: mocks.trackCommand } } as any;
@@ -499,7 +499,7 @@ describe('dispatchSlashCommand models routing', () => {
       session: {
         identity: { getResourceId: vi.fn(() => 'resource-1') },
         thread: { getId: vi.fn(() => null) },
-        mode: { get: vi.fn(() => 'build') },
+        mode: 'build',
       },
     } as any;
     const ctx = { analytics: { trackCommand: mocks.trackCommand } } as any;

--- a/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -291,7 +291,10 @@ describe('MastraTUI queueing', () => {
       harness: {
         createThread,
         sendSignal,
-        session: { stream: { isActive: () => false }, displayState: { get: () => ({ isRunning: false }) } },
+        session: {
+          stream: { isActive: () => false },
+          displayState: { get: () => ({ isRunning: false }) },
+        },
       } as unknown as TUIState['harness'],
       chatContainer: new Container(),
     });
@@ -630,7 +633,9 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: 'plan-goal-456',
       harness: {
-        switchMode,
+        session: {
+          switchMode,
+        },
       } as any,
       goalManager: {
         applyEvaluation,
@@ -658,7 +663,9 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: undefined,
       harness: {
-        switchMode,
+        session: {
+          switchMode,
+        },
       } as any,
       goalManager: {
         applyEvaluation: vi.fn(),
@@ -764,7 +771,9 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: 'plan-goal-failed',
       harness: {
-        switchMode,
+        session: {
+          switchMode,
+        },
       } as any,
       goalManager: {
         applyEvaluation: vi.fn(),

--- a/mastracode/src/tui/__tests__/state.test.ts
+++ b/mastracode/src/tui/__tests__/state.test.ts
@@ -44,7 +44,7 @@ import { createTUIState } from '../state.js';
 function createHarness() {
   return {
     session: {
-      mode: { resolve: vi.fn(() => ({ id: 'build', metadata: { color: '#7c3aed' } })) },
+      mode: { id: 'build', metadata: { color: '#7c3aed' } },
     },
   };
 }
@@ -129,6 +129,5 @@ describe('createTUIState', () => {
     expect(state.projectInfo).toEqual({ rootPath: '/tmp/mastra-code-project', gitBranch: 'main' });
 
     expect(state.editor.getModeColor?.()).toBe('#7c3aed');
-    expect(harness.session.mode.resolve).toHaveBeenCalled();
   });
 });

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -72,7 +72,7 @@ export async function dispatchSlashCommand(
       action: 'attempted',
       threadId: state.session.thread.getId(),
       resourceId: state.session.identity.getResourceId(),
-      mode: state.session.mode.get(),
+      mode: state.session.mode,
     });
   };
   const trimmedInput = input.trim();

--- a/mastracode/src/tui/commands/__tests__/report-issue.test.ts
+++ b/mastracode/src/tui/commands/__tests__/report-issue.test.ts
@@ -13,7 +13,9 @@ import { handleReportIssueCommand } from '../report-issue.js';
 function createCtx(options?: { hasModelSelected?: boolean; pendingNewThread?: boolean }) {
   const state = {
     pendingNewThread: options?.pendingNewThread ?? false,
-    session: { model: { hasSelection: vi.fn(() => options?.hasModelSelected ?? true) } },
+    session: {
+      model: options?.hasModelSelected === false ? undefined : 'model-id',
+    },
     harness: {
       createThread: vi.fn().mockResolvedValue(undefined),
     },

--- a/mastracode/src/tui/commands/__tests__/threads.test.ts
+++ b/mastracode/src/tui/commands/__tests__/threads.test.ts
@@ -78,7 +78,7 @@ function createContext(threads: HarnessThread[]) {
         list: vi.fn(async () => threads),
         firstUserMessages: vi.fn(async () => new Map()),
       },
-      mode: { get: vi.fn(() => 'build') },
+      mode: { id: 'build' },
     },
     harness: {
       setResourceId: vi.fn(),

--- a/mastracode/src/tui/commands/browser.ts
+++ b/mastracode/src/tui/commands/browser.ts
@@ -435,7 +435,7 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
       return;
     }
 
-    const currentMode = ctx.state.session.mode.resolve();
+    const currentMode = ctx.state.session.mode;
     const currentAgent = resolveModeAgent(currentMode, ctx.state.session.state.get());
     let browserInstance = currentAgent?.browser;
 

--- a/mastracode/src/tui/commands/goal.ts
+++ b/mastracode/src/tui/commands/goal.ts
@@ -261,7 +261,7 @@ async function promptForJudgeDefaults(ctx: SlashCommandContext, cancelMessage: s
   }
 
   const settings = loadSettings();
-  const preselectedId = settings.models.goalJudgeModel ?? state.session.model.get() ?? undefined;
+  const preselectedId = settings.models.goalJudgeModel ?? state.session.model ?? undefined;
   const defaultMaxTurns =
     typeof settings.models.goalMaxTurns === 'number' && settings.models.goalMaxTurns > 0
       ? settings.models.goalMaxTurns

--- a/mastracode/src/tui/commands/login.ts
+++ b/mastracode/src/tui/commands/login.ts
@@ -53,7 +53,7 @@ async function performLogin(ctx: SlashCommandContext, providerId: string): Promi
 
         const defaultModel = PROVIDER_DEFAULT_MODELS[providerId as keyof typeof PROVIDER_DEFAULT_MODELS];
         if (defaultModel) {
-          await ctx.state.harness.session.model.switch({ modelId: defaultModel });
+          await ctx.state.harness.session.switchModel({ modelId: defaultModel });
           ctx.showInfo(`Logged in to ${providerName} - switched to ${defaultModel}`);
         } else {
           ctx.showInfo(`Successfully logged in to ${providerName}`);
@@ -93,7 +93,7 @@ export async function handleLoginCommand(ctx: SlashCommandContext, mode: 'login'
     ctx.analytics?.trackInteractivePrompt('login_provider_selector', {
       threadId: ctx.state.session.thread.getId(),
       resourceId: ctx.state.session.identity.getResourceId(),
-      mode: ctx.state.session.mode.get(),
+      mode: ctx.state.session.mode.id,
     });
   }
 

--- a/mastracode/src/tui/commands/mode.ts
+++ b/mastracode/src/tui/commands/mode.ts
@@ -2,7 +2,7 @@ import type { IToolExecutionComponent } from '../components/tool-execution-inter
 import type { SlashCommandContext } from './types.js';
 
 function applyCurrentModeColorToRenderedTools(ctx: SlashCommandContext): void {
-  const color = ctx.state.session.mode.resolve().metadata?.color;
+  const color = ctx.state.session.mode.metadata?.color;
   const modeColor = typeof color === 'string' ? color : undefined;
   for (const tool of ctx.state.allToolComponents as IToolExecutionComponent[]) {
     tool.setCompactToolModeColor?.(modeColor);
@@ -18,13 +18,13 @@ export async function handleModeCommand(ctx: SlashCommandContext, args: string[]
   }
   if (args[0]) {
     try {
-      await ctx.harness.session.mode.switch({ modeId: args[0] });
+      await ctx.harness.session.switchMode({ modeId: args[0] });
       applyCurrentModeColorToRenderedTools(ctx);
     } catch (err) {
       ctx.showError(`Failed to switch mode: ${err instanceof Error ? err.message : String(err)}`);
     }
   } else {
-    const currentMode = ctx.state.session.mode.resolve();
+    const currentMode = ctx.state.session.mode;
     const modeList = modes
       .map(m => `  ${m.id === currentMode?.id ? '* ' : '  '}${m.name}${m.description ? ` - ${m.description}` : ''}`)
       .join('\n');

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -388,10 +388,10 @@ async function applyPack(ctx: SlashCommandContext, pack: ModePack, previousPackI
     }
   }
 
-  const currentModeId = harness.session.mode.get();
+  const currentModeId = harness.session.mode.id;
   const currentModeModel = (pack.models as Record<string, string>)[currentModeId];
   if (currentModeModel) {
-    await harness.session.model.switch({ modelId: currentModeModel });
+    await harness.session.switchModel({ modelId: currentModeModel });
   }
 
   const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };

--- a/mastracode/src/tui/commands/report-issue.ts
+++ b/mastracode/src/tui/commands/report-issue.ts
@@ -5,7 +5,7 @@ const MASTRA_REPO = 'mastra-ai/mastra';
 const MASTRA_LABEL = 'mastracode';
 
 export async function handleReportIssueCommand(ctx: SlashCommandContext, args: string[]): Promise<void> {
-  if (!ctx.state.session.model.hasSelection()) {
+  if (!ctx.state.session.model) {
     ctx.showInfo('No model selected. Use /models to select a model, or /login to authenticate.');
     return;
   }

--- a/mastracode/src/tui/commands/review.ts
+++ b/mastracode/src/tui/commands/review.ts
@@ -2,7 +2,7 @@ import { sendSlashCommandMessage } from './send-slash-command-message.js';
 import type { SlashCommandContext } from './types.js';
 
 export async function handleReviewCommand(ctx: SlashCommandContext, args: string[]): Promise<void> {
-  if (!ctx.state.session.model.hasSelection()) {
+  if (!ctx.state.session.model) {
     ctx.showInfo('No model selected. Use /models to select a model, or /login to authenticate.');
     return;
   }

--- a/mastracode/src/tui/commands/settings.ts
+++ b/mastracode/src/tui/commands/settings.ts
@@ -16,7 +16,7 @@ import { handleApiKeysCommand } from './api-keys.js';
 import type { SlashCommandContext } from './types.js';
 
 function getCurrentModeColor(ctx: SlashCommandContext): string | undefined {
-  const color = ctx.state.session.mode.resolve().metadata?.color;
+  const color = ctx.state.session.mode.metadata?.color;
   return typeof color === 'string' ? color : undefined;
 }
 
@@ -196,7 +196,7 @@ export async function handleSettingsCommand(ctx: SlashCommandContext): Promise<v
     notifications: (state?.notifications ?? 'off') as NotificationMode,
     yolo: state?.yolo === true,
     thinkingLevel: (state?.thinkingLevel ?? 'off') as string,
-    currentModelId: ctx.state.session.model.get() ?? '',
+    currentModelId: ctx.state.session.model ?? '',
     escapeAsCancel: ctx.state.editor.escapeEnabled,
     quietMode: globalSettings.preferences.quietMode,
     quietModeMaxToolPreviewLines: globalSettings.preferences.quietModeMaxToolPreviewLines,

--- a/mastracode/src/tui/commands/think.ts
+++ b/mastracode/src/tui/commands/think.ts
@@ -33,7 +33,7 @@ function persistGlobalThinkingLevel(level: ThinkingLevelSetting): void {
 }
 
 function getModelNote(ctx: SlashCommandContext): string | null {
-  const modelId = ctx.state.session.model.get() ?? '';
+  const modelId = ctx.state.session.model ?? '';
   if (!modelId) return 'No model selected.';
   if (!supportsThinking(modelId)) {
     return `Warning: current model (${modelId}) may not support reasoning effort. Setting will be saved but may not take effect.`;
@@ -43,7 +43,7 @@ function getModelNote(ctx: SlashCommandContext): string | null {
 
 export async function handleThinkCommand(ctx: SlashCommandContext, args: string[] = []): Promise<void> {
   const currentLevel = ((ctx.state.session.state.get() as any)?.thinkingLevel ?? 'off') as string;
-  const modelId = ctx.state.session.model.get() ?? '';
+  const modelId = ctx.state.session.model ?? '';
   const thinkingLevels = getThinkingLevelsForModel(modelId);
   const arg = args[0]?.toLowerCase();
 

--- a/mastracode/src/tui/commands/threads.ts
+++ b/mastracode/src/tui/commands/threads.ts
@@ -14,7 +14,7 @@ export function showThreadLockPrompt(
   ctx.analytics?.trackInteractivePrompt('thread_lock_prompt', {
     threadId: lockedThreadId ?? ctx.state.session.thread.getId(),
     resourceId: ctx.state.session.identity.getResourceId(),
-    mode: ctx.state.session.mode.get(),
+    mode: ctx.state.session.mode.id,
   });
 
   void (async () => {

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -286,7 +286,7 @@ export function handleGoalEvaluation(ctx: EventHandlerContext, payload: GoalEval
     if (goal && goal.id === state.planStartedGoalId) {
       const goalId = state.planStartedGoalId;
       state.planStartedGoalId = undefined;
-      state.harness.session.mode.switch({ modeId: 'plan' }).catch(error => {
+      state.harness.session.switchMode({ modeId: 'plan' }).catch(error => {
         ctx.showError(`Failed to switch to Plan mode: ${error instanceof Error ? error.message : String(error)}`);
         state.planStartedGoalId = goalId;
       });

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -267,7 +267,7 @@ export class MastraTUI {
     if (this.state.options.initialMessage) {
       const msg = this.state.options.initialMessage;
 
-      if (!this.state.session.model.hasSelection()) {
+      if (!this.state.session.model) {
         showInfo(this.state, 'No model selected. Use /models to select a model, or /login to authenticate.');
       } else {
         const messageId = `user-${Date.now()}`;
@@ -325,7 +325,7 @@ export class MastraTUI {
         }
 
         // Check if a model is selected (sync — fast, no reason to defer)
-        if (!this.state.session.model.hasSelection()) {
+        if (!this.state.session.model) {
           showInfo(this.state, 'No model selected. Use /models to select a model, or /login to authenticate.');
           continue;
         }
@@ -427,7 +427,7 @@ export class MastraTUI {
       this.state.analytics?.capture('mastracode_prompt_submitted', {
         threadId: this.state.session.thread.getId(),
         resourceId: this.state.session.identity.getResourceId(),
-        mode: this.state.session.mode.get(),
+        mode: this.state.session.mode,
         hasImages: Boolean(images?.length),
         isFirstPromptInThread: pendingNewThread,
         pendingNewThread,
@@ -753,7 +753,7 @@ export class MastraTUI {
         action: 'created',
         threadId: event.thread.id,
         resourceId: event.thread.resourceId,
-        mode: this.state.session.mode.get(),
+        mode: this.state.session.mode,
         hasTitle: Boolean(event.thread.title),
       });
       return;
@@ -765,7 +765,7 @@ export class MastraTUI {
         threadId: event.threadId,
         previousThreadId: event.previousThreadId,
         resourceId: this.state.session.identity.getResourceId(),
-        mode: this.state.session.mode.get(),
+        mode: this.state.session.mode,
       });
       return;
     }
@@ -774,7 +774,7 @@ export class MastraTUI {
       analytics.capture('mastracode_model_changed', {
         modelId: event.modelId,
         scope: event.scope,
-        mode: event.modeId ?? this.state.session.mode.get(),
+        mode: event.modeId ?? this.state.session.mode,
         threadId: this.state.session.thread.getId(),
         resourceId: this.state.session.identity.getResourceId(),
       });
@@ -1154,7 +1154,7 @@ export class MastraTUI {
           const { PROVIDER_DEFAULT_MODELS } = await import('../auth/storage.js');
           const defaultModel = PROVIDER_DEFAULT_MODELS[providerId as keyof typeof PROVIDER_DEFAULT_MODELS];
           if (defaultModel) {
-            await this.state.harness.session.model.switch({ modelId: defaultModel });
+            await this.state.harness.session.switchModel({ modelId: defaultModel });
             showInfo(this.state, `Logged in to ${providerName} - switched to ${defaultModel}`);
           } else {
             showInfo(this.state, `Successfully logged in to ${providerName}`);
@@ -1293,10 +1293,10 @@ export class MastraTUI {
       }
     }
 
-    const currentModeId = harness.session.mode.get();
+    const currentModeId = harness.session.mode.id;
     const currentModeModel = (modePack.models as Record<string, string>)[currentModeId];
     if (currentModeModel) {
-      await harness.session.model.switch({ modelId: currentModeModel });
+      await harness.session.switchModel({ modelId: currentModeModel });
     }
 
     const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };
@@ -1386,7 +1386,7 @@ export class MastraTUI {
     const tools = this.state.allToolComponents.filter(
       (tool): tool is IToolExecutionComponent => typeof tool.setQuietModeDisplay === 'function',
     );
-    const color = this.state.harness?.session.mode.resolve().metadata?.color;
+    const color = this.state.harness?.session.mode.metadata?.color;
     const modeColor = typeof color === 'string' ? color : undefined;
     for (const tool of tools) {
       tool.setCompactToolModeColor?.(modeColor);

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -62,7 +62,7 @@ function getPendingUserMessageLabel(isInterjection?: boolean): string | undefine
 }
 
 function getCurrentModeColor(state: TUIState): string | undefined {
-  const color = state.session.mode.resolve().metadata?.color;
+  const color = state.session.mode.metadata?.color;
   return typeof color === 'string' ? color : undefined;
 }
 

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -152,11 +152,11 @@ export function setupKeyboardShortcuts(
 
     const modes = state.harness.listModes();
     if (modes.length <= 1) return;
-    const currentId = state.session.mode.get();
+    const currentId = state.session.mode.id;
     const currentIndex = modes.findIndex(m => m.id === currentId);
     const nextIndex = (currentIndex + 1) % modes.length;
     const nextMode = modes[nextIndex]!;
-    await state.session.mode.switch({ modeId: nextMode.id });
+    await state.session.switchMode({ modeId: nextMode.id });
   });
 
   // Ctrl+Y - toggle YOLO mode

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -386,7 +386,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
     if (result.activeGoalJudge) {
       return mastra.blue;
     }
-    const color = result.session.mode.resolve()?.metadata?.color;
+    const color = result.session.mode?.metadata?.color;
     return typeof color === 'string' ? color : undefined;
   };
   return result;

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -81,7 +81,7 @@ export function updateStatusLine(state: TUIState): void {
   let modeBadge = '';
   let modeBadgeWidth = 0;
   const modes = state.harness.listModes();
-  const currentMode = modes.length > 1 ? state.session.mode.resolve() : undefined;
+  const currentMode = modes.length > 1 ? state.session.mode : undefined;
   const judgeModeColor = mastra.blue;
   // Use judge color for goal judge activity, OM color for OM activity, otherwise mode color
   const currentModeColor = currentMode?.metadata?.color;

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -476,7 +476,6 @@ export class Harness<TState = {}> {
       state: {
         initialState: config.initialState,
         stateSchema: config.stateSchema,
-        emit: event => this.emit(event),
       },
     });
 
@@ -3535,7 +3534,10 @@ export class Harness<TState = {}> {
    */
   subscribe(listener: HarnessEventListener): () => void {
     this.listeners.push(listener);
+    const sessionListener = this.#session?.subscribe(listener);
+
     return () => {
+      sessionListener?.();
       const index = this.listeners.indexOf(listener);
       if (index !== -1) {
         this.listeners.splice(index, 1);

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -471,14 +471,6 @@ export class Harness<TState = {}> {
     this.config = config;
     this.#instructions = config.instructions;
 
-    this.#session = new Session({
-      resourceId: config.resourceId ?? config.id,
-      state: {
-        initialState: config.initialState,
-        stateSchema: config.stateSchema,
-      },
-    });
-
     const defaultMode = config.defaultModeId
       ? config.modes.find(mode => mode.id === config.defaultModeId)
       : (config.modes.find(mode => mode.default || mode.metadata?.default === true) ?? config.modes[0]);
@@ -489,22 +481,39 @@ export class Harness<TState = {}> {
           : 'Harness requires at least one agent mode',
       );
     }
-    this.#session.mode.set({ modeId: defaultMode.id });
+
+    // Seed the selected model: an explicit initialState.currentModelId wins,
+    // otherwise fall back to the default mode's model. The model lives on the
+    // session, not in persisted state, so initialState.currentModelId is read
+    // here as a construction-time input only.
+    const initialModelId = (config.initialState as { currentModelId?: string } | undefined)?.currentModelId;
+    let modelIdToUse = initialModelId;
+    if (!modelIdToUse && defaultMode.defaultModelId) {
+      modelIdToUse = defaultMode.defaultModelId;
+    }
+
+    if (!modelIdToUse) {
+      throw new Error('No model id to use');
+    }
+
+    this.#session = new Session({
+      resourceId: config.resourceId ?? config.id,
+      state: {
+        initialState: config.initialState,
+        stateSchema: config.stateSchema,
+      },
+      availableModes: config.modes,
+      mode: defaultMode,
+      model: modelIdToUse,
+      trackModelUse: this.config.modelUseCountTracker,
+    });
+
     this.#session.setStore({
       get: key => this.#session.thread.getSetting({ key }),
       set: (key, value) => this.#session.thread.setSetting({ key, value }),
     });
     this.#session.setCategoryResolver(toolName => this.getToolCategory({ toolName }));
     this.#session.setSubagentNameResolver(agentType => this.getSubagentDisplayName(agentType));
-    this.#session.mode.setResolver(modeId => this.config.modes.find(m => m.id === modeId) ?? null, {
-      abort: () => this.abort(),
-      emit: event => this.emit(event),
-    });
-    this.#session.model.setResolver({
-      getCurrentModeId: () => this.#session.mode.get(),
-      emit: event => this.emit(event),
-      trackModelUse: this.config.modelUseCountTracker,
-    });
     this.#session.thread.connect(this.createThreadDataStore());
 
     // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
@@ -519,17 +528,6 @@ export class Harness<TState = {}> {
       this.browser = config.browser;
     } else if (typeof config.browser === 'function') {
       this.browserFn = config.browser;
-    }
-
-    // Seed the selected model: an explicit initialState.currentModelId wins,
-    // otherwise fall back to the default mode's model. The model lives on the
-    // session, not in persisted state, so initialState.currentModelId is read
-    // here as a construction-time input only.
-    const initialModelId = (config.initialState as { currentModelId?: string } | undefined)?.currentModelId;
-    if (initialModelId) {
-      this.#session.model.set({ modelId: initialModelId });
-    } else if (defaultMode.defaultModelId) {
-      this.#session.model.set({ modelId: defaultMode.defaultModelId });
     }
   }
 
@@ -967,7 +965,7 @@ export class Harness<TState = {}> {
    * never mutated.
    */
   private resolveCurrentModeInstructions(): string | undefined {
-    const mode = this.#session.mode.resolve();
+    const mode = this.#session.mode;
     const combined = [this.#instructions ?? '', mode?.instructions ?? ''].filter(Boolean).join('\n');
     return combined || undefined;
   }
@@ -998,7 +996,7 @@ export class Harness<TState = {}> {
    * which read/write the durable `threadState` `'goal'` slot.
    */
   getCurrentAgent(): Agent {
-    const mode = this.#session.mode.resolve();
+    const mode = this.#session.mode;
 
     return this.propagateRuntimeServicesToAgent(this.getAgentForMode(mode));
   }
@@ -1007,7 +1005,7 @@ export class Harness<TState = {}> {
    * Get a short display name from the current model ID.
    */
   getModelName(): string {
-    const modelId = this.#session.model.get();
+    const modelId = this.#session.model;
     if (!modelId || modelId === 'unknown') return modelId || 'unknown';
     const parts = modelId.split('/');
     return parts[parts.length - 1] || modelId;
@@ -1017,7 +1015,7 @@ export class Harness<TState = {}> {
    * Get the full model ID (e.g., "anthropic/claude-sonnet-4").
    */
   getFullModelId(): string {
-    return this.#session.model.get();
+    return this.#session.model;
   }
 
   /**
@@ -1025,7 +1023,7 @@ export class Harness<TState = {}> {
    * Uses app-provided catalog/auth hooks; Harness does not resolve gateway auth itself.
    */
   async getCurrentModelAuthStatus(): Promise<ModelAuthStatus> {
-    const modelId = this.#session.model.get();
+    const modelId = this.#session.model;
     if (!modelId) return { hasAuth: true };
 
     try {
@@ -1136,14 +1134,14 @@ export class Harness<TState = {}> {
       updatedAt: now,
     };
 
-    const currentStateModel = this.#session.model.get();
-    const currentMode = this.#session.mode.resolve();
+    const currentStateModel = this.#session.model;
+    const currentMode = this.#session.mode;
     const modelId = currentStateModel || currentMode.defaultModelId;
 
     const metadata: Record<string, unknown> = {};
     if (modelId) {
       metadata.currentModelId = modelId;
-      metadata[`modeModelId_${this.#session.mode.get()}`] = modelId;
+      metadata[`modeModelId_${this.#session.mode.id}`] = modelId;
     }
 
     // Auto-tag with projectPath from state so threads are scoped to the working directory
@@ -1216,7 +1214,7 @@ export class Harness<TState = {}> {
     this.#session.thread.set({ threadId: thread.id });
 
     if (modelId && !currentStateModel) {
-      this.#session.model.set({ modelId });
+      this.#session.model = modelId;
     }
 
     this.#session.resetTokenUsage();
@@ -1412,9 +1410,12 @@ export class Harness<TState = {}> {
       if (meta?.currentModeId) {
         const savedModeId = meta.currentModeId as string;
         const modeExists = this.config.modes.some(m => m.id === savedModeId);
-        if (modeExists && savedModeId !== this.#session.mode.get()) {
-          previousModeIdForEmit = this.#session.mode.get();
-          this.#session.mode.set({ modeId: savedModeId });
+        if (modeExists && savedModeId !== this.#session.mode.id) {
+          previousModeIdForEmit = this.#session.mode.id;
+          const mode = this.config.modes.find(m => m.id === savedModeId);
+          if (mode) {
+            this.#session.mode = mode;
+          }
         }
       }
 
@@ -1422,23 +1423,24 @@ export class Harness<TState = {}> {
       // the session (source of truth for the selected model).
       // Order: per-mode thread metadata → mode's defaultModelId → legacy
       // global currentModelId (set by createThread).
-      const currentModeId = this.#session.mode.get();
+      const currentModeId = this.#session.mode.id;
       const modeModelKey = `modeModelId_${currentModeId}`;
-      if (meta?.[modeModelKey]) {
-        this.#session.model.set({ modelId: meta[modeModelKey] as string });
+      const persistedModeModel = meta?.[modeModelKey];
+      if (typeof persistedModeModel === 'string') {
+        this.#session.model = persistedModeModel;
       } else {
         const currentMode = this.config.modes.find(m => m.id === currentModeId);
         if (currentMode?.defaultModelId) {
-          this.#session.model.set({ modelId: currentMode.defaultModelId });
+          this.#session.model = currentMode.defaultModelId as string;
         } else if (meta?.currentModelId) {
-          this.#session.model.set({ modelId: meta.currentModelId as string });
+          this.#session.model = meta.currentModelId as string;
         }
       }
 
       if (previousModeIdForEmit !== undefined) {
         this.emit({
           type: 'mode_changed',
-          modeId: this.#session.mode.get(),
+          modeId: this.#session.mode.id,
           previousModeId: previousModeIdForEmit,
         });
       }
@@ -1884,7 +1886,7 @@ export class Harness<TState = {}> {
 
     // Auto-enable Anthropic server-side fallbacks for fable-5 so a classifier
     // block is transparently retried on the fallback model instead of failing.
-    const fableFallback = buildFableFallbackProviderOptions(this.#session.model.get());
+    const fableFallback = buildFableFallbackProviderOptions(this.#session.model);
     if (fableFallback) {
       shared.providerOptions = { anthropic: { ...fableFallback.anthropic } };
     }
@@ -3405,7 +3407,7 @@ export class Harness<TState = {}> {
     // switch) and move to the default execution mode.
     this.#session.suspensions.delete({ toolCallId });
 
-    const currentMode = this.#session.mode.resolve();
+    const currentMode = this.#session.mode;
     const transitionModeId =
       currentMode.transitionsTo ??
       this.config.defaultModeId ??
@@ -3413,9 +3415,9 @@ export class Harness<TState = {}> {
       this.config.modes[0]?.id;
 
     const transitionMode = this.listModes().find(mode => mode.id === transitionModeId);
-    if (transitionMode && transitionMode.id !== this.#session.mode.get()) {
+    if (transitionMode && transitionMode.id !== this.#session.mode.id) {
       await new Promise(resolveTimeout => setTimeout(resolveTimeout, 0));
-      await this.#session.mode.switch({ modeId: transitionMode.id });
+      await this.#session.switchMode({ modeId: transitionMode.id });
       // The mode switch aborts the in-flight run but does not wait for it to
       // finalize. If the caller (e.g. mastracode's plan-approval handler)
       // immediately fires a system-reminder signal, that signal can land in
@@ -3612,14 +3614,14 @@ export class Harness<TState = {}> {
 
     // Auto-create subagent tool if subagent definitions are configured
     if (this.config.subagents?.length && this.config.resolveModel) {
-      const currentMode = this.#session.mode.resolve();
+      const currentMode = this.#session.mode;
       const hasMemory = Boolean(this.config.memory);
       builtInTools.subagent = createSubagentTool({
         subagents: this.config.subagents,
         resolveModel: this.config.resolveModel,
         harnessTools: resolvedHarnessTools,
         fallbackModelId: currentMode?.defaultModelId,
-        getParentModelId: () => this.#session.model.get(),
+        getParentModelId: () => this.#session.model,
         // Resolved lazily so forked subagents see the current mode's agent
         // even if the mode switches between tool-call scheduling and execution.
         getParentAgent: () => {
@@ -3692,7 +3694,7 @@ export class Harness<TState = {}> {
     // supported yet.  validateModes() already prevents setting both on the
     // same mode.
     if (this.config.agent) {
-      const currentMode = this.#session.mode.resolve();
+      const currentMode = this.#session.mode;
       const modeTools = currentMode.tools ?? currentMode.additionalTools;
       if (modeTools) {
         result.modeTools = modeTools;
@@ -3717,8 +3719,8 @@ export class Harness<TState = {}> {
       threadId: this.#session.thread.getId(),
       resourceId: this.#session.identity.getResourceId(),
       session: {
-        modeId: this.#session.mode.get(),
-        modelId: this.#session.model.get(),
+        modeId: this.#session.mode.id,
+        modelId: this.#session.model,
         state: {
           get: () => this.#session.state.get(),
           set: updates => this.#session.state.set(updates),
@@ -3937,7 +3939,7 @@ export class Harness<TState = {}> {
   async getSession(): Promise<HarnessSession> {
     return {
       currentThreadId: this.#session.thread.getId(),
-      currentModeId: this.#session.mode.get(),
+      currentModeId: this.#session.mode.id,
       threads: await this.#session.thread.list(),
     };
   }

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -651,236 +651,6 @@ export class SessionRun {
   }
 }
 
-/**
- * Owns the session's currently-selected model. Source of truth for "which model
- * is active", plus the per-mode model memory persisted to the thread-settings
- * store (so each mode remembers the model it was last used with).
- */
-export class SessionModel {
-  #id = '';
-  readonly #store: () => ThreadSettingsStore | undefined;
-  /**
-   * Reads the active mode id. Injected by the Harness via {@link setResolver},
-   * since {@link switch} defaults a model change to the current mode.
-   */
-  #getCurrentModeId: (() => string) | undefined;
-  /** Emits Harness events (`model_changed`). Injected via {@link setResolver}. */
-  #emit: ((event: HarnessEvent) => void) | undefined;
-  /** App hook to track model usage for ranking. Injected via {@link setResolver}. */
-  #trackModelUse: ModelUseCountTracker | undefined;
-
-  constructor(store: () => ThreadSettingsStore | undefined) {
-    this.#store = store;
-  }
-
-  /**
-   * Attach the Harness-owned dependencies {@link switch} needs: the active-mode
-   * accessor, the event emitter, and the optional model-use tracker. The
-   * Harness injects these once.
-   */
-  setResolver(options: {
-    getCurrentModeId: () => string;
-    emit: (event: HarnessEvent) => void;
-    trackModelUse?: ModelUseCountTracker;
-  }): void {
-    this.#getCurrentModeId = options.getCurrentModeId;
-    this.#emit = options.emit;
-    this.#trackModelUse = options.trackModelUse;
-  }
-
-  /** The currently-selected model id ('' when none selected yet). */
-  get(): string {
-    return this.#id;
-  }
-
-  /** Whether a model is currently selected. */
-  hasSelection(): boolean {
-    return this.#id !== '';
-  }
-
-  /** Set the in-memory selected model id (no persistence). */
-  set({ modelId }: { modelId: string }): void {
-    this.#id = modelId;
-  }
-
-  /** Persist `modelId` as the last-used model for `modeId`. */
-  async saveForMode({ modeId, modelId }: { modeId: string; modelId: string }): Promise<void> {
-    await this.#store()?.set(modeModelKey(modeId), modelId);
-  }
-
-  /**
-   * Resolve the model for `modeId`: the persisted per-mode model if present,
-   * else `defaultModelId`, else null.
-   */
-  async resolveForMode({
-    modeId,
-    defaultModelId,
-  }: {
-    modeId: string;
-    defaultModelId?: string;
-  }): Promise<string | null> {
-    const stored = (await this.#store()?.get(modeModelKey(modeId))) as string | undefined;
-    if (stored) return stored;
-    return defaultModelId ?? null;
-  }
-
-  /**
-   * Switch to a different model at runtime.
-   *
-   * When `scope` is `'thread'` (the default), the model is persisted as the
-   * per-mode model for `modeId` so it's restored when switching back. The
-   * in-memory selection only updates when the target mode is the active mode.
-   * Reports the selection to the model-use tracker and emits `model_changed`.
-   */
-  async switch({
-    modelId,
-    scope = 'thread',
-    modeId,
-  }: {
-    modelId: string;
-    scope?: 'global' | 'thread';
-    modeId?: string;
-  }): Promise<void> {
-    const currentModeId = this.#getCurrentModeId?.() ?? '';
-    const targetModeId = modeId ?? currentModeId;
-
-    if (targetModeId === currentModeId) {
-      this.set({ modelId });
-    }
-
-    if (scope === 'thread') {
-      await this.saveForMode({ modeId: targetModeId, modelId });
-    }
-
-    try {
-      await Promise.resolve(this.#trackModelUse?.(modelId));
-    } catch (error) {
-      console.error('Failed to track model usage count', error);
-    }
-
-    this.#emit?.({ type: 'model_changed', modelId, scope, modeId: targetModeId });
-  }
-}
-
-/**
- * Owns the session's currently-selected mode and the logic for switching modes.
- * Holds the active mode id and runs the version-guarded switch sequence —
- * persisting the selection and coordinating the per-mode model with
- * {@link SessionModel}. The Harness still owns the mode *definitions*
- * (`config.modes`); this owns "which mode is active" and how a switch unfolds.
- */
-export class SessionMode {
-  /** Id of the currently-selected mode. Empty until the Harness resolves its default mode. */
-  #id = '';
-  /**
-   * Monotonically increasing counter bumped on each switch. A slower in-flight
-   * switch detects it was superseded by a newer one and bails.
-   */
-  #switchVersion = 0;
-  readonly #store: () => ThreadSettingsStore | undefined;
-  readonly #model: SessionModel;
-  /**
-   * Resolves a mode id to its full definition. Injected by the Harness via
-   * {@link setResolver}, since the mode *catalog* (`config.modes`) is host config.
-   */
-  #resolveMode: ((modeId: string) => HarnessMode | null) | undefined;
-  /**
-   * Aborts any in-progress generation before a switch. Injected by the Harness
-   * via {@link setResolver}, since aborting a run is Harness-owned orchestration.
-   */
-  #abort: (() => void) | undefined;
-  /**
-   * Emits Harness events (mode_changed / model_changed) during a switch.
-   * Injected by the Harness via {@link setResolver}.
-   */
-  #emit: ((event: HarnessEvent) => void) | undefined;
-
-  constructor(store: () => ThreadSettingsStore | undefined, model: SessionModel) {
-    this.#store = store;
-    this.#model = model;
-  }
-
-  /**
-   * Attach the resolver that maps a mode id to its definition, plus the
-   * Harness-owned orchestration callbacks ({@link switch} uses to abort the
-   * in-flight run and emit events). The Harness owns the mode catalog
-   * (`config.modes`) and injects these once.
-   */
-  setResolver(
-    resolve: (modeId: string) => HarnessMode | null,
-    options?: { abort?: () => void; emit?: (event: HarnessEvent) => void },
-  ): void {
-    this.#resolveMode = resolve;
-    this.#abort = options?.abort;
-    this.#emit = options?.emit;
-  }
-
-  /** The currently-selected mode id. */
-  get(): string {
-    return this.#id;
-  }
-
-  /**
-   * Resolve the currently-selected mode id to its full definition against the
-   * host's mode catalog. Throws if the selected mode id isn't in the catalog.
-   */
-  resolve(): HarnessMode {
-    const mode = this.#resolveMode?.(this.#id) ?? null;
-    if (!mode) {
-      throw new Error(`Mode not found: ${this.#id}`);
-    }
-    return mode;
-  }
-
-  /** Set the currently-selected mode id (on default resolution or hydration). */
-  set({ modeId }: { modeId: string }): void {
-    this.#id = modeId;
-  }
-
-  /**
-   * Switch to a different mode.
-   *
-   * Aborts any in-progress generation, emits `mode_changed`, then runs the
-   * version-guarded sequence: remember the outgoing mode's model, persist the
-   * new mode, then resolve and apply the incoming mode's model — emitting
-   * `model_changed` once applied. A newer switch starting mid-flight supersedes
-   * this one, which then bails before emitting `model_changed`.
-   */
-  async switch({ modeId }: { modeId: string }): Promise<void> {
-    const mode = this.#resolveMode?.(modeId) ?? null;
-    if (!mode) {
-      throw new Error(`Mode not found: ${modeId}`);
-    }
-
-    this.#abort?.();
-
-    const previousModeId = this.#id;
-    const previousModelId = this.#model.get();
-    const version = ++this.#switchVersion;
-    this.#id = modeId;
-
-    // Emit the mode change immediately so UIs can update without waiting for
-    // the storage round-trips below.
-    this.#emit?.({ type: 'mode_changed', modeId, previousModeId });
-
-    // Remember the outgoing mode's model before moving on.
-    if (previousModelId) {
-      await this.#model.saveForMode({ modeId: previousModeId, modelId: previousModelId });
-    }
-    if (this.#switchVersion !== version) return;
-
-    await this.#store()?.set(MODE_ID_KEY, modeId);
-    if (this.#switchVersion !== version) return;
-
-    const modelId = await this.#model.resolveForMode({ modeId, defaultModelId: mode.defaultModelId });
-    if (this.#switchVersion !== version) return;
-    if (modelId) {
-      this.#model.set({ modelId });
-      this.#emit?.({ type: 'model_changed', modelId } as HarnessEvent);
-    }
-  }
-}
-
 type SessionStateUpdater<TState, TResult> = HarnessRequestStateUpdater<TState, TResult>;
 
 interface SessionStateOptions<TState> {
@@ -1525,9 +1295,10 @@ export class Session<TState = unknown> {
   /** Resolves a subagent's display name from Harness config, injected via {@link setSubagentNameResolver}. */
   #resolveSubagentName: ((agentType: string) => string | undefined) | undefined;
   /** The session's currently-selected model (source of truth) + per-mode memory. */
-  readonly model = new SessionModel(() => this.#store);
+  model: string;
+  mode: HarnessMode;
+  readonly #availableModes: HarnessMode[];
   /** The session's currently-selected mode and switch sequence. */
-  readonly mode = new SessionMode(() => this.#store, this.model);
   /** Transient run identity (run id, trace id, operation counter) for the active run. */
   readonly run = new SessionRun();
   /** Live subscription to the active thread's agent event stream. */
@@ -1547,14 +1318,26 @@ export class Session<TState = unknown> {
   /** The session-owned Harness state domain. */
   readonly state: HarnessRequestState<TState>;
   #listeners: HarnessEventListener[] = [];
+  #switchVersion = 0;
+  /** App hook to track model usage for ranking. */
+  #trackModelUse: ModelUseCountTracker | undefined;
+
   constructor({
     id,
     resourceId,
     state,
+    mode,
+    availableModes,
+    model,
+    trackModelUse,
   }: {
     id?: string;
     resourceId: string;
     state?: Omit<SessionStateOptions<TState>, 'emit'>;
+    mode: HarnessMode;
+    availableModes: HarnessMode[];
+    model: string;
+    trackModelUse: ModelUseCountTracker | undefined;
   }) {
     this.#id = id ?? `sess-${randomUUID()}`;
     this.identity = new SessionIdentity({ resourceId });
@@ -1569,14 +1352,18 @@ export class Session<TState = unknown> {
       state
         ? {
             ...state,
-            emit: this.#emit.bind(this),
+            emit: this.emit.bind(this),
           }
         : {
             initialState: {
-              emit: this.#emit.bind(this),
+              emit: this.emit.bind(this),
             } as TState,
           },
     );
+    this.#availableModes = availableModes;
+    this.mode = mode;
+    this.model = model;
+    this.#trackModelUse = trackModelUse;
   }
 
   /**
@@ -1634,6 +1421,79 @@ export class Session<TState = unknown> {
     this.approval.cancel();
     this.stream.abort();
     this.run.requestAbort();
+  }
+
+  async switchMode({ modeId }: { modeId: string }): Promise<void> {
+    const mode = this.#availableModes.find(mode => mode.id === modeId) ?? null;
+    if (!mode) {
+      throw new Error(`Mode not found: ${modeId}`);
+    }
+
+    this.abortRun();
+
+    const previousModeId = this.mode.id;
+    const previousModelId = this.model;
+    const version = ++this.#switchVersion;
+
+    // Emit the mode change immediately so UIs can update without waiting for
+    // the storage round-trips below.
+    this.emit({ type: 'mode_changed', modeId, previousModeId });
+
+    // Remember the outgoing mode's model before moving on.
+    if (previousModelId) {
+      await this.#store?.set(modeModelKey(previousModeId), previousModelId);
+    }
+    if (this.#switchVersion !== version) return;
+
+    await this.#store?.set(MODE_ID_KEY, modeId);
+    if (this.#switchVersion !== version) return;
+
+    this.mode = mode;
+    const savedModelId = await this.#store?.get(modeModelKey(modeId));
+    if (this.#switchVersion !== version) return;
+
+    const modelId = typeof savedModelId === 'string' && savedModelId ? savedModelId : mode.defaultModelId;
+    if (modelId) {
+      this.model = modelId;
+      this.emit({ type: 'model_changed', modelId } as HarnessEvent);
+    }
+  }
+
+  /**
+   * Switch to a different model at runtime.
+   *
+   * When `scope` is `'thread'` (the default), the model is persisted as the
+   * per-mode model for `modeId` so it's restored when switching back. The
+   * in-memory selection only updates when the target mode is the active mode.
+   * Reports the selection to the model-use tracker and emits `model_changed`.
+   */
+  async switchModel({
+    modelId,
+    scope = 'thread',
+    modeId,
+  }: {
+    modelId: string;
+    scope?: 'global' | 'thread';
+    modeId?: string;
+  }): Promise<void> {
+    const currentModeId = this.mode.id;
+    const targetModeId = modeId ?? currentModeId;
+
+    if (scope === 'thread') {
+      await this.#store?.set(modeModelKey(targetModeId), modelId);
+    }
+
+    if (targetModeId === currentModeId) {
+      this.model = modelId;
+    }
+
+    try {
+      await Promise.resolve(this.#trackModelUse?.(modelId));
+    } catch (error) {
+      console.error('Failed to track model usage count', error);
+    }
+
+    this.emit({ type: 'model_changed', modelId, scope, modeId: targetModeId });
   }
 
   /**
@@ -1736,8 +1596,8 @@ export class Session<TState = unknown> {
     };
   }
 
-  #emit(event: HarnessEvent): void {
-    let eventWithSessionId = {
+  emit(event: HarnessEvent): void {
+    const eventWithSessionId = {
       ...event,
       sessionId: this.#id,
     };

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { Agent } from '../agent';
 import type { AgentThreadSubscription } from '../agent/types';
 import type { RequestContext } from '../request-context';
@@ -9,6 +10,7 @@ import { createEmptyTokenUsage, defaultDisplayState, defaultOMProgressState } fr
 import type {
   HarnessDisplayState,
   HarnessEvent,
+  HarnessEventListener,
   HarnessMessage,
   HarnessMode,
   HarnessRequestState,
@@ -1509,6 +1511,7 @@ export class SessionDisplayState {
 }
 
 export class Session<TState = unknown> {
+  readonly #id: string;
   /** Tool categories the user has granted "allow" for the lifetime of this session. */
   readonly #grantedCategories = new Set<string>();
   /** Individual tool names the user has granted "allow" for the lifetime of this session. */
@@ -1543,8 +1546,17 @@ export class Session<TState = unknown> {
   readonly displayState: SessionDisplayState;
   /** The session-owned Harness state domain. */
   readonly state: HarnessRequestState<TState>;
-
-  constructor({ resourceId, state }: { resourceId: string; state?: SessionStateOptions<TState> }) {
+  #listeners: HarnessEventListener[] = [];
+  constructor({
+    id,
+    resourceId,
+    state,
+  }: {
+    id?: string;
+    resourceId: string;
+    state?: Omit<SessionStateOptions<TState>, 'emit'>;
+  }) {
+    this.#id = id ?? `sess-${randomUUID()}`;
     this.identity = new SessionIdentity({ resourceId });
     this.thread = new SessionThread(() => this.identity.getResourceId());
     this.displayState = new SessionDisplayState({
@@ -1553,7 +1565,18 @@ export class Session<TState = unknown> {
       getThreadId: () => this.thread.getId(),
       clearFollowUps: () => this.followUps.clear(),
     });
-    this.state = new SessionState(state ?? { initialState: {} as TState });
+    this.state = new SessionState(
+      state
+        ? {
+            ...state,
+            emit: this.#emit.bind(this),
+          }
+        : {
+            initialState: {
+              emit: this.#emit.bind(this),
+            } as TState,
+          },
+    );
   }
 
   /**
@@ -1693,6 +1716,63 @@ export class Session<TState = unknown> {
     addOptionalUsageField(this.#tokenUsage, 'cacheCreationInputTokens', stepUsage.cacheCreationInputTokens);
     if (stepUsage.raw !== undefined) {
       this.#tokenUsage.raw = stepUsage.raw;
+    }
+  }
+
+  // ===========================================================================
+  // Event System
+  // ===========================================================================
+
+  /**
+   * Subscribe to harness events. Returns an unsubscribe function.
+   */
+  subscribe(listener: HarnessEventListener): () => void {
+    this.#listeners.push(listener);
+    return () => {
+      const index = this.#listeners.indexOf(listener);
+      if (index !== -1) {
+        this.#listeners.splice(index, 1);
+      }
+    };
+  }
+
+  #emit(event: HarnessEvent): void {
+    let eventWithSessionId = {
+      ...event,
+      sessionId: this.#id,
+    };
+    // The Session owns the display-state reducer; fold the event into the
+    // canonical snapshot before dispatching to listeners. The Harness still owns
+    // the event bus (listeners) and the display_state_changed fan-out.
+    this.displayState.apply(eventWithSessionId);
+
+    this.#dispatchToListeners(eventWithSessionId);
+
+    if (eventWithSessionId.type !== 'display_state_changed') {
+      this.#dispatchDisplayStateChanged();
+    }
+  }
+
+  #dispatchDisplayStateChanged(): void {
+    // After every event, emit display_state_changed so UIs that prefer a single
+    // subscribe-and-render pattern can do so. We dispatch directly to listeners
+    // (not through emit()) to avoid infinite recursion.
+    this.#dispatchToListeners({
+      type: 'display_state_changed',
+      displayState: this.displayState.get(),
+    });
+  }
+
+  #dispatchToListeners(event: HarnessEvent): void {
+    for (const listener of this.#listeners) {
+      try {
+        const result = listener(event);
+        if (result && typeof result === 'object' && 'catch' in result) {
+          (result as Promise<void>).catch(err => console.error('Error in harness event listener:', err));
+        }
+      } catch (err) {
+        console.error('Error in harness event listener:', err);
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes harness session events so state updates notify subscribers and keep display state in sync.

Before, session-owned state updates could miss harness subscribers because the session state emitter was no longer wired through. Now sessions dispatch those events, tag them with a session id, update display state, and keep harness subscriptions connected to the active session.

Tests: `pnpm --filter ./packages/core check` and `pnpm --filter ./packages/core test:unit -- src/harness/display-state.test.ts src/harness/session-state.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

Your harness has a “chatty messenger” (the Session) that should tell UI listeners whenever state changes. This PR fixes a wiring bug where those updates stopped reaching the harness subscribers, so the screen could drift out of sync. Now the Session sends updates through its own event bus, tagged to the right session, keeping everyone synced.

## Problem

Harness session state updates were failing to notify harness subscribers because the session’s state emitter was no longer connected to the harness event handling pipeline, causing `displayState` to fall out of sync.

## Solution

Route session state events through the Session’s internal event bus so that:
- Sessions dispatch their own state update events
- Events are tagged with a `sessionId` so they’re attributable to the correct session
- `displayState` stays updated via the session’s canonical event flow
- Harness subscriptions remain connected to the active session

## Changes

### `.changeset/wide-games-sink.md`
- Added a changelog entry for a `patch` release of `@mastra/core`, noting harness session state event notification + display state synchronization fixes.

### `packages/core/src/harness/harness.ts`
- Created `Session` without the old `emit`-callback forwarding to `Harness.emit`.
- Updated `Harness.subscribe()` to subscribe/unsubscribe properly to the underlying `Session`.
- Adjusted session mode/model handling to match the new `Session` API shape (direct properties + constructor seeding rather than follow-up `mode.set()`/`model.set()` calls).

### `packages/core/src/harness/session.ts`
- Added a per-session internal `sessionId` (generated with `randomUUID()` when not provided).
- Ensured every emitted `HarnessEvent` is augmented with `sessionId`.
- Introduced `Session.subscribe(listener)` with internal listener management.
- Updated internal dispatch so events are applied to canonical `displayState`, subscribers are notified, and non-`display_state_changed` events also trigger a synthetic `display_state_changed`.

### Supporting API migrations (call sites + tests)
- Updated downstream code to use the new Session API (e.g., `harness.session.model` / `harness.session.mode` direct values and `switchModel` / `switchMode` methods).
- Updated headless/TUI tests and analytics payloads accordingly.

## Validation

- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core test:unit -- src/harness/display-state.test.ts src/harness/session-state.test.ts`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->