### PR TITLE
docs: clarify test cast guidance

### DIFF
--- a/.claude/skills/playground-msw-tests/SKILL.md
+++ b/.claude/skills/playground-msw-tests/SKILL.md
@@ -65,9 +65,6 @@ contract.
 - ✅ Use direct imports and inferred types from real SDK, hook, component, DOM,
   or Testing Library APIs for MSW payloads, request payloads, hook inputs, and
   component events.
-- ✅ If jsdom lacks a concrete browser primitive, add the smallest adapter or
-  polyfill at the DOM boundary only. Keep call sites typed by the API the real
-  hook/component already consumes.
 - ✅ Register MSW handlers per test with `server.use(...)` so handlers reset
   between tests via the global `afterEach`.
 - ✅ Render through `MastraReactProvider` + `QueryClientProvider` + `MemoryRouter`

--- a/.claude/skills/playground-msw-tests/SKILL.md
+++ b/.claude/skills/playground-msw-tests/SKILL.md
@@ -47,7 +47,8 @@ contract.
   cache, gating and transport bugs.
 - ❌ Inline TypeScript types in tests (`type AgentLite = { id: string }`) —
   these drift silently from the real SDK.
-- ❌ `as any` / `as unknown as ListAgentsResponse` on fixture data.
+- ❌ `as any` / `as unknown as ListAgentsResponse` on fixture data, MSW
+  responses, request payloads, hook inputs, or component event inputs.
 - ❌ Returning bespoke shapes from MSW handlers that don't match the real
   `@mastra/client-js` response. If a field is optional, include it as optional
   in the fixture, don't omit the type.
@@ -58,6 +59,9 @@ contract.
 - ✅ Type every fixture with a response type re-exported from `@mastra/client-js`
   (e.g. `ListStoredAgentsResponse`, `GetAgentResponse`, `BuilderSettingsResponse`,
   `GetToolResponse`, `GetWorkflowResponse`, `ListStoredSkillsResponse`).
+- ✅ Use typed builders or named helpers for test data and test events. If jsdom
+  lacks a concrete browser primitive, keep the adapter small and typed to the
+  public hook/component boundary so call sites stay cast-free.
 - ✅ Register MSW handlers per test with `server.use(...)` so handlers reset
   between tests via the global `afterEach`.
 - ✅ Render through `MastraReactProvider` + `QueryClientProvider` + `MemoryRouter`
