### PR TITLE
refactor(core): move subagent model accessors to session.subagents.model

### DIFF
--- a/.changeset/wild-pumas-grow.md
+++ b/.changeset/wild-pumas-grow.md
@@ -1,0 +1,24 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Moved the subagent model accessors off the Harness onto `session.subagents.model`. Reading and setting the global or per-`agentType` subagent model now lives on the session, next to the state it reads and writes, and is grouped under `session.subagents` to leave room for future subagent settings.
+
+**Before**
+
+```typescript
+const modelId = harness.getSubagentModelId({ agentType: 'explore' });
+await harness.setSubagentModelId({ modelId: 'anthropic/claude-sonnet-4', agentType: 'explore' });
+```
+
+**After**
+
+```typescript
+const modelId = harness.session.subagents.model.get({ agentType: 'explore' });
+await harness.session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4', agentType: 'explore' });
+```
+
+`get()` prefers the per-`agentType` value, then the global subagent model, returning `null` when neither is set. `set()` persists to thread settings and emits a `subagent_model_changed` event. Removed `Harness.getSubagentModelId` and `Harness.setSubagentModelId`.
+
+`mastracode` is updated to consume the new API: the `/subagents` command, model-pack activation, and startup model restoration read and set subagent models via `session.subagents.model`.

