### PR TITLE
fix: sanitize numeric SSE content from Cloudflare Workers AI

### DIFF
--- a/.changeset/fix-cf-sse-content-numbers.md
+++ b/.changeset/fix-cf-sse-content-numbers.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': patch
+---
+
+Fix Cloudflare Workers AI streaming dropping numeric content tokens
+
+When using Cloudflare Workers AI with streaming, citation markers like `[^1]`
+rendered as `[^]` because single-digit content tokens were sent as numbers
+instead of strings. Numeric tokens are now properly preserved so citations and
+other digit-based content render correctly.

--- a/packages/core/src/llm/model/cloudflare-workers-ai-sse.test.ts
+++ b/packages/core/src/llm/model/cloudflare-workers-ai-sse.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { fixSseContent, sanitizingFetch } from './gateways/models-dev';
+
+describe('fixSseContent', () => {
+  it('replaces boolean content with empty string', () => {
+    expect(fixSseContent('"content":true')).toBe('"content":""');
+    expect(fixSseContent('"content":false')).toBe('"content":""');
+  });
+
+  it('replaces null content with empty string', () => {
+    expect(fixSseContent('"content":null')).toBe('"content":""');
+  });
+
+  it('wraps numeric content in quotes to preserve the digit', () => {
+    expect(fixSseContent('"content":1')).toBe('"content":"1"');
+    expect(fixSseContent('"content":2')).toBe('"content":"2"');
+    expect(fixSseContent('"content":-1')).toBe('"content":"-1"');
+    expect(fixSseContent('"content":3.14')).toBe('"content":"3.14"');
+  });
+
+  it('leaves string content unchanged', () => {
+    expect(fixSseContent('"content":"normal string"')).toBe('"content":"normal string"');
+    expect(fixSseContent('"content":" [^1]"')).toBe('"content":" [^1]"');
+    expect(fixSseContent('"content":"^"')).toBe('"content":"^"');
+  });
+
+  it('fixes numeric content in a full SSE line', () => {
+    const input = 'data: {"id":"x","choices":[{"index":0,"delta":{"content":1}}]}';
+    const expected = 'data: {"id":"x","choices":[{"index":0,"delta":{"content":"1"}}]}';
+    expect(fixSseContent(input)).toBe(expected);
+  });
+});
+
+describe('sanitizingFetch', () => {
+  it('sanitizes numeric content in SSE response bodies preserving citation digits', async () => {
+    const chunks = [
+      'data: {"choices":[{"index":0,"delta":{"content":" ["}}]}\n\n',
+      'data: {"choices":[{"index":0,"delta":{"content":"^"}}]}\n\n',
+      'data: {"choices":[{"index":0,"delta":{"content":1}}]}\n\n',
+      'data: {"choices":[{"index":0,"delta":{"content":"]."}}]}\n\n',
+    ];
+    const innerFetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(ctrl) {
+            for (const c of chunks) ctrl.enqueue(new TextEncoder().encode(c));
+            ctrl.close();
+          },
+        }),
+        { headers: { 'content-type': 'text/event-stream' } },
+      );
+
+    const sanitized = await sanitizingFetch(innerFetch)('https://example.com');
+    const text = await sanitized.text();
+
+    expect(text).toContain('"content":"1"');
+    expect(text).toContain('"content":" ["');
+    expect(text).toContain('"content":"^"');
+    expect(text).toContain('"content":"]."');
+    expect(text).not.toContain('"content":1,');
+    expect(text).not.toContain('"content":1\n');
+  });
+
+  it('handles numeric content split across stream chunk boundaries', async () => {
+    const chunks = [
+      'data: {"choices":[{"index":0,"delta":{"content":',
+      '1}}]}\n\ndata: {"choices":[{"index":0,"delta":{"content":"ok"}}]}\n\n',
+    ];
+    const innerFetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(ctrl) {
+            for (const c of chunks) ctrl.enqueue(new TextEncoder().encode(c));
+            ctrl.close();
+          },
+        }),
+        { headers: { 'content-type': 'text/event-stream' } },
+      );
+
+    const sanitized = await sanitizingFetch(innerFetch)('https://example.com');
+    const text = await sanitized.text();
+
+    expect(text).toContain('"content":"1"');
+    expect(text).toContain('"content":"ok"');
+  });
+});

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -104,6 +104,42 @@ const PROVIDER_OVERRIDES: Record<string, Partial<ProviderConfig>> = {
   },
 };
 
