### PR TITLE
chore(vercel): Add rename warnings

### DIFF
--- a/.changeset/quick-feet-act.md
+++ b/.changeset/quick-feet-act.md
@@ -1,0 +1,5 @@
+---
+'@mastra/vercel': patch
+---
+
+Added warnings to VercelSandbox and VercelMicroVMSandbox class names. VercelSandbox will be renamed to VercelServerlessSandbox and VercelMicroVMSandbox will be renamed to VercelSandbox in a future release.

--- a/workspaces/vercel/src/index.ts
+++ b/workspaces/vercel/src/index.ts
@@ -1,6 +1,8 @@
+/** @deprecated Will be renamed to `VercelServerlessSandbox` in a future release. */
 export { VercelSandbox, type VercelSandboxOptions } from './sandbox';
 export { vercelSandboxProvider } from './provider';
 
+/** @deprecated Will be renamed to `VercelSandbox` in a future release. */
 export { VercelMicroVMSandbox, type VercelMicroVMSandboxOptions, type VercelMicroVMRuntime } from './microvm';
 export { VercelMicroVMProcessManager } from './microvm/process-manager';
 export { vercelMicroVMSandboxProvider } from './microvm-provider';

--- a/workspaces/vercel/src/microvm/index.ts
+++ b/workspaces/vercel/src/microvm/index.ts
@@ -26,6 +26,8 @@ import { VercelMicroVMProcessManager } from './process-manager';
 
 const LOG_PREFIX = '[VercelMicroVMSandbox]';
 
+let deprecatedNameWarned = false;
+
 /** Vercel Sandbox runtimes (default `node24`). */
 export type VercelMicroVMRuntime = 'node24' | 'node22' | 'node26' | 'python3.13';
 
@@ -97,6 +99,8 @@ export interface VercelMicroVMSandboxOptions extends Omit<MastraSandboxOptions, 
  *
  * const result = await workspace.sandbox.executeCommand('node', ['--version']);
  * ```
+ *
+ * @deprecated Will be renamed to `VercelSandbox` in a future release.
  */
 export class VercelMicroVMSandbox extends MastraSandbox {
   readonly id: string;
@@ -127,6 +131,11 @@ export class VercelMicroVMSandbox extends MastraSandbox {
       name: 'VercelMicroVMSandbox',
       processes: new VercelMicroVMProcessManager({ env: options.env ?? {} }),
     });
+
+    if (!deprecatedNameWarned) {
+      deprecatedNameWarned = true;
+      console.warn('VercelMicroVMSandbox will be renamed to VercelSandbox in a future release.');
+    }
 
     this.id = options.id ?? `vercel-microvm-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     this._sandboxName = options.sandboxName;

--- a/workspaces/vercel/src/sandbox/index.ts
+++ b/workspaces/vercel/src/sandbox/index.ts
@@ -22,6 +22,8 @@ import { getExecutorSource } from '../executor';
 
 const LOG_PREFIX = '[VercelSandbox]';
 
+let deprecatedNameWarned = false;
+
 const VERCEL_API_BASE = 'https://api.vercel.com';
 
 /**
@@ -66,6 +68,9 @@ export interface VercelSandboxOptions extends Omit<MastraSandboxOptions, 'proces
 // Implementation
 // =============================================================================
 
+/**
+ * @deprecated Will be renamed to `VercelServerlessSandbox` in a future release.
+ */
 export class VercelSandbox extends MastraSandbox {
   readonly id: string;
   readonly name = 'VercelSandbox';
@@ -90,6 +95,11 @@ export class VercelSandbox extends MastraSandbox {
 
   constructor(options: VercelSandboxOptions = {}) {
     super({ name: 'VercelSandbox' });
+
+    if (!deprecatedNameWarned) {
+      deprecatedNameWarned = true;
+      console.warn('VercelSandbox will be renamed to VercelServerlessSandbox in a future release.');
+    }
 
     this.id = `vercel-sandbox-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     this._token = options.token || process.env.VERCEL_TOKEN || '';


### PR DESCRIPTION
## Description

In a future release we want to rename `VercelSandbox` to `VercelServerlessSandbox` and `VercelMicroVMSandbox` to `VercelSandbox`. This PR adds warnings to the old names to prepare users for the change. The warnings will be removed in a future release.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR warns users that some Vercel sandbox classes are going to have new names in the future. It adds friendly warning messages (shown once per process) and documentation to help developers know they should update their code before the actual name change happens.

## Overview

This PR introduces deprecation warnings for Vercel sandbox classes to prepare users for upcoming renaming changes:
- `VercelSandbox` → will be renamed to `VercelServerlessSandbox`
- `VercelMicroVMSandbox` → will be renamed to `VercelSandbox`

## Changes Made

1. **Documentation Updates**: Added JSDoc `@deprecated` annotations to `VercelSandbox` and `VercelMicroVMSandbox` exports in `workspaces/vercel/src/index.ts`, clearly stating their future names.

2. **Runtime Warnings**: Implemented deprecation warnings in the constructors of both classes:
   - `VercelSandbox` in `workspaces/vercel/src/sandbox/index.ts`: Emits a one-time `console.warn` notification
   - `VercelMicroVMSandbox` in `workspaces/vercel/src/microvm/index.ts`: Emits a one-time `console.warn` notification
   - Both use a module-level flag (`deprecatedNameWarned`) to ensure the warning is only shown once per process

3. **Changelog**: Added a changeset entry for the `@mastra/vercel` package documenting the deprecation warnings.

## Impact

- Users will see clear warnings when instantiating deprecated classes, giving them time to update their code before the renaming occurs
- The deprecation is communicated through both static documentation (JSDoc) and runtime warnings
- The warnings are non-intrusive, triggering only once per process instance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->