### PR TITLE
refactor(core): remove deprecated Harness.getState/setState wrappers

### DIFF
--- a/.changeset/brave-melons-rest.md
+++ b/.changeset/brave-melons-rest.md
@@ -1,0 +1,24 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Removed the deprecated `Harness.getState()` and `Harness.setState()` compatibility wrappers, along with the unused private `updateState`. Harness state has lived on the session for a while; these were thin proxies marked `@deprecated`.
+
+**Before**
+
+```typescript
+const state = harness.getState();
+await harness.setState({ count: 1 });
+```
+
+**After**
+
+```typescript
+const state = harness.session.state.get();
+await harness.session.state.set({ count: 1 });
+```
+
+This does not affect the tool-facing harness context, which continues to expose `state` / `getState` / `setState` / `updateState` alongside `session.state`.
+
+`mastracode` is updated to set browser settings via `session.state.set()`.

--- a/mastracode/e2e/terminal-backend.ts
+++ b/mastracode/e2e/terminal-backend.ts
@@ -358,7 +358,7 @@ async function startMastraCodeApp(
     const browser = await createBrowserFromSettings(settings.browser);
     if (browser) {
       result.harness.setBrowser(browser);
-      await result.harness.setState({ activeBrowserSettings: settings.browser });
+      await result.harness.session.state.set({ activeBrowserSettings: settings.browser });
     }
   }
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -874,37 +874,6 @@ export class Harness<TState = {}> {
   }
 
   // ===========================================================================
-  // State Management
-  // ===========================================================================
-
-  /**
-   * Get current harness state (read-only snapshot).
-   * @deprecated Prefer `harness.session.state.get()`.
-   */
-  getState(): Readonly<TState> {
-    return this.#session.state.get();
-  }
-
-  /**
-   * Update harness state. Validates against schema if provided.
-   * Emits state_changed event.
-   * @deprecated Prefer `harness.session.state.set(...)`.
-   */
-  async setState(updates: Partial<TState>): Promise<void> {
-    return this.#session.state.set(updates);
-  }
-
-  private async updateState<TResult>(
-    updater: (
-      state: Readonly<TState>,
-    ) =>
-      | { updates?: Partial<TState>; events?: HarnessEvent[]; result: TResult }
-      | Promise<{ updates?: Partial<TState>; events?: HarnessEvent[]; result: TResult }>,
-  ): Promise<TResult> {
-    return this.#session.state.update(updater);
-  }
-
-  // ===========================================================================
   // Mode Management
   // ===========================================================================
 
