### PR TITLE
fix(playground): move mobile search to header

### DIFF
--- a/.changeset/mobile-search-header.md
+++ b/.changeset/mobile-search-header.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Improved Studio mobile navigation by moving search from the drawer to the top bar.

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   ErrorBoundary,
   LogoWithoutText,
   MainSidebar,
@@ -7,7 +8,9 @@ import {
   ThemeProvider,
   Toaster,
   TooltipProvider,
+  useMainSidebar,
 } from '@mastra/playground-ui';
+import { Search } from 'lucide-react';
 import { useLocation } from 'react-router';
 import { AppSidebar } from './ui/app-sidebar';
 import { AuthRequired } from '@/domains/auth/components/auth-required';
@@ -16,7 +19,7 @@ import { isAuthenticated } from '@/domains/auth/types';
 import { ExperimentalUIProvider } from '@/domains/experimental-ui/experimental-ui-context';
 import { UI_EXPERIMENTS } from '@/domains/experimental-ui/experiments';
 import { useExperimentalUIEnabled } from '@/domains/experimental-ui/use-experimental-ui-enabled';
-import { NavigationCommand } from '@/lib/command';
+import { NavigationCommand, useNavigationCommand } from '@/lib/command';
 import {
   RouteHeader,
   RouteHeaderActionsProvider,
@@ -28,13 +31,34 @@ import {
 import { cn } from '@/lib/utils';
 
 function MobileNavbar() {
+  const { setOpenMobile } = useMainSidebar();
+  const { setOpen: setNavigationCommandOpen } = useNavigationCommand({ enableShortcut: false });
+
+  const openNavigationCommand = () => {
+    setOpenMobile(false);
+    setNavigationCommandOpen(true);
+  };
+
   return (
-    <header className="lg:hidden sticky top-0 z-20 flex h-12 shrink-0 items-center gap-3 border-b border-border1 bg-surface1 px-3">
-      <MainSidebar.MobileTrigger />
-      <span className="flex items-center gap-2">
-        <LogoWithoutText className="size-[1.5rem] shrink-0" />
-        <span className="font-display text-sm whitespace-nowrap">Mastra Studio</span>
-      </span>
+    <header className="lg:hidden sticky top-0 z-20 flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border1 bg-surface1 px-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <MainSidebar.MobileTrigger />
+        <span className="flex min-w-0 items-center gap-2">
+          <LogoWithoutText className="size-[1.5rem] shrink-0" />
+          <span className="font-display text-sm whitespace-nowrap">Mastra Studio</span>
+        </span>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-md"
+        tooltip="Search"
+        aria-label="Search and navigate"
+        onClick={openNavigationCommand}
+        className="shrink-0"
+      >
+        <Search />
+      </Button>
     </header>
   );
 }

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -126,37 +126,39 @@ export function AppSidebar() {
         )}
       </div>
 
-      <div className="mb-2">
-        <MainSidebar.NavList>
-          <MainSidebar.NavLink
-            asChild
-            state={state}
-            link={{
-              name: 'Search',
-              url: '#',
-              icon: <Search />,
-            }}
-          >
-            <button
-              type="button"
-              onClick={openNavigationCommand}
-              aria-label="Search and navigate"
-              className="border border-border1 bg-surface3 text-neutral5 hover:bg-surface4 hover:text-neutral6 active:bg-surface5 [&_svg]:text-neutral4 [&:hover_svg]:text-neutral5"
+      {!isMobile && (
+        <div className="mb-2">
+          <MainSidebar.NavList>
+            <MainSidebar.NavLink
+              asChild
+              state={state}
+              link={{
+                name: 'Search',
+                url: '#',
+                icon: <Search />,
+              }}
             >
-              <Search />
-              <MainSidebar.NavLabel state={state}>Search</MainSidebar.NavLabel>
-              {state !== 'collapsed' && (
-                <kbd
-                  aria-hidden="true"
-                  className="ml-auto rounded border border-border1 bg-surface4 px-1.5 py-0.5 font-mono text-[10px] leading-none text-neutral3"
-                >
-                  {commandShortcutLabel}
-                </kbd>
-              )}
-            </button>
-          </MainSidebar.NavLink>
-        </MainSidebar.NavList>
-      </div>
+              <button
+                type="button"
+                onClick={openNavigationCommand}
+                aria-label="Search and navigate"
+                className="border border-border1 bg-surface3 text-neutral5 hover:bg-surface4 hover:text-neutral6 active:bg-surface5 [&_svg]:text-neutral4 [&:hover_svg]:text-neutral5"
+              >
+                <Search />
+                <MainSidebar.NavLabel state={state}>Search</MainSidebar.NavLabel>
+                {state !== 'collapsed' && (
+                  <kbd
+                    aria-hidden="true"
+                    className="ml-auto rounded border border-border1 bg-surface4 px-1.5 py-0.5 font-mono text-[10px] leading-none text-neutral3"
+                  >
+                    {commandShortcutLabel}
+                  </kbd>
+                )}
+              </button>
+            </MainSidebar.NavLink>
+          </MainSidebar.NavList>
+        </div>
+      )}
 
       {isAgentBuilderVisible && (
         <div className="mb-1">


### PR DESCRIPTION
Moves the Studio search action out of the mobile sidebar drawer and into the mobile top bar, aligned to the far right next to Mastra Studio. Desktop keeps the existing sidebar search row.

<img width="744" height="1352" alt="CleanShot 2026-06-22 at 09 07 25" src="https://github.com/user-attachments/assets/fc163aca-15f9-4acb-b2ea-0d1ad2a32e2f" />

This fixes the mobile menu crowding and makes global Studio search available from the header.

Validated with `git diff --check`, touched-file ESLint, `pnpm --filter ./packages/playground typecheck`, `pnpm --filter ./packages/playground test:run`, `pnpm --filter ./packages/playground build`, and a mobile Playwright smoke check. Full package lint is currently blocked by an unrelated existing `import/order` error in `src/domains/workflows/workflow/use-workflow-graph-runtime.tsx`.

CodeRabbit CLI is installed but not signed in locally, so I could not run the local CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

On mobile phones, the search button was cluttering the sidebar menu. This PR moves it to the top navigation bar instead, so it's easier to find without crowding the menu. The desktop version stays the same.

## Overview

This PR relocates the Studio search functionality on mobile devices from the sidebar drawer to the mobile top header, positioned on the far right next to "Mastra Studio". The desktop interface remains unchanged, with search continuing to appear in the sidebar for desktop users.

## Changes

**New Changeset**
- Added `.changeset/mobile-search-header.md` documenting the patch bump for `@internal/playground`

**Mobile Header Updates** (`packages/playground/src/components/layout.tsx`)
- Added `Button` and `useMainSidebar` imports
- Added `NavigationCommand` import and hook for triggering the search/navigation UI
- Implemented `openNavigationCommand` handler that closes the mobile sidebar and opens the navigation command interface with shortcuts disabled
- Added a ghost icon button with the `Search` icon to the mobile header, wired to the `openNavigationCommand` handler

**Sidebar Conditional Rendering** (`packages/playground/src/components/ui/app-sidebar.tsx`)
- Wrapped the "Search" navigation item in `AppSidebar` with a `!isMobile` guard, ensuring it only displays on non-mobile layouts
- This prevents the search option from appearing in the sidebar on mobile devices

## Validation Completed

- Whitespace and formatting validation using `git diff --check`
- ESLint checks on modified files
- TypeScript type checking
- Test execution
- Production build verification
- Mobile smoke testing using Playwright

<!-- end of auto-generated comment: release notes by coderabbit.ai -->