### PR TITLE
fix(core): fix CI test failures (tool concurrency, data-part schema, dir-size test)

### DIFF
--- a/.changeset/archil-filesystem-provider.md
+++ b/.changeset/archil-filesystem-provider.md
@@ -1,0 +1,18 @@
+---
+'@mastra/archil': minor
+---
+
+Added `@mastra/archil` — an Archil filesystem provider for Mastra workspaces, backed by Archil's elastic, serverless filesystems for AI agents. Exposes `ArchilFilesystem` and the `archilFilesystemProvider` descriptor for `MastraEditor`, supporting creating disks, reading/writing files, running commands, and searching.
+
+**Usage**
+
+```typescript
+import { archilFilesystemProvider } from '@mastra/archil';
+
+// Register the provider with a MastraEditor, configuring it with either an
+// existing disk or options to create one on init.
+const provider = archilFilesystemProvider;
+
+// { diskId: 'dsk-0123456789abcdef' } or { createDiskOptions: { ... } }
+// apiKey falls back to the ARCHIL_API_KEY env var.
+```

--- a/.changeset/fix-tool-concurrency-inactive-approval.md
+++ b/.changeset/fix-tool-concurrency-inactive-approval.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix tool-call concurrency incorrectly running tools in parallel when a registered approval or suspending tool is active but not called in a given step. The agentic execution loop recomputed concurrency from the tools the model actually called (`calledToolNames`) instead of the step's effective active tool set, so an available-but-uncalled approval/suspending tool no longer forced sequential execution. Concurrency is now recomputed from the step's active tools, preserving sequential execution when approval/suspension may be required while still allowing safe parallel tool calls when the suspending tools are inactive.

--- a/.changeset/fix-tool-concurrency-inactive-approval.md
+++ b/.changeset/fix-tool-concurrency-inactive-approval.md
@@ -2,4 +2,6 @@
 '@mastra/core': patch
 ---
 
