### PR TITLE
refactor(core): move Harness model name accessors to session.model

### DIFF
--- a/.changeset/brave-melons-rest.md
+++ b/.changeset/brave-melons-rest.md
@@ -1,0 +1,24 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Removed the deprecated `Harness.getState()` and `Harness.setState()` compatibility wrappers, along with the unused private `updateState`. Harness state has lived on the session for a while; these were thin proxies marked `@deprecated`.
+
+**Before**
+
+```typescript
+const state = harness.getState();
+await harness.setState({ count: 1 });
+```
+
+**After**
+
+```typescript
+const state = harness.session.state.get();
+await harness.session.state.set({ count: 1 });
+```
+
+This does not affect the tool-facing harness context, which continues to expose `state` / `getState` / `setState` / `updateState` alongside `session.state`.
+
+`mastracode` is updated to set browser settings via `session.state.set()`.

--- a/.changeset/curly-turtles-talk.md
+++ b/.changeset/curly-turtles-talk.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Moved the observational-memory model accessors off the Harness onto `session.om`. Reading and switching the observer/reflector models and reading observation/reflection thresholds now live on the session, next to the state they read and write.
+
+**Before**
+
+```typescript
+const observer = harness.getObserverModelId();
+await harness.switchObserverModel({ modelId: 'openai/gpt-4o' });
+```
+
+**After**
+
+```typescript
+const observer = harness.session.om.observer.modelId();
+await harness.session.om.observer.switchModel({ modelId: 'openai/gpt-4o' });
+```
+
+The accessors are grouped by role under `session.om.observer` and `session.om.reflector`, each exposing `modelId()`, `threshold()`, `resolvedModel()`, and `switchModel({ modelId })`.
+
+Removed `Harness.getObserverModelId`, `getReflectorModelId`, `getObservationThreshold`, `getReflectionThreshold`, `getResolvedObserverModel`, `getResolvedReflectorModel`, `switchObserverModel`, and `switchReflectorModel`.
+
+`mastracode` is updated to consume the new API: the `/om` command and status line now read and switch observer/reflector models via `session.om`.

--- a/.changeset/silly-walls-attack.md
+++ b/.changeset/silly-walls-attack.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Moved the tool-permission rule accessors off the Harness onto `session.permissions`. Reading and writing the persisted per-category / per-tool approval policies now lives on the session, next to the state it reads and writes.
+
+**Before**
+
+```typescript
+const rules = harness.getPermissionRules();
+harness.setPermissionForCategory({ category: 'execute', policy: 'ask' });
+harness.setPermissionForTool({ toolName: 'dangerous_tool', policy: 'deny' });
+```
+
+**After**
+
+```typescript
+const rules = harness.session.permissions.getRules();
+await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' });
+await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' });
+```
+
+Removed `Harness.getPermissionRules`, `Harness.setPermissionForCategory`, and `Harness.setPermissionForTool`. The setters now return a promise that resolves once the change is persisted to session state, so callers that read the rules back can await the write. Tool-category resolution stays on the harness as `harness.getToolCategory()` since it reads harness config rather than session state.
+
+`mastracode` is updated to consume the new API: the `/permissions` command reads and sets policies via `session.permissions`.

--- a/.changeset/sunny-geckos-carry.md
+++ b/.changeset/sunny-geckos-carry.md
@@ -1,0 +1,22 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Replaced `Harness.getModelName()` and `Harness.getFullModelId()` with session accessors. The full model id is read via the existing `harness.session.model.get()`, and the short display name moves to a new `harness.session.model.displayName()`.
+
+**Before**
+
+```typescript
+const name = harness.getModelName();
+const fullId = harness.getFullModelId();
+```
+
+**After**
+
+```typescript
+const name = harness.session.model.displayName();
+const fullId = harness.session.model.get();
+```
+
+`mastracode` is updated to consume the new API: the TUI status line and message renderer now read the model id via `harness.session.model.get()`.

--- a/.changeset/wild-pumas-grow.md
+++ b/.changeset/wild-pumas-grow.md
@@ -1,0 +1,24 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Moved the subagent model accessors off the Harness onto `session.subagents.model`. Reading and setting the global or per-`agentType` subagent model now lives on the session, next to the state it reads and writes, and is grouped under `session.subagents` to leave room for future subagent settings.
+
+**Before**
+
+```typescript
+const modelId = harness.getSubagentModelId({ agentType: 'explore' });
+await harness.setSubagentModelId({ modelId: 'anthropic/claude-sonnet-4', agentType: 'explore' });
+```
+
+**After**
+
+```typescript
+const modelId = harness.session.subagents.model.get({ agentType: 'explore' });
+await harness.session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4', agentType: 'explore' });
+```
+
+`get()` prefers the per-`agentType` value, then the global subagent model, returning `null` when neither is set. `set()` persists to thread settings and emits a `subagent_model_changed` event. Removed `Harness.getSubagentModelId` and `Harness.setSubagentModelId`.
+
+`mastracode` is updated to consume the new API: the `/subagents` command, model-pack activation, and startup model restoration read and set subagent models via `session.subagents.model`.

--- a/docs/src/content/en/docs/harness/subagents.mdx
+++ b/docs/src/content/en/docs/harness/subagents.mdx
@@ -93,16 +93,16 @@ Set a global or per-type subagent model at runtime:
 
 ```typescript
 // Global subagent model
-await harness.setSubagentModelId({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
+await harness.session.subagents.model.set({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
 
 // Per-type override
-await harness.setSubagentModelId({
+await harness.session.subagents.model.set({
   modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__',
   agentType: 'explore',
 })
 
 // Read current model
-const modelId = harness.getSubagentModelId({ agentType: 'explore' })
+const modelId = harness.session.subagents.model.get({ agentType: 'explore' })
 ```
 
 ## Related

