### PR TITLE
fix(core): stop SaveQueueManager from silently dropping messages on s…

### DIFF
--- a/.changeset/save-queue-silent-message-loss.md
+++ b/.changeset/save-queue-silent-message-loss.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Fixed silent loss of conversation history when saving messages to storage failed.
+
+Previously, if a storage write failed during an agent run (transient connection drop, timeout, constraint violation, pool exhaustion), the unsaved messages were already drained from the message list and the error was swallowed. The agent run completed as if everything was persisted, leaving a permanent hole in the thread history that was never retried.
+
+Now a failed save keeps the messages queued so the next flush retries them, and the error is propagated to the caller of `flushMessages()` so the agent run can surface or handle it. A single failure no longer stalls later saves for the same thread.
+
+Also fixed a related issue where rapidly calling `batchMessages()` within the debounce window left the superseded call's promise hanging forever. Every promise now settles when the batched save completes.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -884,6 +884,26 @@ export class MessageList {
     return messages.map(message => this.transformMessageForTranscript(message));
   }
 
+  /**
+   * Returns the unsaved user/response messages (transformed for persistence)
+   * without clearing them from the unsaved tracking. Pair with
+   * {@link clearUnsavedMessages} to only drop messages once a storage write has
+   * succeeded, so a failed save can be retried instead of silently lost.
+   */
+  public getUnsavedMessages(): MastraDBMessage[] {
+    const messages = this.messages.filter(m => this.newUserMessages.has(m) || this.newResponseMessages.has(m));
+    return messages.map(message => this.transformMessageForTranscript(message));
+  }
+
+  /**
+   * Marks the given messages (matched by id) as saved by removing them from the
+   * unsaved user/response tracking. Messages added after {@link getUnsavedMessages}
+   * was called remain unsaved and will be picked up by the next save.
+   */
+  public clearUnsavedMessages(messages: MastraDBMessage[]): void {
+    this.stateManager.clearUnsavedMessages(new Set(messages.map(m => m.id)));
+  }
+
   private transformToolStateDataForTranscript(data: unknown, phase: 'approval' | 'suspend'): unknown {
     if (!data || typeof data !== 'object') {
       return data;

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -889,19 +889,38 @@ export class MessageList {
    * without clearing them from the unsaved tracking. Pair with
    * {@link clearUnsavedMessages} to only drop messages once a storage write has
    * succeeded, so a failed save can be retried instead of silently lost.
+   *
+   * The returned messages are deep-cloned so they are an immutable snapshot of the
+   * content at read time: streaming that appends more parts to the same message id
+   * during the in-flight save cannot mutate the payload being written, and
+   * {@link clearUnsavedMessages} can reliably detect whether the live message
+   * changed since this snapshot.
    */
   public getUnsavedMessages(): MastraDBMessage[] {
     const messages = this.messages.filter(m => this.newUserMessages.has(m) || this.newResponseMessages.has(m));
-    return messages.map(message => this.transformMessageForTranscript(message));
+    return messages.map(message => structuredClone(this.transformMessageForTranscript(message)));
   }
 
   /**
-   * Marks the given messages (matched by id) as saved by removing them from the
-   * unsaved user/response tracking. Messages added after {@link getUnsavedMessages}
-   * was called remain unsaved and will be picked up by the next save.
+   * Marks the given messages (the snapshots returned by {@link getUnsavedMessages})
+   * as saved by removing them from the unsaved user/response tracking. A message is
+   * only cleared when the live message still matches the snapshot that was persisted;
+   * if its content changed while the save was in flight (e.g. streaming appended more
+   * parts to the same id), it stays tracked so the newer content is written by the
+   * next save instead of being silently dropped. Messages added after
+   * {@link getUnsavedMessages} was called also remain unsaved.
    */
   public clearUnsavedMessages(messages: MastraDBMessage[]): void {
-    this.stateManager.clearUnsavedMessages(new Set(messages.map(m => m.id)));
+    const savedIds = new Set<string>();
+    for (const saved of messages) {
+      const live = this.messages.find(m => m.id === saved.id);
+      // Drop from tracking only if nothing changed since the snapshot was taken.
+      // A missing live message means it was already removed, so clearing is safe.
+      if (!live || messagesAreEqual(this.transformMessageForTranscript(live), saved)) {
+        savedIds.add(saved.id);
+      }
+    }
+    this.stateManager.clearUnsavedMessages(savedIds);
   }
 
   private transformToolStateDataForTranscript(data: unknown, phase: 'approval' | 'suspend'): unknown {

--- a/packages/core/src/agent/message-list/state/MessageStateManager.ts
+++ b/packages/core/src/agent/message-list/state/MessageStateManager.ts
@@ -183,6 +183,20 @@ export class MessageStateManager {
   }
 
   /**
+   * Remove specific unsaved user/response messages (matched by id) from the new
+   * message tracking. Used to mark messages as saved only after a successful
+   * storage write, so a failed save can be retried instead of silently dropped.
+   */
+  clearUnsavedMessages(ids: Set<string>): void {
+    for (const message of this.newUserMessages) {
+      if (ids.has(message.id)) this.newUserMessages.delete(message);
+    }
+    for (const message of this.newResponseMessages) {
+      if (ids.has(message.id)) this.newResponseMessages.delete(message);
+    }
+  }
+
+  /**
    * Clear all messages from all sources (but not persisted tracking)
    */
   clearAll(): void {

--- a/packages/core/src/agent/message-list/tests/clear-unsaved-messages.test.ts
+++ b/packages/core/src/agent/message-list/tests/clear-unsaved-messages.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { MastraDBMessage } from '../';
+import { MessageList } from '../index';
+
+function makeAssistantMessage(text: string, id: string): MastraDBMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: { format: 2, parts: [{ type: 'text', text }] },
+    createdAt: new Date(),
+  };
+}
+
+function allText(message: MastraDBMessage | undefined): string {
+  return (message?.content?.parts ?? [])
+    .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+    .map(p => p.text)
+    .join('');
+}
+
+describe('MessageList.clearUnsavedMessages', () => {
+  it('clears messages that are unchanged since they were read', () => {
+    const list = new MessageList();
+    list.add(makeAssistantMessage('hello', 'msg-1'), 'response');
+
+    const snapshot = list.getUnsavedMessages();
+    expect(snapshot).toHaveLength(1);
+
+    list.clearUnsavedMessages(snapshot);
+
+    expect(list.getUnsavedMessages()).toHaveLength(0);
+  });
+
+  it('returns an immutable snapshot that later streaming cannot mutate', () => {
+    const list = new MessageList();
+    list.add(makeAssistantMessage('hello', 'msg-1'), 'response');
+
+    const snapshot = list.getUnsavedMessages();
+    // Streaming appends another part to the same message id after the snapshot.
+    list.add(makeAssistantMessage(' world', 'msg-1'), 'response');
+
+    // The snapshot handed to the storage write must not have changed.
+    expect(allText(snapshot[0])).toBe('hello');
+  });
+
+  it('keeps a message tracked when its content changed during the in-flight save', () => {
+    const list = new MessageList();
+    list.add(makeAssistantMessage('hello', 'msg-1'), 'response');
+
+    // Simulate the SaveQueueManager flow: read the unsaved snapshot, then have
+    // streaming append more content to the same message id while the save is
+    // in flight (before clearUnsavedMessages runs).
+    const snapshot = list.getUnsavedMessages();
+    list.add(makeAssistantMessage(' world', 'msg-1'), 'response');
+
+    // Clearing with the stale snapshot must NOT drop the message, because its
+    // newer content has not been persisted yet.
+    list.clearUnsavedMessages(snapshot);
+
+    const stillUnsaved = list.getUnsavedMessages();
+    expect(stillUnsaved).toHaveLength(1);
+    expect(allText(stillUnsaved[0])).toContain('world');
+
+    // A subsequent save with the up-to-date snapshot clears it.
+    list.clearUnsavedMessages(stillUnsaved);
+    expect(list.getUnsavedMessages()).toHaveLength(0);
+  });
+
+  it('clears only the persisted snapshot and keeps messages added afterwards', () => {
+    const list = new MessageList();
+    const userMsg: MastraDBMessage = {
+      id: 'user-1',
+      role: 'user',
+      content: { format: 2, parts: [{ type: 'text', text: 'question' }] },
+      createdAt: new Date(),
+    };
+    list.add(userMsg, 'input');
+
+    const snapshot = list.getUnsavedMessages();
+    expect(snapshot.map(m => m.id)).toEqual(['user-1']);
+
+    // A new assistant response arrives after the snapshot was taken.
+    list.add(makeAssistantMessage('answer', 'asst-1'), 'response');
+
+    list.clearUnsavedMessages(snapshot);
+
+    const remaining = list.getUnsavedMessages();
+    expect(remaining.map(m => m.id)).toEqual(['asst-1']);
+  });
+});

--- a/packages/core/src/agent/save-queue/index.ts
+++ b/packages/core/src/agent/save-queue/index.ts
@@ -17,6 +17,10 @@ export class SaveQueueManager {
   }
   private saveQueues = new Map<string, Promise<void>>();
   private saveDebounceTimers = new Map<string, NodeJS.Timeout>();
+  // Callers waiting on a debounced save for a thread. Every caller within a
+  // debounce window must settle when the batched save completes, so superseded
+  // debounce calls cannot be abandoned (and left hanging forever).
+  private pendingDebounceResolvers = new Map<string, Array<{ resolve: () => void; reject: (err: unknown) => void }>>();
 
   /**
    * Debounces save operations for a thread, ensuring that consecutive save requests
@@ -28,24 +32,39 @@ export class SaveQueueManager {
    */
   private debounceSave(threadId: string, messageList: MessageList, memoryConfig?: MemoryConfigInternal): Promise<void> {
     return new Promise((resolve, reject) => {
+      const resolvers = this.pendingDebounceResolvers.get(threadId) ?? [];
+      resolvers.push({ resolve, reject });
+      this.pendingDebounceResolvers.set(threadId, resolvers);
+
       if (this.saveDebounceTimers.has(threadId)) {
         clearTimeout(this.saveDebounceTimers.get(threadId)!);
       }
       this.saveDebounceTimers.set(
         threadId,
         setTimeout(() => {
-          this.enqueueSave(threadId, messageList, memoryConfig)
-            .then(resolve)
-            .catch(err => {
+          this.saveDebounceTimers.delete(threadId);
+          const pending = this.takePendingDebounceResolvers(threadId);
+          this.enqueueSave(threadId, messageList, memoryConfig).then(
+            () => {
+              for (const p of pending) p.resolve();
+            },
+            err => {
               this.logger?.error?.('Error in debounceSave', { err, threadId });
-              reject(err);
-            })
-            .finally(() => {
-              this.saveDebounceTimers.delete(threadId);
-            });
+              for (const p of pending) p.reject(err);
+            },
+          );
         }, this.debounceMs),
       );
     });
+  }
+
+  /**
+   * Removes and returns the callers waiting on a debounced save for a thread.
+   */
+  private takePendingDebounceResolvers(threadId: string) {
+    const pending = this.pendingDebounceResolvers.get(threadId) ?? [];
+    this.pendingDebounceResolvers.delete(threadId);
+    return pending;
   }
 
   /**
@@ -53,15 +72,25 @@ export class SaveQueueManager {
    * only one save runs at a time per thread. If a save is already in progress for the thread,
    * the new save is queued to run after the previous completes.
    *
+   * The promise returned to the caller rejects if the save fails, so callers (e.g.
+   * `flushMessages`) can surface or retry the error. The queue chain itself always
+   * settles successfully so a single failure does not stall later saves.
+   *
    * @param threadId - The ID of the thread whose messages should be saved.
    * @param messageList - The MessageList instance containing unsaved messages.
    * @param memoryConfig - Optional memory configuration to use for saving.
    */
-  private enqueueSave(threadId: string, messageList: MessageList, memoryConfig?: MemoryConfigInternal) {
+  private enqueueSave(
+    threadId: string,
+    messageList: MessageList,
+    memoryConfig?: MemoryConfigInternal,
+  ): Promise<void> {
     const prev = this.saveQueues.get(threadId) || Promise.resolve();
-    const next = prev
-      .then(() => this.persistUnsavedMessages(messageList, memoryConfig))
+    const result = prev.then(() => this.persistUnsavedMessages(messageList, memoryConfig));
+    const next = result
       .catch(err => {
+        // Swallow on the queue chain only so subsequent saves still run; the
+        // error is propagated to the caller via `result`.
         this.logger?.error?.('Error in enqueueSave', { err, threadId });
       })
       .then(() => {
@@ -70,7 +99,7 @@ export class SaveQueueManager {
         }
       });
     this.saveQueues.set(threadId, next);
-    return next;
+    return result;
   }
 
   /**
@@ -88,17 +117,20 @@ export class SaveQueueManager {
 
   /**
    * Persists any unsaved messages from the MessageList to memory storage.
-   * Drains the list of unsaved messages and writes them using the memory backend.
+   * Reads the unsaved messages and only clears them from the list after a
+   * successful write, so a failed save (e.g. transient storage error) leaves the
+   * messages queued for the next flush instead of silently dropping them.
    * @param messageList - The MessageList instance for the current thread.
    * @param memoryConfig - The memory configuration for saving.
    */
   private async persistUnsavedMessages(messageList: MessageList, memoryConfig?: MemoryConfigInternal) {
-    const newMessages = messageList.drainUnsavedMessages();
+    const newMessages = messageList.getUnsavedMessages();
     if (newMessages.length > 0 && this.memory) {
       await this.memory.saveMessages({
         messages: newMessages,
         memoryConfig,
       });
+      messageList.clearUnsavedMessages(newMessages);
     }
   }
 
@@ -134,6 +166,20 @@ export class SaveQueueManager {
   async flushMessages(messageList: MessageList, threadId?: string, memoryConfig?: MemoryConfigInternal) {
     if (!threadId) return;
     this.clearDebounce(threadId);
-    return this.enqueueSave(threadId, messageList, memoryConfig);
+    // A flush supersedes any pending debounced save for this thread. Adopt its
+    // waiting callers so they settle with this flush instead of hanging.
+    const pending = this.takePendingDebounceResolvers(threadId);
+    const save = this.enqueueSave(threadId, messageList, memoryConfig);
+    if (pending.length > 0) {
+      save.then(
+        () => {
+          for (const p of pending) p.resolve();
+        },
+        err => {
+          for (const p of pending) p.reject(err);
+        },
+      );
+    }
+    return save;
   }
 }

--- a/packages/core/src/agent/save-queue/save-queue.test.ts
+++ b/packages/core/src/agent/save-queue/save-queue.test.ts
@@ -98,6 +98,79 @@ describe('SaveQueueManager', () => {
     expect(totalSaves).toBeGreaterThan(0);
   });
 
+  it('propagates save failures to flushMessages callers instead of swallowing them', async () => {
+    mockMemory.saveMessages = vi.fn(async () => {
+      throw new Error('storage down');
+    });
+
+    const manager = new SaveQueueManager({ memory: mockMemory });
+    const list = new MessageList({ threadId: 'thread-fail' });
+    list.add(makeTestMessage('m1', 'thread-fail', 'user', 'Hello'), 'user');
+
+    await expect(manager.flushMessages(list, 'thread-fail')).rejects.toThrow('storage down');
+  });
+
+  it('re-queues messages when a save fails so the next flush retries them', async () => {
+    let shouldFail = true;
+    mockMemory.saveMessages = vi.fn(async ({ messages }) => {
+      if (shouldFail) {
+        shouldFail = false;
+        throw new Error('transient failure');
+      }
+      saved.push(...messages);
+    });
+
+    const manager = new SaveQueueManager({ memory: mockMemory });
+    const list = new MessageList({ threadId: 'thread-retry' });
+    list.add(makeTestMessage('m1', 'thread-retry', 'user', 'Hello'), 'user');
+
+    // First flush fails — messages must NOT be dropped.
+    await expect(manager.flushMessages(list, 'thread-retry')).rejects.toThrow('transient failure');
+    expect(list.getUnsavedMessages().length).toBe(1);
+
+    // A later flush succeeds and persists the previously failed message.
+    await manager.flushMessages(list, 'thread-retry');
+    expect(saved.map(m => m.id)).toContain('m1');
+    expect(list.getUnsavedMessages().length).toBe(0);
+  });
+
+  it('does not stall later saves after a failed save', async () => {
+    let call = 0;
+    mockMemory.saveMessages = vi.fn(async ({ messages }) => {
+      call++;
+      if (call === 1) throw new Error('boom');
+      saved.push(...messages);
+    });
+
+    const manager = new SaveQueueManager({ memory: mockMemory });
+    const list1 = new MessageList({ threadId: 'thread-q' });
+    list1.add(makeTestMessage('m1', 'thread-q', 'user', 'first'), 'user');
+    const failing = manager.flushMessages(list1, 'thread-q');
+
+    const list2 = new MessageList({ threadId: 'thread-q' });
+    list2.add(makeTestMessage('m2', 'thread-q', 'user', 'second'), 'user');
+    const succeeding = manager.flushMessages(list2, 'thread-q');
+
+    await expect(failing).rejects.toThrow('boom');
+    await expect(succeeding).resolves.toBeUndefined();
+    expect(saved.map(m => m.id)).toContain('m2');
+  });
+
+  it('settles superseded debounce promises when the batched save completes', async () => {
+    const manager = new SaveQueueManager({ memory: mockMemory });
+    const list = new MessageList({ threadId: 'thread-debounce' });
+
+    list.add(makeTestMessage('m1', 'thread-debounce', 'user', 'Hello'), 'user');
+    const first = manager.batchMessages(list, 'thread-debounce');
+    list.add(makeTestMessage('m2', 'thread-debounce', 'user', 'World'), 'user');
+    const second = manager.batchMessages(list, 'thread-debounce');
+
+    // The superseded first promise must settle, not hang.
+    await expect(Promise.all([first, second])).resolves.toBeDefined();
+    expect(saveCalls).toBe(1);
+    expect(saved.length).toBe(2);
+  });
+
   it('should flush buffered parts via drainUnsavedMessages before persisting', async () => {
     let savedMessages: any[] = [];
 


### PR DESCRIPTION
## Description

`SaveQueueManager` drained unsaved messages from the `MessageList` **before** attempting the storage write, and then swallowed any error from `memory.saveMessages()` (`packages/core/src/agent/save-queue/index.ts`). The drained messages were never re-queued, the promise returned to callers resolved successfully, and the agent run completed as if everything was persisted. The result was **permanent, silent loss of conversation history** whenever the storage backend had a transient failure (connection drop, constraint violation, timeout, pool exhaustion):

```ts
private enqueueSave(threadId, messageList, memoryConfig) {
  const next = prev
    .then(() => this.persistUnsavedMessages(messageList, memoryConfig))
    .catch(err => {
      this.logger?.error?.('Error in enqueueSave', { err, threadId }); // swallowed
    })
    .then(() => { ... });
}
```

Callers rely on `flushMessages()` for durability at critical transitions (end of a stream in `prepare-stream/map-results-step.ts`, before suspension in `durable/workflows/steps/tool-call.ts`) — all of them were told "success" even when the write failed, and the messages were already gone from the list so nothing retried them.

There was a second, related defect: when `debounceSave()` was called again within the debounce window, the previous timer was cleared but the previous caller's `Promise` was abandoned — its `resolve`/`reject` were never invoked, so any code `await`ing that earlier `batchMessages()` call hung forever.

### Changes

- **Persist, then clear.** `persistUnsavedMessages()` now reads the unsaved messages with a new `MessageList.getUnsavedMessages()` (no clear) and only drops them via `clearUnsavedMessages()` **after** a successful write. A failed save leaves the messages queued for the next flush. Messages added during the in-flight save are matched by id and remain unsaved.
- **Propagate the error.** `enqueueSave()` returns a result promise that rejects on failure (so `flushMessages()` callers can surface/retry), while the internal per-thread queue chain still settles successfully so a single failure does not stall later saves for the same thread.
- **No more hanging promises.** Debounce callers are tracked per thread and all settle when the batched save completes; a flush that supersedes a pending debounce adopts its waiting callers.
- Add regression tests covering all four behaviors.

No public API changes. The success path is unchanged.

### Before / after (public API behavior)

```ts
// Before: a transient storage failure was swallowed — flushMessages() resolved
// "successfully", the messages were dropped, and nothing retried them.
await agent.generate('hello', { memory: { thread, resource } });

// After: the failure propagates so the run can surface/retry it, and the
// messages stay queued for the next flush instead of being lost.
try {
  await agent.generate('hello', { memory: { thread, resource } });
} catch (error) {
  // handle the transient storage failure
}
```

**Files changed**
- `packages/core/src/agent/save-queue/index.ts` — clear messages only after a successful write; propagate save errors to `flushMessages()` callers; settle superseded debounce promises
- `packages/core/src/agent/message-list/message-list.ts` — add `getUnsavedMessages()` (peek) and `clearUnsavedMessages()` (clear-on-success)
- `packages/core/src/agent/message-list/state/MessageStateManager.ts` — add `clearUnsavedMessages(ids)` to drop specific messages by id
- `packages/core/src/agent/save-queue/save-queue.test.ts` — new regression tests
- `.changeset/save-queue-silent-message-loss.md` — patch changeset

## Related issue(s)

Fixes: #18256

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## How it was tested

- **New regression tests** (`save-queue.test.ts`) assert that:
  - a save failure propagates to `flushMessages()` callers (instead of resolving as success),
  - failed messages are re-queued and persisted by a later flush,
  - a failed save does not stall later saves on the same thread, and
  - superseded debounce promises settle when the batched save completes (instead of hanging).
- Ran `src/agent/save-queue`, `src/agent/message-list`, and `src/agent/__tests__/save-and-errors.test.ts` for `@mastra/core` — all green (490 passed), no type errors.
- `tsc` typecheck (run by Vitest) is clean on the changed files.

## Checklist

- [ ] I have linked the related issue(s) in the description above _(pending — replace #XXXX once the issue is filed)_
- [x] I have made corresponding changes to the documentation (if applicable) _(none needed; internal behavior only)_
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR _(after PR is opened)_

## Diff summary

```diff
-  private async persistUnsavedMessages(messageList, memoryConfig) {
-    const newMessages = messageList.drainUnsavedMessages();
-    if (newMessages.length > 0 && this.memory) {
-      await this.memory.saveMessages({ messages: newMessages, memoryConfig });
-    }
-  }
+  private async persistUnsavedMessages(messageList, memoryConfig) {
+    const newMessages = messageList.getUnsavedMessages();
+    if (newMessages.length > 0 && this.memory) {
+      await this.memory.saveMessages({ messages: newMessages, memoryConfig });
+      // Only clear after a successful write so a failed save can be retried.
+      messageList.clearUnsavedMessages(newMessages);
+    }
+  }

   private enqueueSave(threadId, messageList, memoryConfig): Promise<void> {
     const prev = this.saveQueues.get(threadId) || Promise.resolve();
-    const next = prev
-      .then(() => this.persistUnsavedMessages(messageList, memoryConfig))
-      .catch(err => { this.logger?.error?.('Error in enqueueSave', { err, threadId }); })
+    const result = prev.then(() => this.persistUnsavedMessages(messageList, memoryConfig));
+    const next = result
+      // Swallow on the queue chain only so later saves still run; the error is
+      // propagated to the caller via `result`.
+      .catch(err => { this.logger?.error?.('Error in enqueueSave', { err, threadId }); })
       .then(() => { if (this.saveQueues.get(threadId) === next) this.saveQueues.delete(threadId); });
     this.saveQueues.set(threadId, next);
-    return next;
+    return result;
   }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes sure chat messages don’t “vanish” when the system tries to save them but something goes wrong (like a temporary database/network issue). It also makes sure callers waiting on a debounced save don’t get stuck forever—promises are now correctly settled when the batch finishes.

## Summary

This PR fixes two issues in `SaveQueueManager` that could (1) permanently lose conversation history and (2) cause hanging promises.

### 1) Critical Issue: Silent message loss on storage save failures
Previously, `persistUnsavedMessages()` would remove (drain) unsaved messages from the `MessageList` before calling `memory.saveMessages()`, then swallow any save error—so failed writes meant messages were neither retried nor reported.

**Fix**
- `MessageList` now provides:
  - `getUnsavedMessages()` to read an immutable snapshot of unsaved messages (deep-cloned for persistence).
  - `clearUnsavedMessages(messages)` to clear only the specific snapshot entries that were successfully persisted, using ID comparisons plus `messagesAreEqual` to avoid clearing messages that changed since the snapshot.
- `persistUnsavedMessages()` now:
  - reads unsaved messages via `getUnsavedMessages()` (no clearing up front),
  - clears them only after `memory.saveMessages()` succeeds,
  - leaves them queued when the save fails, enabling retry on the next flush.

### 2) Secondary Issue: Debounced callers could hang indefinitely
When `debounceSave()` was called again inside the debounce window, the old timer was replaced and earlier callers’ promises were not properly settled.

**Fix**
- `SaveQueueManager` now tracks all waiting debounce callers per thread via a `pendingDebounceResolvers` structure.
- When the debounced timer fires, it enqueues the save and resolves/rejects all pending callers with the same result.
- If `flushMessages()` happens while a debounce is pending, the flush adopts and settles the pending debounce waiters using the flush’s `enqueueSave(...)` promise.

### Supporting changes / verification
- `enqueueSave()` was adjusted to return the actual result promise (so failures reject correctly), while the internal per-thread queue chain still settles in a way that prevents one failure from blocking later saves.
- Added regression tests covering:
  - error propagation from `flushMessages()`,
  - re-queuing after failed saves so later flushes retry,
  - avoiding stalling later saves after an earlier failure,
  - ensuring superseded debounce promises settle (no hangs).
- Added `MessageStateManager.clearUnsavedMessages(ids)` to support selective clearing of persisted snapshot IDs.
- Includes a patch changeset note describing both behavioral fixes (`@mastra/core`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->