### PR TITLE
fix(playground-ui): add code editor line wrapping option

### DIFF
--- a/.changeset/four-crews-sink.md
+++ b/.changeset/four-crews-sink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a CodeEditor option to disable line wrapping when callers need horizontally scrollable content.

--- a/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor.test.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { EditorView } from '@codemirror/view';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CodeEditor } from '../code-editor';
+
+const codeMirrorProps = vi.hoisted(() => [] as Array<{ extensions: unknown[] }>);
+
+vi.mock('@uiw/react-codemirror', () => ({
+  default: (props: { extensions: unknown[] }) => {
+    codeMirrorProps.push(props);
+    return <div data-testid="mock-code-mirror" />;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  codeMirrorProps.length = 0;
+});
+
+describe('CodeEditor', () => {
+  it('wraps long lines by default', () => {
+    render(<CodeEditor value="long content" showCopyButton={false} />);
+
+    expect(codeMirrorProps.at(-1)?.extensions).toContain(EditorView.lineWrapping);
+  });
+
+  it('can preserve long lines behind horizontal scrolling', () => {
+    render(<CodeEditor value="long content" showCopyButton={false} lineWrapping={false} />);
+
+    expect(codeMirrorProps.at(-1)?.extensions).not.toContain(EditorView.lineWrapping);
+  });
+});

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -27,6 +27,9 @@ const meta: Meta<typeof CodeEditor> = {
     highlightVariables: {
       control: { type: 'boolean' },
     },
+    lineWrapping: {
+      control: { type: 'boolean' },
+    },
   },
 };
 
@@ -119,6 +122,17 @@ export const LargeContent: Story = {
       },
     },
     className: 'w-[600px] max-h-[400px] overflow-auto',
+  },
+};
+
+export const WithoutLineWrapping: Story = {
+  args: {
+    data: {
+      output:
+        'https://example.com/search?q=this-is-a-very-long-url-with-structured-query-parameters-that-should-stay-on-one-line-for-inspection&filter=recent&sort=created_at_desc',
+    },
+    lineWrapping: false,
+    className: 'w-[400px] overflow-x-auto',
   },
 };
 

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -236,6 +236,8 @@ export type CodeEditorProps = {
   autoFocus?: boolean;
   /** Show line numbers in the gutter (default: true) */
   lineNumbers?: boolean;
+  /** Wrap long lines within the editor viewport (default: true) */
+  lineWrapping?: boolean;
   /** When false, makes the editor read-only */
   editable?: boolean;
 } & Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>;
@@ -254,6 +256,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
       schema,
       autoFocus,
       lineNumbers = true,
+      lineWrapping = true,
       editable,
       ...props
     },
@@ -265,7 +268,9 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
     const extensions = useMemo(() => {
       const exts: Extension[] = [];
 
-      exts.push(EditorView.lineWrapping);
+      if (lineWrapping) {
+        exts.push(EditorView.lineWrapping);
+      }
 
       if (language === 'json') {
         exts.push(jsonLanguage);
@@ -286,7 +291,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
       }
 
       return exts;
-    }, [language, highlightVariables, schema, editable]);
+    }, [language, highlightVariables, schema, editable, lineWrapping]);
 
     return (
       <div


### PR DESCRIPTION
Follow-up to #18214.

That PR made `CodeEditor` wrap by default, which is still the right default for tool outputs and long JSON. Some consumers still need preserved long lines and horizontal scrolling, though.

This adds a `lineWrapping` prop to `CodeEditor`. It defaults to `true`, preserving the current wrapped behavior, and callers can pass `lineWrapping={false}` to omit CodeMirror's line-wrapping extension.

Validation:
- `pnpm prettier:changed`
- `pnpm --filter ./packages/playground-ui test --run src/ds/components/CodeEditor/__tests__/code-editor.test.tsx`
- `pnpm --filter ./packages/playground-ui typecheck`
- `pnpm build:playground-ui`
- `pnpm lint`
- `git diff --check`
- `npx -y react-doctor@latest . --verbose --diff`

CodeRabbit CLI is installed, but `coderabbit doctor` reports the CLI is not signed in, so I did not run a local CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a new switch to the CodeEditor component that controls whether long lines of text wrap to the next line or scroll horizontally. By default, long lines wrap (the current behavior), but you can now turn off wrapping if you need to see the entire line without breaking it up.

## Overview

The PR extends the `CodeEditor` component in the `@mastra/playground-ui` package with a new `lineWrapping` prop that provides flexible control over line wrapping behavior. This follows up on PR `#18214` which made line wrapping the default, allowing consumers to opt out when horizontal scrolling is preferred.

## Changes

### Component Implementation
- Added optional `lineWrapping?: boolean` prop to `CodeEditorProps` in `code-editor.tsx`, defaulting to `true`
- Updated the CodeMirror `extensions` logic to conditionally include `EditorView.lineWrapping` based on the prop value
- Modified the `useMemo` dependency list to include `lineWrapping` for proper reactivity

### Testing
- Created a new test suite in `code-editor.test.tsx` using React Testing Library and Vitest
- Tests verify default line-wrapping behavior with `EditorView.lineWrapping` included by default
- Tests verify that setting `lineWrapping={false}` excludes the `EditorView.lineWrapping` extension

### Documentation & Stories
- Added `lineWrapping` boolean control to Storybook's `meta.argTypes` for interactive testing
- Created a new `WithoutLineWrapping` story demonstrating the prop with a long URL string and horizontal overflow

### Changeset
- Added `.changeset/four-crews-sink.md` marking a minor version bump for `@mastra/playground-ui`

## Files Modified
- `packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx` (+7/-2)
- `packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor.test.tsx` (+34/-0)
- `packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx` (+14/-0)
- `.changeset/four-crews-sink.md` (+5/-0)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->