### PR TITLE
docs: discourage implementation-mirror tests

### DIFF
--- a/.claude/skills/playground-msw-tests/SKILL.md
+++ b/.claude/skills/playground-msw-tests/SKILL.md
@@ -45,6 +45,9 @@ contract.
 
 - ❌ `vi.mock('@/domains/.../hooks/use-agents')` — mocking our own hooks hides
   cache, gating and transport bugs.
+- ❌ Implementation-mirror tests — do not duplicate source class strings,
+  branch logic, generated shapes, or calculations without asserting a real
+  behavior or regression.
 - ❌ Inline TypeScript types in tests (`type AgentLite = { id: string }`) —
   these drift silently from the real SDK.
 - ❌ `as any` / `as unknown as ListAgentsResponse` on fixture data.

--- a/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
+++ b/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
@@ -85,6 +85,7 @@ describe('AgentEditPage', () => {
 - **Outer `describe`** = the unit under test (the hook, component, or function).
 - **Inner `describe('when <context>')`** = one precondition: an input shape, an RBAC capability, a feature flag, or a loading/error/empty/success state — each set up with a **real MSW fixture**, never a mocked hook.
 - **`it('<outcome>')`** = one Then. Split multi-assert cases into separate `it`s so a failure names the exact broken outcome.
+- Avoid implementation-mirror tests: do not duplicate source class strings, branch logic, generated shapes, or calculations unless the assertion protects a real behavior or regression.
 - Keep single-context units **flat** — don't nest `when` blocks for their own sake.
 
 Fixtures live in a nearby `__tests__/fixtures/` folder, typed with response types re-exported from `@mastra/client-js`. No bespoke inline types, no `as any`, no `as unknown as`.


### PR DESCRIPTION
Adds a concise testing anti-pattern to the playground and React testing skills: avoid implementation-mirror tests that duplicate source class strings, branch logic, generated shapes, or calculations without asserting a real behavior or regression.

This keeps the guidance separate from the DataList UI PR.

Validation:
- pnpm exec prettier --check .claude/skills/playground-msw-tests/SKILL.md .claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change adds a simple reminder to writing tests: don’t just copy the code you’re testing. Tests should check real behavior, so they can catch bugs instead of repeating the same logic.

### Summary
- Added an anti-pattern note to the playground MSW testing skill warning against “implementation-mirror tests.”
- Added matching guidance to the React testing BDD rules to discourage duplicating source strings, branches, generated shapes, or calculations unless it protects against a real regression.
- Kept these documentation updates separate from the DataList UI work.

### Validation
- Ran Prettier checks on the updated skill documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->