### PR TITLE
docs: fix broken link to data download guide in longmemeval README

### DIFF
--- a/explorations/longmemeval/README.md
+++ b/explorations/longmemeval/README.md
@@ -66,7 +66,7 @@ export HF_TOKEN=your_token_here
 pnpm download
 ```
 
-If automatic download fails, see [DOWNLOAD_GUIDE.md](./DOWNLOAD_GUIDE.md) for manual download instructions.
+If automatic download fails, see [DATA_DOWNLOAD_GUIDE.md](./DATA_DOWNLOAD_GUIDE.md) for manual download instructions.
 
 ## Usage
 


### PR DESCRIPTION
## Problem

`explorations/longmemeval/README.md` links to `./DOWNLOAD_GUIDE.md` for the manual download instructions, but that file does not exist — it returns a 404. The file is named `DATA_DOWNLOAD_GUIDE.md`.

```
raw .../DOWNLOAD_GUIDE.md       → 404
raw .../DATA_DOWNLOAD_GUIDE.md  → 200
```

So a reader whose automatic download fails follows the link and hits a dead end.

## Fix

Point the link (and its text) to the correct, existing `DATA_DOWNLOAD_GUIDE.md`.

```diff
- see [DOWNLOAD_GUIDE.md](./DOWNLOAD_GUIDE.md) for manual download instructions.
+ see [DATA_DOWNLOAD_GUIDE.md](./DATA_DOWNLOAD_GUIDE.md) for manual download instructions.
```

Docs-only, one line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a broken help link in the README. If the automatic download doesn’t work, the manual instructions now point to the correct file instead of a missing one.

## Summary
Updated `explorations/longmemeval/README.md` to replace the broken manual download link from `./DOWNLOAD_GUIDE.md` to `./DATA_DOWNLOAD_GUIDE.md`.

## Impact
Docs-only change; no code behavior was modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->