### PR TITLE
fix(mastracode): bridge Stagehand AI ops onto Codex OAuth /responses

### DIFF
--- a/.changeset/fix-mastracode-stagehand-codex-oauth.md
+++ b/.changeset/fix-mastracode-stagehand-codex-oauth.md
@@ -1,0 +1,17 @@
+---
+'mastracode': patch
+---
+
+Fix Stagehand AI ops (`observe`, `act`, `extract`) failing with `Bad Request` (HTTP 400) when the user is signed in to OpenAI Codex OAuth.
+
+Stagehand drives its browser actions through AI SDK's non-streaming `generateText`, but Codex's `/responses` backend only accepts streamed requests and replies with Server-Sent Events. The previous integration routed Stagehand traffic to Codex by rewriting the request URL inside a custom `fetch`, but did not translate between the streaming and non-streaming shapes — so every Stagehand AI call was rejected by Codex.
+
+MastraCode now configures Stagehand with proper AI SDK provider options (`baseURL`, `headers`, `middleware`) and a dedicated `buildCodexStagehandFetch` that:
+
+- Injects (and refreshes) the Codex OAuth bearer per call
+- Forces `stream: true` on the outgoing request body
+- Aggregates the SSE response into the non-streaming JSON shape `@ai-sdk/openai`'s Responses parser expects
+
+The shared OAuth-bearer-refresh logic is extracted into a `getCodexBearer` helper used by both the main agent fetch and the Stagehand fetch.
+
+`observe`, `act`, and `extract` now work end-to-end against Codex OAuth using the `__GATEWAY_OPENAI_MODEL_MINI__` Codex-compatible model, with no `OPENAI_API_KEY` required.

