### PR TITLE
fix(chroma): return per-metric similarity score from query()

### DIFF
--- a/.changeset/chroma-per-metric-score.md
+++ b/.changeset/chroma-per-metric-score.md
@@ -1,0 +1,5 @@
+---
+'@mastra/chroma': patch
+---
+
+Fixed `ChromaVector.query()` returning wrong similarity scores for non-cosine collections. Scores were always computed as `1 - distance`, which is only correct for cosine. Euclidean collections returned unbounded negative scores, breaking `minScore` thresholds and rerank weighting and making scores incomparable with other vector stores. Scores are now derived from the collection's actual metric (`euclidean` → `1 / (1 + sqrt(distance))` since Chroma's `l2` space returns squared distances, `dotproduct` → `1 - distance`, `cosine` → `1 - distance`), matching the convention used across the other Mastra vector stores. A missing distance now scores `0` instead of a perfect `1`.

--- a/.changeset/chroma-per-metric-score.md
+++ b/.changeset/chroma-per-metric-score.md
@@ -2,4 +2,9 @@
 '@mastra/chroma': patch
 ---
 
-Fixed `ChromaVector.query()` returning wrong similarity scores for non-cosine collections. Scores were always computed as `1 - distance`, which is only correct for cosine. Euclidean collections returned unbounded negative scores, breaking `minScore` thresholds and rerank weighting and making scores incomparable with other vector stores. Scores are now derived from the collection's actual metric (`euclidean` → `1 / (1 + sqrt(distance))` since Chroma's `l2` space returns squared distances, `dotproduct` → `1 - distance`, `cosine` → `1 - distance`), matching the convention used across the other Mastra vector stores. A missing distance now scores `0` instead of a perfect `1`.
+Fixed similarity scoring in `ChromaVector.query()` for non-cosine indexes.
+
+- Euclidean indexes now return bounded, positive scores instead of unbounded negative ones.
+- Dotproduct indexes now use the correct score conversion.
+- A missing distance now scores `0` instead of a perfect `1`.
+- `minScore` filtering and rerank weighting now behave consistently with the other Mastra vector stores.

--- a/stores/chroma/src/vector/distance-to-score.test.ts
+++ b/stores/chroma/src/vector/distance-to-score.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { distanceToScore } from './distance-to-score';
+
+describe('distanceToScore', () => {
+  it('converts cosine distance with 1 - distance', () => {
+    expect(distanceToScore(0, 'cosine')).toBe(1);
+    expect(distanceToScore(0.25, 'cosine')).toBeCloseTo(0.75);
+    expect(distanceToScore(2, 'cosine')).toBe(-1);
+  });
+
+  it('maps euclidean (squared L2) distance into a bounded 0..1 score', () => {
+    expect(distanceToScore(0, 'euclidean')).toBe(1);
+    expect(distanceToScore(1, 'euclidean')).toBeCloseTo(0.5);
+    expect(distanceToScore(25, 'euclidean')).toBeCloseTo(1 / 6);
+  });
+
+  it('keeps euclidean scores monotonic and never negative', () => {
+    const near = distanceToScore(0.5, 'euclidean');
+    const far = distanceToScore(25, 'euclidean');
+    expect(near).toBeGreaterThan(far);
+    expect(far).toBeGreaterThan(0);
+  });
+
+  it('recovers the dot product from dotproduct distance with 1 - distance', () => {
+    expect(distanceToScore(0.1, 'dotproduct')).toBeCloseTo(0.9);
+    expect(distanceToScore(0.7, 'dotproduct')).toBeCloseTo(0.3);
+  });
+});

--- a/stores/chroma/src/vector/distance-to-score.ts
+++ b/stores/chroma/src/vector/distance-to-score.ts
@@ -1,0 +1,10 @@
+export function distanceToScore(distance: number, metric: 'cosine' | 'euclidean' | 'dotproduct'): number {
+  switch (metric) {
+    case 'euclidean':
+      return 1 / (1 + Math.sqrt(distance));
+    case 'dotproduct':
+    case 'cosine':
+    default:
+      return 1 - distance;
+  }
+}

