### PR TITLE
fix(playground): use ghost buttons for assistant actions

### DIFF
--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -140,7 +140,8 @@ const CopyButton = ({ text }: { text: string }) => {
   const [copied, setCopied] = useState(false);
   return (
     <Button
-      size="icon-md"
+      variant="ghost"
+      size="xs"
       tooltip="Copy"
       aria-label="Copy"
       onClick={() => {
@@ -178,11 +179,17 @@ const AssistantActionBar = ({
     )}
     {(onReadAloud || onStopSpeaking) &&
       (isSpeaking ? (
-        <Button size="icon-md" tooltip="Stop" aria-label="Stop" onClick={() => onStopSpeaking?.()}>
+        <Button variant="ghost" size="xs" tooltip="Stop" aria-label="Stop" onClick={() => onStopSpeaking?.()}>
           <StopCircleIcon />
         </Button>
       ) : (
-        <Button size="icon-md" tooltip="Read aloud" aria-label="Read aloud" onClick={() => onReadAloud?.(text)}>
+        <Button
+          variant="ghost"
+          size="xs"
+          tooltip="Read aloud"
+          aria-label="Read aloud"
+          onClick={() => onReadAloud?.(text)}
+        >
           <AudioLinesIcon />
         </Button>
       ))}

--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -141,7 +141,7 @@ const CopyButton = ({ text }: { text: string }) => {
   return (
     <Button
       variant="ghost"
-      size="xs"
+      size="icon-xs"
       tooltip="Copy"
       aria-label="Copy"
       onClick={() => {
@@ -179,13 +179,13 @@ const AssistantActionBar = ({
     )}
     {(onReadAloud || onStopSpeaking) &&
       (isSpeaking ? (
-        <Button variant="ghost" size="xs" tooltip="Stop" aria-label="Stop" onClick={() => onStopSpeaking?.()}>
+        <Button variant="ghost" size="icon-xs" tooltip="Stop" aria-label="Stop" onClick={() => onStopSpeaking?.()}>
           <StopCircleIcon />
         </Button>
       ) : (
         <Button
           variant="ghost"
-          size="xs"
+          size="icon-xs"
           tooltip="Read aloud"
           aria-label="Read aloud"
           onClick={() => onReadAloud?.(text)}


### PR DESCRIPTION
This switches the assistant message action controls from default medium icon buttons to compact `icon-xs` ghost buttons, matching the requested action bar styling while keeping the existing tooltips and aria labels.

Validated with `pnpm exec prettier --check packages/playground/src/lib/ai-ui/messages/message-row.tsx`, `pnpm --dir packages/playground exec eslint src/lib/ai-ui/messages/message-row.tsx`, `pnpm --filter ./packages/playground typecheck`, and `git diff --check`. I also ran the required changeset command; the custom CLI exited without creating a changeset because it detected zero changed packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the buttons that control assistant messages in the playground smaller and uses a lighter visual style. Instead of regular-sized buttons, they're now tiny "ghost" buttons (buttons with minimal styling), which gives the interface a more compact appearance.

## Changes

The pull request modifies `packages/playground/src/lib/ai-ui/messages/message-row.tsx` to update the styling of assistant message action controls:

- Switches action buttons from default icon buttons to compact extra-small (xs) ghost buttons
- Updates the copy button to use `icon-xs` sizing with `variant="ghost"` styling
- Reduces the "Stop" and "Read aloud" buttons to `icon-xs` size
- Preserves all existing tooltips and aria labels for accessibility

## Implementation Details

The change was implemented through two commits:
1. First commit: Switches assistant action controls to ghost button styling
2. Second commit: Refines icon sizing for the assistant actions

## Validation

All checks passed:
- Prettier (code formatting)
- ESLint (linting)
- TypeScript type checking
- Git diff (whitespace validation)

The changeset command detected zero changed packages and did not create a changeset file.

**Lines changed:** +10/-3  
**Complexity:** Low  
**Tests added:** None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->