### PR TITLE
ci: recover corrupt pnpm store by deleting only the index, not the whole store

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -58,47 +58,47 @@ runs:
           exit 0
         fi
 
-        if ! grep -q "database disk image is malformed" /tmp/pnpm-store-status.log; then
+        # A corrupt store index surfaces as a SQLite error from `pnpm store
+        # status`. The exact message depends on how the index got truncated
+        # ("database disk image is malformed", "file is not a database", etc.),
+        # so match the SQLite error family rather than one literal string. Any
+        # other non-zero status is a real failure and should be surfaced.
+        if ! grep -qE "ERR_SQLITE_ERROR|database disk image is malformed|file is not a database" /tmp/pnpm-store-status.log; then
           cat /tmp/pnpm-store-status.log
           exit "$status"
         fi
 
-        # The restored store cache is corrupt. On these runners pnpm/action-setup
-        # installs pnpm beneath the same directory as the store, and pnpm's own
-        # files are hard-linked into the store, so `rm -rf "$store_path"` also
-        # deletes the pnpm binary the PATH shim points at. That broke the next
-        # `pnpm install` with a MODULE_NOT_FOUND for pnpm.mjs. Remove the corrupt
-        # store, then reinstall pnpm into a dedicated directory and put it ahead
-        # on PATH so later steps use a working pnpm instead of the broken shim.
-        echo "Detected corrupt pnpm store cache at $store_path; removing restored store."
-        rm -rf "$store_path"
+        # The restored store cache is corrupt: pnpm's store index (a SQLite
+        # database) is malformed, usually because the cache archive was snapshot
+        # mid-write. Only the index is corrupt — the content-addressed package
+        # files under files/ are intact.
+        #
+        # Earlier attempts to recover by removing the whole store (rm -rf) and
+        # reinstalling pnpm did not work on these runners:
+        #   * pnpm/action-setup installs pnpm beneath the store and hard-links
+        #     pnpm's own files into it, so wiping the store deleted the pnpm
+        #     binary the PATH shim pointed at (MODULE_NOT_FOUND for pnpm.mjs).
+        #   * Reinstalling pnpm and relinking the store left the remaining
+        #     content mismatched against the lockfile integrity, so the next
+        #     frozen install failed with ERR_PNPM_MODIFIED_DEPENDENCY.
+        #
+        # Instead, delete only the corrupt index and keep files/ (and the pnpm
+        # binary hard-linked into it). pnpm rebuilds the index from the content
+        # files on the next operation, so the binary survives and store content
+        # still matches the lockfile.
+        echo "Detected corrupt pnpm store index at $store_path; deleting only the store index, preserving content."
+        # pnpm >=11 keeps the index in index.db; older versions used
+        # index-v5.json* plus an index/ directory. Remove whichever exist.
+        rm -rf \
+          "$store_path/index.db" \
+          "$store_path/index.db-shm" \
+          "$store_path/index.db-wal" \
+          "$store_path"/index-v*.json* \
+          "$store_path/index"
 
-        if pnpm --version >/dev/null 2>&1; then
-          exit 0
-        fi
-
-        # Resolve the pnpm version the same way pnpm/action-setup does: from the
-        # explicit input if given, otherwise the packageManager field. This keeps
-        # the reinstalled pnpm in sync with the workspace automatically.
-        pnpm_version="$PNPM_VERSION"
-        if [ -z "$pnpm_version" ]; then
-          pnpm_version=$(node -p "(require('./$PACKAGE_JSON_FILE').packageManager||'').replace(/^pnpm@/,'').split('+')[0]")
-        fi
-
-        echo "pnpm binary was removed with the corrupt store; reinstalling pnpm@$pnpm_version."
-        # Install into a dedicated prefix with npm (corepack on the bundled Node
-        # version fails signature verification with "Cannot find matching keyid").
-        # npm places a working pnpm at <prefix>/bin; prepend it to PATH so the
-        # rest of the job stops using the action-setup shim that points at the
-        # deleted store-linked binary.
-        recovery_prefix="$RUNNER_TEMP/pnpm-recovery"
-        mkdir -p "$recovery_prefix"
-        npm install -g --prefix "$recovery_prefix" "pnpm@$pnpm_version"
-        echo "$recovery_prefix/bin" >> "$GITHUB_PATH"
-        PATH="$recovery_prefix/bin:$PATH" pnpm --version
-      env:
-        PNPM_VERSION: ${{ inputs.version }}
-        PACKAGE_JSON_FILE: ${{ inputs.package-json-file || 'package.json' }}
+        # Confirm pnpm and the store are usable again before continuing.
+        pnpm --version
+        pnpm store status
 
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}


