### PR TITLE
fix(ci): align affected test detection with PR diffs

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check for code changes
         id: filter
         run: |
-          CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
+          CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
             | grep -vE '^(docs/|examples/|\.changeset/|explorations/)' || true)
           if [ -n "$CHANGED" ]; then
             echo "has_code=true" >> $GITHUB_OUTPUT
@@ -96,8 +96,7 @@ jobs:
         id: compute
         run: |
           CHANGED=$(git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
             | grep -E '/src/.*\.(ts|tsx)$' \
             | grep -vE '__fixtures__|/fixtures/' \
             || true)

--- a/scripts/affected-tests.mjs
+++ b/scripts/affected-tests.mjs
@@ -84,7 +84,16 @@ function discoverTestFiles() {
   // Use two patterns: '*.test.ts' catches top-level files (e.g. src/foo.test.ts)
   // and '**/*.test.ts' catches nested files. Dedupe via Set.
   // Also include .test.tsx and .spec.ts/.spec.tsx for completeness.
-  const patterns = ['*.test.ts', '**/*.test.ts', '*.test.tsx', '**/*.test.tsx', '*.spec.ts', '**/*.spec.ts'];
+  const patterns = [
+    '*.test.ts',
+    '**/*.test.ts',
+    '*.test.tsx',
+    '**/*.test.tsx',
+    '*.spec.ts',
+    '**/*.spec.ts',
+    '*.spec.tsx',
+    '**/*.spec.tsx',
+  ];
 
   const files = new Set();
   for (const pattern of patterns) {
@@ -299,6 +308,10 @@ const allAffected = new Set();
 const verboseChains = new Map(); // testFile → chain of files
 
 for (const changedFile of changedRelative) {
+  if (testSet.has(changedFile)) {
+    allAffected.add(changedFile);
+  }
+
   // BFS through the reverse index starting from the changed file
   const visited = new Set();
   const queue = [changedFile];


### PR DESCRIPTION
This makes the affected-test prebuild job use the same merge-base diff shape that GitHub uses for PR changed files. That avoids pulling unrelated files from main into the affected source list when a branch is behind main.

It also includes changed test files directly in the tests to run, so editing a test always runs that test even if no source file depends on it.

Before, a PR could show fewer changed files in GitHub than the affected-test job considered. After, the job starts from the PR-visible diff and adds any changed test files to the run list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes the test system to match what GitHub actually shows as changed in a pull request. Before, if your feature branch fell behind the main branch, the CI might think more files changed than they actually did. Now the CI uses the same calculation as GitHub to determine what changed, and it always runs tests that were directly modified.

## Overview

This PR updates the continuous integration affected-test detection logic to align with GitHub's PR change display. The fix ensures that the CI system analyzes exactly the same set of changed files that developers see in the GitHub UI, preventing unnecessary inclusion of unrelated files from the main branch when a feature branch falls behind.

## Key Changes

The fix implements two main improvements:

1. **Merge-base diff alignment**: Both the `changes` and `affected-tests` workflow steps now use the symmetric three-dot diff format (`base...head`) instead of the two-argument form (`base head`). This matches GitHub's approach for calculating PR-visible changes.

2. **Direct test file inclusion**: Modified test files are now immediately recognized as affected tests. Previously, only transitively dependent test files were included; now any changed test file is directly included in the test run list, ensuring that modifications to tests always trigger their execution.

## Changes by File

### `.github/workflows/prebuild.yml`
- Updated `git diff --name-only` commands in both the `changes` and `affected-tests` steps from two-argument form to symmetric three-dot form
- This ensures the workflow uses the same diff calculation as GitHub for determining changed files

### `scripts/affected-tests.mjs`
- Expanded test file discovery with a comprehensive `patterns` array covering multiple test file conventions: `*.test.ts/tsx`, `**/*.test.ts/tsx`, `*.spec.ts/spec.tsx`, and `**/*.spec.ts/spec.tsx`
- Added logic in the reverse-BFS phase to immediately mark changed files as affected when the changed file itself is a test file (membership in `testSet`)
- This ensures modified test files bypass dependency analysis and are always included in the affected test list

<!-- end of auto-generated comment: release notes by coderabbit.ai -->