### PR TITLE
refactor(core): move tool-permission rules to session.permissions

### DIFF
--- a/.changeset/silly-walls-attack.md
+++ b/.changeset/silly-walls-attack.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Moved the tool-permission rule accessors off the Harness onto `session.permissions`. Reading and writing the persisted per-category / per-tool approval policies now lives on the session, next to the state it reads and writes.
+
+**Before**
+
+```typescript
+const rules = harness.getPermissionRules();
+harness.setPermissionForCategory({ category: 'execute', policy: 'ask' });
+harness.setPermissionForTool({ toolName: 'dangerous_tool', policy: 'deny' });
+```
+
+**After**
+
+```typescript
+const rules = harness.session.permissions.getRules();
+await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' });
+await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' });
+```
+
+Removed `Harness.getPermissionRules`, `Harness.setPermissionForCategory`, and `Harness.setPermissionForTool`. The setters now return a promise that resolves once the change is persisted to session state, so callers that read the rules back can await the write. Tool-category resolution stays on the harness as `harness.getToolCategory()` since it reads harness config rather than session state.
+
+`mastracode` is updated to consume the new API: the `/permissions` command reads and sets policies via `session.permissions`.

--- a/docs/src/content/en/docs/harness/tool-approvals.mdx
+++ b/docs/src/content/en/docs/harness/tool-approvals.mdx
@@ -23,10 +23,10 @@ Set policies per-category or per-tool. Per-tool policies take precedence over ca
 
 ```typescript
 // Category-level: all execute tools require approval
-harness.setPermissionForCategory({ category: 'execute', policy: 'ask' })
+await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' })
 
 // Tool-level: this specific tool is always blocked
-harness.setPermissionForTool({ toolName: 'dangerous_tool', policy: 'deny' })
+await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' })
 ```
 
 ### Tool categories

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -698,33 +698,6 @@ harness.respondToToolSuspension({
 
 ### Permissions
 
-The harness owns the permission _policy_ — the rules that decide when a tool requires approval. Session-scoped _grants_ (which tools and categories are auto-approved for the current conversation) live on the session: see [`session.grantCategory()`](/reference/harness/session#permissions), [`session.grantTool()`](/reference/harness/session#permissions), and [`session.getGrants()`](/reference/harness/session#permissions).
-
-#### `setPermissionForCategory({ category, policy })`
-
-Set the permission policy for a tool category.
-
-```typescript
-harness.setPermissionForCategory({ category: 'execute', policy: 'ask' })
-```
-
-#### `setPermissionForTool({ toolName, policy })`
-
-Set the permission policy for a specific tool. Per-tool policies take precedence over category policies.
-
-```typescript
-harness.setPermissionForTool({ toolName: 'dangerous_tool', policy: 'deny' })
-```
-
-#### `getPermissionRules()`
-
-Return the current permission rules.
-
-```typescript
-const rules = harness.getPermissionRules()
-// { categories: { execute: 'ask' }, tools: { dangerous_tool: 'deny' } }
-```
-
 #### `getToolCategory({ toolName })`
 
 Resolve a tool's category using the configured `toolCategoryResolver`.

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -380,6 +380,35 @@ Resolve the role's model ID to a model instance via the harness's `resolveModel`
 const observerModel = harness.session.om.observer.resolvedModel()
 ```
 
+## Permissions
+
+`session.permissions` owns the persisted tool-approval _policy_ — the per-category and per-tool rules consulted during approval resolution. These are distinct from the in-memory session _grants_ documented under [Methods → Permissions](#permissions); grants reset each session, whereas these rules are persisted in session state.
+
+### `session.permissions.getRules()`
+
+Return the current permission rules, or empty rules (`{ categories: {}, tools: {} }`) when none are set.
+
+```typescript
+const rules = harness.session.permissions.getRules()
+// { categories: { execute: 'ask' }, tools: { dangerous_tool: 'deny' } }
+```
+
+### `session.permissions.setForCategory({ category, policy })`
+
+Set the approval policy (`'allow' | 'ask' | 'deny'`) for a tool category. Resolves once the change is persisted to session state.
+
+```typescript
+await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' })
+```
+
+### `session.permissions.setForTool({ toolName, policy })`
+
+Set the approval policy for a specific tool. Per-tool policies take precedence over category policies. Resolves once persisted.
+
+```typescript
+await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' })
+```
+
 ## Run
 
 `session.run` owns run and trace identity plus abort state for the in-flight run.

--- a/mastracode/src/tui/commands/permissions.ts
+++ b/mastracode/src/tui/commands/permissions.ts
@@ -14,7 +14,7 @@ export async function handlePermissionsCommand(ctx: SlashCommandContext, args: s
       ctx.showInfo(`Invalid policy: ${policy}. Must be one of: ${validPolicies.join(', ')}`);
       return;
     }
-    ctx.harness.setPermissionForCategory({ category, policy });
+    await ctx.state.session.permissions.setForCategory({ category, policy });
     ctx.showInfo(`Set ${category} policy to: ${policy}`);
     return;
   }
@@ -23,7 +23,7 @@ export async function handlePermissionsCommand(ctx: SlashCommandContext, args: s
 
 async function showPermissions(ctx: SlashCommandContext): Promise<void> {
   const { TOOL_CATEGORIES, getToolsForCategory } = await import('../../permissions.js');
-  const rules = ctx.harness.getPermissionRules();
+  const rules = ctx.state.session.permissions.getRules();
   const grants = ctx.state.session.getGrants();
   const isYolo = (ctx.state.session.state.get() as any)?.yolo === true;
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -54,7 +54,6 @@ import type {
   HarnessThread,
   ModelAuthStatus,
   PermissionPolicy,
-  PermissionRules,
   TokenUsage,
   ToolCategory,
 } from './types';
@@ -513,6 +512,10 @@ export class Harness<TState = {}> {
       emit: event => this.emit(event),
       omConfig: this.config.omConfig,
       resolveModel: this.config.resolveModel,
+    });
+    this.#session.permissions.setResolver({
+      getState: () => this.#session.state.get() as Record<string, unknown>,
+      setState: updates => this.#session.state.set(updates as Partial<TState>),
     });
     this.#session.thread.connect(this.createThreadDataStore());
 
@@ -1637,24 +1640,6 @@ export class Harness<TState = {}> {
     return this.config.toolCategoryResolver?.(toolName) ?? null;
   }
 
-  setPermissionForCategory({ category, policy }: { category: ToolCategory; policy: PermissionPolicy }): void {
-    const rules = this.getPermissionRules();
-    rules.categories[category] = policy;
-    void this.setState({ permissionRules: rules } as unknown as Partial<TState>);
-  }
-
-  setPermissionForTool({ toolName, policy }: { toolName: string; policy: PermissionPolicy }): void {
-    const rules = this.getPermissionRules();
-    rules.tools[toolName] = policy;
-    void this.setState({ permissionRules: rules } as unknown as Partial<TState>);
-  }
-
-  getPermissionRules(): PermissionRules {
-    const state = this.#session.state.get() as Record<string, unknown>;
-    const rules = state.permissionRules as PermissionRules | undefined;
-    return rules ?? { categories: {}, tools: {} };
-  }
-
   /**
    * Resolve whether a tool call should be auto-approved, denied, or asked.
    * Resolution chain: per-tool deny → yolo → per-tool policy → session tool grant →
@@ -1662,7 +1647,7 @@ export class Harness<TState = {}> {
    */
   private resolveToolApproval(toolName: string): PermissionPolicy {
     const state = this.#session.state.get() as Record<string, unknown>;
-    const rules = this.getPermissionRules();
+    const rules = this.#session.permissions.getRules();
 
     const toolPolicy = rules.tools[toolName];
     if (toolPolicy === 'deny') return 'deny';
@@ -3594,7 +3579,7 @@ export class Harness<TState = {}> {
       }
     }
 
-    const permissionRules = this.getPermissionRules();
+    const permissionRules = this.#session.permissions.getRules();
     for (const [toolId, policy] of Object.entries(permissionRules.tools)) {
       if (policy === 'deny') {
         delete builtInTools[toolId];

--- a/packages/core/src/harness/session-permissions.test.ts
+++ b/packages/core/src/harness/session-permissions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+
+function createHarness(storage: InMemoryStore) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new Harness({
+    id: 'test-harness',
+    storage,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+}
+
+describe('session.permissions', () => {
+  let storage: InMemoryStore;
+
+  beforeEach(() => {
+    storage = new InMemoryStore();
+  });
+
+  it('returns empty rules when none are set', () => {
+    const harness = createHarness(storage);
+    expect(harness.session.permissions.getRules()).toEqual({ categories: {}, tools: {} });
+  });
+
+  it('setForCategory persists the policy to session state', async () => {
+    const harness = createHarness(storage);
+
+    await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' });
+
+    expect(harness.session.permissions.getRules().categories.execute).toBe('ask');
+    expect((harness.session.state.get() as any).permissionRules.categories.execute).toBe('ask');
+  });
+
+  it('setForTool persists the policy to session state', async () => {
+    const harness = createHarness(storage);
+
+    await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' });
+
+    expect(harness.session.permissions.getRules().tools.dangerous_tool).toBe('deny');
+    expect((harness.session.state.get() as any).permissionRules.tools.dangerous_tool).toBe('deny');
+  });
+
+  it('reflects rules already present in session state', async () => {
+    const harness = createHarness(storage);
+    await harness.session.state.set({
+      permissionRules: { categories: { read: 'allow' }, tools: {} },
+    } as any);
+
+    expect(harness.session.permissions.getRules().categories.read).toBe('allow');
+  });
+
+  it('merges new policies without dropping existing ones', async () => {
+    const harness = createHarness(storage);
+
+    await harness.session.permissions.setForCategory({ category: 'execute', policy: 'deny' });
+    await harness.session.permissions.setForTool({ toolName: 'fetch', policy: 'allow' });
+
+    const rules = harness.session.permissions.getRules();
+    expect(rules.categories.execute).toBe('deny');
+    expect(rules.tools.fetch).toBe('allow');
+  });
+});

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -17,6 +17,8 @@ import type {
   HarnessRequestStateUpdater,
   HarnessThread,
   ModelUseCountTracker,
+  PermissionPolicy,
+  PermissionRules,
   TokenUsage,
   ToolCategory,
 } from './types';
@@ -1011,6 +1013,49 @@ class SessionOM {
   }
 }
 
+/**
+ * Owns the session's tool-permission rules: the per-category and per-tool
+ * approval policies persisted in session state under `permissionRules`. The
+ * Harness injects the session-state read/write once via {@link setResolver}.
+ *
+ * These are the persisted rules consulted during tool-approval resolution; they
+ * are distinct from the in-memory "allow for this session" grants on the
+ * Session.
+ */
+class SessionPermissions {
+  #getState: (() => Record<string, unknown>) | undefined;
+  #setState: ((updates: Record<string, unknown>) => Promise<void>) | undefined;
+
+  /** Attach the session-state read/write. The Harness injects these once. */
+  setResolver(options: {
+    getState: () => Record<string, unknown>;
+    setState: (updates: Record<string, unknown>) => Promise<void>;
+  }): void {
+    this.#getState = options.getState;
+    this.#setState = options.setState;
+  }
+
+  /** The current permission rules, or empty rules when none are set. */
+  getRules(): PermissionRules {
+    const rules = this.#getState?.().permissionRules as PermissionRules | undefined;
+    return rules ?? { categories: {}, tools: {} };
+  }
+
+  /** Set the approval policy for a tool category. Resolves once persisted. */
+  setForCategory({ category, policy }: { category: ToolCategory; policy: PermissionPolicy }): Promise<void> {
+    const rules = this.getRules();
+    rules.categories[category] = policy;
+    return this.#setState?.({ permissionRules: rules }) ?? Promise.resolve();
+  }
+
+  /** Set the approval policy for an individual tool. Resolves once persisted. */
+  setForTool({ toolName, policy }: { toolName: string; policy: PermissionPolicy }): Promise<void> {
+    const rules = this.getRules();
+    rules.tools[toolName] = policy;
+    return this.#setState?.({ permissionRules: rules }) ?? Promise.resolve();
+  }
+}
+
 type SessionStateUpdater<TState, TResult> = HarnessRequestStateUpdater<TState, TResult>;
 
 interface SessionStateOptions<TState> {
@@ -1659,6 +1704,8 @@ export class Session<TState = unknown> {
   readonly mode = new SessionMode(() => this.#store, this.model);
   /** The session's observational-memory model selection (observer/reflector). */
   readonly om = new SessionOM();
+  /** The session's persisted tool-permission rules (per-category / per-tool). */
+  readonly permissions = new SessionPermissions();
   /** Transient run identity (run id, trace id, operation counter) for the active run. */
   readonly run = new SessionRun();
   /** Live subscription to the active thread's agent event stream. */


### PR DESCRIPTION
## What & why

Continues moving Harness session-state proxies onto the `Session` so reads/writes live next to the state they touch. This PR moves the persisted tool-approval **policy** accessors onto a new `session.permissions`.

Stacked on the observational-memory move (#18201).

## API change

**Before**
```typescript
const rules = harness.getPermissionRules();
harness.setPermissionForCategory({ category: 'execute', policy: 'ask' });
harness.setPermissionForTool({ toolName: 'dangerous_tool', policy: 'deny' });
```

**After**
```typescript
const rules = harness.session.permissions.getRules();
await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' });
await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' });
```

- Removed `Harness.getPermissionRules`, `setPermissionForCategory`, `setPermissionForTool`.
- The setters now **return a promise** that resolves once the change is persisted to session state, so callers reading the rules back can await the write (the old void-returning Harness methods were fire-and-forget).
- `harness.getToolCategory()` **stays on the Harness** — it reads `config.toolCategoryResolver`, not session state.
- The Harness injects the session-state read/write once via `setResolver` and routes its internal approval-resolution reads through `session.permissions.getRules()`.

## Consumers

- MastraCode `/permissions` command reads and sets policies via `session.permissions`.

## Test plan

- `pnpm build:core` + `pnpm --filter ./packages/core check` — clean
- `mastracode` tsc — clean
- `pnpm exec vitest run src/harness` — 312 passing (incl. new `session-permissions.test.ts`, 5 tests)
- docs prettier + remark — clean