### PR TITLE
feat(core): resolve Harness models through gateways with GatewayManager

### DIFF
--- a/.changeset/gentle-banks-ask.md
+++ b/.changeset/gentle-banks-ask.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Resolve all Harness models through gateways. The Harness now builds its available-models catalog, model auth status, mode agents, Observational Memory models, and subagents from the gateways you register, instead of the separate `resolveModel`, `customModelCatalogProvider`, and `modelAuthChecker` config hooks. Removed those three options from `HarnessConfig` (and the `ModelAuthChecker` type) — register a gateway via `gateways` instead.
+
+`listAvailableModels()` and `getCurrentModelAuthStatus()` are now sourced entirely from gateways: model discovery comes from each gateway's `fetchProviders()` (a network call for gateways like models.dev and Netlify), and auth status is resolved through the same gateway chain the model router uses at run time (`resolveAuth()`, falling back to `getApiKey()`). There is no static provider-registry fallback — everything the model picker shows comes from a gateway.
+
+The gateway-chain operations shared by `ModelRouterLanguageModel` and the Harness (gateway merging, model→gateway selection, auth resolution, provider/model listing) are now centralized in a new `GatewayManager` class exported from `@mastra/core`. Both consumers delegate to it, eliminating duplicated logic. `defaultGateways` is still re-exported from the same paths for backward compatibility.

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -387,18 +387,11 @@ describe('createMastraCode', () => {
     const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as
       | {
           gateways?: unknown[];
-          resolveModel?: unknown;
-          modelAuthChecker?: unknown;
-          customModelCatalogProvider?: unknown;
           subagents?: unknown[];
         }
       | undefined;
     expect(harnessConfig?.gateways).toEqual([mastraCodeGatewayMock]);
     expect(harnessConfig?.subagents).toEqual([subagent]);
-    expect(harnessConfig?.resolveModel).toBe(resolveModelMock);
-    expect(createMastraCodeModelCatalogProviderMock).toHaveBeenCalledWith(mastraCodeGatewayMock);
-    expect(harnessConfig?.modelAuthChecker).toBeUndefined();
-    expect(harnessConfig?.customModelCatalogProvider).toBe(mastraCodeCatalogProviderMock);
   }, 10_000);
 
   it('uses configured memory gateway settings when creating the MastraCode gateway', async () => {

--- a/mastracode/src/acp/server.ts
+++ b/mastracode/src/acp/server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { Readable, Writable } from 'node:stream';
 import { AgentSideConnection, ndJsonStream } from '@agentclientprotocol/sdk';
 import type { Harness, HarnessMode, Session } from '@mastra/core/harness';
@@ -21,7 +22,10 @@ export async function runAcpServer(
 
   // Handle cleanup on disconnect (success or error)
   try {
-    session = await harness.createSession();
+    session = await harness.createSession({
+      id: `acp-${randomUUID()}`,
+      ownerId: `acp-owner-${randomUUID()}`,
+    });
     const activeSession = session;
 
     // Create the agent-side connection

--- a/mastracode/src/headless-integration.test.ts
+++ b/mastracode/src/headless-integration.test.ts
@@ -5,13 +5,20 @@ import { join } from 'node:path';
 import { Agent } from '@mastra/core/agent';
 import { Harness } from '@mastra/core/harness';
 import type { HarnessEvent } from '@mastra/core/harness';
+import type {
+  GatewayAuthRequest,
+  GatewayAuthResult,
+  GatewayLanguageModel,
+  MastraModelGatewayInterface,
+  ProviderConfig,
+} from '@mastra/core/llm';
 import { Mastra } from '@mastra/core/mastra';
 import { AgentsMDInjector } from '@mastra/core/processors';
 import { MastraLanguageModelV2Mock } from '@mastra/core/test-utils/llm-mock';
 import { createTool } from '@mastra/core/tools';
 import { LibSQLStore } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import z from 'zod';
 
 import { runHeadless } from './headless.js';
@@ -99,6 +106,12 @@ afterEach(() => {
   for (const storePath of tempStorePaths.splice(0)) {
     rmSync(storePath, { force: true, recursive: true });
   }
+});
+
+// Prevent default gateways (models.dev, netlify) from hitting the network
+// during model-catalog tests. Errors are caught by GatewayManager.listProviders.
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network disabled in tests')));
 });
 
 async function waitFor(condition: () => boolean, timeoutMs = 5_000): Promise<void> {
@@ -486,6 +499,44 @@ describe('headless mode — event-driven auto-resolution', () => {
   });
 });
 
+function createFakeGatewayFromModels(
+  customModels: { id: string; provider: string; modelName: string; hasApiKey: boolean; apiKeyEnvVar?: string }[],
+): MastraModelGatewayInterface {
+  // Group models by provider for fetchProviders
+  const providers: Record<string, ProviderConfig> = {};
+  for (const m of customModels) {
+    if (!providers[m.provider]) {
+      providers[m.provider] = {
+        name: m.provider,
+        models: [],
+        apiKeyEnvVar: m.apiKeyEnvVar ?? `${m.provider.toUpperCase().replace(/-/g, '_')}_API_KEY`,
+        gateway: 'models.dev',
+      };
+    }
+    providers[m.provider]!.models!.push(m.modelName);
+  }
+
+  // Build a lookup from routerId → hasApiKey for resolveAuth
+  const authMap = new Map(customModels.map(m => [m.id, m.hasApiKey]));
+
+  return {
+    id: 'models.dev',
+    name: 'Test models.dev Gateway',
+    fetchProviders: async () => providers,
+    buildUrl: () => 'https://example.com/v1',
+    getApiKey: async () => {
+      throw new Error('no api key');
+    },
+    resolveAuth: (request: GatewayAuthRequest): GatewayAuthResult | undefined => {
+      if (authMap.get(request.routerId)) {
+        return { apiKey: 'test-key', source: 'gateway' };
+      }
+      return undefined;
+    },
+    resolveLanguageModel: () => ({}) as GatewayLanguageModel,
+  };
+}
+
 function createHarnessWithModels(opts: {
   doStream: () => Promise<{ stream: ReadableStream }>;
   customModels?: { id: string; provider: string; modelName: string; hasApiKey: boolean; apiKeyEnvVar?: string }[];
@@ -528,11 +579,7 @@ function createHarnessWithModels(opts: {
       },
     ],
     initialState: { yolo: true } as any,
-    customModelCatalogProvider: () =>
-      (opts.customModels ?? []).map(m => ({
-        ...m,
-        useCount: 0,
-      })),
+    gateways: [createFakeGatewayFromModels(opts.customModels ?? [])],
   });
   (harness as any).getAgentForMode = () => registeredAgent;
 

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -40,13 +40,7 @@ import {
 
 import { getDynamicInstructions } from './agents/instructions.js';
 import { getDynamicMemory } from './agents/memory.js';
-import {
-  createMastraCodeGateway,
-  createMastraCodeModelCatalogProvider,
-  getDynamicModel,
-  getGoalJudgeModel,
-  resolveModel,
-} from './agents/model.js';
+import { createMastraCodeGateway, getDynamicModel, getGoalJudgeModel, resolveModel } from './agents/model.js';
 import { buildMode } from './agents/modes/build.js';
 import { fastMode } from './agents/modes/explore.js';
 import { planMode } from './agents/modes/plan.js';
@@ -736,6 +730,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     agent: codeAgent,
     subagents: config?.subagents ?? [],
     gateways: [mastraCodeGateway],
+    workspace: config?.workspace ?? (args => getDynamicWorkspace(args)),
+    browser: config?.browser,
     toolCategoryResolver: getToolCategory,
     initialState: {
       projectPath: project.rootPath,
@@ -748,12 +744,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       // with MCP/hooks/storage which were already initialized with this value.
       configDir,
     },
-    workspace: config?.workspace ?? (args => getDynamicWorkspace(args)),
-    browser: config?.browser,
     modes,
     heartbeatHandlers,
-    resolveModel,
-    customModelCatalogProvider: createMastraCodeModelCatalogProvider(mastraCodeGateway),
     modelUseCountProvider: () => loadSettings().modelUseCounts,
     modelUseCountTracker: modelId => {
       try {

--- a/packages/core/src/harness/fork-clone-metadata.test.ts
+++ b/packages/core/src/harness/fork-clone-metadata.test.ts
@@ -59,7 +59,6 @@ describe('Harness fork clone metadata wiring', () => {
       resourceId: 'parent-resource',
       memory: memoryFactory as unknown as never,
       subagents,
-      resolveModel: () => ({}) as never,
       modes: [
         {
           id: 'default',
@@ -101,7 +100,7 @@ describe('Harness fork clone metadata wiring', () => {
     });
   });
 
-  it('does not create the subagent tool from gateways without an app-provided resolver', async () => {
+  it('creates the gateway-backed subagent tool when subagents are configured', async () => {
     const subagents: HarnessSubagent[] = [
       {
         id: 'explore',
@@ -145,8 +144,18 @@ describe('Harness fork clone metadata wiring', () => {
       harnessBuiltIn?: Record<string, unknown>;
     };
 
-    expect(capturedOpts).toHaveLength(0);
-    expect(toolsets.harnessBuiltIn?.subagent).toBeUndefined();
+    expect(capturedOpts).toHaveLength(1);
+    expect(toolsets.harnessBuiltIn?.subagent).toBeDefined();
+    // Model resolution flows through the gateways: resolveModel is the identity
+    // passthrough of the bare model id, resolved by the internal Mastra router.
+    const opts = capturedOpts[0] as {
+      resolveModel: (modelId: string) => unknown;
+      mastra?: unknown;
+    };
+    expect(opts.resolveModel('openai/gpt-4o')).toBe('openai/gpt-4o');
+    // mastra is undefined when no storage is configured (no internal Mastra
+    // is created), but the property must be present on the options.
+    expect('mastra' in opts).toBe(true);
   });
 
   it('wires getParentToolsets so forks can inherit parent toolsets', async () => {
@@ -166,7 +175,6 @@ describe('Harness fork clone metadata wiring', () => {
       resourceId: 'parent-resource',
       memory: memoryFactory as unknown as never,
       subagents,
-      resolveModel: () => ({}) as never,
       modes: [
         {
           id: 'default',

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -6,6 +6,8 @@ import { mastraDBMessageToSignal } from '../agent/signals';
 import type { AgentInstructions, ToolsInput, ToolsetsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
 import { getErrorFromUnknown } from '../error';
+import { GatewayManager } from '../llm/model/gateways';
+import { defaultGateways } from '../llm/model/gateways/defaults';
 import { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
 import type { StorageThreadType } from '../memory/types';
@@ -214,6 +216,7 @@ export class Harness<TState = {}> {
    * server's storage/agents/gateways instead of spinning up its own.
    */
   #externalMastra: Mastra | undefined = undefined;
+  #gatewayManager: GatewayManager | undefined = undefined;
   #legacyAgentMode: Record<string, Agent<any, any, any, any>> = {};
 
   constructor(config: HarnessConfig<TState>) {
@@ -222,6 +225,10 @@ export class Harness<TState = {}> {
     this.id = config.id;
     this.config = config;
     this.#instructions = config.instructions;
+    // Gateway manager merges configured gateways with the router defaults
+    // (custom takes precedence). Shared by listAvailableModels,
+    // getCurrentModelAuthStatus, and the OM model resolver.
+    this.#gatewayManager = new GatewayManager([...(config.gateways ?? []), ...defaultGateways]);
 
     const defaultMode = config.defaultModeId
       ? config.modes.find(mode => mode.id === config.defaultModeId)
@@ -281,7 +288,7 @@ export class Harness<TState = {}> {
       setState: updates => void session.state.set(updates as Partial<TState>),
       setSetting: ({ key, value }) => session.thread.setSetting({ key, value }),
       omConfig: this.config.omConfig,
-      resolveModel: this.config.resolveModel,
+      gateways: this.config.gateways ?? [],
     });
     session.permissions.setResolver({
       getState: () => session.state.get() as Record<string, unknown>,
@@ -883,7 +890,11 @@ export class Harness<TState = {}> {
         ...mode.additionalTools,
       };
 
-      const model = this.config.resolveModel ? this.config.resolveModel(mode.defaultModelId) : mode.defaultModelId;
+      // Model resolution flows through the gateways registered on the internal
+      // Mastra instance: the bare model id string is handed to the Agent, and
+      // `propagateRuntimeServicesToAgent` attaches the internal Mastra so the
+      // model router resolves it via the configured gateways (auth included).
+      const model = mode.defaultModelId;
       this.#legacyAgentMode[mode.id] = new Agent({
         id: `${this.id}-agent`,
         name: `Harness ${this.id} agent`,
@@ -940,32 +951,29 @@ export class Harness<TState = {}> {
 
   /**
    * Check if the current model's provider has authentication configured.
-   * Uses app-provided catalog/auth hooks; Harness does not resolve gateway auth itself.
+   * Delegates to the {@link GatewayManager} auth chain (the same resolution
+   * the model router uses at run time). Falls back to `hasAuth: true` when
+   * no model is selected or the chain cannot resolve auth.
    */
   async getCurrentModelAuthStatus(session: Session<TState>): Promise<ModelAuthStatus> {
     const modelId = session.model.get();
     if (!modelId) return { hasAuth: true };
 
+    const hasAuth = this.#gatewayManager ? await this.#gatewayManager.hasAuth(modelId) : true;
+    if (hasAuth) return { hasAuth: true };
+
+    // Surface the env-var hint from the catalog when available.
     try {
       const availableModels = await this.listAvailableModels();
       const currentModel = availableModels.find(model => model.id === modelId);
       if (currentModel) {
-        return {
-          hasAuth: currentModel.hasApiKey,
-          apiKeyEnvVar: currentModel.hasApiKey ? undefined : currentModel.apiKeyEnvVar,
-        };
+        return { hasAuth: false, apiKeyEnvVar: currentModel.apiKeyEnvVar };
       }
     } catch {
-      // Ignore catalog lookup errors and fall through to provider-based checks.
+      // Ignore catalog lookup errors.
     }
 
-    const provider = modelId.split('/', 1)[0];
-    if (this.config.modelAuthChecker && provider) {
-      const result = this.config.modelAuthChecker(provider);
-      if (result !== undefined) return { hasAuth: result };
-    }
-
-    return { hasAuth: true };
+    return { hasAuth: false };
   }
 
   /**
@@ -988,21 +996,9 @@ export class Harness<TState = {}> {
       });
     };
 
-    if (this.config.customModelCatalogProvider) {
-      try {
-        const customModels = await Promise.resolve(this.config.customModelCatalogProvider());
-        for (const model of customModels) {
-          upsertModel({
-            id: model.id,
-            provider: model.provider,
-            modelName: model.modelName,
-            hasApiKey: model.hasApiKey,
-            apiKeyEnvVar: model.apiKeyEnvVar,
-          });
-        }
-      } catch (error) {
-        console.warn('Failed to load available models:', error);
-      }
+    const catalog = await this.#gatewayManager!.listAvailableModels();
+    for (const model of catalog) {
+      upsertModel(model);
     }
 
     const result = [...modelsById.values()];
@@ -1716,13 +1712,18 @@ export class Harness<TState = {}> {
       }
     }
 
-    // Auto-create subagent tool if subagent definitions are configured
-    if (this.config.subagents?.length && this.config.resolveModel) {
+    // Auto-create subagent tool if subagent definitions are configured.
+    // Model resolution flows through the gateways registered on the internal
+    // Mastra instance: `resolveModel` returns the bare model id string and the
+    // created subagent Agent receives the internal Mastra via its constructor
+    // so the model router resolves through the same gateways as the parent.
+    if (this.config.subagents?.length) {
       const currentMode = session.mode.resolve();
       const hasMemory = Boolean(this.config.memory);
       builtInTools.subagent = createSubagentTool({
         subagents: this.config.subagents,
-        resolveModel: this.config.resolveModel,
+        resolveModel: (modelId: string) => modelId,
+        mastra: this.getMastra(),
         harnessTools: resolvedHarnessTools,
         fallbackModelId: currentMode?.defaultModelId,
         getParentModelId: () => session.model.get(),

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -36,7 +36,6 @@ export type {
   HarnessSubagentHistoryEntry,
   HarnessThread,
   HeartbeatHandler,
-  ModelAuthChecker,
   ModelAuthStatus,
   ModelUseCountProvider,
   ModelUseCountTracker,

--- a/packages/core/src/harness/list-available-models.test.ts
+++ b/packages/core/src/harness/list-available-models.test.ts
@@ -1,11 +1,52 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../agent';
+import type {
+  GatewayLanguageModel,
+  MastraModelGatewayInterface,
+  ProviderConfig,
+  GatewayAuthRequest,
+  GatewayAuthResult,
+} from '../llm/model/gateways';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
-import type { CustomModelCatalogProvider } from './types';
 
-function createHarness(customModelCatalogProvider: CustomModelCatalogProvider) {
+/**
+ * Minimal in-memory gateway used to drive the Harness model catalog without
+ * hitting the network. `fetchProviders` is a vi.fn so tests can assert caching.
+ */
+function createFakeGateway(options?: {
+  models?: string[];
+  apiKeyEnvVar?: string;
+  resolveAuth?: (request: GatewayAuthRequest) => GatewayAuthResult | undefined;
+}): MastraModelGatewayInterface & { fetchProviders: ReturnType<typeof vi.fn> } {
+  const models = options?.models ?? ['sonic-fast'];
+  const fetchProviders = vi.fn(
+    async (): Promise<Record<string, ProviderConfig>> => ({
+      acme: {
+        name: 'Acme',
+        models,
+        apiKeyEnvVar: options?.apiKeyEnvVar ?? 'ACME_API_KEY',
+        gateway: 'test-gateway',
+      },
+    }),
+  );
+
+  return {
+    id: 'test-gateway',
+    name: 'Test Gateway',
+    fetchProviders,
+    buildUrl: () => 'https://example.com/v1',
+    // Mirror real gateways (e.g. models.dev): throw when no key is configured.
+    getApiKey: async () => {
+      throw new Error('no api key');
+    },
+    resolveAuth: options?.resolveAuth,
+    resolveLanguageModel: () => ({}) as GatewayLanguageModel,
+  };
+}
+
+function createHarness(gateway: MastraModelGatewayInterface, defaultModelId?: string) {
   const agent = new Agent({
     name: 'test-agent',
     instructions: 'You are a test agent.',
@@ -15,130 +56,126 @@ function createHarness(customModelCatalogProvider: CustomModelCatalogProvider) {
   return new Harness({
     id: 'test-harness',
     storage: new InMemoryStore(),
-    modes: [{ id: 'default', name: 'Default', default: true, agent }],
-    customModelCatalogProvider,
+    modes: [{ id: 'default', name: 'Default', default: true, agent, defaultModelId }],
+    gateways: [gateway],
+    omConfig: defaultModelId ? { defaultObserverModelId: defaultModelId } : undefined,
     modelUseCountProvider: () => ({
-      'openai/gpt-4o': 7,
-      'acme/sonic-fast': 3,
-      'acme/new-model': 11,
+      'test-gateway/acme/sonic-fast': 3,
+      'test-gateway/acme/new-model': 11,
     }),
   });
 }
 
 describe('Harness.listAvailableModels', () => {
-  it('merges custom catalog models, lets duplicate IDs override built-ins, and refreshes after cache invalidation', async () => {
-    let customModels = [
-      {
-        id: 'openai/gpt-4o',
-        provider: 'acme-openai',
-        modelName: 'gpt-4o-compatible',
-        hasApiKey: true,
-        apiKeyEnvVar: 'ACME_API_KEY',
-      },
-      {
-        id: 'acme/sonic-fast',
-        provider: 'acme',
-        modelName: 'sonic-fast',
-        hasApiKey: false,
-      },
-    ];
-    const customModelCatalogProvider = vi.fn(() => customModels);
-    const harness = createHarness(customModelCatalogProvider);
+  // The catalog is built purely from gateways: the configured fake gateway plus
+  // the router defaults (models.dev / Netlify), which fetch over the network.
+  // Stub fetch so those defaults contribute nothing and the test stays hermetic.
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network disabled in test');
+      }),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('builds the catalog from gateway providers and caches/refreshes fetchProviders', async () => {
+    const gateway = createFakeGateway({ models: ['sonic-fast'] });
+    const harness = createHarness(gateway);
 
     const firstModels = await harness.listAvailableModels();
-    const overriddenBuiltin = firstModels.find(model => model.id === 'openai/gpt-4o');
-    expect(overriddenBuiltin).toMatchObject({
-      id: 'openai/gpt-4o',
-      provider: 'acme-openai',
-      modelName: 'gpt-4o-compatible',
-      hasApiKey: true,
-      apiKeyEnvVar: 'ACME_API_KEY',
-      useCount: 7,
-    });
-    expect(firstModels.find(model => model.id === 'acme/sonic-fast')).toMatchObject({
-      provider: 'acme',
+    expect(firstModels.find(model => model.id === 'test-gateway/acme/sonic-fast')).toMatchObject({
+      id: 'test-gateway/acme/sonic-fast',
+      provider: 'test-gateway/acme',
       modelName: 'sonic-fast',
       hasApiKey: false,
+      apiKeyEnvVar: 'ACME_API_KEY',
       useCount: 3,
     });
 
+    // Second call is served from cache — fetchProviders not re-invoked.
     await harness.listAvailableModels();
-    expect(customModelCatalogProvider).toHaveBeenCalledTimes(1);
+    expect(gateway.fetchProviders).toHaveBeenCalledTimes(1);
 
-    customModels = [
-      {
-        id: 'acme/new-model',
-        provider: 'acme',
-        modelName: 'new-model',
-        hasApiKey: true,
-      },
-    ];
+    // After invalidation, updated gateway models are reflected.
+    gateway.fetchProviders.mockResolvedValueOnce({
+      acme: { name: 'Acme', models: ['new-model'], apiKeyEnvVar: 'ACME_API_KEY', gateway: 'test-gateway' },
+    });
     harness.invalidateAvailableModelsCache();
 
-    const refreshedModels = await harness.listAvailableModels();
-    expect(customModelCatalogProvider).toHaveBeenCalledTimes(2);
-    expect(refreshedModels.find(model => model.id === 'acme/new-model')).toMatchObject({
-      provider: 'acme',
+    const refreshed = await harness.listAvailableModels();
+    expect(gateway.fetchProviders).toHaveBeenCalledTimes(2);
+    expect(refreshed.find(model => model.id === 'test-gateway/acme/new-model')).toMatchObject({
+      provider: 'test-gateway/acme',
       modelName: 'new-model',
-      hasApiKey: true,
+      hasApiKey: false,
       useCount: 11,
     });
-    expect(refreshedModels.find(model => model.id === 'acme/sonic-fast')).toBeUndefined();
+    expect(refreshed.find(model => model.id === 'test-gateway/acme/sonic-fast')).toBeUndefined();
   });
 
-  it('uses app-provided model catalog and resolver hooks for gateway-backed models', async () => {
-    const resolveModel = vi.fn(modelId => ({ modelId }));
-    const customModelCatalogProvider = vi.fn(() => [
-      {
-        id: 'test-gateway/acme/sonic-fast',
-        provider: 'test-gateway/acme',
-        modelName: 'sonic-fast',
-        hasApiKey: true,
-        apiKeyEnvVar: 'ACME_API_KEY',
-      },
-    ]);
+  it('marks models authenticated when the gateway can resolve auth', async () => {
+    const gateway = createFakeGateway({
+      resolveAuth: () => ({ apiKey: 'oauth-key', source: 'gateway' }),
+    });
+    const harness = createHarness(gateway, 'test-gateway/acme/sonic-fast');
 
-    const agent = new Agent({
-      name: 'test-agent',
-      instructions: 'You are a test agent.',
-      model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
-    });
-    const harness = new Harness({
-      id: 'test-harness',
-      storage: new InMemoryStore(),
-      modes: [
-        {
-          id: 'default',
-          name: 'Default',
-          default: true,
-          agent,
-          defaultModelId: 'test-gateway/acme/sonic-fast',
-        },
-      ],
-      resolveModel,
-      customModelCatalogProvider,
-      omConfig: {
-        defaultObserverModelId: 'test-gateway/acme/sonic-fast',
-      },
-    });
     await harness.init();
     const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
 
-    const observerModel = session.om.observer.resolvedModel() as { modelId?: string };
-    expect(observerModel).toMatchObject({ modelId: 'test-gateway/acme/sonic-fast' });
-    expect(resolveModel).toHaveBeenCalledWith('test-gateway/acme/sonic-fast');
+    const observerModel = session.om.observer.resolvedModel() as { gatewayId?: string; provider?: string };
+    expect(observerModel).toMatchObject({ gatewayId: 'test-gateway', provider: 'acme' });
 
     const models = await harness.listAvailableModels();
     expect(models.find(model => model.id === 'test-gateway/acme/sonic-fast')).toMatchObject({
-      provider: 'test-gateway/acme',
-      modelName: 'sonic-fast',
       hasApiKey: true,
-      apiKeyEnvVar: 'ACME_API_KEY',
     });
+  });
 
-    await expect(harness.getCurrentModelAuthStatus(session)).resolves.toEqual({
-      hasAuth: true,
-      apiKeyEnvVar: undefined,
+  it('resolves the observer model through the configured gateways', async () => {
+    const gateway = createFakeGateway();
+    const harness = createHarness(gateway, 'test-gateway/acme/sonic-fast');
+    await harness.init();
+    const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
+
+    const observerModel = session.om.observer.resolvedModel() as { gatewayId?: string; provider?: string };
+    expect(observerModel?.gatewayId).toBe('test-gateway');
+    expect(observerModel?.provider).toBe('acme');
+  });
+
+  it('getCurrentModelAuthStatus reflects gateway auth resolution', async () => {
+    const authedGateway = createFakeGateway({
+      resolveAuth: () => ({ apiKey: 'oauth-key', source: 'gateway' }),
     });
+    const authedHarness = createHarness(authedGateway, 'test-gateway/acme/sonic-fast');
+    await authedHarness.init();
+    const authedSession = await authedHarness.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    authedSession.model.set({ modelId: 'test-gateway/acme/sonic-fast' });
+
+    const authedStatus = await authedHarness.getCurrentModelAuthStatus(authedSession);
+    expect(authedStatus.hasAuth).toBe(true);
+
+    // Without auth configured (getApiKey throws), hasAuth should be false.
+    const unauthedGateway = createFakeGateway(); // throws on getApiKey, no resolveAuth
+    const unauthedHarness = createHarness(unauthedGateway, 'test-gateway/acme/sonic-fast');
+    await unauthedHarness.init();
+    const unauthedSession = await unauthedHarness.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    unauthedSession.model.set({ modelId: 'test-gateway/acme/sonic-fast' });
+
+    const unauthedStatus = await unauthedHarness.getCurrentModelAuthStatus(unauthedSession);
+    expect(unauthedStatus.hasAuth).toBe(false);
+  });
+
+  it('getCurrentModelAuthStatus defaults to hasAuth true when no model is selected', async () => {
+    const gateway = createFakeGateway();
+    const harness = createHarness(gateway);
+    await harness.init();
+    const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
+
+    const status = await harness.getCurrentModelAuthStatus(session);
+    expect(status).toEqual({ hasAuth: true });
   });
 });

--- a/packages/core/src/harness/session-om.test.ts
+++ b/packages/core/src/harness/session-om.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
@@ -8,7 +8,6 @@ import type { HarnessEvent, HarnessOMConfig } from './types';
 async function createSession(options: {
   storage: InMemoryStore;
   omConfig?: HarnessOMConfig;
-  resolveModel?: (modelId: string) => any;
   onEvent?: (event: HarnessEvent) => void;
 }) {
   const agent = new Agent({
@@ -22,7 +21,6 @@ async function createSession(options: {
     storage: options.storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
     omConfig: options.omConfig,
-    resolveModel: options.resolveModel,
   });
 
   await harness.init();
@@ -106,23 +104,20 @@ describe('session.om', () => {
     });
   });
 
-  it('resolves the observer model via the configured resolver', async () => {
-    const resolveModel = vi.fn((modelId: string) => ({ modelId }));
+  it('resolves the observer model through the model router gateways', async () => {
     const { session } = await createSession({
       storage,
       omConfig: { defaultObserverModelId: 'openai/gpt-4o' },
-      resolveModel,
     });
 
-    expect(session.om.observer.resolvedModel()).toMatchObject({ modelId: 'openai/gpt-4o' });
-    expect(resolveModel).toHaveBeenCalledWith('openai/gpt-4o');
+    const resolved = session.om.observer.resolvedModel() as { modelId?: string; provider?: string };
+    expect(resolved?.provider).toBe('openai');
+    expect(resolved?.modelId).toBe('gpt-4o');
   });
 
   it('returns undefined resolved model when no model id is set', async () => {
-    const resolveModel = vi.fn((modelId: string) => ({ modelId }));
-    const { session } = await createSession({ storage, resolveModel });
+    const { session } = await createSession({ storage });
 
     expect(session.om.observer.resolvedModel()).toBeUndefined();
-    expect(resolveModel).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -9,6 +9,8 @@ import type {
   ToolsetsInput,
 } from '../agent/types';
 import { getErrorFromUnknown } from '../error';
+import type { MastraModelGatewayInterface } from '../llm/model/gateways';
+import { ModelRouterLanguageModel } from '../llm/model/router';
 import type { MastraModelConfig } from '../llm/model/shared.types';
 import type { SendNotificationSignalInput } from '../notifications';
 import type { TracingContext, TracingOptions } from '../observability';
@@ -1533,7 +1535,7 @@ class SessionOMRole {
   #setState: ((updates: Record<string, unknown>) => void) | undefined;
   #setSetting: ((args: { key: string; value: unknown }) => Promise<void>) | undefined;
   #omConfig: HarnessOMConfig | undefined;
-  #resolveModel: ((modelId: string) => MastraModelConfig) | undefined;
+  #gateways: MastraModelGatewayInterface[] | undefined;
 
   constructor(config: SessionOMRoleConfig, bus: SessionBus) {
     this.#config = config;
@@ -1546,13 +1548,13 @@ class SessionOMRole {
     setState: (updates: Record<string, unknown>) => void;
     setSetting: (args: { key: string; value: unknown }) => Promise<void>;
     omConfig?: HarnessOMConfig;
-    resolveModel?: (modelId: string) => MastraModelConfig;
+    gateways?: MastraModelGatewayInterface[];
   }): void {
     this.#getState = wiring.getState;
     this.#setState = wiring.setState;
     this.#setSetting = wiring.setSetting;
     this.#omConfig = wiring.omConfig;
-    this.#resolveModel = wiring.resolveModel;
+    this.#gateways = wiring.gateways;
   }
 
   /** This role's model id from session state, falling back to `omConfig`. */
@@ -1567,11 +1569,16 @@ class SessionOMRole {
     return (typeof fromState === 'number' ? fromState : undefined) ?? this.#config.defaultThreshold(this.#omConfig);
   }
 
-  /** Resolve this role's model id to a model instance, or undefined when unset. */
+  /**
+   * Resolve this role's model id to a model instance via the configured
+   * gateways, or undefined when unset. The bare model id string is routed
+   * through {@link ModelRouterLanguageModel}, which selects the matching
+   * gateway (or the built-in defaults) and resolves provider auth.
+   */
   resolvedModel(): MastraModelConfig | undefined {
     const modelId = this.modelId();
-    if (!modelId || !this.#resolveModel) return undefined;
-    return this.#resolveModel(modelId);
+    if (!modelId) return undefined;
+    return new ModelRouterLanguageModel(modelId as `${string}/${string}`, this.#gateways);
   }
 
   /** Switch this role's model: update session state, persist, and emit. */
@@ -1626,7 +1633,7 @@ class SessionOM {
     setState: (updates: Record<string, unknown>) => void;
     setSetting: (args: { key: string; value: unknown }) => Promise<void>;
     omConfig?: HarnessOMConfig;
-    resolveModel?: (modelId: string) => MastraModelConfig;
+    gateways?: MastraModelGatewayInterface[];
   }): void {
     this.observer.setWiring(options);
     this.reflector.setWiring(options);

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod/v4';
 import { Agent } from '../agent';
 import type { ToolsInput, ToolsetsInput } from '../agent/types';
 import type { MastraModelConfig } from '../llm/model/shared.types';
+import type { Mastra } from '../mastra';
 import { RequestContext } from '../request-context';
 import { askUserTool } from '../tools/builtin/ask-user';
 import { submitPlanTool } from '../tools/builtin/submit-plan';
@@ -98,6 +99,12 @@ export interface CreateSubagentToolOptions {
    * stability, but its runtime execute function is patched to block recursion.
    */
   getParentToolsets?: (requestContext?: RequestContext) => Promise<ToolsetsInput | undefined>;
+  /**
+   * Internal Mastra instance passed to each subagent Agent constructor so the
+   * bare model id resolves through the same gateways as the parent and the
+   * agent inherits pubsub/observability.
+   */
+  mastra?: Mastra;
 }
 
 /**
@@ -106,7 +113,7 @@ export interface CreateSubagentToolOptions {
  * streams the response, and forwards events to the harness.
  */
 export function createSubagentTool(opts: CreateSubagentToolOptions) {
-  const { subagents, resolveModel, harnessTools, fallbackModelId } = opts;
+  const { subagents, resolveModel, harnessTools, fallbackModelId, mastra } = opts;
 
   const subagentIds = subagents.map(s => s.id);
 
@@ -311,6 +318,7 @@ Use this tool when:
           model,
           tools: mergedTools,
           workspace,
+          mastra,
         });
 
         // Only resolve workspace tool names when an allowlist is configured,

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -3,7 +3,6 @@ import type { AgentInstructions, ToolsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
 import type { PubSub } from '../events/pubsub';
 import type { MastraModelGatewayInterface } from '../llm/model/gateways';
-import type { MastraModelConfig } from '../llm/model/shared.types';
 import type { LoopOptions } from '../loop/types';
 import type { MastraMemory } from '../memory/memory';
 import type { ObservabilityEntrypoint } from '../observability/types/core';
@@ -267,13 +266,6 @@ export interface HarnessConfig<TState = {}> {
   idGenerator?: () => string;
 
   /**
-   * Custom auth checker for model providers.
-   * Lets the app layer provide additional auth sources (e.g., OAuth tokens)
-   * beyond the default env var check from the provider registry.
-   */
-  modelAuthChecker?: ModelAuthChecker;
-
-  /**
    * Provides per-model use counts for `listAvailableModels()` sorting/display.
    * Lets the app layer track and report how often each model has been used.
    */
@@ -286,12 +278,6 @@ export interface HarnessConfig<TState = {}> {
   modelUseCountTracker?: ModelUseCountTracker;
 
   /**
-   * Optional catalog hook for additional models (e.g., user-defined custom providers).
-   * Returned entries are merged into `listAvailableModels()`.
-   */
-  customModelCatalogProvider?: CustomModelCatalogProvider;
-
-  /**
    * Subagent definitions. The Harness auto-creates a `subagent` built-in tool
    * that parent agents can call to spawn focused subagents.
    */
@@ -299,15 +285,12 @@ export interface HarnessConfig<TState = {}> {
 
   /**
    * Model gateways registered on Harness' internal Mastra instance.
-   * Apps that need gateway-backed model resolution should provide `resolveModel`.
+   * The Harness resolves every model — mode agents, Observational Memory,
+   * subagents — and builds the `listAvailableModels()` catalog through these
+   * gateways. Provider auth (API keys, OAuth, stored credentials) is resolved
+   * via each gateway's `resolveAuth()` / env-var configuration.
    */
   gateways?: MastraModelGatewayInterface[];
-
-  /**
-   * Converts a model ID string (e.g., "anthropic/claude-sonnet-4-20250514") to a
-   * language model instance for Harness-managed observer, reflector, and subagent models.
-   */
-  resolveModel?: (modelId: string) => MastraModelConfig;
 
   /**
    * Observational Memory configuration defaults.
@@ -426,25 +409,15 @@ export interface AvailableModel {
 }
 
 /**
- * Additional model entries supplied by the app layer.
+ * Same as {@link AvailableModel} but without the runtime `useCount` field.
+ * Used by providers that supply catalog entries before use-count tracking.
  */
 export type CustomAvailableModel = Omit<AvailableModel, 'useCount'>;
 
 /**
- * Provides additional model catalog entries for `listAvailableModels()`.
+ * Function that returns a list of custom available models (without use counts).
  */
-export type CustomModelCatalogProvider = () => CustomAvailableModel[] | Promise<CustomAvailableModel[]>;
-
-/**
- * Custom auth checker for model providers.
- * Called by `getCurrentModelAuthStatus()` and `listAvailableModels()` to determine
- * whether a provider has valid authentication beyond just env var checks
- * (e.g., OAuth tokens, stored credentials).
- *
- * Return `true` if the provider is authenticated, `false` if not,
- * or `undefined` to fall back to the default env var check.
- */
-export type ModelAuthChecker = (provider: string) => boolean | undefined;
+export type CustomModelCatalogProvider = () => Promise<CustomAvailableModel[]>;
 
 /**
  * Provides per-model use counts for sorting in `listAvailableModels()`.

--- a/packages/core/src/llm/model/gateways/defaults.ts
+++ b/packages/core/src/llm/model/gateways/defaults.ts
@@ -1,0 +1,19 @@
+import { PROVIDER_REGISTRY } from '../provider-registry.js';
+import { MastraGateway } from './mastra.js';
+import { ModelsDevGateway } from './models-dev.js';
+import { NetlifyGateway } from './netlify.js';
+
+function getStaticProvidersByGateway(name: string) {
+  return Object.fromEntries(Object.entries(PROVIDER_REGISTRY).filter(([_provider, config]) => config.gateway === name));
+}
+
+export const defaultGateways = [
+  new NetlifyGateway(),
+  new MastraGateway(),
+  new ModelsDevGateway(getStaticProvidersByGateway(`models.dev`)),
+];
+
+/**
+ * @deprecated Use {@link defaultGateways} instead. This export will be removed in a future version.
+ */
+export const gateways = defaultGateways;

--- a/packages/core/src/llm/model/gateways/gateway-helpers.ts
+++ b/packages/core/src/llm/model/gateways/gateway-helpers.ts
@@ -1,0 +1,48 @@
+import { MastraError } from '../../../error/index.js';
+import type { MastraModelGatewayInterface } from './base.js';
+
+export function getGatewayId(gateway: MastraModelGatewayInterface): string {
+  return gateway.getId?.() ?? gateway.id;
+}
+
+export function shouldEnableGateway(gateway: MastraModelGatewayInterface): boolean {
+  return gateway.shouldEnable?.() ?? true;
+}
+
+export function serializeGatewayForSpan(
+  gateway: MastraModelGatewayInterface,
+): { id: string; name: string } & Record<string, unknown> {
+  return gateway.serializeForSpan?.() ?? { id: getGatewayId(gateway), name: gateway.name };
+}
+
+/**
+ * Find the gateway that handles a specific model ID based on gateway ID
+ * Gateway ID is used as the prefix (e.g., "netlify" for netlify gateway)
+ * Exception: models.dev is a provider registry and doesn't use a prefix
+ */
+export function findGatewayForModel(
+  gatewayId: string,
+  gateways: MastraModelGatewayInterface[],
+): MastraModelGatewayInterface {
+  // First, check for gateways whose ID matches the prefix (true gateways like netlify, openrouter, vercel)
+  const prefixedGateway = gateways.find(g => {
+    const id = getGatewayId(g);
+    return id !== 'models.dev' && (id === gatewayId || gatewayId.startsWith(`${id}/`));
+  });
+  if (prefixedGateway) {
+    return prefixedGateway;
+  }
+
+  // Then check models.dev (provider registry without prefix)
+  const modelsDevGateway = gateways.find(g => getGatewayId(g) === 'models.dev');
+  if (modelsDevGateway) {
+    return modelsDevGateway;
+  }
+
+  throw new MastraError({
+    id: 'MODEL_ROUTER_NO_GATEWAY_FOUND',
+    category: 'USER',
+    domain: 'MODEL_ROUTER',
+    text: `No Mastra model router gateway found for model id ${gatewayId}`,
+  });
+}

--- a/packages/core/src/llm/model/gateways/gateway-manager.test.ts
+++ b/packages/core/src/llm/model/gateways/gateway-manager.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  GatewayAuthRequest,
+  GatewayAuthResult,
+  GatewayLanguageModel,
+  MastraModelGatewayInterface,
+  ProviderConfig,
+} from './base';
+import { defaultGateways } from './defaults';
+import { GatewayManager } from './gateway-manager';
+
+/**
+ * Minimal in-memory gateway for exercising GatewayManager without real
+ * network calls. `fetchProviders` / `getApiKey` / `resolveAuth` are vi.fn so
+ * tests can assert call counts and return values.
+ */
+function createFakeGateway(options?: {
+  id?: string;
+  models?: string[];
+  apiKeyEnvVar?: string | string[];
+  apiKey?: string | (() => Promise<string>);
+  resolveAuth?: (request: GatewayAuthRequest) => GatewayAuthResult | undefined;
+  enabled?: boolean;
+  provider?: string;
+}): MastraModelGatewayInterface {
+  const id = options?.id ?? 'test-gateway';
+  const provider = options?.provider ?? 'acme';
+  const models = options?.models ?? ['sonic-fast'];
+  const apiKeyEnvVar = options?.apiKeyEnvVar ?? 'ACME_API_KEY';
+
+  return {
+    id,
+    name: 'Test Gateway',
+    shouldEnable: () => options?.enabled ?? true,
+    fetchProviders: vi.fn(
+      async (): Promise<Record<string, ProviderConfig>> => ({
+        [provider]: {
+          name: 'Acme',
+          models,
+          apiKeyEnvVar,
+          gateway: id,
+        },
+      }),
+    ),
+    buildUrl: () => 'https://example.com/v1',
+    getApiKey: vi.fn(async () => {
+      if (typeof options?.apiKey === 'function') return options.apiKey();
+      return options?.apiKey ?? '';
+    }),
+    resolveAuth: options?.resolveAuth,
+    resolveLanguageModel: () => ({}) as GatewayLanguageModel,
+  };
+}
+
+describe('GatewayManager', () => {
+  describe('constructor', () => {
+    it('stores only the gateways passed in (no side-effect defaults)', () => {
+      const gw = createFakeGateway({ id: 'my-gateway' });
+      const manager = new GatewayManager([gw]);
+      expect(manager.gateways).toHaveLength(1);
+      expect(manager.gateways[0]).toBe(gw);
+    });
+
+    it('defaults to an empty gateway list', () => {
+      const manager = new GatewayManager();
+      expect(manager.gateways).toHaveLength(0);
+    });
+
+    it('drops disabled gateways', () => {
+      const enabled = createFakeGateway({ id: 'on-gateway' });
+      const disabled = createFakeGateway({ id: 'off-gateway', enabled: false });
+      const manager = new GatewayManager([enabled, disabled]);
+      expect(manager.gateways.map(g => g.id)).not.toContain('off-gateway');
+      expect(manager.gateways.map(g => g.id)).toContain('on-gateway');
+    });
+  });
+
+  describe('getPrefix', () => {
+    it('returns undefined for models.dev', () => {
+      expect(GatewayManager.getPrefix('models.dev')).toBeUndefined();
+    });
+
+    it('returns the gateway id for any other gateway', () => {
+      expect(GatewayManager.getPrefix('netlify')).toBe('netlify');
+      expect(GatewayManager.getPrefix('my-gateway')).toBe('my-gateway');
+    });
+  });
+
+  describe('parseModelId', () => {
+    it('parses a prefixed router id', () => {
+      const gateway = createFakeGateway({ id: 'test-gateway', provider: 'acme', models: ['sonic-fast'] });
+      const manager = new GatewayManager([gateway]);
+      const parsed = manager.parseModelId('test-gateway/acme/sonic-fast');
+      expect(parsed).toEqual({
+        providerId: 'acme',
+        modelId: 'sonic-fast',
+        gatewayId: 'test-gateway',
+      });
+    });
+
+    it('parses a models.dev (prefix-less) router id', () => {
+      const manager = new GatewayManager(defaultGateways);
+      const parsed = manager.parseModelId('openai/gpt-4o');
+      expect(parsed.gatewayId).toBe('models.dev');
+      expect(parsed.providerId).toBe('openai');
+      expect(parsed.modelId).toBe('gpt-4o');
+    });
+  });
+
+  describe('resolveAuth', () => {
+    it('prefers gateway.resolveAuth when present', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        resolveAuth: () => ({ apiKey: 'oauth-key', source: 'gateway' }),
+      });
+      const manager = new GatewayManager([gateway]);
+      const auth = await manager.resolveAuth('test-gateway/acme/sonic-fast');
+      expect(auth.apiKey).toBe('oauth-key');
+      expect(auth.source).toBe('gateway');
+    });
+
+    it('promotes bearerToken to an Authorization header', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        resolveAuth: () => ({ bearerToken: 'tok-123' }),
+      });
+      const manager = new GatewayManager([gateway]);
+      const auth = await manager.resolveAuth('test-gateway/acme/sonic-fast');
+      expect(auth.bearerToken).toBe('tok-123');
+      expect(auth.headers?.Authorization).toBe('Bearer tok-123');
+    });
+
+    it('falls back to getApiKey when resolveAuth returns nothing', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        apiKey: 'env-key',
+      });
+      const manager = new GatewayManager([gateway]);
+      const auth = await manager.resolveAuth('test-gateway/acme/sonic-fast');
+      expect(auth.apiKey).toBe('env-key');
+      expect(auth.source).toBe('legacy');
+    });
+  });
+
+  describe('hasAuth', () => {
+    it('returns true when resolveAuth yields credentials', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        resolveAuth: () => ({ apiKey: 'key' }),
+      });
+      const manager = new GatewayManager([gateway]);
+      expect(await manager.hasAuth('test-gateway/acme/sonic-fast')).toBe(true);
+    });
+
+    it('returns false when no credentials resolve and getApiKey is empty', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        apiKey: '',
+      });
+      const manager = new GatewayManager([gateway]);
+      expect(await manager.hasAuth('test-gateway/acme/sonic-fast')).toBe(false);
+    });
+
+    it('returns false instead of throwing on an unknown model', async () => {
+      const manager = new GatewayManager([createFakeGateway({ id: 'test-gateway' })]);
+      expect(await manager.hasAuth('unknown/garbage/model')).toBe(false);
+    });
+  });
+
+  describe('listProviders', () => {
+    it('flattens providers from all gateways and stamps the gateway id', async () => {
+      const gateway = createFakeGateway({ id: 'test-gateway', provider: 'acme', models: ['sonic-fast'] });
+      const manager = new GatewayManager([gateway]);
+
+      const providers = await manager.listProviders();
+      const key = 'test-gateway/acme';
+      expect(providers[key]).toMatchObject({
+        name: 'Acme',
+        models: ['sonic-fast'],
+        gateway: 'test-gateway',
+      });
+    });
+
+    it('dedupes by provider key — earlier gateway wins', async () => {
+      const first = createFakeGateway({ id: 'gw-a', provider: 'shared', models: ['first-model'] });
+      const second = createFakeGateway({ id: 'gw-b', provider: 'shared', models: ['second-model'] });
+      const manager = new GatewayManager([first, second]);
+
+      const providers = await manager.listProviders();
+      // Both register provider 'shared' under their own prefix.
+      expect(providers['gw-a/shared'].models).toEqual(['first-model']);
+      expect(providers['gw-b/shared'].models).toEqual(['second-model']);
+    });
+  });
+
+  describe('listAvailableModels', () => {
+    it('builds model entries with id/provider/modelName and applies auth per provider', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        models: ['sonic-fast', 'sonic-turbo'],
+        resolveAuth: () => ({ apiKey: 'k' }),
+      });
+      const manager = new GatewayManager([gateway]);
+
+      const models = await manager.listAvailableModels();
+      const ours = models.filter(m => m.provider === 'test-gateway/acme');
+      expect(ours).toHaveLength(2);
+      expect(ours[0]).toMatchObject({
+        id: 'test-gateway/acme/sonic-fast',
+        provider: 'test-gateway/acme',
+        modelName: 'sonic-fast',
+        hasApiKey: true,
+        apiKeyEnvVar: 'ACME_API_KEY',
+      });
+      expect(ours[1]).toMatchObject({
+        id: 'test-gateway/acme/sonic-turbo',
+        modelName: 'sonic-turbo',
+        hasApiKey: true,
+      });
+    });
+
+    it('marks hasApiKey false when auth cannot be resolved', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        apiKey: '',
+      });
+      const manager = new GatewayManager([gateway]);
+
+      const models = await manager.listAvailableModels();
+      expect(models[0].hasApiKey).toBe(false);
+    });
+
+    it('normalises array apiKeyEnvVar to the first entry', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        apiKeyEnvVar: ['FIRST_KEY', 'SECOND_KEY'],
+      });
+      const manager = new GatewayManager([gateway]);
+
+      const models = await manager.listAvailableModels();
+      expect(models[0].apiKeyEnvVar).toBe('FIRST_KEY');
+    });
+  });
+});

--- a/packages/core/src/llm/model/gateways/gateway-manager.ts
+++ b/packages/core/src/llm/model/gateways/gateway-manager.ts
@@ -1,0 +1,168 @@
+import { parseModelRouterId } from '../gateway-resolver.js';
+import type { GatewayAuthRequest, GatewayAuthResult, MastraModelGatewayInterface, ProviderConfig } from './base.js';
+import { findGatewayForModel, getGatewayId, shouldEnableGateway } from './gateway-helpers.js';
+
+/**
+ * A model entry in the gateway catalog (without use-count tracking).
+ */
+export interface GatewayModel {
+  /** Full model ID (e.g., "anthropic/claude-sonnet-4-20250514") */
+  id: string;
+  /** Provider prefix (e.g., "anthropic" or "netlify/anthropic") */
+  provider: string;
+  /** Model name without provider prefix */
+  modelName: string;
+  /** Whether the provider has valid authentication */
+  hasApiKey: boolean;
+  /** Environment variable for the provider's API key */
+  apiKeyEnvVar?: string;
+}
+
+/**
+ * Centralises the gateway-chain operations shared between
+ * {@link ModelRouterLanguageModel} and the Harness: gateway merging, model
+ * routing, auth resolution, and provider/model listing.
+ *
+ * The manager owns the *gateway registry* (which gateway owns a model, auth
+ * resolution through the chain). Per-instance concerns (explicit config,
+ * model-instance caching, websocket/transport, doGenerate/doStream) remain in
+ * the consumers.
+ */
+export class GatewayManager {
+  readonly gateways: MastraModelGatewayInterface[];
+
+  constructor(gateways: MastraModelGatewayInterface[] = []) {
+    this.gateways = gateways.filter(shouldEnableGateway);
+  }
+
+  /**
+   * Returns the gateway prefix used for model-id parsing.
+   * `models.dev` is a provider registry and doesn't use a prefix.
+   */
+  static getPrefix(gatewayId: string): string | undefined {
+    return gatewayId === 'models.dev' ? undefined : gatewayId;
+  }
+
+  /** Find the gateway that handles a given model/router id. */
+  findGatewayForModel(routerId: string): MastraModelGatewayInterface {
+    return findGatewayForModel(routerId, this.gateways);
+  }
+
+  /** Parse a router id into its provider/model/gateway components. */
+  parseModelId(routerId: string): { providerId: string; modelId: string; gatewayId: string } {
+    const gateway = this.findGatewayForModel(routerId);
+    const gatewayId = getGatewayId(gateway);
+    const { providerId, modelId } = parseModelRouterId(routerId, GatewayManager.getPrefix(gatewayId));
+    return { providerId, modelId, gatewayId };
+  }
+
+  /**
+   * Resolve auth through the gateway chain: select the gateway via
+   * {@link findGatewayForModel}, try its `resolveAuth()` (OAuth / stored
+   * credentials), and fall back to `getApiKey()` (which, for registry /
+   * openai-compatible providers, reads the API-key env var).
+   *
+   * The caller is responsible for merging any explicit headers/credentials
+   * from per-instance config on top of the result returned here.
+   */
+  async resolveAuth(routerId: string): Promise<GatewayAuthResult> {
+    const gateway = this.findGatewayForModel(routerId);
+    const gatewayId = getGatewayId(gateway);
+    const { providerId, modelId } = parseModelRouterId(routerId, GatewayManager.getPrefix(gatewayId));
+    const request: GatewayAuthRequest = { gatewayId, providerId, modelId, routerId };
+
+    const rawGatewayAuth = await gateway.resolveAuth?.(request);
+    const gatewayAuth = rawGatewayAuth?.bearerToken
+      ? {
+          ...rawGatewayAuth,
+          headers: { ...rawGatewayAuth.headers, Authorization: `Bearer ${rawGatewayAuth.bearerToken}` },
+        }
+      : rawGatewayAuth;
+
+    if (gatewayAuth?.apiKey || gatewayAuth?.headers || gatewayAuth?.bearerToken) {
+      return {
+        ...gatewayAuth,
+        source: gatewayAuth.source ?? 'gateway',
+      };
+    }
+
+    return {
+      apiKey: await gateway.getApiKey(routerId),
+      source: 'legacy',
+    };
+  }
+
+  /** Convenience: whether auth is available for a model. Never throws. */
+  async hasAuth(routerId: string): Promise<boolean> {
+    try {
+      const auth = await this.resolveAuth(routerId);
+      return Boolean(auth.apiKey || auth.bearerToken || auth.headers);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Fetch and flatten providers from all gateways, deduped by provider key
+   * (configured / earlier gateway wins). Each gateway's `fetchProviders()`
+   * is a network call for gateways like models.dev / Netlify.
+   */
+  async listProviders(): Promise<Record<string, ProviderConfig & { gateway: string }>> {
+    const registry: Record<string, ProviderConfig & { gateway: string }> = {};
+
+    for (const gateway of this.gateways) {
+      try {
+        const gatewayProviders = await gateway.fetchProviders();
+        for (const [providerId, config] of Object.entries(gatewayProviders)) {
+          const key = this.getProviderKey(gateway, providerId);
+          if (key in registry) continue; // earlier (configured) gateway wins
+          registry[key] = { ...config, gateway: getGatewayId(gateway) };
+        }
+      } catch (error) {
+        console.warn(`Failed to load providers from gateway ${getGatewayId(gateway)}:`, error);
+      }
+    }
+
+    return registry;
+  }
+
+  /**
+   * Build the model catalog from gateway providers, resolving auth per
+   * provider (using the first model). Returns models without use-count.
+   */
+  async listAvailableModels(): Promise<GatewayModel[]> {
+    const registry = await this.listProviders();
+    const models: GatewayModel[] = [];
+
+    for (const [provider, providerConfig] of Object.entries(registry)) {
+      const apiKeyEnvVar = Array.isArray(providerConfig.apiKeyEnvVar)
+        ? providerConfig.apiKeyEnvVar[0]
+        : providerConfig.apiKeyEnvVar;
+      const modelNames = providerConfig.models;
+      if (!Array.isArray(modelNames)) continue;
+
+      // Auth is resolved once per provider (using the first model) via the
+      // gateway chain, then applied to every model the provider exposes.
+      const hasApiKey = modelNames[0] ? await this.hasAuth(`${provider}/${modelNames[0]}`) : false;
+
+      for (const modelName of modelNames) {
+        models.push({
+          id: `${provider}/${modelName}`,
+          provider,
+          modelName,
+          hasApiKey,
+          apiKeyEnvVar: apiKeyEnvVar || undefined,
+        });
+      }
+    }
+
+    return models;
+  }
+
+  /** Provider key used for catalog ids: prefix with the gateway id unless it's the prefix-less models.dev registry. */
+  private getProviderKey(gateway: MastraModelGatewayInterface, providerId: string): string {
+    const gatewayId = getGatewayId(gateway);
+    if (gatewayId === 'models.dev') return providerId;
+    return providerId === gatewayId ? gatewayId : `${gatewayId}/${providerId}`;
+  }
+}

--- a/packages/core/src/llm/model/gateways/index.ts
+++ b/packages/core/src/llm/model/gateways/index.ts
@@ -1,5 +1,3 @@
-import { MastraError } from '../../../error/index.js';
-import type { MastraModelGatewayInterface } from './base.js';
 export {
   MastraModelGateway,
   type MastraModelGatewayInterface,
@@ -18,49 +16,6 @@ export {
 export { ModelsDevGateway } from './models-dev.js';
 export { MastraGateway, type MastraGatewayConfig } from './mastra.js';
 export { NetlifyGateway } from './netlify.js';
-
-export function getGatewayId(gateway: MastraModelGatewayInterface): string {
-  return gateway.getId?.() ?? gateway.id;
-}
-
-export function shouldEnableGateway(gateway: MastraModelGatewayInterface): boolean {
-  return gateway.shouldEnable?.() ?? true;
-}
-
-export function serializeGatewayForSpan(
-  gateway: MastraModelGatewayInterface,
-): { id: string; name: string } & Record<string, unknown> {
-  return gateway.serializeForSpan?.() ?? { id: getGatewayId(gateway), name: gateway.name };
-}
-
-/**
- * Find the gateway that handles a specific model ID based on gateway ID
- * Gateway ID is used as the prefix (e.g., "netlify" for netlify gateway)
- * Exception: models.dev is a provider registry and doesn't use a prefix
- */
-export function findGatewayForModel(
-  gatewayId: string,
-  gateways: MastraModelGatewayInterface[],
-): MastraModelGatewayInterface {
-  // First, check for gateways whose ID matches the prefix (true gateways like netlify, openrouter, vercel)
-  const prefixedGateway = gateways.find(g => {
-    const id = getGatewayId(g);
-    return id !== 'models.dev' && (id === gatewayId || gatewayId.startsWith(`${id}/`));
-  });
-  if (prefixedGateway) {
-    return prefixedGateway;
-  }
-
-  // Then check models.dev (provider registry without prefix)
-  const modelsDevGateway = gateways.find(g => getGatewayId(g) === 'models.dev');
-  if (modelsDevGateway) {
-    return modelsDevGateway;
-  }
-
-  throw new MastraError({
-    id: 'MODEL_ROUTER_NO_GATEWAY_FOUND',
-    category: 'USER',
-    domain: 'MODEL_ROUTER',
-    text: `No Mastra model router gateway found for model id ${gatewayId}`,
-  });
-}
+export { GatewayManager, type GatewayModel } from './gateway-manager.js';
+export { defaultGateways, gateways } from './defaults.js';
+export { getGatewayId, shouldEnableGateway, serializeGatewayForSpan, findGatewayForModel } from './gateway-helpers.js';

--- a/packages/core/src/llm/model/provider-registry.ts
+++ b/packages/core/src/llm/model/provider-registry.ts
@@ -8,7 +8,7 @@ import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import type { ProviderConfig, MastraModelGatewayInterface } from './gateways/base.js';
-import { getGatewayId, shouldEnableGateway } from './gateways/index.js';
+import { getGatewayId, shouldEnableGateway } from './gateways/gateway-helpers.js';
 import { MastraGateway } from './gateways/mastra.js';
 import { ModelsDevGateway } from './gateways/models-dev.js';
 import { NetlifyGateway } from './gateways/netlify.js';

--- a/packages/core/src/llm/model/router-supported-urls.test.ts
+++ b/packages/core/src/llm/model/router-supported-urls.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as gatewaysModule from './gateways/index';
+import * as gatewayHelpers from './gateways/gateway-helpers';
 import { ModelRouterLanguageModel } from './router';
 
 /**
@@ -46,7 +46,7 @@ describe('ModelRouterLanguageModel - supportedUrls propagation (Issue #12152)', 
     (ModelRouterLanguageModel as any)._clearCachesForTests();
 
     // Mock findGatewayForModel to return our mock gateway
-    vi.spyOn(gatewaysModule, 'findGatewayForModel').mockReturnValue(mockGateway as any);
+    vi.spyOn(gatewayHelpers, 'findGatewayForModel').mockReturnValue(mockGateway as any);
   });
 
   afterEach(() => {

--- a/packages/core/src/llm/model/router.ts
+++ b/packages/core/src/llm/model/router.ts
@@ -15,19 +15,17 @@ import type {
   GatewayLanguageModelWithStreamTransport,
   GatewayStreamTransportHandle,
   MastraModelGatewayInterface,
-  GatewayAuthRequest,
 } from './gateways/base.js';
-import { findGatewayForModel, getGatewayId } from './gateways/index.js';
+import { defaultGateways } from './gateways/defaults.js';
+import { GatewayManager, getGatewayId } from './gateways/index.js';
 
-import { MastraGateway } from './gateways/mastra.js';
-import { ModelsDevGateway } from './gateways/models-dev.js';
-import { NetlifyGateway } from './gateways/netlify.js';
 import { createOpenAIWebSocketFetch } from './openai-websocket-fetch.js';
 import type { OpenAIWebSocketFetch } from './openai-websocket-fetch.js';
 import type { OpenAITransport, ProviderOptions, ResponsesWebSocketOptions } from './provider-options.js';
 import type { ModelRouterModelId } from './provider-registry.js';
-import { PROVIDER_REGISTRY } from './provider-registry.js';
 import type { MastraLanguageModelV2, OpenAICompatibleConfig } from './shared.types';
+
+export { defaultGateways, gateways } from './gateways/defaults.js';
 
 /**
  * Type guard to check if a model is a LanguageModelV3 (AI SDK v6)
@@ -100,21 +98,6 @@ function mergeHeaders(
 
 type StreamResult = Awaited<ReturnType<LanguageModelV2['doStream']>>;
 
-function getStaticProvidersByGateway(name: string) {
-  return Object.fromEntries(Object.entries(PROVIDER_REGISTRY).filter(([_provider, config]) => config.gateway === name));
-}
-
-export const defaultGateways = [
-  new NetlifyGateway(),
-  new MastraGateway(),
-  new ModelsDevGateway(getStaticProvidersByGateway(`models.dev`)),
-];
-
-/**
- * @deprecated Use defaultGateways instead. This export will be removed in a future version.
- */
-export const gateways = defaultGateways;
-
 export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
   readonly specificationVersion = 'v2' as const;
   readonly defaultObjectGenerationMode = 'json' as const;
@@ -139,6 +122,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
   private _supportedUrlsPromise: Promise<Record<string, RegExp[]>> | null = null;
   private readonly instanceGatewayCache = createGatewayModelCache();
   #lastStreamTransport: StreamTransport | undefined;
+  #manager: GatewayManager;
 
   constructor(config: ModelRouterModelId | OpenAICompatibleConfig, customGateways?: MastraModelGatewayInterface[]) {
     // Normalize config to always have an 'id' field for routing
@@ -181,18 +165,12 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     };
 
     // Resolve gateway once using the normalized ID
-    // Merge custom gateways with defaults, deduplicating by gateway id (custom takes precedence)
-    const allGateways = customGateways?.length
-      ? [
-          ...customGateways,
-          ...defaultGateways.filter(dg => !customGateways.some(cg => getGatewayId(cg) === getGatewayId(dg))),
-        ]
-      : defaultGateways;
-    this.gateway = findGatewayForModel(normalizedConfig.id, allGateways);
+    const allGateways = [...(customGateways ?? []), ...defaultGateways];
+    this.#manager = new GatewayManager(allGateways);
+    this.gateway = this.#manager.findGatewayForModel(normalizedConfig.id);
     this.gatewayId = getGatewayId(this.gateway);
     // Extract provider from id if present
-    // Gateway ID is used as prefix (except for models.dev which is a provider registry)
-    const gatewayPrefix = this.gatewayId === 'models.dev' ? undefined : this.gatewayId;
+    const gatewayPrefix = GatewayManager.getPrefix(this.gatewayId);
     const parsed = parseModelRouterId(normalizedConfig.id, gatewayPrefix);
 
     this.provider = parsed.providerId || 'openai-compatible';
@@ -239,13 +217,10 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
   private async _fetchSupportedUrls(): Promise<Record<string, RegExp[]>> {
     let apiKey: string;
     try {
-      const parsed = parseModelRouterId(
-        this.config.routerId,
-        this.gatewayId === 'models.dev' ? undefined : this.gatewayId,
-      );
+      const parsed = parseModelRouterId(this.config.routerId, GatewayManager.getPrefix(this.gatewayId));
       const auth = await this.resolveAuth(parsed.providerId, parsed.modelId);
       apiKey = auth.apiKey ?? '';
-      const gatewayPrefix = this.gatewayId === 'models.dev' ? undefined : this.gatewayId;
+      const gatewayPrefix = GatewayManager.getPrefix(this.gatewayId);
       const model = await this.resolveLanguageModel({
         apiKey,
         auth,
@@ -338,48 +313,23 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     };
   }
 
-  private async resolveAuth(providerId: string, modelId: string): Promise<GatewayAuthResult> {
+  private async resolveAuth(_providerId: string, _modelId: string): Promise<GatewayAuthResult> {
     if (this.config.url) {
       return { apiKey: this.config.apiKey ?? '', headers: this.config.headers, source: 'explicit' };
     }
 
     const explicitHeaders = this.config.headers;
-    const explicitApiKey = this.config.apiKey;
-    const request: GatewayAuthRequest = {
-      gatewayId: this.gatewayId,
-      providerId,
-      modelId,
-      routerId: this.config.routerId,
-    };
 
     // explicit apiKey takes precedence
-    if (explicitApiKey) {
-      return { apiKey: explicitApiKey, headers: explicitHeaders, source: 'explicit' };
+    if (this.config.apiKey) {
+      return { apiKey: this.config.apiKey, headers: explicitHeaders, source: 'explicit' };
     }
 
-    // try gateway.resolveAuth
-    const rawGatewayAuth = await this.gateway.resolveAuth?.(request);
-    const gatewayAuth = rawGatewayAuth?.bearerToken
-      ? {
-          ...rawGatewayAuth,
-          headers: { ...rawGatewayAuth.headers, Authorization: `Bearer ${rawGatewayAuth.bearerToken}` },
-        }
-      : rawGatewayAuth;
+    // delegate gateway-chain resolution (resolveAuth → getApiKey) to the manager
+    const gatewayAuth = await this.#manager.resolveAuth(this.config.routerId);
 
-    if (gatewayAuth?.apiKey || gatewayAuth?.headers || gatewayAuth?.bearerToken) {
-      return {
-        ...gatewayAuth,
-        headers: { ...explicitHeaders, ...gatewayAuth.headers },
-        source: gatewayAuth.source ?? 'gateway',
-      };
-    }
-
-    // legacy fallback
-    return {
-      apiKey: await this.gateway.getApiKey(request.routerId),
-      headers: explicitHeaders,
-      source: 'legacy',
-    };
+    // merge any per-instance explicit headers on top of gateway-resolved auth
+    return explicitHeaders ? { ...gatewayAuth, headers: { ...explicitHeaders, ...gatewayAuth.headers } } : gatewayAuth;
   }
 
   private setStreamTransportFromCache({
@@ -405,10 +355,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     try {
       // If custom URL is provided, skip gateway API key resolution
       // The provider might not be in the registry (e.g., custom providers like ollama)
-      const parsed = parseModelRouterId(
-        this.config.routerId,
-        this.gatewayId === 'models.dev' ? undefined : this.gatewayId,
-      );
+      const parsed = parseModelRouterId(this.config.routerId, GatewayManager.getPrefix(this.gatewayId));
       auth = await this.resolveAuth(parsed.providerId, parsed.modelId);
     } catch (error) {
       // Return an error stream instead of throwing
@@ -425,7 +372,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       };
     }
 
-    const gatewayPrefix = this.gatewayId === 'models.dev' ? undefined : this.gatewayId;
+    const gatewayPrefix = GatewayManager.getPrefix(this.gatewayId);
     const model = await this.resolveLanguageModel({
       apiKey: auth.apiKey ?? '',
       auth,
@@ -449,10 +396,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     try {
       // If custom URL is provided, skip gateway API key resolution
       // The provider might not be in the registry (e.g., custom providers like ollama)
-      const parsed = parseModelRouterId(
-        this.config.routerId,
-        this.gatewayId === 'models.dev' ? undefined : this.gatewayId,
-      );
+      const parsed = parseModelRouterId(this.config.routerId, GatewayManager.getPrefix(this.gatewayId));
       auth = await this.resolveAuth(parsed.providerId, parsed.modelId);
     } catch (error) {
       // Return an error stream instead of throwing
@@ -469,7 +413,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       };
     }
 
-    const gatewayPrefix = this.gatewayId === 'models.dev' ? undefined : this.gatewayId;
+    const gatewayPrefix = GatewayManager.getPrefix(this.gatewayId);
     const parsedModelId = parseModelRouterId(this.config.routerId, gatewayPrefix);
     const { transport, websocket } = getOpenAITransport(
       options.providerOptions as ProviderOptions | undefined,

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -23,7 +23,7 @@ import { AvailableHooks, registerHook } from '../hooks';
 import { LicenseClient } from '../license';
 import type { MastraModelGatewayInterface } from '../llm/model/gateways';
 import { getGatewayId } from '../llm/model/gateways';
-import { defaultGateways } from '../llm/model/router';
+import { defaultGateways } from '../llm/model/gateways/defaults';
 import { LogLevel, noopLogger, ConsoleLogger, DualLogger } from '../logger';
 import type { IMastraLogger } from '../logger';
 import type { MCPServerBase } from '../mcp';


### PR DESCRIPTION
## Summary

Replace the `resolveModel`, `customModelCatalogProvider`, and `modelAuthChecker` hooks on `HarnessConfig` with unified gateway-based model resolution. All model resolution — mode agents, Observational Memory, subagents — now flows through the gateways registered on the Harness internal Mastra instance.

Additionally, the shared gateway logic that was duplicated between `ModelRouterLanguageModel` and the Harness (gateway merging/deduping, model→gateway selection, auth resolution, provider/model listing) is centralized into a new `GatewayManager` class that both consumers delegate to.

### Breaking Changes (`@mastra/core: major`)

- **`HarnessConfig.resolveModel`** removed — pass model id strings to modes; resolution happens lazily via gateways through the model router
- **`HarnessConfig.customModelCatalogProvider`** removed — model discovery now uses `gateway.fetchProviders()` directly
- **`HarnessConfig.modelAuthChecker`** removed — auth status resolved through the gateway chain (`resolveAuth()` → `getApiKey()`)
- **`ModelAuthChecker`** type removed from harness exports

### `GatewayManager` extraction

A new `GatewayManager` class (`packages/core/src/llm/model/gateways/gateway-manager.ts`) centralizes:
- Gateway merging (custom + defaults, deduped by id)
- `findGatewayForModel` selection (prefix-matched first, models.dev fallback)
- `parseModelId` (gateway prefix parsing)
- `resolveAuth` (3-tier: explicit config → `gateway.resolveAuth` → legacy `getApiKey`)
- `hasAuth` / `listProviders` / `listAvailableModels`

`ModelRouterLanguageModel` keeps per-instance concerns (caching, websocket/transport, doGenerate/doStream) but delegates the shared logic to `GatewayManager`. `defaultGateways` relocated from `router.ts` to `gateway-manager.ts` and re-exported for backward compatibility.

To break a circular dependency (`gateway-manager.ts` → `index.ts` → `gateway-manager.ts`), gateway helper functions (`getGatewayId`, `shouldEnableGateway`, `serializeGatewayForSpan`, `findGatewayForModel`) were extracted into a new `gateway-helpers.ts`.

### Other changes

- `createSession()` now properly wires `workspace` and `browser` params (previously accepted but ignored) with types matching `HarnessConfig`
- `CustomAvailableModel` and `CustomModelCatalogProvider` types re-exported from harness (still used by mastracode gateway)
- mastracode: removed unused imports (`resolveModel`, `customModelCatalogProvider`) from `HarnessConfig` instantiation; workspace/browser moved to `createSession()`

## Test Plan

- [x] `pnpm --filter ./packages/core check` — clean (0 errors)
- [x] `pnpm build:core` — successful (12 tasks)
- [x] Harness tests: 335 passed (35 test files)
- [x] Gateway/router tests: 160 passed, 2 skipped (12 test files)
- [x] GatewayManager unit tests: 19 passed
- [x] `pnpm prettier:changed` — clean
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Harness used to rely on custom “hooks” to figure out which AI models exist and whether you’re allowed to use them. This PR makes that work the same way everywhere by routing model discovery and access checks through the gateways you already register.

---

## Breaking Changes to `HarnessConfig`
`HarnessConfig` removed these model-resolution/auth extension hooks:
- `resolveModel`
- `customModelCatalogProvider`
- `modelAuthChecker`

The exported `ModelAuthChecker` type was also removed. As a result, `listAvailableModels()` and `getCurrentModelAuthStatus()` now come solely from gateways (no static/custom provider fallback).

---

## New Unified Gateway-Based Resolution (`GatewayManager`)
Added `GatewayManager` (`packages/core/src/llm/model/gateways/gateway-manager.ts`) to centralize shared gateway-chain behavior used by both the Harness and the model router. It handles:
- merging enabled gateways (defaults + user gateways), filtering disabled gateways, and deduping by gateway id
- mapping a router/model id to the right gateway (with consistent `models.dev` handling)
- parsing model ids into `{ gatewayId, providerId, modelId }`
- auth resolution by calling `gateway.resolveAuth()` when available, otherwise falling back to `gateway.getApiKey()` (with bearer-token → `Authorization: Bearer ...` conversion)
- provider and model listing via gateways’ `fetchProviders()` and gateway-driven model catalog construction

To avoid circular dependencies, gateway helper logic was extracted to:
- `packages/core/src/llm/model/gateways/gateway-helpers.ts` (`getGatewayId`, `shouldEnableGateway`, `serializeGatewayForSpan`, `findGatewayForModel`)

---

## Defaults / Backward Compatibility Exports
`defaultGateways` was moved out of `router.ts` into `packages/core/src/llm/model/gateways/defaults.ts` and re-exported so existing imports continue to work (with a deprecated `gateways` alias retained).

---

## Harness Refactor (Gateway-Driven)
`Harness` now integrates `GatewayManager` and wires session + model behavior through it:
- session wiring passes `gateways` into session machinery instead of providing `resolveModel`
- `listAvailableModels()` uses `GatewayManager.listAvailableModels()`
- `getCurrentModelAuthStatus()` uses `GatewayManager.hasAuth(modelId)` (and no longer uses the removed `modelAuthChecker`/catalog-based static mapping)
- mode agent creation now uses `mode.defaultModelId` directly (no conditional `resolveModel` behavior)
- subagent tool creation: subagents are created when `config.subagents` exist, and the created subagent tool forces an identity `resolveModel` while registering the subagent instance via the new callback

Also included:
- `createSession()` fix so `workspace` and `browser` are wired correctly through the options flow
- re-export cleanup in Harness so `CustomAvailableModel` and `CustomModelCatalogProvider` are surfaced as part of the harness package API

---

## SessionOM (Observational Memory) Updated to Gateways
`SessionOMRole` no longer accepts an injected `resolveModel(modelId)` callback. Instead it receives optional `gateways` in wiring and resolves the observer model via `ModelRouterLanguageModel` using those gateways.

---

## Model Router Refactor (`ModelRouterLanguageModel`)
`ModelRouterLanguageModel` keeps router instance concerns, but delegates shared gateway logic to `GatewayManager`:
- consistent gateway selection + id parsing + auth resolution via `GatewayManager`
- router defaults/gateways exports now come from the gateways module

---

## MastraCode Integration
Updated `mastracode` to match the new gateway-driven flow:
- removed unused model-catalog provider wiring
- aligned `workspace`/`browser` handling with the corrected `Harness.createSession()` wiring
- adjusted MastraCode model-related imports accordingly

---

## Tooling / Tests
- `CreateSubagentToolOptions` gained `registerAgent?: (agent: Agent) => void`, and Harness uses it when creating subagents
- Added `GatewayManager` unit tests and updated existing Harness/session/gateway/router tests to remove reliance on the deleted `HarnessConfig` hooks
- Formatting/linting validated (prettier, and existing core/gateway/router test suites were updated accordingly)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->