### PR TITLE
fix(mastracode): use sessions in ACP server

### DIFF
--- a/.changeset/hot-jars-brake.md
+++ b/.changeset/hot-jars-brake.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added a public ACP export so workflows can import the ACP agent with `import { MastraCodeAcpAgent } from 'mastracode/acp'`.

--- a/.changeset/true-mirrors-dig.md
+++ b/.changeset/true-mirrors-dig.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed ACP server mode so sessions can start, receive prompts, and handle tool approvals after the Harness session changes.

--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -42,6 +42,16 @@
         "default": "./dist/tui.cjs"
       }
     },
+    "./acp": {
+      "import": {
+        "types": "./dist/acp.d.ts",
+        "default": "./dist/acp.js"
+      },
+      "require": {
+        "types": "./dist/acp.d.ts",
+        "default": "./dist/acp.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/mastracode/src/__tests__/package-metadata.test.ts
+++ b/mastracode/src/__tests__/package-metadata.test.ts
@@ -39,6 +39,10 @@ describe('mastracode package metadata', () => {
         import: { types: './dist/tui/index.d.ts', default: './dist/tui.js' },
         require: { types: './dist/tui/index.d.ts', default: './dist/tui.cjs' },
       },
+      './acp': {
+        import: { types: './dist/acp.d.ts', default: './dist/acp.js' },
+        require: { types: './dist/acp.d.ts', default: './dist/acp.cjs' },
+      },
       './package.json': './package.json',
     });
     expect(pkg.engines?.node).toBe('>=22.19.0');

--- a/mastracode/src/acp.ts
+++ b/mastracode/src/acp.ts
@@ -1,0 +1,1 @@
+export { MastraCodeAcpAgent } from './acp/agent.js';

--- a/mastracode/src/acp/agent.test.ts
+++ b/mastracode/src/acp/agent.test.ts
@@ -1,8 +1,9 @@
-import type { ContentBlock } from '@agentclientprotocol/sdk';
+import type { AgentSideConnection, ContentBlock, PromptResponse } from '@agentclientprotocol/sdk';
+import type { Harness, HarnessEvent, HarnessMode, Session } from '@mastra/core/harness';
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { extractTextFromContentBlocks, mapStopReason } from './agent.js';
+import { MastraCodeAcpAgent, extractTextFromContentBlocks, mapStopReason } from './agent.js';
 
 describe('ACP Agent - Text Extraction', () => {
   it('extracts text from text blocks', () => {
@@ -87,5 +88,62 @@ describe('ACP Agent - StopReason Mapping', () => {
 
   it('maps suspended to end_turn', () => {
     expect(mapStopReason('suspended')).toBe('end_turn');
+  });
+});
+
+describe('ACP Agent - Prompt concurrency', () => {
+  it('serializes thread switching for concurrent prompts', async () => {
+    let eventListener: ((event: HarnessEvent) => void) | undefined;
+    const switchThread = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const session = {
+      subscribe: vi.fn(listener => {
+        eventListener = listener;
+        return vi.fn();
+      }),
+      thread: {
+        create: vi.fn().mockResolvedValueOnce({ id: 'thread-1' }).mockResolvedValueOnce({ id: 'thread-2' }),
+        switch: switchThread,
+      },
+      mode: { get: vi.fn(() => 'default') },
+      model: { get: vi.fn(() => 'test-model') },
+      sendMessage,
+    } as unknown as Session;
+    const harness = {
+      listAvailableModels: vi.fn().mockResolvedValue([]),
+    } as unknown as Harness;
+    const connection = {
+      sessionUpdate: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentSideConnection;
+
+    const agent = new MastraCodeAcpAgent(connection, harness, session, [] satisfies HarnessMode[]);
+    const { sessionId: firstSessionId } = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    const { sessionId: secondSessionId } = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    switchThread.mockClear();
+
+    const firstPrompt = agent.prompt({
+      sessionId: firstSessionId,
+      prompt: [{ type: 'text', text: 'first' }],
+    });
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1));
+
+    const secondPrompt = agent.prompt({
+      sessionId: secondSessionId,
+      prompt: [{ type: 'text', text: 'second' }],
+    });
+    await Promise.resolve();
+
+    expect(switchThread).toHaveBeenCalledTimes(1);
+    expect(switchThread).toHaveBeenNthCalledWith(1, { threadId: 'thread-1' });
+
+    eventListener?.({ type: 'agent_end', reason: 'complete' } as HarnessEvent);
+    await expect(firstPrompt).resolves.toMatchObject({ stopReason: 'end_turn' });
+
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(2));
+    expect(switchThread).toHaveBeenCalledTimes(2);
+    expect(switchThread).toHaveBeenNthCalledWith(2, { threadId: 'thread-2' });
+
+    eventListener?.({ type: 'agent_end', reason: 'complete' } as HarnessEvent);
+    await expect(secondPrompt).resolves.toMatchObject({ stopReason: 'end_turn' } satisfies Partial<PromptResponse>);
   });
 });

--- a/mastracode/src/acp/agent.ts
+++ b/mastracode/src/acp/agent.ts
@@ -11,7 +11,7 @@ import type {
   ContentBlock,
 } from '@agentclientprotocol/sdk';
 import { PROTOCOL_VERSION } from '@agentclientprotocol/sdk';
-import type { Harness, HarnessMode } from '@mastra/core/harness';
+import type { Harness, HarnessMode, Session } from '@mastra/core/harness';
 import { handleHarnessEvent } from './event-mapper.js';
 import type { PromptState } from './event-mapper.js';
 
@@ -22,6 +22,7 @@ import type { PromptState } from './event-mapper.js';
 export class MastraCodeAcpAgent implements Agent {
   private readonly connection: AgentSideConnection;
   private readonly harness: Harness;
+  private readonly session: Session;
   private readonly modes: HarnessMode[];
   private readonly sessionMap = new Map<string, string>(); // sessionId -> threadId
   private currentPromptState: PromptState | null = null;
@@ -35,14 +36,15 @@ export class MastraCodeAcpAgent implements Agent {
     return threadId;
   }
 
-  constructor(connection: AgentSideConnection, harness: Harness, modes: HarnessMode[]) {
+  constructor(connection: AgentSideConnection, harness: Harness, session: Session, modes: HarnessMode[]) {
     this.connection = connection;
     this.harness = harness;
+    this.session = session;
     this.modes = modes;
 
     // Register persistent event listener
-    this.harness.subscribe(event => {
-      handleHarnessEvent(event, this.currentPromptState, this.connection, this.harness);
+    this.session.subscribe(event => {
+      handleHarnessEvent(event, this.currentPromptState, this.connection, this.session);
     });
   }
 
@@ -65,12 +67,12 @@ export class MastraCodeAcpAgent implements Agent {
   }
 
   async newSession(_request: NewSessionRequest): Promise<NewSessionResponse> {
-    const thread = await this.harness.createThread();
+    const thread = await this.session.thread.create();
     const sessionId = thread.id;
     this.sessionMap.set(sessionId, thread.id);
 
     // Switch to the new thread
-    await this.harness.switchThread({ threadId: thread.id });
+    await this.session.thread.switch({ threadId: thread.id });
 
     // Build modes list from constructor param
     const availableModes = this.modes.map((m: HarnessMode) => ({
@@ -78,13 +80,13 @@ export class MastraCodeAcpAgent implements Agent {
       name: m.name ?? m.id,
     }));
 
-    const currentModeId = this.harness.session.mode.get();
+    const currentModeId = this.session.mode.get();
 
     // Build models list (best-effort)
     let models: NewSessionResponse['models'];
     try {
       const availableModels = await this.harness.listAvailableModels();
-      const currentModelId = this.harness.session.model.get();
+      const currentModelId = this.session.model.get();
       models = {
         currentModelId: currentModelId ?? '',
         availableModels: availableModels.map(m => ({
@@ -114,7 +116,7 @@ export class MastraCodeAcpAgent implements Agent {
 
     // Ensure we're on the right thread
     const threadId = this.getThreadIdOrThrow(sessionId);
-    await this.harness.switchThread({ threadId });
+    await this.session.thread.switch({ threadId });
 
     // Serialize prompts via mutex
     const prevMutex = this.promptMutex;
@@ -148,9 +150,9 @@ export class MastraCodeAcpAgent implements Agent {
         };
       });
 
-      // Send the message to the harness
+      // Send the message to the session
       try {
-        await this.harness.sendMessage({ content: text });
+        await this.session.sendMessage({ content: text });
       } catch (error) {
         this.currentPromptState = null;
         throw error;
@@ -176,19 +178,19 @@ export class MastraCodeAcpAgent implements Agent {
   }
 
   async cancel(_notification: CancelNotification): Promise<void> {
-    this.harness.abort();
+    this.session.abort();
   }
 
   async setSessionMode(params: { sessionId: string; modeId: string }): Promise<void> {
     const threadId = this.getThreadIdOrThrow(params.sessionId);
-    await this.harness.switchThread({ threadId });
-    this.harness.session.mode.set({ modeId: params.modeId });
+    await this.session.thread.switch({ threadId });
+    this.session.mode.set({ modeId: params.modeId });
   }
 
   async unstable_setSessionModel(params: { sessionId: string; modelId: string }): Promise<void> {
     const threadId = this.getThreadIdOrThrow(params.sessionId);
-    await this.harness.switchThread({ threadId });
-    this.harness.session.model.set({ modelId: params.modelId });
+    await this.session.thread.switch({ threadId });
+    this.session.model.set({ modelId: params.modelId });
   }
 }
 

--- a/mastracode/src/acp/agent.ts
+++ b/mastracode/src/acp/agent.ts
@@ -24,6 +24,7 @@ export class MastraCodeAcpAgent implements Agent {
   private readonly harness: Harness;
   private readonly session: Session;
   private readonly modes: HarnessMode[];
+  private readonly unsubscribeSessionEvents: () => void;
   private readonly sessionMap = new Map<string, string>(); // sessionId -> threadId
   private currentPromptState: PromptState | null = null;
   private promptMutex: Promise<void> = Promise.resolve();
@@ -43,9 +44,13 @@ export class MastraCodeAcpAgent implements Agent {
     this.modes = modes;
 
     // Register persistent event listener
-    this.session.subscribe(event => {
+    this.unsubscribeSessionEvents = this.session.subscribe(event => {
       handleHarnessEvent(event, this.currentPromptState, this.connection, this.session);
     });
+  }
+
+  dispose(): void {
+    this.unsubscribeSessionEvents();
   }
 
   async initialize(_request: InitializeRequest): Promise<InitializeResponse> {

--- a/mastracode/src/acp/agent.ts
+++ b/mastracode/src/acp/agent.ts
@@ -119,9 +119,7 @@ export class MastraCodeAcpAgent implements Agent {
     // Extract text from content blocks
     const text = extractTextFromContentBlocks(contentBlocks);
 
-    // Ensure we're on the right thread
     const threadId = this.getThreadIdOrThrow(sessionId);
-    await this.session.thread.switch({ threadId });
 
     // Serialize prompts via mutex
     const prevMutex = this.promptMutex;
@@ -133,6 +131,9 @@ export class MastraCodeAcpAgent implements Agent {
     await prevMutex;
 
     try {
+      // Ensure we're on the right thread while prompts are serialized
+      await this.session.thread.switch({ threadId });
+
       // Create prompt state that will be resolved when agent_end fires
       const result = new Promise<{
         reason: 'complete' | 'aborted' | 'error' | 'suspended';

--- a/mastracode/src/acp/event-mapper.test.ts
+++ b/mastracode/src/acp/event-mapper.test.ts
@@ -1,5 +1,5 @@
 import type { AgentSideConnection } from '@agentclientprotocol/sdk';
-import type { Harness, HarnessEvent } from '@mastra/core/harness';
+import type { HarnessEvent, Session } from '@mastra/core/harness';
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -8,7 +8,7 @@ import { handleHarnessEvent } from './event-mapper.js';
 
 describe('ACP Event Mapper', () => {
   let mockConnection: AgentSideConnection;
-  let mockHarness: Harness;
+  let mockSession: Session;
   let sessionUpdateSpy: ReturnType<typeof vi.fn>;
   let requestPermissionSpy: ReturnType<typeof vi.fn>;
 
@@ -23,12 +23,10 @@ describe('ACP Event Mapper', () => {
       requestPermission: requestPermissionSpy,
     } as unknown as AgentSideConnection;
 
-    mockHarness = {
-      session: {
-        respondToToolApproval: vi.fn(),
-      },
+    mockSession = {
+      respondToToolApproval: vi.fn(),
       respondToToolSuspension: vi.fn(),
-    } as unknown as Harness;
+    } as unknown as Session;
   });
 
   function createPromptState(sessionId: string): PromptState {
@@ -59,7 +57,7 @@ describe('ACP Event Mapper', () => {
         },
       };
 
-      handleHarnessEvent(event1, state, mockConnection, mockHarness);
+      handleHarnessEvent(event1, state, mockConnection, mockSession);
 
       expect(sessionUpdateSpy).toHaveBeenCalledWith({
         sessionId: 'session-1',
@@ -86,7 +84,7 @@ describe('ACP Event Mapper', () => {
         },
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       expect(sessionUpdateSpy).toHaveBeenCalledWith({
         sessionId: 'session-1',
@@ -111,7 +109,7 @@ describe('ACP Event Mapper', () => {
         },
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
       expect(sessionUpdateSpy).not.toHaveBeenCalled();
     });
   });
@@ -127,7 +125,7 @@ describe('ACP Event Mapper', () => {
         args: { path: '/test.js', content: 'code' },
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       expect(sessionUpdateSpy).toHaveBeenCalledWith({
         sessionId: 'session-1',
@@ -161,7 +159,7 @@ describe('ACP Event Mapper', () => {
           args: {},
         };
 
-        handleHarnessEvent(event, state, mockConnection, mockHarness);
+        handleHarnessEvent(event, state, mockConnection, mockSession);
 
         expect(sessionUpdateSpy).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -185,7 +183,7 @@ describe('ACP Event Mapper', () => {
         isError: false,
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       expect(sessionUpdateSpy).toHaveBeenCalledWith({
         sessionId: 'session-1',
@@ -208,7 +206,7 @@ describe('ACP Event Mapper', () => {
         isError: true,
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       expect(sessionUpdateSpy).toHaveBeenCalledWith({
         sessionId: 'session-1',
@@ -233,7 +231,7 @@ describe('ACP Event Mapper', () => {
         args: { path: '/important.js' },
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       // Wait for async permission handling
       await vi.waitFor(() => {
@@ -251,7 +249,7 @@ describe('ACP Event Mapper', () => {
         });
       });
 
-      expect(mockHarness.session.respondToToolApproval).toHaveBeenCalledWith({
+      expect(mockSession.respondToToolApproval).toHaveBeenCalledWith({
         decision: 'approve',
       });
     });
@@ -270,13 +268,13 @@ describe('ACP Event Mapper', () => {
         args: {},
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       await vi.waitFor(() => {
         expect(requestPermissionSpy).toHaveBeenCalled();
       });
 
-      expect(mockHarness.session.respondToToolApproval).toHaveBeenCalledWith({
+      expect(mockSession.respondToToolApproval).toHaveBeenCalledWith({
         decision: 'decline',
       });
     });
@@ -295,11 +293,11 @@ describe('ACP Event Mapper', () => {
           args: {},
         };
 
-        handleHarnessEvent(event, state, mockConnection, mockHarness);
+        handleHarnessEvent(event, state, mockConnection, mockSession);
 
         // Should not request permission
         expect(requestPermissionSpy).not.toHaveBeenCalled();
-        expect(mockHarness.session.respondToToolApproval).toHaveBeenCalledWith({
+        expect(mockSession.respondToToolApproval).toHaveBeenCalledWith({
           decision: 'approve',
         });
       } finally {
@@ -320,9 +318,9 @@ describe('ACP Event Mapper', () => {
         suspendPayload: {},
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
-      expect(mockHarness.respondToToolSuspension).toHaveBeenCalledWith({
+      expect(mockSession.respondToToolSuspension).toHaveBeenCalledWith({
         toolCallId: 'tool-123',
         resumeData: 'Yes',
       });
@@ -339,9 +337,9 @@ describe('ACP Event Mapper', () => {
         suspendPayload: { kind: 'sandbox_access_request' },
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
-      expect(mockHarness.respondToToolSuspension).toHaveBeenCalledWith({
+      expect(mockSession.respondToToolSuspension).toHaveBeenCalledWith({
         toolCallId: 'tool-123',
         resumeData: 'Yes',
       });
@@ -358,7 +356,7 @@ describe('ACP Event Mapper', () => {
         suspendPayload: {},
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       await vi.waitFor(() => {
         expect(requestPermissionSpy).toHaveBeenCalledWith({
@@ -375,7 +373,7 @@ describe('ACP Event Mapper', () => {
         });
       });
 
-      expect(mockHarness.respondToToolSuspension).toHaveBeenCalledWith({
+      expect(mockSession.respondToToolSuspension).toHaveBeenCalledWith({
         toolCallId: 'tool-123',
         resumeData: { action: 'approved' },
       });
@@ -392,9 +390,9 @@ describe('ACP Event Mapper', () => {
         suspendPayload: {},
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
-      expect(mockHarness.respondToToolSuspension).toHaveBeenCalledWith({
+      expect(mockSession.respondToToolSuspension).toHaveBeenCalledWith({
         toolCallId: 'tool-123',
         resumeData: 'Proceed with your best judgment. Do not ask further questions.',
       });
@@ -415,7 +413,7 @@ describe('ACP Event Mapper', () => {
         },
       };
 
-      handleHarnessEvent(event1, state, mockConnection, mockHarness);
+      handleHarnessEvent(event1, state, mockConnection, mockSession);
 
       expect(state.usage).toEqual({
         promptTokens: 100,
@@ -433,7 +431,7 @@ describe('ACP Event Mapper', () => {
         },
       };
 
-      handleHarnessEvent(event2, state, mockConnection, mockHarness);
+      handleHarnessEvent(event2, state, mockConnection, mockSession);
 
       expect(state.usage).toEqual({
         promptTokens: 150,
@@ -453,7 +451,7 @@ describe('ACP Event Mapper', () => {
         reason: 'complete',
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       expect(state.resolve).toHaveBeenCalledWith('complete');
     });
@@ -466,7 +464,7 @@ describe('ACP Event Mapper', () => {
         reason: 'aborted',
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       expect(state.resolve).toHaveBeenCalledWith('aborted');
     });
@@ -479,7 +477,7 @@ describe('ACP Event Mapper', () => {
         reason: 'error',
       };
 
-      handleHarnessEvent(event, state, mockConnection, mockHarness);
+      handleHarnessEvent(event, state, mockConnection, mockSession);
 
       expect(state.resolve).toHaveBeenCalledWith('error');
     });
@@ -497,7 +495,7 @@ describe('ACP Event Mapper', () => {
         },
       };
 
-      handleHarnessEvent(event, null, mockConnection, mockHarness);
+      handleHarnessEvent(event, null, mockConnection, mockSession);
 
       expect(sessionUpdateSpy).not.toHaveBeenCalled();
     });
@@ -514,7 +512,7 @@ describe('ACP Event Mapper', () => {
       ];
 
       ignoredEvents.forEach(event => {
-        handleHarnessEvent(event, state, mockConnection, mockHarness);
+        handleHarnessEvent(event, state, mockConnection, mockSession);
       });
 
       expect(sessionUpdateSpy).not.toHaveBeenCalled();

--- a/mastracode/src/acp/event-mapper.ts
+++ b/mastracode/src/acp/event-mapper.ts
@@ -1,5 +1,5 @@
 import type { SessionNotification, RequestPermissionRequest, AgentSideConnection } from '@agentclientprotocol/sdk';
-import type { Harness, HarnessEvent, TokenUsage } from '@mastra/core/harness';
+import type { HarnessEvent, Session, TokenUsage } from '@mastra/core/harness';
 
 let autoApprove = false;
 
@@ -55,7 +55,7 @@ export function handleHarnessEvent(
   event: HarnessEvent,
   state: PromptState | null,
   connection: AgentSideConnection,
-  harness: Harness,
+  session: Session,
 ): void {
   if (!state) return;
 
@@ -106,13 +106,13 @@ export function handleHarnessEvent(
       break;
 
     case 'tool_approval_required':
-      void handleToolApproval(state, connection, harness, event).catch(err => {
+      void handleToolApproval(state, connection, session, event).catch(err => {
         process.stderr.write(`[acp] handleToolApproval error: ${err}\n`);
       });
       break;
 
     case 'tool_suspended':
-      void handleToolSuspended(state, connection, harness, event).catch(err => {
+      void handleToolSuspended(state, connection, session, event).catch(err => {
         process.stderr.write(`[acp] handleToolSuspended error: ${err}\n`);
       });
       break;
@@ -140,12 +140,12 @@ function sendUpdate(connection: AgentSideConnection, sessionId: string, update: 
 async function handleToolApproval(
   state: PromptState,
   connection: AgentSideConnection,
-  harness: Harness,
+  session: Session,
   event: Extract<HarnessEvent, { type: 'tool_approval_required' }>,
 ): Promise<void> {
   // Auto-approve if --dangerous-auto-approve flag is set
   if (autoApprove) {
-    harness.session.respondToToolApproval({ decision: 'approve' });
+    session.respondToToolApproval({ decision: 'approve' });
     return;
   }
 
@@ -166,27 +166,27 @@ async function handleToolApproval(
     const resp = await connection.requestPermission(req);
     if (resp.outcome.outcome === 'selected') {
       const decision = resp.outcome.optionId === 'approve' ? 'approve' : 'decline';
-      harness.session.respondToToolApproval({ decision });
+      session.respondToToolApproval({ decision });
     } else {
-      harness.session.respondToToolApproval({ decision: 'decline' });
+      session.respondToToolApproval({ decision: 'decline' });
     }
   } catch (err) {
     process.stderr.write(`[acp] requestPermission error: ${err}\n`);
-    harness.session.respondToToolApproval({ decision: 'decline' });
+    session.respondToToolApproval({ decision: 'decline' });
   }
 }
 
 async function handleToolSuspended(
   state: PromptState,
   connection: AgentSideConnection,
-  harness: Harness,
+  session: Session,
   event: Extract<HarnessEvent, { type: 'tool_suspended' }>,
 ): Promise<void> {
   const { toolCallId, toolName, args, suspendPayload } = event;
 
   // Auto-resolve certain suspensions (mirrors headless.ts autoResolve)
   if (toolName === 'request_access' || (suspendPayload as any)?.kind === 'sandbox_access_request') {
-    harness.respondToToolSuspension({ toolCallId, resumeData: 'Yes' });
+    void session.respondToToolSuspension({ toolCallId, resumeData: 'Yes' });
     return;
   }
 
@@ -209,15 +209,15 @@ async function handleToolSuspended(
       const resp = await connection.requestPermission(req);
       const action =
         resp.outcome.outcome === 'selected' && resp.outcome.optionId === 'approve' ? 'approved' : 'rejected';
-      harness.respondToToolSuspension({ toolCallId, resumeData: { action } });
+      void session.respondToToolSuspension({ toolCallId, resumeData: { action } });
     } catch {
-      harness.respondToToolSuspension({ toolCallId, resumeData: { action: 'rejected' } });
+      void session.respondToToolSuspension({ toolCallId, resumeData: { action: 'rejected' } });
     }
     return;
   }
 
   // For ask_user and other suspensions, auto-resolve
-  harness.respondToToolSuspension({
+  void session.respondToToolSuspension({
     toolCallId,
     resumeData: 'Proceed with your best judgment. Do not ask further questions.',
   });

--- a/mastracode/src/acp/server.ts
+++ b/mastracode/src/acp/server.ts
@@ -16,9 +16,10 @@ export async function runAcpServer(
   const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
   const output = Writable.toWeb(process.stdout) as WritableStream<Uint8Array>;
   const stream = ndJsonStream(output, input);
+  const session = await harness.createSession();
 
   // Create the agent-side connection
-  const connection = new AgentSideConnection(conn => new MastraCodeAcpAgent(conn, harness, modes), stream);
+  const connection = new AgentSideConnection(conn => new MastraCodeAcpAgent(conn, harness, session, modes), stream);
 
   // Handle cleanup on disconnect (success or error)
   try {

--- a/mastracode/src/acp/server.ts
+++ b/mastracode/src/acp/server.ts
@@ -1,6 +1,6 @@
 import { Readable, Writable } from 'node:stream';
 import { AgentSideConnection, ndJsonStream } from '@agentclientprotocol/sdk';
-import type { Harness, HarnessMode } from '@mastra/core/harness';
+import type { Harness, HarnessMode, Session } from '@mastra/core/harness';
 import { MastraCodeAcpAgent } from './agent.js';
 
 /**
@@ -16,15 +16,25 @@ export async function runAcpServer(
   const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
   const output = Writable.toWeb(process.stdout) as WritableStream<Uint8Array>;
   const stream = ndJsonStream(output, input);
-  const session = await harness.createSession();
-
-  // Create the agent-side connection
-  const connection = new AgentSideConnection(conn => new MastraCodeAcpAgent(conn, harness, session, modes), stream);
+  let session: Session | undefined;
+  let agent: MastraCodeAcpAgent | undefined;
 
   // Handle cleanup on disconnect (success or error)
   try {
+    session = await harness.createSession();
+    const activeSession = session;
+
+    // Create the agent-side connection
+    const connection = new AgentSideConnection(conn => {
+      agent = new MastraCodeAcpAgent(conn, harness, activeSession, modes);
+      return agent;
+    }, stream);
+
     await connection.closed;
   } finally {
+    agent?.dispose();
+    session?.thread.detachFromCurrent();
+    await session?.thread.clearAndReleaseLock();
     if (cleanup) {
       await cleanup();
     }

--- a/mastracode/tsup.config.ts
+++ b/mastracode/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     index: 'src/index.ts',
     cli: 'src/main.ts',
     tui: 'src/tui/index.ts',
+    acp: 'src/acp.ts',
   },
   format: ['esm', 'cjs'],
   clean: true,


### PR DESCRIPTION
Fixes `mastracode --acp` after the Harness session refactor. The ACP server now creates a Session up front and routes thread switching, prompts, cancellation, and tool approval responses through that session instead of the removed Harness methods.\n\nBefore, ACP called removed APIs like `harness.subscribe()`, `harness.sendMessage()`, and `harness.session.mode.get()`.\n\nAfter, ACP uses `session.subscribe()`, `session.sendMessage()`, `session.mode.get()`, and related session-scoped APIs.\n\nVerified with `pnpm --filter ./mastracode test -- run src/acp/`, `pnpm --filter ./mastracode check`, `pnpm prettier:changed`, and `pnpm lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 - What is this PR doing?
Your ACP server used to talk to Harness in a way that no longer exists. This PR fixes it by creating a `Session` when the server starts and routing all ACP actions (prompts, cancels, tool approvals, etc.) through that `Session`.

---

## Overview
This PR restores and stabilizes `mastracode --acp` after a Harness session refactor. The ACP server now creates a `Session` at startup and updates the agent + event handling logic to use session APIs instead of removed Harness methods.

---

## What changed

### Session-based API migration
Deprecated calls were replaced with their `Session` equivalents:
- `harness.subscribe()` → `session.subscribe()`
- `harness.sendMessage()` → `session.sendMessage()`
- `harness.session.mode.get()` → `session.mode.get()`

### Updated operation flows to use the `Session`
All major ACP flows now route through the injected `session`, including:
- thread switching (via `session.thread.switch()`)
- prompt sending (`session.sendMessage()`)
- cancellation (`session.abort()`)
- tool approval/suspension responses (`session.respondToToolApproval()` / `session.respondToToolSuspension()`)

### Thread-switching race condition fix
To prevent concurrent prompts from stepping on each other, the thread switch is moved inside the mutex-protected block in the prompt handling path. A regression test was added to verify that concurrent prompts serialize thread switching correctly.

### Session lifecycle management on shutdown
The PR tracks and properly disposes session resources:
- stores the session event unsubscribe callback
- unsubscribes on shutdown via a new `dispose()` flow
- ensures active session resources are released in cleanup logic (including server teardown details like thread detachment/lock clearing)

### API export improvements
To support external imports without deep internal paths:
- `MastraCodeAcpAgent` is exported from `mastracode/acp`
- package entrypoints and metadata were updated to include the `./acp` subpath export

### Build/test/validation updates
Verified via ACP unit tests, type checking, formatting, and linting:
- `pnpm --filter ./mastracode test -- run src/acp/`
- `pnpm --filter ./mastracode check`
- `pnpm prettier:changed`
- `pnpm lint`

---

## Files notably updated
- `mastracode/src/acp/server.ts`
- `mastracode/src/acp/agent.ts`
- `mastracode/src/acp/event-mapper.ts` + `event-mapper.test.ts`
- `mastracode/src/acp/agent.test.ts`
- `mastracode/src/acp.ts`
- `mastracode/package.json`
- `mastracode/tsup.config.ts`
- `mastracode/src/__tests__/package-metadata.test.ts`
- changesets: `true-mirrors-dig.md`, `hot-jars-brake.md`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->