--- a/.changeset/swift-rivers-stream.md
+++ b/.changeset/swift-rivers-stream.md
@@ -14,4 +14,4 @@ MastraCode now configures Stagehand with proper AI SDK provider options (`baseUR
 
 The shared OAuth-bearer-refresh logic is extracted into a `getCodexBearer` helper used by both the main agent fetch and the Stagehand fetch.
 
-`observe`, `act`, and `extract` now work end-to-end against Codex OAuth using the `__GATEWAY_OPENAI_MODEL_MINI__` Codex-compatible model, with no `OPENAI_API_KEY` required.
+`observe`, `act`, and `extract` now work end-to-end against Codex OAuth using a Codex-compatible OpenAI model, with no `OPENAI_API_KEY` required.

--- a/mastracode/src/onboarding/settings.ts
+++ b/mastracode/src/onboarding/settings.ts
@@ -9,7 +9,7 @@ import { dirname, join } from 'node:path';
 import type { MastraBrowser } from '@mastra/core/browser';
 import type { LSPConfig } from '@mastra/core/workspace';
 import { AuthStorage } from '../auth/storage.js';
-import { buildOpenAICodexOAuthFetch } from '../providers/openai-codex.js';
+import { buildCodexStagehandFetch, createCodexMiddleware } from '../providers/openai-codex.js';
 import { getAppDataDir } from '../utils/project.js';
 
 /** A saved custom pack — user-defined model selections for each mode. */
@@ -1006,19 +1006,34 @@ export async function createBrowserFromSettings(settings: BrowserSettings): Prom
       recording: browserRecordingOptions(),
     };
 
-    // When the user has an active OpenAI subscription (OAuth), configure
-    // Stagehand's model to use the subscription. The subscription takes priority
-    // over OPENAI_API_KEY since it provides access through the user's plan.
-    // The custom fetch rewrites requests to the Codex endpoint and injects the
-    // OAuth access token as the Bearer credential.
+    // When the user has an active OpenAI Codex (ChatGPT) subscription, route
+    // Stagehand through the Codex endpoint. We use the AI SDK provider's
+    // standard hooks (baseURL, headers, fetch, and middleware) instead of a
+    // URL-rewriting fetch:
+    //   - baseURL: target Codex's Responses API directly (no URL rewriting).
+    //   - headers: static Codex identifiers (originator, UA, account id).
+    //   - fetch: a tiny refresher that injects the live OAuth bearer per call,
+    //     since AI SDK takes `apiKey` as a static string.
+    //   - middleware: createCodexMiddleware() sets `store: false`, which Codex
+    //     requires on every request.
+    // Model is `gpt-5.4-mini`, the current ChatGPT-sign-in Codex whitelist
+    // pick suited to Stagehand's vision + structured-output workload.
     const authStorage = new AuthStorage();
     const cred = authStorage.get('openai-codex');
     if (cred?.type === 'oauth') {
+      const accountId = (cred as any).accountId as string | undefined;
       stagehandOpts.model = {
-        modelName: 'openai/gpt-4.1-mini',
+        modelName: 'openai/gpt-5.4-mini',
         apiKey: 'codex-oauth',
-        fetch: buildOpenAICodexOAuthFetch({ authStorage }),
-      };
+        baseURL: 'https://chatgpt.com/backend-api/codex',
+        headers: {
+          originator: 'mastracode',
+          'User-Agent': 'mastracode',
+          ...(accountId ? { 'ChatGPT-Account-ID': accountId } : {}),
+        },
+        fetch: buildCodexStagehandFetch(authStorage),
+        middleware: createCodexMiddleware(),
+      } as any;
     }
 
     return cdpUrl

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -102,6 +102,41 @@ export function createCodexMiddleware(reasoningEffort?: string): LanguageModelMi
 }
 
 /**
+ * Get a live OAuth bearer token for the Codex OAuth credential.
+ *
+ * Refreshes the token if it's expired, and returns the credential's
+ * accountId alongside the access token. Throws if the user isn't logged in
+ * or if the refresh fails.
+ *
+ * This is the only piece of Codex auth that is genuinely shared between
+ * the main agent's fetch (`buildOpenAICodexOAuthFetch`) and the Stagehand
+ * fetch (`buildCodexStagehandFetch`).
+ */
+async function getCodexBearer(
+  authStorage?: AuthStorage,
+): Promise<{ accessToken: string; accountId: string | undefined }> {
+  const storage = authStorage ?? getAuthStorage();
+  storage.reload();
+
+  const cred = storage.get('openai-codex');
+  if (!cred || cred.type !== 'oauth') {
+    throw new Error('Not logged in to OpenAI Codex. Run /login first.');
+  }
+
+  let accessToken = cred.access;
+  if (Date.now() >= cred.expires) {
+    const refreshedToken = await storage.getApiKey('openai-codex');
+    if (!refreshedToken) {
+      throw new Error('Failed to refresh OpenAI Codex token. Please /login again.');
+    }
+    accessToken = refreshedToken;
+    storage.reload();
+  }
+
+  return { accessToken, accountId: (cred as any).accountId as string | undefined };
+}
+
+/**
  * Build a fetch function that handles OpenAI Codex OAuth.
  * Preserves non-authorization headers from init.
  * When rewriteUrl is true (default), rewrites /v1/responses and /chat/completions
@@ -112,25 +147,7 @@ export function buildOpenAICodexOAuthFetch(
   opts: { authStorage?: AuthStorage; rewriteUrl?: boolean } = {},
 ): typeof fetch {
   return (async (url: string | URL | Request, init?: Parameters<typeof fetch>[1]) => {
-    const storage = opts.authStorage ?? getAuthStorage();
-    storage.reload();
-
-    const cred = storage.get('openai-codex');
-    if (!cred || cred.type !== 'oauth') {
-      throw new Error('Not logged in to OpenAI Codex. Run /login first.');
-    }
-
-    let accessToken = cred.access;
-    if (Date.now() >= cred.expires) {
-      const refreshedToken = await storage.getApiKey('openai-codex');
-      if (!refreshedToken) {
-        throw new Error('Failed to refresh OpenAI Codex token. Please /login again.');
-      }
-      accessToken = refreshedToken;
-      storage.reload();
-    }
-
-    const accountId = (cred as any).accountId as string | undefined;
+    const { accessToken, accountId } = await getCodexBearer(opts.authStorage);
 
     // Preserve non-authorization headers
     const headers = new Headers();
@@ -185,6 +202,190 @@ export function buildOpenAICodexOAuthFetch(
       throw error;
     }
   }) as typeof fetch;
+}
+
+/**
+ * Build a fetch function for Stagehand-on-Codex.
+ *
+ * The Codex backend has two requirements that AI SDK's non-streaming
+ * `generateText` path doesn't naturally satisfy:
+ *
+ *   1. `stream: true` must be set on every request body.
+ *   2. The response is delivered as Server-Sent Events; AI SDK's
+ *      non-streaming code path expects a single JSON body.
+ *
+ * This fetch forces streaming on the outgoing request, collects the SSE
+ * events, and synthesizes the non-streaming JSON shape that
+ * `@ai-sdk/openai`'s Responses API parser expects.
+ *
+ * Headers, OAuth refresh, and URL targeting are handled by the caller via
+ * `baseURL` / `headers` on the AI SDK provider; this fetch only injects the
+ * live OAuth bearer per call.
+ */
+export function buildCodexStagehandFetch(authStorage: AuthStorage): typeof fetch {
+  return (async (url: string | URL | Request, init?: Parameters<typeof fetch>[1]) => {
+    // Refresh + inject the OAuth bearer per call
+    const { accessToken } = await getCodexBearer(authStorage);
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', `Bearer ${accessToken}`);
+    headers.set('Accept', 'text/event-stream');
+
+    // Force stream: true on the request body
+    type FetchBody = NonNullable<Parameters<typeof fetch>[1]>['body'];
+    let body: FetchBody | undefined = init?.body;
+    if (typeof init?.body === 'string') {
+      try {
+        const parsed = JSON.parse(init.body) as Record<string, unknown>;
+        parsed.stream = true;
+        body = JSON.stringify(parsed);
+        if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+      } catch {
+        // Not JSON; leave as-is
+      }
+    }
+
+    const upstream = await fetch(url, { ...init, headers, body });
+    if (!upstream.ok) return upstream;
+
+    // Aggregate SSE -> synthesized non-streaming Response
+    const aggregated = await aggregateCodexStream(upstream);
+    return new Response(aggregated, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+/**
+ * Read an SSE Response and reduce it to a single JSON string matching the
+ * non-streaming OpenAI Responses-API shape.
+ *
+ * Event vocabulary we care about (per OpenAI Responses API streaming):
+ *   - response.created         → carries `response` object (id, model, usage stub)
+ *   - response.output_item.added/done → output items (message, reasoning, etc.)
+ *   - response.output_text.delta → text chunks
+ *   - response.completed       → final `response` snapshot incl. usage
+ *   - response.error / error   → bubble up as a thrown body
+ *
+ * Reasoning events (`response.reasoning_summary.*`) are intentionally ignored
+ * for the non-streaming text response.
+ */
+async function aggregateCodexStream(response: Response): Promise<string> {
+  if (!response.body) {
+    throw new Error('Codex streaming response had no body');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+
+  let finalResponse: any = null;
+  let createdResponse: any = null;
+  // Track output_items by index so we can rebuild the final array
+  const items = new Map<number, any>();
+  // Accumulate output_text deltas keyed by item_index + content_index
+  const textBuffers = new Map<string, string>();
+
+  const handleEvent = (event: { event?: string; data?: string }) => {
+    if (!event.data || event.data === '[DONE]') return;
+    let payload: any;
+    try {
+      payload = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+    const type: string = payload.type ?? event.event ?? '';
+
+    switch (type) {
+      case 'response.created': {
+        createdResponse = payload.response ?? createdResponse;
+        break;
+      }
+      case 'response.output_item.added': {
+        if (typeof payload.output_index === 'number' && payload.item) {
+          items.set(payload.output_index, payload.item);
+        }
+        break;
+      }
+      case 'response.output_item.done': {
+        if (typeof payload.output_index === 'number' && payload.item) {
+          items.set(payload.output_index, payload.item);
+        }
+        break;
+      }
+      case 'response.output_text.delta': {
+        const key = `${payload.output_index}:${payload.content_index ?? 0}`;
+        textBuffers.set(key, (textBuffers.get(key) ?? '') + (payload.delta ?? ''));
+        break;
+      }
+      case 'response.completed': {
+        finalResponse = payload.response ?? finalResponse;
+        break;
+      }
+      case 'response.error':
+      case 'error': {
+        throw new Error(
+          `Codex stream error: ${JSON.stringify(payload.error ?? payload)}`,
+        );
+      }
+      default:
+        // Ignore reasoning / unknown events
+        break;
+    }
+  };
+
+  // SSE parser: events separated by blank line; lines like "event: x" / "data: y"
+  const processChunk = (chunk: string) => {
+    buffer += chunk;
+    let sepIdx: number;
+    while ((sepIdx = buffer.indexOf('\n\n')) !== -1) {
+      const raw = buffer.slice(0, sepIdx);
+      buffer = buffer.slice(sepIdx + 2);
+      const event: { event?: string; data?: string } = {};
+      const dataLines: string[] = [];
+      for (const line of raw.split('\n')) {
+        if (line.startsWith('event:')) {
+          event.event = line.slice(6).trim();
+        } else if (line.startsWith('data:')) {
+          dataLines.push(line.slice(5).trimStart());
+        }
+      }
+      if (dataLines.length > 0) {
+        event.data = dataLines.join('\n');
+      }
+      handleEvent(event);
+    }
+  };
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    processChunk(decoder.decode(value, { stream: true }));
+  }
+  processChunk(decoder.decode());
+
+  // Stitch accumulated text deltas back into their items
+  const base = finalResponse ?? createdResponse ?? { output: [] };
+  const finalItems = Array.from(items.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([index, item]) => {
+      // Patch message-type items' content text using buffered deltas
+      if (item?.type === 'message' && Array.isArray(item.content)) {
+        item.content = item.content.map((c: any, ci: number) => {
+          const key = `${index}:${ci}`;
+          if (textBuffers.has(key)) {
+            return { ...c, text: textBuffers.get(key) };
+          }
+          return c;
+        });
+      }
+      return item;
+    });
+
+  base.output = finalItems.length > 0 ? finalItems : base.output ?? [];
+
+  return JSON.stringify(base);
 }
 
 /**

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -324,9 +324,7 @@ async function aggregateCodexStream(response: Response): Promise<string> {
       }
       case 'response.error':
       case 'error': {
-        throw new Error(
-          `Codex stream error: ${JSON.stringify(payload.error ?? payload)}`,
-        );
+        throw new Error(`Codex stream error: ${JSON.stringify(payload.error ?? payload)}`);
       }
       default:
         // Ignore reasoning / unknown events
@@ -335,8 +333,9 @@ async function aggregateCodexStream(response: Response): Promise<string> {
   };
 
   // SSE parser: events separated by blank line; lines like "event: x" / "data: y"
+  // Normalize CRLF→LF so \r\n\r\n event boundaries parse correctly (SSE spec allows CRLF).
   const processChunk = (chunk: string) => {
-    buffer += chunk;
+    buffer += chunk.replace(/\r\n/g, '\n');
     let sepIdx: number;
     while ((sepIdx = buffer.indexOf('\n\n')) !== -1) {
       const raw = buffer.slice(0, sepIdx);
@@ -357,13 +356,17 @@ async function aggregateCodexStream(response: Response): Promise<string> {
     }
   };
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    processChunk(decoder.decode(value, { stream: true }));
+  try {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      processChunk(decoder.decode(value, { stream: true }));
+    }
+    processChunk(decoder.decode());
+  } finally {
+    reader.releaseLock();
   }
-  processChunk(decoder.decode());
 
   // Stitch accumulated text deltas back into their items
   const base = finalResponse ?? createdResponse ?? { output: [] };
@@ -383,7 +386,7 @@ async function aggregateCodexStream(response: Response): Promise<string> {
       return item;
     });
 
-  base.output = finalItems.length > 0 ? finalItems : base.output ?? [];
+  base.output = finalItems.length > 0 ? finalItems : (base.output ?? []);
 
   return JSON.stringify(base);
 }


### PR DESCRIPTION
## Summary

Stagehand's AI-driven browser tools (`observe`, `act`, `extract`) fail with HTTP 400 `Bad Request` for any user signed in to OpenAI Codex OAuth in MastraCode. This PR fixes that and lets those tools work end-to-end without requiring `OPENAI_API_KEY`.

## Background

MastraCode integrates Stagehand for browser automation. Stagehand drives its AI calls through AI SDK's non-streaming `generateText`. Independently, when the user signs in to OpenAI Codex OAuth, MastraCode routes Stagehand traffic to the Codex `/responses` backend so it can reuse the user's ChatGPT subscription.

Two facts about Codex's backend that the previous integration didn't account for:

1. `/responses` **only accepts streamed requests** (`stream: true`).
2. The response is delivered as **Server-Sent Events**, not a single JSON body.

The previous integration plugged into the AI SDK by giving it a custom `fetch` that rewrote the request URL to Codex's endpoint and swapped the bearer token. That handled auth and routing, but didn't translate between Stagehand's non-streaming shape and Codex's streaming shape — so every Stagehand AI call hit HTTP 400.

## What changed

The Stagehand model config in `mastracode/src/onboarding/settings.ts` now uses the AI SDK provider's public configuration to express each concern at the right layer:

| Layer | Field | Job |
|---|---|---|
| Transport URL | `baseURL` | AI SDK targets `/responses` directly; no URL rewriting needed |
| Static identity | `headers` | `originator`, `User-Agent`, `ChatGPT-Account-ID` |
| Dynamic per-call surgery | `fetch` | OAuth bearer refresh, force `stream: true`, SSE→JSON bridge |
| Semantic AI-SDK transforms | `middleware` | Inject `instructions` and `store: false` (existing `createCodexMiddleware`) |

The new `buildCodexStagehandFetch` in `mastracode/src/providers/openai-codex.ts` is the only piece doing dynamic work. It:

1. Refreshes/injects the Codex OAuth bearer per call
2. Parses the outgoing JSON body, flips `stream: true`, re-serializes
3. Reads the SSE response (handling `response.created`, `response.output_item.added/done`, `response.output_text.delta`, `response.completed`, and `response.error`) and emits a synthesized non-streaming JSON envelope matching what `@ai-sdk/openai`'s Responses parser expects

The OAuth-bearer-refresh logic that was duplicated across the main agent fetch and the Stagehand fetch is extracted into a shared `getCodexBearer` helper.

## Verification

Tested locally against Codex OAuth, with no `OPENAI_API_KEY` set:

- `navigate` → ✅
- `observe` → ✅ returned actionable selectors and descriptions
- `extract` → ✅ returned structured text
- `act` → ✅ executed a real click and the browser navigated

`pnpm check` (typecheck) passes cleanly.

## Test plan for reviewers

1. Sign in to OpenAI Codex OAuth in MastraCode (`/login`, pick `openai-codex`)
2. Make sure `OPENAI_API_KEY` is **not** set in the environment
3. In a chat, run a Stagehand workflow that calls `navigate`, then `observe`, then `extract`, then `act` on `https://example.com`
4. Each AI op should return a successful, well-shaped result (no `Bad Request` errors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Stagehand's browser tools stopped working when people logged in with OpenAI Codex. The problem was a mismatch in how they were talking to each other: Stagehand was sending regular messages, but Codex only understood streaming messages. This PR fixes the conversation by properly translating between the two communication styles, so they can understand each other again.

---

## Technical Summary

### Root Cause
Stagehand's AI-driven browser tools (`observe`, `act`, `extract`) were failing with HTTP 400 errors when users were signed into OpenAI Codex OAuth. The issue stemmed from a fundamental mismatch between:
- **Stagehand's request style**: Non-streaming requests via AI SDK's `generateText`
- **Codex's expectation**: Streaming-only requests with Server-Sent Events (SSE) responses

The previous integration routed Stagehand traffic through a custom `fetch` function that rewrote URLs and swapped authentication tokens, but didn't translate the underlying request/response shapes.

### Solution

**`mastracode/src/onboarding/settings.ts`**
Reconfigures the Stagehand model for Codex OAuth integration using AI SDK provider configuration layers:
- Routes to Codex via fixed `baseURL` (eliminates URL rewriting)
- Supplies Codex identity via `headers` (`originator`, `User-Agent`, `ChatGPT-Account-ID`)
- Uses `createCodexMiddleware` to inject required `instructions` and `store: false` parameters
- Implements per-call dynamic handling via a new `buildCodexStagehandFetch` function

**`mastracode/src/providers/openai-codex.ts`**
- Extracts shared OAuth bearer refresh logic into `getCodexBearer(authStorage?)` helper to avoid duplication
- Adds new exported `buildCodexStagehandFetch(authStorage)` function that:
  - Refreshes OAuth bearer tokens per request
  - Forces `stream: true` on outgoing requests
  - Aggregates SSE responses into non-streaming JSON format via new `aggregateCodexStream(response)` function
  - Handles Responses streaming event types (created, output item added/done, text delta, completed, error)
  - Returns JSON compatible with AI SDK's Responses parser

### Verification
Solution verified end-to-end with Codex OAuth (no `OPENAI_API_KEY` required), confirming all operations succeed: `navigate`, `observe`, `extract`, and `act`.

### Follow-up Refinements
- SSE reader connection cleanup in exception handling
- CRLF normalization for proper event boundary detection in SSE streams
- Changeset housekeeping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->