### PR TITLE
fix: attribute browser click navigations to agent

### DIFF
--- a/.changeset/plain-tools-double.md
+++ b/.changeset/plain-tools-double.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed browser state updates to attribute click-driven navigation to the assistant when the browser click result reports the new URL.

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -83,19 +83,24 @@ describe('BrowserContextProcessor', () => {
     const createStateArgs = (
       browserCtx?: BrowserContext,
       activeStateSignals: any[] = [],
-      options: { contextWindow?: { hasSnapshot?: boolean }; lastSnapshot?: any } = {},
+      options: {
+        contextWindow?: { hasSnapshot?: boolean };
+        lastSnapshot?: any;
+        steps?: any[];
+        messageListMessages?: MastraDBMessage[];
+      } = {},
     ) => {
       const requestContext = new RequestContext();
       if (browserCtx) requestContext.set('browser', browserCtx);
       return {
         messages: [],
-        messageList: createMockMessageList() as any,
+        messageList: createMockMessageList(options.messageListMessages) as any,
         requestContext,
         state: {},
         abort: vi.fn() as any,
         retryCount: 0,
         stepNumber: 0,
-        steps: [],
+        steps: options.steps ?? [],
         resourceId: 'resource-1',
         threadId: 'thread-1',
         activeStateSignals,
@@ -587,6 +592,192 @@ describe('BrowserContextProcessor', () => {
           mode: 'delta',
           contents: 'changed: user changed active tab URL to https://www.google.com/',
           delta: { activeUrl: 'https://www.google.com/', activeUrlChangeSource: 'user' },
+        }),
+      );
+    });
+
+    it('attributes active URL changes to the agent when the latest browser click returned that URL', async () => {
+      const snapshot = await processor.computeStateSignal(
+        createStateArgs({ provider: 'agent-browser', isOpen: true, currentUrl: 'https://example.com' }),
+      );
+      expect(snapshot).toBeDefined();
+      const activeSignal = createSignal({
+        type: 'state',
+        contents: snapshot!.contents,
+        metadata: {
+          state: { id: 'browser', threadId: 'thread-1', cacheKey: snapshot!.cacheKey, version: 1 },
+          browser: snapshot!.metadata!.browser,
+        },
+      });
+
+      const result = await processor.computeStateSignal(
+        createStateArgs(
+          {
+            provider: 'agent-browser',
+            isOpen: true,
+            currentUrl: 'https://example.com/review-trip',
+          },
+          [activeSignal as any],
+          {
+            steps: [
+              {
+                toolResults: [
+                  {
+                    type: 'tool-result',
+                    toolName: 'browser_click',
+                    output: { success: true, url: 'https://example.com/review-trip' },
+                  },
+                ],
+              },
+            ],
+          },
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          mode: 'delta',
+          contents: 'changed: agent changed active tab URL to https://example.com/review-trip',
+          delta: { activeUrl: 'https://example.com/review-trip', activeUrlChangeSource: 'agent' },
+        }),
+      );
+    });
+
+    it('overrides user attribution when the latest browser click in message history returned the active URL', async () => {
+      const snapshot = await processor.computeStateSignal(
+        createStateArgs({ provider: 'agent-browser', isOpen: true, currentUrl: 'https://example.com' }),
+      );
+      expect(snapshot).toBeDefined();
+      const activeSignal = createSignal({
+        type: 'state',
+        contents: snapshot!.contents,
+        metadata: {
+          state: { id: 'browser', threadId: 'thread-1', cacheKey: snapshot!.cacheKey, version: 1 },
+          browser: snapshot!.metadata!.browser,
+        },
+      });
+
+      const result = await processor.computeStateSignal(
+        createStateArgs(
+          {
+            provider: 'agent-browser',
+            isOpen: true,
+            currentUrl: 'https://example.com/pricing',
+            activeUrlChangeSource: 'user',
+          },
+          [activeSignal as any],
+          {
+            messageListMessages: [
+              {
+                id: 'assistant-1',
+                role: 'assistant',
+                content: {
+                  format: 2,
+                  parts: [
+                    {
+                      type: 'tool-invocation',
+                      toolInvocation: {
+                        state: 'result',
+                        toolName: 'browser_click',
+                        result: { success: true, url: 'https://example.com/pricing' },
+                      },
+                    },
+                  ],
+                },
+              } as any,
+            ],
+          },
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          mode: 'delta',
+          contents: 'changed: agent changed active tab URL to https://example.com/pricing',
+          delta: { activeUrl: 'https://example.com/pricing', activeUrlChangeSource: 'agent' },
+        }),
+      );
+    });
+
+    it('keeps user attribution when the latest browser click returned a different URL', async () => {
+      const snapshot = await processor.computeStateSignal(
+        createStateArgs({ provider: 'agent-browser', isOpen: true, currentUrl: 'https://example.com' }),
+      );
+      expect(snapshot).toBeDefined();
+      const activeSignal = createSignal({
+        type: 'state',
+        contents: snapshot!.contents,
+        metadata: {
+          state: { id: 'browser', threadId: 'thread-1', cacheKey: snapshot!.cacheKey, version: 1 },
+          browser: snapshot!.metadata!.browser,
+        },
+      });
+
+      const result = await processor.computeStateSignal(
+        createStateArgs(
+          {
+            provider: 'agent-browser',
+            isOpen: true,
+            currentUrl: 'https://www.google.com/',
+          },
+          [activeSignal as any],
+          {
+            steps: [
+              {
+                toolResults: [
+                  {
+                    type: 'tool-result',
+                    toolName: 'browser_click',
+                    output: { success: true, url: 'https://example.com' },
+                  },
+                ],
+              },
+            ],
+          },
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          mode: 'delta',
+          contents: 'changed: user changed active tab URL to https://www.google.com/',
+          delta: { activeUrl: 'https://www.google.com/', activeUrlChangeSource: 'user' },
+        }),
+      );
+    });
+
+    it('includes active URL change source when the URL changes but source stays the same', async () => {
+      const activeSignal = createSignal({
+        type: 'state',
+        contents: 'Browser is open. Active tab URL: https://example.com.',
+        metadata: {
+          state: { id: 'browser', threadId: 'thread-1', cacheKey: 'old', version: 1 },
+          browser: {
+            processId: 'browser-process',
+            open: true,
+            activeUrl: 'https://example.com',
+            activeUrlChangeSource: 'agent',
+          },
+        },
+      });
+
+      const result = await processor.computeStateSignal(
+        createStateArgs(
+          {
+            provider: 'agent-browser',
+            isOpen: true,
+            currentUrl: 'https://example.com/pricing',
+            activeUrlChangeSource: 'agent',
+          },
+          [activeSignal as any],
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          mode: 'delta',
+          contents: 'changed: agent changed active tab URL to https://example.com/pricing',
+          delta: { activeUrl: 'https://example.com/pricing', activeUrlChangeSource: 'agent' },
         }),
       );
     });

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -656,6 +656,79 @@ describe('BrowserContextProcessor', () => {
           browser: snapshot!.metadata!.browser,
         },
       });
