### PR TITLE
docs(guides): add a guide for paying x402 (HTTP 402) APIs from an agent

### DIFF
--- a/docs/src/content/en/guides/guide/pay-x402-apis.mdx
+++ b/docs/src/content/en/guides/guide/pay-x402-apis.mdx
@@ -1,0 +1,120 @@
+---
+title: "Guide: Building an agent that can pay for APIs (x402)"
+description: "A step-by-step guide to giving a Mastra agent a budget-bound wallet so it can pay for x402 (HTTP 402) APIs autonomously."
+---
+
+import Steps from "@site/src/components/Steps";
+import StepItem from "@site/src/components/StepItem";
+
+# Building an agent that can pay for APIs (x402)
+
+Some APIs and resources are paywalled with [x402](https://x402.org) — the "HTTP 402 Payment Required"
+standard that lets a server quote a price and a client pay it inline, no account or API key needed.
+To let a Mastra agent pay for those resources autonomously, you give it a wallet — bounded by a spend
+policy it cannot exceed.
+
+This guide uses [PipRail](https://piprail.com), a self-custodial x402 SDK, through its MCP server
+(`@piprail/mcp`). It runs as a separate process, so its dependencies never enter your project's tree,
+and payments settle straight from your own wallet — no facilitator, no fee, verified against your own
+RPC. The agent gets PipRail's payment tools, capped by limits you set.
+
+## Prerequisites
+
+- Node.js `v22.13.0` or later installed
+- An API key from a supported [Model Provider](/models)
+- An existing Mastra project (Follow the [installation guide](/guides/getting-started/quickstart) to set up a new project)
+- A wallet key with a small balance to pay from (or omit it to run read-only: discover, quote and plan still work)
+
+## Giving an agent a payment wallet
+
+<Steps>
+  <StepItem title="Install dependencies">
+    Install the Mastra MCP client. The PipRail server itself is run on demand via `npx`, so there is
+    nothing else to add to your dependencies.
+
+    ```bash npm2yarn
+    npm install @mastra/mcp
+    ```
+  </StepItem>
+
+  <StepItem title="Configure the MCP client">
+    Create `src/mastra/mcp.ts` and point an `MCPClient` at the PipRail server. The `env` block sets the
+    chain and the spend policy the agent cannot exceed:
+
+    ```ts title="src/mastra/mcp.ts"
+    import { MCPClient } from '@mastra/mcp'
+
+    export const piprailMcp = new MCPClient({
+      id: 'piprail',
+      servers: {
+        piprail: {
+          command: 'npx',
+          args: ['-y', '@piprail/mcp'],
+          env: {
+            PIPRAIL_PRIVATE_KEY: process.env.PIPRAIL_PRIVATE_KEY ?? '', // omit for read-only
+            PIPRAIL_CHAIN: 'base',
+            PIPRAIL_MAX_AMOUNT: '0.10', // max per payment (token units)
+            PIPRAIL_MAX_TOTAL: '5.00', // lifetime budget per token
+            PIPRAIL_TOKENS: 'USDC',
+          },
+        },
+      },
+    })
+    ```
+  </StepItem>
+
+  <StepItem title="Define the agent">
+    Create `src/mastra/agents/payment-agent.ts` and hand the agent the PipRail tools. Mastra namespaces
+    MCP tools by the server key, so they surface as `piprail_piprail_*` — the agent reads exact names
+    from its tool schema, so the instructions describe each tool by role rather than hard-coding names:
+
+    ```ts title="src/mastra/agents/payment-agent.ts"
+    import { Agent } from '@mastra/core/agent'
+    import { piprailMcp } from '../mcp'
+
+    export const paymentAgent = new Agent({
+      id: 'payment-agent',
+      name: 'Payment Agent',
+      instructions: `You can pay for x402-gated APIs and resources, within a hard spend policy you
+    cannot exceed. Always quote the price and plan the payment first; only call the pay tool when the
+    user wants the resource and it is within budget. The pay tool is the only one that moves money;
+    the rest are read-only.`,
+      model: 'openai/gpt-5.5',
+      tools: await piprailMcp.listTools(),
+    })
+    ```
+  </StepItem>
+
+  <StepItem title="Register the agent with Mastra">
+    In your `src/mastra/index.ts` file, register the agent:
+
+    ```ts title="src/mastra/index.ts" {2, 5}
+    import { Mastra } from '@mastra/core'
+    import { paymentAgent } from './agents/payment-agent'
+
+    export const mastra = new Mastra({
+      agents: { paymentAgent },
+    })
+    ```
+  </StepItem>
+
+  <StepItem title="Test your agent">
+    Set `PIPRAIL_PRIVATE_KEY` (and your model provider key) in `.env`, then start [Studio](/docs/studio/overview)
+    with `mastra dev`:
+
+    ```bash
+    mastra dev
+    ```
+
+    Inside Studio, open the **"Payment Agent"** and try: "What does `https://piprail.com/x402/demo` cost,
+    and can I afford it?" The agent quotes the price (0.01 USDC on Base) and plans the payment. Ask it to
+    pay and it settles on-chain and returns the unlocked response — and if you set a cap below the price,
+    it refuses, so the agent can never overspend.
+  </StepItem>
+</Steps>
+
+## Next steps
+
+The same agent works across every chain PipRail supports (EVM, Solana, and more) by changing
+`PIPRAIL_CHAIN`. For the full tool reference, multi-chain setup, and the spend-policy options, see the
+[PipRail × Mastra guide](https://docs.piprail.com/integrations/mastra/).

--- a/docs/src/content/en/guides/sidebars.js
+++ b/docs/src/content/en/guides/sidebars.js
@@ -226,6 +226,11 @@ const sidebars = {
               id: 'guide/signal-provider',
               label: 'Signals: CI Signal Provider',
             },
+            {
+              type: 'doc',
+              id: 'guide/pay-x402-apis',
+              label: 'MCP: Pay for x402 APIs',
+            },
           ],
         },
         {


### PR DESCRIPTION
Addresses #18293.

Adds a Tutorials → Fundamentals guide — **Building an agent that can pay for APIs (x402)** — showing how to give a Mastra agent a budget-bound wallet so it can pay [x402](https://x402.org) ("HTTP 402 Payment Required") APIs autonomously.

### What's in it
- `docs/src/content/en/guides/guide/pay-x402-apis.mdx` — a `Steps`/`StepItem` guide that wires an x402 payment MCP server via `MCPClient`, hands its tools to an `Agent`, registers it with `Mastra`, and tests it in Studio against a live endpoint.
- Sidebar entry under Tutorials → Fundamentals (`MCP: Pay for x402 APIs`).

Docs only — no code changes.

### Approach
It uses [PipRail](https://piprail.com)'s MCP server (`@piprail/mcp`, MIT, self-custodial; runs via `npx`, so nothing enters the user's dependency tree) as the concrete example — the same pattern as the existing **Firecrawl**, **Web Search (Exa)**, and **Notes MCP Server** guides. The focus is the capability: quote → plan → pay, bounded by a spend cap the agent cannot exceed.

### Verified against current docs
- `MCPClient({ servers: { … } })` → `await mcp.listTools()` → `new Agent({ tools })` ([MCP overview](https://mastra.ai/docs/mcp/overview), [Agent ref](https://mastra.ai/reference/agents/agent))
- model router string `openai/gpt-5.5` ([Agents overview](https://mastra.ai/docs/agents/overview))
- The guide notes Mastra's `<serverKey>_<toolName>` namespacing so the example is runtime-accurate.

Happy to adjust scope, framing, or the example per your direction — opening the implementation alongside the issue since it's docs-only and self-contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a teaching guide that shows developers how to build an AI agent that can automatically pay for services on the internet. Think of it like giving an AI assistant both a credit card and instructions on when to use it – the agent can check prices, make a payment plan, and complete the transaction all on its own.

---

## Overview

This PR adds a new documentation guide demonstrating how to build a Mastra agent capable of autonomously paying for x402 ("HTTP 402 Payment Required") gated APIs. The guide covers the complete implementation flow from environment setup through live testing in Studio.

## Changes

**New Documentation Guide** (`docs/src/content/en/guides/guide/pay-x402-apis.mdx`)
- Comprehensive walkthrough using PipRail's MCP server (`@piprail/mcp`) as a concrete example
- Covers setup of MCP client configuration with wallet and spend-limit environment variables
- Demonstrates agent creation with PipRail tools exposed through the MCP client
- Includes agent instruction patterns that guide the payment flow: quote → plan → pay
- Shows agent registration with Mastra in the project entrypoint
- Provides testing guidance in Studio with expected behaviors for quoting, planning, on-chain settlement, and budget cap enforcement
- Explains multi-chain support via `PIPRAIL_CHAIN` environment variable configuration

**Sidebar Navigation Update** (`docs/src/content/en/guides/sidebars.js`)
- Added new sidebar entry under Tutorials → Fundamentals section
- Label: "MCP: Pay for x402 APIs"
- Positioned after the "Signals: CI Signal Provider" entry

## Technical Details

- Follows the same pattern as existing MCP guides (Firecrawl, Web Search with Exa, Notes MCP Server)
- Uses verified Mastra API patterns: `MCPClient({ servers: { … } })` → `await mcp.listTools()` → `new Agent({ tools })`
- Leverages Mastra's `<serverKey>_<toolName>` tool namespacing convention
- Uses model router string syntax (`openai/gpt-5.5`)
- Addresses issue `#18293`

This is a documentation-only PR with no code changes to the main codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->