### PR TITLE
fix: repair workflow auth and alpha version failures

### DIFF
--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -88,7 +88,7 @@ jobs:
         if: steps.ensure-prerelease.outputs.restored != 'true' && steps.check-changes.outputs.has_changes == 'true'
         run: |
           cd packages/mcp-docs-server
-          pnpm version prerelease --preid alpha --no-git-tag-version
+          pnpm version prerelease --preid alpha --no-git-checks --no-git-tag-version
           cd ../..
 
       - name: Commit and push version changes

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -33,7 +33,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
           owner: mastra-ai
           permission-contents: write
-          permission-organization-administration: write
+          permission-administration: write
 
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10


### PR DESCRIPTION
## Summary
- Request repository administration permission instead of organization administration for the sync templates GitHub App token.
- Allow the alpha prerelease package bump to run after changesets has intentionally modified the working tree.

## Test plan
- pnpm prettier:changed
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 - What's this PR about?

This PR fixes two automated workflow problems: one change loosens overly strict permissions for the template sync workflow (only asking for what it actually needs), and another change allows the alpha version bump to complete successfully even after other tools have already modified some files.

## Overview

This pull request fixes two issues in GitHub Actions workflows that were causing failures or using excessive permissions.

## Changes

### Sync Templates Workflow - Reduced Permission Scope
In `.github/workflows/sync-templates.yml`, the Dane App Auth action now uses `permission-administration: write` instead of `permission-organization-administration: write`. This reduces the required permission scope from organization-level administration to repository-level administration, following the principle of least privilege.

### Alpha Prerelease Workflow - Allow Working Tree Modifications
In `.github/workflows/cron-alpha-publish.yml`, the `pnpm version prerelease` command now includes the `--no-git-checks` flag. This allows the alpha prerelease package bump to execute after the changesets tool has intentionally modified files in the working tree, preventing workflow failures that occurred when the git state check was too strict.

## Validation

The changes have been validated using `pnpm prettier:changed` and `git diff --check` to ensure proper code formatting and whitespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->