### PR TITLE
feat(voice-google-gemini-live): add sendContext() for context seeding

### DIFF
--- a/.changeset/itchy-frogs-type.md
+++ b/.changeset/itchy-frogs-type.md
@@ -2,7 +2,7 @@
 '@mastra/voice-google-gemini-live': minor
 ---
 
-Added `sendContext()` method to `GeminiLiveVoice` for seeding conversation history into a live session without triggering a model response. This maps to Gemini Live's `client_content` frame with `turnComplete: false`, letting apps replay prior turns (e.g. from Mastra Memory) on a cold connect so the model has context before the user speaks.
+Added `sendContext()` method to `GeminiLiveVoice` for seeding conversation history into a fresh voice session without triggering a model response. This lets apps replay prior turns from Mastra Memory (or any external store) on a cold connect so the model has full context before the user speaks — enabling seamless handoff between text chat and voice on a shared thread.
 
 **Usage:**
 

--- a/.changeset/itchy-frogs-type.md
+++ b/.changeset/itchy-frogs-type.md
@@ -1,0 +1,19 @@
+---
+'@mastra/voice-google-gemini-live': minor
+---
+
+Added `sendContext()` method to `GeminiLiveVoice` for seeding conversation history into a live session without triggering a model response. This maps to Gemini Live's `client_content` frame with `turnComplete: false`, letting apps replay prior turns (e.g. from Mastra Memory) on a cold connect so the model has context before the user speaks.
+
+**Usage:**
+
+```ts
+await voice.connect();
+
+await voice.sendContext([
+  { role: 'user', content: 'What is the weather?' },
+  { role: 'assistant', content: 'It is 72°F in San Francisco.' },
+]);
+
+// Model stays silent until the user actually speaks
+await voice.send(micStream);
+```

--- a/docs/src/content/en/reference/voice/google-gemini-live.mdx
+++ b/docs/src/content/en/reference/voice/google-gemini-live.mdx
@@ -280,6 +280,53 @@ Converts text to speech and sends it to the model. Can accept either a string or
 
 Returns: `Promise<void>` (responses are emitted via `speaker` and `writing` events)
 
