### PR TITLE
fix: propagate ifIdle through SignalProviderTarget so notification signals wake idle threads

### DIFF
--- a/.changeset/clever-items-dig.md
+++ b/.changeset/clever-items-dig.md
@@ -1,0 +1,6 @@
+---
+'@mastra/github-signals': patch
+'@mastra/core': patch
+---
+
+Fix notification signals not waking idle threads

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -128,6 +128,21 @@ export type AgentSignalActiveBehavior = 'deliver' | 'persist' | 'discard';
 export type AgentSignalIdleBehavior = 'wake' | 'persist' | 'discard';
 
 /**
+ * Options applied when a signal targets an idle thread.
+ *
+ * Controls whether the thread should be woken, the signal persisted without
+ * waking, or the signal discarded. Also carries optional stream options
+ * (e.g. request context) and attributes for the delivery message.
+ *
+ * @experimental Agent signals are experimental and may change in a future release.
+ */
+export type AgentSignalIfIdleOptions<OUTPUT = unknown> = {
+  behavior?: AgentSignalIdleBehavior;
+  streamOptions?: AgentExecutionOptions<OUTPUT>;
+  attributes?: AgentSignalAttributes;
+};
+
+/**
  * @experimental Agent signals are experimental and may change in a future release.
  */
 export type SendAgentSignalOptions<OUTPUT = unknown> =
@@ -143,11 +158,7 @@ export type SendAgentSignalOptions<OUTPUT = unknown> =
       resourceId: string;
       threadId: string;
       ifActive?: { behavior?: AgentSignalActiveBehavior; attributes?: AgentSignalAttributes };
-      ifIdle?: {
-        behavior?: AgentSignalIdleBehavior;
-        streamOptions?: AgentExecutionOptions<OUTPUT>;
-        attributes?: AgentSignalAttributes;
-      };
+      ifIdle?: AgentSignalIfIdleOptions<OUTPUT>;
     };
 
 /**

--- a/packages/core/src/signals/signal-provider.ts
+++ b/packages/core/src/signals/signal-provider.ts
@@ -1,8 +1,8 @@
 import type { Agent } from '../agent/agent';
+import type { AgentSignalIfIdleOptions } from '../agent/types';
 import type { Mastra } from '../mastra';
 import type { SendNotificationSignalInput } from '../notifications/types';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
-import type { AgentSignalIfIdleOptions } from '../agent/types';
 
 /**
  * Identifies a specific agent thread that a signal provider targets.

--- a/packages/core/src/signals/signal-provider.ts
+++ b/packages/core/src/signals/signal-provider.ts
@@ -2,6 +2,7 @@ import type { Agent } from '../agent/agent';
 import type { Mastra } from '../mastra';
 import type { SendNotificationSignalInput } from '../notifications/types';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
+import type { AgentSignalIfIdleOptions } from '../agent/types';
 
 /**
  * Identifies a specific agent thread that a signal provider targets.
@@ -12,6 +13,8 @@ export type SignalProviderTarget = {
   threadId: string;
   resourceId: string;
   agentId?: string;
+  /** Options for signal delivery when the target thread is idle — forwarded to sendNotificationSignal */
+  ifIdle?: AgentSignalIfIdleOptions<unknown>;
 };
 
 /**
@@ -458,6 +461,7 @@ export abstract class SignalProvider<TId extends string = string> {
     await agent.sendNotificationSignal(notification, {
       resourceId: target.resourceId,
       threadId: target.threadId,
+      ...(target.ifIdle ? { ifIdle: target.ifIdle } : {}),
     });
   }
 

--- a/signals/github/src/index.ts
+++ b/signals/github/src/index.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
-import type { AgentSignalInput, Agent } from '@mastra/core/agent';
+import type { AgentSignalInput, Agent, AgentSignalIfIdleOptions } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import type { Mastra } from '@mastra/core/mastra';
 import type { StorageThreadType } from '@mastra/core/memory';
@@ -269,6 +269,7 @@ type GithubPollingThread = {
   threadId: string;
   resourceId: string;
   agentId?: string;
+  ifIdle?: AgentSignalIfIdleOptions<unknown>;
 };
 
 type GithubPollingState = GithubPollingThread & {


### PR DESCRIPTION
Notification signals weren't waking idle threads because `notify()` was discarding the `ifIdle` config from the target. When a provider's poll cycle ran outside any request context, `agent.sendNotificationSignal` eventually hit `resolveModel()` with no `modelId` to fall back on.

The fix threads `ifIdle` through `SignalProviderTarget` so `notify()` passes it to `sendNotificationSignal`, which forwards it to `agent.stream()`. The caller controls the behavior — wake, persist, or discard — plus the stream options (including `requestContext` with the model and session state).

**Before** — `notify()` only forwarded resourceId/threadId:

```ts
// signal-provider.ts
await agent.sendNotificationSignal(inputs, {
  resourceId: target.resourceId,
  threadId: target.threadId,
});
```

**After** — `notify()` spreads `target.ifIdle` if present:

```ts
// signal-provider.ts
await agent.sendNotificationSignal(inputs, {
  resourceId: target.resourceId,
  threadId: target.threadId,
  ...(target.ifIdle && { ifIdle: target.ifIdle }),
});
```

GitHub signals weren't affected — they already handled wake correctly through their own `getNotificationStreamOptions` callback. `GithubPollingThread` just gains the optional field for type consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When notification signals tried to wake up idle threads, they were failing because a setting that controlled how to handle the wake-up (called `ifIdle`) was being thrown away. This fix makes sure that setting is passed along properly so notifications can wake up idle threads as intended.

## Problem

Notification signals were failing to wake idle threads because the `ifIdle` configuration was being discarded by the `notify()` method in `SignalProviderTarget`. When a provider's poll cycle ran outside any request context, `agent.sendNotificationSignal` had no way to apply the idle-thread handling behavior, causing the notifications to fail.

## Solution

The fix ensures the `ifIdle` configuration is propagated through the notification signal chain:

1. **Type definition for idle handling** (`packages/core/src/agent/types.ts`):
   - Introduced `AgentSignalIfIdleOptions<OUTPUT>` as a dedicated type for configuring idle thread behavior
   - Updated `SendAgentSignalOptions<OUTPUT>` to use this new type

2. **Signal provider updated** (`packages/core/src/signals/signal-provider.ts`):
   - `SignalProviderTarget` now supports an optional `ifIdle` delivery option
   - The `notify()` method now forwards `ifIdle` to `agent.sendNotificationSignal()` when present (previously only forwarded `resourceId` and `threadId`)

3. **GitHub signals consistency** (`signals/github/src/index.ts`):
   - Extended the internal `GithubPollingThread` type with an optional `ifIdle` field for consistency (GitHub signals already handled idle behavior correctly through their own callbacks)

4. **Version updates** (`.changeset/clever-items-dig.md`):
   - Patch version bumps for `@mastra/github-signals` and `@mastra/core`

## Impact

Callers like the Slack signals provider can now pass `ifIdle` configuration on the target, and the `notify()` method will respect it instead of discarding it. This enables the caller to control whether to wake, persist, or discard the signal, along with stream options including request context containing model and session state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->