@@ -1462,7 +1431,7 @@ export class Harness<TState = {}> {
       }
 
       if (Object.keys(updates).length > 0) {
-        await this.setState(updates as unknown as Partial<TState>);
+        await this.#session.state.set(updates as unknown as Partial<TState>);
       }
 
       if (!hasObservationThreshold) {

--- a/packages/core/src/harness/om-threshold-persistence.test.ts
+++ b/packages/core/src/harness/om-threshold-persistence.test.ts
@@ -33,17 +33,17 @@ describe('Harness OM threshold persistence', () => {
     await harness.init();
 
     const threadA = await harness.createThread();
-    await harness.setState({ observationThreshold: 12000, reflectionThreshold: 21000 } as any);
+    await harness.session.state.set({ observationThreshold: 12000, reflectionThreshold: 21000 } as any);
     await harness.session.thread.setSetting({ key: 'observationThreshold', value: 12000 });
     await harness.session.thread.setSetting({ key: 'reflectionThreshold', value: 21000 });
 
     await harness.createThread();
-    await harness.setState({ observationThreshold: 33000, reflectionThreshold: 44000 } as any);
+    await harness.session.state.set({ observationThreshold: 33000, reflectionThreshold: 44000 } as any);
 
     await harness.switchThread({ threadId: threadA.id });
 
-    expect((harness.getState() as any).observationThreshold).toBe(12000);
-    expect((harness.getState() as any).reflectionThreshold).toBe(21000);
+    expect((harness.session.state.get() as any).observationThreshold).toBe(12000);
+    expect((harness.session.state.get() as any).reflectionThreshold).toBe(21000);
   });
 
   it('persists current thresholds onto an existing thread when metadata does not define overrides', async () => {
@@ -54,12 +54,12 @@ describe('Harness OM threshold persistence', () => {
     await harness.init();
 
     const thread = await harness.createThread();
-    await harness.setState({ observationThreshold: 18000, reflectionThreshold: 28000 } as any);
+    await harness.session.state.set({ observationThreshold: 18000, reflectionThreshold: 28000 } as any);
 
     await harness.switchThread({ threadId: thread.id });
 
-    expect((harness.getState() as any).observationThreshold).toBe(18000);
-    expect((harness.getState() as any).reflectionThreshold).toBe(28000);
+    expect((harness.session.state.get() as any).observationThreshold).toBe(18000);
+    expect((harness.session.state.get() as any).reflectionThreshold).toBe(28000);
 
     const memory = await storage.getStore('memory');
     const savedThread = await memory?.getThreadById({ threadId: thread.id });

--- a/packages/core/src/harness/session-state.test.ts
+++ b/packages/core/src/harness/session-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { Harness } from './harness';
 import type { HarnessConfig, HarnessEvent } from './types';
@@ -28,7 +28,7 @@ describe('Harness session state', () => {
     });
 
     expect(harness.session.state.get()).toEqual({ count: 1, label: 'ready' });
-    expect(harness.getState()).toEqual({ count: 1, label: 'ready' });
+    expect(harness.session.state.get()).toEqual({ count: 1, label: 'ready' });
   });
 
   it('get() returns a shallow snapshot', () => {
@@ -101,20 +101,6 @@ describe('Harness session state', () => {
     expect(harness.session.state.get()).toEqual({ count: 2 });
   });
 
-  it('keeps Harness compatibility wrappers delegated to session.state', async () => {
-    const harness = createHarness<{ count: number }>({ initialState: { count: 0 } });
-    const setSpy = vi.spyOn(harness.session.state, 'set');
-
-    await harness.setState({ count: 2 });
-    const result = await (
-      harness as unknown as { updateState: Harness<{ count: number }>['session']['state']['update'] }
-    ).updateState(state => ({ updates: { count: state.count + 1 }, result: state.count }));
-
-    expect(setSpy).toHaveBeenCalledWith({ count: 2 });
-    expect(result).toBe(2);
-    expect(harness.getState()).toEqual({ count: 3 });
-    expect(harness.session.state.get()).toEqual({ count: 3 });
-  });
 
   it('exposes session.state and deprecated flattened state accessors in request context', async () => {
     const harness = createHarness<{ count: number }>({ initialState: { count: 0 } });

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -1250,8 +1250,7 @@ class SessionState<TState = unknown> {
  *
  * Currently owns:
  * - the live Harness state (`session.state`): schema-validated snapshots and
- *   serialized updates that emit `state_changed`. `Harness.getState()` /
- *   `Harness.setState()` are compatibility wrappers over this domain.
+ *   serialized updates that emit `state_changed`.
  * - session-scoped permission grants — the "allow for this session" approvals a
  *   user makes when a tool or tool category is gated behind the permission check.
  * - the live token-usage counter for the active thread. The Session holds the

--- a/packages/core/src/harness/task-tools.test.ts
+++ b/packages/core/src/harness/task-tools.test.ts
@@ -155,24 +155,24 @@ describe('assignTaskIds', () => {
 
 // Generic harness state serialization. Tasks are no longer a harness session
 // state source of truth (they live on the agent state-signal lane), so these
-// tests exercise `updateState`/`setState` ordering with neutral state keys.
+// tests exercise `session.state.update`/`session.state.set` ordering with neutral state keys.
 describe('harness state transactions', () => {
   it('serializes state updates against the latest committed state', async () => {
     const harness = createHarness();
-    await harness.setState({ counter: 0 });
+    await harness.session.state.set({ counter: 0 });
 
     let releaseFirst!: () => void;
     const firstUpdateGate = new Promise<void>(resolve => {
       releaseFirst = resolve;
     });
 
-    const firstUpdate = (harness as any).updateState(async (state: Record<string, unknown>) => {
+    const firstUpdate = harness.session.state.update(async (state: Record<string, unknown>) => {
       await firstUpdateGate;
       const next = (state.counter as number) + 1;
       return { updates: { counter: next }, result: next };
     });
 
-    const secondUpdate = (harness as any).updateState((state: Record<string, unknown>) => {
+    const secondUpdate = harness.session.state.update((state: Record<string, unknown>) => {
       expect(state.counter).toBe(1);
       const next = (state.counter as number) + 1;
       return { updates: { counter: next }, result: next };
@@ -181,7 +181,7 @@ describe('harness state transactions', () => {
     releaseFirst();
     await Promise.all([firstUpdate, secondUpdate]);
 
-    expect(harness.getState().counter).toBe(2);
+    expect(harness.session.state.get().counter).toBe(2);
   });
 
   it('serializes direct setState calls with queued state transactions', async () => {
@@ -219,8 +219,8 @@ describe('harness state transactions', () => {
       ],
     });
 
-    const setStatePromise = harness.setState({ seed: 'initial' });
-    const transactionPromise = (harness as any).updateState((state: Record<string, unknown>) => {
+    const setStatePromise = harness.session.state.set({ seed: 'initial' });
+    const transactionPromise = harness.session.state.update((state: Record<string, unknown>) => {
       expect(state.seed).toBe('initial');
       return { updates: { marker: 'after-set-state' }, result: undefined };
     });
@@ -228,7 +228,7 @@ describe('harness state transactions', () => {
     releaseValidation();
     await Promise.all([setStatePromise, transactionPromise]);
 
-    expect(harness.getState()).toMatchObject({
+    expect(harness.session.state.get()).toMatchObject({
       seed: 'initial',
       marker: 'after-set-state',
     });
@@ -321,6 +321,6 @@ describe('task tool display bridge', () => {
     ]);
 
     // Tasks are no longer mirrored into harness session state.
-    expect(harness.getState().tasks).toBeUndefined();
+    expect(harness.session.state.get().tasks).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What & why

Closes out the single-session API cleanup by removing the last deprecated state proxies on the Harness. `Harness.getState()` / `setState()` were `@deprecated` thin wrappers over `session.state.*`; the private `updateState()` had no remaining callers.

Stacked on the `session.subagents.model` PR.

## API change

**Before**
```typescript
const state = harness.getState();
await harness.setState({ count: 1 });
```

**After**
```typescript
const state = harness.session.state.get();
await harness.session.state.set({ count: 1 });
```

- Removed `Harness.getState`, `Harness.setState`, and the unused private `Harness.updateState`.
- Internal OM threshold hydration now calls `session.state.set()` directly.
- **The tool-facing harness context is unaffected** — it still exposes `state` / `getState` / `setState` / `updateState` alongside `session.state` (separate consumer surface).

## Consumers

- mastracode e2e terminal backend sets browser settings via `session.state.set()`.

## Test plan

- `pnpm build:core` + `pnpm --filter ./packages/core check` — clean
- `mastracode` tsc — clean
- `pnpm exec vitest run src/harness` — 315 passing (removed one obsolete wrapper-delegation test; retargeted serialization tests to `session.state.update`)

## Note

This is the final clean extraction in the single-session series. Remaining Harness methods (run control, threads, subscribe, workspace/browser/heartbeat) are entangled with Harness-owned resources (`listeners`, `workspace`, `browser`, memory) and belong to the future multi-session "session factory" work, not piecemeal getter moves.