+### `sendContext()`
+
+Sends conversation history into the live session without triggering a model response. Use this to seed prior turns (e.g. from Mastra Memory) on a cold connect so the model has context before the user speaks.
+
+```typescript
+await voice.sendContext([
+  { role: 'user', content: 'What is the weather?' },
+  { role: 'assistant', content: 'It is 72°F in San Francisco.' },
+])
+
+// Model stays silent until the user actually speaks.
+await voice.send(micStream)
+```
+
+<PropertiesTable
+  content={[
+  {
+    name: 'turns',
+    type: 'IncrementalTurn[]',
+    description: 'Prior conversation turns to seed into the session. Each turn has a `role` ("user" or "assistant") and `content` string.',
+    isOptional: false,
+  },
+  {
+    name: 'options',
+    type: 'object',
+    description: 'Optional configuration.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'turnComplete',
+            type: 'boolean',
+            description: 'Whether to mark the turn as complete and trigger a model response.',
+            isOptional: true,
+            defaultValue: 'false',
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+Returns: `Promise<void>`
+
 ### `listen()`
 
 Processes audio input for speech recognition. Takes a readable stream of audio data and returns the transcribed text.

--- a/docs/src/content/en/reference/voice/google-gemini-live.mdx
+++ b/docs/src/content/en/reference/voice/google-gemini-live.mdx
@@ -299,7 +299,8 @@ await voice.send(micStream)
   {
     name: 'turns',
     type: 'IncrementalTurn[]',
-    description: 'Prior conversation turns to seed into the session. Each turn has a `role` ("user" or "assistant") and `content` string. Both roles are supported on newer models (e.g. `gemini-2.5-flash-native-audio-preview-12-2025`). Some older models only accept user-role turns.',
+    description:
+      'Prior conversation turns to seed into the session. Each turn has a `role` ("user" or "assistant") and `content` string. Both roles are supported on newer models (e.g. `gemini-2.5-flash-native-audio-preview-12-2025`). Some older models only accept user-role turns.',
     isOptional: false,
   },
   {

--- a/docs/src/content/en/reference/voice/google-gemini-live.mdx
+++ b/docs/src/content/en/reference/voice/google-gemini-live.mdx
@@ -299,7 +299,7 @@ await voice.send(micStream)
   {
     name: 'turns',
     type: 'IncrementalTurn[]',
-    description: 'Prior conversation turns to seed into the session. Each turn has a `role` ("user" or "assistant") and `content` string.',
+    description: 'Prior conversation turns to seed into the session. Each turn has a `role` ("user" or "assistant") and `content` string. Both roles are supported on newer models (e.g. `gemini-2.5-flash-native-audio-preview-12-2025`). Some older models only accept user-role turns.',
     isOptional: false,
   },
   {

--- a/voice/google-gemini-live-api/src/index.test.ts
+++ b/voice/google-gemini-live-api/src/index.test.ts
@@ -605,6 +605,67 @@ describe('GeminiLiveVoice', () => {
       const info = voice.getSessionInfo();
       expect(info.config?.enableResumption).toBe(true);
     });
+
+    describe('sendContext', () => {
+      beforeEach(() => {
+        (voice as any).state = 'connected';
+        (voice as any).ws = {
+          send: vi.fn(),
+          readyState: 1,
+          close: vi.fn(),
+          once: vi.fn(),
+        };
+        (voice as any).connectionManager.setWebSocket((voice as any).ws);
+        mockWs = (voice as any).ws;
+      });
+
+      it('should send client_content with turnComplete: false by default', async () => {
+        await voice.sendContext([
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: 'Hi there!' },
+        ]);
+
+        expect(mockWs.send).toHaveBeenCalledTimes(1);
+        const sentData = JSON.parse(mockWs.send.mock.calls[0][0]);
+        expect(sentData).toHaveProperty('client_content');
+        expect(sentData.client_content.turnComplete).toBe(false);
+        expect(sentData.client_content.turns).toHaveLength(2);
+        expect(sentData.client_content.turns[0]).toEqual({ role: 'user', parts: [{ text: 'Hello' }] });
+        expect(sentData.client_content.turns[1]).toEqual({ role: 'model', parts: [{ text: 'Hi there!' }] });
+      });
+
+      it('should allow turnComplete: true override', async () => {
+        await voice.sendContext([{ role: 'user', content: 'Final message' }], { turnComplete: true });
+
+        const sentData = JSON.parse(mockWs.send.mock.calls[0][0]);
+        expect(sentData.client_content.turnComplete).toBe(true);
+      });
+
+      it('should update local context history', async () => {
+        voice.clearContext();
+        await voice.sendContext([
+          { role: 'user', content: 'Question' },
+          { role: 'assistant', content: 'Answer' },
+        ]);
+
+        const history = voice.getContextHistory();
+        expect(history).toHaveLength(2);
+        expect(history[0].role).toBe('user');
+        expect(history[0].content).toBe('Question');
+        expect(history[1].role).toBe('assistant');
+        expect(history[1].content).toBe('Answer');
+      });
+
+      it('should skip sending when turns array is empty', async () => {
+        await voice.sendContext([]);
+        expect(mockWs.send).not.toHaveBeenCalled();
+      });
+
+      it('should throw when not connected', async () => {
+        (voice as any).state = 'disconnected';
+        await expect(voice.sendContext([{ role: 'user', content: 'Hello' }])).rejects.toThrow('Not connected');
+      });
+    });
   });
 
   describe('Event System', () => {

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -16,6 +16,7 @@ import type {
   AudioConfig,
   GeminiLiveServerMessage,
   GeminiSessionConfig,
+  IncrementalTurn,
   UpdateMessage,
 } from './types';
 import { GeminiLiveError } from './utils/errors';
@@ -651,6 +652,61 @@ export class GeminiLiveVoice extends MastraVoice<
     } catch (error) {
       this.log('Failed to send text message', error);
       throw this.createAndEmitError(GeminiLiveErrorCode.AUDIO_PROCESSING_ERROR, 'Failed to send text message', error);
+    }
+  }
+
+  /**
+   * Send conversation history into the live session without triggering a model response.
+   *
+   * Maps to a single Gemini Live `client_content` frame with `turnComplete` defaulting
+   * to `false`, which loads the turns into context silently. The model only responds
+   * once a subsequent turn completes (e.g. via {@link speak} or user audio).
+   *
+   * @param turns Prior conversation turns to seed into the session.
+   * @param options.turnComplete Whether to mark the turn as complete (default `false`).
+   *
+   * @example
+   * ```typescript
+   * await voice.connect();
+   *
+   * // Replay prior conversation without triggering a reply.
+   * await voice.sendContext([
+   *   { role: 'user', content: 'What is the weather?' },
+   *   { role: 'assistant', content: 'It is 72°F in San Francisco.' },
+   * ]);
+   *
+   * // Agent stays silent until the user actually speaks.
+   * await voice.send(micStream);
+   * ```
+   */
+  async sendContext(turns: IncrementalTurn[], options?: { turnComplete?: boolean }): Promise<void> {
+    this.validateConnectionState();
+
+    if (!turns || turns.length === 0) {
+      this.log('sendContext called with empty turns, skipping');
+      return;
+    }
+
+    const message = {
+      client_content: {
+        turns: turns.map(t => ({
+          role: t.role === 'assistant' ? 'model' : 'user',
+          parts: [{ text: t.content }],
+        })),
+        turnComplete: options?.turnComplete ?? false,
+      },
+    };
+
+    try {
+      this.sendEvent('client_content', message);
+      this.log('Context seeded', { turnCount: turns.length, turnComplete: options?.turnComplete ?? false });
+
+      for (const turn of turns) {
+        this.addToContext(turn.role, turn.content);
+      }
+    } catch (error) {
+      this.log('Failed to send context', error);
+      throw this.createAndEmitError(GeminiLiveErrorCode.AUDIO_PROCESSING_ERROR, 'Failed to send context', error);
     }
   }
 
@@ -2203,3 +2259,5 @@ export class GeminiLiveVoice extends MastraVoice<
     }
   }
 }
