### PR TITLE
fix(@mastra/google-cloud-pubsub): handle concurrent init race on ungrouped topics

### DIFF
--- a/.changeset/silly-pubsub-race.md
+++ b/.changeset/silly-pubsub-race.md
@@ -1,0 +1,5 @@
+---
+'@mastra/google-cloud-pubsub': patch
+---
+
+Fixed a startup race where concurrent subscribers to the same ungrouped topic could fail to attach. When a producer's `agent.stream()` and a consumer's `agent.observe()` subscribe to a fresh run topic within Google Cloud Pub/Sub's subscription-creation window, both raced to create the same subscription. The loser received an `ALREADY_EXISTS` error and, for ungrouped topics, fell through and threw `Failed to subscribe to topic`, killing the observe attach. Concurrent `init()` calls are now coalesced into a single create attempt, and an `ALREADY_EXISTS` result attaches to the existing subscription regardless of whether a group is set.

--- a/pubsub/google-cloud-pubsub/src/group.test.ts
+++ b/pubsub/google-cloud-pubsub/src/group.test.ts
@@ -99,6 +99,43 @@ describe.sequential('GoogleCloudPubSub group support', () => {
       expect(msgs1[0]!.type).toBe('hello');
       expect(msgs2[0]!.type).toBe('hello');
     });
+
+    it('two subscribers racing on a fresh topic both attach and receive (issue #18203)', async () => {
+      // A producer (agent.stream) and a consumer (agent.observe) can subscribe to the
+      // same fresh topic within the subscription-creation window, so both reach init()
+      // and race createSubscription for the same name. The loser must attach to the
+      // existing subscription instead of failing, and both callbacks must receive events.
+      const pubsub = createPubSub();
+      const topic = uniqueTopic();
+
+      const collected1: Event[] = [];
+      const collected2: Event[] = [];
+
+      // Subscribe concurrently (no await between) so the two init() calls overlap.
+      await Promise.all([
+        pubsub.subscribe(topic, (event, ack) => {
+          collected1.push(event);
+          ack?.();
+        }),
+        pubsub.subscribe(topic, (event, ack) => {
+          collected2.push(event);
+          ack?.();
+        }),
+      ]);
+
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      await pubsub.publish(topic, makeEvent({ type: 'raced' }));
+
+      const [msgs1, msgs2] = await Promise.all([
+        waitForMessages(1, collected1, 5000),
+        waitForMessages(1, collected2, 5000),
+      ]);
+
+      expect(msgs1.length).toBe(1);
+      expect(msgs2.length).toBe(1);
+      expect(msgs1[0]!.type).toBe('raced');
+      expect(msgs2[0]!.type).toBe('raced');
+    });
   });
 
   describe('group (competing consumers)', () => {

--- a/pubsub/google-cloud-pubsub/src/group.test.ts
+++ b/pubsub/google-cloud-pubsub/src/group.test.ts
@@ -1,3 +1,4 @@
+import { PubSub as PubSubClient } from '@google-cloud/pubsub';
 import type { Event } from '@mastra/core/events';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
 import { GoogleCloudPubSub } from '.';
@@ -135,6 +136,36 @@ describe.sequential('GoogleCloudPubSub group support', () => {
       expect(msgs2.length).toBe(1);
       expect(msgs1[0]!.type).toBe('raced');
       expect(msgs2[0]!.type).toBe('raced');
+    });
+
+    it('re-attaches to an existing subscription when createSubscription returns ALREADY_EXISTS (issue #18203)', async () => {
+      // Drive the ungrouped recovery branch directly: pre-create the exact subscription
+      // the adapter will use (out-of-band) so its own createSubscription loses with
+      // ALREADY_EXISTS (gRPC code 6). For an ungrouped topic the adapter must re-attach
+      // to the existing subscription instead of returning undefined and throwing. This
+      // also mirrors the restart case where a subscription survives a previous process.
+      const pubsub = createPubSub();
+      const topic = uniqueTopic();
+      const subscriptionName = pubsub.getSubscriptionName(topic);
+
+      const raw = new PubSubClient({ projectId: 'pubsub-test', apiEndpoint: EMULATOR_HOST });
+      await raw.createTopic(topic);
+      await raw.topic(topic).createSubscription(subscriptionName);
+
+      const collected: Event[] = [];
+      await pubsub.subscribe(topic, (event, ack) => {
+        collected.push(event);
+        ack?.();
+      });
+
+      await pubsub.publish(topic, makeEvent({ type: 'recovered' }));
+
+      await waitForMessages(1, collected, 5000);
+
+      expect(collected.length).toBe(1);
+      expect(collected[0]!.type).toBe('recovered');
+
+      await raw.close();
     });
   });
 