--- a/docs/src/content/en/docs/harness/tool-approvals.mdx
+++ b/docs/src/content/en/docs/harness/tool-approvals.mdx
@@ -23,10 +23,10 @@ Set policies per-category or per-tool. Per-tool policies take precedence over ca
 
 ```typescript
 // Category-level: all execute tools require approval
-harness.setPermissionForCategory({ category: 'execute', policy: 'ask' })
+await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' })
 
 // Tool-level: this specific tool is always blocked
-harness.setPermissionForTool({ toolName: 'dangerous_tool', policy: 'deny' })
+await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' })
 ```
 
 ### Tool categories

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -501,23 +501,7 @@ To read the active mode, use [`session.mode.get()`](/reference/harness/session#m
 
 ### Models
 
-To read the active model ID, use [`session.model.get()`](/reference/harness/session#model); to check whether a model is selected, use [`session.model.hasSelection()`](/reference/harness/session#model).
-
-#### `getModelName()`
-
-Return a short display name from the current model ID. For example, `"claude-sonnet-4"` from `"anthropic/claude-sonnet-4"`.
-
-```typescript
-const name = harness.getModelName()
-```
-
-#### `getFullModelId()`
-
-Return the complete model ID string.
-
-```typescript
-const fullId = harness.getFullModelId()
-```
+To read the active model ID, use [`session.model.get()`](/reference/harness/session#model); for a short display name, use [`session.model.displayName()`](/reference/harness/session#model); to check whether a model is selected, use [`session.model.hasSelection()`](/reference/harness/session#model).
 
 #### `getCurrentModelAuthStatus()`
 

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -779,31 +779,6 @@ if (record) {
 
 The observer/reflector model selection and observation/reflection thresholds live on the Session under [`session.om`](/reference/harness/session#observational-memory), grouped by role. Read them with `session.om.observer.modelId()` / `session.om.reflector.modelId()` and `session.om.observer.threshold()` / `session.om.reflector.threshold()`, and change a role's model with `session.om.observer.switchModel()` / `session.om.reflector.switchModel()`.
 
-### Subagents
-
-#### `getSubagentModelId({ agentType? })`
-
-Retrieve the subagent model ID. Prioritizes per-type settings over the global setting.
-
-```typescript
-const modelId = harness.getSubagentModelId({ agentType: 'explore' })
-```
-
-#### `setSubagentModelId({ modelId, agentType? })`
-
-Set the subagent model ID. Pass an `agentType` to set a per-type override, or omit it to set the global default. Persists to thread settings and emits a `subagent_model_changed` event.
-
-```typescript
-// Set global subagent model
-await harness.setSubagentModelId({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
-
-// Set per-type model
-await harness.setSubagentModelId({
-  modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__',
-  agentType: 'explore',
-})
-```
-
 ### Forked subagents
 
 By default, a subagent runs with a fresh context — it doesn't see the parent conversation. **Forked subagents** opt into a different model: the subagent runs on a clone of the parent thread and reuses the parent agent's full configuration. This is useful when the subagent needs the full context of the conversation so far (e.g., recalling earlier user-supplied facts), and when prompt-cache hit rates matter.

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -804,53 +804,7 @@ if (record) {
 }
 ```
 
-#### `getObserverModelId()`
-
-Return the observer model ID from state or the default from `omConfig`.
-
-```typescript
-const modelId = harness.getObserverModelId()
-```
-
-#### `getReflectorModelId()`
-
-Return the reflector model ID from state or the default from `omConfig`.
-
-```typescript
-const modelId = harness.getReflectorModelId()
-```
-
-#### `switchObserverModel({ modelId })`
-
-Switch the observer model. Persists the setting to thread metadata and emits an `om_model_changed` event.
-
-```typescript
-await harness.switchObserverModel({ modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__' })
-```
-
-#### `switchReflectorModel({ modelId })`
-
-Switch the reflector model. Persists the setting to thread metadata and emits an `om_model_changed` event.
-
-```typescript
-await harness.switchReflectorModel({ modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__' })
-```
-
-#### `getObservationThreshold()`
-
-Return the observation threshold in tokens from state or the default from `omConfig`.
-
-```typescript
-const threshold = harness.getObservationThreshold()
-```
-
-#### `getReflectionThreshold()`
-
-Return the reflection threshold in tokens from state or the default from `omConfig`.
-
-```typescript
-const threshold = harness.getReflectionThreshold()
-```
+The observer/reflector model selection and observation/reflection thresholds live on the Session under [`session.om`](/reference/harness/session#observational-memory), grouped by role. Read them with `session.om.observer.modelId()` / `session.om.reflector.modelId()` and `session.om.observer.threshold()` / `session.om.reflector.threshold()`, and change a role's model with `session.om.observer.switchModel()` / `session.om.reflector.switchModel()`.
 
 ### Subagents
 

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -698,33 +698,6 @@ harness.respondToToolSuspension({
 
 ### Permissions
 
-The harness owns the permission _policy_ — the rules that decide when a tool requires approval. Session-scoped _grants_ (which tools and categories are auto-approved for the current conversation) live on the session: see [`session.grantCategory()`](/reference/harness/session#permissions), [`session.grantTool()`](/reference/harness/session#permissions), and [`session.getGrants()`](/reference/harness/session#permissions).
-
-#### `setPermissionForCategory({ category, policy })`
-
-Set the permission policy for a tool category.
-
-```typescript
-harness.setPermissionForCategory({ category: 'execute', policy: 'ask' })
-```
-
-#### `setPermissionForTool({ toolName, policy })`
-
-Set the permission policy for a specific tool. Per-tool policies take precedence over category policies.
-
-```typescript
-harness.setPermissionForTool({ toolName: 'dangerous_tool', policy: 'deny' })
-```
-
-#### `getPermissionRules()`
-
-Return the current permission rules.
-
-```typescript
-const rules = harness.getPermissionRules()
-// { categories: { execute: 'ask' }, tools: { dangerous_tool: 'deny' } }
-```
-
 #### `getToolCategory({ toolName })`
 
 Resolve a tool's category using the configured `toolCategoryResolver`.

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -380,6 +380,35 @@ Resolve the role's model ID to a model instance via the harness's `resolveModel`
 const observerModel = harness.session.om.observer.resolvedModel()
 ```
 
+## Permissions
+
+`session.permissions` owns the persisted tool-approval _policy_ — the per-category and per-tool rules consulted during approval resolution. These are distinct from the in-memory session _grants_ documented under [Methods → Permissions](#permissions); grants reset each session, whereas these rules are persisted in session state.
+
+### `session.permissions.getRules()`
+
+Return the current permission rules, or empty rules (`{ categories: {}, tools: {} }`) when none are set.
+
+```typescript
+const rules = harness.session.permissions.getRules()
+// { categories: { execute: 'ask' }, tools: { dangerous_tool: 'deny' } }
+```
+
+### `session.permissions.setForCategory({ category, policy })`
+
+Set the approval policy (`'allow' | 'ask' | 'deny'`) for a tool category. Resolves once the change is persisted to session state.
+
+```typescript
+await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' })
+```
+
+### `session.permissions.setForTool({ toolName, policy })`
+
+Set the approval policy for a specific tool. Per-tool policies take precedence over category policies. Resolves once persisted.
+
+```typescript
+await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' })
+```
+
 ## Run
 
 `session.run` owns run and trace identity plus abort state for the in-flight run.

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -308,6 +308,14 @@ Return the active model ID.
 const modelId = harness.session.model.get()
 ```
 
+### `session.model.displayName()`
+
+Return a short display name for the active model: the last segment of the model ID (for example, `claude-sonnet-4` from `anthropic/claude-sonnet-4`). Returns `'unknown'` when no model is selected.
+
+```typescript
+const name = harness.session.model.displayName()
+```
+
 ### `session.model.hasSelection()`
 
 Check whether a model is currently selected.

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -341,6 +341,45 @@ await harness.session.model.switch({
 await harness.session.model.switch({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
 ```
 
+## Observational Memory
+
+The observational-memory model selection, grouped by role under `session.om.observer` and `session.om.reflector`. Both roles expose the same methods. Reads return the value from session state when set, falling back to the harness's `omConfig` defaults.
+
+### `session.om.observer.modelId()` / `session.om.reflector.modelId()`
+
+Return the role's model ID, or `undefined` when neither session state nor `omConfig` provides one.
+
+```typescript
+const observer = harness.session.om.observer.modelId()
+const reflector = harness.session.om.reflector.modelId()
+```
+
+### `session.om.observer.threshold()` / `session.om.reflector.threshold()`
+
+Return the role's threshold in tokens (observation threshold for the observer, reflection threshold for the reflector), or `undefined` when unset.
+
+```typescript
+const observationThreshold = harness.session.om.observer.threshold()
+const reflectionThreshold = harness.session.om.reflector.threshold()
+```
+
+### `session.om.observer.switchModel({ modelId })` / `session.om.reflector.switchModel({ modelId })`
+
+Switch the role's model. Persists the setting to thread metadata and emits an `om_model_changed` event.
+
+```typescript
+await harness.session.om.observer.switchModel({ modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__' })
+await harness.session.om.reflector.switchModel({ modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__' })
+```
+
+### `session.om.observer.resolvedModel()` / `session.om.reflector.resolvedModel()`
+
+Resolve the role's model ID to a model instance via the harness's `resolveModel`, or `undefined` when no model ID is set or no resolver is configured.
+
+```typescript
+const observerModel = harness.session.om.observer.resolvedModel()
+```
+
 ## Run
 
 `session.run` owns run and trace identity plus abort state for the in-flight run.

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -310,7 +310,7 @@ const modelId = harness.session.model.get()
 
 ### `session.model.displayName()`
 
-Return a short display name for the active model: the last segment of the model ID (for example, `claude-sonnet-4` from `anthropic/claude-sonnet-4`). Returns `'unknown'` when no model is selected.
+Return a short display name for the active model: the last segment of the model ID (for example, `__AI_SDK_ANTHROPIC_MODEL_SONNET__` from `__GATEWAY_ANTHROPIC_MODEL_SONNET__`). Returns `'unknown'` when no model is selected.
 
 ```typescript
 const name = harness.session.model.displayName()

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -409,6 +409,33 @@ Set the approval policy for a specific tool. Per-tool policies take precedence o
 await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' })
 ```
 
+## Subagents
+
+`session.subagents` owns subagent configuration. It currently exposes the subagent model selection under `session.subagents.model`.
+
+### `session.subagents.model.get({ agentType? })`
+
+Return the subagent model ID, preferring the per-`agentType` value when one is given, then the global subagent model, or `null` when neither is set.
+
+```typescript
+const modelId = harness.session.subagents.model.get({ agentType: 'explore' })
+```
+
+### `session.subagents.model.set({ modelId, agentType? })`
+
+Set the subagent model ID. Pass an `agentType` to set a per-type override, or omit it to set the global default. Persists to thread settings and emits a `subagent_model_changed` event.
+
+```typescript
+// Set the global subagent model
+await harness.session.subagents.model.set({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
+
+// Set a per-type override
+await harness.session.subagents.model.set({
+  modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__',
+  agentType: 'explore',
+})
+```
+
 ## Run
 
 `session.run` owns run and trace identity plus abort state for the in-flight run.

--- a/mastracode/e2e/terminal-backend.ts
+++ b/mastracode/e2e/terminal-backend.ts
@@ -358,7 +358,7 @@ async function startMastraCodeApp(
     const browser = await createBrowserFromSettings(settings.browser);
     if (browser) {
       result.harness.setBrowser(browser);
-      await result.harness.setState({ activeBrowserSettings: settings.browser });
+      await result.harness.session.state.set({ activeBrowserSettings: settings.browser });
     }
   }
 

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -432,7 +432,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
               },
             },
             workspace: harness.getWorkspace(),
-            getSubagentModelId: params => harness.getSubagentModelId(params),
+            getSubagentModelId: params => harness.session.subagents.model.get(params ?? {}),
           };
           requestContext.set('harness', harnessContext);
 

--- a/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -630,7 +630,7 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: 'plan-goal-456',
       harness: {
-        switchMode,
+        session: { mode: { switch: switchMode } },
       } as any,
       goalManager: {
         applyEvaluation,
@@ -658,7 +658,7 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: undefined,
       harness: {
-        switchMode,
+        session: { mode: { switch: switchMode } },
       } as any,
       goalManager: {
         applyEvaluation: vi.fn(),
@@ -683,7 +683,7 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: 'plan-goal-123',
       harness: {
-        switchMode,
+        session: { mode: { switch: switchMode } },
       } as any,
       goalManager: {
         applyEvaluation: vi.fn(),
@@ -710,7 +710,7 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: 'plan-goal-321',
       harness: {
-        switchMode,
+        session: { mode: { switch: switchMode } },
       } as any,
       goalManager: {
         applyEvaluation: vi.fn(),
@@ -737,7 +737,7 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: 'plan-goal-xyz',
       harness: {
-        switchMode,
+        session: { mode: { switch: switchMode } },
       } as any,
       goalManager: {
         applyEvaluation: vi.fn(),
@@ -764,7 +764,7 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: 'plan-goal-failed',
       harness: {
-        switchMode,
+        session: { mode: { switch: switchMode } },
       } as any,
       goalManager: {
         applyEvaluation: vi.fn(),
@@ -796,7 +796,7 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: originalGoalId,
       harness: {
-        switchMode,
+        session: { mode: { switch: switchMode } },
       } as any,
       goalManager: {
         applyEvaluation: vi.fn(),
@@ -823,7 +823,7 @@ describe('MastraTUI queueing', () => {
     const state = createQueueState({
       planStartedGoalId: originalGoalId,
       harness: {
-        switchMode,
+        session: { mode: { switch: switchMode } },
       } as any,
       goalManager: {
         applyEvaluation: vi.fn(),

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -637,8 +637,8 @@ describe('renderExistingMessages subagents', () => {
     state.harness = {
       session: {
         displayState: { get: () => ({ isRunning: false }) },
+        model: { get: () => 'openai/gpt-5.5' },
       },
-      getFullModelId: () => 'openai/gpt-5.5',
     } as unknown as TUIState['harness'];
 
     await renderExistingMessages(state);

--- a/mastracode/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/src/tui/__tests__/status-line.test.ts
@@ -83,9 +83,6 @@ function createState() {
     },
     harness: {
       listModes: vi.fn(() => [{ id: 'build', name: 'build', metadata: { color: '#00ff00' } }]),
-      getObserverModelId: vi.fn(() => 'openai/gpt-4o'),
-      getReflectorModelId: vi.fn(() => 'openai/gpt-4o-mini'),
-      getFullModelId: vi.fn(() => 'anthropic/claude-sonnet-4-20250514'),
       session: {
         displayState: {
           get: vi.fn(() => ({
@@ -100,6 +97,13 @@ function createState() {
         mode: {
           get: vi.fn(() => 'build'),
           resolve: vi.fn(() => ({ id: 'build', name: 'build', metadata: { color: '#00ff00' } })),
+        },
+        model: {
+          get: vi.fn(() => 'anthropic/claude-sonnet-4-20250514'),
+        },
+        om: {
+          observer: { modelId: vi.fn(() => 'openai/gpt-4o') },
+          reflector: { modelId: vi.fn(() => 'openai/gpt-4o-mini') },
         },
       },
     },
@@ -224,7 +228,7 @@ describe('updateStatusLine', () => {
 
   it('preserves the gateway prefix when compacting gateway-backed model ids', () => {
     const state = createState();
-    state.harness.getFullModelId.mockReturnValue('mastra/anthropic/claude-opus-4.6');
+    state.harness.session.model.get.mockReturnValue('mastra/anthropic/claude-opus-4.6');
     process.stdout.columns = 25;
 
     updateStatusLine(state);
@@ -236,7 +240,7 @@ describe('updateStatusLine', () => {
 
   it('rewrites fireworks-ai long paths and kimi version separator at full width', () => {
     const state = createState();
-    state.harness.getFullModelId.mockReturnValue('fireworks-ai/accounts/fireworks/models/kimi-k2p6');
+    state.harness.session.model.get.mockReturnValue('fireworks-ai/accounts/fireworks/models/kimi-k2p6');
     process.stdout.columns = 200;
 
     updateStatusLine(state);
@@ -249,7 +253,7 @@ describe('updateStatusLine', () => {
 
   it('rewrites fireworks-ai long paths and kimi version separator when compacted', () => {
     const state = createState();
-    state.harness.getFullModelId.mockReturnValue('fireworks-ai/accounts/fireworks/models/kimi-k2p6');
+    state.harness.session.model.get.mockReturnValue('fireworks-ai/accounts/fireworks/models/kimi-k2p6');
     process.stdout.columns = 25;
 
     updateStatusLine(state);
@@ -262,7 +266,7 @@ describe('updateStatusLine', () => {
 
   it('rewrites kimi version separator for non-fireworks models', () => {
     const state = createState();
-    state.harness.getFullModelId.mockReturnValue('moonshot/kimi-k1p5');
+    state.harness.session.model.get.mockReturnValue('moonshot/kimi-k1p5');
     process.stdout.columns = 200;
 
     updateStatusLine(state);
@@ -274,7 +278,7 @@ describe('updateStatusLine', () => {
 
   it('rewrites minimax-m2p7 version separator', () => {
     const state = createState();
-    state.harness.getFullModelId.mockReturnValue('fireworks-ai/accounts/fireworks/models/minimax-m2p7');
+    state.harness.session.model.get.mockReturnValue('fireworks-ai/accounts/fireworks/models/minimax-m2p7');
     process.stdout.columns = 200;
 
     updateStatusLine(state);

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -398,7 +398,7 @@ async function applyPack(ctx: SlashCommandContext, pack: ModePack, previousPackI
   for (const [agentType, modeId] of Object.entries(subagentModeMap)) {
     const saModelId = (pack.models as Record<string, string>)[modeId];
     if (saModelId) {
-      await harness.setSubagentModelId({ modelId: saModelId, agentType });
+      await harness.session.subagents.model.set({ modelId: saModelId, agentType });
     }
   }
 

--- a/mastracode/src/tui/commands/om.ts
+++ b/mastracode/src/tui/commands/om.ts
@@ -83,10 +83,10 @@ export async function handleOMCommand(ctx: SlashCommandContext): Promise<void> {
 
   const harnessState = ctx.state.session.state.get() as Record<string, unknown> | undefined;
   const config = {
-    observerModelId: ctx.state.harness.getObserverModelId() ?? '',
-    reflectorModelId: ctx.state.harness.getReflectorModelId() ?? '',
-    observationThreshold: ctx.state.harness.getObservationThreshold() ?? 30_000,
-    reflectionThreshold: ctx.state.harness.getReflectionThreshold() ?? 40_000,
+    observerModelId: ctx.state.session.om.observer.modelId() ?? '',
+    reflectorModelId: ctx.state.session.om.reflector.modelId() ?? '',
+    observationThreshold: ctx.state.session.om.observer.threshold() ?? 30_000,
+    reflectionThreshold: ctx.state.session.om.reflector.threshold() ?? 40_000,
     cavemanObservations: (harnessState?.cavemanObservations as boolean | undefined) ?? false,
     observeAttachments: (harnessState?.observeAttachments as 'auto' | boolean | undefined) ?? 'auto',
   };
@@ -97,15 +97,15 @@ export async function handleOMCommand(ctx: SlashCommandContext): Promise<void> {
       {
         onObserverModelChange: async model => {
           await promptForApiKeyIfNeeded(ctx.state.ui, model, ctx.authStorage);
-          const currentReflector = ctx.state.harness.getReflectorModelId() ?? null;
-          await ctx.state.harness.switchObserverModel({ modelId: model.id });
+          const currentReflector = ctx.state.session.om.reflector.modelId() ?? null;
+          await ctx.state.session.om.observer.switchModel({ modelId: model.id });
           persistOmRoleOverride('observer', model.id, currentReflector);
           ctx.showInfo(`Observer model → ${model.id}`);
         },
         onReflectorModelChange: async model => {
           await promptForApiKeyIfNeeded(ctx.state.ui, model, ctx.authStorage);
-          const currentObserver = ctx.state.harness.getObserverModelId() ?? null;
-          await ctx.state.harness.switchReflectorModel({ modelId: model.id });
+          const currentObserver = ctx.state.session.om.observer.modelId() ?? null;
+          await ctx.state.session.om.reflector.switchModel({ modelId: model.id });
           persistOmRoleOverride('reflector', model.id, currentObserver);
           ctx.showInfo(`Reflector model → ${model.id}`);
         },

--- a/mastracode/src/tui/commands/permissions.ts
+++ b/mastracode/src/tui/commands/permissions.ts
@@ -14,7 +14,7 @@ export async function handlePermissionsCommand(ctx: SlashCommandContext, args: s
       ctx.showInfo(`Invalid policy: ${policy}. Must be one of: ${validPolicies.join(', ')}`);
       return;
     }
-    ctx.harness.setPermissionForCategory({ category, policy });
+    await ctx.state.session.permissions.setForCategory({ category, policy });
     ctx.showInfo(`Set ${category} policy to: ${policy}`);
     return;
   }
@@ -23,7 +23,7 @@ export async function handlePermissionsCommand(ctx: SlashCommandContext, args: s
 
 async function showPermissions(ctx: SlashCommandContext): Promise<void> {
   const { TOOL_CATEGORIES, getToolsForCategory } = await import('../../permissions.js');
-  const rules = ctx.harness.getPermissionRules();
+  const rules = ctx.state.session.permissions.getRules();
   const grants = ctx.state.session.getGrants();
   const isYolo = (ctx.state.session.state.get() as any)?.yolo === true;
 

--- a/mastracode/src/tui/commands/subagents.ts
+++ b/mastracode/src/tui/commands/subagents.ts
@@ -37,7 +37,7 @@ async function showSubagentModelListForScope(
     return;
   }
 
-  const currentSubagentModel = ctx.state.harness.getSubagentModelId({ agentType });
+  const currentSubagentModel = ctx.state.session.subagents.model.get({ agentType });
   const scopeLabel = scope === 'global' ? `${agentTypeLabel} · Global` : `${agentTypeLabel} · Thread`;
 
   return new Promise(resolve => {
@@ -50,7 +50,7 @@ async function showSubagentModelListForScope(
         ctx.state.ui.hideOverlay();
         await promptForApiKeyIfNeeded(ctx.state.ui, model, ctx.authStorage);
         try {
-          await ctx.state.harness.setSubagentModelId({ modelId: model.id, agentType });
+          await ctx.state.session.subagents.model.set({ modelId: model.id, agentType });
           if (scope === 'global') {
             const settings = loadSettings();
             settings.models.subagentModels[agentType] = model.id;

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -1303,7 +1303,7 @@ export class MastraTUI {
     for (const [agentType, modeId] of Object.entries(subagentModeMap)) {
       const saModelId = (modePack.models as Record<string, string>)[modeId];
       if (saModelId) {
-        await harness.setSubagentModelId({ modelId: saModelId, agentType });
+        await harness.session.subagents.model.set({ modelId: saModelId, agentType });
       }
     }
 

--- a/mastracode/src/tui/render-messages.test.ts
+++ b/mastracode/src/tui/render-messages.test.ts
@@ -274,8 +274,8 @@ describe('renderExistingMessages subagents', () => {
       session: {
         thread: { listActiveMessages: vi.fn().mockResolvedValue([message]) },
         displayState: { get: () => ({ isRunning: false }), restoreTasks: vi.fn() },
+        model: { get: () => 'openai/gpt-5.5' },
       },
-      getFullModelId: () => 'openai/gpt-5.5',
       setState: vi.fn().mockResolvedValue(undefined),
     } as unknown as TUIState['harness'];
 

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -723,10 +723,7 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
             // Parse embedded metadata for model ID, duration, tool calls
             const meta = rawResult ? parseSubagentMeta(rawResult) : null;
             const resultText = meta?.text ?? rawResult;
-            const currentModelId =
-              typeof (state.harness as { getFullModelId?: () => string }).getFullModelId === 'function'
-                ? (state.harness as { getFullModelId: () => string }).getFullModelId()
-                : undefined;
+            const currentModelId = state.harness.session.model.get() || undefined;
             const modelId = meta?.modelId ?? subArgs?.modelId ?? (subArgs?.forked ? currentModelId : undefined);
             const durationMs = meta?.durationMs ?? 0;
 

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -141,8 +141,8 @@ export function updateStatusLine(state: TUIState): void {
       ? state.activeGoalJudge?.modelId
       : showOMMode
         ? isObserving
-          ? state.harness.getObserverModelId()
-          : state.harness.getReflectorModelId()
+          ? state.harness.session.om.observer.modelId()
+          : state.harness.session.om.reflector.modelId()
         : state.harness.session.model.get()) ?? '';
   // Rewrite Fireworks AI long paths: fireworks-ai/accounts/fireworks/models/<name> → fireworks/<name>
   let fullModelId = rawModelId.startsWith('fireworks-ai/accounts/fireworks/models/')

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -143,7 +143,7 @@ export function updateStatusLine(state: TUIState): void {
         ? isObserving
           ? state.harness.getObserverModelId()
           : state.harness.getReflectorModelId()
-        : state.harness.getFullModelId()) ?? '';
+        : state.harness.session.model.get()) ?? '';
   // Rewrite Fireworks AI long paths: fireworks-ai/accounts/fireworks/models/<name> → fireworks/<name>
   let fullModelId = rawModelId.startsWith('fireworks-ai/accounts/fireworks/models/')
     ? 'fireworks/' + rawModelId.slice('fireworks-ai/accounts/fireworks/models/'.length)

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1005,23 +1005,6 @@ export class Harness<TState = {}> {
   }
 
   /**
-   * Get a short display name from the current model ID.
-   */
-  getModelName(): string {
-    const modelId = this.#session.model.get();
-    if (!modelId || modelId === 'unknown') return modelId || 'unknown';
-    const parts = modelId.split('/');
-    return parts[parts.length - 1] || modelId;
-  }
-
-  /**
-   * Get the full model ID (e.g., "anthropic/claude-sonnet-4").
-   */
-  getFullModelId(): string {
-    return this.#session.model.get();
-  }
-
-  /**
    * Check if the current model's provider has authentication configured.
    * Uses app-provided catalog/auth hooks; Harness does not resolve gateway auth itself.
    */

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -874,37 +874,6 @@ export class Harness<TState = {}> {
   }
 
   // ===========================================================================
-  // State Management
-  // ===========================================================================
-
-  /**
-   * Get current harness state (read-only snapshot).
-   * @deprecated Prefer `harness.session.state.get()`.
-   */
-  getState(): Readonly<TState> {
-    return this.#session.state.get();
-  }
-
-  /**
-   * Update harness state. Validates against schema if provided.
-   * Emits state_changed event.
-   * @deprecated Prefer `harness.session.state.set(...)`.
-   */
-  async setState(updates: Partial<TState>): Promise<void> {
-    return this.#session.state.set(updates);
-  }
-
-  private async updateState<TResult>(
-    updater: (
-      state: Readonly<TState>,
-    ) =>
-      | { updates?: Partial<TState>; events?: HarnessEvent[]; result: TResult }
-      | Promise<{ updates?: Partial<TState>; events?: HarnessEvent[]; result: TResult }>,
-  ): Promise<TResult> {
-    return this.#session.state.update(updater);
-  }
-
-  // ===========================================================================
   // Mode Management
   // ===========================================================================
 
@@ -1462,7 +1431,7 @@ export class Harness<TState = {}> {
       }
 
       if (Object.keys(updates).length > 0) {
-        await this.setState(updates as unknown as Partial<TState>);
+        await this.#session.state.set(updates as unknown as Partial<TState>);
       }
 
       if (!hasObservationThreshold) {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -507,7 +507,7 @@ export class Harness<TState = {}> {
     });
     this.#session.om.setResolver({
       getState: () => this.#session.state.get() as Record<string, unknown>,
-      setState: updates => void this.#session.state.set(updates as Partial<TState>),
+      setState: updates => this.#session.state.set(updates as Partial<TState>),
       setSetting: ({ key, value }) => this.#session.thread.setSetting({ key, value }),
       emit: event => this.emit(event),
       omConfig: this.config.omConfig,
@@ -519,7 +519,7 @@ export class Harness<TState = {}> {
     });
     this.#session.subagents.setResolver({
       getState: () => this.#session.state.get() as Record<string, unknown>,
-      setState: updates => void this.#session.state.set(updates as Partial<TState>),
+      setState: updates => this.#session.state.set(updates as Partial<TState>),
       setSetting: ({ key, value }) => this.#session.thread.setSetting({ key, value }),
       emit: event => this.emit(event),
     });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -517,6 +517,12 @@ export class Harness<TState = {}> {
       getState: () => this.#session.state.get() as Record<string, unknown>,
       setState: updates => this.#session.state.set(updates as Partial<TState>),
     });
+    this.#session.subagents.setResolver({
+      getState: () => this.#session.state.get() as Record<string, unknown>,
+      setState: updates => void this.#session.state.set(updates as Partial<TState>),
+      setSetting: ({ key, value }) => this.#session.thread.setSetting({ key, value }),
+      emit: event => this.emit(event),
+    });
     this.#session.thread.connect(this.createThreadDataStore());
 
     // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
@@ -1609,27 +1615,6 @@ export class Harness<TState = {}> {
     } catch {
       return null;
     }
-  }
-
-  // ===========================================================================
-  // Subagent Model Management
-  // ===========================================================================
-
-  getSubagentModelId({ agentType }: { agentType?: string } = {}): string | null {
-    const state = this.#session.state.get() as Record<string, unknown>;
-    if (agentType) {
-      const perType = state[`subagentModelId_${agentType}`];
-      if (typeof perType === 'string') return perType;
-    }
-    const global = state.subagentModelId;
-    return typeof global === 'string' ? global : null;
-  }
-
-  async setSubagentModelId({ modelId, agentType }: { modelId: string; agentType?: string }): Promise<void> {
-    const key = agentType ? `subagentModelId_${agentType}` : 'subagentModelId';
-    void this.setState({ [key]: modelId } as unknown as Partial<TState>);
-    await this.#session.thread.setSetting({ key, value: modelId });
-    this.emit({ type: 'subagent_model_changed', modelId, scope: 'thread', agentType } as HarnessEvent);
   }
 
   // ===========================================================================
@@ -3638,7 +3623,7 @@ export class Harness<TState = {}> {
       abortSignal: this.#session.run.getAbortSignal(),
       workspace: this.workspace,
       emitEvent: event => this.emit(event),
-      getSubagentModelId: params => this.getSubagentModelId(params),
+      getSubagentModelId: params => this.#session.subagents.model.get(params ?? {}),
     };
 
     requestContext.set('harness', harnessContext);

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -506,6 +506,14 @@ export class Harness<TState = {}> {
       emit: event => this.emit(event),
       trackModelUse: this.config.modelUseCountTracker,
     });
+    this.#session.om.setResolver({
+      getState: () => this.#session.state.get() as Record<string, unknown>,
+      setState: updates => void this.#session.state.set(updates as Partial<TState>),
+      setSetting: ({ key, value }) => this.#session.thread.setSetting({ key, value }),
+      emit: event => this.emit(event),
+      omConfig: this.config.omConfig,
+      resolveModel: this.config.resolveModel,
+    });
     this.#session.thread.connect(this.createThreadDataStore());
 
     // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
@@ -1449,13 +1457,13 @@ export class Harness<TState = {}> {
       }
 
       if (!hasObservationThreshold) {
-        const observationThreshold = this.getObservationThreshold();
+        const observationThreshold = this.#session.om.observer.threshold();
         if (observationThreshold !== undefined) {
           await this.#session.thread.setSetting({ key: 'observationThreshold', value: observationThreshold });
         }
       }
       if (!hasReflectionThreshold) {
-        const reflectionThreshold = this.getReflectionThreshold();
+        const reflectionThreshold = this.#session.om.reflector.threshold();
         if (reflectionThreshold !== undefined) {
           await this.#session.thread.setSetting({ key: 'reflectionThreshold', value: reflectionThreshold });
         }
@@ -1598,70 +1606,6 @@ export class Harness<TState = {}> {
     } catch {
       return null;
     }
-  }
-
-  /**
-   * Returns the observer model ID from state, falling back to omConfig defaults.
-   */
-  getObserverModelId(): string | undefined {
-    return (this.#session.state.get() as any).observerModelId ?? this.config.omConfig?.defaultObserverModelId;
-  }
-
-  /**
-   * Returns the reflector model ID from state, falling back to omConfig defaults.
-   */
-  getReflectorModelId(): string | undefined {
-    return (this.#session.state.get() as any).reflectorModelId ?? this.config.omConfig?.defaultReflectorModelId;
-  }
-
-  /**
-   * Returns the observation threshold from state, falling back to omConfig defaults.
-   */
-  getObservationThreshold(): number | undefined {
-    return (this.#session.state.get() as any).observationThreshold ?? this.config.omConfig?.defaultObservationThreshold;
-  }
-
-  /**
-   * Returns the reflection threshold from state, falling back to omConfig defaults.
-   */
-  getReflectionThreshold(): number | undefined {
-    return (this.#session.state.get() as any).reflectionThreshold ?? this.config.omConfig?.defaultReflectionThreshold;
-  }
-
-  /**
-   * Resolves the observer model ID to a language model instance via the configured resolver.
-   */
-  getResolvedObserverModel() {
-    const modelId = this.getObserverModelId();
-    if (!modelId || !this.config.resolveModel) return undefined;
-    return this.config.resolveModel(modelId);
-  }
-
-  /**
-   * Resolves the reflector model ID to a language model instance via the configured resolver.
-   */
-  getResolvedReflectorModel() {
-    const modelId = this.getReflectorModelId();
-    if (!modelId || !this.config.resolveModel) return undefined;
-    return this.config.resolveModel(modelId);
-  }
-
-  /**
-   * Switch the Observer model.
-   */
-  async switchObserverModel({ modelId }: { modelId: string }): Promise<void> {
-    void this.setState({ observerModelId: modelId } as unknown as Partial<TState>);
-    await this.#session.thread.setSetting({ key: 'observerModelId', value: modelId });
-    this.emit({ type: 'om_model_changed', role: 'observer', modelId } as HarnessEvent);
-  }
-
-  /**
-   * Switch the Reflector model.
-   */
-  async switchReflectorModel({ modelId }: { modelId: string }): Promise<void> {
-    void this.setState({ reflectorModelId: modelId } as unknown as Partial<TState>);
-    await this.#session.thread.setSetting({ key: 'reflectorModelId', value: modelId });
-    this.emit({ type: 'om_model_changed', role: 'reflector', modelId } as HarnessEvent);
   }
 
   // ===========================================================================

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -54,7 +54,6 @@ import type {
   HarnessThread,
   ModelAuthStatus,
   PermissionPolicy,
-  PermissionRules,
   TokenUsage,
   ToolCategory,
 } from './types';
@@ -513,6 +512,10 @@ export class Harness<TState = {}> {
       emit: event => this.emit(event),
       omConfig: this.config.omConfig,
       resolveModel: this.config.resolveModel,
+    });
+    this.#session.permissions.setResolver({
+      getState: () => this.#session.state.get() as Record<string, unknown>,
+      setState: updates => this.#session.state.set(updates as Partial<TState>),
     });
     this.#session.thread.connect(this.createThreadDataStore());
 
@@ -1637,24 +1640,6 @@ export class Harness<TState = {}> {
     return this.config.toolCategoryResolver?.(toolName) ?? null;
   }
 
-  setPermissionForCategory({ category, policy }: { category: ToolCategory; policy: PermissionPolicy }): void {
-    const rules = this.getPermissionRules();
-    rules.categories[category] = policy;
-    void this.setState({ permissionRules: rules } as unknown as Partial<TState>);
-  }
-
-  setPermissionForTool({ toolName, policy }: { toolName: string; policy: PermissionPolicy }): void {
-    const rules = this.getPermissionRules();
-    rules.tools[toolName] = policy;
-    void this.setState({ permissionRules: rules } as unknown as Partial<TState>);
-  }
-
-  getPermissionRules(): PermissionRules {
-    const state = this.#session.state.get() as Record<string, unknown>;
-    const rules = state.permissionRules as PermissionRules | undefined;
-    return rules ?? { categories: {}, tools: {} };
-  }
-
   /**
    * Resolve whether a tool call should be auto-approved, denied, or asked.
    * Resolution chain: per-tool deny → yolo → per-tool policy → session tool grant →
@@ -1662,7 +1647,7 @@ export class Harness<TState = {}> {
    */
   private resolveToolApproval(toolName: string): PermissionPolicy {
     const state = this.#session.state.get() as Record<string, unknown>;
-    const rules = this.getPermissionRules();
+    const rules = this.#session.permissions.getRules();
 
     const toolPolicy = rules.tools[toolName];
     if (toolPolicy === 'deny') return 'deny';
@@ -3594,7 +3579,7 @@ export class Harness<TState = {}> {
       }
     }
 
-    const permissionRules = this.getPermissionRules();
+    const permissionRules = this.#session.permissions.getRules();
     for (const [toolId, policy] of Object.entries(permissionRules.tools)) {
       if (policy === 'deny') {
         delete builtInTools[toolId];

--- a/packages/core/src/harness/list-available-models.test.ts
+++ b/packages/core/src/harness/list-available-models.test.ts
@@ -122,7 +122,7 @@ describe('Harness.listAvailableModels', () => {
       },
     });
 
-    const observerModel = harness.getResolvedObserverModel() as { modelId?: string };
+    const observerModel = harness.session.om.observer.resolvedModel() as { modelId?: string };
     expect(observerModel).toMatchObject({ modelId: 'test-gateway/acme/sonic-fast' });
     expect(resolveModel).toHaveBeenCalledWith('test-gateway/acme/sonic-fast');
 

--- a/packages/core/src/harness/om-threshold-persistence.test.ts
+++ b/packages/core/src/harness/om-threshold-persistence.test.ts
@@ -33,17 +33,17 @@ describe('Harness OM threshold persistence', () => {
     await harness.init();
 
     const threadA = await harness.createThread();
-    await harness.setState({ observationThreshold: 12000, reflectionThreshold: 21000 } as any);
+    await harness.session.state.set({ observationThreshold: 12000, reflectionThreshold: 21000 } as any);
     await harness.session.thread.setSetting({ key: 'observationThreshold', value: 12000 });
     await harness.session.thread.setSetting({ key: 'reflectionThreshold', value: 21000 });
 
     await harness.createThread();
-    await harness.setState({ observationThreshold: 33000, reflectionThreshold: 44000 } as any);
+    await harness.session.state.set({ observationThreshold: 33000, reflectionThreshold: 44000 } as any);
 
     await harness.switchThread({ threadId: threadA.id });
 
-    expect((harness.getState() as any).observationThreshold).toBe(12000);
-    expect((harness.getState() as any).reflectionThreshold).toBe(21000);
+    expect((harness.session.state.get() as any).observationThreshold).toBe(12000);
+    expect((harness.session.state.get() as any).reflectionThreshold).toBe(21000);
   });
 
   it('persists current thresholds onto an existing thread when metadata does not define overrides', async () => {
@@ -54,12 +54,12 @@ describe('Harness OM threshold persistence', () => {
     await harness.init();
 
     const thread = await harness.createThread();
-    await harness.setState({ observationThreshold: 18000, reflectionThreshold: 28000 } as any);
+    await harness.session.state.set({ observationThreshold: 18000, reflectionThreshold: 28000 } as any);
 
     await harness.switchThread({ threadId: thread.id });
 
-    expect((harness.getState() as any).observationThreshold).toBe(18000);
-    expect((harness.getState() as any).reflectionThreshold).toBe(28000);
+    expect((harness.session.state.get() as any).observationThreshold).toBe(18000);
+    expect((harness.session.state.get() as any).reflectionThreshold).toBe(28000);
 
     const memory = await storage.getStore('memory');
     const savedThread = await memory?.getThreadById({ threadId: thread.id });

--- a/packages/core/src/harness/session-om.test.ts
+++ b/packages/core/src/harness/session-om.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+import type { HarnessEvent, HarnessOMConfig } from './types';
+
+function createHarness(options: {
+  storage: InMemoryStore;
+  omConfig?: HarnessOMConfig;
+  resolveModel?: (modelId: string) => any;
+  onEvent?: (event: HarnessEvent) => void;
+}) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  const harness = new Harness({
+    id: 'test-harness',
+    storage: options.storage,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    omConfig: options.omConfig,
+    resolveModel: options.resolveModel,
+  });
+
+  if (options.onEvent) harness.subscribe(options.onEvent);
+
+  return harness;
+}
+
+describe('session.om', () => {
+  let storage: InMemoryStore;
+
+  beforeEach(() => {
+    storage = new InMemoryStore();
+  });
+
+  it('falls back to omConfig defaults for model ids and thresholds', () => {
+    const harness = createHarness({
+      storage,
+      omConfig: {
+        defaultObserverModelId: 'openai/gpt-4o',
+        defaultReflectorModelId: 'openai/gpt-4o-mini',
+        defaultObservationThreshold: 30_000,
+        defaultReflectionThreshold: 40_000,
+      },
+    });
+
+    expect(harness.session.om.observer.modelId()).toBe('openai/gpt-4o');
+    expect(harness.session.om.reflector.modelId()).toBe('openai/gpt-4o-mini');
+    expect(harness.session.om.observer.threshold()).toBe(30_000);
+    expect(harness.session.om.reflector.threshold()).toBe(40_000);
+  });
+
+  it('returns undefined when no state value and no omConfig default exist', () => {
+    const harness = createHarness({ storage });
+
+    expect(harness.session.om.observer.modelId()).toBeUndefined();
+    expect(harness.session.om.reflector.modelId()).toBeUndefined();
+    expect(harness.session.om.observer.threshold()).toBeUndefined();
+    expect(harness.session.om.reflector.threshold()).toBeUndefined();
+  });
+
+  it('prefers session-state values over omConfig defaults', async () => {
+    const harness = createHarness({
+      storage,
+      omConfig: { defaultObserverModelId: 'openai/gpt-4o' },
+    });
+    await harness.session.state.set({ observerModelId: 'anthropic/claude-sonnet-4' } as any);
+
+    expect(harness.session.om.observer.modelId()).toBe('anthropic/claude-sonnet-4');
+  });
+
+  it('observer.switchModel persists to thread settings and emits om_model_changed', async () => {
+    const events: HarnessEvent[] = [];
+    const harness = createHarness({ storage, onEvent: event => events.push(event) });
+    await harness.init();
+    await harness.createThread();
+
+    await harness.session.om.observer.switchModel({ modelId: 'anthropic/claude-sonnet-4' });
+
+    expect(harness.session.om.observer.modelId()).toBe('anthropic/claude-sonnet-4');
+    expect(await harness.session.thread.getSetting({ key: 'observerModelId' })).toBe('anthropic/claude-sonnet-4');
+    expect(events).toContainEqual({
+      type: 'om_model_changed',
+      role: 'observer',
+      modelId: 'anthropic/claude-sonnet-4',
+    });
+  });
+
+  it('reflector.switchModel persists to thread settings and emits om_model_changed', async () => {
+    const events: HarnessEvent[] = [];
+    const harness = createHarness({ storage, onEvent: event => events.push(event) });
+    await harness.init();
+    await harness.createThread();
+
+    await harness.session.om.reflector.switchModel({ modelId: 'openai/gpt-4o-mini' });
+
+    expect(harness.session.om.reflector.modelId()).toBe('openai/gpt-4o-mini');
+    expect(await harness.session.thread.getSetting({ key: 'reflectorModelId' })).toBe('openai/gpt-4o-mini');
+    expect(events).toContainEqual({
+      type: 'om_model_changed',
+      role: 'reflector',
+      modelId: 'openai/gpt-4o-mini',
+    });
+  });
+
+  it('resolves the observer model via the configured resolver', () => {
+    const resolveModel = vi.fn((modelId: string) => ({ modelId }));
+    const harness = createHarness({
+      storage,
+      omConfig: { defaultObserverModelId: 'openai/gpt-4o' },
+      resolveModel,
+    });
+
+    expect(harness.session.om.observer.resolvedModel()).toMatchObject({ modelId: 'openai/gpt-4o' });
+    expect(resolveModel).toHaveBeenCalledWith('openai/gpt-4o');
+  });
+
+  it('returns undefined resolved model when no model id is set', () => {
+    const resolveModel = vi.fn((modelId: string) => ({ modelId }));
+    const harness = createHarness({ storage, resolveModel });
+
+    expect(harness.session.om.observer.resolvedModel()).toBeUndefined();
+    expect(resolveModel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/harness/session-permissions.test.ts
+++ b/packages/core/src/harness/session-permissions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+
+function createHarness(storage: InMemoryStore) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new Harness({
+    id: 'test-harness',
+    storage,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+}
+
+describe('session.permissions', () => {
+  let storage: InMemoryStore;
+
+  beforeEach(() => {
+    storage = new InMemoryStore();
+  });
+
+  it('returns empty rules when none are set', () => {
+    const harness = createHarness(storage);
+    expect(harness.session.permissions.getRules()).toEqual({ categories: {}, tools: {} });
+  });
+
+  it('setForCategory persists the policy to session state', async () => {
+    const harness = createHarness(storage);
+
+    await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' });
+
+    expect(harness.session.permissions.getRules().categories.execute).toBe('ask');
+    expect((harness.session.state.get() as any).permissionRules.categories.execute).toBe('ask');
+  });
+
+  it('setForTool persists the policy to session state', async () => {
+    const harness = createHarness(storage);
+
+    await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' });
+
+    expect(harness.session.permissions.getRules().tools.dangerous_tool).toBe('deny');
+    expect((harness.session.state.get() as any).permissionRules.tools.dangerous_tool).toBe('deny');
+  });
+
+  it('reflects rules already present in session state', async () => {
+    const harness = createHarness(storage);
+    await harness.session.state.set({
+      permissionRules: { categories: { read: 'allow' }, tools: {} },
+    } as any);
+
+    expect(harness.session.permissions.getRules().categories.read).toBe('allow');
+  });
+
+  it('merges new policies without dropping existing ones', async () => {
+    const harness = createHarness(storage);
+
+    await harness.session.permissions.setForCategory({ category: 'execute', policy: 'deny' });
+    await harness.session.permissions.setForTool({ toolName: 'fetch', policy: 'allow' });
+
+    const rules = harness.session.permissions.getRules();
+    expect(rules.categories.execute).toBe('deny');
+    expect(rules.tools.fetch).toBe('allow');
+  });
+});

--- a/packages/core/src/harness/session-state.test.ts
+++ b/packages/core/src/harness/session-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { Harness } from './harness';
 import type { HarnessConfig, HarnessEvent } from './types';
@@ -28,7 +28,7 @@ describe('Harness session state', () => {
     });
 
     expect(harness.session.state.get()).toEqual({ count: 1, label: 'ready' });
-    expect(harness.getState()).toEqual({ count: 1, label: 'ready' });
+    expect(harness.session.state.get()).toEqual({ count: 1, label: 'ready' });
   });
 
   it('get() returns a shallow snapshot', () => {
@@ -101,20 +101,6 @@ describe('Harness session state', () => {
     expect(harness.session.state.get()).toEqual({ count: 2 });
   });
 
-  it('keeps Harness compatibility wrappers delegated to session.state', async () => {
-    const harness = createHarness<{ count: number }>({ initialState: { count: 0 } });
-    const setSpy = vi.spyOn(harness.session.state, 'set');
-
-    await harness.setState({ count: 2 });
-    const result = await (
-      harness as unknown as { updateState: Harness<{ count: number }>['session']['state']['update'] }
-    ).updateState(state => ({ updates: { count: state.count + 1 }, result: state.count }));
-
-    expect(setSpy).toHaveBeenCalledWith({ count: 2 });
-    expect(result).toBe(2);
-    expect(harness.getState()).toEqual({ count: 3 });
-    expect(harness.session.state.get()).toEqual({ count: 3 });
-  });
 
   it('exposes session.state and deprecated flattened state accessors in request context', async () => {
     const harness = createHarness<{ count: number }>({ initialState: { count: 0 } });

--- a/packages/core/src/harness/session-state.test.ts
+++ b/packages/core/src/harness/session-state.test.ts
@@ -101,7 +101,6 @@ describe('Harness session state', () => {
     expect(harness.session.state.get()).toEqual({ count: 2 });
   });
 
-
   it('exposes session.state and deprecated flattened state accessors in request context', async () => {
     const harness = createHarness<{ count: number }>({ initialState: { count: 0 } });
 

--- a/packages/core/src/harness/session-subagents.test.ts
+++ b/packages/core/src/harness/session-subagents.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+import type { HarnessEvent } from './types';
+
+function createHarness(options: { storage: InMemoryStore; onEvent?: (event: HarnessEvent) => void }) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  const harness = new Harness({
+    id: 'test-harness',
+    storage: options.storage,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+
+  if (options.onEvent) harness.subscribe(options.onEvent);
+
+  return harness;
+}
+
+describe('session.subagents.model', () => {
+  let storage: InMemoryStore;
+
+  beforeEach(() => {
+    storage = new InMemoryStore();
+  });
+
+  it('returns null when no subagent model is set', () => {
+    const harness = createHarness({ storage });
+    expect(harness.session.subagents.model.get()).toBeNull();
+    expect(harness.session.subagents.model.get({ agentType: 'explore' })).toBeNull();
+  });
+
+  it('set (global) persists to thread settings and emits subagent_model_changed', async () => {
+    const events: HarnessEvent[] = [];
+    const harness = createHarness({ storage, onEvent: event => events.push(event) });
+    await harness.init();
+    await harness.createThread();
+
+    await harness.session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4' });
+
+    expect(harness.session.subagents.model.get()).toBe('anthropic/claude-sonnet-4');
+    expect(await harness.session.thread.getSetting({ key: 'subagentModelId' })).toBe('anthropic/claude-sonnet-4');
+    expect(events).toContainEqual({
+      type: 'subagent_model_changed',
+      modelId: 'anthropic/claude-sonnet-4',
+      scope: 'thread',
+      agentType: undefined,
+    });
+  });
+
+  it('set (per agentType) persists under an agentType-scoped key', async () => {
+    const harness = createHarness({ storage });
+    await harness.init();
+    await harness.createThread();
+
+    await harness.session.subagents.model.set({ modelId: 'openai/gpt-4o-mini', agentType: 'explore' });
+
+    expect(harness.session.subagents.model.get({ agentType: 'explore' })).toBe('openai/gpt-4o-mini');
+    expect(await harness.session.thread.getSetting({ key: 'subagentModelId_explore' })).toBe('openai/gpt-4o-mini');
+  });
+
+  it('prefers the per-agentType value over the global value', async () => {
+    const harness = createHarness({ storage });
+    await harness.init();
+    await harness.createThread();
+
+    await harness.session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4' });
+    await harness.session.subagents.model.set({ modelId: 'openai/gpt-4o-mini', agentType: 'explore' });
+
+    expect(harness.session.subagents.model.get({ agentType: 'explore' })).toBe('openai/gpt-4o-mini');
+    // An agentType with no specific override falls back to the global value.
+    expect(harness.session.subagents.model.get({ agentType: 'plan' })).toBe('anthropic/claude-sonnet-4');
+  });
+});

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -1250,8 +1250,7 @@ class SessionState<TState = unknown> {
  *
  * Currently owns:
  * - the live Harness state (`session.state`): schema-validated snapshots and
- *   serialized updates that emit `state_changed`. `Harness.getState()` /
- *   `Harness.setState()` are compatibility wrappers over this domain.
+ *   serialized updates that emit `state_changed`.
  * - session-scoped permission grants — the "allow for this session" approvals a
  *   user makes when a tool or tool category is gated behind the permission check.
  * - the live token-usage counter for the active thread. The Session holds the

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -696,6 +696,18 @@ export class SessionModel {
     return this.#id !== '';
   }
 
+  /**
+   * A short display name for the selected model: the last segment of the model
+   * id (e.g. `anthropic/claude-sonnet-4` -> `claude-sonnet-4`). Returns
+   * `'unknown'` when no model is selected.
+   */
+  displayName(): string {
+    const modelId = this.#id;
+    if (!modelId || modelId === 'unknown') return modelId || 'unknown';
+    const parts = modelId.split('/');
+    return parts[parts.length - 1] || modelId;
+  }
+
   /** Set the in-memory selected model id (no persistence). */
   set({ modelId }: { modelId: string }): void {
     this.#id = modelId;

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -17,6 +17,8 @@ import type {
   HarnessRequestStateUpdater,
   HarnessThread,
   ModelUseCountTracker,
+  PermissionPolicy,
+  PermissionRules,
   TokenUsage,
   ToolCategory,
 } from './types';
@@ -1011,6 +1013,49 @@ class SessionOM {
   }
 }
 
+/**
+ * Owns the session's tool-permission rules: the per-category and per-tool
+ * approval policies persisted in session state under `permissionRules`. The
+ * Harness injects the session-state read/write once via {@link setResolver}.
+ *
+ * These are the persisted rules consulted during tool-approval resolution; they
+ * are distinct from the in-memory "allow for this session" grants on the
+ * Session.
+ */
+class SessionPermissions {
+  #getState: (() => Record<string, unknown>) | undefined;
+  #setState: ((updates: Record<string, unknown>) => Promise<void>) | undefined;
+
+  /** Attach the session-state read/write. The Harness injects these once. */
+  setResolver(options: {
+    getState: () => Record<string, unknown>;
+    setState: (updates: Record<string, unknown>) => Promise<void>;
+  }): void {
+    this.#getState = options.getState;
+    this.#setState = options.setState;
+  }
+
+  /** The current permission rules, or empty rules when none are set. */
+  getRules(): PermissionRules {
+    const rules = this.#getState?.().permissionRules as PermissionRules | undefined;
+    return rules ?? { categories: {}, tools: {} };
+  }
+
+  /** Set the approval policy for a tool category. Resolves once persisted. */
+  setForCategory({ category, policy }: { category: ToolCategory; policy: PermissionPolicy }): Promise<void> {
+    const rules = this.getRules();
+    rules.categories[category] = policy;
+    return this.#setState?.({ permissionRules: rules }) ?? Promise.resolve();
+  }
+
+  /** Set the approval policy for an individual tool. Resolves once persisted. */
+  setForTool({ toolName, policy }: { toolName: string; policy: PermissionPolicy }): Promise<void> {
+    const rules = this.getRules();
+    rules.tools[toolName] = policy;
+    return this.#setState?.({ permissionRules: rules }) ?? Promise.resolve();
+  }
+}
+
 type SessionStateUpdater<TState, TResult> = HarnessRequestStateUpdater<TState, TResult>;
 
 interface SessionStateOptions<TState> {
@@ -1659,6 +1704,8 @@ export class Session<TState = unknown> {
   readonly mode = new SessionMode(() => this.#store, this.model);
   /** The session's observational-memory model selection (observer/reflector). */
   readonly om = new SessionOM();
+  /** The session's persisted tool-permission rules (per-category / per-tool). */
+  readonly permissions = new SessionPermissions();
   /** Transient run identity (run id, trace id, operation counter) for the active run. */
   readonly run = new SessionRun();
   /** Live subscription to the active thread's agent event stream. */

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -1,5 +1,6 @@
 import type { Agent } from '../agent';
 import type { AgentThreadSubscription } from '../agent/types';
+import type { MastraModelConfig } from '../llm/model/shared.types';
 import type { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
 import type { PublicSchema, StandardSchemaWithJSON } from '../schema';
@@ -11,6 +12,7 @@ import type {
   HarnessEvent,
   HarnessMessage,
   HarnessMode,
+  HarnessOMConfig,
   HarnessRequestState,
   HarnessRequestStateUpdater,
   HarnessThread,
@@ -891,6 +893,124 @@ export class SessionMode {
   }
 }
 
+/** Per-role wiring + state/config keys a {@link SessionOMRole} reads and writes. */
+interface SessionOMRoleConfig {
+  /** The event `role` and `om_model_changed` discriminator for this role. */
+  role: 'observer' | 'reflector';
+  /** Session-state / thread-settings key holding this role's model id. */
+  modelIdKey: 'observerModelId' | 'reflectorModelId';
+  /** Session-state key holding this role's threshold. */
+  thresholdKey: 'observationThreshold' | 'reflectionThreshold';
+  /** Resolve this role's default model id from `omConfig`. */
+  defaultModelId: (omConfig: HarnessOMConfig | undefined) => string | undefined;
+  /** Resolve this role's default threshold from `omConfig`. */
+  defaultThreshold: (omConfig: HarnessOMConfig | undefined) => number | undefined;
+}
+
+/**
+ * One observational-memory role (observer or reflector): its model id, resolved
+ * model instance, threshold, and model switch. Reads return the session-state
+ * value when set, falling back to the Harness's `omConfig` defaults. The shared
+ * wiring is injected by {@link SessionOM.setResolver}.
+ */
+class SessionOMRole {
+  readonly #config: SessionOMRoleConfig;
+  #getState: (() => Record<string, unknown>) | undefined;
+  #setState: ((updates: Record<string, unknown>) => void) | undefined;
+  #setSetting: ((args: { key: string; value: unknown }) => Promise<void>) | undefined;
+  #emit: ((event: HarnessEvent) => void) | undefined;
+  #omConfig: HarnessOMConfig | undefined;
+  #resolveModel: ((modelId: string) => MastraModelConfig) | undefined;
+
+  constructor(config: SessionOMRoleConfig) {
+    this.#config = config;
+  }
+
+  /** @internal Injected by {@link SessionOM.setResolver}. */
+  setWiring(wiring: {
+    getState: () => Record<string, unknown>;
+    setState: (updates: Record<string, unknown>) => void;
+    setSetting: (args: { key: string; value: unknown }) => Promise<void>;
+    emit: (event: HarnessEvent) => void;
+    omConfig?: HarnessOMConfig;
+    resolveModel?: (modelId: string) => MastraModelConfig;
+  }): void {
+    this.#getState = wiring.getState;
+    this.#setState = wiring.setState;
+    this.#setSetting = wiring.setSetting;
+    this.#emit = wiring.emit;
+    this.#omConfig = wiring.omConfig;
+    this.#resolveModel = wiring.resolveModel;
+  }
+
+  /** This role's model id from session state, falling back to `omConfig`. */
+  modelId(): string | undefined {
+    const fromState = this.#getState?.()[this.#config.modelIdKey];
+    return (typeof fromState === 'string' ? fromState : undefined) ?? this.#config.defaultModelId(this.#omConfig);
+  }
+
+  /** This role's threshold from session state, falling back to `omConfig`. */
+  threshold(): number | undefined {
+    const fromState = this.#getState?.()[this.#config.thresholdKey];
+    return (typeof fromState === 'number' ? fromState : undefined) ?? this.#config.defaultThreshold(this.#omConfig);
+  }
+
+  /** Resolve this role's model id to a model instance, or undefined when unset. */
+  resolvedModel(): MastraModelConfig | undefined {
+    const modelId = this.modelId();
+    if (!modelId || !this.#resolveModel) return undefined;
+    return this.#resolveModel(modelId);
+  }
+
+  /** Switch this role's model: update session state, persist, and emit. */
+  async switchModel({ modelId }: { modelId: string }): Promise<void> {
+    this.#setState?.({ [this.#config.modelIdKey]: modelId });
+    await this.#setSetting?.({ key: this.#config.modelIdKey, value: modelId });
+    this.#emit?.({ type: 'om_model_changed', role: this.#config.role, modelId });
+  }
+}
+
+/**
+ * Owns the session's observational-memory model selection, grouped by role:
+ * {@link SessionOM.observer} and {@link SessionOM.reflector}. The Harness owns
+ * `omConfig` and the model resolver, so it injects them — plus the session-state
+ * read/write and thread-settings persistence — once via {@link setResolver},
+ * which fans the wiring out to both roles.
+ */
+class SessionOM {
+  readonly observer = new SessionOMRole({
+    role: 'observer',
+    modelIdKey: 'observerModelId',
+    thresholdKey: 'observationThreshold',
+    defaultModelId: omConfig => omConfig?.defaultObserverModelId,
+    defaultThreshold: omConfig => omConfig?.defaultObservationThreshold,
+  });
+  readonly reflector = new SessionOMRole({
+    role: 'reflector',
+    modelIdKey: 'reflectorModelId',
+    thresholdKey: 'reflectionThreshold',
+    defaultModelId: omConfig => omConfig?.defaultReflectorModelId,
+    defaultThreshold: omConfig => omConfig?.defaultReflectionThreshold,
+  });
+
+  /**
+   * Attach the session-state read/write, thread-settings persistence, event
+   * emitter, and the Harness-owned `omConfig` defaults plus model resolver. The
+   * Harness injects these once; the wiring is shared by both roles.
+   */
+  setResolver(options: {
+    getState: () => Record<string, unknown>;
+    setState: (updates: Record<string, unknown>) => void;
+    setSetting: (args: { key: string; value: unknown }) => Promise<void>;
+    emit: (event: HarnessEvent) => void;
+    omConfig?: HarnessOMConfig;
+    resolveModel?: (modelId: string) => MastraModelConfig;
+  }): void {
+    this.observer.setWiring(options);
+    this.reflector.setWiring(options);
+  }
+}
+
 type SessionStateUpdater<TState, TResult> = HarnessRequestStateUpdater<TState, TResult>;
 
 interface SessionStateOptions<TState> {
@@ -1537,6 +1657,8 @@ export class Session<TState = unknown> {
   readonly model = new SessionModel(() => this.#store);
   /** The session's currently-selected mode and switch sequence. */
   readonly mode = new SessionMode(() => this.#store, this.model);
+  /** The session's observational-memory model selection (observer/reflector). */
+  readonly om = new SessionOM();
   /** Transient run identity (run id, trace id, operation counter) for the active run. */
   readonly run = new SessionRun();
   /** Live subscription to the active thread's agent event stream. */

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -702,7 +702,7 @@ export class SessionModel {
 
   /**
    * A short display name for the selected model: the last segment of the model
-   * id (e.g. `__GATEWAY_ANTHROPIC_MODEL_SONNET__` -> `__AI_SDK_ANTHROPIC_MODEL_SONNET__`). Returns
+   * id (e.g. `anthropic/claude-sonnet-4` -> `claude-sonnet-4`). Returns
    * `'unknown'` when no model is selected.
    */
   displayName(): string {

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -1056,6 +1056,86 @@ class SessionPermissions {
   }
 }
 
+/** The session-state / thread-settings key holding a subagent model id. */
+function subagentModelKey(agentType?: string): string {
+  return agentType ? `subagentModelId_${agentType}` : 'subagentModelId';
+}
+
+/**
+ * The subagent model selection. Reads prefer the per-`agentType` value and fall
+ * back to the global subagent model; writes persist to thread settings and emit
+ * a `subagent_model_changed` event. Wiring is injected by
+ * {@link SessionSubagents.setResolver}.
+ */
+class SessionSubagentModel {
+  #getState: (() => Record<string, unknown>) | undefined;
+  #setState: ((updates: Record<string, unknown>) => void) | undefined;
+  #setSetting: ((args: { key: string; value: unknown }) => Promise<void>) | undefined;
+  #emit: ((event: HarnessEvent) => void) | undefined;
+
+  /** @internal Injected by {@link SessionSubagents.setResolver}. */
+  setWiring(wiring: {
+    getState: () => Record<string, unknown>;
+    setState: (updates: Record<string, unknown>) => void;
+    setSetting: (args: { key: string; value: unknown }) => Promise<void>;
+    emit: (event: HarnessEvent) => void;
+  }): void {
+    this.#getState = wiring.getState;
+    this.#setState = wiring.setState;
+    this.#setSetting = wiring.setSetting;
+    this.#emit = wiring.emit;
+  }
+
+  /**
+   * The subagent model id, preferring the `agentType`-specific value when one is
+   * given, then the global subagent model, or `null` when neither is set.
+   */
+  get({ agentType }: { agentType?: string } = {}): string | null {
+    const state = this.#getState?.() ?? {};
+    if (agentType) {
+      const perType = state[subagentModelKey(agentType)];
+      if (typeof perType === 'string') return perType;
+    }
+    const global = state.subagentModelId;
+    return typeof global === 'string' ? global : null;
+  }
+
+  /**
+   * Set the subagent model id (per-`agentType` when given, otherwise global).
+   * Persists to thread settings and emits `subagent_model_changed`.
+   */
+  async set({ modelId, agentType }: { modelId: string; agentType?: string }): Promise<void> {
+    const key = subagentModelKey(agentType);
+    this.#setState?.({ [key]: modelId });
+    await this.#setSetting?.({ key, value: modelId });
+    this.#emit?.({ type: 'subagent_model_changed', modelId, scope: 'thread', agentType });
+  }
+}
+
+/**
+ * The session's subagent configuration. Currently exposes the subagent model
+ * selection under {@link SessionSubagents.model}; grouped under `subagents` to
+ * leave room for additional subagent settings. The Harness injects the
+ * session-state read/write, thread-settings persistence, and event emitter once
+ * via {@link setResolver}.
+ */
+class SessionSubagents {
+  readonly model = new SessionSubagentModel();
+
+  /**
+   * Attach the session-state read/write, thread-settings persistence, and event
+   * emitter. The Harness injects these once.
+   */
+  setResolver(options: {
+    getState: () => Record<string, unknown>;
+    setState: (updates: Record<string, unknown>) => void;
+    setSetting: (args: { key: string; value: unknown }) => Promise<void>;
+    emit: (event: HarnessEvent) => void;
+  }): void {
+    this.model.setWiring(options);
+  }
+}
+
 type SessionStateUpdater<TState, TResult> = HarnessRequestStateUpdater<TState, TResult>;
 
 interface SessionStateOptions<TState> {
@@ -1706,6 +1786,8 @@ export class Session<TState = unknown> {
   readonly om = new SessionOM();
   /** The session's persisted tool-permission rules (per-category / per-tool). */
   readonly permissions = new SessionPermissions();
+  /** The session's subagent configuration (currently the subagent model). */
+  readonly subagents = new SessionSubagents();
   /** Transient run identity (run id, trace id, operation counter) for the active run. */
   readonly run = new SessionRun();
   /** Live subscription to the active thread's agent event stream. */

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -702,7 +702,7 @@ export class SessionModel {
 
   /**
    * A short display name for the selected model: the last segment of the model
-   * id (e.g. `anthropic/claude-sonnet-4` -> `claude-sonnet-4`). Returns
+   * id (e.g. `__GATEWAY_ANTHROPIC_MODEL_SONNET__` -> `__AI_SDK_ANTHROPIC_MODEL_SONNET__`). Returns
    * `'unknown'` when no model is selected.
    */
   displayName(): string {

--- a/packages/core/src/harness/switch-model.test.ts
+++ b/packages/core/src/harness/switch-model.test.ts
@@ -42,16 +42,16 @@ describe('session.model.displayName', () => {
   it('returns the last segment of a provider-prefixed model id', async () => {
     const harness = createHarness();
 
-    await harness.session.model.switch({ modelId: 'anthropic/__AI_SDK_ANTHROPIC_MODEL_SONNET__' });
+    await harness.session.model.switch({ modelId: 'anthropic/claude-sonnet-4' });
 
-    expect(harness.session.model.displayName()).toBe('__AI_SDK_ANTHROPIC_MODEL_SONNET__');
+    expect(harness.session.model.displayName()).toBe('claude-sonnet-4');
   });
 
   it('returns the whole id when there is no provider prefix', async () => {
     const harness = createHarness();
 
-    await harness.session.model.switch({ modelId: '__AI_SDK_OPENAI_MODEL_BASE__' });
+    await harness.session.model.switch({ modelId: 'gpt-4o' });
 
-    expect(harness.session.model.displayName()).toBe('__AI_SDK_OPENAI_MODEL_BASE__');
+    expect(harness.session.model.displayName()).toBe('gpt-4o');
   });
 });

--- a/packages/core/src/harness/switch-model.test.ts
+++ b/packages/core/src/harness/switch-model.test.ts
@@ -42,16 +42,16 @@ describe('session.model.displayName', () => {
   it('returns the last segment of a provider-prefixed model id', async () => {
     const harness = createHarness();
 
-    await harness.session.model.switch({ modelId: 'anthropic/claude-sonnet-4' });
+    await harness.session.model.switch({ modelId: 'anthropic/__AI_SDK_ANTHROPIC_MODEL_SONNET__' });
 
-    expect(harness.session.model.displayName()).toBe('claude-sonnet-4');
+    expect(harness.session.model.displayName()).toBe('__AI_SDK_ANTHROPIC_MODEL_SONNET__');
   });
 
   it('returns the whole id when there is no provider prefix', async () => {
     const harness = createHarness();
 
-    await harness.session.model.switch({ modelId: 'gpt-4o' });
+    await harness.session.model.switch({ modelId: '__AI_SDK_OPENAI_MODEL_BASE__' });
 
-    expect(harness.session.model.displayName()).toBe('gpt-4o');
+    expect(harness.session.model.displayName()).toBe('__AI_SDK_OPENAI_MODEL_BASE__');
   });
 });

--- a/packages/core/src/harness/switch-model.test.ts
+++ b/packages/core/src/harness/switch-model.test.ts
@@ -30,3 +30,28 @@ describe('session.model.switch', () => {
     expect(trackModelUse).toHaveBeenCalledWith('openai/gpt-5.3-codex');
   });
 });
+
+describe('session.model.displayName', () => {
+  it("returns 'unknown' when no model is selected", () => {
+    const harness = createHarness();
+
+    expect(harness.session.model.hasSelection()).toBe(false);
+    expect(harness.session.model.displayName()).toBe('unknown');
+  });
+
+  it('returns the last segment of a provider-prefixed model id', async () => {
+    const harness = createHarness();
+
+    await harness.session.model.switch({ modelId: 'anthropic/claude-sonnet-4' });
+
+    expect(harness.session.model.displayName()).toBe('claude-sonnet-4');
+  });
+
+  it('returns the whole id when there is no provider prefix', async () => {
+    const harness = createHarness();
+
+    await harness.session.model.switch({ modelId: 'gpt-4o' });
+
+    expect(harness.session.model.displayName()).toBe('gpt-4o');
+  });
+});

--- a/packages/core/src/harness/task-tools.test.ts
+++ b/packages/core/src/harness/task-tools.test.ts
@@ -155,24 +155,24 @@ describe('assignTaskIds', () => {
 
 // Generic harness state serialization. Tasks are no longer a harness session
 // state source of truth (they live on the agent state-signal lane), so these
-// tests exercise `updateState`/`setState` ordering with neutral state keys.
+// tests exercise `session.state.update`/`session.state.set` ordering with neutral state keys.
 describe('harness state transactions', () => {
   it('serializes state updates against the latest committed state', async () => {
     const harness = createHarness();
-    await harness.setState({ counter: 0 });
+    await harness.session.state.set({ counter: 0 });
 
     let releaseFirst!: () => void;
     const firstUpdateGate = new Promise<void>(resolve => {
       releaseFirst = resolve;
     });
 
-    const firstUpdate = (harness as any).updateState(async (state: Record<string, unknown>) => {
+    const firstUpdate = harness.session.state.update(async (state: Record<string, unknown>) => {
       await firstUpdateGate;
       const next = (state.counter as number) + 1;
       return { updates: { counter: next }, result: next };
     });
 
-    const secondUpdate = (harness as any).updateState((state: Record<string, unknown>) => {
+    const secondUpdate = harness.session.state.update((state: Record<string, unknown>) => {
       expect(state.counter).toBe(1);
       const next = (state.counter as number) + 1;
       return { updates: { counter: next }, result: next };
@@ -181,7 +181,7 @@ describe('harness state transactions', () => {
     releaseFirst();
     await Promise.all([firstUpdate, secondUpdate]);
 
-    expect(harness.getState().counter).toBe(2);
+    expect(harness.session.state.get().counter).toBe(2);
   });
 
   it('serializes direct setState calls with queued state transactions', async () => {
@@ -219,8 +219,8 @@ describe('harness state transactions', () => {
       ],
     });
 
-    const setStatePromise = harness.setState({ seed: 'initial' });
-    const transactionPromise = (harness as any).updateState((state: Record<string, unknown>) => {
+    const setStatePromise = harness.session.state.set({ seed: 'initial' });
+    const transactionPromise = harness.session.state.update((state: Record<string, unknown>) => {
       expect(state.seed).toBe('initial');
       return { updates: { marker: 'after-set-state' }, result: undefined };
     });
@@ -228,7 +228,7 @@ describe('harness state transactions', () => {
     releaseValidation();
     await Promise.all([setStatePromise, transactionPromise]);
 
-    expect(harness.getState()).toMatchObject({
+    expect(harness.session.state.get()).toMatchObject({
       seed: 'initial',
       marker: 'after-set-state',
     });
@@ -321,6 +321,6 @@ describe('task tool display bridge', () => {
     ]);
 
     // Tasks are no longer mirrored into harness session state.
-    expect(harness.getState().tasks).toBeUndefined();
+    expect(harness.session.state.get().tasks).toBeUndefined();
   });
 });

--- a/workspaces/archil/package.json
+++ b/workspaces/archil/package.json
@@ -23,7 +23,7 @@
     "build:lib": "pnpm build",
     "build:watch": "pnpm build --watch",
     "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
-    "test:cloud": "vitest run ./src/**/*.integration.test.ts",
+    "test:cloud": "vitest run --passWithNoTests ./src/**/*.integration.test.ts",
     "test:watch": "vitest watch",
     "test": "vitest run ./src/**/*.integration.test.ts",
     "lint": "eslint ."


### PR DESCRIPTION
Continues moving session-state proxies off the Harness onto `session`. `Harness.getModelName()` and `Harness.getFullModelId()` were thin wrappers around the session's model state, so this removes them:

- The full model id is already available via `session.model.get()`, so callers move there (no new method needed).
- The short display name becomes a new `session.model.displayName()`, living next to the model id it derives from.

Before:

```typescript
const name = harness.getModelName()
const fullId = harness.getFullModelId()
```

After:

```typescript
const name = harness.session.model.displayName()
const fullId = harness.session.model.get()
```

Updates the MastraCode TUI callers (status line + subagent message renderer — the latter also drops a now-unneeded `typeof` capability guard), the harness reference docs, and adds `displayName()` unit coverage. Harness is still under development so this ships as a minor.

## Test plan
- `pnpm build:core`, `pnpm --filter ./packages/core check`, mastracode `tsc --noEmit` — all clean
- Harness tests: 297 existing + 3 new `displayName()` cases pass
- Docs: prettier, remark, frontmatter, and reference-sidebar checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Previously, code asked the `Harness` for the “current model” (like the model’s name/ID) even though that information actually lives in the session. Now the `session` object owns that knowledge, so the UI, commands, and docs use the session directly instead of wrapper methods.

## Overview
This refactor moves model identity access off `Harness` and onto `session.model`, replacing:
- `Harness.getFullModelId()` → `harness.session.model.get()`
- `Harness.getModelName()` → `harness.session.model.displayName()` (new short display label)

It also relocates related responsibilities to session scopes—most notably observational memory (OM) and permissions—updates MastraCode TUI rendering/commands to use the new session APIs, and expands unit test coverage for `displayName()`.

## Changes

### Core API changes
- **Removed from `Harness`:**
  - `getModelName()`, `getFullModelId()`
  - OM model/threshold/resolution/switching APIs (observer + reflector)
  - permission-rule APIs
  - subagent model helpers
  - additional harness state compatibility wrappers (`getState()`, `setState()`) removed as part of the same migration effort
- **Added/introduced on `session`:**
  - `SessionModel.displayName()` to derive a short UI label from the selected model id (last `/` segment), returning `'unknown'` when no model is selected (including when the stored value is literally `'unknown'`).
  - New session entry points: `session.om`, `session.permissions`, `session.subagents`, with per-role (`observer`/`reflector`) OM operations and persistence/event behavior.

### MastraCode TUI updates
- **Status line** now pulls model identifiers from `state.harness.session.*` APIs (OM roles use `session.om.*.modelId()`, non-OM fallback uses `session.model.get()`), aligning status rendering with the new session ownership.
- **Message rendering** derives `currentModelId` from `state.harness.session.model.get()` (and removes an unnecessary `typeof` capability guard in the process).
- **OM / permissions / subagents commands** now read/write via `ctx.state.session.om` / `ctx.state.session.permissions` / `ctx.state.session.subagents` instead of the removed `Harness` methods.

### Documentation
- Updated harness reference docs to describe the new session APIs:
  - Added `session.model.displayName()` guidance.
  - Reworked Observational Memory docs to use `session.om.observer.*` / `session.om.reflector.*`.
  - Removed outdated/obsolete `Harness` entries from the harness reference (including permissions-related `Harness` methods).

### Tests
- Added a new unit test suite for `harness.session.model.displayName()` with **3 new cases**:
  - returns `'unknown'` when nothing is selected
  - returns the last segment for provider-prefixed IDs
  - returns the full ID when there’s no provider prefix
- Updated/added session-focused tests for OM, permissions, and subagents, and adjusted existing TUI tests/mocks for the new state shape.
- Overall test run reported: **297 existing tests + 3 new `displayName()` cases**, all passing.

## Release / validation
- Changesets record **minor bump for `@mastra/core`** and **patch bump for `mastracode`** to reflect the API migration.
- Validation reported passing:
  - `pnpm build:core`
  - `pnpm --filter ./packages/core check`
  - docs checks (prettier/remark/frontmatter/reference-sidebar)
  - MastraCode TUI `tsc --noEmit`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->