### PR TITLE
fix(memory): hard-split oversized words in chunkText

### DIFF
--- a/.changeset/memory-chunktext-oversized-words.md
+++ b/.changeset/memory-chunktext-oversized-words.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed `chunkText` producing oversized chunks for whitespace-free content. It only split on whitespace, so a single long "word" — a base64 payload, a minified bundle, a long URL, or spaceless CJK text — became one chunk larger than the embedder's token limit, causing `embedMany` to reject and breaking semantic-recall indexing and recall for that turn. Oversized words are now hard-split by character count so every chunk stays within budget. Also fixed an off-by-one that emitted an empty leading chunk when the first word already exceeded the budget, which some embedding providers reject.

--- a/packages/memory/src/chunk-text.test.ts
+++ b/packages/memory/src/chunk-text.test.ts
@@ -1,0 +1,76 @@
+import { InMemoryStore } from '@mastra/core/storage';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Memory } from './index';
+
+class TestableMemory extends Memory {
+  public testChunkText(text: string, tokenSize?: number): string[] {
+    return this.chunkText(text, tokenSize);
+  }
+}
+
+describe('Memory.chunkText', () => {
+  let memory: TestableMemory;
+
+  beforeEach(() => {
+    memory = new TestableMemory({ storage: new InMemoryStore() });
+  });
+
+  it('keeps every chunk within the character budget for unbroken content', () => {
+    const tokenSize = 10;
+    const charSize = tokenSize * 4;
+    const text = 'a'.repeat(charSize * 3 + 7);
+
+    const chunks = memory.testChunkText(text, tokenSize);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join('')).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(charSize);
+    }
+  });
+
+  it('never emits an empty chunk when the first word is oversized', () => {
+    const tokenSize = 10;
+    const text = 'x'.repeat(tokenSize * 4 + 5);
+
+    const chunks = memory.testChunkText(text, tokenSize);
+
+    expect(chunks).not.toContain('');
+    expect(chunks[0]).not.toBe('');
+  });
+
+  it('splits spaceless content that has no whitespace to break on', () => {
+    const tokenSize = 5;
+    const charSize = tokenSize * 4;
+    const text = '世'.repeat(charSize * 2);
+
+    const chunks = memory.testChunkText(text, tokenSize);
+
+    expect(chunks.length).toBe(2);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(charSize);
+    }
+  });
+
+  it('still packs normal whitespace-separated text into few chunks', () => {
+    const chunks = memory.testChunkText('the quick brown fox jumps', 4096);
+
+    expect(chunks).toEqual(['the quick brown fox jumps']);
+  });
+
+  it('flushes the current chunk before an oversized word and keeps the remainder', () => {
+    const tokenSize = 10;
+    const charSize = tokenSize * 4;
+    const text = `short ${'y'.repeat(charSize + 3)} tail`;
+
+    const chunks = memory.testChunkText(text, tokenSize);
+
+    expect(chunks).not.toContain('');
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(charSize);
+    }
+    expect(chunks[0]).toBe('short');
+    expect(chunks.join('').includes('y'.repeat(charSize))).toBe(true);
+  });
+});

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -951,28 +951,41 @@ ${workingMemory}`;
   }
 
   protected chunkText(text: string, tokenSize = 4096) {
-    // Convert token size to character size with some buffer
     const charSize = tokenSize * CHARS_PER_TOKEN;
     const chunks: string[] = [];
     let currentChunk = '';
 
-    // Split text into words to avoid breaking words
     const words = text.split(/\s+/);
 
     for (const word of words) {
-      // Add space before word unless it's the first word in the chunk
+      if (word.length > charSize) {
+        if (currentChunk) {
+          chunks.push(currentChunk);
+          currentChunk = '';
+        }
+        for (let i = 0; i < word.length; i += charSize) {
+          const slice = word.slice(i, i + charSize);
+          if (slice.length === charSize) {
+            chunks.push(slice);
+          } else {
+            currentChunk = slice;
+          }
+        }
+        continue;
+      }
+
       const wordWithSpace = currentChunk ? ' ' + word : word;
 
-      // If adding this word would exceed the chunk size, start a new chunk
       if (currentChunk.length + wordWithSpace.length > charSize) {
-        chunks.push(currentChunk);
+        if (currentChunk) {
+          chunks.push(currentChunk);
+        }
         currentChunk = word;
       } else {
         currentChunk += wordWithSpace;
       }
     }
 
-    // Add the final chunk if not empty
     if (currentChunk) {
       chunks.push(currentChunk);
     }


### PR DESCRIPTION
## Summary

`Memory.chunkText()` splits message content for embedding but only breaks on whitespace (`text.split(/\s+/)`). Any single whitespace-free "word" longer than the char budget (`tokenSize * 4`, default 16,384) is emitted as **one oversized chunk** that the embedding provider then rejects.

This breaks on real content:
- a base64 data URI / attachment payload in message content,
- a long minified JS/JSON blob or a long URL with query params,
- spaceless CJK text (no whitespace to split on at all → the whole message is one "word").

The oversized chunk makes `embedMany` throw the provider's max-token error, failing `embedMessageContent` → semantic-recall save/recall for that turn with an opaque error.

There was also an off-by-one: when the **first** word already exceeds the budget, the code pushed the current (empty) chunk, so `chunks[0] === ''` — and some providers reject empty inputs.

Closes #18234.

## Fix

- Hard-split any single word longer than `charSize` into `charSize`-length character slices, so every chunk is guaranteed within budget. The trailing remainder stays as the current chunk so following short words still pack onto it.
- Only push `currentChunk` when it's non-empty, removing the empty leading chunk.

Whitespace-separated text still packs into the same few chunks as before.

## Tests

New unit tests (`chunk-text.test.ts`, via a `TestableMemory` subclass exposing the protected method, matching the existing test pattern):
- every chunk within budget for unbroken content, and the content round-trips;
- no empty chunk when the first word is oversized;
- spaceless CJK content splits correctly;
- normal whitespace text stays in one chunk;
- an oversized word flushes the current chunk first and keeps the remainder.

5 passed. `tsc --noEmit`, eslint, and prettier all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The system used to break up text into smaller pieces for processing, but it only split on spaces. When it encountered long words with no spaces (like base64 data, long URLs, or minified code), the whole thing would become one huge chunk that was too big to process. This PR makes it smarter: if a single word is too long, it gets chopped up into smaller pieces so everything fits.

## What Changed

### Core Fix: `Memory.chunkText()` Hard-Splits Oversized Words
The `chunkText()` method in `packages/memory/src/index.ts` was updated to handle words longer than the character budget (default 16,384 characters). Previously, the method only broke text at whitespace boundaries, which meant single long words—common in base64 payloads, minified JavaScript/JSON, long URLs, and spaceless CJK text—would remain as oversized chunks that embedding providers reject.

The fix adds logic to detect when a word exceeds the character budget and forcibly split it into fixed-length character slices (`charSize`-sized chunks), with the remainder becoming the current chunk for accumulating subsequent shorter words. This guarantees every chunk stays within budget while preserving normal whitespace-packing behavior for regular text.

Additionally, the fix eliminates an off-by-one error where an empty string would be pushed as the first chunk when the first word itself exceeded the budget, which some embedding providers reject.

### Test Coverage: Five New Unit Tests
A comprehensive test suite was added in `packages/memory/src/chunk-text.test.ts` with five test cases covering:
1. All chunks stay within budget for unbroken content while preserving full text round-tripping
2. No empty chunk is produced when the first word is oversized
3. Spaceless/unbroken content (no whitespace) is properly split into expected chunks within budget
4. Normal whitespace-separated text still packs efficiently into single chunks
5. Oversized words trigger chunk flushing and remainder handling with no empty chunks

### Changelog Entry
A new changeset document (`packages/memory/.changeset/memory-chunktext-oversized-words.md`) was added to track this patch-level fix for `@mastra/memory`.

## Impact

This fix restores `embedMessageContent` and semantic-recall indexing/recall operations for messages containing whitespace-free content (URLs, base64 data, minified code, spaceless CJK text) that were previously failing when embedding providers rejected oversized chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->