### PR TITLE
refactor(core): move Harness model switching to session.model.switch

### DIFF
--- a/.changeset/eleven-islands-boil.md
+++ b/.changeset/eleven-islands-boil.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Replaced `Harness.switchModel()` with `harness.session.model.switch()`. Model switching now lives on the session, alongside the active mode/model state it already owns.
+
+**Before**
+
+```typescript
+await harness.switchModel({ modelId: 'openai/gpt-5' });
+```
+
+**After**
+
+```typescript
+await harness.session.model.switch({ modelId: 'openai/gpt-5' });
+```

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -354,7 +354,7 @@ await harness.sendMessage({ content: 'Hello!' })
     name: 'modelUseCountTracker',
     type: 'ModelUseCountTracker',
     description:
-      'Callback invoked when a model is selected via `switchModel()`. Use to track and persist model usage for ranking.',
+      'Callback invoked when a model is selected via `session.model.switch()`. Use to track and persist model usage for ranking.',
     isOptional: true,
   },
   {
@@ -517,18 +517,6 @@ Return the complete model ID string.
 
 ```typescript
 const fullId = harness.getFullModelId()
-```
-
-#### `switchModel({ modelId, scope?, modeId? })`
-
-Switch the active model. When `scope` is `'thread'`, the model ID is persisted to thread metadata so it's restored when switching back. Emits a `model_changed` event.
-
-```typescript
-// Set for current session only
-await harness.switchModel({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
-
-// Persist to the current thread
-await harness.switchModel({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__', scope: 'thread' })
 ```
 
 #### `getCurrentModelAuthStatus()`

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -298,7 +298,7 @@ await harness.session.mode.switch({ modeId: 'build' })
 
 ## Model
 
-`session.model` owns the active model selection, including per-mode model memory. Switching models is performed on the [`Harness`](/reference/harness/harness-class#switchmodel-modelid-scope-modeid-).
+`session.model` owns the active model selection, including per-mode model memory.
 
 ### `session.model.get()`
 
@@ -316,6 +316,18 @@ Check whether a model is currently selected.
 if (harness.session.model.hasSelection()) {
   // Ready to send messages
 }
+```
+
+### `session.model.switch({ modelId, scope?, modeId? })`
+
+Switch the active model. When `scope` is `'thread'` (the default), the model ID is persisted as the per-mode model so it's restored when switching back. Reports the selection to the harness's `modelUseCountTracker` and emits a `model_changed` event.
+
+```typescript
+// Set for the current session only
+await harness.session.model.switch({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__', scope: 'global' })
+
+// Persist to the current thread (default)
+await harness.session.model.switch({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
 ```
 
 ## Run

--- a/mastracode/VERIFICATION.md
+++ b/mastracode/VERIFICATION.md
@@ -15,7 +15,7 @@ Expected result: each thread restores its own pack selection instead of using on
 ## 2) Model usage ranking
 
 - [ ] Open `/models` and choose a pack that uses a model you can repeatedly select.
-- [ ] Re-select the same model multiple times (through pack switches or model picks that call `switchModel`).
+- [ ] Re-select the same model multiple times (through pack switches or model picks that call `session.model.switch`).
 - [ ] Re-open the model selector.
 - [ ] Confirm frequently selected models appear higher in the sorted list.
 

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -432,7 +432,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
       const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
       return failEarly(`Model "${args.model}" has no API key configured.${keyHint}`);
     }
-    await harness.switchModel({ modelId: args.model });
+    await harness.session.model.switch({ modelId: args.model });
     if (!emit) process.stderr.write(`[model] ${args.model}\n`);
   } else if (args.mode) {
     // --mode flag: look up model from effectiveDefaults (resolved from settings at startup)
@@ -447,7 +447,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
         const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
         return failEarly(`Model "${modelId}" (mode: ${args.mode}) has no API key configured.${keyHint}`);
       }
-      await harness.switchModel({ modelId });
+      await harness.session.model.switch({ modelId });
       if (!emit) process.stderr.write(`[model] ${modelId} (mode: ${args.mode})\n`);
     } else {
       const warnMsg = `--mode ${args.mode} has no configured model, using default`;

--- a/mastracode/src/tui/commands/login.ts
+++ b/mastracode/src/tui/commands/login.ts
@@ -53,7 +53,7 @@ async function performLogin(ctx: SlashCommandContext, providerId: string): Promi
 
         const defaultModel = PROVIDER_DEFAULT_MODELS[providerId as keyof typeof PROVIDER_DEFAULT_MODELS];
         if (defaultModel) {
-          await ctx.state.harness.switchModel({ modelId: defaultModel });
+          await ctx.state.harness.session.model.switch({ modelId: defaultModel });
           ctx.showInfo(`Logged in to ${providerName} - switched to ${defaultModel}`);
         } else {
           ctx.showInfo(`Successfully logged in to ${providerName}`);

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -391,7 +391,7 @@ async function applyPack(ctx: SlashCommandContext, pack: ModePack, previousPackI
   const currentModeId = harness.session.mode.get();
   const currentModeModel = (pack.models as Record<string, string>)[currentModeId];
   if (currentModeModel) {
-    await harness.switchModel({ modelId: currentModeModel });
+    await harness.session.model.switch({ modelId: currentModeModel });
   }
 
   const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -1154,7 +1154,7 @@ export class MastraTUI {
           const { PROVIDER_DEFAULT_MODELS } = await import('../auth/storage.js');
           const defaultModel = PROVIDER_DEFAULT_MODELS[providerId as keyof typeof PROVIDER_DEFAULT_MODELS];
           if (defaultModel) {
-            await this.state.harness.switchModel({ modelId: defaultModel });
+            await this.state.harness.session.model.switch({ modelId: defaultModel });
             showInfo(this.state, `Logged in to ${providerName} - switched to ${defaultModel}`);
           } else {
             showInfo(this.state, `Successfully logged in to ${providerName}`);
@@ -1296,7 +1296,7 @@ export class MastraTUI {
     const currentModeId = harness.session.mode.get();
     const currentModeModel = (modePack.models as Record<string, string>)[currentModeId];
     if (currentModeModel) {
-      await harness.switchModel({ modelId: currentModeModel });
+      await harness.session.model.switch({ modelId: currentModeModel });
     }
 
     const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -501,6 +501,11 @@ export class Harness<TState = {}> {
       abort: () => this.abort(),
       emit: event => this.emit(event),
     });
+    this.#session.model.setResolver({
+      getCurrentModeId: () => this.#session.mode.get(),
+      emit: event => this.emit(event),
+      trackModelUse: this.config.modelUseCountTracker,
+    });
     this.#session.thread.connect(this.createThreadDataStore());
 
     // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
@@ -1014,37 +1019,6 @@ export class Harness<TState = {}> {
    */
   getFullModelId(): string {
     return this.#session.model.get();
-  }
-
-  /**
-   * Switch to a different model at runtime.
-   */
-  async switchModel({
-    modelId,
-    scope = 'thread',
-    modeId,
-  }: {
-    modelId: string;
-    scope?: 'global' | 'thread';
-    modeId?: string;
-  }): Promise<void> {
-    const targetModeId = modeId ?? this.#session.mode.get();
-
-    if (targetModeId === this.#session.mode.get()) {
-      this.#session.model.set({ modelId });
-    }
-
-    if (scope === 'thread') {
-      await this.#session.model.saveForMode({ modeId: targetModeId, modelId });
-    }
-
-    try {
-      await Promise.resolve(this.config.modelUseCountTracker?.(modelId));
-    } catch (error) {
-      console.error('Failed to track model usage count', error);
-    }
-
-    this.emit({ type: 'model_changed', modelId, scope, modeId: targetModeId } as HarnessEvent);
   }
 
   /**

--- a/packages/core/src/harness/mode-model-persistence.test.ts
+++ b/packages/core/src/harness/mode-model-persistence.test.ts
@@ -76,7 +76,7 @@ describe('Harness mode-model persistence across restarts', () => {
     const thread = await session1.createThread();
 
     await session1.session.mode.switch({ modeId: 'fast' });
-    await session1.switchModel({ modelId: 'cerebras/qwen-3-coder-480b' });
+    await session1.session.model.switch({ modelId: 'cerebras/qwen-3-coder-480b' });
     expect(session1.session.model.get()).toBe('cerebras/qwen-3-coder-480b');
 
     const session2 = createHarness(storage);
@@ -91,7 +91,7 @@ describe('Harness mode-model persistence across restarts', () => {
     const session1 = createHarness(storage);
     await session1.init();
     const thread = await session1.createThread();
-    await session1.switchModel({ modelId: 'anthropic/claude-opus-4-6' });
+    await session1.session.model.switch({ modelId: 'anthropic/claude-opus-4-6' });
 
     const session2 = createHarness(storage);
     await session2.init();

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -14,6 +14,7 @@ import type {
   HarnessRequestState,
   HarnessRequestStateUpdater,
   HarnessThread,
+  ModelUseCountTracker,
   TokenUsage,
   ToolCategory,
 } from './types';
@@ -656,9 +657,33 @@ export class SessionRun {
 export class SessionModel {
   #id = '';
   readonly #store: () => ThreadSettingsStore | undefined;
+  /**
+   * Reads the active mode id. Injected by the Harness via {@link setResolver},
+   * since {@link switch} defaults a model change to the current mode.
+   */
+  #getCurrentModeId: (() => string) | undefined;
+  /** Emits Harness events (`model_changed`). Injected via {@link setResolver}. */
+  #emit: ((event: HarnessEvent) => void) | undefined;
+  /** App hook to track model usage for ranking. Injected via {@link setResolver}. */
+  #trackModelUse: ModelUseCountTracker | undefined;
 
   constructor(store: () => ThreadSettingsStore | undefined) {
     this.#store = store;
+  }
+
+  /**
+   * Attach the Harness-owned dependencies {@link switch} needs: the active-mode
+   * accessor, the event emitter, and the optional model-use tracker. The
+   * Harness injects these once.
+   */
+  setResolver(options: {
+    getCurrentModeId: () => string;
+    emit: (event: HarnessEvent) => void;
+    trackModelUse?: ModelUseCountTracker;
+  }): void {
+    this.#getCurrentModeId = options.getCurrentModeId;
+    this.#emit = options.emit;
+    this.#trackModelUse = options.trackModelUse;
   }
 
   /** The currently-selected model id ('' when none selected yet). */
@@ -695,6 +720,43 @@ export class SessionModel {
     const stored = (await this.#store()?.get(modeModelKey(modeId))) as string | undefined;
     if (stored) return stored;
     return defaultModelId ?? null;
+  }
+
+  /**
+   * Switch to a different model at runtime.
+   *
+   * When `scope` is `'thread'` (the default), the model is persisted as the
+   * per-mode model for `modeId` so it's restored when switching back. The
+   * in-memory selection only updates when the target mode is the active mode.
+   * Reports the selection to the model-use tracker and emits `model_changed`.
+   */
+  async switch({
+    modelId,
+    scope = 'thread',
+    modeId,
+  }: {
+    modelId: string;
+    scope?: 'global' | 'thread';
+    modeId?: string;
+  }): Promise<void> {
+    const currentModeId = this.#getCurrentModeId?.() ?? '';
+    const targetModeId = modeId ?? currentModeId;
+
+    if (targetModeId === currentModeId) {
+      this.set({ modelId });
+    }
+
+    if (scope === 'thread') {
+      await this.saveForMode({ modeId: targetModeId, modelId });
+    }
+
+    try {
+      await Promise.resolve(this.#trackModelUse?.(modelId));
+    } catch (error) {
+      console.error('Failed to track model usage count', error);
+    }
+
+    this.#emit?.({ type: 'model_changed', modelId, scope, modeId: targetModeId });
   }
 }
 

--- a/packages/core/src/harness/switch-model.test.ts
+++ b/packages/core/src/harness/switch-model.test.ts
@@ -19,12 +19,12 @@ function createHarness(onModelUse?: (modelId: string) => void) {
   });
 }
 
-describe('Harness.switchModel', () => {
+describe('session.model.switch', () => {
   it('tracks model selection via modelUseCountTracker', async () => {
     const trackModelUse = vi.fn<(modelId: string) => void>();
     const harness = createHarness(trackModelUse);
 
-    await harness.switchModel({ modelId: 'openai/gpt-5.3-codex' });
+    await harness.session.model.switch({ modelId: 'openai/gpt-5.3-codex' });
 
     expect(trackModelUse).toHaveBeenCalledTimes(1);
     expect(trackModelUse).toHaveBeenCalledWith('openai/gpt-5.3-codex');


### PR DESCRIPTION
Follow-up to the mode-switch refactor, same idea for models. `Harness.switchModel()` was a thin proxy over session state, so this removes it and moves the switching logic onto `session.model`, where the active model already lives. The orchestration (per-mode persistence, model-use tracking, and the `model_changed` event) now lives on `SessionModel`, with the Harness injecting the bits it owns (active-mode accessor, emitter, usage tracker).

Before:

```typescript
await harness.switchModel({ modelId: 'openai/gpt-5' })
```

After:

```typescript
await harness.session.model.switch({ modelId: 'openai/gpt-5' })
```

Updated the MastraCode callers (TUI + headless), the harness tests, and the Harness reference docs. Stacked on the mode-switch PR. Harness is still under development so this ships as a minor.