### PR TITLE
chore(docs): Move agent builder sidebar entry

### DIFF
--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -87,26 +87,6 @@ const sidebars = {
             },
           ],
         },
-        {
-          type: 'category',
-          label: 'Agent Builder',
-          customProps: {
-            tags: ['new'],
-          },
-          items: [
-            { type: 'doc', id: 'agent-builder/overview', label: 'Overview' },
-            { type: 'doc', id: 'agent-builder/configuration', label: 'Configuration' },
-            { type: 'doc', id: 'agent-builder/access-control', label: 'Access control' },
-            { type: 'doc', id: 'agent-builder/model-policy', label: 'Model policy' },
-            { type: 'doc', id: 'agent-builder/memory', label: 'Memory' },
-            { type: 'doc', id: 'agent-builder/workspace', label: 'Workspace' },
-            { type: 'doc', id: 'agent-builder/browser', label: 'Browser' },
-            { type: 'doc', id: 'agent-builder/channels', label: 'Channels' },
-            { type: 'doc', id: 'agent-builder/integrations', label: 'Tool providers' },
-            { type: 'doc', id: 'agent-builder/skill-registries', label: 'Skill registries' },
-            { type: 'doc', id: 'agent-builder/deploying', label: 'Deploying' },
-          ],
-        },
       ],
     },
     {
@@ -336,6 +316,26 @@ const sidebars = {
           id: 'workflows/scheduled-workflows',
           label: 'Scheduled Workflows',
         },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Agent Builder',
+      customProps: {
+        tags: ['new'],
+      },
+      items: [
+        { type: 'doc', id: 'agent-builder/overview', label: 'Overview' },
+        { type: 'doc', id: 'agent-builder/configuration', label: 'Configuration' },
+        { type: 'doc', id: 'agent-builder/access-control', label: 'Access control' },
+        { type: 'doc', id: 'agent-builder/model-policy', label: 'Model policy' },
+        { type: 'doc', id: 'agent-builder/memory', label: 'Memory' },
+        { type: 'doc', id: 'agent-builder/workspace', label: 'Workspace' },
+        { type: 'doc', id: 'agent-builder/browser', label: 'Browser' },
+        { type: 'doc', id: 'agent-builder/channels', label: 'Channels' },
+        { type: 'doc', id: 'agent-builder/integrations', label: 'Tool providers' },
+        { type: 'doc', id: 'agent-builder/skill-registries', label: 'Skill registries' },
+        { type: 'doc', id: 'agent-builder/deploying', label: 'Deploying' },
       ],
     },
     {


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)
This PR reorganizes the documentation sidebar by moving the "Agent Builder" section to a different location in the menu. Think of it like rearranging items on a shelf so they're in a better spot for people to find them.

## Summary
The `Agent Builder` documentation section was relocated within the `docsSidebar` array in `docs/src/content/en/docs/sidebars.js`. The section, which includes 11 documentation items (Overview, Configuration, Access Control, Model Policy, Memory, Workspace, Browser, Channels, Tool Providers, Skill Registries, and Deploying), was moved to appear after the Workflows section in the documentation hierarchy.

The `Agent Builder` category retains its `new` tag indicator and maintains all of its child documentation items in their original structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->