### PR TITLE
fix(voice-google-gemini-live): emit history_config in setup frame to fix sendContext() WS 1007 rejection

### DIFF
--- a/.changeset/gemini-live-history-config.md
+++ b/.changeset/gemini-live-history-config.md
@@ -1,0 +1,5 @@
+---
+"@mastra/voice-google-gemini-live": patch
+---
+
+Fix sendContext() being rejected (WS 1007) on gemini-3.1-flash-live-preview by emitting `history_config: { initial_history_in_client_content: true }` in the setup frame. Also exposes `initialHistoryInClientContent` on `GeminiSessionConfig` so callers can opt out explicitly.

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -1890,6 +1890,14 @@ export class GeminiLiveVoice extends MastraVoice<
        * { handle } resumes a previous session.
        */
       session_resumption?: { handle?: string };
+      /**
+       * Opts the session into seeding initial conversation history via send_client_content frames.
+       * Must be present in the setup frame for sendContext() to work on gemini-3.1-flash-live-preview
+       * and later 3.x models — without it the server closes the WebSocket with code 1007.
+       */
+      history_config?: {
+        initial_history_in_client_content?: boolean;
+      };
     }
 
     // Native-audio models require `response_modalities: ["AUDIO"]` at setup time. This is a voice
@@ -1933,6 +1941,17 @@ export class GeminiLiveVoice extends MastraVoice<
         // { handle } resumes a previous session. Only included when enableResumption is set.
         ...(this.options.sessionConfig?.enableResumption && {
           session_resumption: this.isResuming && this.sessionHandle ? { handle: this.sessionHandle } : {},
+        }),
+        // history_config opts the session into send_client_content-based history seeding.
+        // Required by gemini-3.1-flash-live-preview (and later 3.x models) for sendContext() to
+        // succeed — without this field in the setup frame the server closes the WebSocket with
+        // code 1007 ("Request contains an invalid argument."). Defaults to true so that
+        // sendContext() works out of the box; set initialHistoryInClientContent: false on
+        // sessionConfig to opt out explicitly.
+        ...(this.options.sessionConfig?.initialHistoryInClientContent !== false && {
+          history_config: {
+            initial_history_in_client_content: true,
+          },
         }),
       },
     };

--- a/voice/google-gemini-live-api/src/types.ts
+++ b/voice/google-gemini-live-api/src/types.ts
@@ -49,6 +49,13 @@ export interface GeminiToolConfig {
 export interface GeminiSessionConfig {
   /** Enable session resumption after network interruptions */
   enableResumption?: boolean;
+  /**
+   * Opt in to seeding initial conversation history via send_client_content frames.
+   * Required by the Gemini Live v1alpha endpoint when calling sendContext() on
+   * gemini-3.1-flash-live-preview and later 3.x models.
+   * Defaults to true so that sendContext() works out of the box.
+   */
+  initialHistoryInClientContent?: boolean;
   /** Maximum session duration (e.g., '24h', '2h') */
   maxDuration?: string;
   /** Enable automatic context compression */


### PR DESCRIPTION
## Description

`sendContext()` on `gemini-3.1-flash-live-preview` was being rejected by the Gemini Live v1alpha WebSocket endpoint with close code 1007 ("Request contains an invalid argument."). The root cause was that `sendInitialConfig()` never emitted a `history_config` block in the setup frame, which is required by the model to accept `send_client_content` history seeding frames.

**Fix:**
- Always emit `history_config: { initial_history_in_client_content: true }` in the setup frame (defaults to true so `sendContext()` works out of the box)
- Added `history_config` field to the local `LiveGenerateContentSetup` interface
- Exposed `initialHistoryInClientContent?: boolean` on `GeminiSessionConfig` so callers can explicitly opt out by setting it to `false`

No change to `sendContext()` itself — the existing `client_content` payload shape was already correct.

## Related issue(s)

Fixes #18363

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When trying to add previous chat messages to a Gemini Live chat session, the server was rejecting the request. This PR fixes it by making sure the client tells the server upfront "I'm going to add history" during the initial setup conversation. It's like getting permission before trying to do something, rather than trying to do it and getting rejected.

---

## Summary

This PR fixes the `sendContext()` method failing with WebSocket close code 1007 on the `gemini-3.1-flash-live-preview` model. The issue occurred because the setup frame never included a `history_config` block that the Gemini Live v1alpha endpoint requires to accept history-seeding frames.

The fix adds support for history configuration in the setup frame with the following changes:

1. **Setup Frame Enhancement**: The `sendInitialConfig()` method now conditionally includes `history_config: { initial_history_in_client_content: true }` in the setup message, enabling history seeding by default.

2. **Configuration Option**: Added an optional `initialHistoryInClientContent?: boolean` parameter to `GeminiSessionConfig`, allowing callers to explicitly disable the feature if needed. The default behavior is `true`.

3. **Interface Update**: The `LiveGenerateContentSetup` interface now includes the `history_config` field.

The `sendContext()` method's payload structure required no changes—it was already correctly structured; only the server-side opt-in configuration was missing.

## Changes

- **voice/google-gemini-live-api/src/index.ts**: Modified `sendInitialConfig()` to emit `history_config` in the setup frame based on the session configuration
- **voice/google-gemini-live-api/src/types.ts**: Added `initialHistoryInClientContent?: boolean` property to `GeminiSessionConfig`
- **Changeset**: Documented the patch-level fix

This is a bug fix with no breaking changes. The feature is enabled by default, allowing the existing `sendContext()` API to work without additional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->