### PR TITLE
Handle unsupported logs storage in Studio

### DIFF
--- a/.changeset/gentle-logs-pause.md
+++ b/.changeset/gentle-logs-pause.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Show an unavailable state when the configured observability storage does not support listing logs, and stop polling the logs endpoint for that non-transient capability error.

--- a/packages/playground-ui/src/domains/logs/components/logs-error-content.test.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-error-content.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { LogsErrorContent } from './logs-error-content';
+
+describe('LogsErrorContent', () => {
+  it('renders an unavailable state when the storage provider cannot list logs', () => {
+    render(
+      <LogsErrorContent
+        error={new Error('This storage provider does not support listing logs')}
+        resource="logs"
+        errorTitle="Failed to load logs"
+      />,
+    );
+
+    expect(screen.getByText('Logs are not available with your current storage')).toBeTruthy();
+    expect(screen.queryByText('Failed to load logs')).toBeNull();
+  });
+});

--- a/packages/playground-ui/src/domains/logs/components/logs-error-content.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-error-content.tsx
@@ -1,7 +1,13 @@
+import { CircleSlashIcon } from 'lucide-react';
+import { EmptyState } from '@/ds/components/EmptyState';
 import { ErrorState } from '@/ds/components/ErrorState';
 import { PermissionDenied } from '@/ds/components/PermissionDenied';
 import { SessionExpired } from '@/ds/components/SessionExpired';
