### PR TITLE
ci: gate combined store tests on affected-tests graph

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -155,14 +155,21 @@ jobs:
 
       - name: Save affected-tests outputs for downstream workflow
         if: always()
+        env:
+          AFFECTED_WORKSPACE_TESTS: ${{ steps.compute.outputs.affected_workspace_tests }}
+          AFFECTED_MEMORY_TESTS: ${{ steps.compute.outputs.affected_memory_tests }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           mkdir -p /tmp/affected-outputs
-          echo "${{ steps.compute.outputs.affected_workspace_tests }}" > /tmp/affected-outputs/affected_workspace_tests.txt
-          echo "${{ steps.compute.outputs.affected_memory_tests }}" > /tmp/affected-outputs/affected_memory_tests.txt
+          echo "$AFFECTED_WORKSPACE_TESTS" > /tmp/affected-outputs/affected_workspace_tests.txt
+          echo "$AFFECTED_MEMORY_TESTS" > /tmp/affected-outputs/affected_memory_tests.txt
+          echo "$BASE_SHA" > /tmp/affected-outputs/base_sha.txt
+          echo "$HEAD_SHA" > /tmp/affected-outputs/head_sha.txt
 
       - name: Upload affected-tests artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: affected-tests-outputs
           path: /tmp/affected-outputs/
@@ -248,11 +255,15 @@ jobs:
 
       - name: Check for stores changes
         id: check
+        env:
+          AFFECTED_STORE_TESTS: ${{ needs.affected-tests.outputs.affected_store_tests }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           STORES_CHANGED=false
 
           # Run when the affected-tests graph found store test files impacted
-          if [ "${{ needs.affected-tests.outputs.affected_store_tests }}" = "true" ]; then
+          if [ "$AFFECTED_STORE_TESTS" = "true" ]; then
             STORES_CHANGED=true
           fi
 
@@ -262,7 +273,7 @@ jobs:
           # alias resolution, so they are not duplicated here.
           # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
           DIRECT=$(git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
+            "$BASE_SHA...$HEAD_SHA" \
             | grep -vE '\.md$' \
             | grep -E '^(stores/|\.github/workflows/test-combined-stores\.yml|\.github/workflows/prebuild\.yml)' \
             || true)
@@ -308,11 +319,15 @@ jobs:
 
       - name: Check for workspace changes
         id: check
+        env:
+          AFFECTED_WORKSPACE_TESTS: ${{ needs.affected-tests.outputs.affected_workspace_tests }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           WORKSPACES_CHANGED=false
 
           # Run when the affected-tests graph found workspace test files impacted
-          if [ "${{ needs.affected-tests.outputs.affected_workspace_tests }}" = "true" ]; then
+          if [ "$AFFECTED_WORKSPACE_TESTS" = "true" ]; then
             WORKSPACES_CHANGED=true
           fi
 
@@ -322,7 +337,7 @@ jobs:
           # cross-package alias resolution, so they are not duplicated here.
           # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
           DIRECT=$(git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
+            "$BASE_SHA...$HEAD_SHA" \
             | grep -vE '\.md$' \
             | grep -E '^(workspaces/|\.github/workflows/test-workspaces\.yml|\.github/workflows/secrets\.test-workspaces\.yml|\.github/workflows/prebuild\.yml)' \
             || true)
@@ -363,11 +378,15 @@ jobs:
 
       - name: Check for memory changes
         id: check
+        env:
+          AFFECTED_MEMORY_TESTS: ${{ needs.affected-tests.outputs.affected_memory_tests }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           MEMORY_CHANGED=false
 
           # Run when the affected-tests graph found memory integration test files impacted
-          if [ "${{ needs.affected-tests.outputs.affected_memory_tests }}" = "true" ]; then
+          if [ "$AFFECTED_MEMORY_TESTS" = "true" ]; then
             MEMORY_CHANGED=true
           fi
 
@@ -378,7 +397,7 @@ jobs:
           # not duplicated here.
           # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
           DIRECT=$(git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
+            "$BASE_SHA...$HEAD_SHA" \
             | grep -vE '\.md$' \
             | grep -E '^(packages/memory/|\.github/workflows/prebuild\.yml)' \
             || true)

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -83,6 +83,7 @@ jobs:
       test_files: ${{ steps.compute.outputs.test_files }}
       affected_store_tests: ${{ steps.compute.outputs.affected_store_tests }}
       affected_workspace_tests: ${{ steps.compute.outputs.affected_workspace_tests }}
+      affected_memory_tests: ${{ steps.compute.outputs.affected_memory_tests }}
     permissions:
       contents: read
     steps:
@@ -109,6 +110,7 @@ jobs:
             echo "test_files=" >> $GITHUB_OUTPUT
             echo "affected_store_tests=false" >> $GITHUB_OUTPUT
             echo "affected_workspace_tests=false" >> $GITHUB_OUTPUT
+            echo "affected_memory_tests=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -132,6 +134,9 @@ jobs:
             const affectedWorkspaceTests = (data.affectedTests || []).some(file => file.startsWith('workspaces/'));
             fs.appendFileSync(process.env.GITHUB_OUTPUT, \`affected_workspace_tests=\${affectedWorkspaceTests}\n\`);
 
+            const affectedMemoryTests = (data.affectedTests || []).some(file => file.startsWith('packages/memory/integration-tests/'));
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, \`affected_memory_tests=\${affectedMemoryTests}\n\`);
+
             console.error(\`Affected: \${count}/\${total} tests (\${(ratio * 100).toFixed(1)}%)\`);
 
             if (ratio > 0.5) {
@@ -153,6 +158,7 @@ jobs:
         run: |
           mkdir -p /tmp/affected-outputs
           echo "${{ steps.compute.outputs.affected_workspace_tests }}" > /tmp/affected-outputs/affected_workspace_tests.txt
+          echo "${{ steps.compute.outputs.affected_memory_tests }}" > /tmp/affected-outputs/affected_memory_tests.txt
 
       - name: Upload affected-tests artifact
         if: always()
@@ -343,11 +349,11 @@ jobs:
   memory-check-changes:
     name: Detect memory changes
     if: github.repository == 'mastra-ai/mastra' && needs.changes.outputs.has_code == 'true'
-    needs: changes
+    needs: [changes, affected-tests]
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     outputs:
-      changed: ${{ steps.changes.outputs.changed == 'true' || steps.integration-test-manifest.outputs.changed == 'true' }}
+      memory-changed: ${{ steps.check.outputs.memory-changed }}
     permissions:
       contents: read
     steps:
@@ -355,32 +361,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm and Node.js
-        uses: ./.github/actions/setup-pnpm-node
-        with:
-          install-dependencies: 'false'
-
-      - name: Check for memory package changes using Turborepo
-        id: changes
-        uses: ./.github/actions/turbo-changed
-        with:
-          packages: '@mastra/memory'
-          tasks: 'build,test'
-          base-ref: 'origin/main'
-
-      - name: Check for memory integration test manifest changes
-        id: integration-test-manifest
+      - name: Check for memory changes
+        id: check
         run: |
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -qx 'packages/memory/integration-tests/package.json'; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+          MEMORY_CHANGED=false
+
+          # Run when the affected-tests graph found memory integration test files impacted
+          if [ "${{ needs.affected-tests.outputs.affected_memory_tests }}" = "true" ]; then
+            MEMORY_CHANGED=true
           fi
+
+          # Direct path fallback for changes not covered by the affected-test graph
+          # (memory package configs, integration test setup/config, CI workflow edits).
+          # Core source changes that affect memory integration tests are already caught
+          # by the affected-tests graph via cross-package alias resolution, so they are
+          # not duplicated here.
+          # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
+          DIRECT=$(git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
+            | grep -vE '\.md$' \
+            | grep -E '^(packages/memory/|\.github/workflows/prebuild\.yml)' \
+            || true)
+
+          if [ -n "$DIRECT" ]; then
+            MEMORY_CHANGED=true
+          fi
+
+          echo "memory-changed=$MEMORY_CHANGED" >> "$GITHUB_OUTPUT"
 
   memory-test:
     name: Memory Tests
     needs: [memory-check-changes, prebuild]
-    if: always() && github.repository == 'mastra-ai/mastra' && needs.memory-check-changes.outputs.changed == 'true' && needs.prebuild.result == 'success'
+    if: always() && github.repository == 'mastra-ai/mastra' && needs.memory-check-changes.outputs.memory-changed == 'true' && needs.prebuild.result == 'success'
     runs-on: starsling-ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -81,6 +81,7 @@ jobs:
     outputs:
       run_full: ${{ steps.compute.outputs.run_full }}
       test_files: ${{ steps.compute.outputs.test_files }}
+      affected_store_tests: ${{ steps.compute.outputs.affected_store_tests }}
     permissions:
       contents: read
     steps:
@@ -105,6 +106,7 @@ jobs:
             echo "No src/ changes detected — running full suite."
             echo "run_full=true" >> $GITHUB_OUTPUT
             echo "test_files=" >> $GITHUB_OUTPUT
+            echo "affected_store_tests=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -121,6 +123,9 @@ jobs:
             const count = data.count || 0;
             const total = data.testFiles || 1;
             const ratio = count / total;
+
+            const affectedStoreTests = (data.affectedTests || []).some(file => file.startsWith('stores/'));
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, \`affected_store_tests=\${affectedStoreTests}\n\`);
 
             console.error(\`Affected: \${count}/\${total} tests (\${(ratio * 100).toFixed(1)}%)\`);
 
@@ -204,11 +209,11 @@ jobs:
   combined-stores-check-changes:
     name: Detect stores changes
     if: github.repository == 'mastra-ai/mastra' && needs.changes.outputs.has_code == 'true'
-    needs: changes
+    needs: [changes, affected-tests]
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     outputs:
-      stores-changed: ${{ steps.filter.outputs.stores }}
+      stores-changed: ${{ steps.check.outputs.stores-changed }}
     permissions:
       contents: read
     steps:
@@ -217,16 +222,29 @@ jobs:
           fetch-depth: 0
 
       - name: Check for stores changes
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          base: ${{ github.event.pull_request.base.ref }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          filters: |
-            stores:
-              - 'stores/**'
-              - 'packages/core/**'
-              - '.github/workflows/test-combined-stores.yml'
+        id: check
+        run: |
+          STORES_CHANGED=false
+
+          # Run when the affected-tests graph found store test files impacted
+          if [ "${{ needs.affected-tests.outputs.affected_store_tests }}" = "true" ]; then
+            STORES_CHANGED=true
+          fi
+
+          # Direct path fallback for changes not covered by the affected-test graph
+          # (store packages/configs, core storage+vector interfaces, CI workflow edits).
+          # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
+          DIRECT=$(git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
+            | grep -vE '\.md$' \
+            | grep -E '^(stores/|packages/core/src/storage/|packages/core/src/vector/|\.github/workflows/test-combined-stores\.yml|\.github/workflows/prebuild\.yml)' \
+            || true)
+
+          if [ -n "$DIRECT" ]; then
+            STORES_CHANGED=true
+          fi
+
+          echo "stores-changed=$STORES_CHANGED" >> "$GITHUB_OUTPUT"
 
   combined-stores-tests:
     name: Combined Store Tests

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -232,12 +232,14 @@ jobs:
           fi
 
           # Direct path fallback for changes not covered by the affected-test graph
-          # (store packages/configs, core storage+vector interfaces, CI workflow edits).
+          # (store packages/configs, CI workflow edits). Core storage/vector source
+          # changes are already caught by the affected-tests graph via cross-package
+          # alias resolution, so they are not duplicated here.
           # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
           DIRECT=$(git diff --name-only \
             "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
             | grep -vE '\.md$' \
-            | grep -E '^(stores/|packages/core/src/storage/|packages/core/src/vector/|\.github/workflows/test-combined-stores\.yml|\.github/workflows/prebuild\.yml)' \
+            | grep -E '^(stores/|\.github/workflows/test-combined-stores\.yml|\.github/workflows/prebuild\.yml)' \
             || true)
 
           if [ -n "$DIRECT" ]; then

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -82,6 +82,7 @@ jobs:
       run_full: ${{ steps.compute.outputs.run_full }}
       test_files: ${{ steps.compute.outputs.test_files }}
       affected_store_tests: ${{ steps.compute.outputs.affected_store_tests }}
+      affected_workspace_tests: ${{ steps.compute.outputs.affected_workspace_tests }}
     permissions:
       contents: read
     steps:
@@ -107,6 +108,7 @@ jobs:
             echo "run_full=true" >> $GITHUB_OUTPUT
             echo "test_files=" >> $GITHUB_OUTPUT
             echo "affected_store_tests=false" >> $GITHUB_OUTPUT
+            echo "affected_workspace_tests=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -127,6 +129,9 @@ jobs:
             const affectedStoreTests = (data.affectedTests || []).some(file => file.startsWith('stores/'));
             fs.appendFileSync(process.env.GITHUB_OUTPUT, \`affected_store_tests=\${affectedStoreTests}\n\`);
 
+            const affectedWorkspaceTests = (data.affectedTests || []).some(file => file.startsWith('workspaces/'));
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, \`affected_workspace_tests=\${affectedWorkspaceTests}\n\`);
+
             console.error(\`Affected: \${count}/\${total} tests (\${(ratio * 100).toFixed(1)}%)\`);
 
             if (ratio > 0.5) {
@@ -142,6 +147,20 @@ jobs:
               fs.appendFileSync(process.env.GITHUB_OUTPUT, 'AFFECTED_EOF\n');
             }
           "
+
+      - name: Save affected-tests outputs for downstream workflow
+        if: always()
+        run: |
+          mkdir -p /tmp/affected-outputs
+          echo "${{ steps.compute.outputs.affected_workspace_tests }}" > /tmp/affected-outputs/affected_workspace_tests.txt
+
+      - name: Upload affected-tests artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: affected-tests-outputs
+          path: /tmp/affected-outputs/
+          retention-days: 1
 
   test-suite:
     name: Unit and E2E Tests
@@ -266,10 +285,52 @@ jobs:
       ABHI_CLOUDFLARE_API_TOKEN: ${{ secrets.ABHI_CLOUDFLARE_API_TOKEN }}
       ABHI_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ABHI_CLOUDFLARE_ACCOUNT_ID }}
 
+  workspace-check-changes:
+    name: Detect workspace changes
+    if: github.repository == 'mastra-ai/mastra' && needs.changes.outputs.has_code == 'true'
+    needs: [changes, affected-tests]
+    runs-on: starsling-ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      workspaces-changed: ${{ steps.check.outputs.workspaces-changed }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+
+      - name: Check for workspace changes
+        id: check
+        run: |
+          WORKSPACES_CHANGED=false
+
+          # Run when the affected-tests graph found workspace test files impacted
+          if [ "${{ needs.affected-tests.outputs.affected_workspace_tests }}" = "true" ]; then
+            WORKSPACES_CHANGED=true
+          fi
+
+          # Direct path fallback for changes not covered by the affected-test graph
+          # (workspace packages/configs, CI workflow edits). Core source changes that
+          # affect workspace tests are already caught by the affected-tests graph via
+          # cross-package alias resolution, so they are not duplicated here.
+          # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
+          DIRECT=$(git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
+            | grep -vE '\.md$' \
+            | grep -E '^(workspaces/|\.github/workflows/test-workspaces\.yml|\.github/workflows/secrets\.test-workspaces\.yml|\.github/workflows/prebuild\.yml)' \
+            || true)
+
+          if [ -n "$DIRECT" ]; then
+            WORKSPACES_CHANGED=true
+          fi
+
+          echo "workspaces-changed=$WORKSPACES_CHANGED" >> "$GITHUB_OUTPUT"
+
   workspace-tests:
     name: Workspace Tests
-    needs: [changes, prebuild]
-    if: always() && github.repository == 'mastra-ai/mastra' && needs.changes.outputs.has_code == 'true' && needs.prebuild.result == 'success'
+    needs: [changes, workspace-check-changes, prebuild]
+    if: always() && github.repository == 'mastra-ai/mastra' && needs.workspace-check-changes.outputs.workspaces-changed == 'true' && needs.prebuild.result == 'success'
     uses: ./.github/workflows/test-workspaces.yml
     permissions:
       contents: read

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -15,14 +15,16 @@ jobs:
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     runs-on: starsling-ubuntu-24.04
     outputs:
-      workspaces-changed: ${{ steps.changes.outputs.workspaces }}
+      workspaces-changed: ${{ steps.check.outputs.workspaces-changed }}
     permissions:
       contents: read
+      actions: read
       statuses: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
           persist-credentials: false
       - name: Set pending status
         uses: ./.github/workflows/shared-actions/set-pr-status
@@ -34,16 +36,49 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - name: Check for workspace package changes
-        uses: dorny/paths-filter@v3
-        id: changes
+      - name: Download affected-tests artifact
+        uses: actions/download-artifact@v6
         with:
-          base: main
-          ref: ${{ github.event.workflow_run.head_sha }}
-          filters: |
-            workspaces:
-              - 'workspaces/**'
-              - 'packages/core/**'
+          name: affected-tests-outputs
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/affected-outputs
+        continue-on-error: true
+
+      - name: Check for workspace changes
+        id: check
+        run: |
+          WORKSPACES_CHANGED=false
+
+          # Check affected-tests graph output from prebuild workflow.
+          # The artifact may be missing when the prebuild had no code changes
+          # (affected-tests job skipped) — in that case fall through to the
+          # direct path check below.
+          if [ -f /tmp/affected-outputs/affected_workspace_tests.txt ]; then
+            AFFECTED=$(cat /tmp/affected-outputs/affected_workspace_tests.txt | tr -d '[:space:]')
+            if [ "$AFFECTED" = "true" ]; then
+              WORKSPACES_CHANGED=true
+            fi
+          fi
+
+          # Direct path fallback for changes not covered by the affected-test graph
+          # (workspace packages/configs, CI workflow edits). Core source changes that
+          # affect workspace tests are already caught by the affected-tests graph via
+          # cross-package alias resolution, so they are not duplicated here.
+          # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
+          # Fetch base branch so the three-dot diff resolves (checkout may be shallow).
+          git fetch --no-tags --prune origin main 2>/dev/null || true
+          DIRECT=$(git diff --name-only \
+            origin/main...${{ github.event.workflow_run.head_sha }} \
+            | grep -vE '\.md$' \
+            | grep -E '^(workspaces/|\.github/workflows/test-workspaces\.yml|\.github/workflows/secrets\.test-workspaces\.yml|\.github/workflows/prebuild\.yml)' \
+            || true)
+
+          if [ -n "$DIRECT" ]; then
+            WORKSPACES_CHANGED=true
+          fi
+
+          echo "workspaces-changed=$WORKSPACES_CHANGED" >> "$GITHUB_OUTPUT"
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -21,9 +21,10 @@ jobs:
       actions: read
       statuses: write
     steps:
+      # Checkout the default branch so local actions are loaded from a trusted
+      # ref, not the workflow_run head SHA which may come from an untrusted PR.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Set pending status
@@ -37,7 +38,7 @@ jobs:
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Download affected-tests artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
           name: affected-tests-outputs
           run-id: ${{ github.event.workflow_run.id }}
@@ -47,6 +48,8 @@ jobs:
 
       - name: Check for workspace changes
         id: check
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           WORKSPACES_CHANGED=false
 
@@ -66,13 +69,35 @@ jobs:
           # affect workspace tests are already caught by the affected-tests graph via
           # cross-package alias resolution, so they are not duplicated here.
           # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
-          # Fetch base branch so the three-dot diff resolves (checkout may be shallow).
-          git fetch --no-tags --prune origin main 2>/dev/null || true
-          DIRECT=$(git diff --name-only \
-            origin/main...${{ github.event.workflow_run.head_sha }} \
-            | grep -vE '\.md$' \
-            | grep -E '^(workspaces/|\.github/workflows/test-workspaces\.yml|\.github/workflows/secrets\.test-workspaces\.yml|\.github/workflows/prebuild\.yml)' \
-            || true)
+          # Use base/head SHAs from the prebuild artifact when available so the diff
+          # targets the correct PR base. Fall back to origin/main when the artifact
+          # is absent (prebuild skipped, no code changes).
+          BASE_SHA=""
+          DIFF_HEAD="$HEAD_SHA"
+          if [ -f /tmp/affected-outputs/base_sha.txt ]; then
+            BASE_SHA=$(cat /tmp/affected-outputs/base_sha.txt | tr -d '[:space:]')
+          fi
+          if [ -f /tmp/affected-outputs/head_sha.txt ]; then
+            DIFF_HEAD=$(cat /tmp/affected-outputs/head_sha.txt | tr -d '[:space:]')
+          fi
+
+          # Fetch the head commit so the three-dot diff resolves.
+          git fetch --no-tags --prune origin "$DIFF_HEAD" 2>/dev/null || true
+
+          if [ -n "$BASE_SHA" ]; then
+            DIRECT=$(git diff --name-only \
+              "$BASE_SHA...$DIFF_HEAD" \
+              | grep -vE '\.md$' \
+              | grep -E '^(workspaces/|\.github/workflows/test-workspaces\.yml|\.github/workflows/secrets\.test-workspaces\.yml|\.github/workflows/prebuild\.yml)' \
+              || true)
+          else
+            git fetch --no-tags --prune origin main 2>/dev/null || true
+            DIRECT=$(git diff --name-only \
+              "origin/main...$DIFF_HEAD" \
+              | grep -vE '\.md$' \
+              | grep -E '^(workspaces/|\.github/workflows/test-workspaces\.yml|\.github/workflows/secrets\.test-workspaces\.yml|\.github/workflows/prebuild\.yml)' \
+              || true)
+          fi
 
           if [ -n "$DIRECT" ]; then
             WORKSPACES_CHANGED=true

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -53,25 +53,9 @@ jobs:
         run: |
           WORKSPACES_CHANGED=false
 
-          # Check affected-tests graph output from prebuild workflow.
-          # The artifact may be missing when the prebuild had no code changes
-          # (affected-tests job skipped) — in that case fall through to the
-          # direct path check below.
-          if [ -f /tmp/affected-outputs/affected_workspace_tests.txt ]; then
-            AFFECTED=$(cat /tmp/affected-outputs/affected_workspace_tests.txt | tr -d '[:space:]')
-            if [ "$AFFECTED" = "true" ]; then
-              WORKSPACES_CHANGED=true
-            fi
-          fi
-
-          # Direct path fallback for changes not covered by the affected-test graph
-          # (workspace packages/configs, CI workflow edits). Core source changes that
-          # affect workspace tests are already caught by the affected-tests graph via
-          # cross-package alias resolution, so they are not duplicated here.
-          # Ignore markdown-only changes so docs/changelog-only edits don't trigger.
-          # Use base/head SHAs from the prebuild artifact when available so the diff
-          # targets the correct PR base. Fall back to origin/main when the artifact
-          # is absent (prebuild skipped, no code changes).
+          # Read base/head SHAs from the prebuild artifact when available so
+          # the diff targets the correct PR base. Fall back to origin/main +
+          # the workflow_run head SHA when the artifact is absent.
           BASE_SHA=""
           DIFF_HEAD="$HEAD_SHA"
           if [ -f /tmp/affected-outputs/base_sha.txt ]; then
@@ -81,26 +65,60 @@ jobs:
             DIFF_HEAD=$(cat /tmp/affected-outputs/head_sha.txt | tr -d '[:space:]')
           fi
 
-          # Fetch the head commit so the three-dot diff resolves.
+          # Fetch refs so the three-dot diff resolves.
           git fetch --no-tags --prune origin "$DIFF_HEAD" 2>/dev/null || true
-
-          if [ -n "$BASE_SHA" ]; then
-            DIRECT=$(git diff --name-only \
-              "$BASE_SHA...$DIFF_HEAD" \
-              | grep -vE '\.md$' \
-              | grep -E '^(workspaces/|\.github/workflows/test-workspaces\.yml|\.github/workflows/secrets\.test-workspaces\.yml|\.github/workflows/prebuild\.yml)' \
-              || true)
-          else
+          if [ -z "$BASE_SHA" ]; then
             git fetch --no-tags --prune origin main 2>/dev/null || true
-            DIRECT=$(git diff --name-only \
-              "origin/main...$DIFF_HEAD" \
-              | grep -vE '\.md$' \
-              | grep -E '^(workspaces/|\.github/workflows/test-workspaces\.yml|\.github/workflows/secrets\.test-workspaces\.yml|\.github/workflows/prebuild\.yml)' \
-              || true)
+            DIFF_RANGE="origin/main...$DIFF_HEAD"
+          else
+            DIFF_RANGE="$BASE_SHA...$DIFF_HEAD"
           fi
+
+          # Check affected-tests graph output from prebuild workflow.
+          # Track validity so we can fail closed if the artifact is missing
+          # or contains an unexpected value (e.g. the affected-tests compute
+          # step failed but the artifact was still uploaded via if: always).
+          ARTIFACT_VALID=false
+          if [ -f /tmp/affected-outputs/affected_workspace_tests.txt ]; then
+            AFFECTED=$(cat /tmp/affected-outputs/affected_workspace_tests.txt | tr -d '[:space:]')
+            if [ "$AFFECTED" = "true" ]; then
+              WORKSPACES_CHANGED=true
+              ARTIFACT_VALID=true
+            elif [ "$AFFECTED" = "false" ]; then
+              ARTIFACT_VALID=true
+            fi
+          fi
+
+          # Direct path fallback for changes not covered by the affected-test
+          # graph (workspace packages/configs, CI workflow edits). Core source
+          # changes that affect workspace tests are already caught by the
+          # affected-tests graph via cross-package alias resolution, so they
+          # are not duplicated here.
+          # Ignore markdown-only changes so docs/changelog-only edits don't
+          # trigger.
+          DIRECT=$(git diff --name-only \
+            "$DIFF_RANGE" \
+            | grep -vE '\.md$' \
+            | grep -E '^(workspaces/|\.github/workflows/test-workspaces\.yml|\.github/workflows/secrets\.test-workspaces\.yml|\.github/workflows/prebuild\.yml)' \
+            || true)
 
           if [ -n "$DIRECT" ]; then
             WORKSPACES_CHANGED=true
+          fi
+
+          # Fail closed: if the affected-tests artifact was unavailable or
+          # invalid, graph-only workspace impacts can't be determined. If
+          # there are any code changes, run the tests to be safe. When there
+          # are no code changes (docs-only PR), tests are correctly skipped.
+          if [ "$ARTIFACT_VALID" = "false" ]; then
+            ANY_CODE=$(git diff --name-only \
+              "$DIFF_RANGE" \
+              | grep -vE '\.md$' \
+              | grep -vE '^docs/' \
+              || true)
+            if [ -n "$ANY_CODE" ]; then
+              WORKSPACES_CHANGED=true
+            fi
           fi
 
           echo "workspaces-changed=$WORKSPACES_CHANGED" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The Combined Store Tests workflow used to trigger on every `packages/core/**` change via a broad `dorny/paths-filter` match. That's expensive — it spins up databases and runs all store packages even when the change has nothing to do with storage.

This replaces the broad filter with a two-part gate:

1. **Affected-tests graph** — the `affected-tests` job already builds a reverse-dependency graph with madge. It now exposes an `affected_store_tests` output that's `true` when any impacted test file lives under `stores/`.

2. **Direct path fallback** — a conservative git-diff check for changes the static graph may miss: `stores/**`, `packages/core/src/storage/**`, `packages/core/src/vector/**`, and the two relevant workflow files. Markdown-only changes are excluded so docs/changelog edits don't trigger it.

So a change to `packages/core/src/agent/**` no longer kicks off the full store test suite, while a change to `packages/core/src/storage/**` or any `stores/**` package still does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes CI smarter: it checks whether your changes are actually likely to affect the slow “store / workspace / memory” tests. If the change doesn’t touch the right files (based on dependency-aware analysis), CI skips the expensive test suites and only falls back to simpler file checks when needed.

## Summary
- **`.github/workflows/prebuild.yml` (`affected-tests`)**
  - Adds new outputs: `affected_store_tests`, `affected_workspace_tests`, `affected_memory_tests`.
  - When there are **no matching `src/*.ts|tsx` changes**, it exits early with `run_full=true`, clears `test_files`, and sets all three affected flags to `false`.
  - After running `scripts/affected-tests.mjs`, computes the booleans by checking whether the graph’s impacted files start with:
    - `stores/` → `affected_store_tests`
    - `workspaces/` → `affected_workspace_tests`
    - `packages/memory/integration-tests/` → `affected_memory_tests`
  - Uploads an **`affected-tests-outputs`** artifact containing:
    - `affected_workspace_tests.txt`, `affected_memory_tests.txt`
    - `base_sha.txt`, `head_sha.txt`

- **`.github/workflows/prebuild.yml` change gates (replacing prior broader triggers)**
  - **`combined-stores-check-changes` → `stores-changed`**
    - If `needs.affected-tests.outputs.affected_store_tests == 'true'`, sets `stores-changed=true`.
    - Otherwise falls back to a `git diff --name-only "$BASE_SHA...$HEAD_SHA"` check, ignoring `*.md`, for changes under:
      - `stores/`
      - `.github/workflows/test-combined-stores.yml`
      - `.github/workflows/prebuild.yml`
  - **`workspace-check-changes` → `workspaces-changed`**
    - If `needs.affected-tests.outputs.affected_workspace_tests == 'true'`, sets `workspaces-changed=true`.
    - Otherwise falls back to `git diff --name-only "$BASE_SHA...$HEAD_SHA"` (ignoring `*.md`) for:
      - `workspaces/`
      - `.github/workflows/test-workspaces.yml`
      - `.github/workflows/secrets.test-workspaces.yml`
      - `.github/workflows/prebuild.yml`
  - **`memory-check-changes` → `memory-changed`**
    - If `needs.affected-tests.outputs.affected_memory_tests == 'true'`, sets `memory-changed=true`.
    - Otherwise falls back to `git diff --name-only "$BASE_SHA...$HEAD_SHA"` (ignoring `*.md`) for:
      - `packages/memory/`
      - `.github/workflows/prebuild.yml`
  - **`combined-stores-tests`, `workspace-tests`, and `memory-test`** are rewired to run only when their respective `*-changed` outputs are `true`.

- **`.github/workflows/secrets.test-workspaces.yml` (workspace gating for cloud tests)**
  - `check-changes` now:
    - Downloads the **`affected-tests-outputs`** artifact (best-effort; continue-on-error).
    - Sets `workspaces-changed=true` when `affected_workspace_tests.txt` is `true`.
    - If the artifact is missing/unhelpful, falls back to `git diff --name-only` using:
      - `base_sha.txt` + `head_sha.txt` when available (so diffs target the correct PR base),
      - otherwise `origin/main...<head_sha>`.
    - Ignores `*.md` and triggers only on:
      - `workspaces/`
      - `.github/workflows/test-workspaces.yml`
      - `.github/workflows/secrets.test-workspaces.yml`
      - `.github/workflows/prebuild.yml`
  - Tightens `check-changes` permissions and checks out the **default branch** (trusted ref) to avoid loading local actions from an untrusted PR `workflow_run` head.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->