### PR TITLE
fix(dsql): add missing $ prefix for SQL placeholders in listThreads

### DIFF
--- a/.changeset/strict-items-chew.md
+++ b/.changeset/strict-items-chew.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dsql': patch
+---
+
+Fixed SQL query failures when filtering threads by resourceId or metadata in Aurora DSQL storage

--- a/stores/dsql/src/storage/domains/memory/index.ts
+++ b/stores/dsql/src/storage/domains/memory/index.ts
@@ -230,7 +230,7 @@ export class MemoryDSQL extends MemoryStorage {
       let paramIndex = 1;
 
       if (filter?.resourceId) {
-        whereClauses.push(`"resourceId" = ${paramIndex}`);
+        whereClauses.push(`"resourceId" = $${paramIndex}`);
         queryParams.push(filter.resourceId);
         paramIndex++;
       }
@@ -238,7 +238,7 @@ export class MemoryDSQL extends MemoryStorage {
       // Aurora DSQL stores JSONB as TEXT, so cast to jsonb for containment operator
       if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
         for (const [key, value] of Object.entries(filter.metadata)) {
-          whereClauses.push(`metadata::jsonb @> ${paramIndex}::jsonb`);
+          whereClauses.push(`metadata::jsonb @> $${paramIndex}::jsonb`);
           queryParams.push(JSON.stringify({ [key]: value }));
           paramIndex++;
         }
@@ -262,7 +262,7 @@ export class MemoryDSQL extends MemoryStorage {
       }
 
       const limitValue = perPageInput === false ? total : perPage;
-      const dataQuery = `SELECT id, "resourceId", title, metadata, "createdAt", "createdAtZ", "updatedAt", "updatedAtZ" ${baseQuery} ORDER BY "${field}" ${direction} LIMIT ${paramIndex} OFFSET ${paramIndex + 1}`;
+      const dataQuery = `SELECT id, "resourceId", title, metadata, "createdAt", "createdAtZ", "updatedAt", "updatedAtZ" ${baseQuery} ORDER BY "${field}" ${direction} LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`;
       const rows = await this.#db.client.manyOrNone<StorageThreadType & { createdAtZ: Date; updatedAtZ: Date }>(
         dataQuery,
         [...queryParams, limitValue, offset],


### PR DESCRIPTION
## Description

Fix missing `$` prefix on SQL parameter placeholders in the `listThreads` method of the Aurora DSQL memory store. The placeholders were written as `${paramIndex}` (plain template literal) instead of `$${paramIndex}` (literal `$` followed by the index), causing PostgreSQL to receive invalid queries like `WHERE "resourceId" = 1` instead of `WHERE "resourceId" = $1`.

Three lines fixed in `stores/dsql/src/storage/domains/memory/index.ts`:
- `"resourceId"` filter condition
- `metadata::jsonb` containment filter
- `LIMIT` / `OFFSET` pagination parameters

## Related issue(s)

Fixes #18310

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable) — N/A
- [ ] I have added tests that prove my fix is effective or that my feature works — happy to add a test if you can point me to the right place
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes a bug where the database was receiving incomplete instructions for finding threads. Instead of saying "give me item `#1`", the system was trying to say "give me item 1" (without the proper symbol), which the database couldn't understand. This PR adds back the missing symbols so the database gets the right instructions.

## Problem

The Aurora DSQL memory store's `listThreads` method had a critical bug in SQL query generation where parameter placeholders were missing the required `$` prefix. When constructing parameterized queries, the code used template literals that evaluated to plain numbers (e.g., `WHERE "resourceId" = 1`) instead of proper PostgreSQL parameter references (e.g., `WHERE "resourceId" = $1`). This caused syntactically invalid SQL queries when filtering by `resourceId` or `metadata`.

## Solution

The fix updates three SQL query construction areas in `stores/dsql/src/storage/domains/memory/index.ts` to use proper parameter placeholder syntax with the `$` prefix:

1. **resourceId filter condition**: Changed from `${paramIndex}` to `$${paramIndex}` to generate correct parameter references in the WHERE clause
2. **metadata containment filter**: Updated the JSON containment check (`metadata::jsonb @> ...::jsonb`) to use parameterized placeholders instead of interpolating the placeholder index
3. **pagination parameters**: Corrected LIMIT and OFFSET clauses to use `$<index>` syntax for parameter references

## Changes

- **`.changeset/strict-items-chew.md`**: Added Changesets entry documenting the patch version bump for `@mastra/dsql`
- **`stores/dsql/src/storage/domains/memory/index.ts`**: Updated SQL query generation in `listThreads` method to properly parameterize WHERE clause filters and pagination parameters

## Classification

**Type**: Non-breaking bug fix
**Related Issue**: `#18310`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->