--- a/pubsub/google-cloud-pubsub/src/group.test.ts
+++ b/pubsub/google-cloud-pubsub/src/group.test.ts
@@ -149,23 +149,25 @@ describe.sequential('GoogleCloudPubSub group support', () => {
       const subscriptionName = pubsub.getSubscriptionName(topic);
 
       const raw = new PubSubClient({ projectId: 'pubsub-test', apiEndpoint: EMULATOR_HOST });
-      await raw.createTopic(topic);
-      await raw.topic(topic).createSubscription(subscriptionName);
+      try {
+        await raw.createTopic(topic);
+        await raw.topic(topic).createSubscription(subscriptionName);
 
-      const collected: Event[] = [];
-      await pubsub.subscribe(topic, (event, ack) => {
-        collected.push(event);
-        ack?.();
-      });
+        const collected: Event[] = [];
+        await pubsub.subscribe(topic, (event, ack) => {
+          collected.push(event);
+          ack?.();
+        });
 
-      await pubsub.publish(topic, makeEvent({ type: 'recovered' }));
+        await pubsub.publish(topic, makeEvent({ type: 'recovered' }));
 
-      await waitForMessages(1, collected, 5000);
+        await waitForMessages(1, collected, 5000);
 
-      expect(collected.length).toBe(1);
-      expect(collected[0]!.type).toBe('recovered');
-
-      await raw.close();
+        expect(collected.length).toBe(1);
+        expect(collected[0]!.type).toBe('recovered');
+      } finally {
+        await raw.close();
+      }
     });
   });
 

--- a/pubsub/google-cloud-pubsub/src/index.ts
+++ b/pubsub/google-cloud-pubsub/src/index.ts
@@ -9,6 +9,10 @@ export class GoogleCloudPubSub extends PubSub {
   private ackBuffer: Record<string, Promise<any>> = {};
   private activeSubscriptions: Record<string, Subscription> = {};
   private activeCbs: Record<string, Set<EventCallback>> = {};
+  // Coalesces concurrent init() calls for the same subscription so racing
+  // subscribers (e.g. a producer stream and a consumer observe on the same
+  // run topic) share a single createTopic/createSubscription attempt.
+  private inFlightInit: Record<string, Promise<Subscription | undefined>> = {};
   // Tracks the actual anonymous message listener registered on each subscription,
   // so we can remove it cleanly on the final unsubscribe.
   private messageListeners: Record<string, (message: Message) => void> = {};
@@ -37,36 +41,54 @@ export class GoogleCloudPubSub extends PubSub {
     }
   }
 
