### PR TITLE
fix(chroma): normalize query scores per distance metric

### DIFF
--- a/.changeset/neat-bats-sit.md
+++ b/.changeset/neat-bats-sit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/chroma': patch
+---
+
+Fixed Chroma vector store score normalization. Scores are now computed per distance metric so euclidean collections return values in (0, 1] instead of negative numbers, matching @mastra/pg and @mastra/duckdb. A missing distance now yields a score of 0 instead of a perfect score of 1.

--- a/stores/chroma/src/vector/index.test.ts
+++ b/stores/chroma/src/vector/index.test.ts
@@ -474,6 +474,68 @@ describe('ChromaVector Integration Tests', () => {
     });
   });
 
+  describe('Per-metric score normalization', () => {
+    const cosineIndex = 'metric-cosine-index';
+    const euclideanIndex = 'metric-euclidean-index';
+
+    afterEach(async () => {
+      for (const indexName of [cosineIndex, euclideanIndex]) {
+        try {
+          await vectorDB.deleteIndex({ indexName });
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    });
+
+    it('keeps euclidean scores in (0, 1] instead of going negative', async () => {
+      await vectorDB.createIndex({ indexName: euclideanIndex, dimension: 2, metric: 'euclidean' });
+      await vectorDB.upsert({
+        indexName: euclideanIndex,
+        vectors: [
+          [0, 0],
+          [3, 4],
+        ],
+        ids: ['near', 'far'],
+      });
+
+      const results = await vectorDB.query({ indexName: euclideanIndex, queryVector: [0, 0], topK: 2 });
+
+      const near = results.find(r => r.id === 'near')!;
+      const far = results.find(r => r.id === 'far')!;
+
+      // Exact match → distance 0 → score 1
+      expect(near.score).toBeCloseTo(1, 5);
+      // Squared-L2 distance is 25 → 1 / (1 + 25) ≈ 0.0385, NOT 1 - 25 = -24
+      expect(far.score).toBeGreaterThan(0);
+      expect(far.score).toBeLessThanOrEqual(1);
+      expect(far.score).toBeCloseTo(1 / 26, 5);
+      // Closer vector still ranks higher
+      expect(near.score).toBeGreaterThan(far.score);
+    }, 15000);
+
+    it('keeps cosine scores as 1 - distance', async () => {
+      await vectorDB.createIndex({ indexName: cosineIndex, dimension: 2, metric: 'cosine' });
+      await vectorDB.upsert({
+        indexName: cosineIndex,
+        vectors: [
+          [1, 0],
+          [0, 1],
+        ],
+        ids: ['same', 'orthogonal'],
+      });
+
+      const results = await vectorDB.query({ indexName: cosineIndex, queryVector: [1, 0], topK: 2 });
+
+      const same = results.find(r => r.id === 'same')!;
+      const orthogonal = results.find(r => r.id === 'orthogonal')!;
+
+      expect(same.score).toBeCloseTo(1, 5);
+      // Orthogonal cosine distance is 1 → score 0
+      expect(orthogonal.score).toBeCloseTo(0, 5);
+    }, 15000);
+  });
+
   describe('Performance and Concurrency', () => {
     const perfTestIndex = 'perf-test-index';
 

--- a/stores/chroma/src/vector/index.ts
+++ b/stores/chroma/src/vector/index.ts
@@ -187,6 +187,26 @@ export class ChromaVector extends MastraVector<ChromaVectorFilter> {
     return translatedFilter ? (translatedFilter as Where) : undefined;
   }
 
+  /**
+   * Converts a Chroma distance into a similarity score (higher = more similar) based on the
+   * collection's HNSW space. This keeps scores in a comparable range across metrics, matching
+   * the conventions used by @mastra/pg and @mastra/duckdb.
+   *
+   * - cosine (`cosine`): distance in [0, 2] → `1 - distance`
+   * - euclidean (`l2`): squared-L2 distance in [0, ∞) → `1 / (1 + distance)`, kept in (0, 1]
+   * - dotproduct (`ip`): Chroma returns `1 - <a, b>` → `1 - distance` recovers the inner product
+   */
+  private distanceToScore(distance: number, space: string | undefined): number {
+    switch (space) {
+      case 'l2':
+        return 1 / (1 + distance);
+      case 'ip':
+      case 'cosine':
+      default:
+        return 1 - distance;
+    }
+  }
+
   async query<T extends Metadata = Metadata>({
     indexName,
     queryVector,
@@ -222,11 +242,15 @@ export class ChromaVector extends MastraVector<ChromaVectorFilter> {
         include: includeVector ? [...defaultInclude, 'embeddings'] : defaultInclude,
       });
 
+      // Resolve the collection's distance space so scores are normalized per metric,
+      // consistent with @mastra/pg and @mastra/duckdb.
+      const space = collection.configuration.hnsw?.space || collection.configuration.spann?.space || undefined;
+
       return (results.ids[0] || []).map((id: string, index: number) => {
-        // Chroma returns distances (lower = more similar), convert to similarity scores (higher = more similar)
-        // For cosine: similarity = 1 - distance
-        const distance = results.distances?.[0]?.[index] || 0;
-        const score = 1 - distance;
+        // Chroma returns distances (lower = more similar); convert to similarity scores (higher = more similar).
+        // A missing distance means "no information", which must not become a perfect score.
+        const distance = results.distances?.[0]?.[index];
+        const score = distance == null ? 0 : this.distanceToScore(distance, space);
         return {
           id,
           score,


### PR DESCRIPTION
## Description

`ChromaVector.query()` converted Chroma's distance into Mastra's `QueryResult.score` with the cosine-only formula `1 - distance`, regardless of the collection's metric. For `euclidean` (`l2`) collections Chroma returns squared-L2 distances in `[0, ∞)`, so scores came back in `(-∞, 1]` — a far match could score `-24`. Mastra's `score` is a store-agnostic similarity (higher = more similar, nominally `0..1`): `@mastra/pg`, `@mastra/duckdb`, and `@mastra/s3vectors` all convert per metric. Negative/unbounded scores break `minScore` thresholds and `@mastra/rag`'s `rerank` vector weighting, and silently diverge from the same query against pg/duckdb.

Separately, `const distance = results.distances?.[0]?.[index] || 0` turned a **missing** distance into `0`, i.e. a perfect score of `1` — absence of information became maximal similarity.

### Changes

- `query()` now resolves the collection's HNSW space (`collection.configuration.hnsw?.space || collection.configuration.spann?.space`) and converts distance → score per metric, matching the other stores:
  - cosine (`cosine`) → `1 - distance`
  - euclidean (`l2`) → `1 / (1 + distance)` (maps into `(0, 1]`)
  - dotproduct (`ip`) → `1 - distance` (Chroma's `ip` distance is `1 - <a, b>`, so this recovers the inner product)
- A missing distance now yields `score: 0` instead of `1` (the `|| 0` fallback was replaced with an explicit `distance == null` check).
- Extracted the conversion into a private `distanceToScore(distance, space)` helper.
- Added regression tests for euclidean and cosine score semantics.

Ranking order is unchanged for callers that only compared scores relatively (all conversions are monotonic), but absolute values now mean "more similar = higher" within the documented range, so threshold-based and cross-store consumers behave correctly.

**Files changed**
- `stores/chroma/src/vector/index.ts` — per-metric distance→score conversion, `distanceToScore` helper, missing-distance fix
- `stores/chroma/src/vector/index.test.ts` — new per-metric score-normalization regression tests
- `.changeset/neat-bats-sit.md` — patch changeset

## Related issue(s)

Fixes: #18316

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## How it was tested

- **Reproduced on `main`**: an `euclidean` collection with vectors `near=[0,0]` / `far=[3,4]` queried with `[0,0]` returned `near: 1`, `far: -24` (`1 - 25`). The same data on `@mastra/pg` returns `near: 1`, `far: ~0.038`.
- **New regression tests** (`index.test.ts` → "Per-metric score normalization"), run against the Dockerized Chroma `1.5.9` instance from `docker-compose.yaml`:
  - euclidean: exact match scores `≈ 1`, far match in `(0, 1]` and `≈ 1/26`, closer vector ranks higher (no negative scores)
  - cosine: identical vector scores `≈ 1`, orthogonal vector scores `≈ 0`
  - Both pass with the fix (the euclidean assertion fails on the unpatched `-24` score).
- `tsc --noEmit`, ESLint, and Prettier all clean on the changed files.

## Checklist

- [ ] I have linked the related issue(s) in the description above _(pending — file the issue first)_
- [x] I have made corresponding changes to the documentation (if applicable) _(none needed; behavior now matches the documented store-agnostic `score` contract)_
- [x] I have added tests that prove my fix is effective
- [ ] I have addressed all Coderabbit comments on this PR _(after PR is opened)_

## Diff summary

```diff
+      // Resolve the collection's distance space so scores are normalized per metric,
+      // consistent with @mastra/pg and @mastra/duckdb.
+      const space = collection.configuration.hnsw?.space || collection.configuration.spann?.space || undefined;
+
       return (results.ids[0] || []).map((id: string, index: number) => {
-        const distance = results.distances?.[0]?.[index] || 0;
-        const score = 1 - distance;
+        const distance = results.distances?.[0]?.[index];
+        const score = distance == null ? 0 : this.distanceToScore(distance, space);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

ChromaVector was using a "one-size-fits-all" formula to convert distance measurements into similarity scores, even though different types of distance measurements need different formulas. This caused scores to become negative or incorrectly scaled depending on which distance metric the vector collection used. The PR fixes this by using the correct formula for each metric type, so similarity scores are always in the right 0-1 range, matching how other Mastra vector stores work.

## What was fixed

**Root cause**: ChromaVector's `query()` method was using a single distance-to-score formula (`1 - distance`) for all distance metrics. This worked for cosine distance but produced incorrect results for other metrics:
- **Euclidean collections**: Return squared-L2 distances in `[0, ∞)`. Under the cosine formula, these became negative scores (e.g., distance 25 → score -24) instead of normalized values in `(0, 1]`
- **Missing distances**: Were treated as a score of `1` (perfect match), when they should indicate absence of information

## Changes made

1. **Added metric-aware score normalization**: A new `distanceToScore(distance, space)` helper method that applies the correct conversion based on the collection's distance metric:
   - `l2` (euclidean): Uses `1 / (1 + distance)` to map squared distances to `(0, 1]`
   - `cosine`: Uses `1 - distance` (existing behavior)
   - `ip` (dot product): Uses `1 - distance` (recovers inner product)

2. **Updated query scoring**: Modified the `query()` method to:
   - Resolve the collection's distance metric from `collection.configuration.hnsw?.space` or `collection.configuration.spann?.space`
   - Apply the metric-appropriate normalization to each result's score
   - Handle missing distances by explicitly setting score to `0`

3. **Added regression tests**: New test suite validates score normalization across metrics:
   - Euclidean index: Confirms scores stay in `(0, 1]` and follow `1 / (1 + distance)` formula
   - Cosine index: Confirms scores follow `1 - distance` formula

## Why this matters

- **Correct score ranges**: Scores now always represent similarity in the documented `[0, 1]` range
- **Threshold-based filtering works**: Queries like "find vectors with score > 0.5" now function correctly instead of filtering based on negative values
- **Cross-store portability**: Same query returns consistent score ranges whether using ChromaVector, `@mastra/pg`, `@mastra/duckdb`, or `@mastra/s3vectors`
- **Ranking preserved**: All conversions are monotonic—result ordering remains unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->