### PR TITLE
fix(observability): emit metrics independently of span export filtering

### DIFF
--- a/.changeset/rich-dingos-matter.md
+++ b/.changeset/rich-dingos-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed auto-extracted metrics (duration, token usage, cost) being silently dropped when spans are filtered via `excludeSpanTypes` or `spanFilter`. Previously, excluding a span type to reduce per-span costs in platforms like Langfuse also suppressed its aggregate metrics. Metrics are now emitted independently of span export filtering.

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -695,23 +695,19 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    * then routes the exported tracing event through the ObservabilityBus.
    */
   protected emitSpanEnded(span: AnySpan): void {
-    const exportedSpan = this.getSpanForExport(span);
-
-    if (exportedSpan) {
+    // Emit metrics independently of export filtering: users who exclude span
+    // types (e.g. MODEL_STEP) to cut per-span costs should still get duration,
+    // token, and cost metrics. Only skip metrics for invalid or internal spans.
+    if (span.isValid && !(span.isInternal && !this.config.includeInternalSpans)) {
       try {
-        // TODO: We intentionally export first so auto-extracted metrics are skipped
-        // when the span is filtered out by processors. Metrics still use the live
-        // span for correlation and parent traversal, but current span processors
-        // mutate spans in place during export, so those mutations can still affect
-        // the live span before metrics run. Future options to explore:
-        // 1. Make span processors pure/non-mutating.
-        // 2. Split trace processors from metric-specific processors/enrichers.
-        // 3. Revisit whether auto-extracted metrics should run before export.
         emitAutoExtractedMetrics(span, this.getMetricsContext(span));
       } catch (err) {
         this.logger.error('[Observability] Auto-extraction error:', err);
       }
+    }
 
+    const exportedSpan = this.getSpanForExport(span);
+    if (exportedSpan) {
       const event: TracingEvent = { type: TracingEventType.SPAN_ENDED, exportedSpan };
       this.emitTracingEvent(event);
     }

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -69,6 +69,13 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    */
   #mastraEnvironment?: string;
 
+  /**
+   * For excluded MODEL_GENERATION spans whose constructor clears `attributes`,
+   * we stash the lightweight provider/model from creation options so
+   * `captureExcludedModelUsage` can still build cost context.
+   */
+  #excludedModelMeta = new WeakMap<AnySpan, { provider?: string; model?: string }>();
+
   constructor(config: ObservabilityInstanceConfig) {
     super({ component: RegisteredLogger.OBSERVABILITY, name: config.serviceName });
 
@@ -233,6 +240,17 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       tags,
       requestContext,
     });
+
+    // For excluded MODEL_GENERATION spans the constructor clears attributes,
+    // losing provider/model needed for cost estimation. Stash them from the
+    // original creation options so captureExcludedModelUsage can use them.
+    if (rest.type === SpanType.MODEL_GENERATION && this.config.excludeSpanTypes?.includes(SpanType.MODEL_GENERATION)) {
+      const attrs = rest.attributes as ModelGenerationAttributes | undefined;
+      const model = attrs?.responseModel ?? attrs?.model;
+      if (attrs?.provider || model) {
+        this.#excludedModelMeta.set(span, { provider: attrs?.provider, model });
+      }
+    }
 
     if (span.isEvent) {
       this.emitSpanEnded(span);
@@ -693,6 +711,7 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
         if (!this.config.spanFilter(exportedSpan)) return undefined;
       } catch (error) {
         this.logger.error(`[Observability] spanFilter error`, error);
+        // On filter error, keep the span to avoid silent data loss
       }
     }
 
