### PR TITLE
MASTRA-4413 feat(core, stores): experiments tenancy columns + targetType contract

### DIFF
--- a/.changeset/experiments-tenancy-columns.md
+++ b/.changeset/experiments-tenancy-columns.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': minor
+---
+
+Added multi-tenant scoping columns (`organizationId`, `projectId`) to the experiments domain so experiment records and per-item results inherit the tenancy bucket of their parent dataset.
+
+`Experiment`, `ExperimentResult`, `CreateExperimentInput`, and `AddExperimentResultInput` now carry optional `organizationId` / `projectId` fields. `ListExperimentsInput` and `ListExperimentResultsInput` gain a `filters: ExperimentTenancyFilters` block (mirrors `DatasetTenancyFilters`) for scoping queries within a `(organizationId, projectId)` bucket. Tenancy is hydrated from the parent dataset on `createExperiment` and denormalized onto each `ExperimentResult` for efficient tenancy-scoped queries.
+
+The corresponding columns are also added to the `mastra_experiments` and `mastra_experiment_results` table schemas. Existing rows backfill to `null`, matching the rest of the dataset-tenancy surface.
+
+This release also clarifies the `targetType` contract via JSDoc:
+
+- `CreateDatasetInput.targetType` remains optional. Datasets without a `TargetType` are **not experiment-eligible** — the experiment runner requires a non-null `CreateExperimentInput.targetType` to resolve an executor.
+- `Experiment.targetType` / `CreateExperimentInput.targetType` stay required. An experiment by definition replays inputs against a specific target.
+
+No behavior change for existing OSS-created experiments; the new fields are additive and optional.

--- a/.changeset/experiments-tenancy-columns.md
+++ b/.changeset/experiments-tenancy-columns.md
@@ -1,5 +1,10 @@
 ---
 '@mastra/core': minor
+'@mastra/libsql': patch
+'@mastra/pg': patch
+'@mastra/mongodb': patch
+'@mastra/mysql': patch
+'@mastra/spanner': patch
 ---
 
 Added multi-tenant scoping columns (`organizationId`, `projectId`) to the experiments domain so experiment records and per-item results inherit the tenancy bucket of their parent dataset.

--- a/.changeset/experiments-tenancy-columns.md
+++ b/.changeset/experiments-tenancy-columns.md
@@ -19,3 +19,34 @@ This release also clarifies the `targetType` contract via JSDoc:
 - `Experiment.targetType` / `CreateExperimentInput.targetType` stay required. An experiment by definition replays inputs against a specific target.
 
 No behavior change for existing OSS-created experiments; the new fields are additive and optional.
+
+Example:
+
+```ts
+// Create an experiment scoped to a tenancy bucket. When the parent dataset
+// already carries `organizationId` / `projectId`, `runExperiment` hydrates
+// these fields automatically from the dataset record.
+const experiment = await storage.createExperiment({
+  name: 'qa-regression',
+  datasetId: 'ds_123',
+  datasetVersion: 1,
+  targetType: 'agent',
+  targetId: 'agent_qa',
+  totalItems: 10,
+  organizationId: 'org_123',
+  projectId: 'proj_123',
+});
+
+// List experiments within a tenancy bucket.
+const experiments = await storage.listExperiments({
+  pagination: { page: 0, perPage: 20 },
+  filters: { organizationId: 'org_123', projectId: 'proj_123' },
+});
+
+// List per-item results within the same bucket.
+const results = await storage.listExperimentResults({
+  experimentId: experiment.id,
+  pagination: { page: 0, perPage: 50 },
+  filters: { organizationId: 'org_123', projectId: 'proj_123' },
+});
+```

--- a/packages/core/src/datasets/dataset.ts
+++ b/packages/core/src/datasets/dataset.ts
@@ -354,6 +354,8 @@ export class Dataset {
       description: config.description,
       metadata: config.metadata,
       agentVersion: config.agentVersion,
+      organizationId: dataset.organizationId ?? null,
+      projectId: dataset.projectId ?? null,
     });
 
     const experimentId = run.id;

--- a/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
@@ -818,4 +818,68 @@ describe('runExperiment', () => {
       expect(result.experiments.length).toBe(0);
     });
   });
+
+  describe('tenancy hydration', () => {
+    it('hydrates organizationId and projectId from the parent dataset onto experiment + results', async () => {
+      // Create a tenancy-scoped dataset with items
+      const tenantDs = await datasetsStorage.createDataset({
+        name: 'Tenant Dataset',
+        organizationId: 'org_tenant',
+        projectId: 'proj_tenant',
+      });
+      await datasetsStorage.addItem({
+        datasetId: tenantDs.id,
+        input: { prompt: 'A' },
+        groundTruth: { text: 'a' },
+      });
+      await datasetsStorage.addItem({
+        datasetId: tenantDs.id,
+        input: { prompt: 'B' },
+        groundTruth: { text: 'b' },
+      });
+
+      const result = await runExperiment(mastra, {
+        datasetId: tenantDs.id,
+        targetType: 'agent',
+        targetId: 'test-agent',
+      });
+
+      const storedRun = await experimentsStorage.getExperimentById({ id: result.experimentId });
+      expect(storedRun?.organizationId).toBe('org_tenant');
+      expect(storedRun?.projectId).toBe('proj_tenant');
+
+      const persisted = await experimentsStorage.listExperimentResults({
+        experimentId: result.experimentId,
+        pagination: { page: 0, perPage: 50 },
+      });
+      expect(persisted.results).toHaveLength(2);
+      for (const r of persisted.results) {
+        expect(r.organizationId).toBe('org_tenant');
+        expect(r.projectId).toBe('proj_tenant');
+      }
+    });
+
+    it('defaults tenancy to null when the parent dataset has no tenancy bucket', async () => {
+      // The default test dataset (set up in beforeEach) has no tenancy
+      const result = await runExperiment(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+      });
+
+      const storedRun = await experimentsStorage.getExperimentById({ id: result.experimentId });
+      expect(storedRun?.organizationId).toBeNull();
+      expect(storedRun?.projectId).toBeNull();
+
+      const persisted = await experimentsStorage.listExperimentResults({
+        experimentId: result.experimentId,
+        pagination: { page: 0, perPage: 50 },
+      });
+      expect(persisted.results.length).toBeGreaterThan(0);
+      for (const r of persisted.results) {
+        expect(r.organizationId).toBeNull();
+        expect(r.projectId).toBeNull();
+      }
+    });
+  });
 });

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -319,6 +319,8 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
         targetId: targetId ?? 'inline',
         totalItems: items.length,
         agentVersion,
+        organizationId: datasetRecord?.organizationId ?? null,
+        projectId: datasetRecord?.projectId ?? null,
       });
     }
     // Update status to running (both sync and async paths)
@@ -467,6 +469,8 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
               completedAt: itemCompletedAt,
               retryCount,
               traceId: execResult.traceId,
