### PR TITLE
Preserve unsent composer drafts per thread

### DIFF
--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
@@ -22,7 +22,7 @@ interface AgentMemoryProps {
 
 export function AgentMemory({ agentId, threadId, memoryType }: AgentMemoryProps) {
   const isGatewayMemory = memoryType === 'gateway';
-  const { threadInput: chatInputValue } = useThreadInput();
+  const { threadInput: chatInputValue } = useThreadInput(threadId);
 
   const { paths, navigate } = useLinkComponent();
 

--- a/packages/playground/src/domains/conversation/context/ThreadInputContext.tsx
+++ b/packages/playground/src/domains/conversation/context/ThreadInputContext.tsx
@@ -1,19 +1,36 @@
-import { createContext, useContext, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import type { ReactNode, SetStateAction } from 'react';
+import { resolveThreadInputKey, ThreadInputContext } from './thread-input-context';
 
-const ThreadInputContext = createContext<{
-  threadInput: string;
-  setThreadInput: React.Dispatch<React.SetStateAction<string>>;
-}>({
-  threadInput: '',
-  setThreadInput: () => {},
-});
+export const ThreadInputProvider = ({ children }: { children: ReactNode }) => {
+  const [threadInputs, setThreadInputs] = useState<Record<string, string>>({});
 
-export const ThreadInputProvider = ({ children }: { children: React.ReactNode }) => {
-  const [threadInput, setThreadInput] = useState('');
+  const getThreadInput = useCallback(
+    (threadId?: string) => threadInputs[resolveThreadInputKey(threadId)] ?? '',
+    [threadInputs],
+  );
 
-  return <ThreadInputContext.Provider value={{ threadInput, setThreadInput }}>{children}</ThreadInputContext.Provider>;
-};
+  const setThreadInputForThread = useCallback((threadId: string | undefined, value: SetStateAction<string>) => {
+    setThreadInputs(prev => {
+      const key = resolveThreadInputKey(threadId);
+      const previousValue = prev[key] ?? '';
+      const nextValue = typeof value === 'function' ? value(previousValue) : value;
 
-export const useThreadInput = () => {
-  return useContext(ThreadInputContext);
+      if (nextValue === previousValue) return prev;
+
+      if (nextValue.length === 0) {
+        if (!(key in prev)) return prev;
+
+        const nextInputs = { ...prev };
+        delete nextInputs[key];
+        return nextInputs;
+      }
+
+      return { ...prev, [key]: nextValue };
+    });
+  }, []);
+
+  const value = useMemo(() => ({ getThreadInput, setThreadInputForThread }), [getThreadInput, setThreadInputForThread]);
+
+  return <ThreadInputContext.Provider value={value}>{children}</ThreadInputContext.Provider>;
 };

--- a/packages/playground/src/domains/conversation/context/thread-input-context.ts
+++ b/packages/playground/src/domains/conversation/context/thread-input-context.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+import type { SetStateAction } from 'react';
+
+export interface ThreadInputContextValue {
+  getThreadInput: (threadId?: string) => string;
+  setThreadInputForThread: (threadId: string | undefined, value: SetStateAction<string>) => void;
+}
+
+const FALLBACK_THREAD_INPUT_KEY = '__default__';
+
+export const resolveThreadInputKey = (threadId?: string) => threadId || FALLBACK_THREAD_INPUT_KEY;
+
+export const ThreadInputContext = createContext<ThreadInputContextValue>({
+  getThreadInput: () => '',
+  setThreadInputForThread: () => {},
+});

--- a/packages/playground/src/domains/conversation/context/useThreadInput.ts
+++ b/packages/playground/src/domains/conversation/context/useThreadInput.ts
@@ -1,0 +1,23 @@
+import { use, useCallback } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { ThreadInputContext } from './thread-input-context';
+
+type ThreadInputSetter = Dispatch<SetStateAction<string>>;
+
+export const useThreadInput = (
+  threadId?: string,
+): {
+  threadInput: string;
+  setThreadInput: ThreadInputSetter;
+} => {
+  const { getThreadInput, setThreadInputForThread } = use(ThreadInputContext);
+  const setThreadInput = useCallback<ThreadInputSetter>(
+    value => setThreadInputForThread(threadId, value),
+    [setThreadInputForThread, threadId],
+  );
+
+  return {
+    threadInput: getThreadInput(threadId),
+    setThreadInput,
+  };
+};

--- a/packages/playground/src/domains/conversation/index.ts
+++ b/packages/playground/src/domains/conversation/index.ts
@@ -1,1 +1,2 @@
-export * from './context/ThreadInputContext';
+export { ThreadInputProvider } from './context/ThreadInputContext';
+export { useThreadInput } from './context/useThreadInput';

--- a/packages/playground/src/lib/ai-ui/__tests__/thread.test.tsx
+++ b/packages/playground/src/lib/ai-ui/__tests__/thread.test.tsx
@@ -12,6 +12,7 @@ import { ChatProvider } from '../chat/chat-provider';
 import { Thread } from '../thread';
 import { WorkingMemoryProvider } from '@/domains/agents/context/agent-working-memory-context';
 import { BrowserSessionProvider } from '@/domains/agents/context/browser-session-provider';
+import { ThreadInputProvider } from '@/domains/conversation';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';
@@ -66,14 +67,14 @@ const baseHandlers = () => [
   ),
 ];
 
-const Wrapper = ({ children }: { children: ReactNode }) => {
+const Wrapper = ({ children, threadId = 'thread-1' }: { children: ReactNode; threadId?: string }) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return (
     <MastraReactProvider baseUrl={BASE_URL}>
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <BrowserSessionProvider agentId="agent-1" threadId="thread-1" enabled={false}>
-            <WorkingMemoryProvider agentId="agent-1" threadId="thread-1" resourceId="agent-1">
+          <BrowserSessionProvider agentId="agent-1" threadId={threadId} enabled={false}>
+            <WorkingMemoryProvider agentId="agent-1" threadId={threadId} resourceId="agent-1">
               {children}
             </WorkingMemoryProvider>
           </BrowserSessionProvider>
@@ -83,14 +84,27 @@ const Wrapper = ({ children }: { children: ReactNode }) => {
   );
 };
 
-const renderThread = (initialMessages: MastraDBMessage[], props: { hasModelList?: boolean } = { hasModelList: true }) =>
-  render(
-    <Wrapper>
-      <ChatProvider agentId="agent-1" threadId="thread-1" initialMessages={initialMessages}>
-        <Thread agentId="agent-1" agentName="Helper" threadId="thread-1" hasModelList={props.hasModelList} />
-      </ChatProvider>
-    </Wrapper>,
+const renderThreadTree = (
+  initialMessages: MastraDBMessage[],
+  options: { hasModelList?: boolean; threadId?: string } = {},
+) => {
+  const { hasModelList = true, threadId = 'thread-1' } = options;
+
+  return (
+    <Wrapper threadId={threadId}>
+      <ThreadInputProvider>
+        <ChatProvider key={threadId} agentId="agent-1" threadId={threadId} initialMessages={initialMessages}>
+          <Thread agentId="agent-1" agentName="Helper" threadId={threadId} hasModelList={hasModelList} />
+        </ChatProvider>
+      </ThreadInputProvider>
+    </Wrapper>
   );
+};
+
+const renderThread = (
+  initialMessages: MastraDBMessage[],
+  options: { hasModelList?: boolean; threadId?: string } = { hasModelList: true },
+) => render(renderThreadTree(initialMessages, options));
 
 const userMessage = (text: string): MastraDBMessage => ({
   id: `m-${text}`,
@@ -199,6 +213,49 @@ describe('Thread', () => {
     expect(JSON.stringify(captured[0].body.messages ?? [])).toContain('hello from composer');
     // Composer clears after sending.
     expect((textarea as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('restores unsent composer drafts when switching threads', async () => {
+    server.use(...baseHandlers());
+
+    let rendered: ReturnType<typeof render> | undefined;
+    await act(async () => {
+      rendered = render(renderThreadTree([], { threadId: 'thread-1' }));
+    });
+
+    const firstThreadTextarea = screen.getByPlaceholderText('Enter your message...') as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(firstThreadTextarea, { target: { value: 'first thread draft' } });
+    });
+    expect(firstThreadTextarea.value).toBe('first thread draft');
+
+    await act(async () => {
+      rendered?.rerender(renderThreadTree([], { threadId: 'thread-2' }));
+    });
+
+    const secondThreadTextarea = screen.getByPlaceholderText('Enter your message...') as HTMLTextAreaElement;
+    expect(secondThreadTextarea.value).toBe('');
+
+    await act(async () => {
+      fireEvent.change(secondThreadTextarea, { target: { value: 'second thread draft' } });
+    });
+    expect(secondThreadTextarea.value).toBe('second thread draft');
+
+    await act(async () => {
+      rendered?.rerender(renderThreadTree([], { threadId: 'thread-1' }));
+    });
+
+    expect((screen.getByPlaceholderText('Enter your message...') as HTMLTextAreaElement).value).toBe(
+      'first thread draft',
+    );
+
+    await act(async () => {
+      rendered?.rerender(renderThreadTree([], { threadId: 'thread-2' }));
+    });
+
+    expect((screen.getByPlaceholderText('Enter your message...') as HTMLTextAreaElement).value).toBe(
+      'second thread draft',
+    );
   });
 
   it('does not send when the composer is empty', async () => {

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -147,6 +147,7 @@ export const Thread = ({
 
         <Composer
           agentId={agentId}
+          threadId={threadId}
           hasModelList={hasModelList}
           hideModelSwitcher={hideModelSwitcher}
           runOptionsSlot={runOptionsSlot}
@@ -171,15 +172,15 @@ const ThreadWelcome = ({ agentName }: ThreadWelcomeProps) => {
 
 interface ComposerProps {
   agentId?: string;
+  threadId?: string;
   hasModelList?: boolean;
   hideModelSwitcher?: boolean;
   runOptionsSlot?: React.ReactNode;
 }
 
-const Composer = ({ agentId, hasModelList, hideModelSwitcher, runOptionsSlot }: ComposerProps) => {
-  const { setThreadInput } = useThreadInput();
+const Composer = ({ agentId, threadId, hasModelList, hideModelSwitcher, runOptionsSlot }: ComposerProps) => {
+  const { threadInput: text, setThreadInput } = useThreadInput(threadId);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [text, setText] = useState('');
   const send = useChatSend();
   const { attachments, toCoreUserMessages, clear } = useComposerAttachments();
   const { isRunning, canSendWhileStreaming, cancelRun } = useChatRunning();
@@ -194,8 +195,7 @@ const Composer = ({ agentId, hasModelList, hideModelSwitcher, runOptionsSlot }: 
     if (isEmpty || sendBlocked || !canExecuteAgent) return;
     const coreUserMessages = attachments.length > 0 ? await toCoreUserMessages() : undefined;
     const message = text;
-    setText('');
-    setThreadInput?.('');
+    setThreadInput('');
     clear();
     setSendPulseKey(k => k + 1);
     send({ message, attachments: coreUserMessages });
@@ -233,8 +233,7 @@ const Composer = ({ agentId, hasModelList, hideModelSwitcher, runOptionsSlot }: 
                 className="field-sizing-content min-h-17 w-full text-ui-lg leading-ui-lg placeholder:text-neutral3 text-neutral6 bg-transparent focus:outline-hidden resize-none outline-hidden disabled:cursor-not-allowed disabled:opacity-50 px-3 pt-3 pb-2"
                 placeholder={canExecuteAgent ? 'Enter your message...' : "You don't have permission to execute agents"}
                 onChange={e => {
-                  setText(e.target.value);
-                  setThreadInput?.(e.target.value);
+                  setThreadInput(e.target.value);
                 }}
                 onKeyDown={e => {
                   // Ignore Enter while an IME composition is active (e.g. committing a
@@ -262,8 +261,7 @@ const Composer = ({ agentId, hasModelList, hideModelSwitcher, runOptionsSlot }: 
               canSendWhileStreaming={canSendWhileStreaming}
               onCancel={() => void cancelRun()}
               onSetText={value => {
-                setText(value);
-                setThreadInput?.(value);
+                setThreadInput(value);
               }}
             />
           </div>


### PR DESCRIPTION
## Summary
- Store thread composer input by thread ID instead of a single shared value
- Restore drafts when switching between threads in the playground composer
- Update memory sidebar access to read the matching thread draft
- Add a regression test covering draft restoration across thread switches

## Testing
- Unit tests added for thread draft persistence across thread changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Instead of having one shared notepad for what you're typing, each conversation thread now has its own notepad that remembers your unsent message. When you switch between different threads, the app automatically shows you what you were typing in each one, so you don't lose your drafts.

## Changes Overview

This PR refactors the composer draft persistence system to store message drafts on a per-thread basis rather than maintaining a single shared value across all threads. The changes enable automatic recovery of unsent messages when users navigate between different threads in the playground composer.

## Technical Changes

**Context and Hook Restructuring:**
- Created a new `thread-input-context.ts` file with a `ThreadInputContextValue` interface that manages per-thread input state through `getThreadInput()` and `setThreadInputForThread()` methods
- Introduced `resolveThreadInputKey()` function that maps thread IDs to storage keys (using a default key when no thread ID is provided)
- Refactored `ThreadInputProvider` to manage a `Record<string, string>` of thread-scoped inputs instead of a single string value
- Moved `useThreadInput()` hook to a new dedicated file (`useThreadInput.ts`) where it now accepts an optional `threadId` parameter and delegates to the context's thread-specific methods
- Updated `packages/playground/src/domains/conversation/index.ts` to explicitly export `ThreadInputProvider` and `useThreadInput` instead of using wildcard exports

**Component Updates:**
- Modified `AgentMemory` component to call `useThreadInput(threadId)` with the current thread ID, ensuring it displays the correct draft for the active thread
- Updated `Thread` component to pass `threadId` to the `Composer` component
- Refactored `Composer` to manage draft state through `useThreadInput(threadId)` instead of local component state, with draft clearing now delegating to the thread-input context

**Test Coverage:**
- Enhanced test harness to support multiple thread IDs with `ThreadInputProvider` integrated into the test tree
- Added a new regression test that validates draft persistence and restoration across thread switches, verifying that previously unsent messages are correctly recovered when navigating between different threads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->