### PR TITLE
feat(voyageai): add voyage-context-4 contextualized embedding model

### DIFF
--- a/.changeset/voyage-context-4-embedding.md
+++ b/.changeset/voyage-context-4-embedding.md
@@ -1,0 +1,18 @@
+---
+'@mastra/voyageai': minor
+---
+
+Added support for the `voyage-context-4` contextualized chunk embedding model (preview). Each chunk is embedded with awareness of the other chunks in the same document, capturing both local detail and document-level context. Supports flexible output dimensions (256, 512, 1024, 2048).
+
+```typescript
+import { voyage, voyageContextualizedEmbedding } from '@mastra/voyageai';
+
+// Pre-configured model
+const result = await voyage.context4.doEmbed({
+  values: [['Paragraph 1 from doc 1...', 'Paragraph 2 from doc 1...'], ['Content from doc 2...']],
+  inputType: 'document',
+});
+
+// Or configure explicitly
+const model = voyageContextualizedEmbedding({ model: 'voyage-context-4', outputDimension: 512 });
+```

--- a/embedders/voyageai/README.md
+++ b/embedders/voyageai/README.md
@@ -203,9 +203,10 @@ console.log(grouped.embeddingsByDocument); // [[[...], [...]], [[...]]]
 
 ### Contextualized Models
 
-| Model              | Use Case                     |
-| ------------------ | ---------------------------- |
-| `voyage-context-3` | Chunks with document context |
+| Model              | Use Case                                  |
+| ------------------ | ----------------------------------------- |
+| `voyage-context-4` | Chunks with document context, best quality (preview) |
+| `voyage-context-3` | Chunks with document context              |
 
 ### Reranker Models
 
@@ -339,7 +340,7 @@ type VoyageTextModel =
 
 type VoyageMultimodalModel = 'voyage-multimodal-3' | 'voyage-multimodal-3.5';
 
-type VoyageContextModel = 'voyage-context-3';
+type VoyageContextModel = 'voyage-context-3' | 'voyage-context-4';
 
 type VoyageInputType = 'query' | 'document' | null;
 type VoyageOutputDimension = 256 | 512 | 1024 | 2048;

--- a/embedders/voyageai/src/__tests__/integration.test.ts
+++ b/embedders/voyageai/src/__tests__/integration.test.ts
@@ -142,6 +142,7 @@ describeWithApiKey('VoyageAI Integration Tests', () => {
     it('should have contextualized model', () => {
       expect(voyage.contextualized.modelId).toBe('voyage-context-3');
       expect(voyage.context3.modelId).toBe('voyage-context-3');
+      expect(voyage.context4.modelId).toBe('voyage-context-4');
     });
   });
 
@@ -206,6 +207,40 @@ describeWithApiKey('VoyageAI Integration Tests', () => {
     it('should support custom dimensions for contextualized embeddings', async () => {
       const model = voyageContextualizedEmbedding({
         model: 'voyage-context-3',
+        outputDimension: 512,
+      });
+
+      const result = await model.doEmbed({
+        values: [['Single chunk for testing']],
+        inputType: 'document',
+      });
+
+      expect(result.embeddings[0]!.length).toBe(512);
+    });
+
+    it('should create voyage-context-4 model', () => {
+      const model = voyageContextualizedEmbedding('voyage-context-4');
+      expect(model.modelId).toBe('voyage-context-4');
+    });
+
+    it('should embed document chunks with voyage-context-4', async () => {
+      const model = voyageContextualizedEmbedding('voyage-context-4');
+
+      const result = await model.doEmbed({
+        values: [['This is the first paragraph of document one.', 'This is the second paragraph.']],
+        inputType: 'document',
+      });
+
+      // Should return 2 embeddings (one per chunk)
+      expect(result.embeddings).toHaveLength(2);
+      expect(result.chunkCounts).toEqual([2]);
+      // Default dimension is 1024
+      expect(result.embeddings[0]!.length).toBe(1024);
+    });
+
+    it('should support custom dimensions with voyage-context-4', async () => {
+      const model = voyageContextualizedEmbedding({
+        model: 'voyage-context-4',
         outputDimension: 512,
       });
 

--- a/embedders/voyageai/src/index.ts
+++ b/embedders/voyageai/src/index.ts
@@ -196,6 +196,7 @@ export const voyage: VoyageTextEmbeddingModelV3 & {
   // Contextualized model
   contextualized: VoyageContextualizedEmbeddingModel;
   context3: VoyageContextualizedEmbeddingModel;
+  context4: VoyageContextualizedEmbeddingModel;
 
   // Reranker models
   reranker: VoyageRelevanceScorer;
@@ -276,6 +277,7 @@ export const voyage: VoyageTextEmbeddingModelV3 & {
       get: () => lazy('contextualized', () => createVoyageContextualizedEmbedding('voyage-context-3')),
     },
     context3: { get: () => lazy('context3', () => createVoyageContextualizedEmbedding('voyage-context-3')) },
+    context4: { get: () => lazy('context4', () => createVoyageContextualizedEmbedding('voyage-context-4')) },
     // Reranker models
     reranker: { get: () => lazy('reranker', () => createVoyageReranker('rerank-2.5')) },
     reranker25: { get: () => lazy('reranker25', () => createVoyageReranker('rerank-2.5')) },

--- a/embedders/voyageai/src/types.ts
+++ b/embedders/voyageai/src/types.ts
@@ -28,7 +28,7 @@ export type VoyageMultimodalModel = 'voyage-multimodal-3' | 'voyage-multimodal-3
 /**
  * VoyageAI contextualized chunk embedding models
  */
-export type VoyageContextModel = 'voyage-context-3';
+export type VoyageContextModel = 'voyage-context-3' | 'voyage-context-4';
 
 /**
  * All VoyageAI embedding models
@@ -292,6 +292,13 @@ export const MULTIMODAL_MODEL_INFO: Record<VoyageMultimodalModel, Omit<VoyageMod
  */
 export const CONTEXTUALIZED_MODEL_INFO: Record<VoyageContextModel, Omit<VoyageModelInfo, 'id'>> = {
   'voyage-context-3': {
+    maxInputTokens: 32000,
+    defaultDimension: 1024,
+    supportedDimensions: [256, 512, 1024, 2048],
+    isMultimodal: false,
+    isContextualized: true,
+  },
+  'voyage-context-4': {
     maxInputTokens: 32000,
     defaultDimension: 1024,
     supportedDimensions: [256, 512, 1024, 2048],


### PR DESCRIPTION
Add support for VoyageAI models: voyage-context-4

- feat(voyageai): add voyage-context-4 contextualized embedding model
- docs: add durable agents conceptual doc and update background-tasks for `untilIdle` (#18357)
- chore: regenerate providers and docs [skip ci]
- fix(agent): preserve durable agent tools when the editor forks for stored overrides (#18121)
- fix(playground): render tool args as static code (#18292)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This adds support for a newer VoyageAI embedding model, `voyage-context-4`, so the system can turn text chunks into embeddings with better context awareness. It also updates the docs, types, and tests so the new model is available and works like the existing one.

### What changed
- Added preview support for `voyage-context-4` in VoyageAI embedder metadata and types
- Exposed a new `voyage.context4` convenience accessor
- Updated README examples and model type docs
- Added integration tests covering default behavior and custom output dimensions
- Added a changeset entry for the `@mastra/voyageai` minor release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->