### PR TITLE
Restore Mastra Code built-in subagent execution

### DIFF
--- a/.changeset/bright-subagents-restore.md
+++ b/.changeset/bright-subagents-restore.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Restored built-in subagent execution and rendering in Mastra Code.

--- a/mastracode/e2e/scenarios/subagent-delegation.ts
+++ b/mastracode/e2e/scenarios/subagent-delegation.ts
@@ -9,7 +9,6 @@ export const subagentDelegationScenario: McE2eScenario = {
   name: 'subagent-delegation',
   description: 'Delegate to an AIMock-driven Explore subagent and render completed subagent activity in the TUI.',
   testName: 'renders real TUI subagent delegation and completed result activity',
-  skipReason: 'current main no longer renders expected subagent progress rows/request count for this delegation flow',
   useOpenAIModel: true,
   aimockFixture: 'subagent-delegation.json',
   prepare({ projectDir }) {
@@ -34,6 +33,14 @@ export const subagentDelegationScenario: McE2eScenario = {
       terminal,
       10_000,
     );
+
+    const history = terminal.serializeHistory?.().output ?? terminal.serialize().view;
+    const renderedSubagentLines = history.match(/subagent\s+explore\s+openai\/gpt-5\.4-mini/g) ?? [];
+    if (renderedSubagentLines.length !== 1) {
+      throw new Error(
+        `Expected exactly one rendered Explore subagent component, found ${renderedSubagentLines.length}.\n\n${history}`,
+      );
+    }
 
     terminal.keyCtrlC();
   },

--- a/mastracode/e2e/scenarios/subagent-model-startup-restore.ts
+++ b/mastracode/e2e/scenarios/subagent-model-startup-restore.ts
@@ -13,8 +13,6 @@ export const subagentModelStartupRestoreScenario = {
   name: 'subagent-model-startup-restore',
   description: 'Restores persisted subagent model defaults during TUI startup and uses them for delegation.',
   testName: 'uses persisted subagent model defaults for delegated subagents',
-  skipReason:
-    'current main subagent delegation flow no longer renders expected progress/result path for restored model defaults',
   useOpenAIModel: true,
   aimockFixture: 'subagent-model-startup-restore.json',
   prepare({ appDataDir, projectDir }) {

--- a/mastracode/e2e/scenarios/subagent-plan-execute-tools.ts
+++ b/mastracode/e2e/scenarios/subagent-plan-execute-tools.ts
@@ -21,7 +21,6 @@ export const subagentPlanExecuteToolsScenario: McE2eScenario = {
   name: 'subagent-plan-execute-tools',
   description: 'Delegate Plan and Execute subagents and verify execute inherits workspace write tools in the real TUI.',
   testName: 'runs Plan and Execute subagents with expected workspace tool boundaries',
-  skipReason: 'current main execute subagent does not write expected workspace file in this flow',
   projectFixture: 'long-branch',
   useOpenAIModel: true,
   aimockFixture: 'subagent-plan-execute-tools.json',

--- a/mastracode/src/agents/subagents/execute.ts
+++ b/mastracode/src/agents/subagents/execute.ts
@@ -1,0 +1,57 @@
+/**
+ * Execute subagent — focused task execution with write capabilities.
+ *
+ * This subagent is given a specific implementation task and uses both
+ * read and write tools to complete it. It can modify files, run commands,
+ * and perform actual development work within a constrained scope.
+ */
+import type { HarnessSubagent } from '@mastra/core/harness';
+
+import { MC_TOOLS } from '../../tool-names.js';
+
+export const executeSubagent: HarnessSubagent = {
+  id: 'execute',
+  name: 'Execute',
+  description:
+    "Task execution with write capabilities. Use for 'implement feature X', 'fix bug Y', 'refactor module Z'.",
+  instructions: `You are a focused execution agent. Your job is to complete a specific, well-defined task by making the necessary changes to the codebase.
+
+## Rules
+- You have FULL ACCESS to read, write, and execute within your task scope.
+- Stay focused on the specific task given. Do not make unrelated changes.
+- Read files before modifying them — use view first, then string_replace_lsp or write_file.
+- Verify your changes work by running relevant tests or checking for errors.
+
+## Tool Strategy
+- **Read first**: Always view a file before editing it
+- **Edit precisely**: Use string_replace_lsp with enough context to match uniquely
+- **Use specialized tools**: Prefer view/search_content/find_files over shell commands for reading
+- **Parallelize**: Make independent tool calls together (e.g., view multiple files at once)
+
+## Workflow
+. Understand the task and explore relevant code
+. For complex tasks (3+ steps): track progress internally and summarize it in your final answer
+. Make changes incrementally — verify each change before moving on
+. Run tests or type-check to verify
+
+## Efficiency
+Your output returns to the parent agent. Be concise:
+- Don't repeat file contents in your response
+- Summarize what changed, don't narrate each step
+- Keep your final summary under 300 words
+
+## Output Format
+End with a structured summary:
+. **Completed**: What you implemented (1-2 sentences)
+. **Changes**: Files modified/created
+. **Verification**: How you verified it works
+. **Notes**: Follow-up needed (if any)`,
+  allowedWorkspaceTools: [
+    MC_TOOLS.VIEW,
+    MC_TOOLS.SEARCH_CONTENT,
+    MC_TOOLS.FIND_FILES,
+    MC_TOOLS.STRING_REPLACE_LSP,
+    MC_TOOLS.WRITE_FILE,
+    MC_TOOLS.EXECUTE_COMMAND,
+  ],
+};

--- a/mastracode/src/agents/subagents/explore.ts
+++ b/mastracode/src/agents/subagents/explore.ts
@@ -1,0 +1,44 @@
+/**
+ * Explore subagent — read-only codebase exploration.
+ *
+ * This subagent is given a focused task (e.g., "find all usages of X",
+ * "understand how module Y works") and uses read-only tools to explore
+ * the codebase, then returns a concise summary of its findings.
+ */
+import type { HarnessSubagent } from '@mastra/core/harness';
+
+import { MC_TOOLS } from '../../tool-names.js';
+
+export const exploreSubagent: HarnessSubagent = {
+  id: 'explore',
+  name: 'Explore',
+  description:
+    "Read-only codebase exploration. Use for questions like 'find all usages of X', 'how does module Y work'.",
+  instructions: `You are an expert code explorer. Your job is to investigate a codebase and answer a specific question or gather specific information.
+
+## Rules
+- You have READ-ONLY access. You cannot modify files or run commands.
+- Be thorough — search broadly first, then drill into relevant files.
+- After gathering enough information, produce a clear, concise summary of your findings.
+
+## Tool Strategy
+- **Start broad**: Use find_files (glob) to understand project structure
+- **Search smart**: Use search_content (grep) with specific patterns — avoid overly broad searches
+- **Read efficiently**: Use view with view_range for large files — don't read entire files if you only need a section
+- **Parallelize**: Make multiple independent tool calls in one round when exploring different areas
+
+## Efficiency
+Your output returns to the parent agent. Be concise:
+- Don't include raw file contents in your response — summarize what you found
+- Reference files by path and line number, not by copying code
+- If a search returns many results, report the count and key examples, not every match
+
+## Output Format
+End with a structured summary:
+. **Answer**: Direct answer to the question (1-2 sentences)
+. **Key Files**: Most relevant files with line numbers
+. **Details**: Additional context if needed
+
+Keep your summary under 300 words.`,
+  allowedWorkspaceTools: [MC_TOOLS.VIEW, MC_TOOLS.SEARCH_CONTENT, MC_TOOLS.FIND_FILES],
+};

--- a/mastracode/src/agents/subagents/plan.ts
+++ b/mastracode/src/agents/subagents/plan.ts
@@ -1,0 +1,46 @@
+/**
+ * Plan subagent — read-only analysis and planning.
+ *
+ * This subagent is given a task to analyze and produces a structured
+ * implementation plan. It can read the codebase to understand existing
+ * patterns and architecture, but cannot modify anything.
+ */
+import type { HarnessSubagent } from '@mastra/core/harness';
+
+import { MC_TOOLS } from '../../tool-names.js';
+
+export const planSubagent: HarnessSubagent = {
+  id: 'plan',
+  name: 'Plan',
+  description:
+    "Read-only analysis and planning. Use for 'create an implementation plan for X', 'analyze the architecture of Y'.",
+  instructions: `You are an expert software architect and planner. Your job is to analyze a codebase and produce a detailed implementation plan for a given task.
+
+## Rules
+- You have READ-ONLY access. You cannot modify files or run commands.
+- First, explore the codebase to understand existing patterns, architecture, and conventions.
+- Produce a concrete, actionable plan — not vague suggestions.
+
+## Tool Strategy
+- **Discover structure**: Use find_files (glob) to understand project layout and find relevant files
+- **Find patterns**: Use search_content (grep) to locate existing implementations, imports, and conventions
+- **Understand deeply**: Use view with view_range to read specific sections of key files
+- **Parallelize**: Make multiple independent tool calls when exploring different areas
+
+## Efficiency
+Your output returns to the parent agent. Be concise:
+- Don't include raw file contents — reference by path and line number
+- Focus on actionable details, not general observations
+- If you find many similar patterns, describe the pattern once with examples
+
+## Output Format
+Structure your plan as:
+
+. **Summary**: One-paragraph overview (2-3 sentences)
+. **Files to Change**: List each file with specific changes needed
+. **Implementation Order**: Numbered steps in dependency order
+. **Risks**: Potential issues or edge cases (if any)
+
+Be specific about code locations (file paths, function names, line numbers). Keep the plan actionable and under 500 words.`,
+  allowedWorkspaceTools: [MC_TOOLS.VIEW, MC_TOOLS.SEARCH_CONTENT, MC_TOOLS.FIND_FILES],
+};

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -48,9 +48,9 @@ import { buildMode } from './agents/modes/build.js';
 import { fastMode } from './agents/modes/explore.js';
 import { planMode } from './agents/modes/plan.js';
 import { getStaticallyLoadedInstructionPaths } from './agents/prompts/agent-instructions.js';
-// import { executeSubagent } from './agents/subagents/execute.js';
-// import { exploreSubagent } from './agents/subagents/explore.js';
-// import { planSubagent } from './agents/subagents/plan.js';
+import { executeSubagent } from './agents/subagents/execute.js';
+import { exploreSubagent } from './agents/subagents/explore.js';
+import { planSubagent } from './agents/subagents/plan.js';
 import { attachOMThreadStatePersistence, restoreOMThreadStateForCurrentThread } from './agents/thread-caveman-state.js';
 import { createDynamicTools, createToolHooks } from './agents/tools.js';
 
@@ -561,8 +561,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     ],
   });
 
-  // const defaultSubAgents: Array<HarnessSubagent> = [];
-  // const defaultSubagents = [exploreSubagent, planSubagent, executeSubagent];
+  const defaultSubagents: HarnessSubagent[] = [exploreSubagent, planSubagent, executeSubagent];
 
   const defaultModes: HarnessMode[] = [
     {
@@ -661,11 +660,30 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     throw new Error('MastraCode requires at least one mode');
   }
 
-  // Map subagent types to mode models: explore→fast, plan→plan, execute→build
-  // const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };
-  // Subagents inherit workspace tools from the parent agent's workspace automatically.
-  // Apply disabledTools filter to both default and custom subagents.
-  // const subagents = [];
+  // Map subagent types to mode models: explore→fast, plan→plan, execute→build.
+  const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };
+  const subagents = (config?.subagents ?? defaultSubagents).map(subagent => {
+    const modeId = subagentModeMap[subagent.id];
+    const model = modeId ? effectiveDefaults[modeId] : undefined;
+    let filtered = subagent;
+    if (config?.disabledTools?.length) {
+      if (subagent.allowedWorkspaceTools) {
+        filtered = {
+          ...filtered,
+          allowedWorkspaceTools: subagent.allowedWorkspaceTools.filter(tool => !config.disabledTools!.includes(tool)),
+        };
+      }
+      if (subagent.tools) {
+        filtered = {
+          ...filtered,
+          tools: Object.fromEntries(
+            Object.entries(subagent.tools).filter(([tool]) => !config.disabledTools!.includes(tool)),
+          ),
+        };
+      }
+    }
+    return model ? { ...filtered, defaultModelId: model } : filtered;
+  });
 
   // Build initial state with global preferences
   const globalInitialState: Partial<MastraCodeState> = {};
@@ -723,7 +741,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     pubsub: signalsPubSub,
     stateSchema: typedStateSchema,
     agent: codeAgent,
-    subagents: config?.subagents ?? [],
+    subagents,
     gateways: [mastraCodeGateway],
     toolCategoryResolver: getToolCategory,
     initialState: {

--- a/mastracode/src/tui/components/subagent-execution.ts
+++ b/mastracode/src/tui/components/subagent-execution.ts
@@ -76,6 +76,14 @@ export class SubagentExecutionComponent extends Container implements IToolExecut
 
   // ── Mutation API ──────────────────────────────────────────────────────
 
+  updateMetadata(agentType: string, task: string, modelId?: string, forked?: boolean): void {
+    this.agentType = agentType;
+    this.task = task;
+    this.modelId = modelId;
+    this.forked = forked ?? false;
+    this.rebuild();
+  }
+
   addToolStart(name: string, args: unknown): void {
     this.toolCalls.push({ name, args, done: false });
     this.rebuild();

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -16,12 +16,14 @@ import { NotificationSummaryComponent } from '../components/notification-summary
 import { NotificationComponent } from '../components/notification.js';
 import { ReactiveSignalComponent } from '../components/reactive-signal.js';
 import { StateSignalComponent } from '../components/state-signal.js';
+import { SubagentExecutionComponent } from '../components/subagent-execution.js';
 import { SystemReminderComponent } from '../components/system-reminder.js';
 import { TemporalGapComponent } from '../components/temporal-gap.js';
 import { ToolExecutionComponentEnhanced } from '../components/tool-execution-enhanced.js';
 import { UserMessageComponent } from '../components/user-message.js';
 import { addChildBeforeMessageOrFollowUps } from '../render-messages.js';
 import { getMarkdownTheme } from '../theme.js';
+import { formatToolResult, isToolResultError } from './tool.js';
 
 import type { EventHandlerContext } from './types.js';
 
@@ -448,8 +450,38 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
   }
 
   state.streamingMessage = message;
-  // Check for new tool calls
+  // Check for new tool calls and completed tool results
   for (const content of message.content) {
+    if (content.type === 'tool_result') {
+      const subagentComponent = state.pendingSubagents.get(content.id);
+      if (subagentComponent) {
+        const effectiveIsError = content.isError || isToolResultError(content.result);
+        subagentComponent.finish(effectiveIsError, 0, formatToolResult(content.result));
+        state.pendingSubagents.delete(content.id);
+        reconcileChatBoundarySpacers(state.chatContainer);
+        state.ui.requestRender();
+      }
+
+      const component = state.pendingTools.get(content.id);
+      if (component) {
+        component.updateResult(
+          {
+            content: [
+              {
+                type: 'text',
+                text: formatToolResult(content.result),
+              },
+            ],
+            isError: content.isError,
+          },
+          false,
+        );
+        state.pendingTools.delete(content.id);
+        reconcileChatBoundarySpacers(state.chatContainer);
+      }
+      continue;
+    }
+
     if (content.type === 'tool_call') {
       // For subagent calls, freeze the current streaming component
       // with content before the tool call, then create a new one.
@@ -465,12 +497,28 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
           ...message,
           content: preContent,
         });
+
+        const subArgs = content.args as
+          | { agentType?: string; task?: string; modelId?: string; forked?: boolean }
+          | undefined;
+        const component = new SubagentExecutionComponent(
+          subArgs?.agentType ?? 'unknown',
+          subArgs?.task ?? '',
+          state.ui,
+          subArgs?.modelId,
+          { collapseOnComplete: false, expandOnComplete: state.quietMode, forked: subArgs?.forked },
+        );
+        ctx.addChildBeforeFollowUps(component);
+        state.pendingSubagents.set(content.id, component);
+        state.allToolComponents.push(component as never);
+
         state.streamingComponent = new AssistantMessageComponent(
           undefined,
           state.hideThinkingBlock,
           getMarkdownTheme(),
         );
         ctx.addChildBeforeFollowUps(state.streamingComponent);
+        reconcileChatBoundarySpacers(state.chatContainer);
         createdStreamingComponent = true;
         continue;
       }

--- a/mastracode/src/tui/handlers/subagent.ts
+++ b/mastracode/src/tui/handlers/subagent.ts
@@ -16,6 +16,13 @@ export function handleSubagentStart(
   forked?: boolean,
 ): void {
   const { state } = ctx;
+  const existingComponent = state.pendingSubagents.get(toolCallId);
+  if (existingComponent) {
+    existingComponent.updateMetadata(agentType, task, modelId, forked);
+    state.ui.requestRender();
+    return;
+  }
+
   const component = new SubagentExecutionComponent(agentType, task, state.ui, modelId, {
     collapseOnComplete: false,
     expandOnComplete: state.quietMode,

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -84,7 +84,7 @@ function ensureSubmitPlanComponent(
  * Handles objects, strings, and other types.
  * Extracts content from common tool return structures like { content: "...", isError: false }
  */
-function isToolResultError(result: unknown): boolean {
+export function isToolResultError(result: unknown): boolean {
   return typeof result === 'object' && result !== null && (result as Record<string, unknown>).isError === true;
 }
 
@@ -448,14 +448,15 @@ export function handleToolInputEnd(_ctx: EventHandlerContext, _toolCallId: strin
 
 export function handleToolEnd(ctx: EventHandlerContext, toolCallId: string, result: unknown, isError: boolean): void {
   const { state } = ctx;
-  // If this is a subagent tool, store the result in the SubagentExecutionComponent
+  // If no dedicated subagent_end event is emitted, finalize the subagent
+  // component from the parent tool result so it does not remain stuck as running.
   const subagentComponent = state.pendingSubagents.get(toolCallId);
   if (subagentComponent) {
-    // The final result is available here
-    const resultText = formatToolResult(result);
-    // We'll need to wait for subagent_end to set this
-    // Store it temporarily
-    (subagentComponent as any)._pendingResult = resultText;
+    subagentComponent.finish(isToolResultError(result), 0, formatToolResult(result));
+    state.pendingSubagents.delete(toolCallId);
+    reconcileToolBoundaries(ctx);
+    state.ui.requestRender();
+    return;
   }
 
   // File modification tracking is handled by the Harness display state


### PR DESCRIPTION
<!-- stack-nav -->

## Stack navigation

Position: 4 of 6

Previous: #18245
Next: #18247

Full stack:
1. #18327 — Stabilize Mastra Code e2e paths
2. #18248 — Restore prompt task and tool rendering
3. #18245 — Restore forked subagent runtime behavior
4. #18246 — Restore built-in subagent execution
5. #18247 — Restore persistent goal flows
6. #18249 — Restore model selector and slash UI
