### PR TITLE
refactor(core): route notifications to the resource-owning session via get-or-create createSession

### DIFF
--- a/.changeset/quick-otters-jump.md
+++ b/.changeset/quick-otters-jump.md
@@ -1,0 +1,29 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Made `harness.createSession()` get-or-create by resourceId and added `harness.getSessionByResource()` so notification delivery runs as the session that owns the target thread.
+
+A resourceId now maps to exactly one durable session per Harness: calling `createSession({ resourceId })` twice returns the same session, so a user/thread always resumes their own session and the in-flight creation is shared by concurrent callers. This is the multi-session behavior a long-running / multiplayer server needs — work can be driven on a thread whether or not a human is currently attached, and it runs with that thread's own model/mode/state instead of an arbitrary session.
+
+**Before**
+
+```typescript
+// createSession was a pure factory: two calls for the same resource produced
+// two independent sessions, and notification delivery had no way to find
+// "the session that owns this resource".
+const a = await harness.createSession({ resourceId: 'user-a' });
+const b = await harness.createSession({ resourceId: 'user-a' }); // different object
+```
+
+**After**
+
+```typescript
+const a = await harness.createSession({ resourceId: 'user-a' });
+const b = await harness.createSession({ resourceId: 'user-a' }); // same session as a
+
+const session = await harness.getSessionByResource('user-a'); // === a
+```
+
+`mastracode` resolves notification stream options from the target resource's session (falling back to the active session's model, then the mode default) so a woken GitHub-signal notification always has a model to run with.

