### PR TITLE
fix(ci): stage generated capability files so Regenerate Providers & Docs can rebase/push

### DIFF
--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -73,11 +73,13 @@ jobs:
         run: |
           pnpm prettier --write packages/core/src/llm/model/provider-registry.json
           pnpm prettier --write packages/core/src/llm/model/provider-types.generated.d.ts
+          pnpm prettier --write packages/core/src/llm/model/capabilities/
           pnpm prettier --write docs/src/content/en/models/**/*.{mdx,ts,js}
       - name: Check for changes
         id: git-check
         run: |
-          git diff --exit-code packages/core/src/llm/model/provider-registry.json packages/core/src/llm/model/provider-types.generated.d.ts docs/src/content/en/models/ || echo "changed=true" >> $GITHUB_OUTPUT
+          git add --intent-to-add packages/core/src/llm/model/capabilities/
+          git diff --exit-code packages/core/src/llm/model/provider-registry.json packages/core/src/llm/model/provider-types.generated.d.ts packages/core/src/llm/model/capabilities/ docs/src/content/en/models/ || echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: Create changeset
         if: steps.git-check.outputs.changed == 'true'
@@ -116,15 +118,18 @@ jobs:
         run: |
           git add packages/core/src/llm/model/provider-registry.json
           git add packages/core/src/llm/model/provider-types.generated.d.ts
+          # The generator rewrites and adds per-provider capability files. These
+          # must be staged too; otherwise they linger as unstaged/untracked
+          # changes that abort the rebase below and never make it onto main.
+          git add packages/core/src/llm/model/capabilities/
           git add docs/src/content/en/models/
           if [ -n "${CHANGESET_FILE}" ]; then
             git add "${CHANGESET_FILE}"
           fi
           git commit -m "chore: regenerate providers and docs [skip ci]"
-          # Use --autostash so any leftover unstaged changes from the generation
-          # and formatting steps (e.g. files touched by Prettier but not staged)
-          # don't abort the rebase with "cannot pull with rebase: You have
-          # unstaged changes." Autostash safely stashes and restores them.
+          # Use --autostash as a safeguard so any unexpected leftover unstaged
+          # changes don't abort the rebase with "cannot pull with rebase: You
+          # have unstaged changes." Autostash safely stashes and restores them.
           git pull --rebase --autostash
           git push
 

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -121,7 +121,11 @@ jobs:
             git add "${CHANGESET_FILE}"
           fi
           git commit -m "chore: regenerate providers and docs [skip ci]"
-          git pull --rebase
+          # Use --autostash so any leftover unstaged changes from the generation
+          # and formatting steps (e.g. files touched by Prettier but not staged)
+          # don't abort the rebase with "cannot pull with rebase: You have
+          # unstaged changes." Autostash safely stashes and restores them.
+          git pull --rebase --autostash
           git push
 
       - name: Log summary


### PR DESCRIPTION
## Problem

The scheduled **Regenerate Providers & Docs** workflow (`regenerate-provider-registry.yml`) fails in the **Commit and push changes** step with exit code 128:

```
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
##[error]Process completed with exit code 128.
```

Failing run: https://github.com/mastra-ai/mastra/actions/runs/27923860053/job/82622401229

## Root cause

`pnpm --filter @mastra/core generate:providers` regenerates an entire directory of per-provider capability files — `packages/core/src/llm/model/capabilities/*.json` — both modifying existing ones and creating new ones.

The commit step only staged `provider-registry.json`, `provider-types.generated.d.ts`, `docs/src/content/en/models/`, and the changeset. The `capabilities/*.json` changes were therefore left **unstaged/untracked** after `git commit`, so the subsequent `git pull --rebase` aborted on a dirty working tree — and even when it would not abort, those regenerated capability files would never land on `main`.

Reproduced locally: a single generation run produced **87 modified** tracked capability files and **16 new untracked** ones (e.g. `groq.json`, `minimax.json`, `vultr.json`, `neon.json`).

## Fix

Do the right thing — actually commit the generated capability files:

1. **Stage the directory** in the commit step: `git add packages/core/src/llm/model/capabilities/`.
2. **Include it in change detection.** The `Check for changes` step uses `git diff`, which ignores untracked files, so a `git add --intent-to-add` is run first so newly-created provider files are detected.
3. **Format it with Prettier** alongside the other generated outputs.
4. Keep `git pull --rebase --autostash` as a safeguard against any unexpected leftover unstaged changes.

## Testing

Locally on an equivalent checkout:
- Ran `generate:providers`; confirmed the capability files were the source of the dirty tree.
- Ran the exact updated `Check for changes` logic → correctly reports `changed=true`, including for brand-new untracked provider files.
- Simulated the updated staging step → all 105 generated files (registry, types, all capability files incl. new ones) staged, leaving the working tree clean before the rebase.

CI-only change; no application code affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A scheduled workflow regenerates provider data and docs, then tries to “rebase and push” those changes. It used to crash because Git saw leftover temporary file changes and refused to rebase. Now it temporarily saves (stashes) those leftovers automatically while rebasing, so the push can succeed.

## Changes

This PR fixes a failing GitHub Actions workflow (`.github/workflows/regenerate-provider-registry.yml`) in the “Commit and push changes” step, which previously errored with: `cannot pull with rebase: You have unstaged changes`.

### What was changed
- Updated the workflow’s rebase command from `git pull --rebase` to `git pull --rebase --autostash`, with comments explaining that `--autostash` prevents rebase aborts by stashing/restoring unexpected leftover unstaged changes.
- Expanded Prettier formatting to also format per-provider capability files under `packages/core/src/llm/model/capabilities/`.
- Hardened change detection and committing so capability-file changes are included:
  - “Check for changes” now includes `packages/core/src/llm/model/capabilities/` (and docs models) in the `git diff --exit-code` check.
  - “Commit and push changes” stages `packages/core/src/llm/model/capabilities/` (and `docs/src/content/en/models/`) before committing/pulling.

## Details

- **File modified:** `.github/workflows/regenerate-provider-registry.yml`
- **Lines changed:** +11/-2
- **Scope:** CI workflow configuration only; no application code affected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->