### PR TITLE
test(core): account for harness stream wrapper in tracing-propagation tests

### DIFF
--- a/packages/core/src/harness/tracing-propagation.test.ts
+++ b/packages/core/src/harness/tracing-propagation.test.ts
@@ -42,6 +42,16 @@ describe('Harness tracing propagation', () => {
   let session: Session;
   let streamSpy: ReturnType<typeof vi.spyOn>;
 
+  function getInitialStreamOptions() {
+    const initialStreamCall = streamSpy.mock.calls.find(([, options]) => {
+      return !(options as Record<string, unknown> | undefined)?.untilIdle;
+    });
+
+    expect(initialStreamCall).toBeDefined();
+
+    return initialStreamCall![1] as Record<string, unknown>;
+  }
+
   beforeEach(async () => {
     agent = createAgent();
     harness = new Harness({
@@ -67,9 +77,7 @@ describe('Harness tracing propagation', () => {
 
     await session.sendMessage({ content: 'hello', tracingContext });
 
-    expect(streamSpy).toHaveBeenCalledTimes(1);
-
-    const [, streamOptions] = streamSpy.mock.calls[0]!;
+    const streamOptions = getInitialStreamOptions();
 
     expect(streamOptions).toHaveProperty('tracingContext');
     expect((streamOptions as any).tracingContext).toBe(tracingContext);
@@ -84,9 +92,7 @@ describe('Harness tracing propagation', () => {
 
     await session.sendMessage({ content: 'hello', tracingOptions });
 
-    expect(streamSpy).toHaveBeenCalledTimes(1);
-
-    const [, streamOptions] = streamSpy.mock.calls[0]!;
+    const streamOptions = getInitialStreamOptions();
 
     expect(streamOptions).toHaveProperty('tracingOptions');
     expect((streamOptions as any).tracingOptions).toBe(tracingOptions);
@@ -95,9 +101,7 @@ describe('Harness tracing propagation', () => {
   it('should not include tracingContext/tracingOptions when not provided', async () => {
     await session.sendMessage({ content: 'hello' });
 
-    expect(streamSpy).toHaveBeenCalledTimes(1);
-
-    const [, streamOptions] = streamSpy.mock.calls[0]!;
+    const streamOptions = getInitialStreamOptions();
 
     expect(streamOptions).not.toHaveProperty('tracingContext');
     expect(streamOptions).not.toHaveProperty('tracingOptions');


### PR DESCRIPTION
Cherry-picks `713bd136eb` from `feat/playground-env-vars-editor` (PR #18371) to fix 3 flakey tests in `packages/core/src/harness/tracing-propagation.test.ts`.

## Background

After commit `f1ec385386` ("fix(channels): use streamUntilIdle so background tasks complete"), `session.sendMessage` now legitimately invokes `agent.stream` **twice**:

1. Outer call from `thread-stream-runtime.ts:1978` with `untilIdle: true` (the idle-loop wrapper).
2. Inner call from `runStreamUntilIdle` at `stream-until-idle.ts:536` (the actual stream).

The existing tests still asserted `expect(streamSpy).toHaveBeenCalledTimes(1)` and read `streamSpy.mock.calls[0]`, which fails consistently on main:

```
AssertionError: expected "stream" to be called 1 times, but got 2 times
```

## Fix

Adds a `getInitialStreamOptions()` helper that filters out the outer `untilIdle: true` call and returns the inner call's options. Test-only change, no production code touched.

## Verification

```
npx vitest run src/harness/tracing-propagation.test.ts
# Test Files  1 passed (1)
# Tests       4 passed (4)
```

## Why split from #18371?

The fix is bundled inside an unrelated playground UI feature PR. Extracting it lets us unblock the flake on main independently of that PR's review cycle.

## Credit

Original commit by @damienschneider01 on branch `feat/playground-env-vars-editor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The tests in this file were written to check something about a specific function call, but due to a recent change, that function is now being called twice (once on the outside and once on the inside). The tests kept failing because they expected it to be called only once. This PR fixes the tests by making them smarter—instead of always looking at the first call, they now pick the right one to look at.

## Summary of changes

In `packages/core/src/harness/tracing-propagation.test.ts`, the tests now determine which `agent.stream()` invocation to inspect by introducing a helper (`getInitialStreamOptions`) that selects the first stream call whose `options.untilIdle` is not set. The tracing-related test cases (forwarding `tracingContext`, forwarding `tracingOptions`, and ensuring neither is included when absent) were updated to use this helper instead of destructuring the first `streamSpy.mock.calls[0]`, and the explicit `toHaveBeenCalledTimes(1)` assertion was removed from each affected test.

This is a test-only change with no modifications to production code. All four tests in the file now pass.

Lines changed: +13/-9

<!-- end of auto-generated comment: release notes by coderabbit.ai -->