### PR TITLE
fix(redis): extend nodeRedisPreset to cover list operations

### DIFF
--- a/.changeset/redis-list-op-aliases.md
+++ b/.changeset/redis-list-op-aliases.md
@@ -1,0 +1,5 @@
+---
+'@mastra/redis': patch
+---
+
+`nodeRedisPreset` now adapts the three list operations (`llen`, `rpush`, `lrange`) to their camelCase forms on `node-redis` v4+ clients (`lLen`, `rPush`, `lRange`). Extends the same adapter pattern already used for `set` and `scan`. ioredis and Upstash users are unaffected (defaults remain lowercase, matching their APIs).

--- a/stores/redis/src/cache.ts
+++ b/stores/redis/src/cache.ts
@@ -22,6 +22,9 @@ export interface RedisServerCacheOptions {
     pattern: string,
     count: number,
   ) => Promise<[string | number, string[]]>;
+  getListLength?: (client: RedisClient, key: string) => Promise<number>;
+  pushToList?: (client: RedisClient, key: string, value: unknown) => Promise<number>;
+  getListRange?: (client: RedisClient, key: string, start: number, stop: number) => Promise<unknown[]>;
 }
 
 const defaultSetWithExpiry = (client: RedisClient, key: string, value: unknown, seconds: number): Promise<unknown> => {
@@ -37,6 +40,23 @@ const defaultScanKeys = (
   return client.scan(cursor, 'MATCH', pattern, 'COUNT', count);
 };
 
+const defaultGetListLength = (client: RedisClient, key: string): Promise<number> => {
+  return client.llen(key);
+};
+
+const defaultPushToList = (client: RedisClient, key: string, value: unknown): Promise<number> => {
+  return client.rpush(key, value);
+};
+
+const defaultGetListRange = (
+  client: RedisClient,
+  key: string,
+  start: number,
+  stop: number,
+): Promise<unknown[]> => {
+  return client.lrange(key, start, stop);
+};
+
 export class RedisServerCache extends MastraServerCache {
   private client: RedisClient;
   private keyPrefix: string;
@@ -48,6 +68,9 @@ export class RedisServerCache extends MastraServerCache {
     pattern: string,
     count: number,
   ) => Promise<[string | number, string[]]>;
+  private getListLength: (client: RedisClient, key: string) => Promise<number>;
+  private pushToList: (client: RedisClient, key: string, value: unknown) => Promise<number>;
+  private getListRange: (client: RedisClient, key: string, start: number, stop: number) => Promise<unknown[]>;
 
   constructor(config: { client: RedisClient }, options: RedisServerCacheOptions = {}) {
     super({ name: 'RedisServerCache' });
@@ -57,6 +80,9 @@ export class RedisServerCache extends MastraServerCache {
     this.ttlSeconds = options.ttlSeconds ?? 300;
     this.setWithExpiry = options.setWithExpiry ?? defaultSetWithExpiry;
     this.scanKeys = options.scanKeys ?? defaultScanKeys;
+    this.getListLength = options.getListLength ?? defaultGetListLength;
+    this.pushToList = options.pushToList ?? defaultPushToList;
+    this.getListRange = options.getListRange ?? defaultGetListRange;
   }
 
   private getKey(key: string): string {
@@ -101,13 +127,13 @@ export class RedisServerCache extends MastraServerCache {
 
   async listLength(key: string): Promise<number> {
     const fullKey = this.getKey(key);
-    return this.client.llen(fullKey);
+    return this.getListLength(this.client, fullKey);
   }
 
   async listPush(key: string, value: unknown): Promise<void> {
     const fullKey = this.getKey(key);
     const serialized = this.serialize(value);
-    await this.client.rpush(fullKey, serialized);
+    await this.pushToList(this.client, fullKey, serialized);
 
     if (this.ttlSeconds > 0) {
       await this.client.expire(fullKey, this.ttlSeconds);
@@ -116,7 +142,7 @@ export class RedisServerCache extends MastraServerCache {
 
   async listFromTo(key: string, from: number, to: number = -1): Promise<unknown[]> {
     const fullKey = this.getKey(key);
-    const values = await this.client.lrange(fullKey, from, to);
+    const values = await this.getListRange(this.client, fullKey, from, to);
     return values.map(v => this.deserialize(v));
   }
 
@@ -152,8 +178,21 @@ export const upstashPreset: Pick<RedisServerCacheOptions, 'setWithExpiry' | 'sca
     client.scan(cursor, { match: pattern, count } as any) as Promise<[string | number, string[]]>,
 };
 
-export const nodeRedisPreset: Pick<RedisServerCacheOptions, 'setWithExpiry' | 'scanKeys'> = {
+// node-redis v4+ exposes Redis multi-word commands as camelCase only
+// (lLen / rPush / lRange), not as lowercase aliases. The defaults in this
+// module use ioredis-style lowercase, so node-redis users need adapters that
+// forward to the camelCase methods. Single-word commands (set, scan, del,
+// expire, incr, get) work in lowercase under node-redis and don't need
+// adapters; the existing setWithExpiry / scanKeys adapters only exist to
+// reshape arguments, not to alias method names.
+export const nodeRedisPreset: Pick<
+  RedisServerCacheOptions,
+  'setWithExpiry' | 'scanKeys' | 'getListLength' | 'pushToList' | 'getListRange'
+> = {
   setWithExpiry: (client, key, value, seconds) => client.set(key, value, { EX: seconds } as any),
   scanKeys: (client, cursor, pattern, count) =>
     client.scan(cursor, { MATCH: pattern, COUNT: count } as any) as Promise<[string | number, string[]]>,
+  getListLength: (client, key) => (client as any).lLen(key),
+  pushToList: (client, key, value) => (client as any).rPush(key, value),
+  getListRange: (client, key, start, stop) => (client as any).lRange(key, start, stop),
 };

--- a/stores/redis/src/index.test.ts
+++ b/stores/redis/src/index.test.ts
@@ -232,5 +232,40 @@ describe('RedisServerCache', () => {
       // node-redis uses { MATCH, COUNT } style
       expect(mockClient.scan).toHaveBeenCalledWith('0', { MATCH: 'mastra:cache:*', COUNT: 100 });
     });
+
+    it('routes list length through lLen (camelCase) on node-redis clients', async () => {
+      const nodeMock: any = { ...createMockClient(), lLen: vi.fn().mockResolvedValue(7) };
+      const nodeCache = new RedisServerCache({ client: nodeMock }, nodeRedisPreset);
+
+      const result = await nodeCache.listLength('my-list');
+
+      expect(result).toBe(7);
+      expect(nodeMock.lLen).toHaveBeenCalledWith('mastra:cache:my-list');
+      expect(nodeMock.llen).not.toHaveBeenCalled();
+    });
+
+    it('routes list push through rPush (camelCase) on node-redis clients', async () => {
+      const nodeMock: any = { ...createMockClient(), rPush: vi.fn().mockResolvedValue(1) };
+      const nodeCache = new RedisServerCache({ client: nodeMock }, nodeRedisPreset);
+
+      await nodeCache.listPush('my-list', { event: 'test' });
+
+      expect(nodeMock.rPush).toHaveBeenCalledWith('mastra:cache:my-list', '{"event":"test"}');
+      expect(nodeMock.rpush).not.toHaveBeenCalled();
+    });
+
+    it('routes list range through lRange (camelCase) on node-redis clients', async () => {
+      const nodeMock: any = {
+        ...createMockClient(),
+        lRange: vi.fn().mockResolvedValue(['"a"', '"b"']),
+      };
+      const nodeCache = new RedisServerCache({ client: nodeMock }, nodeRedisPreset);
+
+      const result = await nodeCache.listFromTo('my-list', 0, -1);
+
+      expect(result).toEqual(['a', 'b']);
+      expect(nodeMock.lRange).toHaveBeenCalledWith('mastra:cache:my-list', 0, -1);
+      expect(nodeMock.lrange).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

`nodeRedisPreset` already adapts `set` and `scan` for `node-redis`'s differing API shapes via `setWithExpiry` / `scanKeys`. This PR extends the same adapter pattern to the three list operations (`llen`, `rpush`, `lrange`) that `RedisServerCache` calls directly — `node-redis` v4+ exposes those as camelCase only (`lLen`, `rPush`, `lRange`), so any `node-redis` user whose code paths exercise the list ops (notably `CachingPubSub`) hits a runtime `TypeError`.

- Adds `getListLength`, `pushToList`, `getListRange` to `RedisServerCacheOptions`
- Defaults match the existing ioredis-style lowercase calls — ioredis users unaffected
- `nodeRedisPreset` populates the new fields with the camelCase methods
- `upstashPreset` unchanged (Upstash list ops are lowercase)

Fixes #18407.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change teaches Redis cache code to speak two slightly different “dialects” of Redis so it works with more clients. In practice, it stops node-redis from breaking when cache features use list commands like add-to-list and read-from-list.

## Summary
- Added list-operation adapter hooks to `RedisServerCacheOptions`:
  - `getListLength`
  - `pushToList`
  - `getListRange`
- Updated `RedisServerCache` to use those adapters instead of calling list commands directly.
- Extended `nodeRedisPreset` to map list operations to node-redis camelCase methods:
  - `lLen`
  - `rPush`
  - `lRange`
- Kept existing ioredis and Upstash behavior unchanged by preserving lowercase defaults.
- Added tests covering the node-redis preset for list length, push, and range behavior.
- Included a changeset documenting the new support.

## Impact
This fixes the runtime `TypeError` seen when list-backed cache paths are used with node-redis v4+, including flows exercised by `CachingPubSub`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->