-Fix tool-call concurrency incorrectly running tools in parallel when a registered approval or suspending tool is active but not called in a given step. The agentic execution loop recomputed concurrency from the tools the model actually called (`calledToolNames`) instead of the step's effective active tool set, so an available-but-uncalled approval/suspending tool no longer forced sequential execution. Concurrency is now recomputed from the step's active tools, preserving sequential execution when approval/suspension may be required while still allowing safe parallel tool calls when the suspending tools are inactive.
+Fixed tool calls running in parallel even when a tool that requires approval or can suspend was available in a step. This could let tool calls bypass an approval step when the model didn't call the approval tool that turn.
+
+Tool calls now run one at a time whenever an approval or suspending tool is available in a step. Parallel tool calls are still allowed when no such tool is available.

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -110,11 +110,16 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
       async ({ inputData }) => {
         const typedInputData = inputData as LLMIterationData<Tools, OUTPUT>;
         const toolCalls = typedInputData.output.toolCalls || [];
-        const calledToolNames = [...new Set(toolCalls.map(toolCall => toolCall.toolName))];
+        // Recompute concurrency from the step's effective active tool set (set by
+        // llm-execution-step), NOT from the tools the model actually called. A
+        // registered approval/suspending tool that the model did not call this
+        // step must still force sequential execution, so narrowing to called
+        // tool names here would incorrectly allow concurrent execution.
+        const stepActiveTools = _internal?.stepActiveTools as string[] | undefined;
         toolCallForeachOptions.concurrency = resolveToolCallConcurrency({
           requireToolApproval: rest.requireToolApproval,
           tools: ((_internal?.stepTools as Tools | undefined) ?? rest.tools) as Tools | undefined,
-          activeTools: calledToolNames,
+          activeTools: stepActiveTools,
           configuredConcurrency: configuredToolCallConcurrency,
         });
         return toolCalls;

--- a/packages/core/src/processors/step-schema.ts
+++ b/packages/core/src/processors/step-schema.ts
@@ -306,7 +306,10 @@ export const DataPartSchema: z.ZodType<DataPartType> = z
   .object({
     type: z.string().refine(t => t.startsWith('data-'), { message: 'Type must start with "data-"' }),
     id: z.string().optional(),
-    data: z.unknown(),
+    // In Zod v4, a bare z.unknown() field is treated as non-optional, so a
+    // missing `data` key would fail validation. data-* parts may omit data
+    // (see DataPartType where `data` is optional), so mark it optional.
+    data: z.unknown().optional(),
   })
   .passthrough();
 

--- a/packages/core/src/workspace/filesystem/fs-utils.test.ts
+++ b/packages/core/src/workspace/filesystem/fs-utils.test.ts
@@ -330,7 +330,11 @@ describe('fsStat', () => {
     const stat = await fsStat(dir, 'subdir');
 
     expect(stat.type).toBe('directory');
-    expect(stat.size).toBe(0);
+    // Directory size is the filesystem block size, which varies by platform
+    // (e.g. 0 on some filesystems, 64 on macOS, 4096 on Linux), so only assert
+    // it is a non-negative number rather than a specific value.
+    expect(typeof stat.size).toBe('number');
+    expect(stat.size).toBeGreaterThanOrEqual(0);
     expect(stat.mimeType).toBeUndefined();
   });
 


### PR DESCRIPTION
## Problem

CI on the alpha version PR [#18189](https://github.com/mastra-ai/mastra/pull/18189) is red across all three UNIT test shards. That PR only bumps versions/changelogs (zero source changes), so it is **not** the cause — it merely surfaced three failures that were already red on `main`:

| Shard | Failing test | Origin |
|---|---|---|
| 1 | `agent/__tests__/tool-concurrency-active-tools.test.ts` → *does not leak concurrency decisions across concurrent runs* | regression in #18243 |
| 2 | `processors/step-schema.test.ts` (lines 183, 198) | test added in #18264 exposed a latent schema bug |
| 3 | `workspace/filesystem/fs-utils.test.ts` → *returns stat for a directory* | bad assertion added in #17870 |

## Root causes & fixes

### 1. Tool concurrency regression (introduced by #18243)
`#18243` added a concurrency recompute in the `map-tool-calls` step that used `activeTools: calledToolNames` — the tools the model actually *called* this step. That drops registered-but-uncalled approval/suspending tools, so `resolveToolCallConcurrency` only inspected the called (safe) tools and returned 10 (concurrent) when it should return 1 (sequential).

I confirmed this with runtime JSONL instrumentation: for the sequential run, the recompute logged `calledToolNames=['tool-1','tool-2']` and `resolvedConcurrency=10`, even though the registered `approval-tool` should force sequential.

**Fix:** recompute from the step's effective active tool set (`_internal.stepActiveTools`, already set by `llm-execution-step`) instead of `calledToolNames`. This still keeps safe parallel calls concurrent when suspending tools are *inactive* (the scenario #18243 targeted, covered by the unit test in `tool-call-concurrency.test.ts` which uses explicit `activeTools`), while correctly forcing sequential execution when an approval/suspending tool is active but uncalled.

### 2. `DataPartSchema` rejects `data-*` parts without `data` (exposed by #18264)
The schema declared `data: z.unknown()`. In **Zod v4**, a bare `z.unknown()` field is treated as *non-optional*, so `{ type: 'data-stream' }` failed validation — even though the declared `DataPartType` type has `data?: unknown` (optional).

**Fix:** `data: z.unknown().optional()`, aligning the schema with its own type.

### 3. Directory `stat.size` assertion is platform-dependent (added by #17870)
The test asserted a directory's `stat.size === 0`, but directory size is the filesystem block size, which varies by platform (0 on some filesystems, 64 on macOS, 4096/60 on the Linux CI runner).

**Fix:** assert the size is a non-negative number rather than exactly 0.

## Verification

- All three previously-failing test files now pass, plus the broader loop/agentic-execution, tool-concurrency, and tool-approval suites (151 tests) and the schema/fs-utils suites.
- `pnpm --filter ./packages/core check` (tsc) passes with no errors.
- Temporary debug instrumentation was removed; the diff contains only the fixes + a changeset.

Once merged into `main`, the version PR #18189's CI should go green on re-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR fixes three test problems so the same code behaves consistently on every machine. It ensures the agent respects “special” tools that should control execution order, allows an optional `data` field where appropriate, and stops tests from assuming directory sizes are identical across filesystems/OSes.

## Changes

### Tool Concurrency Fix (tool execution ordering)
In the agent workflow’s `map-tool-calls` step, tool-call concurrency is recomputed using the step’s effective active tool set (`_internal.stepActiveTools`) instead of only the tools the model actually called. This prevents approval/suspending tools that are available for the step from being ignored.

### DataPartSchema Validation Fix
`DataPartSchema` now treats the `data` field as optional (`z.unknown().optional()`), matching the `DataPartType` TypeScript definition and avoiding validation failures for parts that omit `data`.

### Directory Size Assertion Fix
The `fsStat` directory stat test no longer requires `stat.size === 0`. It now asserts `stat.size` is a non-negative number to account for platform/filesystem differences.

### Release notes (changesets)
- Added a patch changeset for `@mastra/core` documenting the tool concurrency fix.
- Added a minor changeset for `@mastra/archil` documenting the Archil filesystem provider.

## Testing
Verified passing the affected tests and broader related suites (151 tests total), with TypeScript compilation passing without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->