### PR TITLE
ci: reinstall pnpm after wiping a corrupt store cache

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -54,13 +54,44 @@ runs:
         status=$?
         set -e
 
-        if [ "$status" -ne 0 ] && grep -q "database disk image is malformed" /tmp/pnpm-store-status.log; then
-          echo "Detected corrupt pnpm store cache at $store_path; removing restored store."
-          rm -rf "$store_path"
-        elif [ "$status" -ne 0 ]; then
+        if [ "$status" -eq 0 ]; then
+          exit 0
+        fi
+
+        if ! grep -q "database disk image is malformed" /tmp/pnpm-store-status.log; then
           cat /tmp/pnpm-store-status.log
           exit "$status"
         fi
+
+        # The restored store cache is corrupt. On these runners pnpm/action-setup
+        # installs pnpm beneath the same directory as the store, and the pnpm
+        # binary is content-addressed into the store, so `rm -rf "$store_path"`
+        # also deletes files the running pnpm depends on. That broke the next
+        # `pnpm install` with a MODULE_NOT_FOUND for pnpm.mjs. Remove the corrupt
+        # store, then reinstall pnpm so its binary is intact before installing.
+        echo "Detected corrupt pnpm store cache at $store_path; removing restored store."
+        rm -rf "$store_path"
+
+        if pnpm --version >/dev/null 2>&1; then
+          exit 0
+        fi
+
+        # Resolve the pnpm version the same way pnpm/action-setup does: from the
+        # explicit input if given, otherwise the packageManager field. This keeps
+        # the reinstall in sync with the rest of the workspace automatically.
+        pnpm_version="$PNPM_VERSION"
+        if [ -z "$pnpm_version" ]; then
+          pnpm_version=$(node -p "(require('./$PACKAGE_JSON_FILE').packageManager||'').replace(/^pnpm@/,'').split('+')[0]")
+        fi
+
+        # pnpm/action-setup installs pnpm with `npm install` into the directory
+        # whose node_modules/.bin is PNPM_HOME, so reinstall into that same root.
+        pnpm_install_root=$(cd "$PNPM_HOME/../.." && pwd)
+        echo "pnpm binary was removed with the corrupt store; reinstalling pnpm@$pnpm_version into $pnpm_install_root."
+        npm install --prefix "$pnpm_install_root" "pnpm@$pnpm_version"
+      env:
+        PNPM_VERSION: ${{ inputs.version }}
+        PACKAGE_JSON_FILE: ${{ inputs.package-json-file || 'package.json' }}
 
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}


### PR DESCRIPTION
## Summary

CI jobs that run the `setup-pnpm-node` composite action were failing at the **Setup pnpm and Node.js** step with:

```
Error: Cannot find module '/home/ubuntu/setup-pnpm/node_modules/.bin/global/v11/.../node_modules/pnpm/bin/pnpm.mjs'
code: 'MODULE_NOT_FOUND'
```

This broke `Build`, `Detect memory changes`, `Detect affected tests`, and any other job that sets up pnpm.

## Root cause

#18438 added a recovery step that wipes the pnpm store when it reports `database disk image is malformed` (an intermittent corruption of the cached SQLite store index on the self-hosted runners). The recovery did `rm -rf "$store_path"`.

On these runners, `pnpm/action-setup` installs pnpm beneath the same directory as the store (`~/setup-pnpm/node_modules/.bin/`), and pnpm uses a content-addressable store with hard links. The freshly self-installed pnpm binary's package files are backed by content blobs that physically live in the store. Removing the corrupt store therefore deleted files the running pnpm binary depends on, leaving dangling references — so the next `pnpm install --frozen-lockfile` failed with `MODULE_NOT_FOUND` for `pnpm.mjs`.

## Fix

Keep the corrupt-store cleanup, but after wiping the store, detect whether the pnpm binary survived and reinstall it into the same root `pnpm/action-setup` uses when it did not. The pnpm version is resolved from the `packageManager` field (matching how `pnpm/action-setup` resolves it), so it stays in sync with the workspace and avoids a hardcoded version drifting.

The corrupt cached archives that triggered this run were also deleted so the next run rebuilds a clean store.

## Test plan

- [ ] CI re-runs and the `Setup pnpm and Node.js` step completes (cache miss path repopulates a clean store).
- [ ] When a corrupt store is restored, the recovery wipes it, reinstalls pnpm, and `pnpm install` succeeds rather than failing with `MODULE_NOT_FOUND`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes CI smarter when a pnpm cache gets broken. If the cache cleanup accidentally removes files pnpm needs, CI now checks whether pnpm still works and reinstalls it so the next steps can keep going.

## Summary
- Improved corrupt pnpm store recovery in `.github/actions/setup-pnpm-node/action.yaml`.
- Keeps the store cleanup for the specific “database disk image is malformed” failure case, but now:
  - exits early when the pnpm store check succeeds,
  - prints the log and fails normally for unrelated errors,
  - verifies whether `pnpm` still works after deleting the corrupt store.
- If pnpm is broken after cleanup, it reinstalls pnpm in the same root used by `pnpm/action-setup`.
- Resolves the pnpm version from the workspace `packageManager` field when no explicit version is provided, keeping it aligned with the repo.
- Removes the cached corrupt archives so the next run can rebuild a clean store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->