### PR TITLE
ci: build @internal/core before generating provider registry

### DIFF
--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Build vendored ai-v6 package
         run: pnpm --filter @internal/ai-v6 build
 
+      - name: Build internal core package
+        # The generate:providers script imports @mastra/core source, which
+        # re-exports @internal/core/error. That subpath resolves to the
+        # package's dist output, so @internal/core must be built first or the
+        # script fails with ERR_MODULE_NOT_FOUND.
+        run: pnpm turbo build --filter @internal/core
+
       - name: Generate provider registry
         run: pnpm --filter @mastra/core generate:providers
 


### PR DESCRIPTION
## Problem

The scheduled **Regenerate Providers & Docs** workflow ([run 27904919757](https://github.com/mastra-ai/mastra/actions/runs/27904919757)) is failing at the **Generate provider registry** step:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../packages/core/node_modules/@internal/core/dist/error/index.js'
  imported from .../packages/core/src/error/index.ts
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @mastra/core@1.45.0 generate:providers: `tsx scripts/generate-providers.ts`
```

## Root cause

`generate:providers` runs `tsx scripts/generate-providers.ts` against `@mastra/core` **source**. That source re-exports `@internal/core/error` (via `packages/core/src/error/index.ts`), and the `./error` export subpath resolves to `@internal/core`'s **dist** output (`dist/error/index.js`).

The workflow only built `@internal/ai-v6` before this step, so `@internal/core` was never built and its `dist/` did not exist — causing `ERR_MODULE_NOT_FOUND`.

## Fix

Add a step to build `@internal/core` (via `turbo`, so any transitive build deps are also covered) before generating the registry.

## Verification

Locally, after building `@internal/core`, `pnpm --filter @mastra/core generate:providers` runs to completion (registered 104 providers / 2045 attachment-capable models). Without the build it reproduces the same `ERR_MODULE_NOT_FOUND`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A CI workflow kept breaking because it tried to use a piece of code that hadn't been compiled yet. The fix is to compile that code first, before trying to use it.

## Summary

This PR fixes a failing CI workflow in the "Regenerate Providers & Docs" scheduled job. The workflow was failing at the "Generate provider registry" step with a module not found error for `@internal/core/dist/error/index.js`.

### Root Cause

The `generate:providers` script imports `@mastra/core` source code, which re-exports functionality from `@internal/core/error`. These exports resolve to the compiled `dist/` output of `@internal/core`. However, the workflow was only building the `@internal/ai-v6` package before running the provider registry generation, leaving `@internal/core` uncompiled. This caused the module resolution to fail.

### Changes

Added a new build step ("Build internal core package") that runs `pnpm turbo build --filter `@internal/core`` before the "Generate provider registry" step. Building through turbo ensures transitive build dependencies are handled correctly.

### Verification

The fix has been verified locally—after building `@internal/core`, running `pnpm --filter `@mastra/core` generate:providers` completes successfully, registering 104 providers and 2,045 attachment-capable models. Without the build step, the same `ERR_MODULE_NOT_FOUND` error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->