-  async init(topicName: string, group?: string) {
-    try {
-      await this.pubsub.createTopic(topicName);
-    } catch {
-      // no-op
-    }
-    const subscriptionName = this.getSubscriptionName(topicName, group);
+  async init(topicName: string, group?: string): Promise<Subscription | undefined> {
     const subscriptionKey = group ? `${topicName}:${group}` : topicName;
-    try {
-      const [sub] = await this.pubsub.topic(topicName).createSubscription(subscriptionName, {
-        enableMessageOrdering: true,
-        enableExactlyOnceDelivery: topicName === 'workflows' || !!group,
-      });
-      this.activeSubscriptions[subscriptionKey] = sub;
-      return sub;
-    } catch {
-      // Subscription may already exist (e.g. shared group subscription created by another process).
-      // Get the existing subscription instead.
-      if (group) {
-        try {
-          const sub = this.pubsub.subscription(subscriptionName);
-          this.activeSubscriptions[subscriptionKey] = sub;
-          return sub;
-        } catch {
-          // no-op
-        }
-      }
+
+    // Reuse an in-flight init so concurrent subscribers don't race to create the
+    // same subscription. The promise is registered synchronously below (before any
+    // await), so a second caller arriving during the create window reuses it.
+    if (this.inFlightInit[subscriptionKey]) {
+      return this.inFlightInit[subscriptionKey];
     }
 
-    return undefined;
+    const subscriptionName = this.getSubscriptionName(topicName, group);
+    const initPromise = (async (): Promise<Subscription | undefined> => {
+      try {
+        await this.pubsub.createTopic(topicName);
+      } catch {
+        // no-op
+      }
+      try {
+        const [sub] = await this.pubsub.topic(topicName).createSubscription(subscriptionName, {
+          enableMessageOrdering: true,
+          enableExactlyOnceDelivery: topicName === 'workflows' || !!group,
+        });
+        this.activeSubscriptions[subscriptionKey] = sub;
+        return sub;
+      } catch (error) {
+        // The subscription may already exist: created concurrently by a racing
+        // subscriber (ALREADY_EXISTS / gRPC code 6), shared by another process via
+        // a group, or surviving a previous process. In all of these cases attach to
+        // the existing subscription instead of failing. Ungrouped subscriptions hit
+        // this on the concurrent-create race, so we must not gate it on `group`.
+        const alreadyExists = (error as { code?: number } | undefined)?.code === 6;
+        if (alreadyExists || group) {
+          try {
+            const sub = this.pubsub.subscription(subscriptionName);
+            this.activeSubscriptions[subscriptionKey] = sub;
+            return sub;
+          } catch {
+            // no-op
+          }
+        }
+      }
+      return undefined;
+    })().finally(() => {
+      delete this.inFlightInit[subscriptionKey];
+    });
+
+    this.inFlightInit[subscriptionKey] = initPromise;
+    return initPromise;
   }
 
   async destroy(topicName: string) {


### PR DESCRIPTION
## Description

When a producer (`agent.stream()`) and a consumer (`agent.observe()`) subscribe to the same fresh topic at nearly the same time, the observe attach can throw `Failed to subscribe to topic`.

Both calls reach `init()` within Pub/Sub's subscription-creation window and call `createSubscription` for the same name. One wins; the other gets `ALREADY_EXISTS` (gRPC code 6). The old catch block only re-attached to the existing subscription when a `group` was set, so for an ungrouped topic `init()` fell through and returned `undefined`, and `subscribe()` then threw.

Re-attaching on `ALREADY_EXISTS` alone isn't enough: the two racing calls still construct two separate subscription objects for one underlying Pub/Sub subscription. The second object is a fresh handle, so the `isOpen` guard in `subscribe()` doesn't apply to it and it opens its own stream, and only one object ends up tracked in `activeSubscriptions` — the other is never closed on `unsubscribe`, leaving an open pull that never acks and gets redelivered.

So the fix does two things:

- Coalesce concurrent `init()` calls with an in-flight promise keyed on the subscription key, so racing subscribers share a single `createSubscription` and a single subscription object.
- On `ALREADY_EXISTS`, attach to the existing subscription regardless of `group`. This still helps for the genuine cases where the subscription already exists from another process or survived a restart.

## Related issue(s)

Fixes #18203

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## ELI5

If two things try to set up the same Pub/Sub subscription at the exact same time, one can “win” and the other can mistakenly crash with an error. This PR makes the second one wait/share the first setup, and if it still hits “already exists,” it just connects to the subscription that’s already there.

## Problem

A race condition in the Google Cloud Pub/Sub adapter caused concurrent initialization calls to fail when a producer (`agent.stream()`) and consumer (`agent.observe()`) subscribed to the same fresh **ungrouped** topic simultaneously. Both calls could enter `init()` and both attempt `createSubscription` for the same subscription name during Pub/Sub’s subscription-creation window. The “losing” call receives `ALREADY_EXISTS` (gRPC code 6), and the previous logic only re-attached on `ALREADY_EXISTS` when a `group` was set—so for ungrouped topics `init()` could fall through and `subscribe()` threw “Failed to subscribe to topic.”

## Solution

The fix adds two complementary behaviors:

1. **Coalesce concurrent `init()` calls**: introduces an in-flight promise map keyed by the subscription key so racing callers share one in-progress `createSubscription` attempt and the resulting subscription object.
2. **Reconnect on `ALREADY_EXISTS` for all topics**: on `ALREADY_EXISTS` (code 6), the adapter now re-attaches to the existing subscription **regardless of whether `group` is set**, improving both the startup race and resilience after restarts.

## Changes

- **`pubsub/google-cloud-pubsub/src/index.ts`**
  - Add `inFlightInit` to coalesce concurrent `init()` calls.
  - Update `init(topicName: string, group?: string)` to re-attach on `ALREADY_EXISTS` even when ungrouped.
  - Ensure `inFlightInit` is cleared in a `finally` block and cache the resolved subscription in `activeSubscriptions`.
- **`pubsub/google-cloud-pubsub/src/group.test.ts`**
  - Add concurrent-subscribe test for fresh **ungrouped** topics (verifies both callbacks receive the message).
  - Add recovery test that pre-creates the expected subscription out-of-band to force the adapter’s `ALREADY_EXISTS` path and verify re-attachment works.
- **`.changeset/silly-pubsub-race.md`**
  - Mark as a **patch** release noting the startup-window race fix for `@mastra/google-cloud-pubsub`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine two kids trying to grab the same toy at the same time - both reach for it and get confused. This PR fixes a similar problem in Google Cloud's message system where two parts of the code try to start listening to the same topic simultaneously and one ends up failing. The fix makes them take turns politely (they wait for each other) and if one still gets rejected, they just share what the other one got instead of giving up.

## Summary

This PR fixes a **startup-window race condition** in the Google Cloud Pub/Sub adapter where concurrent subscribers to the same ungrouped topic fail during simultaneous initialization.

### The Problem

When `agent.stream()` (producer) and `agent.observe()` (consumer) subscribe to the same fresh ungrouped topic within GCP's ~9-second subscription-creation window, both call `init()` and attempt to `createSubscription` for the same subscription name. The loser receives an `ALREADY_EXISTS` error (gRPC code 6). The original error-handling only re-attached to existing subscriptions when a `group` was configured; for ungrouped topics, `init()` returned `undefined`, causing `subscribe()` to fail.

### The Solution

Two complementary changes ensure concurrent subscribers cooperate:

1. **Concurrent `init()` call coalescing**: A new `inFlightInit` map caches in-flight promises keyed by subscription key. Racing callers reuse the same promise and share the resulting subscription object, eliminating duplicate `createSubscription` attempts.

2. **Re-attach on `ALREADY_EXISTS` for all topics**: The error handler now re-attaches to existing subscriptions regardless of group configuration. This provides resilience whether subscriptions already exist from concurrent processes or survive process restarts.

### Changes

- **`.changeset/silly-pubsub-race.md`**: Adds a patch-level changeset documenting the race condition fix for ungrouped topics.

- **`pubsub/google-cloud-pubsub/src/group.test.ts`**: Adds two test cases covering issue `#18203`:
  - Concurrent concurrent `subscribe()` calls on a fresh ungrouped topic (without awaiting between calls), verifying both subscribers receive published messages.
  - Pre-created subscription scenario where the adapter encounters `ALREADY_EXISTS` and re-attaches successfully.
  - Includes resource cleanup in try/finally to prevent client leaks.

- **`pubsub/google-cloud-pubsub/src/index.ts`**: Refactors `GoogleCloudPubSub.init()` to:
  - Check the `inFlightInit` map and reuse existing promises for the same subscription key
  - Clear the in-flight entry in a `finally` block to permit retries on subsequent calls
  - Attach to existing subscriptions on `ALREADY_EXISTS` (error code 6) for all topics, not just grouped ones
  - Record successfully resolved subscriptions into `activeSubscriptions[subscriptionKey]`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->