### PR TITLE
Restore forked subagent runtime behavior

### DIFF
--- a/.changeset/common-rings-roll.md
+++ b/.changeset/common-rings-roll.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed forked subagents freezing on long threads.

--- a/packages/core/src/harness/fork-clone-metadata.test.ts
+++ b/packages/core/src/harness/fork-clone-metadata.test.ts
@@ -101,6 +101,107 @@ describe('Harness fork clone metadata wiring', () => {
     });
   });
 
+  it('appends a synthetic completed result to the fork clone without pre-scanning history', async () => {
+    // When the fork clone callback receives excludeToolCallId, the harness
+    // should clone normally (preserving messages, WM, OM, embeddings, and clone
+    // metadata) and append a synthetic completed subagent result. It must not
+    // pre-scan the whole parent thread, because long real threads can make a
+    // full recall expensive enough to freeze startup.
+    const cloneThread = vi.fn().mockResolvedValue({
+      thread: {
+        id: 'forked-thread-id',
+        resourceId: 'parent-resource',
+        title: 'Fork: Explore subagent',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        metadata: {},
+      },
+      clonedMessages: [],
+      messageIdMap: {},
+    });
+
+    const recall = vi.fn();
+    const saveMessages = vi.fn().mockResolvedValue({ messages: [] });
+    const memoryFactory = vi.fn().mockResolvedValue({ cloneThread, recall, saveMessages });
+
+    const subagents: HarnessSubagent[] = [
+      {
+        id: 'explore',
+        name: 'Explore',
+        description: 'Explore',
+        instructions: 'Be exploratory.',
+        forked: true,
+      },
+    ];
+
+    const harness = new Harness({
+      id: 'test',
+      resourceId: 'parent-resource',
+      memory: memoryFactory as unknown as never,
+      subagents,
+      resolveModel: () => ({}) as never,
+      modes: [
+        {
+          id: 'default',
+          name: 'Default',
+          default: true,
+          defaultModelId: 'openai/gpt-4o',
+          agent: new Agent({
+            name: 'parent',
+            instructions: 'parent',
+            model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+          }),
+        },
+      ],
+    });
+
+    await harness.init();
+
+    await (harness as unknown as { buildToolsets(ctx: RequestContext): Promise<unknown> }).buildToolsets(
+      new RequestContext(),
+    );
+
+    expect(capturedOpts).toHaveLength(1);
+    const cloneCb = capturedOpts[0]!.cloneThreadForFork as (a: {
+      sourceThreadId: string;
+      title?: string;
+      excludeToolCallId?: string;
+    }) => Promise<unknown>;
+
+    await cloneCb({ sourceThreadId: 'parent-thread-xyz', title: 'Fork', excludeToolCallId: 'tc-sub-1' });
+
+    expect(recall).not.toHaveBeenCalled();
+    expect(cloneThread).toHaveBeenCalledTimes(1);
+    expect(cloneThread).toHaveBeenCalledWith({
+      sourceThreadId: 'parent-thread-xyz',
+      resourceId: 'parent-resource',
+      title: 'Fork',
+      metadata: {
+        forkedSubagent: true,
+        parentThreadId: 'parent-thread-xyz',
+      },
+    });
+
+    expect(saveMessages).toHaveBeenCalledTimes(1);
+    const savedMessage = saveMessages.mock.calls[0]![0].messages[0];
+    expect(savedMessage.threadId).toBe('forked-thread-id');
+    expect(savedMessage.resourceId).toBe('parent-resource');
+    expect(savedMessage.role).toBe('assistant');
+    expect(savedMessage.content.parts).toEqual([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'tc-sub-1',
+          toolName: 'subagent',
+          args: {},
+          result:
+            'The subagent tool call is complete. The current context window is now the forked subagent. Complete the delegated task directly using the available tools; do not call the subagent tool again.',
+        },
+      },
+    ]);
+  });
+
   it('does not create the subagent tool from gateways without an app-provided resolver', async () => {
     const subagents: HarnessSubagent[] = [
       {

--- a/packages/core/src/harness/fork-clone-metadata.test.ts
+++ b/packages/core/src/harness/fork-clone-metadata.test.ts
@@ -156,10 +156,9 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
-    await (harness as unknown as { buildToolsets(ctx: RequestContext): Promise<unknown> }).buildToolsets(
-      new RequestContext(),
-    );
+    await (harness as any).buildToolsets(session, new RequestContext());
 
     expect(capturedOpts).toHaveLength(1);
     const cloneCb = capturedOpts[0]!.cloneThreadForFork as (a: {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -766,18 +766,12 @@ export class Harness<TState = {}> {
 
     const memoryStorage = await this.getMemoryStorage();
 
-    if (limit) {
-      const result = await memoryStorage.listMessages({
-        threadId,
-        perPage: limit,
-        page: 0,
-        orderBy: { field: 'createdAt', direction: 'DESC' },
-      });
-      return result.messages.map(msg => this.convertToHarnessMessage(msg)).reverse();
-    }
-
     const result = await memoryStorage.listMessages({ threadId, perPage: false });
-    return result.messages.map(msg => this.convertToHarnessMessage(msg));
+    const messages = result.messages.map(msg => this.convertToHarnessMessage(msg));
+
+    if (!limit) return messages;
+
+    return messages.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()).slice(-limit);
   }
 
   private async queryFirstUserMessages({ threadIds }: { threadIds: string[] }): Promise<Map<string, HarnessMessage>> {
@@ -1729,7 +1723,7 @@ export class Harness<TState = {}> {
         // that thread pickers / startup flows can hide transient fork threads —
         // see `listThreads` (filtered by default).
         cloneThreadForFork: hasMemory
-          ? async ({ sourceThreadId, resourceId, title }) => {
+          ? async ({ sourceThreadId, resourceId, title, excludeToolCallId }) => {
               const memory = await this.resolveMemory(session);
               const result = await memory.cloneThread({
                 sourceThreadId,
@@ -1740,6 +1734,42 @@ export class Harness<TState = {}> {
                   parentThreadId: sourceThreadId,
                 },
               });
+
+              // Mark the cloned context as already being inside the forked subagent.
+              // We intentionally append this instead of pre-scanning/filtering the
+              // parent thread: long threads can be expensive to recall in full, while
+              // cloneThread already preserves messages, working memory, OM, and clone
+              // metadata in the storage/memory layer.
+              if (excludeToolCallId) {
+                await memory.saveMessages({
+                  messages: [
+                    {
+                      id: randomUUID(),
+                      role: 'assistant',
+                      createdAt: new Date(),
+                      threadId: result.thread.id,
+                      resourceId: result.thread.resourceId,
+                      content: {
+                        format: 2,
+                        parts: [
+                          {
+                            type: 'tool-invocation',
+                            toolInvocation: {
+                              state: 'result',
+                              toolCallId: excludeToolCallId,
+                              toolName: 'subagent',
+                              args: {},
+                              result:
+                                'The subagent tool call is complete. The current context window is now the forked subagent. Complete the delegated task directly using the available tools; do not call the subagent tool again.',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                });
+              }
+
               return { id: result.thread.id, resourceId: result.thread.resourceId };
             }
           : undefined,

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -108,6 +108,7 @@ const FABLE_FALLBACK_MODEL = 'claude-opus-4-8';
  * mid-task even though it promised to continue. See {@link buildSharedRunOptions}.
  */
 const HARNESS_MAX_STEPS = 1000;
+const HARNESS_MESSAGE_HISTORY_FETCH_LIMIT = 5_000;
 
 /**
  * Returns Anthropic `providerOptions` that enable a server-side fallback to
@@ -766,7 +767,11 @@ export class Harness<TState = {}> {
 
     const memoryStorage = await this.getMemoryStorage();
 
-    const result = await memoryStorage.listMessages({ threadId, perPage: false });
+    const result = await memoryStorage.listMessages({
+      threadId,
+      perPage: limit ? Math.max(limit, HARNESS_MESSAGE_HISTORY_FETCH_LIMIT) : false,
+      orderBy: limit ? { field: 'createdAt', direction: 'DESC' } : undefined,
+    });
     const messages = result.messages.map(msg => this.convertToHarnessMessage(msg));
 
     if (!limit) return messages;

--- a/packages/core/src/harness/signal-history.test.ts
+++ b/packages/core/src/harness/signal-history.test.ts
@@ -5,6 +5,29 @@ import { signalToMastraDBMessage } from '../agent/signals';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 
+function createTextDbMessage({
+  id,
+  text,
+  threadId,
+  resourceId,
+  createdAt,
+}: {
+  id: string;
+  text: string;
+  threadId: string;
+  resourceId: string;
+  createdAt: Date;
+}) {
+  return {
+    id,
+    role: 'user' as const,
+    threadId,
+    resourceId,
+    createdAt,
+    content: { format: 2 as const, parts: [{ type: 'text' as const, text }] },
+  };
+}
+
 describe('Harness signal history rendering', () => {
   async function createHarnessWithThread() {
     const storage = new InMemoryStore();
@@ -28,6 +51,37 @@ describe('Harness signal history rendering', () => {
 
     return { harness, session, memoryStorage, thread };
   }
+
+  it('loads the newest bounded history window even when storage pagination returns the oldest rows', async () => {
+    const { harness, memoryStorage, thread } = await createHarnessWithThread();
+    const messages = Array.from({ length: 5 }, (_, index) =>
+      createTextDbMessage({
+        id: `message-${index + 1}`,
+        text: `message ${index + 1}`,
+        threadId: thread.id,
+        resourceId: thread.resourceId,
+        createdAt: new Date(`2026-06-19T12:00:0${index}.000Z`),
+      }),
+    );
+    await memoryStorage.saveMessages({ messages });
+
+    const originalListMessages = memoryStorage.listMessages.bind(memoryStorage);
+    vi.spyOn(memoryStorage, 'listMessages').mockImplementation(async input => {
+      if (input.perPage !== false && input.perPage === 2) {
+        const all = await originalListMessages({
+          ...input,
+          perPage: false,
+          orderBy: { field: 'createdAt', direction: 'ASC' },
+        });
+        return { ...all, messages: all.messages.slice(0, 2), perPage: 2, hasMore: true };
+      }
+      return originalListMessages(input);
+    });
+
+    const loaded = await harness.session.thread.listActiveMessages({ limit: 2 });
+
+    expect(loaded.map(message => message.id)).toEqual(['message-4', 'message-5']);
+  });
 
   it('renders persisted user-message signals as user content', async () => {
     const { session, memoryStorage, thread } = await createHarnessWithThread();

--- a/packages/core/src/harness/signal-history.test.ts
+++ b/packages/core/src/harness/signal-history.test.ts
@@ -53,7 +53,7 @@ describe('Harness signal history rendering', () => {
   }
 
   it('loads the newest bounded history window even when storage pagination returns the oldest rows', async () => {
-    const { harness, memoryStorage, thread } = await createHarnessWithThread();
+    const { session, memoryStorage, thread } = await createHarnessWithThread();
     const messages = Array.from({ length: 5 }, (_, index) =>
       createTextDbMessage({
         id: `message-${index + 1}`,
@@ -78,7 +78,7 @@ describe('Harness signal history rendering', () => {
       return originalListMessages(input);
     });
 
-    const loaded = await harness.session.thread.listActiveMessages({ limit: 2 });
+    const loaded = await session.thread.listActiveMessages({ limit: 2 });
 
     expect(loaded.map(message => message.id)).toEqual(['message-4', 'message-5']);
   });

--- a/packages/core/src/harness/signal-history.test.ts
+++ b/packages/core/src/harness/signal-history.test.ts
@@ -66,20 +66,27 @@ describe('Harness signal history rendering', () => {
     await memoryStorage.saveMessages({ messages });
 
     const originalListMessages = memoryStorage.listMessages.bind(memoryStorage);
-    vi.spyOn(memoryStorage, 'listMessages').mockImplementation(async input => {
-      if (input.perPage !== false && input.perPage === 2) {
+    const listMessages = vi.spyOn(memoryStorage, 'listMessages').mockImplementation(async input => {
+      if (input.perPage !== false && typeof input.perPage === 'number') {
         const all = await originalListMessages({
           ...input,
           perPage: false,
           orderBy: { field: 'createdAt', direction: 'ASC' },
         });
-        return { ...all, messages: all.messages.slice(0, 2), perPage: 2, hasMore: true };
+        return { ...all, messages: all.messages.slice(0, input.perPage), perPage: input.perPage, hasMore: false };
       }
       return originalListMessages(input);
     });
 
     const loaded = await session.thread.listActiveMessages({ limit: 2 });
 
+    expect(listMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: thread.id,
+        perPage: 5_000,
+        orderBy: { field: 'createdAt', direction: 'DESC' },
+      }),
+    );
     expect(loaded.map(message => message.id)).toEqual(['message-4', 'message-5']);
   });
 

--- a/packages/core/src/harness/subagent-tool.test.ts
+++ b/packages/core/src/harness/subagent-tool.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { RequestContext } from '../request-context';
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '../request-context';
 
 // We need to mock Agent before importing tools.ts.
 const { mockStream, MockAgent, mockCreateWorkspaceTools } = vi.hoisted(() => {
@@ -126,7 +126,7 @@ describe('createSubagentTool requestContext forwarding', () => {
     expect(result.content).not.toContain('<subagent-meta');
   });
 
-  it('forwards a copy of requestContext with threadId/resourceId stripped', async () => {
+  it('does not forward requestContext or memory to non-forked subagent streams', async () => {
     mockStream.mockResolvedValue(createMockStreamResponse('result text'));
 
     const tool = createSubagentTool({
@@ -135,7 +135,6 @@ describe('createSubagentTool requestContext forwarding', () => {
       fallbackModelId: 'test-model',
     });
 
-    // Build a requestContext with harness data including threadId/resourceId
     const requestContext = new RequestContext();
     const harnessCtx: Partial<HarnessRequestContext> = {
       emitEvent: vi.fn(),
@@ -143,6 +142,9 @@ describe('createSubagentTool requestContext forwarding', () => {
       resourceId: 'parent-resource-456',
     };
     requestContext.set('harness', harnessCtx);
+    requestContext.set(MASTRA_THREAD_ID_KEY, 'reserved-parent-thread');
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'reserved-parent-resource');
+    requestContext.set('custom-key', 'custom-value');
 
     const result = await (tool as any).execute(
       { agentType: 'explore', task: 'Find all usages of foo' },
@@ -150,48 +152,13 @@ describe('createSubagentTool requestContext forwarding', () => {
     );
 
     expect(mockStream).toHaveBeenCalledTimes(1);
-    const streamCall = mockStream.mock.calls[0]!;
-    const subagentCtx = streamCall[1].requestContext;
-    // Should be a new instance (not the parent's context)
-    expect(subagentCtx).not.toBe(requestContext);
-    // Harness context should have threadId/resourceId cleared
-    const subagentHarness = subagentCtx.get('harness') as Partial<HarnessRequestContext>;
-    expect(subagentHarness.threadId).toBeNull();
-    expect(subagentHarness.resourceId).toBe('');
-    // Other harness fields should be preserved
-    expect(subagentHarness.emitEvent).toBe(harnessCtx.emitEvent);
+    const streamOpts = mockStream.mock.calls[0]![1];
+    expect(streamOpts.requestContext).toBeUndefined();
+    expect(streamOpts.memory).toBeUndefined();
     expect(result.isError).toBe(false);
   });
 
-  it('forwards requestContext copy when harness context is not set', async () => {
-    mockStream.mockResolvedValue(createMockStreamResponse('result text'));
-
-    const tool = createSubagentTool({
-      subagents,
-      resolveModel,
-      fallbackModelId: 'test-model',
-    });
-
-    // RequestContext without harness data — still should be forwarded
-    const requestContext = new RequestContext();
-    requestContext.set('custom-key', 'custom-value');
-
-    const result = await (tool as any).execute(
-      { agentType: 'explore', task: 'Explore something' },
-      { requestContext, agent: { toolCallId: 'tc-2' } },
-    );
-
-    expect(mockStream).toHaveBeenCalledTimes(1);
-    const streamCall = mockStream.mock.calls[0]!;
-    const subagentCtx = streamCall[1].requestContext;
-    // Should be a new instance but with same data
-    expect(subagentCtx).not.toBe(requestContext);
-    // Verify the custom data is accessible through the forwarded context
-    expect(subagentCtx.get('custom-key')).toBe('custom-value');
-    expect(result.isError).toBe(false);
-  });
-
-  it('passes maxSteps, abortSignal, and requireToolApproval alongside requestContext', async () => {
+  it('passes maxSteps, abortSignal, and requireToolApproval without requestContext', async () => {
     const abortController = new AbortController();
     mockStream.mockResolvedValue(createMockStreamResponse('done'));
 
@@ -221,8 +188,7 @@ describe('createSubagentTool requestContext forwarding', () => {
       abortSignal: abortController.signal,
       requireToolApproval: false,
     });
-    // Subagent gets a copy of the request context (not the original)
-    expect(streamOpts.requestContext).toBeInstanceOf(RequestContext);
+    expect(streamOpts.requestContext).toBeUndefined();
   });
 
   it('returns partial subagent output when the parent aborts during streaming', async () => {
@@ -309,7 +275,7 @@ describe('createSubagentTool requestContext forwarding', () => {
     expect(streamOpts.stopWhen).toBe(stopFn);
   });
 
-  it('forwards default RequestContext when parent context has no explicit requestContext', async () => {
+  it('does not create a default requestContext for non-forked subagent streams', async () => {
     mockStream.mockResolvedValue(createMockStreamResponse('result text'));
 
     const tool = createSubagentTool({
@@ -318,7 +284,6 @@ describe('createSubagentTool requestContext forwarding', () => {
       fallbackModelId: 'test-model',
     });
 
-    // Execute without requestContext — core's createTool wrapper creates a default one
     const result = await (tool as any).execute(
       { agentType: 'explore', task: 'Explore something' },
       { agent: { toolCallId: 'tc-4' } },
@@ -326,8 +291,7 @@ describe('createSubagentTool requestContext forwarding', () => {
 
     expect(mockStream).toHaveBeenCalledTimes(1);
     const streamCall = mockStream.mock.calls[0]!;
-    // The core creates a default RequestContext when none is provided
-    expect(streamCall[1].requestContext).toBeInstanceOf(RequestContext);
+    expect(streamCall[1].requestContext).toBeUndefined();
     expect(result.isError).toBe(false);
   });
 });
@@ -429,6 +393,40 @@ describe('createSubagentTool workspace propagation', () => {
     await (tool as any).execute({ agentType: 'explore', task: 'Find stuff' }, { agent: { toolCallId: 'tc-ws-2' } });
 
     expect(MockAgent.lastConstructorOpts.workspace).toBeUndefined();
+  });
+
+  it('configures direct provider-compat processors for non-forked subagent runs', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('result'));
+
+    const parentAgent = {
+      listErrorProcessors: vi.fn(),
+      listConfiguredInputProcessors: vi.fn(),
+    };
+
+    const tool = createSubagentTool({
+      subagents,
+      resolveModel,
+      fallbackModelId: 'test-model',
+      getParentAgent: () => parentAgent as any,
+    });
+
+    await (tool as any).execute(
+      { agentType: 'explore', task: 'Find stuff' },
+      { agent: { toolCallId: 'tc-processors' } },
+    );
+
+    expect(MockAgent.lastConstructorOpts.memory).toBeUndefined();
+    expect(MockAgent.lastConstructorOpts.inputProcessors.map((processor: { id: string }) => processor.id)).toEqual([
+      'provider-history-compat',
+    ]);
+    expect(MockAgent.lastConstructorOpts.errorProcessors.map((processor: { id: string }) => processor.id)).toEqual([
+      'stream-error-retry-processor',
+      'prefill-error-handler',
+      'provider-history-compat',
+    ]);
+    expect(MockAgent.lastConstructorOpts.outputProcessors).toBeUndefined();
+    expect(parentAgent.listConfiguredInputProcessors).not.toHaveBeenCalled();
+    expect(parentAgent.listErrorProcessors).not.toHaveBeenCalled();
   });
 });
 
@@ -660,6 +658,7 @@ describe('createSubagentTool forked subagent behavior', () => {
       sourceThreadId: 'parent-thread-1',
       resourceId: 'parent-resource-1',
       title: expect.stringContaining('Fork:'),
+      excludeToolCallId: 'tc-fork-1',
     });
 
     // Parent agent's stream is used — no fresh Agent is constructed for the fork.
@@ -667,13 +666,16 @@ describe('createSubagentTool forked subagent behavior', () => {
     expect(mockStream).not.toHaveBeenCalled();
 
     const [taskArg, streamOpts] = parentStream.mock.calls[0]!;
-    expect(taskArg).toContain('Dig deeper');
+    expect(taskArg).toContain('!IMPORTANT!: All previous context was from the original thread');
+    expect(taskArg).toContain('YOU are now a forked subagent');
     expect(taskArg).toContain('Do not call the `subagent` tool');
+    expect(taskArg).toContain('User task:\nDig deeper');
+    expect(taskArg.indexOf('YOU are now a forked subagent')).toBeLessThan(taskArg.indexOf('User task:\nDig deeper'));
     // Memory option points at the cloned thread so history is inherited
     // without polluting the parent thread.
     expect(streamOpts.memory).toEqual({ thread: 'forked-thread-1', resource: 'parent-resource-1' });
-    // Forked runs need multiple steps so an accidental nested-subagent call can
-    // consume the runtime stub and then produce a direct answer on the next step.
+    // Forked runs get a larger step budget for inherited parent tools; the
+    // synthetic completed subagent result prevents recursive delegation.
     expect(streamOpts.maxSteps).toBe(1000);
 
     expect(harnessCtx.emitEvent).toHaveBeenCalledWith(
@@ -1033,7 +1035,7 @@ describe('createSubagentTool forked subagent behavior', () => {
     expect(patchedSubagent.execute).not.toBe(originalSubagentExecute);
     const stubResult = await patchedSubagent.execute({}, {});
     expect(stubResult.isError).toBe(true);
-    expect(stubResult.content).toMatch(/maximum allowed subagent nesting level/i);
+    expect(stubResult.content).toMatch(/YOU are now a forked subagent/i);
     expect(originalSubagentExecute).not.toHaveBeenCalled();
 
     const patchedTaskWrite = streamOpts.toolsets.harnessBuiltIn.task_write;
@@ -1103,8 +1105,8 @@ describe('createSubagentTool forked subagent behavior', () => {
     expect(streamOpts.toolsets).toBeUndefined();
   });
 
-  it('non-forked path is unchanged: strips threadId/resourceId and constructs a fresh Agent', async () => {
-    // Sanity check that wiring fork helpers does NOT affect the default path.
+  it('non-forked path is unchanged: omits request context and constructs a fresh Agent', async () => {
+    // Sanity check that wiring fork helpers does NOT route the default path through the parent agent.
     const { parentAgent, parentStream } = makeParentAgent();
     const cloneThreadForFork = vi.fn();
 
@@ -1136,10 +1138,7 @@ describe('createSubagentTool forked subagent behavior', () => {
     expect(mockStream).toHaveBeenCalledTimes(1);
 
     const streamOpts = mockStream.mock.calls[0]![1];
-    const harness = streamOpts.requestContext.get('harness') as Partial<HarnessRequestContext>;
-    expect(harness.threadId).toBeNull();
-    expect(harness.resourceId).toBe('');
-    // memory option is NOT set for non-forked runs
+    expect(streamOpts.requestContext).toBeUndefined();
     expect(streamOpts.memory).toBeUndefined();
   });
 });

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod/v4';
 import { Agent } from '../agent';
 import type { ToolsInput, ToolsetsInput } from '../agent/types';
 import type { MastraModelConfig } from '../llm/model/shared.types';
+import { PrefillErrorHandler, ProviderHistoryCompat, StreamErrorRetryProcessor } from '../processors';
 import { RequestContext } from '../request-context';
 import { askUserTool } from '../tools/builtin/ask-user';
 import { submitPlanTool } from '../tools/builtin/submit-plan';
@@ -20,7 +21,7 @@ import type { HarnessRequestContext, HarnessSubagent } from './types';
 export { askUserTool };
 
 const FORKED_SUBAGENT_NESTING_NOTICE =
-  'Do not call the `subagent` tool. You are currently running inside a forked subagent, and this is the maximum allowed subagent nesting level. Further subagent calls will return an error. Answer the task directly using the conversation history and the other tools available to you.';
+  '!IMPORTANT!: All previous context was from the original thread. YOU are now a forked subagent; you are not the same agent that all previous context related to. That context is there for your understanding. Do not call the `subagent` tool again. Use the previous context and available tools to complete the following task directly.';
 
 const FORKED_SUBAGENT_TASK_NOTICE =
   'Do not call `task_write`, `task_update`, `task_complete`, or `task_check` inside a forked subagent. Forked subagents keep the parent task-tool schemas for prompt-cache stability, but the parent agent owns the visible task list. Track forked subagent work in your final answer instead.';
@@ -89,6 +90,12 @@ export interface CreateSubagentToolOptions {
     sourceThreadId: string;
     resourceId?: string;
     title?: string;
+    /**
+     * Tool-call ID of the current `subagent` invocation. The harness appends a
+     * synthetic completed result with this ID to the cloned fork history so the
+     * forked model knows it is already running inside the delegated context.
+     */
+    excludeToolCallId?: string;
   }) => Promise<{ id: string; resourceId: string }>;
   /**
    * Resolves the toolsets the parent agent runs with for the current request.
@@ -220,6 +227,7 @@ Use this tool when:
             sourceThreadId: parentThreadId,
             resourceId: harnessCtx?.resourceId,
             title: `Fork: ${definition.name} subagent`,
+            excludeToolCallId: toolCallId,
           });
         } catch (err) {
           return {
@@ -231,11 +239,11 @@ Use this tool when:
         subagentToRun = parentAgent;
         // Display value only; forked runs use the parent agent's configured model.
         resolvedModelId = opts.getParentModelId?.() || 'parent-agent';
-        task = `${task}\n\n${FORKED_SUBAGENT_NESTING_NOTICE}\n\n${FORKED_SUBAGENT_TASK_NOTICE}`;
+        task = `${FORKED_SUBAGENT_NESTING_NOTICE}\n\n${FORKED_SUBAGENT_TASK_NOTICE}\n\nUser task:\n${task}`;
         streamMemory = { thread: forkedThread.id, resource: forkedThread.resourceId };
-        // Allow a recovery step if the forked model accidentally calls the
-        // inherited-but-disabled `subagent` tool. Without this, the single-step
-        // default can return only the stub tool result instead of the answer.
+        // Forked subagents may need a larger budget to use the inherited parent
+        // tool environment. Recursion is prevented by the synthetic completed
+        // subagent result in cloned history, not by constraining step count.
         streamMaxSteps = 1000;
         streamStopWhen = undefined;
         streamPrepareStep = undefined;
@@ -311,6 +319,8 @@ Use this tool when:
           model,
           tools: mergedTools,
           workspace,
+          inputProcessors: [new ProviderHistoryCompat()],
+          errorProcessors: [new StreamErrorRetryProcessor(), new PrefillErrorHandler(), new ProviderHistoryCompat()],
         });
 
         // Only resolve workspace tool names when an allowlist is configured,
@@ -338,15 +348,9 @@ Use this tool when:
               })
             : undefined;
 
-        // Build a request context for the subagent that inherits sandbox paths
-        // and harness state but strips threadId/resourceId so the subagent
-        // doesn't trigger OM enrichment on the parent's memory thread.
-        if (context?.requestContext) {
-          subagentRequestContext = new RequestContext(context.requestContext.entries());
-          if (harnessCtx) {
-            subagentRequestContext.set('harness', { ...harnessCtx, threadId: null, resourceId: '' });
-          }
-        }
+        // Match the original non-forked subagent contract: the parent request
+        // context is only read above for event forwarding / abort / model lookup.
+        // The fresh subagent Agent runs without inherited request context or memory.
       }
 
       const startTime = Date.now();

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
@@ -170,20 +170,17 @@ export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefin
       // Determine the judge model config. A non-string agent `goal.judge` (a
       // resolved model or a model-resolver function) is the consumer's own
       // resolver and takes precedence: it knows how to inject provider
-      // credentials. When the ThreadState record carries a judge model override,
-      // pass it into the resolver so consumers can resolve that explicit model
-      // through their credential-aware gateway. If the resolver declines it,
-      // fall back to the effective string id.
+      // credentials. Otherwise use the effective `judgeModelId` string (record
+      // override → agent config). A judge model is the activation switch: if none
+      // is configured, the goal step does nothing.
       const nonStringAgentJudge = goal.judge && typeof goal.judge !== 'string' ? goal.judge : undefined;
 
+      // A model-resolver function is the consumer's own resolver: run it first so
+      // it can inject provider credentials. It may return `undefined` (e.g. no
+      // judge configured) → no-op.
       let judgeModelConfig: unknown = nonStringAgentJudge ?? effective.judgeModelId;
       if (typeof judgeModelConfig === 'function') {
-        judgeModelConfig =
-          (await (judgeModelConfig as (args: any) => unknown)({
-            requestContext,
-            mastra,
-            judgeModelId: effective.judgeModelId,
-          })) ?? effective.judgeModelId;
+        judgeModelConfig = await (judgeModelConfig as (args: any) => unknown)({ requestContext, mastra });
       }
       if (!judgeModelConfig) {
         return inputData;

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
@@ -170,17 +170,20 @@ export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefin
       // Determine the judge model config. A non-string agent `goal.judge` (a
       // resolved model or a model-resolver function) is the consumer's own
       // resolver and takes precedence: it knows how to inject provider
-      // credentials. Otherwise use the effective `judgeModelId` string (record
-      // override → agent config). A judge model is the activation switch: if none
-      // is configured, the goal step does nothing.
+      // credentials. When the ThreadState record carries a judge model override,
+      // pass it into the resolver so consumers can resolve that explicit model
+      // through their credential-aware gateway. If the resolver declines it,
+      // fall back to the effective string id.
       const nonStringAgentJudge = goal.judge && typeof goal.judge !== 'string' ? goal.judge : undefined;
 
-      // A model-resolver function is the consumer's own resolver: run it first so
-      // it can inject provider credentials. It may return `undefined` (e.g. no
-      // judge configured) → no-op.
       let judgeModelConfig: unknown = nonStringAgentJudge ?? effective.judgeModelId;
       if (typeof judgeModelConfig === 'function') {
-        judgeModelConfig = await (judgeModelConfig as (args: any) => unknown)({ requestContext, mastra });
+        judgeModelConfig =
+          (await (judgeModelConfig as (args: any) => unknown)({
+            requestContext,
+            mastra,
+            judgeModelId: effective.judgeModelId,
+          })) ?? effective.judgeModelId;
       }
       if (!judgeModelConfig) {
         return inputData;


### PR DESCRIPTION
<!-- stack-nav -->

## Stack navigation

Position: 3 of 6

Previous: #18248
Next: #18246

Full stack:
1. #18327 — Stabilize Mastra Code e2e paths
2. #18248 — Restore prompt task and tool rendering
3. #18245 — Restore forked subagent runtime behavior
4. #18246 — Restore built-in subagent execution
5. #18247 — Restore persistent goal flows
6. #18249 — Restore model selector and slash UI
