### PR TITLE
ci: refetch modified packages when corrupt store content survives index reset

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -45,6 +45,7 @@ runs:
         cache_dependency_path: ${{ inputs.cache-dependency-path || 'pnpm-lock.yaml' }}
 
     - name: Reset corrupt pnpm store cache
+      id: reset-store
       if: ${{ inputs.package-manager-cache == 'true' }}
       shell: bash
       run: |
@@ -58,35 +59,25 @@ runs:
           exit 0
         fi
 
-        # A corrupt store index surfaces as a SQLite error from `pnpm store
-        # status`. The exact message depends on how the index got truncated
-        # ("database disk image is malformed", "file is not a database", etc.),
-        # so match the SQLite error family rather than one literal string. Any
-        # other non-zero status is a real failure and should be surfaced.
-        if ! grep -qE "ERR_SQLITE_ERROR|database disk image is malformed|file is not a database" /tmp/pnpm-store-status.log; then
+        # A corrupt restored store cache surfaces in one of two ways from
+        # `pnpm store status`:
+        #   * a SQLite error if the store index is malformed
+        #     ("database disk image is malformed", "file is not a database"), or
+        #   * ERR_PNPM_MODIFIED_DEPENDENCY if cached content files were captured
+        #     mid-write and no longer match their content hashes.
+        # Any other non-zero status is a real failure and should be surfaced.
+        if ! grep -qE "ERR_SQLITE_ERROR|database disk image is malformed|file is not a database|ERR_PNPM_MODIFIED_DEPENDENCY" /tmp/pnpm-store-status.log; then
           cat /tmp/pnpm-store-status.log
           exit "$status"
         fi
 
-        # The restored store cache is corrupt: pnpm's store index (a SQLite
-        # database) is malformed, usually because the cache archive was snapshot
-        # mid-write. Only the index is corrupt — the content-addressed package
-        # files under files/ are intact.
-        #
-        # Earlier attempts to recover by removing the whole store (rm -rf) and
-        # reinstalling pnpm did not work on these runners:
-        #   * pnpm/action-setup installs pnpm beneath the store and hard-links
-        #     pnpm's own files into it, so wiping the store deleted the pnpm
-        #     binary the PATH shim pointed at (MODULE_NOT_FOUND for pnpm.mjs).
-        #   * Reinstalling pnpm and relinking the store left the remaining
-        #     content mismatched against the lockfile integrity, so the next
-        #     frozen install failed with ERR_PNPM_MODIFIED_DEPENDENCY.
-        #
-        # Instead, delete only the corrupt index and keep files/ (and the pnpm
-        # binary hard-linked into it). pnpm rebuilds the index from the content
-        # files on the next operation, so the binary survives and store content
-        # still matches the lockfile.
-        echo "Detected corrupt pnpm store index at $store_path; deleting only the store index, preserving content."
+        # Recover by deleting only the store index, keeping the content-addressed
+        # files/ (into which pnpm's own binary is hard-linked). pnpm rebuilds the
+        # index from the content on the next operation, so the binary survives.
+        # Wiping the whole store instead removed pnpm itself (MODULE_NOT_FOUND for
+        # pnpm.mjs) and reinstalling/relinking it left content mismatched against
+        # the lockfile (ERR_PNPM_MODIFIED_DEPENDENCY).
+        echo "Detected corrupt pnpm store at $store_path; deleting only the store index, preserving content."
         # pnpm >=11 keeps the index in index.db; older versions used
         # index-v5.json* plus an index/ directory. Remove whichever exist.
         rm -rf \
@@ -96,11 +87,31 @@ runs:
           "$store_path"/index-v*.json* \
           "$store_path/index"
 
-        # Confirm pnpm and the store are usable again before continuing.
         pnpm --version
-        pnpm store status
+
+        # Re-check the store. If only the index was corrupt this now passes. If
+        # content files were also mutated, pnpm still reports them; signal the
+        # install step to refetch the modified packages with --force (which is
+        # exactly what pnpm recommends for ERR_PNPM_MODIFIED_DEPENDENCY).
+        set +e
+        pnpm store status >/tmp/pnpm-store-status-after.log 2>&1
+        after=$?
+        set -e
+        if [ "$after" -ne 0 ]; then
+          if ! grep -qE "ERR_PNPM_MODIFIED_DEPENDENCY" /tmp/pnpm-store-status-after.log; then
+            cat /tmp/pnpm-store-status-after.log
+            exit "$after"
+          fi
+          echo "Store content was also modified; the install step will refetch with --force."
+          echo "force-install=true" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: |
+        if [ "${{ steps.reset-store.outputs.force-install }}" = "true" ]; then
+          pnpm install --frozen-lockfile --force
+        else
+          pnpm install --frozen-lockfile
+        fi


### PR DESCRIPTION
## Summary

Follow-up to #18443. The index-only store recovery merged there fixes a corrupt store **index**, but a corrupt restored cache can also contain **content** files captured mid-write. In that case `pnpm store status` (and the subsequent frozen install) fails with `ERR_PNPM_MODIFIED_DEPENDENCY` even after the index is rebuilt.

Observed on a run for #18436: after the index deletion, the recovery step's own `pnpm store status` reported:

```
[ERR_PNPM_MODIFIED_DEPENDENCY] Packages in the store have been mutated
...
You can run pnpm install --force to refetch the modified packages
```

## Fix

Make the recovery handle both corruption shapes:

1. Broaden the corruption check to also match `ERR_PNPM_MODIFIED_DEPENDENCY` (mutated content), in addition to the SQLite index errors.
2. After deleting the index, re-check the store. If only the index was bad, this passes and the install runs normally. If content is also mutated, set a step output so the install step runs `pnpm install --frozen-lockfile --force` — which refetches the modified packages (pnpm's documented remedy) while keeping the lockfile frozen.

The index-only case still recovers without a reinstall and without forcing.

## Why not just `--force` always

`--force` re-downloads packages, so it's only used on the recovery path when content is actually mutated. Healthy and index-only runs keep the fast frozen install.

## Test plan

- [ ] On a run with a corrupt store **index** only, recovery deletes the index, `pnpm store status` passes, and the plain frozen install succeeds.
- [ ] On a run with mutated store **content**, recovery sets the force flag and `pnpm install --frozen-lockfile --force` succeeds.
- [ ] On a clean run, recovery is a no-op and the plain frozen install runs.

Verified locally on pnpm 11.5.1: `pnpm install --frozen-lockfile --force` is accepted and succeeds; the index-only path recovers and runs the plain frozen install without setting the force flag.

## Note

The persistently corrupt `pnpm-cache-*` entries (including the ~1 GB `b044e336…` blob on `main` that was restored on every run, plus several partial ~19 MB stores) have been deleted, so CI rebuilds clean stores now. This change ensures future mid-write store corruption is recovered automatically instead of blocking CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change helps CI recover when a saved pnpm cache is broken in two different ways: sometimes the index is bad, and sometimes the package files themselves are damaged. If only the index was broken, CI keeps installing normally; if damaged package files are still found, CI retries the install in a way that re-downloads the bad packages.

## Summary
- Added a named reset step in the pnpm setup action to handle corrupt store cache recovery more cleanly.
- Extended corruption detection to include `ERR_PNPM_MODIFIED_DEPENDENCY` alongside SQLite index-related failures.
- After clearing the store index, the workflow rechecks `pnpm store status`:
  - if it passes, installation continues normally with `--frozen-lockfile`
  - if mutated content is still detected, the action sets `force-install=true`
- Updated the install step to conditionally add `--force` only on the recovery path, so healthy runs still preserve frozen-lockfile behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->