+
+export type { IncrementalTurn } from './types';

--- a/voice/google-gemini-live-api/src/types.ts
+++ b/voice/google-gemini-live-api/src/types.ts
@@ -107,6 +107,14 @@ export interface GeminiLiveVoiceConfig {
 }
 
 /**
+ * A single conversation turn for context seeding via {@link GeminiLiveVoice.sendContext}.
+ */
+export interface IncrementalTurn {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/**
  * Runtime options that can be passed to methods
  */
 export interface GeminiLiveVoiceOptions {


### PR DESCRIPTION
## Description

Adds a public `sendContext()` method to `GeminiLiveVoice` that sends conversation history into a Gemini Live session without triggering a model response. This replaces the need to reach into the private `sendEvent` method, which broke on every minor version bump.

- Maps turns to a single `client_content` frame with `turnComplete` defaulting to `false`
- Converts `assistant` role to `model` for Gemini's wire format
- Syncs seeded turns to the provider's internal context history via `addToContext()`
- Exports `IncrementalTurn` type for consumers
- Verified against real Gemini Live API with `gemini-2.5-flash-native-audio-preview-12-2025` (full user+assistant history) and `gemini-3.1-flash-live-preview` (user-only history)

## Related Issue(s)

Fixes #18285

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets your Gemini voice session start with “already-discussed chat history,” without making Gemini talk immediately. It’s like preloading the AI’s memory card so it stays quiet until the user speaks.

## Overview

Adds a public `sendContext()` method to `GeminiLiveVoice` so developers can seed previous conversation turns on a cold Gemini Live connect, replacing a previous workaround that relied on the private `sendEvent()` API.

## Key Changes

**New Public Method: `sendContext()`**
- Signature: `sendContext(turns: IncrementalTurn[], options?: { turnComplete?: boolean }): Promise<void>`
- Input: an array of `{ role: 'user' | 'assistant'; content: string }` (via the new `IncrementalTurn` type)
- Sends **one** Gemini `client_content` frame containing all provided turns
- Defaults `turnComplete` to `false`, so seeding does **not** trigger an immediate model response
- Applies Gemini wire-format requirements by mapping `assistant` → `model` within `client_content.turns`
- Keeps provider state consistent by also appending the seeded turns into internal context via `addToContext()` (so `getContextHistory()` reflects what was sent)
- Connection/edge-case behavior:
  - Rejects with `Not connected` when not connected
  - No-ops when `turns` is empty (no WebSocket `send`)
  - Throws a standardized `GeminiLiveError` using `AUDIO_PROCESSING_ERROR` if sending or context update fails

**New Public Type Export**
- Exports `IncrementalTurn` for consumers.

**Documentation & Release Notes**
- Adds reference docs for `sendContext()` (including a `connect() → sendContext([...]) → send(micStream)` style example)
- Adds a changeset entry documenting the new capability.

## Testing

Added tests covering:
- Default behavior sends `turnComplete: false`
- Correct formatting of the outgoing `client_content.turns` (including assistant→model normalization)
- `turnComplete: true` override behavior
- Internal context history updates after seeding
- `sendContext([])` causes no WebSocket send
- Rejection when the voice session is disconnected

## Model Notes (Role Support Variations)

Gemini Live models vary in what they accept for seeded `client_content`: some support both user and assistant roles, while others only accept user-role turns. `sendContext()` follows Gemini’s required wire format, so behavior can differ based on the selected Gemini Live endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->