### PR TITLE
Remove Browser Agent runtime dependency install

### DIFF
--- a/templates/template-browser-agent/.env.example
+++ b/templates/template-browser-agent/.env.example
@@ -12,9 +12,4 @@ TURSO_AUTH_TOKEN=
 BROWSER_HEADLESS=true
 
 # Optional: connect to a hosted Chrome/Browserbase/Browserless instance instead of launching local Chromium.
-# If unset on Linux as root, the template installs Playwright's Chromium system dependencies at first browser use.
 BROWSER_CDP_URL=
-
-# Optional: skip runtime `playwright install-deps chromium`.
-# Only set this if your runtime image already includes Chromium's Linux system libraries.
-BROWSER_SKIP_INSTALL_DEPS=false

--- a/templates/template-browser-agent/README.md
+++ b/templates/template-browser-agent/README.md
@@ -12,13 +12,13 @@ This demo runs in Mastra Studio, but you can connect this agent to your React, N
 
 - A [Mastra Gateway API key](https://mastra.ai/docs/models/gateways/mastra).
 - A [Turso](https://turso.tech) database URL + auth token (or swap to `:memory:` for ephemeral local runs).
-- Playwright Chromium is installed by the `playwright-chromium` package during dependency install. On Linux root runtimes, the template runs `playwright install-deps chromium` before the first local browser launch. You can set `BROWSER_CDP_URL` for a hosted Chrome/Browserbase/Browserless instance instead.
+- Playwright Chromium is installed by the `playwright-chromium` package during dependency install. Server images must include Chromium's Linux shared libraries, or you can set `BROWSER_CDP_URL` for a hosted Chrome/Browserbase/Browserless instance instead.
 
 ## Quickstart 🚀
 
 1. **Add your API keys**
    - Copy `.env.example` to `.env` and fill it in. Set `BROWSER_HEADLESS=false` if you want to watch the agent click around locally.
-   - For server deployments, leave `BROWSER_SKIP_INSTALL_DEPS=false` so Linux Chromium system dependencies are installed before first browser use, or set `BROWSER_CDP_URL` to a hosted browser endpoint.
+   - For server deployments, use a runtime image with Chromium's Linux shared libraries or set `BROWSER_CDP_URL` to a hosted browser endpoint.
 2. **Start the dev server**
    - Run `npm run dev` and open [localhost:4111](http://localhost:4111).
 
@@ -43,7 +43,7 @@ export const browserAgent = new Agent({
 });
 ```
 
-Passing `browser` to the agent automatically registers the full browser toolset (`browser_goto`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_scroll`, `browser_screenshot`, etc.) on the agent. The template installs Playwright's Linux system dependencies before first local browser launch when running as root; set `BROWSER_CDP_URL` to connect to a remote browser instead.
+Passing `browser` to the agent automatically registers the full browser toolset (`browser_goto`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_scroll`, `browser_screenshot`, etc.) on the agent. Use a runtime image with Chromium's Linux shared libraries for local browser launches, or set `BROWSER_CDP_URL` to connect to a remote browser instead.
 
 ## Making it yours
 

--- a/templates/template-browser-agent/src/mastra/agents/browser-agent.ts
+++ b/templates/template-browser-agent/src/mastra/agents/browser-agent.ts
@@ -1,83 +1,12 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
-import { AgentBrowser, AgentBrowserThreadManager } from '@mastra/agent-browser';
-import type { AgentBrowserThreadManagerConfig } from '@mastra/agent-browser';
-import { createRequire } from 'node:module';
-import { dirname, join, normalize } from 'node:path';
-import { spawn } from 'node:child_process';
+import { AgentBrowser } from '@mastra/agent-browser';
 import 'playwright-chromium';
-
-const require = createRequire(import.meta.url);
-let installDepsPromise: Promise<void> | undefined;
-
-function shouldInstallLinuxDeps() {
-  return (
-    process.platform === 'linux' &&
-    typeof process.getuid === 'function' &&
-    process.getuid() === 0 &&
-    process.env.BROWSER_SKIP_INSTALL_DEPS !== 'true' &&
-    !process.env.BROWSER_CDP_URL
-  );
-}
-
-function resolvePlaywrightCli() {
-  const packageEntry = require.resolve('playwright-chromium');
-  const cliPath = normalize(join(dirname(packageEntry), 'cli.js'));
-
-  if (!cliPath.endsWith('/node_modules/playwright-chromium/cli.js')) {
-    throw new Error(`Unexpected playwright-chromium CLI path: ${cliPath}`);
-  }
-
-  return cliPath;
-}
-
-async function installPlaywrightLinuxDeps() {
-  if (!shouldInstallLinuxDeps()) return;
-
-  installDepsPromise ??= new Promise<void>((resolve, reject) => {
-    const child = spawn(process.execPath, [resolvePlaywrightCli(), 'install-deps', 'chromium'], {
-      shell: false,
-      stdio: 'inherit',
-    });
-
-    const timeout = setTimeout(() => {
-      installDepsPromise = undefined;
-      child.kill('SIGTERM');
-      reject(new Error('Timed out installing Playwright Chromium system dependencies'));
-    }, 120_000);
-
-    child.once('error', error => {
-      clearTimeout(timeout);
-      installDepsPromise = undefined;
-      reject(error);
-    });
-
-    child.once('exit', code => {
-      clearTimeout(timeout);
-      if (code === 0) {
-        resolve();
-      } else {
-        installDepsPromise = undefined;
-        reject(new Error(`Failed to install Playwright Chromium system dependencies: exit code ${code}`));
-      }
-    });
-  });
-
-  await installDepsPromise;
-}
-
-class RuntimeDepsThreadManager extends AgentBrowserThreadManager {
-  protected override async createSession(threadId: string) {
-    await installPlaywrightLinuxDeps();
-    return super.createSession(threadId);
-  }
-}
 
 const browser = new AgentBrowser({
   headless: process.env.BROWSER_HEADLESS !== 'false',
   ...(process.env.BROWSER_CDP_URL ? { cdpUrl: process.env.BROWSER_CDP_URL, scope: 'shared' as const } : {}),
-  createThreadManager: (config: AgentBrowserThreadManagerConfig) => new RuntimeDepsThreadManager(config),
 });
 
 export const browserAgent = new Agent({


### PR DESCRIPTION
## Summary
- Remove the Browser Agent template's runtime `playwright install-deps chromium` workaround.
- Keep `playwright-chromium` installed so the template still provides the Chromium browser binary during dependency install.
- Update Browser Agent docs/env examples to point users at runtime images with Chromium system libraries or `BROWSER_CDP_URL`.

## Notes
- Checked `template-claw-assistant`; it does not have the same runtime dependency installer, so this PR only changes `template-browser-agent`.
- This pairs with the Platform runtime base image work so server deploys get Chromium shared libraries from the image instead of app startup.

## Test plan
- Isolated Browser Agent template copy:
  - `npm install --ignore-workspace`
  - `npx tsc --noEmit`
  - `npm run build`
  - `cp .env.example .env && npx mastra lint --preflight`
- `npx prettier --write templates/template-browser-agent/src/mastra/agents/browser-agent.ts templates/template-browser-agent/README.md`
- `git diff --check`