+              organizationId: datasetRecord?.organizationId ?? null,
+              projectId: datasetRecord?.projectId ?? null,
               ...(execResult.toolMockReport ? { toolMockReport: execResult.toolMockReport } : {}),
             });
           } catch (persistError) {

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -573,6 +573,8 @@ export const EXPERIMENTS_SCHEMA: Record<string, StorageColumn> = {
   startedAt: { type: 'timestamp', nullable: true },
   completedAt: { type: 'timestamp', nullable: true },
   agentVersion: { type: 'text', nullable: true },
+  organizationId: { type: 'text', nullable: true },
+  projectId: { type: 'text', nullable: true },
   createdAt: { type: 'timestamp', nullable: false },
   updatedAt: { type: 'timestamp', nullable: false },
 };
@@ -593,6 +595,8 @@ export const EXPERIMENT_RESULTS_SCHEMA: Record<string, StorageColumn> = {
   status: { type: 'text', nullable: true },
   tags: { type: 'jsonb', nullable: true },
   toolMockReport: { type: 'jsonb', nullable: true },
+  organizationId: { type: 'text', nullable: true },
+  projectId: { type: 'text', nullable: true },
   createdAt: { type: 'timestamp', nullable: false },
 };
 

--- a/packages/core/src/storage/domains/experiments/inmemory.ts
+++ b/packages/core/src/storage/domains/experiments/inmemory.ts
@@ -46,6 +46,8 @@ export class ExperimentsInMemory extends ExperimentsStorage {
       succeededCount: 0,
       failedCount: 0,
       skippedCount: 0,
+      organizationId: input.organizationId ?? null,
+      projectId: input.projectId ?? null,
       startedAt: null,
       completedAt: null,
       createdAt: now,
@@ -101,6 +103,12 @@ export class ExperimentsInMemory extends ExperimentsStorage {
     if (args.status) {
       experiments = experiments.filter(r => r.status === args.status);
     }
+    if (args.filters?.organizationId !== undefined) {
+      experiments = experiments.filter(r => (r.organizationId ?? null) === args.filters!.organizationId);
+    }
+    if (args.filters?.projectId !== undefined) {
+      experiments = experiments.filter(r => (r.projectId ?? null) === args.filters!.projectId);
+    }
 
     // Sort by createdAt descending (newest first)
     experiments.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
@@ -150,6 +158,8 @@ export class ExperimentsInMemory extends ExperimentsStorage {
       status: input.status ?? null,
       tags: input.tags ?? null,
       toolMockReport: input.toolMockReport ?? null,
+      organizationId: input.organizationId ?? null,
+      projectId: input.projectId ?? null,
       createdAt: now,
     };
     this.db.experimentResults.set(result.id, result);
@@ -186,6 +196,12 @@ export class ExperimentsInMemory extends ExperimentsStorage {
     }
     if (args.status) {
       results = results.filter(r => r.status === args.status);
+    }
+    if (args.filters?.organizationId !== undefined) {
+      results = results.filter(r => (r.organizationId ?? null) === args.filters!.organizationId);
+    }
+    if (args.filters?.projectId !== undefined) {
+      results = results.filter(r => (r.projectId ?? null) === args.filters!.projectId);
     }
 
     // Sort by startedAt ascending (execution order)

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -2488,6 +2488,16 @@ export interface CreateDatasetInput {
   inputSchema?: Record<string, unknown> | null;
   groundTruthSchema?: Record<string, unknown> | null;
   requestContextSchema?: Record<string, unknown> | null;
+  /**
+   * Discriminator for the target this dataset's items will be replayed against.
+   * Optional because a dataset can exist purely as a collection of items
+   * (e.g. emitted by a detector for a target kind OSS doesn't yet know how to
+   * run). Datasets created without a {@link TargetType} are **not
+   * experiment-eligible**: the experiment runner requires a non-null
+   * {@link CreateExperimentInput.targetType} to resolve an executor, so a
+   * downstream consumer must either set this on create or refuse to run an
+   * experiment against the dataset.
+   */
   targetType?: TargetType;
   targetIds?: string[];
   scorerIds?: string[];
@@ -2643,6 +2653,10 @@ export interface Experiment {
   failedCount: number;
   skippedCount: number;
   agentVersion?: string | null;
+  /** Multi-tenant organization/account scope. Hydrated from the parent dataset on create. */
+  organizationId?: string | null;
+  /** Platform project scope. Pairs with {@link Experiment.organizationId} to form the experiment's tenancy bucket. */
+  projectId?: string | null;
   startedAt: Date | null;
   completedAt: Date | null;
   createdAt: Date;
@@ -2667,6 +2681,10 @@ export interface ExperimentResult {
   status: ExperimentResultStatus | null;
   tags: string[] | null;
   toolMockReport?: DatasetToolMockReport | null;
+  /** Multi-tenant organization/account scope. Denormalized from the parent experiment for efficient tenancy-scoped queries. */
+  organizationId?: string | null;
+  /** Platform project scope. Pairs with {@link ExperimentResult.organizationId} to form the result's tenancy bucket. */
+  projectId?: string | null;
   createdAt: Date;
 }
 
@@ -2686,9 +2704,26 @@ export interface CreateExperimentInput {
   datasetId: string | null;
   datasetVersion: number | null;
   agentVersion?: string;
+  /**
+   * Discriminator for the target this experiment runs against. Required because
+   * an experiment by definition replays inputs through a specific target; the
+   * runner uses this to resolve the correct executor. Datasets whose
+   * {@link CreateDatasetInput.targetType} is absent are not experiment-eligible.
+   */
   targetType: TargetType;
   targetId: string;
   totalItems: number;
+  /**
+   * Multi-tenant organization/account scope. Should be hydrated from the parent
+   * dataset on create so experiments inherit their dataset's tenancy bucket.
+   */
+  organizationId?: string | null;
+  /**
+   * Platform project scope. Pairs with {@link CreateExperimentInput.organizationId}
+   * to form the (organizationId, projectId) tenancy bucket. Hydrated from the
+   * parent dataset on create.
+   */
+  projectId?: string | null;
 }
 
 export interface UpdateExperimentInput {
@@ -2726,6 +2761,20 @@ export interface AddExperimentResultInput {
    * ran with mocks — see `served`/`unconsumed`/`liveCalls`/`failure`.
    */
   toolMockReport?: DatasetToolMockReport | null;
+  /** Multi-tenant organization/account scope. Should be hydrated from the parent experiment on insert. */
+  organizationId?: string | null;
+  /** Platform project scope. Hydrated from the parent experiment on insert. */
+  projectId?: string | null;
+}
+
+/**
+ * Multi-tenant scoping filters for experiment queries. Mirrors
+ * {@link DatasetTenancyFilters} so the experiments domain can be queried
+ * within a tenancy bucket using the same shape.
+ */
+export interface ExperimentTenancyFilters {
+  organizationId?: string;
+  projectId?: string;
 }
 
 export interface ListExperimentsInput {
@@ -2734,6 +2783,8 @@ export interface ListExperimentsInput {
   targetId?: string;
   agentVersion?: string;
   status?: ExperimentStatus;
+  /** Multi-tenant scoping filters. See {@link ExperimentTenancyFilters}. */
+  filters?: ExperimentTenancyFilters;
   pagination: StoragePagination;
 }
 
@@ -2746,6 +2797,8 @@ export interface ListExperimentResultsInput {
   experimentId: string;
   traceId?: string;
   status?: ExperimentResultStatus;
+  /** Multi-tenant scoping filters. See {@link ExperimentTenancyFilters}. */
+  filters?: ExperimentTenancyFilters;
   pagination: StoragePagination;
 }
 

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -2645,6 +2645,14 @@ export interface Experiment {
   metadata?: Record<string, unknown>;
   datasetId: string | null;
   datasetVersion: number | null;
+  /**
+   * The kind of executor this experiment runs against (agent / workflow / scorer / processor).
+   *
+   * Required: an experiment by definition replays inputs against a specific target, so the runner
+   * always needs a target type to resolve the executor. This differs from
+   * {@link CreateDatasetInput.targetType} (optional) — a dataset can exist without a designated
+   * target, but a dataset without one is not experiment-eligible.
+   */
   targetType: TargetType;
   targetId: string;
   status: ExperimentStatus;

--- a/stores/_test-utils/src/domains/datasets/index.ts
+++ b/stores/_test-utils/src/domains/datasets/index.ts
@@ -339,6 +339,53 @@ export function createDatasetsTests({
           expect(tombstone!.projectId).toBe('proj_batch');
         }
       });
+
+      it('addItem inherits tenancy from parent dataset onto the live row', async () => {
+        const ds = await datasetsStorage.createDataset({
+          name: 'scd2-add-tenancy',
+          organizationId: 'org_add',
+          projectId: 'proj_add',
+        });
+        const item = await datasetsStorage.addItem({ datasetId: ds.id, input: { q: 'hello' } });
+
+        expect(item.organizationId).toBe('org_add');
+        expect(item.projectId).toBe('proj_add');
+
+        // Also assert via listItems so we exercise the persisted row mapper, not just the returned value
+        const listed = await datasetsStorage.listItems({
+          datasetId: ds.id,
+          pagination: { page: 0, perPage: 10 },
+        });
+        const persisted = listed.items.find(i => i.id === item.id);
+        expect(persisted).toBeDefined();
+        expect(persisted!.organizationId).toBe('org_add');
+        expect(persisted!.projectId).toBe('proj_add');
+      });
+
+      it('updateItem re-inherits tenancy from parent dataset onto the new live row', async () => {
+        const ds = await datasetsStorage.createDataset({
+          name: 'scd2-update-tenancy',
+          organizationId: 'org_update',
+          projectId: 'proj_update',
+        });
+        const item = await datasetsStorage.addItem({ datasetId: ds.id, input: { q: 'v1' } });
+
+        const updated = await datasetsStorage.updateItem({
+          id: item.id,
+          datasetId: ds.id,
+          input: { q: 'v2' },
+        });
+
+        expect(updated.organizationId).toBe('org_update');
+        expect(updated.projectId).toBe('proj_update');
+
+        // History should include the new live row carrying tenancy
+        const history = await datasetsStorage.getItemHistory(item.id);
+        const live = history.find(h => h.validTo === null && !h.isDeleted);
+        expect(live).toBeDefined();
+        expect(live!.organizationId).toBe('org_update');
+        expect(live!.projectId).toBe('proj_update');
+      });
     });
 
     // ---------------------------------------------------------------------------

--- a/stores/_test-utils/src/domains/experiments/index.ts
+++ b/stores/_test-utils/src/domains/experiments/index.ts
@@ -523,5 +523,151 @@ export function createExperimentsTests({
         expect(list.experiments).toHaveLength(0);
       });
     });
+
+    // ---------------------------------------------------------------------------
+    // Tenancy
+    // ---------------------------------------------------------------------------
+    describe('Tenancy', () => {
+      beforeEach(async () => {
+        await experimentsStorage.dangerouslyClearAll();
+      });
+
+      it('createExperiment persists organizationId and projectId', async () => {
+        const exp = await experimentsStorage.createExperiment({
+          name: 'tenancy-create',
+          datasetId: null,
+          datasetVersion: null,
+          targetType: 'agent',
+          targetId: 'agent-1',
+          totalItems: 1,
+          organizationId: 'org_a',
+          projectId: 'proj_a',
+        });
+
+        expect(exp.organizationId).toBe('org_a');
+        expect(exp.projectId).toBe('proj_a');
+
+        const reread = await experimentsStorage.getExperimentById({ id: exp.id });
+        expect(reread?.organizationId).toBe('org_a');
+        expect(reread?.projectId).toBe('proj_a');
+      });
+
+      it('createExperiment defaults tenancy fields to null when omitted', async () => {
+        const exp = await experimentsStorage.createExperiment({
+          name: 'tenancy-null',
+          datasetId: null,
+          datasetVersion: null,
+          targetType: 'agent',
+          targetId: 'agent-1',
+          totalItems: 1,
+        });
+
+        expect(exp.organizationId).toBeNull();
+        expect(exp.projectId).toBeNull();
+      });
+
+      it('listExperiments filters by organizationId and projectId', async () => {
+        await experimentsStorage.createExperiment({
+          name: 'a-1',
+          datasetId: null,
+          datasetVersion: null,
+          targetType: 'agent',
+          targetId: 'agent-1',
+          totalItems: 1,
+          organizationId: 'org_a',
+          projectId: 'proj_1',
+        });
+        await experimentsStorage.createExperiment({
+          name: 'a-2',
+          datasetId: null,
+          datasetVersion: null,
+          targetType: 'agent',
+          targetId: 'agent-1',
+          totalItems: 1,
+          organizationId: 'org_a',
+          projectId: 'proj_2',
+        });
+        await experimentsStorage.createExperiment({
+          name: 'b-1',
+          datasetId: null,
+          datasetVersion: null,
+          targetType: 'agent',
+          targetId: 'agent-1',
+          totalItems: 1,
+          organizationId: 'org_b',
+          projectId: 'proj_1',
+        });
+
+        const byOrg = await experimentsStorage.listExperiments({
+          pagination: { page: 0, perPage: 50 },
+          filters: { organizationId: 'org_a' },
+        });
+        expect(byOrg.experiments.map(e => e.name).sort()).toEqual(['a-1', 'a-2']);
+
+        const byOrgAndProject = await experimentsStorage.listExperiments({
+          pagination: { page: 0, perPage: 50 },
+          filters: { organizationId: 'org_a', projectId: 'proj_1' },
+        });
+        expect(byOrgAndProject.experiments.map(e => e.name)).toEqual(['a-1']);
+      });
+
+      it('addExperimentResult persists tenancy and listExperimentResults filters by it', async () => {
+        const exp = await experimentsStorage.createExperiment({
+          name: 'results-tenancy',
+          datasetId: null,
+          datasetVersion: null,
+          targetType: 'agent',
+          targetId: 'agent-1',
+          totalItems: 2,
+          organizationId: 'org_a',
+          projectId: 'proj_a',
+        });
+
+        await experimentsStorage.addExperimentResult({
+          experimentId: exp.id,
+          itemId: 'item-1',
+          itemDatasetVersion: null,
+          input: { x: 1 },
+          output: { y: 1 },
+          groundTruth: null,
+          error: null,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          retryCount: 0,
+          organizationId: 'org_a',
+          projectId: 'proj_a',
+        });
+        await experimentsStorage.addExperimentResult({
+          experimentId: exp.id,
+          itemId: 'item-2',
+          itemDatasetVersion: null,
+          input: { x: 2 },
+          output: { y: 2 },
+          groundTruth: null,
+          error: null,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          retryCount: 0,
+          organizationId: 'org_b',
+          projectId: 'proj_b',
+        });
+
+        const orgA = await experimentsStorage.listExperimentResults({
+          experimentId: exp.id,
+          pagination: { page: 0, perPage: 50 },
+          filters: { organizationId: 'org_a' },
+        });
+        expect(orgA.results.map(r => r.itemId)).toEqual(['item-1']);
+        expect(orgA.results[0]!.organizationId).toBe('org_a');
+        expect(orgA.results[0]!.projectId).toBe('proj_a');
+
+        const projB = await experimentsStorage.listExperimentResults({
+          experimentId: exp.id,
+          pagination: { page: 0, perPage: 50 },
+          filters: { projectId: 'proj_b' },
+        });
+        expect(projB.results.map(r => r.itemId)).toEqual(['item-2']);
+      });
+    });
   }); // describeExperiments
 }

