### PR TITLE
fix(azure): use dynamic host port for Azurite integration test

### DIFF
--- a/.changeset/clever-beers-run.md
+++ b/.changeset/clever-beers-run.md
@@ -1,0 +1,5 @@
+---
+'@mastra/azure': patch
+---
+
+Fixed the Azurite integration test failing in CI with address already in use on port 10000. Docker now exposes the container on a dynamically assigned host port instead of a fixed mapping, and the test script discovers the actual port at runtime via docker compose port. This eliminates conflicts with other services or lingering containers on the runner.

--- a/workspaces/azure/docker-compose.yml
+++ b/workspaces/azure/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite:3.35.0
     ports:
-      - '10000:10000'
+      - '10000'
     command: azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck
     healthcheck:
       test: ['CMD', 'nc', '-z', '127.0.0.1', '10000']

--- a/workspaces/azure/package.json
+++ b/workspaces/azure/package.json
@@ -35,7 +35,7 @@
     "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
     "test:watch": "vitest watch",
     "pretest": "docker compose up -d --wait",
-    "test": "AZURE_STORAGE_CONNECTION_STRING='DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;' TEST_AZURE_CONTAINER=test-container vitest run integration.test.ts",
+    "test": "PORT=$(docker compose port azurite 10000 | cut -d: -f2) && AZURE_STORAGE_CONNECTION_STRING=\"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:${PORT}/devstoreaccount1;\" TEST_AZURE_CONTAINER=test-container vitest run integration.test.ts",
     "posttest": "docker compose down -v",
     "test:cloud": "vitest run integration.test.ts",
     "lint": "eslint ."


### PR DESCRIPTION
The Azurite integration test was binding to a fixed host port 10000, which fails in CI with `address already in use` when the port is occupied by another process or a lingering container from a cancelled job.

Docker now exposes the container on a dynamically assigned host port, and the test script discovers it at runtime via `docker compose port`.

Before:
```yml
ports:
  - '10000:10000'
```
```sh
AZURE_STORAGE_CONNECTION_STRING='...;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
```

After:
```yml
ports:
  - '10000'
```
```sh
PORT=$(docker compose port azurite 10000 | cut -d: -f2)
AZURE_STORAGE_CONNECTION_STRING="...;BlobEndpoint=http://127.0.0.1:${PORT}/devstoreaccount1;"
```

All 90 integration tests and 95 unit tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops the Azure test from always trying to use the same door number on the computer. Instead, it lets Docker pick a free port and then asks Docker which one it picked, so the test won’t fail when that port is already taken.

## Summary
- Updated the Azurite Docker setup to expose port `10000` on a dynamically assigned host port instead of a fixed `10000:10000` mapping.
- Changed the Azure integration test script to look up the assigned port at runtime with `docker compose port` and build the storage connection string from that value.
- Added a changeset to document the patch release for `@mastra/azure`.

## Why
- Prevents CI and local test failures caused by `address already in use` conflicts on port `10000`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->