### PR TITLE
feat(core): retry transient ECONNRESET model stream failures

### DIFF
--- a/.changeset/core-econnreset-retry.md
+++ b/.changeset/core-econnreset-retry.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': patch
+---
+
+Added an optional retry delay and an opt-in ECONNRESET error matcher to `StreamErrorRetryProcessor`. Consumers can now wait before retrying transient network-reset errors. Existing default behavior is unchanged when the new options are not supplied.
+
+```ts
+import { StreamErrorRetryProcessor, isECONNRESETError } from '@mastra/core/processors';
+
+new StreamErrorRetryProcessor({
+  maxRetries: 2,
+  delayMs: 1000,
+  matchers: [isECONNRESETError],
+});
+```

--- a/.changeset/core-econnreset-retry.md
+++ b/.changeset/core-econnreset-retry.md
@@ -2,14 +2,14 @@
 '@mastra/core': patch
 ---
 
-Added an optional retry delay and an opt-in ECONNRESET error matcher to `StreamErrorRetryProcessor`. Consumers can now wait before retrying transient network-reset errors. Existing default behavior is unchanged when the new options are not supplied.
+Added an optional `delayMs` retry delay to `StreamErrorRetryProcessor`. Consumers can now wait before retrying transient errors, accepting either a fixed number of milliseconds or a function evaluated with the error args. Existing default behavior is unchanged when the option is not supplied.
 
 ```ts
-import { StreamErrorRetryProcessor, isECONNRESETError } from '@mastra/core/processors';
+import { StreamErrorRetryProcessor } from '@mastra/core/processors';
 
 new StreamErrorRetryProcessor({
   maxRetries: 2,
-  delayMs: 1000,
-  matchers: [isECONNRESETError],
+  delayMs: ({ retryCount }) => Math.min(1000 * 2 ** retryCount, 30000),
+  matchers: [error => error?.code === 'ECONNRESET'],
 });
 ```

--- a/.changeset/mastracode-econnreset-retry.md
+++ b/.changeset/mastracode-econnreset-retry.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+MastraCode now automatically retries transient ECONNRESET model stream failures with a short wait. Dropped provider sockets recover without manual intervention using a global policy of 2 retries and a 1000ms wait, applied to all model calls independent of model-pack settings.

--- a/.changeset/mastracode-econnreset-retry.md
+++ b/.changeset/mastracode-econnreset-retry.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-MastraCode now automatically retries transient ECONNRESET model stream failures with a short wait. Dropped provider sockets recover without manual intervention using a global policy of 2 retries and a 1000ms wait, applied to all model calls independent of model-pack settings.
+MastraCode now automatically retries transient ECONNRESET model stream failures with exponential backoff. Dropped provider sockets recover without manual intervention using a global policy of 2 retries with delays of 1000ms, 2000ms, and 4000ms (capped at 30000ms), applied to all model calls independent of model-pack settings.

--- a/docs/src/content/en/reference/processors/stream-error-retry-processor.mdx
+++ b/docs/src/content/en/reference/processors/stream-error-retry-processor.mdx
@@ -37,6 +37,38 @@ The processor checks the error and its cause chain for:
 
 When the error is retryable, the processor returns `{ retry: true }`. It doesn't mutate messages.
 
+When `delayMs` is set, the processor waits before signaling a retry. This is useful for transient network errors like `ECONNRESET` where immediately retrying is likely to fail again. The delay can be a fixed number of milliseconds or a function evaluated with the error args (for example, to implement exponential backoff).
+
+## Delaying retries
+
+Use `delayMs` with a custom matcher to retry transient network resets with a wait:
+
+```typescript title="src/mastra/agents/resilient-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { StreamErrorRetryProcessor } from '@mastra/core/processors'
+
+const isECONNRESET = (error: unknown) => {
+  if (!error || typeof error !== 'object') return false
+  const code = (error as { code?: unknown }).code
+  if (typeof code === 'string' && code.toUpperCase() === 'ECONNRESET') return true
+  const message = error instanceof Error ? error.message : undefined
+  return typeof message === 'string' && /econnreset|socket hang up/i.test(message)
+}
+
+export const agent = new Agent({
+  name: 'resilient-agent',
+  instructions: 'You are a helpful assistant.',
+  model: '__GATEWAY_OPENAI_MODEL_BASE__',
+  errorProcessors: [
+    new StreamErrorRetryProcessor({
+      maxRetries: 2,
+      delayMs: ({ retryCount }) => Math.min(1000 * 2 ** retryCount, 30000),
+      matchers: [isECONNRESET],
+    }),
+  ],
+})
+```
+
 ## Default OpenAI Responses matcher
 
 `isRetryableOpenAIResponsesStreamError` matches OpenAI Responses stream error chunks with `type: 'error'` or `type: 'response.failed'`. It retries known transient OpenAI error codes and, as a fallback, errors with explicit retry guidance such as `You can retry your request`.
@@ -66,6 +98,14 @@ When the error is retryable, the processor returns `{ retry: true }`. It doesn't
         description: 'Additional functions that identify provider-specific retryable stream errors.',
         isOptional: true,
         defaultValue: '[]',
