### PR TITLE
chore(playground): debarrel small playground-ui components

### DIFF
--- a/packages/playground/eslint.config.js
+++ b/packages/playground/eslint.config.js
@@ -27,8 +27,16 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import keyboard shortcut hooks from @mastra/playground-ui/hooks/use-keyboard-shortcut-label.',
   },
   {
+    importNames: ['AlertDialog'],
+    message: 'Import AlertDialog from @mastra/playground-ui/components/AlertDialog.',
+  },
+  {
     importNames: ['Avatar', 'AvatarProps', 'AvatarSize'],
     message: 'Import Avatar exports from @mastra/playground-ui/components/Avatar.',
+  },
+  {
+    importNames: ['Breadcrumb', 'BreadcrumbProps', 'Crumb', 'CrumbProps'],
+    message: 'Import Breadcrumb exports from @mastra/playground-ui/components/Breadcrumb.',
   },
   {
     importNames: [
@@ -46,6 +54,14 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
       'CardFooterProps',
     ],
     message: 'Import Card exports from @mastra/playground-ui/components/Card.',
+  },
+  {
+    importNames: ['Checkbox', 'CheckboxProps', 'CheckedState'],
+    message: 'Import Checkbox exports from @mastra/playground-ui/components/Checkbox.',
+  },
+  {
+    importNames: ['Chip', 'ChipProps', 'ChipsGroup', 'ChipsGroupProps'],
+    message: 'Import Chip exports from @mastra/playground-ui/components/Chip.',
   },
   {
     importNames: ['Combobox', 'ComboboxOption', 'ComboboxProps'],
@@ -74,8 +90,16 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import CodeDiff exports from @mastra/playground-ui/components/CodeDiff.',
   },
   {
+    importNames: ['Column', 'Columns', 'ColumnsProps', 'MultiColumn', 'MultiColumnProps'],
+    message: 'Import Columns exports from @mastra/playground-ui/components/Columns.',
+  },
+  {
     importNames: ['ContentBlock', 'ContentBlockChildren', 'ContentBlockProps', 'ContentBlocks', 'ContentBlocksProps'],
     message: 'Import ContentBlocks exports from @mastra/playground-ui/components/ContentBlocks.',
+  },
+  {
+    importNames: ['CopyButton', 'CopyButtonProps'],
+    message: 'Import CopyButton exports from @mastra/playground-ui/components/CopyButton.',
   },
   {
     importNames: [
@@ -132,8 +156,69 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import ErrorBoundary exports from @mastra/playground-ui/components/ErrorBoundary.',
   },
   {
+    importNames: ['ErrorState', 'ErrorStateProps'],
+    message: 'Import ErrorState exports from @mastra/playground-ui/components/ErrorState.',
+  },
+  {
+    importNames: [
+      'FieldBlock',
+      'FieldBlocksLayout',
+      'TextFieldBlock',
+      'TextFieldBlockProps',
+      'SearchFieldBlock',
+      'SearchFieldBlockProps',
+      'SelectFieldBlock',
+      'SelectFieldBlockProps',
+    ],
+    message: 'Import FormFieldBlocks exports from @mastra/playground-ui/components/FormFieldBlocks.',
+  },
+  {
+    importNames: ['Header', 'HeaderProps', 'HeaderTitle', 'HeaderAction', 'HeaderGroup'],
+    message: 'Import Header exports from @mastra/playground-ui/components/Header.',
+  },
+  {
+    importNames: ['HorizontalBars'],
+    message: 'Import HorizontalBars from @mastra/playground-ui/components/HorizontalBars.',
+  },
+  {
     importNames: ['Kbd', 'KbdProps'],
     message: 'Import Kbd exports from @mastra/playground-ui/components/Kbd.',
+  },
+  {
+    importNames: [
+      'JSONSchemaForm',
+      'Root',
+      'JSONSchemaFormRootProps',
+      'Field',
+      'JSONSchemaFormFieldProps',
+      'FieldList',
+      'JSONSchemaFormFieldListProps',
+      'FieldName',
+      'JSONSchemaFormFieldNameProps',
+      'FieldType',
+      'JSONSchemaFormFieldTypeProps',
+      'FieldDescription',
+      'JSONSchemaFormFieldDescriptionProps',
+      'FieldOptional',
+      'JSONSchemaFormFieldOptionalProps',
+      'FieldNullable',
+      'JSONSchemaFormFieldNullableProps',
+      'FieldRemove',
+      'JSONSchemaFormFieldRemoveProps',
+      'NestedFields',
+      'JSONSchemaFormNestedFieldsProps',
+      'AddField',
+      'JSONSchemaFormAddFieldProps',
+      'useJSONSchemaForm',
+      'useJSONSchemaFormField',
+      'useJSONSchemaFormNestedContext',
+      'SchemaField',
+      'SchemaFieldType',
+      'createField',
+      'fieldsToJSONSchema',
+      'jsonSchemaToFields',
+    ],
+    message: 'Import JSONSchemaForm exports from @mastra/playground-ui/components/JSONSchemaForm.',
   },
   {
     importNames: [
@@ -189,6 +274,45 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import KeyValueList exports from @mastra/playground-ui/components/KeyValueList.',
   },
   {
+    importNames: ['ListSearch', 'ListSearchProps'],
+    message: 'Import ListSearch exports from @mastra/playground-ui/components/ListSearch.',
+  },
+  {
+    importNames: ['Logo', 'LogoProps', 'LogoWithoutText'],
+    message: 'Import Logo exports from @mastra/playground-ui/components/Logo.',
+  },
+  {
+    importNames: [
+      'MainHeader',
+      'MainHeaderRootProps',
+      'MainHeaderTitleProps',
+      'MainHeaderDescriptionProps',
+      'MainHeaderColumnProps',
+    ],
+    message: 'Import MainHeader exports from @mastra/playground-ui/components/MainHeader.',
+  },
+  {
+    importNames: [
+      'MainSidebar',
+      'MainSidebarProvider',
+      'SidebarState',
+      'MainSidebarProviderProps',
+      'useMainSidebar',
+      'useMaybeSidebar',
+      'navItemClasses',
+      'NavLink',
+      'NavSection',
+      'MainSidebarTrigger',
+      'MainSidebarMobileTrigger',
+      'getIsLinkActive',
+    ],
+    message: 'Import MainSidebar exports from @mastra/playground-ui/components/MainSidebar.',
+  },
+  {
+    importNames: ['MarkdownRenderer', 'MarkdownRendererProps'],
+    message: 'Import MarkdownRenderer exports from @mastra/playground-ui/components/MarkdownRenderer.',
+  },
+  {
     importNames: ['MetricsDataTable'],
     message: 'Import MetricsDataTable from @mastra/playground-ui/components/MetricsDataTable.',
   },
@@ -209,6 +333,10 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import MetricsCard from @mastra/playground-ui/components/MetricsCard.',
   },
   {
+    importNames: ['Notice', 'NoticeVariant', 'NoticeRootProps', 'NoticeMessageProps'],
+    message: 'Import Notice exports from @mastra/playground-ui/components/Notice.',
+  },
+  {
     importNames: ['PageHeader', 'PageHeaderRootProps', 'PageHeaderTitleProps', 'PageHeaderDescriptionProps'],
     message: 'Import PageHeader exports from @mastra/playground-ui/components/PageHeader.',
   },
@@ -217,8 +345,36 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import PendingIndicator exports from @mastra/playground-ui/components/PendingIndicator.',
   },
   {
+    importNames: [
+      'PropertyFilterOption',
+      'PropertyFilterField',
+      'PropertyFilterToken',
+      'PropertyFilterActions',
+      'PropertyFilterActionsProps',
+      'PropertyFilterApplied',
+      'PropertyFilterAppliedProps',
+      'PropertyFilterCreator',
+      'PropertyFilterCreatorProps',
+      'PickMultiPanel',
+      'PickMultiPanelProps',
+    ],
+    message: 'Import PropertyFilter exports from @mastra/playground-ui/components/PropertyFilter.',
+  },
+  {
     importNames: ['PrevNextNav'],
     message: 'Import PrevNextNav from @mastra/playground-ui/components/PrevNextNav.',
+  },
+  {
+    importNames: ['RadioGroup', 'RadioGroupItem'],
+    message: 'Import RadioGroup exports from @mastra/playground-ui/components/RadioGroup.',
+  },
+  {
+    importNames: ['Searchbar', 'SearchbarWrapper', 'SearchbarProps'],
+    message: 'Import Searchbar exports from @mastra/playground-ui/components/Searchbar.',
+  },
+  {
+    importNames: ['Section', 'SectionProps', 'SectionRoot', 'SubSectionRoot', 'SectionRootProps'],
+    message: 'Import Section exports from @mastra/playground-ui/components/Section.',
   },
   {
     importNames: ['SettingsRow'],
@@ -243,6 +399,22 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
   {
     importNames: ['Slider', 'SliderProps'],
     message: 'Import Slider exports from @mastra/playground-ui/components/Slider.',
+  },
+  {
+    importNames: ['StatusBadge', 'StatusBadgeProps'],
+    message: 'Import StatusBadge exports from @mastra/playground-ui/components/StatusBadge.',
+  },
+  {
+    importNames: ['Switch', 'SwitchProps'],
+    message: 'Import Switch exports from @mastra/playground-ui/components/Switch.',
+  },
+  {
+    importNames: ['Textarea', 'TextareaProps'],
+    message: 'Import Textarea exports from @mastra/playground-ui/components/Textarea.',
+  },
+  {
+    importNames: ['ThemeProvider', 'useTheme', 'ThemeProviderProps', 'Theme', 'ResolvedTheme', 'ThemeContextValue'],
+    message: 'Import ThemeProvider exports from @mastra/playground-ui/components/ThemeProvider.',
   },
   {
     importNames: [

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -1,15 +1,8 @@
-import {
-  Button,
-  LogoWithoutText,
-  MainSidebar,
-  MainSidebarProvider,
-  PageHeadingContext,
-  ThemeProvider,
-  Toaster,
-  TooltipProvider,
-  useMainSidebar,
-} from '@mastra/playground-ui';
+import { Button, PageHeadingContext, Toaster, TooltipProvider } from '@mastra/playground-ui';
 import { ErrorBoundary } from '@mastra/playground-ui/components/ErrorBoundary';
+import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
+import { MainSidebar, MainSidebarProvider, useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import { ThemeProvider } from '@mastra/playground-ui/components/ThemeProvider';
 import { Search } from 'lucide-react';
 import { useLocation } from 'react-router';
 import { AppSidebar } from './ui/app-sidebar';

--- a/packages/playground/src/components/minimal-layout.tsx
+++ b/packages/playground/src/components/minimal-layout.tsx
@@ -1,4 +1,5 @@
-import { ThemeProvider, Toaster, TooltipProvider } from '@mastra/playground-ui';
+import { Toaster, TooltipProvider } from '@mastra/playground-ui';
+import { ThemeProvider } from '@mastra/playground-ui/components/ThemeProvider';
 import { AuthRequired } from '@/domains/auth/components/auth-required';
 
 export const MinimalLayout = ({ children }: { children: React.ReactNode }) => {

--- a/packages/playground/src/components/session-header.tsx
+++ b/packages/playground/src/components/session-header.tsx
@@ -1,14 +1,6 @@
-import {
-  Header,
-  HeaderAction,
-  HeaderTitle,
-  LogoWithoutText,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@mastra/playground-ui';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui';
+import { Header, HeaderAction, HeaderTitle } from '@mastra/playground-ui/components/Header';
+import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { useMemo } from 'react';
 import { AuthStatus } from '@/domains/auth/components/auth-status';
 import { useRequestContextPresets } from '@/domains/request-context/hooks/use-request-context-presets';

--- a/packages/playground/src/components/ui/__tests__/app-sidebar-agent-builder-link.test.tsx
+++ b/packages/playground/src/components/ui/__tests__/app-sidebar-agent-builder-link.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import type { BuilderSettingsResponse } from '@mastra/client-js';
-import { MainSidebarProvider, TooltipProvider } from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MainSidebarProvider } from '@mastra/playground-ui/components/MainSidebar';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -1,5 +1,7 @@
-import { LogoWithoutText, MainSidebar, cn, useMainSidebar } from '@mastra/playground-ui';
-import type { NavLink } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
+import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
+import { MainSidebar, useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import type { NavLink } from '@mastra/playground-ui/components/MainSidebar';
 import { useKeyboardShortcutLabel } from '@mastra/playground-ui/hooks/use-keyboard-shortcut-label';
 import { Search, Wrench } from 'lucide-react';
 import { useLocation } from 'react-router';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/__tests__/delete-agent-action.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/__tests__/delete-agent-action.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import type * as PlaygroundUi from '@mastra/playground-ui';
-import { DropdownMenu, TooltipProvider } from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-builder-mobile-menu.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-builder-mobile-menu.tsx
@@ -1,4 +1,5 @@
-import { Button, DropdownMenu } from '@mastra/playground-ui';
+import { Button } from '@mastra/playground-ui';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { EyeIcon, Globe, LockIcon, MoreVerticalIcon, PencilIcon } from 'lucide-react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/browser.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/browser.tsx
@@ -1,4 +1,6 @@
-import { StatusBadge, Switch, Txt } from '@mastra/playground-ui';
+import { Txt } from '@mastra/playground-ui';
+import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { GlobeIcon } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/filterable-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/filterable-list.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import type { CSSProperties, ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { useAgentColor } from '../../../contexts/agent-color-context';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/integrations.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/integrations.tsx
@@ -1,4 +1,5 @@
-import { Skeleton, StatusBadge, Txt } from '@mastra/playground-ui';
+import { Skeleton, Txt } from '@mastra/playground-ui';
+import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { useEditPage } from '@/domains/agent-builder/contexts/edit-page-context';
 import { usePublishAndConnectChannel } from '@/domains/agent-builder/hooks/use-publish-and-connect-channel';
 import { PlatformIcon } from '@/domains/agents/components/agent-channels/platform-icons';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/skills.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/skills.tsx
@@ -1,5 +1,6 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
-import { Checkbox, Txt } from '@mastra/playground-ui';
+import { Txt } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { useFormContext } from 'react-hook-form';
 import type { AgentBuilderEditFormValues } from '../../../schemas';
 

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tool-grid.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tool-grid.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, Txt, cn } from '@mastra/playground-ui';
+import { Txt, cn } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import type { CSSProperties, ReactNode } from 'react';
 import { useAgentColor } from '../../../contexts/agent-color-context';
 import type { AgentTool } from '../../../types/agent-tool';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-filter-pane.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-filter-pane.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, ScrollArea, Skeleton, Txt, cn } from '@mastra/playground-ui';
+import { ScrollArea, Skeleton, Txt, cn } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { memo, useMemo, useState } from 'react';
 import { useToolkits } from '../../../../tool-providers/hooks/use-toolkits';
 import { useAgentColor } from '../../../contexts/agent-color-context';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-searchbar.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-searchbar.tsx
@@ -1,5 +1,5 @@
-import type { SearchbarProps } from '@mastra/playground-ui';
-import { Searchbar } from '@mastra/playground-ui';
+import type { SearchbarProps } from '@mastra/playground-ui/components/Searchbar';
+import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
 
 export const AgentSearchbar = (props: SearchbarProps) => {
   return <Searchbar {...props} className="bg-surface3" />;

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/connect-channel-message.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/connect-channel-message.tsx
@@ -1,4 +1,5 @@
-import { Button, StatusBadge, Txt } from '@mastra/playground-ui';
+import { Button, Txt } from '@mastra/playground-ui';
+import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { useState } from 'react';
 import { ChannelDialog } from './publish-channel-dialogs';
 import { PlatformIcon } from '@/domains/agents/components/agent-channels/platform-icons';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/delete-agent-action.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/delete-agent-action.tsx
@@ -1,4 +1,6 @@
-import { AlertDialog, Button, DropdownMenu, toast } from '@mastra/playground-ui';
+import { Button, toast } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/edit-top-bar.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/edit-top-bar.tsx
@@ -1,4 +1,5 @@
-import { Breadcrumb, Button, Crumb } from '@mastra/playground-ui';
+import { Button } from '@mastra/playground-ui';
+import { Breadcrumb, Crumb } from '@mastra/playground-ui/components/Breadcrumb';
 import { RefreshCwIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Link } from 'react-router';

--- a/packages/playground/src/domains/agent-builder/components/agent-starter/agent-builder-starter.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-starter/agent-builder-starter.tsx
@@ -1,4 +1,5 @@
-import { Button, Spinner, Textarea, toast } from '@mastra/playground-ui';
+import { Button, Spinner, toast } from '@mastra/playground-ui';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { ArrowUpIcon } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import { useRef, useState } from 'react';

--- a/packages/playground/src/domains/agent-builder/components/agent-view/view-top-bar.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-view/view-top-bar.tsx
@@ -1,4 +1,5 @@
-import { Breadcrumb, Button, Crumb } from '@mastra/playground-ui';
+import { Button } from '@mastra/playground-ui';
+import { Breadcrumb, Crumb } from '@mastra/playground-ui/components/Breadcrumb';
 import { RefreshCwIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Link } from 'react-router';

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-textarea.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-textarea.tsx
@@ -1,5 +1,6 @@
-import { cn, Textarea } from '@mastra/playground-ui';
-import type { TextareaProps } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
+import type { TextareaProps } from '@mastra/playground-ui/components/Textarea';
 import { forwardRef } from 'react';
 
 export type ChatTextareaProps = Omit<TextareaProps, 'size' | 'variant' | 'rows'>;

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -6,11 +6,11 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
   Icon,
-  MarkdownRenderer,
   Skeleton,
   Txt,
 } from '@mastra/playground-ui';
 import { Card } from '@mastra/playground-ui/components/Card';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { MessageFactory } from '@mastra/react';
 import type {
   MastraDBMessageMetadata,

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/__tests__/delete-skill-action.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/__tests__/delete-skill-action.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import type * as PlaygroundUi from '@mastra/playground-ui';
-import { DropdownMenu, TooltipProvider } from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/delete-skill-action.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/delete-skill-action.tsx
@@ -1,4 +1,6 @@
-import { AlertDialog, Button, DropdownMenu, toast } from '@mastra/playground-ui';
+import { Button, toast } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/skill-builder-mobile-menu.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/skill-builder-mobile-menu.tsx
@@ -1,4 +1,5 @@
-import { Button, DropdownMenu } from '@mastra/playground-ui';
+import { Button } from '@mastra/playground-ui';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Globe, LockIcon, MoreVerticalIcon } from 'lucide-react';
 import { useFormContext, useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
@@ -8,11 +8,11 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
-  MarkdownRenderer,
   ScrollArea,
   SkillIcon,
   cn,
 } from '@mastra/playground-ui';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { Check, Download, ExternalLink, Github, Loader2, Package, Search } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';

--- a/packages/playground/src/domains/agent-builder/components/skill-list/copy-skill-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/copy-skill-dialog.tsx
@@ -1,4 +1,5 @@
-import { AlertDialog, Input } from '@mastra/playground-ui';
+import { Input } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { useEffect, useState } from 'react';
 
 export interface CopySkillDialogProps {

--- a/packages/playground/src/domains/agent-builder/components/skill-starter/skill-builder-starter.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-starter/skill-builder-starter.tsx
@@ -1,4 +1,5 @@
-import { Button, Spinner, Textarea, toast } from '@mastra/playground-ui';
+import { Button, Spinner, toast } from '@mastra/playground-ui';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { ArrowUpIcon, BookOpen, FileText, GraduationCap, Wrench } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import { useMemo, useRef, useState } from 'react';

--- a/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-sidebar.test.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-sidebar.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { MainSidebarProvider, TooltipProvider } from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MainSidebarProvider } from '@mastra/playground-ui/components/MainSidebar';
 import { cleanup, render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-layout.tsx
@@ -1,4 +1,4 @@
-import { MainSidebarProvider } from '@mastra/playground-ui';
+import { MainSidebarProvider } from '@mastra/playground-ui/components/MainSidebar';
 import { Outlet } from 'react-router';
 import { AgentBuilderMobileBottomBar } from './agent-builder-mobile-bottom-bar';
 import { AgentBuilderSidebar } from './agent-builder-sidebar';

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-sidebar.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-sidebar.tsx
@@ -1,5 +1,7 @@
-import { AgentIcon, LogoWithoutText, MainSidebar, cn, useMainSidebar } from '@mastra/playground-ui';
-import type { NavLink } from '@mastra/playground-ui';
+import { AgentIcon, cn } from '@mastra/playground-ui';
+import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
+import { MainSidebar, useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import type { NavLink } from '@mastra/playground-ui/components/MainSidebar';
 import { Blocks, LibraryIcon, ServerCogIcon, StarIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useLocation } from 'react-router';

--- a/packages/playground/src/domains/agents/agent-header.tsx
+++ b/packages/playground/src/domains/agents/agent-header.tsx
@@ -1,4 +1,6 @@
-import { Header, Breadcrumb, Crumb, Button, HeaderAction, Icon, DocsIcon, AgentIcon } from '@mastra/playground-ui';
+import { Button, Icon, DocsIcon, AgentIcon } from '@mastra/playground-ui';
+import { Breadcrumb, Crumb } from '@mastra/playground-ui/components/Breadcrumb';
+import { Header, HeaderAction } from '@mastra/playground-ui/components/Header';
 import { Link } from 'react-router';
 import { AgentCombobox } from '@/domains/agents/components/agent-combobox';
 

--- a/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
+++ b/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
@@ -1,14 +1,6 @@
-import {
-  Button,
-  DataList,
-  DataListSkeleton,
-  ListSearch,
-  NoDataPageLayout,
-  PageLayout,
-  StatusBadge,
-  Txt,
-  toast,
-} from '@mastra/playground-ui';
+import { Button, DataList, DataListSkeleton, NoDataPageLayout, PageLayout, Txt, toast } from '@mastra/playground-ui';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { useMemo, useState } from 'react';
 import {
   useChannelPlatforms,

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
@@ -1,6 +1,7 @@
-import { DropdownMenu, Icon, cn } from '@mastra/playground-ui';
+import { Icon, cn } from '@mastra/playground-ui';
 import type { JsonSchema } from '@mastra/playground-ui';
 import { ContentBlocks } from '@mastra/playground-ui/components/ContentBlocks';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { FileText, PenLine, PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import type { InstructionBlock } from '../agent-edit-page/utils/form-validation';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
@@ -1,17 +1,8 @@
-import {
-  EntityName,
-  EntityDescription,
-  EntityContent,
-  Entity,
-  ScrollArea,
-  Searchbar,
-  Section,
-  SubSectionRoot,
-  Switch,
-  AgentIcon,
-  cn,
-} from '@mastra/playground-ui';
+import { EntityName, EntityDescription, EntityContent, Entity, ScrollArea, AgentIcon, cn } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
+import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
+import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/information-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/information-page.tsx
@@ -1,4 +1,6 @@
-import { Input, Label, ScrollArea, SectionRoot, SubSectionRoot, Textarea } from '@mastra/playground-ui';
+import { Input, Label, ScrollArea } from '@mastra/playground-ui';
+import { SectionRoot, SubSectionRoot } from '@mastra/playground-ui/components/Section';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Controller } from 'react-hook-form';
 
 import { useAgentEditFormContext } from '../../context/agent-edit-form-context';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/memory-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/memory-page.tsx
@@ -13,9 +13,9 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Switch,
   MemoryIcon,
 } from '@mastra/playground-ui';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Controller, useWatch } from 'react-hook-form';
 
 import { useAgentEditFormContext } from '../../context/agent-edit-form-context';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
@@ -5,17 +5,15 @@ import {
   Entity,
   Input,
   Label,
-  RadioGroup,
-  RadioGroupItem,
   ScrollArea,
-  Searchbar,
-  Section,
-  SubSectionRoot,
-  Switch,
   JudgeIcon,
   cn,
 } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
+import { RadioGroup, RadioGroupItem } from '@mastra/playground-ui/components/RadioGroup';
+import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
+import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-simple-form.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-simple-form.tsx
@@ -1,4 +1,5 @@
-import { CodeEditor, Input, MarkdownRenderer, Txt } from '@mastra/playground-ui';
+import { CodeEditor, Input, Txt } from '@mastra/playground-ui';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 
 export interface SkillSimpleFormProps {
   name: string;

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skills-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skills-page.tsx
@@ -7,9 +7,9 @@ import {
   EntityName,
   EntityDescription,
   ScrollArea,
-  Searchbar,
-  Switch,
 } from '@mastra/playground-ui';
+import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Plus, Drill } from 'lucide-react';
 import { useState } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
@@ -4,18 +4,17 @@ import {
   EntityDescription,
   EntityContent,
   Entity,
-  Notice,
   Popover,
   PopoverTrigger,
   PopoverContent,
   ScrollArea,
-  Section,
-  SubSectionRoot,
   Icon,
   ToolsIcon,
   cn,
 } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
+import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { PlusIcon, XIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/variables-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/variables-page.tsx
@@ -1,5 +1,7 @@
-import { JSONSchemaForm, jsonSchemaToFields, ScrollArea } from '@mastra/playground-ui';
-import type { JsonSchema, SchemaField } from '@mastra/playground-ui';
+import { ScrollArea } from '@mastra/playground-ui';
+import type { JsonSchema } from '@mastra/playground-ui';
+import { JSONSchemaForm, jsonSchemaToFields } from '@mastra/playground-ui/components/JSONSchemaForm';
+import type { SchemaField } from '@mastra/playground-ui/components/JSONSchemaForm';
 import { Plus, PlusIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
@@ -4,14 +4,13 @@ import {
   EntityContent,
   Entity,
   ScrollArea,
-  Searchbar,
-  Section,
-  SubSectionRoot,
-  Switch,
   WorkflowIcon,
   cn,
 } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
+import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
+import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
@@ -1,8 +1,6 @@
 import {
   Button,
   Input,
-  JSONSchemaForm,
-  jsonSchemaToFields,
   Label,
   ScrollArea,
   Spinner,
@@ -10,13 +8,15 @@ import {
   TabList,
   Tab,
   TabContent,
-  Textarea,
   Icon,
   AgentIcon,
   ToolsIcon,
   VariablesIcon,
 } from '@mastra/playground-ui';
-import type { JsonSchema, SchemaField } from '@mastra/playground-ui';
+import type { JsonSchema } from '@mastra/playground-ui';
+import { JSONSchemaForm, jsonSchemaToFields } from '@mastra/playground-ui/components/JSONSchemaForm';
+import type { SchemaField } from '@mastra/playground-ui/components/JSONSchemaForm';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Check, PlusIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import type { RefObject } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
@@ -9,9 +9,9 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Switch,
   MemoryIcon,
 } from '@mastra/playground-ui';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { ChevronRight } from 'lucide-react';
 import { useState } from 'react';
 import { Controller, useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/scorers-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/scorers-section.tsx
@@ -5,13 +5,12 @@ import {
   Button,
   Input,
   Label,
-  RadioGroup,
-  RadioGroupItem,
-  Textarea,
   JudgeIcon,
   Icon,
 } from '@mastra/playground-ui';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
+import { RadioGroup, RadioGroupItem } from '@mastra/playground-ui/components/RadioGroup';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Trash2, ChevronRight } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import type { Control } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-list.tsx
@@ -1,7 +1,8 @@
 import type { DropResult, DroppableProvided } from '@hello-pangea/dnd';
 import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
 import type { GetAgentResponse, ReorderModelListParams, UpdateModelInModelListParams } from '@mastra/client-js';
-import { Switch, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Icon } from '@mastra/playground-ui';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Icon } from '@mastra/playground-ui';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { GripVertical } from 'lucide-react';
 import { useState } from 'react';
 import { AgentMetadataModelSwitcher } from './agent-metadata-model-switcher';

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
@@ -1,5 +1,6 @@
 import type { UpdateModelParams } from '@mastra/client-js';
-import { Notice, Button, Spinner } from '@mastra/playground-ui';
+import { Button, Spinner } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Lock, RotateCcw } from 'lucide-react';
 import { useState, useEffect, useMemo } from 'react';
 import { useModelReset } from '../../context/model-reset-context';

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -2,7 +2,6 @@ import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import type { GetToolResponse, GetWorkflowResponse } from '@mastra/client-js';
 import {
   codeLanguages,
-  Notice,
   Badge,
   useCodemirrorTheme,
   Skeleton,
@@ -16,6 +15,7 @@ import {
   ToolsIcon,
   WorkflowIcon,
 } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import CodeMirror, { EditorView } from '@uiw/react-codemirror';
 import { GaugeIcon, Folder, Globe } from 'lucide-react';
 import { useActivatedSkills } from '../../context/activated-skills-context';

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
@@ -1,6 +1,5 @@
 import {
   Badge,
-  CopyButton,
   HoverPopover,
   PopoverTrigger,
   PopoverContent,
@@ -11,6 +10,7 @@ import {
   cn,
 } from '@mastra/playground-ui';
 import type { JsonSchema, JsonSchemaProperty } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { Braces, ChevronDown, ChevronRight, Wrench, Cpu, Eye, Pencil } from 'lucide-react';
 import { useState, useMemo } from 'react';
 

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
@@ -1,18 +1,18 @@
 import {
   Badge,
   Button,
-  Checkbox,
-  Chip,
   Collapsible,
   CollapsibleTrigger,
   CollapsibleContent,
-  CopyButton,
   ScrollArea,
   Spinner,
   Txt,
   Icon,
   cn,
 } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { Chip } from '@mastra/playground-ui/components/Chip';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import {

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -2,8 +2,6 @@ import type { DatasetRecord } from '@mastra/client-js';
 import {
   Badge,
   Button,
-  Column,
-  Columns,
   Dialog,
   DialogContent,
   DialogHeader,
@@ -12,9 +10,7 @@ import {
   EmptyState,
   DataList,
   DataListSkeleton,
-  Searchbar,
   Spinner,
-  StatusBadge,
   Tabs,
   TabContent,
   TabList,
@@ -22,6 +18,9 @@ import {
   Txt,
   toast,
 } from '@mastra/playground-ui';
+import { Column, Columns } from '@mastra/playground-ui/components/Columns';
+import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
+import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { Database, GaugeIcon, FlaskConical, ChevronLeft, Plus, Paperclip } from 'lucide-react';
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
@@ -1,9 +1,6 @@
 import {
   Badge,
   Button,
-  Checkbox,
-  Column,
-  Columns,
   Dialog,
   DialogContent,
   DialogHeader,
@@ -11,15 +8,17 @@ import {
   DialogBody,
   DialogFooter,
   DataList,
-  DropdownMenu,
   Label,
   Spinner,
-  Textarea,
   Txt,
   Icon,
   toast,
   cn,
 } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { Column, Columns } from '@mastra/playground-ui/components/Columns';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { useMastraClient } from '@mastra/react';
 import {
   CheckCircle,

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-scorers.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-scorers.tsx
@@ -1,4 +1,6 @@
-import { Badge, Label, ScrollArea, Searchbar, Switch, Txt, Icon } from '@mastra/playground-ui';
+import { Badge, Label, ScrollArea, Txt, Icon } from '@mastra/playground-ui';
+import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Calculator, CheckCircle2, Loader2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
@@ -1,5 +1,6 @@
 import { v4 as uuid } from '@lukeed/uuid';
-import { Notice, Button } from '@mastra/playground-ui';
+import { Button } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Save } from 'lucide-react';
 import { useMemo } from 'react';
 import { useFormState } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
@@ -2,8 +2,6 @@ import {
   Badge,
   Button,
   ButtonsGroup,
-  CopyButton,
-  DropdownMenu,
   Input,
   Label,
   HoverPopover,
@@ -21,6 +19,8 @@ import {
   DialogFooter,
 } from '@mastra/playground-ui';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Check, ChevronDown, Clock, Download, GitPullRequest, Info, MessageSquare, Save } from 'lucide-react';
 import { useMemo, useState, useCallback } from 'react';
 

--- a/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -1,7 +1,5 @@
 import {
   Button,
-  Chip,
-  CopyButton,
   Dialog,
   DialogContent,
   DialogHeader,
@@ -9,13 +7,15 @@ import {
   DialogBody,
   ScrollArea,
   Spinner,
-  Textarea,
   Txt,
   Icon,
   toast,
   cn,
 } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { useQueryClient } from '@tanstack/react-query';
 import { Play, Sparkles, Clock, ChevronRight, ChevronDown, Pencil, Save, X, Trash2 } from 'lucide-react';
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-playground/scorer-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/scorer-detail-view.tsx
@@ -1,5 +1,7 @@
 import type { GetScorerResponse } from '@mastra/client-js';
-import { Badge, Button, Chip, Switch, Txt, Icon } from '@mastra/playground-ui';
+import { Badge, Button, Txt, Icon } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Pencil } from 'lucide-react';
 
 interface LinkedDataset {

--- a/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
@@ -1,16 +1,5 @@
-import {
-  Badge,
-  Button,
-  Input,
-  Label,
-  ScrollArea,
-  Spinner,
-  Textarea,
-  Txt,
-  Icon,
-  toast,
-  cn,
-} from '@mastra/playground-ui';
+import { Badge, Button, Input, Label, ScrollArea, Spinner, Txt, Icon, toast, cn } from '@mastra/playground-ui';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { useMastraClient } from '@mastra/react';
 import { ArrowLeft, Play, Save, Plus, Trash2, CheckCircle2, XCircle, AlertCircle } from 'lucide-react';
 import { useState, useCallback, useEffect } from 'react';

--- a/packages/playground/src/domains/agents/components/browser-view/browser-thumbnail.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-thumbnail.tsx
@@ -1,4 +1,5 @@
-import { Button, StatusBadge, cn } from '@mastra/playground-ui';
+import { Button, cn } from '@mastra/playground-ui';
+import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { Monitor, ChevronUp, ChevronDown, Maximize2, X } from 'lucide-react';
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useBrowserFrame, useBrowserSession } from '../../context/browser-session-context';

--- a/packages/playground/src/domains/agents/components/browser-view/browser-view-header.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-view-header.tsx
@@ -1,4 +1,5 @@
-import { StatusBadge, cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
+import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { X, ChevronDown, ChevronUp, Minus } from 'lucide-react';
 import type { StreamStatus } from '../../hooks/use-browser-stream';
 

--- a/packages/playground/src/domains/agents/components/browser-view/browser-view-panel.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-view-panel.tsx
@@ -1,4 +1,5 @@
-import { Button, StatusBadge, cn } from '@mastra/playground-ui';
+import { Button, cn } from '@mastra/playground-ui';
+import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { X, Minimize2, ExternalLink, Globe } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { useBrowserSession } from '../../context/browser-session-context';

--- a/packages/playground/src/domains/agents/components/chat-threads.tsx
+++ b/packages/playground/src/domains/agents/components/chat-threads.tsx
@@ -1,5 +1,6 @@
 import type { StorageThreadType } from '@mastra/core/memory';
-import { AlertDialog, Icon, Skeleton } from '@mastra/playground-ui';
+import { Icon, Skeleton } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import {

--- a/packages/playground/src/domains/agents/components/composer-model-settings.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-settings.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Checkbox,
   Dialog,
   DialogBody,
   DialogContent,
@@ -10,8 +9,6 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-  RadioGroup,
-  RadioGroupItem,
   Skeleton,
   Tooltip,
   TooltipContent,
@@ -19,7 +16,9 @@ import {
   Txt,
   cn,
 } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { Entry } from '@mastra/playground-ui/components/Entry';
+import { RadioGroup, RadioGroupItem } from '@mastra/playground-ui/components/RadioGroup';
 import { Slider } from '@mastra/playground-ui/components/Slider';
 import { Info, Sliders } from 'lucide-react';
 import { useState } from 'react';

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  MarkdownRenderer,
   ScrollArea,
   Skeleton,
   Tooltip,
@@ -9,6 +8,7 @@ import {
   toast,
   cn,
 } from '@mastra/playground-ui';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { RefreshCcwIcon, ExternalLink } from 'lucide-react';
 import { useState } from 'react';

--- a/packages/playground/src/domains/agents/components/model-picker/provider-not-connected-alert.tsx
+++ b/packages/playground/src/domains/agents/components/model-picker/provider-not-connected-alert.tsx
@@ -1,5 +1,5 @@
 import type { Provider } from '@mastra/client-js';
-import { Notice } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 
 export interface ProviderNotConnectedAlertProps {
   provider: Provider;

--- a/packages/playground/src/domains/agents/components/request-context-run-options.tsx
+++ b/packages/playground/src/domains/agents/components/request-context-run-options.tsx
@@ -1,4 +1,5 @@
-import { CopyButton, ScrollArea, Txt, Icon, cn } from '@mastra/playground-ui';
+import { ScrollArea, Txt, Icon, cn } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { FileJson, FormInput } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/request-context.tsx
+++ b/packages/playground/src/domains/agents/components/request-context.tsx
@@ -1,7 +1,6 @@
 import { jsonLanguage } from '@codemirror/lang-json';
 import {
   Button,
-  Notice,
   useCodemirrorTheme,
   Select,
   SelectContent,
@@ -18,6 +17,7 @@ import {
   isValidJson,
   toast,
 } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import CodeMirror from '@uiw/react-codemirror';
 import { Braces, CopyIcon, ExternalLink, X } from 'lucide-react';

--- a/packages/playground/src/domains/auth/components/auth-required.tsx
+++ b/packages/playground/src/domains/auth/components/auth-required.tsx
@@ -1,4 +1,4 @@
-import { LogoWithoutText } from '@mastra/playground-ui';
+import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { Lock } from 'lucide-react';
 import { useAuthCapabilities } from '../hooks/use-auth-capabilities';
 import { isAuthenticated } from '../types';

--- a/packages/playground/src/domains/auth/components/login-layout.tsx
+++ b/packages/playground/src/domains/auth/components/login-layout.tsx
@@ -1,4 +1,4 @@
-import { LogoWithoutText } from '@mastra/playground-ui';
+import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import type { ReactNode } from 'react';
 
 export type LoginLayoutProps = {

--- a/packages/playground/src/domains/auth/components/route-permissions-gate.tsx
+++ b/packages/playground/src/domains/auth/components/route-permissions-gate.tsx
@@ -1,4 +1,5 @@
-import { ErrorState, Spinner, Button } from '@mastra/playground-ui';
+import { Spinner, Button } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 
 import { usePermissionPatterns } from '../hooks/use-permission-patterns';
 import { ALL_SIDEBAR_PERMISSIONS } from '../route-permissions';

--- a/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
+++ b/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
@@ -3,13 +3,13 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  Textarea,
   Icon,
   RuleBuilder,
   countLeafRules,
   cn,
 } from '@mastra/playground-ui';
 import type { JsonSchema, RuleGroup } from '@mastra/playground-ui';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { ChevronRight, Ruler, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/domains/configuration/components/header-list-form.tsx
+++ b/packages/playground/src/domains/configuration/components/header-list-form.tsx
@@ -1,4 +1,5 @@
-import { Button, TextFieldBlock, Txt } from '@mastra/playground-ui';
+import { Button, Txt } from '@mastra/playground-ui';
+import { TextFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { Plus, Trash } from 'lucide-react';
 import { useId } from 'react';
 

--- a/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
@@ -1,5 +1,4 @@
 import {
-  CopyButton,
   Spinner,
   Tooltip,
   TooltipContent,
@@ -15,6 +14,7 @@ import {
   DialogBody,
 } from '@mastra/playground-ui';
 import { CodeBlock } from '@mastra/playground-ui/components/CodeBlock';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { MoveRight, ExternalLink, Info } from 'lucide-react';
 import { useState } from 'react';
 import { useMastraPackages } from '../hooks/use-mastra-packages';

--- a/packages/playground/src/domains/configuration/components/playground-config-guard.tsx
+++ b/packages/playground/src/domains/configuration/components/playground-config-guard.tsx
@@ -1,4 +1,4 @@
-import { LogoWithoutText } from '@mastra/playground-ui';
+import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { StudioConfigForm } from './studio-config-form';
 
 export const PlaygroundConfigGuard = () => {

--- a/packages/playground/src/domains/configuration/components/studio-config-form.tsx
+++ b/packages/playground/src/domains/configuration/components/studio-config-form.tsx
@@ -1,4 +1,5 @@
-import { Button, TextFieldBlock, TooltipProvider, toast } from '@mastra/playground-ui';
+import { Button, TooltipProvider, toast } from '@mastra/playground-ui';
+import { TextFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { SaveIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useStudioConfig } from '../context/studio-config-state';

--- a/packages/playground/src/domains/datasets/components/create-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/create-dataset-dialog.tsx
@@ -9,9 +9,9 @@ import {
   DialogBody,
   Input,
   Label,
-  SelectFieldBlock,
   toast,
 } from '@mastra/playground-ui';
+import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { useState } from 'react';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 import { SchemaConfigSection } from './schema-config-section';

--- a/packages/playground/src/domains/datasets/components/csv-import/validation-summary.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/validation-summary.tsx
@@ -1,4 +1,4 @@
-import { Notice } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 ('use client');
 
 export interface ValidationError {

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-header.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-header.tsx
@@ -1,15 +1,8 @@
 'use client';
 
-import {
-  Button,
-  ButtonsGroup,
-  DropdownMenu,
-  MainHeader,
-  TextAndIcon,
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from '@mastra/playground-ui';
+import { Button, ButtonsGroup, TextAndIcon, Tooltip, TooltipTrigger, TooltipContent } from '@mastra/playground-ui';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { format } from 'date-fns/format';
 import { MoreVertical, Pencil, Copy, Trash2, Play, DatabaseIcon, Calendar1Icon, HistoryIcon } from 'lucide-react';
 

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-header.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-header.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import type { DatasetItem } from '@mastra/client-js';
-import { CopyButton, MainHeader, TextAndIcon } from '@mastra/playground-ui';
+import { TextAndIcon } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { format } from 'date-fns/format';
 import { Calendar1Icon, HistoryIcon, FileCodeIcon } from 'lucide-react';
 

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-page-tabs.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-page-tabs.tsx
@@ -1,5 +1,7 @@
 import type { DatasetItem } from '@mastra/client-js';
-import { AlertDialog, Chip, Tabs, Tab, TabList, TabContent, toast } from '@mastra/playground-ui';
+import { Tabs, Tab, TabList, TabContent, toast } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import { useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { useDebounce } from 'use-debounce';

--- a/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
@@ -1,5 +1,6 @@
 import type { DatasetItem } from '@mastra/client-js';
-import { AlertDialog, Button, CodeEditor, Label, TextAndIcon, getShortId, Icon, toast } from '@mastra/playground-ui';
+import { Button, CodeEditor, Label, TextAndIcon, getShortId, Icon, toast } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { KeyValueList } from '@mastra/playground-ui/components/KeyValueList';
 import { Sections } from '@mastra/playground-ui/components/Sections';
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';

--- a/packages/playground/src/domains/datasets/components/dataset-health-card.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-health-card.tsx
@@ -1,5 +1,6 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { HorizontalBars, CHART_COLORS } from '@mastra/playground-ui';
+import { CHART_COLORS } from '@mastra/playground-ui';
+import { HorizontalBars } from '@mastra/playground-ui/components/HorizontalBars';
 import { MetricsCard } from '@mastra/playground-ui/components/MetricsCard';
 import { useMemo } from 'react';
 

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -2,13 +2,13 @@ import type { DatasetExperiment, DatasetRecord } from '@mastra/client-js';
 import {
   AgentIcon,
   Button,
-  Chip,
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
   ProcessorIcon,
   ScorersIcon,
   WorkflowIcon,
 } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import { useMemo } from 'react';
 import type { DatasetTargetType } from '../target-type-options';
 import { getDatasetTargetTypes, matchesDatasetTargetFilter } from './helpers';

--- a/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
@@ -1,4 +1,6 @@
-import { Button, ButtonsGroup, SelectFieldBlock, ListSearch } from '@mastra/playground-ui';
+import { Button, ButtonsGroup } from '@mastra/playground-ui';
+import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { Plus, XIcon } from 'lucide-react';
 import { DATASET_EXPERIMENT_OPTIONS, DATASET_TARGET_OPTIONS } from './datasets-list/helpers';
 

--- a/packages/playground/src/domains/datasets/components/delete-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/delete-dataset-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { AlertDialog, toast } from '@mastra/playground-ui';
+import { toast } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 
 export interface DeleteDatasetDialogProps {

--- a/packages/playground/src/domains/datasets/components/edit-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/edit-dataset-dialog.tsx
@@ -9,9 +9,9 @@ import {
   DialogBody,
   Input,
   Label,
-  SelectFieldBlock,
   toast,
 } from '@mastra/playground-ui';
+import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { useReducer } from 'react';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 import { SchemaConfigSection } from './schema-config-section';

--- a/packages/playground/src/domains/datasets/components/experiments/comparison-item-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/comparison-item-panel.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import type { CompareExperimentsResponse } from '@mastra/client-js';
-import { Button, ButtonsGroup, Chip, Column, MainHeader, Notice } from '@mastra/playground-ui';
+import { Button, ButtonsGroup } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
+import { Column } from '@mastra/playground-ui/components/Columns';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { PrevNextNav } from '@mastra/playground-ui/components/PrevNextNav';
 import { Sections } from '@mastra/playground-ui/components/Sections';
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';

--- a/packages/playground/src/domains/datasets/components/experiments/comparison-items-list.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/comparison-items-list.tsx
@@ -1,5 +1,5 @@
 import type { CompareExperimentsResponse } from '@mastra/client-js';
-import { Column } from '@mastra/playground-ui';
+import { Column } from '@mastra/playground-ui/components/Columns';
 import { ItemList } from '@mastra/playground-ui/components/ItemList';
 import type { ItemListColumn } from '@mastra/playground-ui/components/ItemList';
 import { ScoreDelta } from './score-delta';

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-comparison.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-comparison.tsx
@@ -1,16 +1,8 @@
-import {
-  Button,
-  Chip,
-  ChipsGroup,
-  Columns,
-  Notice,
-  Spinner,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-  cn,
-} from '@mastra/playground-ui';
+import { Button, Spinner, Tooltip, TooltipContent, TooltipTrigger, cn } from '@mastra/playground-ui';
+import { Chip, ChipsGroup } from '@mastra/playground-ui/components/Chip';
+import { Columns } from '@mastra/playground-ui/components/Columns';
 import { ItemList } from '@mastra/playground-ui/components/ItemList';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { useState, useMemo } from 'react';
 import { useCompareExperiments } from '../../hooks/use-compare-experiments';
 import { useDatasetExperiment } from '../../hooks/use-dataset-experiments';

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
@@ -1,5 +1,6 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { Chip, DataList, EmptyState, Tooltip, TooltipContent, TooltipTrigger, cn } from '@mastra/playground-ui';
+import { DataList, EmptyState, Tooltip, TooltipContent, TooltipTrigger, cn } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import { format, isThisYear, isToday } from 'date-fns';
 import { Play } from 'lucide-react';
 

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-toolbar.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Button, ButtonsGroup, Chip, SelectFieldBlock } from '@mastra/playground-ui';
+import { Button, ButtonsGroup } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
+import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { GitCompare, MoveRightIcon, XIcon } from 'lucide-react';
 import type { DatasetExperimentsFilters } from '../../hooks/use-dataset-experiments';
 

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments.tsx
@@ -1,5 +1,5 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { Column, Columns } from '@mastra/playground-ui';
+import { Column, Columns } from '@mastra/playground-ui/components/Columns';
 import { useState, useMemo } from 'react';
 import type { DatasetExperimentsFilters } from '../../hooks/use-dataset-experiments';
 import { DatasetExperimentsList } from './dataset-experiments-list';

--- a/packages/playground/src/domains/datasets/components/experiments/experiment-in-comparison-info.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/experiment-in-comparison-info.tsx
@@ -1,6 +1,7 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { Button, Chip, TextAndIcon } from '@mastra/playground-ui';
-import type { ChipProps } from '@mastra/playground-ui';
+import { Button, TextAndIcon } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
+import type { ChipProps } from '@mastra/playground-ui/components/Chip';
 import { format } from 'date-fns';
 import { LayersIcon, TargetIcon, CalendarIcon, ArrowRightIcon, ArrowLeftIcon } from 'lucide-react';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground/src/domains/datasets/components/experiments/score-delta.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/score-delta.tsx
@@ -1,4 +1,5 @@
-import { cn, Chip } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import { ArrowDownIcon, ArrowUpIcon } from 'lucide-react';
 
 interface ScoreDeltaProps {

--- a/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Checkbox,
   Dialog,
   DialogContent,
   DialogHeader,
@@ -11,11 +10,12 @@ import {
   Label,
   ScrollArea,
   Spinner,
-  Textarea,
   Txt,
   Icon,
   toast,
 } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Sparkles, Trash2, Plus } from 'lucide-react';
 import { useState, useCallback, useRef } from 'react';
 

--- a/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import type { DatasetItem } from '@mastra/client-js';
-import { AlertDialog, Button, ButtonsGroup, DropdownMenu, toast } from '@mastra/playground-ui';
+import { Button, ButtonsGroup, toast } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
 import { DataPanel } from '@mastra/playground-ui/components/DataPanel';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { format } from 'date-fns/format';
 import {
   BracesIcon,

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-toolbar.tsx
@@ -1,16 +1,10 @@
 'use client';
 
-import {
-  Button,
-  ButtonsGroup,
-  Chip,
-  Column,
-  DropdownMenu,
-  SearchFieldBlock,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@mastra/playground-ui';
+import { Button, ButtonsGroup, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
+import { Column } from '@mastra/playground-ui/components/Columns';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
+import { SearchFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import {
   Plus,
   Upload,

--- a/packages/playground/src/domains/datasets/components/items/dataset-items.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { DatasetItem } from '@mastra/client-js';
-import { Notice, toast } from '@mastra/playground-ui';
+import { toast } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { ArrowRightToLineIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';

--- a/packages/playground/src/domains/datasets/components/items/dataset-versions-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-versions-panel.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Button, ButtonsGroup, Checkbox, Column } from '@mastra/playground-ui';
+import { Button, ButtonsGroup } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { Column } from '@mastra/playground-ui/components/Columns';
 import { ItemList } from '@mastra/playground-ui/components/ItemList';
 import { format } from 'date-fns';
 import { XIcon, GitCompareIcon, ArrowRightIcon } from 'lucide-react';

--- a/packages/playground/src/domains/datasets/components/schema-config-section.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-config-section.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {
-  Notice,
   Collapsible,
   CollapsibleTrigger,
   CollapsibleContent,
@@ -11,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import type { JSONSchema7 } from 'json-schema';
 import { ChevronRight } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';

--- a/packages/playground/src/domains/datasets/components/schema-settings/schema-field.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-settings/schema-field.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { CodeEditor, Switch, cn } from '@mastra/playground-ui';
+import { CodeEditor, cn } from '@mastra/playground-ui';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import type { JSONSchema7 } from 'json-schema';
 import { useState, useEffect, useRef } from 'react';
 

--- a/packages/playground/src/domains/datasets/components/versions/dataset-compare-version-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/versions/dataset-compare-version-toolbar.tsx
@@ -1,4 +1,5 @@
-import { Column, SelectFieldBlock } from '@mastra/playground-ui';
+import { Column } from '@mastra/playground-ui/components/Columns';
+import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { format } from 'date-fns';
 import { useDatasetVersions } from '../../hooks/use-dataset-versions';
 

--- a/packages/playground/src/domains/datasets/components/versions/dataset-compare-versions-list.tsx
+++ b/packages/playground/src/domains/datasets/components/versions/dataset-compare-versions-list.tsx
@@ -1,5 +1,6 @@
 import type { DatasetItem } from '@mastra/client-js';
-import { Tooltip, TooltipContent, TooltipTrigger, Chip, cn } from '@mastra/playground-ui';
+import { Tooltip, TooltipContent, TooltipTrigger, cn } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import { ItemList } from '@mastra/playground-ui/components/ItemList';
 import { BanIcon, EqualIcon, PenIcon, PlusIcon } from 'lucide-react';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Button, ButtonsGroup, Checkbox, Column } from '@mastra/playground-ui';
+import { Button, ButtonsGroup } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { Column } from '@mastra/playground-ui/components/Columns';
 import { ItemList } from '@mastra/playground-ui/components/ItemList';
 import { GitCompareIcon } from 'lucide-react';
 import { useState } from 'react';

--- a/packages/playground/src/domains/experimental-ui/experimental-ui-manager.tsx
+++ b/packages/playground/src/domains/experimental-ui/experimental-ui-manager.tsx
@@ -1,4 +1,5 @@
-import { Popover, PopoverTrigger, PopoverContent, RadioGroup, RadioGroupItem, Button } from '@mastra/playground-ui';
+import { Popover, PopoverTrigger, PopoverContent, Button } from '@mastra/playground-ui';
+import { RadioGroup, RadioGroupItem } from '@mastra/playground-ui/components/RadioGroup';
 import { FlaskConicalIcon } from 'lucide-react';
 import { useMaybeExperimentalUI } from './experimental-ui-context';
 

--- a/packages/playground/src/domains/experiments/components/experiment-page-header.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-page-header.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import type { DatasetExperiment } from '@mastra/client-js';
-import { CopyButton, MainHeader, TextAndIcon } from '@mastra/playground-ui';
+import { TextAndIcon } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { format } from 'date-fns';
 import { PlayCircle, Calendar1Icon, CrosshairIcon, GitBranch } from 'lucide-react';
 import { useAgents } from '../../agents/hooks/use-agents';

--- a/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
@@ -4,7 +4,6 @@ import type { DatasetExperimentResult } from '@mastra/client-js';
 import type { ExperimentStatus } from '@mastra/core/storage';
 import {
   Button,
-  Chip,
   Icon,
   SpanDataPanelView,
   Tabs,
@@ -18,6 +17,7 @@ import {
   useSpanDetail,
   useTraceSpanNavigation,
 } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import { ClipboardCheck } from 'lucide-react';
 import { useState, useMemo, useCallback } from 'react';
 

--- a/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import type { ClientScoreRowData, DatasetExperimentResult } from '@mastra/client-js';
-import { Button, ButtonsGroup, DataList, Notice, TraceIcon } from '@mastra/playground-ui';
+import { Button, ButtonsGroup, DataList, TraceIcon } from '@mastra/playground-ui';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
 import { DataPanel } from '@mastra/playground-ui/components/DataPanel';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { format } from 'date-fns/format';
 import {
   ChevronsDownUpIcon,

--- a/packages/playground/src/domains/experiments/components/experiment-result-span-pane.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-span-pane.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Button, Column, MainHeader, getShortId, useSpanDetail } from '@mastra/playground-ui';
+import { Button, getShortId, useSpanDetail } from '@mastra/playground-ui';
+import { Column } from '@mastra/playground-ui/components/Columns';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { PrevNextNav } from '@mastra/playground-ui/components/PrevNextNav';
 import { BracesIcon, XIcon } from 'lucide-react';
 import { ExperimentTraceSpanDetails } from './experiment-trace-span-details';

--- a/packages/playground/src/domains/experiments/components/experiment-result-trace-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-trace-panel.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Button, Column, MainHeader, getShortId } from '@mastra/playground-ui';
+import { Button, getShortId } from '@mastra/playground-ui';
+import { Column } from '@mastra/playground-ui/components/Columns';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { EyeIcon, XIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useExperimentTrace } from '../hooks/use-experiment-trace';

--- a/packages/playground/src/domains/experiments/components/experiment-status-card.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-status-card.tsx
@@ -1,5 +1,5 @@
 import type { DatasetExperiment, DatasetRecord } from '@mastra/client-js';
-import { HorizontalBars } from '@mastra/playground-ui';
+import { HorizontalBars } from '@mastra/playground-ui/components/HorizontalBars';
 import { MetricsCard } from '@mastra/playground-ui/components/MetricsCard';
 import { useMemo } from 'react';
 

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-tools.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-tools.tsx
@@ -1,5 +1,6 @@
 import type { LightSpanRecord } from '@mastra/core/storage';
-import { Button, ButtonsGroup, SearchFieldBlock, Icon } from '@mastra/playground-ui';
+import { Button, ButtonsGroup, Icon } from '@mastra/playground-ui';
+import { SearchFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { XIcon, CircleDashedIcon } from 'lucide-react';
 import { Fragment, useEffect, useState } from 'react';
 import { useThrottledCallback } from 'use-debounce';

--- a/packages/playground/src/domains/experiments/components/experiments-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-list.tsx
@@ -1,10 +1,7 @@
 import type { DatasetExperiment, DatasetRecord } from '@mastra/client-js';
-import {
-  Chip,
-  DataList as EntityList,
-  DataListSkeleton as EntityListSkeleton,
-  StatusBadge,
-} from '@mastra/playground-ui';
+import { DataList as EntityList, DataListSkeleton as EntityListSkeleton } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
+import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { useMemo } from 'react';
 import { useLinkComponent } from '@/lib/framework';
 

--- a/packages/playground/src/domains/experiments/components/experiments-toolbar.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-toolbar.tsx
@@ -1,4 +1,6 @@
-import { Button, ButtonsGroup, SelectFieldBlock, ListSearch } from '@mastra/playground-ui';
+import { Button, ButtonsGroup } from '@mastra/playground-ui';
+import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { XIcon } from 'lucide-react';
 import { EXPERIMENT_STATUS_OPTIONS } from './experiments-list-options';
 

--- a/packages/playground/src/domains/mcps/components/MCPDetail.tsx
+++ b/packages/playground/src/domains/mcps/components/MCPDetail.tsx
@@ -2,7 +2,6 @@ import type { McpToolInfo } from '@mastra/client-js';
 import type { ServerInfo } from '@mastra/core/mcp';
 import {
   Badge,
-  CopyButton,
   Entity,
   EntityContent,
   EntityDescription,
@@ -14,6 +13,7 @@ import {
   Icon,
   McpServerIcon,
 } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { useEffect, useRef, useState } from 'react';
 import { useMCPServerTools } from '../hooks/useMCPServerTools';
 import { ToolIconMap } from '@/domains/tools';

--- a/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-form-sidebar.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-form-sidebar.tsx
@@ -9,9 +9,9 @@ import {
   SelectTrigger,
   SelectValue,
   Spinner,
-  Textarea,
   Icon,
 } from '@mastra/playground-ui';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Check, PlusIcon, XIcon } from 'lucide-react';
 import { Controller, useWatch } from 'react-hook-form';
 import type { UseFormReturn } from 'react-hook-form';

--- a/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-tool-preview.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-tool-preview.tsx
@@ -5,13 +5,13 @@ import {
   EntityIcon,
   EntityName,
   Spinner,
-  Switch,
   Txt,
   Icon,
   McpServerIcon,
   ToolsIcon,
   cn,
 } from '@mastra/playground-ui';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import type { TryConnectMcpMutation } from '../../hooks/use-try-connect-mcp';
 
 interface MCPClientToolPreviewProps {

--- a/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
@@ -6,12 +6,11 @@ import {
   EntityContent,
   EntityDescription,
   EntityName,
-  Section,
-  SubSectionRoot,
   Icon,
   McpServerIcon,
   stringToColor,
 } from '@mastra/playground-ui';
+import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
 import { LaptopMinimal, PlusIcon, XIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/domains/metrics/components/metrics-toolbar.tsx
+++ b/packages/playground/src/domains/metrics/components/metrics-toolbar.tsx
@@ -1,5 +1,6 @@
-import type { PropertyFilterField, PropertyFilterToken } from '@mastra/playground-ui';
-import { PropertyFilterActions, PropertyFilterApplied, cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
+import type { PropertyFilterField, PropertyFilterToken } from '@mastra/playground-ui/components/PropertyFilter';
+import { PropertyFilterActions, PropertyFilterApplied } from '@mastra/playground-ui/components/PropertyFilter';
 
 type MetricsToolbarProps = {
   /** Keep all filter pills but reset each value to its neutral state

--- a/packages/playground/src/domains/processors/components/processor-panel.tsx
+++ b/packages/playground/src/domains/processors/components/processor-panel.tsx
@@ -3,7 +3,6 @@ import {
   Badge,
   Button,
   useCodemirrorTheme,
-  CopyButton,
   MainContentContent,
   Select,
   SelectContent,
@@ -14,6 +13,7 @@ import {
   Txt,
   toast,
 } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import CodeMirror from '@uiw/react-codemirror';
 import { useState, useId, useEffect } from 'react';
 import type {

--- a/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-sidebar.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-sidebar.tsx
@@ -1,15 +1,8 @@
-import {
-  Button,
-  Input,
-  JSONSchemaForm,
-  jsonSchemaToFields,
-  Label,
-  ScrollArea,
-  Spinner,
-  Textarea,
-  Txt,
-} from '@mastra/playground-ui';
-import type { JsonSchema, SchemaField } from '@mastra/playground-ui';
+import { Button, Input, Label, ScrollArea, Spinner, Txt } from '@mastra/playground-ui';
+import type { JsonSchema } from '@mastra/playground-ui';
+import { JSONSchemaForm, jsonSchemaToFields } from '@mastra/playground-ui/components/JSONSchemaForm';
+import type { SchemaField } from '@mastra/playground-ui/components/JSONSchemaForm';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Check, Plus, PlusIcon, Save } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/request-context/components/request-context-schema-form.tsx
+++ b/packages/playground/src/domains/request-context/components/request-context-schema-form.tsx
@@ -1,4 +1,5 @@
-import { CopyButton, Txt } from '@mastra/playground-ui';
+import { Txt } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { useMemo } from 'react';
 import { parse } from 'superjson';

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -1,12 +1,9 @@
 import {
   Badge,
   Button,
-  Checkbox,
   DataList,
-  DropdownMenu,
   Label,
   Spinner,
-  Textarea,
   Txt,
   Icon,
   cn,
@@ -17,6 +14,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { useMastraClient } from '@mastra/react';
 import {
   CheckCircle,

--- a/packages/playground/src/domains/review/components/review-item-card.tsx
+++ b/packages/playground/src/domains/review/components/review-item-card.tsx
@@ -1,4 +1,5 @@
-import { Badge, Button, Textarea, TooltipProvider, Txt, Icon, cn } from '@mastra/playground-ui';
+import { Badge, Button, TooltipProvider, Txt, Icon, cn } from '@mastra/playground-ui';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { ThumbsUp, ThumbsDown, Trash2, CheckCircle, GaugeIcon } from 'lucide-react';
 import { useState } from 'react';
 import { TagPicker } from './tag-picker';

--- a/packages/playground/src/domains/review/components/review-item-panel.tsx
+++ b/packages/playground/src/domains/review/components/review-item-panel.tsx
@@ -1,6 +1,8 @@
-import { AlertDialog, Badge, Button, ButtonsGroup, Textarea, Txt, Icon } from '@mastra/playground-ui';
+import { Badge, Button, ButtonsGroup, Txt, Icon } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
 import { DataPanel } from '@mastra/playground-ui/components/DataPanel';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { CheckCircle, FileInputIcon, FileOutputIcon, GaugeIcon, ThumbsDown, ThumbsUp, Trash2 } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';
 import type { ReviewItem } from './review-item-card';

--- a/packages/playground/src/domains/review/components/review-pipeline-card.tsx
+++ b/packages/playground/src/domains/review/components/review-pipeline-card.tsx
@@ -1,5 +1,5 @@
 import type { DatasetExperiment, DatasetRecord, ExperimentReviewCounts } from '@mastra/client-js';
-import { HorizontalBars } from '@mastra/playground-ui';
+import { HorizontalBars } from '@mastra/playground-ui/components/HorizontalBars';
 import { MetricsCard } from '@mastra/playground-ui/components/MetricsCard';
 import { useMemo } from 'react';
 

--- a/packages/playground/src/domains/schedules/components/schedules-page.tsx
+++ b/packages/playground/src/domains/schedules/components/schedules-page.tsx
@@ -1,4 +1,5 @@
-import { ErrorState, ListSearch } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { useState } from 'react';
 import { useSchedules } from '../hooks/use-schedules';
 import { SchedulesList } from './schedules-list';

--- a/packages/playground/src/domains/scores/components/scorer-edit-page/scorer-edit-sidebar.tsx
+++ b/packages/playground/src/domains/scores/components/scorer-edit-page/scorer-edit-sidebar.tsx
@@ -1,14 +1,6 @@
-import {
-  Button,
-  Input,
-  Label,
-  RadioGroup,
-  RadioGroupItem,
-  ScrollArea,
-  Spinner,
-  Textarea,
-  Icon,
-} from '@mastra/playground-ui';
+import { Button, Input, Label, ScrollArea, Spinner, Icon } from '@mastra/playground-ui';
+import { RadioGroup, RadioGroupItem } from '@mastra/playground-ui/components/RadioGroup';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Check, Save } from 'lucide-react';
 import type { RefObject } from 'react';
 import { Controller, useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
@@ -1,5 +1,6 @@
 import type { GetScorerResponse } from '@mastra/client-js';
-import { Chip, DataList as EntityList, DataListSkeleton as EntityListSkeleton, AgentIcon } from '@mastra/playground-ui';
+import { DataList as EntityList, DataListSkeleton as EntityListSkeleton, AgentIcon } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import { WorkflowIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground/src/domains/scores/components/scores-tools.tsx
+++ b/packages/playground/src/domains/scores/components/scores-tools.tsx
@@ -1,4 +1,5 @@
-import { Button, ButtonsGroup, SelectFieldBlock, Icon } from '@mastra/playground-ui';
+import { Button, ButtonsGroup, Icon } from '@mastra/playground-ui';
+import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { XIcon } from 'lucide-react';
 
 export type ScoreEntityOption = { value: string; label: string; type: 'AGENT' | 'WORKFLOW' | 'ALL' };

--- a/packages/playground/src/domains/shared/components/review-item-card.tsx
+++ b/packages/playground/src/domains/shared/components/review-item-card.tsx
@@ -1,4 +1,5 @@
-import { Badge, Button, Textarea, TooltipProvider, Txt, Icon, cn } from '@mastra/playground-ui';
+import { Badge, Button, TooltipProvider, Txt, Icon, cn } from '@mastra/playground-ui';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { ThumbsUp, ThumbsDown, Trash2, CheckCircle } from 'lucide-react';
 import { useState } from 'react';
 import { TagPicker } from './tag-picker';

--- a/packages/playground/src/domains/templates/template-form.tsx
+++ b/packages/playground/src/domains/templates/template-form.tsx
@@ -1,4 +1,5 @@
-import { Button, SelectFieldBlock, TextFieldBlock, Spinner, cn } from '@mastra/playground-ui';
+import { Button, Spinner, cn } from '@mastra/playground-ui';
+import { SelectFieldBlock, TextFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { ArrowRightIcon, PackageOpenIcon } from 'lucide-react';
 import { Fragment } from 'react';
 import { AgentMetadataModelSwitcher } from '../agents/components/agent-metadata/agent-metadata-model-switcher';

--- a/packages/playground/src/domains/templates/templates-tools.tsx
+++ b/packages/playground/src/domains/templates/templates-tools.tsx
@@ -1,4 +1,5 @@
-import { Button, SearchFieldBlock, SelectFieldBlock, cn } from '@mastra/playground-ui';
+import { Button, cn } from '@mastra/playground-ui';
+import { SearchFieldBlock, SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { XIcon } from 'lucide-react';
 
 type TemplatesToolsProps = {

--- a/packages/playground/src/domains/tool-providers/components/integration-tools-section.tsx
+++ b/packages/playground/src/domains/tool-providers/components/integration-tools-section.tsx
@@ -1,13 +1,5 @@
-import {
-  Badge,
-  Entity,
-  EntityContent,
-  EntityName,
-  EntityDescription,
-  Section,
-  SubSectionRoot,
-  stringToColor,
-} from '@mastra/playground-ui';
+import { Badge, Entity, EntityContent, EntityName, EntityDescription, stringToColor } from '@mastra/playground-ui';
+import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { Plug } from 'lucide-react';
 import { useMemo, useState } from 'react';
 

--- a/packages/playground/src/domains/tool-providers/components/manage-connection-form.tsx
+++ b/packages/playground/src/domains/tool-providers/components/manage-connection-form.tsx
@@ -1,4 +1,5 @@
-import { AlertDialog, Button, DialogBody, Icon, Input, Spinner, Txt, toast } from '@mastra/playground-ui';
+import { Button, DialogBody, Icon, Input, Spinner, Txt, toast } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { ChevronLeft, Link2 } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/domains/tool-providers/components/selected-tool-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/selected-tool-list.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { useMemo } from 'react';
 
 interface SelectedToolListProps {

--- a/packages/playground/src/domains/tool-providers/components/tool-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/tool-list.tsx
@@ -1,4 +1,6 @@
-import { Badge, Checkbox, ScrollArea, Searchbar, SearchbarWrapper, Skeleton, Txt, cn } from '@mastra/playground-ui';
+import { Badge, ScrollArea, Skeleton, Txt, cn } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { Searchbar, SearchbarWrapper } from '@mastra/playground-ui/components/Searchbar';
 import { useState } from 'react';
 
 import { useProviderTools } from '../hooks/use-provider-tools';

--- a/packages/playground/src/domains/tools/components/ToolExecutor.tsx
+++ b/packages/playground/src/domains/tools/components/ToolExecutor.tsx
@@ -1,6 +1,7 @@
 import { jsonLanguage } from '@codemirror/lang-json';
 import type { MCPToolType } from '@mastra/core/mcp';
-import { useCodemirrorTheme, CopyButton, MainContentContent, Tabs, Tab, TabList, cn } from '@mastra/playground-ui';
+import { useCodemirrorTheme, MainContentContent, Tabs, Tab, TabList, cn } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import CodeMirror from '@uiw/react-codemirror';
 import { useState } from 'react';
 import type { ZodType } from 'zod';

--- a/packages/playground/src/domains/traces/components/span-scoring.tsx
+++ b/packages/playground/src/domains/traces/components/span-scoring.tsx
@@ -1,5 +1,7 @@
 import type { GetScorerResponse } from '@mastra/client-js';
-import { Button, Notice, SelectFieldBlock, TextAndIcon, toast } from '@mastra/playground-ui';
+import { Button, TextAndIcon, toast } from '@mastra/playground-ui';
+import { SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { InfoIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTriggerScorer } from '../hooks/use-trigger-scorer';

--- a/packages/playground/src/domains/workflows/runs/workflow-run-list.tsx
+++ b/packages/playground/src/domains/workflows/runs/workflow-run-list.tsx
@@ -1,4 +1,5 @@
-import { AlertDialog, Icon, Skeleton, Spinner, Txt } from '@mastra/playground-ui';
+import { Icon, Skeleton, Spinner, Txt } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { formatDate } from 'date-fns';
 import { useState } from 'react';
 import { WorkflowRunStatusIcon } from '../components/workflow-run-status-icon';

--- a/packages/playground/src/domains/workflows/workflow/workflow-code-dialog-content.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-code-dialog-content.tsx
@@ -1,7 +1,8 @@
 import { javascript } from '@codemirror/lang-javascript';
 import { jsonLanguage } from '@codemirror/lang-json';
 import { EditorView } from '@codemirror/view';
-import { useCodemirrorTheme, CopyButton } from '@mastra/playground-ui';
+import { useCodemirrorTheme } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import CodeMirror from '@uiw/react-codemirror';
 
 export const CodeDialogContent = ({

--- a/packages/playground/src/domains/workflows/workflow/workflow-run-options.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-run-options.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, Txt } from '@mastra/playground-ui';
+import { Txt } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { useContext } from 'react';
 import { WorkflowRunContext } from '../context/workflow-run-context';
 

--- a/packages/playground/src/domains/workflows/workflow/workflow-step-action-bar.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-step-action-bar.tsx
@@ -7,8 +7,8 @@ import {
   DialogHeader,
   DialogDescription,
   DialogBody,
-  DropdownMenu,
 } from '@mastra/playground-ui';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import {
   AlertCircleIcon,
   BracesIcon,

--- a/packages/playground/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -1,6 +1,8 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
 import type { WorkflowRunStatus } from '@mastra/core/workflows';
-import { ScrollArea, Skeleton, Txt, Icon, Badge, WorkflowIcon, toast, Switch, CopyButton } from '@mastra/playground-ui';
+import { ScrollArea, Skeleton, Txt, Icon, Badge, WorkflowIcon, toast } from '@mastra/playground-ui';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Loader2 } from 'lucide-react';
 import { useState, useEffect, useContext, useRef } from 'react';
 import { WorkflowRequestContextDialog } from '../components/workflow-request-context-dialog';

--- a/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
+++ b/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Input,
-  MarkdownRenderer,
   ScrollArea,
   SkillIcon,
   cn,
@@ -12,6 +11,7 @@ import {
   DialogDescription,
   DialogBody,
 } from '@mastra/playground-ui';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { Search, Download, ExternalLink, Loader2, Package, Github, Check, Folder } from 'lucide-react';
 import { useState, useCallback, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';

--- a/packages/playground/src/domains/workspace/components/file-browser.tsx
+++ b/packages/playground/src/domains/workspace/components/file-browser.tsx
@@ -1,7 +1,5 @@
 import {
-  AlertDialog,
   Button,
-  CopyButton,
   Tooltip,
   TooltipTrigger,
   TooltipContent,
@@ -10,6 +8,8 @@ import {
   AzureIcon,
   GoogleIcon,
 } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import {
   File,
   Folder,

--- a/packages/playground/src/domains/workspace/components/skill-actions.tsx
+++ b/packages/playground/src/domains/workspace/components/skill-actions.tsx
@@ -1,4 +1,5 @@
-import { AlertDialog, Button } from '@mastra/playground-ui';
+import { Button } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { Trash2, Loader2, Download } from 'lucide-react';
 
 export interface SkillUpdateButtonProps {

--- a/packages/playground/src/domains/workspace/components/skill-detail.tsx
+++ b/packages/playground/src/domains/workspace/components/skill-detail.tsx
@@ -1,4 +1,5 @@
-import { MarkdownRenderer, SkillIcon } from '@mastra/playground-ui';
+import { SkillIcon } from '@mastra/playground-ui';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import {
   FileText,
   Code,

--- a/packages/playground/src/exports.ts
+++ b/packages/playground/src/exports.ts
@@ -11,6 +11,7 @@ export {
 
 export { PlaygroundQueryClient } from './lib/tanstack-query';
 
-export { usePlaygroundStore, useTheme, type Theme, type ResolvedTheme } from '@mastra/playground-ui';
+export { usePlaygroundStore } from '@mastra/playground-ui';
+export { useTheme, type Theme, type ResolvedTheme } from '@mastra/playground-ui/components/ThemeProvider';
 
 export { isWorkspaceV1Supported } from '@mastra/playground-ui/utils';

--- a/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
@@ -1,4 +1,6 @@
-import { Badge, Icon, MarkdownRenderer, Notice, cn } from '@mastra/playground-ui';
+import { Badge, Icon, cn } from '@mastra/playground-ui';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { CheckCircleIcon, ChevronUpIcon } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/lib/ai-ui/messages/renderers/status-renderers.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/status-renderers.tsx
@@ -1,4 +1,4 @@
-import { Notice } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import type {
   ErrorRendererProps,
   MessageStatusRenderers,

--- a/packages/playground/src/lib/ai-ui/tools/badges/observation-marker-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/observation-marker-badge.tsx
@@ -1,4 +1,4 @@
-import { MarkdownRenderer } from '@mastra/playground-ui';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { Brain, XCircle, Loader2, ChevronDown, ChevronRight, Unplug, CloudCog } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { ObservationRenderer } from './observation-renderer';

--- a/packages/playground/src/lib/ai-ui/tools/badges/observation-renderer.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/observation-renderer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { MarkdownRenderer, cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { useMemo } from 'react';
 
 // Priority emoji to color mapping

--- a/packages/playground/src/lib/command/navigation-command.tsx
+++ b/packages/playground/src/lib/command/navigation-command.tsx
@@ -1,4 +1,4 @@
-import { useMaybeSidebar, AgentIcon, McpServerIcon, ScrollArea, ToolsIcon, WorkflowIcon } from '@mastra/playground-ui';
+import { AgentIcon, McpServerIcon, ScrollArea, ToolsIcon, WorkflowIcon } from '@mastra/playground-ui';
 import {
   CommandDialog,
   CommandEmpty,
@@ -9,6 +9,7 @@ import {
   CommandShortcut,
 } from '@mastra/playground-ui/components/Command';
 import { Kbd } from '@mastra/playground-ui/components/Kbd';
+import { useMaybeSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { useKeyboardShortcutLabel } from '@mastra/playground-ui/hooks/use-keyboard-shortcut-label';
 import {
   Cpu,

--- a/packages/playground/src/lib/form/components/boolean-field.tsx
+++ b/packages/playground/src/lib/form/components/boolean-field.tsx
@@ -1,5 +1,6 @@
 import type { AutoFormFieldProps } from '@autoform/react';
-import { Checkbox, Txt } from '@mastra/playground-ui';
+import { Txt } from '@mastra/playground-ui';
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import React from 'react';
 
 export const BooleanField: React.FC<AutoFormFieldProps> = ({ field, label, id, inputProps }) => (

--- a/packages/playground/src/lib/form/components/error-message.tsx
+++ b/packages/playground/src/lib/form/components/error-message.tsx
@@ -1,4 +1,4 @@
-import { Notice } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import React from 'react';
 
 export const ErrorMessage: React.FC<{ error: string }> = ({ error }) => <Notice variant="destructive" title={error} />;

--- a/packages/playground/src/lib/route-header/route-header.tsx
+++ b/packages/playground/src/lib/route-header/route-header.tsx
@@ -1,4 +1,6 @@
-import { Breadcrumb, Button, Crumb, DocsIcon, Header, Icon } from '@mastra/playground-ui';
+import { Button, DocsIcon, Icon } from '@mastra/playground-ui';
+import { Breadcrumb, Crumb } from '@mastra/playground-ui/components/Breadcrumb';
+import { Header } from '@mastra/playground-ui/components/Header';
 import { Link } from 'react-router';
 import { RouteHeaderActionsSlot } from './route-header-actions';
 import { useRouteHeaderCrumbsOverride } from './route-header-crumbs-context';

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -3,14 +3,14 @@ import {
   AgentIcon,
   Button,
   EmptyState,
-  ErrorState,
-  ListSearch,
   PageLayout,
   PermissionDenied,
   SessionExpired,
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
 import { PlusIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/pages/agent-builder/favorite/index.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/index.tsx
@@ -1,14 +1,14 @@
 import type { ListStoredAgentsParams, StoredSkillResponse } from '@mastra/client-js';
 import {
   EmptyState,
-  ErrorState,
-  ListSearch,
   PageLayout,
   PermissionDenied,
   SessionExpired,
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
 import { SparklesIcon, StarIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -1,14 +1,14 @@
 import type { ListStoredAgentsParams } from '@mastra/client-js';
 import {
   EmptyState,
-  ErrorState,
-  ListSearch,
   PageLayout,
   PermissionDenied,
   SessionExpired,
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
 import { LibraryIcon, SparklesIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/pages/agent-builder/skills/index.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/index.tsx
@@ -2,14 +2,14 @@ import type { StoredSkillResponse } from '@mastra/client-js';
 import {
   Button,
   EmptyState,
-  ErrorState,
-  ListSearch,
   PageLayout,
   PermissionDenied,
   SessionExpired,
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
 import { DownloadIcon, PlusIcon, SparklesIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/pages/agent-builder/skills/view.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/view.tsx
@@ -1,4 +1,5 @@
-import { Button, MarkdownRenderer, Spinner } from '@mastra/playground-ui';
+import { Button, Spinner } from '@mastra/playground-ui';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { ArrowLeftIcon, PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -1,6 +1,4 @@
 import {
-  ErrorState,
-  ListSearch,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -8,6 +6,8 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { useState } from 'react';
 import { AgentHeaderCreateAction } from '@/domains/agents/agent-header-actions';
 import { AgentsList } from '@/domains/agents/components/agent-list/agents-list';

--- a/packages/playground/src/pages/cms/agents/edit-layout.tsx
+++ b/packages/playground/src/pages/cms/agents/edit-layout.tsx
@@ -1,4 +1,5 @@
-import { Notice, Badge, Button, MainContentLayout, Spinner } from '@mastra/playground-ui';
+import { Badge, Button, MainContentLayout, Spinner } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Check, Download, GitPullRequest, Save } from 'lucide-react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { Outlet, useLocation, useNavigate, useParams, useSearchParams } from 'react-router';

--- a/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
+++ b/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
@@ -1,5 +1,6 @@
 import type { UpdateStoredPromptBlockParams } from '@mastra/client-js';
-import { Notice, Badge, Button, MainContentLayout, Spinner, toast } from '@mastra/playground-ui';
+import { Badge, Button, MainContentLayout, Spinner, toast } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { useMastraClient } from '@mastra/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState } from 'react';

--- a/packages/playground/src/pages/cms/scorers/edit/index.tsx
+++ b/packages/playground/src/pages/cms/scorers/edit/index.tsx
@@ -1,5 +1,6 @@
 import type { UpdateStoredScorerParams } from '@mastra/client-js';
-import { Notice, Badge, Button, MainContentLayout, Spinner, toast } from '@mastra/playground-ui';
+import { Badge, Button, MainContentLayout, Spinner, toast } from '@mastra/playground-ui';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { useMastraClient } from '@mastra/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   EmptyState,
-  ErrorState,
   PageLayout,
   PermissionDenied,
   SessionExpired,
@@ -9,6 +8,7 @@ import {
   is403ForbiddenError,
   is404NotFoundError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ArrowLeft, PlayCircle } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Link, useParams } from 'react-router';

--- a/packages/playground/src/pages/datasets/dataset/experiments/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiments/index.tsx
@@ -2,12 +2,12 @@ import {
   Button,
   MainContentContent,
   MainContentLayout,
-  MainHeader,
   PermissionDenied,
   SessionExpired,
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { GitCompare, ArrowLeft } from 'lucide-react';
 import { useParams, useSearchParams, Link } from 'react-router';
 import { DatasetExperimentsComparison } from '@/domains/datasets';

--- a/packages/playground/src/pages/datasets/dataset/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/index.tsx
@@ -1,9 +1,7 @@
 import {
   Button,
   ButtonsGroup,
-  DropdownMenu,
   EmptyState,
-  ErrorState,
   PageLayout,
   PermissionDenied,
   SessionExpired,
@@ -15,6 +13,8 @@ import {
   is404NotFoundError,
 } from '@mastra/playground-ui';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { format } from 'date-fns/format';
 import { ArrowLeft, Copy, DatabaseIcon, MoreVertical, Pencil, Play, Trash2 } from 'lucide-react';
 import type { ReactNode } from 'react';

--- a/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
@@ -2,11 +2,8 @@ import type { DatasetItem } from '@mastra/client-js';
 import {
   Button,
   ButtonsGroup,
-  Column,
-  Columns,
   MainContentContent,
   MainContentLayout,
-  MainHeader,
   PermissionDenied,
   Select,
   SelectContent,
@@ -19,6 +16,8 @@ import {
   is403ForbiddenError,
 } from '@mastra/playground-ui';
 import { CodeDiff } from '@mastra/playground-ui/components/CodeDiff';
+import { Column, Columns } from '@mastra/playground-ui/components/Columns';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { ArrowLeft, GitCompareIcon, History, DiffIcon, ColumnsIcon } from 'lucide-react';
 import { Fragment, useState } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router';

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -1,14 +1,8 @@
 import {
-  AlertDialog,
   Button,
   ButtonsGroup,
-  Column,
-  Columns,
-  CopyButton,
   MainContentContent,
   MainContentLayout,
-  MainHeader,
-  Notice,
   PermissionDenied,
   SessionExpired,
   TextAndIcon,
@@ -16,6 +10,11 @@ import {
   is403ForbiddenError,
   toast,
 } from '@mastra/playground-ui';
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
+import { Column, Columns } from '@mastra/playground-ui/components/Columns';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { format } from 'date-fns';
 import {
   ArrowRightToLineIcon,

--- a/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
@@ -1,12 +1,8 @@
 import {
   Button,
   ButtonsGroup,
-  Chip,
-  Column,
-  Columns,
   MainContentContent,
   MainContentLayout,
-  MainHeader,
   PermissionDenied,
   Select,
   SelectContent,
@@ -18,7 +14,10 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import { CodeDiff } from '@mastra/playground-ui/components/CodeDiff';
+import { Column, Columns } from '@mastra/playground-ui/components/Columns';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { format } from 'date-fns';
 import { ArrowLeft, HistoryIcon, GitCompareIcon, ColumnsIcon, GitCompareArrowsIcon } from 'lucide-react';
 import { Fragment, useState } from 'react';

--- a/packages/playground/src/pages/datasets/dataset/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/versions/index.tsx
@@ -1,16 +1,15 @@
 import {
   Button,
-  Column,
-  Columns,
   MainContentContent,
   MainContentLayout,
-  MainHeader,
   PermissionDenied,
   SessionExpired,
   TextAndIcon,
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { Column, Columns } from '@mastra/playground-ui/components/Columns';
+import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { ArrowLeft, ScaleIcon, HistoryIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useParams, useSearchParams, useNavigate, Link } from 'react-router';

--- a/packages/playground/src/pages/datasets/index.tsx
+++ b/packages/playground/src/pages/datasets/index.tsx
@@ -1,5 +1,4 @@
 import {
-  ErrorState,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -7,6 +6,7 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { useCallback, useMemo, useState } from 'react';
 import { CreateDatasetDialog, DatasetsList, DatasetsToolbar, getDatasetTagOptions } from '@/domains/datasets';
 import { NoDatasetsInfo } from '@/domains/datasets/components/datasets-list/no-datasets-info';

--- a/packages/playground/src/pages/evaluation/index.tsx
+++ b/packages/playground/src/pages/evaluation/index.tsx
@@ -1,5 +1,4 @@
 import {
-  ErrorState,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -7,6 +6,7 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { MetricsFlexGrid } from '@mastra/playground-ui/components/MetricsFlexGrid';
 import { useMemo } from 'react';
 import { DatasetHealthCard } from '@/domains/datasets';

--- a/packages/playground/src/pages/experiments/experiment/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/index.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   EmptyState,
-  ErrorState,
   PageLayout,
   PermissionDenied,
   SessionExpired,
@@ -9,6 +8,7 @@ import {
   is403ForbiddenError,
   is404NotFoundError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ArrowLeft, PlayCircle } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Link, useParams } from 'react-router';

--- a/packages/playground/src/pages/experiments/index.tsx
+++ b/packages/playground/src/pages/experiments/index.tsx
@@ -1,5 +1,4 @@
 import {
-  ErrorState,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -7,6 +6,7 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { useMemo, useState } from 'react';
 import { useDatasets } from '@/domains/datasets/hooks/use-datasets';
 import { useExperiments } from '@/domains/datasets/hooks/use-experiments';

--- a/packages/playground/src/pages/logs/index.tsx
+++ b/packages/playground/src/pages/logs/index.tsx
@@ -6,7 +6,6 @@ import {
   LogsToolbar,
   NoLogsInfo,
   PageLayout,
-  PropertyFilterCreator,
   SpanDetailsView,
   TraceDetailsView,
   buildLogsListFilters,
@@ -24,6 +23,7 @@ import {
   useTraceLightSpans,
 } from '@mastra/playground-ui';
 import { DateTimeRangePicker } from '@mastra/playground-ui/components/DateTimeRangePicker';
+import { PropertyFilterCreator } from '@mastra/playground-ui/components/PropertyFilter';
 import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 

--- a/packages/playground/src/pages/mcps/index.tsx
+++ b/packages/playground/src/pages/mcps/index.tsx
@@ -1,6 +1,4 @@
 import {
-  ErrorState,
-  ListSearch,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -8,6 +6,8 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { useState } from 'react';
 import { McpServersList } from '@/domains/mcps/components/mcps-list/mcps-list';
 import { NoMCPServersInfo } from '@/domains/mcps/components/mcps-list/no-mcp-servers-info';

--- a/packages/playground/src/pages/metrics/index.tsx
+++ b/packages/playground/src/pages/metrics/index.tsx
@@ -1,15 +1,12 @@
-import type { DatePreset, DateRange, PropertyFilterToken } from '@mastra/playground-ui';
+import type { DatePreset, DateRange } from '@mastra/playground-ui';
 import {
-  Notice,
   Button,
   DateRangeSelector,
   EmptyState,
-  ErrorState,
   MetricsProvider,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
-  PropertyFilterCreator,
   SessionExpired,
   applyMetricsPropertyFilterTokens,
   clearSavedMetricsFilters,
@@ -29,7 +26,11 @@ import {
   useServiceNames,
   useTags,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { MetricsFlexGrid } from '@mastra/playground-ui/components/MetricsFlexGrid';
+import { Notice } from '@mastra/playground-ui/components/Notice';
+import { PropertyFilterCreator } from '@mastra/playground-ui/components/PropertyFilter';
+import type { PropertyFilterToken } from '@mastra/playground-ui/components/PropertyFilter';
 import { CircleSlashIcon, ExternalLinkIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';

--- a/packages/playground/src/pages/processors/index.tsx
+++ b/packages/playground/src/pages/processors/index.tsx
@@ -1,6 +1,4 @@
 import {
-  ErrorState,
-  ListSearch,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -8,6 +6,8 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { useState } from 'react';
 import { NoProcessorsInfo } from '@/domains/processors/components/processors-list/no-processors-info';
 import { ProcessorsList } from '@/domains/processors/components/processors-list/processors-list';

--- a/packages/playground/src/pages/prompt-blocks/index.tsx
+++ b/packages/playground/src/pages/prompt-blocks/index.tsx
@@ -1,7 +1,5 @@
 import {
   Button,
-  ErrorState,
-  ListSearch,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -9,6 +7,8 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';

--- a/packages/playground/src/pages/scorers/index.tsx
+++ b/packages/playground/src/pages/scorers/index.tsx
@@ -1,5 +1,4 @@
 import {
-  ErrorState,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -7,6 +6,7 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { useState } from 'react';
 import { ScorersToolbar, useScorers } from '@/domains/scores';
 import { NoScorersInfo } from '@/domains/scores/components/scorers-list/no-scorers-info';

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ErrorState,
   PageLayout,
   PermissionDenied,
   SessionExpired,
@@ -8,6 +7,7 @@ import {
   is403ForbiddenError,
   toast,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { PencilIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router';

--- a/packages/playground/src/pages/settings/index.tsx
+++ b/packages/playground/src/pages/settings/index.tsx
@@ -1,15 +1,8 @@
-import {
-  PageLayout,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  useTheme,
-} from '@mastra/playground-ui';
-import type { Theme } from '@mastra/playground-ui';
+import { PageLayout, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui';
 import { SectionCard } from '@mastra/playground-ui/components/SectionCard';
 import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
+import { useTheme } from '@mastra/playground-ui/components/ThemeProvider';
+import type { Theme } from '@mastra/playground-ui/components/ThemeProvider';
 import type { LucideIcon } from 'lucide-react';
 import { MonitorIcon, MoonIcon, SunIcon } from 'lucide-react';
 import { StudioConfigForm } from '@/domains/configuration/components/studio-config-form';

--- a/packages/playground/src/pages/templates/index.tsx
+++ b/packages/playground/src/pages/templates/index.tsx
@@ -1,4 +1,5 @@
-import { Header, HeaderTitle, Icon, MainContentLayout } from '@mastra/playground-ui';
+import { Icon, MainContentLayout } from '@mastra/playground-ui';
+import { Header, HeaderTitle } from '@mastra/playground-ui/components/Header';
 import { PackageIcon } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';

--- a/packages/playground/src/pages/tools/index.tsx
+++ b/packages/playground/src/pages/tools/index.tsx
@@ -1,6 +1,4 @@
 import {
-  ErrorState,
-  ListSearch,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -8,6 +6,8 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { useState } from 'react';
 import { useAgents } from '@/domains/agents/hooks/use-agents';
 import { NoToolsInfo } from '@/domains/tools/components/tools-list/no-tools-info';

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -3,11 +3,8 @@ import {
   Button,
   Label,
   NoTracesInfo,
-  Notice,
   PageLayout,
-  PropertyFilterCreator,
   SpanDataPanelView,
-  Switch,
   TraceDataPanelView,
   TracesErrorContent,
   TracesLayout,
@@ -31,6 +28,9 @@ import {
 } from '@mastra/playground-ui';
 import type { SpanTab } from '@mastra/playground-ui';
 import { DateTimeRangePicker } from '@mastra/playground-ui/components/DateTimeRangePicker';
+import { Notice } from '@mastra/playground-ui/components/Notice';
+import { PropertyFilterCreator } from '@mastra/playground-ui/components/PropertyFilter';
+import { Switch } from '@mastra/playground-ui/components/Switch';
 import { CircleSlash2, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';

--- a/packages/playground/src/pages/workflows/index.tsx
+++ b/packages/playground/src/pages/workflows/index.tsx
@@ -1,7 +1,5 @@
 import {
   Button,
-  ErrorState,
-  ListSearch,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -9,6 +7,8 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { CalendarClockIcon } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';

--- a/packages/playground/src/pages/workflows/schedule.tsx
+++ b/packages/playground/src/pages/workflows/schedule.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ErrorState,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -9,6 +8,7 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ArrowLeftIcon, PauseIcon, PlayIcon } from 'lucide-react';
 import { Link, useParams } from 'react-router';
 import { ScheduleStatusText } from '@/domains/schedules/components/schedule-status-badge';

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ErrorState,
   NoDataPageLayout,
   PageLayout,
   PermissionDenied,
@@ -14,6 +13,7 @@ import {
   is403ForbiddenError,
   toast,
 } from '@mastra/playground-ui';
+import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { FileText, Wand2, Search, ChevronDown, Bot, Server } from 'lucide-react';
 import { useState, useCallback } from 'react';
 import { useSearchParams, useParams, useNavigate } from 'react-router';

--- a/packages/playground/src/store/playground-store.ts
+++ b/packages/playground/src/store/playground-store.ts
@@ -1,1 +1,2 @@
-export { usePlaygroundStore, useTheme, type Theme, type ResolvedTheme } from '@mastra/playground-ui';
+export { usePlaygroundStore } from '@mastra/playground-ui';
+export { useTheme, type Theme, type ResolvedTheme } from '@mastra/playground-ui/components/ThemeProvider';


### PR DESCRIPTION
Moves the requested `@mastra/playground-ui` components used in `packages/playground` from the root barrel to exact component subpaths, for perf/import hygiene and to avoid pulling the playground-ui root barrel at those call sites. The package ESLint config now blocks those component specifiers from being reintroduced through `@mastra/playground-ui`.

No changeset is included because this does not change runtime behavior or public package APIs; it only rewrites internal imports in `packages/playground`.

Validation:
- `pnpm prettier:changed`
- `pnpm --filter ./packages/playground typecheck`
- `pnpm --filter ./packages/playground lint`
- `pnpm lint`
- `npx -y react-doctor@latest . --verbose --diff`