--- a/mastracode/e2e/scenarios/github-signals-polling-inbox.ts
+++ b/mastracode/e2e/scenarios/github-signals-polling-inbox.ts
@@ -173,9 +173,13 @@ values
         if (!agent || !originalSendNotificationSignal) return;
         type SendNotificationSignal = typeof agent.sendNotificationSignal;
         const sendScopedNotificationSignal = ((notification: unknown, target: unknown) => {
+          // Scope the target to this fixture's resource/thread, but preserve the
+          // delivery options (ifIdle/ifActive) — they carry the stream options
+          // (model/mode/state) the woken run needs to resolve a model.
           const scopedTarget =
             target && typeof target === 'object'
               ? {
+                  ...(target as Record<string, unknown>),
                   resourceId: (target as { resourceId?: string }).resourceId,
                   threadId: (target as { threadId?: string }).threadId,
                 }
@@ -187,10 +191,17 @@ values
         }) as SendNotificationSignal;
         agent.sendNotificationSignal = sendScopedNotificationSignal;
         const pollTimer = setTimeout(() => {
-          void result.githubSignals?.startPollingForThread(
-            { threadId: threadFixture.threadId, resourceId: threadFixture.resourceId },
-            { pollImmediately: true },
-          );
+          void (async () => {
+            // The notification targets a seeded resource that the startup
+            // session is not on. In the multi-session world the woken run uses
+            // the target resource's own session, so materialize one before
+            // polling — mirroring how a server would have a session per thread.
+            await result.harness.createSession({ resourceId: threadFixture.resourceId });
+            await result.githubSignals?.startPollingForThread(
+              { threadId: threadFixture.threadId, resourceId: threadFixture.resourceId },
+              { pollImmediately: true },
+            );
+          })();
         }, 250);
         pollTimer.unref?.();
       },

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -418,8 +418,18 @@ export async function createMastraCode(config?: MastraCodeConfig) {
           process.env.GITCRAWL_BIN ??
           process.env.MASTRACODE_GITCRAWL_COMMAND ??
           process.env.GITCRAWL_COMMAND,
-        getNotificationStreamOptions: ({ resourceId, threadId }) => {
-          const session = activeSession!;
+        getNotificationStreamOptions: async ({ resourceId, threadId }) => {
+          // Run the woken notification as the session that owns the target
+          // resource so it uses that session's model/mode/state. Fall back to
+          // the current session only when no session owns the resource yet.
+          const session = (await harness.getSessionByResource(resourceId)) ?? activeSession!;
+          // A long-running system must be able to drive work unattended, so a
+          // target session without an explicit model selection falls back to a
+          // real model rather than failing the run: the current session's live
+          // selection (what the user actually picked), then the mode's default.
+          const modeId = session.mode.get();
+          const defaultModeModelId = harness.listModes().find(mode => mode.id === modeId)?.defaultModelId;
+          const modelId = session.model.get() || activeSession?.model.get() || defaultModeModelId || '';
           const requestContext = new RequestContext();
           const harnessContext: HarnessRequestContext = {
             harnessId: harness.id,
@@ -429,8 +439,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
             threadId,
             resourceId,
             session: {
-              modeId: session.mode.get(),
-              modelId: session.model.get(),
+              modeId,
+              modelId,
               state: {
                 get: () => session.state.get(),
                 set: updates => session.state.set(updates),

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -194,6 +194,15 @@ export class Harness<TState = {}> {
    * every {@link createSession} call. The Harness itself holds no session.
    */
   readonly #defaultMode: HarnessMode;
+  /**
+   * Live sessions created by {@link createSession}, keyed by resourceId. A
+   * resourceId maps to exactly one session per Harness (get-or-create). Stores
+   * the in-flight creation promise so concurrent calls share one session. Lets
+   * Harness-external callers (e.g. notification delivery) resolve "the session
+   * that owns this resource" so a woken run uses that session's model/mode/state
+   * instead of an arbitrary one.
+   */
+  readonly #sessionsByResource = new Map<string, Promise<Session<TState>>>();
   private availableModelsCache: AvailableModel[] | null = null;
   private availableModelsCacheTime: number = 0;
   readonly #instructions?: string;
@@ -324,9 +333,35 @@ export class Harness<TState = {}> {
    * workspace are ready.
    */
   async createSession({ resourceId }: { resourceId?: string } = {}): Promise<Session<TState>> {
+    const effectiveResourceId = resourceId ?? this.config.resourceId ?? this.config.id;
+
+    // Get-or-create: a resourceId maps to exactly one durable session per
+    // Harness. Asking for the same resource twice returns the same session, so
+    // a user/thread always resumes their own session and notification delivery
+    // reuses it rather than spawning a split-brain duplicate. Cache the in-flight
+    // promise so concurrent calls for the same resource resolve to one session.
+    const existing = this.#sessionsByResource.get(effectiveResourceId);
+    if (existing) {
+      return existing;
+    }
+
+    const creation = this.#createSessionForResource(effectiveResourceId);
+    this.#sessionsByResource.set(effectiveResourceId, creation);
+    try {
+      return await creation;
+    } catch (error) {
+      // Don't cache a failed creation — let the next call retry.
+      if (this.#sessionsByResource.get(effectiveResourceId) === creation) {
+        this.#sessionsByResource.delete(effectiveResourceId);
+      }
+      throw error;
+    }
+  }
+
+  async #createSessionForResource(effectiveResourceId: string): Promise<Session<TState>> {
     const session = this.#wireSession(
       new Session({
-        resourceId: resourceId ?? this.config.resourceId ?? this.config.id,
+        resourceId: effectiveResourceId,
         state: {
           initialState: this.config.initialState,
           stateSchema: this.config.stateSchema,
@@ -362,6 +397,16 @@ export class Harness<TState = {}> {
     }
 
     return session;
+  }
+
+  /**
+   * Resolve a live session by resourceId, if one was created for it via
+   * {@link createSession}. Returns `undefined` when no session owns the
+   * resource. Used by notification delivery to run woken signals as the session
+   * that owns the target thread, rather than an arbitrary session.
+   */
+  async getSessionByResource(resourceId: string): Promise<Session<TState> | undefined> {
+    return this.#sessionsByResource.get(resourceId);
   }
 
   // ===========================================================================
@@ -922,9 +967,27 @@ export class Harness<TState = {}> {
    * the active thread — since those are Harness-owned.
    */
   setResourceId(session: Session<TState>, { resourceId }: { resourceId: string }): void {
+    const previousResourceId = session.identity.getResourceId();
     session.thread.cleanupSubscription();
     session.identity.setResourceId({ resourceId });
     session.thread.clear();
+
+    // Re-key the resource registry so this session is the one resolved for its
+    // new resourceId (and is no longer resolved for the old one). This session
+    // becomes the authoritative owner of the target resource, replacing any
+    // prior session registered there.
+    void this.#dropSessionFromRegistry(previousResourceId, session);
+    this.#sessionsByResource.set(resourceId, Promise.resolve(session));
+  }
+
+  /** Remove `resourceId` from the registry only if it still resolves to `session`. */
+  async #dropSessionFromRegistry(resourceId: string, session: Session<TState>): Promise<void> {
+    const pending = this.#sessionsByResource.get(resourceId);
+    if (!pending) return;
+    const resolved = await pending.catch(() => undefined);
+    if (resolved === session && this.#sessionsByResource.get(resourceId) === pending) {
+      this.#sessionsByResource.delete(resourceId);
+    }
   }
 
   async getKnownResourceIds(session: Session<TState>): Promise<string[]> {

--- a/packages/core/src/harness/session-isolation.test.ts
+++ b/packages/core/src/harness/session-isolation.test.ts
@@ -111,3 +111,38 @@ describe('Harness.createSession — cross-session isolation', () => {
     expect(bEvents.some(e => e.type === 'mode_changed')).toBe(false);
   });
 });
+
+describe('Harness session registry', () => {
+  it('resolves a created session by its resourceId', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const a = await harness.createSession({ resourceId: 'user-a' });
+    const b = await harness.createSession({ resourceId: 'user-b' });
+
+    expect(await harness.getSessionByResource('user-a')).toBe(a);
+    expect(await harness.getSessionByResource('user-b')).toBe(b);
+    expect(await harness.getSessionByResource('user-unknown')).toBeUndefined();
+  });
+
+  it('returns the same session for the same resourceId (get-or-create)', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const first = await harness.createSession({ resourceId: 'user-a' });
+    const second = await harness.createSession({ resourceId: 'user-a' });
+
+    expect(second).toBe(first);
+  });
+
+  it('follows a session when its resourceId changes', async () => {
+    const harness = createHarness(new InMemoryStore());
+    await harness.init();
+
+    const a = await harness.createSession({ resourceId: 'user-a' });
+    harness.setResourceId(a, { resourceId: 'user-a-renamed' });
+
+    expect(await harness.getSessionByResource('user-a-renamed')).toBe(a);
+    expect(await harness.getSessionByResource('user-a')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Makes `harness.createSession()` **get-or-create by resourceId** and adds `harness.getSessionByResource()`, so notification delivery runs as the session that owns the target thread rather than an arbitrary one.

A resourceId now maps to exactly **one durable session per Harness**:
- `createSession({ resourceId })` returns the existing session for that resourceId if present, otherwise creates it.
- The in-flight creation promise is cached, so concurrent callers for the same resource share a single session.
- `setResourceId` re-keys the registry so a re-pointed session stays resolvable.

MastraCode resolves notification stream options from the **target resource's session** (falling back to the active session's model, then the mode's default model) so a woken signal always has a model to run with.

## Why

In a long-running / multiplayer system (e.g. a server with a session per Slack thread), work arrives from the world — a CI run finishes, a PR gets a comment — and must be driven on a thread whether or not a human is currently attached. Previously notification delivery pulled the model from a captured singleton `activeSession`, which only made sense when a Harness owned exactly one session. With the multi-session factory, a notification for resource B could run against the wrong session and fail with `No model selected`.

Get-or-create gives a thread/user one authoritative session that notifications reuse, instead of spawning split-brain duplicates.

## Notable findings

- The `github-signals-polling-inbox` e2e never actually passed: its scoped-target wrapper was **stripping `ifIdle`**, dropping the stream options (and model) the woken run needs. Fixed to preserve delivery options, and to materialize the target resource's session before polling.

## Verification

- `pnpm --filter ./packages/core check` ✓ and `pnpm --filter ./mastracode exec tsc --noEmit` ✓
- 33 harness test files pass (incl. previously-failing `mode-model-persistence` and new get-or-create / registry tests)
- `github-signals-polling-inbox` e2e ✓ (3.5s, was timing out)
- Full e2e suite: **101 passed / 19 skipped / 0 failed**
- mastracode units: 1318 pass (2 failures are the pre-existing `MASTRA_GATEWAY_URL` env leak; pass with a clean env)

Stacked on #18266 (`refactor/harness-create-session`).