--- a/stores/_test-utils/src/domains/experiments/index.ts
+++ b/stores/_test-utils/src/domains/experiments/index.ts
@@ -611,20 +611,34 @@ export function createExperimentsTests({
         expect(byOrgAndProject.experiments.map(e => e.name)).toEqual(['a-1']);
       });
 
-      it('addExperimentResult persists tenancy and listExperimentResults filters by it', async () => {
-        const exp = await experimentsStorage.createExperiment({
-          name: 'results-tenancy',
+      it('addExperimentResult persists tenancy inherited from parent and listExperimentResults filters by it', async () => {
+        // Two experiments under distinct tenancies — results denormalize their
+        // parent's tenancy, mirroring the materializer/runner contract. We do
+        // NOT cross-stamp results from a different tenancy onto the same
+        // experiment: that would violate the parent→child invariant.
+        const expA = await experimentsStorage.createExperiment({
+          name: 'results-tenancy-a',
           datasetId: null,
           datasetVersion: null,
           targetType: 'agent',
           targetId: 'agent-1',
-          totalItems: 2,
+          totalItems: 1,
           organizationId: 'org_a',
           projectId: 'proj_a',
         });
+        const expB = await experimentsStorage.createExperiment({
+          name: 'results-tenancy-b',
+          datasetId: null,
+          datasetVersion: null,
+          targetType: 'agent',
+          targetId: 'agent-1',
+          totalItems: 1,
+          organizationId: 'org_b',
+          projectId: 'proj_b',
+        });
 
         await experimentsStorage.addExperimentResult({
-          experimentId: exp.id,
+          experimentId: expA.id,
           itemId: 'item-1',
           itemDatasetVersion: null,
           input: { x: 1 },
@@ -634,11 +648,11 @@ export function createExperimentsTests({
           startedAt: new Date(),
           completedAt: new Date(),
           retryCount: 0,
-          organizationId: 'org_a',
-          projectId: 'proj_a',
+          organizationId: expA.organizationId,
+          projectId: expA.projectId,
         });
         await experimentsStorage.addExperimentResult({
-          experimentId: exp.id,
+          experimentId: expB.id,
           itemId: 'item-2',
           itemDatasetVersion: null,
           input: { x: 2 },
@@ -648,25 +662,38 @@ export function createExperimentsTests({
           startedAt: new Date(),
           completedAt: new Date(),
           retryCount: 0,
-          organizationId: 'org_b',
-          projectId: 'proj_b',
+          organizationId: expB.organizationId,
+          projectId: expB.projectId,
         });
 
-        const orgA = await experimentsStorage.listExperimentResults({
-          experimentId: exp.id,
+        // Filtering expA's results by org_a returns the one inherited result;
+        // filtering by org_b returns nothing because expA's results inherit
+        // expA's tenancy.
+        const expAOrgA = await experimentsStorage.listExperimentResults({
+          experimentId: expA.id,
           pagination: { page: 0, perPage: 50 },
           filters: { organizationId: 'org_a' },
         });
-        expect(orgA.results.map(r => r.itemId)).toEqual(['item-1']);
-        expect(orgA.results[0]!.organizationId).toBe('org_a');
-        expect(orgA.results[0]!.projectId).toBe('proj_a');
+        expect(expAOrgA.results.map(r => r.itemId)).toEqual(['item-1']);
+        expect(expAOrgA.results[0]!.organizationId).toBe('org_a');
+        expect(expAOrgA.results[0]!.projectId).toBe('proj_a');
 
-        const projB = await experimentsStorage.listExperimentResults({
-          experimentId: exp.id,
+        const expAOrgB = await experimentsStorage.listExperimentResults({
+          experimentId: expA.id,
+          pagination: { page: 0, perPage: 50 },
+          filters: { organizationId: 'org_b' },
+        });
+        expect(expAOrgB.results).toEqual([]);
+
+        // Symmetric check for expB filtered by its own project.
+        const expBProjB = await experimentsStorage.listExperimentResults({
+          experimentId: expB.id,
           pagination: { page: 0, perPage: 50 },
           filters: { projectId: 'proj_b' },
         });
-        expect(projB.results.map(r => r.itemId)).toEqual(['item-2']);
+        expect(expBProjB.results.map(r => r.itemId)).toEqual(['item-2']);
+        expect(expBProjB.results[0]!.organizationId).toBe('org_b');
+        expect(expBProjB.results[0]!.projectId).toBe('proj_b');
       });
     });
   }); // describeExperiments

--- a/stores/libsql/src/storage/domains/experiments/index.ts
+++ b/stores/libsql/src/storage/domains/experiments/index.ts
@@ -50,12 +50,12 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENTS,
       schema: EXPERIMENTS_SCHEMA,
-      ifNotExists: ['agentVersion'],
+      ifNotExists: ['agentVersion', 'organizationId', 'projectId'],
     });
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: EXPERIMENT_RESULTS_SCHEMA,
-      ifNotExists: ['status', 'tags', 'toolMockReport'],
+      ifNotExists: ['status', 'tags', 'toolMockReport', 'organizationId', 'projectId'],
     });
 
     // Indexes — idempotent, safe to run on every init
@@ -71,6 +71,15 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
         },
         {
           sql: `CREATE UNIQUE INDEX IF NOT EXISTS idx_experiment_results_exp_item ON "${TABLE_EXPERIMENT_RESULTS}" ("experimentId", "itemId")`,
+          args: [],
+        },
+        // Tenancy: leading-tenant indexes for multi-tenant scans (parity with datasets domain).
+        {
+          sql: `CREATE INDEX IF NOT EXISTS idx_experiments_org_project ON "${TABLE_EXPERIMENTS}" ("organizationId", "projectId")`,
+          args: [],
+        },
+        {
+          sql: `CREATE INDEX IF NOT EXISTS idx_experiment_results_org_project ON "${TABLE_EXPERIMENT_RESULTS}" ("organizationId", "projectId")`,
           args: [],
         },
       ],
@@ -90,6 +99,8 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       datasetId: (row.datasetId as string | null) ?? null,
       datasetVersion: row.datasetVersion != null ? (row.datasetVersion as number) : null,
       agentVersion: (row.agentVersion as string | null) ?? null,
+      organizationId: (row.organizationId as string | null) ?? null,
+      projectId: (row.projectId as string | null) ?? null,
       targetType: row.targetType as Experiment['targetType'],
       targetId: row.targetId as string,
       name: (row.name as string) ?? undefined,
@@ -114,6 +125,8 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       experimentId: row.experimentId as string,
       itemId: row.itemId as string,
       itemDatasetVersion: row.itemDatasetVersion != null ? (row.itemDatasetVersion as number) : null,
+      organizationId: (row.organizationId as string | null) ?? null,
+      projectId: (row.projectId as string | null) ?? null,
       input: safelyParseJSON(row.input as string),
       output: row.output ? safelyParseJSON(row.output as string) : null,
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth as string) : null,
@@ -143,6 +156,8 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
           datasetId: input.datasetId ?? null,
           datasetVersion: input.datasetVersion ?? null,
           agentVersion: input.agentVersion ?? null,
+          organizationId: input.organizationId ?? null,
+          projectId: input.projectId ?? null,
           targetType: input.targetType,
           targetId: input.targetId,
           name: input.name ?? null,
@@ -165,6 +180,8 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
         datasetId: input.datasetId,
         datasetVersion: input.datasetVersion,
         agentVersion: input.agentVersion ?? null,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         targetType: input.targetType,
         targetId: input.targetId,
         name: input.name,
@@ -319,6 +336,17 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
         conditions.push('status = ?');
         queryParams.push(args.status);
       }
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          conditions.push('organizationId = ?');
+          queryParams.push(organizationId);
+        }
+        if (projectId !== undefined) {
+          conditions.push('projectId = ?');
+          queryParams.push(projectId);
+        }
+      }
 
       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
