### PR TITLE
fix: preserve processor message boundaries

### DIFF
--- a/.changeset/fancy-planets-train.md
+++ b/.changeset/fancy-planets-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Preserved response message boundaries when processor message arrays are reapplied after output step processing.

--- a/.changeset/gentle-falcons-push.md
+++ b/.changeset/gentle-falcons-push.md
@@ -1,0 +1,5 @@
+---
+'@mastra/github-signals': patch
+---
+
+Avoided reapplying unchanged messages when GitHub signals only emit subscription hint side effects.

--- a/mastracode/e2e/scenarios/github-signals-polling-inbox.ts
+++ b/mastracode/e2e/scenarios/github-signals-polling-inbox.ts
@@ -245,16 +245,7 @@ values
     terminal.submit('Read the GitHub polling notification from the inbox.');
     await runtime.waitForScreenText(/Read the GitHub polling notification from the inbox\./i, terminal, 8_000);
     await runtime.waitForScreenText(/mastra-ai\/mastra#17640 CI recovered/i, terminal, 30_000);
-    await terminal.flushInput?.();
-    await runtime.waitForScreenText(/│ ›/i, terminal, 60_000);
-    terminal.submit(
-      `!sqlite3 "$MC_E2E_DB_PATH" "select 'GITHUB_POLLING_INBOX_STATUS=' || status || ':' || kind from mastra_notifications where source='github' order by createdAt desc limit 1;"`,
-    );
-    await runtime.waitForScreenText(
-      /GITHUB_POLLING_INBOX_STATUS=(seen|pending):pull-request-ci-recovered/i,
-      terminal,
-      8_000,
-    );
+    await runtime.waitForScreenText(/"markedSeen": 1/i, terminal, 30_000);
 
     await terminal.flushInput?.();
     await runtime.waitForScreenText(/│ ›/i, terminal, 15_000);

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -77,6 +77,10 @@ function mergeSignalDataParts<T extends { role: string; parts: Array<{ type: str
   return result;
 }
 
+type MessageListAddOptions = {
+  merge?: boolean;
+};
+
 export class MessageList {
   private messages: MastraDBMessage[] = [];
 
@@ -232,7 +236,7 @@ export class MessageList {
     return signalForTranscript;
   }
 
-  public add(messages: MessageListInput, messageSource: MessageSource) {
+  public add(messages: MessageListInput, messageSource: MessageSource, options: MessageListAddOptions = {}) {
     if (messageSource === `user`) messageSource = `input`;
 
     if (!messages) return this;
@@ -272,6 +276,7 @@ export class MessageList {
                 }
               : nestedMessage,
             messageSource,
+            options,
           );
         }
         continue;
@@ -285,6 +290,7 @@ export class MessageList {
             }
           : messageInput,
         messageSource,
+        options,
       );
     }
     return this;
@@ -1377,7 +1383,7 @@ export class MessageList {
     };
   }
 
