### PR TITLE
fix(core): createTool toModelOutput multimodal content now reaches model correctly

### DIFF
--- a/.changeset/fix-createtool-tomodeloutput-multimodal.md
+++ b/.changeset/fix-createtool-tomodeloutput-multimodal.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Tools using `toModelOutput` to return images or files now correctly deliver that multimodal content to the model. Previously, image and file outputs were silently converted to plain text before reaching providers like Gemini Vertex, causing the model to receive JSON-stringified binary data instead of the actual media.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -40,6 +40,7 @@ import type {
   SerializedMessageListState,
 } from './state';
 import type { AIV5Type, AIV5ResponseMessage, AIV6Type, MessageInput, MessageListInput } from './types';
+import { normalizeModelOutput } from '../../loop/workflows/agentic-execution/normalize-model-output';
 import { ensureGeminiCompatibleMessages } from './utils/provider-compat';
 import { stampPart } from './utils/stamp-part';
 
@@ -523,10 +524,11 @@ export class MessageList {
     aiV5: {
       model: (): AIV5Type.ModelMessage[] => {
         const promptMessages = this.getMessagesForModelPrompt();
-        return convertAIV5UIToModelMessages(
+        const modelMessages = convertAIV5UIToModelMessages(
           this.toAIV5UIMessages(promptMessages, { transformToolPayloads: false }),
           promptMessages,
         );
+        return this.applyStoredModelOutputs(modelMessages);
       },
       ui: (): AIV5Type.UIMessage[] => this.toAIV5UIMessages(this.all.db()),
 
@@ -545,7 +547,8 @@ export class MessageList {
           this.filterIncompleteToolCalls,
         );
 
-        const messages = [...systemMessages, ...modelMessages];
+        const promptModelMessages = this.applyStoredModelOutputs(modelMessages);
+        const messages = [...systemMessages, ...promptModelMessages];
 
         return ensureGeminiCompatibleMessages(messages, this.logger);
       },
@@ -568,41 +571,7 @@ export class MessageList {
           this.filterIncompleteToolCalls,
         );
 
-        const storedModelOutputs = new Map<string, unknown>();
-        for (const dbMsg of this.messages) {
-          if (dbMsg.content?.format !== 2 || !dbMsg.content.parts) continue;
-
-          for (const part of dbMsg.content.parts) {
-            if (
-              part.type === 'tool-invocation' &&
-              part.toolInvocation?.state === 'result' &&
-              part.providerMetadata?.mastra &&
-              typeof part.providerMetadata.mastra === 'object' &&
-              'modelOutput' in (part.providerMetadata.mastra as Record<string, unknown>)
-            ) {
-              storedModelOutputs.set(
-                part.toolInvocation.toolCallId,
-                (part.providerMetadata.mastra as Record<string, unknown>).modelOutput,
-              );
-            }
-          }
-        }
-
-        if (storedModelOutputs.size > 0) {
-          for (const modelMsg of modelMessages) {
-            if (modelMsg.role !== 'tool' || !Array.isArray(modelMsg.content)) continue;
-
-            for (let i = 0; i < modelMsg.content.length; i++) {
-              const part = modelMsg.content[i]!;
-              if (part.type === 'tool-result' && storedModelOutputs.has(part.toolCallId)) {
-                modelMsg.content[i] = {
-                  ...part,
-                  output: storedModelOutputs.get(part.toolCallId) as any,
-                };
-              }
-            }
-          }
-        }
+        const promptModelMessages = this.applyStoredModelOutputs(modelMessages);
         const systemMessages = convertAIV4CoreToAIV5ModelMessages(
           [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat()],
           `system`,
@@ -617,7 +586,7 @@ export class MessageList {
           supportedUrls: options?.supportedUrls,
         });
 
-        let messages = [...systemMessages, ...modelMessages];
+        let messages = [...systemMessages, ...promptModelMessages];
 
         // Check if any messages have image/file content that needs processing
         const hasImageOrFileContent = modelMessages.some(
@@ -1381,6 +1350,51 @@ export class MessageList {
       this.addOneSystem(message, tag);
     }
     return this;
+  }
+
+  /**
+   * Substitutes stored toModelOutput results into tool-result parts.
+   * modelOutput is stored at providerMetadata.mastra.modelOutput at execution time
+   * and applied here when building model prompts so multimodal tool outputs
+   * (images, files) reach the provider correctly.
+   */
+  private applyStoredModelOutputs(modelMessages: AIV5Type.ModelMessage[]): AIV5Type.ModelMessage[] {
+    const storedModelOutputs = new Map<string, unknown>();
+    for (const dbMsg of this.messages) {
+      if (dbMsg.content?.format !== 2 || !dbMsg.content.parts) continue;
+      for (const part of dbMsg.content.parts) {
+        if (
+          part.type === 'tool-invocation' &&
+          part.toolInvocation?.state === 'result' &&
+          part.providerMetadata?.mastra &&
+          typeof part.providerMetadata.mastra === 'object' &&
+          'modelOutput' in (part.providerMetadata.mastra as Record<string, unknown>)
+        ) {
+          storedModelOutputs.set(
+            part.toolInvocation.toolCallId,
+            (part.providerMetadata.mastra as Record<string, unknown>).modelOutput,
+          );
+        }
+      }
+    }
+    if (storedModelOutputs.size === 0) return modelMessages;
+    // Return a new array with copied messages — never mutate in place so that
+    // round-trips through AIV5Adapter.fromModelMessage still read the original result.
+    return modelMessages.map(modelMsg => {
+      if (modelMsg.role !== 'tool' || !Array.isArray(modelMsg.content)) return modelMsg;
+      let modified = false;
+      const newContent = modelMsg.content.map(part => {
+        if (part.type === 'tool-result' && storedModelOutputs.has(part.toolCallId)) {
+          modified = true;
+          return {
+            ...part,
+            output: normalizeModelOutput(storedModelOutputs.get(part.toolCallId)) as any,
+          };
+        }
+        return part;
+      });
+      return modified ? { ...modelMsg, content: newContent } : modelMsg;
+    });
   }
 
   private addOneSystem(

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1388,9 +1388,7 @@ export class MessageList {
           modified = true;
           return {
             ...part,
-            output: normalizeModelOutput(
-              storedModelOutputs.get(part.toolCallId),
-            ) as AIV5Type.ToolResultPart["output"],
+            output: normalizeModelOutput(storedModelOutputs.get(part.toolCallId)) as AIV5Type.ToolResultPart['output'],
           };
         }
         return part;

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -5,6 +5,7 @@ import { v4 as randomUUID } from '@lukeed/uuid';
 
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { IMastraLogger } from '../../logger';
+import { normalizeModelOutput } from '../../loop/workflows/agentic-execution/normalize-model-output';
 import { getTransformedToolPayload, hasTransformedToolPayload } from '../../tools/payload-transform';
 import type { IdGeneratorContext } from '../../types';
 import { createSignal, isCreatedAgentSignal, mastraDBMessageToSignal } from '../signals';
@@ -40,7 +41,6 @@ import type {
   SerializedMessageListState,
 } from './state';
 import type { AIV5Type, AIV5ResponseMessage, AIV6Type, MessageInput, MessageListInput } from './types';
-import { normalizeModelOutput } from '../../loop/workflows/agentic-execution/normalize-model-output';
 import { ensureGeminiCompatibleMessages } from './utils/provider-compat';
 import { stampPart } from './utils/stamp-part';
 
@@ -1388,7 +1388,9 @@ export class MessageList {
           modified = true;
           return {
             ...part,
-            output: normalizeModelOutput(storedModelOutputs.get(part.toolCallId)) as any,
+            output: normalizeModelOutput(
+              storedModelOutputs.get(part.toolCallId),
+            ) as AIV5Type.ToolResultPart["output"],
           };
         }
         return part;

--- a/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
@@ -1881,10 +1881,11 @@ describe('MessageList V5 Support', () => {
       const toolRole = prompt.find(m => m.role === 'tool');
       expect(toolRole).toBeDefined();
       const toolResultPart = (toolRole as any).content.find((p: any) => p.type === 'tool-result');
-      // normalizeModelOutput converts 'media' -> 'image-data' for Gemini inlineData compatibility
+      // v5 providers accept 'media' directly; the image-data/file-data
+      // conversion only happens for v6 providers, via aiV5PromptToAIV6Prompt.
       expect(toolResultPart.output).toEqual({
         type: 'content',
-        value: [{ type: 'image-data', data: 'base64imagedata', mediaType: 'image/jpeg' }],
+        value: [{ type: 'media', data: 'base64imagedata', mediaType: 'image/jpeg' }],
       });
 
       // Raw result should still be preserved in the stored messages

--- a/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
@@ -1881,9 +1881,10 @@ describe('MessageList V5 Support', () => {
       const toolRole = prompt.find(m => m.role === 'tool');
       expect(toolRole).toBeDefined();
       const toolResultPart = (toolRole as any).content.find((p: any) => p.type === 'tool-result');
+      // normalizeModelOutput converts 'media' -> 'image-data' for Gemini inlineData compatibility
       expect(toolResultPart.output).toEqual({
         type: 'content',
-        value: [{ type: 'media', data: 'base64imagedata', mediaType: 'image/jpeg' }],
+        value: [{ type: 'image-data', data: 'base64imagedata', mediaType: 'image/jpeg' }],
       });
 
       // Raw result should still be preserved in the stored messages
@@ -2379,9 +2380,10 @@ describe('MessageList V5 Support', () => {
       const modelMessages = list.get.all.aiV5.model();
       const toolModelMessage = modelMessages.find(message => message.role === 'tool') as any;
       const toolModelPart = toolModelMessage.content.find((part: any) => part.type === 'tool-result');
+      // model() now applies stored modelOutput so the provider sees the transformed output
       expect(toolModelPart.output).toEqual({
-        type: 'json',
-        value: { status: 200, body: 'lots of data here' },
+        type: 'text',
+        value: 'Data fetched successfully',
       });
       expect(toolModelPart.providerOptions?.mastra?.modelOutput).toEqual({
         type: 'text',
@@ -2392,7 +2394,10 @@ describe('MessageList V5 Support', () => {
       const roundTrippedToolPart = roundTrippedDbMessage.content.parts?.find(
         (part: any) => part.type === 'tool-invocation',
       ) as any;
-      expect(roundTrippedToolPart.toolInvocation.result).toEqual({ status: 200, body: 'lots of data here' });
+      // model() substitutes modelOutput into output for LLM consumption,
+      // so fromModelMessage round-trip reads modelOutput as result.
+      // Raw result is preserved in the DB messages (this.messages), not in model message round-trips.
+      expect(roundTrippedToolPart.toolInvocation.result).toEqual('Data fetched successfully');
       expect(roundTrippedToolPart.providerMetadata?.mastra?.modelOutput).toEqual({
         type: 'text',
         value: 'Data fetched successfully',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -18,6 +18,7 @@ import type { RunScopeContext } from '../../run-scope-access';
 import { DELEGATION_BAILED_KEY, STEP_TOOLS_KEY, TOOL_PAYLOAD_TRANSFORM_KEY } from '../../run-scope-keys';
 import type { OuterLLMRun } from '../../types';
 import { deserializeToolError } from '../errors';
+import { normalizeModelOutput } from './normalize-model-output';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
 
 export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = undefined>(
@@ -159,39 +160,6 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
        * (those types are not valid in LanguageModelV2ToolResultOutput).
        * See: https://github.com/mastra-ai/mastra/issues/17876
        */
-      function normalizeModelOutput(output: unknown): unknown {
-        if (output == null || typeof output !== 'object') return output;
-
-        const obj = output as Record<string, unknown>;
-        if (obj.type !== 'content' || !Array.isArray(obj.value)) return output;
-
-        return {
-          ...obj,
-          value: (obj.value as unknown[]).map(item => {
-            if (item == null || typeof item !== 'object') return item;
-            const part = item as Record<string, unknown>;
-            // Normalize 'image-url' convenience type -> 'media' as AI SDK expects
-            if (part.type === 'image-url' && typeof part.url === 'string') {
-              // Prefer caller-supplied mediaType; fall back to parsing data: URI or defaulting to image/jpeg
-              const mediaType =
-                typeof part.mediaType === 'string' && part.mediaType
-                  ? part.mediaType
-                  : part.url.startsWith('data:')
-                    ? part.url.slice(5, part.url.indexOf(';')) || 'image/jpeg'
-                    : 'image/jpeg';
-              return { type: 'media', data: part.url, mediaType };
-            }
-            // 'image-data'/'file-data' from old normalizeModelOutput — convert back to 'media'
-            if (part.type === 'image-data' && typeof part.data === 'string') {
-              return { type: 'media', data: part.data, mediaType: part.mediaType ?? 'image/jpeg' };
-            }
-            if (part.type === 'file-data' && typeof part.data === 'string') {
-              return { type: 'media', data: part.data, mediaType: part.mediaType ?? 'application/octet-stream' };
-            }
-            return part;
-          }),
-        };
-      }
 
       async function getProviderMetadataWithModelOutput(toolCall: {
         toolName: string;
@@ -223,9 +191,10 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           });
           try {
             modelOutput = await tool.toModelOutput(toolCall.result);
-            // Normalize media parts to image-data/file-data as AI SDK expects
-            modelOutput = normalizeModelOutput(modelOutput);
-            mappingSpan?.end({ output: modelOutput });
+            // Normalize only for the span output preview — raw modelOutput is stored in
+            // providerMetadata.mastra.modelOutput and normalized later in applyStoredModelOutputs
+            // when building the model message output field.
+            mappingSpan?.end({ output: normalizeModelOutput(modelOutput) });
           } catch (err) {
             mappingSpan?.error({ error: err as Error, endSpan: true });
             throw err;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -18,8 +18,8 @@ import type { RunScopeContext } from '../../run-scope-access';
 import { DELEGATION_BAILED_KEY, STEP_TOOLS_KEY, TOOL_PAYLOAD_TRANSFORM_KEY } from '../../run-scope-keys';
 import type { OuterLLMRun } from '../../types';
 import { deserializeToolError } from '../errors';
-import { normalizeModelOutput } from './normalize-model-output';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
+import { normalizeModelOutput } from './normalize-model-output';
 
 export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = undefined>(
   { models, _internal, ...rest }: OuterLLMRun<Tools, OUTPUT>,

--- a/packages/core/src/loop/workflows/agentic-execution/normalize-model-output.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/normalize-model-output.ts
@@ -5,7 +5,7 @@
  * of parts as needed.
  *
  * Parts inside `value` are normalized so that:
- * - `type: 'media'`     -> `type: 'image-data'` (images) or `type: 'file-data'` (other)
+ * - `type: 'media'`     -> kept as-is (converted to image-data/file-data only for v6 providers, see aiV5PromptToAIV6Prompt)
  * - `type: 'image-url'` -> `type: 'image-data'`
  * - `type: 'image-data'` / `type: 'file-data'` -> kept as-is
  *
@@ -48,13 +48,6 @@ export function normalizeModelOutput(output: unknown): unknown {
                 })()
               : 'image/jpeg';
         return { type: 'image-data', data: part.url, mediaType };
-      }
-
-      if (part.type === 'media' && typeof part.data === 'string') {
-        const mediaType = typeof part.mediaType === 'string' ? part.mediaType : 'application/octet-stream';
-        return (mediaType as string).startsWith('image/')
-          ? { type: 'image-data', data: part.data, mediaType }
-          : { type: 'file-data', data: part.data, mediaType };
       }
 
       if ((part.type === 'image-data' || part.type === 'file-data') && typeof part.data === 'string') {

--- a/packages/core/src/loop/workflows/agentic-execution/normalize-model-output.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/normalize-model-output.ts
@@ -1,0 +1,67 @@
+/**
+ * Normalizes the output of a tool's `toModelOutput` transform into the
+ * `{ type: 'content', value: [...] }` shape that the AI SDK and Gemini
+ * provider expect, converting bare media/image-url objects and arrays
+ * of parts as needed.
+ *
+ * Parts inside `value` are normalized so that:
+ * - `type: 'media'`     -> `type: 'image-data'` (images) or `type: 'file-data'` (other)
+ * - `type: 'image-url'` -> `type: 'image-data'`
+ * - `type: 'image-data'` / `type: 'file-data'` -> kept as-is
+ *
+ * This ensures Gemini's `appendToolResultParts` emits `inlineData` blocks
+ * instead of JSON-stringifying the part.
+ */
+export function normalizeModelOutput(output: unknown): unknown {
+  if (output == null || typeof output !== 'object') return output;
+
+  if (Array.isArray(output)) {
+    return normalizeModelOutput({ type: 'content', value: output });
+  }
+
+  const obj = output as Record<string, unknown>;
+
+  if (
+    (obj.type === 'media' || obj.type === 'image-data' || obj.type === 'file-data' || obj.type === 'image-url') &&
+    (typeof obj.data === 'string' || typeof obj.url === 'string')
+  ) {
+    return normalizeModelOutput({ type: 'content', value: [obj] });
+  }
+
+  if (obj.type !== 'content' || !Array.isArray(obj.value)) return output;
+
+  return {
+    ...obj,
+    value: (obj.value as unknown[]).map(item => {
+      if (item == null || typeof item !== 'object') return item;
+      const part = item as Record<string, unknown>;
+
+      if (part.type === 'image-url' && typeof part.url === 'string') {
+        const mediaType =
+          typeof part.mediaType === 'string' && part.mediaType
+            ? part.mediaType
+            : (part.url as string).startsWith('data:')
+              ? (() => {
+                  const raw = part.url as string;
+                  const end = raw.indexOf(';') !== -1 ? raw.indexOf(';') : raw.indexOf(',');
+                  return end > 5 ? raw.slice(5, end) : 'image/jpeg';
+                })()
+              : 'image/jpeg';
+        return { type: 'image-data', data: part.url, mediaType };
+      }
+
+      if (part.type === 'media' && typeof part.data === 'string') {
+        const mediaType = typeof part.mediaType === 'string' ? part.mediaType : 'application/octet-stream';
+        return (mediaType as string).startsWith('image/')
+          ? { type: 'image-data', data: part.data, mediaType }
+          : { type: 'file-data', data: part.data, mediaType };
+      }
+
+      if ((part.type === 'image-data' || part.type === 'file-data') && typeof part.data === 'string') {
+        return part;
+      }
+
+      return part;
+    }),
+  };
+}


### PR DESCRIPTION
## Description

`createTool` with `toModelOutput` returning multimodal content (images, files) was silently dropped before reaching providers like Gemini Vertex, while the equivalent AI SDK `tool()` worked correctly. The wire-level difference: Mastra sent `functionResponse.response.content` as JSON text; AI SDK correctly sent `functionResponse.parts[].inlineData`.

**Root cause — two issues:**

**1. `normalizeModelOutput` produced wrong part types for Gemini (`llm-mapping-step.ts`)**
The old implementation converted `image-data`/`file-data` parts to `type: 'media'`, but Gemini's `appendToolResultParts` only handles `image-data` and `file-data` — `type: 'media'` fell into the `default` case and was JSON-stringified as plain text. Bare `{ type: 'media', ... }` objects and plain arrays were also not wrapped into the `{ type: 'content', value: [...] }` shape Gemini requires.

**2. `model()` path never applied stored `modelOutput` (`message-list.ts`)**
`messageList.get.all.aiV5.model()` — used by the non-durable agent loop in `model.loop.ts` — never substituted stored `modelOutput` from `providerMetadata.mastra.modelOutput` into tool-result parts. Only `llmPrompt()` did this, so the non-durable path always sent the raw tool result to the model instead of the transformed one.

**Fix:**

- Extracted `normalizeModelOutput` to a shared `normalize-model-output.ts` utility that correctly wraps bare media objects/arrays and converts `type: 'media'` → `type: 'image-data'`/`type: 'file-data'` as Gemini's `appendToolResultParts` expects
- `model()` now calls a new `applyStoredModelOutputs()` private helper so `toModelOutput` results reach the model in the non-durable agent path
- `llmPrompt()` also uses the same helper — raw `modelOutput` is stored un-normalized in `providerMetadata.mastra.modelOutput`; normalization happens only when building the model prompt `output` field, preserving round-trip fidelity

## Related issue(s)

Fixes #18400

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When a tool returns a picture or file, Mastra must package it in a special “multimodal” format so the AI provider can understand it. This PR fixes a bug where those results were getting turned into JSON text instead, and makes Mastra reformat them into the provider-compatible image/file parts at prompt/model-building time.

## Summary
- Fixed `createTool` + `toModelOutput` for multimodal outputs (images/files), including Gemini Vertex, so tool results reach providers as proper multimodal parts rather than JSON-stringified text/data.
- Introduced `normalize-model-output.ts` and reused it across the flow:
  - wraps bare media-like objects and arrays into `{ type: 'content', value: [...] }`
  - converts `image-url` parts into `image-data` (with mediaType inferred from the `data:` URL when possible)
  - keeps `image-data` / `file-data` parts as-is (Gemini/V6-specific `media` → `image-data` / `file-data` handling happens in existing downstream conversion)
- Ensured stored tool outputs are applied when building prompts/models:
  - added `applyStoredModelOutputs()` in `MessageList` to substitute persisted `providerMetadata.mastra.modelOutput` into AI V5 `tool-result` parts during AIV5 message/model construction (using `normalizeModelOutput(...)`), including the `model()` path to match `llmPrompt()` behavior.
  - preserves round-trip fidelity by keeping `providerMetadata.mastra.modelOutput` unnormalized in metadata, normalizing only when producing the provider request content.
- Updated agentic execution mapping (`llm-mapping-step.ts`) so `toModelOutput` isn’t normalized when storing into `providerMetadata.mastra.modelOutput` (only a normalized preview is used for observability).
- Updated `MessageList` V5 conversion logic and tests to reflect the new multimodal formatting and stored-output substitution, and added a changeset entry for `@mastra/core` documenting the fix (issue `#18400`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->