### PR TITLE
feat(observability): log toModelOutput result in tool-result telemetry spans

### DIFF
--- a/.changeset/log-tomodeloutput-in-telemetry.md
+++ b/.changeset/log-tomodeloutput-in-telemetry.md
@@ -2,4 +2,4 @@
 "@mastra/observability": patch
 ---
 
-Tool results with `toModelOutput` now show the transformed content in both telemetry span output and trace previews. Previously, locally-executed tools always logged `undefined` as the span output and `[tool-result]` as the preview, making it impossible to see what was actually sent to the model. Now the span output reflects the `toModelOutput`-transformed value (via `providerMetadata.mastra.modelOutput`) when defined, falling back to the raw result otherwise.
+Tool results with `toModelOutput` now show the transformed content in both telemetry span output and trace previews. Previously, locally-executed tools always logged `undefined` as the span output and `[tool-result]` as the preview, making it impossible to see what was actually sent to the model. Now the span output reflects the actual value sent to the model when a tool defines `toModelOutput`, falling back to the raw result otherwise.

--- a/.changeset/log-tomodeloutput-in-telemetry.md
+++ b/.changeset/log-tomodeloutput-in-telemetry.md
@@ -1,0 +1,5 @@
+---
+"@mastra/observability": patch
+---
+
+Tool results with `toModelOutput` now show the transformed content in both telemetry span output and trace previews. Previously, locally-executed tools always logged `undefined` as the span output and `[tool-result]` as the preview, making it impossible to see what was actually sent to the model. Now the span output reflects the `toModelOutput`-transformed value (via `providerMetadata.mastra.modelOutput`) when defined, falling back to the raw result otherwise.

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -156,8 +156,8 @@ describe('ModelSpanTracker', () => {
       expect(span.isEvent).toBe(true);
       // toolCallId and toolName are in metadata (tool-result specific fields)
       expect(span.metadata).toMatchObject({ toolCallId, toolName });
-      // output is omitted; TOOL_CALL captures the full result payload
-      expect(span.output).toBeUndefined();
+      // output now reflects the actual value sent to the model (raw result when no toModelOutput)
+      expect(span.output).toEqual({ text: 'Hello world!' });
     });
 
     it('should pass through tool-output chunks without creating spans', async () => {
@@ -289,8 +289,8 @@ describe('ModelSpanTracker', () => {
       expect(span.isEvent).toBe(true);
       // toolCallId and toolName are in metadata
       expect(span.metadata).toMatchObject({ toolCallId, toolName });
-      // output is omitted; TOOL_CALL captures the full result payload
-      expect(span.output).toBeUndefined();
+      // output now reflects the actual value sent to the model (raw result when no toModelOutput)
+      expect(span.output).toEqual({ output: 'Workflow result', status: 'success' });
     });
   });
 
@@ -356,8 +356,8 @@ describe('ModelSpanTracker', () => {
       expect(span.isEvent).toBe(true);
       // toolCallId and toolName are in metadata
       expect(span.metadata).toMatchObject({ toolCallId, toolName });
-      // output is omitted; TOOL_CALL captures the full result payload
-      expect(span.output).toBeUndefined();
+      // output now reflects the actual value sent to the model (raw result when no toModelOutput)
+      expect(span.output).toEqual({ text: 'Streamed content' });
     });
   });
 
@@ -397,12 +397,12 @@ describe('ModelSpanTracker', () => {
       expect(toolResultSpans).toHaveLength(1);
 
       const span = toolResultSpans[0]!;
-      // args should not be in metadata and output is omitted entirely
+      // args should not be in metadata
       expect(span.metadata).not.toHaveProperty('args');
       // toolCallId and toolName should be in metadata
       expect(span.metadata).toMatchObject({ toolCallId, toolName });
-      // output is omitted; TOOL_CALL captures the full result payload
-      expect(span.output).toBeUndefined();
+      // output now reflects the actual value sent to the model (raw result when no toModelOutput)
+      expect(span.output).toEqual({ output: 'tool result' });
     });
 
     it('should keep tool-result output for provider-executed tools', async () => {
@@ -529,15 +529,16 @@ describe('ModelSpanTracker', () => {
         toolCallId: 'call_agent1',
         toolName: 'agent-first',
       });
-      // output is omitted; TOOL_CALL captures the full result payload
-      expect(agent1Span!.output).toBeUndefined();
+      // output now reflects the actual value sent to the model (raw result when no
+      // toModelOutput is defined, or providerMetadata.mastra.modelOutput when it is).
+      expect(agent1Span!.output).toEqual({ text: 'Agent1: Hello' });
 
       expect(agent2Span).toBeDefined();
       expect(agent2Span!.metadata).toMatchObject({
         toolCallId: 'call_agent2',
         toolName: 'agent-second',
       });
-      expect(agent2Span!.output).toBeUndefined();
+      expect(agent2Span!.output).toEqual({ text: 'Agent2: World' });
     });
   });
 

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -97,8 +97,33 @@ function summarizePart(part: unknown): string {
         return '[reasoning]';
       case 'tool-call':
         return `[tool: ${formatPreviewLabel((part as { toolName?: unknown }).toolName, 'unknown')}]`;
-      case 'tool-result':
+      case 'tool-result': {
+        // Prefer the toModelOutput-transformed value (AI SDK v5: `output`,
+        // AI SDK v4 array: `content[].text`, raw fallback: `result`).
+        // Only fall back to the static placeholder when no content is found,
+        // so tools that define toModelOutput are visible in telemetry previews.
+        const p = part as {
+          output?: unknown;
+          content?: unknown;
+          result?: unknown;
+        };
+        if (p.output != null) {
+          return summarizeMessageContent(p.output) || '[tool-result]';
+        }
+        if (Array.isArray(p.content) && p.content.length > 0) {
+          return p.content
+            .map((c: unknown) => summarizePart(c))
+            .filter(Boolean)
+            .join('') || '[tool-result]';
+        }
+        if (typeof p.content === 'string' && p.content.length > 0) {
+          return p.content;
+        }
+        if (p.result != null) {
+          return summarizeMessageContent(p.result) || '[tool-result]';
+        }
         return '[tool-result]';
+      }
       default:
         return `[${part.type}]`;
     }
