### PR TITLE
fix(pg): guard numeric range filters so mixed-type metadata doesn't fail the whole query

### DIFF
--- a/.changeset/pgvector-numeric-filter-mixed-type.md
+++ b/.changeset/pgvector-numeric-filter-mixed-type.md
@@ -1,0 +1,24 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed PgVector numeric range filters (`$gt`, `$gte`, `$lt`, `$lte`) failing the entire query when any row's metadata held a non-numeric value at the filtered path.
+
+Because JSONB metadata is schemaless, a single document with a value like `{ price: 'N/A' }` made Postgres cast the whole column to `numeric` and raise `invalid input syntax for type numeric` (`22P02`), breaking all range-filtered vector queries (and semantic recall using `semanticRecall.filter`) on that index. Non-numeric values are now simply excluded from the result, matching the behavior of the other Mastra vector stores and MongoDB-style `$gt` semantics.
+
+```typescript
+await pgVector.upsert({
+  indexName: 'products',
+  vectors: [[1, 0], [0, 1]],
+  metadata: [{ price: 100 }, { price: 'N/A' }],
+});
+
+// Before: threw "invalid input syntax for type numeric: N/A"
+// After: returns only the row whose price is actually a number
+await pgVector.query({
+  indexName: 'products',
+  queryVector: [1, 0],
+  topK: 10,
+  filter: { price: { $gt: 50 } },
+});
+```

--- a/.changeset/pgvector-numeric-filter-mixed-type.md
+++ b/.changeset/pgvector-numeric-filter-mixed-type.md
@@ -2,9 +2,9 @@
 '@mastra/pg': patch
 ---
 
-Fixed PgVector numeric range filters (`$gt`, `$gte`, `$lt`, `$lte`) failing the entire query when any row's metadata held a non-numeric value at the filtered path.
+Fixed PgVector numeric range filters (`$gt`, `$gte`, `$lt`, `$lte`) so rows with non-numeric metadata values no longer fail the whole query.
 
-Because JSONB metadata is schemaless, a single document with a value like `{ price: 'N/A' }` made Postgres cast the whole column to `numeric` and raise `invalid input syntax for type numeric` (`22P02`), breaking all range-filtered vector queries (and semantic recall using `semanticRecall.filter`) on that index. Non-numeric values are now simply excluded from the result, matching the behavior of the other Mastra vector stores and MongoDB-style `$gt` semantics.
+A single document with a value like `{ price: 'N/A' }` used to make the entire query error out, breaking all range-filtered vector queries (and semantic recall using `semanticRecall.filter`) on that index. Rows whose value isn't a number are now skipped for numeric range checks instead, matching the behavior of the other Mastra vector stores. Numeric rows still match as expected.
 
 ```typescript
 await pgVector.upsert({

--- a/stores/pg/src/vector/sql-builder.test.ts
+++ b/stores/pg/src/vector/sql-builder.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFilterQuery } from './sql-builder';
+
+describe('buildFilterQuery - numeric range operators', () => {
+  // JSONB metadata is schemaless: a single row with a non-numeric value at a
+  // filtered path (e.g. { price: 'N/A' }) used to make Postgres cast the whole
+  // column to ::numeric and raise 22P02, failing the entire query. The generated
+  // SQL must guard the cast with jsonb_typeof so non-numeric rows simply don't match.
+  const operators = [
+    { op: '$gt', symbol: '>' },
+    { op: '$gte', symbol: '>=' },
+    { op: '$lt', symbol: '<' },
+    { op: '$lte', symbol: '<=' },
+  ] as const;
+
+  for (const { op, symbol } of operators) {
+    it(`${op} guards the numeric cast with jsonb_typeof so mixed-type metadata doesn't fail the query`, () => {
+      const { sql, values } = buildFilterQuery({ price: { [op]: 50 } }, 0, 10);
+
+      // The value is appended after [minScore, topK].
+      expect(values).toEqual([0, 10, 50]);
+      expect(sql).toContain(`jsonb_typeof(metadata#>'{price}') = 'number'`);
+      expect(sql).toContain(`(metadata#>>'{price}')::numeric ${symbol} $3::numeric`);
+      expect(sql).toContain('ELSE FALSE');
+      // The bare, unguarded cast must no longer appear on its own.
+      expect(sql).not.toMatch(/(?<!THEN )\(metadata#>>'\{price\}'\)::numeric/);
+    });
+  }
+
+  it('combines guarded conditions with AND for a range on the same field', () => {
+    const { sql, values } = buildFilterQuery({ price: { $gte: 20, $lte: 80 } }, 0, 10);
+
+    expect(values).toEqual([0, 10, 20, 80]);
+    expect(sql).toContain(`jsonb_typeof(metadata#>'{price}') = 'number'`);
+    expect(sql).toContain(`(metadata#>>'{price}')::numeric >= $3::numeric`);
+    expect(sql).toContain(`(metadata#>>'{price}')::numeric <= $4::numeric`);
+  });
+
+  it('keeps text comparison (no cast, no guard) when the filter value is non-numeric', () => {
+    // e.g. ISO date strings sort correctly as text and never hit the numeric cast.
+    const { sql } = buildFilterQuery({ createdAt: { $gt: '2024-01-01' } }, 0, 10);
+
+    expect(sql).toContain(`metadata#>>'{createdAt}' > $3::text`);
+    expect(sql).not.toContain('::numeric');
+    expect(sql).not.toContain('jsonb_typeof');
+  });
+
+  it('rewrites the guard to the element alias inside $elemMatch', () => {
+    const { sql } = buildFilterQuery({ items: { $elemMatch: { price: { $gt: 10 } } } }, 0, 10);
+
+    // Both the jsonb_typeof guard and the cast must reference `elem`, not `metadata`.
+    expect(sql).toContain(`jsonb_typeof(elem#>'{price}') = 'number'`);
+    expect(sql).toContain(`(elem#>>'{price}')::numeric > `);
+    expect(sql).not.toContain(`metadata#>'{price}'`);
+  });
+});