+      const latestBrowserStateMessage = createSignal({
+        type: 'state',
+        tagName: 'state',
+        contents: snapshot!.contents,
+        metadata: {
+          state: { id: 'browser', threadId: 'thread-1', cacheKey: snapshot!.cacheKey, version: 1, mode: 'snapshot' },
+        },
+      }).toDBMessage({ threadId: 'thread-1', resourceId: 'resource-1' });
+
+      const result = await processor.computeStateSignal(
+        createStateArgs(
+          {
+            provider: 'agent-browser',
+            isOpen: true,
+            currentUrl: 'https://example.com/pricing',
+            activeUrlChangeSource: 'user',
+          },
+          [activeSignal as any],
+          {
+            messageListMessages: [
+              latestBrowserStateMessage,
+              {
+                id: 'assistant-1',
+                role: 'assistant',
+                content: {
+                  format: 2,
+                  parts: [
+                    {
+                      type: 'tool-invocation',
+                      toolInvocation: {
+                        state: 'result',
+                        toolName: 'browser_click',
+                        result: { success: true, url: 'https://example.com/pricing' },
+                      },
+                    },
+                  ],
+                },
+              } as any,
+            ],
+          },
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          mode: 'delta',
+          contents: 'changed: agent changed active tab URL to https://example.com/pricing',
+          delta: { activeUrl: 'https://example.com/pricing', activeUrlChangeSource: 'agent' },
+        }),
+      );
+    });
+
+    it('does not use stale browser click history before the latest browser state signal', async () => {
+      const snapshot = await processor.computeStateSignal(
+        createStateArgs({ provider: 'agent-browser', isOpen: true, currentUrl: 'https://example.com' }),
+      );
+      expect(snapshot).toBeDefined();
+      const activeSignal = createSignal({
+        type: 'state',
+        contents: snapshot!.contents,
+        metadata: {
+          state: { id: 'browser', threadId: 'thread-1', cacheKey: snapshot!.cacheKey, version: 1 },
+          browser: snapshot!.metadata!.browser,
+        },
+      });
+      const latestBrowserStateMessage = createSignal({
+        type: 'state',
+        tagName: 'state',
+        contents: 'changed: agent changed active tab URL to https://example.com/docs',
+        metadata: {
+          state: { id: 'browser', threadId: 'thread-1', cacheKey: 'latest-browser-state', version: 2, mode: 'delta' },
+        },
+      }).toDBMessage({ threadId: 'thread-1', resourceId: 'resource-1' });
 
       const result = await processor.computeStateSignal(
         createStateArgs(
@@ -685,6 +758,7 @@ describe('BrowserContextProcessor', () => {
                   ],
                 },
               } as any,
+              latestBrowserStateMessage,
             ],
           },
         ),