--- a/docs/src/content/en/docs/harness/subagents.mdx
+++ b/docs/src/content/en/docs/harness/subagents.mdx
@@ -93,16 +93,16 @@ Set a global or per-type subagent model at runtime:
 
 ```typescript
 // Global subagent model
-await harness.setSubagentModelId({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
+await harness.session.subagents.model.set({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
 
 // Per-type override
-await harness.setSubagentModelId({
+await harness.session.subagents.model.set({
   modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__',
   agentType: 'explore',
 })
 
 // Read current model
-const modelId = harness.getSubagentModelId({ agentType: 'explore' })
+const modelId = harness.session.subagents.model.get({ agentType: 'explore' })
 ```
 
 ## Related

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -779,31 +779,6 @@ if (record) {
 
 The observer/reflector model selection and observation/reflection thresholds live on the Session under [`session.om`](/reference/harness/session#observational-memory), grouped by role. Read them with `session.om.observer.modelId()` / `session.om.reflector.modelId()` and `session.om.observer.threshold()` / `session.om.reflector.threshold()`, and change a role's model with `session.om.observer.switchModel()` / `session.om.reflector.switchModel()`.
 
-### Subagents
-
-#### `getSubagentModelId({ agentType? })`
-
-Retrieve the subagent model ID. Prioritizes per-type settings over the global setting.
-
-```typescript
-const modelId = harness.getSubagentModelId({ agentType: 'explore' })
-```
-
-#### `setSubagentModelId({ modelId, agentType? })`
-
-Set the subagent model ID. Pass an `agentType` to set a per-type override, or omit it to set the global default. Persists to thread settings and emits a `subagent_model_changed` event.
-
-```typescript
-// Set global subagent model
-await harness.setSubagentModelId({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
-
-// Set per-type model
-await harness.setSubagentModelId({
-  modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__',
-  agentType: 'explore',
-})
-```
-
 ### Forked subagents
 
 By default, a subagent runs with a fresh context — it doesn't see the parent conversation. **Forked subagents** opt into a different model: the subagent runs on a clone of the parent thread and reuses the parent agent's full configuration. This is useful when the subagent needs the full context of the conversation so far (e.g., recalling earlier user-supplied facts), and when prompt-cache hit rates matter.

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -409,6 +409,33 @@ Set the approval policy for a specific tool. Per-tool policies take precedence o
 await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' })
 ```
 
+## Subagents
+
+`session.subagents` owns subagent configuration. It currently exposes the subagent model selection under `session.subagents.model`.
+
+### `session.subagents.model.get({ agentType? })`
+
+Return the subagent model ID, preferring the per-`agentType` value when one is given, then the global subagent model, or `null` when neither is set.
+
+```typescript
+const modelId = harness.session.subagents.model.get({ agentType: 'explore' })
+```
+
+### `session.subagents.model.set({ modelId, agentType? })`
+
+Set the subagent model ID. Pass an `agentType` to set a per-type override, or omit it to set the global default. Persists to thread settings and emits a `subagent_model_changed` event.
+
+```typescript
+// Set the global subagent model
+await harness.session.subagents.model.set({ modelId: '__GATEWAY_ANTHROPIC_MODEL_SONNET__' })
+
+// Set a per-type override
+await harness.session.subagents.model.set({
+  modelId: '__GATEWAY_ANTHROPIC_MODEL_HAIKU__',
+  agentType: 'explore',
+})
+```
+
 ## Run
 
 `session.run` owns run and trace identity plus abort state for the in-flight run.

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -432,7 +432,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
               },
             },
             workspace: harness.getWorkspace(),
-            getSubagentModelId: params => harness.getSubagentModelId(params),
+            getSubagentModelId: params => harness.session.subagents.model.get(params ?? {}),
           };
           requestContext.set('harness', harnessContext);
 

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -398,7 +398,7 @@ async function applyPack(ctx: SlashCommandContext, pack: ModePack, previousPackI
   for (const [agentType, modeId] of Object.entries(subagentModeMap)) {
     const saModelId = (pack.models as Record<string, string>)[modeId];
     if (saModelId) {
-      await harness.setSubagentModelId({ modelId: saModelId, agentType });
+      await harness.session.subagents.model.set({ modelId: saModelId, agentType });
     }
   }
 

--- a/mastracode/src/tui/commands/subagents.ts
+++ b/mastracode/src/tui/commands/subagents.ts
@@ -37,7 +37,7 @@ async function showSubagentModelListForScope(
     return;
   }
 
-  const currentSubagentModel = ctx.state.harness.getSubagentModelId({ agentType });
+  const currentSubagentModel = ctx.state.session.subagents.model.get({ agentType });
   const scopeLabel = scope === 'global' ? `${agentTypeLabel} · Global` : `${agentTypeLabel} · Thread`;
 
   return new Promise(resolve => {
@@ -50,7 +50,7 @@ async function showSubagentModelListForScope(
         ctx.state.ui.hideOverlay();
         await promptForApiKeyIfNeeded(ctx.state.ui, model, ctx.authStorage);
         try {
-          await ctx.state.harness.setSubagentModelId({ modelId: model.id, agentType });
+          await ctx.state.session.subagents.model.set({ modelId: model.id, agentType });
           if (scope === 'global') {
             const settings = loadSettings();
             settings.models.subagentModels[agentType] = model.id;

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -1303,7 +1303,7 @@ export class MastraTUI {
     for (const [agentType, modeId] of Object.entries(subagentModeMap)) {
       const saModelId = (modePack.models as Record<string, string>)[modeId];
       if (saModelId) {
-        await harness.setSubagentModelId({ modelId: saModelId, agentType });
+        await harness.session.subagents.model.set({ modelId: saModelId, agentType });
       }
     }
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -517,6 +517,12 @@ export class Harness<TState = {}> {
       getState: () => this.#session.state.get() as Record<string, unknown>,
       setState: updates => this.#session.state.set(updates as Partial<TState>),
     });
+    this.#session.subagents.setResolver({
+      getState: () => this.#session.state.get() as Record<string, unknown>,
+      setState: updates => void this.#session.state.set(updates as Partial<TState>),
+      setSetting: ({ key, value }) => this.#session.thread.setSetting({ key, value }),
+      emit: event => this.emit(event),
+    });
     this.#session.thread.connect(this.createThreadDataStore());
 
     // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
@@ -1609,27 +1615,6 @@ export class Harness<TState = {}> {
     } catch {
       return null;
     }
-  }
-
-  // ===========================================================================
-  // Subagent Model Management
-  // ===========================================================================
-
-  getSubagentModelId({ agentType }: { agentType?: string } = {}): string | null {
-    const state = this.#session.state.get() as Record<string, unknown>;
-    if (agentType) {
-      const perType = state[`subagentModelId_${agentType}`];
-      if (typeof perType === 'string') return perType;
-    }
-    const global = state.subagentModelId;
-    return typeof global === 'string' ? global : null;
-  }
-
-  async setSubagentModelId({ modelId, agentType }: { modelId: string; agentType?: string }): Promise<void> {
-    const key = agentType ? `subagentModelId_${agentType}` : 'subagentModelId';
-    void this.setState({ [key]: modelId } as unknown as Partial<TState>);
-    await this.#session.thread.setSetting({ key, value: modelId });
-    this.emit({ type: 'subagent_model_changed', modelId, scope: 'thread', agentType } as HarnessEvent);
   }
 
   // ===========================================================================
@@ -3638,7 +3623,7 @@ export class Harness<TState = {}> {
       abortSignal: this.#session.run.getAbortSignal(),
       workspace: this.workspace,
       emitEvent: event => this.emit(event),
-      getSubagentModelId: params => this.getSubagentModelId(params),
+      getSubagentModelId: params => this.#session.subagents.model.get(params ?? {}),
     };
 
     requestContext.set('harness', harnessContext);

--- a/packages/core/src/harness/session-subagents.test.ts
+++ b/packages/core/src/harness/session-subagents.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+import type { HarnessEvent } from './types';
+
+function createHarness(options: { storage: InMemoryStore; onEvent?: (event: HarnessEvent) => void }) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  const harness = new Harness({
+    id: 'test-harness',
+    storage: options.storage,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+
+  if (options.onEvent) harness.subscribe(options.onEvent);
+
+  return harness;
+}
+
+describe('session.subagents.model', () => {
+  let storage: InMemoryStore;
+
+  beforeEach(() => {
+    storage = new InMemoryStore();
+  });
+
+  it('returns null when no subagent model is set', () => {
+    const harness = createHarness({ storage });
+    expect(harness.session.subagents.model.get()).toBeNull();
+    expect(harness.session.subagents.model.get({ agentType: 'explore' })).toBeNull();
+  });
+
+  it('set (global) persists to thread settings and emits subagent_model_changed', async () => {
+    const events: HarnessEvent[] = [];
+    const harness = createHarness({ storage, onEvent: event => events.push(event) });
+    await harness.init();
+    await harness.createThread();
+
+    await harness.session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4' });
+
+    expect(harness.session.subagents.model.get()).toBe('anthropic/claude-sonnet-4');
+    expect(await harness.session.thread.getSetting({ key: 'subagentModelId' })).toBe('anthropic/claude-sonnet-4');
+    expect(events).toContainEqual({
+      type: 'subagent_model_changed',
+      modelId: 'anthropic/claude-sonnet-4',
+      scope: 'thread',
+      agentType: undefined,
+    });
+  });
+
+  it('set (per agentType) persists under an agentType-scoped key', async () => {
+    const harness = createHarness({ storage });
+    await harness.init();
+    await harness.createThread();
+
+    await harness.session.subagents.model.set({ modelId: 'openai/gpt-4o-mini', agentType: 'explore' });
+
+    expect(harness.session.subagents.model.get({ agentType: 'explore' })).toBe('openai/gpt-4o-mini');
+    expect(await harness.session.thread.getSetting({ key: 'subagentModelId_explore' })).toBe('openai/gpt-4o-mini');
+  });
+
+  it('prefers the per-agentType value over the global value', async () => {
+    const harness = createHarness({ storage });
+    await harness.init();
+    await harness.createThread();
+
+    await harness.session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4' });
+    await harness.session.subagents.model.set({ modelId: 'openai/gpt-4o-mini', agentType: 'explore' });
+
+    expect(harness.session.subagents.model.get({ agentType: 'explore' })).toBe('openai/gpt-4o-mini');
+    // An agentType with no specific override falls back to the global value.
+    expect(harness.session.subagents.model.get({ agentType: 'plan' })).toBe('anthropic/claude-sonnet-4');
+  });
+});

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -1056,6 +1056,86 @@ class SessionPermissions {
   }
 }
 
+/** The session-state / thread-settings key holding a subagent model id. */
+function subagentModelKey(agentType?: string): string {
+  return agentType ? `subagentModelId_${agentType}` : 'subagentModelId';
+}
+
+/**
+ * The subagent model selection. Reads prefer the per-`agentType` value and fall
+ * back to the global subagent model; writes persist to thread settings and emit
+ * a `subagent_model_changed` event. Wiring is injected by
+ * {@link SessionSubagents.setResolver}.
+ */
+class SessionSubagentModel {
+  #getState: (() => Record<string, unknown>) | undefined;
+  #setState: ((updates: Record<string, unknown>) => void) | undefined;
+  #setSetting: ((args: { key: string; value: unknown }) => Promise<void>) | undefined;
+  #emit: ((event: HarnessEvent) => void) | undefined;
+
+  /** @internal Injected by {@link SessionSubagents.setResolver}. */
+  setWiring(wiring: {
+    getState: () => Record<string, unknown>;
+    setState: (updates: Record<string, unknown>) => void;
+    setSetting: (args: { key: string; value: unknown }) => Promise<void>;
+    emit: (event: HarnessEvent) => void;
+  }): void {
+    this.#getState = wiring.getState;
+    this.#setState = wiring.setState;
+    this.#setSetting = wiring.setSetting;
+    this.#emit = wiring.emit;
+  }
+
+  /**
+   * The subagent model id, preferring the `agentType`-specific value when one is
+   * given, then the global subagent model, or `null` when neither is set.
+   */
+  get({ agentType }: { agentType?: string } = {}): string | null {
+    const state = this.#getState?.() ?? {};
+    if (agentType) {
+      const perType = state[subagentModelKey(agentType)];
+      if (typeof perType === 'string') return perType;
+    }
+    const global = state.subagentModelId;
+    return typeof global === 'string' ? global : null;
+  }
+
+  /**
+   * Set the subagent model id (per-`agentType` when given, otherwise global).
+   * Persists to thread settings and emits `subagent_model_changed`.
+   */
+  async set({ modelId, agentType }: { modelId: string; agentType?: string }): Promise<void> {
+    const key = subagentModelKey(agentType);
+    this.#setState?.({ [key]: modelId });
+    await this.#setSetting?.({ key, value: modelId });
+    this.#emit?.({ type: 'subagent_model_changed', modelId, scope: 'thread', agentType });
+  }
+}
+
+/**
+ * The session's subagent configuration. Currently exposes the subagent model
+ * selection under {@link SessionSubagents.model}; grouped under `subagents` to
+ * leave room for additional subagent settings. The Harness injects the
+ * session-state read/write, thread-settings persistence, and event emitter once
+ * via {@link setResolver}.
+ */
+class SessionSubagents {
+  readonly model = new SessionSubagentModel();
+
+  /**
+   * Attach the session-state read/write, thread-settings persistence, and event
+   * emitter. The Harness injects these once.
+   */
+  setResolver(options: {
+    getState: () => Record<string, unknown>;
+    setState: (updates: Record<string, unknown>) => void;
+    setSetting: (args: { key: string; value: unknown }) => Promise<void>;
+    emit: (event: HarnessEvent) => void;
+  }): void {
+    this.model.setWiring(options);
+  }
+}
+
 type SessionStateUpdater<TState, TResult> = HarnessRequestStateUpdater<TState, TResult>;
 
 interface SessionStateOptions<TState> {
@@ -1706,6 +1786,8 @@ export class Session<TState = unknown> {
   readonly om = new SessionOM();
   /** The session's persisted tool-permission rules (per-category / per-tool). */
   readonly permissions = new SessionPermissions();
+  /** The session's subagent configuration (currently the subagent model). */
+  readonly subagents = new SessionSubagents();
   /** Transient run identity (run id, trace id, operation counter) for the active run. */
   readonly run = new SessionRun();
   /** Live subscription to the active thread's agent event stream. */


### PR DESCRIPTION
## What & why

Continues moving Harness session-state proxies onto the `Session` so reads/writes live next to the state they touch. This PR moves the subagent model accessors onto a new `session.subagents.model`.

Grouped under `session.subagents` (rather than a flat `session.subagentModel`) to leave room for future subagent settings.

Stacked on the `session.permissions` PR.

## API change

**Before**
```typescript
const modelId = harness.getSubagentModelId({ agentType: 'explore' });
await harness.setSubagentModelId({ modelId: 'anthropic/claude-sonnet-4', agentType: 'explore' });
```

**After**
```typescript
const modelId = harness.session.subagents.model.get({ agentType: 'explore' });
await harness.session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4', agentType: 'explore' });
```

- `get()` prefers the per-`agentType` value, then the global subagent model, returning `null` when neither is set.
- `set()` persists to thread settings and emits `subagent_model_changed`.
- Removed `Harness.getSubagentModelId` / `setSubagentModelId`.
- The harness-context `getSubagentModelId` callback (passed to tools) now delegates to `session.subagents.model.get()`.

## Consumers

- MastraCode `/subagents` command, model-pack activation, and startup model restoration read/set via `session.subagents.model`.

## Test plan

- `pnpm build:core` + `pnpm --filter ./packages/core check` — clean
- `mastracode` tsc — clean
- `pnpm exec vitest run src/harness` — 316 passing (incl. new `session-subagents.test.ts`, 4 tests)
- e2e: `models-pack-activation-persistence` passes; `subagent-model-startup-restore` is pre-skipped on main (unrelated delegation-rendering reason)
- docs prettier + remark — clean