### PR TITLE
fix(playground-ui): prevent DataList header click overlap

### DIFF
--- a/.changeset/curly-buttons-deny.md
+++ b/.changeset/curly-buttons-deny.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed DataList selection headers so grouped header cells no longer cover select-all checkboxes.

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
@@ -1,9 +1,15 @@
 // @vitest-environment jsdom
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { createRef } from 'react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { DataList } from './data-list';
+
+beforeAll(() => {
+  if (typeof window.PointerEvent === 'undefined') {
+    window.PointerEvent = window.MouseEvent as unknown as typeof PointerEvent;
+  }
+});
 
 afterEach(() => {
   cleanup();
@@ -191,6 +197,33 @@ describe('DataListRoot', () => {
       const cell = container.querySelector<HTMLElement>('.data-list-top > *');
       expect(cell?.querySelector('span.truncate')).toBeNull();
       expect(cell?.querySelector('[data-testid="icon"]')).not.toBeNull();
+    });
+  });
+
+  describe('selection header layout', () => {
+    it('keeps grouped header cells from covering the select-all checkbox', () => {
+      const onToggle = vi.fn();
+      const { container } = render(
+        <DataList columns="auto 1fr 1fr">
+          <DataList.Top hasLeadingCell>
+            <DataList.TopSelectCell checked={false} onToggle={onToggle} aria-label="Select all" />
+            <DataList.TopCells colStart={2} data-testid="header-cells">
+              <DataList.TopCell>Name</DataList.TopCell>
+              <DataList.TopCell>Description</DataList.TopCell>
+            </DataList.TopCells>
+          </DataList.Top>
+        </DataList>,
+      );
+
+      const headerCells = container.querySelector<HTMLElement>('[data-testid="header-cells"]');
+      expect(headerCells?.style.gridColumn).toBe('2 / -1');
+      expect(headerCells?.className).toContain('pointer-events-none');
+      expect(headerCells?.className).toContain('[&>*]:pointer-events-auto');
+      expect(headerCells?.className).not.toContain('col-span-full');
+
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Select all' }));
+
+      expect(onToggle).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cells.tsx
@@ -28,7 +28,12 @@ export const DataListTopCells = forwardRef<HTMLDivElement, DataListTopCellsProps
     return (
       <div
         ref={ref}
-        className={cn('grid grid-cols-subgrid gap-8 col-span-full px-5', flushLeft && 'pl-0!', className)}
+        className={cn(
+          'grid grid-cols-subgrid gap-8 px-5 pointer-events-none [&>*]:pointer-events-auto',
+          !colStart && 'col-span-full',
+          flushLeft && 'pl-0!',
+          className,
+        )}
         style={colStart ? { ...style, gridColumn: `${colStart} / -1` } : style}
         {...rest}
       >


### PR DESCRIPTION
## What

- Make DataList.TopCells transparent to pointer events so grouped non-interactive headers cannot cover the leading select-all checkbox.
- Keep direct children pointer-interactive for future header content such as tooltips.
- Avoid emitting col-span-full when colStart provides an explicit grid span.
- Add a focused DataList regression test for the selection header layout.

## Validation

- pnpm exec prettier --check .changeset/curly-buttons-deny.md packages/playground-ui/src/ds/components/DataList/data-list-top-cells.tsx packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
- pnpm --filter ./packages/playground-ui exec eslint src/ds/components/DataList/data-list-top-cells.tsx src/ds/components/DataList/data-list-root.test.tsx --max-warnings 0
- pnpm --filter ./packages/playground-ui exec vitest run src/ds/components/DataList/data-list-root.test.tsx
- pnpm --filter ./packages/playground-ui typecheck
- pnpm build:playground-ui
- Playwright dataset-items-list spec against kitchen-sink on 4112 with a temporary local config: 7/7 passed
- npx -y react-doctor@latest . --verbose --diff (exit 0; existing warnings outside this fix)

CodeRabbit CLI local review was attempted but could not run in this non-interactive environment without an API key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The DataList component had a problem where the header cells were blocking clicks to the "select all" checkbox. This PR fixes it by making the header cells transparent to mouse clicks (but keeping their inner content clickable), like putting an invisible sheet over the headers that doesn't block important buttons underneath.

## Overview

This PR fixes a pointer event overlap issue in the DataList component where header cells were preventing interaction with the select-all checkbox. The fix makes header cells transparent to pointer events while preserving interactivity for their child elements.

## Changes

**packages/playground-ui/src/ds/components/DataList/data-list-top-cells.tsx**
- Added `pointer-events-none` class to DataListTopCells with `[&>*]:pointer-events-auto` to allow child elements to remain interactive
- Modified `col-span-full` logic to only apply when `colStart` is not provided, preventing conflicting grid layout directives
- Refactored className composition into multiple conditional arguments for improved clarity

**packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx**
- Added `PointerEvent` polyfill for jsdom environments
- Imported additional testing utilities (`fireEvent`, `screen`) and lifecycle setup (`beforeAll`)
- Added new "selection header layout" test suite to verify that grouped header cells don't cover the select-all checkbox, asserting correct grid positioning and pointer-events behavior

**.changeset/curly-buttons-deny.md**
- Documented patch release for `@mastra/playground-ui`

## Validation

All checks passed:
- Code formatting (Prettier)
- Linting (ESLint)
- Unit tests (Vitest)
- Type checking (TypeScript)
- Build verification
- End-to-end tests (7/7 passed on Playwright)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->