--- a/stores/chroma/src/vector/index.test.ts
+++ b/stores/chroma/src/vector/index.test.ts
@@ -558,6 +558,56 @@ describe('ChromaVector Integration Tests', () => {
       expect(pages).toHaveLength(Math.ceil(batchSize / pageSize));
     }, 30000);
   });
+
+  describe('score semantics (similarity, not raw distance)', () => {
+    const cosineIndex = 'score-cosine';
+    const euclideanIndex = 'score-euclidean';
+
+    afterEach(async () => {
+      for (const indexName of [cosineIndex, euclideanIndex]) {
+        try {
+          await vectorDB.deleteIndex({ indexName });
+        } catch {
+          continue;
+        }
+      }
+    });
+
+    it('returns a higher score for the closer vector on a cosine index', async () => {
+      await vectorDB.createIndex({ indexName: cosineIndex, dimension: 2, metric: 'cosine' });
+      await vectorDB.upsert({
+        indexName: cosineIndex,
+        vectors: [
+          [1, 0],
+          [0, 1],
+        ],
+        ids: ['exact', 'far'],
+      });
+
+      const results = await vectorDB.query({ indexName: cosineIndex, queryVector: [1, 0], topK: 2 });
+      const byId = Object.fromEntries(results.map(r => [r.id, r.score]));
+      expect(byId.exact).toBeGreaterThan(byId.far);
+      expect(byId.exact).toBeCloseTo(1, 5);
+    }, 15000);
+
+    it('maps euclidean distance into a descending, non-negative score', async () => {
+      await vectorDB.createIndex({ indexName: euclideanIndex, dimension: 2, metric: 'euclidean' });
+      await vectorDB.upsert({
+        indexName: euclideanIndex,
+        vectors: [
+          [0, 0],
+          [3, 4],
+        ],
+        ids: ['near', 'far'],
+      });
+
+      const results = await vectorDB.query({ indexName: euclideanIndex, queryVector: [0, 0], topK: 2 });
+      const byId = Object.fromEntries(results.map(r => [r.id, r.score]));
+      expect(byId.near).toBeGreaterThan(byId.far);
+      expect(byId.far).toBeGreaterThan(0);
+      expect(byId.near).toBeCloseTo(1, 5);
+    }, 15000);
+  });
 });
 
 // Shared vector store test suite

--- a/stores/chroma/src/vector/index.ts
+++ b/stores/chroma/src/vector/index.ts
@@ -15,6 +15,7 @@ import type {
 } from '@mastra/core/vector';
 import { ChromaClient, CloudClient } from 'chromadb';
 import type { ChromaClientArgs, RecordSet, Where, WhereDocument, Collection, Metadata, Search } from 'chromadb';
+import { distanceToScore } from './distance-to-score';
 import type { ChromaVectorFilter } from './filter';
 import { ChromaFilterTranslator } from './filter';
 
@@ -222,11 +223,12 @@ export class ChromaVector extends MastraVector<ChromaVectorFilter> {
         include: includeVector ? [...defaultInclude, 'embeddings'] : defaultInclude,
       });
 
