### PR TITLE
refactor(core): move the event bus onto the Session (multi-session phase 1)

### DIFF
--- a/.changeset/curvy-rivers-shine.md
+++ b/.changeset/curvy-rivers-shine.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+The Harness event bus now lives on the Session. Each `Session` owns its own listeners and emit pipeline (`session.subscribe()` / internal `session.emit()`), so events emitted on one session are delivered only to that session's subscribers — never to another session's. This is the isolation foundation for serving a single Harness to multiple concurrent sessions (e.g. one Harness backing many channel threads).
+
+Breaking (Harness is under active development): `Harness.subscribe()` is removed. Subscribe on the session instead:
+
+```diff
+- harness.subscribe(listener)
++ harness.session.subscribe(listener)
+```
+
+Session subsystems (mode/model/om/permissions/subagents/state) no longer receive an injected `emit` callback — they emit directly to their session's bus. `mastracode` is updated to subscribe via `harness.session.subscribe()`.

--- a/mastracode/src/__tests__/tool-approval-libsql.test.ts
+++ b/mastracode/src/__tests__/tool-approval-libsql.test.ts
@@ -121,7 +121,7 @@ describe('tool approval with LibSQLStore via Harness', () => {
 
     // Collect events
     const events: any[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -131,7 +131,7 @@ describe('tool approval with LibSQLStore via Harness', () => {
     // Send message — should hit tool-call-approval and auto-approve (policy = 'ask')
     // We need to respond to the approval prompt
     const approvalPromise = new Promise<void>(resolve => {
-      harness.subscribe(event => {
+      harness.session.subscribe(event => {
         if (event.type === 'tool_approval_required') {
           // Must be async — the approval gate is armed after emit returns
           queueMicrotask(() => {

--- a/mastracode/src/agents/thread-caveman-state.ts
+++ b/mastracode/src/agents/thread-caveman-state.ts
@@ -76,7 +76,7 @@ async function restoreSettingsForThread(harness: Harness<Record<string, unknown>
  * the host.
  */
 export function attachOMThreadStatePersistence(harness: Harness<Record<string, unknown>>): void {
-  harness.subscribe(event => {
+  harness.session.subscribe(event => {
     if (event.type === 'thread_changed' || event.type === 'thread_created') {
       const threadId = event.type === 'thread_changed' ? event.threadId : event.thread.id;
       void restoreSettingsForThread(harness, threadId).catch(() => {

--- a/mastracode/src/headless-integration.test.ts
+++ b/mastracode/src/headless-integration.test.ts
@@ -191,7 +191,7 @@ describe('headless mode — event-driven auto-resolution', () => {
     await harness.selectOrCreateThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -232,7 +232,7 @@ describe('headless mode — event-driven auto-resolution', () => {
     await harness.selectOrCreateThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -253,7 +253,7 @@ describe('headless mode — event-driven auto-resolution', () => {
     await harness.selectOrCreateThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -295,7 +295,7 @@ describe('headless mode — event-driven auto-resolution', () => {
     await harness.selectOrCreateThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -365,7 +365,7 @@ describe('headless mode — event-driven auto-resolution', () => {
     await harness.selectOrCreateThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -577,10 +577,6 @@ describe('headless mode — --output-format contracts', () => {
       message: 'Browser state changed',
     };
     const harness = {
-      subscribe: vi.fn((next: (event: HarnessEvent) => void) => {
-        listener = next;
-        return () => {};
-      }),
       sendMessage: vi.fn(async () => {
         listener?.({ type: 'agent_start', runId: 'run-state' } as HarnessEvent);
         listener?.({
@@ -594,7 +590,13 @@ describe('headless mode — --output-format contracts', () => {
         } as HarnessEvent);
         listener?.({ type: 'agent_end', reason: 'complete' } as HarnessEvent);
       }),
-      session: { thread: { getId: vi.fn(() => 'thread-state') } },
+      session: {
+        subscribe: vi.fn((next: (event: HarnessEvent) => void) => {
+          listener = next;
+          return () => {};
+        }),
+        thread: { getId: vi.fn(() => 'thread-state') },
+      },
     } as unknown as Harness<Record<string, unknown>>;
 
     const {
@@ -650,7 +652,7 @@ describe('headless mode — --model flag', () => {
     await harness.selectOrCreateThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     const exitCode = await runHeadless(harness, {
       prompt: 'Hello',
@@ -688,7 +690,7 @@ describe('headless mode — --model flag', () => {
     });
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     const exitCode = await runHeadless(harness, {
       prompt: 'Hello',
@@ -730,7 +732,7 @@ describe('headless mode — --model flag', () => {
     });
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     const exitCode = await runHeadless(harness, {
       prompt: 'Hello',
@@ -890,7 +892,7 @@ describe('headless mode — --model flag', () => {
     await harness.selectOrCreateThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     const exitCode = await runHeadless(harness, {
       prompt: 'Hello',
@@ -916,7 +918,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     await harness.selectOrCreateThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     const exitCode = await runHeadless(
       harness,
@@ -1056,7 +1058,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     });
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     // No effectiveDefaults passed — should warn, not error
     const exitCode = await runHeadless(harness, {

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -470,7 +470,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
   const streamCtx = { lastTextLength: 0 };
 
   const done = new Promise<number>(resolve => {
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       const result = autoResolve(harness, event);
       if (result.resolved) {
         if (emit) emit(result.json);

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -708,7 +708,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
 
   // Sync hookManager session ID on thread changes
   if (hookManager) {
-    harness.subscribe((event: HarnessEvent) => {
+    harness.session.subscribe((event: HarnessEvent) => {
       if (event.type === 'thread_changed') {
         hookManager.setSessionId(event.threadId);
       } else if (event.type === 'thread_created') {
@@ -736,7 +736,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       }
     };
 
-    harness.subscribe((event: HarnessEvent) => {
+    harness.session.subscribe((event: HarnessEvent) => {
       if (event.type === 'thread_changed') void startGithubPollingForCurrentThread(event.threadId);
       else if (event.type === 'thread_created') void startGithubPollingForCurrentThread(event.thread.id);
     });

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -555,7 +555,7 @@ export function subscribeToHarness(state: TUIState, handleEvent: (event: any) =>
       if (stack) process.stderr.write(stack + '\n');
     }
   };
-  state.unsubscribe = state.harness.subscribe(listener);
+  state.unsubscribe = state.harness.session.subscribe(listener);
 }
 
 // =============================================================================

--- a/packages/core/src/harness/__tests__/harness-ask-user.test.ts
+++ b/packages/core/src/harness/__tests__/harness-ask-user.test.ts
@@ -102,7 +102,7 @@ describe('Harness: ask_user native suspension', () => {
     );
 
     const events: any[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     await harness.sendMessage({ content: 'Ask me where to deploy' });
 
@@ -123,7 +123,7 @@ describe('Harness: ask_user native suspension', () => {
     const { harness } = await buildHarness('resume', JSON.stringify({ question: 'Your name?' }));
 
     const events: any[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     await harness.sendMessage({ content: 'Ask my name' });
 
@@ -155,7 +155,7 @@ describe('Harness: ask_user native suspension', () => {
     );
 
     const events: any[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     await harness.sendMessage({ content: 'Ask me to pick' });
 
@@ -323,7 +323,7 @@ describe('Harness: ask_user native suspension', () => {
     await harness.createThread();
 
     const events: any[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     await harness.sendMessage({ content: 'Ask me three things' });
 

--- a/packages/core/src/harness/__tests__/harness-finish-reason.test.ts
+++ b/packages/core/src/harness/__tests__/harness-finish-reason.test.ts
@@ -111,7 +111,7 @@ describe('Harness: non-success finish reasons', () => {
     );
 
     const events: any[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -136,7 +136,7 @@ describe('Harness: non-success finish reasons', () => {
     const harness = await buildHarness('content-filter-no-details', () => createFinishReasonStream('content-filter'));
 
     const events: any[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -152,7 +152,7 @@ describe('Harness: non-success finish reasons', () => {
     const harness = await buildHarness('length', () => createFinishReasonStream('length'));
 
     const events: any[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -177,7 +177,7 @@ describe('Harness: non-success finish reasons', () => {
     );
 
     const events: any[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -197,7 +197,7 @@ describe('Harness: non-success finish reasons', () => {
     const harness = await buildHarness('stop', () => createFinishReasonStream('stop'));
 
     const events: any[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 

--- a/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
+++ b/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
@@ -166,7 +166,7 @@ describe('Harness: tool suspension and resumption', () => {
 
     // Collect all events
     const events: any[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -294,7 +294,7 @@ describe('Harness: tool suspension and resumption', () => {
     await harness.init();
 
     const events: any[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -22,9 +22,9 @@ function createHarness(storage?: InMemoryStore, opts?: { subagents?: HarnessSuba
   });
 }
 
-// Helper to call the private emit method
+// Helper to emit an event on the harness's session bus.
 function emit(harness: Harness, event: HarnessEvent) {
-  (harness as any).emit(event);
+  harness.session.emit(event);
 }
 
 describe('defaultDisplayState', () => {
@@ -328,7 +328,7 @@ describe('tool lifecycle', () => {
 
   it('uses display transforms while processing tool stream chunks', async () => {
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     const result = await (harness as any).processStream(
       {
@@ -399,7 +399,7 @@ describe('tool lifecycle', () => {
 
   it('preserves explicit null display transforms', async () => {
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     const result = await (harness as any).processStream(
       {
@@ -1437,7 +1437,7 @@ describe('display_state_changed emission', () => {
   beforeEach(() => {
     harness = createHarness();
     events = [];
-    harness.subscribe((event: HarnessEvent) => {
+    harness.session.subscribe((event: HarnessEvent) => {
       events.push(event);
     });
   });
@@ -1523,7 +1523,7 @@ describe('display_state_changed emission', () => {
 
   it('display_state_changed reflects state at time of each event', () => {
     const snapshots: boolean[] = [];
-    harness.subscribe((event: HarnessEvent) => {
+    harness.session.subscribe((event: HarnessEvent) => {
       if (event.type === 'display_state_changed') {
         snapshots.push(event.displayState.isRunning);
       }

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -44,8 +44,6 @@ import type {
   AvailableModel,
   HeartbeatHandler,
   HarnessConfig,
-  HarnessEvent,
-  HarnessEventListener,
   HarnessMessage,
   HarnessMessageContent,
   HarnessMode,
@@ -442,7 +440,6 @@ export class Harness<TState = {}> {
   readonly id: string;
 
   private config: HarnessConfig<TState>;
-  private listeners: HarnessEventListener[] = [];
   private workspace: Workspace | undefined = undefined;
   private workspaceFn:
     | ((ctx: {
@@ -487,7 +484,6 @@ export class Harness<TState = {}> {
         state: {
           initialState: config.initialState,
           stateSchema: config.stateSchema,
-          emit: event => this.emit(event),
         },
       }),
       defaultMode,
@@ -514,9 +510,10 @@ export class Harness<TState = {}> {
    * thread data store, and seed the initial mode + model. Returns the same
    * session for convenient assignment.
    *
-   * All wiring routes through the Harness (`this.emit`, `this.config`), so the
-   * Harness remains the owner of config and the event bus. Extracted from the
-   * constructor so additional sessions can be wired the same way.
+   * The session owns its own event bus, so the Harness no longer injects an
+   * `emit` callback — `#wireSession` only injects genuinely Harness-owned
+   * dependencies (config catalog, resolvers, tracker, thread store). Extracted
+   * from the constructor so additional sessions can be wired the same way.
    */
   #wireSession(session: Session<TState>, defaultMode: HarnessMode): Session<TState> {
     session.mode.set({ modeId: defaultMode.id });
@@ -528,18 +525,15 @@ export class Harness<TState = {}> {
     session.setSubagentNameResolver(agentType => this.getSubagentDisplayName(agentType));
     session.mode.setResolver(modeId => this.config.modes.find(m => m.id === modeId) ?? null, {
       abort: () => this.abort(),
-      emit: event => this.emit(event),
     });
     session.model.setResolver({
       getCurrentModeId: () => session.mode.get(),
-      emit: event => this.emit(event),
       trackModelUse: this.config.modelUseCountTracker,
     });
     session.om.setResolver({
       getState: () => session.state.get() as Record<string, unknown>,
       setState: updates => void session.state.set(updates as Partial<TState>),
       setSetting: ({ key, value }) => session.thread.setSetting({ key, value }),
-      emit: event => this.emit(event),
       omConfig: this.config.omConfig,
       resolveModel: this.config.resolveModel,
     });
@@ -551,7 +545,6 @@ export class Harness<TState = {}> {
       getState: () => session.state.get() as Record<string, unknown>,
       setState: updates => void session.state.set(updates as Partial<TState>),
       setSetting: ({ key, value }) => session.thread.setSetting({ key, value }),
-      emit: event => this.emit(event),
     });
     session.thread.connect(this.createThreadDataStore());
 
@@ -651,12 +644,12 @@ export class Harness<TState = {}> {
           this.workspace = new Workspace(this.config.workspace as WorkspaceConfig);
         }
 
-        this.emit({ type: 'workspace_status_changed', status: 'initializing' });
+        this.#session.emit({ type: 'workspace_status_changed', status: 'initializing' });
         await this.workspace.init();
         this.workspaceInitialized = true;
 
-        this.emit({ type: 'workspace_status_changed', status: 'ready' });
-        this.emit({
+        this.#session.emit({ type: 'workspace_status_changed', status: 'ready' });
+        this.#session.emit({
           type: 'workspace_ready',
           workspaceId: this.workspace.id,
           workspaceName: this.workspace.name,
@@ -666,8 +659,8 @@ export class Harness<TState = {}> {
         this.workspace = undefined;
         this.workspaceInitialized = false;
 
-        this.emit({ type: 'workspace_status_changed', status: 'error', error: err });
-        this.emit({ type: 'workspace_error', error: err });
+        this.#session.emit({ type: 'workspace_status_changed', status: 'error', error: err });
+        this.#session.emit({ type: 'workspace_error', error: err });
       }
     }
 
@@ -1208,7 +1201,7 @@ export class Harness<TState = {}> {
     }
 
     this.#session.resetTokenUsage();
-    this.emit({ type: 'thread_created', thread });
+    this.#session.emit({ type: 'thread_created', thread });
     await this.ensureCurrentAgentThreadSubscription();
 
     return thread;
@@ -1252,7 +1245,7 @@ export class Harness<TState = {}> {
       this.#session.resetTokenUsage();
     }
 
-    this.emit({ type: 'thread_deleted', threadId });
+    this.#session.emit({ type: 'thread_deleted', threadId });
   }
 
   async renameThread({ title }: { title: string }): Promise<void> {
@@ -1326,7 +1319,7 @@ export class Harness<TState = {}> {
     this.#session.thread.set({ threadId: clonedThread.id });
     await this.loadThreadMetadata();
     this.#session.resetTokenUsage();
-    this.emit({ type: 'thread_created', thread: clonedThread });
+    this.#session.emit({ type: 'thread_created', thread: clonedThread });
     await this.ensureCurrentAgentThreadSubscription();
 
     return clonedThread;
@@ -1357,7 +1350,7 @@ export class Harness<TState = {}> {
 
     await this.loadThreadMetadata();
 
-    this.emit({ type: 'thread_changed', threadId, previousThreadId });
+    this.#session.emit({ type: 'thread_changed', threadId, previousThreadId });
     await this.ensureCurrentAgentThreadSubscription();
   }
 
@@ -1424,7 +1417,7 @@ export class Harness<TState = {}> {
       }
 
       if (previousModeIdForEmit !== undefined) {
-        this.emit({
+        this.#session.emit({
           type: 'mode_changed',
           modeId: this.#session.mode.get(),
           previousModeId: previousModeIdForEmit,
@@ -1571,7 +1564,7 @@ export class Harness<TState = {}> {
         if (foundStatus) break;
       }
 
-      this.emit({
+      this.#session.emit({
         type: 'om_status',
         windows: {
           active: {
@@ -1798,9 +1791,9 @@ export class Harness<TState = {}> {
           threadId,
           ifIdle: { streamOptions: streamOptions as any },
         });
-        this.emit({ type: 'follow_up_queued', count: this.#session.followUps.count(), runId: result.runId });
+        this.#session.emit({ type: 'follow_up_queued', count: this.#session.followUps.count(), runId: result.runId });
       } else {
-        this.emit({ type: 'follow_up_queued', count: this.#session.followUps.count() });
+        this.#session.emit({ type: 'follow_up_queued', count: this.#session.followUps.count() });
         await this.sendMessage({
           content: next.content,
           requestContext: next.requestContext,
@@ -1811,7 +1804,7 @@ export class Harness<TState = {}> {
       return true;
     } catch (error) {
       this.#session.followUps.requeue(next);
-      this.emit({ type: 'follow_up_queued', count: this.#session.followUps.count() });
+      this.#session.emit({ type: 'follow_up_queued', count: this.#session.followUps.count() });
       throw error;
     }
   }
@@ -1832,17 +1825,17 @@ export class Harness<TState = {}> {
         : aborted || this.#session.run.isAbortRequested()
           ? 'aborted'
           : 'complete';
-    this.emit({ type: 'agent_end', reason });
+    this.#session.emit({ type: 'agent_end', reason });
     this.#session.run.reset();
     await this.drainFollowUpQueue();
   }
 
   private async handleSubscribedStreamError(error: unknown): Promise<void> {
     if (error instanceof Error && error.name === 'AbortError') {
-      this.emit({ type: 'agent_end', reason: 'aborted' });
+      this.#session.emit({ type: 'agent_end', reason: 'aborted' });
     } else {
-      this.emit({ type: 'error', error: getErrorFromUnknown(error) });
-      this.emit({ type: 'agent_end', reason: 'error' });
+      this.#session.emit({ type: 'error', error: getErrorFromUnknown(error) });
+      this.#session.emit({ type: 'agent_end', reason: 'error' });
     }
     this.#session.stream.detach();
     this.#session.run.reset();
@@ -1872,7 +1865,7 @@ export class Harness<TState = {}> {
           this.#session.run.ensureAbortController();
           this.#session.run.setRunId({ runId: subscription.activeRunId() ?? ('runId' in chunk ? chunk.runId : null) });
           this.#session.run.setTraceId({ traceId: null });
-          this.emit({ type: 'agent_start' });
+          this.#session.emit({ type: 'agent_start' });
         }
 
         if (chunk.type === 'start') {
@@ -1906,7 +1899,7 @@ export class Harness<TState = {}> {
               !suspended
             ) {
               isError = true;
-              this.emit({ type: 'error', error: new Error(currentRun.terminalError) });
+              this.#session.emit({ type: 'error', error: new Error(currentRun.terminalError) });
             }
             await this.finishSubscribedStreamRun({
               suspended,
@@ -2050,7 +2043,7 @@ export class Harness<TState = {}> {
     let emittedAgentEnd = false;
     const unsubscribeAgentEnd = wasActive
       ? undefined
-      : this.subscribe(event => {
+      : this.#session.subscribe(event => {
           if (event.type === 'agent_end') emittedAgentEnd = true;
         });
     const signal = this.sendSignal({
@@ -2065,7 +2058,7 @@ export class Harness<TState = {}> {
       await this.waitForCurrentThreadStreamIdle();
       unsubscribeAgentEnd?.();
       if (!emittedAgentEnd && !this.#session.suspensions.hasPending()) {
-        this.emit({ type: 'agent_end', reason: 'complete' });
+        this.#session.emit({ type: 'agent_end', reason: 'complete' });
       }
     }
     return;
@@ -2458,7 +2451,7 @@ export class Harness<TState = {}> {
 
   private finishCurrentMessageAndRotate(state: HarnessStreamState): void {
     if (!this.hasCurrentMessageContent(state)) return;
-    this.emit({ type: 'message_end', message: state.currentMessage });
+    this.#session.emit({ type: 'message_end', message: state.currentMessage });
     state.lastFinishedMessage = state.currentMessage;
     state.currentMessage = this.createEmptyAssistantMessage();
     state.textContentById.clear();
@@ -2478,7 +2471,7 @@ export class Harness<TState = {}> {
   }
 
   private abortForOmFailure({ operationType, stage, error }: { operationType: string; stage: string; error: string }) {
-    this.emit({
+    this.#session.emit({
       type: 'error',
       error: new Error(`Observational memory ${operationType} ${stage} failed: ${error}`),
     });
@@ -2492,7 +2485,7 @@ export class Harness<TState = {}> {
     const state = this.createStreamState();
     const requestContext = await this.buildRequestContext(requestContextInput);
     this.#session.run.nextOperation();
-    this.emit({ type: 'agent_start' });
+    this.#session.emit({ type: 'agent_start' });
 
     let result: { message: HarnessMessage; suspended?: boolean } | undefined;
     let error = false;
@@ -2526,10 +2519,10 @@ export class Harness<TState = {}> {
     // silently stops without a visible terminal state.
     if (state.terminalError && !error && !aborted && !this.#session.run.isAbortRequested() && !result.suspended) {
       error = true;
-      this.emit({ type: 'error', error: new Error(state.terminalError) });
+      this.#session.emit({ type: 'error', error: new Error(state.terminalError) });
     }
 
-    this.emit({
+    this.#session.emit({
       type: 'agent_end',
       reason: error
         ? 'error'
@@ -2560,7 +2553,7 @@ export class Harness<TState = {}> {
         const textIndex = state.currentMessage.content.length;
         state.currentMessage.content.push({ type: 'text', text: '' });
         state.textContentById.set(chunk.payload.id, { index: textIndex, text: '' });
-        this.emit({ type: 'message_start', message: { ...state.currentMessage } });
+        this.#session.emit({ type: 'message_start', message: { ...state.currentMessage } });
         break;
       }
 
@@ -2572,7 +2565,7 @@ export class Harness<TState = {}> {
           if (textContent && textContent.type === 'text') {
             textContent.text = textState.text;
           }
-          this.emit({ type: 'message_update', message: { ...state.currentMessage } });
+          this.#session.emit({ type: 'message_update', message: { ...state.currentMessage } });
         }
         break;
       }
@@ -2581,7 +2574,7 @@ export class Harness<TState = {}> {
         const thinkingIndex = state.currentMessage.content.length;
         state.currentMessage.content.push({ type: 'thinking', thinking: '' });
         state.thinkingContentById.set(chunk.payload.id, { index: thinkingIndex, text: '' });
-        this.emit({ type: 'message_update', message: { ...state.currentMessage } });
+        this.#session.emit({ type: 'message_update', message: { ...state.currentMessage } });
         break;
       }
 
@@ -2593,14 +2586,14 @@ export class Harness<TState = {}> {
           if (thinkingContent && thinkingContent.type === 'thinking') {
             thinkingContent.thinking = thinkingState.text;
           }
-          this.emit({ type: 'message_update', message: { ...state.currentMessage } });
+          this.#session.emit({ type: 'message_update', message: { ...state.currentMessage } });
         }
         break;
       }
 
       case 'tool-call-input-streaming-start': {
         const { toolCallId, toolName } = chunk.payload;
-        this.emit({ type: 'tool_input_start', toolCallId, toolName });
+        this.#session.emit({ type: 'tool_input_start', toolCallId, toolName });
         break;
       }
 
@@ -2608,7 +2601,7 @@ export class Harness<TState = {}> {
         const { toolCallId, argsTextDelta, toolName } = chunk.payload;
         const transform = getTransformedToolPayload(chunk.metadata, 'display', 'input-delta');
         if (!transform?.suppress) {
-          this.emit({
+          this.#session.emit({
             type: 'tool_input_delta',
             toolCallId,
             argsTextDelta: hasTransformedToolPayload(transform) ? transform.transformed : argsTextDelta,
@@ -2620,7 +2613,7 @@ export class Harness<TState = {}> {
 
       case 'tool-call-input-streaming-end': {
         const { toolCallId } = chunk.payload;
-        this.emit({ type: 'tool_input_end', toolCallId });
+        this.#session.emit({ type: 'tool_input_end', toolCallId });
         break;
       }
 
@@ -2633,13 +2626,13 @@ export class Harness<TState = {}> {
           name: toolCall.toolName,
           args,
         });
-        this.emit({
+        this.#session.emit({
           type: 'tool_start',
           toolCallId: toolCall.toolCallId,
           toolName: toolCall.toolName,
           args,
         });
-        this.emit({ type: 'message_update', message: { ...state.currentMessage } });
+        this.#session.emit({ type: 'message_update', message: { ...state.currentMessage } });
         break;
       }
 
@@ -2655,20 +2648,20 @@ export class Harness<TState = {}> {
           isError: toolResult.isError ?? false,
           ...(providerMetadata ? { providerMetadata } : {}),
         });
-        this.emit({
+        this.#session.emit({
           type: 'tool_end',
           toolCallId: toolResult.toolCallId,
           result,
           isError: toolResult.isError ?? false,
           ...(providerMetadata ? { providerMetadata } : {}),
         });
-        this.emit({ type: 'message_update', message: { ...state.currentMessage } });
+        this.#session.emit({ type: 'message_update', message: { ...state.currentMessage } });
         break;
       }
 
       case 'tool-error': {
         const toolError = chunk.payload;
-        this.emit({
+        this.#session.emit({
           type: 'tool_end',
           toolCallId: toolError.toolCallId,
           result: getDisplayTransform(chunk.metadata, 'error', toolError.error),
@@ -2698,7 +2691,7 @@ export class Harness<TState = {}> {
         }
 
         const approvalPromise = this.#session.approval.arm({ toolName });
-        this.emit({ type: 'tool_approval_required', toolCallId, toolName, args: toolArgs });
+        this.#session.emit({ type: 'tool_approval_required', toolCallId, toolName, args: toolArgs });
 
         const approval = await approvalPromise;
         this.#session.approval.clearToolName();
@@ -2728,7 +2721,7 @@ export class Harness<TState = {}> {
         }
         state.isSuspended = true;
 
-        this.emit({
+        this.#session.emit({
           type: 'tool_suspended',
           toolCallId: suspToolCallId,
           toolName: suspToolName,
@@ -2742,7 +2735,7 @@ export class Harness<TState = {}> {
 
       case 'error': {
         const streamError = getErrorFromUnknown(chunk.payload.error);
-        this.emit({ type: 'error', error: streamError });
+        this.#session.emit({ type: 'error', error: streamError });
         break;
       }
 
@@ -2774,7 +2767,7 @@ export class Harness<TState = {}> {
           this.#session.addUsage(stepUsage);
 
           this.persistTokenUsage().catch(() => {});
-          this.emit({ type: 'usage_update', usage: stepUsage });
+          this.#session.emit({ type: 'usage_update', usage: stepUsage });
         }
         break;
       }
@@ -2788,7 +2781,7 @@ export class Harness<TState = {}> {
         // substitution is invisible.
         const fallbackNotice = describeServerSideFallback(finishProviderMetadata);
         if (fallbackNotice) {
-          this.emit({ type: 'info', message: fallbackNotice });
+          this.#session.emit({ type: 'info', message: fallbackNotice });
         }
         if (finishReason === 'stop' || finishReason === 'end-turn') {
           state.currentMessage.stopReason = 'complete';
@@ -2820,7 +2813,7 @@ export class Harness<TState = {}> {
         this.finishCurrentMessageAndRotate(state);
         // Forward the payload so consumers (the TUI's judge display) can render
         // judge progress and the decision.
-        this.emit({ type: 'goal_evaluation', payload: chunk.payload });
+        this.#session.emit({ type: 'goal_evaluation', payload: chunk.payload });
         break;
       }
 
@@ -2836,7 +2829,7 @@ export class Harness<TState = {}> {
           const buffObs = w.buffered?.observations ?? {};
           const buffRef = w.buffered?.reflection ?? {};
 
-          this.emit({
+          this.#session.emit({
             type: 'om_status',
             windows: {
               active: {
@@ -2870,14 +2863,14 @@ export class Harness<TState = {}> {
         const payload = (chunk as any).data as Record<string, any> | undefined;
         if (payload && payload.cycleId) {
           if (payload.operationType === 'observation') {
-            this.emit({
+            this.#session.emit({
               type: 'om_observation_start',
               cycleId: payload.cycleId,
               operationType: payload.operationType,
               tokensToObserve: payload.tokensToObserve ?? 0,
             });
           } else if (payload.operationType === 'reflection') {
-            this.emit({
+            this.#session.emit({
               type: 'om_reflection_start',
               cycleId: payload.cycleId,
               tokensToReflect: payload.tokensToObserve ?? 0,
@@ -2890,7 +2883,7 @@ export class Harness<TState = {}> {
         const payload = (chunk as any).data as Record<string, any> | undefined;
         if (payload && payload.cycleId) {
           if (payload.operationType === 'reflection') {
-            this.emit({
+            this.#session.emit({
               type: 'om_reflection_end',
               cycleId: payload.cycleId,
               durationMs: payload.durationMs ?? 0,
@@ -2898,7 +2891,7 @@ export class Harness<TState = {}> {
               observations: payload.observations,
             });
           } else {
-            this.emit({
+            this.#session.emit({
               type: 'om_observation_end',
               cycleId: payload.cycleId,
               durationMs: payload.durationMs ?? 0,
@@ -2919,14 +2912,14 @@ export class Harness<TState = {}> {
           const error = payload.error ?? 'Unknown error';
 
           if (operationType === 'reflection') {
-            this.emit({
+            this.#session.emit({
               type: 'om_reflection_failed',
               cycleId: payload.cycleId ?? 'unknown',
               error,
               durationMs: payload.durationMs ?? 0,
             });
           } else {
-            this.emit({
+            this.#session.emit({
               type: 'om_observation_failed',
               cycleId: payload.cycleId ?? 'unknown',
               error,
@@ -2943,7 +2936,7 @@ export class Harness<TState = {}> {
       case 'data-om-buffering-start': {
         const payload = (chunk as any).data as Record<string, any> | undefined;
         if (payload && payload.cycleId) {
-          this.emit({
+          this.#session.emit({
             type: 'om_buffering_start',
             cycleId: payload.cycleId,
             operationType: payload.operationType ?? 'observation',
@@ -2955,7 +2948,7 @@ export class Harness<TState = {}> {
       case 'data-om-buffering-end': {
         const payload = (chunk as any).data as Record<string, any> | undefined;
         if (payload && payload.cycleId) {
-          this.emit({
+          this.#session.emit({
             type: 'om_buffering_end',
             cycleId: payload.cycleId,
             operationType: payload.operationType ?? 'observation',
@@ -2972,7 +2965,7 @@ export class Harness<TState = {}> {
           const operationType = payload.operationType ?? 'observation';
           const error = payload.error ?? 'Unknown error';
 
-          this.emit({
+          this.#session.emit({
             type: 'om_buffering_failed',
             cycleId: payload.cycleId,
             operationType,
@@ -2990,31 +2983,31 @@ export class Harness<TState = {}> {
           const stateSignal = toStateSignalContent(payload);
           if (stateSignal) {
             state.currentMessage.content.push(stateSignal);
-            this.emit({ type: 'message_update', message: state.currentMessage });
+            this.#session.emit({ type: 'message_update', message: state.currentMessage });
           }
         } else if (payload?.type === 'reactive' && payload.tagName === 'system-reminder') {
           const reminder = toSystemReminderContent(payload);
           if (reminder) {
             state.currentMessage.content.push(reminder);
-            this.emit({ type: 'message_update', message: state.currentMessage });
+            this.#session.emit({ type: 'message_update', message: state.currentMessage });
           }
         } else if (payload?.type === 'notification' && payload.tagName === 'notification-summary') {
           const notificationSummary = toNotificationSummaryContent(payload);
           if (notificationSummary) {
             state.currentMessage.content.push(notificationSummary);
-            this.emit({ type: 'message_update', message: state.currentMessage });
+            this.#session.emit({ type: 'message_update', message: state.currentMessage });
           }
         } else if (payload?.type === 'notification' && payload.tagName === 'notification') {
           const notification = toNotificationContent(payload);
           if (notification) {
             state.currentMessage.content.push(notification);
-            this.emit({ type: 'message_update', message: state.currentMessage });
+            this.#session.emit({ type: 'message_update', message: state.currentMessage });
           }
         } else if (payload?.type === 'reactive') {
           const reactiveSignal = toReactiveSignalContent(payload);
           if (reactiveSignal) {
             state.currentMessage.content.push(reactiveSignal);
-            this.emit({ type: 'message_update', message: state.currentMessage });
+            this.#session.emit({ type: 'message_update', message: state.currentMessage });
           }
         }
         break;
@@ -3025,7 +3018,7 @@ export class Harness<TState = {}> {
         if (message) {
           if (state.currentMessage.content.length > 0) {
             state.currentMessage.stopReason ??= 'complete';
-            this.emit({ type: 'message_end', message: { ...state.currentMessage } });
+            this.#session.emit({ type: 'message_end', message: { ...state.currentMessage } });
             state.currentMessage = {
               id: this.generateId(),
               role: 'assistant',
@@ -3035,8 +3028,8 @@ export class Harness<TState = {}> {
             state.textContentById.clear();
             state.thinkingContentById.clear();
           }
-          this.emit({ type: 'message_start', message });
-          this.emit({ type: 'message_end', message });
+          this.#session.emit({ type: 'message_start', message });
+          this.#session.emit({ type: 'message_end', message });
         }
         break;
       }
@@ -3046,14 +3039,14 @@ export class Harness<TState = {}> {
         const reminder = payload ? toSystemReminderContent(payload) : undefined;
         if (reminder) {
           state.currentMessage.content.push(reminder);
-          this.emit({ type: 'message_update', message: state.currentMessage });
+          this.#session.emit({ type: 'message_update', message: state.currentMessage });
         }
         break;
       }
       case 'data-om-activation': {
         const payload = (chunk as any).data as Record<string, any> | undefined;
         if (payload && payload.cycleId) {
-          this.emit({
+          this.#session.emit({
             type: 'om_activation',
             cycleId: payload.cycleId,
             operationType: payload.operationType ?? 'observation',
@@ -3076,7 +3069,7 @@ export class Harness<TState = {}> {
       case 'data-om-thread-update': {
         const payload = (chunk as any).data as Record<string, any> | undefined;
         if (payload && payload.newTitle) {
-          this.emit({
+          this.#session.emit({
             type: 'om_thread_title_updated',
             cycleId: payload.cycleId ?? 'unknown',
             threadId: payload.threadId ?? this.#session.thread.getId() ?? 'unknown',
@@ -3091,14 +3084,14 @@ export class Harness<TState = {}> {
       case 'data-sandbox-stdout': {
         const d = (chunk as any).data as Record<string, any> | undefined;
         if (d?.output && d?.toolCallId) {
-          this.emit({ type: 'shell_output', toolCallId: d.toolCallId, output: d.output, stream: 'stdout' });
+          this.#session.emit({ type: 'shell_output', toolCallId: d.toolCallId, output: d.output, stream: 'stdout' });
         }
         break;
       }
       case 'data-sandbox-stderr': {
         const d = (chunk as any).data as Record<string, any> | undefined;
         if (d?.output && d?.toolCallId) {
-          this.emit({ type: 'shell_output', toolCallId: d.toolCallId, output: d.output, stream: 'stderr' });
+          this.#session.emit({ type: 'shell_output', toolCallId: d.toolCallId, output: d.output, stream: 'stderr' });
         }
         break;
       }
@@ -3110,7 +3103,7 @@ export class Harness<TState = {}> {
 
   private finishStreamState(state: HarnessStreamState): { message: HarnessMessage; suspended?: boolean } {
     if (this.hasCurrentMessageContent(state) || !state.lastFinishedMessage) {
-      this.emit({ type: 'message_end', message: state.currentMessage });
+      this.#session.emit({ type: 'message_end', message: state.currentMessage });
       return { message: state.currentMessage, suspended: state.isSuspended || undefined };
     }
 
@@ -3133,10 +3126,10 @@ export class Harness<TState = {}> {
     this.#session.displayState.clearPendingSuspensions();
     this.#session.abortRun();
     // Clearing the suspension mirror is a direct mutation, so it doesn't flow
-    // through emit()'s display-state reducer. Notify subscribers explicitly when
-    // we actually removed something, otherwise stale suspension UI can linger.
+    // through the display-state reducer. Notify subscribers explicitly when we
+    // actually removed something, otherwise stale suspension UI can linger.
     if (hadPendingSuspensions) {
-      this.dispatchDisplayStateChanged();
+      this.#session.emit({ type: 'display_state_changed', displayState: this.#session.displayState.get() });
     }
   }
 
@@ -3160,7 +3153,7 @@ export class Harness<TState = {}> {
   async steer({ content, requestContext }: { content: string; requestContext?: RequestContext }): Promise<void> {
     this.abort();
     this.#session.followUps.clear();
-    this.emit({ type: 'follow_up_queued', count: 0 });
+    this.#session.emit({ type: 'follow_up_queued', count: 0 });
     await this.sendMessage({ content, requestContext });
   }
 
@@ -3170,7 +3163,7 @@ export class Harness<TState = {}> {
   async followUp({ content, requestContext }: { content: string; requestContext?: RequestContext }): Promise<void> {
     if (this.#session.run.isRunning()) {
       this.#session.followUps.enqueue({ content, requestContext });
-      this.emit({ type: 'follow_up_queued', count: this.#session.followUps.count() });
+      this.#session.emit({ type: 'follow_up_queued', count: this.#session.followUps.count() });
     } else {
       await this.sendMessage({ content, requestContext });
     }
@@ -3246,8 +3239,8 @@ export class Harness<TState = {}> {
       });
     } catch (error) {
       const err = getErrorFromUnknown(error);
-      this.emit({ type: 'error', error: err });
-      this.emit({ type: 'agent_end', reason: 'error' });
+      this.#session.emit({ type: 'error', error: err });
+      this.#session.emit({ type: 'agent_end', reason: 'error' });
     }
   }
 
@@ -3413,55 +3406,10 @@ export class Harness<TState = {}> {
   // ===========================================================================
   // Event System
   // ===========================================================================
-
-  /**
-   * Subscribe to harness events. Returns an unsubscribe function.
-   */
-  subscribe(listener: HarnessEventListener): () => void {
-    this.listeners.push(listener);
-    return () => {
-      const index = this.listeners.indexOf(listener);
-      if (index !== -1) {
-        this.listeners.splice(index, 1);
-      }
-    };
-  }
-
-  private emit(event: HarnessEvent): void {
-    // The Session owns the display-state reducer; fold the event into the
-    // canonical snapshot before dispatching to listeners. The Harness still owns
-    // the event bus (listeners) and the display_state_changed fan-out.
-    this.#session.displayState.apply(event);
-
-    this.dispatchToListeners(event);
-
-    if (event.type !== 'display_state_changed') {
-      this.dispatchDisplayStateChanged();
-    }
-  }
-
-  private dispatchDisplayStateChanged(): void {
-    // After every event, emit display_state_changed so UIs that prefer a single
-    // subscribe-and-render pattern can do so. We dispatch directly to listeners
-    // (not through emit()) to avoid infinite recursion.
-    this.dispatchToListeners({
-      type: 'display_state_changed',
-      displayState: this.#session.displayState.get(),
-    });
-  }
-
-  private dispatchToListeners(event: HarnessEvent): void {
-    for (const listener of this.listeners) {
-      try {
-        const result = listener(event);
-        if (result && typeof result === 'object' && 'catch' in result) {
-          (result as Promise<void>).catch(err => console.error('Error in harness event listener:', err));
-        }
-      } catch (err) {
-        console.error('Error in harness event listener:', err);
-      }
-    }
-  }
+  //
+  // The Session owns the event bus. To observe events, subscribe on a session:
+  // `harness.session.subscribe(listener)`. Internal orchestration emits on the
+  // session it is driving via `session.emit(...)`.
 
   // ===========================================================================
   // Runtime Context
@@ -3609,7 +3557,7 @@ export class Harness<TState = {}> {
       },
       abortSignal: this.#session.run.getAbortSignal(),
       workspace: this.workspace,
-      emitEvent: event => this.emit(event),
+      emitEvent: event => this.#session.emit(event),
       getSubagentModelId: params => this.#session.subagents.model.get(params ?? {}),
     };
 
@@ -3715,9 +3663,9 @@ export class Harness<TState = {}> {
     if (this.workspaceFn) return;
     if (this.workspace && this.workspaceInitialized) {
       try {
-        this.emit({ type: 'workspace_status_changed', status: 'destroying' });
+        this.#session.emit({ type: 'workspace_status_changed', status: 'destroying' });
         await this.workspace.destroy();
-        this.emit({ type: 'workspace_status_changed', status: 'destroyed' });
+        this.#session.emit({ type: 'workspace_status_changed', status: 'destroyed' });
       } catch (error) {
         console.warn('Workspace destroy failed:', error);
       } finally {

--- a/packages/core/src/harness/mode-model-persistence.test.ts
+++ b/packages/core/src/harness/mode-model-persistence.test.ts
@@ -49,69 +49,69 @@ describe('Harness mode-model persistence across restarts', () => {
   });
 
   it('restores the saved mode and falls back to its defaultModelId when no per-mode model was explicitly persisted', async () => {
-    // Session 1: start in build, switch to fast (no explicit model change),
+    // Harness 1: start in build, switch to fast (no explicit model change),
     // then "exit" — i.e. simulate reopening with a fresh harness pointed at
     // the same thread.
-    const session1 = createHarness(storage);
-    await session1.init();
-    const thread = await session1.createThread();
-    expect(session1.session.mode.get()).toBe('build');
+    const harness1 = createHarness(storage);
+    await harness1.init();
+    const thread = await harness1.createThread();
+    expect(harness1.session.mode.get()).toBe('build');
 
-    await session1.session.mode.switch({ modeId: 'fast' });
-    expect(session1.session.mode.get()).toBe('fast');
-    expect(session1.session.model.get()).toBe('cerebras/zai-glm-4.7');
+    await harness1.session.mode.switch({ modeId: 'fast' });
+    expect(harness1.session.mode.get()).toBe('fast');
+    expect(harness1.session.model.get()).toBe('cerebras/zai-glm-4.7');
 
-    // Session 2: reopen and resume the same thread.
-    const session2 = createHarness(storage);
-    await session2.init();
-    await session2.switchThread({ threadId: thread.id });
+    // Harness 2: reopen and resume the same thread.
+    const harness2 = createHarness(storage);
+    await harness2.init();
+    await harness2.switchThread({ threadId: thread.id });
 
-    expect(session2.session.mode.get()).toBe('fast');
-    expect(session2.session.model.get()).toBe('cerebras/zai-glm-4.7');
+    expect(harness2.session.mode.get()).toBe('fast');
+    expect(harness2.session.model.get()).toBe('cerebras/zai-glm-4.7');
   });
 
   it('restores an explicitly chosen per-mode model on reopen', async () => {
-    const session1 = createHarness(storage);
-    await session1.init();
-    const thread = await session1.createThread();
+    const harness1 = createHarness(storage);
+    await harness1.init();
+    const thread = await harness1.createThread();
 
-    await session1.session.mode.switch({ modeId: 'fast' });
-    await session1.session.model.switch({ modelId: 'cerebras/qwen-3-coder-480b' });
-    expect(session1.session.model.get()).toBe('cerebras/qwen-3-coder-480b');
+    await harness1.session.mode.switch({ modeId: 'fast' });
+    await harness1.session.model.switch({ modelId: 'cerebras/qwen-3-coder-480b' });
+    expect(harness1.session.model.get()).toBe('cerebras/qwen-3-coder-480b');
 
-    const session2 = createHarness(storage);
-    await session2.init();
-    await session2.switchThread({ threadId: thread.id });
+    const harness2 = createHarness(storage);
+    await harness2.init();
+    await harness2.switchThread({ threadId: thread.id });
 
-    expect(session2.session.mode.get()).toBe('fast');
-    expect(session2.session.model.get()).toBe('cerebras/qwen-3-coder-480b');
+    expect(harness2.session.mode.get()).toBe('fast');
+    expect(harness2.session.model.get()).toBe('cerebras/qwen-3-coder-480b');
   });
 
   it('keeps the default mode and its persisted model on reopen when the user never switched modes', async () => {
-    const session1 = createHarness(storage);
-    await session1.init();
-    const thread = await session1.createThread();
-    await session1.session.model.switch({ modelId: 'anthropic/claude-opus-4-6' });
+    const harness1 = createHarness(storage);
+    await harness1.init();
+    const thread = await harness1.createThread();
+    await harness1.session.model.switch({ modelId: 'anthropic/claude-opus-4-6' });
 
-    const session2 = createHarness(storage);
-    await session2.init();
-    await session2.switchThread({ threadId: thread.id });
+    const harness2 = createHarness(storage);
+    await harness2.init();
+    await harness2.switchThread({ threadId: thread.id });
 
-    expect(session2.session.mode.get()).toBe('build');
-    expect(session2.session.model.get()).toBe('anthropic/claude-opus-4-6');
+    expect(harness2.session.mode.get()).toBe('build');
+    expect(harness2.session.model.get()).toBe('anthropic/claude-opus-4-6');
   });
 
   it('emits mode_changed with the correct previousModeId when restoring a mode from thread metadata', async () => {
-    const session1 = createHarness(storage);
-    await session1.init();
-    const thread = await session1.createThread();
-    await session1.session.mode.switch({ modeId: 'plan' });
+    const harness1 = createHarness(storage);
+    await harness1.init();
+    const thread = await harness1.createThread();
+    await harness1.session.mode.switch({ modeId: 'plan' });
 
-    const session2 = createHarness(storage);
-    await session2.init();
+    const harness2 = createHarness(storage);
+    await harness2.init();
 
     const events: Array<{ type: 'mode_changed'; modeId: string; previousModeId: string }> = [];
-    session2.subscribe(event => {
+    harness2.session.subscribe(event => {
       if (event.type === 'mode_changed') {
         events.push({
           type: event.type,
@@ -121,7 +121,7 @@ describe('Harness mode-model persistence across restarts', () => {
       }
     });
 
-    await session2.switchThread({ threadId: thread.id });
+    await harness2.switchThread({ threadId: thread.id });
 
     const restoreEvent = events.find(e => e.modeId === 'plan');
     expect(restoreEvent).toBeDefined();

--- a/packages/core/src/harness/om-failure-abort.test.ts
+++ b/packages/core/src/harness/om-failure-abort.test.ts
@@ -22,7 +22,7 @@ describe('Harness OM failure abort behavior', () => {
   it('aborts stream and emits an error when OM buffering fails', async () => {
     const harness = createHarness();
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     harness.session.run.ensureAbortController();
 
@@ -55,7 +55,7 @@ describe('Harness OM failure abort behavior', () => {
   it('aborts stream and emits an error when OM observation run fails', async () => {
     const harness = createHarness();
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     harness.session.run.ensureAbortController();
 

--- a/packages/core/src/harness/repro-mc-bug.test.ts
+++ b/packages/core/src/harness/repro-mc-bug.test.ts
@@ -90,7 +90,7 @@ describe('mc send-message reproduction', () => {
     await harness.createThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe((event: HarnessEvent) => {
+    harness.session.subscribe((event: HarnessEvent) => {
       events.push(event);
     });
 
@@ -133,7 +133,7 @@ describe('mc send-message reproduction', () => {
     await harness.createThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe((event: HarnessEvent) => {
+    harness.session.subscribe((event: HarnessEvent) => {
       events.push(event);
     });
 
@@ -186,7 +186,7 @@ describe('mc send-message reproduction', () => {
     await harness.createThread();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe((event: HarnessEvent) => {
+    harness.session.subscribe((event: HarnessEvent) => {
       events.push(event);
     });
 

--- a/packages/core/src/harness/session-bus.test.ts
+++ b/packages/core/src/harness/session-bus.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Session } from './session';
+import type { HarnessEvent } from './types';
+
+describe('Session event bus', () => {
+  it('delivers emitted events to its own subscribers', () => {
+    const session = new Session({ resourceId: 'r1' });
+    const received: HarnessEvent[] = [];
+    session.subscribe(event => { received.push(event); });
+
+    session.emit({ type: 'mode_changed', modeId: 'build', previousModeId: 'plan' });
+
+    // The mode_changed event plus the synthetic display_state_changed fan-out.
+    expect(received.map(e => e.type)).toEqual(['mode_changed', 'display_state_changed']);
+  });
+
+  it('does not deliver one session\'s events to another session\'s subscribers', () => {
+    const a = new Session({ resourceId: 'a' });
+    const b = new Session({ resourceId: 'b' });
+    const aReceived: HarnessEvent[] = [];
+    const bReceived: HarnessEvent[] = [];
+    a.subscribe(event => { aReceived.push(event); });
+    b.subscribe(event => { bReceived.push(event); });
+
+    a.emit({ type: 'mode_changed', modeId: 'build', previousModeId: 'plan' });
+
+    expect(aReceived.some(e => e.type === 'mode_changed')).toBe(true);
+    expect(bReceived).toEqual([]);
+
+    b.emit({ type: 'mode_changed', modeId: 'plan', previousModeId: 'build' });
+
+    // a still only saw its own emit; b only saw its own.
+    expect(aReceived.filter(e => e.type === 'mode_changed')).toHaveLength(1);
+    expect(bReceived.some(e => e.type === 'mode_changed')).toBe(true);
+  });
+
+  it('stops delivering after unsubscribe', () => {
+    const session = new Session({ resourceId: 'r1' });
+    const listener = vi.fn();
+    const unsubscribe = session.subscribe(listener);
+
+    session.emit({ type: 'mode_changed', modeId: 'build', previousModeId: 'plan' });
+    expect(listener).toHaveBeenCalled();
+
+    listener.mockClear();
+    unsubscribe();
+    session.emit({ type: 'mode_changed', modeId: 'plan', previousModeId: 'build' });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('routes subsystem events (state_changed) through the session bus', async () => {
+    const session = new Session<{ count: number }>({ resourceId: 'r1', state: { initialState: { count: 0 } } });
+    const received: HarnessEvent[] = [];
+    session.subscribe(event => { received.push(event); });
+
+    await session.state.set({ count: 1 });
+
+    const stateChanged = received.find(e => e.type === 'state_changed');
+    expect(stateChanged).toBeDefined();
+    expect((stateChanged as { state: Record<string, unknown> }).state.count).toBe(1);
+  });
+});

--- a/packages/core/src/harness/session-om.test.ts
+++ b/packages/core/src/harness/session-om.test.ts
@@ -25,7 +25,7 @@ function createHarness(options: {
     resolveModel: options.resolveModel,
   });
 
-  if (options.onEvent) harness.subscribe(options.onEvent);
+  if (options.onEvent) harness.session.subscribe(options.onEvent);
 
   return harness;
 }

--- a/packages/core/src/harness/session-state.test.ts
+++ b/packages/core/src/harness/session-state.test.ts
@@ -49,7 +49,7 @@ describe('Harness session state', () => {
       },
     });
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     await harness.session.state.set({ count: 1 });
 

--- a/packages/core/src/harness/session-subagents.test.ts
+++ b/packages/core/src/harness/session-subagents.test.ts
@@ -18,7 +18,7 @@ function createHarness(options: { storage: InMemoryStore; onEvent?: (event: Harn
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
   });
 
-  if (options.onEvent) harness.subscribe(options.onEvent);
+  if (options.onEvent) harness.session.subscribe(options.onEvent);
 
   return harness;
 }

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -10,6 +10,7 @@ import { createEmptyTokenUsage, defaultDisplayState, defaultOMProgressState } fr
 import type {
   HarnessDisplayState,
   HarnessEvent,
+  HarnessEventListener,
   HarnessMessage,
   HarnessMode,
   HarnessOMConfig,
@@ -661,32 +662,27 @@ export class SessionRun {
 export class SessionModel {
   #id = '';
   readonly #store: () => ThreadSettingsStore | undefined;
+  /** This session's event bus; {@link switch} emits `model_changed` here. */
+  readonly #bus: SessionBus;
   /**
    * Reads the active mode id. Injected by the Harness via {@link setResolver},
    * since {@link switch} defaults a model change to the current mode.
    */
   #getCurrentModeId: (() => string) | undefined;
-  /** Emits Harness events (`model_changed`). Injected via {@link setResolver}. */
-  #emit: ((event: HarnessEvent) => void) | undefined;
   /** App hook to track model usage for ranking. Injected via {@link setResolver}. */
   #trackModelUse: ModelUseCountTracker | undefined;
 
-  constructor(store: () => ThreadSettingsStore | undefined) {
+  constructor(store: () => ThreadSettingsStore | undefined, bus: SessionBus) {
     this.#store = store;
+    this.#bus = bus;
   }
 
   /**
    * Attach the Harness-owned dependencies {@link switch} needs: the active-mode
-   * accessor, the event emitter, and the optional model-use tracker. The
-   * Harness injects these once.
+   * accessor and the optional model-use tracker. The Harness injects these once.
    */
-  setResolver(options: {
-    getCurrentModeId: () => string;
-    emit: (event: HarnessEvent) => void;
-    trackModelUse?: ModelUseCountTracker;
-  }): void {
+  setResolver(options: { getCurrentModeId: () => string; trackModelUse?: ModelUseCountTracker }): void {
     this.#getCurrentModeId = options.getCurrentModeId;
-    this.#emit = options.emit;
     this.#trackModelUse = options.trackModelUse;
   }
 
@@ -772,7 +768,7 @@ export class SessionModel {
       console.error('Failed to track model usage count', error);
     }
 
-    this.#emit?.({ type: 'model_changed', modelId, scope, modeId: targetModeId });
+    this.#bus.emit({ type: 'model_changed', modelId, scope, modeId: targetModeId });
   }
 }
 
@@ -793,6 +789,8 @@ export class SessionMode {
   #switchVersion = 0;
   readonly #store: () => ThreadSettingsStore | undefined;
   readonly #model: SessionModel;
+  /** This session's event bus; {@link switch} emits mode_changed / model_changed here. */
+  readonly #bus: SessionBus;
   /**
    * Resolves a mode id to its full definition. Injected by the Harness via
    * {@link setResolver}, since the mode *catalog* (`config.modes`) is host config.
@@ -803,30 +801,22 @@ export class SessionMode {
    * via {@link setResolver}, since aborting a run is Harness-owned orchestration.
    */
   #abort: (() => void) | undefined;
-  /**
-   * Emits Harness events (mode_changed / model_changed) during a switch.
-   * Injected by the Harness via {@link setResolver}.
-   */
-  #emit: ((event: HarnessEvent) => void) | undefined;
 
-  constructor(store: () => ThreadSettingsStore | undefined, model: SessionModel) {
+  constructor(store: () => ThreadSettingsStore | undefined, model: SessionModel, bus: SessionBus) {
     this.#store = store;
     this.#model = model;
+    this.#bus = bus;
   }
 
   /**
    * Attach the resolver that maps a mode id to its definition, plus the
-   * Harness-owned orchestration callbacks ({@link switch} uses to abort the
-   * in-flight run and emit events). The Harness owns the mode catalog
-   * (`config.modes`) and injects these once.
+   * Harness-owned abort callback ({@link switch} uses to abort the in-flight
+   * run before switching). The Harness owns the mode catalog (`config.modes`)
+   * and injects these once.
    */
-  setResolver(
-    resolve: (modeId: string) => HarnessMode | null,
-    options?: { abort?: () => void; emit?: (event: HarnessEvent) => void },
-  ): void {
+  setResolver(resolve: (modeId: string) => HarnessMode | null, options?: { abort?: () => void }): void {
     this.#resolveMode = resolve;
     this.#abort = options?.abort;
-    this.#emit = options?.emit;
   }
 
   /** The currently-selected mode id. */
@@ -875,7 +865,7 @@ export class SessionMode {
 
     // Emit the mode change immediately so UIs can update without waiting for
     // the storage round-trips below.
-    this.#emit?.({ type: 'mode_changed', modeId, previousModeId });
+    this.#bus.emit({ type: 'mode_changed', modeId, previousModeId });
 
     // Remember the outgoing mode's model before moving on.
     if (previousModelId) {
@@ -890,7 +880,7 @@ export class SessionMode {
     if (this.#switchVersion !== version) return;
     if (modelId) {
       this.#model.set({ modelId });
-      this.#emit?.({ type: 'model_changed', modelId } as HarnessEvent);
+      this.#bus.emit({ type: 'model_changed', modelId } as HarnessEvent);
     }
   }
 }
@@ -917,15 +907,16 @@ interface SessionOMRoleConfig {
  */
 class SessionOMRole {
   readonly #config: SessionOMRoleConfig;
+  readonly #bus: SessionBus;
   #getState: (() => Record<string, unknown>) | undefined;
   #setState: ((updates: Record<string, unknown>) => void) | undefined;
   #setSetting: ((args: { key: string; value: unknown }) => Promise<void>) | undefined;
-  #emit: ((event: HarnessEvent) => void) | undefined;
   #omConfig: HarnessOMConfig | undefined;
   #resolveModel: ((modelId: string) => MastraModelConfig) | undefined;
 
-  constructor(config: SessionOMRoleConfig) {
+  constructor(config: SessionOMRoleConfig, bus: SessionBus) {
     this.#config = config;
+    this.#bus = bus;
   }
 
   /** @internal Injected by {@link SessionOM.setResolver}. */
@@ -933,14 +924,12 @@ class SessionOMRole {
     getState: () => Record<string, unknown>;
     setState: (updates: Record<string, unknown>) => void;
     setSetting: (args: { key: string; value: unknown }) => Promise<void>;
-    emit: (event: HarnessEvent) => void;
     omConfig?: HarnessOMConfig;
     resolveModel?: (modelId: string) => MastraModelConfig;
   }): void {
     this.#getState = wiring.getState;
     this.#setState = wiring.setState;
     this.#setSetting = wiring.setSetting;
-    this.#emit = wiring.emit;
     this.#omConfig = wiring.omConfig;
     this.#resolveModel = wiring.resolveModel;
   }
@@ -968,7 +957,7 @@ class SessionOMRole {
   async switchModel({ modelId }: { modelId: string }): Promise<void> {
     this.#setState?.({ [this.#config.modelIdKey]: modelId });
     await this.#setSetting?.({ key: this.#config.modelIdKey, value: modelId });
-    this.#emit?.({ type: 'om_model_changed', role: this.#config.role, modelId });
+    this.#bus.emit({ type: 'om_model_changed', role: this.#config.role, modelId });
   }
 }
 
@@ -980,31 +969,41 @@ class SessionOMRole {
  * which fans the wiring out to both roles.
  */
 class SessionOM {
-  readonly observer = new SessionOMRole({
-    role: 'observer',
-    modelIdKey: 'observerModelId',
-    thresholdKey: 'observationThreshold',
-    defaultModelId: omConfig => omConfig?.defaultObserverModelId,
-    defaultThreshold: omConfig => omConfig?.defaultObservationThreshold,
-  });
-  readonly reflector = new SessionOMRole({
-    role: 'reflector',
-    modelIdKey: 'reflectorModelId',
-    thresholdKey: 'reflectionThreshold',
-    defaultModelId: omConfig => omConfig?.defaultReflectorModelId,
-    defaultThreshold: omConfig => omConfig?.defaultReflectionThreshold,
-  });
+  readonly observer: SessionOMRole;
+  readonly reflector: SessionOMRole;
+
+  constructor(bus: SessionBus) {
+    this.observer = new SessionOMRole(
+      {
+        role: 'observer',
+        modelIdKey: 'observerModelId',
+        thresholdKey: 'observationThreshold',
+        defaultModelId: omConfig => omConfig?.defaultObserverModelId,
+        defaultThreshold: omConfig => omConfig?.defaultObservationThreshold,
+      },
+      bus,
+    );
+    this.reflector = new SessionOMRole(
+      {
+        role: 'reflector',
+        modelIdKey: 'reflectorModelId',
+        thresholdKey: 'reflectionThreshold',
+        defaultModelId: omConfig => omConfig?.defaultReflectorModelId,
+        defaultThreshold: omConfig => omConfig?.defaultReflectionThreshold,
+      },
+      bus,
+    );
+  }
 
   /**
-   * Attach the session-state read/write, thread-settings persistence, event
-   * emitter, and the Harness-owned `omConfig` defaults plus model resolver. The
-   * Harness injects these once; the wiring is shared by both roles.
+   * Attach the session-state read/write, thread-settings persistence, and the
+   * Harness-owned `omConfig` defaults plus model resolver. The Harness injects
+   * these once; the wiring is shared by both roles.
    */
   setResolver(options: {
     getState: () => Record<string, unknown>;
     setState: (updates: Record<string, unknown>) => void;
     setSetting: (args: { key: string; value: unknown }) => Promise<void>;
-    emit: (event: HarnessEvent) => void;
     omConfig?: HarnessOMConfig;
     resolveModel?: (modelId: string) => MastraModelConfig;
   }): void {
@@ -1068,22 +1067,24 @@ function subagentModelKey(agentType?: string): string {
  * {@link SessionSubagents.setResolver}.
  */
 class SessionSubagentModel {
+  readonly #bus: SessionBus;
   #getState: (() => Record<string, unknown>) | undefined;
   #setState: ((updates: Record<string, unknown>) => void) | undefined;
   #setSetting: ((args: { key: string; value: unknown }) => Promise<void>) | undefined;
-  #emit: ((event: HarnessEvent) => void) | undefined;
+
+  constructor(bus: SessionBus) {
+    this.#bus = bus;
+  }
 
   /** @internal Injected by {@link SessionSubagents.setResolver}. */
   setWiring(wiring: {
     getState: () => Record<string, unknown>;
     setState: (updates: Record<string, unknown>) => void;
     setSetting: (args: { key: string; value: unknown }) => Promise<void>;
-    emit: (event: HarnessEvent) => void;
   }): void {
     this.#getState = wiring.getState;
     this.#setState = wiring.setState;
     this.#setSetting = wiring.setSetting;
-    this.#emit = wiring.emit;
   }
 
   /**
@@ -1108,7 +1109,7 @@ class SessionSubagentModel {
     const key = subagentModelKey(agentType);
     this.#setState?.({ [key]: modelId });
     await this.#setSetting?.({ key, value: modelId });
-    this.#emit?.({ type: 'subagent_model_changed', modelId, scope: 'thread', agentType });
+    this.#bus.emit({ type: 'subagent_model_changed', modelId, scope: 'thread', agentType });
   }
 }
 
@@ -1120,17 +1121,20 @@ class SessionSubagentModel {
  * via {@link setResolver}.
  */
 class SessionSubagents {
-  readonly model = new SessionSubagentModel();
+  readonly model: SessionSubagentModel;
+
+  constructor(bus: SessionBus) {
+    this.model = new SessionSubagentModel(bus);
+  }
 
   /**
-   * Attach the session-state read/write, thread-settings persistence, and event
-   * emitter. The Harness injects these once.
+   * Attach the session-state read/write and thread-settings persistence. The
+   * Harness injects these once.
    */
   setResolver(options: {
     getState: () => Record<string, unknown>;
     setState: (updates: Record<string, unknown>) => void;
     setSetting: (args: { key: string; value: unknown }) => Promise<void>;
-    emit: (event: HarnessEvent) => void;
   }): void {
     this.model.setWiring(options);
   }
@@ -1141,7 +1145,6 @@ type SessionStateUpdater<TState, TResult> = HarnessRequestStateUpdater<TState, T
 interface SessionStateOptions<TState> {
   initialState?: Partial<TState>;
   stateSchema?: PublicSchema<TState, any>;
-  emit?: (event: HarnessEvent) => void;
 }
 
 /**
@@ -1155,15 +1158,15 @@ class SessionState<TState = unknown> {
   #state: TState;
   #updateQueue: Promise<void> = Promise.resolve();
   readonly #schema: StandardSchemaWithJSON | undefined;
-  readonly #emit: ((event: HarnessEvent) => void) | undefined;
+  readonly #bus: SessionBus;
 
-  constructor({ initialState, stateSchema, emit }: SessionStateOptions<TState>) {
+  constructor({ initialState, stateSchema }: SessionStateOptions<TState>, bus: SessionBus) {
     this.#schema = stateSchema ? toStandardSchema(stateSchema) : undefined;
     this.#state = {
       ...this.getSchemaDefaults(),
       ...(initialState as Record<string, unknown> | undefined),
     } as TState;
-    this.#emit = emit;
+    this.#bus = bus;
   }
 
   get(): Readonly<TState> {
@@ -1209,7 +1212,7 @@ class SessionState<TState = unknown> {
       this.#state = newState as TState;
     }
 
-    this.#emit?.({ type: 'state_changed', state: this.get() as Record<string, unknown>, changedKeys });
+    this.#bus.emit({ type: 'state_changed', state: this.get() as Record<string, unknown>, changedKeys });
   }
 
   set(updates: Partial<TState>): Promise<void> {
@@ -1229,7 +1232,7 @@ class SessionState<TState = unknown> {
         await this.apply(update.updates);
       }
       for (const event of update.events ?? []) {
-        this.#emit?.(event);
+        this.#bus.emit(event);
       }
       return update.result;
     });
@@ -1764,7 +1767,57 @@ export class SessionDisplayState {
   }
 }
 
+/**
+ * A session's event bus. Owns the listener list and the full emit pipeline:
+ * fold the event into the canonical display state, dispatch to this session's
+ * listeners, then fan out a synthetic `display_state_changed`. Each session
+ * has its own bus, so events never cross between sessions. Subsystems hold a
+ * reference to their session's bus and call {@link emit} directly.
+ */
+export class SessionBus {
+  readonly #listeners: HarnessEventListener[] = [];
+  #displayState: SessionDisplayState | undefined;
+
+  /** Attach the display-state reducer the bus folds events into. Set once by the Session. */
+  setDisplayState(displayState: SessionDisplayState): void {
+    this.#displayState = displayState;
+  }
+
+  subscribe(listener: HarnessEventListener): () => void {
+    this.#listeners.push(listener);
+    return () => {
+      const index = this.#listeners.indexOf(listener);
+      if (index !== -1) {
+        this.#listeners.splice(index, 1);
+      }
+    };
+  }
+
+  emit(event: HarnessEvent): void {
+    this.#displayState?.apply(event);
+    this.#dispatch(event);
+    if (event.type !== 'display_state_changed' && this.#displayState) {
+      this.#dispatch({ type: 'display_state_changed', displayState: this.#displayState.get() });
+    }
+  }
+
+  #dispatch(event: HarnessEvent): void {
+    for (const listener of this.#listeners) {
+      try {
+        const result = listener(event);
+        if (result && typeof result === 'object' && 'catch' in result) {
+          (result as Promise<void>).catch(err => console.error('Error in session event listener:', err));
+        }
+      } catch (err) {
+        console.error('Error in session event listener:', err);
+      }
+    }
+  }
+}
+
 export class Session<TState = unknown> {
+  /** This session's event bus. Constructed first so every subsystem can route its events here. */
+  readonly #bus = new SessionBus();
   /** Tool categories the user has granted "allow" for the lifetime of this session. */
   readonly #grantedCategories = new Set<string>();
   /** Individual tool names the user has granted "allow" for the lifetime of this session. */
@@ -1778,15 +1831,15 @@ export class Session<TState = unknown> {
   /** Resolves a subagent's display name from Harness config, injected via {@link setSubagentNameResolver}. */
   #resolveSubagentName: ((agentType: string) => string | undefined) | undefined;
   /** The session's currently-selected model (source of truth) + per-mode memory. */
-  readonly model = new SessionModel(() => this.#store);
+  readonly model = new SessionModel(() => this.#store, this.#bus);
   /** The session's currently-selected mode and switch sequence. */
-  readonly mode = new SessionMode(() => this.#store, this.model);
+  readonly mode = new SessionMode(() => this.#store, this.model, this.#bus);
   /** The session's observational-memory model selection (observer/reflector). */
-  readonly om = new SessionOM();
+  readonly om = new SessionOM(this.#bus);
   /** The session's persisted tool-permission rules (per-category / per-tool). */
   readonly permissions = new SessionPermissions();
   /** The session's subagent configuration (currently the subagent model). */
-  readonly subagents = new SessionSubagents();
+  readonly subagents = new SessionSubagents(this.#bus);
   /** Transient run identity (run id, trace id, operation counter) for the active run. */
   readonly run = new SessionRun();
   /** Live subscription to the active thread's agent event stream. */
@@ -1815,7 +1868,30 @@ export class Session<TState = unknown> {
       getThreadId: () => this.thread.getId(),
       clearFollowUps: () => this.followUps.clear(),
     });
-    this.state = new SessionState(state ?? { initialState: {} as TState });
+    this.#bus.setDisplayState(this.displayState);
+    this.state = new SessionState(state ?? { initialState: {} as TState }, this.#bus);
+  }
+
+  // ===========================================================================
+  // Event bus
+  // ===========================================================================
+
+  /**
+   * Subscribe to this session's events. Returns an unsubscribe function.
+   * Listeners are scoped to this session: a session never delivers its events
+   * to another session's subscribers.
+   */
+  subscribe(listener: HarnessEventListener): () => void {
+    return this.#bus.subscribe(listener);
+  }
+
+  /**
+   * Emit an event on this session. Delegates to this session's bus, which folds
+   * the event into the canonical display state, dispatches to this session's
+   * listeners, then fans out a synthetic `display_state_changed`.
+   */
+  emit(event: HarnessEvent): void {
+    this.#bus.emit(event);
   }
 
   /**

--- a/packages/core/src/harness/signal-history.test.ts
+++ b/packages/core/src/harness/signal-history.test.ts
@@ -64,7 +64,7 @@ describe('Harness signal history rendering', () => {
   it('emits agent_end when a system-reminder signal starts an idle run', async () => {
     const { harness } = await createHarnessWithThread();
     const events: Array<{ type: string; reason?: string }> = [];
-    const unsubscribe = harness.subscribe(event => {
+    const unsubscribe = harness.session.subscribe(event => {
       events.push(event as { type: string; reason?: string });
     });
 

--- a/packages/core/src/harness/signal-messages.test.ts
+++ b/packages/core/src/harness/signal-messages.test.ts
@@ -390,7 +390,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -456,7 +456,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -479,7 +479,7 @@ describe('Harness signal messages', () => {
     });
     const harness = createHarness(storage, agent);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
     vi.spyOn(agent, 'subscribeToThread').mockResolvedValue({
@@ -526,7 +526,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
     const sendMessage = vi.spyOn(harness, 'sendMessage').mockResolvedValue(undefined);
@@ -622,7 +622,7 @@ describe('Harness signal messages', () => {
     });
     const harness = createHarness(storage, agent);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -654,7 +654,7 @@ describe('Harness signal messages', () => {
     });
     const harness = createHarness(storage, agent);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -702,7 +702,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -738,7 +738,7 @@ describe('Harness signal messages', () => {
       initialState: { yolo: true } as any,
     });
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -799,7 +799,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -825,7 +825,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -912,7 +912,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -951,7 +951,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
 
@@ -998,7 +998,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
     const state = (harness as any).createStreamState();
@@ -1054,7 +1054,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
     const state = (harness as any).createStreamState();
@@ -1098,7 +1098,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
     const state = (harness as any).createStreamState();
@@ -1152,7 +1152,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
     const state = (harness as any).createStreamState();
@@ -1230,7 +1230,7 @@ describe('Harness signal messages', () => {
     const storage = new InMemoryStore();
     const harness = createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event);
     });
     const state = (harness as any).createStreamState();

--- a/packages/core/src/harness/task-tools.test.ts
+++ b/packages/core/src/harness/task-tools.test.ts
@@ -287,7 +287,7 @@ describe('task tool display bridge', () => {
     const harness = createHarness();
 
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     // Real harness request context — wires emitEvent -> harness.emit, the
     // display-only bridge the agnostic task tools call when present.

--- a/packages/core/src/harness/thread-locking.test.ts
+++ b/packages/core/src/harness/thread-locking.test.ts
@@ -279,7 +279,7 @@ describe('Harness thread locking', () => {
 
     it('emits thread_deleted event', async () => {
       const events: string[] = [];
-      harness.subscribe(event => {
+      harness.session.subscribe(event => {
         if (event.type === 'thread_deleted') events.push(event.threadId);
       });
 

--- a/packages/core/src/harness/token-usage.test.ts
+++ b/packages/core/src/harness/token-usage.test.ts
@@ -85,7 +85,7 @@ describe('step-finish token usage extraction', () => {
       raw: { provider: 'test-provider' },
     };
     const events: HarnessEvent[] = [];
-    harness.subscribe(event => events.push(event));
+    harness.session.subscribe(event => events.push(event));
 
     await (harness as any).processStream({ fullStream: mockStream(usage) });
 

--- a/packages/core/src/harness/tracing-propagation.test.ts
+++ b/packages/core/src/harness/tracing-propagation.test.ts
@@ -113,7 +113,7 @@ describe('Harness tracing propagation', () => {
 
   it('starts a new message with a clean abort state after a stale operation was aborted', async () => {
     const events: Array<{ type: string; reason?: string }> = [];
-    harness.subscribe(event => {
+    harness.session.subscribe(event => {
       events.push(event as { type: string; reason?: string });
     });
     harness.session.run.requestAbort();


### PR DESCRIPTION
## What & why

**Phase 1** of making the Harness multi-session capable (toward serving one Harness in the server and connecting it to a channel — e.g. running MastraCode in Slack, which is inherently multiplayer: each thread/user is a session).

This PR moves the **event bus onto the Session**. Today the Harness owns a single broadcast listener list, so if one Harness ever backs multiple sessions, their events would cross-contaminate. After this change each `Session` owns its own bus, and events emitted on one session reach only that session's subscribers.

> Stacked on #18213 (extract `#wireSession`). Review that first.

## Change

- New `SessionBus`: owns the listener list and the full emit pipeline (fold into display state → dispatch to this session's listeners → synthetic `display_state_changed` fan-out).
- Each `Session` constructs a `SessionBus` and passes it to its subsystems. `mode`/`model`/`om`/`permissions`/`subagents`/`state` now hold their session's bus and emit directly — the Harness no longer injects an `emit` callback through `#wireSession`.
- `Session.subscribe()` / `Session.emit()` are the public bus surface.
- **Removed `Harness.subscribe()`** and the private `Harness.emit()` / dispatch helpers. The Harness drives its default session internally via `this.#session.emit(...)`; consumers subscribe with `harness.session.subscribe(...)`.

```diff
- harness.subscribe(listener)
+ harness.session.subscribe(listener)
```

- `mastracode` and all harness tests updated to subscribe on the session.
- Renamed misleading `session1`/`session2` Harness variables in a persistence test to `harness1`/`harness2`.

## Roadmap (context)

- Phase 0 (#18213): extract `#wireSession`.
- **Phase 1 (this PR): per-session event bus.**
- Next: parameterize run-control by session + `harness.createSession({ resourceId })`.

## Test plan

- `pnpm --filter ./packages/core check` — clean
- `pnpm exec vitest run src/harness` — 319 passing (315 prior + 4 new `session-bus.test.ts`, which proves two sessions do not cross-talk)
- `mastracode` tsc — clean; headless + tool-approval unit tests pass
- Full MastraCode e2e suite (`MC_E2E_VITEST_SCENARIOS=all`) — **101 passed / 19 skipped / 0 failed**
