### PR TITLE
chore(playground): debarrel low-use playground-ui imports

### DIFF
--- a/packages/playground/eslint.config.js
+++ b/packages/playground/eslint.config.js
@@ -11,12 +11,86 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import useCopyToClipboard from @mastra/playground-ui/hooks/use-copy-to-clipboard.',
   },
   {
+    importNames: ['useAutoscroll', 'UseAutoscrollOptions'],
+    message: 'Import useAutoscroll exports from @mastra/playground-ui/hooks/use-autoscroll.',
+  },
+  {
+    importNames: ['useInView'],
+    message: 'Import useInView from @mastra/playground-ui/hooks/use-in-view.',
+  },
+  {
+    importNames: ['useIsMobile'],
+    message: 'Import useIsMobile from @mastra/playground-ui/hooks/use-is-mobile.',
+  },
+  {
+    importNames: ['useIsApplePlatform', 'useKeyboardShortcutLabel'],
+    message: 'Import keyboard shortcut hooks from @mastra/playground-ui/hooks/use-keyboard-shortcut-label.',
+  },
+  {
+    importNames: [
+      'Card',
+      'CardHeader',
+      'CardTitle',
+      'CardDescription',
+      'CardContent',
+      'CardFooter',
+      'CardProps',
+      'CardHeaderProps',
+      'CardTitleProps',
+      'CardDescriptionProps',
+      'CardContentProps',
+      'CardFooterProps',
+    ],
+    message: 'Import Card exports from @mastra/playground-ui/components/Card.',
+  },
+  {
     importNames: ['Combobox', 'ComboboxOption', 'ComboboxProps'],
     message: 'Import Combobox exports from @mastra/playground-ui/components/Combobox.',
   },
   {
+    importNames: [
+      'CalendarProps',
+      'DatePicker',
+      'DateTimePicker',
+      'DateTimePickerContent',
+      'DateTimePickerProps',
+      'DefaultTrigger',
+      'TimePicker',
+      'TimePickerProps',
+    ],
+    message: 'Import DateTimePicker exports from @mastra/playground-ui/components/DateTimePicker.',
+  },
+  {
+    importNames: ['EntityHeader', 'EntityHeaderProps'],
+    message: 'Import EntityHeader exports from @mastra/playground-ui/components/EntityHeader.',
+  },
+  {
+    importNames: ['Entry', 'EntryProps'],
+    message: 'Import Entry exports from @mastra/playground-ui/components/Entry.',
+  },
+  {
+    importNames: ['ErrorBoundary', 'ErrorBoundaryFallbackProps', 'ErrorBoundaryProps'],
+    message: 'Import ErrorBoundary exports from @mastra/playground-ui/components/ErrorBoundary.',
+  },
+  {
+    importNames: ['Kbd', 'KbdProps'],
+    message: 'Import Kbd exports from @mastra/playground-ui/components/Kbd.',
+  },
+  {
+    importNames: ['MetricsDataTable'],
+    message: 'Import MetricsDataTable from @mastra/playground-ui/components/MetricsDataTable.',
+  },
+  {
+    importNames: ['MetricsLineChart', 'MetricsLineChartSeries', 'MetricsLineChartTooltip'],
+    message: 'Import MetricsLineChart exports from @mastra/playground-ui/components/MetricsLineChart.',
+  },
+  {
     importNames: ['MetricsKpiCard'],
     message: 'Import MetricsKpiCard from @mastra/playground-ui/components/MetricsKpiCard.',
+  },
+  {
+    importNames: ['PendingIndicator', 'PendingIndicatorProps'],
+    message: 'Import PendingIndicator exports from @mastra/playground-ui/components/PendingIndicator.',
   },
   {
     importNames: ['PrevNextNav'],
@@ -27,8 +101,16 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import SettingsRow from @mastra/playground-ui/components/SettingsRow.',
   },
   {
+    importNames: ['Shimmer', 'ShimmerProps'],
+    message: 'Import Shimmer exports from @mastra/playground-ui/components/Shimmer.',
+  },
+  {
     importNames: ['SideDialog', 'SideDialogRootProps'],
     message: 'Import SideDialog exports from @mastra/playground-ui/components/SideDialog.',
+  },
+  {
+    importNames: ['Tree'],
+    message: 'Import Tree exports from @mastra/playground-ui/components/Tree.',
   },
 ].flatMap(restriction =>
   restriction.importNames.map(importName => ({

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ErrorBoundary,
   LogoWithoutText,
   MainSidebar,
   MainSidebarProvider,
@@ -10,6 +9,7 @@ import {
   TooltipProvider,
   useMainSidebar,
 } from '@mastra/playground-ui';
+import { ErrorBoundary } from '@mastra/playground-ui/components/ErrorBoundary';
 import { Search } from 'lucide-react';
 import { useLocation } from 'react-router';
 import { AppSidebar } from './ui/app-sidebar';

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -1,5 +1,6 @@
-import { LogoWithoutText, MainSidebar, cn, useKeyboardShortcutLabel, useMainSidebar } from '@mastra/playground-ui';
+import { LogoWithoutText, MainSidebar, cn, useMainSidebar } from '@mastra/playground-ui';
 import type { NavLink } from '@mastra/playground-ui';
+import { useKeyboardShortcutLabel } from '@mastra/playground-ui/hooks/use-keyboard-shortcut-label';
 import { Search, Wrench } from 'lucide-react';
 import { useLocation } from 'react-router';
 import { useAgentBuilderSidebarVisibility } from '@/domains/agent-builder/hooks/use-agent-builder-sidebar-visibility';

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -1,7 +1,6 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import {
   Button,
-  Card,
   cn,
   Collapsible,
   CollapsibleContent,
@@ -11,6 +10,7 @@ import {
   Skeleton,
   Txt,
 } from '@mastra/playground-ui';
+import { Card } from '@mastra/playground-ui/components/Card';
 import { MessageFactory } from '@mastra/react';
 import type {
   MastraDBMessageMetadata,

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-file-tree.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-file-tree.tsx
@@ -1,5 +1,6 @@
 import { v4 as uuid } from '@lukeed/uuid';
-import { Button, TooltipProvider, Tree } from '@mastra/playground-ui';
+import { Button, TooltipProvider } from '@mastra/playground-ui';
+import { Tree } from '@mastra/playground-ui/components/Tree';
 import { File, FileCode, FileJson, FileText, Folder, FolderOpen, FolderPlus, Image, Plus, Trash2 } from 'lucide-react';
 import type { MouseEvent, ReactNode } from 'react';
 import { useCallback, useRef, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-layout.tsx
+++ b/packages/playground/src/domains/agents/components/agent-layout.tsx
@@ -1,4 +1,5 @@
-import { PanelDrawer, PanelSeparator, useIsMobile } from '@mastra/playground-ui';
+import { PanelDrawer, PanelSeparator } from '@mastra/playground-ui';
+import { useIsMobile } from '@mastra/playground-ui/hooks/use-is-mobile';
 import { Panel, useDefaultLayout, Group } from 'react-resizable-panels';
 
 export interface AgentLayoutProps {

--- a/packages/playground/src/domains/agents/components/composer-model-settings.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-settings.tsx
@@ -6,7 +6,6 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  Entry,
   Label,
   Popover,
   PopoverContent,
@@ -21,6 +20,7 @@ import {
   Txt,
   cn,
 } from '@mastra/playground-ui';
+import { Entry } from '@mastra/playground-ui/components/Entry';
 import { Info, Sliders } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/domains/datasets/hooks/use-dataset-experiments.ts
+++ b/packages/playground/src/domains/datasets/hooks/use-dataset-experiments.ts
@@ -1,6 +1,6 @@
 import type { ClientScoreRowData } from '@mastra/client-js';
 import type { ExperimentStatus } from '@mastra/core/storage';
-import { useInView } from '@mastra/playground-ui';
+import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
 import { useMastraClient } from '@mastra/react';
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';

--- a/packages/playground/src/domains/datasets/hooks/use-dataset-items.ts
+++ b/packages/playground/src/domains/datasets/hooks/use-dataset-items.ts
@@ -1,4 +1,4 @@
-import { useInView } from '@mastra/playground-ui';
+import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
 import { useMastraClient } from '@mastra/react';
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';

--- a/packages/playground/src/domains/schedules/hooks/use-schedule-triggers.ts
+++ b/packages/playground/src/domains/schedules/hooks/use-schedule-triggers.ts
@@ -1,5 +1,5 @@
 import type { ScheduleTriggerResponse } from '@mastra/client-js';
-import { useInView } from '@mastra/playground-ui';
+import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
 import { useMastraClient } from '@mastra/react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';

--- a/packages/playground/src/domains/scores/components/scores-over-time-card.tsx
+++ b/packages/playground/src/domains/scores/components/scores-over-time-card.tsx
@@ -1,4 +1,6 @@
-import { MetricsCard, MetricsDataTable, MetricsLineChart, Tabs, TabList, Tab, TabContent } from '@mastra/playground-ui';
+import { MetricsCard, Tabs, TabList, Tab, TabContent } from '@mastra/playground-ui';
+import { MetricsDataTable } from '@mastra/playground-ui/components/MetricsDataTable';
+import { MetricsLineChart } from '@mastra/playground-ui/components/MetricsLineChart';
 import { useMemo } from 'react';
 import type { ScorerSummary, ScoresOverTimePoint } from '../hooks/use-score-metrics';
 

--- a/packages/playground/src/domains/scores/hooks/use-scorers.tsx
+++ b/packages/playground/src/domains/scores/hooks/use-scorers.tsx
@@ -1,5 +1,6 @@
 import type { GetScorerResponse, ListScoresResponse } from '@mastra/client-js';
-import { toast, useInView } from '@mastra/playground-ui';
+import { toast } from '@mastra/playground-ui';
+import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
 import { useMastraClient } from '@mastra/react';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';

--- a/packages/playground/src/domains/workflows/components/workflow-entity-header.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-entity-header.tsx
@@ -1,12 +1,5 @@
-import {
-  Badge,
-  EntityHeader,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-  WorkflowIcon,
-} from '@mastra/playground-ui';
+import { Badge, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, WorkflowIcon } from '@mastra/playground-ui';
+import { EntityHeader } from '@mastra/playground-ui/components/EntityHeader';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { CopyIcon, Cpu } from 'lucide-react';
 

--- a/packages/playground/src/domains/workflows/components/workflow-layout.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-layout.tsx
@@ -1,4 +1,5 @@
-import { CollapsiblePanel, PanelDrawer, PanelSeparator, useIsMobile } from '@mastra/playground-ui';
+import { CollapsiblePanel, PanelDrawer, PanelSeparator } from '@mastra/playground-ui';
+import { useIsMobile } from '@mastra/playground-ui/hooks/use-is-mobile';
 import { useState } from 'react';
 import type { CSSProperties } from 'react';
 import { Panel, useDefaultLayout, Group } from 'react-resizable-panels';

--- a/packages/playground/src/domains/workflows/workflow/workflow-timeline.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-timeline.tsx
@@ -1,4 +1,5 @@
-import { Button, CheckIcon, CrossIcon, Dialog, Icon, Txt, cn, useAutoscroll } from '@mastra/playground-ui';
+import { Button, CheckIcon, CrossIcon, Dialog, Icon, Txt, cn } from '@mastra/playground-ui';
+import { useAutoscroll } from '@mastra/playground-ui/hooks/use-autoscroll';
 import {
   ChevronDown,
   CirclePause,

--- a/packages/playground/src/hooks/use-workflow-runs.ts
+++ b/packages/playground/src/hooks/use-workflow-runs.ts
@@ -1,5 +1,6 @@
 import type { WorkflowRuns } from '@mastra/core/storage';
-import { toast, useInView } from '@mastra/playground-ui';
+import { toast } from '@mastra/playground-ui';
+import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
 import { useMastraClient } from '@mastra/react';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';

--- a/packages/playground/src/lib/ai-ui/messages/reasoning-streaming-line.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/reasoning-streaming-line.tsx
@@ -1,4 +1,5 @@
-import { Shimmer, Txt } from '@mastra/playground-ui';
+import { Txt } from '@mastra/playground-ui';
+import { Shimmer } from '@mastra/playground-ui/components/Shimmer';
 import { Loader2 } from 'lucide-react';
 
 export interface ReasoningStreamingLineProps {

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -1,5 +1,7 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
-import { Avatar, Button, ButtonsGroup, cn, PendingIndicator, ScrollArea, useAutoscroll } from '@mastra/playground-ui';
+import { Avatar, Button, ButtonsGroup, cn, ScrollArea } from '@mastra/playground-ui';
+import { PendingIndicator } from '@mastra/playground-ui/components/PendingIndicator';
+import { useAutoscroll } from '@mastra/playground-ui/hooks/use-autoscroll';
 import type { MessageFactoryPart } from '@mastra/react';
 import { CLIENT_MESSAGE_ID_KEY, useSpeechRecognition } from '@mastra/react';
 import { ArrowUp, Mic } from 'lucide-react';

--- a/packages/playground/src/lib/command/navigation-command.tsx
+++ b/packages/playground/src/lib/command/navigation-command.tsx
@@ -8,13 +8,13 @@ import {
   CommandItem,
   CommandList,
   CommandShortcut,
-  Kbd,
   McpServerIcon,
   ScrollArea,
   ToolsIcon,
   WorkflowIcon,
-  useKeyboardShortcutLabel,
 } from '@mastra/playground-ui';
+import { Kbd } from '@mastra/playground-ui/components/Kbd';
+import { useKeyboardShortcutLabel } from '@mastra/playground-ui/hooks/use-keyboard-shortcut-label';
 import {
   Cpu,
   EyeIcon,

--- a/packages/playground/src/lib/form/components/date-field.tsx
+++ b/packages/playground/src/lib/form/components/date-field.tsx
@@ -1,5 +1,6 @@
 import type { AutoFormFieldProps } from '@autoform/react';
-import { Button, DatePicker, Popover, PopoverContent, PopoverTrigger, cn } from '@mastra/playground-ui';
+import { Button, Popover, PopoverContent, PopoverTrigger, cn } from '@mastra/playground-ui';
+import { DatePicker } from '@mastra/playground-ui/components/DateTimePicker';
 import { format, isValid } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
 import React, { useState, useEffect } from 'react';


### PR DESCRIPTION
Moves the lowest-use Playground UI component imports and the remaining shared hook imports off the root `@mastra/playground-ui` barrel and onto their public component or hook subpaths.

Adds matching named-import ESLint restrictions in `packages/playground` so these imports do not drift back to the root barrel.

Validated with `pnpm prettier:changed`, `pnpm --filter ./packages/playground lint`, `pnpm build:playground-ui`, `pnpm --filter @mastra/ai-sdk build:lib`, `pnpm --filter @mastra/ai-sdk build:patch-commonjs`, `pnpm --filter ./packages/playground typecheck`, and `pnpm lint`. CodeRabbit CLI is installed, but `coderabbit doctor` reported it is not signed in, so I could not run a local CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR reorganizes how code imports components and hooks in the playground package. Instead of importing everything from one main barrel (`@mastra/playground-ui`), the PR moves imports of specific, less-commonly-used components and hooks to come directly from their own dedicated paths (like `@mastra/playground-ui/components/Card` or `@mastra/playground-ui/hooks/use-is-mobile`). The PR also adds rules to prevent these imports from being mixed back into the main barrel in the future.

## Changes

### ESLint Configuration
- Expanded the `restrictedPlaygroundUiBarrelImportSpecifiers` list in `packages/playground/eslint.config.js` to restrict importing from the barrel for multiple components and hooks
- Restricted components include: `Card`, `DateTimePicker`, `EntityHeader`, `Entry`, `ErrorBoundary`, `Kbd`, `MetricsDataTable`, `MetricsLineChart`, `MetricsKpiCard`, `PendingIndicator`, `Shimmer`, `Tree`, and `SideDialog`
- Restricted hooks include: `useAutoscroll`, `useInView`, `useIsMobile`, `useIsApplePlatform`, and `useKeyboardShortcutLabel`

### Component and Hook Import Updates
Updated 18 files across multiple domains to import from dedicated subpaths instead of the main barrel:

- **Hooks**: `useKeyboardShortcutLabel`, `useIsMobile`, `useInView`, `useAutoscroll` now import from their respective `@mastra/playground-ui/hooks/` paths
- **Components**: `ErrorBoundary`, `Card`, `Tree`, `Entry`, `EntityHeader`, `Kbd`, `MetricsDataTable`, `MetricsLineChart`, `PendingIndicator`, `Shimmer`, `DateTimePicker` now import from their respective `@mastra/playground-ui/components/` paths

Affected files:
- `packages/playground/src/components/layout.tsx` - `ErrorBoundary`
- `packages/playground/src/components/ui/app-sidebar.tsx` - `useKeyboardShortcutLabel`
- `packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx` - `Card`
- `packages/playground/src/domains/agents/components/agent-cms-pages/skill-file-tree.tsx` - `Tree`
- `packages/playground/src/domains/agents/components/agent-layout.tsx` - `useIsMobile`
- `packages/playground/src/domains/agents/components/composer-model-settings.tsx` - `Entry`
- `packages/playground/src/domains/datasets/hooks/use-dataset-experiments.ts` - `useInView`
- `packages/playground/src/domains/datasets/hooks/use-dataset-items.ts` - `useInView`
- `packages/playground/src/domains/schedules/hooks/use-schedule-triggers.ts` - `useInView`
- `packages/playground/src/domains/scores/components/scores-over-time-card.tsx` - `MetricsDataTable`, `MetricsLineChart`
- `packages/playground/src/domains/scores/hooks/use-scorers.tsx` - `useInView`
- `packages/playground/src/domains/workflows/components/workflow-entity-header.tsx` - `EntityHeader`
- `packages/playground/src/domains/workflows/components/workflow-layout.tsx` - `useIsMobile`
- `packages/playground/src/domains/workflows/workflow/workflow-timeline.tsx` - `useAutoscroll`
- `packages/playground/src/hooks/use-workflow-runs.ts` - `useInView`
- `packages/playground/src/lib/ai-ui/messages/reasoning-streaming-line.tsx` - `Shimmer`
- `packages/playground/src/lib/ai-ui/thread.tsx` - `PendingIndicator`, `useAutoscroll`
- `packages/playground/src/lib/command/navigation-command.tsx` - `Kbd`, `useKeyboardShortcutLabel`
- `packages/playground/src/lib/form/components/date-field.tsx` - `DateTimePicker`

## Validation

The author validated these changes with:
- Code formatting check (`pnpm prettier:changed`)
- Linting (`pnpm --filter ./packages/playground lint` and `pnpm lint`)
- Build verification (`pnpm build:playground-ui`, SDK builds)
- Type checking (`pnpm --filter ./packages/playground typecheck`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->