### PR DESCRIPTION
## Summary

Follow-up to #18438 → #18441. The corrupt-pnpm-store recovery still breaks CI, now with a different error. This replaces the "wipe the store and reinstall pnpm" strategy with a surgical fix: delete only the corrupt store index and keep the content.

## The failure chain so far

1. #18438 added recovery: on `database disk image is malformed`, `rm -rf "$store_path"`.
2. That deleted pnpm's own binary (hard-linked into the store) → `MODULE_NOT_FOUND` for `pnpm.mjs`.
3. #18439/#18441 reinstalled pnpm after the wipe (npm) and put it on PATH.
4. New failure (run on #18436): `pnpm install --frozen-lockfile` now fails with

```
[ERR_PNPM_MODIFIED_DEPENDENCY] Packages in the store have been mutated
...
You can run pnpm install --force to refetch the modified packages
```

Wiping the store and reinstalling/relinking leaves the remaining store content mismatched against the lockfile integrity. `--force` is not a fix — by design it does not bypass pnpm's integrity check.

## Root cause

Only the **store index** (a SQLite database) is corrupt. The content-addressed package files under `files/` are intact, and pnpm's binary is hard-linked into the store. Destroying the whole store throws away good content and the binary; rebuilding it from a partial state mismatches the lockfile.

## Fix

On detected corruption, delete **only the index**, preserving `files/`:

- `index.db`, `index.db-shm`, `index.db-wal` (pnpm ≥ 11)
- `index-v*.json*` and `index/` (older layouts)

pnpm rebuilds the index from the content files on the next operation, so:

- the pnpm binary survives (no `MODULE_NOT_FOUND`),
- store content still matches the lockfile (no `ERR_PNPM_MODIFIED_DEPENDENCY`),
- no reinstall is needed (no corepack keyid / npm relink issues).

Also broadens corruption detection to the SQLite error family (`ERR_SQLITE_ERROR` / `database disk image is malformed` / `file is not a database`) instead of one literal message, since the corruption surfaces differently depending on how the index was truncated.

## Test plan

- [ ] On a run that restores a corrupt store, recovery deletes the index, `pnpm store status` reports the store is fine, and `pnpm install --frozen-lockfile` succeeds.
- [ ] On a clean run, recovery is a no-op.

Verified locally with pnpm 11.5.1 across three cases: (A) garbage index (`file is not a database`), (B) zeroed/truncated index (malformed-image family), (C) healthy store. A and B are detected, the index-only deletion clears corruption, `pnpm store status` returns "Packages in the store are untouched", and a frozen install succeeds with no `MODULE_NOT_FOUND` and no `ERR_PNPM_MODIFIED_DEPENDENCY`. C early-exits without touching the store.

## Note

This supersedes the recovery logic merged in #18441 (npm reinstall) and #18440 (corepack). No changeset — consistent with the earlier CI-only recovery PRs (#18438–#18441).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes the way CI recovers when pnpm’s cache gets corrupted. Instead of throwing away the whole cache and starting over, it now only removes the broken “table of contents” part so pnpm can rebuild it from the good files already there.

## Summary
- Broadened pnpm store corruption detection to catch SQLite-style failures, including `ERR_SQLITE_ERROR`, `database disk image is malformed`, and `file is not a database`.
- Changed recovery to delete only corrupt store index artifacts (`index.db*`, `index-v*.json*`, and `index/`) rather than wiping the entire pnpm store.
- Preserved the content-addressed store data and pnpm binary, avoiding follow-up failures caused by reinstalling pnpm from a damaged store.
- Added validation after recovery to ensure `pnpm --version` and `pnpm store status` succeed before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->