### PR TITLE
feat(core): register Harness on Mastra and inherit instance storage

### DIFF
--- a/.changeset/large-rules-grow.md
+++ b/.changeset/large-rules-grow.md
@@ -2,7 +2,7 @@
 '@mastra/core': minor
 ---
 
-Allow `Harness` instances to be registered on a `Mastra` instance via `new Mastra({ harnesses })`, reachable through `mastra.getHarness(id)` and `mastra.listHarnesses()` (matching the `getAgent`/`listAgents` convention).
+Allow `Harness` instances to be registered on a `Mastra` instance via `new Mastra({ harnesses })`, reachable through `mastra.getHarness(key)`, `mastra.getHarnessById(id)`, and `mastra.listHarnesses()` (matching the `getAgent`/`getAgentById`/`listAgents` convention). `getHarness` looks a Harness up by its registration key; `getHarnessById` looks it up by the `id` passed to the `Harness` constructor, falling back to a key match.
 
 Harnesses are keyed by id (like agents and workflows), so one Mastra can host several — e.g. a `code` harness and a `support` harness — each with its own modes and agents. A registered Harness uses the parent Mastra (its storage, agents, gateways, and observability) instead of building its own internal one during `init()`. A standalone Harness keeps creating its internal Mastra exactly as before, so existing consumers (e.g. MastraCode) are unaffected. The rule is simply: use the injected Mastra if registered, otherwise the lazily-created internal one.
 

--- a/.changeset/large-rules-grow.md
+++ b/.changeset/large-rules-grow.md
@@ -1,0 +1,20 @@
+---
+'@mastra/core': minor
+---
+
+Allow `Harness` instances to be registered on a `Mastra` instance via `new Mastra({ harnesses })`, reachable through `mastra.getHarness(id)` and `mastra.listHarnesses()` (matching the `getAgent`/`listAgents` convention).
+
+Harnesses are keyed by id (like agents and workflows), so one Mastra can host several — e.g. a `code` harness and a `support` harness — each with its own modes and agents. A registered Harness uses the parent Mastra (its storage, agents, gateways, and observability) instead of building its own internal one during `init()`. A standalone Harness keeps creating its internal Mastra exactly as before, so existing consumers (e.g. MastraCode) are unaffected. The rule is simply: use the injected Mastra if registered, otherwise the lazily-created internal one.
+
+When registered on a Mastra, the Harness also **inherits that instance's storage** — every thread, message, permission, and observational-memory read/write is routed through `mastra.getStorage()` rather than the Harness's own `config.storage`, so the host and its Harnesses persist to a single store. A standalone Harness falls back to its own `config.storage`.
+
+This is the foundation for exposing Harness sessions over HTTP through the Mastra server.
+
+```typescript
+const code = new Harness({ id: 'code', modes });
+const support = new Harness({ id: 'support', modes });
+const mastra = new Mastra({ harnesses: { code, support }, storage });
+
+mastra.getHarness('code') === code; // true
+code.getMastra() === mastra; // true — no separate internal Mastra
+```

--- a/.changeset/large-rules-grow.md
+++ b/.changeset/large-rules-grow.md
@@ -2,19 +2,14 @@
 '@mastra/core': minor
 ---
 
-Allow `Harness` instances to be registered on a `Mastra` instance via `new Mastra({ harnesses })`, reachable through `mastra.getHarness(key)`, `mastra.getHarnessById(id)`, and `mastra.listHarnesses()` (matching the `getAgent`/`getAgentById`/`listAgents` convention). `getHarness` looks a Harness up by its registration key; `getHarnessById` looks it up by the `id` passed to the `Harness` constructor, falling back to a key match.
+Register `Harness` instances on `Mastra`.
 