@@ -693,8 +767,8 @@ describe('BrowserContextProcessor', () => {
       expect(result).toEqual(
         expect.objectContaining({
           mode: 'delta',
-          contents: 'changed: agent changed active tab URL to https://example.com/pricing',
-          delta: { activeUrl: 'https://example.com/pricing', activeUrlChangeSource: 'agent' },
+          contents: 'changed: user changed active tab URL to https://example.com/pricing',
+          delta: { activeUrl: 'https://example.com/pricing', activeUrlChangeSource: 'user' },
         }),
       );
     });

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -143,16 +143,23 @@ export class BrowserContextProcessor {
       browserState.activeUrl &&
       previousState.activeUrl !== browserState.activeUrl &&
       previousState.processId === browserState.processId &&
-      !browserState.activeUrlChangeSource
+      browserState.activeUrlChangeSource !== 'agent'
     ) {
-      browserState = { ...browserState, activeUrlChangeSource: 'user' };
+      const recentClickUrl =
+        getMostRecentBrowserClickResultUrl(args.steps) ??
+        getMostRecentBrowserClickResultUrlFromMessageList(args.messageList);
+      const activeUrlChangeSource = recentClickUrl === browserState.activeUrl ? 'agent' : browserState.activeUrlChangeSource ?? 'user';
+      browserState = {
+        ...browserState,
+        activeUrlChangeSource,
+      };
     }
 
     const changed = getChangedBrowserState(previousState, browserState);
     if (previousState && Object.keys(changed).length === 0 && !shouldRefreshSnapshot) return;
 
     const isDelta = Boolean(previousState && !shouldRefreshSnapshot);
-    return {
+    const result = {
       id: 'browser',
       cacheKey: stableBrowserStateCacheKey(browserState),
       mode: isDelta ? 'delta' : 'snapshot',
@@ -167,7 +174,8 @@ export class BrowserContextProcessor {
       metadata: {
         browser: browserState,
       },
-    };
+    } satisfies Exclude<ComputeStateSignalResult, undefined | void>;
+    return result;
   }
 }
 
@@ -203,6 +211,61 @@ function getMostRecentBrowserState(
     if (browserState) return browserState;
   }
   return undefined;
