### PR TITLE
ci: reinstall pnpm into a dedicated dir and prepend to PATH after corrupt-store wipe

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -64,11 +64,12 @@ runs:
         fi
 
         # The restored store cache is corrupt. On these runners pnpm/action-setup
-        # installs pnpm beneath the same directory as the store, and the pnpm
-        # binary is content-addressed into the store, so `rm -rf "$store_path"`
-        # also deletes files the running pnpm depends on. That broke the next
+        # installs pnpm beneath the same directory as the store, and pnpm's own
+        # files are hard-linked into the store, so `rm -rf "$store_path"` also
+        # deletes the pnpm binary the PATH shim points at. That broke the next
         # `pnpm install` with a MODULE_NOT_FOUND for pnpm.mjs. Remove the corrupt
-        # store, then reinstall pnpm so its binary is intact before installing.
+        # store, then reprovision pnpm via corepack (whose cache is independent of
+        # the store) and put it ahead on PATH so later steps use a working pnpm.
         echo "Detected corrupt pnpm store cache at $store_path; removing restored store."
         rm -rf "$store_path"
 
@@ -78,20 +79,27 @@ runs:
 
         # Resolve the pnpm version the same way pnpm/action-setup does: from the
         # explicit input if given, otherwise the packageManager field. This keeps
-        # the reinstall in sync with the rest of the workspace automatically.
+        # the reprovisioned pnpm in sync with the workspace automatically.
         pnpm_version="$PNPM_VERSION"
         if [ -z "$pnpm_version" ]; then
           pnpm_version=$(node -p "(require('./$PACKAGE_JSON_FILE').packageManager||'').replace(/^pnpm@/,'').split('+')[0]")
         fi
 
-        # pnpm/action-setup installs pnpm with `npm install` into the directory
-        # whose node_modules/.bin is PNPM_HOME, so reinstall into that same root.
-        pnpm_install_root=$(cd "$PNPM_HOME/../.." && pwd)
-        echo "pnpm binary was removed with the corrupt store; reinstalling pnpm@$pnpm_version into $pnpm_install_root."
-        npm install --prefix "$pnpm_install_root" "pnpm@$pnpm_version"
+        echo "pnpm binary was removed with the corrupt store; reprovisioning pnpm@$pnpm_version via corepack."
+        # corepack stores its shims and the pnpm package outside the pnpm store,
+        # so it is unaffected by the wipe. Materialize a pnpm shim in a dedicated
+        # directory and prepend it to PATH so the rest of the job stops using the
+        # action-setup shim that points at the deleted store-linked binary.
+        corepack_bin="$RUNNER_TEMP/pnpm-recovery-bin"
+        mkdir -p "$corepack_bin"
+        corepack prepare "pnpm@$pnpm_version" --activate
+        corepack enable pnpm --install-directory "$corepack_bin"
+        echo "$corepack_bin" >> "$GITHUB_PATH"
+        PATH="$corepack_bin:$PATH" pnpm --version
       env:
         PNPM_VERSION: ${{ inputs.version }}
         PACKAGE_JSON_FILE: ${{ inputs.package-json-file || 'package.json' }}
+        COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}


### PR DESCRIPTION
## Summary

Follow-up to #18439. The corrupt-store recovery still failed `pnpm install` with `MODULE_NOT_FOUND`, because the previous reinstall placed pnpm in the wrong location.

## What was still broken

After `rm -rf "$store_path"`, #18439 reinstalled pnpm with `npm install --prefix <action-setup root>`. But the pnpm binary that subsequent steps invoke is the `pnpm/action-setup` shim on PATH, which points at:

```
$PNPM_HOME/global/v11/<hash>/node_modules/pnpm/bin/pnpm.mjs
```

That file's content is hard-linked into the store that was just wiped, so it is gone. The `npm install` copy landed at a different path (`<root>/node_modules/pnpm`), so `pnpm --version` inside the recovery step passed, but the **next** step still ran the action-setup shim and hit:

```
Error: Cannot find module '.../global/v11/<hash>/node_modules/pnpm/bin/pnpm.mjs'
code: 'MODULE_NOT_FOUND'
```

(Observed on PR #18436's `Build` job.)

## Fix

Reprovision pnpm with **corepack** instead of `npm install`. corepack keeps its shims and the pnpm package in its own cache, outside the pnpm store, so it is unaffected by the wipe. The recovery now:

1. Removes the corrupt store.
2. If pnpm is broken, resolves the pinned version from `packageManager`, runs `corepack prepare pnpm@<ver> --activate`, and materializes a shim in a dedicated directory via `corepack enable pnpm --install-directory`.
3. Prepends that directory to `PATH` via `$GITHUB_PATH` (later entries take precedence) so subsequent steps stop using the broken action-setup shim.
4. Verifies `pnpm --version` runs from the new shim before continuing.

## Test plan

- [ ] On a run that restores a corrupt store, the recovery wipes it, reprovisions pnpm via corepack, and `pnpm install --frozen-lockfile` succeeds instead of failing with `MODULE_NOT_FOUND`.
- [ ] On a clean run (no corruption), the recovery is a no-op and pnpm continues to work as before.

Verified the corepack command sequence locally: `corepack prepare` + `corepack enable --install-directory` produce a working pnpm shim that resolves the pinned version even with the original pnpm removed from PATH.
