### PR TITLE
fix(playground-ui): make DataList lined by default

### DIFF
--- a/.changeset/orange-beers-sneeze.md
+++ b/.changeset/orange-beers-sneeze.md
@@ -1,0 +1,17 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Removed the default DataList variant. DataList now uses the lined treatment when no variant is provided; use variant="striped" only when zebra rows are needed.
+
+**Before**
+
+```tsx
+<DataList columns={columns} variant="default" />
+```
+
+**After**
+
+```tsx
+<DataList columns={columns} />
+```

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
@@ -17,13 +17,37 @@ const Header = () => (
 );
 
 describe('DataListRoot', () => {
-  /**
-   * Virtualization (traces/logs) relies on `scrollRef` pointing at the scrolling
-   * grid in the default variant. These guard the wiring so the striped/ScrollArea
-   * work can't silently break it.
-   */
-  describe('default variant — native scroll (virtualization path)', () => {
-    it('forwards scrollRef to the scrollable grid, not a wrapper', () => {
+  describe('lined default variant — ScrollArea (overlay scrollbar + horizontal mask)', () => {
+    it('uses lined styling when no variant is provided', () => {
+      const { container } = render(
+        <DataList columns="1fr 1fr">
+          <Header />
+          <DataList.RowButton>
+            <DataList.Cell>one</DataList.Cell>
+            <DataList.Cell>first row</DataList.Cell>
+          </DataList.RowButton>
+          <DataList.RowButton>
+            <DataList.Cell>two</DataList.Cell>
+            <DataList.Cell>second row</DataList.Cell>
+          </DataList.RowButton>
+        </DataList>,
+      );
+
+      const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
+      expect(grid).not.toBeNull();
+      expect(grid).not.toBe(container.firstElementChild);
+      expect(grid?.className).not.toContain('overflow-auto');
+      expect(grid?.className).toContain('gap-y-px');
+      expect(grid?.className).toContain('[&_.data-list-row]:after:absolute');
+      expect(grid?.className).toContain('[&_.data-list-row]:after:content-[""]');
+      expect(grid?.className).toContain('[&_.data-list-row]:after:inset-x-2');
+      expect(grid?.className).toContain('[&_.data-list-row]:after:-bottom-px');
+      expect(grid?.className).toContain('[&_.data-list-row]:after:bg-neutral6/10');
+      expect(grid?.className).not.toContain('[&_.data-list-row]:even:bg-surface-overlay-soft');
+      expect(grid?.className).not.toContain('[&_.data-list-row]:after:hidden');
+    });
+
+    it('forwards scrollRef to the scrolling viewport that contains the grid', () => {
       const scrollRef = createRef<HTMLDivElement>();
       const { container } = render(
         <DataList columns="1fr 1fr" scrollRef={scrollRef}>
@@ -32,21 +56,10 @@ describe('DataListRoot', () => {
       );
 
       expect(scrollRef.current).not.toBeNull();
-      // the ref'd element is the grid itself and is the scroll container
-      expect(scrollRef.current).toBe(container.firstElementChild);
-      expect(scrollRef.current?.className).toContain('overflow-auto');
-      expect(scrollRef.current?.style.gridTemplateColumns).toBe('1fr 1fr');
-    });
-
-    it('does not introduce an intermediate scroll wrapper', () => {
-      const { container } = render(
-        <DataList columns="1fr 1fr">
-          <Header />
-        </DataList>,
-      );
-      // grid is the top-level node — no ScrollArea viewport/content above it
       const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
-      expect(grid).toBe(container.firstElementChild);
+      expect(grid).not.toBeNull();
+      expect(scrollRef.current).not.toBe(grid);
+      expect(scrollRef.current?.contains(grid)).toBe(true);
     });
   });
 

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -6,13 +6,12 @@ import { cn } from '@/lib/utils';
 /**
  * Visual treatment for the whole list.
  *
- * - `default`: bordered card, `surface2` body, hairline row separators.
  * - `striped`: borderless and full-bleed, zebra-striped rows (every other row
  *   tinted), contrasting sticky header band, no row separators.
  * - `lined`: borderless and full-bleed like `striped`, but rows stay transparent
  *   and use subtle separators instead of zebra tints.
  */
-export type DataListVariant = 'default' | 'striped' | 'lined';
+export type DataListVariant = 'striped' | 'lined';
 
 export type DataListRootProps = {
   children: ReactNode;
@@ -21,8 +20,8 @@ export type DataListRootProps = {
   variant?: DataListVariant;
   /**
    * Ref to the scroll container — pass this to TanStack Virtual's
-   * `getScrollElement` when virtualizing. Without it, the list behaves as a
-   * normal scrollable grid.
+   * `getScrollElement` when virtualizing. Without it, the ScrollArea viewport
+   * scrolls normally.
    */
   scrollRef?: RefObject<HTMLDivElement | null>;
 };
@@ -66,7 +65,6 @@ const borderlessTableStyles = [
 const dataListRootVariants = cva('grid min-w-0 max-w-full content-start', {
   variants: {
     variant: {
-      default: 'bg-surface2 border border-border1 rounded-xl',
       striped: cn(
         ...borderlessTableStyles,
         '[&_.data-list-row]:after:hidden',
@@ -80,38 +78,26 @@ const dataListRootVariants = cva('grid min-w-0 max-w-full content-start', {
     },
   },
   defaultVariants: {
-    variant: 'default',
+    variant: 'lined',
   },
 });
 
-export function DataListRoot({ children, columns, className, variant = 'default', scrollRef }: DataListRootProps) {
-  const usesOverlayScrollArea = variant === 'striped' || variant === 'lined';
-
+export function DataListRoot({ children, columns, className, variant = 'lined', scrollRef }: DataListRootProps) {
   const grid = (
     <div
-      // Borderless table variants scroll inside the ScrollArea viewport (below);
-      // default scrolls the grid natively, so it owns `scrollRef`.
-      ref={usesOverlayScrollArea ? undefined : scrollRef}
-      className={cn(
-        dataListRootVariants({ variant }),
-        // Default is its own scroll container; borderless table variants delegate
-        // scrolling to the ScrollArea viewport, so the grid just lays out.
-        !usesOverlayScrollArea && 'max-h-full overflow-auto',
-        !usesOverlayScrollArea && className,
-      )}
+      // Lists scroll inside the ScrollArea viewport (below); the grid just lays out.
+      className={dataListRootVariants({ variant })}
       style={{ gridTemplateColumns: columns }}
     >
       {children}
     </div>
   );
 
-  if (!usesOverlayScrollArea) return grid;
-
-  // Borderless table variants always use the DS ScrollArea: an overlay scrollbar
-  // (no reserved gutter, so the sticky header spans the full width and both top
-  // corners clip cleanly) plus the default edge fades. When the list virtualizes
-  // it passes a `scrollRef`; forwarding it as `viewportRef` makes the virtualizer
-  // scroll this viewport, so virtualization works without a native scrollbar.
+  // DataList uses the DS ScrollArea: an overlay scrollbar (no reserved gutter,
+  // so the sticky header spans the full width and both top corners clip cleanly)
+  // plus the default edge fades. When the list virtualizes it passes a
+  // `scrollRef`; forwarding it as `viewportRef` makes the virtualizer scroll
+  // this viewport.
   //
   // `rounded-t-xl` clips the viewport top. Masks default to every overflowing
   // edge except the top — a top fade would fade the opaque sticky header.

--- a/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
@@ -12,7 +12,7 @@ type DataListStoryArgs = {
   variant: DataListVariant;
 };
 
-const VARIANT_OPTIONS: DataListVariant[] = ['default', 'striped', 'lined'];
+const VARIANT_OPTIONS: DataListVariant[] = ['lined', 'striped'];
 
 const meta: Meta<DataListStoryArgs> = {
   title: 'DataDisplay/DataList',
@@ -20,7 +20,7 @@ const meta: Meta<DataListStoryArgs> = {
     layout: 'padded',
   },
   args: {
-    variant: 'default',
+    variant: 'lined',
   },
   argTypes: {
     variant: {


### PR DESCRIPTION
Removes the old DataList `variant="default"` root treatment and makes the lined ScrollArea treatment the default when no variant is passed. `variant="striped"` remains the explicit alternate for zebra rows, and the Storybook controls plus root tests now reflect the new API.

Before:

```tsx
<DataList columns={columns} variant="default" />
```

After:

```tsx
<DataList columns={columns} />
```

Validated with `pnpm --filter ./packages/playground-ui test --run src/ds/components/DataList/data-list-root.test.tsx`, `pnpm build:playground-ui`, `pnpm prettier --check ...`, `git diff --check`, `pnpm --filter ./packages/playground-ui lint`, `pnpm --filter ./packages/playground-ui typecheck`, `pnpm --filter ./packages/playground-ui test --run`, `pnpm --filter ./packages/playground-ui build-storybook`, and `npx -y react-doctor@latest . --verbose --diff`. CodeRabbit CLI is installed, but `coderabbit doctor` reported it is not signed in, so I could not run a local CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

The DataList component used to require you to write `variant="default"` every time you wanted its basic lined-style appearance. This PR simplifies things by making that lined style the automatic choice—so now you don't have to write anything special, and if you want stripes instead, you explicitly ask for `variant="striped"`. It's a breaking change because code that relied on the old behavior will need to be updated.

## Overview

This PR changes the default styling behavior of the DataList component in the playground-ui package by removing the `'default'` variant and making the lined ScrollArea appearance the new default when no variant is specified. The `'striped'` variant option remains available for zebra-striped row styling.

## Changes

**DataList Component Logic** (`data-list-root.tsx`)
- `DataListVariant` type narrowed from `'default' | 'striped' | 'lined'` to `'striped' | 'lined'`
- Default variant changed from `'default'` to `'lined'`
- Updated prop documentation for `scrollRef` to clarify its role with ScrollArea viewport
- Refactored component to always use ScrollArea wrapper instead of conditionally switching between native scrolling and overlay ScrollArea
- Removed conditional logic for `ref`, `overflow-auto`, and early returns; grid now only handles layout

**Test Updates** (`data-list-root.test.tsx`)
- Replaced "default variant — native scroll" test assertions with new "lined default variant — ScrollArea (overlay scrollbar + horizontal mask)" coverage
- Updated grid/className checks to validate lined variant CSS classes (gap, separator, after-mask)
- Modified `scrollRef` expectations: now expects `scrollRef.current` to be the ScrollArea viewport wrapper containing the grid, rather than the grid itself

**Storybook Configuration** (`data-list.stories.tsx`)
- Updated variant control options from `['default', 'striped', 'lined']` to `['lined', 'striped']`
- Changed story default variant from `'default'` to `'lined'`

**Changeset** (`.changeset/orange-beers-sneeze.md`)
- Documents the breaking change with before/after usage examples

## Public API Changes

- **Type**: `DataListVariant` now exports `'striped' | 'lined'` instead of `'default' | 'striped' | 'lined'`
- **Default Behavior**: `DataListRoot` now defaults to `variant="lined"` instead of `variant="default"`

## Breaking Change Notice

This is a breaking change to the DataList component's public API. Code that explicitly passed `variant="default"` will need to be updated to either omit the variant prop or switch to `variant="striped"` if zebra-striping is desired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->