### PR TITLE
fix(core): wait for harness stream teardown after abort

### DIFF
--- a/.changeset/four-zoos-fry.md
+++ b/.changeset/four-zoos-fry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed harness follow-up messages sent immediately after an abort so they wait for the aborted stream to finish cleaning up before starting the next run.

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -803,6 +803,29 @@ export class SessionStream {
   #subscription: AgentThreadSubscription<any> | null = null;
   /** Dedup key (`agentId:resourceId:threadId`) for the open subscription, or null. */
   #key: string | null = null;
+  readonly #teardownWaiters = new Set<() => void>();
+
+  #notifyTeardown(): void {
+    const waiters = [...this.#teardownWaiters];
+    this.#teardownWaiters.clear();
+    for (const waiter of waiters) waiter();
+  }
+
+  waitForTeardown(signal: AbortSignal): Promise<void> {
+    return new Promise(resolve => {
+      const done = () => {
+        signal.removeEventListener('abort', abort);
+        resolve();
+      };
+      const abort = () => {
+        this.#teardownWaiters.delete(done);
+        resolve();
+      };
+      if (signal.aborted) return resolve();
+      this.#teardownWaiters.add(done);
+      signal.addEventListener('abort', abort, { once: true });
+    });
+  }
 
   /** Build the dedup key identifying a subscription to `threadId` for `agent`. */
   static keyFor({ agent, resourceId, threadId }: { agent: Agent; resourceId: string; threadId: string }): string {
@@ -852,6 +875,7 @@ export class SessionStream {
     this.#subscription?.unsubscribe();
     this.#subscription = null;
     this.#key = null;
+    this.#notifyTeardown();
   }
 
   /** Fully tear down the live subscription: abort, unsubscribe, and clear. */
@@ -860,6 +884,7 @@ export class SessionStream {
     this.#subscription?.unsubscribe();
     this.#subscription = null;
     this.#key = null;
+    this.#notifyTeardown();
   }
 }
 
@@ -1120,6 +1145,29 @@ export class SessionRun {
   #abortController: AbortController | null = null;
   /** Whether an abort has been requested for the current run. */
   #abortRequested = false;
+  readonly #teardownWaiters = new Set<() => void>();
+
+  #notifyTeardown(): void {
+    const waiters = [...this.#teardownWaiters];
+    this.#teardownWaiters.clear();
+    for (const waiter of waiters) waiter();
+  }
+
+  waitForTeardown(signal: AbortSignal): Promise<void> {
+    return new Promise(resolve => {
+      const done = () => {
+        signal.removeEventListener('abort', abort);
+        resolve();
+      };
+      const abort = () => {
+        this.#teardownWaiters.delete(done);
+        resolve();
+      };
+      if (signal.aborted) return resolve();
+      this.#teardownWaiters.add(done);
+      signal.addEventListener('abort', abort, { once: true });
+    });
+  }
 
   /** The current run id (null when idle). */
   getRunId(): string | null {
@@ -1150,6 +1198,7 @@ export class SessionRun {
     this.#traceId = null;
     this.#abortController = null;
     this.#abortRequested = false;
+    this.#notifyTeardown();
   }
 
   /** Bump and return the operation counter at the start of a new operation. */
@@ -2694,10 +2743,29 @@ export class Session<TState = unknown> {
    * be drained with the previous run's already-aborted abortSignal.
    */
   private async waitForStreamIdle(timeoutMs = 1_000): Promise<void> {
-    const deadline = Date.now() + timeoutMs;
-    while (this.stream.isActive() || this.run.getRunId() !== null) {
-      if (Date.now() >= deadline) return;
-      await new Promise(resolve => setTimeout(resolve, 0));
+    if (!this.stream.isActive() && this.run.getRunId() === null) return;
+
+    let lifecycleWait: AbortController | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<'timeout'>(resolve => {
+      timeout = setTimeout(() => resolve('timeout'), timeoutMs);
+    });
+
+    try {
+      while (this.stream.isActive() || this.run.getRunId() !== null) {
+        lifecycleWait = new AbortController();
+        const result = await Promise.race([
+          this.stream.waitForTeardown(lifecycleWait.signal),
+          this.run.waitForTeardown(lifecycleWait.signal),
+          timeoutPromise,
+        ]);
+        lifecycleWait.abort();
+        lifecycleWait = undefined;
+        if (result === 'timeout') return;
+      }
+    } finally {
+      lifecycleWait?.abort();
+      if (timeout) clearTimeout(timeout);
     }
   }
 

--- a/packages/core/src/harness/signal-messages.test.ts
+++ b/packages/core/src/harness/signal-messages.test.ts
@@ -511,6 +511,55 @@ describe('Harness signal messages', () => {
     );
   });
 
+  it('waits for post-abort stream teardown before starting the follow-up run', async () => {
+    const storage = new InMemoryStore();
+    const agent = new Agent({
+      id: 'abort-idle-wait-agent',
+      name: 'abort-idle-wait-agent',
+      instructions: 'You are a test agent.',
+      model: createTextStreamModel('World'),
+    });
+    const { harness, session } = await createHarness(storage, agent);
+    let activeRunId: string | null = 'run-1';
+    vi.spyOn(agent, 'subscribeToThread').mockResolvedValue({
+      stream: (async function* () {})(),
+      unsubscribe: vi.fn(),
+      abort: vi.fn(),
+      activeRunId: () => activeRunId,
+    });
+    const thread = await session.thread.create();
+
+    session.run.ensureAbortController();
+    session.run.setRunId({ runId: 'run-1' });
+    session.abort();
+
+    const buildToolsets = vi.spyOn(harness as any, 'buildToolsets');
+    const sendSignal = vi.spyOn(agent, 'sendSignal').mockReturnValue({
+      accepted: Promise.resolve({ action: 'deliver', runId: 'new-run-id' }),
+      signal: createSignal({ type: 'user-message', contents: 'follow-up after abort' }),
+    });
+
+    const signal = session.sendSignal({ content: 'follow-up after abort' });
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(buildToolsets).not.toHaveBeenCalled();
+    expect(sendSignal).not.toHaveBeenCalled();
+
+    activeRunId = null;
+    session.run.reset();
+
+    await expect(signal.accepted).resolves.toEqual({ accepted: true, runId: undefined });
+    expect(buildToolsets).toHaveBeenCalledTimes(1);
+    expect(sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({ contents: 'follow-up after abort' }),
+      expect.objectContaining({
+        resourceId: thread.resourceId,
+        threadId: thread.id,
+        ifIdle: expect.objectContaining({ streamOptions: expect.any(Object) }),
+      }),
+    );
+  });
+
   it('tracks queued follow-ups in display state while running', async () => {
     const storage = new InMemoryStore();
     const { session } = await createHarness(storage);


### PR DESCRIPTION
This replaces the harness post-abort idle spin-loop with teardown waiters, so an immediate follow-up message waits for the aborted stream to finish cleaning up before starting the next run.

Before, the harness waited by repeatedly scheduling `setTimeout(0)` until the stream looked idle or the safety timeout expired. Now it wakes when the run or stream teardown path advances, while keeping the same 1s fallback timeout.

I added a regression test that sends a follow-up while the aborted run still has lingering stream/run state, verifies it does not start early, then confirms it starts a fresh idle run after teardown.

Verified with:

```bash
pnpm --filter ./packages/core test signal-messages.test.ts -- --bail 1 --reporter=dot
pnpm --filter ./packages/core check
pnpm build:core
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you tell someone to stop doing a task (like cleaning a room), but then immediately ask them to do a new task. The problem is they might start the new task before finishing cleaning up from the old one, causing confusion. This PR fixes that by making sure people wait until the old cleanup is done before starting anything new.

## Overview

This PR resolves a race condition in the harness stream abort behavior where follow-up messages could start executing before a previously aborted stream had fully completed its cleanup. The fix replaces the polling-based idle detection mechanism with event-driven teardown waiters that deterministically signal when cleanup is complete.

## Changes

### Core Implementation Changes

**`packages/core/src/harness/session.ts`**

- Added `waitForTeardown(signal: AbortSignal): Promise<void>` method to `SessionStream` to allow callers to wait until the stream completes its cleanup process
- Added `waitForTeardown(signal: AbortSignal): Promise<void>` method to `SessionRun` to signal when the run's teardown is complete
- `SessionStream` now maintains an internal waiter set that resolves pending teardown promises when the stream is detached or fully cleaned up
- `SessionRun` triggers teardown notifications during `reset()` to allow deterministic waiting for run cleanup completion
- Replaced the previous `waitForStreamIdle` polling loop (which used repeated `setTimeout(0)` scheduling with a 1-second timeout) with event-driven teardown signal awaiting that leverages the new `waitForTeardown` methods on both `SessionStream` and `SessionRun`

### Test Coverage

**`packages/core/src/harness/signal-messages.test.ts`**

Added a regression test that verifies follow-up dispatch after an aborted run correctly waits for post-abort teardown:
- Confirms that follow-up messages sent immediately after `session.abort()` do not start executing while the stream still has lingering state
- Validates that after teardown completes (when `activeRunId` is nulled and `session.run.reset()` is called), the follow-up message is accepted and dispatched through the standard idle path
- Ensures no premature invocation of stream initialization or agent signal dispatch during the wait window

### Documentation

**`.changeset/four-zoos-fry.md`**

Added a changeset entry for `@mastra/core` documenting the patch-level fix to ensure follow-up messages sent after an abort properly wait for stream cleanup completion before starting the next run.

## Technical Details

The solution replaces the spin-loop approach with a more efficient event-driven pattern:
- **Previous approach**: Repeatedly scheduled `setTimeout(0)` callbacks until the stream appeared idle or a 1-second safety timeout expired
- **New approach**: Uses `waitForTeardown()` promises that are resolved when teardown actually completes, while maintaining the 1-second fallback timeout as a safety measure

This ensures immediate follow-up messages are properly blocked until the aborted stream has fully completed its cleanup process, preventing the race condition where state from the previous run could interfere with the new one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->