### PR TITLE
fix: correct playground changeset package

### DIFF
--- a/.changeset/wet-teeth-hammer.md
+++ b/.changeset/wet-teeth-hammer.md
@@ -1,6 +1,6 @@
 ---
 '@mastra/playground-ui': patch
-'@mastra/playground': patch
+'@internal/playground': patch
 ---
 
 Move the Memory Studio (timeline, flamegraph, and observational-memory detail) into the agent chat view as an opt-in panel.


### PR DESCRIPTION
Fixes a bad changeset package key introduced in .changeset/wet-teeth-hammer.md.

Before:
```
'@mastra/playground': patch
```

After:
```
'@internal/playground': patch
```

The actual package name in packages/playground/package.json is @internal/playground, and changeset status now resolves the changeset successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This fixes a label on a release note so it points to the right app name. Because the package name now matches the real one, the release tooling can figure out the change correctly.

## Summary
- Updated `.changeset/wet-teeth-hammer.md` to change the patch target from `@mastra/playground` to `@internal/playground`.
- Left the rest of the changeset description unchanged.
- This resolves the package key mismatch so changeset status can complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->