### PR TITLE
fix(core): prevent silent message loss in SaveQueueManager on storage failure

### DIFF
--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -890,6 +890,32 @@ export class MessageList {
     return messages.map(message => this.transformMessageForTranscript(message));
   }
 
+  /**
+   * Re-marks a set of messages as unsaved so they will be included in the next flush.
+   * Used by SaveQueueManager to restore messages when a storage write fails, preventing
+   * permanent data loss from transient backend errors.
+   *
+   * Each message is matched against the internal messages list by ID and re-added to the
+   * appropriate unsaved set (user or response) based on how it was originally tracked.
+   * Messages not found in the internal list (e.g. already evicted) are silently skipped.
+   */
+  public restoreUnsavedMessages(messages: MastraDBMessage[]): void {
+    const byId = new Map(this.messages.map(m => [m.id, m]));
+    for (const msg of messages) {
+      const original = byId.get(msg.id);
+      if (!original) continue;
+      // Re-add to whichever unsaved set is appropriate.  At the time of restore
+      // both sets are already clear (drainUnsavedMessages cleared them), so we
+      // use the persisted sets — which are never cleared — to infer the original
+      // source classification.
+      if (this.stateManager.getUserMessagesPersisted().has(original)) {
+        this.newUserMessages.add(original);
+      } else if (this.stateManager.getResponseMessagesPersisted().has(original)) {
+        this.newResponseMessages.add(original);
+      }
+    }
+  }
+
   private transformToolStateDataForTranscript(data: unknown, phase: 'approval' | 'suspend'): unknown {
     if (!data || typeof data !== 'object') {
       return data;

--- a/packages/core/src/agent/save-queue/index.ts
+++ b/packages/core/src/agent/save-queue/index.ts
@@ -17,10 +17,17 @@ export class SaveQueueManager {
   }
   private saveQueues = new Map<string, Promise<void>>();
   private saveDebounceTimers = new Map<string, NodeJS.Timeout>();
+  // Superseded debounce callers that are waiting on the next scheduled save to settle their promise.
+  private pendingDebounceSettlers = new Map<string, Array<{ resolve: () => void; reject: (err: unknown) => void }>>();
 
   /**
    * Debounces save operations for a thread, ensuring that consecutive save requests
    * are batched and only the latest is executed after a short delay.
+   *
+   * When a second call arrives before the timer fires, the first caller's promise is
+   * parked in pendingDebounceSettlers so that it is settled (resolved or rejected)
+   * alongside the winning save rather than hanging forever.
+   *
    * @param threadId - The ID of the thread to debounce saves for.
    * @param messageList - The MessageList instance containing unsaved messages.
    * @param memoryConfig - Optional memory configuration to use for saving.
@@ -28,17 +35,33 @@ export class SaveQueueManager {
    */
   private debounceSave(threadId: string, messageList: MessageList, memoryConfig?: MemoryConfigInternal): Promise<void> {
     return new Promise((resolve, reject) => {
+      // Register this call's settlers before touching the timer so that any call —
+      // whether it wins the debounce race or is superseded — will always be settled.
+      const settlers = this.pendingDebounceSettlers.get(threadId) ?? [];
+      settlers.push({ resolve, reject });
+      this.pendingDebounceSettlers.set(threadId, settlers);
+
       if (this.saveDebounceTimers.has(threadId)) {
+        // A timer is already running; reset it so the debounce window restarts.
+        // The new timer will settle all accumulated settlers (including this one).
         clearTimeout(this.saveDebounceTimers.get(threadId)!);
       }
+
       this.saveDebounceTimers.set(
         threadId,
         setTimeout(() => {
+          // Claim every settler accumulated since the first debounceSave call for
+          // this thread, then clear the list before the async work begins.
+          const batch = this.pendingDebounceSettlers.get(threadId) ?? [];
+          this.pendingDebounceSettlers.delete(threadId);
+
           this.enqueueSave(threadId, messageList, memoryConfig)
-            .then(resolve)
+            .then(() => {
+              for (const s of batch) s.resolve();
+            })
             .catch(err => {
               this.logger?.error?.('Error in debounceSave', { err, threadId });
-              reject(err);
+              for (const s of batch) s.reject(err);
             })
             .finally(() => {
               this.saveDebounceTimers.delete(threadId);
@@ -53,18 +76,21 @@ export class SaveQueueManager {
    * only one save runs at a time per thread. If a save is already in progress for the thread,
    * the new save is queued to run after the previous completes.
    *
+   * Errors from persistUnsavedMessages are propagated to the caller so that flushMessages
+   * and batchMessages do not silently resolve on storage failures.
+   *
    * @param threadId - The ID of the thread whose messages should be saved.
    * @param messageList - The MessageList instance containing unsaved messages.
    * @param memoryConfig - Optional memory configuration to use for saving.
    */
   private enqueueSave(threadId: string, messageList: MessageList, memoryConfig?: MemoryConfigInternal) {
     const prev = this.saveQueues.get(threadId) || Promise.resolve();
+    // Recover from any error in the preceding save so this save still runs even when
+    // the previous one failed.  The error from *this* save is propagated to the caller.
     const next = prev
+      .catch(() => {})
       .then(() => this.persistUnsavedMessages(messageList, memoryConfig))
-      .catch(err => {
-        this.logger?.error?.('Error in enqueueSave', { err, threadId });
-      })
-      .then(() => {
+      .finally(() => {
         if (this.saveQueues.get(threadId) === next) {
           this.saveQueues.delete(threadId);
         }
@@ -88,17 +114,29 @@ export class SaveQueueManager {
 
   /**
    * Persists any unsaved messages from the MessageList to memory storage.
-   * Drains the list of unsaved messages and writes them using the memory backend.
+   *
+   * Messages are drained from the unsaved sets only after a successful write so that a
+   * transient storage failure leaves them eligible for the next flush attempt.  On failure
+   * the drained messages are restored to the MessageList and the error is re-thrown so
+   * callers (flushMessages / batchMessages) can observe and surface it.
+   *
    * @param messageList - The MessageList instance for the current thread.
    * @param memoryConfig - The memory configuration for saving.
    */
   private async persistUnsavedMessages(messageList: MessageList, memoryConfig?: MemoryConfigInternal) {
     const newMessages = messageList.drainUnsavedMessages();
-    if (newMessages.length > 0 && this.memory) {
+    if (newMessages.length === 0 || !this.memory) {
+      return;
+    }
+    try {
       await this.memory.saveMessages({
         messages: newMessages,
         memoryConfig,
       });
+    } catch (err) {
+      // Restore the drained messages so the next flush can retry them.
+      messageList.restoreUnsavedMessages(newMessages);
+      throw err;
     }
   }
 
@@ -134,6 +172,18 @@ export class SaveQueueManager {
   async flushMessages(messageList: MessageList, threadId?: string, memoryConfig?: MemoryConfigInternal) {
     if (!threadId) return;
     this.clearDebounce(threadId);
-    return this.enqueueSave(threadId, messageList, memoryConfig);
+    // Claim any settlers that were waiting on the cancelled debounce so they are
+    // resolved/rejected alongside this immediate save rather than hanging forever.
+    const superseded = this.pendingDebounceSettlers.get(threadId) ?? [];
+    this.pendingDebounceSettlers.delete(threadId);
+    const save = this.enqueueSave(threadId, messageList, memoryConfig);
+    if (superseded.length > 0) {
+      save.then(() => {
+        for (const s of superseded) s.resolve();
+      }).catch(err => {
+        for (const s of superseded) s.reject(err);
+      });
+    }
+    return save;
   }
 }


### PR DESCRIPTION
Fixes #18256

Three defects in `packages/core/src/agent/save-queue/index.ts` combined to produce permanent, undetectable conversation-history loss on any transient storage failure.

## What was broken

**Defect 1 — drain-before-write data loss**

`persistUnsavedMessages` called `messageList.drainUnsavedMessages()` before the `memory.saveMessages` write completed. A failed write left the `newUserMessages` / `newResponseMessages` sets already empty, so there was nothing to retry. Subsequent turns saved normally, leaving a silent hole in the thread history.

**Defect 2 — silent error swallow**

`enqueueSave` caught the error from `persistUnsavedMessages`, logged it, and resolved the chain as success. Every caller of `flushMessages` — including `prepare-stream/map-results-step` at stream end and `durable/workflows/steps/tool-call` before suspension — was told the save succeeded even when it had not.

**Defect 3 — abandoned debounce promise**

`debounceSave` created a new `Promise` per call but, when a second call arrived within the debounce window and `clearTimeout` cancelled the previous timer, the first caller's `resolve`/`reject` were never invoked. Any code awaiting the earlier `batchMessages()` call hung forever.

## What changed

**`packages/core/src/agent/save-queue/index.ts`**

- `persistUnsavedMessages`: wraps the `saveMessages` call in try/catch; on failure calls `messageList.restoreUnsavedMessages(newMessages)` to put the drained messages back, then re-throws so callers observe the error
- `enqueueSave`: removes the `.catch(err => { log })` that swallowed errors; adds a leading `.catch(() => {})` on `prev` so a failed predecessor does not block the next queued save
- `debounceSave`: each call registers its `{resolve, reject}` in `pendingDebounceSettlers` before touching the timer; the winning timer claims the full batch and settles all of them together
- `flushMessages`: when it cancels a live debounce timer it also claims and forwards any pending settlers to the immediate `enqueueSave` result, so those promises never hang

**`packages/core/src/agent/message-list/message-list.ts`**

- Adds `restoreUnsavedMessages(messages: MastraDBMessage[]): void` — looks up each message by ID in the internal messages list and re-adds it to the correct unsaved set (`newUserMessages` or `newResponseMessages`) using the persisted-set tracking to recover the original source classification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This fix stops chat messages from getting lost when saving fails. If a save doesn’t work, the messages are put back so they can be tried again, and any waiting callers now always get a result instead of hanging forever.

### What changed
- `MessageList` can now restore drained unsaved messages after a failed save by putting them back into the right unsaved tracking set.
- `SaveQueueManager` now rethrows storage save errors instead of swallowing them, so failed saves are visible to callers.
- Debounced save calls now keep track of all waiting promises and settle them all when the save runs or is superseded.
- `flushMessages` now also settles any pending debounced callers when it cancels a debounce and forces an immediate save.

### Result
- Failed `memory.saveMessages()` calls no longer cause silent conversation-history loss.
- Earlier `batchMessages()` callers no longer hang indefinitely when replaced by a newer debounced call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->