@@ -951,7 +976,13 @@ export class ModelSpanTracker {
               if (providerExecuted !== undefined) metadata.providerExecuted = providerExecuted;
               if (providerMetadata !== undefined) metadata.providerMetadata = providerMetadata;
 
-              this.#createEventSpan(chunk.type, providerExecuted ? result : undefined, { metadata });
+              // For locally-executed tools, prefer the toModelOutput-transformed value stored at
+              // providerMetadata.mastra.modelOutput (set by llm-mapping-step). Fall back to the
+              // raw result so the span always carries the actual value sent to the model.
+              // For provider-executed tools the result comes directly from the model stream.
+              const modelOutput = (providerMetadata as any)?.mastra?.modelOutput;
+              const spanOutput = providerExecuted ? result : (modelOutput ?? result);
+              this.#createEventSpan(chunk.type, spanOutput, { metadata });
               break;
             }
 


### PR DESCRIPTION
## Description

Previously, `tool-result` telemetry spans always logged `undefined` as the output for locally-executed tools, and showed `[tool-result]` as the static preview placeholder — even when a tool defined `toModelOutput`. This made traces in Mastra Studio and Langfuse show `[tool: {toolName}]` instead of the actual content sent to the model, making debugging nearly impossible.

**Root cause:** `#createEventSpan` was called with `providerExecuted ? result : undefined` — meaning locally-executed tools always produced an empty span output. The `toModelOutput`-transformed value is stored at `providerMetadata.mastra.modelOutput` by `llm-mapping-step`, but was never read by the tracing layer.

**Fix:**
- In `tool-result` span creation, read `providerMetadata.mastra.modelOutput` (the `toModelOutput`-transformed value) and use it as span output, falling back to raw `result` when not defined
- In `summarizePart()`, expand the `tool-result` case to prefer `output` → `content` → `result` instead of always returning `[tool-result]`, so trace previews reflect the actual content
- Updated tests to assert the new correct behavior

## Related issue(s)

Fixes #18356

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

When tools run inside the system, their results should show up in tracing/logs exactly as the AI model receives them. This PR fixes telemetry so it records and previews the real transformed tool output (instead of `undefined` or a generic placeholder), making traces much easier to debug.

## Overview

This PR fixes Observability telemetry for `tool-result` spans so locally executed tools report the same model-facing value that was sent to the LLM—especially for tools that use `toModelOutput` transformations.

## What was wrong

Previously, `tool-result` telemetry for locally executed tools:
- recorded `undefined` as the span `output`
- showed a static `[tool-result]` preview, hiding the actual content sent to the model

## What changed

### 1. Correct span output for locally executed tools
- Updated span creation to use `providerMetadata.mastra.modelOutput` as the `tool-result` span `output` when available
- If `providerMetadata.mastra.modelOutput` isn’t present, it falls back to the raw tool result

### 2. Better trace preview summarization
- Updated `summarizePart()` so `tool-result` previews prefer:
  1) `output`
  2) `content` (summarized when it’s a non-empty array or non-empty string)
  3) `result`
  4) `"[tool-result]"` only if none of the above are usable

## Tests
- Updated `observability/mastra/src/model-tracing.test.ts` assertions to verify `tool-result` span `output` now matches the expected payload (including locally executed/transformed cases), rather than being `undefined`.

## Changeset
- Added a patch changeset for `@mastra/observability` documenting the telemetry fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->