### PR TITLE
docs(studio): document studio.auth for separate Studio and API authentication

### DIFF
--- a/docs/src/content/en/docs/studio/auth.mdx
+++ b/docs/src/content/en/docs/studio/auth.mdx
@@ -150,6 +150,47 @@ const rbac = new StaticRBACProvider({
 })
 ```
 
+## Separate Studio and API authentication
+
+By default, `server.auth` secures both Studio and your API routes with the same provider. If your Studio is for internal team members and your API serves external customers, configure `studio.auth` to use a different provider for each:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { SimpleAuth } from '@mastra/core/server'
+import { MastraAuthClerk } from '@mastra/auth-clerk'
+
+export const mastra = new Mastra({
+  server: {
+    // External customers authenticate via Clerk
+    auth: new MastraAuthClerk({
+      publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+      secretKey: process.env.CLERK_SECRET_KEY,
+      jwksUri: process.env.CLERK_JWKS_URI,
+    }),
+  },
+  studio: {
+    // Internal team uses a shared API key
+    auth: new SimpleAuth({
+      users: {
+        'my-studio-key': {
+          id: 'team',
+          name: 'Internal Team',
+          role: 'admin',
+        },
+      },
+    }),
+  },
+})
+```
+
+When `studio.auth` is set, Studio uses it instead of `server.auth`. When it is not set, Studio requests fall back to `server.auth`.
+
+:::note
+
+Any provider supported by `server.auth` can also be used for `studio.auth`. See the [Auth overview](/docs/server/auth) for the full list.
+
+:::
+
 ## Login methods
 
 Studio adapts its login screen based on the auth provider:


### PR DESCRIPTION
## What does this PR do?

Adds a missing section to the Studio auth docs page covering the `studio.auth` option — which lets you configure separate authentication for Studio (internal team) vs your API routes (external customers).

Closes #18193

## Problem

The `studio.auth` option is defined and documented in `packages/core/src/mastra/index.ts` source code, but absent from the Studio auth docs page. Users on Discord asked how to sign into a deployed Studio when using a 3rd party auth provider for their API — they could not find `studio.auth` anywhere in the docs.

## Change

Added **one new section** (`## Separate Studio and API authentication`) before the existing `## Login methods` table in `docs/src/content/en/docs/studio/auth.mdx`:

- Explains when `studio.auth` is useful (internal vs external audience)
- Shows a complete example: Clerk for the API, `SimpleAuth` for Studio
- Documents the fallback (`studio.auth` not set → falls back to `server.auth`)
- Links to the auth overview for the full provider list

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Test coverage improvement
- [x] Documentation update

## Notes

Docs only — no code changes, no changeset required. Code style matches the existing `studio/auth.mdx` examples exactly (no semicolons, `process.env` without `!`, string literals for `SimpleAuth` keys).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR adds documentation explaining how to use different login systems for different parts of your app - kind of like how your office might have one badge system for employees but a different visitor pass system for customers. Specifically, it shows developers how to let their internal team use one login method for the Studio dashboard while customers use a different login method for the API.

---

## Overview

Added documentation for the `studio.auth` configuration option to the Studio authentication documentation page (`docs/src/content/en/docs/studio/auth.mdx`). This new section explains how to configure separate authentication providers for the Studio interface (internal team) versus API routes (external customers).

## What's Being Documented

The `studio.auth` option, which was already defined in the source code but lacked public documentation, now includes:

- **Purpose**: Explanation of when separate authentication is useful (internal vs external audiences)
- **Configuration example**: Complete working code example showing Clerk for API authentication (`server.auth`) and `SimpleAuth` for Studio authentication (`studio.auth`)
- **Fallback behavior**: When `studio.auth` is not configured, Studio authentication falls back to `server.auth` for backward compatibility
- **Provider flexibility**: Any provider supported by `server.auth` can also be used for `studio.auth`
- **Reference link**: Directs users to the auth overview page for the complete list of supported providers

## Changes

- Added a new subsection titled "Separate Studio and API authentication" to the Studio auth documentation
- Includes TypeScript configuration examples styled consistently with existing documentation conventions (no semicolons, unadorned `process.env` references, string literals for `SimpleAuth` keys)

## Notes

- Documentation-only change with no code modifications
- No changeset required
- Directly addresses issue `#18193`, where users needed guidance on configuring separate authentication for the deployed Studio interface while using third-party providers for API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->