@@ -404,6 +432,8 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
           experimentId: input.experimentId,
           itemId: input.itemId,
           itemDatasetVersion: input.itemDatasetVersion ?? null,
+          organizationId: input.organizationId ?? null,
+          projectId: input.projectId ?? null,
           input: input.input,
           output: input.output,
           groundTruth: input.groundTruth,
@@ -424,6 +454,8 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
         experimentId: input.experimentId,
         itemId: input.itemId,
         itemDatasetVersion: input.itemDatasetVersion,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         input: input.input,
         output: input.output,
         groundTruth: input.groundTruth,
@@ -553,6 +585,17 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       if (args.status) {
         conditions.push('status = ?');
         queryParams.push(args.status);
+      }
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          conditions.push('organizationId = ?');
+          queryParams.push(organizationId);
+        }
+        if (projectId !== undefined) {
+          conditions.push('projectId = ?');
+          queryParams.push(projectId);
+        }
       }
 
       const whereClause = `WHERE ${conditions.join(' AND ')}`;

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -57,6 +57,8 @@ function transformExperimentRow(row: Record<string, unknown>): Experiment {
     metadata: parseJsonField(row.metadata) ?? undefined,
     datasetId: (row.datasetId as string | null) ?? null,
     datasetVersion: row.datasetVersion != null ? Number(row.datasetVersion) : null,
+    organizationId: (row.organizationId as string | null) ?? null,
+    projectId: (row.projectId as string | null) ?? null,
     targetType: row.targetType as Experiment['targetType'],
     targetId: row.targetId as string,
     status: row.status as Experiment['status'],
@@ -78,6 +80,8 @@ function transformExperimentResultRow(row: Record<string, unknown>): ExperimentR
     experimentId: row.experimentId as string,
     itemId: row.itemId as string,
     itemDatasetVersion: row.itemDatasetVersion != null ? Number(row.itemDatasetVersion) : null,
+    organizationId: (row.organizationId as string | null) ?? null,
+    projectId: (row.projectId as string | null) ?? null,
     input: parseJsonField(row.input),
     output: parseJsonField(row.output) ?? null,
     groundTruth: parseJsonField(row.groundTruth) ?? null,
@@ -126,11 +130,14 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
       { collection: TABLE_EXPERIMENTS, keys: { id: 1 }, options: { unique: true } },
       { collection: TABLE_EXPERIMENTS, keys: { datasetId: 1 } },
       { collection: TABLE_EXPERIMENTS, keys: { createdAt: -1, id: 1 } },
+      // Tenancy: leading-tenant indexes for multi-tenant scans (parity with datasets domain).
+      { collection: TABLE_EXPERIMENTS, keys: { organizationId: 1, projectId: 1 } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { id: 1 }, options: { unique: true } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1 } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1, itemId: 1 }, options: { unique: true } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { createdAt: -1 } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1, startedAt: 1, id: 1 } },
+      { collection: TABLE_EXPERIMENT_RESULTS, keys: { organizationId: 1, projectId: 1 } },
     ];
   }
 
