### PR TITLE
fix(core): keep safe parallel tool calls concurrent

### DIFF
--- a/.changeset/stale-buses-peel.md
+++ b/.changeset/stale-buses-peel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed parallel tool calls being serialized by unrelated suspendable tools.

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -109,7 +109,15 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
     .map(
       async ({ inputData }) => {
         const typedInputData = inputData as LLMIterationData<Tools, OUTPUT>;
-        return typedInputData.output.toolCalls || [];
+        const toolCalls = typedInputData.output.toolCalls || [];
+        const calledToolNames = [...new Set(toolCalls.map(toolCall => toolCall.toolName))];
+        toolCallForeachOptions.concurrency = resolveToolCallConcurrency({
+          requireToolApproval: rest.requireToolApproval,
+          tools: ((_internal?.stepTools as Tools | undefined) ?? rest.tools) as Tools | undefined,
+          activeTools: calledToolNames,
+          configuredConcurrency: configuredToolCallConcurrency,
+        });
+        return toolCalls;
       },
       { id: 'map-tool-calls' },
     )

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.test.ts
@@ -72,6 +72,20 @@ describe('tool call concurrency resolution', () => {
     ).toBe(false);
   });
 
+  it('keeps parallel tool calls concurrent when unrelated available tools can suspend', () => {
+    expect(
+      resolveToolCallConcurrency({
+        tools: {
+          subagent: safeTool,
+          ask_user: suspendTool,
+          submit_plan: suspendTool,
+        },
+        activeTools: ['subagent'],
+        configuredConcurrency: 4,
+      }),
+    ).toBe(4);
+  });
+
   it('ignores unknown active tool names', () => {
     expect(
       effectiveToolSetRequiresSequentialExecution({


### PR DESCRIPTION
## Summary

Fixes tool-call workflow scheduling so safe parallel tool calls remain concurrent even when unrelated available tools can suspend.

Previously, the workflow decided tool-call foreach concurrency from the full available toolset. In harness-heavy agents, suspendable tools like ask_user or submit_plan could force all tool calls to execute one-at-a-time, even when the current model response only called safe tools such as multiple subagents.

This PR recalculates concurrency from the actual tool calls emitted in the current iteration before the foreach step runs.

## Test plan

- pnpm vitest run packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.test.ts packages/core/src/loop/workflows/agentic-execution/index.test.ts --reporter=dot --bail 1
- pnpm --filter ./packages/core check
- pnpm prettier:changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Think of an agent workflow like a chef with multiple kitchen tools: some are safe and can be used in parallel, while others require special approval. Previously, if “approval-needed” tools merely existed, the chef would still slow everything down to one-at-a-time. Now the chef only looks at the tools actually being used in the current step, so safe tools can run concurrently even when other risky tools are available but not invoked.

## Changes
- Fixes tool-call scheduling in `createAgenticExecutionWorkflow` so tool-call `foreach` concurrency is recalculated from the *current iteration’s emitted* `toolCalls` rather than from the full set of available tools.
- Updates the workflow map step to:
  - derive active tool names from the current LLM iteration’s `toolCalls`
  - recompute `toolCallForeachOptions.concurrency` using `resolveToolCallConcurrency` with the active tool subset (including handling `requireToolApproval` and tool metadata from `_internal.stepTools` / `rest.tools`)
- Adds test coverage in `tool-call-concurrency.test.ts` to ensure configured concurrency (e.g., `4`) is preserved when only safe parallel tools (like `subagent`) are active, even if other suspendable tools (e.g., `ask_user`, `submit_plan`) are available but not called.
- Adds a changeset for a patch release documenting the parallel tool-call serialization fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->