### PR TITLE
fix(mastracode): revert Stagehand Codex OAuth routing

### DIFF
--- a/.changeset/nice-needles-rush.md
+++ b/.changeset/nice-needles-rush.md
@@ -1,5 +1,0 @@
----
-'mastracode': minor
----
-
-Added automatic OpenAI subscription support for Stagehand browser automation. When a user has an active OpenAI subscription (authenticated via /login), Stagehand now uses the subscription credentials for its AI operations (act/extract/observe) instead of requiring a separate OPENAI_API_KEY.

--- a/mastracode/src/onboarding/settings.ts
+++ b/mastracode/src/onboarding/settings.ts
@@ -8,8 +8,6 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { MastraBrowser } from '@mastra/core/browser';
 import type { LSPConfig } from '@mastra/core/workspace';
-import { AuthStorage } from '../auth/storage.js';
-import { buildOpenAICodexOAuthFetch } from '../providers/openai-codex.js';
 import { getAppDataDir } from '../utils/project.js';
 
 /** A saved custom pack — user-defined model selections for each mode. */
@@ -998,28 +996,13 @@ export async function createBrowserFromSettings(settings: BrowserSettings): Prom
 
   if (provider === 'stagehand') {
     const { StagehandBrowser } = await import('@mastra/stagehand');
-    const stagehandOpts: Record<string, unknown> = {
+    const stagehandOpts = {
       env: stagehand?.env ?? 'LOCAL',
       apiKey: stagehand?.apiKey ?? process.env.BROWSERBASE_API_KEY,
       projectId: stagehand?.projectId ?? process.env.BROWSERBASE_PROJECT_ID,
       preserveUserDataDir: stagehand?.preserveUserDataDir,
       recording: browserRecordingOptions(),
     };
-
-    // When the user has an active OpenAI subscription (OAuth), configure
-    // Stagehand's model to use the subscription. The subscription takes priority
-    // over OPENAI_API_KEY since it provides access through the user's plan.
-    // The custom fetch rewrites requests to the Codex endpoint and injects the
-    // OAuth access token as the Bearer credential.
-    const authStorage = new AuthStorage();
-    const cred = authStorage.get('openai-codex');
-    if (cred?.type === 'oauth') {
-      stagehandOpts.model = {
-        modelName: 'openai/gpt-4.1-mini',
-        apiKey: 'codex-oauth',
-        fetch: buildOpenAICodexOAuthFetch({ authStorage }),
-      };
-    }
 
     return cdpUrl
       ? new StagehandBrowser({ ...launchConfig, cdpUrl, scope: 'shared', ...stagehandOpts })


### PR DESCRIPTION
## Summary
- Reverts automatic routing of Stagehand browser automation through OpenAI Codex OAuth credentials.
- Restores the previous Stagehand model configuration behavior so observe/act/extract use the normal Stagehand/OpenAI configuration path.
- Removes the changeset for the reverted behavior.

## Test plan
- pnpm --filter ./mastracode check
- pnpm --filter ./mastracode test -- src/onboarding/__tests__/settings.test.ts --run

## Notes
- Repo-wide `pnpm lint` was started but skipped per request after focused Mastra Code checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes a feature that tried to use special OpenAI Codex login credentials for Stagehand browser automation. It turns out the Codex system didn't accept the requests properly, so the team is removing this feature and going back to the standard way of using Stagehand.

## Changes

### Files Removed
- `.changeset/nice-needles-rush.md` - Changeset documenting the now-reverted Stagehand OpenAI Codex OAuth integration feature

### Files Modified
- `mastracode/src/onboarding/settings.ts` - Removes the OpenAI Codex OAuth integration logic:
  - Removed imports: `AuthStorage` and `buildOpenAICodexOAuthFetch`
  - Removed the runtime check for `openai-codex` OAuth credentials in `createBrowserFromSettings`
  - Removed the logic that set `stagehandOpts.model` to a hardcoded Codex model with OAuth-backed fetch
  - Stagehand provider initialization remains unchanged but now uses the default configuration path

## Rationale

The Codex OAuth endpoint was rejecting observe operation payloads with bad request responses, necessitating the revert of the automatic routing behavior. This change ensures that Stagehand browser automation (observe, act, and extract operations) continues to use the standard Stagehand/OpenAI configuration instead of attempting to route through the Codex OAuth endpoint.

## Testing

Verified via `pnpm --filter ./mastracode check` and focused test execution on `src/onboarding/__tests__/settings.test.ts`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->