@@ -178,6 +185,8 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
       metadata: input.metadata ?? null,
       datasetId: input.datasetId ?? null,
       datasetVersion: input.datasetVersion ?? null,
+      organizationId: input.organizationId ?? null,
+      projectId: input.projectId ?? null,
       targetType: input.targetType,
       targetId: input.targetId,
       status: 'pending' as const,
@@ -203,6 +212,8 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
         metadata: input.metadata,
         datasetId: input.datasetId ?? null,
         datasetVersion: input.datasetVersion ?? null,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         targetType: input.targetType,
         targetId: input.targetId,
         status: 'pending',
@@ -312,6 +323,15 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
       if (args.status) {
         filter.status = args.status;
       }
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          filter.organizationId = organizationId;
+        }
+        if (projectId !== undefined) {
+          filter.projectId = projectId;
+        }
+      }
 
       const total = await collection.countDocuments(filter);
 
@@ -391,6 +411,8 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
       experimentId: input.experimentId,
       itemId: input.itemId,
       itemDatasetVersion: input.itemDatasetVersion ?? null,
+      organizationId: input.organizationId ?? null,
+      projectId: input.projectId ?? null,
       input: input.input,
       output: input.output ?? null,
       groundTruth: input.groundTruth ?? null,
@@ -414,6 +436,8 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
         experimentId: input.experimentId,
         itemId: input.itemId,
         itemDatasetVersion: input.itemDatasetVersion ?? null,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         input: input.input,
         output: input.output ?? null,
         groundTruth: input.groundTruth ?? null,
@@ -523,6 +547,15 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
       }
       if (args.status) {
         filter.status = args.status;
+      }
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          filter.organizationId = organizationId;
+        }
+        if (projectId !== undefined) {
+          filter.projectId = projectId;
+        }
       }
 
       const total = await collection.countDocuments(filter);

