### PR TITLE
chore(husky): use pnpm version from package.json in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,8 @@
-corepack pnpm@11.3.0 --version || {
-  echo "Pre-commit requires corepack pnpm@11.3.0"
+corepack pnpm --version || {
+  echo "Pre-commit requires pnpm (via corepack)"
   exit 0
 }
 
 # Formatting on staged files
-corepack pnpm@11.3.0 lint-staged --quiet
+corepack pnpm lint-staged --quiet
 


### PR DESCRIPTION
## Summary

The `.husky/pre-commit` hook hardcoded `corepack pnpm@11.3.0`, which had drifted from the `packageManager` field in `package.json` (currently `11.5.1`). This meant the pre-commit hook was running a stale pnpm version unless someone remembered to update it manually.

This change drops the hardcoded version pin so `corepack pnpm` resolves to whatever `package.json` declares via its `packageManager` field. Bumping pnpm in the future only requires updating `package.json` — the hook stays in sync automatically.

## Test plan

- [x] `corepack pnpm --version` returns `11.5.1` (matches package.json)
- [x] `bash .husky/pre-commit` exits 0 and runs lint-staged with `pnpm v11.5.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the pre-commit check use the same pnpm version the repo already says to use, instead of hardcoding an older one. That means fewer surprise breakages and less manual maintenance when pnpm gets updated.

## Summary
- Updated `.husky/pre-commit` to use `corepack pnpm` instead of pinning `corepack pnpm@11.3.0`.
- The hook now relies on the pnpm version declared in `package.json` (`packageManager`, currently `11.5.1`).
- Kept the version check and `lint-staged` flow working with the repo’s configured pnpm version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->