### PR TITLE
chore(playground): command palette search follow-ups

### DIFF
--- a/.changeset/heavy-colts-start.md
+++ b/.changeset/heavy-colts-start.md
@@ -2,4 +2,10 @@
 '@mastra/playground-ui': minor
 ---
 
-Improved command palette keyboard handling, input affordance/style slots, scroll-area-backed lists, shortcut labels, overlay behavior, and inline examples.
+Added more layout control to the command palette primitives.
+
+- **`CommandDialog`**: new `showOverlay`, `overlayClassName`, `contentClassName`, and `commandClassName` props. `Escape` now reaches the dialog close handler while other keys are still stopped from leaking to global listeners.
+- **`CommandInput`**: new `rightSlot` prop for inline hints (e.g. an `Esc` chip) and a `wrapperClassName`.
+- **`CommandList`**: new `scrollArea` mode that wraps the list in `ScrollArea` for masked, scrollable results.
+- **`DialogContent`**: new `showOverlay` and `overlayClassName` props so a dialog can opt out of the page-dimming overlay.
+- **`useKeyboardShortcutLabel`**: new hook that renders platform-aware shortcut labels (⌘ on Apple, Ctrl elsewhere).

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -134,7 +134,6 @@ export function AppSidebar() {
             link={{
               name: 'Search',
               url: '#',
-              icon: <Search />,
             }}
           >
             <button


### PR DESCRIPTION
Follow-up cleanup after #18142 (merged), addressing the non-blocking review nits.

## Changes
- **Sidebar Search nav link**: removed the unused `icon: <Search />` from the `link` prop. With `asChild`, `MainSidebarNavLink` slots the button's own `<Search />` and only uses `link` for the collapsed tooltip, so the prop's icon was never rendered.
- **Changeset**: rewrote the `@mastra/playground-ui` entry into scannable, per-prop release notes (`CommandDialog` / `CommandInput` / `CommandList` / `DialogContent` props + `useKeyboardShortcutLabel`).

## Not done (and why)
- CodeRabbit's Stylelint `declaration-empty-line-before` suggestion on `navigation-command.css` is a **false positive** — this repo has no Stylelint config or lint step, and the CSS already matches the file's existing style. No change.

## Validation
- `pnpm --filter ./packages/playground typecheck` — pass
- `eslint` on the edited `app-sidebar.tsx` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR cleans up some leftover code from a previous change and improves documentation. It removes an icon property that wasn't actually being used in the sidebar search button, and rewrites the release notes to better explain the new features that were added to the UI library.

## Changes Overview

### Sidebar Navigation Cleanup
- Removed the unused `icon: <Search />` prop from the sidebar search navigation link in `MainSidebarNavLink`
- The icon is already rendered directly within the button component itself (via the `asChild` prop), so the redundant prop declaration in the `link` object was removed

### Changeset Documentation Update
- Rewrote the `@mastra/playground-ui` changeset entry with more detailed, scannable release notes organized by specific component
- Added documentation for:
  - `CommandDialog`: overlay and className controls, Escape key handling
  - `CommandInput`: `rightSlot` prop for inline hints, `wrapperClassName` 
  - `CommandList`: `scrollArea` mode for rendering results in a ScrollArea
  - `DialogContent`: overlay opt-out controls
  - `useKeyboardShortcutLabel` hook: platform-aware keyboard shortcut label rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->