### PR TITLE
Restore Mastra Code task list TUI rendering

### DIFF
--- a/.changeset/gentle-tasks-render.md
+++ b/.changeset/gentle-tasks-render.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Restored task list progress and history rendering behavior in Mastra Code.

--- a/mastracode/e2e/fixtures/task-inline-transitions.json
+++ b/mastracode/e2e/fixtures/task-inline-transitions.json
@@ -3,7 +3,6 @@
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
         "userMessage": "Exercise task inline transitions through real task tools.",
         "hasToolResult": false
       },
@@ -31,14 +30,16 @@
           }
         ]
       },
-      "streamingProfile": { "ttft": 200, "tps": 30 }
+      "streamingProfile": {
+        "ttft": 200,
+        "tps": 30
+      }
     },
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
-        "toolCallId": "call_task_inline_write",
-        "hasToolResult": true
+        "hasToolResult": true,
+        "turnIndex": 1
       },
       "response": {
         "toolCalls": [
@@ -55,9 +56,8 @@
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
-        "toolCallId": "call_task_inline_complete",
-        "hasToolResult": true
+        "hasToolResult": true,
+        "turnIndex": 2
       },
       "response": {
         "toolCalls": [
@@ -74,9 +74,8 @@
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
-        "toolCallId": "call_task_inline_clear",
-        "hasToolResult": true
+        "hasToolResult": true,
+        "turnIndex": 3
       },
       "response": {
         "content": "Task inline transition e2e complete."

--- a/mastracode/e2e/fixtures/task-patch-tools.json
+++ b/mastracode/e2e/fixtures/task-patch-tools.json
@@ -3,7 +3,6 @@
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
         "userMessage": "Exercise task patch tools through real task tools.",
         "hasToolResult": false
       },
@@ -29,9 +28,8 @@
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
-        "toolCallId": "call_task_patch_write",
-        "hasToolResult": true
+        "hasToolResult": true,
+        "turnIndex": 1
       },
       "response": {
         "toolCalls": [
@@ -50,9 +48,8 @@
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
-        "toolCallId": "call_task_patch_update",
-        "hasToolResult": true
+        "hasToolResult": true,
+        "turnIndex": 2
       },
       "response": {
         "toolCalls": [
@@ -67,9 +64,8 @@
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
-        "toolCallId": "call_task_patch_check",
-        "hasToolResult": true
+        "hasToolResult": true,
+        "turnIndex": 3
       },
       "response": {
         "content": "Task patch e2e complete."

--- a/mastracode/e2e/fixtures/task-prompt-context-next-turn.json
+++ b/mastracode/e2e/fixtures/task-prompt-context-next-turn.json
@@ -2,7 +2,6 @@
   "fixtures": [
     {
       "match": {
-        "endpoint": "chat",
         "model": "gpt-5.4-mini",
         "userMessage": "Create a prompt-context e2e task.",
         "hasToolResult": false
@@ -28,10 +27,9 @@
     },
     {
       "match": {
-        "endpoint": "chat",
         "model": "gpt-5.4-mini",
-        "toolCallId": "call_task_prompt_write",
-        "hasToolResult": true
+        "hasToolResult": true,
+        "turnIndex": 1
       },
       "response": {
         "content": "Task state seeded for prompt-context verification."
@@ -39,11 +37,10 @@
     },
     {
       "match": {
-        "endpoint": "chat",
         "model": "gpt-5.4-mini",
         "userMessage": "Confirm current task prompt context.",
-        "hasToolResult": false,
-        "systemMessage": ["<current-task-list>", "{id: prompt-context-e2e}", "Verify current task list prompt context"]
+        "hasToolResult": true,
+        "turnIndex": 2
       },
       "response": {
         "content": "Current task prompt context observed."

--- a/mastracode/e2e/scenarios/file-autocomplete.ts
+++ b/mastracode/e2e/scenarios/file-autocomplete.ts
@@ -32,10 +32,11 @@ export const fileAutocompleteScenario = {
     await runtime.waitForScreenText(/Branch: feature\/super-long-branch-name/i, terminal);
     await runtime.waitForScreenText(/│ ›/i, terminal, 10_000);
 
-    await typeTextSlowly(terminal, 'Attach @auto', 10);
+    await typeTextSlowly(terminal, 'Attach @auto', 25);
     await terminal.flushInput?.();
     await runtime.waitForScreenText(/Attach @auto/i, terminal, 10_000);
     await runtime.waitForScreenText(/autocomplete-target\.ts/i, terminal, 30_000);
+    await new Promise(resolve => setTimeout(resolve, 300));
     runtime.printScreen('file autocomplete suggestions', terminal);
 
     terminal.write('\t');

--- a/mastracode/e2e/scenarios/task-inline-transitions.ts
+++ b/mastracode/e2e/scenarios/task-inline-transitions.ts
@@ -5,7 +5,6 @@ export const taskInlineTransitionsScenario: McE2eScenario = {
   name: 'task-inline-transitions',
   description: 'Drive task tools through AIMock and verify completed and cleared inline TUI transitions.',
   testName: 'renders completed and cleared task inline transitions from real task tools',
-  skipReason: 'current main task tool request shape no longer matches the AIMock inline-transition fixture',
   useOpenAIModel: true,
   aimockFixture: 'task-inline-transitions.json',
   async run({ terminal, runtime }) {
@@ -14,9 +13,14 @@ export const taskInlineTransitionsScenario: McE2eScenario = {
     await (expect(terminal.getByText(/Project:|Resource ID:|>/gi, { full: true, strict: false })) as any).toBeVisible();
     terminal.submit('Exercise task inline transitions through real task tools.');
 
-    await runtime.waitForScreenText(/Tasks\s+\[2\/2 completed\]/i, terminal, 8_000);
     await runtime.waitForScreenText(/✓\s+Plan task inline e2e/i, terminal, 8_000);
     await runtime.waitForScreenText(/✓\s+Finish task inline e2e/i, terminal, 8_000);
+    await runtime.waitForOutputText(/Tasks/i, terminal, 8_000);
+    await runtime.waitForOutputText(/✓ Plan task inline e2e/i, terminal, 8_000);
+    await runtime.waitForOutputText(/▶ Finishing task inline e2e/i, terminal, 8_000);
+    await runtime.waitForOutputText(/Tasks\s+\[2\/2 completed\]/i, terminal, 8_000);
+    await runtime.waitForOutputText(/Plan task inline e2e/i, terminal, 8_000);
+    await runtime.waitForOutputText(/Finish task inline e2e/i, terminal, 8_000);
 
     await runtime.waitForScreenText(/Tasks cleared/i, terminal, 8_000);
     await runtime.waitForScreenText(/Task inline transition e2e complete\./i, terminal, 8_000);

--- a/mastracode/e2e/scenarios/task-patch-tools.ts
+++ b/mastracode/e2e/scenarios/task-patch-tools.ts
@@ -5,7 +5,6 @@ export const taskPatchToolsScenario: McE2eScenario = {
   name: 'task-patch-tools',
   description: 'Drive task patch/check tools through the real TUI and verify their rendered output.',
   testName: 'patches tasks and renders task check output from real task tools',
-  skipReason: 'current main task-state/tool-result request shape no longer matches the AIMock task patch fixture',
   useOpenAIModel: true,
   aimockFixture: 'task-patch-tools.json',
   async run({ terminal, runtime }) {
@@ -16,6 +15,8 @@ export const taskPatchToolsScenario: McE2eScenario = {
 
     await runtime.waitForScreenText(/Tasks\s+\[0\/1 completed\]/i, terminal, 8_000);
     await runtime.waitForScreenText(/Verifying task patch e2e/i, terminal, 8_000);
+    await runtime.waitForOutputText(/Tasks/i, terminal, 8_000);
+    await runtime.waitForOutputText(/▶ Verifying task patch e2e/i, terminal, 8_000);
     await runtime.waitForScreenText(/Task Status:\s+\[0\/1 completed\]/i, terminal, 8_000);
     await runtime.waitForScreenText(/All tasks completed:\s+NO/i, terminal, 8_000);
     await runtime.waitForScreenText(/Task patch e2e complete\./i, terminal, 8_000);

--- a/mastracode/e2e/scenarios/task-prompt-context-next-turn.ts
+++ b/mastracode/e2e/scenarios/task-prompt-context-next-turn.ts
@@ -5,7 +5,6 @@ export const taskPromptContextNextTurnScenario: McE2eScenario = {
   name: 'task-prompt-context-next-turn',
   description: 'Verify live task state is injected into the next user turn system prompt.',
   testName: 'includes current task list in next-turn prompt context after task_write',
-  skipReason: 'current main task-state request shape no longer matches the AIMock prompt-context fixture',
   useOpenAIModel: true,
   aimockFixture: 'task-prompt-context-next-turn.json',
   async run({ terminal, runtime }) {
@@ -28,11 +27,10 @@ export const taskPromptContextNextTurnScenario: McE2eScenario = {
       throw new Error(`Expected task prompt-context scenario to make 3 AIMock requests, received ${requests.length}`);
     }
     const finalRequest = JSON.stringify(requests[2]);
-    for (const needle of [
-      '<current-task-list>',
-      '{id: prompt-context-e2e}',
-      'Verify current task list prompt context',
-    ]) {
+    if (!finalRequest.includes('<current-task-list') && !finalRequest.includes('<task-list-update')) {
+      throw new Error('Expected final AIMock request to include task state signal context');
+    }
+    for (const needle of ['prompt-context-e2e', 'Verify current task list prompt context']) {
       if (!finalRequest.includes(needle)) {
         throw new Error(`Expected final AIMock request to include ${needle}`);
       }

--- a/mastracode/e2e/terminal-backend.ts
+++ b/mastracode/e2e/terminal-backend.ts
@@ -167,6 +167,16 @@ class EmulatedTerminal implements Terminal {
     }
     return { view: lines.join('\n') };
   }
+
+  serializeHistory(): { output: string } {
+    const lines: string[] = [];
+    const buffer = this.xterm.buffer.active;
+    for (let index = 0; index < buffer.length; index += 1) {
+      const line = buffer.getLine(index);
+      lines.push(line?.translateToString(true) ?? '');
+    }
+    return { output: lines.join('\n') };
+  }
 }
 
 function countMatches(text: string, pattern: string | RegExp): number {
@@ -207,6 +217,9 @@ function createScenarioTerminal(terminal: EmulatedTerminal): McE2eTerminal {
     serialize() {
       return terminal.serialize();
     },
+    serializeHistory() {
+      return terminal.serializeHistory();
+    },
     submit(text: string) {
       terminal.sendInput(`${text}\r`);
     },
@@ -240,6 +253,21 @@ async function waitForScreenTextAbsent(pattern: RegExp, terminal: McE2eTerminal,
   await emulatedTerminal?.();
   if (!pattern.test(terminal.serialize().view)) return;
   throw new Error('Timed out waiting for ' + pattern + ' to disappear\n\n' + terminal.serialize().view);
+}
+
+async function waitForOutputText(pattern: RegExp, terminal: McE2eTerminal, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  const emulatedTerminal = (terminal as { flushInput?: () => Promise<void> }).flushInput;
+  const getOutput = () => terminal.serializeHistory?.().output ?? terminal.serialize().view;
+  while (Date.now() < deadline) {
+    await emulatedTerminal?.();
+    if (pattern.test(getOutput())) return;
+    await sleep(100);
+  }
+  await emulatedTerminal?.();
+  const output = getOutput();
+  if (pattern.test(output)) return;
+  throw new Error('Timed out waiting for ' + pattern + '\n\n' + output);
 }
 
 function writeConsoleLineToTerminal(terminal: Terminal, values: unknown[]): void {
@@ -394,6 +422,7 @@ export async function runTerminalBackend(runConfig: TerminalRunConfig): Promise<
     },
     sleep,
     startLiveOutput() {},
+    waitForOutputText,
     waitForScreenText,
     waitForScreenTextAbsent,
   };

--- a/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -103,6 +103,8 @@ function createQueueContext(state: TUIState, overrides: Partial<EventHandlerCont
     queueFollowUpMessage: vi.fn(),
     renderExistingMessages: vi.fn(),
     renderClearedTasksInline: vi.fn(),
+    renderCompletedTasksInline: vi.fn(),
+    renderTaskDeltaInline: vi.fn(),
     refreshModelAuthStatus: vi.fn(),
     ...overrides,
   };

--- a/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
+++ b/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
@@ -65,6 +65,8 @@ function createMockContext(state: TUIState): EventHandlerContext {
     queueFollowUpMessage: vi.fn(),
     renderExistingMessages: vi.fn(),
     renderClearedTasksInline: vi.fn(),
+    renderCompletedTasksInline: vi.fn(),
+    renderTaskDeltaInline: vi.fn(),
     refreshModelAuthStatus: vi.fn(),
   };
 }

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -30,8 +30,16 @@ function createState(): TUIState {
     messageComponentsById: new Map(),
     pendingSignalMessageComponentsById: new Map(),
     followUpComponents: [],
-    session: { displayState: { get: () => ({ isRunning: false }) } },
-    harness: { session: { displayState: { get: () => ({ isRunning: false }) } } },
+    session: {
+      state: {
+        get: vi.fn(() => ({})),
+        set: vi.fn(),
+      },
+      displayState: {
+        get: () => ({ isRunning: false }),
+        restoreTasks: vi.fn(),
+      },
+    },
   } as unknown as TUIState;
 }
 
@@ -612,6 +620,115 @@ describe('renderExistingMessages signals', () => {
     expect(rendered).toContain('╭ steer ');
     expect(rendered).toContain('continue from history');
     expect(rendered).not.toContain('stale preview');
+  });
+});
+
+describe('renderExistingMessages tasks', () => {
+  it('renders persisted task additions and crossed-off tasks inline', async () => {
+    const initialTasks = [
+      {
+        id: 'history-task-1',
+        content: 'Loaded history task one',
+        status: 'pending',
+        activeForm: 'Loading history task one',
+      },
+    ];
+    const updatedTasks = [
+      { ...initialTasks[0], status: 'completed' },
+      {
+        id: 'history-task-2',
+        content: 'Loaded history task two',
+        status: 'in_progress',
+        activeForm: 'Loading history task two',
+      },
+      {
+        id: 'history-task-3',
+        content: 'Loaded history task three',
+        status: 'pending',
+        activeForm: 'Loading history task three',
+      },
+    ];
+    const message: HarnessMessage = {
+      id: 'assistant-task-delta-history',
+      role: 'assistant',
+      createdAt: new Date(),
+      content: [
+        { type: 'tool_call', id: 'task-write-1', name: 'task_write', args: { tasks: initialTasks } },
+        {
+          type: 'tool_result',
+          id: 'task-write-1',
+          name: 'task_write',
+          result: { tasks: initialTasks },
+          isError: false,
+        },
+        { type: 'tool_call', id: 'task-complete-1', name: 'task_complete', args: { id: 'history-task-1' } },
+        {
+          type: 'tool_result',
+          id: 'task-complete-1',
+          name: 'task_complete',
+          result: { tasks: updatedTasks },
+          isError: false,
+        },
+      ],
+    } as unknown as HarnessMessage;
+    const state = createState();
+    state.session = {
+      ...state.session,
+      thread: { listActiveMessages: vi.fn().mockResolvedValue([message]) },
+    } as unknown as TUIState['session'];
+
+    await renderExistingMessages(state);
+
+    const rendered = state.chatContainer
+      .render(100)
+      .join('\n')
+      .replace(/\x1b\[[0-9;]*m/g, '');
+    expect(rendered).toContain('Tasks');
+    expect(rendered).toContain('○ Loaded history task one');
+    expect(rendered).toContain('▶ Loading history task two');
+    expect(rendered).toContain('○ Loaded history task three');
+    expect(rendered).toContain('✓ Loaded history task one');
+  });
+
+  it('renders completed persisted task_write history inline', async () => {
+    const tasks = [
+      {
+        id: 'history-task-1',
+        content: 'Loaded history task one',
+        status: 'completed',
+        activeForm: 'Loading history task one',
+      },
+      {
+        id: 'history-task-2',
+        content: 'Loaded history task two',
+        status: 'completed',
+        activeForm: 'Loading history task two',
+      },
+    ];
+    const message: HarnessMessage = {
+      id: 'assistant-task-history',
+      role: 'assistant',
+      createdAt: new Date(),
+      content: [
+        { type: 'tool_call', id: 'task-write-1', name: 'task_write', args: { tasks } },
+        { type: 'tool_result', id: 'task-write-1', name: 'task_write', result: { tasks }, isError: false },
+      ],
+    } as unknown as HarnessMessage;
+    const state = createState();
+    state.session = {
+      ...state.session,
+      thread: { listActiveMessages: vi.fn().mockResolvedValue([message]) },
+    } as unknown as TUIState['session'];
+
+    await renderExistingMessages(state);
+
+    const rendered = state.chatContainer
+      .render(100)
+      .join('\n')
+      .replace(/\x1b\[[0-9;]*m/g, '');
+    expect(rendered).toContain('Tasks [2/2 completed]');
+    expect(rendered).toContain('Loaded history task one');
+    expect(rendered).toContain('Loaded history task two');
   });
 });
 

--- a/mastracode/src/tui/components/task-progress.ts
+++ b/mastracode/src/tui/components/task-progress.ts
@@ -10,6 +10,26 @@ import chalk from 'chalk';
 import { getTermWidth, theme } from '../theme.js';
 import { truncateAnsi } from './ansi.js';
 
+export function formatTaskProgressLine(task: TaskItemInput, indent = '    '): string {
+  switch (task.status) {
+    case 'completed': {
+      const icon = theme.fg('success', '\u2713');
+      const text = chalk.hex(theme.getTheme().success).strikethrough(task.content);
+      return `${indent}${icon} ${text}`;
+    }
+    case 'in_progress': {
+      const icon = theme.fg('warning', '\u25B6');
+      const text = theme.bold(theme.fg('warning', task.activeForm));
+      return `${indent}${icon} ${text}`;
+    }
+    case 'pending': {
+      const icon = theme.fg('dim', '\u25CB');
+      const text = theme.fg('dim', task.content);
+      return `${indent}${icon} ${text}`;
+    }
+  }
+}
+
 export class TaskProgressComponent extends Container {
   private tasks: TaskItemInput[] = [];
   private quietMode = false;
@@ -68,7 +88,7 @@ export class TaskProgressComponent extends Container {
 
     // Render each task
     for (const task of this.tasks) {
-      this.addChild(new Text(this.formatTaskLine(task), 0, 0));
+      this.addChild(new Text(formatTaskProgressLine(task), 0, 0));
     }
   }
 
@@ -117,28 +137,6 @@ export class TaskProgressComponent extends Container {
         const icon = theme.fg('dim', '○');
         const text = theme.fg('muted', task.content);
         return `${icon} ${text}`;
-      }
-    }
-  }
-
-  private formatTaskLine(task: TaskItemInput): string {
-    const indent = '    ';
-
-    switch (task.status) {
-      case 'completed': {
-        const icon = theme.fg('success', '\u2713');
-        const text = chalk.hex(theme.getTheme().success).strikethrough(task.content);
-        return `${indent}${icon} ${text}`;
-      }
-      case 'in_progress': {
-        const icon = theme.fg('warning', '\u25B6');
-        const text = theme.bold(theme.fg('warning', task.activeForm));
-        return `${indent}${icon} ${text}`;
-      }
-      case 'pending': {
-        const icon = theme.fg('dim', '\u25CB');
-        const text = theme.fg('dim', task.content);
-        return `${indent}${icon} ${text}`;
       }
     }
   }

--- a/mastracode/src/tui/event-dispatch.test.ts
+++ b/mastracode/src/tui/event-dispatch.test.ts
@@ -63,6 +63,8 @@ function createMockEctx(): EventHandlerContext {
     renderExistingMessages: vi.fn().mockResolvedValue(undefined),
     refreshModelAuthStatus: vi.fn().mockResolvedValue(undefined),
     renderClearedTasksInline: vi.fn(),
+    renderCompletedTasksInline: vi.fn(),
+    renderTaskDeltaInline: vi.fn(),
   } as unknown as EventHandlerContext;
 }
 
@@ -197,16 +199,35 @@ describe('dispatchEvent thread lifecycle', () => {
 });
 
 describe('dispatchEvent task updates', () => {
-  it('updates the pinned list and resets the insert index without an inline receipt when all tasks complete', async () => {
+  it('renders task delta receipts for live non-terminal task updates', async () => {
+    const previousTasks = [
+      { id: 'task-1', content: 'Task 1', status: 'pending' as const, activeForm: 'Working on task 1' },
+    ];
+    const tasks = [
+      { id: 'task-1', content: 'Task 1', status: 'completed' as const, activeForm: 'Working on task 1' },
+      { id: 'task-2', content: 'Task 2', status: 'in_progress' as const, activeForm: 'Working on task 2' },
+      { id: 'task-3', content: 'Task 3', status: 'pending' as const, activeForm: 'Working on task 3' },
+    ];
+    const state = createMockTUIState(createMockHarness({}, previousTasks));
+    const ectx = createMockEctx();
+
+    await dispatchEvent({ type: 'task_updated', tasks }, ectx, state);
+
+    expect(state.taskProgress!.updateTasks).toHaveBeenCalledWith(tasks);
+    expect(ectx.renderTaskDeltaInline).toHaveBeenCalledWith(previousTasks, tasks, 5);
+    expect(ectx.renderCompletedTasksInline).not.toHaveBeenCalled();
+    expect(ectx.renderClearedTasksInline).not.toHaveBeenCalled();
+  });
+
+  it('renders a completed-task receipt when all tasks complete live', async () => {
     const tasks = [{ id: 'task-1', content: 'Task 1', status: 'completed' as const, activeForm: 'Completing task 1' }];
     const state = createMockTUIState(createMockHarness());
     const ectx = createMockEctx();
 
     await dispatchEvent({ type: 'task_updated', tasks }, ectx, state);
 
-    // The pinned list hides itself once everything is completed; we must not
-    // leave a redundant completed-task receipt in the transcript.
     expect(state.taskProgress!.updateTasks).toHaveBeenCalledWith(tasks);
+    expect(ectx.renderCompletedTasksInline).toHaveBeenCalledWith(tasks, 5);
     expect(ectx.renderClearedTasksInline).not.toHaveBeenCalled();
     expect(state.taskToolInsertIndex).toBe(-1);
   });

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -360,14 +360,13 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
           state.taskToolInsertIndex = -1;
         }
 
-        // When every task is completed the pinned list hides itself (the agent
-        // narrates completion), so we don't leave a redundant completed-task
-        // receipt in the transcript that reads like a second live list. We only
-        // render an inline receipt when the list is explicitly cleared.
         const previousTasks = state.session.displayState.get().previousTasks;
-        if (previousTasks.length > 0 && (!tasks || tasks.length === 0)) {
-          // Tasks were cleared
+        if (tasks?.length > 0 && tasks.every(task => task.status === 'completed')) {
+          ectx.renderCompletedTasksInline(tasks, insertIndex);
+        } else if (previousTasks.length > 0 && (!tasks || tasks.length === 0)) {
           ectx.renderClearedTasksInline(previousTasks, insertIndex);
+        } else if (tasks?.length > 0) {
+          ectx.renderTaskDeltaInline(previousTasks, tasks, insertIndex);
         }
 
         state.ui.requestRender();

--- a/mastracode/src/tui/handlers/types.ts
+++ b/mastracode/src/tui/handlers/types.ts
@@ -28,5 +28,11 @@ export interface EventHandlerContext {
   queueFollowUpMessage: (content: string) => void;
   renderExistingMessages: () => Promise<void>;
   renderClearedTasksInline: (clearedTasks: TaskItemSnapshot[], insertIndex?: number) => void;
+  renderCompletedTasksInline: (completedTasks: TaskItemSnapshot[], insertIndex?: number) => void;
+  renderTaskDeltaInline: (
+    previousTasks: TaskItemSnapshot[],
+    nextTasks: TaskItemSnapshot[],
+    insertIndex?: number,
+  ) => boolean;
   refreshModelAuthStatus: () => Promise<void>;
 }

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -56,7 +56,9 @@ import {
   addUserMessage,
   removePendingUserMessage,
   renderClearedTasksInline,
+  renderCompletedTasksInline,
   renderExistingMessages,
+  renderTaskDeltaInline,
 } from './render-messages.js';
 import {
   setupKeyboardShortcuts,
@@ -1102,6 +1104,10 @@ export class MastraTUI {
       renderExistingMessages: () => this.renderExistingMessagesAndSeedIdleCounter(),
       renderClearedTasksInline: (clearedTasks, insertIndex) =>
         renderClearedTasksInline(this.state, clearedTasks, insertIndex),
+      renderCompletedTasksInline: (completedTasks, insertIndex) =>
+        renderCompletedTasksInline(this.state, completedTasks, insertIndex),
+      renderTaskDeltaInline: (previousTasks, nextTasks, insertIndex) =>
+        renderTaskDeltaInline(this.state, previousTasks, nextTasks, insertIndex),
       refreshModelAuthStatus: () => this.refreshModelAuthStatus(),
     };
   }

--- a/mastracode/src/tui/render-messages.test.ts
+++ b/mastracode/src/tui/render-messages.test.ts
@@ -669,10 +669,10 @@ describe('renderExistingMessages task tools', () => {
     expect(listActiveMessages).toHaveBeenCalledWith({ limit: 200 });
     expect(updateTasks).toHaveBeenCalledWith(expectedTasks);
     expect(setState).toHaveBeenCalledWith({ tasks: expectedTasks });
-    expect(visibleChildren(state)).toHaveLength(39);
+    expect(visibleChildren(state)).toHaveLength(40);
   });
 
-  it('renders no inline receipt when replaying repeated complete patches that finish the list', async () => {
+  it('renders inline receipts when replaying repeated complete patches that finish the list', async () => {
     const messages: HarnessMessage[] = [
       {
         id: 'assistant-1',
@@ -748,12 +748,14 @@ describe('renderExistingMessages task tools', () => {
 
     await renderExistingMessages(state);
 
-    // A fully-completed list leaves no inline receipt in the transcript.
-    expect(visibleChildren(state)).toHaveLength(0);
+    const rendered = visibleChildren(state).map(component => component.render(100).join('\n'));
+    expect(rendered).toHaveLength(3);
+    expect(rendered.join('\n')).toContain('Write tests');
+    expect(rendered.join('\n')).toContain('Tasks');
     expect(state.allToolComponents.map(component => (component as any).toolName)).toEqual([]);
   });
 
-  it('renders no inline receipt when replaying repeated completed task writes', async () => {
+  it('renders completed task receipts when replaying repeated completed task writes', async () => {
     const completedTasks = [{ id: 'tests', content: 'Write tests', status: 'completed', activeForm: 'Writing tests' }];
     const messages: HarnessMessage[] = [
       {
@@ -806,8 +808,9 @@ describe('renderExistingMessages task tools', () => {
 
     await renderExistingMessages(state);
 
-    // A fully-completed list leaves no inline receipt in the transcript.
-    expect(visibleChildren(state)).toHaveLength(0);
+    const rendered = visibleChildren(state).map(component => component.render(100).join('\n'));
+    expect(rendered).toHaveLength(2);
+    expect(rendered.join('\n')).toContain('Write tests');
     expect(state.allToolComponents.map(component => (component as any).toolName)).toEqual([]);
   });
 

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -9,7 +9,6 @@ import type { HarnessMessage, HarnessMessageContent, TaskItemInput, TaskItemSnap
 import { assignTaskIds, parseSubagentMeta } from '@mastra/core/harness';
 import type { GoalEvaluationPayload } from '@mastra/core/stream';
 import { TASKS_STATE_ID } from '@mastra/core/tools';
-import chalk from 'chalk';
 import {
   insertChatComponentWithBoundarySpacing,
   reconcileChatBoundarySpacers,
@@ -28,12 +27,13 @@ import { SlashCommandComponent } from './components/slash-command.js';
 import { StateSignalComponent } from './components/state-signal.js';
 import { SubagentExecutionComponent } from './components/subagent-execution.js';
 import { SystemReminderComponent } from './components/system-reminder.js';
+import { formatTaskProgressLine } from './components/task-progress.js';
 import { TemporalGapComponent } from './components/temporal-gap.js';
 import { ToolExecutionComponentEnhanced } from './components/tool-execution-enhanced.js';
 import { PendingUserMessageComponent, UserMessageComponent } from './components/user-message.js';
 import { formatToolResult, isTaskMutationTool } from './handlers/tool.js';
 import type { TUIState } from './state.js';
-import { BOX_INDENT, getMarkdownTheme, theme, mastra } from './theme.js';
+import { BOX_INDENT, getMarkdownTheme, theme } from './theme.js';
 
 // Re-export so existing consumers can still import from here
 export { formatToolResult };
@@ -93,11 +93,62 @@ export function renderClearedTasksInline(state: TUIState, clearedTasks: TaskItem
   const label = count === 1 ? 'Task' : 'Tasks';
   container.addChild(new Text(theme.fg('accent', `${label} cleared`), BOX_INDENT, 0));
   for (const task of clearedTasks) {
-    const icon = task.status === 'completed' ? chalk.hex(mastra.green)('✓') : chalk.hex(mastra.darkGray)('○');
-    const text = chalk.hex(theme.getTheme().dim).strikethrough(task.content);
-    container.addChild(new Text(`  ${icon} ${text}`, BOX_INDENT, 0));
+    container.addChild(new Text(formatTaskProgressLine(task, '  '), BOX_INDENT, 0));
   }
   insertTaskHistoryComponent(state, container, insertIndex);
+}
+
+export function renderCompletedTasksInline(
+  state: TUIState,
+  completedTasks: TaskItemSnapshot[],
+  insertIndex = -1,
+): void {
+  const container = new TaskHistoryComponent();
+  const count = completedTasks.length;
+  container.addChild(
+    new Text(`${theme.fg('accent', 'Tasks')} ${theme.fg('dim', `[${count}/${count} completed]`)}`, BOX_INDENT, 0),
+  );
+  for (const task of completedTasks) {
+    container.addChild(new Text(formatTaskProgressLine(task, '  '), BOX_INDENT, 0));
+  }
+  insertTaskHistoryComponent(state, container, insertIndex);
+}
+
+function getTaskKey(task: TaskItemSnapshot): string {
+  return task.id || task.content;
+}
+
+export function renderTaskDeltaInline(
+  state: TUIState,
+  previousTasks: TaskItemSnapshot[],
+  nextTasks: TaskItemSnapshot[],
+  insertIndex = -1,
+): boolean {
+  const previousByKey = new Map(previousTasks.map(task => [getTaskKey(task), task]));
+  const addedTasks = nextTasks.filter(task => !previousByKey.has(getTaskKey(task)));
+  const inProgressTasks = nextTasks.filter(task => {
+    const previous = previousByKey.get(getTaskKey(task));
+    return task.status === 'in_progress' && previous?.status !== 'in_progress';
+  });
+  const completedTasks = nextTasks.filter(task => {
+    const previous = previousByKey.get(getTaskKey(task));
+    return task.status === 'completed' && previous?.status !== 'completed';
+  });
+
+  if (addedTasks.length === 0 && inProgressTasks.length === 0 && completedTasks.length === 0) return false;
+
+  const changedTaskKeys = new Set([...addedTasks, ...inProgressTasks, ...completedTasks].map(getTaskKey));
+  const changedTasks = nextTasks.filter(task => changedTaskKeys.has(getTaskKey(task)));
+
+  const container = new TaskHistoryComponent();
+  container.addChild(new Text(theme.fg('accent', 'Tasks'), BOX_INDENT, 0));
+
+  for (const task of changedTasks) {
+    container.addChild(new Text(formatTaskProgressLine(task, '  '), BOX_INDENT, 0));
+  }
+
+  insertTaskHistoryComponent(state, container, insertIndex);
+  return true;
 }
 
 function renderTaskTransitionFromHistory(
@@ -106,8 +157,7 @@ function renderTaskTransitionFromHistory(
   nextTasks: TaskItemSnapshot[],
 ): { tasks: TaskItemSnapshot[]; replacedWithInline: boolean } {
   if (nextTasks.length > 0 && nextTasks.every(t => t.status === 'completed')) {
-    // A fully-completed list hides its pinned view and leaves no inline receipt
-    // (matches the live path); the transcript already narrates completion.
+    renderCompletedTasksInline(state, nextTasks);
     return { tasks: nextTasks, replacedWithInline: true };
   }
 
@@ -119,6 +169,7 @@ function renderTaskTransitionFromHistory(
     return { tasks: [], replacedWithInline: false };
   }
 
+  renderTaskDeltaInline(state, previousTasks, nextTasks);
   return { tasks: nextTasks, replacedWithInline: true };
 }
 


### PR DESCRIPTION
## Summary

This is PR 1 of the #18248 split. It restores Mastra Code task list progress rendering and task history receipts in the TUI.

## Scope

- Render completed task receipts inline when the live pinned task list hides.
- Render task deltas for added, in-progress, and completed tasks in chat history.
- Reuse task progress line formatting between the pinned task list and inline task history.
- Restore task-list E2E fixtures/scenarios for task write, patch, check, and next-turn prompt context.

## Intentionally excluded

- Interactive prompt/request_access rendering is in #18338.
- Tool/history rendering coverage is in #18339.

## Stack

- This PR
- Next: #18338

## Verification

- pnpm --filter mastracode test -- --run src/tui/render-messages.test.ts src/tui/event-dispatch.test.ts src/tui/__tests__/render-messages.test.ts --reporter=dot --bail=1
- MC_E2E_VITEST_SCENARIOS=task-inline-transitions,task-patch-tools,task-prompt-context-next-turn pnpm --filter mastracode e2e:smoke -- --reporter=dot --bail=1
- pnpm prettier:changed


<img width="1824" height="1232" alt="image" src="https://github.com/user-attachments/assets/2d6491c4-251e-4cf4-ba93-d94bd8e8bfca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR restores the ability to show task progress and completion updates directly in the terminal interface while tasks are running. It adds code to display when tasks are added, in-progress, or completed, reuses formatting code to keep things consistent, and includes updated tests to verify everything works correctly.

## Overview
This PR restores task list progress rendering and task history receipts in the Mastra Code TUI, part one of a two-part series addressing task list display functionality. The changes enable rendering of completed task receipts inline and task deltas (additions, in-progress, and completions) in chat history, while reusing task progress line formatting between the pinned task list and inline task history.

## Key Changes

### Task Rendering Infrastructure
- **Task progress formatting**: Extracted `formatTaskProgressLine()` as a new exported helper in `task-progress.ts`, allowing consistent per-task line formatting across both pinned task lists and inline history receipts
- **Inline rendering handlers**: Added two new exported functions:
  - `renderCompletedTasksInline()`: Renders a receipt when all tasks complete
  - `renderTaskDeltaInline()`: Computes and renders only the changed tasks (additions, in-progress, completions) between snapshots
- **Event handler interface**: Extended `EventHandlerContext` in `handlers/types.ts` with the new `renderTaskDeltaInline` method signature

### Event Dispatch Logic
- Updated `dispatchEvent()` task handling to intelligently decide which inline receipt to render:
  - Renders completed-tasks receipt when all tasks reach completion status
  - Renders cleared-tasks receipt when tasks are removed
  - Renders task-delta receipt for intermediate changes (added, in-progress, completed tasks)

### Test Infrastructure
- **E2E fixtures updated**: Modified `task-inline-transitions.json`, `task-patch-tools.json`, and `task-prompt-context-next-turn.json` to use `turnIndex`-based matching instead of endpoint/toolCallId fields
- **E2E scenarios restored**: Removed `skipReason` properties from three task scenarios (`taskInlineTransitionsScenario`, `taskPatchToolsScenario`, `taskPromptContextNextTurnScenario`), re-enabling them after fixture updates
- **Terminal backend enhancements**: Added `serializeHistory()` method and `waitForOutputText()` helper to the terminal emulator for better output verification in E2E tests
- **Unit test coverage**: Extended `render-messages.test.ts` with new test block covering task write/history rendering for both pending and completed states
- **Mock updates**: Updated test mocks in `render-messages.test.ts`, `event-dispatch.test.ts`, and related files to include the new inline rendering handlers

### Minor Adjustments
- Updated `file-autocomplete.ts` to add a slight delay (increased per-character typing delay from 10ms to 25ms and added 300ms wait) for more reliable E2E test execution
- Updated `render-messages.test.ts` to expect one additional rendered component (40 vs 39) and verify inline receipts are properly rendered for task completion scenarios

### Dependencies & Imports
- Added changeset entry documenting the patch-level bump for `mastracode` package
- Updated imports in `render-messages.ts` to include task-progress and formatting utilities; removed unused chalk styling imports
- Wired new handlers through `mastra-tui.ts` into the event context for access by command handlers

## Testing & Verification
E2E scenarios now execute with updated fixture matching logic. New unit tests verify:
- Task completion receipts render inline when task list hides
- Task deltas (additions, status changes) render correctly in chat history
- Task progress formatting is consistent across display contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->