### PR TITLE
fix(playground): add pointer cursor to agent header copy

### DIFF
--- a/packages/playground/src/domains/agents/components/agent-entity-header.tsx
+++ b/packages/playground/src/domains/agents/components/agent-entity-header.tsx
@@ -30,7 +30,7 @@ export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
               type="button"
               onClick={handleCopy}
               aria-label="Copy Agent ID for use in code"
-              className="group/agent-title text-neutral6 flex min-w-0 max-w-full items-center gap-2"
+              className="group/agent-title text-neutral6 flex min-w-0 max-w-full cursor-pointer items-center gap-2"
               data-testid="agent-entity-header-copy-id"
             >
               <span className="flex size-7 shrink-0 items-center justify-center">


### PR DESCRIPTION
This fixes the agent header copy trigger so it uses a pointer cursor like an interactive control. The button already handled copy and tooltip behavior; it was only missing the cursor affordance.

Validation: `git diff --check`, `pnpm exec eslint packages/playground/src/domains/agents/components/agent-entity-header.tsx`, `pnpm --filter ./packages/playground typecheck`, `pnpm --filter ./packages/playground build`, and `npx -y react-doctor@latest . --scope changed --base origin/main --verbose`.

Note: full `pnpm --filter ./packages/playground lint` still fails on a pre-existing import-order issue in `packages/playground/src/domains/workflows/workflow/use-workflow-graph-runtime.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR makes a button that copies an agent ID look more clickable by adding a pointer cursor (the hand icon you see when hovering over links). The button already worked and showed a tooltip, it just needed this visual cue to tell users they can click it.

## Summary

Adds the `cursor-pointer` Tailwind CSS class to the copy button in the agent header component (`AgentEntityHeader`) in the playground package. This provides a visual affordance indicating to users that the button is interactive and clickable.

The change was made to:
- `packages/playground/src/domains/agents/components/agent-entity-header.tsx`

The modification adds the missing cursor style to the button's className while preserving existing layout, truncation behavior, and group-based hover/focus states that control the visibility of the copy icon.

## Validation

The author verified the changes using:
- `git diff --check` for whitespace verification
- ESLint check on the modified file
- TypeScript type checking for the playground package
- Build verification for the playground package
- React Doctor analysis on changed files against the main branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->