### PR TITLE
ci: recover from corrupt restored pnpm store cache

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -45,6 +45,7 @@ runs:
         cache_dependency_path: ${{ inputs.cache-dependency-path || 'pnpm-lock.yaml' }}
 
     - name: Reset corrupt pnpm store cache
+      if: ${{ inputs.package-manager-cache == 'true' }}
       shell: bash
       run: |
         set +e

--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -44,6 +44,23 @@ runs:
         cache: ${{ inputs.package-manager-cache == 'true' }}
         cache_dependency_path: ${{ inputs.cache-dependency-path || 'pnpm-lock.yaml' }}
 
+    - name: Reset corrupt pnpm store cache
+      shell: bash
+      run: |
+        set +e
+        store_path=$(pnpm store path --silent)
+        pnpm store status >/tmp/pnpm-store-status.log 2>&1
+        status=$?
+        set -e
+
+        if [ "$status" -ne 0 ] && grep -q "database disk image is malformed" /tmp/pnpm-store-status.log; then
+          echo "Detected corrupt pnpm store cache at $store_path; removing restored store."
+          rm -rf "$store_path"
+        elif [ "$status" -ne 0 ]; then
+          cat /tmp/pnpm-store-status.log
+          exit "$status"
+        fi
+
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}
       shell: bash

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -76,22 +76,9 @@ jobs:
           HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
-      - name: Setup pnpm
+      - name: Setup pnpm and Node.js
         if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-        with:
-          run_install: false
-          cache: true
-
-      - name: Setup Node.js
-        if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 22.13.0
-
-      - name: Install dependencies
-        if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}
-        run: pnpm install --frozen-lockfile
+        uses: ./.github/actions/setup-pnpm-node
 
       - name: Build
         if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}


### PR DESCRIPTION
## Summary

CI installs have been failing across multiple PRs with `[ERR_SQLITE_ERROR] database disk image is malformed` during `pnpm install --frozen-lockfile`. The error comes from the restored pnpm store's SQLite index, which can be corrupt when the GitHub Actions cache is restored. This is a **shared cache problem, not a branch-specific failure** — any PR that restores the bad cache hits it.

This PR makes CI self-heal when it restores a corrupt store, and ensures all PR install paths benefit from that recovery.

## Changes

- **`.github/actions/setup-pnpm-node/action.yaml`**: Add a "Reset corrupt pnpm store cache" step that runs `pnpm store status` and, when it detects `database disk image is malformed`, deletes the restored store so the subsequent install rebuilds it cleanly. Any other non-zero status is surfaced (logged + exit) rather than silently swallowed.
- **`.github/workflows/changed-test-gate.yml`**: Replace the inline `pnpm/action-setup` + `setup-node` + `pnpm install` steps with the shared `./.github/actions/setup-pnpm-node` action so the changed-tests job gets the same recovery. Caching and frozen-lockfile install behavior are preserved (both default to on in the shared action).

## Verification

- Both YAML files parse cleanly.
- The only remaining direct `pnpm/action-setup` uses are in `npm-publish.yml`, none of which enable `cache: true` — so they have no restored store to corrupt and don't need the reset.
- The changed-test-gate job already checks out the repo before setup, so the local composite-action path resolves.

## Test plan

- [ ] CI install steps complete without the SQLite `database disk image is malformed` error.
- [ ] changed-test-gate job builds and runs changed tests as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
CI sometimes grabs a “saved” pnpm package cache, but if that saved cache is corrupted, pnpm can crash and refuse to install. This PR detects the corruption, wipes only the broken cached store so pnpm can rebuild it, and shares the same fix with the changed-tests workflow.

## Summary
- Updated `.github/actions/setup-pnpm-node/action.yaml` to run `pnpm store status` after pnpm is set up.
- When the status check fails with `database disk image is malformed`, the action deletes the restored pnpm store so the next `pnpm install --frozen-lockfile` can recreate a healthy store.
- Other `pnpm store status` failures now fail the step (instead of being silently ignored).
- Refined the recovery logic to run the store reset only when `package-manager-cache == 'true'`, avoiding unnecessary/unsafe behavior on jobs without a restored cache.
- Updated `.github/workflows/changed-test-gate.yml` to use the shared `./.github/actions/setup-pnpm-node` composite action (instead of inline pnpm/node setup steps) so the same cache corruption recovery behavior is applied there as well.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->