### PR TITLE
fix(playground-ui): render readable trace payloads

### DIFF
--- a/.changeset/tiny-comics-wink.md
+++ b/.changeset/tiny-comics-wink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved trace and log data panels to render string payloads as readable JSON, markdown, or wrapped text.

--- a/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
@@ -152,7 +152,7 @@ export function LogDetailsView({
           </KV>
 
           {log.data && Object.keys(log.data).length > 0 && (
-            <DataDetailsPanel.CodeSection title="Data" codeStr={JSON.stringify(log.data, null, 2)} className="mt-6" />
+            <DataDetailsPanel.CodeSection title="Data" data={log.data} className="mt-6" />
           )}
         </DataDetailsPanel.Content>
       )}

--- a/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
@@ -296,25 +296,25 @@ function SpanDataPanelContent({
           title="Input"
           dialogTitle={buildDialogTitle('Input', <FileInputIcon />, { spanId, traceId })}
           icon={<FileInputIcon />}
-          codeStr={JSON.stringify(span.input ?? null, null, 2)}
+          data={span.input ?? null}
         />
         <DataPanel.CodeSection
           title="Output"
           dialogTitle={buildDialogTitle('Output', <FileOutputIcon />, { spanId, traceId })}
           icon={<FileOutputIcon />}
-          codeStr={JSON.stringify(span.output ?? null, null, 2)}
+          data={span.output ?? null}
         />
         <DataPanel.CodeSection
           title="Metadata"
           dialogTitle={buildDialogTitle('Metadata', <BracesIcon />, { spanId, traceId })}
           icon={<BracesIcon />}
-          codeStr={JSON.stringify(span.metadata ?? null, null, 2)}
+          data={span.metadata ?? null}
         />
         <DataPanel.CodeSection
           title="Attributes"
           dialogTitle={buildDialogTitle('Attributes', <BracesIcon />, { spanId, traceId })}
           icon={<BracesIcon />}
-          codeStr={JSON.stringify(span.attributes ?? null, null, 2)}
+          data={span.attributes ?? null}
         />
       </div>
     </>

--- a/packages/playground-ui/src/domains/traces/components/span-details-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-details-view.tsx
@@ -66,26 +66,10 @@ export function SpanDetailsView({ spanId, span, isLoading, onClose }: SpanDetail
 
           <br />
 
-          <DataDetailsPanel.CodeSection
-            title="Input"
-            icon={<FileInputIcon />}
-            codeStr={JSON.stringify(span.input ?? null, null, 2)}
-          />
-          <DataDetailsPanel.CodeSection
-            title="Output"
-            icon={<FileOutputIcon />}
-            codeStr={JSON.stringify(span.output ?? null, null, 2)}
-          />
-          <DataDetailsPanel.CodeSection
-            title="Metadata"
-            icon={<BracesIcon />}
-            codeStr={JSON.stringify(span.metadata ?? null, null, 2)}
-          />
-          <DataDetailsPanel.CodeSection
-            title="Attributes"
-            icon={<BracesIcon />}
-            codeStr={JSON.stringify(span.attributes ?? null, null, 2)}
-          />
+          <DataDetailsPanel.CodeSection title="Input" icon={<FileInputIcon />} data={span.input ?? null} />
+          <DataDetailsPanel.CodeSection title="Output" icon={<FileOutputIcon />} data={span.output ?? null} />
+          <DataDetailsPanel.CodeSection title="Metadata" icon={<BracesIcon />} data={span.metadata ?? null} />
+          <DataDetailsPanel.CodeSection title="Attributes" icon={<BracesIcon />} data={span.attributes ?? null} />
         </DataDetailsPanel.Content>
       )}
     </DataDetailsPanel>

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDataCodeSectionPayload } from './data-code-section-utils';
+
+describe('resolveDataCodeSectionPayload', () => {
+  it('pretty-prints object values as JSON', () => {
+    expect(resolveDataCodeSectionPayload({ data: { query: 'hello', count: 2 } })).toEqual({
+      mode: 'json',
+      value: '{\n  "query": "hello",\n  "count": 2\n}',
+      copyValue: '{\n  "query": "hello",\n  "count": 2\n}',
+      hasMultilineText: false,
+    });
+  });
+
+  it('pretty-prints JSON stored as a string', () => {
+    expect(resolveDataCodeSectionPayload({ data: '{"items":[{"title":"First"}]}' })).toEqual({
+      mode: 'json',
+      value: '{\n  "items": [\n    {\n      "title": "First"\n    }\n  ]\n}',
+      copyValue: '{\n  "items": [\n    {\n      "title": "First"\n    }\n  ]\n}',
+      hasMultilineText: false,
+    });
+  });
+
+  it('renders markdown-looking strings as markdown content', () => {
+    expect(resolveDataCodeSectionPayload({ data: '### Page\\n- One\\n- Two' })).toEqual({
+      mode: 'markdown',
+      value: '### Page\n- One\n- Two',
+      copyValue: '### Page\n- One\n- Two',
+      hasMultilineText: false,
+    });
+  });
+
+  it('keeps ordinary strings as wrapped text', () => {
+    expect(resolveDataCodeSectionPayload({ data: 'A long unstructured tool result' })).toEqual({
+      mode: 'text',
+      value: 'A long unstructured tool result',
+      copyValue: 'A long unstructured tool result',
+      hasMultilineText: false,
+    });
+  });
+
+  it('keeps empty strings as valid text payloads', () => {
+    expect(resolveDataCodeSectionPayload({ data: '' })).toEqual({
+      mode: 'text',
+      value: '',
+      copyValue: '',
+      hasMultilineText: false,
+    });
+  });
+
+  it('keeps codeStr backward-compatible', () => {
+    expect(resolveDataCodeSectionPayload({ codeStr: JSON.stringify({ output: '**Done**' }, null, 2) })).toEqual({
+      mode: 'json',
+      value: '{\n  "output": "**Done**"\n}',
+      copyValue: '{\n  "output": "**Done**"\n}',
+      hasMultilineText: false,
+    });
+  });
+});

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section-utils.ts
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section-utils.ts
@@ -1,0 +1,122 @@
+export type DataCodeSectionRenderMode = 'json' | 'markdown' | 'text';
+
+export interface DataCodeSectionPayload {
+  mode: DataCodeSectionRenderMode;
+  value: string;
+  copyValue: string;
+  hasMultilineText: boolean;
+}
+
+interface ResolvePayloadArgs {
+  data?: unknown;
+  codeStr?: string;
+}
+
+export function resolveDataCodeSectionPayload({ data, codeStr = '' }: ResolvePayloadArgs): DataCodeSectionPayload | null {
+  const source = data !== undefined ? data : parseCodeString(codeStr);
+
+  if (source == null) return null;
+
+  if (typeof source === 'string') {
+    return resolveStringPayload(source);
+  }
+
+  const value = stringifyJson(source);
+
+  if (!value || value === 'null') return null;
+
+  return {
+    mode: 'json',
+    value,
+    copyValue: value,
+    hasMultilineText: containsInnerNewline(source),
+  };
+}
+
+export function containsInnerNewline(obj: unknown): boolean {
+  if (typeof obj === 'string') {
+    const idx = obj.indexOf('\n');
+    return idx !== -1 && idx !== obj.length - 1;
+  } else if (Array.isArray(obj)) {
+    return obj.some(item => containsInnerNewline(item));
+  } else if (obj && typeof obj === 'object') {
+    return Object.values(obj).some(value => containsInnerNewline(value));
+  }
+  return false;
+}
+
+function resolveStringPayload(source: string): DataCodeSectionPayload | null {
+  const embeddedJson = parseEmbeddedJson(source);
+
+  if (embeddedJson !== undefined) {
+    const value = stringifyJson(embeddedJson);
+
+    return {
+      mode: 'json',
+      value,
+      copyValue: value,
+      hasMultilineText: containsInnerNewline(embeddedJson),
+    };
+  }
+
+  const value = normalizeEscapedNewlines(source);
+
+  return {
+    mode: looksLikeMarkdown(value) ? 'markdown' : 'text',
+    value,
+    copyValue: value,
+    hasMultilineText: false,
+  };
+}
+
+function parseCodeString(codeStr: string): unknown {
+  if (!codeStr || codeStr === 'null') return null;
+
+  try {
+    return JSON.parse(codeStr);
+  } catch {
+    return codeStr;
+  }
+}
+
+function parseEmbeddedJson(source: string): unknown | undefined {
+  const trimmed = source.trim();
+
+  if (!trimmed || (trimmed[0] !== '{' && trimmed[0] !== '[')) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+function stringifyJson(value: unknown): string {
+  try {
+    const stringified = JSON.stringify(value, null, 2);
+    return stringified ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function normalizeEscapedNewlines(source: string): string {
+  return source.replace(/\\n/g, '\n');
+}
+
+function looksLikeMarkdown(source: string): boolean {
+  return [
+    /^#{1,6}\s/m,
+    /^[-*+]\s/m,
+    /^\d+\.\s/m,
+    /^>\s/m,
+    /```/,
+    /\*\*[^*]+\*\*/,
+    /__[^_]+__/,
+    /`[^`]+`/,
+    /\[[^\]]+\]\([^)]+\)/,
+    /\n\|.+\|\n\|[-:|\s]+\|/,
+  ].some(pattern => pattern.test(source));
+}

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.tsx
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.tsx
@@ -14,6 +14,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { Button } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { CopyButton } from '@/ds/components/CopyButton';
+import { resolveDataCodeSectionPayload } from '@/ds/components/DataCodeSection/data-code-section-utils';
 import { DataPanelSectionHeading } from '@/ds/components/DataPanel/data-panel-section-heading';
 import {
   Dialog,
@@ -24,6 +25,7 @@ import {
   DialogDescription,
 } from '@/ds/components/Dialog';
 import { SearchFieldBlock } from '@/ds/components/FormFieldBlocks/fields/search-field-block';
+import { MarkdownRenderer } from '@/ds/components/MarkdownRenderer';
 import { useTheme } from '@/ds/components/ThemeProvider';
 import { cn } from '@/lib/utils';
 
@@ -140,12 +142,14 @@ export interface DataCodeSectionProps {
   title: React.ReactNode;
   dialogTitle?: React.ReactNode;
   icon?: React.ReactNode;
+  data?: unknown;
   codeStr?: string;
   simplified?: boolean;
   className?: string;
 }
 
 export function DataCodeSection({
+  data,
   codeStr = '',
   title,
   dialogTitle,
@@ -163,14 +167,8 @@ export function DataCodeSection({
   const editorRef = useRef<ReactCodeMirrorRef>(null);
   const expandedEditorRef = useRef<ReactCodeMirrorRef>(null);
 
-  const hasMultilineText = useMemo(() => {
-    try {
-      const parsed = JSON.parse(codeStr);
-      return containsInnerNewline(parsed || '');
-    } catch {
-      return false;
-    }
-  }, [codeStr]);
+  const payload = useMemo(() => resolveDataCodeSectionPayload({ data, codeStr }), [data, codeStr]);
+  const canUseCodeEditor = payload?.mode === 'json' && !simplified;
 
   const dispatchSearch = useCallback((query: string) => {
     const view = editorRef.current?.view;
@@ -236,18 +234,70 @@ export function DataCodeSection({
     dispatchExpandedSearch('');
   }, [dispatchExpandedSearch]);
 
-  const finalCodeStr = showAsMultilineText ? codeStr?.replace(/\\n/g, '\n') : codeStr;
-  const expandedFinalCodeStr = expandedMultiline ? codeStr?.replace(/\\n/g, '\n') : codeStr;
-  const usePlainTextView = simplified || showAsMultilineText;
+  if (!payload) return null;
 
-  if (!codeStr || codeStr === 'null') return null;
+  const hasMultilineText = payload.hasMultilineText;
+  const copyValue = payload.copyValue;
+  const finalCodeStr = showAsMultilineText ? payload.value.replace(/\\n/g, '\n') : payload.value;
+  const expandedFinalCodeStr = expandedMultiline ? payload.value.replace(/\\n/g, '\n') : payload.value;
+  const useInlinePlainTextView = simplified || showAsMultilineText || payload.mode === 'text';
+  const useExpandedPlainTextView = simplified || expandedMultiline || payload.mode === 'text';
+  const useMarkdownView = payload.mode === 'markdown' && !simplified;
+
+  let inlineContent: React.ReactNode;
+  if (useMarkdownView) {
+    inlineContent = <MarkdownRenderer>{payload.value}</MarkdownRenderer>;
+  } else if (useInlinePlainTextView) {
+    inlineContent = (
+      <div className="text-neutral4 font-mono break-all">
+        <pre className="text-wrap">{finalCodeStr}</pre>
+      </div>
+    );
+  } else {
+    inlineContent = (
+      <ReactCodeMirror
+        ref={editorRef}
+        extensions={[json(), EditorView.lineWrapping, searchHighlightExtension()]}
+        theme={theme}
+        value={payload.value}
+        editable={false}
+      />
+    );
+  }
+
+  let expandedContent: React.ReactNode;
+  if (useMarkdownView) {
+    expandedContent = (
+      <div className="dark:bg-black/20 bg-surface3 p-3 overflow-hidden rounded-lg border dark:border-white/10 border-border1 text-neutral4 text-ui-sm break-all overflow-y-auto">
+        <MarkdownRenderer>{payload.value}</MarkdownRenderer>
+      </div>
+    );
+  } else if (useExpandedPlainTextView) {
+    expandedContent = (
+      <div className="dark:bg-black/20 bg-surface3 p-3 overflow-hidden rounded-lg border dark:border-white/10 border-border1 text-neutral4 text-ui-sm break-all overflow-y-auto">
+        <div className="text-neutral4 font-mono break-all">
+          <pre className="text-wrap">{expandedFinalCodeStr}</pre>
+        </div>
+      </div>
+    );
+  } else {
+    expandedContent = (
+      <ReactCodeMirror
+        ref={expandedEditorRef}
+        extensions={[json(), EditorView.lineWrapping, searchHighlightExtension()]}
+        theme={theme}
+        value={payload.value}
+        editable={false}
+      />
+    );
+  }
 
   return (
     <div className={cn('flex flex-col gap-2', className)}>
       <div className="flex items-center justify-between">
         <DataPanelSectionHeading icon={icon}>{title}</DataPanelSectionHeading>
         <div className="flex items-center gap-2">
-          {!usePlainTextView && (
+          {canUseCodeEditor && !showAsMultilineText && (
             <SearchFieldBlock
               name="code-section-search"
               label="Search code"
@@ -262,8 +312,8 @@ export function DataCodeSection({
             />
           )}
           <ButtonsGroup>
-            <CopyButton content={codeStr || 'No content'} size="sm" />
-            {hasMultilineText && (
+            <CopyButton content={copyValue} size="sm" />
+            {canUseCodeEditor && hasMultilineText && (
               <Button
                 size="sm"
                 aria-label={showAsMultilineText ? 'Show escaped newlines' : 'Show multiline text'}
@@ -281,19 +331,7 @@ export function DataCodeSection({
       </div>
 
       <div className="dark:bg-black/20 bg-surface3 p-3 overflow-hidden rounded-lg border dark:border-white/10 border-border1 text-neutral4 text-ui-sm break-all max-h-[30vh] overflow-y-auto">
-        {usePlainTextView ? (
-          <div className="text-neutral4 font-mono break-all">
-            <pre className="text-wrap">{finalCodeStr}</pre>
-          </div>
-        ) : (
-          <ReactCodeMirror
-            ref={editorRef}
-            extensions={[json(), EditorView.lineWrapping, searchHighlightExtension()]}
-            theme={theme}
-            value={codeStr}
-            editable={false}
-          />
-        )}
+        {inlineContent}
       </div>
 
       <Dialog open={expandedOpen} onOpenChange={setExpandedOpen}>
@@ -309,7 +347,7 @@ export function DataCodeSection({
             </DialogTitle>
             <DialogDescription>Expanded code view</DialogDescription>
             <div className="flex items-center gap-2 shrink-0">
-              {!expandedMultiline && (
+              {canUseCodeEditor && !expandedMultiline && (
                 <SearchFieldBlock
                   name="expanded-code-search"
                   label="Search code"
@@ -322,8 +360,8 @@ export function DataCodeSection({
                 />
               )}
               <ButtonsGroup>
-                <CopyButton content={codeStr || 'No content'} size="sm" />
-                {hasMultilineText && (
+                <CopyButton content={copyValue} size="sm" />
+                {canUseCodeEditor && hasMultilineText && (
                   <Button
                     size="sm"
                     aria-label={expandedMultiline ? 'Show escaped newlines' : 'Show multiline text'}
@@ -341,37 +379,9 @@ export function DataCodeSection({
               </ButtonsGroup>
             </div>
           </DialogHeader>
-          <div className="overflow-auto px-6 pb-6">
-            {expandedMultiline ? (
-              <div className="dark:bg-black/20 bg-surface3 p-3 overflow-hidden rounded-lg border dark:border-white/10 border-border1 text-neutral4 text-ui-sm break-all overflow-y-auto">
-                <div className="text-neutral4 font-mono break-all">
-                  <pre className="text-wrap">{expandedFinalCodeStr}</pre>
-                </div>
-              </div>
-            ) : (
-              <ReactCodeMirror
-                ref={expandedEditorRef}
-                extensions={[json(), EditorView.lineWrapping, searchHighlightExtension()]}
-                theme={theme}
-                value={codeStr}
-                editable={false}
-              />
-            )}
-          </div>
+          <div className="overflow-auto px-6 pb-6">{expandedContent}</div>
         </DialogContent>
       </Dialog>
     </div>
   );
-}
-
-function containsInnerNewline(obj: unknown): boolean {
-  if (typeof obj === 'string') {
-    const idx = obj.indexOf('\n');
-    return idx !== -1 && idx !== obj.length - 1;
-  } else if (Array.isArray(obj)) {
-    return obj.some(item => containsInnerNewline(item));
-  } else if (obj && typeof obj === 'object') {
-    return Object.values(obj).some(value => containsInnerNewline(value));
-  }
-  return false;
 }

--- a/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel-code-section.tsx
+++ b/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel-code-section.tsx
@@ -10,6 +10,8 @@ import { useMemo, useState } from 'react';
 import { Button } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { CopyButton } from '@/ds/components/CopyButton';
+import { resolveDataCodeSectionPayload } from '@/ds/components/DataCodeSection/data-code-section-utils';
+import { MarkdownRenderer } from '@/ds/components/MarkdownRenderer';
 import { useTheme } from '@/ds/components/ThemeProvider';
 import { cn } from '@/lib/utils';
 
@@ -82,12 +84,14 @@ const useCodemirrorTheme = (): Extension => {
 export interface DataDetailsPanelCodeSectionProps {
   title: React.ReactNode;
   icon?: React.ReactNode;
+  data?: unknown;
   codeStr?: string;
   simplified?: boolean;
   className?: string;
 }
 
 export function DataDetailsPanelCodeSection({
+  data,
   codeStr = '',
   title,
   icon,
@@ -96,19 +100,34 @@ export function DataDetailsPanelCodeSection({
 }: DataDetailsPanelCodeSectionProps) {
   const theme = useCodemirrorTheme();
   const [showAsMultilineText, setShowAsMultilineText] = useState(false);
-  const hasMultilineText = useMemo(() => {
-    try {
-      const parsed = JSON.parse(codeStr);
-      return containsInnerNewline(parsed || '');
-    } catch {
-      return false;
-    }
-  }, [codeStr]);
+  const payload = useMemo(() => resolveDataCodeSectionPayload({ data, codeStr }), [data, codeStr]);
+  const canUseCodeEditor = payload?.mode === 'json' && !simplified;
 
-  const finalCodeStr = showAsMultilineText ? codeStr?.replace(/\\n/g, '\n') : codeStr;
-  const usePlainTextView = simplified || showAsMultilineText;
+  if (!payload) return null;
 
-  if (!codeStr || codeStr === 'null') return null;
+  const finalCodeStr = showAsMultilineText ? payload.value.replace(/\\n/g, '\n') : payload.value;
+  const usePlainTextView = simplified || showAsMultilineText || payload.mode === 'text';
+  const useMarkdownView = payload.mode === 'markdown' && !simplified;
+
+  let content: React.ReactNode;
+  if (useMarkdownView) {
+    content = <MarkdownRenderer>{payload.value}</MarkdownRenderer>;
+  } else if (usePlainTextView) {
+    content = (
+      <div className="text-neutral4 font-mono break-all">
+        <pre className="text-wrap">{finalCodeStr}</pre>
+      </div>
+    );
+  } else {
+    content = (
+      <ReactCodeMirror
+        extensions={[json(), EditorView.lineWrapping]}
+        theme={theme}
+        value={payload.value}
+        editable={false}
+      />
+    );
+  }
 
   return (
     <div className={cn('flex flex-col gap-2', className)}>
@@ -123,8 +142,8 @@ export function DataDetailsPanelCodeSection({
           {title}
         </div>
         <ButtonsGroup>
-          <CopyButton content={codeStr || 'No content'} size="sm" />
-          {hasMultilineText && (
+          <CopyButton content={payload.copyValue} size="sm" />
+          {canUseCodeEditor && payload.hasMultilineText && (
             <Button
               size="sm"
               aria-label={showAsMultilineText ? 'Show escaped newlines' : 'Show multiline text'}
@@ -136,31 +155,8 @@ export function DataDetailsPanelCodeSection({
         </ButtonsGroup>
       </div>
       <div className="dark:bg-black/20 bg-surface3 p-3 overflow-hidden rounded-lg border dark:border-white/10 border-border1 text-neutral4 text-ui-sm break-all max-h-[30vh] overflow-y-auto">
-        {usePlainTextView ? (
-          <div className="text-neutral4 font-mono break-all">
-            <pre className="text-wrap">{finalCodeStr}</pre>
-          </div>
-        ) : (
-          <ReactCodeMirror
-            extensions={[json(), EditorView.lineWrapping]}
-            theme={theme}
-            value={codeStr}
-            editable={false}
-          />
-        )}
+        {content}
       </div>
     </div>
   );
-}
-
-function containsInnerNewline(obj: unknown): boolean {
-  if (typeof obj === 'string') {
-    const idx = obj.indexOf('\n');
-    return idx !== -1 && idx !== obj.length - 1;
-  } else if (Array.isArray(obj)) {
-    return obj.some(item => containsInnerNewline(item));
-  } else if (obj && typeof obj === 'object') {
-    return Object.values(obj).some(value => containsInnerNewline(value));
-  }
-  return false;
 }

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
@@ -37,6 +37,8 @@ describe('MarkdownRenderer', () => {
     expect(token.style.getPropertyValue('--shiki-light')).toBe('#24292f');
     expect(token.style.getPropertyValue('--shiki-dark')).toBe('#c9d1d9');
     expect(token.closest('pre')).not.toBeNull();
+    expect(token.closest('pre')?.classList.contains('whitespace-pre-wrap')).toBe(true);
+    expect(token.closest('pre')?.classList.contains('break-words')).toBe(true);
   });
 
   it('renders inline code as a plain non-copyable <code> element', () => {

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -31,7 +31,7 @@ const CodeBlock = ({ children, className, language, ...restProps }: CodeBlockPro
   const code = typeof children === 'string' ? children : childrenTakeAllStringContents(children);
 
   const preClass = cn(
-    'overflow-x-scroll rounded-md border bg-surface1/50 p-4 font-mono text-sm [scrollbar-width:none]',
+    'overflow-x-auto whitespace-pre-wrap break-words rounded-md border bg-surface1/50 p-4 font-mono text-sm [scrollbar-width:none]',
     className,
   );
 


### PR DESCRIPTION
Follow-up to #18214 for the remaining readable payload work from #17973. The wrapping fix was merged, but string payloads were still rendered as quoted JSON strings, so markdown-like tool output and JSON encoded inside strings were still hard to read.

This adds shared payload formatting for the data code sections: objects still render as formatted JSON, JSON strings are parsed and pretty-printed, markdown-like strings render through the existing markdown renderer, and ordinary strings stay as wrapped text. Trace span panels and log details now pass raw payload values into that formatter instead of pre-stringifying everything. Markdown fenced code blocks also wrap to avoid bringing back horizontal scrolling inside rendered markdown.

Validated with focused Vitest coverage for the formatter and markdown wrapping, package typecheck, targeted playground-ui build, repo formatting, repo lint, and React Doctor. CodeRabbit CLI is installed, but `coderabbit doctor` reports it is not signed in, so a local CodeRabbit review could not be run.