### PR TITLE
fix(ci): correct triage workflow API paths and use base URL variable

### DIFF
--- a/.github/workflows/call-external-mastra-workflow.yml
+++ b/.github/workflows/call-external-mastra-workflow.yml
@@ -43,7 +43,7 @@ jobs:
           # Create the workflow run and capture the runId
           http_code=$(curl -w "%{http_code}" -o /tmp/create_response.json -s \
             --max-time 30 \
-            "${BASE_URL}/${WORKFLOW_NAME}/create-run" \
+            "${BASE_URL}/api/workflows/${WORKFLOW_NAME}/create-run" \
             -X 'POST' \
             -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
             -H 'Referer: https://cloud.mastra.ai/' \
@@ -77,7 +77,7 @@ jobs:
 
           http_code=$(curl -w "%{http_code}" -o /tmp/start_response.json -s \
             --max-time 300 \
-            "${BASE_URL}/${WORKFLOW_NAME}/start?runId=${runId}" \
+            "${BASE_URL}/api/workflows/${WORKFLOW_NAME}/start?runId=${runId}" \
             -X 'POST' \
             -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
             -H 'Referer: https://cloud.mastra.ai/' \

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -44,7 +44,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          MASTRA_BASE_URL: 'https://shrilling-scarce-finland.mastra.cloud'
+          MASTRA_BASE_URL: ${{ vars.MASTRA_CLOUD_BASE_URL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_TEAM_ID: ${{ secrets.SLACK_TEAM_ID }}
           CHANNEL_ID: ${{ secrets.CHANNEL_ID }}


### PR DESCRIPTION
The issue triage workflows had two small problems.

The external workflow calls were missing the `/api/workflows` prefix, so the create-run and start requests pointed at the wrong path:

\`\`\`
"${BASE_URL}/${WORKFLOW_NAME}/create-run"
"${BASE_URL}/api/workflows/${WORKFLOW_NAME}/create-run"
\`\`\`

And the triage workflow hardcoded the Mastra Cloud base URL, so it now reads from a repo variable instead:

\`\`\`
MASTRA_BASE_URL: ${{ vars.MASTRA_CLOUD_BASE_URL }}
\`\`\`

No package code changes, so no changeset needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes two workflow mistakes that were making CI call the wrong web addresses. It also makes one workflow use a shared saved setting for the Mastra Cloud URL instead of hardcoding it, so it’s easier to move between environments.

## Summary
- Fixed the external workflow request paths to include `/api/workflows` for both `create-run` and `start`.
- Updated `issue-triage` to read `MASTRA_BASE_URL` from `vars.MASTRA_CLOUD_BASE_URL` instead of a hardcoded URL.
- No package code was changed, and no changeset is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->