-import { is401UnauthorizedError, is403ForbiddenError } from '@/lib/query-utils';
+import {
+  is401UnauthorizedError,
+  is403ForbiddenError,
+  isUnsupportedObservabilityOperationError,
+} from '@/lib/query-utils';
 
 export interface LogsErrorContentProps {
   /** The error from a useLogs query. */
@@ -20,6 +26,15 @@ export interface LogsErrorContentProps {
 export function LogsErrorContent({ error, resource, errorTitle }: LogsErrorContentProps) {
   if (is401UnauthorizedError(error)) return <SessionExpired />;
   if (is403ForbiddenError(error)) return <PermissionDenied resource={resource} />;
+  if (isUnsupportedObservabilityOperationError(error, 'logs')) {
+    return (
+      <EmptyState
+        iconSlot={<CircleSlashIcon />}
+        titleSlot="Logs are not available with your current storage"
+        descriptionSlot="The configured observability storage provider does not support listing logs. Switch to a storage provider with logs support to view runtime logs in Studio."
+      />
+    );
+  }
   const message = error instanceof Error ? error.message : undefined;
   return <ErrorState title={errorTitle} message={message ?? 'Unknown error'} />;
 }

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs.test.ts
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs.test.ts
@@ -1,0 +1,22 @@
+import type { Query } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+
+import { getLogsRefetchInterval } from './use-logs';
+
+describe('getLogsRefetchInterval', () => {
+  it('disables polling when the storage provider cannot list logs', () => {
+    const query = {
+      state: {
+        error: new Error('This storage provider does not support listing logs'),
+      },
+    } as Query;
+
+    expect(getLogsRefetchInterval(query)).toBe(false);
+  });
+
+  it('keeps polling for supported logs queries', () => {
+    const query = { state: { error: null } } as Query;
+
+    expect(getLogsRefetchInterval(query)).toBe(10000);
+  });
+});

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 
 import type { LogRecord } from '../types';
 import { useInView } from '@/hooks/use-in-view';
+import { isUnsupportedObservabilityOperationError } from '@/lib/query-utils';
 
 interface UseLogsReturn {
   data: LogRecord[] | undefined;
@@ -18,6 +19,7 @@ interface UseLogsReturn {
 }
 
 const LOGS_PER_PAGE = 20;
+const LOGS_REFETCH_INTERVAL_MS = 10000;
 
 export interface LogsFilters {
   filters?: ListLogsArgs['filters'];
@@ -49,6 +51,13 @@ function selectLogs(data: { pages: ListLogsResponse[] }) {
   return result;
 }
 
+export function getLogsRefetchInterval(query: { state: { error: unknown } }) {
+  if (isUnsupportedObservabilityOperationError(query.state.error, 'logs')) {
+    return false;
+  }
+  return LOGS_REFETCH_INTERVAL_MS;
+}
+
 export const useLogs: (props?: LogsFilters) => UseLogsReturn = ({ filters }: LogsFilters = {}) => {
   const client = useMastraClient();
   const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
@@ -65,7 +74,7 @@ export const useLogs: (props?: LogsFilters) => UseLogsReturn = ({ filters }: Log
     getNextPageParam,
     select: selectLogs,
     retry: false,
-    refetchInterval: 10000,
+    refetchInterval: getLogsRefetchInterval,
   });
 
   const { hasNextPage, isFetchingNextPage, fetchNextPage, data, isLoading, isError, error } = query;

--- a/packages/playground-ui/src/lib/query-utils.test.ts
+++ b/packages/playground-ui/src/lib/query-utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { isUnsupportedObservabilityOperationError } from './query-utils';
+
+describe('isUnsupportedObservabilityOperationError', () => {
+  it('matches the requested unsupported observability operation', () => {
+    const error = new Error('This storage provider does not support listing logs');
+
+    expect(isUnsupportedObservabilityOperationError(error, 'logs')).toBe(true);
+    expect(isUnsupportedObservabilityOperationError(error, 'metrics')).toBe(false);
+  });
+});

--- a/packages/playground-ui/src/lib/query-utils.ts
+++ b/packages/playground-ui/src/lib/query-utils.ts
@@ -103,6 +103,26 @@ export function isBranchesNotSupportedError(error: unknown): boolean {
   return message.includes('does not support listing trace branches');
 }
 
+export type UnsupportedObservabilityOperation = 'logs' | 'metrics' | 'scores' | 'feedback';
+
+/**
+ * Check if an error came from an observability storage provider that does not
+ * implement a list operation. These are capability gaps, not transient failures.
+ *
+ * The server serializes these as plain HTTP errors, so the original MastraError
+ * ID is not available in the browser. Match the stable base-storage message text
+ * instead, like the trace branch support check above.
+ */
+export function isUnsupportedObservabilityOperationError(
+  error: unknown,
+  operation: UnsupportedObservabilityOperation,
+): boolean {
+  if (!error || typeof error !== 'object' || !('message' in error)) return false;
+  const message = (error as { message: unknown }).message;
+  if (typeof message !== 'string') return false;
+  return message.includes(`does not support listing ${operation}`);
+}
+
 /**
  * Check if error has a status code that shouldn't be retried.
  * Used to prevent retrying client errors that won't resolve.


### PR DESCRIPTION
Fixes #18377

## Summary

- show a storage-unavailable empty state when Studio logs are backed by an observability storage provider that does not support listing logs
- stop the logs query from polling every 10 seconds after that deterministic unsupported-storage error
- add focused coverage for the error matcher, polling decision, and logs error content

## Root cause

Some observability storage providers do not implement log listing. Studio currently treats that capability gap like a generic load failure, so the logs page continues to poll and repeatedly reports `This storage provider does not support listing logs`.

The server serializes these errors as plain HTTP errors before they reach the browser, so the UI cannot match on the original MastraError id. This follows the existing trace branch support check pattern and matches the stable base-storage message text.

## User impact

Users with a storage provider that cannot list logs now see a clear unavailable state instead of a generic error. The page also stops repeating the same failing request every 10 seconds, which avoids noisy local/server log output while the storage capability remains unsupported.

## Validation

- `corepack pnpm --filter @mastra/playground-ui exec vitest run src/lib/query-utils.test.ts src/domains/logs/hooks/use-logs.test.ts src/domains/logs/components/logs-error-content.test.tsx`
- `corepack pnpm --filter @mastra/playground-ui typecheck`
- `corepack pnpm --filter @mastra/playground-ui exec eslint src/lib/query-utils.ts src/domains/logs/components/logs-error-content.tsx src/domains/logs/hooks/use-logs.ts src/lib/query-utils.test.ts src/domains/logs/hooks/use-logs.test.ts src/domains/logs/components/logs-error-content.test.tsx`
- `corepack pnpm prettier --check .changeset/gentle-logs-pause.md packages/playground-ui/src/lib/query-utils.ts packages/playground-ui/src/domains/logs/components/logs-error-content.tsx packages/playground-ui/src/domains/logs/hooks/use-logs.ts packages/playground-ui/src/lib/query-utils.test.ts packages/playground-ui/src/domains/logs/hooks/use-logs.test.ts packages/playground-ui/src/domains/logs/components/logs-error-content.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine your phone trying to read a book from a library that doesn't let you browse the shelves—it just kept trying the same thing over and over again. This PR fixes that: when the logs storage doesn't support listing logs, the app now shows a friendly "not available" message and stops trying repeatedly, instead of showing repeated errors.

## Overview

This PR updates the playground UI to gracefully handle cases where the observability storage provider does not support log listing operations. Previously, such capability gaps were treated as transient errors, causing the logs page to continuously poll and repeatedly display error messages. The PR introduces detection logic for these unsupported operations and implements appropriate UI treatment and polling prevention.

## Changes

### Error Detection and Classification

- Added `isUnsupportedObservabilityOperationError` utility function in `query-utils.ts` that detects when an error indicates an unsupported observability operation (logs, metrics, scores, or feedback)
- The function matches against the stable server error message pattern: `"does not support listing ${operation}"`
- Added corresponding type `UnsupportedObservabilityOperation` to enumerate supported operations
- Includes comprehensive test coverage for the error matcher

### Polling Prevention

- Modified `use-logs.ts` hook to conditionally disable polling when the unsupported storage error is detected
- Introduced `getLogsRefetchInterval` helper that returns `false` (disabling polling) for unsupported log errors, and the standard 10-second interval otherwise
- Added test coverage validating that polling is disabled for unsupported storage errors and enabled for other cases

### UI Updates

- Updated `LogsErrorContent` component to detect and handle the unsupported storage case
- When the storage provider cannot list logs, displays a user-friendly empty state with "Logs are not available with your current storage" message instead of an error state
- Maintains existing error handling for 401 (SessionExpired), 403 (PermissionDenied), and other error conditions
- Includes test coverage verifying the correct message is displayed for the unsupported storage case

### Release Documentation

- Added changeset entry documenting the new UI behavior for the patch release

## Testing

Comprehensive test coverage added across:
- Error matcher logic (`query-utils.test.ts`)
- Polling decision logic (`use-logs.test.ts`)
- Error content component rendering (`logs-error-content.test.tsx`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->