### PR TITLE
refactor(core): add harness.createSession() factory and remove the singleton session

### DIFF
--- a/.changeset/curvy-otters-run.md
+++ b/.changeset/curvy-otters-run.md
@@ -17,12 +17,13 @@ await harness.respondToToolSuspension({ toolCallId, approved: true });
 **After**
 
 ```typescript
-await harness.session.sendMessage({ content: 'hello' });
-harness.session.sendSignal({ content: 'steer the run' });
-harness.session.abort();
-await harness.session.respondToToolSuspension({ toolCallId, approved: true });
+const session = await harness.createSession();
+await session.sendMessage({ content: 'hello' });
+session.sendSignal({ content: 'steer the run' });
+session.abort();
+await session.respondToToolSuspension({ toolCallId, approved: true });
 ```
 
 Removed `Harness.sendMessage`, `Harness.sendSignal`, `Harness.sendNotificationSignal`, `Harness.steer`, `Harness.followUp`, `Harness.abort`, `Harness.respondToToolSuspension`, `Harness.saveSystemReminderMessage`, and `Harness.waitForCurrentThreadStreamIdle`. The `Session` reaches Harness-owned machinery through the injected `SessionMachinery` provider, so the heavy run loop is still constructed and owned by the Harness while being parameterized by the session it runs on.
 
-`mastracode` is updated to consume the new API: the TUI run loop, slash-command dispatch, goal lifecycle, prompt handlers, and headless entry points all drive run-control through `session.*`.
+`mastracode` is updated to consume the new API: the TUI run loop, slash-command dispatch, goal lifecycle, prompt handlers, and headless entry points all drive run-control through the session returned by `harness.createSession()`.

--- a/.changeset/harness-create-session.md
+++ b/.changeset/harness-create-session.md
@@ -1,0 +1,33 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Made the Harness a pure factory + shared-resource owner and removed its singleton session. The Harness no longer holds a `#session` field or exposes a `harness.session` getter; instead, callers create fully isolated sessions via `harness.createSession()`. Each session owns its own mode, model, state, thread, run-control, event bus, and stream engine, so a single Harness can now serve many concurrent sessions (e.g. one per user/thread in a server or channel adapter) without cross-session state or event leakage.
+
+`harness.createSession({ resourceId? })` constructs and wires a new `Session`, replays the current workspace status onto it, and selects or creates its thread before returning. Harness methods that previously read the singleton session are now parameterized by an explicit `session` argument (`setResourceId`, `getKnownResourceIds`, `getCurrentModelAuthStatus`, `loadOMProgress`, `getObservationalMemoryRecord`, `destroy`). `harness.init()` is now idempotent, so repeated calls reuse the same initialization instead of rebuilding internal state.
+
+**Before**
+
+```typescript
+const harness = new Harness(config);
+await harness.init();
+const session = harness.session; // singleton
+await session.sendMessage({ content: 'hello' });
+```
+
+**After**
+
+```typescript
+const harness = new Harness(config);
+await harness.init();
+const session = await harness.createSession({ resourceId });
+await session.sendMessage({ content: 'hello' });
+
+// A second, fully isolated session from the same Harness:
+const other = await harness.createSession({ resourceId: otherUser });
+```
+
+Removed `harness.session`, `harness.getSession()`, the singleton `#session` field, and the deprecated `harness.subscribe`/`harness.emit`/`harness.memory` delegators.
+
+`mastracode` is updated to consume the new API: composition roots call `createSession()` once at startup and store the result on `state.session`, and all per-session operations flow through that session object.

--- a/.changeset/quick-otters-jump.md
+++ b/.changeset/quick-otters-jump.md
@@ -1,0 +1,29 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Made `harness.createSession()` get-or-create by resourceId and added `harness.getSessionByResource()` so notification delivery runs as the session that owns the target thread.
+
+A resourceId now maps to exactly one durable session per Harness: calling `createSession({ resourceId })` twice returns the same session, so a user/thread always resumes their own session and the in-flight creation is shared by concurrent callers. This is the multi-session behavior a long-running / multiplayer server needs — work can be driven on a thread whether or not a human is currently attached, and it runs with that thread's own model/mode/state instead of an arbitrary session.
+
+**Before**
+
+```typescript
+// createSession was a pure factory: two calls for the same resource produced
+// two independent sessions, and notification delivery had no way to find
+// "the session that owns this resource".
+const a = await harness.createSession({ resourceId: 'user-a' });
+const b = await harness.createSession({ resourceId: 'user-a' }); // different object
+```
+
+**After**
+
+```typescript
+const a = await harness.createSession({ resourceId: 'user-a' });
+const b = await harness.createSession({ resourceId: 'user-a' }); // same session as a
+
+const session = await harness.getSessionByResource('user-a'); // === a
+```
+
+`mastracode` resolves notification stream options from the target resource's session (falling back to the active session's model, then the mode default) so a woken GitHub-signal notification always has a model to run with.

--- a/mastracode/e2e/scenarios/active-signal-followup.ts
+++ b/mastracode/e2e/scenarios/active-signal-followup.ts
@@ -18,7 +18,6 @@ export const activeSignalFollowupScenario: McE2eScenario = {
     terminal.write('Start a slow active signal run.');
     await runtime.waitForScreenText(/Start a slow active signal run\./i, terminal);
     terminal.write('\r');
-    await runtime.waitForScreenText(/Created thread:/i, terminal, 8_000);
 
     terminal.submit('Steer while active.');
     await runtime.waitForScreenText(/Steer while active\./i, terminal);

--- a/mastracode/e2e/scenarios/github-signals-polling-inbox.ts
+++ b/mastracode/e2e/scenarios/github-signals-polling-inbox.ts
@@ -173,9 +173,13 @@ values
         if (!agent || !originalSendNotificationSignal) return;
         type SendNotificationSignal = typeof agent.sendNotificationSignal;
         const sendScopedNotificationSignal = ((notification: unknown, target: unknown) => {
+          // Scope the target to this fixture's resource/thread, but preserve the
+          // delivery options (ifIdle/ifActive) — they carry the stream options
+          // (model/mode/state) the woken run needs to resolve a model.
           const scopedTarget =
             target && typeof target === 'object'
               ? {
+                  ...(target as Record<string, unknown>),
                   resourceId: (target as { resourceId?: string }).resourceId,
                   threadId: (target as { threadId?: string }).threadId,
                 }
@@ -187,10 +191,17 @@ values
         }) as SendNotificationSignal;
         agent.sendNotificationSignal = sendScopedNotificationSignal;
         const pollTimer = setTimeout(() => {
-          void result.githubSignals?.startPollingForThread(
-            { threadId: threadFixture.threadId, resourceId: threadFixture.resourceId },
-            { pollImmediately: true },
-          );
+          void (async () => {
+            // The notification targets a seeded resource that the startup
+            // session is not on. In the multi-session world the woken run uses
+            // the target resource's own session, so materialize one before
+            // polling — mirroring how a server would have a session per thread.
+            await result.harness.createSession({ resourceId: threadFixture.resourceId });
+            await result.githubSignals?.startPollingForThread(
+              { threadId: threadFixture.threadId, resourceId: threadFixture.resourceId },
+              { pollImmediately: true },
+            );
+          })();
         }, 250);
         pollTimer.unref?.();
       },

--- a/mastracode/e2e/scenarios/notification-inbox-crud-flow.ts
+++ b/mastracode/e2e/scenarios/notification-inbox-crud-flow.ts
@@ -25,13 +25,13 @@ export const notificationInboxCrudFlowScenario = {
       },
       onCreated: result => {
         const seedNotifications = async () => {
-          const threadId = result.harness.session.thread.getId();
-          if (seeded || !threadId || !result.harness.session.stream.isActive()) return;
+          const threadId = result.session.thread.getId();
+          if (seeded || !threadId || !result.session.stream.isActive()) return;
           seeded = true;
           if (timer) clearInterval(timer);
           const storage = await result.harness.getMastra()?.getStorage()?.getStore('notifications');
           if (!storage) throw new Error('notification storage unavailable');
-          const resourceId = result.harness.session.identity.getResourceId();
+          const resourceId = result.session.identity.getResourceId();
           const agentId = 'code-agent';
           await storage.createNotification({
             id: 'inbox-crud-seen',

--- a/mastracode/e2e/scenarios/notification-inbox-tool-flow.ts
+++ b/mastracode/e2e/scenarios/notification-inbox-tool-flow.ts
@@ -24,8 +24,8 @@ export const notificationInboxToolFlowScenario = {
       },
       onCreated: result => {
         timer = setInterval(() => {
-          const threadId = result.harness.session.thread.getId();
-          if (sent || !threadId || !result.harness.session.stream.isActive()) return;
+          const threadId = result.session.thread.getId();
+          if (sent || !threadId || !result.session.stream.isActive()) return;
           sent = true;
           if (timer) clearInterval(timer);
           const agent = result.harness.getMastra()?.getAgentById('code-agent');
@@ -38,7 +38,7 @@ export const notificationInboxToolFlowScenario = {
               dedupeKey: 'mc-e2e-notification-inbox-tool-flow',
             },
             {
-              resourceId: result.harness.session.identity.getResourceId(),
+              resourceId: result.session.identity.getResourceId(),
               threadId,
               ifIdle: { behavior: 'wake' },
             },

--- a/mastracode/e2e/scenarios/notification-signal-rendering.ts
+++ b/mastracode/e2e/scenarios/notification-signal-rendering.ts
@@ -25,8 +25,8 @@ export const notificationSignalRenderingScenario = {
       },
       onCreated: result => {
         timer = setInterval(() => {
-          const threadId = result.harness.session.thread.getId();
-          if (sent || !threadId || !result.harness.session.stream.isActive()) return;
+          const threadId = result.session.thread.getId();
+          if (sent || !threadId || !result.session.stream.isActive()) return;
           sent = true;
           if (timer) clearInterval(timer);
           const agent = result.harness.getMastra()?.getAgentById('code-agent');
@@ -39,7 +39,7 @@ export const notificationSignalRenderingScenario = {
               dedupeKey: 'mc-e2e-notification-signal',
             },
             {
-              resourceId: result.harness.session.identity.getResourceId(),
+              resourceId: result.session.identity.getResourceId(),
               threadId,
               ifIdle: { behavior: 'wake' },
             },

--- a/mastracode/e2e/scenarios/state-signal-rendering.ts
+++ b/mastracode/e2e/scenarios/state-signal-rendering.ts
@@ -21,8 +21,8 @@ export const stateSignalRenderingScenario: McE2eScenario = {
         let sent = false;
         timer = setInterval(async () => {
           try {
-            const threadId = result.harness.session.thread.getId();
-            if (sent || !threadId || !result.harness.session.stream.isActive()) return;
+            const threadId = result.session.thread.getId();
+            if (sent || !threadId || !result.session.stream.isActive()) return;
             sent = true;
             if (timer) clearInterval(timer);
             const agent = result.harness.getMastra()?.getAgentById('code-agent');
@@ -35,7 +35,7 @@ export const stateSignalRenderingScenario: McE2eScenario = {
                 value: { activeUrl: 'https://example.test/state' },
               },
               {
-                resourceId: result.harness.session.identity.getResourceId(),
+                resourceId: result.session.identity.getResourceId(),
                 threadId,
                 ifActive: { attributes: { source: 'mc-e2e' } },
                 ifIdle: { behavior: 'persist' },

--- a/mastracode/e2e/terminal-backend.ts
+++ b/mastracode/e2e/terminal-backend.ts
@@ -339,6 +339,7 @@ async function startMastraCodeApp(
 
   const tui = new MastraTUI({
     harness: result.harness,
+    session: result.session,
     hookManager: result.hookManager,
     authStorage: result.authStorage,
     mcpManager: result.mcpManager,
@@ -358,7 +359,7 @@ async function startMastraCodeApp(
     const browser = await createBrowserFromSettings(settings.browser);
     if (browser) {
       result.harness.setBrowser(browser);
-      await result.harness.session.state.set({ activeBrowserSettings: settings.browser });
+      await result.session.state.set({ activeBrowserSettings: settings.browser });
     }
   }
 

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -109,7 +109,11 @@ vi.mock('@mastra/core/harness', () => ({
     constructor(config: unknown) {
       harnessConstructorMock(config);
     }
-    get session() {
+    async init() {}
+    getMastra() {
+      return undefined;
+    }
+    async createSession() {
       return {
         subscribe: (eventHandler: unknown) => harnessSubscribeMock(eventHandler),
         identity: {

--- a/mastracode/src/__tests__/tool-approval-libsql.test.ts
+++ b/mastracode/src/__tests__/tool-approval-libsql.test.ts
@@ -118,31 +118,32 @@ describe('tool approval with LibSQLStore via Harness', () => {
     (harness as any).getAgentForMode = () => registeredAgent;
 
     await harness.init();
+    const session = await harness.createSession();
 
     // Collect events
     const events: any[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
     // Create a thread
-    await harness.session.thread.create();
+    await session.thread.create();
 
     // Send message — should hit tool-call-approval and auto-approve (policy = 'ask')
     // We need to respond to the approval prompt
     const approvalPromise = new Promise<void>(resolve => {
-      harness.session.subscribe(event => {
+      session.subscribe(event => {
         if (event.type === 'tool_approval_required') {
           // Must be async — the approval gate is armed after emit returns
           queueMicrotask(() => {
-            harness.session.respondToToolApproval({ decision: 'approve' });
+            session.respondToToolApproval({ decision: 'approve' });
             resolve();
           });
         }
       });
     });
 
-    await Promise.all([harness.session.sendMessage({ content: 'Read test.txt' }), approvalPromise]);
+    await Promise.all([session.sendMessage({ content: 'Read test.txt' }), approvalPromise]);
 
     // The tool should have been called
     expect(mockExecute).toHaveBeenCalledTimes(1);

--- a/mastracode/src/agents/thread-caveman-state.test.ts
+++ b/mastracode/src/agents/thread-caveman-state.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { restoreOMThreadStateForCurrentThread } from './thread-caveman-state.js';
 
-function createHarness({
+function createSession({
   currentThreadId = 'thread-1',
   metadata,
   state = {},
@@ -17,119 +17,117 @@ function createHarness({
   const setState = vi.fn(async (nextState: Record<string, unknown>) => {
     Object.assign(state, nextState);
   });
-  const harness = {
-    session: {
-      state: {
-        get: vi.fn(() => state),
-        set: setState,
-      },
-      thread: {
-        getId: vi.fn(() => activeThreadId),
-        list: vi.fn(async () => {
-          onListThreads?.();
-          return [{ id: 'thread-1', metadata }];
-        }),
-        setSetting: vi.fn(async () => {}),
-      },
+  const session = {
+    state: {
+      get: vi.fn(() => state),
+      set: setState,
+    },
+    thread: {
+      getId: vi.fn(() => activeThreadId),
+      list: vi.fn(async () => {
+        onListThreads?.();
+        return [{ id: 'thread-1', metadata }];
+      }),
+      setSetting: vi.fn(async () => {}),
     },
     switchCurrentThread: (threadId: string | undefined) => {
       activeThreadId = threadId;
     },
   };
 
-  return harness;
+  return session;
 }
 
 describe('restoreOMThreadStateForCurrentThread', () => {
   it('mirrors persisted caveman metadata into harness state for the current thread', async () => {
-    const harness = createHarness({ metadata: { cavemanObservations: true }, state: { cavemanObservations: false } });
+    const session = createSession({ metadata: { cavemanObservations: true }, state: { cavemanObservations: false } });
 
-    await restoreOMThreadStateForCurrentThread(harness as never);
+    await restoreOMThreadStateForCurrentThread(session as never);
 
-    expect(harness.session.thread.list).toHaveBeenCalledWith({ allResources: true });
-    expect(harness.session.state.set).toHaveBeenCalledWith({ cavemanObservations: true });
-    expect(harness.session.thread.setSetting).not.toHaveBeenCalled();
+    expect(session.thread.list).toHaveBeenCalledWith({ allResources: true });
+    expect(session.state.set).toHaveBeenCalledWith({ cavemanObservations: true });
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
   });
 
   it('mirrors persisted false caveman metadata into harness state for the current thread', async () => {
-    const harness = createHarness({ metadata: { cavemanObservations: false }, state: { cavemanObservations: true } });
+    const session = createSession({ metadata: { cavemanObservations: false }, state: { cavemanObservations: true } });
 
-    await restoreOMThreadStateForCurrentThread(harness as never);
+    await restoreOMThreadStateForCurrentThread(session as never);
 
-    expect(harness.session.thread.list).toHaveBeenCalledWith({ allResources: true });
-    expect(harness.session.state.set).toHaveBeenCalledWith({ cavemanObservations: false });
-    expect(harness.session.thread.setSetting).not.toHaveBeenCalled();
+    expect(session.thread.list).toHaveBeenCalledWith({ allResources: true });
+    expect(session.state.set).toHaveBeenCalledWith({ cavemanObservations: false });
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
   });
 
   it('seeds missing thread metadata from the current harness state', async () => {
-    const harness = createHarness({ metadata: {}, state: { cavemanObservations: true } });
+    const session = createSession({ metadata: {}, state: { cavemanObservations: true } });
 
-    await restoreOMThreadStateForCurrentThread(harness as never);
+    await restoreOMThreadStateForCurrentThread(session as never);
 
-    expect(harness.session.state.set).not.toHaveBeenCalled();
-    expect(harness.session.thread.setSetting).toHaveBeenCalledWith({ key: 'cavemanObservations', value: true });
+    expect(session.state.set).not.toHaveBeenCalled();
+    expect(session.thread.setSetting).toHaveBeenCalledWith({ key: 'cavemanObservations', value: true });
   });
 
   it('seeds missing thread metadata from false current harness state', async () => {
-    const harness = createHarness({ metadata: {}, state: { cavemanObservations: false } });
+    const session = createSession({ metadata: {}, state: { cavemanObservations: false } });
 
-    await restoreOMThreadStateForCurrentThread(harness as never);
+    await restoreOMThreadStateForCurrentThread(session as never);
 
-    expect(harness.session.state.set).not.toHaveBeenCalled();
-    expect(harness.session.thread.setSetting).toHaveBeenCalledWith({ key: 'cavemanObservations', value: false });
+    expect(session.state.set).not.toHaveBeenCalled();
+    expect(session.thread.setSetting).toHaveBeenCalledWith({ key: 'cavemanObservations', value: false });
   });
 
   it('does nothing when there is no current thread', async () => {
-    const harness = createHarness({ currentThreadId: '', metadata: { cavemanObservations: true } });
+    const session = createSession({ currentThreadId: '', metadata: { cavemanObservations: true } });
 
-    await restoreOMThreadStateForCurrentThread(harness as never);
+    await restoreOMThreadStateForCurrentThread(session as never);
 
-    expect(harness.session.thread.list).not.toHaveBeenCalled();
-    expect(harness.session.state.set).not.toHaveBeenCalled();
-    expect(harness.session.thread.setSetting).not.toHaveBeenCalled();
+    expect(session.thread.list).not.toHaveBeenCalled();
+    expect(session.state.set).not.toHaveBeenCalled();
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
   });
 
   it('does not apply stale persisted metadata after the current thread changes', async () => {
-    const harness = createHarness({
+    const session = createSession({
       metadata: { cavemanObservations: true },
       state: { cavemanObservations: false },
-      onListThreads: () => harness.switchCurrentThread('thread-2'),
+      onListThreads: () => session.switchCurrentThread('thread-2'),
     });
 
-    await restoreOMThreadStateForCurrentThread(harness as never);
+    await restoreOMThreadStateForCurrentThread(session as never);
 
-    expect(harness.session.state.set).not.toHaveBeenCalled();
-    expect(harness.session.thread.setSetting).not.toHaveBeenCalled();
+    expect(session.state.set).not.toHaveBeenCalled();
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
   });
 
   it('does not seed stale metadata after the current thread changes', async () => {
-    const harness = createHarness({
+    const session = createSession({
       metadata: {},
       state: { cavemanObservations: true },
-      onListThreads: () => harness.switchCurrentThread('thread-2'),
+      onListThreads: () => session.switchCurrentThread('thread-2'),
     });
 
-    await restoreOMThreadStateForCurrentThread(harness as never);
+    await restoreOMThreadStateForCurrentThread(session as never);
 
-    expect(harness.session.state.set).not.toHaveBeenCalled();
-    expect(harness.session.thread.setSetting).not.toHaveBeenCalled();
+    expect(session.state.set).not.toHaveBeenCalled();
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
   });
 
   it('mirrors persisted observeAttachments metadata into harness state', async () => {
-    const harness = createHarness({ metadata: { observeAttachments: 'auto' }, state: { observeAttachments: true } });
+    const session = createSession({ metadata: { observeAttachments: 'auto' }, state: { observeAttachments: true } });
 
-    await restoreOMThreadStateForCurrentThread(harness as never);
+    await restoreOMThreadStateForCurrentThread(session as never);
 
-    expect(harness.session.state.set).toHaveBeenCalledWith({ observeAttachments: 'auto' });
-    expect(harness.session.thread.setSetting).not.toHaveBeenCalled();
+    expect(session.state.set).toHaveBeenCalledWith({ observeAttachments: 'auto' });
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
   });
 
   it('seeds missing observeAttachments metadata from current harness state', async () => {
-    const harness = createHarness({ metadata: {}, state: { observeAttachments: false } });
+    const session = createSession({ metadata: {}, state: { observeAttachments: false } });
 
-    await restoreOMThreadStateForCurrentThread(harness as never);
+    await restoreOMThreadStateForCurrentThread(session as never);
 
-    expect(harness.session.state.set).not.toHaveBeenCalled();
-    expect(harness.session.thread.setSetting).toHaveBeenCalledWith({ key: 'observeAttachments', value: false });
+    expect(session.state.set).not.toHaveBeenCalled();
+    expect(session.thread.setSetting).toHaveBeenCalledWith({ key: 'observeAttachments', value: false });
   });
 });

--- a/mastracode/src/agents/thread-caveman-state.ts
+++ b/mastracode/src/agents/thread-caveman-state.ts
@@ -1,4 +1,4 @@
-import type { Harness, HarnessThread } from '@mastra/core/harness';
+import type { HarnessThread, Session } from '@mastra/core/harness';
 
 interface ThreadStateSetting {
   key: string;
@@ -16,16 +16,16 @@ const THREAD_STATE_SETTINGS: ThreadStateSetting[] = [
   },
 ];
 
-function getStateValue(harness: Harness<Record<string, unknown>>, setting: ThreadStateSetting): unknown {
-  const value = harness.session.state.get()[setting.key];
+function getStateValue(session: Session<Record<string, unknown>>, setting: ThreadStateSetting): unknown {
+  const value = session.state.get()[setting.key];
   return setting.isValid(value) ? value : undefined;
 }
 
 async function findThread(
-  harness: Harness<Record<string, unknown>>,
+  session: Session<Record<string, unknown>>,
   threadId: string,
 ): Promise<HarnessThread | undefined> {
-  const threads = await harness.session.thread.list({ allResources: true });
+  const threads = await session.thread.list({ allResources: true });
   return threads.find(t => t.id === threadId);
 }
 
@@ -35,9 +35,9 @@ async function findThread(
  * - Otherwise, persist the current session.state value to the thread so future
  *   sessions see the user's last-selected setting.
  */
-async function restoreSettingsForThread(harness: Harness<Record<string, unknown>>, threadId: string): Promise<void> {
-  const thread = await findThread(harness, threadId);
-  if (harness.session.thread.getId() !== threadId) return;
+async function restoreSettingsForThread(session: Session<Record<string, unknown>>, threadId: string): Promise<void> {
+  const thread = await findThread(session, threadId);
+  if (session.thread.getId() !== threadId) return;
 
   const updates: Record<string, unknown> = {};
   const settingsToSeed: Array<{ key: string; value: unknown }> = [];
@@ -46,24 +46,24 @@ async function restoreSettingsForThread(harness: Harness<Record<string, unknown>
     const persisted = thread?.metadata?.[setting.key];
 
     if (setting.isValid(persisted)) {
-      if (getStateValue(harness, setting) !== persisted) {
+      if (getStateValue(session, setting) !== persisted) {
         updates[setting.key] = persisted;
       }
       continue;
     }
 
-    const current = getStateValue(harness, setting);
+    const current = getStateValue(session, setting);
     if (current !== undefined) {
       settingsToSeed.push({ key: setting.key, value: current });
     }
   }
 
   if (Object.keys(updates).length > 0) {
-    await harness.session.state.set(updates);
+    await session.state.set(updates);
   }
 
   for (const setting of settingsToSeed) {
-    await harness.session.thread.setSetting(setting);
+    await session.thread.setSetting(setting);
   }
 }
 
@@ -75,11 +75,11 @@ async function restoreSettingsForThread(harness: Harness<Record<string, unknown>
  * settings are mastracode-specific OM concepts, so persistence stays scoped to
  * the host.
  */
-export function attachOMThreadStatePersistence(harness: Harness<Record<string, unknown>>): void {
-  harness.session.subscribe(event => {
+export function attachOMThreadStatePersistence(session: Session<Record<string, unknown>>): void {
+  session.subscribe(event => {
     if (event.type === 'thread_changed' || event.type === 'thread_created') {
       const threadId = event.type === 'thread_changed' ? event.threadId : event.thread.id;
-      void restoreSettingsForThread(harness, threadId).catch(() => {
+      void restoreSettingsForThread(session, threadId).catch(() => {
         // Persistence is best-effort; don't crash the TUI if storage hiccups.
       });
     }
@@ -91,8 +91,8 @@ export function attachOMThreadStatePersistence(harness: Harness<Record<string, u
  * thread. Called once at TUI startup after the initial thread is selected,
  * since the subscription set up later misses the startup `thread_changed` event.
  */
-export async function restoreOMThreadStateForCurrentThread(harness: Harness<Record<string, unknown>>): Promise<void> {
-  const threadId = harness.session.thread.getId();
+export async function restoreOMThreadStateForCurrentThread(session: Session<Record<string, unknown>>): Promise<void> {
+  const threadId = session.thread.getId();
   if (!threadId) return;
-  await restoreSettingsForThread(harness, threadId);
+  await restoreSettingsForThread(session, threadId);
 }

--- a/mastracode/src/evals/context-builder.ts
+++ b/mastracode/src/evals/context-builder.ts
@@ -9,7 +9,7 @@
 import type { MastraDBMessage } from '@mastra/core/agent';
 import { extractTrajectoryFromTrace } from '@mastra/core/evals';
 import type { ScorerRunInputForAgent, ScorerRunOutputForAgent, Trajectory } from '@mastra/core/evals';
-import type { Harness } from '@mastra/core/harness';
+import type { Harness, Session } from '@mastra/core/harness';
 import type { CoreMessage, CoreSystemMessage } from '@mastra/core/llm';
 import type { MastraCompositeStore } from '@mastra/core/storage';
 
@@ -31,6 +31,8 @@ export type MastraCodeEvalContext = {
 export type BuildContextOptions = {
   /** Harness instance to extract data from */
   harness: Harness<any>;
+  /** Session whose state/model/thread is being evaluated */
+  session: Session<any>;
   /** Thread ID to build context for (defaults to current thread) */
   threadId?: string;
   /** Limit messages to the last N turns (user+assistant pairs). Undefined = all messages */
@@ -44,8 +46,8 @@ export type BuildContextOptions = {
  * and packages everything into the format scorers expect.
  */
 export async function buildEvalContext(options: BuildContextOptions): Promise<MastraCodeEvalContext> {
-  const { harness, lastNTurns } = options;
-  const threadId = options.threadId ?? harness.session.thread.getId();
+  const { harness, session, lastNTurns } = options;
+  const threadId = options.threadId ?? session.thread.getId();
 
   if (!threadId) {
     throw new Error('No thread ID available. Start a session before building eval context.');
@@ -64,7 +66,7 @@ export async function buildEvalContext(options: BuildContextOptions): Promise<Ma
   const { trajectory, traceId } = await extractSessionTrajectory(storage, threadId);
 
   // 4. Build request context from Harness state
-  const requestContext = buildRequestContext(harness, threadId);
+  const requestContext = buildRequestContext(session, threadId);
 
   return {
     agentInput: {
@@ -214,13 +216,13 @@ async function extractSessionTrajectory(
 /**
  * Build request context from Harness state for scorer evaluation.
  */
-function buildRequestContext(harness: Harness<any>, threadId: string): Record<string, unknown> {
-  const state = harness.session.state.get() as Record<string, unknown>;
+function buildRequestContext(session: Session<any>, threadId: string): Record<string, unknown> {
+  const state = session.state.get() as Record<string, unknown>;
 
   return {
     threadId,
     mode: state.currentMode ?? state.mode,
-    modelId: harness.session.model.get(),
+    modelId: session.model.get(),
     projectPath: state.projectPath,
     projectName: state.projectName,
     gitBranch: state.gitBranch,

--- a/mastracode/src/headless-integration.test.ts
+++ b/mastracode/src/headless-integration.test.ts
@@ -188,14 +188,14 @@ describe('headless mode — event-driven auto-resolution', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'Say hello' });
+    await session.sendMessage({ content: 'Say hello' });
 
     const types = events.map(e => e.type);
     expect(types).toContain('agent_start');
@@ -229,14 +229,14 @@ describe('headless mode — event-driven auto-resolution', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'Read test.txt' });
+    await session.sendMessage({ content: 'Read test.txt' });
 
     const types = events.map(e => e.type);
     expect(types).toContain('tool_start');
@@ -250,14 +250,14 @@ describe('headless mode — event-driven auto-resolution', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'Do something' });
+    await session.sendMessage({ content: 'Do something' });
 
     const messageUpdates = events.filter(e => e.type === 'message_update');
     expect(messageUpdates.length).toBeGreaterThan(0);
@@ -292,15 +292,15 @@ describe('headless mode — event-driven auto-resolution', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
     // Fire-and-forget (same pattern as headless mode)
-    const sendPromise = harness.session.sendMessage({ content: 'Do something slow' });
+    const sendPromise = session.sendMessage({ content: 'Do something slow' });
 
     // Wait for agent_start, then abort
     await new Promise<void>(resolve => {
@@ -314,7 +314,7 @@ describe('headless mode — event-driven auto-resolution', () => {
       check();
     });
 
-    harness.session.abort();
+    session.abort();
 
     // sendMessage should resolve (possibly with error)
     await sendPromise.catch(() => {});
@@ -362,14 +362,14 @@ describe('headless mode — event-driven auto-resolution', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'Check the nested instructions' });
+    await session.sendMessage({ content: 'Check the nested instructions' });
 
     expect(mockExecute).toHaveBeenCalledTimes(1);
 
@@ -465,14 +465,14 @@ describe('headless mode — --output-format contracts', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const {
       result: exitCode,
       stdout,
       stderr,
     } = await captureProcessOutput(() =>
-      runHeadless(harness, {
+      runHeadless(harness, session, {
         prompt: 'Hello',
         format: 'default',
         outputFormat: 'text',
@@ -492,7 +492,7 @@ describe('headless mode — --output-format contracts', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const {
       result: exitCode,
@@ -500,7 +500,7 @@ describe('headless mode — --output-format contracts', () => {
       stderr,
       stdoutChunks,
     } = await captureProcessOutput(() =>
-      runHeadless(harness, {
+      runHeadless(harness, session, {
         prompt: 'Hello',
         format: 'default',
         outputFormat: 'json',
@@ -530,14 +530,14 @@ describe('headless mode — --output-format contracts', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const {
       result: exitCode,
       stdout,
       stderr,
     } = await captureProcessOutput(() =>
-      runHeadless(harness, {
+      runHeadless(harness, session, {
         prompt: 'Hello',
         format: 'default',
         outputFormat: 'stream-json',
@@ -604,7 +604,7 @@ describe('headless mode — --output-format contracts', () => {
       stdout,
       stderr,
     } = await captureProcessOutput(() =>
-      runHeadless(harness, {
+      runHeadless(harness as unknown as Harness<Record<string, unknown>>, (harness as any).session as any, {
         prompt: 'Describe the browser state',
         format: 'default',
         outputFormat: 'stream-json',
@@ -649,12 +649,12 @@ describe('headless mode — --model flag', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: false,
@@ -668,7 +668,7 @@ describe('headless mode — --model flag', () => {
     expect(modelChanged.modelId).toBe('anthropic/claude-haiku-4-5');
 
     // Verify the harness state was updated
-    expect(harness.session.model.get()).toBe('anthropic/claude-haiku-4-5');
+    expect(session.model.get()).toBe('anthropic/claude-haiku-4-5');
   });
 
   it('returns exit code 1 for an unknown model', async () => {
@@ -680,7 +680,7 @@ describe('headless mode — --model flag', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const stderrCalls: string[] = [];
     const origWrite = process.stderr.write.bind(process.stderr);
@@ -690,9 +690,9 @@ describe('headless mode — --model flag', () => {
     });
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: false,
@@ -722,7 +722,7 @@ describe('headless mode — --model flag', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const stderrCalls: string[] = [];
     const origWrite = process.stderr.write.bind(process.stderr);
@@ -732,9 +732,9 @@ describe('headless mode — --model flag', () => {
     });
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: false,
@@ -756,11 +756,11 @@ describe('headless mode — --model flag', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'json',
       continue_: false,
@@ -795,11 +795,11 @@ describe('headless mode — --model flag', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'json',
       continue_: false,
@@ -828,7 +828,7 @@ describe('headless mode — --model flag', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const stderrCalls: string[] = [];
     const origWrite = process.stderr.write.bind(process.stderr);
@@ -837,7 +837,7 @@ describe('headless mode — --model flag', () => {
       return origWrite(...(args as Parameters<typeof origWrite>));
     });
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: false,
@@ -849,7 +849,7 @@ describe('headless mode — --model flag', () => {
 
     expect(exitCode).toBe(0);
     expect(stderrCalls.join('')).toContain('--model overrides --mode');
-    expect(harness.session.model.get()).toBe('anthropic/claude-haiku-4-5');
+    expect(session.model.get()).toBe('anthropic/claude-haiku-4-5');
   });
 
   it('emits structured warning in JSON mode when --model and --mode are both provided', async () => {
@@ -861,11 +861,11 @@ describe('headless mode — --model flag', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'json',
       continue_: false,
@@ -889,12 +889,12 @@ describe('headless mode — --model flag', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: false,
@@ -915,13 +915,14 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
     const exitCode = await runHeadless(
       harness,
+      session,
       {
         prompt: 'Hello',
         format: 'default',
@@ -932,7 +933,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(harness.session.model.get()).toBe('cerebras/zai-glm-4.7');
+    expect(session.model.get()).toBe('cerebras/zai-glm-4.7');
   });
 
   it('--model still overrides effectiveDefaults', async () => {
@@ -945,10 +946,11 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const exitCode = await runHeadless(
       harness,
+      session,
       {
         prompt: 'Hello',
         format: 'default',
@@ -961,7 +963,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
 
     expect(exitCode).toBe(0);
     // --model should win over effectiveDefaults
-    expect(harness.session.model.get()).toBe('anthropic/claude-haiku-4-5');
+    expect(session.model.get()).toBe('anthropic/claude-haiku-4-5');
   });
 
   it('--mode returns exit code 1 when resolved model is not available', async () => {
@@ -971,7 +973,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const stderrCalls: string[] = [];
     const origWrite = process.stderr.write.bind(process.stderr);
@@ -982,6 +984,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
 
     const exitCode = await runHeadless(
       harness,
+      session,
       {
         prompt: 'Hello',
         format: 'default',
@@ -1014,7 +1017,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const stderrCalls: string[] = [];
     const origWrite = process.stderr.write.bind(process.stderr);
@@ -1025,6 +1028,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
 
     const exitCode = await runHeadless(
       harness,
+      session,
       {
         prompt: 'Hello',
         format: 'default',
@@ -1048,7 +1052,7 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     });
 
     await harness.init();
-    await harness.selectOrCreateThread();
+    const session = await harness.createSession();
 
     const stderrCalls: string[] = [];
     const origWrite = process.stderr.write.bind(process.stderr);
@@ -1058,10 +1062,10 @@ describe('headless mode — --mode with effectiveDefaults', () => {
     });
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
     // No effectiveDefaults passed — should warn, not error
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: false,
@@ -1084,12 +1088,13 @@ describe('headless mode — thread control', () => {
     });
 
     await harness.init();
-    const thread = await harness.session.thread.create({ title: 'target-thread' });
+    const session = await harness.createSession();
+    const thread = await session.thread.create({ title: 'target-thread' });
     const updatedAtBefore = thread.updatedAt.getTime();
 
     await new Promise(resolve => setTimeout(resolve, 300));
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: false,
@@ -1103,7 +1108,7 @@ describe('headless mode — thread control', () => {
     await new Promise(resolve => setTimeout(resolve, 300));
 
     // Verify the targeted thread was actually used (updatedAt advanced)
-    const threads = await harness.session.thread.list();
+    const threads = await session.thread.list();
     const targeted = threads.find(t => t.id === thread.id);
     expect(targeted).toBeDefined();
     expect(targeted!.updatedAt.getTime()).toBeGreaterThan(updatedAtBefore);
@@ -1115,12 +1120,13 @@ describe('headless mode — thread control', () => {
     });
 
     await harness.init();
-    const thread = await harness.session.thread.create({ title: 'my-feature' });
+    const session = await harness.createSession();
+    const thread = await session.thread.create({ title: 'my-feature' });
     const updatedAtBefore = thread.updatedAt.getTime();
 
     await new Promise(resolve => setTimeout(resolve, 300));
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: false,
@@ -1134,7 +1140,7 @@ describe('headless mode — thread control', () => {
     await new Promise(resolve => setTimeout(resolve, 300));
 
     // Verify the titled thread was actually used
-    const threads = await harness.session.thread.list();
+    const threads = await session.thread.list();
     const targeted = threads.find(t => t.id === thread.id);
     expect(targeted).toBeDefined();
     expect(targeted!.updatedAt.getTime()).toBeGreaterThan(updatedAtBefore);
@@ -1146,8 +1152,9 @@ describe('headless mode — thread control', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: false,
@@ -1164,9 +1171,10 @@ describe('headless mode — thread control', () => {
     });
 
     await harness.init();
-    await harness.session.thread.create({ title: 'original-title' });
+    const session = await harness.createSession();
+    await session.thread.create({ title: 'original-title' });
 
-    const exitCode = await runHeadless(harness, {
+    const exitCode = await runHeadless(harness, session, {
       prompt: 'Hello',
       format: 'default',
       continue_: true,
@@ -1176,7 +1184,7 @@ describe('headless mode — thread control', () => {
 
     expect(exitCode).toBe(0);
 
-    const threads = await harness.session.thread.list();
+    const threads = await session.thread.list();
     const titled = threads.find(t => t.title === 'my-new-title');
     expect(titled).toBeDefined();
   });
@@ -1187,15 +1195,16 @@ describe('headless mode — thread control', () => {
     });
 
     await harness.init();
-    harness.setResourceId({ resourceId: 'resource-a' });
-    const alphaOlderThread = await harness.session.thread.create({ title: 'older-alpha' });
-    harness.setResourceId({ resourceId: 'resource-b' });
-    const betaThread = await harness.session.thread.create({ title: 'shared-title' });
+    const session = await harness.createSession();
+    harness.setResourceId(session, { resourceId: 'resource-a' });
+    const alphaOlderThread = await session.thread.create({ title: 'older-alpha' });
+    harness.setResourceId(session, { resourceId: 'resource-b' });
+    const betaThread = await session.thread.create({ title: 'shared-title' });
     await new Promise(resolve => setTimeout(resolve, 5));
-    harness.setResourceId({ resourceId: 'resource-a' });
-    const alphaThread = await harness.session.thread.create({ title: 'shared-title' });
+    harness.setResourceId(session, { resourceId: 'resource-a' });
+    const alphaThread = await session.thread.create({ title: 'shared-title' });
 
-    let exitCode = await runHeadless(harness, {
+    let exitCode = await runHeadless(harness, session, {
       prompt: 'Hello beta',
       format: 'default',
       continue_: false,
@@ -1205,10 +1214,10 @@ describe('headless mode — thread control', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(harness.session.identity.getResourceId()).toBe('resource-b');
-    expect(harness.session.thread.getId()).toBe(betaThread.id);
+    expect(session.identity.getResourceId()).toBe('resource-b');
+    expect(session.thread.getId()).toBe(betaThread.id);
 
-    exitCode = await runHeadless(harness, {
+    exitCode = await runHeadless(harness, session, {
       prompt: 'Hello alpha',
       format: 'default',
       continue_: true,
@@ -1217,9 +1226,9 @@ describe('headless mode — thread control', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(harness.session.identity.getResourceId()).toBe('resource-a');
-    expect(harness.session.thread.getId()).toBe(alphaThread.id);
-    expect(harness.session.thread.getId()).not.toBe(alphaOlderThread.id);
+    expect(session.identity.getResourceId()).toBe('resource-a');
+    expect(session.thread.getId()).toBe(alphaThread.id);
+    expect(session.thread.getId()).not.toBe(alphaOlderThread.id);
   });
 
   it('emits thread_cloned event with new thread ID when cloning a named thread', async () => {
@@ -1264,7 +1273,8 @@ describe('headless mode — thread control', () => {
     (harness as any).getAgentForMode = () => registeredAgent;
 
     await harness.init();
-    const sourceThread = await harness.session.thread.create({ title: 'source-thread' });
+    const session = await harness.createSession();
+    const sourceThread = await session.thread.create({ title: 'source-thread' });
 
     const events: any[] = [];
     const originalWrite = process.stdout.write;
@@ -1278,7 +1288,7 @@ describe('headless mode — thread control', () => {
     }) as any;
 
     try {
-      const exitCode = await runHeadless(harness, {
+      const exitCode = await runHeadless(harness, session, {
         prompt: 'Hello',
         format: 'json',
         continue_: false,

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -4,7 +4,7 @@
 import { existsSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 
-import type { Harness, HarnessEvent, HarnessMessage } from '@mastra/core/harness';
+import type { Harness, HarnessEvent, HarnessMessage, Session } from '@mastra/core/harness';
 
 import { setupDebugLogging } from './utils/debug-log.js';
 import { releaseAllThreadLocks } from './utils/thread-lock.js';
@@ -201,18 +201,18 @@ function resolveExitCode(reason?: string): number {
 }
 
 function autoResolve<TState extends Record<string, unknown>>(
-  harness: Harness<TState>,
+  session: Session<TState>,
   event: HarnessEvent,
 ): { resolved: true; label: string; json: Record<string, unknown> } | { resolved: false } {
   switch (event.type) {
     case 'tool_approval_required': {
-      harness.session.respondToToolApproval({ decision: 'approve' });
+      session.respondToToolApproval({ decision: 'approve' });
       return { resolved: true, label: `[auto-approved] ${event.toolName}`, json: { ...event, autoApproved: true } };
     }
     case 'tool_suspended': {
       const payload = (event.suspendPayload ?? {}) as Record<string, unknown>;
       if (event.toolName === 'request_access' || payload.kind === 'sandbox_access_request') {
-        void harness.session.respondToToolSuspension({ toolCallId: event.toolCallId, resumeData: 'Yes' });
+        void session.respondToToolSuspension({ toolCallId: event.toolCallId, resumeData: 'Yes' });
         return {
           resolved: true,
           label: `[auto-approved sandbox] ${String(payload.path ?? '')}`,
@@ -220,14 +220,14 @@ function autoResolve<TState extends Record<string, unknown>>(
         };
       }
       if (event.toolName === 'submit_plan') {
-        void harness.session.respondToToolSuspension({ toolCallId: event.toolCallId, resumeData: { action: 'approved' } });
+        void session.respondToToolSuspension({ toolCallId: event.toolCallId, resumeData: { action: 'approved' } });
         return {
           resolved: true,
           label: `[auto-approved plan] ${String(payload.title ?? '')}`,
           json: { ...event, autoApproved: true },
         };
       }
-      void harness.session.respondToToolSuspension({
+      void session.respondToToolSuspension({
         toolCallId: event.toolCallId,
         resumeData: 'Proceed with your best judgment. Do not ask further questions.',
       });
@@ -346,18 +346,18 @@ function aggregateIntoSummary(event: HarnessEvent, summary: HeadlessSummary): vo
 function finalizeSummary<TState extends Record<string, unknown>>(
   summary: HeadlessSummary,
   endEvent: Extract<HarnessEvent, { type: 'agent_end' }>,
-  harness: Harness<TState>,
+  session: Session<TState>,
 ): void {
   summary.finishReason = endEvent.reason;
-  summary.threadId = harness.session.thread.getId() ?? undefined;
+  summary.threadId = session.thread.getId() ?? undefined;
 }
 
 /** Resolve a thread by ID or title. Tries exact ID match first, then title. */
 async function resolveThread<TState extends Record<string, unknown>>(
-  harness: Harness<TState>,
+  session: Session<TState>,
   threadIdOrTitle: string,
 ): Promise<{ threadId: string; matchType: 'id' | 'title' } | { error: string }> {
-  const threads = await harness.session.thread.list();
+  const threads = await session.thread.list();
 
   const byId = threads.find(t => t.id === threadIdOrTitle);
   if (byId) return { threadId: byId.id, matchType: 'id' };
@@ -378,6 +378,7 @@ async function resolveThread<TState extends Record<string, unknown>>(
  */
 export async function runHeadless<TState extends Record<string, unknown>>(
   harness: Harness<TState>,
+  session: Session<TState>,
   args: HeadlessArgs & { prompt: string },
   effectiveDefaults?: Record<string, string>,
 ): Promise<number> {
@@ -399,7 +400,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
       } else {
         process.stderr.write(`\nTimeout: ${args.timeout}s elapsed. Aborting.\n`);
       }
-      harness.session.abort();
+      session.abort();
     }, args.timeout * 1000);
   }
 
@@ -432,7 +433,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
       const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
       return failEarly(`Model "${args.model}" has no API key configured.${keyHint}`);
     }
-    await harness.session.model.switch({ modelId: args.model });
+    await session.model.switch({ modelId: args.model });
     if (!emit) process.stderr.write(`[model] ${args.model}\n`);
   } else if (args.mode) {
     // --mode flag: look up model from effectiveDefaults (resolved from settings at startup)
@@ -447,7 +448,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
         const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
         return failEarly(`Model "${modelId}" (mode: ${args.mode}) has no API key configured.${keyHint}`);
       }
-      await harness.session.model.switch({ modelId });
+      await session.model.switch({ modelId });
       if (!emit) process.stderr.write(`[model] ${modelId} (mode: ${args.mode})\n`);
     } else {
       const warnMsg = `--mode ${args.mode} has no configured model, using default`;
@@ -458,7 +459,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
 
   // --- Resolve thinking level ---
   if (args.thinkingLevel) {
-    await harness.session.state.set({ thinkingLevel: args.thinkingLevel } as unknown as Partial<TState>);
+    await session.state.set({ thinkingLevel: args.thinkingLevel } as unknown as Partial<TState>);
     if (!emit) process.stderr.write(`[thinking] ${args.thinkingLevel}\n`);
   }
 
@@ -470,8 +471,8 @@ export async function runHeadless<TState extends Record<string, unknown>>(
   const streamCtx = { lastTextLength: 0 };
 
   const done = new Promise<number>(resolve => {
-    harness.session.subscribe(event => {
-      const result = autoResolve(harness, event);
+    session.subscribe(event => {
+      const result = autoResolve(session, event);
       if (result.resolved) {
         if (emit) emit(result.json);
         else if (!outputFormat) process.stderr.write(result.label + '\n');
@@ -486,7 +487,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
 
       if (event.type === 'agent_end') {
         if (summary) {
-          finalizeSummary(summary, event, harness);
+          finalizeSummary(summary, event, session);
           process.stdout.write(JSON.stringify(summary) + '\n');
         } else if (textBuffer !== null) {
           process.stdout.write(textBuffer);
@@ -508,14 +509,14 @@ export async function runHeadless<TState extends Record<string, unknown>>(
 
   // --- Resource ID ---
   if (args.resourceId) {
-    harness.setResourceId({ resourceId: args.resourceId });
+    harness.setResourceId(session, { resourceId: args.resourceId });
     if (!emit) process.stderr.write(`[resource] ${args.resourceId}\n`);
   }
 
   // --- Thread selection ---
   try {
     if (args.thread) {
-      const result = await resolveThread(harness, args.thread);
+      const result = await resolveThread(session, args.thread);
       if ('error' in result) {
         const msg = result.error;
         if (emit) emit({ type: 'error', error: { message: msg } });
@@ -523,13 +524,13 @@ export async function runHeadless<TState extends Record<string, unknown>>(
         if (timeoutId) clearTimeout(timeoutId);
         return 1;
       }
-      await harness.session.thread.switch({ threadId: result.threadId });
+      await session.thread.switch({ threadId: result.threadId });
       if (!emit) process.stderr.write(`[thread] resumed ${result.threadId} (matched by ${result.matchType})\n`);
     } else if (args.continue_) {
-      const threads = await harness.session.thread.list();
+      const threads = await session.thread.list();
       if (threads.length > 0) {
         const sorted = [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
-        await harness.session.thread.switch({ threadId: sorted[0]!.id });
+        await session.thread.switch({ threadId: sorted[0]!.id });
         if (!emit) process.stderr.write(`[continued] thread ${sorted[0]!.id}\n`);
       } else if (!emit) {
         process.stderr.write(`[info] No existing threads found, starting new thread\n`);
@@ -547,7 +548,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
   // --- Clone ---
   if (args.cloneThread) {
     try {
-      const cloned = await harness.session.thread.clone();
+      const cloned = await session.thread.clone();
       if (emit) emit({ type: 'thread_cloned', threadId: cloned.id });
       else process.stderr.write(`[cloned] thread ${cloned.id}\n`);
     } catch (err) {
@@ -562,7 +563,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
   // --- Title ---
   if (args.title) {
     try {
-      await harness.session.thread.rename({ title: args.title });
+      await session.thread.rename({ title: args.title });
       if (!emit) process.stderr.write(`[title] "${args.title}"\n`);
     } catch (err) {
       const msg = `Failed to set thread title: ${(err as Error).message}`;
@@ -573,7 +574,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
     }
   }
 
-  await harness.session.sendMessage({ content: args.prompt });
+  await session.sendMessage({ content: args.prompt });
 
   const exitCode = await done;
   if (timeoutId) clearTimeout(timeoutId);
@@ -622,7 +623,7 @@ export async function headlessMain(predrainedInput?: string | null): Promise<nev
   }
 
   const result = await createMastraCode({ settingsPath: args.settings });
-  const { harness, mcpManager, effectiveDefaults } = result;
+  const { harness, session, mcpManager, effectiveDefaults } = result;
 
   if (mcpManager?.hasServers()) {
     try {
@@ -633,10 +634,8 @@ export async function headlessMain(predrainedInput?: string | null): Promise<nev
   }
 
   setupDebugLogging();
-  await harness.init();
-  await harness.getMastra()?.startWorkers();
 
-  const exitCode = await runHeadless(harness, { ...args, prompt }, effectiveDefaults);
+  const exitCode = await runHeadless(harness, session, { ...args, prompt }, effectiveDefaults);
 
   // Cleanup
   releaseAllThreadLocks();

--- a/mastracode/src/index.test.ts
+++ b/mastracode/src/index.test.ts
@@ -17,12 +17,23 @@ vi.mock('@mastra/core/agent', () => ({
 
 vi.mock('@mastra/core/harness', () => ({
   Harness: class {
-    session = { subscribe() {} };
-
     constructor(config: { heartbeatHandlers?: Array<{ immediate?: boolean; handler: () => unknown }> }) {
       for (const heartbeat of config.heartbeatHandlers ?? []) {
         if (heartbeat.immediate !== false) void heartbeat.handler();
       }
+    }
+
+    async init() {}
+
+    getMastra() {
+      return undefined;
+    }
+
+    async createSession() {
+      return {
+        subscribe() {},
+        thread: { getId: () => undefined },
+      };
     }
   },
   taskWriteTool: {},

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -418,8 +418,18 @@ export async function createMastraCode(config?: MastraCodeConfig) {
           process.env.GITCRAWL_BIN ??
           process.env.MASTRACODE_GITCRAWL_COMMAND ??
           process.env.GITCRAWL_COMMAND,
-        getNotificationStreamOptions: ({ resourceId, threadId }) => {
-          const session = activeSession!;
+        getNotificationStreamOptions: async ({ resourceId, threadId }) => {
+          // Run the woken notification as the session that owns the target
+          // resource so it uses that session's model/mode/state. Fall back to
+          // the current session only when no session owns the resource yet.
+          const session = (await harness.getSessionByResource(resourceId)) ?? activeSession!;
+          // A long-running system must be able to drive work unattended, so a
+          // target session without an explicit model selection falls back to a
+          // real model rather than failing the run: the current session's live
+          // selection (what the user actually picked), then the mode's default.
+          const modeId = session.mode.get();
+          const defaultModeModelId = harness.listModes().find(mode => mode.id === modeId)?.defaultModelId;
+          const modelId = session.model.get() || activeSession?.model.get() || defaultModeModelId || '';
           const requestContext = new RequestContext();
           const harnessContext: HarnessRequestContext = {
             harnessId: harness.id,
@@ -429,8 +439,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
             threadId,
             resourceId,
             session: {
-              modeId: session.mode.get(),
-              modelId: session.model.get(),
+              modeId,
+              modelId,
               state: {
                 get: () => session.state.get(),
                 set: updates => session.state.set(updates),

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -10,6 +10,7 @@ import type {
   HarnessMode,
   HarnessSubagent,
   HarnessRequestContext,
+  Session,
 } from '@mastra/core/harness';
 import { PROVIDER_REGISTRY } from '@mastra/core/llm';
 import type { ProviderConfig } from '@mastra/core/llm';
@@ -203,6 +204,10 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   const cwd = config?.cwd ?? process.cwd();
   const homeDir = config?.homeDir ?? config?.initialState?.homeDir;
   const configDir = config?.configDir ?? DEFAULT_CONFIG_DIR;
+  // The single session for this process, assigned once `createSession()` runs
+  // below. Config callbacks defined before then (e.g. notification stream
+  // options) read it lazily through this holder.
+  let activeSession: Session<MastraCodeState> | undefined;
   if (configDir !== DEFAULT_CONFIG_DIR) {
     validateConfigDirName(configDir);
   }
@@ -414,25 +419,26 @@ export async function createMastraCode(config?: MastraCodeConfig) {
           process.env.MASTRACODE_GITCRAWL_COMMAND ??
           process.env.GITCRAWL_COMMAND,
         getNotificationStreamOptions: ({ resourceId, threadId }) => {
+          const session = activeSession!;
           const requestContext = new RequestContext();
           const harnessContext: HarnessRequestContext = {
             harnessId: harness.id,
-            state: harness.session.state.get(),
-            getState: () => harness.session.state.get(),
-            setState: updates => harness.session.state.set(updates),
+            state: session.state.get(),
+            getState: () => session.state.get(),
+            setState: updates => session.state.set(updates),
             threadId,
             resourceId,
             session: {
-              modeId: harness.session.mode.get(),
-              modelId: harness.session.model.get(),
+              modeId: session.mode.get(),
+              modelId: session.model.get(),
               state: {
-                get: () => harness.session.state.get(),
-                set: updates => harness.session.state.set(updates),
-                update: updater => harness.session.state.update(updater),
+                get: () => session.state.get(),
+                set: updates => session.state.set(updates),
+                update: updater => session.state.update(updater),
               },
             },
             workspace: harness.getWorkspace(),
-            getSubagentModelId: params => harness.session.subagents.model.get(params ?? {}),
+            getSubagentModelId: params => session.subagents.model.get(params ?? {}),
           };
           requestContext.set('harness', harnessContext);
 
@@ -441,7 +447,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
             requestContext,
             maxSteps: 1000,
             savePerStep: false,
-            requireToolApproval: (harness.session.state.get() as Record<string, unknown>).yolo !== true,
+            requireToolApproval: (session.state.get() as Record<string, unknown>).yolo !== true,
             modelSettings: { temperature: 1 },
           };
         },
@@ -706,9 +712,16 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     // , harnessV1
   });
 
+  // Bring up shared harness resources, then mint the single session that all
+  // work in this process runs through. The Harness owns no session of its own.
+  await harness.init();
+  await harness.getMastra()?.startWorkers();
+  const session = await harness.createSession();
+  activeSession = session;
+
   // Sync hookManager session ID on thread changes
   if (hookManager) {
-    harness.session.subscribe((event: HarnessEvent) => {
+    session.subscribe((event: HarnessEvent) => {
       if (event.type === 'thread_changed') {
         hookManager.setSessionId(event.threadId);
       } else if (event.type === 'thread_created') {
@@ -722,12 +735,12 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       if (!threadId) return;
       githubSignals.stopAllPolling();
       try {
-        const threads = await harness.session.thread.list({ allResources: true });
+        const threads = await session.thread.list({ allResources: true });
         const thread = threads.find((item: { id: string }) => item.id === threadId);
         await githubSignals.startPollingForThread(
           {
             threadId,
-            resourceId: thread?.resourceId ?? harness.session.identity.getResourceId(),
+            resourceId: thread?.resourceId ?? session.identity.getResourceId(),
           },
           { pollImmediately: true },
         );
@@ -736,23 +749,24 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       }
     };
 
-    harness.session.subscribe((event: HarnessEvent) => {
+    session.subscribe((event: HarnessEvent) => {
       if (event.type === 'thread_changed') void startGithubPollingForCurrentThread(event.threadId);
       else if (event.type === 'thread_created') void startGithubPollingForCurrentThread(event.thread.id);
     });
-    void startGithubPollingForCurrentThread(harness.session.thread.getId());
+    void startGithubPollingForCurrentThread(session.thread.getId());
   }
 
   // Persist MastraCode-owned /om settings per-thread (mastracode-only concern;
   // intentionally not in core's harness loadThreadMetadata).
-  const omThreadStateHarness = harness as unknown as Harness<Record<string, unknown>>;
-  attachOMThreadStatePersistence(omThreadStateHarness);
-  await restoreOMThreadStateForCurrentThread(omThreadStateHarness).catch(() => {
+  const omThreadStateSession = session as unknown as Session<Record<string, unknown>>;
+  attachOMThreadStatePersistence(omThreadStateSession);
+  await restoreOMThreadStateForCurrentThread(omThreadStateSession).catch(() => {
     // Persistence is best-effort; don't crash startup if storage hiccups.
   });
 
   return {
     harness,
+    session,
     mcpManager,
     hookManager,
     signalsPubSub,

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -103,10 +103,14 @@ async function tuiMain(pipedInput?: string | null) {
   }
   applyThemeMode(themeMode, detectedBgHex);
 
+  // createMastraCode() brought up shared resources and minted the single
+  // session that all work runs through. The Harness owns no session of its own.
+  const session = result.session;
+
   analytics = createMastraCodeAnalytics({ version: getCurrentVersion() });
   analytics.capture('mastracode_session_started', {
-    mode: harness.session.mode.get(),
-    resourceId: harness.session.identity.getResourceId(),
+    mode: session.mode.get(),
+    resourceId: session.identity.getResourceId(),
     hasAuthStorage: Boolean(authStorage),
     hasMcp: Boolean(mcpManager),
     theme: themeMode,
@@ -114,6 +118,7 @@ async function tuiMain(pipedInput?: string | null) {
 
   const tui = new MastraTUI({
     harness,
+    session,
     hookManager,
     analytics,
     authStorage,
@@ -133,7 +138,7 @@ async function tuiMain(pipedInput?: string | null) {
       .then(browser => {
         if (!browser) return;
         harness.setBrowser(browser);
-        void harness.session.state.set({ activeBrowserSettings: settings.browser } as any).catch(() => {});
+        void session.state.set({ activeBrowserSettings: settings.browser } as any).catch(() => {});
       })
       .catch(() => {});
   }

--- a/mastracode/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/src/tui/__tests__/command-dispatch.test.ts
@@ -338,6 +338,7 @@ describe('dispatchSlashCommand models routing', () => {
     };
     const workspace = { skills: { get: vi.fn().mockResolvedValue(skill) } };
     const ctx = {
+      state,
       getResolvedWorkspace: vi.fn(() => undefined),
       harness: {
         hasWorkspace: vi.fn(() => true),

--- a/mastracode/src/tui/__tests__/harness-mock.ts
+++ b/mastracode/src/tui/__tests__/harness-mock.ts
@@ -159,6 +159,11 @@ export function createMockHarness(opts: MockHarnessOptions = {}) {
     getResolvedWorkspace: vi.fn(async () => undefined),
     getKnownResourceIds: vi.fn(async () => []),
     setResourceId: vi.fn(),
+    // Host-level reads that now take the session as an explicit argument.
+    getCurrentAgent: vi.fn(),
+    getCurrentModelAuthStatus: vi.fn(async () => ({ hasAuth: true, apiKeyEnvVar: undefined })),
+    loadOMProgress: vi.fn(async () => {}),
+    getObservationalMemoryRecord: vi.fn(async () => null),
   };
 
   return deepMerge(base, opts.harness) as unknown as Harness<Record<string, unknown>> & {

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -30,9 +30,8 @@ function createState(): TUIState {
     messageComponentsById: new Map(),
     pendingSignalMessageComponentsById: new Map(),
     followUpComponents: [],
-    harness: {
-      session: { displayState: { get: () => ({ isRunning: false }) } },
-    },
+    session: { displayState: { get: () => ({ isRunning: false }) } },
+    harness: { session: { displayState: { get: () => ({ isRunning: false }) } } },
   } as unknown as TUIState;
 }
 
@@ -633,12 +632,10 @@ describe('renderExistingMessages subagents', () => {
     state.session = {
       ...state.session,
       thread: { listActiveMessages: vi.fn().mockResolvedValue([message]) },
+      model: { get: () => 'openai/gpt-5.5' },
     } as unknown as TUIState['session'];
     state.harness = {
-      session: {
-        displayState: { get: () => ({ isRunning: false }) },
-        model: { get: () => 'openai/gpt-5.5' },
-      },
+      session: state.session,
     } as unknown as TUIState['harness'];
 
     await renderExistingMessages(state);

--- a/mastracode/src/tui/__tests__/state.test.ts
+++ b/mastracode/src/tui/__tests__/state.test.ts
@@ -41,17 +41,20 @@ vi.mock('../../utils/project.js', async importOriginal => {
 
 import { createTUIState } from '../state.js';
 
-function createHarness() {
+function createSession() {
   return {
-    session: {
-      mode: { resolve: vi.fn(() => ({ id: 'build', metadata: { color: '#7c3aed' } })) },
-    },
+    mode: { resolve: vi.fn(() => ({ id: 'build', metadata: { color: '#7c3aed' } })) },
   };
+}
+
+function createHarness(session: ReturnType<typeof createSession>) {
+  return { session };
 }
 
 describe('createTUIState', () => {
   it('initializes the shared TUI runtime defaults used by chat handlers', () => {
-    const harness = createHarness();
+    const session = createSession();
+    const harness = createHarness(session);
     const hookManager = {};
     const analytics = {};
     const authStorage = {};
@@ -60,6 +63,7 @@ describe('createTUIState', () => {
 
     const state = createTUIState({
       harness: harness as never,
+      session: session as never,
       hookManager: hookManager as never,
       analytics: analytics as never,
       authStorage: authStorage as never,

--- a/mastracode/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/src/tui/__tests__/status-line.test.ts
@@ -69,43 +69,37 @@ function createState() {
   const setText = vi.fn();
   const memorySetText = vi.fn();
 
+  const session = {
+    displayState: {
+      get: vi.fn(() => ({
+        omProgress: { status: 'idle' },
+        bufferingMessages: false,
+        bufferingObservations: false,
+      })),
+    },
+    followUps: { count: vi.fn(() => 0) },
+    identity: { getResourceId: vi.fn(() => 'resource-1') },
+    thread: { getId: vi.fn(() => 'thread-1') },
+    mode: {
+      get: vi.fn(() => 'build'),
+      resolve: vi.fn(() => ({ id: 'build', name: 'build', metadata: { color: '#00ff00' } })),
+    },
+    state: { get: vi.fn(() => ({ yolo: false })) },
+    model: {
+      get: vi.fn(() => 'anthropic/claude-sonnet-4-20250514'),
+    },
+    om: {
+      observer: { modelId: vi.fn(() => 'openai/gpt-4o') },
+      reflector: { modelId: vi.fn(() => 'openai/gpt-4o-mini') },
+    },
+  };
+
   return {
     options: {},
-    session: {
-      followUps: { count: vi.fn(() => 0) },
-      identity: { getResourceId: vi.fn(() => 'resource-1') },
-      thread: { getId: vi.fn(() => 'thread-1') },
-      mode: {
-        get: vi.fn(() => 'build'),
-        resolve: vi.fn(() => ({ id: 'build', name: 'build', metadata: { color: '#00ff00' } })),
-      },
-      state: { get: vi.fn(() => ({ yolo: false })) },
-    },
+    session,
     harness: {
       listModes: vi.fn(() => [{ id: 'build', name: 'build', metadata: { color: '#00ff00' } }]),
-      session: {
-        displayState: {
-          get: vi.fn(() => ({
-            omProgress: { status: 'idle' },
-            bufferingMessages: false,
-            bufferingObservations: false,
-          })),
-        },
-        followUps: { count: vi.fn(() => 0) },
-        identity: { getResourceId: vi.fn(() => 'resource-1') },
-        thread: { getId: vi.fn(() => 'thread-1') },
-        mode: {
-          get: vi.fn(() => 'build'),
-          resolve: vi.fn(() => ({ id: 'build', name: 'build', metadata: { color: '#00ff00' } })),
-        },
-        model: {
-          get: vi.fn(() => 'anthropic/claude-sonnet-4-20250514'),
-        },
-        om: {
-          observer: { modelId: vi.fn(() => 'openai/gpt-4o') },
-          reflector: { modelId: vi.fn(() => 'openai/gpt-4o-mini') },
-        },
-      },
+      session,
     },
     statusLine: { setText },
     memoryStatusLine: { setText: memorySetText },

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -303,7 +303,7 @@ async function handleGoalSourceCommand(
     try {
       let workspace = ctx.getResolvedWorkspace();
       if (!workspace && ctx.harness?.hasWorkspace?.()) {
-        workspace = await ctx.harness.resolveWorkspace();
+        workspace = await ctx.harness.resolveWorkspace({ session: ctx.state.session });
       }
       const skill = await workspace?.skills?.get(goalSkill.path || goalSkill.name);
       if (!skill || skill.metadata?.goal !== true) {

--- a/mastracode/src/tui/commands/__tests__/feedback.test.ts
+++ b/mastracode/src/tui/commands/__tests__/feedback.test.ts
@@ -33,8 +33,17 @@ function createCtx(options?: {
 }
 
 describe('handleFeedbackCommand', () => {
-  it('requires trace, run, or thread context before recording feedback', async () => {
+  it('requires trace or run context before recording feedback', async () => {
     const ctx = createCtx({ traceId: null, runId: null, threadId: null });
+
+    await handleFeedbackCommand(ctx, ['up']);
+
+    expect(ctx.addFeedback).not.toHaveBeenCalled();
+    expect(ctx.showError).toHaveBeenCalledWith('No active session to attach feedback to.');
+  });
+
+  it('rejects feedback when only a thread is bound but no run has happened', async () => {
+    const ctx = createCtx({ traceId: null, runId: null, threadId: 'thread-only' });
 
     await handleFeedbackCommand(ctx, ['up']);
 

--- a/mastracode/src/tui/commands/__tests__/github.test.ts
+++ b/mastracode/src/tui/commands/__tests__/github.test.ts
@@ -30,8 +30,14 @@ function createContext() {
     removed: true,
     remainingSubscriptions: 0,
   }));
+  const session = {
+    sendSignal,
+    identity: { getResourceId: vi.fn(() => 'resource-1') },
+    thread: { getId: vi.fn(() => 'thread-1'), list: vi.fn(async () => []) },
+  };
   const ctx = {
     state: {
+      session,
       ui: { requestRender: vi.fn() },
       projectInfo: { rootPath: '/repo' },
       options: {
@@ -46,10 +52,7 @@ function createContext() {
     },
     harness: {
       sendSignal,
-      session: {
-        identity: { getResourceId: vi.fn(() => 'resource-1') },
-        thread: { getId: vi.fn(() => 'thread-1'), list: vi.fn(async () => []) },
-      },
+      session,
     },
     showInfo: vi.fn(),
     showError: vi.fn(),

--- a/mastracode/src/tui/commands/__tests__/new.test.ts
+++ b/mastracode/src/tui/commands/__tests__/new.test.ts
@@ -16,7 +16,11 @@ function createMockState() {
     allShellComponents: [{}],
     taskProgress: { updateTasks: vi.fn() },
     taskToolInsertIndex: 5,
-    session: { state: { set: vi.fn(async () => {}) } },
+    session: {
+      state: { set: vi.fn(async () => {}) },
+      thread: { detachFromCurrent: vi.fn() },
+      displayState: { get: vi.fn(() => ({ modifiedFiles: new Map([['f', true]]) })) },
+    },
     harness: {
       abort: vi.fn(),
       session: {
@@ -43,7 +47,7 @@ describe('handleNewCommand', () => {
     const ctx = createCtx(state);
     const callOrder: string[] = [];
 
-    state.harness.session.thread.detachFromCurrent.mockImplementation(() => {
+    state.session.thread.detachFromCurrent.mockImplementation(() => {
       callOrder.push('detach');
     });
     const origPendingNewThread = Object.getOwnPropertyDescriptor(state, 'pendingNewThread');
@@ -60,7 +64,7 @@ describe('handleNewCommand', () => {
 
     await handleNewCommand(ctx);
 
-    expect(state.harness.session.thread.detachFromCurrent).toHaveBeenCalledOnce();
+    expect(state.session.thread.detachFromCurrent).toHaveBeenCalledOnce();
     expect(callOrder).toEqual(['detach', 'pendingNewThread']);
   });
 

--- a/mastracode/src/tui/commands/__tests__/resource.test.ts
+++ b/mastracode/src/tui/commands/__tests__/resource.test.ts
@@ -40,8 +40,8 @@ function createMockHarness(opts?: { id?: string; resourceId?: string }) {
       },
     },
     harness: {
-      getKnownResourceIds: vi.fn(async () => [...new Set(threads.map(t => t.resourceId))]),
-      setResourceId: vi.fn(({ resourceId }: { resourceId: string }) => {
+      getKnownResourceIds: vi.fn(async (_session: any) => [...new Set(threads.map(t => t.resourceId))]),
+      setResourceId: vi.fn((_session: any, { resourceId }: { resourceId: string }) => {
         currentResourceId = resourceId;
         currentThreadId = null;
       }),
@@ -72,6 +72,7 @@ function createMockCtx(harness: ReturnType<typeof createMockHarness>) {
         allSystemReminderComponents: [] as any[],
         allShellComponents: [] as any[],
         messageComponentsById: new Map<string, any>(),
+        session: (harness as any).session,
         ui: { requestRender: vi.fn() },
       },
       harness: harness as any,
@@ -113,7 +114,7 @@ describe('handleResourceCommand', () => {
     });
 
     it('shows auto-detected note when resource has been overridden', async () => {
-      harness.setResourceId({ resourceId: 'custom-id' });
+      harness.setResourceId(undefined as any, { resourceId: 'custom-id' });
       await handleResourceCommand(ctx, []);
 
       expect(infoMessages[0]).toContain('auto-detected: test-harness');
@@ -139,7 +140,7 @@ describe('handleResourceCommand', () => {
 
       await handleResourceCommand(ctx, ['other-resource']);
 
-      expect(harness.setResourceId).toHaveBeenCalledWith({ resourceId: 'other-resource' });
+      expect(harness.setResourceId).toHaveBeenCalledWith(expect.anything(), { resourceId: 'other-resource' });
       expect(harness.session.thread.switch).toHaveBeenCalledWith({ threadId: latestId });
       expect(ctx.state.pendingNewThread).toBe(false);
       expect(ctx.renderExistingMessages).toHaveBeenCalled();
@@ -161,7 +162,7 @@ describe('handleResourceCommand', () => {
     it('sets pendingNewThread and does not call switchThread', async () => {
       await handleResourceCommand(ctx, ['brand-new-resource']);
 
-      expect(harness.setResourceId).toHaveBeenCalledWith({ resourceId: 'brand-new-resource' });
+      expect(harness.setResourceId).toHaveBeenCalledWith(expect.anything(), { resourceId: 'brand-new-resource' });
       expect(harness.session.thread.switch).not.toHaveBeenCalled();
       expect(ctx.state.pendingNewThread).toBe(true);
       expect(infoMessages[0]).toContain('no existing threads');
@@ -172,18 +173,18 @@ describe('handleResourceCommand', () => {
   describe('reset', () => {
     it('resets to the default resource ID and resumes latest thread', async () => {
       harness._addThread('test-harness', 'default-thread', new Date());
-      harness.setResourceId({ resourceId: 'some-other' });
+      harness.setResourceId(undefined as any, { resourceId: 'some-other' });
 
       await handleResourceCommand(ctx, ['reset']);
 
-      expect(harness.setResourceId).toHaveBeenLastCalledWith({ resourceId: 'test-harness' });
+      expect(harness.setResourceId).toHaveBeenLastCalledWith(expect.anything(), { resourceId: 'test-harness' });
       expect(harness.session.thread.switch).toHaveBeenCalled();
       expect(infoMessages[0]).toContain('Resource ID reset to: test-harness');
       expect(infoMessages[0]).toContain('resumed thread: default-thread');
     });
 
     it('resets to default with no threads available', async () => {
-      harness.setResourceId({ resourceId: 'some-other' });
+      harness.setResourceId(undefined as any, { resourceId: 'some-other' });
 
       await handleResourceCommand(ctx, ['reset']);
 

--- a/mastracode/src/tui/commands/__tests__/skills.test.ts
+++ b/mastracode/src/tui/commands/__tests__/skills.test.ts
@@ -70,6 +70,7 @@ describe('handleSkillCommand', () => {
       },
     };
     const ctx = {
+      state: { session: {} },
       harness: {
         hasWorkspace: vi.fn(() => true),
         resolveWorkspace: vi.fn().mockResolvedValue(workspace),

--- a/mastracode/src/tui/commands/__tests__/thread.test.ts
+++ b/mastracode/src/tui/commands/__tests__/thread.test.ts
@@ -46,6 +46,7 @@ function createMockCtx(harness: ReturnType<typeof createMockHarness>) {
     ctx: {
       state: {
         pendingNewThread: false,
+        session: (harness as any).session,
       },
       harness: harness as any,
       showInfo: vi.fn((msg: string) => infoMessages.push(msg)),

--- a/mastracode/src/tui/commands/clone.ts
+++ b/mastracode/src/tui/commands/clone.ts
@@ -51,7 +51,7 @@ export async function resetUIAfterClone(ctx: CloneResetContext, clonedTitle: str
   state.allSystemReminderComponents = [];
   state.messageComponentsById.clear();
   state.allShellComponents = [];
-  state.harness.session.displayState.clearModifiedFiles();
+  state.session.displayState.clearModifiedFiles();
   // Clear per-thread ephemeral state from the global harness state
   await state.session.state.set({ tasks: [], activePlan: null, sandboxAllowedPaths: [] });
   if (state.taskProgress) {
@@ -81,7 +81,7 @@ export async function handleCloneCommand(ctx: SlashCommandContext): Promise<void
   const customTitle = await askCloneName(state);
 
   try {
-    const clonedThread = await state.harness.session.thread.clone({
+    const clonedThread = await state.session.thread.clone({
       sourceThreadId: currentThreadId,
       ...(customTitle ? { title: customTitle } : {}),
     });

--- a/mastracode/src/tui/commands/cost.ts
+++ b/mastracode/src/tui/commands/cost.ts
@@ -4,7 +4,7 @@ export function handleCostCommand(ctx: SlashCommandContext): void {
   const formatNumber = (n: number) => n.toLocaleString();
 
   // Read from Harness display state (canonical source)
-  const ds = ctx.state.harness.session.displayState.get();
+  const ds = ctx.state.session.displayState.get();
 
   let omTokensText = '';
   if (ds.omProgress.observationTokens > 0) {

--- a/mastracode/src/tui/commands/diff.ts
+++ b/mastracode/src/tui/commands/diff.ts
@@ -39,7 +39,7 @@ export async function handleDiffCommand(ctx: SlashCommandContext, filePath?: str
 
   // No path specified — show summary of all tracked modified files
   // Read from Harness display state (canonical source for file modifications)
-  const modifiedFiles = state.harness.session.displayState.get().modifiedFiles;
+  const modifiedFiles = state.session.displayState.get().modifiedFiles;
   if (modifiedFiles.size === 0) {
     try {
       const { execa } = await import('execa');

--- a/mastracode/src/tui/commands/feedback.ts
+++ b/mastracode/src/tui/commands/feedback.ts
@@ -37,7 +37,9 @@ export async function handleFeedbackCommand(ctx: SlashCommandContext, args: stri
   const runId = ctx.state.session.getCurrentRunId() ?? undefined;
   const threadId = ctx.state.session.thread.getId() ?? undefined;
 
-  if (!traceId && !runId && !threadId) {
+  // Feedback correlates to an actual run/trace. A bound thread alone is not
+  // enough — every session has a thread, but there may be no run to rate yet.
+  if (!traceId && !runId) {
     ctx.showError('No active session to attach feedback to.');
     return;
   }

--- a/mastracode/src/tui/commands/github.ts
+++ b/mastracode/src/tui/commands/github.ts
@@ -44,26 +44,24 @@ async function getCurrentGithubThread(ctx: SlashCommandContext): Promise<{
   resourceId?: string;
   metadata?: Record<string, unknown>;
 }> {
-  const harness = ctx.harness as unknown as {
-    session?: {
-      identity?: {
-        getResourceId?: () => string | undefined;
-      };
-      thread?: {
-        getId?: () => string | undefined;
-        list?: (input?: {
-          allResources?: boolean;
-        }) => Promise<Array<{ id: string; resourceId?: string; metadata?: Record<string, unknown> }>>;
-      };
+  const session = ctx.state.session as unknown as {
+    identity?: {
+      getResourceId?: () => string | undefined;
+    };
+    thread?: {
+      getId?: () => string | undefined;
+      list?: (input?: {
+        allResources?: boolean;
+      }) => Promise<Array<{ id: string; resourceId?: string; metadata?: Record<string, unknown> }>>;
     };
   };
-  const threadId = harness.session?.thread?.getId?.();
+  const threadId = session?.thread?.getId?.();
   if (!threadId) return {};
 
-  const thread = (await harness.session?.thread?.list?.({ allResources: true }))?.find(item => item.id === threadId);
+  const thread = (await session?.thread?.list?.({ allResources: true }))?.find(item => item.id === threadId);
   return {
     threadId,
-    resourceId: thread?.resourceId ?? harness.session?.identity?.getResourceId?.(),
+    resourceId: thread?.resourceId ?? session?.identity?.getResourceId?.(),
     metadata: thread?.metadata,
   };
 }

--- a/mastracode/src/tui/commands/goal.ts
+++ b/mastracode/src/tui/commands/goal.ts
@@ -328,7 +328,7 @@ async function startGoal(
   const goalManager = state.goalManager;
 
   if (state.pendingNewThread) {
-    await state.harness.session.thread.create();
+    await state.session.thread.create();
     state.pendingNewThread = false;
   }
 

--- a/mastracode/src/tui/commands/login.ts
+++ b/mastracode/src/tui/commands/login.ts
@@ -53,7 +53,7 @@ async function performLogin(ctx: SlashCommandContext, providerId: string): Promi
 
         const defaultModel = PROVIDER_DEFAULT_MODELS[providerId as keyof typeof PROVIDER_DEFAULT_MODELS];
         if (defaultModel) {
-          await ctx.state.harness.session.model.switch({ modelId: defaultModel });
+          await ctx.state.session.model.switch({ modelId: defaultModel });
           ctx.showInfo(`Logged in to ${providerName} - switched to ${defaultModel}`);
         } else {
           ctx.showInfo(`Successfully logged in to ${providerName}`);

--- a/mastracode/src/tui/commands/mode.ts
+++ b/mastracode/src/tui/commands/mode.ts
@@ -18,7 +18,7 @@ export async function handleModeCommand(ctx: SlashCommandContext, args: string[]
   }
   if (args[0]) {
     try {
-      await ctx.harness.session.mode.switch({ modeId: args[0] });
+      await ctx.state.session.mode.switch({ modeId: args[0] });
       applyCurrentModeColorToRenderedTools(ctx);
     } catch (err) {
       ctx.showError(`Failed to switch mode: ${err instanceof Error ? err.message : String(err)}`);

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -384,25 +384,25 @@ async function applyPack(ctx: SlashCommandContext, pack: ModePack, previousPackI
     const modelId = (pack.models as Record<string, string>)[mode.id];
     if (modelId) {
       (mode as any).defaultModelId = modelId;
-      await harness.session.thread.setSetting({ key: `modeModelId_${mode.id}`, value: modelId });
+      await ctx.state.session.thread.setSetting({ key: `modeModelId_${mode.id}`, value: modelId });
     }
   }
 
-  const currentModeId = harness.session.mode.get();
+  const currentModeId = ctx.state.session.mode.get();
   const currentModeModel = (pack.models as Record<string, string>)[currentModeId];
   if (currentModeModel) {
-    await harness.session.model.switch({ modelId: currentModeModel });
+    await ctx.state.session.model.switch({ modelId: currentModeModel });
   }
 
   const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };
   for (const [agentType, modeId] of Object.entries(subagentModeMap)) {
     const saModelId = (pack.models as Record<string, string>)[modeId];
     if (saModelId) {
-      await harness.session.subagents.model.set({ modelId: saModelId, agentType });
+      await ctx.state.session.subagents.model.set({ modelId: saModelId, agentType });
     }
   }
 
-  await harness.session.thread.setSetting({ key: THREAD_ACTIVE_MODEL_PACK_ID_KEY, value: pack.id });
+  await ctx.state.session.thread.setSetting({ key: THREAD_ACTIVE_MODEL_PACK_ID_KEY, value: pack.id });
 
   const s = loadSettings();
   const modeDefaults: Record<string, string> = {};
@@ -470,11 +470,11 @@ async function saveCustomPackEdits(ctx: SlashCommandContext, pack: ModePack, pre
 
   if (previousPackId && previousPackId !== pack.id) {
     const harness = ctx.state.harness;
-    const threadId = harness.session.thread.getId();
-    const thread = threadId ? (await harness.session.thread.list()).find(t => t.id === threadId) : undefined;
+    const threadId = ctx.state.session.thread.getId();
+    const thread = threadId ? (await ctx.state.session.thread.list()).find(t => t.id === threadId) : undefined;
     const threadPackId = (thread?.metadata?.[THREAD_ACTIVE_MODEL_PACK_ID_KEY] as string | undefined) ?? null;
     if (threadPackId === previousPackId) {
-      await harness.session.thread.setSetting({ key: THREAD_ACTIVE_MODEL_PACK_ID_KEY, value: pack.id });
+      await ctx.state.session.thread.setSetting({ key: THREAD_ACTIVE_MODEL_PACK_ID_KEY, value: pack.id });
     }
   }
 }
@@ -483,8 +483,8 @@ async function deleteCustomPack(ctx: SlashCommandContext, pack: ModePack): Promi
   if (!pack.id.startsWith('custom:')) return;
 
   const harness = ctx.state.harness;
-  const threadId = harness.session.thread.getId();
-  const thread = threadId ? (await harness.session.thread.list()).find(t => t.id === threadId) : undefined;
+  const threadId = ctx.state.session.thread.getId();
+  const thread = threadId ? (await ctx.state.session.thread.list()).find(t => t.id === threadId) : undefined;
   const threadPackId = (thread?.metadata?.[THREAD_ACTIVE_MODEL_PACK_ID_KEY] as string | undefined) ?? null;
 
   const settings = loadSettings();
@@ -492,7 +492,7 @@ async function deleteCustomPack(ctx: SlashCommandContext, pack: ModePack): Promi
   saveSettings(settings);
 
   if (threadPackId === pack.id) {
-    await harness.session.thread.setSetting({ key: THREAD_ACTIVE_MODEL_PACK_ID_KEY, value: null });
+    await ctx.state.session.thread.setSetting({ key: THREAD_ACTIVE_MODEL_PACK_ID_KEY, value: null });
   }
 }
 
@@ -607,8 +607,8 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
     return;
   }
 
-  const threadId = harness.session.thread.getId();
-  const thread = threadId ? (await harness.session.thread.list()).find(t => t.id === threadId) : undefined;
+  const threadId = ctx.state.session.thread.getId();
+  const thread = threadId ? (await ctx.state.session.thread.list()).find(t => t.id === threadId) : undefined;
   const currentPackId = resolveThreadActiveModelPackId(
     settings,
     packs,

--- a/mastracode/src/tui/commands/name.ts
+++ b/mastracode/src/tui/commands/name.ts
@@ -10,6 +10,6 @@ export async function handleNameCommand(ctx: SlashCommandContext, args: string[]
     ctx.showInfo('No active thread. Send a message first.');
     return;
   }
-  await ctx.harness.session.thread.rename({ title });
+  await ctx.state.session.thread.rename({ title });
   ctx.showInfo(`Thread renamed to: ${title}`);
 }

--- a/mastracode/src/tui/commands/new.ts
+++ b/mastracode/src/tui/commands/new.ts
@@ -7,7 +7,7 @@ export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> 
   // don't leak into the new conversation. Unlike bare abort(), this also
   // unsubscribes from the PubSub topic — preventing another mc instance
   // on the same thread from pushing output into this TUI.
-  state.harness.session.thread.detachFromCurrent();
+  state.session.thread.detachFromCurrent();
 
   state.pendingNewThread = true;
   state.chatContainer.clear();
@@ -19,7 +19,7 @@ export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> 
   state.messageComponentsById.clear();
   state.allShellComponents = [];
   // Clear file tracking in display state (thread_created will also reset this)
-  state.harness.session.displayState.get().modifiedFiles.clear();
+  state.session.displayState.get().modifiedFiles.clear();
   // Clear per-thread ephemeral state from the global harness state
   await state.session.state.set({ tasks: [], activePlan: null, sandboxAllowedPaths: [] });
   if (state.taskProgress) {

--- a/mastracode/src/tui/commands/report-issue.ts
+++ b/mastracode/src/tui/commands/report-issue.ts
@@ -12,7 +12,7 @@ export async function handleReportIssueCommand(ctx: SlashCommandContext, args: s
 
   // Ensure thread exists
   if (ctx.state.pendingNewThread) {
-    await ctx.state.harness.session.thread.create();
+    await ctx.state.session.thread.create();
     ctx.state.pendingNewThread = false;
   }
 

--- a/mastracode/src/tui/commands/resource.ts
+++ b/mastracode/src/tui/commands/resource.ts
@@ -2,12 +2,13 @@ import type { SlashCommandContext } from './types.js';
 
 export async function handleResourceCommand(ctx: SlashCommandContext, args: string[]): Promise<void> {
   const { state, harness } = ctx;
+  const { session } = state;
   const sub = args[0]?.trim();
-  const current = harness.session.identity.getResourceId();
-  const defaultId = harness.session.identity.getDefaultResourceId();
+  const current = session.identity.getResourceId();
+  const defaultId = session.identity.getDefaultResourceId();
 
   if (!sub) {
-    const knownIds = await harness.getKnownResourceIds();
+    const knownIds = await harness.getKnownResourceIds(session);
     const isOverridden = current !== defaultId;
     const lines = [
       `Current: ${current}${isOverridden ? ` (auto-detected: ${defaultId})` : ''}`,
@@ -31,14 +32,14 @@ export async function handleResourceCommand(ctx: SlashCommandContext, args: stri
     return;
   }
 
-  harness.setResourceId({ resourceId: newId });
+  harness.setResourceId(session, { resourceId: newId });
 
   // Try to resume the most recent thread for this resource
-  const threads = await harness.session.thread.list();
+  const threads = await session.thread.list();
   const latest = [...threads].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
 
   if (latest) {
-    await harness.session.thread.switch({ threadId: latest.id });
+    await session.thread.switch({ threadId: latest.id });
     state.chatContainer.clear();
     state.pendingTools.clear();
     state.pendingTaskToolIds?.clear();

--- a/mastracode/src/tui/commands/review.ts
+++ b/mastracode/src/tui/commands/review.ts
@@ -9,7 +9,7 @@ export async function handleReviewCommand(ctx: SlashCommandContext, args: string
 
   // Ensure thread exists
   if (ctx.state.pendingNewThread) {
-    await ctx.state.harness.session.thread.create();
+    await ctx.state.session.thread.create();
     ctx.state.pendingNewThread = false;
   }
 

--- a/mastracode/src/tui/commands/send-slash-command-message.ts
+++ b/mastracode/src/tui/commands/send-slash-command-message.ts
@@ -2,7 +2,7 @@ import { addPendingUserMessage, removePendingUserMessage } from '../render-messa
 import type { SlashCommandContext } from './types.js';
 
 export function isCurrentThreadActive(ctx: SlashCommandContext): boolean {
-  return ctx.harness.session?.stream?.isActive?.() ?? ctx.harness.session?.displayState?.get?.().isRunning ?? false;
+  return ctx.state.session?.stream?.isActive?.() ?? ctx.state.session?.displayState?.get?.().isRunning ?? false;
 }
 
 export async function sendSlashCommandMessage(
@@ -12,12 +12,12 @@ export async function sendSlashCommandMessage(
   options: { renderIdleUserMessage?: boolean } = {},
 ): Promise<void> {
   if (ctx.state.pendingNewThread) {
-    await ctx.harness.session.thread.create();
+    await ctx.state.session.thread.create();
     ctx.state.pendingNewThread = false;
   }
 
   if (isCurrentThreadActive(ctx)) {
-    const signal = ctx.harness.session.sendSignal({ content });
+    const signal = ctx.state.session.sendSignal({ content });
     addPendingUserMessage(ctx.state, signal.id, displayText);
     try {
       await signal.accepted;
@@ -37,5 +37,5 @@ export async function sendSlashCommandMessage(
     });
     ctx.state.ui.requestRender();
   }
-  await ctx.harness.session.sendMessage({ content });
+  await ctx.state.session.sendMessage({ content });
 }

--- a/mastracode/src/tui/commands/skills.ts
+++ b/mastracode/src/tui/commands/skills.ts
@@ -14,7 +14,7 @@ function escapeSkillBoundary(value: string): string {
 async function resolveWorkspace(ctx: SlashCommandContext) {
   let workspace = ctx.getResolvedWorkspace();
   if (!workspace && ctx.harness.hasWorkspace()) {
-    workspace = await ctx.harness.resolveWorkspace();
+    workspace = await ctx.harness.resolveWorkspace({ session: ctx.state.session });
   }
   return workspace;
 }

--- a/mastracode/src/tui/commands/thread.ts
+++ b/mastracode/src/tui/commands/thread.ts
@@ -6,8 +6,8 @@ function formatDateWithLocal(date: Date): string {
 
 export async function handleThreadCommand(ctx: SlashCommandContext): Promise<void> {
   const { harness, state } = ctx;
-  const currentThreadId = harness.session.thread.getId();
-  const currentResourceId = harness.session.identity.getResourceId();
+  const currentThreadId = state.session.thread.getId();
+  const currentResourceId = state.session.identity.getResourceId();
   const isPendingNewThread = state.pendingNewThread;
 
   if (!currentThreadId) {
@@ -21,7 +21,7 @@ export async function handleThreadCommand(ctx: SlashCommandContext): Promise<voi
     return;
   }
 
-  const threads = await harness.session.thread.list({ allResources: true });
+  const threads = await state.session.thread.list({ allResources: true });
   const thread = threads.find(t => t.id === currentThreadId);
 
   const cloneMetadata =

--- a/mastracode/src/tui/commands/threads.ts
+++ b/mastracode/src/tui/commands/threads.ts
@@ -33,7 +33,7 @@ export function showThreadLockPrompt(
     } else if (answer === 'Clone thread' && lockedThreadId) {
       try {
         const customTitle = await askCloneName(ctx.state);
-        const clonedThread = await ctx.state.harness.session.thread.clone({
+        const clonedThread = await ctx.state.session.thread.clone({
           sourceThreadId: lockedThreadId,
           ...(customTitle ? { title: customTitle } : {}),
         });
@@ -116,10 +116,10 @@ export async function handleThreadsCommand(ctx: SlashCommandContext): Promise<vo
         }
 
         if (thread.resourceId !== currentResourceId) {
-          state.harness.setResourceId({ resourceId: thread.resourceId });
+          state.harness.setResourceId(state.session, { resourceId: thread.resourceId });
         }
         try {
-          await state.harness.session.thread.switch({ threadId: thread.id });
+          await state.session.thread.switch({ threadId: thread.id });
         } catch (error) {
           if (error instanceof ThreadLockError) {
             showThreadLockPrompt(ctx, thread.title || thread.id, error.ownerPid, thread.id);
@@ -151,7 +151,7 @@ export async function handleThreadsCommand(ctx: SlashCommandContext): Promise<vo
         }
         try {
           const customTitle = await askCloneName(state);
-          const clonedThread = await state.harness.session.thread.clone({
+          const clonedThread = await state.session.thread.clone({
             sourceThreadId: thread.id,
             ...(customTitle ? { title: customTitle } : {}),
           });

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -154,7 +154,7 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       }
       state.taskToolInsertIndex = -1;
       await ectx.renderExistingMessages();
-      await state.harness.loadOMProgress();
+      await state.harness.loadOMProgress(state.session);
       // Refresh git branch async so TUI status line reflects the current branch
       getCurrentGitBranchAsync(state.projectInfo.rootPath).then(freshBranch => {
         if (freshBranch) {
@@ -364,7 +364,7 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
         // narrates completion), so we don't leave a redundant completed-task
         // receipt in the transcript that reads like a second live list. We only
         // render an inline receipt when the list is explicitly cleared.
-        const previousTasks = state.harness.session.displayState.get().previousTasks;
+        const previousTasks = state.session.displayState.get().previousTasks;
         if (previousTasks.length > 0 && (!tasks || tasks.length === 0)) {
           // Tasks were cleared
           ectx.renderClearedTasksInline(previousTasks, insertIndex);

--- a/mastracode/src/tui/goal-manager.ts
+++ b/mastracode/src/tui/goal-manager.ts
@@ -336,7 +336,7 @@ export class GoalManager {
 
   private getAgent(state: TUIState): Agent | undefined {
     try {
-      return state.harness.getCurrentAgent();
+      return state.harness.getCurrentAgent(state.session);
     } catch {
       return undefined;
     }

--- a/mastracode/src/tui/handlers/__tests__/message.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/message.test.ts
@@ -51,9 +51,8 @@ describe('handleMessageUpdate system reminders', () => {
       hideThinkingBlock: false,
       toolOutputExpanded: false,
       pendingSignalMessageComponentsById: new Map(),
-      harness: {
-        session: { displayState: { get: () => ({ isRunning: true }) } },
-      },
+      session: { displayState: { get: () => ({ isRunning: true }) } },
+      harness: { session: { displayState: { get: () => ({ isRunning: true }) } } },
     } as unknown as TUIState;
 
     ctx = {

--- a/mastracode/src/tui/handlers/__tests__/tool.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/tool.test.ts
@@ -14,9 +14,11 @@ function createContext(bufferText: string | undefined) {
     toolInputBuffers.set('call-1', { text: bufferText, toolName: 'view' });
   }
 
+  const session = { displayState: { get: () => ({ toolInputBuffers }) } };
   const ctx = {
     state: {
-      harness: { session: { displayState: { get: () => ({ toolInputBuffers }) } } },
+      harness: { session },
+      session,
       pendingTools: new Map([['call-1', component]]),
       pendingAskUserComponents: new Map(),
       pendingSubmitPlanComponents: new Map(),

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -286,7 +286,7 @@ export function handleGoalEvaluation(ctx: EventHandlerContext, payload: GoalEval
     if (goal && goal.id === state.planStartedGoalId) {
       const goalId = state.planStartedGoalId;
       state.planStartedGoalId = undefined;
-      state.harness.session.mode.switch({ modeId: 'plan' }).catch(error => {
+      state.session.mode.switch({ modeId: 'plan' }).catch(error => {
         ctx.showError(`Failed to switch to Plan mode: ${error instanceof Error ? error.message : String(error)}`);
         state.planStartedGoalId = goalId;
       });

--- a/mastracode/src/tui/handlers/om.ts
+++ b/mastracode/src/tui/handlers/om.ts
@@ -129,7 +129,7 @@ export function handleOMReflectionEnd(
   // Note: Harness has already updated observationTokens to compressedTokens,
   // so we use tokensToReflect from the start event via the cycleId context.
   // For display purposes, we read the event parameter directly.
-  const ds = state.harness.session.displayState.get();
+  const ds = state.session.displayState.get();
   // Remove in-progress marker — the output box replaces it
   if (state.activeOMMarker) {
     const idx = state.chatContainer.children.indexOf(state.activeOMMarker);

--- a/mastracode/src/tui/handlers/tool.test.ts
+++ b/mastracode/src/tui/handlers/tool.test.ts
@@ -17,6 +17,7 @@ function stripAnsi(text: string): string {
 
 function createToolHandlerContext(): EventHandlerContext {
   const chatContainer = new Container();
+  const session = { displayState: { get: vi.fn(() => ({ toolInputBuffers: new Map() })) } };
   const state = {
     chatContainer,
     ui: { requestRender: vi.fn() },
@@ -32,9 +33,8 @@ function createToolHandlerContext(): EventHandlerContext {
     toolOutputExpanded: false,
     hideThinkingBlock: false,
     taskToolInsertIndex: -1,
-    harness: {
-      session: { displayState: { get: vi.fn(() => ({ toolInputBuffers: new Map() })) } },
-    },
+    session,
+    harness: { session },
   } as unknown as TUIState;
 
   return {
@@ -121,7 +121,7 @@ describe('task tool rendering', () => {
       ['call-1', { toolName: 'view', text: '{"path":"src/example.ts","offset":80,"limit":90}' }],
       ['call-2', { toolName: 'view', text: '{"path":"src/example.ts","offset":1,"limit":25}' }],
     ]);
-    vi.mocked(ctx.state.harness.session.displayState.get).mockReturnValue({ toolInputBuffers: buffers } as any);
+    vi.mocked(ctx.state.session.displayState.get).mockReturnValue({ toolInputBuffers: buffers } as any);
 
     handleToolInputStart(ctx, 'call-1', 'view');
     handleToolInputDelta(ctx, 'call-1', '');
@@ -139,7 +139,7 @@ describe('task tool rendering', () => {
     const buffers = new Map([
       ['call-1', { toolName: 'submit_plan', text: '{"title":"Ship it","plan":"Build the feature"}' }],
     ]);
-    vi.mocked(ctx.state.harness.session.displayState.get).mockReturnValue({ toolInputBuffers: buffers } as any);
+    vi.mocked(ctx.state.session.displayState.get).mockReturnValue({ toolInputBuffers: buffers } as any);
 
     handleToolInputStart(ctx, 'call-1', 'submit_plan');
     handleToolInputDelta(ctx, 'call-1', '{"title":"Ship it","plan":"Build the feature"}');

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -363,7 +363,7 @@ export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: strin
  */
 export function handleToolInputDelta(ctx: EventHandlerContext, toolCallId: string, _argsTextDelta: string): void {
   const { state } = ctx;
-  const ds = state.harness.session.displayState.get();
+  const ds = state.session.displayState.get();
   const buffer = ds.toolInputBuffers.get(toolCallId);
   if (buffer === undefined) return;
 

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -290,7 +290,7 @@ export class MastraTUI {
         } else {
           try {
             if (this.state.pendingNewThread) {
-              await this.state.harness.session.thread.create();
+              await this.state.session.thread.create();
               this.state.pendingNewThread = false;
             }
             this.fireMessage(msg);
@@ -413,7 +413,7 @@ export class MastraTUI {
   private createPendingNewThread(): Promise<void> | undefined {
     if (!this.state.pendingNewThread) return undefined;
     this.state.pendingNewThread = false;
-    return this.state.harness.session.thread.create().then(() => undefined);
+    return this.state.session.thread.create().then(() => undefined);
   }
 
   private sendOptimisticSignal(
@@ -590,7 +590,7 @@ export class MastraTUI {
     // Load OM progress now that we're subscribed (the event during
     // thread selection fired before we were listening).
     // This emits om_status → display_state_changed → updateStatusLine.
-    await this.state.harness.loadOMProgress();
+    await this.state.harness.loadOMProgress(this.state.session);
 
     // Sync current thread metadata — the thread_changed event from
     // promptForThreadSelection fired before we subscribed above.
@@ -640,7 +640,7 @@ export class MastraTUI {
   }
 
   private async refreshModelAuthStatus(): Promise<void> {
-    this.state.modelAuthStatus = await this.state.harness.getCurrentModelAuthStatus();
+    this.state.modelAuthStatus = await this.state.harness.getCurrentModelAuthStatus(this.state.session);
     updateStatusLine(this.state);
   }
 
@@ -783,9 +783,9 @@ export class MastraTUI {
 
   private emitErrorFeedback(errorMessage: string): void {
     const harness = this.state.harness;
-    const traceId = harness.session.run.getTraceId() ?? undefined;
-    const runId = harness.session.getCurrentRunId() ?? undefined;
-    const threadId = harness.session.thread.getId() ?? undefined;
+    const traceId = this.state.session.run.getTraceId() ?? undefined;
+    const runId = this.state.session.getCurrentRunId() ?? undefined;
+    const threadId = this.state.session.thread.getId() ?? undefined;
 
     if (!traceId && !runId && !threadId) return;
 
@@ -1154,7 +1154,7 @@ export class MastraTUI {
           const { PROVIDER_DEFAULT_MODELS } = await import('../auth/storage.js');
           const defaultModel = PROVIDER_DEFAULT_MODELS[providerId as keyof typeof PROVIDER_DEFAULT_MODELS];
           if (defaultModel) {
-            await this.state.harness.session.model.switch({ modelId: defaultModel });
+            await this.state.session.model.switch({ modelId: defaultModel });
             showInfo(this.state, `Logged in to ${providerName} - switched to ${defaultModel}`);
           } else {
             showInfo(this.state, `Successfully logged in to ${providerName}`);
@@ -1286,24 +1286,24 @@ export class MastraTUI {
       const modelId = (modePack.models as Record<string, string>)[mode.id];
       if (modelId) {
         (mode as any).defaultModelId = modelId;
-        await harness.session.thread.setSetting({
+        await this.state.session.thread.setSetting({
           key: `modeModelId_${mode.id}`,
           value: modelId,
         });
       }
     }
 
-    const currentModeId = harness.session.mode.get();
+    const currentModeId = this.state.session.mode.get();
     const currentModeModel = (modePack.models as Record<string, string>)[currentModeId];
     if (currentModeModel) {
-      await harness.session.model.switch({ modelId: currentModeModel });
+      await this.state.session.model.switch({ modelId: currentModeModel });
     }
 
     const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };
     for (const [agentType, modeId] of Object.entries(subagentModeMap)) {
       const saModelId = (modePack.models as Record<string, string>)[modeId];
       if (saModelId) {
-        await harness.session.subagents.model.set({ modelId: saModelId, agentType });
+        await this.state.session.subagents.model.set({ modelId: saModelId, agentType });
       }
     }
 
@@ -1342,8 +1342,8 @@ export class MastraTUI {
 
     settings.onboarding.modePackId = activeModePackId;
     settings.models.activeModelPackId = activeModePackId;
-    if (harness.session.thread.getId()) {
-      await harness.session.thread.setSetting({ key: THREAD_ACTIVE_MODEL_PACK_ID_KEY, value: activeModePackId });
+    if (this.state.session.thread.getId()) {
+      await this.state.session.thread.setSetting({ key: THREAD_ACTIVE_MODEL_PACK_ID_KEY, value: activeModePackId });
     }
 
     settings.models.activeOmPackId = omPack.id;
@@ -1386,7 +1386,7 @@ export class MastraTUI {
     const tools = this.state.allToolComponents.filter(
       (tool): tool is IToolExecutionComponent => typeof tool.setQuietModeDisplay === 'function',
     );
-    const color = this.state.harness?.session.mode.resolve().metadata?.color;
+    const color = this.state.session?.mode.resolve().metadata?.color;
     const modeColor = typeof color === 'string' ? color : undefined;
     for (const tool of tools) {
       tool.setCompactToolModeColor?.(modeColor);

--- a/mastracode/src/tui/render-messages.test.ts
+++ b/mastracode/src/tui/render-messages.test.ts
@@ -27,6 +27,13 @@ function createSessionState(state: Record<string, unknown> = {}, setState = vi.f
 function createState(): TUIState {
   const displayState = { isRunning: false, tasks: [], previousTasks: [] };
   const sessionState = createSessionState();
+  const session = {
+    state: sessionState,
+    mode: { resolve: vi.fn(() => ({ metadata: {} })) },
+    model: { get: vi.fn(() => 'anthropic/claude-sonnet-4') },
+    thread: { listActiveMessages: vi.fn().mockResolvedValue([]) },
+    displayState: { get: () => displayState, restoreTasks: createRestoreDisplayTasks(displayState) },
+  };
   return {
     chatContainer: new Container(),
     ui: { requestRender: vi.fn() },
@@ -41,13 +48,9 @@ function createState(): TUIState {
     pendingSignalMessageComponentsById: new Map(),
     followUpComponents: [],
     quietMode: false,
-    session: {
-      state: sessionState,
-      mode: { resolve: vi.fn(() => ({ metadata: {} })) },
-      thread: { listActiveMessages: vi.fn().mockResolvedValue([]) },
-    },
+    session,
     harness: {
-      session: { displayState: { get: () => displayState, restoreTasks: createRestoreDisplayTasks(displayState) } },
+      session,
       setState: vi.fn().mockResolvedValue(undefined),
     },
   } as unknown as TUIState;
@@ -269,14 +272,11 @@ describe('renderExistingMessages subagents', () => {
       ...(state.session as any),
       thread: { listActiveMessages: vi.fn().mockResolvedValue([message]) },
       state: createSessionState(),
+      displayState: { get: () => ({ isRunning: false }), restoreTasks: vi.fn() },
+      model: { get: () => 'openai/gpt-5.5' },
     } as unknown as TUIState['session'];
     state.harness = {
-      session: {
-        thread: { listActiveMessages: vi.fn().mockResolvedValue([message]) },
-        displayState: { get: () => ({ isRunning: false }), restoreTasks: vi.fn() },
-        model: { get: () => 'openai/gpt-5.5' },
-        state: { set: vi.fn().mockResolvedValue(undefined) },
-      },
+      session: state.session,
     } as unknown as TUIState['harness'];
 
     await renderExistingMessages(state);
@@ -345,14 +345,9 @@ describe('renderExistingMessages task tools', () => {
       ...(state.session as any),
       thread: { listActiveMessages: vi.fn().mockResolvedValue(messages) },
       state: createSessionState({}, setState),
+      displayState: { get: () => displayState, restoreTasks: createRestoreDisplayTasks(displayState) },
     } as unknown as TUIState['session'];
-    state.harness = {
-      session: {
-        thread: { listActiveMessages: vi.fn().mockResolvedValue(messages) },
-        displayState: { get: () => displayState, restoreTasks: createRestoreDisplayTasks(displayState) },
-      },
-      setState,
-    } as unknown as TUIState['harness'];
+    state.harness = { session: state.session, setState } as unknown as TUIState['harness'];
 
     await renderExistingMessages(state);
 
@@ -415,14 +410,9 @@ describe('renderExistingMessages task tools', () => {
       ...(state.session as any),
       thread: { listActiveMessages: vi.fn().mockResolvedValue(messages) },
       state: createSessionState({}, setState),
+      displayState: { get: () => displayState, restoreTasks: createRestoreDisplayTasks(displayState) },
     } as unknown as TUIState['session'];
-    state.harness = {
-      session: {
-        thread: { listActiveMessages: vi.fn().mockResolvedValue(messages) },
-        displayState: { get: () => displayState, restoreTasks: createRestoreDisplayTasks(displayState) },
-      },
-      setState,
-    } as unknown as TUIState['harness'];
+    state.harness = { session: state.session, setState } as unknown as TUIState['harness'];
 
     await renderExistingMessages(state);
 
@@ -532,14 +522,9 @@ describe('renderExistingMessages task tools', () => {
       ...(state.session as any),
       thread: { listActiveMessages: vi.fn().mockResolvedValue(messages) },
       state: createSessionState({}, setState),
+      displayState: { get: () => displayState, restoreTasks: createRestoreDisplayTasks(displayState) },
     } as unknown as TUIState['session'];
-    state.harness = {
-      session: {
-        thread: { listActiveMessages: vi.fn().mockResolvedValue(messages) },
-        displayState: { get: () => displayState, restoreTasks: createRestoreDisplayTasks(displayState) },
-      },
-      setState,
-    } as unknown as TUIState['harness'];
+    state.harness = { session: state.session, setState } as unknown as TUIState['harness'];
 
     await expect(renderExistingMessages(state)).resolves.toBeUndefined();
 

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -212,7 +212,7 @@ export function confirmPendingUserMessage(state: TUIState, messageId: string, te
   const pending = state.pendingSignalMessageComponentsById.get(messageId);
   if (!pending) return;
 
-  if (state.streamingComponent && state.harness.session.displayState.get().isRunning) {
+  if (state.streamingComponent && state.session.displayState.get().isRunning) {
     state.streamingComponent = undefined;
     state.streamingMessage = undefined;
   }
@@ -553,7 +553,7 @@ export function addUserMessage(state: TUIState, message: HarnessMessage, options
 
     state.messageComponentsById.set(message.id, userComponent);
 
-    if (state.streamingComponent && state.harness.session.displayState.get().isRunning) {
+    if (state.streamingComponent && state.session.displayState.get().isRunning) {
       state.chatContainer.addChild(userComponent);
       state.followUpComponents.push(userComponent);
       reconcileChatBoundarySpacers(state.chatContainer);
@@ -723,7 +723,7 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
             // Parse embedded metadata for model ID, duration, tool calls
             const meta = rawResult ? parseSubagentMeta(rawResult) : null;
             const resultText = meta?.text ?? rawResult;
-            const currentModelId = state.harness.session.model.get() || undefined;
+            const currentModelId = state.session.model.get() || undefined;
             const modelId = meta?.modelId ?? subArgs?.modelId ?? (subArgs?.forked ? currentModelId : undefined);
             const durationMs = meta?.durationMs ?? 0;
 
@@ -947,7 +947,7 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
         // Keep the reconstructed task list local to display state in that case.
       }
     }
-    state.harness.session.displayState.restoreTasks(previousTasksAcc);
+    state.session.displayState.restoreTasks(previousTasksAcc);
   }
 
   reconcileChatBoundarySpacers(state.chatContainer);

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -472,7 +472,7 @@ export async function loadSkillCommands(state: TUIState): Promise<void> {
   try {
     let workspace = state.harness.getWorkspace() ?? state.workspace;
     if (!workspace && state.harness.hasWorkspace()) {
-      workspace = await state.harness.resolveWorkspace();
+      workspace = await state.harness.resolveWorkspace({ session: state.session });
     }
     if (!workspace?.skills) {
       state.skillCommands = [];
@@ -555,7 +555,7 @@ export function subscribeToHarness(state: TUIState, handleEvent: (event: any) =>
       if (stack) process.stderr.write(stack + '\n');
     }
   };
-  state.unsubscribe = state.harness.session.subscribe(listener);
+  state.unsubscribe = state.session.subscribe(listener);
 }
 
 // =============================================================================
@@ -604,7 +604,7 @@ export async function promptForThreadSelection(state: TUIState): Promise<void> {
   if (sortedThreads.length === 1) {
     const thread = sortedThreads[0]!;
     try {
-      await state.harness.session.thread.switch({ threadId: thread.id });
+      await state.session.thread.switch({ threadId: thread.id });
       if (!thread.metadata?.projectPath) {
         await state.session.thread.setSetting({ key: 'projectPath', value: currentPath });
       }
@@ -624,7 +624,7 @@ export async function promptForThreadSelection(state: TUIState): Promise<void> {
   // Multiple threads — try each in order until one is unlocked
   for (const thread of sortedThreads) {
     try {
-      await state.harness.session.thread.switch({ threadId: thread.id });
+      await state.session.thread.switch({ threadId: thread.id });
       if (!thread.metadata?.projectPath) {
         await state.session.thread.setSetting({ key: 'projectPath', value: currentPath });
       }
@@ -647,7 +647,7 @@ export async function promptForThreadSelection(state: TUIState): Promise<void> {
 
 export async function renderExistingTasks(state: TUIState): Promise<void> {
   try {
-    const tasks = state.harness.session.displayState.get().tasks;
+    const tasks = state.session.displayState.get().tasks;
 
     if (tasks.length > 0 && state.taskProgress) {
       state.taskProgress.updateTasks(tasks);

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -91,6 +91,9 @@ export interface MastraTUIOptions {
   /** The harness instance to control */
   harness: Harness<any>;
 
+  /** The session created from the harness that all work runs through */
+  session: Session<any>;
+
   /** Hook manager for session lifecycle hooks */
   hookManager?: HookManager;
 
@@ -308,7 +311,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
   const result: TUIState = {
     // Core dependencies
     harness: options.harness,
-    session: options.harness.session,
+    session: options.session,
     options,
     hookManager: options.hookManager,
     analytics: options.analytics,

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -71,7 +71,7 @@ export function updateStatusLine(state: TUIState): void {
   const SEP = '  '; // double-space separator between parts
 
   // --- Determine if we're showing observer/reflector instead of main mode ---
-  const omStatus = state.harness.session.displayState.get().omProgress.status;
+  const omStatus = state.session.displayState.get().omProgress.status;
   const isJudging = Boolean(state.activeGoalJudge);
   const isObserving = omStatus === 'observing';
   const isReflecting = omStatus === 'reflecting';
@@ -141,9 +141,9 @@ export function updateStatusLine(state: TUIState): void {
       ? state.activeGoalJudge?.modelId
       : showOMMode
         ? isObserving
-          ? state.harness.session.om.observer.modelId()
-          : state.harness.session.om.reflector.modelId()
-        : state.harness.session.model.get()) ?? '';
+          ? state.session.om.observer.modelId()
+          : state.session.om.reflector.modelId()
+        : state.session.model.get()) ?? '';
   // Rewrite Fireworks AI long paths: fireworks-ai/accounts/fireworks/models/<name> → fireworks/<name>
   let fullModelId = rawModelId.startsWith('fireworks-ai/accounts/fireworks/models/')
     ? 'fireworks/' + rawModelId.slice('fireworks-ai/accounts/fireworks/models/'.length)
@@ -290,7 +290,7 @@ export function updateStatusLine(state: TUIState): void {
     const useBadge = opts.badge === 'short' ? shortModeBadge : modeBadge;
     const useBadgeWidth = opts.badge === 'short' ? shortModeBadgeWidth : modeBadgeWidth;
     // Memory info — animate label text when buffering is active
-    const ds = state.harness.session.displayState.get();
+    const ds = state.session.displayState.get();
     const msgLabelStyler =
       ds.bufferingMessages && state.gradientAnimator?.isRunning()
         ? (label: string) =>
@@ -311,7 +311,7 @@ export function updateStatusLine(state: TUIState): void {
               state.gradientAnimator!.getFadeProgress(),
             )
         : undefined;
-    const omProg = state.harness.session.displayState.get().omProgress;
+    const omProg = state.session.displayState.get().omProgress;
     const obs = isJudging ? '' : formatObservationStatus(omProg, opts.memCompact, msgLabelStyler);
     const ref = isJudging ? '' : formatReflectionStatus(omProg, opts.memCompact, obsLabelStyler);
     if (obs) {

--- a/packages/core/src/harness/__tests__/harness-ask-user.test.ts
+++ b/packages/core/src/harness/__tests__/harness-ask-user.test.ts
@@ -87,13 +87,14 @@ async function buildHarness(id: string, input: string) {
   });
 
   await harness.init();
-  await harness.session.thread.create();
-  return { harness, registeredAgent };
+  const session = await harness.createSession();
+  await session.thread.create();
+  return { harness, session, registeredAgent };
 }
 
 describe('Harness: ask_user native suspension', () => {
   it('emits tool_suspended carrying the question payload when ask_user suspends', async () => {
-    const { harness } = await buildHarness(
+    const { harness, session } = await buildHarness(
       'emit',
       JSON.stringify({
         question: 'Which environment?',
@@ -102,9 +103,9 @@ describe('Harness: ask_user native suspension', () => {
     );
 
     const events: any[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    await harness.session.sendMessage({ content: 'Ask me where to deploy' });
+    await session.sendMessage({ content: 'Ask me where to deploy' });
 
     const suspendEvent = events.find(e => e.type === 'tool_suspended');
     expect(suspendEvent).toBeDefined();
@@ -115,24 +116,24 @@ describe('Harness: ask_user native suspension', () => {
     expect(suspendEvent.suspendPayload.selectionMode).toBe('single_select');
 
     // Display state should reflect the pending suspension.
-    expect(harness.session.displayState.get().pendingSuspensions.get('call-1')?.toolCallId).toBe('call-1');
-    expect(harness.session.displayState.get().pendingSuspensions.get('call-1')?.toolName).toBe('ask_user');
+    expect(session.displayState.get().pendingSuspensions.get('call-1')?.toolCallId).toBe('call-1');
+    expect(session.displayState.get().pendingSuspensions.get('call-1')?.toolName).toBe('ask_user');
   });
 
   it('resumes the suspended ask_user tool with the answer via respondToToolSuspension', async () => {
-    const { harness } = await buildHarness('resume', JSON.stringify({ question: 'Your name?' }));
+    const { harness, session } = await buildHarness('resume', JSON.stringify({ question: 'Your name?' }));
 
     const events: any[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    await harness.session.sendMessage({ content: 'Ask my name' });
+    await session.sendMessage({ content: 'Ask my name' });
 
     const suspendEvent = events.find(e => e.type === 'tool_suspended');
     expect(suspendEvent).toBeDefined();
 
     events.length = 0;
 
-    await harness.session.respondToToolSuspension({ toolCallId: suspendEvent.toolCallId, resumeData: 'Ada' });
+    await session.respondToToolSuspension({ toolCallId: suspendEvent.toolCallId, resumeData: 'Ada' });
 
     // Wait for the resumed run to finish.
     await vi.waitFor(() => {
@@ -141,11 +142,11 @@ describe('Harness: ask_user native suspension', () => {
     });
 
     expect(events.some(e => e.type === 'error')).toBe(false);
-    expect(harness.session.displayState.get().pendingSuspensions.size).toBe(0);
+    expect(session.displayState.get().pendingSuspensions.size).toBe(0);
   });
 
   it('emits multi_select in the suspend payload when requested', async () => {
-    const { harness } = await buildHarness(
+    const { harness, session } = await buildHarness(
       'multi',
       JSON.stringify({
         question: 'Pick any',
@@ -155,9 +156,9 @@ describe('Harness: ask_user native suspension', () => {
     );
 
     const events: any[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    await harness.session.sendMessage({ content: 'Ask me to pick' });
+    await session.sendMessage({ content: 'Ask me to pick' });
 
     const suspendEvent = events.find(e => e.type === 'tool_suspended');
     expect(suspendEvent.suspendPayload.selectionMode).toBe('multi_select');
@@ -167,49 +168,49 @@ describe('Harness: ask_user native suspension', () => {
     // The agent only surfaces one suspension per step, but the harness must be able
     // to hold several pending suspensions at once and resume exactly the requested
     // one. Drive the toolCallId-keyed tracking directly to assert that selection.
-    const { harness } = await buildHarness('concurrent', JSON.stringify({ question: 'First?' }));
+    const { harness, session } = await buildHarness('concurrent', JSON.stringify({ question: 'First?' }));
 
     const resumed: string[] = [];
-    (harness.session as any).resumeToolCall = async ({ toolCallId }: { toolCallId: string }) => {
+    (session as any).resumeToolCall = async ({ toolCallId }: { toolCallId: string }) => {
       resumed.push(toolCallId);
-      harness.session.suspensions.delete({ toolCallId });
+      session.suspensions.delete({ toolCallId });
     };
 
-    const pending = harness.session.suspensions;
+    const pending = session.suspensions;
     pending.register({ toolCallId: 'call-a', runId: 'run-a', toolName: 'ask_user' });
     pending.register({ toolCallId: 'call-b', runId: 'run-b', toolName: 'ask_user' });
 
     // Explicit toolCallId resumes only that suspension; the other stays pending.
-    await harness.session.respondToToolSuspension({ toolCallId: 'call-b', resumeData: 'two' });
+    await session.respondToToolSuspension({ toolCallId: 'call-b', resumeData: 'two' });
     expect(resumed).toEqual(['call-b']);
     expect(pending.has({ toolCallId: 'call-a' })).toBe(true);
     expect(pending.has({ toolCallId: 'call-b' })).toBe(false);
 
     // The remaining suspension can then be resumed by its own toolCallId.
-    await harness.session.respondToToolSuspension({ toolCallId: 'call-a', resumeData: 'one' });
+    await session.respondToToolSuspension({ toolCallId: 'call-a', resumeData: 'one' });
     expect(resumed).toEqual(['call-b', 'call-a']);
     expect(pending.hasPending()).toBe(false);
   });
 
   it('resolves the sole pending suspension when toolCallId is omitted', async () => {
-    const { harness } = await buildHarness('sole', JSON.stringify({ question: 'Only?' }));
+    const { harness, session } = await buildHarness('sole', JSON.stringify({ question: 'Only?' }));
 
     const resumed: string[] = [];
-    (harness.session as any).resumeToolCall = async ({ toolCallId }: { toolCallId: string }) => {
+    (session as any).resumeToolCall = async ({ toolCallId }: { toolCallId: string }) => {
       resumed.push(toolCallId);
-      harness.session.suspensions.delete({ toolCallId });
+      session.suspensions.delete({ toolCallId });
     };
 
-    const pending = harness.session.suspensions;
+    const pending = session.suspensions;
     pending.register({ toolCallId: 'call-only', runId: 'run-only', toolName: 'ask_user' });
 
-    await harness.session.respondToToolSuspension({ resumeData: 'ok' });
+    await session.respondToToolSuspension({ resumeData: 'ok' });
     expect(resumed).toEqual(['call-only']);
 
     // With more than one pending and no toolCallId, the call is a no-op.
     pending.register({ toolCallId: 'call-x', runId: 'run-x', toolName: 'ask_user' });
     pending.register({ toolCallId: 'call-y', runId: 'run-y', toolName: 'ask_user' });
-    await harness.session.respondToToolSuspension({ resumeData: 'ambiguous' });
+    await session.respondToToolSuspension({ resumeData: 'ambiguous' });
     expect(resumed).toEqual(['call-only']);
     expect(pending.has({ toolCallId: 'call-x' })).toBe(true);
     expect(pending.has({ toolCallId: 'call-y' })).toBe(true);
@@ -219,25 +220,25 @@ describe('Harness: ask_user native suspension', () => {
     // A run parked in a tool suspend() is not actively streaming, so abort() must
     // drop the pending suspensions itself — otherwise the harness reports it is
     // awaiting input forever and the UI can never recover.
-    const { harness } = await buildHarness('abort', JSON.stringify({ question: 'Pick?' }));
+    const { harness, session } = await buildHarness('abort', JSON.stringify({ question: 'Pick?' }));
 
     let resumed = false;
-    (harness.session as any).resumeToolCall = async () => {
+    (session as any).resumeToolCall = async () => {
       resumed = true;
     };
 
-    const pending = harness.session.suspensions;
+    const pending = session.suspensions;
     pending.register({ toolCallId: 'call-a', runId: 'run-a', toolName: 'ask_user' });
     pending.register({ toolCallId: 'call-b', runId: 'run-b', toolName: 'ask_user' });
-    expect(harness.session.suspensions.hasPending()).toBe(true);
+    expect(session.suspensions.hasPending()).toBe(true);
 
-    harness.session.abort();
+    session.abort();
 
-    expect(harness.session.suspensions.hasPending()).toBe(false);
+    expect(session.suspensions.hasPending()).toBe(false);
     expect(pending.hasPending()).toBe(false);
 
     // Resuming a suspension that abort already dropped is a safe no-op.
-    await harness.session.respondToToolSuspension({ toolCallId: 'call-a', resumeData: 'late' });
+    await session.respondToToolSuspension({ toolCallId: 'call-a', resumeData: 'late' });
     expect(resumed).toBe(false);
   });
 
@@ -246,13 +247,13 @@ describe('Harness: ask_user native suspension', () => {
     // resolve the parked gate itself — otherwise the await never settles and the
     // run hangs. Resolving as a decline rejects the gated tool, which is correct
     // for an aborted run.
-    const { harness } = await buildHarness('approval-abort', JSON.stringify({ question: 'Pick?' }));
+    const { harness, session } = await buildHarness('approval-abort', JSON.stringify({ question: 'Pick?' }));
 
-    const approval = harness.session.approval;
+    const approval = session.approval;
     const parked = approval.arm({ toolName: 'edit_file' });
     expect(approval.isArmed()).toBe(true);
 
-    harness.session.abort();
+    session.abort();
 
     const decision = await parked;
     expect(decision.decision).toBe('decline');
@@ -320,12 +321,13 @@ describe('Harness: ask_user native suspension', () => {
       initialState: { yolo: true } as any,
     });
     await harness.init();
-    await harness.session.thread.create();
+    const session = await harness.createSession();
+    await session.thread.create();
 
     const events: any[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    await harness.session.sendMessage({ content: 'Ask me three things' });
+    await session.sendMessage({ content: 'Ask me three things' });
 
     // Only the first question suspends on the initial run.
     let suspensions = events.filter(e => e.type === 'tool_suspended');
@@ -334,7 +336,7 @@ describe('Harness: ask_user native suspension', () => {
     // Answering each question resumes the run and surfaces exactly the next one.
     for (let i = 0; i < questions.length; i++) {
       events.length = 0;
-      await harness.session.respondToToolSuspension({ toolCallId: questions[i].toolCallId, resumeData: 'answer' });
+      await session.respondToToolSuspension({ toolCallId: questions[i].toolCallId, resumeData: 'answer' });
 
       suspensions = events.filter(e => e.type === 'tool_suspended');
       const next = questions[i + 1];
@@ -350,6 +352,6 @@ describe('Harness: ask_user native suspension', () => {
       }
     }
 
-    expect(harness.session.displayState.get().pendingSuspensions.size).toBe(0);
+    expect(session.displayState.get().pendingSuspensions.size).toBe(0);
   });
 });

--- a/packages/core/src/harness/__tests__/harness-finish-reason.test.ts
+++ b/packages/core/src/harness/__tests__/harness-finish-reason.test.ts
@@ -62,8 +62,9 @@ async function buildHarness(id: string, stream: () => ReadableStream) {
   });
 
   await harness.init();
-  await harness.session.thread.create();
-  return harness;
+  const session = await harness.createSession();
+  await session.thread.create();
+  return { harness, session };
 }
 
 describe('describeNonSuccessFinishReason', () => {
@@ -99,7 +100,7 @@ describe('describeNonSuccessFinishReason', () => {
 
 describe('Harness: non-success finish reasons', () => {
   it('finalizes a content-filter refusal into an explicit terminal error state', async () => {
-    const harness = await buildHarness('content-filter', () =>
+    const { session } = await buildHarness('content-filter', () =>
       createFinishReasonStream('content-filter', {
         anthropic: {
           stopDetails: {
@@ -112,11 +113,11 @@ describe('Harness: non-success finish reasons', () => {
     );
 
     const events: any[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'do something blocked' });
+    await session.sendMessage({ content: 'do something blocked' });
 
     // The run must not silently complete.
     const agentEnd = events.find(e => e.type === 'agent_end');
@@ -134,14 +135,14 @@ describe('Harness: non-success finish reasons', () => {
   });
 
   it('surfaces a content-filter refusal even without provider stop details', async () => {
-    const harness = await buildHarness('content-filter-no-details', () => createFinishReasonStream('content-filter'));
+    const { session } = await buildHarness('content-filter-no-details', () => createFinishReasonStream('content-filter'));
 
     const events: any[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'do something blocked' });
+    await session.sendMessage({ content: 'do something blocked' });
 
     expect(events.find(e => e.type === 'agent_end')?.reason).toBe('error');
     const messageEnd = [...events].reverse().find(e => e.type === 'message_end');
@@ -150,14 +151,14 @@ describe('Harness: non-success finish reasons', () => {
   });
 
   it('surfaces a length finish reason as a terminal error state', async () => {
-    const harness = await buildHarness('length', () => createFinishReasonStream('length'));
+    const { session } = await buildHarness('length', () => createFinishReasonStream('length'));
 
     const events: any[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'write a very long answer' });
+    await session.sendMessage({ content: 'write a very long answer' });
 
     expect(events.find(e => e.type === 'agent_end')?.reason).toBe('error');
     const messageEnd = [...events].reverse().find(e => e.type === 'message_end');
@@ -166,7 +167,7 @@ describe('Harness: non-success finish reasons', () => {
   });
 
   it('emits an info notice when a server-side fallback model served the turn', async () => {
-    const harness = await buildHarness('fallback-served', () =>
+    const { session } = await buildHarness('fallback-served', () =>
       createFinishReasonStream('stop', {
         anthropic: {
           iterations: [
@@ -178,11 +179,11 @@ describe('Harness: non-success finish reasons', () => {
     );
 
     const events: any[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'do something borderline' });
+    await session.sendMessage({ content: 'do something borderline' });
 
     // The turn still completes normally — the fallback answered it.
     expect(events.find(e => e.type === 'agent_end')?.reason).toBe('complete');
@@ -195,14 +196,14 @@ describe('Harness: non-success finish reasons', () => {
   });
 
   it('still completes normally on a stop finish reason', async () => {
-    const harness = await buildHarness('stop', () => createFinishReasonStream('stop'));
+    const { session } = await buildHarness('stop', () => createFinishReasonStream('stop'));
 
     const events: any[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'say hi' });
+    await session.sendMessage({ content: 'say hi' });
 
     expect(events.find(e => e.type === 'agent_end')?.reason).toBe('complete');
     expect(events.some(e => e.type === 'error')).toBe(false);

--- a/packages/core/src/harness/__tests__/harness-notifications.test.ts
+++ b/packages/core/src/harness/__tests__/harness-notifications.test.ts
@@ -31,15 +31,17 @@ describe('Harness notification signals', () => {
       resourceId: 'resource-1',
       modes: [{ id: 'default', name: 'Default', default: true, agent: agent as any }],
     });
+    await harness.init();
+    const session = await harness.createSession();
 
-    const result = await harness.session.sendNotificationSignal({
+    const result = await session.sendNotificationSignal({
       source: 'mastracode',
       kind: 'manual',
       priority: 'high',
       summary: 'Check this notification',
     });
 
-    const threadId = harness.session.thread.getId();
+    const threadId = session.thread.getId();
     expect(threadId).toBeTruthy();
     expect(result).toMatchObject({ accepted: true, record: { id: 'notification-1', threadId } });
     expect(agent.subscribeToThread).toHaveBeenCalledTimes(1);

--- a/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
+++ b/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
@@ -97,9 +97,10 @@ describe('Harness: tool suspension and resumption', () => {
     });
 
     await harness.init();
-    await harness.session.thread.create();
+    const session = await harness.createSession();
+    await session.thread.create();
 
-    await harness.session.sendMessage({ content: 'Hello' });
+    await session.sendMessage({ content: 'Hello' });
 
     expect(streamSpy).toHaveBeenCalled();
     const [, streamOptions] = streamSpy.mock.calls[0] as [any, any];
@@ -163,17 +164,18 @@ describe('Harness: tool suspension and resumption', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
     // Collect all events
     const events: any[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.thread.create();
+    await session.thread.create();
 
     // Send a message — the tool should execute and call suspend()
-    await harness.session.sendMessage({ content: 'Deploy to production' });
+    await session.sendMessage({ content: 'Deploy to production' });
 
     // agent_end should fire with reason 'suspended', not 'complete'
     const agentEndEvent = events.find((e: any) => e.type === 'agent_end');
@@ -230,10 +232,11 @@ describe('Harness: tool suspension and resumption', () => {
     });
 
     await harness.init();
-    await harness.session.thread.create();
-    await harness.session.sendMessage({ content: 'Do it' });
+    const session = await harness.createSession();
+    await session.thread.create();
+    await session.sendMessage({ content: 'Do it' });
 
-    const ds = harness.session.displayState.get();
+    const ds = session.displayState.get();
     expect(ds.pendingSuspensions.size).toBe(1);
     const suspension = Array.from(ds.pendingSuspensions.values())[0];
     expect(suspension!.toolName).toBe('confirmAction');
@@ -292,16 +295,17 @@ describe('Harness: tool suspension and resumption', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
     const events: any[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.thread.create();
+    await session.thread.create();
 
     // First message triggers suspension
-    await harness.session.sendMessage({ content: 'Deploy to production' });
+    await session.sendMessage({ content: 'Deploy to production' });
 
     const suspendEnd = events.find((e: any) => e.type === 'agent_end');
     expect(suspendEnd?.reason).toBe('suspended');
@@ -310,7 +314,7 @@ describe('Harness: tool suspension and resumption', () => {
     events.length = 0;
 
     // Resume with data
-    await harness.session.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await session.respondToToolSuspension({ resumeData: { confirmed: true } });
 
     // Should emit agent_start + agent_end(complete) for the resumed run
     const resumeStart = events.find((e: any) => e.type === 'agent_start');
@@ -322,7 +326,7 @@ describe('Harness: tool suspension and resumption', () => {
     expect(events.some((e: any) => e.type === 'error')).toBe(false);
 
     // pending suspensions should be cleared after resume
-    const ds = harness.session.displayState.get();
+    const ds = session.displayState.get();
     expect(ds.pendingSuspensions.size).toBe(0);
   });
 
@@ -374,10 +378,11 @@ describe('Harness: tool suspension and resumption', () => {
     });
 
     await harness.init();
-    await harness.session.thread.create();
+    const session = await harness.createSession();
+    await session.thread.create();
 
-    await harness.session.sendMessage({ content: 'Deploy to production' });
-    await harness.session.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await session.sendMessage({ content: 'Deploy to production' });
+    await session.respondToToolSuspension({ resumeData: { confirmed: true } });
 
     expect(resumeStreamSpy).toHaveBeenCalled();
     const [, resumeOptions] = resumeStreamSpy.mock.calls[0] as [any, any];
@@ -441,10 +446,11 @@ describe('Harness: tool suspension and resumption', () => {
     });
 
     await harness.init();
-    await harness.session.thread.create();
+    const session = await harness.createSession();
+    await session.thread.create();
 
-    await harness.session.sendMessage({ content: 'Deploy to production' });
-    await harness.session.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await session.sendMessage({ content: 'Deploy to production' });
+    await session.respondToToolSuspension({ resumeData: { confirmed: true } });
 
     expect(resumeStreamSpy).toHaveBeenCalled();
     const [, resumeOptions] = resumeStreamSpy.mock.calls[0] as [any, any];

--- a/packages/core/src/harness/clone-thread.test.ts
+++ b/packages/core/src/harness/clone-thread.test.ts
@@ -40,8 +40,9 @@ describe('Harness cloneThread', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
-    const cloned = await harness.session.thread.clone({
+    const cloned = await session.thread.clone({
       sourceThreadId: 'source-thread-id',
       title: 'New title',
       resourceId: 'target-resource',
@@ -76,8 +77,9 @@ describe('Harness cloneThread', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
-    await expect(harness.session.thread.clone({ sourceThreadId: 'source-thread-id' })).rejects.toThrow(
+    await expect(session.thread.clone({ sourceThreadId: 'source-thread-id' })).rejects.toThrow(
       'Dynamic memory factory returned empty value',
     );
   });

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -1,30 +1,19 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { Agent } from '../agent';
 import { RequestContext } from '../request-context';
 import { InMemoryStore } from '../storage/mock';
 import { ChunkFrom } from '../stream/types';
-import { Harness } from './harness';
+import type { Session } from './session';
+import { createTestSession } from './test-utils';
 import type { HarnessEvent, HarnessSubagent, HarnessSubagentHistoryEntry } from './types';
 import { createEmptyTokenUsage, defaultDisplayState } from './types';
 
-function createHarness(storage?: InMemoryStore, opts?: { subagents?: HarnessSubagent[] }) {
-  const agent = new Agent({
-    name: 'test-agent',
-    instructions: 'You are a test agent.',
-    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
-  });
-
-  return new Harness({
-    id: 'test-harness',
-    storage: storage ?? new InMemoryStore(),
-    modes: [{ id: 'default', name: 'Default', default: true, agent }],
-    subagents: opts?.subagents,
-  });
+function createSession(storage?: InMemoryStore, opts?: { subagents?: HarnessSubagent[] }) {
+  return createTestSession({ storage: storage ?? new InMemoryStore(), subagents: opts?.subagents });
 }
 
-// Helper to emit an event on the harness's session bus.
-function emit(harness: Harness, event: HarnessEvent) {
-  harness.session.emit(event);
+// Helper to emit an event on a session bus.
+function emit(session: Session, event: HarnessEvent) {
+  session.emit(event);
 }
 
 describe('defaultDisplayState', () => {
@@ -61,14 +50,15 @@ describe('defaultDisplayState', () => {
 });
 
 describe('session.displayState.get()', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('returns display state with correct initial values', () => {
-    const ds = harness.session.displayState.get();
+    const ds = session.displayState.get();
     expect(ds.isRunning).toBe(false);
     expect(ds.currentMessage).toBeNull();
     expect(ds.tokenUsage).toEqual(createEmptyTokenUsage());
@@ -81,8 +71,8 @@ describe('session.displayState.get()', () => {
   });
 
   it('returns the same reference (not a copy)', () => {
-    const ds1 = harness.session.displayState.get();
-    const ds2 = harness.session.displayState.get();
+    const ds1 = session.displayState.get();
+    const ds2 = session.displayState.get();
     expect(ds1).toBe(ds2);
   });
 });
@@ -92,80 +82,81 @@ describe('session.displayState.get()', () => {
 // ===========================================================================
 
 describe('agent lifecycle', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('sets isRunning to true on agent_start', () => {
-    emit(harness, { type: 'agent_start' });
-    expect(harness.session.displayState.get().isRunning).toBe(true);
+    emit(session, { type: 'agent_start' });
+    expect(session.displayState.get().isRunning).toBe(true);
   });
 
   it('clears activeTools on agent_start', () => {
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
-    expect(harness.session.displayState.get().activeTools.size).toBe(1);
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
+    expect(session.displayState.get().activeTools.size).toBe(1);
 
-    emit(harness, { type: 'agent_start' });
-    expect(harness.session.displayState.get().activeTools.size).toBe(0);
+    emit(session, { type: 'agent_start' });
+    expect(session.displayState.get().activeTools.size).toBe(0);
   });
 
   it('clears toolInputBuffers on agent_start', () => {
-    emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
-    expect(harness.session.displayState.get().toolInputBuffers.size).toBe(1);
+    emit(session, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+    expect(session.displayState.get().toolInputBuffers.size).toBe(1);
 
-    emit(harness, { type: 'agent_start' });
-    expect(harness.session.displayState.get().toolInputBuffers.size).toBe(0);
+    emit(session, { type: 'agent_start' });
+    expect(session.displayState.get().toolInputBuffers.size).toBe(0);
   });
 
   it('clears pendingApproval on agent_start', () => {
-    emit(harness, { type: 'tool_approval_required', toolCallId: 't1', toolName: 'write_file', args: {} });
-    expect(harness.session.displayState.get().pendingApproval).not.toBeNull();
+    emit(session, { type: 'tool_approval_required', toolCallId: 't1', toolName: 'write_file', args: {} });
+    expect(session.displayState.get().pendingApproval).not.toBeNull();
 
-    emit(harness, { type: 'agent_start' });
-    expect(harness.session.displayState.get().pendingApproval).toBeNull();
+    emit(session, { type: 'agent_start' });
+    expect(session.displayState.get().pendingApproval).toBeNull();
   });
 
   it('sets isRunning to false on agent_end', () => {
-    emit(harness, { type: 'agent_start' });
-    expect(harness.session.displayState.get().isRunning).toBe(true);
+    emit(session, { type: 'agent_start' });
+    expect(session.displayState.get().isRunning).toBe(true);
 
-    emit(harness, { type: 'agent_end', reason: 'complete' });
-    expect(harness.session.displayState.get().isRunning).toBe(false);
+    emit(session, { type: 'agent_end', reason: 'complete' });
+    expect(session.displayState.get().isRunning).toBe(false);
   });
 
   it('marks running tools as error on agent_end', () => {
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: { path: 'test.ts' } });
-    expect(harness.session.displayState.get().activeTools.get('t1')?.status).toBe('running');
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: { path: 'test.ts' } });
+    expect(session.displayState.get().activeTools.get('t1')?.status).toBe('running');
 
-    emit(harness, { type: 'agent_end', reason: 'aborted' });
-    expect(harness.session.displayState.get().activeTools.get('t1')?.status).toBe('error');
+    emit(session, { type: 'agent_end', reason: 'aborted' });
+    expect(session.displayState.get().activeTools.get('t1')?.status).toBe('error');
   });
 
   it('marks streaming_input tools as error on agent_end', () => {
-    emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
-    expect(harness.session.displayState.get().activeTools.get('t1')?.status).toBe('streaming_input');
+    emit(session, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+    expect(session.displayState.get().activeTools.get('t1')?.status).toBe('streaming_input');
 
-    emit(harness, { type: 'agent_end', reason: 'aborted' });
-    expect(harness.session.displayState.get().activeTools.get('t1')?.status).toBe('error');
+    emit(session, { type: 'agent_end', reason: 'aborted' });
+    expect(session.displayState.get().activeTools.get('t1')?.status).toBe('error');
   });
 
   it('does not change completed tools on agent_end', () => {
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: { path: 'test.ts' } });
-    emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
-    expect(harness.session.displayState.get().activeTools.get('t1')?.status).toBe('completed');
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: { path: 'test.ts' } });
+    emit(session, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
+    expect(session.displayState.get().activeTools.get('t1')?.status).toBe('completed');
 
-    emit(harness, { type: 'agent_end', reason: 'complete' });
-    expect(harness.session.displayState.get().activeTools.get('t1')?.status).toBe('completed');
+    emit(session, { type: 'agent_end', reason: 'complete' });
+    expect(session.displayState.get().activeTools.get('t1')?.status).toBe('completed');
   });
 
   it('clears activeSubagents on agent_end', () => {
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 'find', modelId: 'gpt-4o' });
-    expect(harness.session.displayState.get().activeSubagents.size).toBe(1);
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 'find', modelId: 'gpt-4o' });
+    expect(session.displayState.get().activeSubagents.size).toBe(1);
 
-    emit(harness, { type: 'agent_end', reason: 'complete' });
-    expect(harness.session.displayState.get().activeSubagents.size).toBe(0);
+    emit(session, { type: 'agent_end', reason: 'complete' });
+    expect(session.displayState.get().activeSubagents.size).toBe(0);
   });
 });
 
@@ -174,7 +165,7 @@ describe('agent lifecycle', () => {
 // ===========================================================================
 
 describe('message streaming', () => {
-  let harness: Harness;
+  let session: Session;
   const msg1 = {
     id: 'm1',
     role: 'assistant' as const,
@@ -188,25 +179,26 @@ describe('message streaming', () => {
     createdAt: new Date(),
   };
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('tracks currentMessage on message_start', () => {
-    emit(harness, { type: 'message_start', message: msg1 as any });
-    expect(harness.session.displayState.get().currentMessage).toBe(msg1);
+    emit(session, { type: 'message_start', message: msg1 as any });
+    expect(session.displayState.get().currentMessage).toBe(msg1);
   });
 
   it('updates currentMessage on message_update', () => {
-    emit(harness, { type: 'message_start', message: msg1 as any });
-    emit(harness, { type: 'message_update', message: msg2 as any });
-    expect(harness.session.displayState.get().currentMessage).toBe(msg2);
+    emit(session, { type: 'message_start', message: msg1 as any });
+    emit(session, { type: 'message_update', message: msg2 as any });
+    expect(session.displayState.get().currentMessage).toBe(msg2);
   });
 
   it('keeps currentMessage reference on message_end', () => {
-    emit(harness, { type: 'message_start', message: msg1 as any });
-    emit(harness, { type: 'message_end', message: msg2 as any });
-    expect(harness.session.displayState.get().currentMessage).toBe(msg2);
+    emit(session, { type: 'message_start', message: msg1 as any });
+    emit(session, { type: 'message_end', message: msg2 as any });
+    expect(session.displayState.get().currentMessage).toBe(msg2);
   });
 });
 
@@ -215,16 +207,17 @@ describe('message streaming', () => {
 // ===========================================================================
 
 describe('tool lifecycle', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   describe('tool_start / tool_end', () => {
     it('creates tool entry on tool_start', () => {
-      emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: { path: 'foo.ts' } });
-      const tool = harness.session.displayState.get().activeTools.get('t1');
+      emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: { path: 'foo.ts' } });
+      const tool = session.displayState.get().activeTools.get('t1');
       expect(tool).toBeDefined();
       expect(tool!.name).toBe('read_file');
       expect(tool!.args).toEqual({ path: 'foo.ts' });
@@ -232,31 +225,31 @@ describe('tool lifecycle', () => {
     });
 
     it('updates existing tool entry on tool_start (after tool_input_start)', () => {
-      emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
-      emit(harness, {
+      emit(session, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+      emit(session, {
         type: 'tool_start',
         toolCallId: 't1',
         toolName: 'write_file',
         args: { path: 'x', content: 'y' },
       });
-      const tool = harness.session.displayState.get().activeTools.get('t1');
+      const tool = session.displayState.get().activeTools.get('t1');
       expect(tool!.status).toBe('running');
       expect(tool!.args).toEqual({ path: 'x', content: 'y' });
     });
 
     it('marks tool as completed on successful tool_end', () => {
-      emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
-      emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'file contents', isError: false });
-      const tool = harness.session.displayState.get().activeTools.get('t1');
+      emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
+      emit(session, { type: 'tool_end', toolCallId: 't1', result: 'file contents', isError: false });
+      const tool = session.displayState.get().activeTools.get('t1');
       expect(tool!.status).toBe('completed');
       expect(tool!.result).toBe('file contents');
       expect(tool!.isError).toBe(false);
     });
 
     it('marks tool as error on failed tool_end', () => {
-      emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
-      emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'not found', isError: true });
-      const tool = harness.session.displayState.get().activeTools.get('t1');
+      emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
+      emit(session, { type: 'tool_end', toolCallId: 't1', result: 'not found', isError: true });
+      const tool = session.displayState.get().activeTools.get('t1');
       expect(tool!.status).toBe('error');
       expect(tool!.isError).toBe(true);
     });
@@ -264,73 +257,75 @@ describe('tool lifecycle', () => {
 
   describe('tool_update', () => {
     it('sets partialResult on existing tool', () => {
-      emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'execute_command', args: {} });
-      emit(harness, { type: 'tool_update', toolCallId: 't1', partialResult: 'partial output' });
-      expect(harness.session.displayState.get().activeTools.get('t1')!.partialResult).toBe('partial output');
+      emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'execute_command', args: {} });
+      emit(session, { type: 'tool_update', toolCallId: 't1', partialResult: 'partial output' });
+      expect(session.displayState.get().activeTools.get('t1')!.partialResult).toBe('partial output');
     });
 
     it('stringifies non-string partialResult', () => {
-      emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'execute_command', args: {} });
-      emit(harness, { type: 'tool_update', toolCallId: 't1', partialResult: { key: 'value' } });
-      expect(harness.session.displayState.get().activeTools.get('t1')!.partialResult).toBe('{"key":"value"}');
+      emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'execute_command', args: {} });
+      emit(session, { type: 'tool_update', toolCallId: 't1', partialResult: { key: 'value' } });
+      expect(session.displayState.get().activeTools.get('t1')!.partialResult).toBe('{"key":"value"}');
     });
 
     it('ignores update for unknown toolCallId', () => {
-      emit(harness, { type: 'tool_update', toolCallId: 'unknown', partialResult: 'x' });
-      expect(harness.session.displayState.get().activeTools.has('unknown')).toBe(false);
+      emit(session, { type: 'tool_update', toolCallId: 'unknown', partialResult: 'x' });
+      expect(session.displayState.get().activeTools.has('unknown')).toBe(false);
     });
   });
 
   describe('shell_output', () => {
     it('appends shell output to tool', () => {
-      emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'execute_command', args: {} });
-      emit(harness, { type: 'shell_output', toolCallId: 't1', output: 'line1\n', stream: 'stdout' });
-      emit(harness, { type: 'shell_output', toolCallId: 't1', output: 'line2\n', stream: 'stderr' });
-      expect(harness.session.displayState.get().activeTools.get('t1')!.shellOutput).toBe('line1\nline2\n');
+      emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'execute_command', args: {} });
+      emit(session, { type: 'shell_output', toolCallId: 't1', output: 'line1\n', stream: 'stdout' });
+      emit(session, { type: 'shell_output', toolCallId: 't1', output: 'line2\n', stream: 'stderr' });
+      expect(session.displayState.get().activeTools.get('t1')!.shellOutput).toBe('line1\nline2\n');
     });
   });
 
   describe('tool_input_start / tool_input_delta / tool_input_end', () => {
     it('creates buffer on tool_input_start', () => {
-      emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
-      const buf = harness.session.displayState.get().toolInputBuffers.get('t1');
+      emit(session, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+      const buf = session.displayState.get().toolInputBuffers.get('t1');
       expect(buf).toBeDefined();
       expect(buf!.text).toBe('');
       expect(buf!.toolName).toBe('write_file');
     });
 
     it('creates tool entry with streaming_input status on tool_input_start', () => {
-      emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
-      const tool = harness.session.displayState.get().activeTools.get('t1');
+      emit(session, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+      const tool = session.displayState.get().activeTools.get('t1');
       expect(tool).toBeDefined();
       expect(tool!.status).toBe('streaming_input');
     });
 
     it('accumulates text on tool_input_delta', () => {
-      emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
-      emit(harness, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '{"path":' });
-      emit(harness, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '"test.ts"}' });
-      expect(harness.session.displayState.get().toolInputBuffers.get('t1')!.text).toBe('{"path":"test.ts"}');
+      emit(session, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+      emit(session, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '{"path":' });
+      emit(session, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '"test.ts"}' });
+      expect(session.displayState.get().toolInputBuffers.get('t1')!.text).toBe('{"path":"test.ts"}');
     });
 
     it('removes buffer on tool_input_end', () => {
-      emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
-      emit(harness, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '{}' });
-      emit(harness, { type: 'tool_input_end', toolCallId: 't1' });
-      expect(harness.session.displayState.get().toolInputBuffers.has('t1')).toBe(false);
+      emit(session, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+      emit(session, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '{}' });
+      emit(session, { type: 'tool_input_end', toolCallId: 't1' });
+      expect(session.displayState.get().toolInputBuffers.has('t1')).toBe(false);
     });
 
     it('ignores delta for unknown toolCallId', () => {
-      emit(harness, { type: 'tool_input_delta', toolCallId: 'unknown', argsTextDelta: 'x' });
-      expect(harness.session.displayState.get().toolInputBuffers.has('unknown')).toBe(false);
+      emit(session, { type: 'tool_input_delta', toolCallId: 'unknown', argsTextDelta: 'x' });
+      expect(session.displayState.get().toolInputBuffers.has('unknown')).toBe(false);
     });
   });
 
   it('uses display transforms while processing tool stream chunks', async () => {
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => {
+      events.push(event);
+    });
 
-    const result = await (harness.session as any).processStream(
+    const result = await (session as any).processStream(
       {
         fullStream: new ReadableStream({
           start(controller) {
@@ -399,9 +394,11 @@ describe('tool lifecycle', () => {
 
   it('preserves explicit null display transforms', async () => {
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => {
+      events.push(event);
+    });
 
-    const result = await (harness.session as any).processStream(
+    const result = await (session as any).processStream(
       {
         fullStream: new ReadableStream({
           start(controller) {
@@ -495,13 +492,13 @@ describe('tool lifecycle', () => {
 
   describe('tool_approval_required', () => {
     it('sets pendingApproval', () => {
-      emit(harness, {
+      emit(session, {
         type: 'tool_approval_required',
         toolCallId: 't1',
         toolName: 'execute_command',
         args: { command: 'rm -rf /' },
       });
-      const approval = harness.session.displayState.get().pendingApproval;
+      const approval = session.displayState.get().pendingApproval;
       expect(approval).not.toBeNull();
       expect(approval!.toolCallId).toBe('t1');
       expect(approval!.toolName).toBe('execute_command');
@@ -511,7 +508,7 @@ describe('tool lifecycle', () => {
 
   describe('tool_suspended', () => {
     it('sets a pendingSuspensions entry', () => {
-      emit(harness, {
+      emit(session, {
         type: 'tool_suspended',
         toolCallId: 't1',
         toolName: 'confirmAction',
@@ -519,7 +516,7 @@ describe('tool lifecycle', () => {
         suspendPayload: { reason: 'Needs confirmation' },
         resumeSchema: undefined,
       });
-      const suspension = harness.session.displayState.get().pendingSuspensions.get('t1');
+      const suspension = session.displayState.get().pendingSuspensions.get('t1');
       expect(suspension).toBeDefined();
       expect(suspension!.toolCallId).toBe('t1');
       expect(suspension!.toolName).toBe('confirmAction');
@@ -528,7 +525,7 @@ describe('tool lifecycle', () => {
     });
 
     it('preserves pendingSuspensions on agent_start so resuming one keeps the rest', () => {
-      emit(harness, {
+      emit(session, {
         type: 'tool_suspended',
         toolCallId: 't1',
         toolName: 'confirmAction',
@@ -536,16 +533,16 @@ describe('tool lifecycle', () => {
         suspendPayload: {},
         resumeSchema: undefined,
       });
-      expect(harness.session.displayState.get().pendingSuspensions.size).toBe(1);
+      expect(session.displayState.get().pendingSuspensions.size).toBe(1);
 
       // Resuming a parked tool restarts the run (a fresh agent_start); the other
       // parallel prompts must survive.
-      emit(harness, { type: 'agent_start' });
-      expect(harness.session.displayState.get().pendingSuspensions.has('t1')).toBe(true);
+      emit(session, { type: 'agent_start' });
+      expect(session.displayState.get().pendingSuspensions.has('t1')).toBe(true);
     });
 
     it('preserves pendingSuspensions on agent_end with reason suspended', () => {
-      emit(harness, {
+      emit(session, {
         type: 'tool_suspended',
         toolCallId: 't1',
         toolName: 'confirmAction',
@@ -553,14 +550,14 @@ describe('tool lifecycle', () => {
         suspendPayload: {},
         resumeSchema: undefined,
       });
-      expect(harness.session.displayState.get().pendingSuspensions.size).toBe(1);
+      expect(session.displayState.get().pendingSuspensions.size).toBe(1);
 
-      emit(harness, { type: 'agent_end', reason: 'suspended' });
-      expect(harness.session.displayState.get().pendingSuspensions.size).toBe(1);
+      emit(session, { type: 'agent_end', reason: 'suspended' });
+      expect(session.displayState.get().pendingSuspensions.size).toBe(1);
     });
 
     it('clears pendingSuspensions on agent_end with non-suspended reason', () => {
-      emit(harness, {
+      emit(session, {
         type: 'tool_suspended',
         toolCallId: 't1',
         toolName: 'confirmAction',
@@ -568,14 +565,14 @@ describe('tool lifecycle', () => {
         suspendPayload: {},
         resumeSchema: undefined,
       });
-      expect(harness.session.displayState.get().pendingSuspensions.size).toBe(1);
+      expect(session.displayState.get().pendingSuspensions.size).toBe(1);
 
-      emit(harness, { type: 'agent_end', reason: 'complete' });
-      expect(harness.session.displayState.get().pendingSuspensions.size).toBe(0);
+      emit(session, { type: 'agent_end', reason: 'complete' });
+      expect(session.displayState.get().pendingSuspensions.size).toBe(0);
     });
 
     it('keeps other parked suspensions when one resumes while another is pending', () => {
-      emit(harness, {
+      emit(session, {
         type: 'tool_suspended',
         toolCallId: 't1',
         toolName: 'ask_user',
@@ -583,7 +580,7 @@ describe('tool lifecycle', () => {
         suspendPayload: { question: 'first?' },
         resumeSchema: undefined,
       });
-      emit(harness, {
+      emit(session, {
         type: 'tool_suspended',
         toolCallId: 't2',
         toolName: 'ask_user',
@@ -591,12 +588,12 @@ describe('tool lifecycle', () => {
         suspendPayload: { question: 'second?' },
         resumeSchema: undefined,
       });
-      expect(harness.session.displayState.get().pendingSuspensions.size).toBe(2);
+      expect(session.displayState.get().pendingSuspensions.size).toBe(2);
 
       // Simulate resuming only t1 (display-state side of handleToolResume).
-      harness.session.displayState.get().pendingSuspensions.delete('t1');
-      expect(harness.session.displayState.get().pendingSuspensions.has('t1')).toBe(false);
-      expect(harness.session.displayState.get().pendingSuspensions.get('t2')?.suspendPayload).toEqual({
+      session.displayState.get().pendingSuspensions.delete('t1');
+      expect(session.displayState.get().pendingSuspensions.has('t1')).toBe(false);
+      expect(session.displayState.get().pendingSuspensions.get('t2')?.suspendPayload).toEqual({
         question: 'second?',
       });
     });
@@ -608,73 +605,74 @@ describe('tool lifecycle', () => {
 // ===========================================================================
 
 describe('modifiedFiles tracking', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('tracks string_replace_lsp modifications', () => {
-    emit(harness, {
+    emit(session, {
       type: 'tool_start',
       toolCallId: 't1',
       toolName: 'string_replace_lsp',
       args: { path: 'src/app.ts' },
     });
-    emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
+    emit(session, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
 
-    const files = harness.session.displayState.get().modifiedFiles;
+    const files = session.displayState.get().modifiedFiles;
     expect(files.has('src/app.ts')).toBe(true);
     expect(files.get('src/app.ts')!.operations).toEqual(['string_replace_lsp']);
   });
 
   it('tracks write_file modifications', () => {
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'write_file', args: { path: 'new.ts' } });
-    emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'write_file', args: { path: 'new.ts' } });
+    emit(session, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
 
-    expect(harness.session.displayState.get().modifiedFiles.has('new.ts')).toBe(true);
+    expect(session.displayState.get().modifiedFiles.has('new.ts')).toBe(true);
   });
 
   it('tracks ast_smart_edit modifications', () => {
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'ast_smart_edit', args: { path: 'src/index.ts' } });
-    emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'ast_smart_edit', args: { path: 'src/index.ts' } });
+    emit(session, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
 
-    expect(harness.session.displayState.get().modifiedFiles.has('src/index.ts')).toBe(true);
+    expect(session.displayState.get().modifiedFiles.has('src/index.ts')).toBe(true);
   });
 
   it('accumulates multiple operations on the same file', () => {
-    emit(harness, {
+    emit(session, {
       type: 'tool_start',
       toolCallId: 't1',
       toolName: 'string_replace_lsp',
       args: { path: 'src/app.ts' },
     });
-    emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
+    emit(session, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
 
-    emit(harness, {
+    emit(session, {
       type: 'tool_start',
       toolCallId: 't2',
       toolName: 'string_replace_lsp',
       args: { path: 'src/app.ts' },
     });
-    emit(harness, { type: 'tool_end', toolCallId: 't2', result: 'ok', isError: false });
+    emit(session, { type: 'tool_end', toolCallId: 't2', result: 'ok', isError: false });
 
-    const entry = harness.session.displayState.get().modifiedFiles.get('src/app.ts');
+    const entry = session.displayState.get().modifiedFiles.get('src/app.ts');
     expect(entry!.operations).toEqual(['string_replace_lsp', 'string_replace_lsp']);
   });
 
   it('does not track file modifications for errored tools', () => {
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'write_file', args: { path: 'fail.ts' } });
-    emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'error', isError: true });
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'write_file', args: { path: 'fail.ts' } });
+    emit(session, { type: 'tool_end', toolCallId: 't1', result: 'error', isError: true });
 
-    expect(harness.session.displayState.get().modifiedFiles.has('fail.ts')).toBe(false);
+    expect(session.displayState.get().modifiedFiles.has('fail.ts')).toBe(false);
   });
 
   it('does not track non-file tools', () => {
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'execute_command', args: { command: 'ls' } });
-    emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'execute_command', args: { command: 'ls' } });
+    emit(session, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
 
-    expect(harness.session.displayState.get().modifiedFiles.size).toBe(0);
+    expect(session.displayState.get().modifiedFiles.size).toBe(0);
   });
 });
 
@@ -683,28 +681,29 @@ describe('modifiedFiles tracking', () => {
 // ===========================================================================
 
 describe('interactive prompts', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('sets a pendingSuspensions entry on tool_suspended', () => {
-    emit(harness, {
+    emit(session, {
       type: 'tool_suspended',
       toolCallId: 'call-1',
       toolName: 'ask_user',
       args: {},
       suspendPayload: { question: 'Which option?' },
     });
-    const s = harness.session.displayState.get().pendingSuspensions.get('call-1');
+    const s = session.displayState.get().pendingSuspensions.get('call-1');
     expect(s).toBeDefined();
     expect(s!.toolCallId).toBe('call-1');
     expect(s!.toolName).toBe('ask_user');
   });
 
   it('sets a pendingSuspensions entry on tool_suspended for submit_plan', () => {
-    emit(harness, {
+    emit(session, {
       type: 'tool_suspended',
       toolCallId: 'call-plan',
       toolName: 'submit_plan',
@@ -712,7 +711,7 @@ describe('interactive prompts', () => {
       suspendPayload: { title: 'Refactor Plan', plan: '# Steps\n1. Do X' },
       resumeSchema: undefined,
     });
-    const s = harness.session.displayState.get().pendingSuspensions.get('call-plan');
+    const s = session.displayState.get().pendingSuspensions.get('call-plan');
     expect(s).toBeDefined();
     expect(s!.toolCallId).toBe('call-plan');
     expect(s!.toolName).toBe('submit_plan');
@@ -725,14 +724,15 @@ describe('interactive prompts', () => {
 // ===========================================================================
 
 describe('subagent lifecycle', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('creates subagent entry on subagent_start', () => {
-    emit(harness, {
+    emit(session, {
       type: 'subagent_start',
       toolCallId: 's1',
       agentType: 'explore',
@@ -740,7 +740,7 @@ describe('subagent lifecycle', () => {
       modelId: 'gpt-4o',
       forked: true,
     });
-    const sub = harness.session.displayState.get().activeSubagents.get('s1');
+    const sub = session.displayState.get().activeSubagents.get('s1');
     expect(sub).toBeDefined();
     expect(sub!.agentType).toBe('explore');
     expect(sub!.task).toBe('Find usages of X');
@@ -749,8 +749,8 @@ describe('subagent lifecycle', () => {
     expect(sub!.toolCalls).toEqual([]);
   });
 
-  it('includes displayName from configured subagent name on subagent_start', () => {
-    harness = createHarness(undefined, {
+  it('includes displayName from configured subagent name on subagent_start', async () => {
+    session = (await createSession(undefined, {
       subagents: [
         {
           id: 'explore',
@@ -759,17 +759,17 @@ describe('subagent lifecycle', () => {
           instructions: 'Find relevant context.',
         },
       ],
-    });
+    })).session;
 
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
 
-    const sub = harness.session.displayState.get().activeSubagents.get('s1');
+    const sub = session.displayState.get().activeSubagents.get('s1');
     expect(sub!.agentType).toBe('explore');
     expect(sub!.displayName).toBe('Explore');
   });
 
-  it('leaves displayName unset when agentType has no configured subagent match', () => {
-    harness = createHarness(undefined, {
+  it('leaves displayName unset when agentType has no configured subagent match', async () => {
+    session = (await createSession(undefined, {
       subagents: [
         {
           id: 'explore',
@@ -778,46 +778,46 @@ describe('subagent lifecycle', () => {
           instructions: 'Find relevant context.',
         },
       ],
-    });
+    })).session;
 
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
 
-    const sub = harness.session.displayState.get().activeSubagents.get('s1');
+    const sub = session.displayState.get().activeSubagents.get('s1');
     expect(sub!.agentType).toBe('execute');
     expect(sub!.displayName).toBeUndefined();
   });
 
   it('appends text on subagent_text_delta', () => {
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
-    emit(harness, { type: 'subagent_text_delta', toolCallId: 's1', agentType: 'explore', textDelta: 'hello ' });
-    emit(harness, { type: 'subagent_text_delta', toolCallId: 's1', agentType: 'explore', textDelta: 'world' });
-    expect(harness.session.displayState.get().activeSubagents.get('s1')!.textDelta).toBe('hello world');
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
+    emit(session, { type: 'subagent_text_delta', toolCallId: 's1', agentType: 'explore', textDelta: 'hello ' });
+    emit(session, { type: 'subagent_text_delta', toolCallId: 's1', agentType: 'explore', textDelta: 'world' });
+    expect(session.displayState.get().activeSubagents.get('s1')!.textDelta).toBe('hello world');
   });
 
   it('tracks subagent tool calls', () => {
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
-    emit(harness, {
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
+    emit(session, {
       type: 'subagent_tool_start',
       toolCallId: 's1',
       agentType: 'explore',
       subToolName: 'read_file',
       subToolArgs: {},
     });
-    const sub = harness.session.displayState.get().activeSubagents.get('s1')!;
+    const sub = session.displayState.get().activeSubagents.get('s1')!;
     expect(sub.toolCalls).toHaveLength(1);
     expect(sub.toolCalls[0]!.name).toBe('read_file');
   });
 
   it('marks subagent tool error on subagent_tool_end', () => {
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
-    emit(harness, {
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
+    emit(session, {
       type: 'subagent_tool_start',
       toolCallId: 's1',
       agentType: 'explore',
       subToolName: 'read_file',
       subToolArgs: {},
     });
-    emit(harness, {
+    emit(session, {
       type: 'subagent_tool_end',
       toolCallId: 's1',
       agentType: 'explore',
@@ -825,13 +825,13 @@ describe('subagent lifecycle', () => {
       subToolResult: 'err',
       isError: true,
     });
-    const sub = harness.session.displayState.get().activeSubagents.get('s1')!;
+    const sub = session.displayState.get().activeSubagents.get('s1')!;
     expect(sub.toolCalls[0]!.isError).toBe(true);
   });
 
   it('marks subagent as completed on subagent_end', () => {
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
-    emit(harness, {
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(session, {
       type: 'subagent_end',
       toolCallId: 's1',
       agentType: 'execute',
@@ -839,14 +839,14 @@ describe('subagent lifecycle', () => {
       isError: false,
       durationMs: 1234,
     });
-    const sub = harness.session.displayState.get().activeSubagents.get('s1')!;
+    const sub = session.displayState.get().activeSubagents.get('s1')!;
     expect(sub.status).toBe('completed');
     expect(sub.durationMs).toBe(1234);
     expect(sub.result).toBe('done');
   });
 
-  it('preserves displayName on terminal subagent history entries', () => {
-    harness = createHarness(undefined, {
+  it('preserves displayName on terminal subagent history entries', async () => {
+    session = (await createSession(undefined, {
       subagents: [
         {
           id: 'execute',
@@ -855,10 +855,10 @@ describe('subagent lifecycle', () => {
           instructions: 'Perform the delegated task.',
         },
       ],
-    });
+    })).session;
 
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
-    emit(harness, {
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(session, {
       type: 'subagent_end',
       toolCallId: 's1',
       agentType: 'execute',
@@ -867,7 +867,7 @@ describe('subagent lifecycle', () => {
       durationMs: 1234,
     });
 
-    const terminalSubagent = harness.session.displayState.get().activeSubagents.get('s1')!;
+    const terminalSubagent = session.displayState.get().activeSubagents.get('s1')!;
     const historyEntry: HarnessSubagentHistoryEntry = terminalSubagent;
 
     expect(terminalSubagent.status).toBe('completed');
@@ -877,8 +877,8 @@ describe('subagent lifecycle', () => {
   });
 
   it('marks subagent as error on failed subagent_end', () => {
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
-    emit(harness, {
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(session, {
       type: 'subagent_end',
       toolCallId: 's1',
       agentType: 'execute',
@@ -886,7 +886,7 @@ describe('subagent lifecycle', () => {
       isError: true,
       durationMs: 500,
     });
-    expect(harness.session.displayState.get().activeSubagents.get('s1')!.status).toBe('error');
+    expect(session.displayState.get().activeSubagents.get('s1')!.status).toBe('error');
   });
 });
 
@@ -895,25 +895,26 @@ describe('subagent lifecycle', () => {
 // ===========================================================================
 
 describe('usage_update', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('updates tokenUsage from internal token counters', () => {
     // Set internal token counters via the private field
-    harness.session.setTokenUsage({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
-    emit(harness, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
+    session.setTokenUsage({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
+    emit(session, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
 
-    const usage = harness.session.displayState.get().tokenUsage;
+    const usage = session.displayState.get().tokenUsage;
     expect(usage.promptTokens).toBe(100);
     expect(usage.completionTokens).toBe(50);
     expect(usage.totalTokens).toBe(150);
   });
 
   it('preserves richer token usage fields from internal token counters', () => {
-    harness.session.setTokenUsage({
+    session.setTokenUsage({
       promptTokens: 100,
       completionTokens: 50,
       totalTokens: 220,
@@ -922,7 +923,7 @@ describe('usage_update', () => {
       cacheCreationInputTokens: 5,
       raw: { provider: 'test-provider' },
     });
-    emit(harness, {
+    emit(session, {
       type: 'usage_update',
       usage: {
         promptTokens: 100,
@@ -935,7 +936,7 @@ describe('usage_update', () => {
       },
     });
 
-    expect(harness.session.displayState.get().tokenUsage).toEqual({
+    expect(session.displayState.get().tokenUsage).toEqual({
       promptTokens: 100,
       completionTokens: 50,
       totalTokens: 220,
@@ -947,13 +948,13 @@ describe('usage_update', () => {
   });
 
   it('accumulates usage across multiple updates', () => {
-    harness.session.setTokenUsage({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
-    emit(harness, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
+    session.setTokenUsage({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
+    emit(session, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
 
-    harness.session.setTokenUsage({ promptTokens: 250, completionTokens: 120, totalTokens: 370 });
-    emit(harness, { type: 'usage_update', usage: { promptTokens: 250, completionTokens: 120, totalTokens: 370 } });
+    session.setTokenUsage({ promptTokens: 250, completionTokens: 120, totalTokens: 370 });
+    emit(session, { type: 'usage_update', usage: { promptTokens: 250, completionTokens: 120, totalTokens: 370 } });
 
-    const usage = harness.session.displayState.get().tokenUsage;
+    const usage = session.displayState.get().tokenUsage;
     expect(usage.promptTokens).toBe(250);
     expect(usage.completionTokens).toBe(120);
     expect(usage.totalTokens).toBe(370);
@@ -965,10 +966,11 @@ describe('usage_update', () => {
 // ===========================================================================
 
 describe('task_updated', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('updates tasks from event payload', () => {
@@ -976,8 +978,8 @@ describe('task_updated', () => {
       { id: 'fix-bug', content: 'Fix bug', status: 'in_progress' as const, activeForm: 'Fixing bug' },
       { id: 'write-tests', content: 'Write tests', status: 'pending' as const, activeForm: 'Writing tests' },
     ];
-    emit(harness, { type: 'task_updated', tasks });
-    expect(harness.session.displayState.get().tasks).toBe(tasks);
+    emit(session, { type: 'task_updated', tasks });
+    expect(session.displayState.get().tasks).toBe(tasks);
   });
 
   it('snapshots current tasks to previousTasks before update', () => {
@@ -987,23 +989,23 @@ describe('task_updated', () => {
       { id: 'task-2', content: 'Task 2', status: 'in_progress' as const, activeForm: 'T2' },
     ];
 
-    emit(harness, { type: 'task_updated', tasks: tasks1 });
-    expect(harness.session.displayState.get().previousTasks).toEqual([]);
+    emit(session, { type: 'task_updated', tasks: tasks1 });
+    expect(session.displayState.get().previousTasks).toEqual([]);
 
-    emit(harness, { type: 'task_updated', tasks: tasks2 });
-    expect(harness.session.displayState.get().previousTasks).toEqual(tasks1);
-    expect(harness.session.displayState.get().tasks).toBe(tasks2);
+    emit(session, { type: 'task_updated', tasks: tasks2 });
+    expect(session.displayState.get().previousTasks).toEqual(tasks1);
+    expect(session.displayState.get().tasks).toBe(tasks2);
   });
 
   it('preserves task ids in current and previous task snapshots', () => {
     const tasks1 = [{ id: 'task-1', content: 'Task 1', status: 'in_progress' as const, activeForm: 'T1' }];
     const tasks2 = [{ id: 'task-1', content: 'Task 1', status: 'completed' as const, activeForm: 'T1' }];
 
-    emit(harness, { type: 'task_updated', tasks: tasks1 });
-    emit(harness, { type: 'task_updated', tasks: tasks2 });
+    emit(session, { type: 'task_updated', tasks: tasks1 });
+    emit(session, { type: 'task_updated', tasks: tasks2 });
 
-    expect(harness.session.displayState.get().previousTasks).toEqual(tasks1);
-    expect(harness.session.displayState.get().tasks).toBe(tasks2);
+    expect(session.displayState.get().previousTasks).toEqual(tasks1);
+    expect(session.displayState.get().tasks).toBe(tasks2);
   });
 });
 
@@ -1012,15 +1014,16 @@ describe('task_updated', () => {
 // ===========================================================================
 
 describe('OM event transitions', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   describe('om_status', () => {
     it('populates omProgress from window data', () => {
-      emit(harness, {
+      emit(session, {
         type: 'om_status',
         windows: {
           active: {
@@ -1044,7 +1047,7 @@ describe('OM event transitions', () => {
         generationCount: 2,
       } as any);
 
-      const omp = harness.session.displayState.get().omProgress;
+      const omp = session.displayState.get().omProgress;
       expect(omp.pendingTokens).toBe(15000);
       expect(omp.threshold).toBe(30000);
       expect(omp.thresholdPercent).toBe(50);
@@ -1056,7 +1059,7 @@ describe('OM event transitions', () => {
     });
 
     it('sets bufferingMessages from buffered.observations.status', () => {
-      emit(harness, {
+      emit(session, {
         type: 'om_status',
         windows: {
           active: { messages: { tokens: 0, threshold: 30000 }, observations: { tokens: 0, threshold: 40000 } },
@@ -1077,12 +1080,12 @@ describe('OM event transitions', () => {
         generationCount: 0,
       } as any);
 
-      expect(harness.session.displayState.get().bufferingMessages).toBe(true);
-      expect(harness.session.displayState.get().bufferingObservations).toBe(false);
+      expect(session.displayState.get().bufferingMessages).toBe(true);
+      expect(session.displayState.get().bufferingObservations).toBe(false);
     });
 
     it('sets bufferingObservations from buffered.reflection.status', () => {
-      emit(harness, {
+      emit(session, {
         type: 'om_status',
         windows: {
           active: { messages: { tokens: 0, threshold: 30000 }, observations: { tokens: 0, threshold: 40000 } },
@@ -1103,33 +1106,33 @@ describe('OM event transitions', () => {
         generationCount: 0,
       } as any);
 
-      expect(harness.session.displayState.get().bufferingMessages).toBe(false);
-      expect(harness.session.displayState.get().bufferingObservations).toBe(true);
+      expect(session.displayState.get().bufferingMessages).toBe(false);
+      expect(session.displayState.get().bufferingObservations).toBe(true);
     });
   });
 
   describe('om_observation_start / end / failed', () => {
     it('sets status to observing on om_observation_start', () => {
-      emit(harness, {
+      emit(session, {
         type: 'om_observation_start',
         cycleId: 'c1',
         operationType: 'observation',
         tokensToObserve: 5000,
       });
-      const omp = harness.session.displayState.get().omProgress;
+      const omp = session.displayState.get().omProgress;
       expect(omp.status).toBe('observing');
       expect(omp.cycleId).toBe('c1');
       expect(omp.startTime).toBeDefined();
     });
 
     it('resets to idle and updates tokens on om_observation_end', () => {
-      emit(harness, {
+      emit(session, {
         type: 'om_observation_start',
         cycleId: 'c1',
         operationType: 'observation',
         tokensToObserve: 5000,
       });
-      emit(harness, {
+      emit(session, {
         type: 'om_observation_end',
         cycleId: 'c1',
         durationMs: 1000,
@@ -1137,7 +1140,7 @@ describe('OM event transitions', () => {
         observationTokens: 6000,
       } as any);
 
-      const omp = harness.session.displayState.get().omProgress;
+      const omp = session.displayState.get().omProgress;
       expect(omp.status).toBe('idle');
       expect(omp.cycleId).toBeUndefined();
       expect(omp.startTime).toBeUndefined();
@@ -1147,15 +1150,15 @@ describe('OM event transitions', () => {
     });
 
     it('resets to idle on om_observation_failed', () => {
-      emit(harness, {
+      emit(session, {
         type: 'om_observation_start',
         cycleId: 'c1',
         operationType: 'observation',
         tokensToObserve: 5000,
       });
-      emit(harness, { type: 'om_observation_failed', cycleId: 'c1', error: 'timeout', durationMs: 500 });
+      emit(session, { type: 'om_observation_failed', cycleId: 'c1', error: 'timeout', durationMs: 500 });
 
-      const omp = harness.session.displayState.get().omProgress;
+      const omp = session.displayState.get().omProgress;
       expect(omp.status).toBe('idle');
       expect(omp.cycleId).toBeUndefined();
     });
@@ -1164,7 +1167,7 @@ describe('OM event transitions', () => {
   describe('om_reflection_start / end / failed', () => {
     it('sets status to reflecting and captures preReflectionTokens', () => {
       // First set some observation tokens via om_status
-      emit(harness, {
+      emit(session, {
         type: 'om_status',
         windows: {
           active: { messages: { tokens: 0, threshold: 30000 }, observations: { tokens: 10000, threshold: 40000 } },
@@ -1185,8 +1188,8 @@ describe('OM event transitions', () => {
         generationCount: 0,
       } as any);
 
-      emit(harness, { type: 'om_reflection_start', cycleId: 'c1', tokensToReflect: 42000 });
-      const omp = harness.session.displayState.get().omProgress;
+      emit(session, { type: 'om_reflection_start', cycleId: 'c1', tokensToReflect: 42000 });
+      const omp = session.displayState.get().omProgress;
       expect(omp.status).toBe('reflecting');
       expect(omp.preReflectionTokens).toBe(10000); // captured from observationTokens before overwrite
       expect(omp.observationTokens).toBe(42000);
@@ -1194,74 +1197,74 @@ describe('OM event transitions', () => {
     });
 
     it('updates to compressed tokens on om_reflection_end', () => {
-      emit(harness, { type: 'om_reflection_start', cycleId: 'c1', tokensToReflect: 42000 });
-      emit(harness, { type: 'om_reflection_end', cycleId: 'c1', durationMs: 2000, compressedTokens: 15000 } as any);
+      emit(session, { type: 'om_reflection_start', cycleId: 'c1', tokensToReflect: 42000 });
+      emit(session, { type: 'om_reflection_end', cycleId: 'c1', durationMs: 2000, compressedTokens: 15000 } as any);
 
-      const omp = harness.session.displayState.get().omProgress;
+      const omp = session.displayState.get().omProgress;
       expect(omp.status).toBe('idle');
       expect(omp.observationTokens).toBe(15000);
     });
 
     it('resets to idle on om_reflection_failed', () => {
-      emit(harness, { type: 'om_reflection_start', cycleId: 'c1', tokensToReflect: 42000 });
-      emit(harness, { type: 'om_reflection_failed', cycleId: 'c1', error: 'timeout', durationMs: 500 });
+      emit(session, { type: 'om_reflection_start', cycleId: 'c1', tokensToReflect: 42000 });
+      emit(session, { type: 'om_reflection_failed', cycleId: 'c1', error: 'timeout', durationMs: 500 });
 
-      expect(harness.session.displayState.get().omProgress.status).toBe('idle');
+      expect(session.displayState.get().omProgress.status).toBe('idle');
     });
   });
 
   describe('om_buffering_start / end / failed / activation', () => {
     it('sets bufferingMessages on observation buffering start', () => {
-      emit(harness, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'observation', tokensToBuffer: 1000 });
-      expect(harness.session.displayState.get().bufferingMessages).toBe(true);
-      expect(harness.session.displayState.get().bufferingObservations).toBe(false);
+      emit(session, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'observation', tokensToBuffer: 1000 });
+      expect(session.displayState.get().bufferingMessages).toBe(true);
+      expect(session.displayState.get().bufferingObservations).toBe(false);
     });
 
     it('sets bufferingObservations on reflection buffering start', () => {
-      emit(harness, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'reflection', tokensToBuffer: 1000 });
-      expect(harness.session.displayState.get().bufferingMessages).toBe(false);
-      expect(harness.session.displayState.get().bufferingObservations).toBe(true);
+      emit(session, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'reflection', tokensToBuffer: 1000 });
+      expect(session.displayState.get().bufferingMessages).toBe(false);
+      expect(session.displayState.get().bufferingObservations).toBe(true);
     });
 
     it('clears bufferingMessages on observation buffering end', () => {
-      emit(harness, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'observation', tokensToBuffer: 1000 });
-      emit(harness, {
+      emit(session, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'observation', tokensToBuffer: 1000 });
+      emit(session, {
         type: 'om_buffering_end',
         cycleId: 'c1',
         operationType: 'observation',
         tokensBuffered: 1000,
         bufferedTokens: 1000,
       } as any);
-      expect(harness.session.displayState.get().bufferingMessages).toBe(false);
+      expect(session.displayState.get().bufferingMessages).toBe(false);
     });
 
     it('clears bufferingObservations on reflection buffering end', () => {
-      emit(harness, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'reflection', tokensToBuffer: 1000 });
-      emit(harness, {
+      emit(session, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'reflection', tokensToBuffer: 1000 });
+      emit(session, {
         type: 'om_buffering_end',
         cycleId: 'c1',
         operationType: 'reflection',
         tokensBuffered: 1000,
         bufferedTokens: 1000,
       } as any);
-      expect(harness.session.displayState.get().bufferingObservations).toBe(false);
+      expect(session.displayState.get().bufferingObservations).toBe(false);
     });
 
     it('clears buffering flag on observation buffering failed', () => {
-      emit(harness, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'observation', tokensToBuffer: 1000 });
-      emit(harness, { type: 'om_buffering_failed', cycleId: 'c1', operationType: 'observation', error: 'timeout' });
-      expect(harness.session.displayState.get().bufferingMessages).toBe(false);
+      emit(session, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'observation', tokensToBuffer: 1000 });
+      emit(session, { type: 'om_buffering_failed', cycleId: 'c1', operationType: 'observation', error: 'timeout' });
+      expect(session.displayState.get().bufferingMessages).toBe(false);
     });
 
     it('clears buffering flag on reflection buffering failed', () => {
-      emit(harness, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'reflection', tokensToBuffer: 1000 });
-      emit(harness, { type: 'om_buffering_failed', cycleId: 'c1', operationType: 'reflection', error: 'timeout' });
-      expect(harness.session.displayState.get().bufferingObservations).toBe(false);
+      emit(session, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'reflection', tokensToBuffer: 1000 });
+      emit(session, { type: 'om_buffering_failed', cycleId: 'c1', operationType: 'reflection', error: 'timeout' });
+      expect(session.displayState.get().bufferingObservations).toBe(false);
     });
 
     it('clears bufferingMessages on observation activation', () => {
-      emit(harness, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'observation', tokensToBuffer: 1000 });
-      emit(harness, {
+      emit(session, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'observation', tokensToBuffer: 1000 });
+      emit(session, {
         type: 'om_activation',
         cycleId: 'c1',
         operationType: 'observation',
@@ -1271,12 +1274,12 @@ describe('OM event transitions', () => {
         messagesActivated: 5,
         generationCount: 1,
       });
-      expect(harness.session.displayState.get().bufferingMessages).toBe(false);
+      expect(session.displayState.get().bufferingMessages).toBe(false);
     });
 
     it('clears bufferingObservations on reflection activation', () => {
-      emit(harness, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'reflection', tokensToBuffer: 1000 });
-      emit(harness, {
+      emit(session, { type: 'om_buffering_start', cycleId: 'c1', operationType: 'reflection', tokensToBuffer: 1000 });
+      emit(session, {
         type: 'om_activation',
         cycleId: 'c1',
         operationType: 'reflection',
@@ -1286,7 +1289,7 @@ describe('OM event transitions', () => {
         messagesActivated: 5,
         generationCount: 1,
       });
-      expect(harness.session.displayState.get().bufferingObservations).toBe(false);
+      expect(session.displayState.get().bufferingObservations).toBe(false);
     });
   });
 });
@@ -1296,49 +1299,50 @@ describe('OM event transitions', () => {
 // ===========================================================================
 
 describe('state_changed threshold syncing', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('updates observation threshold from state_changed', () => {
     // Set some pending tokens first
-    (harness.session.displayState.get() as any).omProgress.pendingTokens = 15000;
+    (session.displayState.get() as any).omProgress.pendingTokens = 15000;
 
-    emit(harness, {
+    emit(session, {
       type: 'state_changed',
       state: { observationThreshold: 20000 },
       changedKeys: ['observationThreshold'],
     });
 
-    const omp = harness.session.displayState.get().omProgress;
+    const omp = session.displayState.get().omProgress;
     expect(omp.threshold).toBe(20000);
     expect(omp.thresholdPercent).toBe(75); // 15000 / 20000 * 100
   });
 
   it('updates reflection threshold from state_changed', () => {
-    (harness.session.displayState.get() as any).omProgress.observationTokens = 20000;
+    (session.displayState.get() as any).omProgress.observationTokens = 20000;
 
-    emit(harness, {
+    emit(session, {
       type: 'state_changed',
       state: { reflectionThreshold: 50000 },
       changedKeys: ['reflectionThreshold'],
     });
 
-    const omp = harness.session.displayState.get().omProgress;
+    const omp = session.displayState.get().omProgress;
     expect(omp.reflectionThreshold).toBe(50000);
     expect(omp.reflectionThresholdPercent).toBe(40); // 20000 / 50000 * 100
   });
 
   it('ignores non-threshold keys in state_changed', () => {
-    const beforeThreshold = harness.session.displayState.get().omProgress.threshold;
-    emit(harness, {
+    const beforeThreshold = session.displayState.get().omProgress.threshold;
+    emit(session, {
       type: 'state_changed',
       state: { yolo: true },
       changedKeys: ['yolo'],
     });
-    expect(harness.session.displayState.get().omProgress.threshold).toBe(beforeThreshold);
+    expect(session.displayState.get().omProgress.threshold).toBe(beforeThreshold);
   });
 });
 
@@ -1347,17 +1351,18 @@ describe('state_changed threshold syncing', () => {
 // ===========================================================================
 
 describe('resetThreadDisplayState', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('resets all thread-scoped state on thread_created', () => {
     // Populate various state
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
-    emit(harness, { type: 'tool_input_start', toolCallId: 't2', toolName: 'write_file' });
-    emit(harness, {
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
+    emit(session, { type: 'tool_input_start', toolCallId: 't2', toolName: 'write_file' });
+    emit(session, {
       type: 'tool_suspended',
       toolCallId: 'p1',
       toolName: 'submit_plan',
@@ -1365,18 +1370,18 @@ describe('resetThreadDisplayState', () => {
       suspendPayload: { title: 'P', plan: '#' },
       resumeSchema: undefined,
     });
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
-    emit(harness, {
+    emit(session, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
+    emit(session, {
       type: 'task_updated',
       tasks: [{ id: 'task-t', content: 'T', status: 'pending', activeForm: 'T' }],
     });
-    emit(harness, { type: 'om_observation_start', cycleId: 'c1', operationType: 'observation', tokensToObserve: 5000 });
-    emit(harness, { type: 'om_buffering_start', cycleId: 'c2', operationType: 'observation', tokensToBuffer: 1000 });
+    emit(session, { type: 'om_observation_start', cycleId: 'c1', operationType: 'observation', tokensToObserve: 5000 });
+    emit(session, { type: 'om_buffering_start', cycleId: 'c2', operationType: 'observation', tokensToBuffer: 1000 });
 
     // Now create new thread
-    emit(harness, { type: 'thread_created', thread: { id: 'new', title: 'New' } } as any);
+    emit(session, { type: 'thread_created', thread: { id: 'new', title: 'New' } } as any);
 
-    const ds = harness.session.displayState.get();
+    const ds = session.displayState.get();
     expect(ds.activeTools.size).toBe(0);
     expect(ds.toolInputBuffers.size).toBe(0);
     expect(ds.pendingApproval).toBeNull();
@@ -1393,36 +1398,36 @@ describe('resetThreadDisplayState', () => {
   });
 
   it('resets tokenUsage to zero on thread_created', () => {
-    harness.session.setTokenUsage({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
-    emit(harness, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
-    expect(harness.session.displayState.get().tokenUsage.totalTokens).toBe(150);
+    session.setTokenUsage({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
+    emit(session, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
+    expect(session.displayState.get().tokenUsage.totalTokens).toBe(150);
 
-    emit(harness, { type: 'thread_created', thread: { id: 'new', title: 'New' } } as any);
-    expect(harness.session.displayState.get().tokenUsage).toEqual(createEmptyTokenUsage());
+    emit(session, { type: 'thread_created', thread: { id: 'new', title: 'New' } } as any);
+    expect(session.displayState.get().tokenUsage).toEqual(createEmptyTokenUsage());
   });
 
   it('preserves isRunning across thread_created', () => {
-    emit(harness, { type: 'agent_start' });
-    expect(harness.session.displayState.get().isRunning).toBe(true);
+    emit(session, { type: 'agent_start' });
+    expect(session.displayState.get().isRunning).toBe(true);
 
-    emit(harness, { type: 'thread_created', thread: { id: 'new', title: 'New' } } as any);
+    emit(session, { type: 'thread_created', thread: { id: 'new', title: 'New' } } as any);
     // isRunning is NOT reset by resetThreadDisplayState
-    expect(harness.session.displayState.get().isRunning).toBe(true);
+    expect(session.displayState.get().isRunning).toBe(true);
   });
 
   it('resets omProgress on thread_changed', () => {
-    emit(harness, { type: 'om_observation_start', cycleId: 'c1', operationType: 'observation', tokensToObserve: 5000 });
-    expect(harness.session.displayState.get().omProgress.status).toBe('observing');
+    emit(session, { type: 'om_observation_start', cycleId: 'c1', operationType: 'observation', tokensToObserve: 5000 });
+    expect(session.displayState.get().omProgress.status).toBe('observing');
 
-    emit(harness, { type: 'thread_changed', threadId: 'other', previousThreadId: 'old' });
-    expect(harness.session.displayState.get().omProgress.status).toBe('idle');
-    expect(harness.session.displayState.get().omProgress.pendingTokens).toBe(0);
+    emit(session, { type: 'thread_changed', threadId: 'other', previousThreadId: 'old' });
+    expect(session.displayState.get().omProgress.status).toBe('idle');
+    expect(session.displayState.get().omProgress.pendingTokens).toBe(0);
   });
 
   it('syncs tokenUsage from internal counters on thread_changed', () => {
-    harness.session.setTokenUsage({ promptTokens: 200, completionTokens: 100, totalTokens: 300 });
-    emit(harness, { type: 'thread_changed', threadId: 'other', previousThreadId: 'old' });
-    expect(harness.session.displayState.get().tokenUsage.totalTokens).toBe(300);
+    session.setTokenUsage({ promptTokens: 200, completionTokens: 100, totalTokens: 300 });
+    emit(session, { type: 'thread_changed', threadId: 'other', previousThreadId: 'old' });
+    expect(session.displayState.get().tokenUsage.totalTokens).toBe(300);
   });
 });
 
@@ -1431,35 +1436,36 @@ describe('resetThreadDisplayState', () => {
 // ===========================================================================
 
 describe('display_state_changed emission', () => {
-  let harness: Harness;
+  let session: Session;
   let events: HarnessEvent[];
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
     events = [];
-    harness.session.subscribe((event: HarnessEvent) => {
+    session.subscribe((event: HarnessEvent) => {
       events.push(event);
     });
   });
 
   it('emits display_state_changed after every non-display_state_changed event', () => {
-    emit(harness, { type: 'agent_start' });
+    emit(session, { type: 'agent_start' });
     expect(events.length).toBe(2);
     expect(events[0]!.type).toBe('agent_start');
     expect(events[1]!.type).toBe('display_state_changed');
   });
 
   it('includes current display state reference in display_state_changed', () => {
-    emit(harness, { type: 'agent_start' });
+    emit(session, { type: 'agent_start' });
     const dscEvent = events.find(e => e.type === 'display_state_changed');
     expect(dscEvent).toBeDefined();
     if (dscEvent?.type === 'display_state_changed') {
-      expect(dscEvent.displayState).toBe(harness.session.displayState.get());
+      expect(dscEvent.displayState).toBe(session.displayState.get());
     }
   });
 
   it('display state is already updated when display_state_changed fires', () => {
-    emit(harness, { type: 'agent_start' });
+    emit(session, { type: 'agent_start' });
     const dscEvent = events.find(e => e.type === 'display_state_changed');
     if (dscEvent?.type === 'display_state_changed') {
       expect(dscEvent.displayState.isRunning).toBe(true);
@@ -1467,7 +1473,7 @@ describe('display_state_changed emission', () => {
   });
 
   it('does not emit display_state_changed for display_state_changed (no recursion)', () => {
-    emit(harness, { type: 'display_state_changed', displayState: harness.session.displayState.get() });
+    emit(session, { type: 'display_state_changed', displayState: session.displayState.get() });
     expect(events.length).toBe(1);
     expect(events[0]!.type).toBe('display_state_changed');
   });
@@ -1475,21 +1481,21 @@ describe('display_state_changed emission', () => {
   it('restores replayed task display state without emitting any event', () => {
     const tasks = [{ id: 'tests', content: 'Write tests', status: 'pending' as const, activeForm: 'Writing tests' }];
 
-    harness.session.displayState.restoreTasks(tasks);
+    session.displayState.restoreTasks(tasks);
 
     // restoreTasks is a pure session-state mutation: it updates the snapshot but
     // does not touch the Harness event bus (the UI re-renders explicitly after a
     // replay). No task_updated and no display_state_changed should fire.
-    expect(harness.session.displayState.get().tasks).toEqual(tasks);
-    expect(harness.session.displayState.get().previousTasks).toEqual([]);
+    expect(session.displayState.get().tasks).toEqual(tasks);
+    expect(session.displayState.get().previousTasks).toEqual([]);
     expect(events).toEqual([]);
   });
 
   it('emits display_state_changed for each event in a sequence', () => {
-    emit(harness, { type: 'agent_start' });
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: { path: 'x' } });
-    emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
-    emit(harness, { type: 'agent_end', reason: 'complete' });
+    emit(session, { type: 'agent_start' });
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: { path: 'x' } });
+    emit(session, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
+    emit(session, { type: 'agent_end', reason: 'complete' });
 
     const dscEvents = events.filter(e => e.type === 'display_state_changed');
     expect(dscEvents.length).toBe(4);
@@ -1497,7 +1503,7 @@ describe('display_state_changed emission', () => {
 
   it('raw subscribe receives every source event and every display_state_changed event', () => {
     for (let i = 0; i < 5; i++) {
-      emit(harness, {
+      emit(session, {
         type: 'tool_input_delta',
         toolCallId: 'missing',
         argsTextDelta: String(i),
@@ -1523,14 +1529,14 @@ describe('display_state_changed emission', () => {
 
   it('display_state_changed reflects state at time of each event', () => {
     const snapshots: boolean[] = [];
-    harness.session.subscribe((event: HarnessEvent) => {
+    session.subscribe((event: HarnessEvent) => {
       if (event.type === 'display_state_changed') {
         snapshots.push(event.displayState.isRunning);
       }
     });
 
-    emit(harness, { type: 'agent_start' });
-    emit(harness, { type: 'agent_end', reason: 'complete' });
+    emit(session, { type: 'agent_start' });
+    emit(session, { type: 'agent_end', reason: 'complete' });
 
     // Note: there are 2 sets of snapshots from the first subscriber and this one
     // Just check the second subscriber's snapshots
@@ -1544,58 +1550,59 @@ describe('display_state_changed emission', () => {
 // ===========================================================================
 
 describe('full lifecycle integration', () => {
-  let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
-    harness = createHarness();
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
   });
 
   it('handles a complete agent run lifecycle', () => {
-    const ds = harness.session.displayState.get();
+    const ds = session.displayState.get();
 
     // Agent starts
-    emit(harness, { type: 'agent_start' });
+    emit(session, { type: 'agent_start' });
     expect(ds.isRunning).toBe(true);
 
     // Message starts streaming
     const msg = { id: 'm1', role: 'assistant' as const, content: [], createdAt: new Date() };
-    emit(harness, { type: 'message_start', message: msg as any });
+    emit(session, { type: 'message_start', message: msg as any });
     expect(ds.currentMessage).toBe(msg);
 
     // Tool input streaming
-    emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'string_replace_lsp' });
+    emit(session, { type: 'tool_input_start', toolCallId: 't1', toolName: 'string_replace_lsp' });
     expect(ds.activeTools.get('t1')?.status).toBe('streaming_input');
     expect(ds.toolInputBuffers.has('t1')).toBe(true);
 
-    emit(harness, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '{"path":"foo.ts"' });
-    emit(harness, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '}' });
+    emit(session, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '{"path":"foo.ts"' });
+    emit(session, { type: 'tool_input_delta', toolCallId: 't1', argsTextDelta: '}' });
     expect(ds.toolInputBuffers.get('t1')!.text).toBe('{"path":"foo.ts"}');
 
-    emit(harness, { type: 'tool_input_end', toolCallId: 't1' });
+    emit(session, { type: 'tool_input_end', toolCallId: 't1' });
     expect(ds.toolInputBuffers.has('t1')).toBe(false);
 
     // Tool runs
-    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'string_replace_lsp', args: { path: 'foo.ts' } });
+    emit(session, { type: 'tool_start', toolCallId: 't1', toolName: 'string_replace_lsp', args: { path: 'foo.ts' } });
     expect(ds.activeTools.get('t1')?.status).toBe('running');
 
-    emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
+    emit(session, { type: 'tool_end', toolCallId: 't1', result: 'ok', isError: false });
     expect(ds.activeTools.get('t1')?.status).toBe('completed');
     expect(ds.modifiedFiles.has('foo.ts')).toBe(true);
 
     // Task update
-    emit(harness, {
+    emit(session, {
       type: 'task_updated',
       tasks: [{ id: 'edit-foo', content: 'Edit foo', status: 'completed', activeForm: 'Editing' }],
     });
     expect(ds.tasks).toHaveLength(1);
 
     // Usage update
-    harness.session.setTokenUsage({ promptTokens: 1000, completionTokens: 500, totalTokens: 1500 });
-    emit(harness, { type: 'usage_update', usage: { promptTokens: 1000, completionTokens: 500, totalTokens: 1500 } });
+    session.setTokenUsage({ promptTokens: 1000, completionTokens: 500, totalTokens: 1500 });
+    emit(session, { type: 'usage_update', usage: { promptTokens: 1000, completionTokens: 500, totalTokens: 1500 } });
     expect(ds.tokenUsage.totalTokens).toBe(1500);
 
     // Agent ends
-    emit(harness, { type: 'agent_end', reason: 'complete' });
+    emit(session, { type: 'agent_end', reason: 'complete' });
     expect(ds.isRunning).toBe(false);
 
     // Modified files and token usage persist after agent_end

--- a/packages/core/src/harness/fork-clone-metadata.test.ts
+++ b/packages/core/src/harness/fork-clone-metadata.test.ts
@@ -76,12 +76,11 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
     // Invoke the private buildToolsets to trigger createSubagentTool with the
     // wired-in cloneThreadForFork callback.
-    await (harness as unknown as { buildToolsets(ctx: RequestContext): Promise<unknown> }).buildToolsets(
-      new RequestContext(),
-    );
+    await (harness as any).buildToolsets(session, new RequestContext());
 
     expect(capturedOpts).toHaveLength(1);
     const captured = capturedOpts[0]!;
@@ -139,10 +138,12 @@ describe('Harness fork clone metadata wiring', () => {
         },
       ],
     });
+    await harness.init();
+    const session = await harness.createSession();
 
     const toolsets = (await (
-      harness as unknown as { buildToolsets(ctx: RequestContext): Promise<Record<string, unknown>> }
-    ).buildToolsets(new RequestContext())) as { harnessBuiltIn?: Record<string, unknown> };
+      harness as any
+    ).buildToolsets(session, new RequestContext())) as { harnessBuiltIn?: Record<string, unknown> };
 
     expect(capturedOpts).toHaveLength(0);
     expect(toolsets.harnessBuiltIn?.subagent).toBeUndefined();
@@ -182,10 +183,9 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
-    await (harness as unknown as { buildToolsets(ctx: RequestContext): Promise<unknown> }).buildToolsets(
-      new RequestContext(),
-    );
+    await (harness as any).buildToolsets(session, new RequestContext());
 
     expect(capturedOpts).toHaveLength(1);
     const captured = capturedOpts[0]!;
@@ -233,13 +233,14 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
     // All modes should return the same agent instance — no forking
-    const buildAgent = harness.getCurrentAgent();
-    await harness.session.mode.switch({ modeId: 'plan' });
-    const planAgent = harness.getCurrentAgent();
-    await harness.session.mode.switch({ modeId: 'build' });
-    const buildAgentAgain = harness.getCurrentAgent();
+    const buildAgent = harness.getCurrentAgent(session);
+    await session.mode.switch({ modeId: 'plan' });
+    const planAgent = harness.getCurrentAgent(session);
+    await session.mode.switch({ modeId: 'build' });
+    const buildAgentAgain = harness.getCurrentAgent(session);
 
     expect(buildAgent).toBe(baseAgent);
     expect(planAgent).toBe(baseAgent);
@@ -280,13 +281,14 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
     // Switch modes multiple times
-    harness.getCurrentAgent();
-    await harness.session.mode.switch({ modeId: 'plan' });
-    harness.getCurrentAgent();
-    await harness.session.mode.switch({ modeId: 'build' });
-    harness.getCurrentAgent();
+    harness.getCurrentAgent(session);
+    await session.mode.switch({ modeId: 'plan' });
+    harness.getCurrentAgent(session);
+    await session.mode.switch({ modeId: 'build' });
+    harness.getCurrentAgent(session);
 
     // The agent's own instructions should remain unchanged
     const agentInstructions = await baseAgent.getInstructions();
@@ -326,18 +328,19 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
-    const resolve = (harness as unknown as { resolveCurrentModeInstructions(): string | undefined })
+    const resolve = (harness as any)
       .resolveCurrentModeInstructions;
 
     // Default mode is 'build'
-    expect(resolve.call(harness)).toBe('Harness global.\nBuild mode.');
+    expect(resolve.call(harness, session)).toBe('Harness global.\nBuild mode.');
 
-    await harness.session.mode.switch({ modeId: 'plan' });
-    expect(resolve.call(harness)).toBe('Harness global.\nPlan mode.');
+    await session.mode.switch({ modeId: 'plan' });
+    expect(resolve.call(harness, session)).toBe('Harness global.\nPlan mode.');
 
-    await harness.session.mode.switch({ modeId: 'build' });
-    expect(resolve.call(harness)).toBe('Harness global.\nBuild mode.');
+    await session.mode.switch({ modeId: 'build' });
+    expect(resolve.call(harness, session)).toBe('Harness global.\nBuild mode.');
   });
 
   it('mode tools are included in toolsets when using shared config.agent', async () => {
@@ -372,21 +375,22 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
     const buildToolsets = (
-      harness as unknown as { buildToolsets(ctx: RequestContext): Promise<Record<string, unknown>> }
+      harness as any
     ).buildToolsets;
 
     // In 'build' mode, mode tools should appear in toolsets
-    const buildResult = (await buildToolsets.call(harness, new RequestContext())) as {
+    const buildResult = (await buildToolsets.call(harness, session, new RequestContext())) as {
       modeTools?: Record<string, unknown>;
     };
     expect(buildResult.modeTools).toBeDefined();
     expect(buildResult.modeTools!.buildTool).toBe(modeTool);
 
     // Switch to 'plan' mode (no mode tools) — modeTools should be absent
-    await harness.session.mode.switch({ modeId: 'plan' });
-    const planResult = (await buildToolsets.call(harness, new RequestContext())) as {
+    await session.mode.switch({ modeId: 'plan' });
+    const planResult = (await buildToolsets.call(harness, session, new RequestContext())) as {
       modeTools?: Record<string, unknown>;
     };
     expect(planResult.modeTools).toBeUndefined();
@@ -433,16 +437,17 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
     // Signal provider should always point at baseAgent, regardless of mode
     expect(signalProvider.getConnectedAgent()).toBe(baseAgent);
     expect(signalProvider.getConnectedAgent()!.hasOwnMemory()).toBe(true);
 
-    await harness.session.mode.switch({ modeId: 'plan' });
+    await session.mode.switch({ modeId: 'plan' });
     expect(signalProvider.getConnectedAgent()).toBe(baseAgent);
     expect(signalProvider.getConnectedAgent()!.hasOwnMemory()).toBe(true);
 
-    await harness.session.mode.switch({ modeId: 'build' });
+    await session.mode.switch({ modeId: 'build' });
     expect(signalProvider.getConnectedAgent()).toBe(baseAgent);
     expect(signalProvider.getConnectedAgent()!.hasOwnMemory()).toBe(true);
   });
@@ -484,13 +489,14 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
     // Deprecated mode.agent path — each mode gets its own agent
-    const currentBuild = harness.getCurrentAgent();
+    const currentBuild = harness.getCurrentAgent(session);
     expect(currentBuild).toBe(buildAgent);
 
-    await harness.session.mode.switch({ modeId: 'plan' });
-    const currentPlan = harness.getCurrentAgent();
+    await session.mode.switch({ modeId: 'plan' });
+    const currentPlan = harness.getCurrentAgent(session);
     expect(currentPlan).toBe(planAgent);
     expect(currentPlan).not.toBe(currentBuild);
   });
@@ -543,6 +549,7 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
 
     // After init, signal provider's connected agent (the base agent) should have memory
     const connectedAgent = signalProvider.getConnectedAgent()!;

--- a/packages/core/src/harness/get-om-record.test.ts
+++ b/packages/core/src/harness/get-om-record.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import type { Session } from './session';
 
 function createHarness(storage: InMemoryStore) {
   const agent = new Agent({
@@ -44,32 +45,35 @@ async function seedObservationalMemory(
 describe('Harness.getObservationalMemoryRecord', () => {
   let storage: InMemoryStore;
   let harness: ReturnType<typeof createHarness>;
+  let session: Session;
 
   beforeEach(async () => {
     storage = new InMemoryStore();
     harness = createHarness(storage);
     await harness.init();
+    session = await harness.createSession();
   });
 
   it('returns null when no thread is selected', async () => {
-    const record = await harness.getObservationalMemoryRecord();
+    session.thread.clear();
+    const record = await harness.getObservationalMemoryRecord(session);
     expect(record).toBeNull();
   });
 
   it('returns null when no OM record exists for the thread', async () => {
-    await harness.session.thread.create();
-    const record = await harness.getObservationalMemoryRecord();
+    await session.thread.create();
+    const record = await harness.getObservationalMemoryRecord(session);
     expect(record).toBeNull();
   });
 
   it('returns the OM record with activeObservations when one exists', async () => {
-    const thread = await harness.session.thread.create();
-    const resourceId = harness.session.identity.getResourceId();
+    const thread = await session.thread.create();
+    const resourceId = session.identity.getResourceId();
     const observationText = '- User prefers dark mode\n- User is building a web UI';
 
     await seedObservationalMemory(storage, thread.id, resourceId, observationText);
 
-    const record = await harness.getObservationalMemoryRecord();
+    const record = await harness.getObservationalMemoryRecord(session);
     expect(record).not.toBeNull();
     expect(record!.activeObservations).toBe(observationText);
     expect(record!.threadId).toBe(thread.id);
@@ -78,21 +82,21 @@ describe('Harness.getObservationalMemoryRecord', () => {
   });
 
   it('returns record for the current thread after switching threads', async () => {
-    const threadA = await harness.session.thread.create();
-    const threadB = await harness.session.thread.create();
-    const resourceId = harness.session.identity.getResourceId();
+    const threadA = await session.thread.create();
+    const threadB = await session.thread.create();
+    const resourceId = session.identity.getResourceId();
 
     await seedObservationalMemory(storage, threadA.id, resourceId, 'Thread A observations');
     await seedObservationalMemory(storage, threadB.id, resourceId, 'Thread B observations');
 
     // Currently on thread B
-    let record = await harness.getObservationalMemoryRecord();
+    let record = await harness.getObservationalMemoryRecord(session);
     expect(record).not.toBeNull();
     expect(record!.activeObservations).toBe('Thread B observations');
 
     // Switch to thread A
-    await harness.session.thread.switch({ threadId: threadA.id });
-    record = await harness.getObservationalMemoryRecord();
+    await session.thread.switch({ threadId: threadA.id });
+    record = await harness.getObservationalMemoryRecord(session);
     expect(record).not.toBeNull();
     expect(record!.activeObservations).toBe('Thread A observations');
   });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -47,7 +47,6 @@ import type {
   HarnessMessageContent,
   HarnessMode,
   HarnessRequestContext,
-  HarnessSession,
   HarnessThread,
   ModelAuthStatus,
   ToolCategory,
@@ -182,12 +181,19 @@ export class Harness<TState = {}> {
       }) => Promise<Workspace | undefined> | Workspace | undefined)
     | undefined = undefined;
   private workspaceInitialized = false;
+  private initPromise: Promise<void> | undefined = undefined;
+  private workspaceError: Error | undefined = undefined;
   private browser: MastraBrowser | undefined = undefined;
   private browserFn:
     | ((ctx: { requestContext: RequestContext }) => Promise<MastraBrowser | undefined> | MastraBrowser | undefined)
     | undefined = undefined;
   private heartbeatTimers = new Map<string, { timer: NodeJS.Timeout; shutdown?: () => void | Promise<void> }>();
-  readonly #session: Session<TState>;
+  /**
+   * The mode every new session starts in. Resolved once at construction from
+   * `config.defaultModeId` (or the configured default/first mode) and reused by
+   * every {@link createSession} call. The Harness itself holds no session.
+   */
+  readonly #defaultMode: HarnessMode;
   private availableModelsCache: AvailableModel[] | null = null;
   private availableModelsCacheTime: number = 0;
   readonly #instructions?: string;
@@ -212,16 +218,7 @@ export class Harness<TState = {}> {
       );
     }
 
-    this.#session = this.#wireSession(
-      new Session({
-        resourceId: config.resourceId ?? config.id,
-        state: {
-          initialState: config.initialState,
-          stateSchema: config.stateSchema,
-        },
-      }),
-      defaultMode,
-    );
+    this.#defaultMode = defaultMode;
 
     // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
     if (config.workspace instanceof Workspace) {
@@ -249,7 +246,8 @@ export class Harness<TState = {}> {
    * dependencies (config catalog, resolvers, tracker, thread store). Extracted
    * from the constructor so additional sessions can be wired the same way.
    */
-  #wireSession(session: Session<TState>, defaultMode: HarnessMode): Session<TState> {
+  #wireSession(session: Session<TState>): Session<TState> {
+    const defaultMode = this.#defaultMode;
     session.mode.set({ modeId: defaultMode.id });
     session.setStore({
       get: key => session.thread.getSetting({ key }),
@@ -280,17 +278,18 @@ export class Harness<TState = {}> {
       setState: updates => void session.state.set(updates as Partial<TState>),
       setSetting: ({ key, value }) => session.thread.setSetting({ key, value }),
     });
-    session.thread.connect(this.createThreadDataStore(), session as Session);
+    session.thread.connect(this.createThreadDataStore(session), session as Session);
     session.setMachinery({
-      getAgent: () => this.getCurrentAgent(),
-      subscribeToThread: ({ resourceId, threadId }) => this.getCurrentAgent().subscribeToThread({ resourceId, threadId }),
-      buildStreamOptions: input => this.buildAgentMessageStreamOptions(input),
-      buildSharedRunOptions: () => this.buildSharedRunOptions(),
-      buildToolsets: requestContext => this.buildToolsets(requestContext),
-      buildRequestContext: requestContext => this.buildRequestContext(requestContext),
-      persistTokenUsage: () => this.persistTokenUsage(),
+      getAgent: () => this.getCurrentAgent(session),
+      subscribeToThread: ({ resourceId, threadId }) =>
+        this.getCurrentAgent(session).subscribeToThread({ resourceId, threadId }),
+      buildStreamOptions: input => this.buildAgentMessageStreamOptions({ session, ...input }),
+      buildSharedRunOptions: () => this.buildSharedRunOptions(session),
+      buildToolsets: requestContext => this.buildToolsets(session, requestContext),
+      buildRequestContext: requestContext => this.buildRequestContext(session, requestContext),
+      persistTokenUsage: () => this.persistTokenUsage(session),
       generateId: () => this.generateId(),
-      resolveTransitionModeId: () => this.resolveTransitionModeId(),
+      resolveTransitionModeId: () => this.resolveTransitionModeId(session),
       saveSystemReminder: input => this.saveSystemReminder(input),
     });
 
@@ -308,6 +307,63 @@ export class Harness<TState = {}> {
     return session;
   }
 
+  /**
+   * Create a new, fully-wired {@link Session} and bring it online: it starts in
+   * the default mode with the seeded model, is connected to the Harness's shared
+   * machinery (agent, storage/lock, config catalog), and has a current thread
+   * (the most recent thread for `resourceId`, or a freshly created one).
+   *
+   * The Harness owns no session of its own — every consumer creates its own
+   * session and drives all work through it (`session.sendMessage`,
+   * `session.mode.switch`, `session.thread.*`, `session.subscribe`, ...). In a
+   * server / multiplayer setting, each request / thread / user gets its own
+   * session, isolated from every other: independent event bus, mode, model,
+   * state, and current thread.
+   *
+   * Call {@link init} once before creating sessions so shared storage and
+   * workspace are ready.
+   */
+  async createSession({ resourceId }: { resourceId?: string } = {}): Promise<Session<TState>> {
+    const session = this.#wireSession(
+      new Session({
+        resourceId: resourceId ?? this.config.resourceId ?? this.config.id,
+        state: {
+          initialState: this.config.initialState,
+          stateSchema: this.config.stateSchema,
+        },
+      }),
+    );
+
+    // Replay current workspace status onto the new session so a session created
+    // after init() still observes the shared workspace being ready (or failed).
+    if (this.workspace && this.workspaceInitialized) {
+      session.emit({ type: 'workspace_status_changed', status: 'ready' });
+      session.emit({
+        type: 'workspace_ready',
+        workspaceId: this.workspace.id,
+        workspaceName: this.workspace.name,
+      });
+    } else if (this.workspaceError) {
+      session.emit({ type: 'workspace_status_changed', status: 'error', error: this.workspaceError });
+      session.emit({ type: 'workspace_error', error: this.workspaceError });
+    }
+
+    // Bring the session online with a current thread: resume the most recent
+    // thread for this resource, or create a fresh one when none exist.
+    const threads = await session.thread.list();
+    if (threads.length === 0) {
+      await session.thread.create();
+    } else {
+      const mostRecent = [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0]!;
+      await this.config.threadLock?.acquire(mostRecent.id);
+      session.thread.set({ threadId: mostRecent.id });
+      await session.thread.loadMetadata();
+      await session.thread.ensureCurrentSubscription();
+    }
+
+    return session;
+  }
+
   // ===========================================================================
   // Accessors
   // ===========================================================================
@@ -319,15 +375,6 @@ export class Harness<TState = {}> {
    */
   getMastra(): Mastra | undefined {
     return this.#internalMastra;
-  }
-
-  /**
-   * The current harness session. Owns per-session runtime state such as
-   * session-scoped permission grants. Prefer `harness.session.*` over the
-   * (removed) re-exposed grant helpers on the Harness.
-   */
-  get session(): Session<TState> {
-    return this.#session;
   }
 
   /**
@@ -360,9 +407,16 @@ export class Harness<TState = {}> {
 
   /**
    * Initialize the harness — loads storage and workspace.
-   * Must be called before using the harness.
+   * Must be called before using the harness. Idempotent: repeated calls
+   * return the same in-flight/completed initialization instead of rebuilding
+   * the internal Mastra instance (which would orphan registered agents).
    */
   async init(): Promise<void> {
+    this.initPromise ??= this.runInit();
+    return this.initPromise;
+  }
+
+  private async runInit(): Promise<void> {
     // Create an internal Mastra instance so agents have access to storage
     // (required for tool approval snapshot persistence/resume).
     // We init storage through Mastra's proxied storage so augmentWithInit
@@ -390,23 +444,16 @@ export class Harness<TState = {}> {
           this.workspace = new Workspace(this.config.workspace as WorkspaceConfig);
         }
 
-        this.#session.emit({ type: 'workspace_status_changed', status: 'initializing' });
         await this.workspace.init();
         this.workspaceInitialized = true;
-
-        this.#session.emit({ type: 'workspace_status_changed', status: 'ready' });
-        this.#session.emit({
-          type: 'workspace_ready',
-          workspaceId: this.workspace.id,
-          workspaceName: this.workspace.name,
-        });
+        this.workspaceError = undefined;
       } catch (error) {
         const err = getErrorFromUnknown(error);
         this.workspace = undefined;
         this.workspaceInitialized = false;
-
-        this.#session.emit({ type: 'workspace_status_changed', status: 'error', error: err });
-        this.#session.emit({ type: 'workspace_error', error: err });
+        // Remember the failure so sessions created later can surface it; the
+        // Harness holds no session of its own to emit onto during init().
+        this.workspaceError = err;
       }
     }
 
@@ -430,26 +477,6 @@ export class Harness<TState = {}> {
     this.startHeartbeats();
   }
 
-  /**
-   * Select the most recent thread, or create one if none exist.
-   */
-  async selectOrCreateThread(): Promise<HarnessThread> {
-    const threads = await this.#session.thread.list();
-
-    if (threads.length === 0) {
-      return await this.#session.thread.create();
-    }
-
-    const sortedThreads = [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
-    const mostRecent = sortedThreads[0]!;
-    await this.config.threadLock?.acquire(mostRecent.id);
-    this.#session.thread.set({ threadId: mostRecent.id });
-    await this.#session.thread.loadMetadata();
-    await this.#session.thread.ensureCurrentSubscription();
-
-    return mostRecent;
-  }
-
   private async getMemoryStorage(): Promise<MemoryStorage> {
     if (!this.config.storage) {
       throw new Error('Storage is not configured on this Harness');
@@ -466,7 +493,7 @@ export class Harness<TState = {}> {
    * through. The Session owns the thread-domain logic; this adapter just maps
    * raw storage rows to Harness types — it does not call back into Session.
    */
-  private createThreadDataStore(): ThreadDataStore {
+  private createThreadDataStore(session: Session<TState>): ThreadDataStore {
     return {
       listThreads: ({ resourceId, includeForkedSubagents }) =>
         this.queryThreads({ resourceId, includeForkedSubagents }),
@@ -480,7 +507,7 @@ export class Harness<TState = {}> {
       saveThread: ({ thread }) => this.persistThreadRow(thread),
       deleteThread: ({ threadId }) => this.deleteThreadRow(threadId),
       cloneThread: ({ sourceThreadId, resourceId, title }) =>
-        this.cloneThreadRow({ sourceThreadId, resourceId, title }),
+        this.cloneThreadRow(session, { sourceThreadId, resourceId, title }),
       acquireLock: threadId => this.config.threadLock?.acquire(threadId) ?? Promise.resolve(),
       releaseLock: threadId => this.config.threadLock?.release(threadId) ?? Promise.resolve(),
       getModeIds: () => this.config.modes.map(m => m.id),
@@ -511,19 +538,22 @@ export class Harness<TState = {}> {
   }
 
   /** Clone a thread (and messages) via the host's memory (gateway primitive for the Session thread domain). */
-  private async cloneThreadRow({
-    sourceThreadId,
-    resourceId,
-    title,
-  }: {
-    sourceThreadId: string;
-    resourceId: string;
-    title?: string;
-  }): Promise<HarnessThread> {
+  private async cloneThreadRow(
+    session: Session<TState>,
+    {
+      sourceThreadId,
+      resourceId,
+      title,
+    }: {
+      sourceThreadId: string;
+      resourceId: string;
+      title?: string;
+    },
+  ): Promise<HarnessThread> {
     if (!this.config.memory) {
       throw new Error('Memory is not configured on this Harness');
     }
-    const memory = await this.resolveMemory();
+    const memory = await this.resolveMemory(session);
     const result = await memory.cloneThread({ sourceThreadId, resourceId, title });
     return {
       id: result.thread.id,
@@ -766,8 +796,8 @@ export class Harness<TState = {}> {
    * `buildAgentMessageStreamOptions` so the agent's own instructions are
    * never mutated.
    */
-  private resolveCurrentModeInstructions(): string | undefined {
-    const mode = this.#session.mode.resolve();
+  private resolveCurrentModeInstructions(session: Session<TState>): string | undefined {
+    const mode = session.mode.resolve();
     const combined = [this.#instructions ?? '', mode?.instructions ?? ''].filter(Boolean).join('\n');
     return combined || undefined;
   }
@@ -797,8 +827,8 @@ export class Harness<TState = {}> {
    * (`setObjective`/`getObjective`/`clearObjective`/`updateObjectiveOptions`),
    * which read/write the durable `threadState` `'goal'` slot.
    */
-  getCurrentAgent(): Agent {
-    const mode = this.#session.mode.resolve();
+  getCurrentAgent(session: Session<TState>): Agent {
+    const mode = session.mode.resolve();
 
     return this.propagateRuntimeServicesToAgent(this.getAgentForMode(mode));
   }
@@ -807,8 +837,8 @@ export class Harness<TState = {}> {
    * Check if the current model's provider has authentication configured.
    * Uses app-provided catalog/auth hooks; Harness does not resolve gateway auth itself.
    */
-  async getCurrentModelAuthStatus(): Promise<ModelAuthStatus> {
-    const modelId = this.#session.model.get();
+  async getCurrentModelAuthStatus(session: Session<TState>): Promise<ModelAuthStatus> {
+    const modelId = session.model.get();
     if (!modelId) return { hasAuth: true };
 
     try {
@@ -885,25 +915,20 @@ export class Harness<TState = {}> {
   // Thread Management
   // ===========================================================================
 
-  async getResolvedMemory(): Promise<MastraMemory | null> {
-    if (!this.config.memory) return null;
-    return this.resolveMemory();
-  }
-
   /**
    * Point the session at a different memory resourceId. The resourceId itself
    * lives on the session (`session.identity`); the Harness orchestrates the
    * surrounding teardown — dropping the current thread subscription and clearing
    * the active thread — since those are Harness-owned.
    */
-  setResourceId({ resourceId }: { resourceId: string }): void {
-    this.#session.thread.cleanupSubscription();
-    this.#session.identity.setResourceId({ resourceId });
-    this.#session.thread.clear();
+  setResourceId(session: Session<TState>, { resourceId }: { resourceId: string }): void {
+    session.thread.cleanupSubscription();
+    session.identity.setResourceId({ resourceId });
+    session.thread.clear();
   }
 
-  async getKnownResourceIds(): Promise<string[]> {
-    const threads = await this.#session.thread.list({ allResources: true });
+  async getKnownResourceIds(session: Session<TState>): Promise<string[]> {
+    const threads = await session.thread.list({ allResources: true });
     const ids = new Set(threads.map(t => t.resourceId));
     return [...ids].sort();
   }
@@ -917,13 +942,13 @@ export class Harness<TState = {}> {
    * Reads the OM record and recent messages to reconstruct status,
    * then emits an `om_status` event for the UI.
    */
-  async loadOMProgress(): Promise<void> {
-    const threadId = this.#session.thread.getId();
+  async loadOMProgress(session: Session<TState>): Promise<void> {
+    const threadId = session.thread.getId();
     if (!threadId) return;
 
     try {
       const memoryStorage = await this.getMemoryStorage();
-      const record = await memoryStorage.getObservationalMemory(threadId, this.#session.identity.getResourceId());
+      const record = await memoryStorage.getObservationalMemory(threadId, session.identity.getResourceId());
 
       if (!record) return;
 
@@ -1010,7 +1035,7 @@ export class Harness<TState = {}> {
         if (foundStatus) break;
       }
 
-      this.#session.emit({
+      session.emit({
         type: 'om_status',
         windows: {
           active: {
@@ -1029,14 +1054,14 @@ export class Harness<TState = {}> {
     }
   }
 
-  async getObservationalMemoryRecord(): Promise<ObservationalMemoryRecord | null> {
-    if (!this.#session.thread.getId()) return null;
+  async getObservationalMemoryRecord(session: Session<TState>): Promise<ObservationalMemoryRecord | null> {
+    if (!session.thread.getId()) return null;
 
     try {
       const memoryStorage = await this.getMemoryStorage();
       return await memoryStorage.getObservationalMemory(
-        this.#session.thread.getId(),
-        this.#session.identity.getResourceId(),
+        session.thread.getId(),
+        session.identity.getResourceId(),
       );
     } catch {
       return null;
@@ -1056,20 +1081,22 @@ export class Harness<TState = {}> {
   // ===========================================================================
 
   private async buildAgentMessageStreamOptions({
+    session,
     requestContext: requestContextInput,
     tracingContext,
     tracingOptions,
   }: {
+    session: Session<TState>;
     requestContext?: RequestContext;
     tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
   }): Promise<Record<string, unknown>> {
-    if (!this.#session.thread.getId()) {
+    if (!session.thread.getId()) {
       throw new Error('Cannot build stream options without a current thread');
     }
 
-    this.#session.run.clearAbortRequested();
-    const requestContext = await this.buildRequestContext(requestContextInput);
+    session.run.clearAbortRequested();
+    const requestContext = await this.buildRequestContext(session, requestContextInput);
     // Resolve mode-aware instructions at call time so the agent's own
     // instructions are never mutated by the harness.
     // When mode/harness instructions exist, combine them with the agent's
@@ -1078,9 +1105,9 @@ export class Harness<TState = {}> {
     // full override.
     let callTimeInstructions: string | undefined;
     if (this.config.agent) {
-      const modeInstructions = this.resolveCurrentModeInstructions();
+      const modeInstructions = this.resolveCurrentModeInstructions(session);
       if (modeInstructions) {
-        const agent = this.getCurrentAgent();
+        const agent = this.getCurrentAgent(session);
         const agentInstructions = await agent.getInstructions({ requestContext });
         const agentStr = this.instructionsToString(agentInstructions);
         callTimeInstructions = [agentStr, modeInstructions].filter(Boolean).join('\n') || undefined;
@@ -1090,15 +1117,15 @@ export class Harness<TState = {}> {
     }
 
     const streamOptions: Record<string, unknown> = {
-      ...this.buildSharedRunOptions(),
-      memory: { thread: this.#session.thread.getId(), resource: this.#session.identity.getResourceId() },
-      abortSignal: this.#session.run.ensureAbortController().signal,
+      ...this.buildSharedRunOptions(session),
+      memory: { thread: session.thread.getId(), resource: session.identity.getResourceId() },
+      abortSignal: session.run.ensureAbortController().signal,
       requestContext,
       ...(tracingContext && { tracingContext }),
       ...(tracingOptions && { tracingOptions }),
       ...(callTimeInstructions && { instructions: callTimeInstructions }),
     };
-    streamOptions.toolsets = await this.buildToolsets(requestContext);
+    streamOptions.toolsets = await this.buildToolsets(session, requestContext);
 
     return streamOptions;
   }
@@ -1109,8 +1136,8 @@ export class Harness<TState = {}> {
    * missing `maxSteps` on resume silently caps the resumed run at the agent's
    * small default and ends it mid-task (see {@link HARNESS_MAX_STEPS}).
    */
-  private buildSharedRunOptions(): Record<string, unknown> {
-    const isYolo = (this.#session.state.get() as Record<string, unknown>).yolo === true;
+  private buildSharedRunOptions(session: Session<TState>): Record<string, unknown> {
+    const isYolo = (session.state.get() as Record<string, unknown>).yolo === true;
     const shared: Record<string, unknown> = {
       maxSteps: HARNESS_MAX_STEPS,
       savePerStep: false,
@@ -1119,7 +1146,7 @@ export class Harness<TState = {}> {
 
     // Auto-enable Anthropic server-side fallbacks for fable-5 so a classifier
     // block is transparently retried on the fallback model instead of failing.
-    const fableFallback = buildFableFallbackProviderOptions(this.#session.model.get());
+    const fableFallback = buildFableFallbackProviderOptions(session.model.get());
     if (fableFallback) {
       shared.providerOptions = { anthropic: { ...fableFallback.anthropic } };
     }
@@ -1180,8 +1207,8 @@ export class Harness<TState = {}> {
    * catalog is Harness config, so this is host-owned. Returns `undefined` when
    * no default mode is configured.
    */
-  private resolveTransitionModeId(): string | undefined {
-    const currentMode = this.#session.mode.resolve();
+  private resolveTransitionModeId(session: Session<TState>): string | undefined {
+    const currentMode = session.mode.resolve();
     const transitionModeId =
       currentMode.transitionsTo ??
       this.config.defaultModeId ??
@@ -1547,7 +1574,7 @@ export class Harness<TState = {}> {
    * and optionally subagent) plus any user-configured tools.
    * Used by sendMessage, handleToolApprove, and handleToolDecline.
    */
-  private async buildToolsets(requestContext: RequestContext): Promise<ToolsetsInput> {
+  private async buildToolsets(session: Session<TState>, requestContext: RequestContext): Promise<ToolsetsInput> {
     const builtInTools: ToolsInput = {
       ask_user: askUserTool,
       submit_plan: submitPlanTool,
@@ -1569,19 +1596,19 @@ export class Harness<TState = {}> {
 
     // Auto-create subagent tool if subagent definitions are configured
     if (this.config.subagents?.length && this.config.resolveModel) {
-      const currentMode = this.#session.mode.resolve();
+      const currentMode = session.mode.resolve();
       const hasMemory = Boolean(this.config.memory);
       builtInTools.subagent = createSubagentTool({
         subagents: this.config.subagents,
         resolveModel: this.config.resolveModel,
         harnessTools: resolvedHarnessTools,
         fallbackModelId: currentMode?.defaultModelId,
-        getParentModelId: () => this.#session.model.get(),
+        getParentModelId: () => session.model.get(),
         // Resolved lazily so forked subagents see the current mode's agent
         // even if the mode switches between tool-call scheduling and execution.
         getParentAgent: () => {
           try {
-            return this.getCurrentAgent();
+            return this.getCurrentAgent(session);
           } catch {
             return undefined;
           }
@@ -1595,10 +1622,10 @@ export class Harness<TState = {}> {
         // see `listThreads` (filtered by default).
         cloneThreadForFork: hasMemory
           ? async ({ sourceThreadId, resourceId, title }) => {
-              const memory = await this.resolveMemory();
+              const memory = await this.resolveMemory(session);
               const result = await memory.cloneThread({
                 sourceThreadId,
-                resourceId: resourceId ?? this.#session.identity.getResourceId(),
+                resourceId: resourceId ?? session.identity.getResourceId(),
                 title,
                 metadata: {
                   forkedSubagent: true,
@@ -1615,7 +1642,7 @@ export class Harness<TState = {}> {
         // prompt-cache prefix, and stripping it would invalidate the cache.
         // Recursive forking is blocked at runtime instead: see the patched
         // `subagent` execute that the forked tool path installs in `tools.ts`.
-        getParentToolsets: forkRequestContext => this.buildToolsets(forkRequestContext ?? requestContext),
+        getParentToolsets: forkRequestContext => this.buildToolsets(session, forkRequestContext ?? requestContext),
       });
     }
 
@@ -1626,7 +1653,7 @@ export class Harness<TState = {}> {
       }
     }
 
-    const permissionRules = this.#session.permissions.getRules();
+    const permissionRules = session.permissions.getRules();
     for (const [toolId, policy] of Object.entries(permissionRules.tools)) {
       if (policy === 'deny') {
         delete builtInTools[toolId];
@@ -1649,7 +1676,7 @@ export class Harness<TState = {}> {
     // supported yet.  validateModes() already prevents setting both on the
     // same mode.
     if (this.config.agent) {
-      const currentMode = this.#session.mode.resolve();
+      const currentMode = session.mode.resolve();
       const modeTools = currentMode.tools ?? currentMode.additionalTools;
       if (modeTools) {
         result.modeTools = modeTools;
@@ -1663,29 +1690,32 @@ export class Harness<TState = {}> {
    * Build request context for agent execution.
    * Tools can access harness state via requestContext.get('harness').
    */
-  private async buildRequestContext(requestContext?: RequestContext): Promise<RequestContext> {
+  private async buildRequestContext(
+    session: Session<TState>,
+    requestContext?: RequestContext,
+  ): Promise<RequestContext> {
     requestContext ??= new RequestContext();
     const harnessContext: HarnessRequestContext<TState> = {
       harnessId: this.id,
-      state: this.#session.state.get(),
-      getState: () => this.#session.state.get(),
-      setState: updates => this.#session.state.set(updates),
-      updateState: updater => this.#session.state.update(updater),
-      threadId: this.#session.thread.getId(),
-      resourceId: this.#session.identity.getResourceId(),
+      state: session.state.get(),
+      getState: () => session.state.get(),
+      setState: updates => session.state.set(updates),
+      updateState: updater => session.state.update(updater),
+      threadId: session.thread.getId(),
+      resourceId: session.identity.getResourceId(),
       session: {
-        modeId: this.#session.mode.get(),
-        modelId: this.#session.model.get(),
+        modeId: session.mode.get(),
+        modelId: session.model.get(),
         state: {
-          get: () => this.#session.state.get(),
-          set: updates => this.#session.state.set(updates),
-          update: updater => this.#session.state.update(updater),
+          get: () => session.state.get(),
+          set: updates => session.state.set(updates),
+          update: updater => session.state.update(updater),
         },
       },
-      abortSignal: this.#session.run.getAbortSignal(),
+      abortSignal: session.run.getAbortSignal(),
       workspace: this.workspace,
-      emitEvent: event => this.#session.emit(event),
-      getSubagentModelId: params => this.#session.subagents.model.get(params ?? {}),
+      emitEvent: event => session.emit(event),
+      getSubagentModelId: params => session.subagents.model.get(params ?? {}),
     };
 
     requestContext.set('harness', harnessContext);
@@ -1709,7 +1739,7 @@ export class Harness<TState = {}> {
   /**
    * Resolve memory from config — handles both static instances and dynamic factory functions.
    */
-  private async resolveMemory(): Promise<MastraMemory> {
+  private async resolveMemory(session: Session<TState>): Promise<MastraMemory> {
     const mem = this.config.memory;
     if (!mem) {
       throw new Error('Memory is not configured on this Harness');
@@ -1717,7 +1747,7 @@ export class Harness<TState = {}> {
     if (typeof mem !== 'function') {
       return mem;
     }
-    const requestContext = await this.buildRequestContext();
+    const requestContext = await this.buildRequestContext(session);
     const resolved = await Promise.resolve(mem({ requestContext }));
     if (!resolved) {
       throw new Error('Dynamic memory factory returned empty value');
@@ -1729,8 +1759,8 @@ export class Harness<TState = {}> {
   // Token Usage
   // ===========================================================================
 
-  private async persistTokenUsage(): Promise<void> {
-    const threadId = this.#session.thread.getId();
+  private async persistTokenUsage(session: Session<TState>): Promise<void> {
+    const threadId = session.thread.getId();
     if (!threadId || !this.config.storage) return;
 
     try {
@@ -1740,7 +1770,7 @@ export class Harness<TState = {}> {
         await memoryStorage.saveThread({
           thread: {
             ...thread,
-            metadata: { ...thread.metadata, tokenUsage: this.#session.getTokenUsage() },
+            metadata: { ...thread.metadata, tokenUsage: session.getTokenUsage() },
             updatedAt: new Date(),
           },
         });
@@ -1764,14 +1794,16 @@ export class Harness<TState = {}> {
    * Useful for code paths outside the request flow (e.g. slash commands).
    */
   async resolveWorkspace({
+    session,
     requestContext,
   }: {
+    session: Session<TState>;
     requestContext?: RequestContext;
-  } = {}): Promise<Workspace | undefined> {
+  }): Promise<Workspace | undefined> {
     if (this.workspace) return this.workspace;
     if (this.workspaceFn) {
       // buildRequestContext resolves the workspace and caches it on this.workspace
-      await this.buildRequestContext(requestContext);
+      await this.buildRequestContext(session, requestContext);
       return this.workspace;
     }
     return undefined;
@@ -1789,10 +1821,10 @@ export class Harness<TState = {}> {
   async destroyWorkspace(): Promise<void> {
     if (this.workspaceFn) return;
     if (this.workspace && this.workspaceInitialized) {
+      // The workspace is a Harness-shared resource torn down at Harness
+      // shutdown; there is no single session to emit lifecycle events onto.
       try {
-        this.#session.emit({ type: 'workspace_status_changed', status: 'destroying' });
         await this.workspace.destroy();
-        this.#session.emit({ type: 'workspace_status_changed', status: 'destroyed' });
       } catch (error) {
         console.warn('Workspace destroy failed:', error);
       } finally {
@@ -1882,21 +1914,11 @@ export class Harness<TState = {}> {
   // ===========================================================================
 
   async destroy(): Promise<void> {
-    this.#session.thread.cleanupSubscription();
+    // The Harness owns no session; per-session teardown (thread-subscription
+    // cleanup) is the caller's responsibility via `session.thread.*`. Here we
+    // only tear down Harness-shared resources.
     await this.stopHeartbeats();
     await this.destroyWorkspace();
-  }
-
-  // ===========================================================================
-  // Session
-  // ===========================================================================
-
-  async getSession(): Promise<HarnessSession> {
-    return {
-      currentThreadId: this.#session.thread.getId(),
-      currentModeId: this.#session.mode.get(),
-      threads: await this.#session.thread.list(),
-    };
   }
 
   // ===========================================================================

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -194,6 +194,15 @@ export class Harness<TState = {}> {
    * every {@link createSession} call. The Harness itself holds no session.
    */
   readonly #defaultMode: HarnessMode;
+  /**
+   * Live sessions created by {@link createSession}, keyed by resourceId. A
+   * resourceId maps to exactly one session per Harness (get-or-create). Stores
+   * the in-flight creation promise so concurrent calls share one session. Lets
+   * Harness-external callers (e.g. notification delivery) resolve "the session
+   * that owns this resource" so a woken run uses that session's model/mode/state
+   * instead of an arbitrary one.
+   */
+  readonly #sessionsByResource = new Map<string, Promise<Session<TState>>>();
   private availableModelsCache: AvailableModel[] | null = null;
   private availableModelsCacheTime: number = 0;
   readonly #instructions?: string;
@@ -324,9 +333,35 @@ export class Harness<TState = {}> {
    * workspace are ready.
    */
   async createSession({ resourceId }: { resourceId?: string } = {}): Promise<Session<TState>> {
+    const effectiveResourceId = resourceId ?? this.config.resourceId ?? this.config.id;
+
+    // Get-or-create: a resourceId maps to exactly one durable session per
+    // Harness. Asking for the same resource twice returns the same session, so
+    // a user/thread always resumes their own session and notification delivery
+    // reuses it rather than spawning a split-brain duplicate. Cache the in-flight
+    // promise so concurrent calls for the same resource resolve to one session.
+    const existing = this.#sessionsByResource.get(effectiveResourceId);
+    if (existing) {
+      return existing;
+    }
+
+    const creation = this.#createSessionForResource(effectiveResourceId);
+    this.#sessionsByResource.set(effectiveResourceId, creation);
+    try {
+      return await creation;
+    } catch (error) {
+      // Don't cache a failed creation — let the next call retry.
+      if (this.#sessionsByResource.get(effectiveResourceId) === creation) {
+        this.#sessionsByResource.delete(effectiveResourceId);
+      }
+      throw error;
+    }
+  }
+
+  async #createSessionForResource(effectiveResourceId: string): Promise<Session<TState>> {
     const session = this.#wireSession(
       new Session({
-        resourceId: resourceId ?? this.config.resourceId ?? this.config.id,
+        resourceId: effectiveResourceId,
         state: {
           initialState: this.config.initialState,
           stateSchema: this.config.stateSchema,
@@ -362,6 +397,16 @@ export class Harness<TState = {}> {
     }
 
     return session;
+  }
+
+  /**
+   * Resolve a live session by resourceId, if one was created for it via
+   * {@link createSession}. Returns `undefined` when no session owns the
+   * resource. Used by notification delivery to run woken signals as the session
+   * that owns the target thread, rather than an arbitrary session.
+   */
+  async getSessionByResource(resourceId: string): Promise<Session<TState> | undefined> {
+    return this.#sessionsByResource.get(resourceId);
   }
 
   // ===========================================================================
@@ -922,9 +967,27 @@ export class Harness<TState = {}> {
    * the active thread — since those are Harness-owned.
    */
   setResourceId(session: Session<TState>, { resourceId }: { resourceId: string }): void {
+    const previousResourceId = session.identity.getResourceId();
     session.thread.cleanupSubscription();
     session.identity.setResourceId({ resourceId });
     session.thread.clear();
+
+    // Re-key the resource registry so this session is the one resolved for its
+    // new resourceId (and is no longer resolved for the old one). This session
+    // becomes the authoritative owner of the target resource, replacing any
+    // prior session registered there.
+    void this.#dropSessionFromRegistry(previousResourceId, session);
+    this.#sessionsByResource.set(resourceId, Promise.resolve(session));
+  }
+
+  /** Remove `resourceId` from the registry only if it still resolves to `session`. */
+  async #dropSessionFromRegistry(resourceId: string, session: Session<TState>): Promise<void> {
+    const pending = this.#sessionsByResource.get(resourceId);
+    if (!pending) return;
+    const resolved = await pending.catch(() => undefined);
+    if (resolved === session && this.#sessionsByResource.get(resourceId) === pending) {
+      this.#sessionsByResource.delete(resourceId);
+    }
   }
 
   async getKnownResourceIds(session: Session<TState>): Promise<string[]> {

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -31,7 +31,6 @@ export type {
   HarnessRequestState,
   HarnessRequestStateUpdater,
   HarnessRequestStateUpdateResult,
-  HarnessSession,
   HarnessStateSchema,
   HarnessSubagent,
   HarnessSubagentHistoryEntry,

--- a/packages/core/src/harness/list-available-models.test.ts
+++ b/packages/core/src/harness/list-available-models.test.ts
@@ -121,8 +121,10 @@ describe('Harness.listAvailableModels', () => {
         defaultObserverModelId: 'test-gateway/acme/sonic-fast',
       },
     });
+    await harness.init();
+    const session = await harness.createSession();
 
-    const observerModel = harness.session.om.observer.resolvedModel() as { modelId?: string };
+    const observerModel = session.om.observer.resolvedModel() as { modelId?: string };
     expect(observerModel).toMatchObject({ modelId: 'test-gateway/acme/sonic-fast' });
     expect(resolveModel).toHaveBeenCalledWith('test-gateway/acme/sonic-fast');
 
@@ -134,6 +136,9 @@ describe('Harness.listAvailableModels', () => {
       apiKeyEnvVar: 'ACME_API_KEY',
     });
 
-    await expect(harness.getCurrentModelAuthStatus()).resolves.toEqual({ hasAuth: true, apiKeyEnvVar: undefined });
+    await expect(harness.getCurrentModelAuthStatus(session)).resolves.toEqual({
+      hasAuth: true,
+      apiKeyEnvVar: undefined,
+    });
   });
 });

--- a/packages/core/src/harness/list-threads-fork-filter.test.ts
+++ b/packages/core/src/harness/list-threads-fork-filter.test.ts
@@ -47,6 +47,9 @@ describe('Harness listThreads — forked subagent filter', () => {
   it('hides forkedSubagent threads by default', async () => {
     const harness = createHarness('rid-1');
     await harness.init();
+    const session = await harness.createSession();
+    // Drop the auto-created starter thread so assertions see only seeded threads.
+    await session.thread.delete({ threadId: session.thread.getId()! });
 
     await writeThreadDirect(harness, { id: 'normal-1', resourceId: 'rid-1', title: 'Normal' });
     await writeThreadDirect(harness, {
@@ -56,7 +59,7 @@ describe('Harness listThreads — forked subagent filter', () => {
       metadata: { forkedSubagent: true, parentThreadId: 'normal-1' },
     });
 
-    const threads = await harness.session.thread.list();
+    const threads = await session.thread.list();
 
     expect(threads.map(t => t.id)).toEqual(['normal-1']);
   });
@@ -64,6 +67,9 @@ describe('Harness listThreads — forked subagent filter', () => {
   it('includes forks when includeForkedSubagents=true', async () => {
     const harness = createHarness('rid-2');
     await harness.init();
+    const session = await harness.createSession();
+    // Drop the auto-created starter thread so assertions see only seeded threads.
+    await session.thread.delete({ threadId: session.thread.getId()! });
 
     await writeThreadDirect(harness, { id: 'normal-2', resourceId: 'rid-2' });
     await writeThreadDirect(harness, {
@@ -72,7 +78,7 @@ describe('Harness listThreads — forked subagent filter', () => {
       metadata: { forkedSubagent: true, parentThreadId: 'normal-2' },
     });
 
-    const threads = await harness.session.thread.list({ includeForkedSubagents: true });
+    const threads = await session.thread.list({ includeForkedSubagents: true });
 
     expect(threads.map(t => t.id).sort()).toEqual(['fork-2', 'normal-2']);
   });
@@ -82,6 +88,9 @@ describe('Harness listThreads — forked subagent filter', () => {
     // explicitly requested.
     const harness = createHarness('rid-3');
     await harness.init();
+    const session = await harness.createSession();
+    // Drop the auto-created starter thread so assertions see only seeded threads.
+    await session.thread.delete({ threadId: session.thread.getId()! });
 
     await writeThreadDirect(harness, { id: 'a-normal', resourceId: 'rid-other' });
     await writeThreadDirect(harness, {
@@ -90,7 +99,7 @@ describe('Harness listThreads — forked subagent filter', () => {
       metadata: { forkedSubagent: true },
     });
 
-    const threads = await harness.session.thread.list({ allResources: true });
+    const threads = await session.thread.list({ allResources: true });
 
     expect(threads.map(t => t.id)).toEqual(['a-normal']);
   });
@@ -99,6 +108,9 @@ describe('Harness listThreads — forked subagent filter', () => {
     // Defensive: only `forkedSubagent === true` should hide a thread.
     const harness = createHarness('rid-4');
     await harness.init();
+    const session = await harness.createSession();
+    // Drop the auto-created starter thread so assertions see only seeded threads.
+    await session.thread.delete({ threadId: session.thread.getId()! });
 
     await writeThreadDirect(harness, { id: 't-undef', resourceId: 'rid-4' });
     await writeThreadDirect(harness, { id: 't-false', resourceId: 'rid-4', metadata: { forkedSubagent: false } });
@@ -108,7 +120,7 @@ describe('Harness listThreads — forked subagent filter', () => {
       metadata: { forkedSubagent: 'true' as unknown as boolean },
     });
 
-    const threads = await harness.session.thread.list();
+    const threads = await session.thread.list();
     expect(threads.map(t => t.id).sort()).toEqual(['t-false', 't-string', 't-undef']);
   });
 });

--- a/packages/core/src/harness/mode-model-persistence.test.ts
+++ b/packages/core/src/harness/mode-model-persistence.test.ts
@@ -54,64 +54,76 @@ describe('Harness mode-model persistence across restarts', () => {
     // the same thread.
     const harness1 = createHarness(storage);
     await harness1.init();
-    const thread = await harness1.session.thread.create();
-    expect(harness1.session.mode.get()).toBe('build');
+    const session1 = await harness1.createSession();
+    const thread = await session1.thread.create();
+    expect(session1.mode.get()).toBe('build');
 
-    await harness1.session.mode.switch({ modeId: 'fast' });
-    expect(harness1.session.mode.get()).toBe('fast');
-    expect(harness1.session.model.get()).toBe('cerebras/zai-glm-4.7');
+    await session1.mode.switch({ modeId: 'fast' });
+    expect(session1.mode.get()).toBe('fast');
+    expect(session1.model.get()).toBe('cerebras/zai-glm-4.7');
 
     // Harness 2: reopen and resume the same thread.
     const harness2 = createHarness(storage);
     await harness2.init();
-    await harness2.session.thread.switch({ threadId: thread.id });
+    const session2 = await harness2.createSession();
+    await session2.thread.switch({ threadId: thread.id });
 
-    expect(harness2.session.mode.get()).toBe('fast');
-    expect(harness2.session.model.get()).toBe('cerebras/zai-glm-4.7');
+    expect(session2.mode.get()).toBe('fast');
+    expect(session2.model.get()).toBe('cerebras/zai-glm-4.7');
   });
 
   it('restores an explicitly chosen per-mode model on reopen', async () => {
     const harness1 = createHarness(storage);
     await harness1.init();
-    const thread = await harness1.session.thread.create();
+    const session1 = await harness1.createSession();
+    const thread = await session1.thread.create();
 
-    await harness1.session.mode.switch({ modeId: 'fast' });
-    await harness1.session.model.switch({ modelId: 'cerebras/qwen-3-coder-480b' });
-    expect(harness1.session.model.get()).toBe('cerebras/qwen-3-coder-480b');
+    await session1.mode.switch({ modeId: 'fast' });
+    await session1.model.switch({ modelId: 'cerebras/qwen-3-coder-480b' });
+    expect(session1.model.get()).toBe('cerebras/qwen-3-coder-480b');
 
     const harness2 = createHarness(storage);
     await harness2.init();
-    await harness2.session.thread.switch({ threadId: thread.id });
+    const session2 = await harness2.createSession();
+    await session2.thread.switch({ threadId: thread.id });
 
-    expect(harness2.session.mode.get()).toBe('fast');
-    expect(harness2.session.model.get()).toBe('cerebras/qwen-3-coder-480b');
+    expect(session2.mode.get()).toBe('fast');
+    expect(session2.model.get()).toBe('cerebras/qwen-3-coder-480b');
   });
 
   it('keeps the default mode and its persisted model on reopen when the user never switched modes', async () => {
     const harness1 = createHarness(storage);
     await harness1.init();
-    const thread = await harness1.session.thread.create();
-    await harness1.session.model.switch({ modelId: 'anthropic/claude-opus-4-6' });
+    const session1 = await harness1.createSession();
+    const thread = await session1.thread.create();
+    await session1.model.switch({ modelId: 'anthropic/claude-opus-4-6' });
 
     const harness2 = createHarness(storage);
     await harness2.init();
-    await harness2.session.thread.switch({ threadId: thread.id });
+    const session2 = await harness2.createSession();
+    await session2.thread.switch({ threadId: thread.id });
 
-    expect(harness2.session.mode.get()).toBe('build');
-    expect(harness2.session.model.get()).toBe('anthropic/claude-opus-4-6');
+    expect(session2.mode.get()).toBe('build');
+    expect(session2.model.get()).toBe('anthropic/claude-opus-4-6');
   });
 
   it('emits mode_changed with the correct previousModeId when restoring a mode from thread metadata', async () => {
     const harness1 = createHarness(storage);
     await harness1.init();
-    const thread = await harness1.session.thread.create();
-    await harness1.session.mode.switch({ modeId: 'plan' });
+    const session1 = await harness1.createSession();
+    const thread = await session1.thread.create();
+    await session1.mode.switch({ modeId: 'plan' });
 
     const harness2 = createHarness(storage);
     await harness2.init();
+    const session2 = await harness2.createSession();
+    // Move session2 onto a fresh build-mode thread so switching to the saved
+    // plan-mode thread below produces an observable mode restoration.
+    await session2.thread.create();
+    expect(session2.mode.get()).toBe('build');
 
     const events: Array<{ type: 'mode_changed'; modeId: string; previousModeId: string }> = [];
-    harness2.session.subscribe(event => {
+    session2.subscribe(event => {
       if (event.type === 'mode_changed') {
         events.push({
           type: event.type,
@@ -121,7 +133,7 @@ describe('Harness mode-model persistence across restarts', () => {
       }
     });
 
-    await harness2.session.thread.switch({ threadId: thread.id });
+    await session2.thread.switch({ threadId: thread.id });
 
     const restoreEvent = events.find(e => e.modeId === 'plan');
     expect(restoreEvent).toBeDefined();
@@ -129,22 +141,23 @@ describe('Harness mode-model persistence across restarts', () => {
   });
 
   it('approving a submit_plan suspension switches to the default mode and clears the suspension', async () => {
-    const session = createHarness(storage);
-    await session.init();
-    await session.session.thread.create();
-    await session.session.mode.switch({ modeId: 'plan' });
+    const harness = createHarness(storage);
+    await harness.init();
+    const session = await harness.createSession();
+    await session.thread.create();
+    await session.mode.switch({ modeId: 'plan' });
 
-    const controller = session.session.run.ensureAbortController();
+    const controller = session.run.ensureAbortController();
 
     // Simulate a submit_plan tool that suspended during a plan-mode run.
-    session.session.suspensions.register({ toolCallId: 'plan-call-1', runId: 'run-1', toolName: 'submit_plan' });
+    session.suspensions.register({ toolCallId: 'plan-call-1', runId: 'run-1', toolName: 'submit_plan' });
 
-    await session.session.respondToToolSuspension({ toolCallId: 'plan-call-1', resumeData: { action: 'approved' } });
+    await session.respondToToolSuspension({ toolCallId: 'plan-call-1', resumeData: { action: 'approved' } });
 
     // Approval abandons the parked plan suspension and switches to the default
     // (execution) mode, aborting the plan-mode run.
-    expect(session.session.suspensions.has({ toolCallId: 'plan-call-1' })).toBe(false);
+    expect(session.suspensions.has({ toolCallId: 'plan-call-1' })).toBe(false);
     expect(controller.signal.aborted).toBe(true);
-    expect(session.session.mode.get()).toBe('build');
+    expect(session.mode.get()).toBe('build');
   });
 });

--- a/packages/core/src/harness/om-failure-abort.test.ts
+++ b/packages/core/src/harness/om-failure-abort.test.ts
@@ -4,29 +4,32 @@ import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 import type { HarnessEvent } from './types';
 
-function createHarness() {
+async function createSession() {
   const agent = new Agent({
     name: 'test-agent',
     instructions: 'You are a test agent.',
     model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
   });
 
-  return new Harness({
+  const harness = new Harness({
     id: 'test-harness',
     storage: new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
   });
+  await harness.init();
+  const session = await harness.createSession();
+  return { session };
 }
 
 describe('Harness OM failure abort behavior', () => {
   it('aborts stream and emits an error when OM buffering fails', async () => {
-    const harness = createHarness();
+    const { session } = await createSession();
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    harness.session.run.ensureAbortController();
+    session.run.ensureAbortController();
 
-    await (harness.session as any).processStream({
+    await (session as any).processStream({
       fullStream: (async function* () {
         yield {
           type: 'data-om-buffering-failed',
@@ -47,19 +50,19 @@ describe('Harness OM failure abort behavior', () => {
       'Observational memory observation buffering failed: Bad Request',
     );
     expect(events.some(e => e.type === 'agent_end' && e.reason === 'aborted')).toBe(true);
-    expect(harness.session.run.isAbortRequested()).toBe(false);
-    expect(harness.session.run.hasAbortController()).toBe(false);
+    expect(session.run.isAbortRequested()).toBe(false);
+    expect(session.run.hasAbortController()).toBe(false);
     expect(events.some(e => e.type === 'message_start')).toBe(false);
   });
 
   it('aborts stream and emits an error when OM observation run fails', async () => {
-    const harness = createHarness();
+    const { session } = await createSession();
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    harness.session.run.ensureAbortController();
+    session.run.ensureAbortController();
 
-    await (harness.session as any).processStream({
+    await (session as any).processStream({
       fullStream: (async function* () {
         yield {
           type: 'data-om-observation-failed',
@@ -81,7 +84,7 @@ describe('Harness OM failure abort behavior', () => {
       'Observational memory reflection run failed: Model unavailable',
     );
     expect(events.some(e => e.type === 'agent_end' && e.reason === 'aborted')).toBe(true);
-    expect(harness.session.run.isAbortRequested()).toBe(false);
+    expect(session.run.isAbortRequested()).toBe(false);
     expect(events.some(e => e.type === 'message_start')).toBe(false);
   });
 });

--- a/packages/core/src/harness/om-threshold-persistence.test.ts
+++ b/packages/core/src/harness/om-threshold-persistence.test.ts
@@ -31,19 +31,20 @@ describe('Harness OM threshold persistence', () => {
       reflectionThreshold: 40000,
     });
     await harness.init();
+    const session = await harness.createSession();
 
-    const threadA = await harness.session.thread.create();
-    await harness.session.state.set({ observationThreshold: 12000, reflectionThreshold: 21000 } as any);
-    await harness.session.thread.setSetting({ key: 'observationThreshold', value: 12000 });
-    await harness.session.thread.setSetting({ key: 'reflectionThreshold', value: 21000 });
+    const threadA = await session.thread.create();
+    await session.state.set({ observationThreshold: 12000, reflectionThreshold: 21000 } as any);
+    await session.thread.setSetting({ key: 'observationThreshold', value: 12000 });
+    await session.thread.setSetting({ key: 'reflectionThreshold', value: 21000 });
 
-    await harness.session.thread.create();
-    await harness.session.state.set({ observationThreshold: 33000, reflectionThreshold: 44000 } as any);
+    await session.thread.create();
+    await session.state.set({ observationThreshold: 33000, reflectionThreshold: 44000 } as any);
 
-    await harness.session.thread.switch({ threadId: threadA.id });
+    await session.thread.switch({ threadId: threadA.id });
 
-    expect((harness.session.state.get() as any).observationThreshold).toBe(12000);
-    expect((harness.session.state.get() as any).reflectionThreshold).toBe(21000);
+    expect((session.state.get() as any).observationThreshold).toBe(12000);
+    expect((session.state.get() as any).reflectionThreshold).toBe(21000);
   });
 
   it('persists current thresholds onto an existing thread when metadata does not define overrides', async () => {
@@ -52,14 +53,15 @@ describe('Harness OM threshold persistence', () => {
       reflectionThreshold: 25000,
     });
     await harness.init();
+    const session = await harness.createSession();
 
-    const thread = await harness.session.thread.create();
-    await harness.session.state.set({ observationThreshold: 18000, reflectionThreshold: 28000 } as any);
+    const thread = await session.thread.create();
+    await session.state.set({ observationThreshold: 18000, reflectionThreshold: 28000 } as any);
 
-    await harness.session.thread.switch({ threadId: thread.id });
+    await session.thread.switch({ threadId: thread.id });
 
-    expect((harness.session.state.get() as any).observationThreshold).toBe(18000);
-    expect((harness.session.state.get() as any).reflectionThreshold).toBe(28000);
+    expect((session.state.get() as any).observationThreshold).toBe(18000);
+    expect((session.state.get() as any).reflectionThreshold).toBe(28000);
 
     const memory = await storage.getStore('memory');
     const savedThread = await memory?.getThreadById({ threadId: thread.id });

--- a/packages/core/src/harness/repro-mc-bug.test.ts
+++ b/packages/core/src/harness/repro-mc-bug.test.ts
@@ -86,17 +86,18 @@ describe('mc send-message reproduction', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
     await harness.getMastra()?.startWorkers();
-    await harness.session.thread.create();
+    await session.thread.create();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe((event: HarnessEvent) => {
+    session.subscribe((event: HarnessEvent) => {
       events.push(event);
     });
 
-    expect(harness.session.model.get()).toBe('anthropic/claude-opus-4-7');
+    expect(session.model.get()).toBe('anthropic/claude-opus-4-7');
 
-    await harness.session.sendMessage({ content: 'Hello!' });
+    await session.sendMessage({ content: 'Hello!' });
 
     const assistantEnd = events.find(
       (e): e is Extract<HarnessEvent, { type: 'message_end' }> =>
@@ -129,15 +130,16 @@ describe('mc send-message reproduction', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
     await harness.getMastra()?.startWorkers();
-    await harness.session.thread.create();
+    await session.thread.create();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe((event: HarnessEvent) => {
+    session.subscribe((event: HarnessEvent) => {
       events.push(event);
     });
 
-    await harness.session.sendMessage({ content: 'Hello!' });
+    await session.sendMessage({ content: 'Hello!' });
 
     // With the fix, the error should propagate through the subscription stream
     // and the harness should emit an error event instead of silently completing
@@ -182,17 +184,18 @@ describe('mc send-message reproduction', () => {
     });
 
     await harness.init();
+    const session = await harness.createSession();
     await harness.getMastra()?.startWorkers();
-    await harness.session.thread.create();
+    await session.thread.create();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe((event: HarnessEvent) => {
+    session.subscribe((event: HarnessEvent) => {
       events.push(event);
     });
 
-    expect(harness.session.model.get()).toBe('anthropic/claude-opus-4-7');
+    expect(session.model.get()).toBe('anthropic/claude-opus-4-7');
 
-    await harness.session.sendMessage({ content: 'Hello!' });
+    await session.sendMessage({ content: 'Hello!' });
 
     const assistantEnd = events.find(
       (e): e is Extract<HarnessEvent, { type: 'message_end' }> =>

--- a/packages/core/src/harness/resource-id.test.ts
+++ b/packages/core/src/harness/resource-id.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import type { Session } from './session';
 
 function createAgent() {
   return new Agent({
@@ -11,69 +12,78 @@ function createAgent() {
   });
 }
 
-function createHarness(opts?: { resourceId?: string; storage?: InMemoryStore }) {
+async function createSession(opts?: { resourceId?: string; storage?: InMemoryStore }) {
   const agent = createAgent();
-  return new Harness({
+  const harness = new Harness({
     id: 'test-harness',
     storage: opts?.storage ?? new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
     ...(opts?.resourceId ? { resourceId: opts.resourceId } : {}),
   });
+  await harness.init();
+  const session = await harness.createSession();
+  return { harness, session };
 }
 
 describe('Harness resource ID', () => {
   describe('getDefaultResourceId', () => {
-    it('returns the harness id when no explicit resourceId is configured', () => {
-      const harness = createHarness();
-      expect(harness.session.identity.getDefaultResourceId()).toBe('test-harness');
+    it('returns the harness id when no explicit resourceId is configured', async () => {
+      const { session } = await createSession();
+      expect(session.identity.getDefaultResourceId()).toBe('test-harness');
     });
 
-    it('returns the configured resourceId when one is provided', () => {
-      const harness = createHarness({ resourceId: 'custom-resource' });
-      expect(harness.session.identity.getDefaultResourceId()).toBe('custom-resource');
+    it('returns the configured resourceId when one is provided', async () => {
+      const { session } = await createSession({ resourceId: 'custom-resource' });
+      expect(session.identity.getDefaultResourceId()).toBe('custom-resource');
     });
 
-    it('still returns the original default after setResourceId is called', () => {
-      const harness = createHarness({ resourceId: 'original' });
-      harness.setResourceId({ resourceId: 'changed' });
-      expect(harness.session.identity.getResourceId()).toBe('changed');
-      expect(harness.session.identity.getDefaultResourceId()).toBe('original');
+    it('still returns the original default after setResourceId is called', async () => {
+      const { harness, session } = await createSession({ resourceId: 'original' });
+      harness.setResourceId(session, { resourceId: 'changed' });
+      expect(session.identity.getResourceId()).toBe('changed');
+      expect(session.identity.getDefaultResourceId()).toBe('original');
     });
   });
 
   describe('getKnownResourceIds', () => {
     let storage: InMemoryStore;
     let harness: Harness;
+    let session: Session;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       storage = new InMemoryStore();
-      harness = createHarness({ storage });
+      const ctx = await createSession({ storage });
+      harness = ctx.harness;
+      session = ctx.session;
+      // Drop the auto-created starter thread so resource-id assertions only
+      // reflect threads explicitly created by each test.
+      await session.thread.delete({ threadId: session.thread.getId()! });
     });
 
     it('returns an empty array when no threads exist', async () => {
-      const ids = await harness.getKnownResourceIds();
+      const ids = await harness.getKnownResourceIds(session);
       expect(ids).toEqual([]);
     });
 
     it('returns unique resource IDs from threads', async () => {
       // Create threads under different resource IDs
-      await harness.session.thread.create({ title: 'thread-1' });
+      await session.thread.create({ title: 'thread-1' });
 
-      harness.setResourceId({ resourceId: 'user-2' });
-      await harness.session.thread.create({ title: 'thread-2' });
+      harness.setResourceId(session, { resourceId: 'user-2' });
+      await session.thread.create({ title: 'thread-2' });
 
-      harness.setResourceId({ resourceId: 'user-3' });
-      await harness.session.thread.create({ title: 'thread-3' });
+      harness.setResourceId(session, { resourceId: 'user-3' });
+      await session.thread.create({ title: 'thread-3' });
 
-      const ids = await harness.getKnownResourceIds();
+      const ids = await harness.getKnownResourceIds(session);
       expect(ids.sort()).toEqual(['test-harness', 'user-2', 'user-3'].sort());
     });
 
     it('does not return duplicate resource IDs', async () => {
-      await harness.session.thread.create({ title: 'thread-1' });
-      await harness.session.thread.create({ title: 'thread-2' });
+      await session.thread.create({ title: 'thread-1' });
+      await session.thread.create({ title: 'thread-2' });
 
-      const ids = await harness.getKnownResourceIds();
+      const ids = await harness.getKnownResourceIds(session);
       expect(ids).toEqual(['test-harness']);
     });
   });

--- a/packages/core/src/harness/session-isolation.test.ts
+++ b/packages/core/src/harness/session-isolation.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+import type { HarnessEvent } from './types';
+
+function createHarness(storage: InMemoryStore) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new Harness({
+    id: 'test-harness',
+    storage,
+    modes: [
+      { id: 'build', name: 'Build', default: true, agent, defaultModelId: 'openai/gpt-4o' },
+      { id: 'plan', name: 'Plan', agent, defaultModelId: 'anthropic/claude-sonnet-4' },
+    ],
+  });
+}
+
+describe('Harness.createSession — cross-session isolation', () => {
+  it('gives each session an independent current thread', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const a = await harness.createSession({ resourceId: 'user-a' });
+    const b = await harness.createSession({ resourceId: 'user-b' });
+
+    expect(a.thread.getId()).toBeDefined();
+    expect(b.thread.getId()).toBeDefined();
+    expect(a.thread.getId()).not.toBe(b.thread.getId());
+  });
+
+  it('isolates mode switches between sessions', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const a = await harness.createSession({ resourceId: 'user-a' });
+    const b = await harness.createSession({ resourceId: 'user-b' });
+
+    expect(a.mode.get()).toBe('build');
+    expect(b.mode.get()).toBe('build');
+
+    await a.mode.switch({ modeId: 'plan' });
+
+    // Only session a moved to plan; b is untouched.
+    expect(a.mode.get()).toBe('plan');
+    expect(b.mode.get()).toBe('build');
+  });
+
+  it('isolates model selection between sessions', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const a = await harness.createSession({ resourceId: 'user-a' });
+    const b = await harness.createSession({ resourceId: 'user-b' });
+
+    await a.model.switch({ modelId: 'cerebras/zai-glm-4.7' });
+
+    expect(a.model.get()).toBe('cerebras/zai-glm-4.7');
+    // b still resolves its mode default, unaffected by a's override.
+    expect(b.model.get()).toBe('openai/gpt-4o');
+  });
+
+  it('isolates session state between sessions', async () => {
+    const storage = new InMemoryStore();
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions: 'You are a test agent.',
+      model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+    });
+    const harness = new Harness<{ counter: number }>({
+      id: 'test-harness',
+      storage,
+      initialState: { counter: 0 },
+      modes: [{ id: 'build', name: 'Build', default: true, agent }],
+    });
+    await harness.init();
+
+    const a = await harness.createSession({ resourceId: 'user-a' });
+    const b = await harness.createSession({ resourceId: 'user-b' });
+
+    await a.state.set({ counter: 5 });
+
+    expect(a.state.get().counter).toBe(5);
+    expect(b.state.get().counter).toBe(0);
+  });
+
+  it('isolates event buses between sessions', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const a = await harness.createSession({ resourceId: 'user-a' });
+    const b = await harness.createSession({ resourceId: 'user-b' });
+
+    const aEvents: HarnessEvent[] = [];
+    const bEvents: HarnessEvent[] = [];
+    a.subscribe(event => {
+      aEvents.push(event);
+    });
+    b.subscribe(event => {
+      bEvents.push(event);
+    });
+
+    await a.mode.switch({ modeId: 'plan' });
+
+    expect(aEvents.some(e => e.type === 'mode_changed')).toBe(true);
+    expect(bEvents.some(e => e.type === 'mode_changed')).toBe(false);
+  });
+});

--- a/packages/core/src/harness/session-isolation.test.ts
+++ b/packages/core/src/harness/session-isolation.test.ts
@@ -111,3 +111,38 @@ describe('Harness.createSession — cross-session isolation', () => {
     expect(bEvents.some(e => e.type === 'mode_changed')).toBe(false);
   });
 });
+
+describe('Harness session registry', () => {
+  it('resolves a created session by its resourceId', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const a = await harness.createSession({ resourceId: 'user-a' });
+    const b = await harness.createSession({ resourceId: 'user-b' });
+
+    expect(await harness.getSessionByResource('user-a')).toBe(a);
+    expect(await harness.getSessionByResource('user-b')).toBe(b);
+    expect(await harness.getSessionByResource('user-unknown')).toBeUndefined();
+  });
+
+  it('returns the same session for the same resourceId (get-or-create)', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const first = await harness.createSession({ resourceId: 'user-a' });
+    const second = await harness.createSession({ resourceId: 'user-a' });
+
+    expect(second).toBe(first);
+  });
+
+  it('follows a session when its resourceId changes', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const a = await harness.createSession({ resourceId: 'user-a' });
+    harness.setResourceId(a, { resourceId: 'user-a-renamed' });
+
+    expect(await harness.getSessionByResource('user-a-renamed')).toBe(a);
+    expect(await harness.getSessionByResource('user-a')).toBeUndefined();
+  });
+});

--- a/packages/core/src/harness/session-om.test.ts
+++ b/packages/core/src/harness/session-om.test.ts
@@ -3,9 +3,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import type { Session } from './session';
 import type { HarnessEvent, HarnessOMConfig } from './types';
 
-function createHarness(options: {
+async function createSession(options: {
   storage: InMemoryStore;
   omConfig?: HarnessOMConfig;
   resolveModel?: (modelId: string) => any;
@@ -25,9 +26,10 @@ function createHarness(options: {
     resolveModel: options.resolveModel,
   });
 
-  if (options.onEvent) harness.session.subscribe(options.onEvent);
-
-  return harness;
+  await harness.init();
+  const session = await harness.createSession();
+  if (options.onEvent) session.subscribe(options.onEvent);
+  return { harness, session };
 }
 
 describe('session.om', () => {
@@ -37,8 +39,8 @@ describe('session.om', () => {
     storage = new InMemoryStore();
   });
 
-  it('falls back to omConfig defaults for model ids and thresholds', () => {
-    const harness = createHarness({
+  it('falls back to omConfig defaults for model ids and thresholds', async () => {
+    const { session } = await createSession({
       storage,
       omConfig: {
         defaultObserverModelId: 'openai/gpt-4o',
@@ -48,41 +50,40 @@ describe('session.om', () => {
       },
     });
 
-    expect(harness.session.om.observer.modelId()).toBe('openai/gpt-4o');
-    expect(harness.session.om.reflector.modelId()).toBe('openai/gpt-4o-mini');
-    expect(harness.session.om.observer.threshold()).toBe(30_000);
-    expect(harness.session.om.reflector.threshold()).toBe(40_000);
+    expect(session.om.observer.modelId()).toBe('openai/gpt-4o');
+    expect(session.om.reflector.modelId()).toBe('openai/gpt-4o-mini');
+    expect(session.om.observer.threshold()).toBe(30_000);
+    expect(session.om.reflector.threshold()).toBe(40_000);
   });
 
-  it('returns undefined when no state value and no omConfig default exist', () => {
-    const harness = createHarness({ storage });
+  it('returns undefined when no state value and no omConfig default exist', async () => {
+    const { session } = await createSession({ storage });
 
-    expect(harness.session.om.observer.modelId()).toBeUndefined();
-    expect(harness.session.om.reflector.modelId()).toBeUndefined();
-    expect(harness.session.om.observer.threshold()).toBeUndefined();
-    expect(harness.session.om.reflector.threshold()).toBeUndefined();
+    expect(session.om.observer.modelId()).toBeUndefined();
+    expect(session.om.reflector.modelId()).toBeUndefined();
+    expect(session.om.observer.threshold()).toBeUndefined();
+    expect(session.om.reflector.threshold()).toBeUndefined();
   });
 
   it('prefers session-state values over omConfig defaults', async () => {
-    const harness = createHarness({
+    const { session } = await createSession({
       storage,
       omConfig: { defaultObserverModelId: 'openai/gpt-4o' },
     });
-    await harness.session.state.set({ observerModelId: 'anthropic/claude-sonnet-4' } as any);
+    await session.state.set({ observerModelId: 'anthropic/claude-sonnet-4' } as any);
 
-    expect(harness.session.om.observer.modelId()).toBe('anthropic/claude-sonnet-4');
+    expect(session.om.observer.modelId()).toBe('anthropic/claude-sonnet-4');
   });
 
   it('observer.switchModel persists to thread settings and emits om_model_changed', async () => {
     const events: HarnessEvent[] = [];
-    const harness = createHarness({ storage, onEvent: event => events.push(event) });
-    await harness.init();
-    await harness.session.thread.create();
+    const { session } = await createSession({ storage, onEvent: event => events.push(event) });
+    await session.thread.create();
 
-    await harness.session.om.observer.switchModel({ modelId: 'anthropic/claude-sonnet-4' });
+    await session.om.observer.switchModel({ modelId: 'anthropic/claude-sonnet-4' });
 
-    expect(harness.session.om.observer.modelId()).toBe('anthropic/claude-sonnet-4');
-    expect(await harness.session.thread.getSetting({ key: 'observerModelId' })).toBe('anthropic/claude-sonnet-4');
+    expect(session.om.observer.modelId()).toBe('anthropic/claude-sonnet-4');
+    expect(await session.thread.getSetting({ key: 'observerModelId' })).toBe('anthropic/claude-sonnet-4');
     expect(events).toContainEqual({
       type: 'om_model_changed',
       role: 'observer',
@@ -92,14 +93,13 @@ describe('session.om', () => {
 
   it('reflector.switchModel persists to thread settings and emits om_model_changed', async () => {
     const events: HarnessEvent[] = [];
-    const harness = createHarness({ storage, onEvent: event => events.push(event) });
-    await harness.init();
-    await harness.session.thread.create();
+    const { session } = await createSession({ storage, onEvent: event => events.push(event) });
+    await session.thread.create();
 
-    await harness.session.om.reflector.switchModel({ modelId: 'openai/gpt-4o-mini' });
+    await session.om.reflector.switchModel({ modelId: 'openai/gpt-4o-mini' });
 
-    expect(harness.session.om.reflector.modelId()).toBe('openai/gpt-4o-mini');
-    expect(await harness.session.thread.getSetting({ key: 'reflectorModelId' })).toBe('openai/gpt-4o-mini');
+    expect(session.om.reflector.modelId()).toBe('openai/gpt-4o-mini');
+    expect(await session.thread.getSetting({ key: 'reflectorModelId' })).toBe('openai/gpt-4o-mini');
     expect(events).toContainEqual({
       type: 'om_model_changed',
       role: 'reflector',
@@ -107,23 +107,23 @@ describe('session.om', () => {
     });
   });
 
-  it('resolves the observer model via the configured resolver', () => {
+  it('resolves the observer model via the configured resolver', async () => {
     const resolveModel = vi.fn((modelId: string) => ({ modelId }));
-    const harness = createHarness({
+    const { session } = await createSession({
       storage,
       omConfig: { defaultObserverModelId: 'openai/gpt-4o' },
       resolveModel,
     });
 
-    expect(harness.session.om.observer.resolvedModel()).toMatchObject({ modelId: 'openai/gpt-4o' });
+    expect(session.om.observer.resolvedModel()).toMatchObject({ modelId: 'openai/gpt-4o' });
     expect(resolveModel).toHaveBeenCalledWith('openai/gpt-4o');
   });
 
-  it('returns undefined resolved model when no model id is set', () => {
+  it('returns undefined resolved model when no model id is set', async () => {
     const resolveModel = vi.fn((modelId: string) => ({ modelId }));
-    const harness = createHarness({ storage, resolveModel });
+    const { session } = await createSession({ storage, resolveModel });
 
-    expect(harness.session.om.observer.resolvedModel()).toBeUndefined();
+    expect(session.om.observer.resolvedModel()).toBeUndefined();
     expect(resolveModel).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/harness/session-permissions.test.ts
+++ b/packages/core/src/harness/session-permissions.test.ts
@@ -4,18 +4,21 @@ import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 
-function createHarness(storage: InMemoryStore) {
+async function createSession(storage: InMemoryStore) {
   const agent = new Agent({
     name: 'test-agent',
     instructions: 'You are a test agent.',
     model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
   });
 
-  return new Harness({
+  const harness = new Harness({
     id: 'test-harness',
     storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
   });
+  await harness.init();
+  const session = await harness.createSession();
+  return { harness, session };
 }
 
 describe('session.permissions', () => {
@@ -25,45 +28,45 @@ describe('session.permissions', () => {
     storage = new InMemoryStore();
   });
 
-  it('returns empty rules when none are set', () => {
-    const harness = createHarness(storage);
-    expect(harness.session.permissions.getRules()).toEqual({ categories: {}, tools: {} });
+  it('returns empty rules when none are set', async () => {
+    const { session } = await createSession(storage);
+    expect(session.permissions.getRules()).toEqual({ categories: {}, tools: {} });
   });
 
   it('setForCategory persists the policy to session state', async () => {
-    const harness = createHarness(storage);
+    const { session } = await createSession(storage);
 
-    await harness.session.permissions.setForCategory({ category: 'execute', policy: 'ask' });
+    await session.permissions.setForCategory({ category: 'execute', policy: 'ask' });
 
-    expect(harness.session.permissions.getRules().categories.execute).toBe('ask');
-    expect((harness.session.state.get() as any).permissionRules.categories.execute).toBe('ask');
+    expect(session.permissions.getRules().categories.execute).toBe('ask');
+    expect((session.state.get() as any).permissionRules.categories.execute).toBe('ask');
   });
 
   it('setForTool persists the policy to session state', async () => {
-    const harness = createHarness(storage);
+    const { session } = await createSession(storage);
 
-    await harness.session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' });
+    await session.permissions.setForTool({ toolName: 'dangerous_tool', policy: 'deny' });
 
-    expect(harness.session.permissions.getRules().tools.dangerous_tool).toBe('deny');
-    expect((harness.session.state.get() as any).permissionRules.tools.dangerous_tool).toBe('deny');
+    expect(session.permissions.getRules().tools.dangerous_tool).toBe('deny');
+    expect((session.state.get() as any).permissionRules.tools.dangerous_tool).toBe('deny');
   });
 
   it('reflects rules already present in session state', async () => {
-    const harness = createHarness(storage);
-    await harness.session.state.set({
+    const { session } = await createSession(storage);
+    await session.state.set({
       permissionRules: { categories: { read: 'allow' }, tools: {} },
     } as any);
 
-    expect(harness.session.permissions.getRules().categories.read).toBe('allow');
+    expect(session.permissions.getRules().categories.read).toBe('allow');
   });
 
   it('merges new policies without dropping existing ones', async () => {
-    const harness = createHarness(storage);
+    const { session } = await createSession(storage);
 
-    await harness.session.permissions.setForCategory({ category: 'execute', policy: 'deny' });
-    await harness.session.permissions.setForTool({ toolName: 'fetch', policy: 'allow' });
+    await session.permissions.setForCategory({ category: 'execute', policy: 'deny' });
+    await session.permissions.setForTool({ toolName: 'fetch', policy: 'allow' });
 
-    const rules = harness.session.permissions.getRules();
+    const rules = session.permissions.getRules();
     expect(rules.categories.execute).toBe('deny');
     expect(rules.tools.fetch).toBe('allow');
   });

--- a/packages/core/src/harness/session-state.test.ts
+++ b/packages/core/src/harness/session-state.test.ts
@@ -1,21 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
 import { Harness } from './harness';
+import type { Session } from './session';
 import type { HarnessConfig, HarnessEvent } from './types';
 
-function createHarness<TState extends Record<string, unknown>>(
+async function createSession<TState extends Record<string, unknown>>(
   config: Partial<HarnessConfig<TState>> = {},
-): Harness<TState> {
-  return new Harness<TState>({
+): Promise<{ harness: Harness<TState>; session: Session<TState> }> {
+  const harness = new Harness<TState>({
     id: 'test-harness',
     modes: [{ id: 'build', defaultModelId: 'test-model' }],
     ...config,
   } as HarnessConfig<TState>);
+  await harness.init();
+  const session = await harness.createSession();
+  return { harness, session };
 }
 
 describe('Harness session state', () => {
-  it('initializes from schema defaults plus initialState', () => {
-    const harness = createHarness<{ count: number; label: string }>({
+  it('initializes from schema defaults plus initialState', async () => {
+    const { session } = await createSession<{ count: number; label: string }>({
       stateSchema: {
         type: 'object',
         properties: {
@@ -27,21 +31,21 @@ describe('Harness session state', () => {
       initialState: { label: 'ready' },
     });
 
-    expect(harness.session.state.get()).toEqual({ count: 1, label: 'ready' });
-    expect(harness.session.state.get()).toEqual({ count: 1, label: 'ready' });
+    expect(session.state.get()).toEqual({ count: 1, label: 'ready' });
+    expect(session.state.get()).toEqual({ count: 1, label: 'ready' });
   });
 
-  it('get() returns a shallow snapshot', () => {
-    const harness = createHarness<{ count: number }>({ initialState: { count: 1 } });
+  it('get() returns a shallow snapshot', async () => {
+    const { session } = await createSession<{ count: number }>({ initialState: { count: 1 } });
 
-    const snapshot = harness.session.state.get() as { count: number };
+    const snapshot = session.state.get() as { count: number };
     snapshot.count = 99;
 
-    expect(harness.session.state.get()).toEqual({ count: 1 });
+    expect(session.state.get()).toEqual({ count: 1 });
   });
 
   it('validates set() updates and emits state_changed events', async () => {
-    const harness = createHarness<{ count: number }>({
+    const { session } = await createSession<{ count: number }>({
       stateSchema: {
         type: 'object',
         properties: { count: { type: 'number', default: 0 } },
@@ -49,18 +53,20 @@ describe('Harness session state', () => {
       },
     });
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe((event: HarnessEvent) => {
+      events.push(event);
+    });
 
-    await harness.session.state.set({ count: 1 });
+    await session.state.set({ count: 1 });
 
-    expect(harness.session.state.get()).toEqual({ count: 1 });
+    expect(session.state.get()).toEqual({ count: 1 });
     expect(events).toContainEqual(
       expect.objectContaining({ type: 'state_changed', state: { count: 1 }, changedKeys: ['count'] }),
     );
   });
 
   it('does not mutate current state when validation fails', async () => {
-    const harness = createHarness<{ count: number }>({
+    const { session } = await createSession<{ count: number }>({
       stateSchema: {
         type: 'object',
         properties: { count: { type: 'number', default: 0 } },
@@ -68,25 +74,25 @@ describe('Harness session state', () => {
       },
     });
 
-    await harness.session.state.set({ count: 1 });
-    await expect(harness.session.state.set({ count: 'bad' as never })).rejects.toThrow('Invalid state update');
+    await session.state.set({ count: 1 });
+    await expect(session.state.set({ count: 'bad' as never })).rejects.toThrow('Invalid state update');
 
-    expect(harness.session.state.get()).toEqual({ count: 1 });
+    expect(session.state.get()).toEqual({ count: 1 });
   });
 
   it('serializes queued updates in order', async () => {
-    const harness = createHarness<{ count: number }>({ initialState: { count: 0 } });
+    const { session } = await createSession<{ count: number }>({ initialState: { count: 0 } });
     const observed: number[] = [];
     let releaseFirst!: () => void;
 
-    const first = harness.session.state.update(async state => {
+    const first = session.state.update(async state => {
       observed.push(state.count);
       await new Promise<void>(resolve => {
         releaseFirst = resolve;
       });
       return { updates: { count: state.count + 1 }, result: 'first' };
     });
-    const second = harness.session.state.update(state => {
+    const second = session.state.update(state => {
       observed.push(state.count);
       return { updates: { count: state.count + 1 }, result: 'second' };
     });
@@ -98,16 +104,18 @@ describe('Harness session state', () => {
     await expect(Promise.all([first, second])).resolves.toEqual(['first', 'second']);
 
     expect(observed).toEqual([0, 1]);
-    expect(harness.session.state.get()).toEqual({ count: 2 });
+    expect(session.state.get()).toEqual({ count: 2 });
   });
 
 
   it('exposes session.state and deprecated flattened state accessors in request context', async () => {
-    const harness = createHarness<{ count: number }>({ initialState: { count: 0 } });
+    const { harness, session } = await createSession<{ count: number }>({ initialState: { count: 0 } });
 
     const requestContext = await (
-      harness as unknown as { buildRequestContext: () => Promise<{ get: (key: string) => unknown }> }
-    ).buildRequestContext();
+      harness as unknown as {
+        buildRequestContext: (session: Session<{ count: number }>) => Promise<{ get: (key: string) => unknown }>;
+      }
+    ).buildRequestContext(session);
     const harnessContext = requestContext.get('harness') as {
       state: Readonly<{ count: number }>;
       getState: () => Readonly<{ count: number }>;

--- a/packages/core/src/harness/session-subagents.test.ts
+++ b/packages/core/src/harness/session-subagents.test.ts
@@ -5,7 +5,7 @@ import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 import type { HarnessEvent } from './types';
 
-function createHarness(options: { storage: InMemoryStore; onEvent?: (event: HarnessEvent) => void }) {
+async function createSession(options: { storage: InMemoryStore; onEvent?: (event: HarnessEvent) => void }) {
   const agent = new Agent({
     name: 'test-agent',
     instructions: 'You are a test agent.',
@@ -18,9 +18,10 @@ function createHarness(options: { storage: InMemoryStore; onEvent?: (event: Harn
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
   });
 
-  if (options.onEvent) harness.session.subscribe(options.onEvent);
-
-  return harness;
+  await harness.init();
+  const session = await harness.createSession();
+  if (options.onEvent) session.subscribe(options.onEvent);
+  return { harness, session };
 }
 
 describe('session.subagents.model', () => {
@@ -30,22 +31,21 @@ describe('session.subagents.model', () => {
     storage = new InMemoryStore();
   });
 
-  it('returns null when no subagent model is set', () => {
-    const harness = createHarness({ storage });
-    expect(harness.session.subagents.model.get()).toBeNull();
-    expect(harness.session.subagents.model.get({ agentType: 'explore' })).toBeNull();
+  it('returns null when no subagent model is set', async () => {
+    const { session } = await createSession({ storage });
+    expect(session.subagents.model.get()).toBeNull();
+    expect(session.subagents.model.get({ agentType: 'explore' })).toBeNull();
   });
 
   it('set (global) persists to thread settings and emits subagent_model_changed', async () => {
     const events: HarnessEvent[] = [];
-    const harness = createHarness({ storage, onEvent: event => events.push(event) });
-    await harness.init();
-    await harness.session.thread.create();
+    const { session } = await createSession({ storage, onEvent: event => events.push(event) });
+    await session.thread.create();
 
-    await harness.session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4' });
+    await session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4' });
 
-    expect(harness.session.subagents.model.get()).toBe('anthropic/claude-sonnet-4');
-    expect(await harness.session.thread.getSetting({ key: 'subagentModelId' })).toBe('anthropic/claude-sonnet-4');
+    expect(session.subagents.model.get()).toBe('anthropic/claude-sonnet-4');
+    expect(await session.thread.getSetting({ key: 'subagentModelId' })).toBe('anthropic/claude-sonnet-4');
     expect(events).toContainEqual({
       type: 'subagent_model_changed',
       modelId: 'anthropic/claude-sonnet-4',
@@ -55,26 +55,24 @@ describe('session.subagents.model', () => {
   });
 
   it('set (per agentType) persists under an agentType-scoped key', async () => {
-    const harness = createHarness({ storage });
-    await harness.init();
-    await harness.session.thread.create();
+    const { session } = await createSession({ storage });
+    await session.thread.create();
 
-    await harness.session.subagents.model.set({ modelId: 'openai/gpt-4o-mini', agentType: 'explore' });
+    await session.subagents.model.set({ modelId: 'openai/gpt-4o-mini', agentType: 'explore' });
 
-    expect(harness.session.subagents.model.get({ agentType: 'explore' })).toBe('openai/gpt-4o-mini');
-    expect(await harness.session.thread.getSetting({ key: 'subagentModelId_explore' })).toBe('openai/gpt-4o-mini');
+    expect(session.subagents.model.get({ agentType: 'explore' })).toBe('openai/gpt-4o-mini');
+    expect(await session.thread.getSetting({ key: 'subagentModelId_explore' })).toBe('openai/gpt-4o-mini');
   });
 
   it('prefers the per-agentType value over the global value', async () => {
-    const harness = createHarness({ storage });
-    await harness.init();
-    await harness.session.thread.create();
+    const { session } = await createSession({ storage });
+    await session.thread.create();
 
-    await harness.session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4' });
-    await harness.session.subagents.model.set({ modelId: 'openai/gpt-4o-mini', agentType: 'explore' });
+    await session.subagents.model.set({ modelId: 'anthropic/claude-sonnet-4' });
+    await session.subagents.model.set({ modelId: 'openai/gpt-4o-mini', agentType: 'explore' });
 
-    expect(harness.session.subagents.model.get({ agentType: 'explore' })).toBe('openai/gpt-4o-mini');
+    expect(session.subagents.model.get({ agentType: 'explore' })).toBe('openai/gpt-4o-mini');
     // An agentType with no specific override falls back to the global value.
-    expect(harness.session.subagents.model.get({ agentType: 'plan' })).toBe('anthropic/claude-sonnet-4');
+    expect(session.subagents.model.get({ agentType: 'plan' })).toBe('anthropic/claude-sonnet-4');
   });
 });

--- a/packages/core/src/harness/signal-history.test.ts
+++ b/packages/core/src/harness/signal-history.test.ts
@@ -21,15 +21,16 @@ describe('Harness signal history rendering', () => {
     });
 
     await harness.init();
-    const thread = await harness.session.thread.create({ title: 'Signal thread' });
+    const session = await harness.createSession();
+    const thread = await session.thread.create({ title: 'Signal thread' });
     const memoryStorage = await storage.getStore('memory');
     if (!memoryStorage) throw new Error('Expected memory storage');
 
-    return { harness, memoryStorage, thread };
+    return { harness, session, memoryStorage, thread };
   }
 
   it('renders persisted user-message signals as user content', async () => {
-    const { harness, memoryStorage, thread } = await createHarnessWithThread();
+    const { harness, session, memoryStorage, thread } = await createHarnessWithThread();
 
     await memoryStorage.saveMessages({
       messages: [
@@ -48,7 +49,7 @@ describe('Harness signal history rendering', () => {
       ],
     });
 
-    const messages = await harness.session.thread.listActiveMessages();
+    const messages = await session.thread.listActiveMessages();
 
     expect(messages).toHaveLength(1);
     expect(messages[0]).toMatchObject({
@@ -62,14 +63,14 @@ describe('Harness signal history rendering', () => {
   });
 
   it('emits agent_end when a system-reminder signal starts an idle run', async () => {
-    const { harness } = await createHarnessWithThread();
+    const { harness, session } = await createHarnessWithThread();
     const events: Array<{ type: string; reason?: string }> = [];
-    const unsubscribe = harness.session.subscribe(event => {
+    const unsubscribe = session.subscribe(event => {
       events.push(event as { type: string; reason?: string });
     });
 
     try {
-      const signal = harness.session.sendSignal({
+      const signal = session.sendSignal({
         type: 'system-reminder',
         contents: 'keep going',
         attributes: { type: 'goal' },
@@ -86,7 +87,7 @@ describe('Harness signal history rendering', () => {
   });
 
   it('renders persisted system-reminder signals as system reminder content', async () => {
-    const { harness, memoryStorage, thread } = await createHarnessWithThread();
+    const { harness, session, memoryStorage, thread } = await createHarnessWithThread();
 
     await memoryStorage.saveMessages({
       messages: [
@@ -103,7 +104,7 @@ describe('Harness signal history rendering', () => {
       ],
     });
 
-    const messages = await harness.session.thread.listActiveMessages();
+    const messages = await session.thread.listActiveMessages();
 
     expect(messages).toEqual([
       {

--- a/packages/core/src/harness/signal-messages.test.ts
+++ b/packages/core/src/harness/signal-messages.test.ts
@@ -36,7 +36,7 @@ async function waitFor(predicate: () => boolean) {
   throw new Error('Timed out waiting for harness events');
 }
 
-function createHarness(
+async function createHarness(
   storage: InMemoryStore,
   agent: Agent<any, any, any, any> = new Agent({
     id: 'test-agent',
@@ -45,22 +45,25 @@ function createHarness(
     model: createTextStreamModel('Hello'),
   }),
 ) {
-  return new Harness({
+  const harness = new Harness({
     id: 'test-harness',
     storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
   });
+  await harness.init();
+  const session = await harness.createSession();
+  return { harness, session };
 }
 
 describe('Harness signal messages', () => {
-  it('converts sendMessage files into fenced text and preserved binary file parts', () => {
-    const harness = createHarness(new InMemoryStore());
-    const createMessageInput = (harness.session as unknown as {
+  it('converts sendMessage files into fenced text and preserved binary file parts', async () => {
+    const { harness, session } = await createHarness(new InMemoryStore());
+    const createMessageInput = (session as unknown as {
         createMessageInput(input: {
           content: string;
           files?: Array<{ data: string; mediaType: string; filename?: string }>;
         }): unknown;
-      }).createMessageInput.bind(harness.session);
+      }).createMessageInput.bind(session);
 
     const input = createMessageInput({
       content: 'Review these attachments.',
@@ -90,14 +93,14 @@ describe('Harness signal messages', () => {
     ]);
   });
 
-  it('uses a longer fence than any backtick run in text attachments', () => {
-    const harness = createHarness(new InMemoryStore());
-    const createMessageInput = (harness.session as unknown as {
+  it('uses a longer fence than any backtick run in text attachments', async () => {
+    const { harness, session } = await createHarness(new InMemoryStore());
+    const createMessageInput = (session as unknown as {
         createMessageInput(input: {
           content: string;
           files?: Array<{ data: string; mediaType: string; filename?: string }>;
         }): unknown;
-      }).createMessageInput.bind(harness.session);
+      }).createMessageInput.bind(session);
 
     const input = createMessageInput({
       content: 'Review this markdown.',
@@ -118,8 +121,8 @@ describe('Harness signal messages', () => {
 
   it('renders persisted user-message signal attributes', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
-    const thread = await harness.session.thread.create();
+    const { harness, session } = await createHarness(storage);
+    const thread = await session.thread.create();
 
     await storage.stores.memory!.saveMessages({
       messages: [
@@ -133,7 +136,7 @@ describe('Harness signal messages', () => {
       ],
     });
 
-    await expect(harness.session.thread.listActiveMessages()).resolves.toEqual([
+    await expect(session.thread.listActiveMessages()).resolves.toEqual([
       {
         id: 'signal-user-1',
         role: 'user',
@@ -146,8 +149,8 @@ describe('Harness signal messages', () => {
 
   it('renders persisted system-reminder signals from signal attributes', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
-    const thread = await harness.session.thread.create();
+    const { harness, session } = await createHarness(storage);
+    const thread = await session.thread.create();
 
     await storage.stores.memory!.saveMessages({
       messages: [
@@ -161,7 +164,7 @@ describe('Harness signal messages', () => {
       ],
     });
 
-    await expect(harness.session.thread.listActiveMessages()).resolves.toEqual([
+    await expect(session.thread.listActiveMessages()).resolves.toEqual([
       {
         id: 'signal-1',
         role: 'user',
@@ -184,8 +187,8 @@ describe('Harness signal messages', () => {
 
   it('normalizes system-reminder contents from text-part arrays', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
-    const thread = await harness.session.thread.create();
+    const { harness, session } = await createHarness(storage);
+    const thread = await session.thread.create();
 
     await storage.stores.memory!.saveMessages({
       messages: [
@@ -202,7 +205,7 @@ describe('Harness signal messages', () => {
       ],
     });
 
-    await expect(harness.session.thread.listActiveMessages()).resolves.toEqual([
+    await expect(session.thread.listActiveMessages()).resolves.toEqual([
       {
         id: 'signal-array',
         role: 'user',
@@ -225,8 +228,8 @@ describe('Harness signal messages', () => {
 
   it('renders persisted generic reactive signals', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
-    const thread = await harness.session.thread.create();
+    const { harness, session } = await createHarness(storage);
+    const thread = await session.thread.create();
 
     await storage.stores.memory!.saveMessages({
       messages: [
@@ -242,7 +245,7 @@ describe('Harness signal messages', () => {
       ],
     });
 
-    await expect(harness.session.thread.listActiveMessages()).resolves.toEqual([
+    await expect(session.thread.listActiveMessages()).resolves.toEqual([
       {
         id: 'reactive-signal-1',
         role: 'user',
@@ -263,8 +266,8 @@ describe('Harness signal messages', () => {
 
   it('renders persisted notification summary signals', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
-    const thread = await harness.session.thread.create();
+    const { harness, session } = await createHarness(storage);
+    const thread = await session.thread.create();
 
     await storage.stores.memory!.saveMessages({
       messages: [
@@ -290,7 +293,7 @@ describe('Harness signal messages', () => {
       ],
     });
 
-    await expect(harness.session.thread.listActiveMessages()).resolves.toEqual([
+    await expect(session.thread.listActiveMessages()).resolves.toEqual([
       {
         id: 'summary-1',
         role: 'user',
@@ -312,8 +315,8 @@ describe('Harness signal messages', () => {
 
   it('renders persisted full notification signals', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
-    const thread = await harness.session.thread.create();
+    const { harness, session } = await createHarness(storage);
+    const thread = await session.thread.create();
 
     await storage.stores.memory!.saveMessages({
       messages: [
@@ -344,7 +347,7 @@ describe('Harness signal messages', () => {
       ],
     });
 
-    await expect(harness.session.thread.listActiveMessages()).resolves.toEqual([
+    await expect(session.thread.listActiveMessages()).resolves.toEqual([
       {
         id: 'notification-signal-1',
         role: 'user',
@@ -384,14 +387,14 @@ describe('Harness signal messages', () => {
 
   it('processes sendMessage streams once through the active thread subscription', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.thread.create();
-    await harness.session.sendMessage({ content: 'hello' });
+    await session.thread.create();
+    await session.sendMessage({ content: 'hello' });
     await waitFor(() => events.some(event => event.type === 'message_end' && event.message.role === 'assistant'));
 
     const assistantStarts = events.filter(
@@ -405,7 +408,7 @@ describe('Harness signal messages', () => {
     expect(assistantStarts).toHaveLength(1);
     expect(assistantEnds).toHaveLength(1);
     expect(assistantEnds[0]?.message.content).toEqual([{ type: 'text', text: 'Hello' }]);
-    expect(harness.session.getCurrentRunId()).toBeNull();
+    expect(session.getCurrentRunId()).toBeNull();
   });
 
   it('sends active text signals without building idle stream options', async () => {
@@ -416,17 +419,17 @@ describe('Harness signal messages', () => {
       instructions: 'You are a test agent.',
       model: createTextStreamModel('Hello'),
     });
-    const harness = createHarness(storage, agent);
+    const { harness, session } = await createHarness(storage, agent);
     vi.spyOn(agent, 'subscribeToThread').mockResolvedValue({
       stream: (async function* () {})(),
       unsubscribe: vi.fn(),
       abort: vi.fn(),
       activeRunId: () => 'active-run-id',
     });
-    const thread = await harness.session.thread.create();
+    const thread = await session.thread.create();
 
     // Simulate an active run from the harness consumer's perspective
-    harness.session.run.setRunId({ runId: 'active-run-id' });
+    session.run.setRunId({ runId: 'active-run-id' });
 
     const buildToolsets = vi.spyOn(harness as any, 'buildToolsets');
     const sendSignal = vi.spyOn(agent, 'sendSignal').mockReturnValue({
@@ -435,7 +438,7 @@ describe('Harness signal messages', () => {
       signal: createSignal({ type: 'user-message', contents: 'active hello' }),
     });
 
-    const signal = harness.session.sendSignal({ content: 'active hello' });
+    const signal = session.sendSignal({ content: 'active hello' });
     await expect(signal.accepted).resolves.toEqual({ accepted: true, runId: 'active-run-id' });
 
     expect(buildToolsets).not.toHaveBeenCalled();
@@ -450,18 +453,18 @@ describe('Harness signal messages', () => {
 
   it('tracks queued follow-ups in display state while running', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    harness.session.run.ensureAbortController();
+    session.run.ensureAbortController();
 
-    await harness.session.followUp({ content: 'queued follow-up' });
+    await session.followUp({ content: 'queued follow-up' });
 
-    expect(harness.session.followUps.count()).toBe(1);
-    expect(harness.session.displayState.get().queuedFollowUps).toBe(1);
+    expect(session.followUps.count()).toBe(1);
+    expect(session.displayState.get().queuedFollowUps).toBe(1);
     expect(events).toContainEqual({ type: 'follow_up_queued', count: 1 });
   });
 
@@ -473,9 +476,9 @@ describe('Harness signal messages', () => {
       instructions: 'You are a test agent.',
       model: createTextStreamModel('Hello'),
     });
-    const harness = createHarness(storage, agent);
+    const { harness, session } = await createHarness(storage, agent);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
     vi.spyOn(agent, 'subscribeToThread').mockResolvedValue({
@@ -490,11 +493,11 @@ describe('Harness signal messages', () => {
       signal: createSignal({ type: 'user', contents: 'queued follow-up' }),
     });
     const sendSignal = vi.spyOn(agent, 'sendSignal');
-    const thread = await harness.session.thread.create();
-    harness.session.run.ensureAbortController();
+    const thread = await session.thread.create();
+    session.run.ensureAbortController();
 
-    await harness.session.followUp({ content: 'queued follow-up' });
-    await harness.session.drainFollowUpQueue();
+    await session.followUp({ content: 'queued follow-up' });
+    await session.drainFollowUpQueue();
 
     expect(queueMessage).toHaveBeenCalledWith(
       'queued follow-up',
@@ -512,26 +515,26 @@ describe('Harness signal messages', () => {
       }),
     );
     expect(sendSignal).not.toHaveBeenCalled();
-    expect(harness.session.followUps.count()).toBe(0);
-    expect(harness.session.displayState.get().queuedFollowUps).toBe(0);
+    expect(session.followUps.count()).toBe(0);
+    expect(session.displayState.get().queuedFollowUps).toBe(0);
     expect(events).toContainEqual({ type: 'follow_up_queued', count: 1 });
     expect(events).toContainEqual({ type: 'follow_up_queued', count: 0, runId: 'queued-run-id' });
   });
 
   it('sends idle follow-ups immediately without marking them queued', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
-    const sendMessage = vi.spyOn(harness.session as any, 'sendMessage').mockResolvedValue(undefined);
+    const sendMessage = vi.spyOn(session as any, 'sendMessage').mockResolvedValue(undefined);
 
-    await harness.session.followUp({ content: 'idle follow-up' });
+    await session.followUp({ content: 'idle follow-up' });
 
     expect(sendMessage).toHaveBeenCalledWith({ content: 'idle follow-up', requestContext: undefined });
-    expect(harness.session.followUps.count()).toBe(0);
-    expect(harness.session.displayState.get().queuedFollowUps).toBe(0);
+    expect(session.followUps.count()).toBe(0);
+    expect(session.displayState.get().queuedFollowUps).toBe(0);
     expect(events.some(event => event.type === 'follow_up_queued')).toBe(false);
   });
 
@@ -543,7 +546,7 @@ describe('Harness signal messages', () => {
       instructions: 'You are a test agent.',
       model: createTextStreamModel('Hello'),
     });
-    const harness = createHarness(storage, agent);
+    const { harness, session } = await createHarness(storage, agent);
     const abort = vi.fn();
     vi.spyOn(agent, 'subscribeToThread').mockResolvedValue({
       stream: (async function* () {})(),
@@ -551,16 +554,16 @@ describe('Harness signal messages', () => {
       abort,
       activeRunId: () => 'active-run-id',
     });
-    await harness.session.thread.create();
+    await session.thread.create();
     vi.spyOn(agent, 'sendSignal').mockReturnValue({
       accepted: true,
       runId: 'active-run-id',
       signal: createSignal({ type: 'user-message', contents: 'active hello' }),
     });
 
-    const signal = harness.session.sendSignal({ content: 'active hello' });
+    const signal = session.sendSignal({ content: 'active hello' });
     await signal.accepted;
-    harness.session.abort();
+    session.abort();
 
     expect(abort).toHaveBeenCalled();
   });
@@ -573,7 +576,7 @@ describe('Harness signal messages', () => {
       instructions: 'You are a test agent.',
       model: createTextStreamModel('Hello'),
     });
-    const harness = createHarness(storage, agent);
+    const { harness, session } = await createHarness(storage, agent);
     const abort = vi.fn(() => true);
     const unsubscribe = vi.fn();
 
@@ -590,22 +593,22 @@ describe('Harness signal messages', () => {
         abort: vi.fn(),
         activeRunId: () => null,
       });
-    await harness.session.thread.create();
+    await session.thread.create();
     vi.spyOn(agent, 'sendSignal').mockReturnValue({
       accepted: true,
       runId: 'active-run-id',
       signal: createSignal({ type: 'user-message', contents: 'active hello' }),
     });
 
-    const signal = harness.session.sendSignal({ content: 'active hello' });
+    const signal = session.sendSignal({ content: 'active hello' });
     await signal.accepted;
-    expect(harness.session.getCurrentRunId()).toBe('active-run-id');
+    expect(session.getCurrentRunId()).toBe('active-run-id');
 
-    await harness.session.thread.create();
+    await session.thread.create();
 
     expect(abort).toHaveBeenCalled();
     expect(unsubscribe).toHaveBeenCalled();
-    expect(harness.session.getCurrentRunId()).toBeNull();
+    expect(session.getCurrentRunId()).toBeNull();
   });
 
   it('emits an error and clears run state when a subscription iterator throws', async () => {
@@ -616,9 +619,9 @@ describe('Harness signal messages', () => {
       instructions: 'You are a test agent.',
       model: createTextStreamModel('Hello'),
     });
-    const harness = createHarness(storage, agent);
+    const { harness, session } = await createHarness(storage, agent);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
@@ -631,13 +634,13 @@ describe('Harness signal messages', () => {
       abort: vi.fn(),
       activeRunId: () => 'run-1',
     });
-    await harness.session.thread.create();
+    await session.thread.create();
 
     await waitFor(() => events.some(event => event.type === 'agent_end' && event.reason === 'error'));
 
     expect(events.some(event => event.type === 'error' && event.error.message === 'subscription failed')).toBe(true);
-    await waitFor(() => harness.session.getCurrentRunId() === null);
-    expect(harness.session.getCurrentRunId()).toBeNull();
+    await waitFor(() => session.getCurrentRunId() === null);
+    expect(session.getCurrentRunId()).toBeNull();
   });
 
   it('ignores trailing chunks from an aborted subscription run', async () => {
@@ -648,9 +651,9 @@ describe('Harness signal messages', () => {
       instructions: 'You are a test agent.',
       model: createTextStreamModel('Hello'),
     });
-    const harness = createHarness(storage, agent);
+    const { harness, session } = await createHarness(storage, agent);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
@@ -676,17 +679,17 @@ describe('Harness signal messages', () => {
       abort,
       activeRunId: () => activeRunId,
     });
-    await harness.session.thread.create();
+    await session.thread.create();
     vi.spyOn(agent, 'sendSignal').mockReturnValue({
       accepted: true,
       runId: 'run-1',
       signal: createSignal({ type: 'user-message', contents: 'active hello' }),
     });
 
-    const signal = harness.session.sendSignal({ content: 'active hello' });
+    const signal = session.sendSignal({ content: 'active hello' });
     await signal.accepted;
     await waitFor(() => events.some(event => event.type === 'agent_start'));
-    harness.session.abort();
+    session.abort();
     await waitFor(() => events.some(event => event.type === 'agent_end'));
     await new Promise(resolve => setTimeout(resolve, 0));
 
@@ -696,16 +699,16 @@ describe('Harness signal messages', () => {
 
   it('starts a new idle signal after a subscription-owned run completes', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.thread.create();
-    await harness.session.sendMessage({ content: 'hi' });
+    await session.thread.create();
+    await session.sendMessage({ content: 'hi' });
 
-    const signal = harness.session.sendSignal({ content: 'hows it going' });
+    const signal = session.sendSignal({ content: 'hows it going' });
     await signal.accepted;
     await waitFor(() =>
       events.some(
@@ -733,8 +736,10 @@ describe('Harness signal messages', () => {
       modes: [{ id: 'default', name: 'Default', default: true, agent }],
       initialState: { yolo: true } as any,
     });
+    await harness.init();
+    const session = await harness.createSession();
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
@@ -769,8 +774,8 @@ describe('Harness signal messages', () => {
       signal: createSignal({ type: 'user-message', contents: 'run tool' }),
     });
 
-    await harness.session.thread.create();
-    const signal = harness.session.sendSignal({ content: 'run tool' });
+    await session.thread.create();
+    const signal = session.sendSignal({ content: 'run tool' });
     await signal.accepted;
     await waitFor(() =>
       events.some(
@@ -793,14 +798,14 @@ describe('Harness signal messages', () => {
 
   it('starts idle text signals through ifIdle stream options', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.thread.create();
-    const signal = harness.session.sendSignal({ content: 'hello from signal' });
+    await session.thread.create();
+    const signal = session.sendSignal({ content: 'hello from signal' });
     await signal.accepted;
     await waitFor(() => events.some(event => event.type === 'message_end' && event.message.role === 'assistant'));
 
@@ -819,15 +824,15 @@ describe('Harness signal messages', () => {
 
   it('does not carry a stale abort reason into a later idle signal run', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.thread.create();
-    harness.session.abort();
-    const signal = harness.session.sendSignal({ content: 'hello after stale abort' });
+    await session.thread.create();
+    session.abort();
+    const signal = session.sendSignal({ content: 'hello after stale abort' });
     await signal.accepted;
     await waitFor(() => events.some(event => event.type === 'agent_end'));
 
@@ -882,38 +887,38 @@ describe('Harness signal messages', () => {
         },
       }),
     });
-    const harness = createHarness(storage, agent);
-    await harness.session.thread.create();
+    const { harness, session } = await createHarness(storage, agent);
+    await session.thread.create();
 
-    const firstIdle = harness.session.sendSignal({ content: 'start first idle stream' });
+    const firstIdle = session.sendSignal({ content: 'start first idle stream' });
     await firstIdle.accepted;
-    await waitFor(() => harness.session.getCurrentRunId() !== null && releaseInitialCalls.length === 1);
-    const firstInterjection = harness.session.sendSignal({ content: 'first active interjection' });
+    await waitFor(() => session.getCurrentRunId() !== null && releaseInitialCalls.length === 1);
+    const firstInterjection = session.sendSignal({ content: 'first active interjection' });
     await firstInterjection.accepted;
     releaseInitialCalls.shift()?.();
-    await waitFor(() => harness.session.getCurrentRunId() === null);
+    await waitFor(() => session.getCurrentRunId() === null);
     expect(JSON.stringify(prompts[1])).toContain('first active interjection');
 
-    const secondIdle = harness.session.sendSignal({ content: 'start second idle stream' });
+    const secondIdle = session.sendSignal({ content: 'start second idle stream' });
     await secondIdle.accepted;
-    await waitFor(() => harness.session.getCurrentRunId() !== null && releaseInitialCalls.length === 1);
-    const secondInterjection = harness.session.sendSignal({ content: 'second active interjection' });
+    await waitFor(() => session.getCurrentRunId() !== null && releaseInitialCalls.length === 1);
+    const secondInterjection = session.sendSignal({ content: 'second active interjection' });
     await secondInterjection.accepted;
     releaseInitialCalls.shift()?.();
-    await waitFor(() => harness.session.getCurrentRunId() === null);
+    await waitFor(() => session.getCurrentRunId() === null);
     expect(JSON.stringify(prompts[3])).toContain('second active interjection');
   });
 
   it('emits echoed file user-message signals as user message events', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.runEngine.processStreamChunk(
-      harness.session.runEngine.createStreamState(),
+    await session.runEngine.processStreamChunk(
+      session.runEngine.createStreamState(),
       {
         type: 'data-user-message',
         data: {
@@ -945,14 +950,14 @@ describe('Harness signal messages', () => {
 
   it('emits echoed user-message signals as user message events', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
 
-    await harness.session.runEngine.processStreamChunk(
-      harness.session.runEngine.createStreamState(),
+    await session.runEngine.processStreamChunk(
+      session.runEngine.createStreamState(),
       {
         type: 'data-user-message',
         data: {
@@ -992,21 +997,21 @@ describe('Harness signal messages', () => {
 
   it('closes the current assistant message when a goal chunk arrives before continuation text', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
-    const state = harness.session.runEngine.createStreamState();
+    const state = session.runEngine.createStreamState();
     const requestContext = new RequestContext();
 
-    await harness.session.runEngine.processStreamChunk(state, { type: 'text-start', payload: { id: 'text-1' } }, requestContext);
-    await harness.session.runEngine.processStreamChunk(
+    await session.runEngine.processStreamChunk(state, { type: 'text-start', payload: { id: 'text-1' } }, requestContext);
+    await session.runEngine.processStreamChunk(
       state,
       { type: 'text-delta', payload: { id: 'text-1', text: 'Fact 1' } },
       requestContext,
     );
-    await harness.session.runEngine.processStreamChunk(
+    await session.runEngine.processStreamChunk(
       state,
       {
         type: 'goal',
@@ -1026,8 +1031,8 @@ describe('Harness signal messages', () => {
       },
       requestContext,
     );
-    await harness.session.runEngine.processStreamChunk(state, { type: 'text-start', payload: { id: 'text-2' } }, requestContext);
-    await harness.session.runEngine.processStreamChunk(
+    await session.runEngine.processStreamChunk(state, { type: 'text-start', payload: { id: 'text-2' } }, requestContext);
+    await session.runEngine.processStreamChunk(
       state,
       { type: 'text-delta', payload: { id: 'text-2', text: 'Fact 2' } },
       requestContext,
@@ -1048,14 +1053,14 @@ describe('Harness signal messages', () => {
 
   it('emits generic reactive signal data parts as renderable message updates', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
-    const state = harness.session.runEngine.createStreamState();
+    const state = session.runEngine.createStreamState();
 
-    await harness.session.runEngine.processStreamChunk(
+    await session.runEngine.processStreamChunk(
       state,
       {
         type: 'data-signal',
@@ -1092,14 +1097,14 @@ describe('Harness signal messages', () => {
 
   it('emits notification summary data parts as renderable message updates', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
-    const state = harness.session.runEngine.createStreamState();
+    const state = session.runEngine.createStreamState();
 
-    await harness.session.runEngine.processStreamChunk(
+    await session.runEngine.processStreamChunk(
       state,
       {
         type: 'data-signal',
@@ -1146,14 +1151,14 @@ describe('Harness signal messages', () => {
 
   it('emits full notification data parts as renderable message updates', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
-    const state = harness.session.runEngine.createStreamState();
+    const state = session.runEngine.createStreamState();
 
-    await harness.session.runEngine.processStreamChunk(
+    await session.runEngine.processStreamChunk(
       state,
       {
         type: 'data-signal',
@@ -1224,14 +1229,14 @@ describe('Harness signal messages', () => {
 
   it('emits state signal data parts as renderable message updates', async () => {
     const storage = new InMemoryStore();
-    const harness = createHarness(storage);
+    const { harness, session } = await createHarness(storage);
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event);
     });
-    const state = harness.session.runEngine.createStreamState();
+    const state = session.runEngine.createStreamState();
 
-    await harness.session.runEngine.processStreamChunk(
+    await session.runEngine.processStreamChunk(
       state,
       {
         type: 'data-signal',

--- a/packages/core/src/harness/switch-model.test.ts
+++ b/packages/core/src/harness/switch-model.test.ts
@@ -4,27 +4,30 @@ import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 
-function createHarness(onModelUse?: (modelId: string) => void) {
+async function createSession(onModelUse?: (modelId: string) => void) {
   const agent = new Agent({
     name: 'test-agent',
     instructions: 'You are a test agent.',
     model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
   });
 
-  return new Harness({
+  const harness = new Harness({
     id: 'test-harness',
     storage: new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
     modelUseCountTracker: onModelUse,
   });
+  await harness.init();
+  const session = await harness.createSession();
+  return { session };
 }
 
 describe('session.model.switch', () => {
   it('tracks model selection via modelUseCountTracker', async () => {
     const trackModelUse = vi.fn<(modelId: string) => void>();
-    const harness = createHarness(trackModelUse);
+    const { session } = await createSession(trackModelUse);
 
-    await harness.session.model.switch({ modelId: 'openai/gpt-5.3-codex' });
+    await session.model.switch({ modelId: 'openai/gpt-5.3-codex' });
 
     expect(trackModelUse).toHaveBeenCalledTimes(1);
     expect(trackModelUse).toHaveBeenCalledWith('openai/gpt-5.3-codex');
@@ -32,26 +35,26 @@ describe('session.model.switch', () => {
 });
 
 describe('session.model.displayName', () => {
-  it("returns 'unknown' when no model is selected", () => {
-    const harness = createHarness();
+  it("returns 'unknown' when no model is selected", async () => {
+    const { session } = await createSession();
 
-    expect(harness.session.model.hasSelection()).toBe(false);
-    expect(harness.session.model.displayName()).toBe('unknown');
+    expect(session.model.hasSelection()).toBe(false);
+    expect(session.model.displayName()).toBe('unknown');
   });
 
   it('returns the last segment of a provider-prefixed model id', async () => {
-    const harness = createHarness();
+    const { session } = await createSession();
 
-    await harness.session.model.switch({ modelId: 'anthropic/claude-sonnet-4' });
+    await session.model.switch({ modelId: 'anthropic/claude-sonnet-4' });
 
-    expect(harness.session.model.displayName()).toBe('claude-sonnet-4');
+    expect(session.model.displayName()).toBe('claude-sonnet-4');
   });
 
   it('returns the whole id when there is no provider prefix', async () => {
-    const harness = createHarness();
+    const { session } = await createSession();
 
-    await harness.session.model.switch({ modelId: 'gpt-4o' });
+    await session.model.switch({ modelId: 'gpt-4o' });
 
-    expect(harness.session.model.displayName()).toBe('gpt-4o');
+    expect(session.model.displayName()).toBe('gpt-4o');
   });
 });

--- a/packages/core/src/harness/task-tools.test.ts
+++ b/packages/core/src/harness/task-tools.test.ts
@@ -9,18 +9,21 @@ import { Harness } from './harness';
 import { assignTaskIds, taskWriteTool } from './tools';
 import type { HarnessEvent } from './types';
 
-function createHarness() {
+async function createSession() {
   const agent = new Agent({
     name: 'test-agent',
     instructions: 'You are a test agent.',
     model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
   });
 
-  return new Harness<Record<string, unknown>>({
+  const harness = new Harness<Record<string, unknown>>({
     id: 'test-harness',
     storage: new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
   });
+  await harness.init();
+  const session = await harness.createSession();
+  return { harness, session };
 }
 
 describe('assignTaskIds', () => {
@@ -158,21 +161,21 @@ describe('assignTaskIds', () => {
 // tests exercise `session.state.update`/`session.state.set` ordering with neutral state keys.
 describe('harness state transactions', () => {
   it('serializes state updates against the latest committed state', async () => {
-    const harness = createHarness();
-    await harness.session.state.set({ counter: 0 });
+    const { harness, session } = await createSession();
+    await session.state.set({ counter: 0 });
 
     let releaseFirst!: () => void;
     const firstUpdateGate = new Promise<void>(resolve => {
       releaseFirst = resolve;
     });
 
-    const firstUpdate = harness.session.state.update(async (state: Record<string, unknown>) => {
+    const firstUpdate = session.state.update(async (state: Record<string, unknown>) => {
       await firstUpdateGate;
       const next = (state.counter as number) + 1;
       return { updates: { counter: next }, result: next };
     });
 
-    const secondUpdate = harness.session.state.update((state: Record<string, unknown>) => {
+    const secondUpdate = session.state.update((state: Record<string, unknown>) => {
       expect(state.counter).toBe(1);
       const next = (state.counter as number) + 1;
       return { updates: { counter: next }, result: next };
@@ -181,7 +184,7 @@ describe('harness state transactions', () => {
     releaseFirst();
     await Promise.all([firstUpdate, secondUpdate]);
 
-    expect(harness.session.state.get().counter).toBe(2);
+    expect(session.state.get().counter).toBe(2);
   });
 
   it('serializes direct setState calls with queued state transactions', async () => {
@@ -218,9 +221,11 @@ describe('harness state transactions', () => {
         },
       ],
     });
+    await harness.init();
+    const session = await harness.createSession();
 
-    const setStatePromise = harness.session.state.set({ seed: 'initial' });
-    const transactionPromise = harness.session.state.update((state: Record<string, unknown>) => {
+    const setStatePromise = session.state.set({ seed: 'initial' });
+    const transactionPromise = session.state.update((state: Record<string, unknown>) => {
       expect(state.seed).toBe('initial');
       return { updates: { marker: 'after-set-state' }, result: undefined };
     });
@@ -228,7 +233,7 @@ describe('harness state transactions', () => {
     releaseValidation();
     await Promise.all([setStatePromise, transactionPromise]);
 
-    expect(harness.session.state.get()).toMatchObject({
+    expect(session.state.get()).toMatchObject({
       seed: 'initial',
       marker: 'after-set-state',
     });
@@ -270,28 +275,30 @@ describe('task tool permissions', () => {
         },
       ],
     });
+    await harness.init();
+    const session = await harness.createSession();
 
-    const toolsets = await (harness as any).buildToolsets(new RequestContext());
+    const toolsets = await (harness as any).buildToolsets(session, new RequestContext());
 
     expect(toolsets.harnessBuiltIn.task_write).toBeUndefined();
     expect(toolsets.harnessBuiltIn.task_update).toBeUndefined();
     expect(toolsets.harnessBuiltIn.task_complete).toBeDefined();
     expect(toolsets.harness.custom_tool).toBeUndefined();
-    expect(harness.session.resolveToolApproval('task_update')).toBe('deny');
-    expect(harness.session.resolveToolApproval('task_complete')).toBe('allow');
+    expect(session.resolveToolApproval('task_update')).toBe('deny');
+    expect(session.resolveToolApproval('task_complete')).toBe('allow');
   });
 });
 
 describe('task tool display bridge', () => {
   it('emits task_updated and updates the display snapshot when a task tool runs with a harness context', async () => {
-    const harness = createHarness();
+    const { harness, session } = await createSession();
 
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
     // Real harness request context — wires emitEvent -> harness.emit, the
     // display-only bridge the agnostic task tools call when present.
-    const requestContext: RequestContext = await (harness as any).buildRequestContext();
+    const requestContext: RequestContext = await (harness as any).buildRequestContext(session);
 
     // Storage with the always-wired threadState domain so the tool can persist.
     const storage = new InMemoryStore();
@@ -316,11 +323,11 @@ describe('task tool display bridge', () => {
 
     // The harness display snapshot tracks the emitted task list (display-only;
     // the task list itself lives on the agent state-signal lane, not in state).
-    expect(harness.session.displayState.get().tasks).toEqual([
+    expect(session.displayState.get().tasks).toEqual([
       { id: 'task_write_tests', content: 'Write tests', status: 'pending', activeForm: 'Writing tests' },
     ]);
 
     // Tasks are no longer mirrored into harness session state.
-    expect(harness.session.state.get().tasks).toBeUndefined();
+    expect(session.state.get().tasks).toBeUndefined();
   });
 });

--- a/packages/core/src/harness/test-utils.ts
+++ b/packages/core/src/harness/test-utils.ts
@@ -1,0 +1,64 @@
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+import type { Session } from './session';
+import type { HarnessConfig, HarnessMode } from './types';
+
+/**
+ * Shared test helpers for the Harness/Session suites.
+ *
+ * Every harness test needs the same boilerplate: an Agent, a default mode, a
+ * storage backend, then `init()` + `createSession()`. These helpers collapse
+ * that into a single call so individual tests only specify what they actually
+ * care about (storage, subagents, omConfig, initialState, a custom agent, ...).
+ */
+
+export function createTestAgent(overrides?: Partial<ConstructorParameters<typeof Agent>[0]>): Agent<any, any, any, any> {
+  return new Agent({
+    id: 'test-agent',
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+    ...(overrides as any),
+  });
+}
+
+export type TestHarnessConfig<TState = {}> = Partial<HarnessConfig<TState>> & {
+  /** Backing agent for the default mode. Ignored if `modes` is provided. */
+  agent?: Agent<any, any, any, any>;
+};
+
+/**
+ * Construct a Harness wired with a single default mode and an in-memory store.
+ * Any field in {@link HarnessConfig} can be overridden; pass `agent` to swap the
+ * backing agent of the auto-generated default mode, or `modes` to take over the
+ * mode list entirely.
+ */
+export function createTestHarness<TState = {}>(config: TestHarnessConfig<TState> = {}): Harness<TState> {
+  const { agent, modes, storage, id, ...rest } = config;
+
+  const defaultModes: HarnessMode[] = [
+    { id: 'default', name: 'Default', default: true, agent: agent ?? createTestAgent() },
+  ];
+
+  return new Harness<TState>({
+    id: id ?? 'test-harness',
+    storage: storage ?? new InMemoryStore(),
+    modes: modes ?? defaultModes,
+    ...rest,
+  } as HarnessConfig<TState>);
+}
+
+/**
+ * Construct a Harness, bring up its shared resources, and mint a single Session
+ * — the standard entry point for harness tests after the multi-session refactor.
+ * Returns both so tests can reach harness-level machinery and the session.
+ */
+export async function createTestSession<TState = {}>(
+  config: TestHarnessConfig<TState> = {},
+): Promise<{ harness: Harness<TState>; session: Session<TState> }> {
+  const harness = createTestHarness<TState>(config);
+  await harness.init();
+  const session = await harness.createSession();
+  return { harness, session };
+}

--- a/packages/core/src/harness/thread-locking.test.ts
+++ b/packages/core/src/harness/thread-locking.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import type { Session } from './session';
 
 function createHarness(threadLock?: { acquire: (id: string) => void; release: (id: string) => void }) {
   const agent = new Agent({
@@ -22,42 +23,48 @@ describe('Harness thread locking', () => {
   let acquire: ReturnType<typeof vi.fn>;
   let release: ReturnType<typeof vi.fn>;
   let harness: ReturnType<typeof createHarness>;
+  let session: Session;
 
   beforeEach(async () => {
     acquire = vi.fn();
     release = vi.fn();
     harness = createHarness({ acquire, release });
     await harness.init();
+    session = await harness.createSession();
+    // createSession() acquires a lock for its auto-created starter thread.
+    // Reset the spies so each test observes only its own lock activity.
+    acquire.mockClear();
+    release.mockClear();
   });
 
   describe('createThread', () => {
     it('acquires lock on the new thread', async () => {
-      const thread = await harness.session.thread.create();
+      const thread = await session.thread.create();
       expect(acquire).toHaveBeenCalledWith(thread.id);
     });
 
     it('releases lock on previous thread when creating a new one', async () => {
-      const first = await harness.session.thread.create();
+      const first = await session.thread.create();
       acquire.mockClear();
       release.mockClear();
 
-      const second = await harness.session.thread.create();
+      const second = await session.thread.create();
       expect(release).toHaveBeenCalledWith(first.id);
       expect(acquire).toHaveBeenCalledWith(second.id);
     });
 
     it('acquire is called before release on createThread', async () => {
-      await harness.session.thread.create();
+      await session.thread.create();
       const callOrder: string[] = [];
       release.mockImplementation(() => callOrder.push('release'));
       acquire.mockImplementation(() => callOrder.push('acquire'));
 
-      await harness.session.thread.create();
+      await session.thread.create();
       expect(callOrder).toEqual(['acquire', 'release']);
     });
 
     it('re-acquires old lock if acquire on new thread fails', async () => {
-      const first = await harness.session.thread.create();
+      const first = await session.thread.create();
       acquire.mockClear();
       release.mockClear();
 
@@ -65,7 +72,7 @@ describe('Harness thread locking', () => {
         throw new Error('Thread is locked');
       });
 
-      await expect(harness.session.thread.create()).rejects.toThrow('Thread is locked');
+      await expect(session.thread.create()).rejects.toThrow('Thread is locked');
       // Should have attempted to re-acquire the old thread's lock
       expect(acquire).toHaveBeenCalledTimes(2); // failed new + re-acquire old
       expect(acquire).toHaveBeenLastCalledWith(first.id);
@@ -74,7 +81,7 @@ describe('Harness thread locking', () => {
     });
 
     it('waits for an async acquire promise before releasing previous thread lock', async () => {
-      await harness.session.thread.create();
+      await session.thread.create();
       acquire.mockClear();
       release.mockClear();
 
@@ -86,7 +93,7 @@ describe('Harness thread locking', () => {
           }),
       );
 
-      const createThreadPromise = harness.session.thread.create();
+      const createThreadPromise = session.thread.create();
       await Promise.resolve();
 
       expect(release).not.toHaveBeenCalled();
@@ -99,53 +106,53 @@ describe('Harness thread locking', () => {
 
   describe('switchThread', () => {
     it('acquires lock on the target thread', async () => {
-      const thread = await harness.session.thread.create({ title: 'thread-a' });
-      await harness.session.thread.create({ title: 'thread-b' });
+      const thread = await session.thread.create({ title: 'thread-a' });
+      await session.thread.create({ title: 'thread-b' });
       acquire.mockClear();
       release.mockClear();
 
-      await harness.session.thread.switch({ threadId: thread.id });
+      await session.thread.switch({ threadId: thread.id });
       expect(acquire).toHaveBeenCalledWith(thread.id);
     });
 
     it('releases lock on previous thread', async () => {
-      const first = await harness.session.thread.create({ title: 'first' });
-      const second = await harness.session.thread.create({ title: 'second' });
+      const first = await session.thread.create({ title: 'first' });
+      const second = await session.thread.create({ title: 'second' });
       acquire.mockClear();
       release.mockClear();
 
-      await harness.session.thread.switch({ threadId: first.id });
+      await session.thread.switch({ threadId: first.id });
       expect(release).toHaveBeenCalledWith(second.id);
       expect(acquire).toHaveBeenCalledWith(first.id);
     });
 
     it('acquire is called before release on switchThread', async () => {
-      const threadA = await harness.session.thread.create({ title: 'first' });
-      await harness.session.thread.create({ title: 'second' });
+      const threadA = await session.thread.create({ title: 'first' });
+      await session.thread.create({ title: 'second' });
       const callOrder: string[] = [];
       release.mockImplementation(() => callOrder.push('release'));
       acquire.mockImplementation(() => callOrder.push('acquire'));
 
-      await harness.session.thread.switch({ threadId: threadA.id });
+      await session.thread.switch({ threadId: threadA.id });
       expect(callOrder).toEqual(['acquire', 'release']);
     });
 
     it('propagates errors from acquire (e.g., lock conflict)', async () => {
-      const threadA = await harness.session.thread.create({ title: 'first' });
-      await harness.session.thread.create({ title: 'second' });
+      const threadA = await session.thread.create({ title: 'first' });
+      await session.thread.create({ title: 'second' });
 
       acquire.mockImplementation(() => {
         throw new Error('Thread is locked by another process');
       });
 
-      await expect(harness.session.thread.switch({ threadId: threadA.id })).rejects.toThrow(
+      await expect(session.thread.switch({ threadId: threadA.id })).rejects.toThrow(
         'Thread is locked by another process',
       );
     });
 
     it('waits for an async release promise before resolving switchThread', async () => {
-      const first = await harness.session.thread.create({ title: 'first' });
-      await harness.session.thread.create({ title: 'second' });
+      const first = await session.thread.create({ title: 'first' });
+      await session.thread.create({ title: 'second' });
       acquire.mockClear();
       release.mockClear();
 
@@ -158,7 +165,7 @@ describe('Harness thread locking', () => {
       );
 
       let settled = false;
-      const switchPromise = harness.session.thread.switch({ threadId: first.id }).then(() => {
+      const switchPromise = session.thread.switch({ threadId: first.id }).then(() => {
         settled = true;
       });
       await Promise.resolve();
@@ -173,118 +180,122 @@ describe('Harness thread locking', () => {
     });
   });
 
-  describe('selectOrCreateThread', () => {
-    it('acquires lock when selecting an existing thread', async () => {
-      // Pre-create a thread so selectOrCreateThread finds it
-      await harness.session.thread.create({ title: 'existing' });
-      acquire.mockClear();
-      release.mockClear();
-
-      // Manually set the same storage so it sees the thread
-      // Instead, create a new harness with same store
-      const store = new InMemoryStore();
+  describe('createSession thread selection', () => {
+    function freshHarness(store: InMemoryStore) {
       const agent = new Agent({
         name: 'test-agent',
         instructions: 'You are a test agent.',
         model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
       });
-      const freshHarness = new Harness({
+      return new Harness({
         id: 'test-harness',
         storage: store,
         modes: [{ id: 'default', name: 'Default', default: true, agent }],
         threadLock: { acquire, release },
       });
-      await freshHarness.init();
+    }
 
-      // Create a thread via this harness so selectOrCreateThread can find it
-      const existing = await freshHarness.session.thread.create({ title: 'existing-thread' });
+    it('resumes and locks the most recent thread for the same resourceId', async () => {
+      const store = new InMemoryStore();
+
+      // First session creates a thread for resource "user-1".
+      const harnessA = freshHarness(store);
+      await harnessA.init();
+      const sessionA = await harnessA.createSession({ resourceId: 'user-1' });
+      const existing = sessionA.thread.getId();
+      expect(existing).toBeDefined();
+
       acquire.mockClear();
       release.mockClear();
 
-      // Create another fresh harness with the same storage
-      const freshHarness2 = new Harness({
-        id: 'test-harness',
-        storage: store,
-        modes: [{ id: 'default', name: 'Default', default: true, agent }],
-        threadLock: { acquire, release },
-      });
-      await freshHarness2.init();
+      // A second session for the same resourceId should resume that thread.
+      const harnessB = freshHarness(store);
+      await harnessB.init();
+      const sessionB = await harnessB.createSession({ resourceId: 'user-1' });
 
-      const selected = await freshHarness2.selectOrCreateThread();
-      expect(selected.id).toBe(existing.id);
-      expect(acquire).toHaveBeenCalledWith(existing.id);
+      expect(sessionB.thread.getId()).toBe(existing);
+      expect(acquire).toHaveBeenCalledWith(existing);
+    });
+
+    it('creates a fresh thread for a different resourceId', async () => {
+      const store = new InMemoryStore();
+
+      const harnessA = freshHarness(store);
+      await harnessA.init();
+      const sessionA = await harnessA.createSession({ resourceId: 'user-1' });
+      const existing = sessionA.thread.getId();
+
+      acquire.mockClear();
+
+      // A session for a different resourceId must not resume user-1's thread.
+      const harnessB = freshHarness(store);
+      await harnessB.init();
+      const sessionB = await harnessB.createSession({ resourceId: 'user-2' });
+
+      expect(sessionB.thread.getId()).not.toBe(existing);
+      expect(acquire).toHaveBeenCalledWith(sessionB.thread.getId());
     });
 
     it('acquires lock when creating a new thread (no existing threads)', async () => {
       const store = new InMemoryStore();
-      const agent = new Agent({
-        name: 'test-agent',
-        instructions: 'You are a test agent.',
-        model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
-      });
-      const freshHarness = new Harness({
-        id: 'test-harness',
-        storage: store,
-        modes: [{ id: 'default', name: 'Default', default: true, agent }],
-        threadLock: { acquire, release },
-      });
-      await freshHarness.init();
+      const harness = freshHarness(store);
+      await harness.init();
 
       acquire.mockClear();
-      const thread = await freshHarness.selectOrCreateThread();
-      expect(acquire).toHaveBeenCalledWith(thread.id);
+      const newSession = await harness.createSession();
+      expect(acquire).toHaveBeenCalledWith(newSession.thread.getId());
     });
   });
 
   describe('deleteThread', () => {
     it('deletes a thread from storage', async () => {
-      const thread = await harness.session.thread.create({ title: 'to-delete' });
-      await harness.session.thread.delete({ threadId: thread.id });
+      const thread = await session.thread.create({ title: 'to-delete' });
+      await session.thread.delete({ threadId: thread.id });
 
-      const threads = await harness.session.thread.list();
+      const threads = await session.thread.list();
       expect(threads.find(t => t.id === thread.id)).toBeUndefined();
     });
 
     it('releases lock when deleting the current thread', async () => {
-      const thread = await harness.session.thread.create({ title: 'current' });
+      const thread = await session.thread.create({ title: 'current' });
       acquire.mockClear();
       release.mockClear();
 
-      await harness.session.thread.delete({ threadId: thread.id });
+      await session.thread.delete({ threadId: thread.id });
       expect(release).toHaveBeenCalledWith(thread.id);
     });
 
     it('clears currentThreadId when deleting the current thread', async () => {
-      const thread = await harness.session.thread.create({ title: 'current' });
-      expect(harness.session.thread.getId()).toBe(thread.id);
+      const thread = await session.thread.create({ title: 'current' });
+      expect(session.thread.getId()).toBe(thread.id);
 
-      await harness.session.thread.delete({ threadId: thread.id });
-      expect(harness.session.thread.getId()).toBeNull();
+      await session.thread.delete({ threadId: thread.id });
+      expect(session.thread.getId()).toBeNull();
     });
 
     it('does not release lock when deleting a non-current thread', async () => {
-      const first = await harness.session.thread.create({ title: 'first' });
-      const second = await harness.session.thread.create({ title: 'second' });
+      const first = await session.thread.create({ title: 'first' });
+      const second = await session.thread.create({ title: 'second' });
       release.mockClear();
 
-      await harness.session.thread.delete({ threadId: first.id });
+      await session.thread.delete({ threadId: first.id });
       // Should not release lock since first is not the current thread (second is)
       expect(release).not.toHaveBeenCalled();
-      expect(harness.session.thread.getId()).toBe(second.id);
+      expect(session.thread.getId()).toBe(second.id);
     });
 
     it('throws when thread does not exist', async () => {
-      await expect(harness.session.thread.delete({ threadId: 'nonexistent' })).rejects.toThrow('Thread not found');
+      await expect(session.thread.delete({ threadId: 'nonexistent' })).rejects.toThrow('Thread not found');
     });
 
     it('emits thread_deleted event', async () => {
       const events: string[] = [];
-      harness.session.subscribe(event => {
+      session.subscribe(event => {
         if (event.type === 'thread_deleted') events.push(event.threadId);
       });
 
-      const thread = await harness.session.thread.create({ title: 'to-delete' });
-      await harness.session.thread.delete({ threadId: thread.id });
+      const thread = await session.thread.create({ title: 'to-delete' });
+      await session.thread.delete({ threadId: thread.id });
       expect(events).toEqual([thread.id]);
     });
   });
@@ -293,10 +304,11 @@ describe('Harness thread locking', () => {
     it('works normally without locking', async () => {
       const unlocked = createHarness(); // no threadLock
       await unlocked.init();
+      const unlockedSession = await unlocked.createSession();
 
-      const threadA = await unlocked.session.thread.create({ title: 'test' });
-      await unlocked.session.thread.create({ title: 'test2' });
-      await unlocked.session.thread.switch({ threadId: threadA.id });
+      const threadA = await unlockedSession.thread.create({ title: 'test' });
+      await unlockedSession.thread.create({ title: 'test2' });
+      await unlockedSession.thread.switch({ threadId: threadA.id });
       // No errors thrown — locking is optional
     });
   });

--- a/packages/core/src/harness/token-usage.test.ts
+++ b/packages/core/src/harness/token-usage.test.ts
@@ -47,17 +47,20 @@ async function* mockStream(usage: Record<string, unknown>) {
 
 describe('step-finish token usage extraction', () => {
   let harness: Harness;
+  let session: Awaited<ReturnType<Harness['createSession']>>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     harness = createHarness();
+    await harness.init();
+    session = await harness.createSession();
   });
 
   it('extracts token usage from AI SDK v5/v6 format (inputTokens/outputTokens)', async () => {
     const usage = { inputTokens: 100, outputTokens: 50, totalTokens: 150 };
 
-    await (harness.session as any).processStream({ fullStream: mockStream(usage) });
+    await (session as any).processStream({ fullStream: mockStream(usage) });
 
-    const tokenUsage = harness.session.getTokenUsage();
+    const tokenUsage = session.getTokenUsage();
     expect(tokenUsage.promptTokens).toBe(100);
     expect(tokenUsage.completionTokens).toBe(50);
     expect(tokenUsage.totalTokens).toBe(150);
@@ -66,9 +69,9 @@ describe('step-finish token usage extraction', () => {
   it('extracts token usage from legacy v4 format (promptTokens/completionTokens)', async () => {
     const usage = { promptTokens: 200, completionTokens: 80, totalTokens: 280 };
 
-    await (harness.session as any).processStream({ fullStream: mockStream(usage) });
+    await (session as any).processStream({ fullStream: mockStream(usage) });
 
-    const tokenUsage = harness.session.getTokenUsage();
+    const tokenUsage = session.getTokenUsage();
     expect(tokenUsage.promptTokens).toBe(200);
     expect(tokenUsage.completionTokens).toBe(80);
     expect(tokenUsage.totalTokens).toBe(280);
@@ -85,9 +88,9 @@ describe('step-finish token usage extraction', () => {
       raw: { provider: 'test-provider' },
     };
     const events: HarnessEvent[] = [];
-    harness.session.subscribe(event => events.push(event));
+    session.subscribe(event => events.push(event));
 
-    await (harness.session as any).processStream({ fullStream: mockStream(usage) });
+    await (session as any).processStream({ fullStream: mockStream(usage) });
 
     const expectedUsage = {
       promptTokens: 100,
@@ -98,8 +101,8 @@ describe('step-finish token usage extraction', () => {
       cacheCreationInputTokens: 5,
       raw: { provider: 'test-provider' },
     };
-    expect(harness.session.getTokenUsage()).toEqual(expectedUsage);
-    expect(harness.session.displayState.get().tokenUsage).toEqual(expectedUsage);
+    expect(session.getTokenUsage()).toEqual(expectedUsage);
+    expect(session.displayState.get().tokenUsage).toEqual(expectedUsage);
     expect(events.find(event => event.type === 'usage_update')).toEqual({
       type: 'usage_update',
       usage: expectedUsage,
@@ -110,7 +113,8 @@ describe('step-finish token usage extraction', () => {
     const storage = new InMemoryStore();
     harness = createHarness(storage);
     await harness.init();
-    const thread = await harness.session.thread.create();
+    session = await harness.createSession();
+    const thread = await session.thread.create();
     const usage = {
       inputTokens: 100,
       outputTokens: 50,
@@ -121,7 +125,7 @@ describe('step-finish token usage extraction', () => {
       raw: { provider: 'test-provider' },
     };
 
-    await (harness.session as any).processStream({ fullStream: mockStream(usage) });
+    await (session as any).processStream({ fullStream: mockStream(usage) });
 
     await expect
       .poll(async () => {
@@ -177,9 +181,9 @@ describe('step-finish token usage extraction', () => {
       };
     }
 
-    await (harness.session as any).processStream({ fullStream: multiStepStream() });
+    await (session as any).processStream({ fullStream: multiStepStream() });
 
-    const tokenUsage = harness.session.getTokenUsage();
+    const tokenUsage = session.getTokenUsage();
     expect(tokenUsage.promptTokens).toBe(250);
     expect(tokenUsage.completionTokens).toBe(120);
     expect(tokenUsage.totalTokens).toBe(370);
@@ -236,9 +240,9 @@ describe('step-finish token usage extraction', () => {
       };
     }
 
-    await (harness.session as any).processStream({ fullStream: multiStepStream() });
+    await (session as any).processStream({ fullStream: multiStepStream() });
 
-    expect(harness.session.getTokenUsage()).toEqual({
+    expect(session.getTokenUsage()).toEqual({
       promptTokens: 250,
       completionTokens: 120,
       totalTokens: 440,
@@ -252,9 +256,9 @@ describe('step-finish token usage extraction', () => {
   it('defaults cache usage fields to 0 when not present in usage', async () => {
     const usage = { inputTokens: 100, outputTokens: 50, totalTokens: 150 };
 
-    await (harness.session as any).processStream({ fullStream: mockStream(usage) });
+    await (session as any).processStream({ fullStream: mockStream(usage) });
 
-    const tokenUsage = harness.session.getTokenUsage();
+    const tokenUsage = session.getTokenUsage();
     expect(tokenUsage.cachedInputTokens).toBe(0);
     expect(tokenUsage.cacheCreationInputTokens).toBe(0);
   });

--- a/packages/core/src/harness/tracing-propagation.test.ts
+++ b/packages/core/src/harness/tracing-propagation.test.ts
@@ -1,58 +1,48 @@
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Agent } from '../agent';
-import { agentThreadStreamRuntime } from '../agent/thread-stream-runtime';
 import type { TracingContext, TracingOptions } from '../observability';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import type { Session } from './session';
 
-function createAgent() {
-  return new Agent({
-    name: 'test-agent',
-    instructions: 'You are a test agent.',
-    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+function createTextStreamModel(responseText: string) {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: responseText },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ]),
+    }),
   });
 }
 
-function createMockStreamResponse(runId: string) {
-  const chunks: any[] = [
-    { type: 'start', runId },
-    { type: 'text-start', runId, payload: { id: 'msg-1' } },
-    { type: 'text-delta', runId, payload: { id: 'msg-1', text: 'Hello' } },
-    { type: 'text-end', runId, payload: { id: 'msg-1' } },
-    {
-      type: 'finish',
-      runId,
-      payload: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 }, finishReason: 'stop' },
-    },
-  ];
-
-  let finish!: () => void;
-  const finished = new Promise<void>(resolve => {
-    finish = resolve;
+function createAgent() {
+  return new Agent({
+    id: 'test-agent',
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: createTextStreamModel('Hello'),
   });
-  const fullStream = new ReadableStream({
-    start(controller) {
-      for (const part of chunks) controller.enqueue(part);
-      controller.close();
-      finish();
-    },
-  });
-
-  return {
-    runId,
-    status: 'running' as const,
-    fullStream,
-    _waitUntilFinished: () => finished,
-  };
 }
 
 describe('Harness tracing propagation', () => {
   let agent: Agent;
   let harness: Harness;
+  let session: Session;
   let streamSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    agentThreadStreamRuntime.resetForTests();
+  beforeEach(async () => {
     agent = createAgent();
     harness = new Harness({
       id: 'test-harness',
@@ -60,20 +50,22 @@ describe('Harness tracing propagation', () => {
       modes: [{ id: 'default', name: 'Default', default: true, agent }],
     });
 
-    streamSpy = vi.spyOn(agent, 'stream').mockImplementation(async (_signal: any, options: any) => {
-      const response = createMockStreamResponse(options?.runId ?? 'mock-run-id');
-      agentThreadStreamRuntime.registerRun(agent, response as any, options);
-      return response as any;
+    // Spy on the real stream so the run actually completes (driving the
+    // session's stream to idle) while still capturing the options it receives.
+    const originalStream = agent.stream.bind(agent);
+    streamSpy = vi.spyOn(agent, 'stream').mockImplementation((signal: any, options: any) => {
+      return originalStream(signal, options);
     });
 
-    (harness as any).currentThreadId = 'test-thread-123';
+    await harness.init();
+    session = await harness.createSession();
   });
 
   it('should forward tracingContext to agent.stream() when provided', async () => {
     const mockSpan = { spanContext: () => ({ traceId: 'abc', spanId: 'def' }) };
     const tracingContext: TracingContext = { currentSpan: mockSpan as any };
 
-    await harness.session.sendMessage({ content: 'hello', tracingContext });
+    await session.sendMessage({ content: 'hello', tracingContext });
 
     expect(streamSpy).toHaveBeenCalledTimes(1);
 
@@ -90,7 +82,7 @@ describe('Harness tracing propagation', () => {
       metadata: { requestId: 'req-789' },
     };
 
-    await harness.session.sendMessage({ content: 'hello', tracingOptions });
+    await session.sendMessage({ content: 'hello', tracingOptions });
 
     expect(streamSpy).toHaveBeenCalledTimes(1);
 
@@ -101,7 +93,7 @@ describe('Harness tracing propagation', () => {
   });
 
   it('should not include tracingContext/tracingOptions when not provided', async () => {
-    await harness.session.sendMessage({ content: 'hello' });
+    await session.sendMessage({ content: 'hello' });
 
     expect(streamSpy).toHaveBeenCalledTimes(1);
 
@@ -113,13 +105,13 @@ describe('Harness tracing propagation', () => {
 
   it('starts a new message with a clean abort state after a stale operation was aborted', async () => {
     const events: Array<{ type: string; reason?: string }> = [];
-    harness.session.subscribe(event => {
+    session.subscribe(event => {
       events.push(event as { type: string; reason?: string });
     });
-    harness.session.run.requestAbort();
+    session.run.requestAbort();
 
-    await harness.session.sendMessage({ content: 'hello' });
+    await session.sendMessage({ content: 'hello' });
 
-    expect(events).toContainEqual({ type: 'agent_end', reason: 'complete' });
+    expect(events.some(event => event.type === 'agent_end' && event.reason === 'complete')).toBe(true);
   });
 });

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -475,15 +475,6 @@ export interface HarnessThread {
   metadata?: Record<string, unknown>;
 }
 
-/**
- * Session info for the current harness instance.
- */
-export interface HarnessSession {
-  currentThreadId: string | null;
-  currentModeId: string;
-  threads: HarnessThread[];
-}
-
 // =============================================================================
 // Events
 // =============================================================================

--- a/packages/core/src/harness/workspace-resolution.test.ts
+++ b/packages/core/src/harness/workspace-resolution.test.ts
@@ -3,6 +3,7 @@ import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Workspace } from '../workspace/workspace';
 import { Harness } from './harness';
+import type { Session } from './session';
 
 /**
  * Create a minimal Workspace instance for testing.
@@ -57,8 +58,10 @@ describe('Harness workspace — static instance', () => {
       modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
       workspace: ws,
     });
+    await harness.init();
+    const session = await harness.createSession();
 
-    const resolved = await harness.resolveWorkspace();
+    const resolved = await harness.resolveWorkspace({ session });
     expect(resolved).toBe(ws);
   });
 });
@@ -72,7 +75,7 @@ describe('Harness workspace — dynamic factory', () => {
   let workspaceFn: ReturnType<typeof vi.fn>;
   let harness: Harness;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     ws = createMockWorkspace('dynamic-ws');
     workspaceFn = vi.fn().mockResolvedValue(ws);
     harness = new Harness({
@@ -81,9 +84,11 @@ describe('Harness workspace — dynamic factory', () => {
       modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
       workspace: workspaceFn,
     });
+    await harness.init();
   });
 
   it('getWorkspace() returns undefined before resolution', () => {
+    // No session created yet, so the dynamic workspace has not been resolved.
     expect(harness.getWorkspace()).toBeUndefined();
   });
 
@@ -92,21 +97,29 @@ describe('Harness workspace — dynamic factory', () => {
   });
 
   it('resolveWorkspace() invokes the factory and caches the result', async () => {
-    const resolved = await harness.resolveWorkspace();
+    const session = await harness.createSession();
+    // createSession resolves the workspace once; the explicit resolve below
+    // should hit the cache rather than re-invoking the factory.
+    workspaceFn.mockClear();
+
+    const resolved = await harness.resolveWorkspace({ session });
 
     expect(resolved).toBe(ws);
-    expect(workspaceFn).toHaveBeenCalledTimes(1);
-    // Subsequent calls to getWorkspace() return the cached value
+    expect(workspaceFn).not.toHaveBeenCalled();
+    // getWorkspace() returns the cached value
     expect(harness.getWorkspace()).toBe(ws);
   });
 
-  it('resolveWorkspace() returns cached workspace on second call without re-invoking factory', async () => {
-    await harness.resolveWorkspace();
-    const resolved2 = await harness.resolveWorkspace();
+  it('resolveWorkspace() returns cached workspace without re-invoking factory', async () => {
+    const session = await harness.createSession();
+    workspaceFn.mockClear();
+
+    await harness.resolveWorkspace({ session });
+    const resolved2 = await harness.resolveWorkspace({ session });
 
     expect(resolved2).toBe(ws);
-    // Factory called once (first resolve), not twice
-    expect(workspaceFn).toHaveBeenCalledTimes(1);
+    // Factory not called again — the workspace was cached at createSession time.
+    expect(workspaceFn).not.toHaveBeenCalled();
   });
 
   it('resolveWorkspace() returns undefined when factory returns undefined', async () => {
@@ -117,8 +130,10 @@ describe('Harness workspace — dynamic factory', () => {
       modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
       workspace: nullFactory,
     });
+    await h.init();
+    const session = await h.createSession();
 
-    const resolved = await h.resolveWorkspace();
+    const resolved = await h.resolveWorkspace({ session });
     expect(resolved).toBeUndefined();
   });
 });
@@ -129,13 +144,16 @@ describe('Harness workspace — dynamic factory', () => {
 
 describe('Harness workspace — none configured', () => {
   let harness: Harness;
+  let session: Session;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     harness = new Harness({
       id: 'test',
       storage: new InMemoryStore(),
       modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
     });
+    await harness.init();
+    session = await harness.createSession();
   });
 
   it('getWorkspace() returns undefined', () => {
@@ -147,7 +165,7 @@ describe('Harness workspace — none configured', () => {
   });
 
   it('resolveWorkspace() returns undefined', async () => {
-    const resolved = await harness.resolveWorkspace();
+    const resolved = await harness.resolveWorkspace({ session });
     expect(resolved).toBeUndefined();
   });
 });
@@ -170,8 +188,10 @@ describe('buildRequestContext caches dynamic workspace', () => {
     // Before — workspace is not resolved
     expect(harness.getWorkspace()).toBeUndefined();
 
+    await harness.init();
+    const session = await harness.createSession();
     // Trigger buildRequestContext indirectly via resolveWorkspace
-    await harness.resolveWorkspace();
+    await harness.resolveWorkspace({ session });
 
     // After — workspace is cached
     expect(harness.getWorkspace()).toBe(ws);


### PR DESCRIPTION
## What

Turns the Harness into a pure factory + shared-resource owner and removes its singleton session. Instead of holding a single `#session` and exposing it via `harness.session`, callers now create fully isolated sessions through `harness.createSession({ resourceId? })`.

Each session owns its own mode, model, state, thread, run-control, event bus, and stream engine. A single Harness can therefore serve many concurrent sessions — one per user/thread in a server or channel adapter — with no cross-session state or event leakage. The Harness retains only genuinely shared machinery (agent, config builders, model catalog/auth, storage/lock gateway), which it injects into each session via the existing `SessionMachinery` provider.

## Key changes

- **`harness.createSession({ resourceId? })`**: constructs and wires a new `Session`, replays current workspace status onto it, and selects/creates its thread before returning a fully ready session.
- **Removed the singleton**: deleted the `#session` field, the `harness.session` getter, `harness.getSession()`, and the deprecated `harness.subscribe` / `harness.emit` / `harness.memory` delegators.
- **Session-parameterized Harness methods**: `setResourceId`, `getKnownResourceIds`, `getCurrentModelAuthStatus`, `loadOMProgress`, `getObservationalMemoryRecord`, and `destroy` now take an explicit `session` argument instead of reading the singleton.
- **Idempotent `harness.init()`**: repeated calls reuse the same initialization (via a cached init promise) instead of rebuilding internal Mastra state. This fixes a double-init bug that orphaned agent registration.
- **MastraCode**: composition roots (`index.ts`, `main.ts`, `headless.ts`) call `createSession()` once at startup and store the result on `state.session`; all per-session operations flow through that session object.
- **Tests**: a shared `test-utils.ts` helper (`createTestHarness` / `createTestSession`) plus a `session-isolation.test.ts` proving two sessions from one Harness have independent mode/model/state/thread and isolated event buses.

## Before / After

```typescript
// Before
const session = harness.session; // singleton
await session.sendMessage({ content: 'hello' });

// After
const session = await harness.createSession({ resourceId });
await session.sendMessage({ content: 'hello' });
const other = await harness.createSession({ resourceId: otherUser }); // fully isolated
```

## Test plan

- `pnpm build:core` — green
- core + mastracode `typecheck` — clean
- harness suite — 325 tests pass (33 files), incl. new isolation tests
- mastracode suite — 1320 tests pass (128 files)
- e2e scenarios pass individually

## Known follow-up

The `github-signals-polling-inbox` e2e scenario still fails and will be addressed in a follow-up diff in this stack. Its `onCreated` callback manually polls a seeded thread on a different `resourceId` before any live session is bound to that thread; under the new isolated-session model that delivery hits a session with no model. The production polling path (poll on `thread_changed`) is correct for multi-session; the scenario premature manual poll needs reworking.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-8) <noreply@mastra.ai>