-Harnesses are keyed by id (like agents and workflows), so one Mastra can host several — e.g. a `code` harness and a `support` harness — each with its own modes and agents. A registered Harness uses the parent Mastra (its storage, agents, gateways, and observability) instead of building its own internal one during `init()`. A standalone Harness keeps creating its internal Mastra exactly as before, so existing consumers (e.g. MastraCode) are unaffected. The rule is simply: use the injected Mastra if registered, otherwise the lazily-created internal one.
-
-When registered on a Mastra, the Harness also **inherits that instance's storage** — every thread, message, permission, and observational-memory read/write is routed through `mastra.getStorage()` rather than the Harness's own `config.storage`, so the host and its Harnesses persist to a single store. A standalone Harness falls back to its own `config.storage`.
-
-This is the foundation for exposing Harness sessions over HTTP through the Mastra server.
+Pass harnesses to `new Mastra({ harnesses })` (keyed like agents and workflows) and look them up with `mastra.getHarness(key)`, `mastra.getHarnessById(id)`, or `mastra.listHarnesses()`. A registered Harness shares the parent Mastra — its storage, agents, gateways, and observability — instead of building its own internal one, and is torn down with `mastra.shutdown()`. A standalone Harness is unchanged. This is the foundation for serving Harness sessions over HTTP.
 
 ```typescript
 const code = new Harness({ id: 'code', modes });
-const support = new Harness({ id: 'support', modes });
-const mastra = new Mastra({ harnesses: { code, support }, storage });
+const mastra = new Mastra({ harnesses: { code }, storage });
 
-mastra.getHarness('code') === code; // true
-code.getMastra() === mastra; // true — no separate internal Mastra
+mastra.getHarness('code') === code; // by registration key
+code.getMastra() === mastra; // shares the parent Mastra and its storage
 ```

