### PR TITLE
Restore Mastra Code interactive prompt rendering

### DIFF
--- a/.changeset/curly-prompts-grant.md
+++ b/.changeset/curly-prompts-grant.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Restored interactive prompt result rendering in Mastra Code.

--- a/mastracode/e2e/scenarios/file-attachment-blocked-retry.ts
+++ b/mastracode/e2e/scenarios/file-attachment-blocked-retry.ts
@@ -41,7 +41,6 @@ export const fileAttachmentBlockedRetryScenario = {
   name: 'file-attachment-blocked-retry',
   description: 'Preserves a pasted image when a user prompt hook blocks the first submit and succeeds on retry.',
   testName: 'preserves pasted image attachments after a blocked submit retry',
-  skipReason: 'current main no longer restores editor attachments after a UserPromptSubmit hook block',
   projectFixture: 'long-branch',
   useOpenAIModel: true,
   aimockFixture: 'file-attachment-blocked-retry.json',
@@ -62,7 +61,7 @@ export const fileAttachmentBlockedRetryScenario = {
             {
               type: 'command',
               command: 'node .mastracode/block-first-attachment.cjs',
-              timeout: 3000,
+              timeout: 10_000,
               description: 'block first attachment submit',
             },
           ],
@@ -73,7 +72,13 @@ export const fileAttachmentBlockedRetryScenario = {
     );
   },
   async inProcessApp({ startMastraCodeApp }) {
-    const restoreFetch = installOpenAIFetchCapture({ capturePath: RAW_REQUEST_CAPTURE_PATH });
+    const restoreFetch = installOpenAIFetchCapture({
+      capturePath: RAW_REQUEST_CAPTURE_PATH,
+      requireBodyIncludes: [
+        { value: 'image/png', label: 'restored image MIME type' },
+        { value: TINY_PNG_BASE64, label: 'restored image payload' },
+      ],
+    });
     const app = await startMastraCodeApp();
     return {
       stop: async () => {

--- a/mastracode/e2e/scenarios/openai-fetch-capture.ts
+++ b/mastracode/e2e/scenarios/openai-fetch-capture.ts
@@ -6,6 +6,7 @@ export type OpenAIFetchCaptureOptions = {
   capturePath: string;
   append?: boolean;
   inputTokens?: number;
+  requireBodyIncludes?: Array<string | { value: string; label?: string }>;
 };
 
 function getFetchUrl(input: Parameters<typeof fetch>[0]): string {
@@ -54,6 +55,14 @@ export function installOpenAIFetchCapture(options: OpenAIFetchCaptureOptions): (
       if (bodyText) {
         if (options.append) appendFileSync(options.capturePath, `${JSON.stringify({ url, body: bodyText })}\n`);
         else writeFileSync(options.capturePath, bodyText);
+
+        for (const required of options.requireBodyIncludes ?? []) {
+          const value = typeof required === 'string' ? required : required.value;
+          const label = typeof required === 'string' ? required : (required.label ?? required.value);
+          if (!bodyText.includes(value)) {
+            throw new Error(`Expected OpenAI request body to include ${label}`);
+          }
+        }
       }
       return originalFetch(input, { ...init, body: nextBody });
     }

--- a/mastracode/e2e/scenarios/prompt-context-instructions.ts
+++ b/mastracode/e2e/scenarios/prompt-context-instructions.ts
@@ -15,7 +15,6 @@ export const promptContextInstructionsScenario: McE2eScenario = {
   name: 'prompt-context-instructions',
   description: 'Verify project instruction files reach the real model request built from a TUI prompt.',
   testName: 'injects winning project instructions into the AIMock-backed TUI model request',
-  skipReason: 'current main no longer includes fixture AGENTS.md content in this TUI model request path',
   projectFixture: 'long-branch',
   useOpenAIModel: true,
   aimockFixture: 'prompt-context-instructions.json',

--- a/mastracode/e2e/scenarios/prompt-queue-interleave.ts
+++ b/mastracode/e2e/scenarios/prompt-queue-interleave.ts
@@ -4,7 +4,6 @@ export const promptQueueInterleaveScenario: McE2eScenario = {
   name: 'prompt-queue-interleave',
   description: 'Exercise queued ask_user and request_access prompts emitted by parallel tool calls.',
   testName: 'answers queued ask_user and request_access prompts sequentially in the real TUI',
-  skipReason: 'current main no longer renders the request_access granted confirmation after queued prompt approval',
   useOpenAIModel: true,
   aimockFixture: 'prompt-queue-interleave.json',
   async run({ terminal, runtime }) {
@@ -32,8 +31,7 @@ export const promptQueueInterleaveScenario: McE2eScenario = {
 
     terminal.write('\r');
 
-    await runtime.waitForScreenText(/Access granted: "\/tmp\/mastracode-prompt-queue-e2e"/i, terminal);
-    await runtime.waitForScreenText(/request_access path="\/tmp\/mastracode-prompt-queue-e2e".*✓/i, terminal);
+    await runtime.waitForScreenText(/✓\s+Granted/i, terminal);
     await runtime.waitForScreenText(/Prompt queue interleave e2e complete\./i, terminal);
     runtime.printScreen('after queued prompts answered', terminal);
 

--- a/mastracode/e2e/scenarios/request-access-modal.ts
+++ b/mastracode/e2e/scenarios/request-access-modal.ts
@@ -10,7 +10,6 @@ export const requestAccessModalScenario: McE2eScenario = {
   name: 'request-access-modal',
   description: 'Exercise request_access approval and same-turn allowed-path use through the real TUI.',
   testName: 'approves request_access and reads the granted external path in the real TUI',
-  skipReason: 'current main no longer renders the request_access granted confirmation after approval',
   useOpenAIModel: true,
   aimockFixture: 'request-access-modal.json',
   prepare() {
@@ -36,7 +35,7 @@ export const requestAccessModalScenario: McE2eScenario = {
 
     terminal.write('\r');
 
-    await runtime.waitForScreenText(/Access granted: "\/tmp\/mastracode-request-access-e2e"/i, terminal);
+    await runtime.waitForScreenText(/✓\s+Granted/i, terminal);
     await runtime.waitForScreenText(/view \/tmp\/mastracode-request-access-e2e\/allowed\.txt/i, terminal);
     await runtime.waitForScreenText(/REQUEST_ACCESS_E2E_GRANTED_FILE/i, terminal);
     await runtime.waitForScreenText(/Request access e2e complete\./i, terminal);

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -280,6 +280,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
   private onSubmit?: (answer: string) => void;
   private onSubmitMulti?: (answers: string[]) => void;
   private onCancel?: () => void;
+  private formatResult?: (answer: string) => string;
   private isNegativeAnswer?: (answer: string) => boolean;
   private allowEmptyInput = false;
   private multiline = false;
@@ -355,6 +356,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
       this.onSubmit = options.onSubmit;
       this.onSubmitMulti = options.onSubmitMulti;
       this.onCancel = options.onCancel;
+      this.formatResult = options.formatResult;
       this.isNegativeAnswer = options.isNegativeAnswer;
       this.allowEmptyInput = Boolean(options.allowEmptyInput);
       this.multiline = Boolean(options.multiline);
@@ -416,6 +418,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     question: string;
     options?: Array<{ label: string; description?: string }>;
     selectionMode?: AskQuestionSelectionMode;
+    formatResult?: (answer: string) => string;
     isNegativeAnswer?: (answer: string) => boolean;
     allowEmptyInput?: boolean;
     allowCustomResponse?: boolean;
@@ -430,6 +433,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     this.onSubmit = options.onSubmit;
     this.onSubmitMulti = options.onSubmitMulti;
     this.onCancel = options.onCancel;
+    this.formatResult = options.formatResult;
     this.isNegativeAnswer = options.isNegativeAnswer;
     this.allowEmptyInput = Boolean(options.allowEmptyInput);
     this.allowCustomResponse = options.allowCustomResponse ?? true;
@@ -564,7 +568,11 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
   private handleAnswer(answer: string): void {
     if (this.answered) return;
     const isNegative = this.isNegativeAnswer?.(answer) ?? false;
-    this.answer(answer, isNegative);
+    const displayAnswer = this.formatResult?.(answer) ?? answer;
+    if (displayAnswer !== answer) {
+      this.borderedBox.items = [];
+    }
+    this.answer(displayAnswer, isNegative);
 
     this.onSubmit?.(answer);
   }

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -210,7 +210,7 @@ export async function handleSandboxAccessRequest(
           },
           formatResult: answer => {
             const approved = answer.toLowerCase().startsWith('y');
-            return approved ? `Granted access to ${requestedPath}` : `Denied access to ${requestedPath}`;
+            return approved ? 'Granted' : 'Denied';
           },
           isNegativeAnswer: answer => !answer.toLowerCase().startsWith('y'),
         },

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -344,6 +344,9 @@ export class MastraTUI {
         const allowed = await this.runUserPromptHook(userInput);
         if (!allowed) {
           this.removeOptimisticUserMessage(optimisticMessageId);
+          this.state.editor.setText(userInput);
+          this.state.pendingImages = images ?? [];
+          this.state.ui.requestRender();
           continue;
         }
 


### PR DESCRIPTION
## Summary

This is PR 2 of the split from #18248. It restores interactive prompt rendering behavior for Mastra Code ask_user/request_access flows and blocked attachment retry handling.

## Scope

- Preserve formatted prompt results such as request access Granted/Denied receipts.
- Restore queued prompt/request_access E2E coverage.
- Restore blocked attachment retry behavior and payload verification.

## Intentionally excluded

- Task list TUI rendering lives in #18248.
- Tool/history rendering lives in the next split PR.

## Verification

- pnpm --filter mastracode test -- --run src/tui/render-messages.test.ts src/tui/event-dispatch.test.ts src/tui/__tests__/render-messages.test.ts src/tui/__tests__/mastra-tui-queueing.test.ts src/tui/__tests__/parallel-interactive-prompts.test.ts src/tui/components/__tests__/ask-question-inline.test.ts --reporter=dot --bail=1
- MC_E2E_VITEST_SCENARIOS=prompt-context-instructions,prompt-queue-interleave,request-access-modal,file-attachment-blocked-retry pnpm --filter mastracode e2e:smoke -- --reporter=dot --bail=1
- pnpm prettier:changed