+      const space = collection.configuration?.hnsw?.space || collection.configuration?.spann?.space || 'cosine';
+      const metric = spaceMappings[space] as 'cosine' | 'euclidean' | 'dotproduct';
+
       return (results.ids[0] || []).map((id: string, index: number) => {
-        // Chroma returns distances (lower = more similar), convert to similarity scores (higher = more similar)
-        // For cosine: similarity = 1 - distance
-        const distance = results.distances?.[0]?.[index] || 0;
-        const score = 1 - distance;
+        const distance = results.distances?.[0]?.[index];
+        const score = distance == null ? 0 : distanceToScore(distance, metric);
         return {
           id,
           score,


### PR DESCRIPTION
## Summary

`ChromaVector.query()` converted Chroma's distance to a `score` using the cosine-only formula `1 - distance` for **every** metric. This is only correct for cosine:

- **euclidean** collections returned scores in `(-∞, 1]` (Chroma's `l2` space returns squared distances, so a far match at distance 25 scored `-24`).
- **dotproduct** collections were mis-scaled.
- The `results.distances?.[0]?.[index] || 0` fallback turned a *missing* distance into a **perfect score of 1**.

Ordering happened to survive for euclidean (the conversion is monotonic), but the documented "score in 0..1, higher is better" contract was broken — `minScore` thresholds, rerank `vector` weighting in `@mastra/rag`, and cross-store portability all produce garbage on negative/unbounded values.

Closes #18316.

## Fix

The metric is already available on the collection (`configuration.hnsw.space`), so `query()` now derives the score per-metric, matching the convention used across the other Mastra vector stores (and the recently merged LanceDB fix #18104):

| metric | conversion |
|---|---|
| cosine | `1 - distance` |
| dotproduct | `1 - distance` (recovers the dot product, matching `@mastra/pg`) |
| euclidean | `1 / (1 + sqrt(distance))` (Chroma `l2` returns squared distance) |

A missing distance now scores `0` instead of `1`. The conversion lives in a small pure helper (`distance-to-score.ts`) so it's unit-testable without a live Chroma.

## Tests

- New unit tests for `distanceToScore` (cosine / euclidean / dotproduct + monotonicity).
- New integration tests asserting the closer vector outscores the far one on both cosine and euclidean indexes, and that euclidean scores stay non-negative.
- Full `@mastra/chroma` suite green against a live Chroma container (171 passed, 6 skipped). Typecheck, eslint, and prettier all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Chroma gives you a “distance” (how far things are), but Mastra expects a “score” where higher means more similar. This PR fixes the math so each distance type gets converted with the right formula—so scores stay in the 0..1 range and missing distances don’t pretend to be perfect matches.

## Summary
This PR fixes `ChromaVector.query()` to correctly convert Chroma distances into normalized similarity scores (0..1, higher is better). Previously, the code always used `score = 1 - distance`, which is only correct for cosine distance; for euclidean (squared L2) it produced unbounded negative scores, and for dotproduct it produced incorrectly scaled scores. It also treated missing distances as `0`, which became a perfect score of `1`, effectively turning “missing” into “best match.”

The fix:
- Determines the metric configured for the Chroma collection from `configuration.hnsw.space` / `configuration.spann.space` (defaulting to `cosine`)
- Converts distances to scores with metric-specific logic via a new helper:
  - **cosine**: `1 - distance`
  - **dotproduct**: `1 - distance`
  - **euclidean** (squared L2): `1 / (1 + sqrt(distance))` (keeps scores bounded in `[0, 1]`)
- Treats `null`/`undefined` distances as score **0** (not 1)

This restores the documented “score in 0..1, higher is better” contract, improving correctness for downstream uses like `minScore` filtering and reranking.

## Changes
- **`stores/chroma/src/vector/distance-to-score.ts`**: Added pure `distanceToScore(distance, metric)` helper
- **`stores/chroma/src/vector/distance-to-score.test.ts`**: Added unit tests covering cosine/euclidean/dotproduct conversions and euclidean monotonicity/non-negativity
- **`stores/chroma/src/vector/index.ts`**: Updated `query()` to resolve the configured metric from collection configuration and convert each returned distance with `distanceToScore` (missing → 0)
- **`stores/chroma/src/vector/index.test.ts`**: Added tests asserting correct higher-is-better ordering for cosine and euclidean
- **`.changeset/chroma-per-metric-score.md`**: Updated changeset to document the user-visible scoring fix with a patch bump

## Testing
Full test suite validation: **171 passed, 6 skipped**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->