### PR TITLE
fix(cli): remove stale telemetry loader export

### DIFF
--- a/.changeset/fix-cli-stale-telemetry-loader-export.md
+++ b/.changeset/fix-cli-stale-telemetry-loader-export.md
@@ -1,0 +1,5 @@
+---
+"mastra": patch
+---
+
+Removed the stale `mastra/telemetry-loader` export that pointed to a file no longer included in the CLI package.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,6 @@
   "exports": {
     ".": "./dist/index.js",
     "./package.json": "./package.json",
-    "./telemetry-loader": "./dist/commands/dev/telemetry-loader.js",
     "./dist/*": [
       "./dist/*",
       "./dist/*.js"


### PR DESCRIPTION
The CLI package still exported `mastra/telemetry-loader`, but that file is no longer built or included in the package tarball. Resolving the subpath currently points to `dist/commands/dev/telemetry-loader.js`, which is missing.

This removes the stale export so the published `exports` map only advertises shipped entrypoints.

Validation:
- `pnpm build:cli`
- `pnpm --filter ./packages/cli typecheck`
- `pnpm prettier:changed`
- `pnpm lint` (passes with existing warnings in `packages/playground-ui`)
- `pnpm test:cli`
- `pnpm --filter ./packages/cli pack --pack-destination /tmp/mastra-cli-pack`
- Verified exact export targets exist in the packed tarball; in a clean install, `mastra` and `mastra/package.json` resolve, while `mastra/telemetry-loader` now returns `ERR_PACKAGE_PATH_NOT_EXPORTED` instead of resolving to a missing JS file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR removes a broken "signpost" from the CLI package that was pointing to a file that no longer exists. Instead of leaving this broken reference in the package, we're removing it so that anyone looking for that entrypoint will get a clear error instead of trying to use something that isn't actually there.

## Changes Made

**Changeset Addition**
- Added `.changeset/fix-cli-stale-telemetry-loader-export.md` to document a patch-level fix for the `mastra` package

**Package Export Map Update**
- Removed the `./telemetry-loader` export subpath from `packages/cli/package.json`
- This export previously referenced `./dist/commands/dev/telemetry-loader.js`, a file no longer included in the built package

## Validation
The changes were validated through:
- CLI build (`pnpm build:cli`)
- Type checking (`pnpm typecheck`)
- Code formatting (`pnpm prettier:changed`)
- Linting (`pnpm lint`)
- Unit tests (`pnpm test:cli`)
- Package creation and export verification (`pnpm pack`)

The pack verification confirmed that attempting to import `mastra/telemetry-loader` now properly returns `ERR_PACKAGE_PATH_NOT_EXPORTED` instead of resolving to a non-existent file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->