--- a/packages/core/src/harness/harness-mastra-registration.test.ts
+++ b/packages/core/src/harness/harness-mastra-registration.test.ts
@@ -40,6 +40,12 @@ describe('Harness ↔ Mastra registration', () => {
     expect(mastra.getHarness('support')).toBe(support);
     expect(Object.keys(mastra.listHarnesses())).toEqual(['code', 'support']);
 
+    // getHarnessById resolves by the Harness's own `id` (not the registration key).
+    expect(mastra.getHarnessById('code-harness')).toBe(code);
+    expect(mastra.getHarnessById('support-harness')).toBe(support);
+    // The registration key is not a valid id lookup, but falls back to a key match.
+    expect(mastra.getHarnessById('code')).toBe(code);
+
     // Each harness resolves to the same parent Mastra but stays independent.
     expect(code.getMastra()).toBe(mastra);
     expect(support.getMastra()).toBe(mastra);
@@ -58,9 +64,10 @@ describe('Harness ↔ Mastra registration', () => {
     expect(agent).toBeDefined();
   });
 
-  it('returns undefined from getHarness when no harness is registered', () => {
+  it('returns undefined from getHarness/getHarnessById when no harness is registered', () => {
     const mastra = new Mastra({});
     expect(mastra.getHarness('code')).toBeUndefined();
+    expect(mastra.getHarnessById('code-harness')).toBeUndefined();
     expect(mastra.listHarnesses()).toEqual({});
   });
 

--- a/packages/core/src/harness/harness-mastra-registration.test.ts
+++ b/packages/core/src/harness/harness-mastra-registration.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { Mastra } from '../mastra';
+import { InMemoryStore } from '../storage/mock';
+import { createTestAgent, createTestHarness } from './test-utils';
+
+describe('Harness ↔ Mastra registration', () => {
+  it('uses its own internal Mastra when standalone', async () => {
+    const harness = createTestHarness({ storage: new InMemoryStore() });
+    await harness.init();
+
+    const mastra = harness.getMastra();
+    expect(mastra).toBeInstanceOf(Mastra);
+  });
+
+  it('uses the parent Mastra when registered on one', async () => {
+    const harness = createTestHarness({ storage: new InMemoryStore() });
+
+    const mastra = new Mastra({ harnesses: { code: harness } });
+
+    // Registered before init(): getMastra() resolves to the parent immediately.
+    expect(harness.getMastra()).toBe(mastra);
+    expect(mastra.getHarness('code')).toBe(harness);
+
+    // init() must not replace the parent Mastra with a fresh internal one.
+    await harness.init();
+    expect(harness.getMastra()).toBe(mastra);
+  });
+
+  it('hosts multiple independent harnesses keyed by id', async () => {
+    const code = createTestHarness({ id: 'code-harness', storage: new InMemoryStore() });
+    const support = createTestHarness({
+      id: 'support-harness',
+      storage: new InMemoryStore(),
+      agent: createTestAgent({ id: 'support-agent', name: 'support-agent' }),
+    });
+
+    const mastra = new Mastra({ harnesses: { code, support } });
+
+    expect(mastra.getHarness('code')).toBe(code);
+    expect(mastra.getHarness('support')).toBe(support);
+    expect(Object.keys(mastra.listHarnesses())).toEqual(['code', 'support']);
+
+    // Each harness resolves to the same parent Mastra but stays independent.
+    expect(code.getMastra()).toBe(mastra);
+    expect(support.getMastra()).toBe(mastra);
+    expect(code).not.toBe(support);
+  });
+
+  it('registers each harness backing agent on the parent Mastra', async () => {
+    const harness = createTestHarness({ storage: new InMemoryStore() });
+    const mastra = new Mastra({ harnesses: { code: harness } });
+
+    await harness.init();
+
+    // The default mode's agent should be registered on the parent Mastra,
+    // reachable by its id, so the parent owns the agent surface.
+    const agent = mastra.getAgentById('test-agent');
+    expect(agent).toBeDefined();
+  });
+
+  it('returns undefined from getHarness when no harness is registered', () => {
+    const mastra = new Mastra({});
+    expect(mastra.getHarness('code')).toBeUndefined();
+    expect(mastra.listHarnesses()).toEqual({});
+  });
+
+  it('inherits the parent Mastra storage when registered', async () => {
+    const parentStore = new InMemoryStore();
+    // The harness is given a *different* store in its own config; once
+    // registered it must read/write through the parent Mastra's store instead.
+    const harness = createTestHarness({ storage: new InMemoryStore() });
+    // Registering the harness wires it to the parent Mastra's storage.
+    new Mastra({ harnesses: { code: harness }, storage: parentStore });
+
+    await harness.init();
+    const session = await harness.createSession();
+    const thread = await session.thread.create();
+
+    // The thread was persisted through the parent Mastra's store, not the
+    // harness's own config.storage.
+    const memory = await parentStore.getStore('memory');
+    const persisted = await memory!.getThreadById({ threadId: thread.id });
+    expect(persisted?.id).toBe(thread.id);
+  });
+
+  it('falls back to its own storage when standalone', async () => {
+    const ownStore = new InMemoryStore();
+    const harness = createTestHarness({ storage: ownStore });
+
+    await harness.init();
+    const session = await harness.createSession();
+    const thread = await session.thread.create();
+
+    const memory = await ownStore.getStore('memory');
+    const persisted = await memory!.getThreadById({ threadId: thread.id });
+    expect(persisted?.id).toBe(thread.id);
+  });
+});

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -515,6 +515,12 @@ export class Harness<TState = {}> {
         ...(gateways ? { gateways } : {}),
       });
       await this.#internalMastra.getStorage()!.init();
+    } else if (this.#externalMastra) {
+      // Registered on a parent Mastra: don't build an internal Mastra, but make
+      // sure the inherited storage is initialized before any session reads or
+      // writes through it. Init is idempotent on MastraCompositeStore, so this
+      // is safe even when the parent already initialized it.
+      await this.#externalMastra.getStorage()?.init();
     }
 
     // Initialize workspace if configured (skip for dynamic factory — resolved per-request)
@@ -806,7 +812,6 @@ export class Harness<TState = {}> {
   }
 
   private propagateRuntimeServicesToAgent(agent: Agent): Agent {
-    const alreadyHasMastra = !!agent.getMastraInstance();
     const workspaceForAgents = this.workspaceFn ?? this.workspace;
     const browserForAgents = this.browserFn ?? this.browser;
 
@@ -823,8 +828,12 @@ export class Harness<TState = {}> {
       agent.__setPubSub(this.config.pubsub);
     }
 
+    // Register the agent on the resolved Mastra (the parent when registered,
+    // otherwise the internal one). Re-bind when the agent currently has no
+    // Mastra OR is bound to a different instance — e.g. an agent that built its
+    // own internal Mastra before this Harness was registered on a parent.
     const mastra = this.getMastra();
-    if (mastra && !alreadyHasMastra) {
+    if (mastra && agent.getMastraInstance() !== mastra) {
       mastra.addAgent(agent);
     }
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -11,6 +11,7 @@ import type { MastraMemory } from '../memory/memory';
 import type { StorageThreadType } from '../memory/types';
 import type { TracingContext, TracingOptions } from '../observability';
 import { RequestContext } from '../request-context';
+import type { MastraCompositeStore } from '../storage/base';
 import type { MemoryStorage } from '../storage/domains/memory/base';
 import type { ObservationalMemoryRecord } from '../storage/types';
 import { Workspace } from '../workspace/workspace';
@@ -206,6 +207,13 @@ export class Harness<TState = {}> {
   private availableModelsCacheTime: number = 0;
   readonly #instructions?: string;
   #internalMastra: Mastra | undefined = undefined;
+  /**
+   * Set when this Harness is registered on a parent Mastra (via
+   * {@link __registerMastra}). When present it is used in place of the
+   * lazily-created internal Mastra, so a server-hosted Harness shares the
+   * server's storage/agents/gateways instead of spinning up its own.
+   */
+  #externalMastra: Mastra | undefined = undefined;
   #legacyAgentMode: Record<string, Agent<any, any, any, any>> = {};
 
   constructor(config: HarnessConfig<TState>) {
@@ -411,12 +419,39 @@ export class Harness<TState = {}> {
   // ===========================================================================
 
   /**
-   * Access the internal Mastra instance.
-   * Available after `init()` when storage is configured.
+   * Access the Mastra instance backing this Harness.
+   *
+   * Returns the parent Mastra when this Harness is registered on one (see
+   * {@link __registerMastra}); otherwise the internal Mastra created during
+   * `init()` when storage is configured.
+   *
    * Useful for scorer registration, observability access, and eval tooling.
    */
   getMastra(): Mastra | undefined {
-    return this.#internalMastra;
+    return this.#externalMastra ?? this.#internalMastra;
+  }
+
+  /**
+   * Register this Harness on a parent Mastra. Called by Mastra during
+   * construction when a harness is passed in its config. Once registered, the
+   * Harness uses the parent Mastra (its storage, agents, gateways, and
+   * observability) instead of building its own internal one during `init()`.
+   *
+   * @internal
+   */
+  __registerMastra(mastra: Mastra): void {
+    this.#externalMastra = mastra;
+  }
+
+  /**
+   * Resolve the storage this Harness reads and writes through.
+   *
+   * When registered on a parent Mastra, the Harness inherits that Mastra's
+   * configured storage so the host and its Harnesses persist to a single store.
+   * A standalone Harness falls back to its own `config.storage`.
+   */
+  #resolveStorage(): MastraCompositeStore | undefined {
+    return this.#externalMastra?.getStorage() ?? this.config.storage;
   }
 
   /**
@@ -463,7 +498,10 @@ export class Harness<TState = {}> {
     // (required for tool approval snapshot persistence/resume).
     // We init storage through Mastra's proxied storage so augmentWithInit
     // tracks it and won't double-init.
-    if (this.config.storage) {
+    //
+    // Skip this when registered on a parent Mastra: that Mastra already owns
+    // storage/agents/gateways, and getMastra() resolves to it.
+    if (this.config.storage && !this.#externalMastra) {
       const enabledGateways = this.config.gateways?.filter(gateway => gateway.shouldEnable?.() ?? true);
       const gateways = enabledGateways?.length
         ? Object.fromEntries(enabledGateways.map(gateway => [gateway.id, gateway]))
@@ -520,10 +558,11 @@ export class Harness<TState = {}> {
   }
 
   private async getMemoryStorage(): Promise<MemoryStorage> {
-    if (!this.config.storage) {
+    const storage = this.#resolveStorage();
+    if (!storage) {
       throw new Error('Storage is not configured on this Harness');
     }
-    const memoryStorage = await this.config.storage.getStore('memory');
+    const memoryStorage = await storage.getStore('memory');
     if (!memoryStorage) {
       throw new Error('Storage does not have a memory domain configured');
     }
@@ -545,7 +584,7 @@ export class Harness<TState = {}> {
       getMetadata: ({ threadId, key }) => this.readThreadMetadataValue({ threadId, key }),
       setMetadata: ({ threadId, key, value }) => this.writeThreadMetadataValue({ threadId, key, value }),
       deleteMetadata: ({ threadId, key }) => this.removeThreadMetadataValue({ threadId, key }),
-      hasStorage: () => !!this.config.storage,
+      hasStorage: () => !!this.#resolveStorage(),
       saveThread: ({ thread }) => this.persistThreadRow(thread),
       deleteThread: ({ threadId }) => this.deleteThreadRow(threadId),
       cloneThread: ({ sourceThreadId, resourceId, title }) =>
@@ -558,7 +597,7 @@ export class Harness<TState = {}> {
 
   /** Persist a thread row to memory storage (gateway primitive for the Session thread domain). */
   private async persistThreadRow(thread: HarnessThread): Promise<void> {
-    if (!this.config.storage) return;
+    if (!this.#resolveStorage()) return;
     const memoryStorage = await this.getMemoryStorage();
     await memoryStorage.saveThread({
       thread: {
@@ -574,7 +613,7 @@ export class Harness<TState = {}> {
 
   /** Delete a thread row from memory storage (gateway primitive for the Session thread domain). */
   private async deleteThreadRow(threadId: string): Promise<void> {
-    if (!this.config.storage) return;
+    if (!this.#resolveStorage()) return;
     const memoryStorage = await this.getMemoryStorage();
     await memoryStorage.deleteThread({ threadId });
   }
@@ -608,7 +647,7 @@ export class Harness<TState = {}> {
   }
 
   private async readThreadMetadataValue({ threadId, key }: { threadId: string; key: string }): Promise<unknown> {
-    if (!this.config.storage) return undefined;
+    if (!this.#resolveStorage()) return undefined;
     try {
       const memoryStorage = await this.getMemoryStorage();
       const thread = await memoryStorage.getThreadById({ threadId });
@@ -629,7 +668,7 @@ export class Harness<TState = {}> {
     key: string;
     value: unknown;
   }): Promise<void> {
-    if (!this.config.storage) return;
+    if (!this.#resolveStorage()) return;
     try {
       const memoryStorage = await this.getMemoryStorage();
       const thread = await memoryStorage.getThreadById({ threadId });
@@ -644,7 +683,7 @@ export class Harness<TState = {}> {
   }
 
   private async removeThreadMetadataValue({ threadId, key }: { threadId: string; key: string }): Promise<void> {
-    if (!this.config.storage) return;
+    if (!this.#resolveStorage()) return;
     try {
       const memoryStorage = await this.getMemoryStorage();
       const thread = await memoryStorage.getThreadById({ threadId });
@@ -665,7 +704,7 @@ export class Harness<TState = {}> {
   }
 
   private async queryThreadById({ threadId }: { threadId: string }): Promise<HarnessThread | null> {
-    if (!this.config.storage) return null;
+    if (!this.#resolveStorage()) return null;
     const memoryStorage = await this.getMemoryStorage();
     const thread = await memoryStorage.getThreadById({ threadId });
     if (!thread) return null;
@@ -686,7 +725,7 @@ export class Harness<TState = {}> {
     resourceId?: string;
     includeForkedSubagents?: boolean;
   }): Promise<HarnessThread[]> {
-    if (!this.config.storage) return [];
+    if (!this.#resolveStorage()) return [];
 
     const memoryStorage = await this.getMemoryStorage();
     const filter: { resourceId?: string } | undefined = resourceId === undefined ? undefined : { resourceId };
@@ -717,7 +756,7 @@ export class Harness<TState = {}> {
     threadId: string;
     limit?: number;
   }): Promise<HarnessMessage[]> {
-    if (!this.config.storage) return [];
+    if (!this.#resolveStorage()) return [];
 
     const memoryStorage = await this.getMemoryStorage();
 
@@ -736,7 +775,7 @@ export class Harness<TState = {}> {
   }
 
   private async queryFirstUserMessages({ threadIds }: { threadIds: string[] }): Promise<Map<string, HarnessMessage>> {
-    if (!this.config.storage || threadIds.length === 0) return new Map();
+    if (!this.#resolveStorage() || threadIds.length === 0) return new Map();
 
     const memoryStorage = await this.getMemoryStorage();
     const result = await memoryStorage.listMessages({
@@ -784,8 +823,9 @@ export class Harness<TState = {}> {
       agent.__setPubSub(this.config.pubsub);
     }
 
-    if (this.#internalMastra && !alreadyHasMastra) {
-      this.#internalMastra.addAgent(agent);
+    const mastra = this.getMastra();
+    if (mastra && !alreadyHasMastra) {
+      mastra.addAgent(agent);
     }
 
     return agent;
@@ -1233,7 +1273,7 @@ export class Harness<TState = {}> {
     role: 'user' | 'assistant' | 'system';
     metadata?: Record<string, unknown>;
   }): Promise<HarnessMessage | null> {
-    if (!this.config.storage) return null;
+    if (!this.#resolveStorage()) return null;
     const memoryStorage = await this.getMemoryStorage();
     const dbMessage = {
       id: randomUUID(),
@@ -1786,7 +1826,7 @@ export class Harness<TState = {}> {
       // from the one the agent resolves and registers — leaving harness-side
       // tools (e.g. request_access) mutating a different filesystem than the
       // agent's workspace tools (e.g. view) read from.
-      const resolved = await Promise.resolve(this.workspaceFn({ requestContext, mastra: this.#internalMastra }));
+      const resolved = await Promise.resolve(this.workspaceFn({ requestContext, mastra: this.getMastra() }));
       harnessContext.workspace = resolved;
       // Cache for getWorkspace() so callers outside request flow (e.g. /skills) can access it
       this.workspace = resolved;
@@ -1820,7 +1860,7 @@ export class Harness<TState = {}> {
 
   private async persistTokenUsage(session: Session<TState>): Promise<void> {
     const threadId = session.thread.getId();
-    if (!threadId || !this.config.storage) return;
+    if (!threadId || !this.#resolveStorage()) return;
 
     try {
       const memoryStorage = await this.getMemoryStorage();

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -14,6 +14,7 @@ import { DatasetsManager } from '../datasets/manager.js';
 import type { MastraDeployer } from '../deployer';
 import type { IMastraEditor } from '../editor';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
+import type { Harness } from '../harness';
 import type { MastraScorer } from '../evals';
 import { EventEmitterPubSub } from '../events/event-emitter';
 import type { PubSub } from '../events/pubsub';
@@ -268,6 +269,15 @@ export interface Config<
    * Workflows provide type-safe, composable task execution with built-in error handling.
    */
   workflows?: TWorkflows;
+
+  /**
+   * Harnesses to host on this Mastra instance, keyed by id. Each registered
+   * Harness uses this Mastra (its storage, agents, gateways, and observability)
+   * instead of building its own internal one, and is reachable via
+   * {@link Mastra.getHarness} / {@link Mastra.listHarnesses}. This is how a
+   * server exposes multiple Harnesses' sessions over HTTP.
+   */
+  harnesses?: Record<string, Harness<any>>;
 
   /**
    * Text-to-speech providers for voice synthesis capabilities.
@@ -580,6 +590,7 @@ export class Mastra<
   #agents: TAgents;
   #logger: TLogger;
   #workflows: TWorkflows;
+  #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
   #observability: ObservabilityEntrypoint;
   #tts?: TTTS;
@@ -1431,6 +1442,13 @@ export class Mastra<
       });
     }
 
+    if (config?.harnesses) {
+      for (const [key, harness] of Object.entries(config.harnesses)) {
+        this.#harnesses[key] = harness;
+        harness.__registerMastra(this);
+      }
+    }
+
     registerHook(AvailableHooks.ON_SCORER_RUN, createOnScorerHook(this));
 
     /*
@@ -1879,6 +1897,22 @@ export class Mastra<
    */
   public listAgents() {
     return this.#agents;
+  }
+
+  /**
+   * Get a Harness hosted on this Mastra instance by id. Returns `undefined`
+   * when no harness is registered under that id. Server route handlers use this
+   * to create and drive sessions over HTTP.
+   */
+  public getHarness(id: string): Harness<any> | undefined {
+    return this.#harnesses[id];
+  }
+
+  /**
+   * List all Harnesses hosted on this Mastra instance, keyed by id.
+   */
+  public listHarnesses(): Record<string, Harness<any>> {
+    return this.#harnesses;
   }
 
   /**

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1900,16 +1900,44 @@ export class Mastra<
   }
 
   /**
-   * Get a Harness hosted on this Mastra instance by id. Returns `undefined`
-   * when no harness is registered under that id. Server route handlers use this
-   * to create and drive sessions over HTTP.
+   * Get a Harness hosted on this Mastra instance by its registration key (the
+   * key it was registered under in `new Mastra({ harnesses })`). Returns
+   * `undefined` when no harness is registered under that key. Server route
+   * handlers use this to create and drive sessions over HTTP.
+   *
+   * @example
+   * ```typescript
+   * const code = new Harness({ id: 'code-harness', modes });
+   * const mastra = new Mastra({ harnesses: { code } });
+   *
+   * mastra.getHarness('code'); // → the Harness (by key)
+   * ```
    */
-  public getHarness(id: string): Harness<any> | undefined {
-    return this.#harnesses[id];
+  public getHarness(key: string): Harness<any> | undefined {
+    return this.#harnesses[key];
   }
 
   /**
-   * List all Harnesses hosted on this Mastra instance, keyed by id.
+   * Get a Harness hosted on this Mastra instance by its unique `id` (the `id`
+   * passed to the `Harness` constructor). Falls back to a registration-key
+   * lookup when no harness matches by id, mirroring {@link getAgentById}.
+   * Returns `undefined` when none is found.
+   *
+   * @example
+   * ```typescript
+   * const code = new Harness({ id: 'code-harness', modes });
+   * const mastra = new Mastra({ harnesses: { code } });
+   *
+   * mastra.getHarnessById('code-harness'); // → the Harness (by id)
+   * ```
+   */
+  public getHarnessById(id: string): Harness<any> | undefined {
+    return Object.values(this.#harnesses).find(harness => harness.id === id) ?? this.#harnesses[id];
+  }
+
+  /**
+   * List all Harnesses hosted on this Mastra instance, keyed by their
+   * registration key.
    */
   public listHarnesses(): Record<string, Harness<any>> {
     return this.#harnesses;

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -14,11 +14,11 @@ import { DatasetsManager } from '../datasets/manager.js';
 import type { MastraDeployer } from '../deployer';
 import type { IMastraEditor } from '../editor';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
-import type { Harness } from '../harness';
 import type { MastraScorer } from '../evals';
 import { EventEmitterPubSub } from '../events/event-emitter';
 import type { PubSub } from '../events/pubsub';
 import type { Event, EventCallback } from '../events/types';
+import type { Harness } from '../harness';
 import { AvailableHooks, registerHook } from '../hooks';
 import { LicenseClient } from '../license';
 import type { MastraModelGatewayInterface } from '../llm/model/gateways';
@@ -4825,6 +4825,19 @@ export class Mastra<
       if (result.status === 'rejected') {
         this.#logger?.error('Failed to destroy workspace during shutdown', {
           workspaceId: workspaceIds[index],
+          error: result.reason,
+        });
+      }
+    });
+
+    // Tear down hosted Harnesses (heartbeats, workspaces) before closing storage,
+    // since teardown may still flush to the shared store.
+    const harnessKeys = Object.keys(this.#harnesses);
+    const harnessTeardown = await Promise.allSettled(harnessKeys.map(key => this.#harnesses[key]!.destroy()));
+    harnessTeardown.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        this.#logger?.error('Failed to destroy harness during shutdown', {
+          harnessKey: harnessKeys[index],
           error: result.reason,
         });
       }


### PR DESCRIPTION
## Summary

Reimplements the core feature of #18271 — letting `Harness` instances be hosted on a `Mastra` instance — and extends it so a registered Harness **inherits the parent Mastra's storage**.

### Registering a Harness on Mastra

- `new Mastra({ harnesses })` accepts harnesses keyed by id (matching the `agents`/`workflows` convention).
- Reachable via `mastra.getHarness(id)` and `mastra.listHarnesses()`.
- During construction, Mastra calls `harness.__registerMastra(this)`.
- A registered Harness uses the parent Mastra (its storage, agents, gateways, observability) instead of building its own internal one during `init()`. A standalone Harness keeps creating its internal Mastra exactly as before, so existing consumers (e.g. MastraCode) are unaffected.

```typescript
const code = new Harness({ id: 'code', modes });
const support = new Harness({ id: 'support', modes });
const mastra = new Mastra({ harnesses: { code, support }, storage });

mastra.getHarness('code') === code;   // true
code.getMastra() === mastra;          // true — no separate internal Mastra
```

### Inheriting the instance's storage

When attached to a Mastra, the Harness no longer reads/writes through its own `config.storage`. A new private `#resolveStorage()` returns `this.#externalMastra?.getStorage() ?? this.config.storage`, and every storage path (thread persistence/deletion, metadata read/write/remove, thread + message queries, first-user-message lookup, message append, token-usage persistence, and the `hasStorage` gateway) is routed through it. The host and its Harnesses therefore persist to a single store. Standalone Harnesses fall back to their own `config.storage`.

## Test plan

- New `harness-mastra-registration.test.ts` covering: standalone internal Mastra, parent-Mastra resolution before/after `init()`, multiple harnesses keyed by id, backing-agent registration on the parent, empty-registry behavior, storage inheritance when registered, and storage fallback when standalone.
- Full harness suite: **36 files / 339 tests pass, no type errors.**

🤖 Generated with Mastra Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR lets a single “main” Mastra host multiple Harness helpers, so they all save to the same database/storage and share the same runtime resources. You can register Harnesses when creating Mastra, then look them up by a key (or by Harness id).

## Overview
Adds first-class Harness registration on a `Mastra` via `new Mastra({ harnesses })` (a keyed dictionary like the existing `agents`/`workflows` pattern). During `Mastra` construction, each provided harness is registered with `harness.__registerMastra(this)`, making the harness “hosted” by the parent `Mastra`.

Hosted Harnesses reuse the parent Mastra’s storage, agents, gateways, and observability (instead of building their own internal Mastra during `Harness.init()`), while standalone Harness behavior remains unchanged.

## Key Changes
### Harness registration & lookup APIs
- `Mastra` `Config` now supports `harnesses?: Record<string, Harness<any>>`.
- New `Mastra` APIs:
  - `mastra.getHarness(key)` — fetch by registration key.
  - `mastra.getHarnessById(id)` — fetch by Harness `id`, with fallback to key lookup.
  - `mastra.listHarnesses()` — list hosted Harnesses keyed by registration key.
- `mastra.shutdown()` now tears down hosted Harnesses (calls `destroy()` on each) before closing shared storage.

### Storage inheritance via resolved storage
- `Harness` gains a private `#resolveStorage()`:
  - if registered on a parent Mastra: uses `parentMastra.getStorage()`
  - otherwise: falls back to `harness.config.storage`
- All thread persistence and related metadata/message operations route through this resolved storage, including:
  - thread persistence and deletion
  - thread metadata read/write/remove
  - thread + message queries
  - user-message lookups
  - message appending
  - token-usage persistence (and related persistence paths are guarded by resolved-storage availability)
- The thread adapter’s `hasStorage` now reflects whether `#resolveStorage()` is available.

### Parent/host wiring during initialization
- `Harness.getMastra()` returns the parent Mastra when hosted; otherwise it returns the internal Mastra created during `Harness.init()` (when storage is configured).
- When hosted, the harness avoids replacing the parent Mastra with a fresh internal one.
- Backing-agent wiring is updated so the harness’s backing agent is registered on the resolved/host Mastra (supporting scenarios where an agent might already be bound elsewhere).

## Documentation / Changeset
- Adds a `@mastra/core` minor changeset documenting:
  - `new Mastra({ harnesses })` usage
  - lookup via `mastra.getHarness(key)`, `mastra.getHarnessById(id)`, and `mastra.listHarnesses()`
  - that hosted Harnesses share the parent Mastra’s storage/resources and are torn down on `mastra.shutdown()`
  - example showing `mastra.getHarness('code') === code` and `code.getMastra() === mastra`.

## Testing
- Adds `harness-mastra-registration.test.ts` covering:
  - standalone Harness uses its own internal Mastra
  - parent-hosted Harness resolves `getMastra()` immediately (before `init()`) and `init()` does not replace it
  - multiple hosted harnesses under different registration keys
  - lookup behavior when no harnesses are registered
  - storage inheritance (hosted persists threads through the parent’s store)
  - fallback to harness-owned storage when standalone
<!-- end of auto-generated comment: release notes by coderabbit.ai -->