+}
+
+function getMostRecentBrowserClickResultUrl(steps: ComputeStateSignalArgs['steps']): string | undefined {
+  for (const step of [...steps].reverse()) {
+    const toolResults = Array.isArray(step.toolResults) ? step.toolResults : [];
+    for (const toolResult of [...toolResults].reverse()) {
+      if (toolResult?.toolName !== 'browser_click') continue;
+      const url = getBrowserClickResultUrl(getToolResultOutputForAttribution(toolResult));
+      if (url) return url;
+    }
+  }
+  return undefined;
+}
+
+function getMostRecentBrowserClickResultUrlFromMessageList(
+  messageList: ComputeStateSignalArgs['messageList'],
+): string | undefined {
+  try {
+    return getMostRecentBrowserClickResultUrlFromMessages(messageList.get.all.db());
+  } catch {
+    return undefined;
+  }
+}
+
+function getMostRecentBrowserClickResultUrlFromMessages(messages: ComputeStateSignalArgs['messages']): string | undefined {
+  for (const message of [...messages].reverse()) {
+    const content = message.content;
+    if (!content || typeof content !== 'object' || Array.isArray(content)) continue;
+    const parts = (content as { parts?: unknown }).parts;
+    if (!Array.isArray(parts)) continue;
+
+    for (const part of [...parts].reverse()) {
+      if (!part || typeof part !== 'object' || Array.isArray(part)) continue;
+      const toolInvocation = (part as { toolInvocation?: unknown }).toolInvocation;
+      if (!toolInvocation || typeof toolInvocation !== 'object' || Array.isArray(toolInvocation)) continue;
+      const invocation = toolInvocation as Record<string, unknown>;
+      if (invocation.toolName !== 'browser_click' || invocation.state !== 'result') continue;
+      const url = getBrowserClickResultUrl(invocation.result ?? invocation.output);
+      if (url) return url;
+    }
+  }
+  return undefined;
+}
+
+function getBrowserClickResultUrl(output: unknown): string | undefined {
+  if (!output || typeof output !== 'object' || Array.isArray(output)) return undefined;
+  if ((output as { success?: unknown }).success !== true) return undefined;
+  const url = (output as { url?: unknown }).url;
+  return typeof url === 'string' && url.length > 0 ? url : undefined;
+}
+
+function getToolResultOutputForAttribution(toolResult: unknown): unknown {
+  if (!toolResult || typeof toolResult !== 'object' || Array.isArray(toolResult)) return undefined;
+  const record = toolResult as Record<string, unknown>;
+  return record.output ?? record.result;
 }
 
 function getBrowserStateFromSignal(signal?: ComputeStateSignalArgs['lastSnapshot']): BrowserState | undefined {
@@ -252,6 +315,10 @@ function getChangedBrowserState(previous: BrowserState | undefined, current: Bro
     if (JSON.stringify(previous[key]) !== JSON.stringify(current[key])) {
       (changed as Record<string, unknown>)[key] = current[key];
     }
+  }
+
+  if (previous.activeUrl !== current.activeUrl && current.activeUrlChangeSource) {
+    changed.activeUrlChangeSource = current.activeUrlChangeSource;
   }
 
   if (!previous.open && current.open) {

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -237,6 +237,8 @@ function getMostRecentBrowserClickResultUrlFromMessageList(
 
 function getMostRecentBrowserClickResultUrlFromMessages(messages: ComputeStateSignalArgs['messages']): string | undefined {
   for (const message of [...messages].reverse()) {
+    if (isBrowserStateSignalMessage(message)) return undefined;
+
     const content = message.content;
     if (!content || typeof content !== 'object' || Array.isArray(content)) continue;
     const parts = (content as { parts?: unknown }).parts;
@@ -253,6 +255,18 @@ function getMostRecentBrowserClickResultUrlFromMessages(messages: ComputeStateSi
     }
   }
   return undefined;
+}
+
+function isBrowserStateSignalMessage(message: ComputeStateSignalArgs['messages'][number]): boolean {
+  const content = message.content;
+  if (!content || typeof content !== 'object' || Array.isArray(content)) return false;
+  const signal = (content as { metadata?: { signal?: unknown } }).metadata?.signal;
+  if (!signal || typeof signal !== 'object' || Array.isArray(signal)) return false;
+  const metadata = (signal as { metadata?: unknown }).metadata;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return false;
+  const state = (metadata as { state?: unknown }).state;
+  if (!state || typeof state !== 'object' || Array.isArray(state)) return false;
+  return (state as { id?: unknown }).id === 'browser';
 }
 
 function getBrowserClickResultUrl(output: unknown): string | undefined {

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -148,7 +148,8 @@ export class BrowserContextProcessor {
       const recentClickUrl =
         getMostRecentBrowserClickResultUrl(args.steps) ??
         getMostRecentBrowserClickResultUrlFromMessageList(args.messageList);
-      const activeUrlChangeSource = recentClickUrl === browserState.activeUrl ? 'agent' : browserState.activeUrlChangeSource ?? 'user';
+      const activeUrlChangeSource =
+        recentClickUrl === browserState.activeUrl ? 'agent' : (browserState.activeUrlChangeSource ?? 'user');
       browserState = {
         ...browserState,
         activeUrlChangeSource,
@@ -235,7 +236,9 @@ function getMostRecentBrowserClickResultUrlFromMessageList(
   }
 }
 
-function getMostRecentBrowserClickResultUrlFromMessages(messages: ComputeStateSignalArgs['messages']): string | undefined {
+function getMostRecentBrowserClickResultUrlFromMessages(
+  messages: ComputeStateSignalArgs['messages'],
+): string | undefined {
   for (const message of [...messages].reverse()) {
     if (isBrowserStateSignalMessage(message)) return undefined;
 


### PR DESCRIPTION
This fixes browser state attribution when an assistant click causes navigation. Previously, a `browser_click` could return the new URL, but the state signal still fell back to `user` because the processor did not connect that click result to the URL delta.

Before:
```txt
browser_click -> { success: true, url: "https://mastra.ai/pricing" }
State delta: browser
  changed: user changed active tab URL to https://mastra.ai/pricing
```

After:
```txt
browser_click -> { success: true, url: "https://mastra.ai/pricing" }
State delta: browser
  changed: agent changed active tab URL to https://mastra.ai/pricing
```

It also keeps manual navigations attributed to the user, including when the URL happens to match an older click result. Added regression coverage for click results from current steps, persisted message history, stale click history after a newer browser state signal, and preserving the URL change source in deltas.

Tested with the focused browser processor tests, typecheck, `pnpm build:core`, and a live smoke test against mastra.ai.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the assistant clicks something and the page URL changes, Mastra needs to remember “the assistant did that,” not blame it on the user. This PR fixes the browser state attribution so URL changes caused by successful assistant clicks are credited to the agent, and it also avoids using old/stale click results to misattribute later manual navigations.

## Changes

### Browser State Attribution for Assistant Clicks
- Updated the browser processor so when a `browser_click` tool result returns a new `url` that matches the updated `activeUrl`, the delta marks the source as `activeUrlChangeSource: 'agent'` (instead of incorrectly attributing to `user`).

### Stale Click Result Prevention (Manual Navigation Edge Case)
- Added logic so older click history isn’t reused once newer browser state signals exist—preventing cases where a user’s manual navigation could be incorrectly attributed to the agent just because the new URL matched a prior click result.

### Correct Delta Reporting
- Ensured `getChangedBrowserState` includes `activeUrlChangeSource` in the returned `changed` delta when `activeUrl` changes and a source is set.

### Implementation / Test Infrastructure
- Added defensive helpers to find the most recent successful `browser_click` URL by scanning:
  - current `steps` tool results (reverse), and
  - prior non-`<state id="browser">` messages in reverse (fallback)
- Refactored `computeStateSignal` result construction for clearer, more reliable attribution behavior.
- Expanded the `processor.test.ts` coverage by enhancing the `computeStateSignal` test helper to seed message history and adding regression tests for:
  - attribution from current click steps
  - persisted history behavior
  - ignoring stale click history
  - preserving/overriding attribution based on whether the latest click URL matches the `activeUrl`
  - retaining URL change source in deltas

## Testing
- Focused browser processor tests
- Typecheck
- `pnpm build:core`
- Live smoke test against mastra.ai

## Changelog / Formatting
- Added a changeset bump for `@mastra/core` (patch).
- Applied Prettier formatting to the browser processor changes to satisfy repo lint checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->