### PR TITLE
fix(workflow): enforce FGA on Run resume paths

### DIFF
--- a/.changeset/dark-rice-tickle.md
+++ b/.changeset/dark-rice-tickle.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+**Fixed:** Closed an authorization bypass where Workflow run resume APIs (`Run.resume`, `Run.resumeAsync`, `Run.resumeStream`, and the evented `EventedRun.resume`) executed persisted snapshots without an internal FGA check. The same `workflows:execute` permission that gates `Workflow.execute` now also gates every resume path, so callers reaching the core API directly (or any handler that skips the built-in server route adapter) cannot continue a suspended run that the configured FGA provider would deny.
+
+When no FGA provider is configured, behavior is unchanged. When FGA is configured and no authenticated user is available, resume now fails closed with the same `authenticated user is required` error the initial execution already raised.
+
+Bug report: https://github.com/mastra-ai/mastra/issues/18165

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -2133,6 +2133,33 @@ export class EventedRun<
       includeResumeLabels?: boolean;
     };
   }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    // FGA authorization check — mirrors Workflow.execute() so the evented
+    // resume path goes through the same `workflows:execute` gate as the
+    // initial execution. Without this, callers reaching EventedRun.resume
+    // directly bypass the internal check while the server route adapter
+    // still enforces it on the HTTP path.
+    const fgaProvider = this.mastra?.getServer()?.fga;
+    if (fgaProvider) {
+      const user = params.requestContext?.get('user' as any);
+      const { getWorkflowFGAResourceId, requireFGA } = await import('../../auth/ee/fga-check');
+      const { MastraFGAPermissions } = await import('../../auth/ee');
+      await requireFGA({
+        fgaProvider,
+        user,
+        resource: { type: 'workflow', id: getWorkflowFGAResourceId(this.workflowId) },
+        permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+        requestContext: params.requestContext,
+        context: {
+          resourceId: this.resourceId,
+        },
+        metadata: {
+          workflowId: this.workflowId,
+          runId: this.runId,
+          resourceId: this.resourceId,
+        },
+      });
+    }
+
     const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
     if (!workflowsStore) {
       throw new Error('Cannot resume workflow: workflows store is required');

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -819,6 +819,101 @@ describe('Workflow (Default Engine Specifics)', () => {
       expect(result).toEqual({ value: 'ok' });
       expect(fgaProvider.require).not.toHaveBeenCalled();
     });
+
+    /**
+     * @see https://github.com/mastra-ai/mastra/issues/18165
+     */
+    describe('Run.resume FGA enforcement', () => {
+      function createSuspendableFGAWorkflow() {
+        const suspendStep = createStep({
+          id: 'fga-suspend-step',
+          inputSchema: z.object({ value: z.string() }),
+          outputSchema: z.object({ value: z.string() }),
+          suspendSchema: z.object({ message: z.string() }),
+          resumeSchema: z.object({ confirm: z.boolean() }),
+          execute: async ({ inputData, resumeData, suspend }) => {
+            if (!resumeData?.confirm) {
+              await suspend({ message: 'awaiting confirm' });
+            }
+            return inputData;
+          },
+        });
+        return createWorkflow({
+          id: 'fga-resume-workflow',
+          inputSchema: z.object({ value: z.string() }),
+          outputSchema: z.object({ value: z.string() }),
+          steps: [suspendStep],
+        })
+          .then(suspendStep)
+          .commit();
+      }
+
+      async function suspendedRun(opts: { runId: string; fgaProvider?: unknown }) {
+        const storage = new MockStore();
+        const workflow = createSuspendableFGAWorkflow();
+        const mastra = new Mastra({
+          logger: false,
+          storage,
+          ...(opts.fgaProvider ? { server: { fga: opts.fgaProvider as any } } : {}),
+        });
+        workflow.__registerMastra(mastra);
+        const run = await workflow.createRun({ runId: opts.runId });
+        const result = await run.start({ inputData: { value: 'ok' } });
+        expect(result.status).toBe('suspended');
+        return run;
+      }
+
+      it('checks workflows:execute on resume with request context metadata', async () => {
+        const fgaProvider = {
+          require: vi.fn().mockResolvedValue(undefined),
+          check: vi.fn(),
+          filterAccessible: vi.fn(),
+        };
+        const run = await suspendedRun({ runId: 'fga-resume-run-1', fgaProvider });
+        const requestContext = new RequestContext();
+        requestContext.set('user', { id: 'user-1' });
+
+        await run.resume({ resumeData: { confirm: true }, requestContext });
+
+        expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+        expect(fgaProvider.require).toHaveBeenCalledWith(
+          { id: 'user-1' },
+          {
+            resource: { type: 'workflow', id: 'fga-resume-workflow' },
+            permission: 'workflows:execute',
+            context: expect.objectContaining({
+              requestContext,
+              metadata: expect.objectContaining({
+                workflowId: 'fga-resume-workflow',
+                runId: 'fga-resume-run-1',
+              }),
+            }),
+          },
+        );
+      });
+
+      it('fails closed on resume when FGA is configured and no user is available', async () => {
+        const fgaProvider = {
+          require: vi.fn().mockResolvedValue(undefined),
+          check: vi.fn(),
+          filterAccessible: vi.fn(),
+        };
+        const run = await suspendedRun({ runId: 'fga-resume-run-2', fgaProvider });
+
+        await expect(
+          run.resume({ resumeData: { confirm: true }, requestContext: new RequestContext() }),
+        ).rejects.toThrow('authenticated user is required');
+        expect(fgaProvider.require).not.toHaveBeenCalled();
+      });
+
+      it('no-ops on resume when no FGA provider is configured', async () => {
+        const run = await suspendedRun({ runId: 'fga-resume-run-3' });
+
+        // No FGA provider → resume completes without any auth indirection.
+        const result = await run.resume({ resumeData: { confirm: true } });
+        expect(result.status).toBe('success');
+      });
+    });
   });
 
   describe('Nested workflow abort listener cleanup (issue #16125)', () => {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -11,7 +11,7 @@ import { isAgentCompatible } from '../agent/subagent';
 import type { SubAgent } from '../agent/subagent';
 import { TripWire } from '../agent/trip-wire';
 import type { AgentStreamOptions } from '../agent/types';
-import { MastraFGAPermissions } from '../auth/ee';
+import { MastraFGAPermissions, getWorkflowFGAResourceId, requireFGA } from '../auth/ee';
 import type { ActorSignal } from '../auth/ee';
 import { MastraBase } from '../base';
 import { RequestContext } from '../di';
@@ -2494,7 +2494,7 @@ export class Workflow<
     const fgaProvider = mastra?.getServer()?.fga;
     if (fgaProvider) {
       const user = requestContext?.get('user' as any);
-      const { getWorkflowFGAResourceId, requireFGA } = await import('../auth/ee/fga-check');
+      
       await requireFGA({
         fgaProvider,
         user,
@@ -3962,7 +3962,7 @@ export class Run<
     const fgaProvider = this.#mastra?.getServer()?.fga;
     if (fgaProvider) {
       const user = params.requestContext?.get('user' as any);
-      const { getWorkflowFGAResourceId, requireFGA } = await import('../auth/ee/fga-check');
+      
       await requireFGA({
         fgaProvider,
         user,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -3954,6 +3954,33 @@ export class Run<
       actor?: ActorSignal;
     } & Partial<ObservabilityContext>,
   ): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    // FGA authorization check — mirrors Workflow.execute() so that resuming a
+    // suspended run goes through the same `workflows:execute` gate. Without
+    // this, callers that reach _resume directly (or via the public resume /
+    // resumeAsync / resumeStream wrappers) bypass the internal check while the
+    // server route adapter still enforces it on the HTTP path.
+    const fgaProvider = this.#mastra?.getServer()?.fga;
+    if (fgaProvider) {
+      const user = params.requestContext?.get('user' as any);
+      const { getWorkflowFGAResourceId, requireFGA } = await import('../auth/ee/fga-check');
+      await requireFGA({
+        fgaProvider,
+        user,
+        resource: { type: 'workflow', id: getWorkflowFGAResourceId(this.workflowId) },
+        permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+        requestContext: params.requestContext,
+        actor: params.actor,
+        context: {
+          resourceId: this.resourceId,
+        },
+        metadata: {
+          workflowId: this.workflowId,
+          runId: this.runId,
+          resourceId: this.resourceId,
+        },
+      });
+    }
+
     const observabilityContext = resolveObservabilityContext(params);
     const workflowsStore = await this.#mastra?.getStorage()?.getStore('workflows');
     const snapshot = await workflowsStore?.loadWorkflowSnapshot({


### PR DESCRIPTION
Fixes #18165.

## What

`Workflow.execute()` already gates execution behind a `workflows:execute` FGA check, but the resume paths — `Run.resume`, `Run.resumeAsync`, `Run.resumeStream` (all funnelling through `Run._resume`), and the evented `EventedRun.resume` — load the persisted snapshot and continue execution without an equivalent internal check.

The built-in server route adapter still enforces FGA on the `/workflows/:workflowId/.../resume*` HTTP path, so this isn't reachable from a stock deployment, but any caller hitting the core API directly or replacing/wrapping the route adapter bypasses the gate. The reporter's filing has the full path-by-path trace.

## How I changed it

Both resume entry points now mirror `Workflow.execute`:

- `packages/core/src/workflows/workflow.ts` — `Run._resume` runs the FGA check before loading the snapshot, using the same `{ type: 'workflow', id: workflowId }` resource, the same `workflows:execute` permission, and the same `resourceId` / `requestContext` / `metadata` shape the execute path uses. `Run.resume`, `Run.resumeAsync`, and `Run.resumeStream` all funnel through `_resume`, so a single insertion covers all three. The `actor` param from `_resume` is also threaded through so trusted-system-actor flows behave consistently across execute / resume.
- `packages/core/src/workflows/evented/workflow.ts` — `EventedRun.resume` gets the matching block; same shape, no `actor` since the evented public resume API doesn't currently expose one.

When no FGA provider is configured, behavior is unchanged (`requireFGA` no-ops). When FGA is configured but no authenticated user is available, resume now fails closed with the same `authenticated user is required` error initial execution already raises — same threat model, same response.

## Tests

Three regression cases added to the existing `FGA checks` describe block in `packages/core/src/workflows/workflow.test.ts`, tagged `@see #18165`:

1. `checks workflows:execute on resume with request context metadata` — asserts `fgaProvider.require` is called exactly once on resume with the expected `{ resource, permission, context }` shape.
2. `fails closed on resume when FGA is configured and no user is available` — asserts the resume rejects with `authenticated user is required` and never reaches the provider.
3. `no-ops on resume when no FGA provider is configured` — asserts existing happy path is untouched.

All 6 FGA tests pass under `pnpm vitest run src/workflows/workflow.test.ts -t FGA`. `pnpm typecheck` clean.

## Changeset

`.changeset/dark-rice-tickle.md` (`@mastra/core`: patch) describes the fix in terms of the user-visible change (resume now respects the same FGA gate as execute).

## Notes

- Kept the fix scoped per CLAUDE.md ("Bug fixes ... MUST include tests" + "Do not change public API behavior beyond the fix"). The resume signatures are unchanged; the new check is purely additive and only takes effect when an FGA provider is configured.
- The reporter also notes the standard HTTP server adapter validates stored `resourceId` ownership — that path is preserved; this fix is the defense-in-depth at the core API boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a “bouncer check” to workflow resume calls. Previously, you could sometimes resume a suspended workflow without proving you’re allowed to—now resume also enforces the same `workflows:execute` permission that the normal workflow start path uses.

## Summary

This PR fixes inconsistent Fine-Grained Authorization (FGA) enforcement at the core API boundary for workflow resume operations. `Workflow.execute()` already gates execution with `workflows:execute`, but the core resume paths (`Run._resume`, public `Run.resume`/`resumeAsync`/`resumeStream`, and the evented `EventedRun.resume`) could load and continue from a persisted “suspended” snapshot without performing the equivalent FGA check—allowing direct/custom callers (bypassing the standard server route adapter) to bypass authorization.

## Changes

**FGA enforcement added to resume before snapshot load**
- `packages/core/src/workflows/workflow.ts`
  - `Run._resume()` now checks `workflows:execute` with the same workflow resource shape and authorization context used by `Workflow.execute()`.
  - The actor passed into resume is forwarded into the FGA check.
  - If an FGA provider is configured but no authenticated user is present in `params.requestContext`, resume fails closed with `authenticated user is required`.
  - If no FGA provider is configured, resume proceeds unchanged.

- `packages/core/src/workflows/evented/workflow.ts`
  - `EventedRun.resume()` now performs the same `workflows:execute` FGA gate before loading the snapshot.
  - The FGA gate includes the same workflow resource, request context, context (`resourceId`), and metadata (`workflowId`, `runId`, `resourceId`).
  - When FGA isn’t configured, the gate is skipped.

**Regression tests added**
- `packages/core/src/workflows/workflow.test.ts`
  - Added tests covering:
    - authorized resume calls (verifies `fgaProvider.require` invocation and expected permission/metadata)
    - unauthenticated resume when FGA is enabled (expects `authenticated user is required`, and ensures `fgaProvider.require` is not called)
    - resume when no FGA provider is configured (proceeds successfully)

**Changeset**
- `.changeset/dark-rice-tickle.md`
  - Documents the closed authorization bypass and the fail-closed behavior when FGA is enabled without an authenticated user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->