### PR TITLE
Fix Browser Agent template Linux browser dependencies

### DIFF
--- a/templates/template-browser-agent/README.md
+++ b/templates/template-browser-agent/README.md
@@ -12,13 +12,13 @@ This demo runs in Mastra Studio, but you can connect this agent to your React, N
 
 - A [Mastra Gateway API key](https://mastra.ai/docs/models/gateways/mastra).
 - A [Turso](https://turso.tech) database URL + auth token (or swap to `:memory:` for ephemeral local runs).
-- Playwright Chromium is installed by the `playwright-chromium` package during dependency install. Linux server images also need Chromium system libraries available in the runtime image, or you can set `BROWSER_CDP_URL` for a hosted Chrome/Browserbase/Browserless instance.
+- Playwright Chromium is installed by the `playwright-chromium` package during dependency install. On Linux root runtimes, the template runs `playwright install-deps chromium` before the first local browser launch. You can set `BROWSER_CDP_URL` for a hosted Chrome/Browserbase/Browserless instance instead.
 
 ## Quickstart 🚀
 
 1. **Add your API keys**
    - Copy `.env.example` to `.env` and fill it in. Set `BROWSER_HEADLESS=false` if you want to watch the agent click around locally.
-   - For server deployments, either use an image that already includes Playwright's Chromium system dependencies or set `BROWSER_CDP_URL` to a hosted browser endpoint.
+   - For server deployments, leave `BROWSER_SKIP_INSTALL_DEPS=false` so Linux Chromium system dependencies are installed before first browser use, or set `BROWSER_CDP_URL` to a hosted browser endpoint.
 2. **Start the dev server**
    - Run `npm run dev` and open [localhost:4111](http://localhost:4111).
 
@@ -43,7 +43,7 @@ export const browserAgent = new Agent({
 });
 ```
 
-Passing `browser` to the agent automatically registers the full browser toolset (`browser_goto`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_scroll`, `browser_screenshot`, etc.) on the agent. For hosted environments that do not include local Chromium dependencies, set `BROWSER_CDP_URL` to connect to a remote browser instead.
+Passing `browser` to the agent automatically registers the full browser toolset (`browser_goto`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_scroll`, `browser_screenshot`, etc.) on the agent. The template installs Playwright's Linux system dependencies before first local browser launch when running as root; set `BROWSER_CDP_URL` to connect to a remote browser instead.
 
 ## Making it yours
 

--- a/templates/template-browser-agent/src/mastra/agents/browser-agent.ts
+++ b/templates/template-browser-agent/src/mastra/agents/browser-agent.ts
@@ -42,6 +42,7 @@ async function installPlaywrightLinuxDeps() {
     });
 
     const timeout = setTimeout(() => {
+      installDepsPromise = undefined;
       child.kill('SIGTERM');
       reject(new Error('Timed out installing Playwright Chromium system dependencies'));
     }, 120_000);

--- a/templates/template-browser-agent/src/mastra/agents/browser-agent.ts
+++ b/templates/template-browser-agent/src/mastra/agents/browser-agent.ts
@@ -1,12 +1,82 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
-import { AgentBrowser } from '@mastra/agent-browser';
+import { AgentBrowser, AgentBrowserThreadManager } from '@mastra/agent-browser';
+import type { AgentBrowserThreadManagerConfig } from '@mastra/agent-browser';
+import { createRequire } from 'node:module';
+import { dirname, join, normalize } from 'node:path';
+import { spawn } from 'node:child_process';
 import 'playwright-chromium';
+
+const require = createRequire(import.meta.url);
+let installDepsPromise: Promise<void> | undefined;
+
+function shouldInstallLinuxDeps() {
+  return (
+    process.platform === 'linux' &&
+    typeof process.getuid === 'function' &&
+    process.getuid() === 0 &&
+    process.env.BROWSER_SKIP_INSTALL_DEPS !== 'true' &&
+    !process.env.BROWSER_CDP_URL
+  );
+}
+
+function resolvePlaywrightCli() {
+  const packageEntry = require.resolve('playwright-chromium');
+  const cliPath = normalize(join(dirname(packageEntry), 'cli.js'));
+
+  if (!cliPath.endsWith('/node_modules/playwright-chromium/cli.js')) {
+    throw new Error(`Unexpected playwright-chromium CLI path: ${cliPath}`);
+  }
+
+  return cliPath;
+}
+
+async function installPlaywrightLinuxDeps() {
+  if (!shouldInstallLinuxDeps()) return;
+
+  installDepsPromise ??= new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, [resolvePlaywrightCli(), 'install-deps', 'chromium'], {
+      shell: false,
+      stdio: 'inherit',
+    });
+
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error('Timed out installing Playwright Chromium system dependencies'));
+    }, 120_000);
+
+    child.once('error', error => {
+      clearTimeout(timeout);
+      installDepsPromise = undefined;
+      reject(error);
+    });
+
+    child.once('exit', code => {
+      clearTimeout(timeout);
+      if (code === 0) {
+        resolve();
+      } else {
+        installDepsPromise = undefined;
+        reject(new Error(`Failed to install Playwright Chromium system dependencies: exit code ${code}`));
+      }
+    });
+  });
+
+  await installDepsPromise;
+}
+
+class RuntimeDepsThreadManager extends AgentBrowserThreadManager {
+  protected override async createSession(threadId: string) {
+    await installPlaywrightLinuxDeps();
+    return super.createSession(threadId);
+  }
+}
 
 const browser = new AgentBrowser({
   headless: process.env.BROWSER_HEADLESS !== 'false',
   ...(process.env.BROWSER_CDP_URL ? { cdpUrl: process.env.BROWSER_CDP_URL, scope: 'shared' as const } : {}),
+  createThreadManager: (config: AgentBrowserThreadManagerConfig) => new RuntimeDepsThreadManager(config),
 });
 
 export const browserAgent = new Agent({


### PR DESCRIPTION
## Summary
- install Playwright Chromium Linux system dependencies lazily before the Browser Agent launches a local browser
- keep server startup unblocked by deferring the install until first browser session creation
- skip the install for remote browser/CDP deployments, non-Linux runtimes, non-root runtimes, or when BROWSER_SKIP_INSTALL_DEPS=true

## Test plan
- Fresh standalone Browser Agent template: npm install --ignore-workspace
- Fresh standalone Browser Agent template: npx tsc --noEmit
- Fresh standalone Browser Agent template: npm run build
- Fresh standalone Browser Agent template: npx mastra lint --preflight
- Fresh standalone Browser Agent template: npm run start reaches Mastra API running
- Verified playwright-chromium/cli.js resolves in deploy-style install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR stops the Browser Agent server from “stalling” while it installs big Chromium/Linux dependencies. Instead, it installs those dependencies only the first time a local browser session is created (and it skips the install for remote/CDP or when explicitly disabled).

## Changes

### `templates/template-browser-agent/README.md`
- Updated docs to explain that `playwright-chromium`/Chromium system dependencies (via `playwright install-deps chromium`) are installed *before the first local browser launch*, not during server startup.
- Clarified when dependency installation is skipped:
  - when `BROWSER_CDP_URL` is set (remote browser/CDP)
  - non-Linux runtimes
  - non-root runtimes
  - `BROWSER_SKIP_INSTALL_DEPS=true`
- Kept `BROWSER_CDP_URL` as the way to connect to a remote browser.
- Revised the “How it works” section to reflect the lazy, root-runtime dependency install behavior.

### `templates/template-browser-agent/src/mastra/agents/browser-agent.ts`
- Removed the previous startup-time side-effect import behavior for `playwright-chromium`.
- Added lazy dependency installation by introducing a `RuntimeDepsThreadManager` that runs the install right before creating the first browser session.
- Dependency install is conditional:
  - Linux only
  - only when running as root
  - skipped when `BROWSER_CDP_URL` is set (remote/CDP deployment)
  - skipped when `BROWSER_SKIP_INSTALL_DEPS=true`
- Implemented deduplication across concurrent sessions using a module-level `installDepsPromise` so only one install runs at a time.
- Added reliability improvements to the retry logic:
  - enforced a 120s timeout for the install
  - on timeout/error/non-zero exit, the cached promise is cleared so later browser sessions can retry instead of reusing a stale rejected promise.

## Commit messages / reliability intent
- Clarified that if the Playwright dependency install times out, the cached install promise is cleared so subsequent browser sessions can attempt the install again (avoids getting stuck on a previous failed install).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->