--- a/stores/pg/src/vector/sql-builder.ts
+++ b/stores/pg/src/vector/sql-builder.ts
@@ -51,8 +51,14 @@ const createNumericOperator = (symbol: string) => {
 
     // Use numeric comparison for numbers, text comparison for strings/dates
     if (isNumeric) {
+      // JSONB metadata is schemaless, so a candidate row may hold a non-numeric
+      // value at this path (e.g. { price: 'N/A' }). Casting the column to ::numeric
+      // unconditionally makes Postgres raise 22P02 and fail the ENTIRE query instead
+      // of that row simply not matching. Guard the cast with jsonb_typeof so only
+      // number-typed rows are compared and everything else is excluded, mirroring the
+      // $size/$in pattern already used in this file and MongoDB-style range semantics.
       return {
-        sql: `(metadata#>>'{${jsonPathKey}}')::numeric ${symbol} $${paramIndex}::numeric`,
+        sql: `(CASE WHEN jsonb_typeof(metadata#>'{${jsonPathKey}}') = 'number' THEN (metadata#>>'{${jsonPathKey}}')::numeric ${symbol} $${paramIndex}::numeric ELSE FALSE END)`,
         needsValue: true,
       };
     } else {
@@ -101,7 +107,11 @@ function buildElemMatchConditions(value: any, paramIndex: number): { sql: string
     }
     const result = operatorFn(paramKey, nextParamIndex, paramValue);
 
-    const sql = result.sql.replaceAll('metadata#>>', 'elem#>>');
+    // Rewrite every column reference to the per-element alias. Order matters:
+    // replace the longer `metadata#>>` token before `metadata#>` so the latter
+    // doesn't partially match the former (e.g. the jsonb_typeof guard emitted by
+    // the numeric operators uses the single-arrow `metadata#>` form).
+    const sql = result.sql.replaceAll('metadata#>>', 'elem#>>').replaceAll('metadata#>', 'elem#>');
     conditions.push(sql);
     if (result.needsValue) {
       values.push(paramValue);


### PR DESCRIPTION
## Description

PgVector's numeric range operators (`$gt`, `$gte`, `$lt`, `$lte`) generated `(metadata#>>'{key}')::numeric <op> $n::numeric`, applying the cast to the **column** side for every candidate row. JSONB metadata is schemaless, so if any scanned row had a non-numeric value at that path (e.g. `{ price: 'N/A' }`, `{ price: 'unknown' }`, or an object), Postgres raised `22P02 invalid input syntax for type numeric` and the **entire query failed** — instead of that row simply not matching, which is what every other Mastra store does and what MongoDB-style `$gt` semantics imply.

This is a realistic production trap: metadata is written by many producers over time, and a single document with a string in a numeric field bricks all range-filtered vector queries (and semantic recall using `semanticRecall.filter`) on that index until the offending row is found and fixed.

```ts
await pgVector.upsert({
  indexName: 'i',
  vectors: [[1, 0], [0, 1]],
  metadata: [{ price: 100 }, { price: 'N/A' }],
});

// Before: MastraError wrapping "invalid input syntax for type numeric: N/A"
// After:  returns only the row whose price is actually a number
await pgVector.query({ indexName: 'i', queryVector: [1, 0], topK: 10, filter: { price: { $gt: 50 } } });
```

### Changes

- **Guard the cast with `jsonb_typeof`.** The numeric branch of `createNumericOperator` now emits
  `CASE WHEN jsonb_typeof(metadata#>'{key}') = 'number' THEN (metadata#>>'{key}')::numeric <op> $n::numeric ELSE FALSE END`,
  mirroring the existing `$size`/`$in` guards already used in the same file. Rows whose value isn't number-typed (including missing keys, where `jsonb_typeof` is `NULL`) are excluded instead of aborting the query. The text-comparison branch (for string/date filter values) is unchanged — it never casts, so it was never affected.
- **`$elemMatch` alias rewrite.** `buildElemMatchConditions` rewrote `metadata#>>` → `elem#>>`; the new guard also introduces the single-arrow `metadata#>` form (required because `jsonb_typeof` takes `jsonb`). The rewrite now also replaces `metadata#>` → `elem#>` (longer token first) so a nested numeric range inside `$elemMatch` type-checks against the element, not the whole metadata column.
- **Tests** asserting the generated SQL for every numeric operator, ranges on the same field, the unaffected text path, and the `$elemMatch` rewrite.

No public API changes. The success path for homogeneous numeric metadata is unchanged.

**Note on string-stored numbers:** the guard matches only JSONB `number`-typed values, so a number stored as a string (`{ price: '100' }`) no longer matches a numeric range filter. This is the intended, store-consistent behavior — it aligns PgVector with the other Mastra stores and avoids the data-dependent crash.

**Files changed**
- `stores/pg/src/vector/sql-builder.ts` — guard the numeric cast with `jsonb_typeof`; extend the `$elemMatch` alias rewrite to the single-arrow form
- `stores/pg/src/vector/sql-builder.test.ts` — new unit tests for the generated SQL
- `.changeset/pgvector-numeric-filter-mixed-type.md` — patch changeset

## Related issue(s)

Fixes #18429

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## How it was tested

- **New unit tests** (`sql-builder.test.ts`, 7 passing) assert that each numeric operator wraps its cast in a `jsonb_typeof(...) = 'number'` guard with an `ELSE FALSE` fallthrough, that same-field ranges combine with `AND`, that non-numeric filter values still use the uncast text path, and that the guard is rewritten to the `elem` alias inside `$elemMatch`.
- Ran the existing `filter.test.ts` suite (75 passing) — no regressions.
- Run locally with:
  ```bash
  pnpm --filter ./stores/pg exec vitest run src/vector/sql-builder.test.ts src/vector/filter.test.ts
  ```

## Checklist

- [ ] I have linked the related issue(s) in the description above _(pending — replace #XXXX once the issue is filed)_
- [x] I have made corresponding changes to the documentation (if applicable) _(none needed; internal SQL behavior only)_
- [x] I have added tests that prove my fix is effective
- [ ] I have addressed all Coderabbit comments on this PR _(after PR is opened)_

## Diff summary

```diff
   if (isNumeric) {
-    return {
-      sql: `(metadata#>>'{${jsonPathKey}}')::numeric ${symbol} $${paramIndex}::numeric`,
-      needsValue: true,
-    };
+    return {
+      sql: `(CASE WHEN jsonb_typeof(metadata#>'{${jsonPathKey}}') = 'number' THEN (metadata#>>'{${jsonPathKey}}')::numeric ${symbol} $${paramIndex}::numeric ELSE FALSE END)`,
+      needsValue: true,
+    };
   }

-  const sql = result.sql.replaceAll('metadata#>>', 'elem#>>');
+  const sql = result.sql.replaceAll('metadata#>>', 'elem#>>').replaceAll('metadata#>', 'elem#>');
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes PgVector range filters stop “crashing” when your JSON metadata has mixed types (like some rows storing `"price": "N/A"` while others store `"price": 12`). Instead of blowing up the whole query, it only compares rows that actually contain numbers.

### What changed
- Updated PgVector numeric range filters (`$gt`, `$gte`, `$lt`, `$lte`) to guard numeric casts with `jsonb_typeof(...) = 'number'`.
- For non-number (or missing) values, the generated predicate now evaluates to `FALSE` rather than throwing `22P02 invalid input syntax for type numeric`.
- Fixed `$elemMatch` SQL alias rewriting so both `metadata#>>` and the newer `metadata#>` forms are rewritten to `elem#>>` / `elem#>` inside nested element conditions.
- Added tests asserting the generated SQL for:
  - guarded numeric operator SQL
  - combining multiple range operators with `AND`
  - non-numeric/text-path behavior (no numeric guards where not needed)
  - `$elemMatch` rewriting (including `metadata#>` cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->