@@ -808,9 +827,10 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
 
   /**
    * When a non-internal MODEL_GENERATION span is excluded by `excludeSpanTypes`,
-   * DefaultSpan.end() drops end-time attributes before auto-extraction can read
-   * them. Capture usage before that happens so token and cost metrics still emit
-   * even though the trace span itself is filtered out.
+   * the BaseSpan constructor clears start-time attributes and DefaultSpan.end()
+   * drops end-time attributes before auto-extraction can read them. Capture
+   * usage from end options and provider/model from the creation-time stash so
+   * token and cost metrics still emit even though the trace span is filtered out.
    */
   private captureExcludedModelUsage<TType extends SpanType>(
     span: Span<TType>,
@@ -825,8 +845,12 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     const usage = endAttrs?.usage ?? liveAttrs?.usage;
     if (!usage) return undefined;
 
-    const provider = endAttrs?.provider ?? liveAttrs?.provider;
-    const model = endAttrs?.responseModel ?? endAttrs?.model ?? liveAttrs?.responseModel ?? liveAttrs?.model;
+    // For excluded spans, the constructor clears start-time attributes
+    // (provider, model). Fall back to the stash populated at creation time.
+    const stashed = this.#excludedModelMeta.get(span);
+    const provider = endAttrs?.provider ?? liveAttrs?.provider ?? stashed?.provider;
+    const model =
+      endAttrs?.responseModel ?? endAttrs?.model ?? liveAttrs?.responseModel ?? liveAttrs?.model ?? stashed?.model;
 
     return { usage, provider, model };
   }

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -696,8 +696,8 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    */
   protected emitSpanEnded(span: AnySpan): void {
     // Emit metrics independently of export filtering: users who exclude span
-    // types (e.g. MODEL_STEP) to cut per-span costs should still get duration,
-    // token, and cost metrics. Only skip metrics for invalid or internal spans.
+    // types (e.g. AGENT_RUN, TOOL_CALL) to cut per-span costs should still get
+    // duration, token, and cost metrics. Only skip metrics for invalid or internal spans.
     if (span.isValid && !(span.isInternal && !this.config.includeInternalSpans)) {
       try {
         emitAutoExtractedMetrics(span, this.getMetricsContext(span));

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -495,6 +495,7 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       // place to read MODEL_GENERATION usage for a filtered span is the
       // end() options being passed in right now.
       const rollupTarget = this.captureModelUsageRollup(span, options);
+      const excludedModelUsage = this.captureExcludedModelUsage(span, options);
 
       originalEnd(options);
 
@@ -502,7 +503,7 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
         this.applyUsageRollup(rollupTarget);
       }
 
-      this.emitSpanEnded(span);
+      this.emitSpanEnded(span, excludedModelUsage);
     };
 
     span.update = (options: UpdateSpanOptions<TType>) => {
@@ -677,6 +678,27 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     return exportedSpan;
   }
 
+  /** Export an already-processed span, returning undefined if filtered out. */
+  private getProcessedSpanForExport(span: AnySpan): AnyExportedSpan | undefined {
+    if (!span.isValid) return undefined;
+    if (span.isInternal && !this.config.includeInternalSpans) return undefined;
+
+    if (this.config.excludeSpanTypes?.includes(span.type)) return undefined;
+
+    const exportedSpan = span.exportSpan(this.config.includeInternalSpans);
+    if (!exportedSpan) return undefined;
+
+    if (this.config.spanFilter) {
+      try {
+        if (!this.config.spanFilter(exportedSpan)) return undefined;
+      } catch (error) {
+        this.logger.error(`[Observability] spanFilter error`, error);
+      }
+    }
+
+    return exportedSpan;
+  }
+
   /**
    * Emit a span started event.
    * Routes through the ObservabilityBus so exporters receive it via onTracingEvent.
@@ -694,19 +716,44 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    * Emits any auto-extracted metrics while the live span tree is still available,
    * then routes the exported tracing event through the ObservabilityBus.
    */
-  protected emitSpanEnded(span: AnySpan): void {
+  protected emitSpanEnded(
+    span: AnySpan,
+    excludedModelUsage?: { usage: UsageStats; provider?: string; model?: string },
+  ): void {
+    let processedSpan: AnySpan | undefined;
+    let spanWasProcessed = false;
+
     // Emit metrics independently of export filtering: users who exclude span
     // types (e.g. AGENT_RUN, TOOL_CALL) to cut per-span costs should still get
-    // duration, token, and cost metrics. Only skip metrics for invalid or internal spans.
+    // duration, token, and cost metrics. Processors still run first so metric
+    // metadata gets the same redaction/transforms as exported spans.
     if (span.isValid && !(span.isInternal && !this.config.includeInternalSpans)) {
+      processedSpan = this.processSpan(span);
+      spanWasProcessed = true;
+
       try {
-        emitAutoExtractedMetrics(span, this.getMetricsContext(span));
+        if (processedSpan) {
+          emitAutoExtractedMetrics(processedSpan, this.getMetricsContext(processedSpan));
+          const processedAttrs = processedSpan.attributes as ModelGenerationAttributes | undefined;
+          if (excludedModelUsage && !processedAttrs?.usage) {
+            emitTokenMetricsForUsage(
+              excludedModelUsage.usage,
+              excludedModelUsage.provider,
+              excludedModelUsage.model,
+              this.getMetricsContext(processedSpan),
+            );
+          }
+        }
       } catch (err) {
         this.logger.error('[Observability] Auto-extraction error:', err);
       }
     }
 
-    const exportedSpan = this.getSpanForExport(span);
+    const exportedSpan = spanWasProcessed
+      ? processedSpan
+        ? this.getProcessedSpanForExport(processedSpan)
+        : undefined
+      : this.getSpanForExport(span);
     if (exportedSpan) {
       const event: TracingEvent = { type: TracingEventType.SPAN_ENDED, exportedSpan };
       this.emitTracingEvent(event);
@@ -757,6 +804,31 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     const model = endAttrs?.responseModel ?? endAttrs?.model ?? liveAttrs?.responseModel ?? liveAttrs?.model;
 
     return { ancestor, usage, provider, model };
+  }
+
+  /**
+   * When a non-internal MODEL_GENERATION span is excluded by `excludeSpanTypes`,
+   * DefaultSpan.end() drops end-time attributes before auto-extraction can read
+   * them. Capture usage before that happens so token and cost metrics still emit
+   * even though the trace span itself is filtered out.
+   */
+  private captureExcludedModelUsage<TType extends SpanType>(
+    span: Span<TType>,
+    endOptions: EndSpanOptions<TType> | undefined,
+  ): { usage: UsageStats; provider?: string; model?: string } | undefined {
+    if (span.type !== SpanType.MODEL_GENERATION) return undefined;
+    if (span.isInternal) return undefined;
+    if (!this.config.excludeSpanTypes?.includes(SpanType.MODEL_GENERATION)) return undefined;
+
+    const endAttrs = (endOptions?.attributes as ModelGenerationAttributes | undefined) ?? undefined;
+    const liveAttrs = span.attributes as ModelGenerationAttributes | undefined;
+    const usage = endAttrs?.usage ?? liveAttrs?.usage;
+    if (!usage) return undefined;
+
+    const provider = endAttrs?.provider ?? liveAttrs?.provider;
+    const model = endAttrs?.responseModel ?? endAttrs?.model ?? liveAttrs?.responseModel ?? liveAttrs?.model;
+
+    return { usage, provider, model };
   }
 
   /**

--- a/observability/mastra/src/span-filtering.test.ts
+++ b/observability/mastra/src/span-filtering.test.ts
@@ -1,5 +1,5 @@
 import { SpanType, SamplingStrategyType, InternalSpans } from '@mastra/core/observability';
-import type { TracingEvent, ObservabilityExporter, AnyExportedSpan } from '@mastra/core/observability';
+import type { TracingEvent, MetricEvent, ObservabilityExporter, AnyExportedSpan } from '@mastra/core/observability';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DefaultObservabilityInstance } from './instances';
 
@@ -492,6 +492,152 @@ describe('Span Filtering', () => {
       // Only AGENT_RUN events should be exported
       const spanTypes = testExporter.events.map(e => e.exportedSpan.type);
       expect(spanTypes).not.toContain(SpanType.MODEL_CHUNK);
+    });
+  });
+
+  describe('metrics decoupled from span export filtering', () => {
+    class MetricCollectingExporter implements ObservabilityExporter {
+      name = 'metric-collector';
+      tracingEvents: TracingEvent[] = [];
+      metricEvents: MetricEvent[] = [];
+
+      async onTracingEvent(event: TracingEvent): Promise<void> {
+        this.tracingEvents.push(event);
+      }
+      async onMetricEvent(event: MetricEvent): Promise<void> {
+        this.metricEvents.push(event);
+      }
+      async exportTracingEvent(event: TracingEvent): Promise<void> {
+        this.tracingEvents.push(event);
+      }
+      async shutdown(): Promise<void> {}
+      async flush(): Promise<void> {}
+    }
+
+    it('should emit duration metrics for spans excluded via excludeSpanTypes', async () => {
+      const collector = new MetricCollectingExporter();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [collector],
+        excludeSpanTypes: [SpanType.AGENT_RUN],
+      });
+
+      const agentSpan = tracing.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+      });
+      agentSpan.end();
+      await tracing.flush();
+
+      // Span should NOT be exported
+      const exportedTypes = collector.tracingEvents.map(e => e.exportedSpan.type);
+      expect(exportedTypes).not.toContain(SpanType.AGENT_RUN);
+
+      // Duration metric SHOULD still be emitted
+      const durationMetric = collector.metricEvents.find(e => e.metric.name === 'mastra_agent_duration_ms');
+      expect(durationMetric).toBeDefined();
+
+      await tracing.shutdown();
+    });
+
+    it('should emit duration metrics for spans dropped by spanFilter', async () => {
+      const collector = new MetricCollectingExporter();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [collector],
+        spanFilter: (span: AnyExportedSpan) => span.type !== SpanType.TOOL_CALL,
+      });
+
+      const agentSpan = tracing.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+      });
+      const toolSpan = agentSpan.createChildSpan({
+        type: SpanType.TOOL_CALL,
+        name: 'test-tool',
+      });
+      toolSpan.end();
+      agentSpan.end();
+      await tracing.flush();
+
+      // TOOL_CALL should NOT be exported
+      const exportedTypes = collector.tracingEvents.map(e => e.exportedSpan.type);
+      expect(exportedTypes).not.toContain(SpanType.TOOL_CALL);
+
+      // Tool duration metric SHOULD still be emitted
+      const toolDuration = collector.metricEvents.find(e => e.metric.name === 'mastra_tool_duration_ms');
+      expect(toolDuration).toBeDefined();
+
+      await tracing.shutdown();
+    });
+
+    it('should not emit metrics for internal spans (no double-count with rollup)', async () => {
+      const collector = new MetricCollectingExporter();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [collector],
+      });
+
+      const processorSpan = tracing.startSpan({
+        type: SpanType.PROCESSOR_RUN,
+        name: 'test-processor',
+      });
+      const hiddenModel = processorSpan.createChildSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: "llm: 'mock'",
+        tracingPolicy: { internal: InternalSpans.ALL },
+      });
+      hiddenModel.end({
+        attributes: {
+          provider: 'mock-provider',
+          model: 'mock-model-id',
+          usage: { inputTokens: 50, outputTokens: 10 },
+        },
+      });
+      processorSpan.end();
+      await tracing.flush();
+
+      // Token metrics should only appear once (from rollup, not duplicated).
+      const inputTokenMetrics = collector.metricEvents.filter(
+        e => e.metric.name === 'mastra_model_total_input_tokens',
+      );
+      expect(inputTokenMetrics).toHaveLength(1);
+      expect(inputTokenMetrics[0]!.metric.value).toBe(50);
+
+      await tracing.shutdown();
+    });
+
+    it('should still emit metrics for exported spans (no regression)', async () => {
+      const collector = new MetricCollectingExporter();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [collector],
+      });
+
+      const agentSpan = tracing.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+      });
+      agentSpan.end();
+      await tracing.flush();
+
+      // Span SHOULD be exported
+      const exportedTypes = collector.tracingEvents.map(e => e.exportedSpan.type);
+      expect(exportedTypes).toContain(SpanType.AGENT_RUN);
+
+      // Duration metric SHOULD also be emitted
+      const durationMetric = collector.metricEvents.find(e => e.metric.name === 'mastra_agent_duration_ms');
+      expect(durationMetric).toBeDefined();
+
+      await tracing.shutdown();
     });
   });
 });

--- a/observability/mastra/src/span-filtering.test.ts
+++ b/observability/mastra/src/span-filtering.test.ts
@@ -2,6 +2,12 @@ import { SpanType, SamplingStrategyType, InternalSpans } from '@mastra/core/obse
 import type { TracingEvent, MetricEvent, ObservabilityExporter, AnyExportedSpan } from '@mastra/core/observability';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DefaultObservabilityInstance } from './instances';
+import { PricingRegistry } from './metrics/pricing-registry';
+import { SensitiveDataFilter } from './span_processors';
+
+const testPricingRegistry = PricingRegistry.fromText(`
+{"i":"mock-provider-mock-model-id","p":"mock-provider","m":"mock-model-id","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"it":{"c":1e-7},"ot":{"c":2e-7}}}]}}}
+`);
 
 // Mock console to avoid noise in test output
 const mockConsole = {
@@ -542,6 +548,73 @@ describe('Span Filtering', () => {
       await tracing.shutdown();
     });
 
+    it('should emit token and cost metrics for model spans excluded via excludeSpanTypes', async () => {
+      const pricingRegistrySpy = vi.spyOn(PricingRegistry, 'getGlobal').mockReturnValue(testPricingRegistry);
+      const collector = new MetricCollectingExporter();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [collector],
+        excludeSpanTypes: [SpanType.MODEL_GENERATION],
+      });
+
+      try {
+        const agentSpan = tracing.startSpan({
+          type: SpanType.AGENT_RUN,
+          name: 'test-agent',
+        });
+        const modelSpan = agentSpan.createChildSpan({
+          type: SpanType.MODEL_GENERATION,
+          name: "llm: 'mock'",
+        });
+        modelSpan.end({
+          attributes: {
+            provider: 'mock-provider',
+            model: 'mock-model-id',
+            usage: { inputTokens: 30, outputTokens: 35 },
+          },
+        });
+        agentSpan.end();
+        await tracing.flush();
+
+        // MODEL_GENERATION should NOT be exported
+        const exportedTypes = collector.tracingEvents.map(e => e.exportedSpan.type);
+        expect(exportedTypes).not.toContain(SpanType.MODEL_GENERATION);
+
+        // Duration, token, and cost metrics SHOULD still be emitted
+        const durationMetric = collector.metricEvents.find(e => e.metric.name === 'mastra_model_duration_ms');
+        expect(durationMetric).toBeDefined();
+
+        const inputTokenMetrics = collector.metricEvents.filter(e => e.metric.name === 'mastra_model_total_input_tokens');
+        expect(inputTokenMetrics).toHaveLength(1);
+        const inputTokenMetric = inputTokenMetrics[0];
+        expect(inputTokenMetric?.metric.value).toBe(30);
+        expect(inputTokenMetric?.metric.costContext).toMatchObject({
+          provider: 'mock-provider',
+          model: 'mock-model-id',
+          costUnit: 'USD',
+          estimatedCost: 0.000003,
+        });
+
+        const outputTokenMetrics = collector.metricEvents.filter(
+          e => e.metric.name === 'mastra_model_total_output_tokens',
+        );
+        expect(outputTokenMetrics).toHaveLength(1);
+        const outputTokenMetric = outputTokenMetrics[0];
+        expect(outputTokenMetric?.metric.value).toBe(35);
+        expect(outputTokenMetric?.metric.costContext).toMatchObject({
+          provider: 'mock-provider',
+          model: 'mock-model-id',
+          costUnit: 'USD',
+          estimatedCost: 0.000007,
+        });
+      } finally {
+        await tracing.shutdown();
+        pricingRegistrySpy.mockRestore();
+      }
+    });
+
     it('should emit duration metrics for spans dropped by spanFilter', async () => {
       const collector = new MetricCollectingExporter();
       const tracing = new DefaultObservabilityInstance({
@@ -634,6 +707,32 @@ describe('Span Filtering', () => {
       // Duration metric SHOULD also be emitted
       const durationMetric = collector.metricEvents.find(e => e.metric.name === 'mastra_agent_duration_ms');
       expect(durationMetric).toBeDefined();
+
+      await tracing.shutdown();
+    });
+
+    it('should apply span output processors before emitting auto-extracted metrics', async () => {
+      const collector = new MetricCollectingExporter();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [collector],
+        spanOutputProcessors: [new SensitiveDataFilter()],
+      });
+
+      const agentSpan = tracing.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+      });
+      agentSpan.end({ metadata: { apiKey: 'sk-real-secret' } });
+      await tracing.flush();
+
+      const endedSpan = collector.tracingEvents.find(e => e.type === 'span_ended')?.exportedSpan;
+      expect(endedSpan?.metadata?.apiKey).toBe('[REDACTED]');
+
+      const durationMetric = collector.metricEvents.find(e => e.metric.name === 'mastra_agent_duration_ms');
+      expect(durationMetric?.metric.metadata?.apiKey).toBe('[REDACTED]');
 
       await tracing.shutdown();
     });

--- a/observability/mastra/src/span-filtering.test.ts
+++ b/observability/mastra/src/span-filtering.test.ts
@@ -586,7 +586,9 @@ describe('Span Filtering', () => {
         const durationMetric = collector.metricEvents.find(e => e.metric.name === 'mastra_model_duration_ms');
         expect(durationMetric).toBeDefined();
 
-        const inputTokenMetrics = collector.metricEvents.filter(e => e.metric.name === 'mastra_model_total_input_tokens');
+        const inputTokenMetrics = collector.metricEvents.filter(
+          e => e.metric.name === 'mastra_model_total_input_tokens',
+        );
         expect(inputTokenMetrics).toHaveLength(1);
         const inputTokenMetric = inputTokenMetrics[0];
         expect(inputTokenMetric?.metric.value).toBe(30);

--- a/observability/mastra/src/span-filtering.test.ts
+++ b/observability/mastra/src/span-filtering.test.ts
@@ -604,9 +604,7 @@ describe('Span Filtering', () => {
       await tracing.flush();
 
       // Token metrics should only appear once (from rollup, not duplicated).
-      const inputTokenMetrics = collector.metricEvents.filter(
-        e => e.metric.name === 'mastra_model_total_input_tokens',
-      );
+      const inputTokenMetrics = collector.metricEvents.filter(e => e.metric.name === 'mastra_model_total_input_tokens');
       expect(inputTokenMetrics).toHaveLength(1);
       expect(inputTokenMetrics[0]!.metric.value).toBe(50);
 

--- a/observability/mastra/src/span-filtering.test.ts
+++ b/observability/mastra/src/span-filtering.test.ts
@@ -513,9 +513,6 @@ describe('Span Filtering', () => {
       async onMetricEvent(event: MetricEvent): Promise<void> {
         this.metricEvents.push(event);
       }
-      async exportTracingEvent(event: TracingEvent): Promise<void> {
-        this.tracingEvents.push(event);
-      }
       async shutdown(): Promise<void> {}
       async flush(): Promise<void> {}
     }
@@ -611,6 +608,59 @@ describe('Span Filtering', () => {
           costUnit: 'USD',
           estimatedCost: 0.000007,
         });
+      } finally {
+        await tracing.shutdown();
+        pricingRegistrySpy.mockRestore();
+      }
+    });
+
+    it('should preserve cost context when provider/model are only in start attributes (real AI SDK pattern)', async () => {
+      const pricingRegistrySpy = vi.spyOn(PricingRegistry, 'getGlobal').mockReturnValue(testPricingRegistry);
+      const collector = new MetricCollectingExporter();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [collector],
+        excludeSpanTypes: [SpanType.MODEL_GENERATION],
+      });
+
+      try {
+        const agentSpan = tracing.startSpan({
+          type: SpanType.AGENT_RUN,
+          name: 'test-agent',
+        });
+        // provider/model set at creation time, matching real AI SDK behaviour
+        const modelSpan = agentSpan.createChildSpan({
+          type: SpanType.MODEL_GENERATION,
+          name: "llm: 'mock'",
+          attributes: {
+            provider: 'mock-provider',
+            model: 'mock-model-id',
+          },
+        });
+        // end() only passes responseModel + usage (not provider/model)
+        modelSpan.end({
+          attributes: {
+            responseModel: 'mock-model-id',
+            usage: { inputTokens: 20, outputTokens: 15 },
+          },
+        });
+        agentSpan.end();
+        await tracing.flush();
+
+        const inputTokenMetrics = collector.metricEvents.filter(
+          e => e.metric.name === 'mastra_model_total_input_tokens',
+        );
+        expect(inputTokenMetrics).toHaveLength(1);
+        expect(inputTokenMetrics[0]?.metric.value).toBe(20);
+        // costContext must have provider from start attributes
+        expect(inputTokenMetrics[0]?.metric.costContext).toMatchObject({
+          provider: 'mock-provider',
+          model: 'mock-model-id',
+          costUnit: 'USD',
+        });
+        expect(inputTokenMetrics[0]?.metric.costContext?.estimatedCost).toBeGreaterThan(0);
       } finally {
         await tracing.shutdown();
         pricingRegistrySpy.mockRestore();


### PR DESCRIPTION
## Description

Auto-extracted metrics (duration, token usage, cost) were silently dropped when spans were filtered via `excludeSpanTypes` or `spanFilter`. Users who excluded span types to reduce per-span costs in platforms like Langfuse unknowingly lost their aggregate metrics.

- Decoupled `emitAutoExtractedMetrics` from the span export guard in `emitSpanEnded` so metrics fire for all valid non-internal spans regardless of export filtering
- Preserved the `isInternal` guard to avoid double-counting with the existing usage rollup mechanism for hidden `MODEL_GENERATION` spans
- Added 4 tests: two proving metrics survive `excludeSpanTypes` and `spanFilter`, one proving no double-count with rollup, one proving no regression for exported spans

## Related Issue(s)

Fixes #15155

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Some settings can hide individual trace “spans” to save money, but the system also accidentally hid the “summary numbers” those spans produce (tokens, latency, cost). This PR makes sure the summary numbers still get emitted even when the detailed spans are filtered out.

## Summary
This PR fixes a bug where auto-extracted aggregate metrics (duration, token usage, and cost) were only emitted when spans successfully passed span export filtering. When spans were filtered out via `excludeSpanTypes` or `spanFilter`, their derived metrics were silently dropped.

### What changed
- In `emitSpanEnded`, auto-extracted metrics are now emitted independently of whether the span is later exported or dropped by span filtering.
- The `isInternal` guard is preserved to prevent double-counting with the existing usage rollup logic (notably around hidden/excluded `MODEL_GENERATION` spans).
- When `MODEL_GENERATION` is excluded by `excludeSpanTypes`, the span `end()` wrapper captures excluded usage/provider/model information before end attributes are discarded, so token/cost metrics can still be produced.
- Span processing/export flow was refactored so export logic can use either the already-processed span (`getProcessedSpanForExport`) or the raw span, keeping processor behavior consistent.

### Tests added/updated
`observability/mastra/src/span-filtering.test.ts` adds coverage that metrics survive filtering:
- Duration metrics are emitted even when spans are excluded by `excludeSpanTypes` (i.e., absent from exported tracing events).
- Duration metrics are emitted even when spans are dropped by `spanFilter` (i.e., absent from exported tracing events).
- Internal-span/rollup scenarios don’t double-count token metrics.
- Regression coverage confirms exported spans still produce their expected duration metrics.
- Verifies `spanOutputProcessors` (e.g., `SensitiveDataFilter`) affect both exported span metadata and auto-extracted duration metric metadata (e.g., `apiKey` redaction).

### Documentation/Release note
A changeset updates `@mastra/observability` with a patch release documenting this non-breaking bug fix that decouples metric emission from span export filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->