-  private addOne(message: MessageInput, messageSource: MessageSource) {
+  private addOne(message: MessageInput, messageSource: MessageSource, options: MessageListAddOptions = {}) {
     if (
       (!(`content` in message) ||
         (!message.content &&
@@ -1469,6 +1475,7 @@ export class MessageList {
     // but replace-by-id can target an older sealed message elsewhere in the list.
     const isLatestFromMemory = latestMessage ? this.memoryMessages.has(latestMessage) : false;
     const shouldMerge =
+      options.merge !== false &&
       latestMessageIsAfterSealedBoundary &&
       !hasSealedReplacementTarget &&
       MessageMerger.shouldMerge(latestMessage, messageV2, messageSource, isLatestFromMemory, this._agentNetworkAppend);
@@ -1555,13 +1562,15 @@ export class MessageList {
           this.messages.push(messageV2);
         } else {
           const isExistingFromMemory = this.memoryMessages.has(existingMessage);
-          const shouldMergeIntoExisting = MessageMerger.shouldMerge(
-            existingMessage,
-            messageV2,
-            messageSource,
-            isExistingFromMemory,
-            this._agentNetworkAppend,
-          );
+          const shouldMergeIntoExisting =
+            options.merge !== false &&
+            MessageMerger.shouldMerge(
+              existingMessage,
+              messageV2,
+              messageSource,
+              isExistingFromMemory,
+              this._agentNetworkAppend,
+            );
           if (shouldMergeIntoExisting) {
             MessageMerger.merge(existingMessage, messageV2);
             this.updateLastCreatedAt(existingMessage);

--- a/packages/core/src/loop/test-utils/aimock/aimock-scenario.ts
+++ b/packages/core/src/loop/test-utils/aimock/aimock-scenario.ts
@@ -69,6 +69,7 @@ export async function createSharedAgent(
   opts: Pick<
     RunLoopScenarioOptions,
     | 'tools'
+    | 'signals'
     | 'instructions'
     | 'memory'
     | 'workspace'
@@ -97,6 +98,7 @@ export async function createSharedAgent(
 async function buildScenarioAgent({
   llm,
   tools,
+  signals,
   instructions,
   memory,
   workspace,
@@ -115,6 +117,7 @@ async function buildScenarioAgent({
   RunLoopScenarioOptions,
   | 'llm'
   | 'tools'
+  | 'signals'
   | 'instructions'
   | 'memory'
   | 'workspace'
@@ -148,6 +151,7 @@ async function buildScenarioAgent({
     instructions: instructions ?? 'You are a test agent driven by scripted AIMock responses.',
     model: modelConfig,
     ...(tools ? { tools } : {}),
+    ...(signals ? { signals } : {}),
     ...(memory ? { memory } : {}),
     ...(workspace ? { workspace } : {}),
     ...(agents ? { agents } : {}),
@@ -199,6 +203,7 @@ export async function runLoopScenario(opts: RunLoopScenarioOptions): Promise<Loo
     fixtures,
     prompt,
     tools,
+    signals,
     instructions,
     stopWhen,
     maxSteps,
@@ -262,6 +267,7 @@ export async function runLoopScenario(opts: RunLoopScenarioOptions): Promise<Loo
     const built = await buildScenarioAgent({
       llm,
       tools,
+      signals,
       instructions,
       memory,
       workspace,

--- a/packages/core/src/loop/test-utils/aimock/scenarios/output-step-processor.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/output-step-processor.scenario.test.ts
@@ -15,6 +15,8 @@
 import { stepCountIs } from '@internal/ai-sdk-v5';
 import { it, expect } from 'vitest';
 import { z } from 'zod/v4';
+import { MockMemory } from '../../../../memory/mock';
+import { TaskSignalProvider } from '../../../../signals';
 import { createTool } from '../../../../tools';
 import { runLoopScenario, useLoopScenarioAimock, describeForAllEngines } from '../aimock-scenario';
 
@@ -70,6 +72,329 @@ describeForAllEngines(
       expect(stepsSeen[0].hasToolCalls).toBe(true);
       // Step 2 had no tool calls (final text)
       expect(stepsSeen[1].hasToolCalls).toBe(false);
+    });
+
+    it('keeps memory messages out of current step content when a no-op processOutputStep returns messages', async () => {
+      const memory = new MockMemory();
+      const threadId = `noop-output-step-memory-thread-${engine}`;
+      const resourceId = `noop-output-step-memory-resource-${engine}`;
+      const stepContents: string[] = [];
+
+      await memory.saveThread({
+        thread: {
+          id: threadId,
+          title: 'No-op Output Step Processor Thread',
+          resourceId,
+          metadata: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      await runLoopScenario({
+        engine,
+        llm: getMock(),
+        prompt: 'Remember this seed fact: MEMORY_ONLY_PRIOR_ASSISTANT_TEXT.',
+        memory,
+        threadId,
+        resourceId,
+        fixtures: llm => {
+          llm.on({ endpoint: 'chat' }, { content: 'Seeded MEMORY_ONLY_PRIOR_ASSISTANT_TEXT into history.' });
+        },
+      });
+
+      getMock().clearRequests();
+      getMock().clearFixtures();
+      getMock().resetMatchCounts();
+
+      const lookupTool = createTool({
+        id: 'lookup_memory_regression',
+        description: 'Look up a value.',
+        inputSchema: z.object({ key: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        execute: async ({ key }) => ({ value: `VALUE_FOR_${key}` }),
+      });
+
+      const noopOutputStepProcessor = {
+        id: 'noop-output-step-return-messages',
+        async processOutputStep({ messages }: { messages: any[] }) {
+          return messages;
+        },
+      };
+
+      const { requests, output } = await runLoopScenario({
+        engine,
+        llm: getMock(),
+        prompt: 'Use the lookup tool for key beta, then answer with only the looked up value.',
+        tools: { lookup_memory_regression: lookupTool },
+        memory,
+        threadId,
+        resourceId,
+        outputProcessors: [noopOutputStepProcessor],
+        stopWhen: stepCountIs(5),
+        onStepFinish: ({ content }: { content: unknown }) => {
+          stepContents.push(JSON.stringify(content));
+        },
+        fixtures: llm => {
+          llm.on(
+            { endpoint: 'chat', hasToolResult: false },
+            {
+              toolCalls: [
+                { id: 'call_lookup_memory_regression', name: 'lookup_memory_regression', arguments: { key: 'beta' } },
+              ],
+            },
+          );
+          llm.on({ endpoint: 'chat', hasToolResult: true }, { content: 'VALUE_FOR_beta' });
+        },
+      });
+
+      expect(requests).toHaveLength(2);
+      expect(stepContents).toHaveLength(2);
+      expect(stepContents[0]).toContain('lookup_memory_regression');
+      expect(stepContents[1]).toContain('VALUE_FOR_beta');
+      expect(stepContents[1]).not.toContain('MEMORY_ONLY_PRIOR_ASSISTANT_TEXT');
+      await expect(output.text).resolves.toContain('VALUE_FOR_beta');
+    });
+
+    it('keeps memory messages out of current step content when no-op processOutputStep overlaps task state signals', async () => {
+      const memory = new MockMemory();
+      const threadId = `noop-output-step-task-signals-thread-${engine}`;
+      const resourceId = `noop-output-step-task-signals-resource-${engine}`;
+      const stepContents: unknown[][] = [];
+      const summarizeStepContent = (content: unknown[]) =>
+        content.map(part => {
+          const item = part as { type?: string; toolCallId?: string; toolName?: string; text?: string };
+          return {
+            type: item.type,
+            ...(item.toolCallId ? { toolCallId: item.toolCallId } : {}),
+            ...(item.toolName ? { toolName: item.toolName } : {}),
+            ...(item.text ? { text: item.text } : {}),
+          };
+        });
+
+      await memory.saveThread({
+        thread: {
+          id: threadId,
+          title: 'No-op Output Step Processor Task Signals Thread',
+          resourceId,
+          metadata: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      await runLoopScenario({
+        engine,
+        llm: getMock(),
+        prompt: 'Seed prior memory text: TASK_SIGNAL_MEMORY_ONLY_TEXT.',
+        memory,
+        threadId,
+        resourceId,
+        fixtures: llm => {
+          llm.on({ endpoint: 'chat' }, { content: 'Seeded TASK_SIGNAL_MEMORY_ONLY_TEXT into prior history.' });
+        },
+      });
+
+      getMock().clearRequests();
+      getMock().clearFixtures();
+      getMock().resetMatchCounts();
+
+      const noopOutputStepProcessor = {
+        id: 'noop-output-step-return-messages-with-task-signals',
+        async processOutputStep({ messages }: { messages: any[] }) {
+          return messages;
+        },
+      };
+
+      const { requests } = await runLoopScenario({
+        engine,
+        llm: getMock(),
+        prompt: 'Create, update, and complete the debugger task, then answer TASK_SIGNAL_DONE.',
+        signals: [new TaskSignalProvider()],
+        memory,
+        threadId,
+        resourceId,
+        outputProcessors: [noopOutputStepProcessor],
+        maxSteps: 6,
+        onStepFinish: ({ content }: { content: unknown[] }) => {
+          stepContents.push(content);
+        },
+        fixtures: llm => {
+          llm.on(
+            { endpoint: 'chat', hasToolResult: false },
+            {
+              toolCalls: [
+                {
+                  id: 'call_task_write_debugger',
+                  name: 'task_write',
+                  arguments: {
+                    tasks: [
+                      {
+                        id: 'debugger_task',
+                        content: 'Inspect debugger state',
+                        status: 'pending',
+                        activeForm: 'Inspecting debugger state',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          );
+          llm.onTurn(2, /.*/, {
+            toolCalls: [
+              {
+                id: 'call_task_update_debugger',
+                name: 'task_update',
+                arguments: { id: 'debugger_task', status: 'in_progress' },
+              },
+            ],
+          });
+          llm.onTurn(3, /.*/, {
+            toolCalls: [
+              {
+                id: 'call_task_complete_debugger',
+                name: 'task_complete',
+                arguments: { id: 'debugger_task' },
+              },
+            ],
+          });
+          llm.onTurn(4, /.*/, { content: 'TASK_SIGNAL_DONE' });
+        },
+      });
+
+      expect(requests).toHaveLength(4);
+      expect(stepContents.map(summarizeStepContent)).toEqual([
+        [
+          { type: 'tool-call', toolCallId: 'call_task_write_debugger', toolName: 'task_write' },
+          { type: 'tool-result', toolCallId: 'call_task_write_debugger', toolName: 'task_write' },
+        ],
+        [
+          { type: 'tool-call', toolCallId: 'call_task_update_debugger', toolName: 'task_update' },
+          { type: 'tool-result', toolCallId: 'call_task_update_debugger', toolName: 'task_update' },
+        ],
+        [
+          { type: 'tool-call', toolCallId: 'call_task_complete_debugger', toolName: 'task_complete' },
+          { type: 'tool-result', toolCallId: 'call_task_complete_debugger', toolName: 'task_complete' },
+        ],
+        [{ type: 'text', text: 'TASK_SIGNAL_DONE' }],
+      ]);
+    });
+
+    it('keeps current visible text in step content when no-op processOutputStep overlaps task state signals', async () => {
+      const memory = new MockMemory();
+      const threadId = `noop-output-step-task-signal-text-thread-${engine}`;
+      const resourceId = `noop-output-step-task-signal-text-resource-${engine}`;
+      const stepContents: unknown[][] = [];
+      const summarizeStepContent = (content: unknown[]) =>
+        content.map(part => {
+          const item = part as { type?: string; toolCallId?: string; toolName?: string; text?: string };
+          return {
+            type: item.type,
+            ...(item.text ? { text: item.text } : {}),
+            ...(item.toolCallId ? { toolCallId: item.toolCallId } : {}),
+            ...(item.toolName ? { toolName: item.toolName } : {}),
+          };
+        });
+
+      await memory.saveThread({
+        thread: {
+          id: threadId,
+          title: 'No-op Output Step Processor Task Signal Text Thread',
+          resourceId,
+          metadata: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      await runLoopScenario({
+        engine,
+        llm: getMock(),
+        prompt: 'Seed prior memory text: TASK_SIGNAL_TEXT_MEMORY_ONLY.',
+        memory,
+        threadId,
+        resourceId,
+        fixtures: llm => {
+          llm.on({ endpoint: 'chat' }, { content: 'Seeded TASK_SIGNAL_TEXT_MEMORY_ONLY into prior history.' });
+        },
+      });
+
+      getMock().clearRequests();
+      getMock().clearFixtures();
+      getMock().resetMatchCounts();
+
+      const noopOutputStepProcessor = {
+        id: 'noop-output-step-return-messages-with-task-signal-text',
+        async processOutputStep({ messages }: { messages: any[] }) {
+          return messages;
+        },
+      };
+
+      const { requests } = await runLoopScenario({
+        engine,
+        llm: getMock(),
+        prompt: 'Narrate while creating and updating the debugger task, then answer TASK_SIGNAL_TEXT_DONE.',
+        signals: [new TaskSignalProvider()],
+        memory,
+        threadId,
+        resourceId,
+        outputProcessors: [noopOutputStepProcessor],
+        maxSteps: 6,
+        onStepFinish: ({ content }: { content: unknown[] }) => {
+          stepContents.push(content);
+        },
+        fixtures: llm => {
+          llm.on(
+            { endpoint: 'chat', hasToolResult: false },
+            {
+              content: 'TEXT_BEFORE_TASK_WRITE',
+              toolCalls: [
+                {
+                  id: 'call_text_task_write_debugger',
+                  name: 'task_write',
+                  arguments: {
+                    tasks: [
+                      {
+                        id: 'debugger_text_task',
+                        content: 'Inspect debugger text state',
+                        status: 'pending',
+                        activeForm: 'Inspecting debugger text state',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          );
+          llm.onTurn(3, /.*/, {
+            content: 'TEXT_BEFORE_TASK_UPDATE',
+            toolCalls: [
+              {
+                id: 'call_text_task_update_debugger',
+                name: 'task_update',
+                arguments: { id: 'debugger_text_task', status: 'in_progress' },
+              },
+            ],
+          });
+          llm.onTurn(5, /.*/, { content: 'TASK_SIGNAL_TEXT_DONE' });
+        },
+      });
+
+      expect(requests).toHaveLength(3);
+      expect(stepContents.map(summarizeStepContent)).toEqual([
+        [
+          { type: 'text', text: 'TEXT_BEFORE_TASK_WRITE' },
+          { type: 'tool-call', toolCallId: 'call_text_task_write_debugger', toolName: 'task_write' },
+          { type: 'tool-result', toolCallId: 'call_text_task_write_debugger', toolName: 'task_write' },
+        ],
+        [
+          { type: 'text', text: 'TEXT_BEFORE_TASK_UPDATE' },
+          { type: 'tool-call', toolCallId: 'call_text_task_update_debugger', toolName: 'task_update' },
+          { type: 'tool-result', toolCallId: 'call_text_task_update_debugger', toolName: 'task_update' },
+        ],
+        [{ type: 'text', text: 'TASK_SIGNAL_TEXT_DONE' }],
+      ]);
     });
   },
   { skip: ['durable'] },

--- a/packages/core/src/loop/test-utils/aimock/types.ts
+++ b/packages/core/src/loop/test-utils/aimock/types.ts
@@ -89,6 +89,8 @@ export interface RunLoopScenarioOptions {
   };
   /** Tools available to the loop. Tool ids must match the scripted tool-call names. */
   tools?: ToolsInput;
+  /** Signal providers registered on the Agent constructor. */
+  signals?: AgentConfig['signals'];
   /**
    * System instructions for the agent. May be a static string or a
    * `DynamicArgument` function `({ requestContext }) => string` to exercise

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -549,14 +549,12 @@ describe('ProcessorRunner', () => {
       const result = await runner.runOutputProcessors(messageList);
 
       const messages = await result.get.all.prompt();
-      expect(messages).toHaveLength(2);
+      const assistantTexts = messages
+        .filter(m => m.role === 'assistant')
+        .flatMap(m => (Array.isArray(m.content) ? m.content : [{ type: 'text' as const, text: m.content }]))
+        .map(part => (part as TextPart).text);
 
-      const assistantMessage = messages.find(m => m.role === 'assistant');
-      expect(assistantMessage).toBeDefined();
-      expect(assistantMessage!.content).toHaveLength(3);
-      expect((assistantMessage!.content[0] as TextPart).text).toBe('initial response');
-      expect((assistantMessage!.content[1] as TextPart).text).toBe('extra message A');
-      expect((assistantMessage!.content[2] as TextPart).text).toBe('extra message B');
+      expect(assistantTexts).toEqual(['initial response', 'extra message A', 'extra message B']);
     });
 
     it('should abort if tripwire is triggered in output processor', async () => {
@@ -622,15 +620,12 @@ describe('ProcessorRunner', () => {
 
       const result = await runner.runOutputProcessors(messageList);
       const messages = await result.get.all.prompt();
+      const assistantTexts = messages
+        .filter(m => m.role === 'assistant')
+        .flatMap(m => (Array.isArray(m.content) ? m.content : [{ type: 'text' as const, text: m.content }]))
+        .map(part => (part as TextPart).text);
 
-      expect(messages).toHaveLength(2);
-
-      const assistantMessage = messages.find(m => m.role === 'assistant');
-      expect(assistantMessage).toBeDefined();
-      expect(assistantMessage!.content).toHaveLength(3);
-      expect((assistantMessage!.content[0] as TextPart).text).toBe('initial response');
-      expect((assistantMessage!.content[1] as TextPart).text).toBe('message from processor 1');
-      expect((assistantMessage!.content[2] as TextPart).text).toBe('message from processor 3');
+      expect(assistantTexts).toEqual(['initial response', 'message from processor 1', 'message from processor 3']);
     });
   });
 

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -701,7 +701,7 @@ export class ProcessorRunner {
             processableMessages = processResult || [];
             for (const message of processResult) {
               messageList.removeByIds([message.id]);
-              messageList.add(message, check.getSource(message) || 'response');
+              messageList.add(message, check.getSource(message) || 'response', { merge: false });
             }
           }
         }
@@ -1231,7 +1231,7 @@ export class ProcessorRunner {
             if (nonSystemMessages.length > 0) {
               for (const message of nonSystemMessages) {
                 messageList.removeByIds([message.id]);
-                messageList.add(message, check.getSource(message) || 'input');
+                messageList.add(message, check.getSource(message) || 'input', { merge: false });
               }
             }
           }
@@ -1265,7 +1265,7 @@ export class ProcessorRunner {
             if (nonSystemMessages.length > 0) {
               for (const message of nonSystemMessages) {
                 messageList.removeByIds([message.id]);
-                messageList.add(message, check.getSource(message) || 'input');
+                messageList.add(message, check.getSource(message) || 'input', { merge: false });
               }
             }
 
@@ -1966,7 +1966,7 @@ export class ProcessorRunner {
                 '';
               messageList.addSystem(systemText);
             } else {
-              messageList.add(message, check.getSource(message) || 'response');
+              messageList.add(message, check.getSource(message) || 'response', { merge: false });
             }
           }
         }
@@ -2197,7 +2197,7 @@ export class ProcessorRunner {
           '';
         messageList.addSystem(systemText);
       } else {
-        messageList.add(message, check.getSource(message) || defaultSource);
+        messageList.add(message, check.getSource(message) || defaultSource, { merge: false });
       }
     }
   }

--- a/signals/github/src/index.ts
+++ b/signals/github/src/index.ts
@@ -1291,16 +1291,16 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
     return { tools };
   }
 
-  async processOutputStep(args: ProcessOutputStepArgs): Promise<MastraDBMessage[]> {
+  async processOutputStep(args: ProcessOutputStepArgs): Promise<void> {
     const evidence = detectPrWorkEvidence({ text: args.text, toolCalls: args.toolCalls });
-    if (!evidence) return args.messages;
+    if (!evidence) return;
 
     const threadContext = this.#getThreadContext(args);
-    if (!threadContext.threadId || !threadContext.resourceId) return args.messages;
+    if (!threadContext.threadId || !threadContext.resourceId) return;
 
     const { threadStore, loadedThread } = await this.#loadThread(threadContext);
     const githubMetadata = getGithubMetadata(loadedThread.metadata);
-    if (githubMetadata.subscriptionHintShown || githubMetadata.subscriptions.length > 0) return args.messages;
+    if (githubMetadata.subscriptionHintShown || githubMetadata.subscriptions.length > 0) return;
 
     let repository: GithubRepository;
     try {
@@ -1311,7 +1311,7 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
         number: evidence.number,
       });
     } catch {
-      return args.messages;
+      return;
     }
 
     await threadStore.saveThread({
@@ -1339,8 +1339,6 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
         },
       },
     });
-
-    return args.messages;
   }
 
   async #resolveThreadStore(): Promise<GithubSignalsThreadStore | undefined> {


### PR DESCRIPTION
## Summary

This PR fixes processor message reapplication so processors that return a message array do not collapse assistant response boundaries when those messages are written back to the agent message list.

The bug showed up with no-op `processOutputStep` processors running alongside task state signals: reapplying the returned message array used the normal message merge path, which could merge separate assistant response messages together. That made later loop steps see stale text/tool content from earlier steps.

Changes included here:

- Add a `merge: false` option to `MessageList.add()` and use it for processor message-array reapply paths.
- Add AIMock regression coverage for no-op output step processors, including TaskSignalProvider scenarios that previously replayed stale step content.
- Update output processor unit expectations to preserve separate assistant messages instead of relying on accidental re-merge behavior.
- Change GitHub signals' output-step processor to return `undefined` when it only performs side effects, avoiding unnecessary unchanged-message reapplication.
- Stabilize the GitHub polling inbox E2E assertion by checking the visible tool result instead of shelling out to sqlite from the TUI.

## Test plan

- `pnpm exec vitest run packages/core/src/loop/test-utils/aimock/scenarios/output-step-processor.scenario.test.ts packages/core/src/processors/runner.test.ts --bail 1 --reporter=dot`
- `pnpm --filter @mastra/github-signals test -- --reporter=dot`
- `pnpm --filter ./packages/core check`