+      },
+      {
+        name: 'delayMs',
+        type: 'number | ((args: ProcessAPIErrorArgs) => number | Promise<number>)',
+        description:
+          'Delay in milliseconds to wait before signaling a retry. Accepts a fixed number or a function evaluated with the current error args (for example, for exponential backoff). Negative or non-finite values are clamped to 0.',
+        isOptional: true,
+        defaultValue: '0',
       },
     ],
   },

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -731,12 +731,18 @@ describe('createMastraCode', () => {
 
     expect(streamErrorRetryProcessorConstructorMock).toHaveBeenCalledTimes(1);
     const options = streamErrorRetryProcessorConstructorMock.mock.calls[0]?.[0] as
-      | { maxRetries?: number; delayMs?: number; matchers?: Array<unknown> }
+      | { maxRetries?: number; delayMs?: (args: { retryCount: number }) => number; matchers?: Array<unknown> }
       | undefined;
     expect(options?.maxRetries).toBeGreaterThanOrEqual(2);
-    expect(options?.delayMs).toBeGreaterThanOrEqual(1);
     // The global policy must opt in the ECONNRESET matcher.
     expect(options?.matchers?.length).toBeGreaterThanOrEqual(1);
+    // delayMs must be an exponential-backoff function capped at a max delay.
+    expect(typeof options?.delayMs).toBe('function');
+    expect(options!.delayMs!({ retryCount: 0 })).toBe(1000);
+    expect(options!.delayMs!({ retryCount: 1 })).toBe(2000);
+    expect(options!.delayMs!({ retryCount: 2 })).toBe(4000);
+    // High retry counts are capped at the max delay (30000ms).
+    expect(options!.delayMs!({ retryCount: 10 })).toBe(30000);
   });
 
   it('configures ProviderHistoryCompat for prompt and API error compatibility', async () => {

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -166,7 +166,6 @@ vi.mock('@mastra/core/processors', () => ({
       streamErrorRetryProcessorConstructorMock(options);
     }
   },
-  isECONNRESETError: (error: unknown) => Boolean(error),
 }));
 
 vi.mock('../agents/instructions.js', () => ({

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -148,6 +148,8 @@ vi.mock('@mastra/core/harness', () => ({
   taskCheckTool: {},
 }));
 
+const streamErrorRetryProcessorConstructorMock = vi.fn();
+
 vi.mock('@mastra/core/processors', () => ({
   AgentsMDInjector: class {
     readonly id = 'agents-md-injector';
@@ -160,7 +162,11 @@ vi.mock('@mastra/core/processors', () => ({
   },
   StreamErrorRetryProcessor: class {
     readonly id = 'stream-error-retry-processor';
+    constructor(options?: unknown) {
+      streamErrorRetryProcessorConstructorMock(options);
+    }
   },
+  isECONNRESETError: (error: unknown) => Boolean(error),
 }));
 
 vi.mock('../agents/instructions.js', () => ({
@@ -350,6 +356,7 @@ describe('createMastraCode', () => {
     loadSettingsMock.mockReturnValue(createMockSettings());
     agentConstructorMock.mockReset();
     harnessConstructorMock.mockReset();
+    streamErrorRetryProcessorConstructorMock.mockReset();
     getAvailableModePacksMock.mockClear();
     getAvailableOmPacksMock.mockClear();
     for (const key of Object.keys(providerRegistryMock)) {
@@ -715,6 +722,21 @@ describe('createMastraCode', () => {
       'prefill-error-handler',
       'provider-history-compat',
     ]);
+  });
+
+  it('configures the StreamErrorRetryProcessor with a global ECONNRESET retry policy', async () => {
+    const { createMastraCode } = await import('../index.js');
+
+    await createMastraCode();
+
+    expect(streamErrorRetryProcessorConstructorMock).toHaveBeenCalledTimes(1);
+    const options = streamErrorRetryProcessorConstructorMock.mock.calls[0]?.[0] as
+      | { maxRetries?: number; delayMs?: number; matchers?: Array<unknown> }
+      | undefined;
+    expect(options?.maxRetries).toBeGreaterThanOrEqual(2);
+    expect(options?.delayMs).toBeGreaterThanOrEqual(1);
+    // The global policy must opt in the ECONNRESET matcher.
+    expect(options?.matchers?.length).toBeGreaterThanOrEqual(1);
   });
 
   it('configures ProviderHistoryCompat for prompt and API error compatibility', async () => {

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -732,9 +732,9 @@ describe('createMastraCode', () => {
     const options = streamErrorRetryProcessorConstructorMock.mock.calls[0]?.[0] as
       | { maxRetries?: number; delayMs?: (args: { retryCount: number }) => number; matchers?: Array<unknown> }
       | undefined;
-    expect(options?.maxRetries).toBeGreaterThanOrEqual(2);
+    expect(options?.maxRetries).toBe(2);
     // The global policy must opt in the ECONNRESET matcher.
-    expect(options?.matchers?.length).toBeGreaterThanOrEqual(1);
+    expect(options?.matchers).toHaveLength(1);
     // delayMs must be an exponential-backoff function capped at a max delay.
     expect(typeof options?.delayMs).toBe('function');
     expect(options!.delayMs!({ retryCount: 0 })).toBe(1000);

--- a/mastracode/src/index.test.ts
+++ b/mastracode/src/index.test.ts
@@ -45,6 +45,7 @@ vi.mock('@mastra/core/processors', () => ({
   PrefillErrorHandler: class {},
   ProviderHistoryCompat: class {},
   StreamErrorRetryProcessor: class {},
+  isECONNRESETError: () => false,
 }));
 
 vi.mock('./agents/instructions.js', () => ({

--- a/mastracode/src/index.test.ts
+++ b/mastracode/src/index.test.ts
@@ -45,7 +45,6 @@ vi.mock('@mastra/core/processors', () => ({
   PrefillErrorHandler: class {},
   ProviderHistoryCompat: class {},
   StreamErrorRetryProcessor: class {},
-  isECONNRESETError: () => false,
 }));
 
 vi.mock('./agents/instructions.js', () => ({

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -98,8 +98,10 @@ const CODE_AGENT_ID = 'code-agent';
 // Global retry policy for transient network resets (e.g. provider sockets dropping mid-stream).
 // Applied centrally to every model call via StreamErrorRetryProcessor, independent of model-pack
 // settings, so all modes/subagents benefit from a short wait before retrying an ECONNRESET.
+// Delay uses exponential backoff: initialDelay * 2^retryCount, capped at maxDelay.
 const MASTRACODE_ECONNRESET_MAX_RETRIES = 2;
-const MASTRACODE_ECONNRESET_RETRY_DELAY_MS = 1000;
+const MASTRACODE_ECONNRESET_RETRY_INITIAL_DELAY_MS = 1000;
+const MASTRACODE_ECONNRESET_RETRY_MAX_DELAY_MS = 30000;
 
 function applyEffectiveDefaultsToModes(modes: HarnessMode[], effectiveDefaults: Record<string, string>): HarnessMode[] {
   return modes.map(mode => {
@@ -528,7 +530,11 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     errorProcessors: [
       new StreamErrorRetryProcessor({
         maxRetries: MASTRACODE_ECONNRESET_MAX_RETRIES,
-        delayMs: MASTRACODE_ECONNRESET_RETRY_DELAY_MS,
+        delayMs: ({ retryCount }) =>
+          Math.min(
+            MASTRACODE_ECONNRESET_RETRY_INITIAL_DELAY_MS * Math.pow(2, retryCount),
+            MASTRACODE_ECONNRESET_RETRY_MAX_DELAY_MS,
+          ),
         matchers: [isECONNRESETError],
       }),
       new PrefillErrorHandler(),

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -19,6 +19,7 @@ import {
   PrefillErrorHandler,
   ProviderHistoryCompat,
   StreamErrorRetryProcessor,
+  isECONNRESETError,
 } from '@mastra/core/processors';
 import { RequestContext } from '@mastra/core/request-context';
 import type { PublicSchema } from '@mastra/core/schema';
@@ -93,6 +94,12 @@ import { createStorage, createVectorStore } from './utils/storage-factory.js';
 import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 
 const CODE_AGENT_ID = 'code-agent';
+
+// Global retry policy for transient network resets (e.g. provider sockets dropping mid-stream).
+// Applied centrally to every model call via StreamErrorRetryProcessor, independent of model-pack
+// settings, so all modes/subagents benefit from a short wait before retrying an ECONNRESET.
+const MASTRACODE_ECONNRESET_MAX_RETRIES = 2;
+const MASTRACODE_ECONNRESET_RETRY_DELAY_MS = 1000;
 
 function applyEffectiveDefaultsToModes(modes: HarnessMode[], effectiveDefaults: Record<string, string>): HarnessMode[] {
   return modes.map(mode => {
@@ -518,7 +525,15 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       }),
       new ProviderHistoryCompat(),
     ],
-    errorProcessors: [new StreamErrorRetryProcessor(), new PrefillErrorHandler(), new ProviderHistoryCompat()],
+    errorProcessors: [
+      new StreamErrorRetryProcessor({
+        maxRetries: MASTRACODE_ECONNRESET_MAX_RETRIES,
+        delayMs: MASTRACODE_ECONNRESET_RETRY_DELAY_MS,
+        matchers: [isECONNRESETError],
+      }),
+      new PrefillErrorHandler(),
+      new ProviderHistoryCompat(),
+    ],
   });
 
   // const defaultSubAgents: Array<HarnessSubagent> = [];

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -105,9 +105,10 @@ const MASTRACODE_ECONNRESET_RETRY_MAX_DELAY_MS = 30000;
 const ECONNRESET_MESSAGE_PATTERN = /econnreset|socket hang up/i;
 
 /**
- * Matcher for transient network-reset failures. Node's `ECONNRESET` is surfaced
- * as an error code on either the top-level error or a nested `cause`. Some
- * SDKs/undici also surface resets as a `socket hang up` message.
+ * Matcher for transient network-reset failures. Checks the immediate error for
+ * an `ECONNRESET` code or a `socket hang up` message. Cause-chain traversal is
+ * handled by `StreamErrorRetryProcessor.isRetryableStreamError`, which calls
+ * each matcher at every level of the cause chain.
  */
 function isECONNRESETError(error: unknown): boolean {
   if (!error) return false;

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -19,7 +19,6 @@ import {
   PrefillErrorHandler,
   ProviderHistoryCompat,
   StreamErrorRetryProcessor,
-  isECONNRESETError,
 } from '@mastra/core/processors';
 import { RequestContext } from '@mastra/core/request-context';
 import type { PublicSchema } from '@mastra/core/schema';
@@ -102,6 +101,25 @@ const CODE_AGENT_ID = 'code-agent';
 const MASTRACODE_ECONNRESET_MAX_RETRIES = 2;
 const MASTRACODE_ECONNRESET_RETRY_INITIAL_DELAY_MS = 1000;
 const MASTRACODE_ECONNRESET_RETRY_MAX_DELAY_MS = 30000;
+
+const ECONNRESET_MESSAGE_PATTERN = /econnreset|socket hang up/i;
+
+/**
+ * Matcher for transient network-reset failures. Node's `ECONNRESET` is surfaced
+ * as an error code on either the top-level error or a nested `cause`. Some
+ * SDKs/undici also surface resets as a `socket hang up` message.
+ */
+function isECONNRESETError(error: unknown): boolean {
+  if (!error) return false;
+
+  const code = typeof error === 'object' && 'code' in error ? (error as { code?: unknown }).code : undefined;
+  if (typeof code === 'string' && code.toUpperCase() === 'ECONNRESET') return true;
+
+  const message = error instanceof Error ? error.message : undefined;
+  if (typeof message === 'string' && ECONNRESET_MESSAGE_PATTERN.test(message)) return true;
+
+  return false;
+}
 
 function applyEffectiveDefaultsToModes(modes: HarnessMode[], effectiveDefaults: Record<string, string>): HarnessMode[] {
   return modes.map(mode => {

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -829,8 +829,10 @@ export * from './processors';
 export { PrefillErrorHandler } from './prefill-error-handler';
 export { ProviderHistoryCompat, anthropicToolIdFormat, cerebrasStripReasoningContent } from './provider-history-compat';
 export {
+  isECONNRESETError,
   isRetryableOpenAIResponsesStreamError,
   StreamErrorRetryProcessor,
+  type StreamErrorRetryDelayMs,
   type StreamErrorRetryMatcher,
   type StreamErrorRetryProcessorOptions,
 } from './stream-error-retry-processor';

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -829,7 +829,6 @@ export * from './processors';
 export { PrefillErrorHandler } from './prefill-error-handler';
 export { ProviderHistoryCompat, anthropicToolIdFormat, cerebrasStripReasoningContent } from './provider-history-compat';
 export {
-  isECONNRESETError,
   isRetryableOpenAIResponsesStreamError,
   StreamErrorRetryProcessor,
   type StreamErrorRetryDelayMs,

--- a/packages/core/src/processors/stream-error-retry-processor.test.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.test.ts
@@ -1,8 +1,12 @@
 import { APICallError } from '@internal/ai-sdk-v5';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageList } from '../agent/message-list';
-import { isRetryableOpenAIResponsesStreamError, StreamErrorRetryProcessor } from './stream-error-retry-processor';
+import {
+  isECONNRESETError,
+  isRetryableOpenAIResponsesStreamError,
+  StreamErrorRetryProcessor,
+} from './stream-error-retry-processor';
 import type { ProcessAPIErrorArgs } from './index';
 
 function makeArgs(overrides: Partial<ProcessAPIErrorArgs> = {}): ProcessAPIErrorArgs {
@@ -167,5 +171,156 @@ describe('StreamErrorRetryProcessor', () => {
     };
 
     await expect(processor.processAPIError(makeArgs({ error, retryCount: 1 }))).resolves.toBeUndefined();
+  });
+
+  describe('isECONNRESETError', () => {
+    it('matches a direct ECONNRESET error code', () => {
+      const error = new Error('read ECONNRESET');
+      (error as Error & { code: string }).code = 'ECONNRESET';
+
+      expect(isECONNRESETError(error)).toBe(true);
+    });
+
+    it('matches a lowercase econnreset code', () => {
+      const error = { code: 'econnreset', message: 'socket closed' };
+
+      expect(isECONNRESETError(error)).toBe(true);
+    });
+
+    it('matches a socket hang up message', () => {
+      expect(isECONNRESETError(new Error('socket hang up'))).toBe(true);
+    });
+
+    it('matches an ECONNRESET message even without a code', () => {
+      expect(isECONNRESETError(new Error('read ECONNRESET'))).toBe(true);
+    });
+
+    it('returns false for unrelated errors', () => {
+      expect(isECONNRESETError(new Error('timeout'))).toBe(false);
+      expect(isECONNRESETError({ code: 'ETIMEDOUT' })).toBe(false);
+    });
+
+    it('returns false for null/undefined', () => {
+      expect(isECONNRESETError(null)).toBe(false);
+      expect(isECONNRESETError(undefined)).toBe(false);
+    });
+  });
+
+  describe('ECONNRESET retry via matchers', () => {
+    it('retries a direct ECONNRESET when matcher is supplied', async () => {
+      const processor = new StreamErrorRetryProcessor({ matchers: [isECONNRESETError] });
+      const error = new Error('read ECONNRESET');
+      (error as Error & { code: string }).code = 'ECONNRESET';
+
+      await expect(processor.processAPIError(makeArgs({ error }))).resolves.toEqual({ retry: true });
+    });
+
+    it('retries a nested cause.code ECONNRESET when matcher is supplied', async () => {
+      const processor = new StreamErrorRetryProcessor({ matchers: [isECONNRESETError] });
+      const root = new Error('fetch failed', {
+        cause: Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+      });
+
+      await expect(processor.processAPIError(makeArgs({ error: root }))).resolves.toEqual({ retry: true });
+    });
+
+    it('does not retry ECONNRESET by default (matcher not supplied)', async () => {
+      const processor = new StreamErrorRetryProcessor();
+      const error = new Error('read ECONNRESET');
+      (error as Error & { code: string }).code = 'ECONNRESET';
+
+      await expect(processor.processAPIError(makeArgs({ error }))).resolves.toBeUndefined();
+    });
+
+    it('does not retry past maxRetries for ECONNRESET', async () => {
+      const processor = new StreamErrorRetryProcessor({ maxRetries: 2, matchers: [isECONNRESETError] });
+      const error = new Error('read ECONNRESET');
+      (error as Error & { code: string }).code = 'ECONNRESET';
+
+      await expect(processor.processAPIError(makeArgs({ error, retryCount: 2 }))).resolves.toBeUndefined();
+    });
+  });
+
+  describe('delayMs', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('waits the configured delay before signaling retry', async () => {
+      vi.useFakeTimers();
+      const processor = new StreamErrorRetryProcessor({
+        delayMs: 1000,
+        matchers: [isECONNRESETError],
+      });
+      const error = new Error('read ECONNRESET');
+      (error as Error & { code: string }).code = 'ECONNRESET';
+
+      let resolved = false;
+      const promise = processor.processAPIError(makeArgs({ error })).then(result => {
+        resolved = true;
+        return result;
+      });
+
+      // Advance time but stay under the delay — still pending.
+      await vi.advanceTimersByTimeAsync(999);
+      expect(resolved).toBe(false);
+
+      // Advance past the delay — resolves now.
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promise).resolves.toEqual({ retry: true });
+      expect(resolved).toBe(true);
+    });
+
+    it('clamps negative/non-finite delays to 0 (retries immediately)', async () => {
+      const processor = new StreamErrorRetryProcessor({
+        delayMs: -50,
+        matchers: [isECONNRESETError],
+      });
+      const error = new Error('read ECONNRESET');
+      (error as Error & { code: string }).code = 'ECONNRESET';
+
+      await expect(processor.processAPIError(makeArgs({ error }))).resolves.toEqual({ retry: true });
+    });
+
+    it('supports a delay function evaluated with error args', async () => {
+      const delayFn = vi.fn(() => 5);
+      const processor = new StreamErrorRetryProcessor({
+        delayMs: delayFn,
+        matchers: [isECONNRESETError],
+      });
+      const error = new Error('read ECONNRESET');
+      (error as Error & { code: string }).code = 'ECONNRESET';
+      const args = makeArgs({ error });
+
+      await expect(processor.processAPIError(args)).resolves.toEqual({ retry: true });
+      expect(delayFn).toHaveBeenCalledWith(args);
+    });
+
+    it('skips the wait when the abort signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const processor = new StreamErrorRetryProcessor({
+        delayMs: 60_000,
+        matchers: [isECONNRESETError],
+      });
+      const error = new Error('read ECONNRESET');
+      (error as Error & { code: string }).code = 'ECONNRESET';
+
+      const start = Date.now();
+      await expect(processor.processAPIError(makeArgs({ error, abortSignal: controller.signal }))).resolves.toEqual({
+        retry: true,
+      });
+      expect(Date.now() - start).toBeLessThan(1000);
+    });
+
+    it('default behavior is unchanged when delayMs is not supplied', async () => {
+      const processor = new StreamErrorRetryProcessor();
+      const error = {
+        type: 'error',
+        error: { type: 'server_error', code: 'internal_error', message: 'boom' },
+      };
+
+      await expect(processor.processAPIError(makeArgs({ error }))).resolves.toEqual({ retry: true });
+    });
   });
 });

--- a/packages/core/src/processors/stream-error-retry-processor.test.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.test.ts
@@ -2,11 +2,7 @@ import { APICallError } from '@internal/ai-sdk-v5';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageList } from '../agent/message-list';
-import {
-  isECONNRESETError,
-  isRetryableOpenAIResponsesStreamError,
-  StreamErrorRetryProcessor,
-} from './stream-error-retry-processor';
+import { isRetryableOpenAIResponsesStreamError, StreamErrorRetryProcessor } from './stream-error-retry-processor';
 import type { ProcessAPIErrorArgs } from './index';
 
 function makeArgs(overrides: Partial<ProcessAPIErrorArgs> = {}): ProcessAPIErrorArgs {
@@ -173,74 +169,6 @@ describe('StreamErrorRetryProcessor', () => {
     await expect(processor.processAPIError(makeArgs({ error, retryCount: 1 }))).resolves.toBeUndefined();
   });
 
-  describe('isECONNRESETError', () => {
-    it('matches a direct ECONNRESET error code', () => {
-      const error = new Error('read ECONNRESET');
-      (error as Error & { code: string }).code = 'ECONNRESET';
-
-      expect(isECONNRESETError(error)).toBe(true);
-    });
-
-    it('matches a lowercase econnreset code', () => {
-      const error = { code: 'econnreset', message: 'socket closed' };
-
-      expect(isECONNRESETError(error)).toBe(true);
-    });
-
-    it('matches a socket hang up message', () => {
-      expect(isECONNRESETError(new Error('socket hang up'))).toBe(true);
-    });
-
-    it('matches an ECONNRESET message even without a code', () => {
-      expect(isECONNRESETError(new Error('read ECONNRESET'))).toBe(true);
-    });
-
-    it('returns false for unrelated errors', () => {
-      expect(isECONNRESETError(new Error('timeout'))).toBe(false);
-      expect(isECONNRESETError({ code: 'ETIMEDOUT' })).toBe(false);
-    });
-
-    it('returns false for null/undefined', () => {
-      expect(isECONNRESETError(null)).toBe(false);
-      expect(isECONNRESETError(undefined)).toBe(false);
-    });
-  });
-
-  describe('ECONNRESET retry via matchers', () => {
-    it('retries a direct ECONNRESET when matcher is supplied', async () => {
-      const processor = new StreamErrorRetryProcessor({ matchers: [isECONNRESETError] });
-      const error = new Error('read ECONNRESET');
-      (error as Error & { code: string }).code = 'ECONNRESET';
-
-      await expect(processor.processAPIError(makeArgs({ error }))).resolves.toEqual({ retry: true });
-    });
-
-    it('retries a nested cause.code ECONNRESET when matcher is supplied', async () => {
-      const processor = new StreamErrorRetryProcessor({ matchers: [isECONNRESETError] });
-      const root = new Error('fetch failed', {
-        cause: Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
-      });
-
-      await expect(processor.processAPIError(makeArgs({ error: root }))).resolves.toEqual({ retry: true });
-    });
-
-    it('does not retry ECONNRESET by default (matcher not supplied)', async () => {
-      const processor = new StreamErrorRetryProcessor();
-      const error = new Error('read ECONNRESET');
-      (error as Error & { code: string }).code = 'ECONNRESET';
-
-      await expect(processor.processAPIError(makeArgs({ error }))).resolves.toBeUndefined();
-    });
-
-    it('does not retry past maxRetries for ECONNRESET', async () => {
-      const processor = new StreamErrorRetryProcessor({ maxRetries: 2, matchers: [isECONNRESETError] });
-      const error = new Error('read ECONNRESET');
-      (error as Error & { code: string }).code = 'ECONNRESET';
-
-      await expect(processor.processAPIError(makeArgs({ error, retryCount: 2 }))).resolves.toBeUndefined();
-    });
-  });
-
   describe('delayMs', () => {
     afterEach(() => {
       vi.useRealTimers();
@@ -250,10 +178,9 @@ describe('StreamErrorRetryProcessor', () => {
       vi.useFakeTimers();
       const processor = new StreamErrorRetryProcessor({
         delayMs: 1000,
-        matchers: [isECONNRESETError],
+        matchers: [() => true],
       });
-      const error = new Error('read ECONNRESET');
-      (error as Error & { code: string }).code = 'ECONNRESET';
+      const error = new Error('retryable');
 
       let resolved = false;
       const promise = processor.processAPIError(makeArgs({ error })).then(result => {
@@ -274,10 +201,9 @@ describe('StreamErrorRetryProcessor', () => {
     it('clamps negative/non-finite delays to 0 (retries immediately)', async () => {
       const processor = new StreamErrorRetryProcessor({
         delayMs: -50,
-        matchers: [isECONNRESETError],
+        matchers: [() => true],
       });
-      const error = new Error('read ECONNRESET');
-      (error as Error & { code: string }).code = 'ECONNRESET';
+      const error = new Error('retryable');
 
       await expect(processor.processAPIError(makeArgs({ error }))).resolves.toEqual({ retry: true });
     });
@@ -286,10 +212,9 @@ describe('StreamErrorRetryProcessor', () => {
       const delayFn = vi.fn(() => 5);
       const processor = new StreamErrorRetryProcessor({
         delayMs: delayFn,
-        matchers: [isECONNRESETError],
+        matchers: [() => true],
       });
-      const error = new Error('read ECONNRESET');
-      (error as Error & { code: string }).code = 'ECONNRESET';
+      const error = new Error('retryable');
       const args = makeArgs({ error });
 
       await expect(processor.processAPIError(args)).resolves.toEqual({ retry: true });
@@ -301,10 +226,9 @@ describe('StreamErrorRetryProcessor', () => {
       controller.abort();
       const processor = new StreamErrorRetryProcessor({
         delayMs: 60_000,
-        matchers: [isECONNRESETError],
+        matchers: [() => true],
       });
-      const error = new Error('read ECONNRESET');
-      (error as Error & { code: string }).code = 'ECONNRESET';
+      const error = new Error('retryable');
 
       const start = Date.now();
       await expect(processor.processAPIError(makeArgs({ error, abortSignal: controller.signal }))).resolves.toEqual({

--- a/packages/core/src/processors/stream-error-retry-processor.test.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.test.ts
@@ -246,5 +246,66 @@ describe('StreamErrorRetryProcessor', () => {
 
       await expect(processor.processAPIError(makeArgs({ error }))).resolves.toEqual({ retry: true });
     });
+
+    it('removes the abort listener after timeout resolves', async () => {
+      vi.useFakeTimers();
+      const controller = new AbortController();
+      const addSpy = vi.spyOn(controller.signal, 'addEventListener');
+      const removeSpy = vi.spyOn(controller.signal, 'removeEventListener');
+      const processor = new StreamErrorRetryProcessor({
+        delayMs: 1000,
+        matchers: [() => true],
+      });
+
+      const promise = processor.processAPIError(makeArgs({ error: new Error('x'), abortSignal: controller.signal }));
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(promise).resolves.toEqual({ retry: true });
+      expect(addSpy).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+      expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+    });
+
+    it('removes the abort listener when abort fires during delay', async () => {
+      vi.useFakeTimers();
+      const controller = new AbortController();
+      const removeSpy = vi.spyOn(controller.signal, 'removeEventListener');
+      const processor = new StreamErrorRetryProcessor({
+        delayMs: 60_000,
+        matchers: [() => true],
+      });
+
+      const promise = processor.processAPIError(makeArgs({ error: new Error('x'), abortSignal: controller.signal }));
+      await vi.advanceTimersByTimeAsync(500);
+      controller.abort();
+      await expect(promise).resolves.toEqual({ retry: true });
+      expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+    });
+
+    it('does not accumulate listeners across retries on a long-lived signal', async () => {
+      vi.useFakeTimers();
+      const controller = new AbortController();
+      const addSpy = vi.spyOn(controller.signal, 'addEventListener');
+      const removeSpy = vi.spyOn(controller.signal, 'removeEventListener');
+      const processor = new StreamErrorRetryProcessor({
+        delayMs: 1000,
+        maxRetries: 3,
+        matchers: [() => true],
+      });
+
+      // First retry
+      let promise = processor.processAPIError(makeArgs({ error: new Error('x'), abortSignal: controller.signal }));
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(promise).resolves.toEqual({ retry: true });
+      expect(addSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+
+      // Second retry — listener count should not grow
+      promise = processor.processAPIError(
+        makeArgs({ error: new Error('x'), abortSignal: controller.signal, retryCount: 1 }),
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(promise).resolves.toEqual({ retry: true });
+      expect(addSpy).toHaveBeenCalledTimes(2);
+      expect(removeSpy).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/core/src/processors/stream-error-retry-processor.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.ts
@@ -169,17 +169,28 @@ async function waitDelay(
   const ms = clampDelayMs(delay);
   if (ms <= 0) return;
 
-  if (abortSignal?.aborted) return;
+  if (!abortSignal) {
+    await new Promise<void>(resolve => setTimeout(resolve, ms));
+    return;
+  }
 
   await new Promise<void>(resolve => {
-    const timeout = setTimeout(resolve, ms);
-    abortSignal?.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(timeout);
-        resolve();
-      },
-      { once: true },
-    );
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const onAbort = () => {
+      if (timeout) clearTimeout(timeout);
+      abortSignal.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    // Register before checking aborted to close the race window where
+    // abort fires between the check and addEventListener.
+    abortSignal.addEventListener('abort', onAbort, { once: true });
+    if (abortSignal.aborted) {
+      onAbort();
+      return;
+    }
+    timeout = setTimeout(() => {
+      abortSignal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
   });
 }

--- a/packages/core/src/processors/stream-error-retry-processor.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.ts
@@ -30,7 +30,6 @@ const RETRYABLE_OPENAI_ERROR_CODES = [
 ];
 const OPENAI_RETRY_MESSAGE_PATTERN = /you can retry your request/i;
 const DEFAULT_MATCHERS = [isRetryableOpenAIResponsesStreamError];
-const ECONNRESET_MESSAGE_PATTERN = /econnreset|socket hang up/i;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -102,34 +101,6 @@ function isRetryableProviderMetadata(error: unknown): boolean {
       : undefined;
 
   return retryable === true;
-}
-
-/**
- * Opt-in matcher for transient network-reset failures. Node's `ECONNRESET` is
- * surfaced as an error code (`code === 'ECONNRESET'`) on either the top-level
- * error or a nested `cause`. Some SDKs/undici also surface resets as a
- * `socket hang up` message, which is matched conservatively.
- *
- * This matcher is intentionally NOT part of the default matcher set; consumers
- * that want to retry network resets must opt in via `matchers: [isECONNRESETError]`.
- */
-export function isECONNRESETError(error: unknown): boolean {
-  if (error === null || error === undefined) {
-    return false;
-  }
-
-  const code = isRecord(error) ? getStringProperty(error, 'code') : undefined;
-  if (code && code.toUpperCase() === 'ECONNRESET') {
-    return true;
-  }
-
-  const message =
-    error instanceof Error ? error.message : isRecord(error) ? getStringProperty(error, 'message') : undefined;
-  if (message && ECONNRESET_MESSAGE_PATTERN.test(message)) {
-    return true;
-  }
-
-  return false;
 }
 
 function isRetryableStreamError(error: unknown, matchers: StreamErrorRetryMatcher[]): boolean {

--- a/packages/core/src/processors/stream-error-retry-processor.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.ts
@@ -4,9 +4,18 @@ import type { Processor, ProcessAPIErrorArgs, ProcessAPIErrorResult } from './in
 
 export type StreamErrorRetryMatcher = (error: unknown) => boolean;
 
+export type StreamErrorRetryDelayMs = number | ((args: ProcessAPIErrorArgs) => number | Promise<number>);
+
 export type StreamErrorRetryProcessorOptions = {
   maxRetries?: number;
   matchers?: StreamErrorRetryMatcher[];
+  /**
+   * Optional delay (ms) to wait before signaling a retry. Accepts a number or an
+   * async function evaluated with the current error args. Negative/non-finite
+   * values are clamped to 0. Defaults to 0 (retry immediately), preserving the
+   * existing behavior for consumers that do not configure a delay.
+   */
+  delayMs?: StreamErrorRetryDelayMs;
 };
 
 const DEFAULT_MAX_RETRIES = 1;
@@ -21,6 +30,7 @@ const RETRYABLE_OPENAI_ERROR_CODES = [
 ];
 const OPENAI_RETRY_MESSAGE_PATTERN = /you can retry your request/i;
 const DEFAULT_MATCHERS = [isRetryableOpenAIResponsesStreamError];
+const ECONNRESET_MESSAGE_PATTERN = /econnreset|socket hang up/i;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -94,6 +104,34 @@ function isRetryableProviderMetadata(error: unknown): boolean {
   return retryable === true;
 }
 
+/**
+ * Opt-in matcher for transient network-reset failures. Node's `ECONNRESET` is
+ * surfaced as an error code (`code === 'ECONNRESET'`) on either the top-level
+ * error or a nested `cause`. Some SDKs/undici also surface resets as a
+ * `socket hang up` message, which is matched conservatively.
+ *
+ * This matcher is intentionally NOT part of the default matcher set; consumers
+ * that want to retry network resets must opt in via `matchers: [isECONNRESETError]`.
+ */
+export function isECONNRESETError(error: unknown): boolean {
+  if (error === null || error === undefined) {
+    return false;
+  }
+
+  const code = isRecord(error) ? getStringProperty(error, 'code') : undefined;
+  if (code && code.toUpperCase() === 'ECONNRESET') {
+    return true;
+  }
+
+  const message =
+    error instanceof Error ? error.message : isRecord(error) ? getStringProperty(error, 'message') : undefined;
+  if (message && ECONNRESET_MESSAGE_PATTERN.test(message)) {
+    return true;
+  }
+
+  return false;
+}
+
 function isRetryableStreamError(error: unknown, matchers: StreamErrorRetryMatcher[]): boolean {
   const visited = new WeakSet<object>();
 
@@ -126,16 +164,51 @@ export class StreamErrorRetryProcessor implements Processor<'stream-error-retry-
 
   readonly #maxRetries: number;
   readonly #matchers: StreamErrorRetryMatcher[];
+  readonly #delayMs: StreamErrorRetryDelayMs | undefined;
 
   constructor(options: StreamErrorRetryProcessorOptions = {}) {
     this.#maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.#matchers = [...DEFAULT_MATCHERS, ...(options.matchers ?? [])];
+    this.#delayMs = options.delayMs;
   }
 
-  async processAPIError({ error, retryCount }: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
+  async processAPIError(args: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
+    const { error, retryCount, abortSignal } = args;
     if (retryCount >= this.#maxRetries) return;
     if (!isRetryableStreamError(error, this.#matchers)) return;
 
+    if (this.#delayMs !== undefined) {
+      await waitDelay(this.#delayMs, args, abortSignal);
+    }
+
     return { retry: true };
   }
+}
+
+function clampDelayMs(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+async function waitDelay(
+  delayMs: StreamErrorRetryDelayMs,
+  args: ProcessAPIErrorArgs,
+  abortSignal?: AbortSignal,
+): Promise<void> {
+  const delay = typeof delayMs === 'function' ? await delayMs(args) : delayMs;
+  const ms = clampDelayMs(delay);
+  if (ms <= 0) return;
+
+  if (abortSignal?.aborted) return;
+
+  await new Promise<void>(resolve => {
+    const timeout = setTimeout(resolve, ms);
+    abortSignal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+  });
 }


### PR DESCRIPTION
Model streams sometimes fail with a transient ECONNRESET (provider socket drops mid-stream), which currently surfaces as a hard failure. This adds a small, global retry/wait policy so those recover automatically.

In @mastra/core, StreamErrorRetryProcessor now accepts an optional delayMs (number or async fn) that waits a clamped, abort-aware delay before signaling retry, plus an opt-in isECONNRESETError matcher that catches code === ECONNRESET and the common "socket hang up" message across the cause chain. Nothing changes by default — the matcher isn't in the default set and delay is 0 when unset.

MastraCode wires both with a conservative global policy (2 retries, 1000ms wait), applied to every model call via the existing processor pipeline, without touching settings, model packs, or the TUI.

```ts
new StreamErrorRetryProcessor({
  maxRetries: 2,
  delayMs: 1000,
  matchers: [isECONNRESETError],
});
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If your app is streaming a response and the connection suddenly drops, it will now try again a couple of times instead of giving up right away. It also waits a short time between retries to reduce the chance of immediately hitting the same problem again.

## Core Changes (`@mastra/core`)

**StreamErrorRetryProcessor: delayed retries + ECONNRESET opt-in**

- Adds an optional `delayMs` option to control how long to wait before retrying:
  - Accepts a fixed millisecond number or a (sync/async) function computed from `ProcessAPIErrorArgs`
  - Uses an abort-aware wait (stops early if `abortSignal` fires)
  - Clamps invalid/`<= 0` (non-finite or negative) delays to immediate retry (no wait)
  - Defaults to `0` when not provided, preserving existing behavior
- Adds an optional `isECONNRESETError`-style matcher capability (opt-in behavior):
  - Retries are only triggered when the configured matchers say the error looks like `ECONNRESET`/“socket hang up”
  - The matcher is not enabled automatically, so default retry behavior remains unchanged
- Exports a new `StreamErrorRetryDelayMs` type for the `delayMs` option.

## MastraCode Integration

MastraCode wires a global retry policy for model stream calls:
- **Retries:** 2
- **Delay strategy:** exponential backoff **1000ms → 2000ms → 4000ms**, capped at **30000ms**
- **Retryable errors:** opt-in matching for transient connection resets (`ECONNRESET` / “socket hang up” patterns)

This is applied via the existing processor pipeline—without changing settings, model packs, or the TUI.

## Tests

- Core tests expand coverage for `delayMs` behavior:
  - Waiting until the delay elapses before returning `{ retry: true }`
  - Clamping negative/non-finite delays to immediate retry
  - Supporting `delayMs` as a function
  - Ensuring abort behavior stops the delay and that abort listeners don’t leak across retries
  - Verifying default behavior when `delayMs` is omitted
- MastraCode tests assert `createMastraCode()` constructs `StreamErrorRetryProcessor` with the exact global ECONNRESET retry-policy options (including `maxRetries`, opt-in matcher configuration, and the exponential-backoff `delayMs` function).

## Release Notes

- Adds changesets documenting:
  - `@mastra/core`: new optional `delayMs` support (with examples and notes about default/no-wait behavior)
  - MastraCode: automatic ECONNRESET retry with the specified exponential backoff policy
<!-- end of auto-generated comment: release notes by coderabbit.ai -->