--- a/stores/mysql/src/storage/domains/experiments/index.ts
+++ b/stores/mysql/src/storage/domains/experiments/index.ts
@@ -97,10 +97,22 @@ export class ExperimentsMySQL extends ExperimentsStorage {
 
   /**
    * Returns default index definitions for the experiments domain tables.
-   * Currently no default indexes are defined for experiments.
    */
   static getDefaultIndexDefs(_prefix: string = ''): CreateIndexOptions[] {
-    return [];
+    return [
+      // Tenancy: leading-tenant indexes for multi-tenant scans (parity with
+      // pg/libsql/spanner/mongodb experiments adapters).
+      {
+        name: 'idx_experiments_org_project',
+        table: TABLE_EXPERIMENTS,
+        columns: ['organizationId', 'projectId'],
+      },
+      {
+        name: 'idx_experiment_results_org_project',
+        table: TABLE_EXPERIMENT_RESULTS,
+        columns: ['organizationId', 'projectId'],
+      },
+    ];
   }
 
   /**
@@ -140,11 +152,12 @@ export class ExperimentsMySQL extends ExperimentsStorage {
 
   /**
    * Creates default indexes for optimal query performance.
-   * Currently no default indexes are defined for experiments.
    */
   async createDefaultIndexes(): Promise<void> {
     if (this.#skipDefaultIndexes) return;
-    // No default indexes for experiments domain
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      await this.operations.createIndex(indexDef);
+    }
   }
 
   /**
@@ -647,6 +660,14 @@ export class ExperimentsMySQL extends ExperimentsStorage {
 
       const conditions: string[] = [`${quoteIdentifier('experimentId', 'column name')} = ?`];
       const params: any[] = [args.experimentId];
+      if (args.traceId) {
+        conditions.push(`${quoteIdentifier('traceId', 'column name')} = ?`);
+        params.push(args.traceId);
+      }
+      if (args.status) {
+        conditions.push(`${quoteIdentifier('status', 'column name')} = ?`);
+        params.push(args.status);
+      }
       if (args.filters) {
         const { organizationId, projectId } = args.filters;
         if (organizationId !== undefined) {

--- a/stores/mysql/src/storage/domains/experiments/index.ts
+++ b/stores/mysql/src/storage/domains/experiments/index.ts
@@ -48,6 +48,8 @@ interface ExperimentRow {
   id: string;
   datasetId: string | null;
   datasetVersion: number | null;
+  organizationId: string | null;
+  projectId: string | null;
   targetType: string;
   targetId: string;
   name: string | null;
@@ -69,6 +71,8 @@ interface ExperimentResultRow {
   experimentId: string;
   itemId: string;
   itemDatasetVersion: number | null;
+  organizationId: string | null;
+  projectId: string | null;
   input: string;
   output: string | null;
   groundTruth: string | null;
@@ -156,6 +160,18 @@ export class ExperimentsMySQL extends ExperimentsStorage {
   async init(): Promise<void> {
     await this.operations.createTable({ tableName: TABLE_EXPERIMENTS, schema: EXPERIMENTS_SCHEMA });
     await this.operations.createTable({ tableName: TABLE_EXPERIMENT_RESULTS, schema: EXPERIMENT_RESULTS_SCHEMA });
+    // Backfill tenancy columns on pre-existing tables so older deployments
+    // keep working when they upgrade in place.
+    await this.operations.alterTable({
+      tableName: TABLE_EXPERIMENTS,
+      schema: EXPERIMENTS_SCHEMA,
+      ifNotExists: ['organizationId', 'projectId'],
+    });
+    await this.operations.alterTable({
+      tableName: TABLE_EXPERIMENT_RESULTS,
+      schema: EXPERIMENT_RESULTS_SCHEMA,
+      ifNotExists: ['organizationId', 'projectId'],
+    });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
   }
@@ -170,6 +186,8 @@ export class ExperimentsMySQL extends ExperimentsStorage {
       id: row.id,
       datasetId: row.datasetId ?? null,
       datasetVersion: row.datasetVersion ?? null,
+      organizationId: row.organizationId ?? null,
+      projectId: row.projectId ?? null,
       targetType: row.targetType as Experiment['targetType'],
       targetId: row.targetId,
       name: row.name ?? undefined,
@@ -193,6 +211,8 @@ export class ExperimentsMySQL extends ExperimentsStorage {
       experimentId: row.experimentId,
       itemId: row.itemId,
       itemDatasetVersion: row.itemDatasetVersion ?? null,
+      organizationId: row.organizationId ?? null,
+      projectId: row.projectId ?? null,
       input: parseJSON<Record<string, unknown>>(row.input),
       output: row.output ? parseJSON<Record<string, unknown>>(row.output) : null,
       groundTruth: row.groundTruth ? parseJSON<Record<string, unknown>>(row.groundTruth) : null,
@@ -218,6 +238,8 @@ export class ExperimentsMySQL extends ExperimentsStorage {
           id,
           datasetId: input.datasetId ?? null,
           datasetVersion: input.datasetVersion ?? null,
+          organizationId: input.organizationId ?? null,
+          projectId: input.projectId ?? null,
           targetType: input.targetType,
           targetId: input.targetId,
           name: input.name ?? null,
@@ -239,6 +261,8 @@ export class ExperimentsMySQL extends ExperimentsStorage {
         id,
         datasetId: input.datasetId,
         datasetVersion: input.datasetVersion,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         targetType: input.targetType,
         targetId: input.targetId,
         name: input.name,
@@ -341,6 +365,17 @@ export class ExperimentsMySQL extends ExperimentsStorage {
       if (args.datasetId) {
         conditions.push(`${quoteIdentifier('datasetId', 'column name')} = ?`);
         params.push(args.datasetId);
+      }
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          conditions.push(`${quoteIdentifier('organizationId', 'column name')} = ?`);
+          params.push(organizationId);
+        }
+        if (projectId !== undefined) {
+          conditions.push(`${quoteIdentifier('projectId', 'column name')} = ?`);
+          params.push(projectId);
+        }
       }
 
       const whereClause = {
@@ -456,6 +491,8 @@ export class ExperimentsMySQL extends ExperimentsStorage {
           experimentId: input.experimentId,
           itemId: input.itemId,
           itemDatasetVersion: input.itemDatasetVersion ?? null,
+          organizationId: input.organizationId ?? null,
+          projectId: input.projectId ?? null,
           input: JSON.stringify(input.input),
           output: input.output ? JSON.stringify(input.output) : null,
           groundTruth: input.groundTruth ? JSON.stringify(input.groundTruth) : null,
@@ -475,6 +512,8 @@ export class ExperimentsMySQL extends ExperimentsStorage {
         experimentId: input.experimentId,
         itemId: input.itemId,
         itemDatasetVersion: input.itemDatasetVersion,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         input: input.input,
         output: input.output,
         groundTruth: input.groundTruth,
@@ -606,9 +645,23 @@ export class ExperimentsMySQL extends ExperimentsStorage {
     try {
       const { page, perPage: perPageInput } = args.pagination;
 
+      const conditions: string[] = [`${quoteIdentifier('experimentId', 'column name')} = ?`];
+      const params: any[] = [args.experimentId];
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          conditions.push(`${quoteIdentifier('organizationId', 'column name')} = ?`);
+          params.push(organizationId);
+        }
+        if (projectId !== undefined) {
+          conditions.push(`${quoteIdentifier('projectId', 'column name')} = ?`);
+          params.push(projectId);
+        }
+      }
+
       const whereClause = {
-        sql: ` WHERE ${quoteIdentifier('experimentId', 'column name')} = ?`,
-        args: [args.experimentId] as any[],
+        sql: ` WHERE ${conditions.join(' AND ')}`,
+        args: params,
       };
 
       const total = await this.operations.loadTotalCount({ tableName: TABLE_EXPERIMENT_RESULTS, whereClause });

--- a/stores/pg/src/storage/domains/experiments/index.ts
+++ b/stores/pg/src/storage/domains/experiments/index.ts
@@ -69,12 +69,12 @@ export class ExperimentsPG extends ExperimentsStorage {
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENTS,
       schema: EXPERIMENTS_SCHEMA,
-      ifNotExists: ['agentVersion'],
+      ifNotExists: ['agentVersion', 'organizationId', 'projectId'],
     });
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: EXPERIMENT_RESULTS_SCHEMA,
-      ifNotExists: ['status', 'tags', 'toolMockReport'],
+      ifNotExists: ['status', 'tags', 'toolMockReport', 'organizationId', 'projectId'],
     });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
@@ -89,6 +89,17 @@ export class ExperimentsPG extends ExperimentsStorage {
         table: TABLE_EXPERIMENT_RESULTS,
         columns: ['experimentId', 'itemId'],
         unique: true,
+      },
+      // Tenancy: leading-tenant indexes for multi-tenant scans (parity with datasets domain).
+      {
+        name: 'idx_experiments_org_project',
+        table: TABLE_EXPERIMENTS,
+        columns: ['organizationId', 'projectId'],
+      },
+      {
+        name: 'idx_experiment_results_org_project',
+        table: TABLE_EXPERIMENT_RESULTS,
+        columns: ['organizationId', 'projectId'],
       },
     ];
   }
@@ -126,6 +137,8 @@ export class ExperimentsPG extends ExperimentsStorage {
       datasetId: (row.datasetId as string | null) ?? null,
       datasetVersion: row.datasetVersion != null ? (row.datasetVersion as number) : null,
       agentVersion: (row.agentVersion as string | null) ?? null,
+      organizationId: (row.organizationId as string | null) ?? null,
+      projectId: (row.projectId as string | null) ?? null,
       targetType: row.targetType as Experiment['targetType'],
       targetId: row.targetId as string,
       status: row.status as Experiment['status'],
@@ -146,6 +159,8 @@ export class ExperimentsPG extends ExperimentsStorage {
       experimentId: row.experimentId as string,
       itemId: row.itemId as string,
       itemDatasetVersion: row.itemDatasetVersion != null ? (row.itemDatasetVersion as number) : null,
+      organizationId: (row.organizationId as string | null) ?? null,
+      projectId: (row.projectId as string | null) ?? null,
       input: safelyParseJSON(row.input),
       output: row.output ? safelyParseJSON(row.output) : null,
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth) : null,
@@ -179,6 +194,8 @@ export class ExperimentsPG extends ExperimentsStorage {
           datasetId: input.datasetId ?? null,
           datasetVersion: input.datasetVersion ?? null,
           agentVersion: input.agentVersion ?? null,
+          organizationId: input.organizationId ?? null,
+          projectId: input.projectId ?? null,
           targetType: input.targetType,
           targetId: input.targetId,
           status: 'pending',
@@ -201,6 +218,8 @@ export class ExperimentsPG extends ExperimentsStorage {
         datasetId: input.datasetId ?? null,
         datasetVersion: input.datasetVersion ?? null,
         agentVersion: input.agentVersion ?? null,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         targetType: input.targetType,
         targetId: input.targetId,
         status: 'pending',
@@ -353,6 +372,17 @@ export class ExperimentsPG extends ExperimentsStorage {
         conditions.push(`"status" = $${paramIndex++}`);
         queryParams.push(args.status);
       }
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          conditions.push(`"organizationId" = $${paramIndex++}`);
+          queryParams.push(organizationId);
+        }
+        if (projectId !== undefined) {
+          conditions.push(`"projectId" = $${paramIndex++}`);
+          queryParams.push(projectId);
+        }
+      }
 
       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
@@ -435,6 +465,8 @@ export class ExperimentsPG extends ExperimentsStorage {
           experimentId: input.experimentId,
           itemId: input.itemId,
           itemDatasetVersion: input.itemDatasetVersion ?? null,
+          organizationId: input.organizationId ?? null,
+          projectId: input.projectId ?? null,
           input: input.input,
           output: input.output ?? null,
           groundTruth: input.groundTruth ?? null,
@@ -455,6 +487,8 @@ export class ExperimentsPG extends ExperimentsStorage {
         experimentId: input.experimentId,
         itemId: input.itemId,
         itemDatasetVersion: input.itemDatasetVersion ?? null,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         input: input.input,
         output: input.output ?? null,
         groundTruth: input.groundTruth ?? null,
@@ -577,6 +611,17 @@ export class ExperimentsPG extends ExperimentsStorage {
       if (args.status) {
         conditions.push(`"status" = $${paramIndex++}`);
         queryParams.push(args.status);
+      }
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          conditions.push(`"organizationId" = $${paramIndex++}`);
+          queryParams.push(organizationId);
+        }
+        if (projectId !== undefined) {
+          conditions.push(`"projectId" = $${paramIndex++}`);
+          queryParams.push(projectId);
+        }
       }
 
       const whereClause = `WHERE ${conditions.join(' AND ')}`;

--- a/stores/spanner/src/storage/domains/experiments/index.ts
+++ b/stores/spanner/src/storage/domains/experiments/index.ts
@@ -42,6 +42,8 @@ function rowToExperiment(row: Record<string, any>): Experiment {
     metadata: t.metadata ?? undefined,
     datasetId: t.datasetId ?? null,
     datasetVersion: t.datasetVersion == null ? null : Number(t.datasetVersion),
+    organizationId: (t.organizationId as string | null | undefined) ?? null,
+    projectId: (t.projectId as string | null | undefined) ?? null,
     targetType: t.targetType,
     targetId: String(t.targetId),
     status: t.status,
@@ -64,6 +66,8 @@ function rowToExperimentResult(row: Record<string, any>): ExperimentResult {
     experimentId: String(t.experimentId),
     itemId: String(t.itemId),
     itemDatasetVersion: t.itemDatasetVersion == null ? null : Number(t.itemDatasetVersion),
+    organizationId: (t.organizationId as string | null | undefined) ?? null,
+    projectId: (t.projectId as string | null | undefined) ?? null,
     input: t.input ?? null,
     output: t.output ?? null,
     groundTruth: t.groundTruth ?? null,
@@ -104,6 +108,18 @@ export class ExperimentsSpanner extends ExperimentsStorage {
   async init(): Promise<void> {
     await this.db.createTable({ tableName: TABLE_EXPERIMENTS, schema: TABLE_SCHEMAS[TABLE_EXPERIMENTS] });
     await this.db.createTable({ tableName: TABLE_EXPERIMENT_RESULTS, schema: TABLE_SCHEMAS[TABLE_EXPERIMENT_RESULTS] });
+    // Backfill tenancy columns on pre-existing tables so older deployments
+    // keep working when they upgrade in place.
+    await this.db.alterTable({
+      tableName: TABLE_EXPERIMENTS,
+      schema: TABLE_SCHEMAS[TABLE_EXPERIMENTS],
+      ifNotExists: ['organizationId', 'projectId'],
+    });
+    await this.db.alterTable({
+      tableName: TABLE_EXPERIMENT_RESULTS,
+      schema: TABLE_SCHEMAS[TABLE_EXPERIMENT_RESULTS],
+      ifNotExists: ['organizationId', 'projectId'],
+    });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
   }
@@ -126,6 +142,17 @@ export class ExperimentsSpanner extends ExperimentsStorage {
         table: TABLE_EXPERIMENT_RESULTS,
         columns: ['experimentId', 'itemId'],
         unique: true,
+      },
+      // Tenancy: leading-tenant indexes for multi-tenant scans (parity with datasets domain).
+      {
+        name: 'mastra_experiments_org_project_idx',
+        table: TABLE_EXPERIMENTS,
+        columns: ['organizationId', 'projectId'],
+      },
+      {
+        name: 'mastra_experiment_results_org_project_idx',
+        table: TABLE_EXPERIMENT_RESULTS,
+        columns: ['organizationId', 'projectId'],
       },
     ];
   }
@@ -156,6 +183,8 @@ export class ExperimentsSpanner extends ExperimentsStorage {
         metadata: input.metadata ?? undefined,
         datasetId: input.datasetId ?? null,
         datasetVersion: input.datasetVersion ?? null,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         targetType: input.targetType,
         targetId: input.targetId,
         status: 'pending',
@@ -178,6 +207,8 @@ export class ExperimentsSpanner extends ExperimentsStorage {
           metadata: experiment.metadata ?? null,
           datasetId: experiment.datasetId,
           datasetVersion: experiment.datasetVersion,
+          organizationId: experiment.organizationId,
+          projectId: experiment.projectId,
           targetType: experiment.targetType,
           targetId: experiment.targetId,
           status: experiment.status,
@@ -302,6 +333,17 @@ export class ExperimentsSpanner extends ExperimentsStorage {
         conditions.push(`${quoteIdent('status', 'column name')} = @status`);
         params.status = args.status;
       }
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          conditions.push(`${quoteIdent('organizationId', 'column name')} = @organizationId`);
+          params.organizationId = organizationId;
+        }
+        if (projectId !== undefined) {
+          conditions.push(`${quoteIdent('projectId', 'column name')} = @projectId`);
+          params.projectId = projectId;
+        }
+      }
       const whereSql = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
       const tableName = quoteIdent(TABLE_EXPERIMENTS, 'table name');
 
@@ -389,6 +431,8 @@ export class ExperimentsSpanner extends ExperimentsStorage {
         experimentId: input.experimentId,
         itemId: input.itemId,
         itemDatasetVersion: input.itemDatasetVersion ?? null,
+        organizationId: input.organizationId ?? null,
+        projectId: input.projectId ?? null,
         input: input.input ?? null,
         output: input.output ?? null,
         groundTruth: input.groundTruth ?? null,
@@ -409,6 +453,8 @@ export class ExperimentsSpanner extends ExperimentsStorage {
           experimentId: result.experimentId,
           itemId: result.itemId,
           itemDatasetVersion: result.itemDatasetVersion,
+          organizationId: result.organizationId,
+          projectId: result.projectId,
           input: result.input,
           output: result.output,
           groundTruth: result.groundTruth,
@@ -547,6 +593,17 @@ export class ExperimentsSpanner extends ExperimentsStorage {
       if (args.status !== undefined) {
         conditions.push(`${quoteIdent('status', 'column name')} = @status`);
         params.status = args.status;
+      }
+      if (args.filters) {
+        const { organizationId, projectId } = args.filters;
+        if (organizationId !== undefined) {
+          conditions.push(`${quoteIdent('organizationId', 'column name')} = @organizationId`);
+          params.organizationId = organizationId;
+        }
+        if (projectId !== undefined) {
+          conditions.push(`${quoteIdent('projectId', 'column name')} = @projectId`);
+          params.projectId = projectId;
+        }
       }
       const whereSql = `WHERE ${conditions.join(' AND ')}`;
       const tableName = quoteIdent(TABLE_EXPERIMENT_RESULTS, 'table name');


### PR DESCRIPTION
## Summary

Adds multi-tenant scoping (`organizationId`, `projectId`) to the **experiments** domain so experiment records and per-item results inherit the tenancy bucket of their parent dataset — mirroring the dataset-tenancy surface introduced in #18314 / renamed in #18386.

Also documents the `targetType` contract on dataset/experiment inputs so the asymmetry between `CreateDatasetInput.targetType?` and `Experiment.targetType` (required) is load-bearing rather than a footgun.

## Why

- The platform writes experiments via a materializer that produces them on behalf of a project. Without tenancy on `Experiment` / `ExperimentResult`, platform queries had to JOIN through the parent dataset on every read, and tenancy-scoped indexes were impossible.
- Datasets already carry `(organizationId, projectId)`. The experiments domain was the last big piece of the datasets feature without tenancy on its rows.

## OSS surface change

`@mastra/core`:
- `Experiment`, `ExperimentResult`, `CreateExperimentInput`, `AddExperimentResultInput` gain optional `organizationId?: string | null` + `projectId?: string | null`.
- New `ExperimentTenancyFilters` (mirrors `DatasetTenancyFilters`).
- `ListExperimentsInput` + `ListExperimentResultsInput` accept `filters: ExperimentTenancyFilters`.
- `EXPERIMENTS_SCHEMA` + `EXPERIMENT_RESULTS_SCHEMA` gain the two nullable text columns.
- `createExperiment` (both `Dataset.run` and `runExperiment`) hydrates tenancy from the parent dataset record. `addExperimentResult` denormalizes tenancy from the parent experiment.

JSDoc:
- `CreateDatasetInput.targetType`: optional, but datasets without one are **not experiment-eligible**.
- `Experiment.targetType` / `CreateExperimentInput.targetType`: required — an experiment by definition replays inputs against a specific target.

## Status

🚧 **Draft** — this PR currently lands:
- [x] Core types + constants + manager wiring
- [x] InMemory adapter
- [x] JSDoc contract for `targetType`
- [x] Changeset
- [ ] pg adapter (DDL + SQL + row mapping)
- [ ] libsql adapter
- [ ] mongodb adapter
- [ ] mysql adapter
- [ ] spanner adapter
- [ ] Shared test harness in `stores/_test-utils/src/domains/experiments/`
- [ ] Typecheck + adapter tests green

Sequencing pg first to lock the pattern, then fanning out to the other four adapters.

## Compat

- No behavior change for existing OSS-created experiments — the new fields are additive and optional. Existing rows backfill to `null` on read.
- Pre-release on the datasets feature, so column adds via `alterTable({ ifNotExists: [...] })` are safe.

## Test plan

- `pnpm --filter @mastra/core check` ✅
- Per adapter: `pnpm test` against the experiments suite (to be added)
- Shared tenancy snapshot tests in `stores/_test-utils/src/domains/experiments/` (to be added)

## Related

- MASTRA-4395 / #18386 — datasets `resourceId` → `projectId` rename (merged, base of this PR)
- MASTRA-4397 — Experiments runner against materialized datasets with tool mocks (this PR unblocks the platform-side materializer)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR teaches experiments to remember *which organization* and *which project* they belong to—just like datasets already do. When you create an experiment from a dataset, it automatically copies that organization/project info, and when the experiment runs, its stored results keep the same info so you can filter by it quickly.

## Overview
Extends the existing multi-tenant (organization/project) tenancy model to the experiments domain by adding `organizationId` and `projectId` across experiment types and storage implementations. Tenancy is inherited from the parent dataset when creating experiments, then denormalized onto experiment results for efficient tenant-scoped queries.

## Changes

### Type and API additions
- Added optional `organizationId` and `projectId` to:
  - `Experiment`
  - `ExperimentResult`
  - `CreateExperimentInput`
  - `AddExperimentResultInput`
- Introduced `ExperimentTenancyFilters` mirroring `DatasetTenancyFilters`
- Added `filters?: ExperimentTenancyFilters` to:
  - `ListExperimentsInput`
  - `ListExperimentResultsInput`
- JSDoc clarification:
  - `CreateDatasetInput.targetType` remains optional, and datasets without it are not experiment-eligible
  - `Experiment.targetType` is required (experiments replay against a specific target)

### Schema updates
- Updated `EXPERIMENTS_SCHEMA` and `EXPERIMENT_RESULTS_SCHEMA` with nullable `organizationId` and `projectId` (`text`, `nullable: true`)
- Existing rows are treated as having `null` tenancy on read (additive/backwards compatible)

### Tenancy hydration/denormalization behavior
- Experiment creation (`createExperiment`, including when invoked via `Dataset.startExperimentAsync` / `runExperiment`) inherits `organizationId` and `projectId` from the parent dataset record
- Experiment result creation (`addExperimentResult`) denormalizes `organizationId` and `projectId` from the parent experiment onto each stored result

### Storage adapter updates (all addressed)
Multi-tenant support was implemented across:
- InMemory
- PostgreSQL
- libsql
- MongoDB
- MySQL
- Spanner

For each adapter, this includes:
- DDL/backfill of the new nullable columns
- Row mapping for reads/writes
- Tenant-aware list filtering for `listExperiments` and `listExperimentResults`
- Composite indexes for `(organizationId, projectId)` to keep tenant-scoped queries fast

**MySQL-specific follow-ups:**
- Added tenancy indexes (`idx_experiments_org_project`, `idx_experiment_results_org_project`) for parity
- Restored `traceId`/`status` filtering in `listExperimentResults` after a refactor accidentally removed it

### Test coverage enhancements
- Added/extended shared tenancy tests to verify:
  - `createExperiment` persists tenancy and defaults to `null` when omitted
  - `listExperiments` and `listExperimentResults` properly filter by tenancy (including combined `(organizationId, projectId)` semantics)
  - `addExperimentResult` consistently inherits tenancy from the correct parent experiment (including a negative-path assertion that cross-bucket filtering returns no rows)
- Added tests in the experiment run flow verifying tenancy hydration from the parent dataset onto both the experiment record and stored results
- Updated dataset SCD-2-style tenancy inheritance tests to ensure tenancy persists through live-row updates

## Backwards compatibility
- All new fields are optional and additive
- Existing OSS-created experiments/workflows continue without behavior changes
- Rows created before this change backfill as `null` tenancy values when read
<!-- end of auto-generated comment: release notes by coderabbit.ai -->