### PR TITLE
Restore Mastra Code tool and history rendering coverage

### DIFF
--- a/.changeset/curly-prompts-grant.md
+++ b/.changeset/curly-prompts-grant.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Restored interactive prompt result rendering in Mastra Code.

--- a/.changeset/old-news-press.md
+++ b/.changeset/old-news-press.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Restored persisted tool output and long-thread history rendering coverage in Mastra Code.

--- a/mastracode/e2e/fixtures/workspace-tool-output-rendering.json
+++ b/mastracode/e2e/fixtures/workspace-tool-output-rendering.json
@@ -3,8 +3,8 @@
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
-        "userMessage": "Render workspace shell and lsp outputs."
+        "userMessage": "Render workspace shell and lsp outputs.",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -34,8 +34,8 @@
     {
       "match": {
         "model": "gpt-5.4-mini",
-        "endpoint": "chat",
-        "hasToolResult": true
+        "userMessage": "Render workspace shell and lsp outputs.",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Workspace tool output rendering complete."

--- a/mastracode/e2e/scenarios/file-attachment-blocked-retry.ts
+++ b/mastracode/e2e/scenarios/file-attachment-blocked-retry.ts
@@ -41,7 +41,6 @@ export const fileAttachmentBlockedRetryScenario = {
   name: 'file-attachment-blocked-retry',
   description: 'Preserves a pasted image when a user prompt hook blocks the first submit and succeeds on retry.',
   testName: 'preserves pasted image attachments after a blocked submit retry',
-  skipReason: 'current main no longer restores editor attachments after a UserPromptSubmit hook block',
   projectFixture: 'long-branch',
   useOpenAIModel: true,
   aimockFixture: 'file-attachment-blocked-retry.json',
@@ -62,7 +61,7 @@ export const fileAttachmentBlockedRetryScenario = {
             {
               type: 'command',
               command: 'node .mastracode/block-first-attachment.cjs',
-              timeout: 3000,
+              timeout: 10_000,
               description: 'block first attachment submit',
             },
           ],
@@ -73,7 +72,13 @@ export const fileAttachmentBlockedRetryScenario = {
     );
   },
   async inProcessApp({ startMastraCodeApp }) {
-    const restoreFetch = installOpenAIFetchCapture({ capturePath: RAW_REQUEST_CAPTURE_PATH });
+    const restoreFetch = installOpenAIFetchCapture({
+      capturePath: RAW_REQUEST_CAPTURE_PATH,
+      requireBodyIncludes: [
+        { value: 'image/png', label: 'restored image MIME type' },
+        { value: TINY_PNG_BASE64, label: 'restored image payload' },
+      ],
+    });
     const app = await startMastraCodeApp();
     return {
       stop: async () => {

--- a/mastracode/e2e/scenarios/index.ts
+++ b/mastracode/e2e/scenarios/index.ts
@@ -45,6 +45,7 @@ import { headlessMcpToolAvailabilityScenario } from './headless-mcp-tool-availab
 import { integrationCommandsScenario } from './integration-commands.js';
 import { lifecycleHooksConfiguredScenario } from './lifecycle-hooks-configured.js';
 import { loginDialogMaskedInputScenario } from './login-dialog-masked-input.js';
+import { longThreadStartupHistoryScenario } from './long-thread-startup-history.js';
 import { mcpHttpToolCallScenario } from './mcp-http-tool-call.js';
 import { mcpLongRunningToolScenario } from './mcp-long-running-tool.js';
 import { mcpReloadConfigScenario } from './mcp-reload-config.js';
@@ -175,6 +176,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'integration-commands': integrationCommandsScenario,
   'lifecycle-hooks-configured': lifecycleHooksConfiguredScenario,
   'login-dialog-masked-input': loginDialogMaskedInputScenario,
+  'long-thread-startup-history': longThreadStartupHistoryScenario,
   'modal-and-shell': modalAndShellScenario,
   'mcp-http-tool-call': mcpHttpToolCallScenario,
   'mcp-long-running-tool': mcpLongRunningToolScenario,

--- a/mastracode/e2e/scenarios/long-thread-startup-history.ts
+++ b/mastracode/e2e/scenarios/long-thread-startup-history.ts
@@ -1,0 +1,62 @@
+import { execFileSync } from 'node:child_process';
+
+import { detectProject } from '../../src/utils/project.js';
+import type { McE2eScenario } from './types.js';
+
+function quoteSql(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+const MESSAGE_COUNT = 3_000;
+
+function padMessageIndex(index: number): string {
+  return String(index).padStart(4, '0');
+}
+
+export const longThreadStartupHistoryScenario: McE2eScenario = {
+  name: 'long-thread-startup-history',
+  description: 'Loads a long persisted startup thread and renders the newest bounded history window.',
+  testName: 'loads the newest messages from a long startup thread',
+  prepare({ dbPath, mastracodeDir, projectDir }) {
+    const startedAt = new Date('2026-06-19T15:30:00.000Z');
+    const resourceId = detectProject(mastracodeDir).resourceId;
+    const threadId = 'thread-mc-e2e-long-startup-history';
+    const title = 'E2E long startup history fixture';
+    const metadata = JSON.stringify({ projectPath: projectDir });
+    const values = Array.from({ length: MESSAGE_COUNT }, (_, offset) => {
+      const messageNumber = offset + 1;
+      const padded = padMessageIndex(messageNumber);
+      const createdAt = new Date(startedAt.getTime() + offset * 1000).toISOString();
+      const text = `LONG_THREAD_HISTORY_MESSAGE_${padded}`;
+      const content = JSON.stringify({ format: 2, parts: [{ type: 'text', text }] });
+      const role = messageNumber % 2 === 0 ? 'assistant' : 'user';
+      return `('msg-long-thread-history-${padded}', ${quoteSql(threadId)}, ${quoteSql(content)}, ${quoteSql(role)}, 'v2', ${quoteSql(createdAt)}, ${quoteSql(resourceId)})`;
+    }).join(',\n  ');
+    const updatedAt = new Date(startedAt.getTime() + (MESSAGE_COUNT - 1) * 1000).toISOString();
+    const sql = `
+insert into mastra_threads (id, resourceId, title, metadata, createdAt, updatedAt)
+values (${quoteSql(threadId)}, ${quoteSql(resourceId)}, ${quoteSql(title)}, ${quoteSql(metadata)}, ${quoteSql(startedAt.toISOString())}, ${quoteSql(updatedAt)});
+insert into mastra_messages (id, thread_id, content, role, type, createdAt, resourceId)
+values
+  ${values};
+`;
+    execFileSync('sqlite3', [dbPath], { input: sql });
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/LONG_THREAD_HISTORY_MESSAGE_3000|│ ›/i, terminal, 15_000);
+
+    await terminal.flushInput?.();
+    await runtime.waitForScreenText(/│ ›/i, terminal, 15_000);
+
+    terminal.submit('/threads');
+    await runtime.waitForScreenText(/E2E long startup history fixture/i, terminal, 15_000);
+    terminal.write('long startup history');
+    await runtime.waitForScreenText(/E2E long startup history fixture/i, terminal, 15_000);
+    terminal.write('\r');
+
+    await runtime.waitForScreenText(/LONG_THREAD_HISTORY_MESSAGE_3000/i, terminal, 15_000);
+    await runtime.waitForScreenTextAbsent(/LONG_THREAD_HISTORY_MESSAGE_0001/i, terminal, 1_000);
+    runtime.printScreen('after long startup history load', terminal);
+  },
+};

--- a/mastracode/e2e/scenarios/notification-inbox-crud-flow.ts
+++ b/mastracode/e2e/scenarios/notification-inbox-crud-flow.ts
@@ -11,7 +11,6 @@ export const notificationInboxCrudFlowScenario = {
   name: 'notification-inbox-crud-flow',
   description: 'Exercise notification_inbox list, markSeen, dismiss, archive, and search through the real TUI.',
   testName: 'manages seeded notification inbox records through CRUD and search actions',
-  skipReason: 'current main collapses notification CRUD tool output before all status assertions remain visible',
   useOpenAIModel: true,
   aimockFixture: 'notification-inbox-crud-flow.json',
   async inProcessApp({ startMastraCodeApp }): Promise<McE2eInProcessApp> {
@@ -118,9 +117,9 @@ export const notificationInboxCrudFlowScenario = {
     runtime.printScreen('after seed turn', terminal);
 
     terminal.submit('Exercise notification inbox CRUD and search.');
-    await runtime.waitForScreenText(/"status": "seen"/i, terminal, 15_000);
-    await runtime.waitForScreenText(/"status": "dismissed"/i, terminal, 15_000);
-    await runtime.waitForScreenText(/"status": "archived"/i, terminal, 15_000);
+    await runtime.waitForOutputText(/"status": "seen"/i, terminal, 15_000);
+    await runtime.waitForOutputText(/"status": "dismissed"/i, terminal, 15_000);
+    await runtime.waitForOutputText(/"status": "archived"/i, terminal, 15_000);
     await runtime.waitForScreenText(/Notification inbox CRUD\/search e2e complete/i, terminal, 15_000);
     runtime.printScreen('after notification inbox crud flow', terminal);
     terminal.keyCtrlC();

--- a/mastracode/e2e/scenarios/openai-fetch-capture.ts
+++ b/mastracode/e2e/scenarios/openai-fetch-capture.ts
@@ -6,6 +6,7 @@ export type OpenAIFetchCaptureOptions = {
   capturePath: string;
   append?: boolean;
   inputTokens?: number;
+  requireBodyIncludes?: Array<string | { value: string; label?: string }>;
 };
 
 function getFetchUrl(input: Parameters<typeof fetch>[0]): string {
@@ -54,6 +55,14 @@ export function installOpenAIFetchCapture(options: OpenAIFetchCaptureOptions): (
       if (bodyText) {
         if (options.append) appendFileSync(options.capturePath, `${JSON.stringify({ url, body: bodyText })}\n`);
         else writeFileSync(options.capturePath, bodyText);
+
+        for (const required of options.requireBodyIncludes ?? []) {
+          const value = typeof required === 'string' ? required : required.value;
+          const label = typeof required === 'string' ? required : (required.label ?? required.value);
+          if (!bodyText.includes(value)) {
+            throw new Error(`Expected OpenAI request body to include ${label}`);
+          }
+        }
       }
       return originalFetch(input, { ...init, body: nextBody });
     }

--- a/mastracode/e2e/scenarios/prompt-context-instructions.ts
+++ b/mastracode/e2e/scenarios/prompt-context-instructions.ts
@@ -15,7 +15,6 @@ export const promptContextInstructionsScenario: McE2eScenario = {
   name: 'prompt-context-instructions',
   description: 'Verify project instruction files reach the real model request built from a TUI prompt.',
   testName: 'injects winning project instructions into the AIMock-backed TUI model request',
-  skipReason: 'current main no longer includes fixture AGENTS.md content in this TUI model request path',
   projectFixture: 'long-branch',
   useOpenAIModel: true,
   aimockFixture: 'prompt-context-instructions.json',

--- a/mastracode/e2e/scenarios/prompt-queue-interleave.ts
+++ b/mastracode/e2e/scenarios/prompt-queue-interleave.ts
@@ -4,7 +4,6 @@ export const promptQueueInterleaveScenario: McE2eScenario = {
   name: 'prompt-queue-interleave',
   description: 'Exercise queued ask_user and request_access prompts emitted by parallel tool calls.',
   testName: 'answers queued ask_user and request_access prompts sequentially in the real TUI',
-  skipReason: 'current main no longer renders the request_access granted confirmation after queued prompt approval',
   useOpenAIModel: true,
   aimockFixture: 'prompt-queue-interleave.json',
   async run({ terminal, runtime }) {
@@ -32,8 +31,7 @@ export const promptQueueInterleaveScenario: McE2eScenario = {
 
     terminal.write('\r');
 
-    await runtime.waitForScreenText(/Access granted: "\/tmp\/mastracode-prompt-queue-e2e"/i, terminal);
-    await runtime.waitForScreenText(/request_access path="\/tmp\/mastracode-prompt-queue-e2e".*✓/i, terminal);
+    await runtime.waitForScreenText(/✓\s+Granted/i, terminal);
     await runtime.waitForScreenText(/Prompt queue interleave e2e complete\./i, terminal);
     runtime.printScreen('after queued prompts answered', terminal);
 

--- a/mastracode/e2e/scenarios/request-access-modal.ts
+++ b/mastracode/e2e/scenarios/request-access-modal.ts
@@ -10,7 +10,6 @@ export const requestAccessModalScenario: McE2eScenario = {
   name: 'request-access-modal',
   description: 'Exercise request_access approval and same-turn allowed-path use through the real TUI.',
   testName: 'approves request_access and reads the granted external path in the real TUI',
-  skipReason: 'current main no longer renders the request_access granted confirmation after approval',
   useOpenAIModel: true,
   aimockFixture: 'request-access-modal.json',
   prepare() {
@@ -36,7 +35,7 @@ export const requestAccessModalScenario: McE2eScenario = {
 
     terminal.write('\r');
 
-    await runtime.waitForScreenText(/Access granted: "\/tmp\/mastracode-request-access-e2e"/i, terminal);
+    await runtime.waitForScreenText(/✓\s+Granted/i, terminal);
     await runtime.waitForScreenText(/view \/tmp\/mastracode-request-access-e2e\/allowed\.txt/i, terminal);
     await runtime.waitForScreenText(/REQUEST_ACCESS_E2E_GRANTED_FILE/i, terminal);
     await runtime.waitForScreenText(/Request access e2e complete\./i, terminal);

--- a/mastracode/e2e/scenarios/tool-history-reload.ts
+++ b/mastracode/e2e/scenarios/tool-history-reload.ts
@@ -9,7 +9,6 @@ export const toolHistoryReloadScenario: McE2eScenario = {
   name: 'tool-history-reload',
   description: 'Load persisted tool call history and verify tool result rendering reconstructs in the real TUI.',
   testName: 'restores completed tool rendering from loaded history',
-  skipReason: 'current main restores loaded view/web tool history but no longer renders seeded task history entries',
   prepare({ dbPath, projectDir }) {
     const now = new Date('2026-06-07T13:00:00.000Z');
     const resourceId = 'mc-e2e-tool-history-resource';

--- a/mastracode/e2e/scenarios/types.ts
+++ b/mastracode/e2e/scenarios/types.ts
@@ -64,6 +64,7 @@ export type ScenarioName =
   | 'integration-commands'
   | 'lifecycle-hooks-configured'
   | 'login-dialog-masked-input'
+  | 'long-thread-startup-history'
   | 'modal-and-shell'
   | 'mcp-http-tool-call'
   | 'mcp-long-running-tool'
@@ -133,6 +134,7 @@ export type McE2eTerminal = {
   flushInput?: () => Promise<void>;
   keyCtrlC: () => void;
   serialize: () => { view: string };
+  serializeHistory?: () => { output: string };
   submit: (text: string) => void;
   write: (text: string) => void;
 };
@@ -141,6 +143,7 @@ export type McE2eScenarioRuntime = {
   printScreen: (label: string, terminal: McE2eTerminal) => void;
   sleep: (ms: number) => Promise<void>;
   startLiveOutput: (terminal: McE2eTerminal) => void;
+  waitForOutputText: (pattern: RegExp, terminal: McE2eTerminal, timeoutMs?: number) => Promise<void>;
   waitForScreenText: (pattern: RegExp, terminal: McE2eTerminal, timeoutMs?: number) => Promise<void>;
   waitForScreenTextAbsent: (pattern: RegExp, terminal: McE2eTerminal, timeoutMs?: number) => Promise<void>;
 };

--- a/mastracode/e2e/scenarios/workspace-tool-output-rendering.ts
+++ b/mastracode/e2e/scenarios/workspace-tool-output-rendering.ts
@@ -7,7 +7,6 @@ export const workspaceToolOutputRenderingScenario: McE2eScenario = {
   name: 'workspace-tool-output-rendering',
   description: 'Drive workspace shell and LSP tools and verify visible TUI output rendering.',
   testName: 'renders execute_command and lsp_inspect workspace tool results',
-  skipReason: 'current main repeats workspace tool calls and never reaches final assistant completion text',
   useOpenAIModel: true,
   aimockFixture: 'workspace-tool-output-rendering.json',
   prepare({ projectDir }) {

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -280,6 +280,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
   private onSubmit?: (answer: string) => void;
   private onSubmitMulti?: (answers: string[]) => void;
   private onCancel?: () => void;
+  private formatResult?: (answer: string) => string;
   private isNegativeAnswer?: (answer: string) => boolean;
   private allowEmptyInput = false;
   private multiline = false;
@@ -355,6 +356,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
       this.onSubmit = options.onSubmit;
       this.onSubmitMulti = options.onSubmitMulti;
       this.onCancel = options.onCancel;
+      this.formatResult = options.formatResult;
       this.isNegativeAnswer = options.isNegativeAnswer;
       this.allowEmptyInput = Boolean(options.allowEmptyInput);
       this.multiline = Boolean(options.multiline);
@@ -416,6 +418,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     question: string;
     options?: Array<{ label: string; description?: string }>;
     selectionMode?: AskQuestionSelectionMode;
+    formatResult?: (answer: string) => string;
     isNegativeAnswer?: (answer: string) => boolean;
     allowEmptyInput?: boolean;
     allowCustomResponse?: boolean;
@@ -430,6 +433,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     this.onSubmit = options.onSubmit;
     this.onSubmitMulti = options.onSubmitMulti;
     this.onCancel = options.onCancel;
+    this.formatResult = options.formatResult;
     this.isNegativeAnswer = options.isNegativeAnswer;
     this.allowEmptyInput = Boolean(options.allowEmptyInput);
     this.allowCustomResponse = options.allowCustomResponse ?? true;
@@ -564,7 +568,11 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
   private handleAnswer(answer: string): void {
     if (this.answered) return;
     const isNegative = this.isNegativeAnswer?.(answer) ?? false;
-    this.answer(answer, isNegative);
+    const displayAnswer = this.formatResult?.(answer) ?? answer;
+    if (displayAnswer !== answer) {
+      this.borderedBox.items = [];
+    }
+    this.answer(displayAnswer, isNegative);
 
     this.onSubmit?.(answer);
   }

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -210,7 +210,7 @@ export async function handleSandboxAccessRequest(
           },
           formatResult: answer => {
             const approved = answer.toLowerCase().startsWith('y');
-            return approved ? `Granted access to ${requestedPath}` : `Denied access to ${requestedPath}`;
+            return approved ? 'Granted' : 'Denied';
           },
           isNegativeAnswer: answer => !answer.toLowerCase().startsWith('y'),
         },

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -344,6 +344,9 @@ export class MastraTUI {
         const allowed = await this.runUserPromptHook(userInput);
         if (!allowed) {
           this.removeOptimisticUserMessage(optimisticMessageId);
+          this.state.editor.setText(userInput);
+          this.state.pendingImages = images ?? [];
+          this.state.ui.requestRender();
           continue;
         }
 


### PR DESCRIPTION
## Summary

This is PR 3 of the split from #18248. It restores Mastra Code workspace/tool output rendering coverage and long-thread history startup coverage.

## Scope

- Restore workspace tool output rendering E2E coverage.
- Restore persisted tool history reload coverage.
- Add terminal output-history helpers used by these E2E assertions.
- Add long-thread startup history coverage.

## Intentionally excluded

- Task list TUI rendering lives in #18248.
- Interactive prompt rendering lives in #18338.

## Verification

- pnpm --filter mastracode test -- --run src/tui/render-messages.test.ts src/tui/event-dispatch.test.ts src/tui/__tests__/render-messages.test.ts src/tui/__tests__/mastra-tui-queueing.test.ts src/tui/__tests__/parallel-interactive-prompts.test.ts src/tui/components/__tests__/ask-question-inline.test.ts --reporter=dot --bail=1
- MC_E2E_VITEST_SCENARIOS=notification-inbox-crud-flow,tool-history-reload,workspace-tool-output-rendering,long-thread-startup-history pnpm --filter mastracode e2e:smoke -- --reporter=dot --bail=1
- pnpm prettier:changed