@@ -139,7 +143,9 @@ export const oneDraftAgent: ListStoredAgentsResponse = {
 ```
 
 **If a required field on the SDK response type is missing from your fixture,
-that's a real test failure — fix the fixture, never `as any` it.**
+that's a real test failure — fix the fixture, never `as any` it.** The same
+applies to hook inputs, component events, and request payloads: type the helper
+at the real boundary instead of casting the test into compiling.
 
 ## Existing Infrastructure to Reuse
 
@@ -236,8 +242,9 @@ through their real implementations against MSW.
 
 Before considering a test done:
 
-- [ ] All fixtures import a type from `@mastra/client-js` and have no `as any`
-      / `as unknown as` casts.
+- [ ] Fixtures, MSW payloads, request payloads, hook inputs, and event helpers
+      are typed at the real boundary and have no `as any` / `as unknown as`
+      casts.
 - [ ] No `vi.mock` of `@/domains/.../hooks/*`, `@/domains/.../services/*`,
       `@mastra/client-js`, or `@mastra/react`.
 - [ ] `pnpm --filter ./packages/playground typecheck` passes — proves fixtures

--- a/.claude/skills/playground-msw-tests/SKILL.md
+++ b/.claude/skills/playground-msw-tests/SKILL.md
@@ -62,12 +62,12 @@ contract.
 - ✅ Type every fixture with a response type re-exported from `@mastra/client-js`
   (e.g. `ListStoredAgentsResponse`, `GetAgentResponse`, `BuilderSettingsResponse`,
   `GetToolResponse`, `GetWorkflowResponse`, `ListStoredSkillsResponse`).
-- ✅ Use typed builders or named helpers for test data and test events, typed
-  from real imports, production input types, or inferred hook/component
-  signatures. Keep the real hook/component import in the test.
-- ✅ If jsdom lacks a concrete browser primitive, keep the adapter small and
-  typed to the DOM or public hook/component boundary so call sites stay
-  cast-free.
+- ✅ Use direct imports and inferred types from real SDK, hook, component, DOM,
+  or Testing Library APIs for MSW payloads, request payloads, hook inputs, and
+  component events.
+- ✅ If jsdom lacks a concrete browser primitive, add the smallest adapter or
+  polyfill at the DOM boundary only. Keep call sites typed by the API the real
+  hook/component already consumes.
 - ✅ Register MSW handlers per test with `server.use(...)` so handlers reset
   between tests via the global `afterEach`.
 - ✅ Render through `MastraReactProvider` + `QueryClientProvider` + `MemoryRouter`
@@ -249,9 +249,9 @@ through their real implementations against MSW.
 Before considering a test done:
 
 - [ ] All fixtures import a response type from `@mastra/client-js`; MSW payloads,
-      request payloads, hook inputs, and event helpers use real imported,
-      production, or inferred boundary types; no `as any` / `as unknown as`
-      casts.
+      request payloads, hook inputs, and component events use direct imports or
+      inferred production boundary types; no bespoke test-only shapes and no
+      `as any` / `as unknown as` casts.
 - [ ] No `vi.mock` of `@/domains/.../hooks/*`, `@/domains/.../services/*`,
       `@mastra/client-js`, or `@mastra/react`.
 - [ ] `pnpm --filter ./packages/playground typecheck` passes — proves fixtures

--- a/.claude/skills/playground-msw-tests/SKILL.md
+++ b/.claude/skills/playground-msw-tests/SKILL.md
@@ -62,9 +62,12 @@ contract.
 - ✅ Type every fixture with a response type re-exported from `@mastra/client-js`
   (e.g. `ListStoredAgentsResponse`, `GetAgentResponse`, `BuilderSettingsResponse`,
   `GetToolResponse`, `GetWorkflowResponse`, `ListStoredSkillsResponse`).
-- ✅ Use typed builders or named helpers for test data and test events. If jsdom
-  lacks a concrete browser primitive, keep the adapter small and typed to the
-  public hook/component boundary so call sites stay cast-free.
+- ✅ Use typed builders or named helpers for test data and test events, typed
+  from real imports, production input types, or inferred hook/component
+  signatures. Keep the real hook/component import in the test.
+- ✅ If jsdom lacks a concrete browser primitive, keep the adapter small and
+  typed to the DOM or public hook/component boundary so call sites stay
+  cast-free.
 - ✅ Register MSW handlers per test with `server.use(...)` so handlers reset
   between tests via the global `afterEach`.
 - ✅ Render through `MastraReactProvider` + `QueryClientProvider` + `MemoryRouter`
@@ -245,8 +248,9 @@ through their real implementations against MSW.
 
 Before considering a test done:
 
-- [ ] Fixtures, MSW payloads, request payloads, hook inputs, and event helpers
-      are typed at the real boundary and have no `as any` / `as unknown as`
+- [ ] All fixtures import a response type from `@mastra/client-js`; MSW payloads,
+      request payloads, hook inputs, and event helpers use real imported,
+      production, or inferred boundary types; no `as any` / `as unknown as`
       casts.
 - [ ] No `vi.mock` of `@/domains/.../hooks/*`, `@/domains/.../services/*`,
       `@mastra/client-js`, or `@mastra/react`.

--- a/.claude/skills/react-best-practices/references/react-best-practices-reference.md
+++ b/.claude/skills/react-best-practices/references/react-best-practices-reference.md
@@ -838,6 +838,8 @@ describe('AgentEditPage', () => {
 
 **BDD structure:** outer `describe` = the unit under test; inner `describe('when <context>')` = one precondition (input shape, RBAC capability, feature flag, loading/error/empty/success), each set up with a real MSW fixture; `it('<outcome>')` = one Then (split multi-assert cases). Keep single-context units flat. Fixtures live in a nearby `__tests__/fixtures/` folder, typed from `@mastra/client-js` — no `as any`, no `as unknown as`.
 
+Do not cast test data, MSW responses, request payloads, hook inputs, or component event inputs to force compatibility. Use production response/input types, typed builders, or named helpers. If jsdom lacks a concrete browser primitive, keep the adapter small and typed to the public hook/component boundary so call sites stay cast-free.
+
 When removing a mock surfaces a real product gap, fix the test/fixture or file the gap — never re-mock to hide it. MSW runs with `onUnhandledRequest: 'error'`, so unstubbed requests fail loudly.
 
 ---

--- a/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
+++ b/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
@@ -90,7 +90,7 @@ describe('AgentEditPage', () => {
 
 Fixtures live in a nearby `__tests__/fixtures/` folder, typed with response types re-exported from `@mastra/client-js`. No bespoke inline types, no `as any`, no `as unknown as`.
 
-Do not cast test data, MSW responses, request payloads, hook inputs, or component event inputs to force compatibility. Use production response/input types from real imports, typed builders, or named helpers inferred from the real hook/component signature. Keep the real hook/component import in the test. If jsdom lacks a concrete browser primitive, keep the adapter small and typed to the DOM or public hook/component boundary so call sites stay cast-free.
+Do not cast test data, MSW responses, request payloads, hook inputs, or component event inputs to force compatibility. Use direct imports and inferred production boundary types from real SDK, hook, component, DOM, or Testing Library APIs. Keep the real hook/component import in the test, and keep fixtures typed with response types re-exported from `@mastra/client-js`. If jsdom lacks a concrete browser primitive, add the smallest adapter or polyfill at the DOM boundary only, typed by the API the real hook/component already consumes.
 
 When removing a mock surfaces a real product gap (an endpoint with no handler, a gating branch that was never exercised), fix the test/fixture or file the gap — never re-mock to paper over it. MSW runs with `onUnhandledRequest: 'error'`, so an unstubbed request fails loudly on purpose.
 

--- a/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
+++ b/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
@@ -90,7 +90,7 @@ describe('AgentEditPage', () => {
 
 Fixtures live in a nearby `__tests__/fixtures/` folder, typed with response types re-exported from `@mastra/client-js`. No bespoke inline types, no `as any`, no `as unknown as`.
 
-Do not cast test data, MSW responses, request payloads, hook inputs, or component event inputs to force compatibility. Use direct imports and inferred production boundary types from real SDK, hook, component, DOM, or Testing Library APIs. Keep the real hook/component import in the test, and keep fixtures typed with response types re-exported from `@mastra/client-js`. If jsdom lacks a concrete browser primitive, add the smallest adapter or polyfill at the DOM boundary only, typed by the API the real hook/component already consumes.
+Do not cast test data, MSW responses, request payloads, hook inputs, or component event inputs to force compatibility. Use direct imports and inferred production boundary types from real SDK, hook, component, DOM, or Testing Library APIs. Keep the real hook/component import in the test, and keep fixtures typed with response types re-exported from `@mastra/client-js`.
 
 When removing a mock surfaces a real product gap (an endpoint with no handler, a gating branch that was never exercised), fix the test/fixture or file the gap — never re-mock to paper over it. MSW runs with `onUnhandledRequest: 'error'`, so an unstubbed request fails loudly on purpose.
 

--- a/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
+++ b/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
@@ -89,6 +89,8 @@ describe('AgentEditPage', () => {
 
 Fixtures live in a nearby `__tests__/fixtures/` folder, typed with response types re-exported from `@mastra/client-js`. No bespoke inline types, no `as any`, no `as unknown as`.
 
+Do not cast test data, MSW responses, request payloads, hook inputs, or component event inputs to force compatibility. Use production response/input types, typed builders, or named helpers. If jsdom lacks a concrete browser primitive, keep the adapter small and typed to the public hook/component boundary so call sites stay cast-free.
+
 When removing a mock surfaces a real product gap (an endpoint with no handler, a gating branch that was never exercised), fix the test/fixture or file the gap — never re-mock to paper over it. MSW runs with `onUnhandledRequest: 'error'`, so an unstubbed request fails loudly on purpose.
 
 ### Wrap mutation calls in `act`

--- a/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
+++ b/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
@@ -90,7 +90,7 @@ describe('AgentEditPage', () => {
 
 Fixtures live in a nearby `__tests__/fixtures/` folder, typed with response types re-exported from `@mastra/client-js`. No bespoke inline types, no `as any`, no `as unknown as`.
 
-Do not cast test data, MSW responses, request payloads, hook inputs, or component event inputs to force compatibility. Use production response/input types, typed builders, or named helpers. If jsdom lacks a concrete browser primitive, keep the adapter small and typed to the public hook/component boundary so call sites stay cast-free.
+Do not cast test data, MSW responses, request payloads, hook inputs, or component event inputs to force compatibility. Use production response/input types from real imports, typed builders, or named helpers inferred from the real hook/component signature. Keep the real hook/component import in the test. If jsdom lacks a concrete browser primitive, keep the adapter small and typed to the DOM or public hook/component boundary so call sites stay cast-free.
 
 When removing a mock surfaces a real product gap (an endpoint with no handler, a gating branch that was never exercised), fix the test/fixture or file the gap — never re-mock to paper over it. MSW runs with `onUnhandledRequest: 'error'`, so an unstubbed request fails loudly on purpose.
 

--- a/embedders/voyageai/README.md
+++ b/embedders/voyageai/README.md
@@ -203,10 +203,10 @@ console.log(grouped.embeddingsByDocument); // [[[...], [...]], [[...]]]
 
 ### Contextualized Models
 
-| Model              | Use Case                                  |
-| ------------------ | ----------------------------------------- |
+| Model              | Use Case                                             |
+| ------------------ | ---------------------------------------------------- |
 | `voyage-context-4` | Chunks with document context, best quality (preview) |
-| `voyage-context-3` | Chunks with document context              |
+| `voyage-context-3` | Chunks with document context                         |
 
 ### Reranker Models
 

--- a/stores/redis/src/cache.ts
+++ b/stores/redis/src/cache.ts
@@ -48,12 +48,7 @@ const defaultPushToList = (client: RedisClient, key: string, value: unknown): Pr
   return client.rpush(key, value);
 };
 
-const defaultGetListRange = (
-  client: RedisClient,
-  key: string,
-  start: number,
-  stop: number,
-): Promise<unknown[]> => {
+const defaultGetListRange = (client: RedisClient, key: string, start: number, stop: number): Promise<unknown[]> => {
   return client.lrange(key, start, stop);
 };
 


### PR DESCRIPTION
## Summary

- Clarify that tests should not force fixture data, MSW responses, request payloads, hook inputs, or component event inputs through `as any` / `as unknown as` casts.
- Make direct real imports and inferred production boundary types the preferred pattern, with fixtures typed from response types re-exported by `@mastra/client-js`.
- Keep the playground MSW skill and canonical react-best-practices testing rule aligned without suggesting bespoke test-only shapes, builders, adapters, or polyfills as a default pattern.

## Checks

- `pnpm prettier --check .claude/skills/playground-msw-tests/SKILL.md .claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md embedders/voyageai/README.md stores/redis/src/cache.ts`
- `git diff --check`