### PR TITLE
fix(voice-google-gemini-live): replace deprecated media_chunks with audio

### DIFF
--- a/.changeset/tangy-beans-rule.md
+++ b/.changeset/tangy-beans-rule.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-google-gemini-live': patch
+---
+
+Fixed realtime audio streaming — the package was sending the deprecated `realtime_input.media_chunks` wire shape, which caused Google's Gemini Live v1alpha endpoint to immediately close the WebSocket (code 1007). Audio frames now use the current `realtime_input.audio` shape. Additionally, the WebSocket close handler now includes the close `code` and `reason` in the `session` event so consumers can see protocol-level errors through the public API.

--- a/.changeset/tangy-beans-rule.md
+++ b/.changeset/tangy-beans-rule.md
@@ -2,4 +2,6 @@
 '@mastra/voice-google-gemini-live': patch
 ---
 
-Fixed realtime audio streaming — the package was sending the deprecated `realtime_input.media_chunks` wire shape, which caused Google's Gemini Live v1alpha endpoint to immediately close the WebSocket (code 1007). Audio frames now use the current `realtime_input.audio` shape. Additionally, the WebSocket close handler now includes the close `code` and `reason` in the `session` event so consumers can see protocol-level errors through the public API.
+Fixed realtime audio streaming being immediately rejected by the Gemini Live API. Audio frames now use the current API format, replacing a deprecated payload shape that caused the connection to close on the first frame.
+
+The `session` event for disconnections now includes `code` and `reason` fields, so consumers can see why the server closed the connection.

--- a/voice/google-gemini-live-api/architecture-llm.md
+++ b/voice/google-gemini-live-api/architecture-llm.md
@@ -478,7 +478,7 @@ OAuth tokens cached for 50 minutes to avoid expensive requests.
 ```json
 {
   "realtime_input": {
-    "media_chunks": [{ "mime_type": "audio/pcm", "data": "base64..." }]
+    "audio": { "mime_type": "audio/pcm", "data": "base64..." }
   }
 }
 ```

--- a/voice/google-gemini-live-api/src/index.test.ts
+++ b/voice/google-gemini-live-api/src/index.test.ts
@@ -253,6 +253,7 @@ describe('GeminiLiveVoice', () => {
       const sentData = JSON.parse(mockWs.send.mock.calls[0][0]);
       expect(sentData).toHaveProperty('realtime_input');
       expect(sentData.realtime_input).toHaveProperty('audio');
+      expect(sentData.realtime_input).not.toHaveProperty('media_chunks');
     });
 
     it('should handle audio stream', async () => {

--- a/voice/google-gemini-live-api/src/index.test.ts
+++ b/voice/google-gemini-live-api/src/index.test.ts
@@ -252,7 +252,7 @@ describe('GeminiLiveVoice', () => {
       expect(mockWs.send).toHaveBeenCalled();
       const sentData = JSON.parse(mockWs.send.mock.calls[0][0]);
       expect(sentData).toHaveProperty('realtime_input');
-      expect(sentData.realtime_input).toHaveProperty('media_chunks');
+      expect(sentData.realtime_input).toHaveProperty('audio');
     });
 
     it('should handle audio stream', async () => {

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -1265,7 +1265,7 @@ export class GeminiLiveVoice extends MastraVoice<
     this.ws.on('close', (code: number, reason: Buffer) => {
       this.log('WebSocket connection closed', { code, reason: reason.toString() });
       this.state = 'disconnected';
-      this.emit('session', { state: 'disconnected' });
+      this.emit('session', { state: 'disconnected', code, reason: reason.toString() });
     });
 
     this.ws.on('error', (error: Error) => {

--- a/voice/google-gemini-live-api/src/managers/AudioStreamManager.ts
+++ b/voice/google-gemini-live-api/src/managers/AudioStreamManager.ts
@@ -377,12 +377,10 @@ export class AudioStreamManager {
       // For real-time streaming
       return {
         realtime_input: {
-          media_chunks: [
-            {
-              mime_type: 'audio/pcm',
-              data: audioData,
-            },
-          ],
+          audio: {
+            mime_type: 'audio/pcm',
+            data: audioData,
+          },
         },
       };
     }

--- a/voice/google-gemini-live-api/src/types.ts
+++ b/voice/google-gemini-live-api/src/types.ts
@@ -157,7 +157,9 @@ export interface GeminiLiveEventMap {
   /** Session state changes */
   session: {
     state: 'connecting' | 'connected' | 'disconnected' | 'disconnecting' | 'error' | 'updated';
-    config?: Record<string, unknown>; // Configuration data when state is 'updated' or 'connected'
+    config?: Record<string, unknown>;
+    code?: number;
+    reason?: string;
   };
   /** Tool calls from the model */
   toolCall: { name: string; args: Record<string, any>; id: string };


### PR DESCRIPTION
## Description

Fixes realtime audio streaming — the package was sending the deprecated `realtime_input.media_chunks` wire shape, which caused Google's Gemini Live v1alpha endpoint to immediately close the WebSocket with code 1007 on the first audio frame. Audio frames now use the current `realtime_input.audio` shape per the official API spec.

- Replaced `media_chunks` array with singular `audio` object in `AudioStreamManager.createAudioMessage()` for the `realtime` message type
- Added `code` and `reason` fields to the `session` disconnected event so consumers can see server-side close reasons through the public API
- Extended `GeminiLiveEventMap.session` type with optional `code?: number` and `reason?: string` fields
- Updated existing unit test assertion from `media_chunks` to `audio`
- Updated `architecture-llm.md` wire format example to match the new shape

## Related Issue(s)

Fixes #18287

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes a bug where the library sent audio in the “wrong” format, so Google’s realtime service immediately shut the WebSocket connection. It updates the audio message format to what Gemini Live expects, and also exposes the disconnect close code and reason so failures are easier to understand.

## Overview

Fixed a critical compatibility issue in `@mastra/voice-google-gemini-live` where realtime audio streaming failed because the package used an outdated `realtime_input.media_chunks` wire format. Gemini Live v1alpha would close the WebSocket immediately on the first audio frame with status code `1007`.

## Changes

**Core Fix — Audio Message Format**
- Updated `AudioStreamManager.createAudioMessage()` for realtime message types to send a singular `audio` object instead of a `media_chunks` array:
  - From: `realtime_input.media_chunks: [{ mime_type, data }]`
  - To: `realtime_input.audio: { mime_type, data }`
- Left the `input`/conversation branch behavior unchanged.

**WebSocket Close Handling Enhancement**
- Enhanced the WebSocket `close` handler to emit a `session` disconnected event that includes close `code` and `reason` in addition to `state: 'disconnected'`.
- This lets API consumers see why the server closed the connection.

**Type Updates**
- Extended `GeminiLiveEventMap.session` to support optional:
  - `code?: number`
  - `reason?: string`

**Tests and Documentation**
- Updated the `Audio Streaming` unit test to assert the new `audio` shape (and that `media_chunks` is not present).
- Updated `architecture-llm.md` to reflect the new realtime audio payload example.

## Impact

- **Bug Fix**: Restores realtime audio streaming compatibility with Gemini Live.
- **Backward Compatible**: No breaking changes intended; the fix updates the realtime audio payload shape and associated diagnostics.
- **Improved Diagnostics**: Consumers can now access server-side close details via the public `session` disconnected event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->