+export function fixSseContent(text: string): string {
+  return text
+    .replace(/"content"\s*:\s*(true|false|null)/g, '"content":""')
+    .replace(/"content"\s*:\s*(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g, '"content":"$1"');
+}
+
+export function sanitizingFetch(inner: typeof fetch): typeof fetch {
+  return async (input, init) => {
+    const r = await inner(input, init);
+    if (!r.body) return r;
+    const ct = r.headers.get('content-type') ?? '';
+    if (!ct.includes('event-stream')) return r;
+    const dec = new TextDecoder();
+    const enc = new TextEncoder();
+    let remainder = '';
+    const fixed = r.body.pipeThrough(
+      new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, ctrl) {
+          const text = remainder + dec.decode(chunk, { stream: true });
+          const lastNewline = text.lastIndexOf('\n');
+          if (lastNewline === -1) {
+            remainder = text;
+            return;
+          }
+          remainder = text.slice(lastNewline + 1);
+          ctrl.enqueue(enc.encode(fixSseContent(text.slice(0, lastNewline + 1))));
+        },
+        flush(ctrl) {
+          if (remainder) ctrl.enqueue(enc.encode(fixSseContent(remainder)));
+        },
+      }),
+    );
+    return new Response(fixed, r);
+  };
+}
+
 export class ModelsDevGateway extends MastraModelGateway {
   readonly id = 'models.dev';
   readonly name = 'models.dev';
@@ -346,6 +382,8 @@ export class ModelsDevGateway extends MastraModelGateway {
           baseURL,
           headers: mastraHeaders,
           supportsStructuredOutputs: true,
+          fetch:
+            providerId === 'cloudflare-workers-ai' ? sanitizingFetch(globalThis.fetch.bind(globalThis)) : undefined,
         }).chatModel(modelId);
       }
     }


### PR DESCRIPTION
Fixes #18289

Cloudflare Workers AI streams single-digit content tokens as JSON
numbers (`"content":1`) instead of strings (`"content":"1"`).
The `@ai-sdk/openai-compatible` Zod schema expects `content` to be
a string, so numeric values are silently rejected. This causes
citation markers like `[^1]` to render as `[^]` (empty brackets).

### Changes

- **models-dev.ts**: Added `fixSseContent()` — converts non-string
  SSE content values in the cloudflare-workers-ai provider before
  Zod parsing. Numbers are wrapped in quotes to preserve the digit,
  booleans/null are replaced with empty string.
- **models-dev.ts**: Added `sanitizingFetch()` — a fetch wrapper
  that pipes SSE response bodies through `fixSseContent` via
  `TransformStream`.
- **models-dev.ts**: Applied the sanitizing fetch only for the
  `cloudflare-workers-ai` provider in `resolveLanguageModel()`.
- **cloudflare-workers-ai-url.test.ts**: Added 5 unit tests for
  `fixSseContent` covering booleans, null, numbers (preserved as
  strings), string passthrough, and full SSE line sanitization.

### Why not fix in @ai-sdk/openai-compatible?

The Zod schema for `content` is internal to `@ai-sdk/openai-compatible`
and it offers no hook to inject preprocessors/transforms. The fetch
wrapper is the only pre-parse interception point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Cloudflare Workers AI streaming sometimes sends tiny pieces of text like `1` as a JSON number instead of text. This makes the parser drop those digits, so citations like `[^1]` turn into `[^]`. This PR intercepts the streaming response and converts numeric content back into string text before parsing.

## Overview

Fixes streaming from the `cloudflare-workers-ai` provider where SSE deltas contain `"content": 1` (number) instead of `"content":"1"` (string). The OpenAI-compatible Zod schema used during parsing expects `content` to be a string, so numeric tokens were being rejected and citation digits disappeared (e.g., `[^1]` → `[^]`).

## Changes

### Core implementation (`packages/core/src/llm/model/gateways/models-dev.ts`)
- **`fixSseContent(text: string): string`**  
  Sanitizes SSE payload text by:
  - Replacing `"content": true|false|null` with `"content":""`
  - Converting numeric `"content": <number>` values (supports negatives/decimals/exponents) into `"content":"<number>"`
  - Leaving existing string `"content":"..."` untouched
- **`sanitizingFetch(inner: typeof fetch): typeof fetch`**  
  Wraps `fetch` for **`content-type` containing `event-stream`** and runs SSE body chunks through a `TransformStream`:
  - Buffers any partial line across chunks
  - Applies `fixSseContent` to complete lines before emitting
  - Sanitizes the remainder on stream flush
- **Integration**  
  In `ModelsDevGateway.resolveLanguageModel()`, the wrapper is applied **only** when `providerId === 'cloudflare-workers-ai'` (passed as the `fetch` option to the OpenAI-compatible client); other providers use the default behavior.

### Tests (`packages/core/src/llm/model/cloudflare-workers-ai-sse.test.ts`)
Added unit tests covering:
- `fixSseContent`:
  - boolean → empty string
  - `null` → empty string
  - numbers (integers, negatives, decimals) → quoted strings
  - string passthrough (including citation-like text)
  - a full SSE line where numeric `content` is corrected
- `sanitizingFetch`:
  - numeric content sanitization across SSE payload boundaries
  - numeric `content` split across stream chunk boundaries

### Release notes (`.changeset/fix-cf-sse-content-numbers.md`)
- Patch release for `@mastra/core` describing the fix for dropping numeric streamed content tokens (and thus digit citations).

## Design notes

Upstream remediation in `@ai-sdk/openai-compatible` wasn’t considered feasible because the internal Zod schema for `content` provides no hook for preprocessing/transforms. This PR uses the earliest available interception point: sanitizing the SSE text before the OpenAI-compatible parser runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->