### PR TITLE
docs(agents): add warning for workflow processors + Observational Memory crash

### DIFF
--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -820,6 +820,24 @@ If a branch uses a mutating strategy like `redact`, map to that branch so its tr
 
 When an agent is registered with Mastra, processor workflows are automatically registered as workflows, allowing you to view and debug them in the [Studio](/docs/studio/overview).
 
+:::caution[Workflow processors are incompatible with Observational Memory]
+
+**Do not combine workflow-based processors with [Observational Memory](/docs/memory/observational-memory).** When Observational Memory is enabled, the agent's message list contains circular references (`ObservationTurn ↔ ObservationStep`) that cannot be serialised. Because workflow processors persist their run state via JSON serialisation, this produces a `Converting circular structure to JSON` error at runtime.
+
+**Workaround:** Use a flat `inputProcessors` / `outputProcessors` array instead of a workflow:
+
+```typescript
+const agent = new Agent({
+  // ✅ flat list — safe with Observational Memory
+  inputProcessors: [new PIIDetector(), new ToxicityFilter()],
+  outputProcessors: [new QualityChecker()],
+  memory: new Memory({ options: { semanticRecall: { enabled: true } } }),
+});
+```
+
+Parallel and conditional logic that you would normally express in a workflow can be reproduced by composing processor classes directly. See [#17933](https://github.com/mastra-ai/mastra/issues/17933) for the underlying issue being tracked.
+:::
+
 ### Retry mechanism
 
 Processors can request that the LLM retry its response with feedback. This is useful for implementing quality checks, output validation, or iterative refinement:


### PR DESCRIPTION
## What does this PR do?

Adds a `:::caution:::` warning to the "Use workflows as processors" section of the agents/processors docs page, documenting a known crash when workflow processors are combined with Observational Memory.

Closes #17945

## Problem

The docs recommend both workflow-based processors and Observational Memory but don't warn that **combining them crashes at runtime**:

```
Converting circular structure to JSON
```

When Observational Memory is enabled, the agent message list contains circular references (`ObservationTurn ↔ ObservationStep`). Workflow processors serialise run state to JSON, which throws on circular references. Users following both recommendations have no guidance on why this crashes or how to fix it.

## Change

Added an `:::caution:::` callout block immediately after the workflow-as-processor section in `docs/src/content/en/docs/agents/processors.mdx` that:

1. **Names the incompatibility** — workflow processors + Observational Memory
2. **Explains the root cause** — circular references in the message list
3. **Shows the workaround** — use a flat `inputProcessors`/`outputProcessors` array instead
4. **Links to the code issue** — #17933 (underlying fix being tracked)

## Type of change

- [ ] Bug fix
- [ ] New feature  
- [ ] Test coverage improvement
- [x] Documentation update

## Notes

No code changes — docs only. No changeset required for documentation PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a warning to the documentation explaining that two features (workflow processors and Observational Memory) that are each recommended separately in the docs can't actually be used together because they conflict and cause the code to crash. It tells users about this problem and suggests a workaround.

## Overview

This is a documentation-only change that adds a caution warning to the "Use workflows as processors" section of the agents/processors documentation page. The warning documents a known incompatibility between workflow-based processors and Observational Memory.

## Problem Addressed

When users follow the documentation's separate recommendations to use:
1. Workflow-based processors (for composing guardrails as nested workflows with parallel execution and conditional branching)
2. Observational Memory (for tracking agent execution)

...the combination causes a runtime crash. Observational Memory creates circular references in the agent's message list (`ObservationTurn` and `ObservationStep` objects reference each other), which cannot be serialized to JSON. Since workflow processors serialize run state during execution, this creates an error: "Converting circular structure to JSON".

## Solution

The added caution callout:
- Names the specific incompatibility (workflow processors + Observational Memory)
- Explains the root cause (circular references in the message list prevent JSON serialization)
- Provides an immediate workaround (use flat `inputProcessors`/`outputProcessors` arrays instead of nested workflows, with equivalent parallel/conditional logic achieved through processor class composition)
- References the underlying code issue `#17933` for tracking the permanent fix

## Changes

- **File**: `docs/src/content/en/docs/agents/processors.mdx`
- **Lines changed**: +18/-0
- **Review effort**: Low

This change closes issue `#17945` and prevents user confusion when combining these two commonly recommended features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->