### PR TITLE
chore(playground): debarrel layout list primitives

### DIFF
--- a/packages/playground/eslint.config.js
+++ b/packages/playground/eslint.config.js
@@ -77,6 +77,10 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import Checkbox exports from @mastra/playground-ui/components/Checkbox.',
   },
   {
+    importNames: ['Collapsible', 'CollapsibleContent', 'CollapsibleTrigger'],
+    message: 'Import Collapsible exports from @mastra/playground-ui/components/Collapsible.',
+  },
+  {
     importNames: ['Chip', 'ChipProps', 'ChipsGroup', 'ChipsGroupProps'],
     message: 'Import Chip exports from @mastra/playground-ui/components/Chip.',
   },
@@ -152,6 +156,10 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import DateTimeRangePicker exports from @mastra/playground-ui/components/DateTimeRangePicker.',
   },
   {
+    importNames: ['DataList', 'DataListSkeleton', 'ScoresDataList'],
+    message: 'Import DataList exports from @mastra/playground-ui/components/DataList.',
+  },
+  {
     importNames: [
       'DataKeysAndValues',
       'DataKeysAndValuesProps',
@@ -191,6 +199,10 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
       'DialogDescription',
     ],
     message: 'Import Dialog exports from @mastra/playground-ui/components/Dialog.',
+  },
+  {
+    importNames: ['Entity', 'EntityContent', 'EntityName', 'EntityDescription', 'EntityIcon'],
+    message: 'Import Entity exports from @mastra/playground-ui/components/Entity.',
   },
   {
     importNames: ['EntityHeader', 'EntityHeaderProps'],
@@ -404,6 +416,10 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import Notice exports from @mastra/playground-ui/components/Notice.',
   },
   {
+    importNames: ['PageLayout', 'NoDataPageLayout', 'PageHeadingContext'],
+    message: 'Import PageLayout exports from @mastra/playground-ui/components/PageLayout.',
+  },
+  {
     importNames: ['PageHeader', 'PageHeaderRootProps', 'PageHeaderTitleProps', 'PageHeaderDescriptionProps'],
     message: 'Import PageHeader exports from @mastra/playground-ui/components/PageHeader.',
   },
@@ -446,6 +462,10 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
   {
     importNames: ['Searchbar', 'SearchbarWrapper', 'SearchbarProps'],
     message: 'Import Searchbar exports from @mastra/playground-ui/components/Searchbar.',
+  },
+  {
+    importNames: ['ScrollArea'],
+    message: 'Import ScrollArea from @mastra/playground-ui/components/ScrollArea.',
   },
   {
     importNames: [

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -1,7 +1,8 @@
-import { Button, PageHeadingContext, Toaster } from '@mastra/playground-ui';
+import { Button, Toaster } from '@mastra/playground-ui';
 import { ErrorBoundary } from '@mastra/playground-ui/components/ErrorBoundary';
 import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { MainSidebar, MainSidebarProvider, useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import { PageHeadingContext } from '@mastra/playground-ui/components/PageLayout';
 import { ThemeProvider } from '@mastra/playground-ui/components/ThemeProvider';
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { Search } from 'lucide-react';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/filterable-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/filterable-list.tsx
@@ -1,5 +1,6 @@
-import { ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { Txt, cn } from '@mastra/playground-ui';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import type { CSSProperties, ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { useAgentColor } from '../../../contexts/agent-color-context';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-filter-pane.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-filter-pane.tsx
@@ -1,5 +1,6 @@
-import { ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { Txt, cn } from '@mastra/playground-ui';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { memo, useMemo, useState } from 'react';
 import { useToolkits } from '../../../../tool-providers/hooks/use-toolkits';

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -1,6 +1,7 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
-import { Button, cn, Collapsible, CollapsibleContent, CollapsibleTrigger, Icon, Txt } from '@mastra/playground-ui';
+import { Button, cn, Icon, Txt } from '@mastra/playground-ui';
 import { Card } from '@mastra/playground-ui/components/Card';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { MessageFactory } from '@mastra/react';

--- a/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
@@ -1,5 +1,5 @@
 import type { BuilderRegistrySkillSummary } from '@mastra/client-js';
-import { Button, ScrollArea, SkillIcon, cn } from '@mastra/playground-ui';
+import { Button, SkillIcon, cn } from '@mastra/playground-ui';
 import {
   Dialog,
   DialogBody,
@@ -10,6 +10,7 @@ import {
 } from '@mastra/playground-ui/components/Dialog';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Check, Download, ExternalLink, Github, Loader2, Package, Search } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';

--- a/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
+++ b/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
@@ -1,5 +1,7 @@
-import { Button, DataList, DataListSkeleton, NoDataPageLayout, PageLayout, Txt, toast } from '@mastra/playground-ui';
+import { Button, Txt, toast } from '@mastra/playground-ui';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { useMemo, useState } from 'react';
 import {

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
@@ -1,5 +1,7 @@
-import { EntityName, EntityDescription, EntityContent, Entity, ScrollArea, AgentIcon, cn } from '@mastra/playground-ui';
+import { AgentIcon, cn } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
+import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { Switch } from '@mastra/playground-ui/components/Switch';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/information-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/information-page.tsx
@@ -1,6 +1,6 @@
-import { ScrollArea } from '@mastra/playground-ui';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { SectionRoot, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Controller } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/instruction-blocks-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/instruction-blocks-page.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea } from '@mastra/playground-ui';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Controller } from 'react-hook-form';
 
 import { useAgentEditFormContext } from '../../context/agent-edit-form-context';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/memory-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/memory-page.tsx
@@ -1,15 +1,9 @@
-import {
-  Button,
-  Entity,
-  EntityContent,
-  EntityName,
-  EntityDescription,
-  ScrollArea,
-  MemoryIcon,
-} from '@mastra/playground-ui';
+import { Button, MemoryIcon } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
+import { Entity, EntityContent, EntityName, EntityDescription } from '@mastra/playground-ui/components/Entity';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Controller, useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
@@ -1,8 +1,10 @@
-import { EntityName, EntityDescription, EntityContent, Entity, ScrollArea, JudgeIcon, cn } from '@mastra/playground-ui';
+import { JudgeIcon, cn } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
+import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { RadioGroup, RadioGroupItem } from '@mastra/playground-ui/components/RadioGroup';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { Switch } from '@mastra/playground-ui/components/Switch';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skills-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skills-page.tsx
@@ -1,6 +1,8 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
-import { Button, Entity, EntityContent, EntityName, EntityDescription, ScrollArea } from '@mastra/playground-ui';
+import { Button } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
+import { Entity, EntityContent, EntityName, EntityDescription } from '@mastra/playground-ui/components/Entity';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Plus, Drill } from 'lucide-react';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
@@ -1,17 +1,9 @@
-import {
-  Button,
-  EntityName,
-  EntityDescription,
-  EntityContent,
-  Entity,
-  ScrollArea,
-  Icon,
-  ToolsIcon,
-  cn,
-} from '@mastra/playground-ui';
+import { Button, Icon, ToolsIcon, cn } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
+import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Popover, PopoverTrigger, PopoverContent } from '@mastra/playground-ui/components/Popover';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { PlusIcon, XIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/variables-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/variables-page.tsx
@@ -1,7 +1,7 @@
-import { ScrollArea } from '@mastra/playground-ui';
 import type { JsonSchema } from '@mastra/playground-ui';
 import { JSONSchemaForm, jsonSchemaToFields } from '@mastra/playground-ui/components/JSONSchemaForm';
 import type { SchemaField } from '@mastra/playground-ui/components/JSONSchemaForm';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Plus, PlusIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
@@ -1,13 +1,7 @@
-import {
-  EntityName,
-  EntityDescription,
-  EntityContent,
-  Entity,
-  ScrollArea,
-  WorkflowIcon,
-  cn,
-} from '@mastra/playground-ui';
+import { WorkflowIcon, cn } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
+import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { Switch } from '@mastra/playground-ui/components/Switch';

--- a/packages/playground/src/domains/agents/components/agent-cms-sidebar/agent-cms-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-sidebar/agent-cms-sidebar.tsx
@@ -1,4 +1,5 @@
-import { ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { Txt, cn } from '@mastra/playground-ui';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Check } from 'lucide-react';
 import { useMemo } from 'react';
 

--- a/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
@@ -1,9 +1,10 @@
-import { Button, ScrollArea, Icon, AgentIcon, ToolsIcon, VariablesIcon } from '@mastra/playground-ui';
+import { Button, Icon, AgentIcon, ToolsIcon, VariablesIcon } from '@mastra/playground-ui';
 import type { JsonSchema } from '@mastra/playground-ui';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { JSONSchemaForm, jsonSchemaToFields } from '@mastra/playground-ui/components/JSONSchemaForm';
 import type { SchemaField } from '@mastra/playground-ui/components/JSONSchemaForm';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tabs, TabList, Tab, TabContent } from '@mastra/playground-ui/components/Tabs';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/agents-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/agents-section.tsx
@@ -1,4 +1,5 @@
-import { Collapsible, CollapsibleTrigger, CollapsibleContent, AgentIcon } from '@mastra/playground-ui';
+import { AgentIcon } from '@mastra/playground-ui';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@mastra/playground-ui/components/Collapsible';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
 import { ChevronRight } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
@@ -1,4 +1,5 @@
-import { Collapsible, CollapsibleTrigger, CollapsibleContent, MemoryIcon } from '@mastra/playground-ui';
+import { MemoryIcon } from '@mastra/playground-ui';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@mastra/playground-ui/components/Collapsible';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/scorers-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/scorers-section.tsx
@@ -1,4 +1,5 @@
-import { Collapsible, CollapsibleTrigger, CollapsibleContent, Button, JudgeIcon, Icon } from '@mastra/playground-ui';
+import { Button, JudgeIcon, Icon } from '@mastra/playground-ui';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@mastra/playground-ui/components/Collapsible';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/tools-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/tools-section.tsx
@@ -1,4 +1,5 @@
-import { Collapsible, CollapsibleTrigger, CollapsibleContent, ToolsIcon } from '@mastra/playground-ui';
+import { ToolsIcon } from '@mastra/playground-ui';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@mastra/playground-ui/components/Collapsible';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
 import { ChevronRight } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/workflows-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/workflows-section.tsx
@@ -1,4 +1,5 @@
-import { Collapsible, CollapsibleTrigger, CollapsibleContent, WorkflowIcon } from '@mastra/playground-ui';
+import { WorkflowIcon } from '@mastra/playground-ui';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@mastra/playground-ui/components/Collapsible';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
 import { ChevronRight } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
@@ -1,12 +1,9 @@
 import type { GetAgentResponse } from '@mastra/client-js';
+import { WorkflowIcon, AgentIcon, ToolsIcon, truncateString } from '@mastra/playground-ui';
 import {
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
-  WorkflowIcon,
-  AgentIcon,
-  ToolsIcon,
-  truncateString,
-} from '@mastra/playground-ui';
+} from '@mastra/playground-ui/components/DataList';
 import { TextAndIcon } from '@mastra/playground-ui/components/Text';
 import { useMemo } from 'react';
 import { extractPrompt } from '../../utils/extractPrompt';

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
@@ -1,8 +1,9 @@
-import { ScrollArea, Txt, Icon, cn } from '@mastra/playground-ui';
+import { Txt, Icon, cn } from '@mastra/playground-ui';
 import type { JsonSchema, JsonSchemaProperty } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { HoverPopover, PopoverTrigger, PopoverContent } from '@mastra/playground-ui/components/Popover';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Braces, ChevronDown, ChevronRight, Wrench, Cpu, Eye, Pencil } from 'lucide-react';
 import { useState, useMemo } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-datasets.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-datasets.tsx
@@ -1,4 +1,5 @@
-import { Button, ScrollArea, Txt, Icon } from '@mastra/playground-ui';
+import { Button, Txt, Icon } from '@mastra/playground-ui';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Plus, Sparkles, Database, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import { useState, useMemo } from 'react';
 

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
@@ -1,17 +1,10 @@
-import {
-  Button,
-  Collapsible,
-  CollapsibleTrigger,
-  CollapsibleContent,
-  ScrollArea,
-  Txt,
-  Icon,
-  cn,
-} from '@mastra/playground-ui';
+import { Button, Txt, Icon, cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { Chip } from '@mastra/playground-ui/components/Chip';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@mastra/playground-ui/components/Collapsible';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -1,7 +1,8 @@
 import type { DatasetRecord } from '@mastra/client-js';
-import { Button, DataList, DataListSkeleton, Txt, toast } from '@mastra/playground-ui';
+import { Button, Txt, toast } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Column, Columns } from '@mastra/playground-ui/components/Columns';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@mastra/playground-ui/components/Dialog';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
@@ -1,7 +1,8 @@
-import { Button, DataList, Txt, Icon, toast, cn } from '@mastra/playground-ui';
+import { Button, Txt, Icon, toast, cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { Column, Columns } from '@mastra/playground-ui/components/Columns';
+import { DataList } from '@mastra/playground-ui/components/DataList';
 import {
   Dialog,
   DialogContent,

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-scorers.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-scorers.tsx
@@ -1,6 +1,7 @@
-import { ScrollArea, Txt, Icon } from '@mastra/playground-ui';
+import { Txt, Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Calculator, CheckCircle2, Loader2 } from 'lucide-react';

--- a/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -1,8 +1,9 @@
-import { Button, ScrollArea, Txt, Icon, toast, cn } from '@mastra/playground-ui';
+import { Button, Txt, Icon, toast, cn } from '@mastra/playground-ui';
 import { Chip } from '@mastra/playground-ui/components/Chip';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@mastra/playground-ui/components/Dialog';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { useQueryClient } from '@tanstack/react-query';

--- a/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
@@ -1,7 +1,8 @@
-import { Button, ScrollArea, Txt, Icon, toast, cn } from '@mastra/playground-ui';
+import { Button, Txt, Icon, toast, cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { useMastraClient } from '@mastra/react';

--- a/packages/playground/src/domains/agents/components/agent-run-options.tsx
+++ b/packages/playground/src/domains/agents/components/agent-run-options.tsx
@@ -1,4 +1,5 @@
-import { ScrollArea, Txt } from '@mastra/playground-ui';
+import { Txt } from '@mastra/playground-ui';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 
 import { AgentRequestContextRunOptionsBody } from './request-context-run-options';
 import { TracingRunOptions } from '@/domains/observability/components/tracing-run-options';

--- a/packages/playground/src/domains/agents/components/agent-settings/agent-settings-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-settings/agent-settings-view.tsx
@@ -1,4 +1,5 @@
-import { Icon, ScrollArea } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Tab, TabContent, TabList, Tabs } from '@mastra/playground-ui/components/Tabs';
 import { Brain, Radio, Settings2 } from 'lucide-react';
 import { useSearchParams } from 'react-router';

--- a/packages/playground/src/domains/agents/components/agent-version-panel.tsx
+++ b/packages/playground/src/domains/agents/components/agent-version-panel.tsx
@@ -1,5 +1,6 @@
-import { ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { Txt, cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { useAgentVersions } from '../hooks/use-agent-versions';
 
 function formatTimestamp(isoString: string): string {

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
@@ -1,5 +1,6 @@
-import { Button, ScrollArea, toast, cn } from '@mastra/playground-ui';
+import { Button, toast, cn } from '@mastra/playground-ui';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';

--- a/packages/playground/src/domains/agents/components/memory-sidebar/code-display.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/code-display.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea } from '@mastra/playground-ui';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 
 interface CodeDisplayProps {
   content: string;

--- a/packages/playground/src/domains/agents/components/request-context-run-options.tsx
+++ b/packages/playground/src/domains/agents/components/request-context-run-options.tsx
@@ -1,5 +1,6 @@
-import { ScrollArea, Txt, Icon, cn } from '@mastra/playground-ui';
+import { Txt, Icon, cn } from '@mastra/playground-ui';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { FileJson, FormInput } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
+++ b/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
@@ -1,14 +1,6 @@
-import {
-  Button,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-  Icon,
-  RuleBuilder,
-  countLeafRules,
-  cn,
-} from '@mastra/playground-ui';
+import { Button, Icon, RuleBuilder, countLeafRules, cn } from '@mastra/playground-ui';
 import type { JsonSchema, RuleGroup } from '@mastra/playground-ui';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { ChevronRight, Ruler, Trash2 } from 'lucide-react';
 import { useState } from 'react';

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-preview-table.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-preview-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DataList } from '@mastra/playground-ui';
+import { DataList } from '@mastra/playground-ui/components/DataList';
 
 export interface CSVPreviewTableProps {
   headers: string[];

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -1,14 +1,10 @@
 import type { DatasetExperiment, DatasetRecord } from '@mastra/client-js';
+import { AgentIcon, Button, ProcessorIcon, ScorersIcon, WorkflowIcon } from '@mastra/playground-ui';
+import { Chip } from '@mastra/playground-ui/components/Chip';
 import {
-  AgentIcon,
-  Button,
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
-  ProcessorIcon,
-  ScorersIcon,
-  WorkflowIcon,
-} from '@mastra/playground-ui';
-import { Chip } from '@mastra/playground-ui/components/Chip';
+} from '@mastra/playground-ui/components/DataList';
 import { useMemo } from 'react';
 import type { DatasetTargetType } from '../target-type-options';
 import { getDatasetTargetTypes, matchesDatasetTargetFilter } from './helpers';

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
@@ -1,6 +1,7 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { DataList, cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
 import { Chip } from '@mastra/playground-ui/components/Chip';
+import { DataList } from '@mastra/playground-ui/components/DataList';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { format, isThisYear, isToday } from 'date-fns';

--- a/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
@@ -1,4 +1,4 @@
-import { Button, ScrollArea, Txt, Icon, toast } from '@mastra/playground-ui';
+import { Button, Txt, Icon, toast } from '@mastra/playground-ui';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import {
   Dialog,
@@ -10,6 +10,7 @@ import {
 } from '@mastra/playground-ui/components/Dialog';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Sparkles, Trash2, Plus } from 'lucide-react';

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
@@ -1,6 +1,7 @@
 import type { DatasetItem } from '@mastra/client-js';
-import { Button, DataList } from '@mastra/playground-ui';
+import { Button } from '@mastra/playground-ui';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
+import { DataList } from '@mastra/playground-ui/components/DataList';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { format, isThisYear, isToday } from 'date-fns';
 import { Plus, Upload, FileJson } from 'lucide-react';

--- a/packages/playground/src/domains/datasets/components/schema-config-section.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-config-section.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@mastra/playground-ui';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@mastra/playground-ui/components/Collapsible';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import type { JSONSchema7 } from 'json-schema';

--- a/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import type { ClientScoreRowData, DatasetExperimentResult } from '@mastra/client-js';
-import { Button, DataList, TraceIcon } from '@mastra/playground-ui';
+import { Button, TraceIcon } from '@mastra/playground-ui';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
+import { DataList } from '@mastra/playground-ui/components/DataList';
 import { DataPanel } from '@mastra/playground-ui/components/DataPanel';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { format } from 'date-fns/format';

--- a/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
@@ -1,5 +1,6 @@
 import type { ClientScoreRowData, DatasetExperimentResult } from '@mastra/client-js';
-import { DataList, DataListSkeleton, cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 
 export type ExperimentResultsListProps = {

--- a/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
@@ -1,6 +1,6 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { PageLayout } from '@mastra/playground-ui';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { format } from 'date-fns';
 import { useAgents } from '@/domains/agents/hooks/use-agents';
 import { ExperimentStats } from '@/domains/experiments/components/experiment-stats';

--- a/packages/playground/src/domains/experiments/components/experiments-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-list.tsx
@@ -1,6 +1,9 @@
 import type { DatasetExperiment, DatasetRecord } from '@mastra/client-js';
-import { DataList as EntityList, DataListSkeleton as EntityListSkeleton } from '@mastra/playground-ui';
 import { Chip } from '@mastra/playground-ui/components/Chip';
+import {
+  DataList as EntityList,
+  DataListSkeleton as EntityListSkeleton,
+} from '@mastra/playground-ui/components/DataList';
 import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
 import { useMemo } from 'react';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground/src/domains/mcps/components/MCPDetail.tsx
+++ b/packages/playground/src/domains/mcps/components/MCPDetail.tsx
@@ -1,18 +1,15 @@
 import type { McpToolInfo } from '@mastra/client-js';
 import type { ServerInfo } from '@mastra/core/mcp';
+import { Txt, FolderIcon, Icon, McpServerIcon } from '@mastra/playground-ui';
+import { Badge } from '@mastra/playground-ui/components/Badge';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import {
   Entity,
   EntityContent,
   EntityDescription,
   EntityIcon,
   EntityName,
-  Txt,
-  FolderIcon,
-  Icon,
-  McpServerIcon,
-} from '@mastra/playground-ui';
-import { Badge } from '@mastra/playground-ui/components/Badge';
-import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+} from '@mastra/playground-ui/components/Entity';
 import { MainContentContent } from '@mastra/playground-ui/components/MainContent';
 import { useEffect, useRef, useState } from 'react';
 import { useMCPServerTools } from '../hooks/useMCPServerTools';

--- a/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-form-sidebar.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-form-sidebar.tsx
@@ -1,6 +1,7 @@
-import { Button, ScrollArea, Icon } from '@mastra/playground-ui';
+import { Button, Icon } from '@mastra/playground-ui';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';

--- a/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-tool-preview.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-tool-preview.tsx
@@ -1,15 +1,11 @@
+import { Txt, Icon, McpServerIcon, ToolsIcon, cn } from '@mastra/playground-ui';
 import {
   Entity,
   EntityContent,
   EntityDescription,
   EntityIcon,
   EntityName,
-  Txt,
-  Icon,
-  McpServerIcon,
-  ToolsIcon,
-  cn,
-} from '@mastra/playground-ui';
+} from '@mastra/playground-ui/components/Entity';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import type { TryConnectMcpMutation } from '../../hooks/use-try-connect-mcp';

--- a/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
@@ -1,15 +1,7 @@
 import type { StoredMCPServerConfig } from '@mastra/client-js';
-import {
-  Button,
-  Entity,
-  EntityContent,
-  EntityDescription,
-  EntityName,
-  Icon,
-  McpServerIcon,
-  stringToColor,
-} from '@mastra/playground-ui';
+import { Button, Icon, McpServerIcon, stringToColor } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
+import { Entity, EntityContent, EntityDescription, EntityName } from '@mastra/playground-ui/components/Entity';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
 import { LaptopMinimal, PlusIcon, XIcon } from 'lucide-react';

--- a/packages/playground/src/domains/mcps/components/mcps-list/mcps-list.tsx
+++ b/packages/playground/src/domains/mcps/components/mcps-list/mcps-list.tsx
@@ -1,12 +1,9 @@
 import type { McpServerListResponse } from '@mastra/client-js';
+import { ToolsIcon, WorkflowIcon, AgentIcon, truncateString } from '@mastra/playground-ui';
 import {
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
-  ToolsIcon,
-  WorkflowIcon,
-  AgentIcon,
-  truncateString,
-} from '@mastra/playground-ui';
+} from '@mastra/playground-ui/components/DataList';
 import { useMastraClient } from '@mastra/react';
 import { useMemo } from 'react';
 import { useMCPServerTools } from '../../hooks/useMCPServerTools';

--- a/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
+++ b/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
@@ -1,4 +1,8 @@
-import { DataList as EntityList, DataListSkeleton as EntityListSkeleton, truncateString } from '@mastra/playground-ui';
+import { truncateString } from '@mastra/playground-ui';
+import {
+  DataList as EntityList,
+  DataListSkeleton as EntityListSkeleton,
+} from '@mastra/playground-ui/components/DataList';
 import { CheckIcon, FileInput, FileOutput } from 'lucide-react';
 import { useMemo } from 'react';
 import type { ProcessorInfo, ProcessorPhase } from '../../hooks/use-processors';

--- a/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-sidebar.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-sidebar.tsx
@@ -1,9 +1,10 @@
-import { Button, ScrollArea, Txt } from '@mastra/playground-ui';
+import { Button, Txt } from '@mastra/playground-ui';
 import type { JsonSchema } from '@mastra/playground-ui';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { JSONSchemaForm, jsonSchemaToFields } from '@mastra/playground-ui/components/JSONSchemaForm';
 import type { SchemaField } from '@mastra/playground-ui/components/JSONSchemaForm';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Check, Plus, PlusIcon, Save } from 'lucide-react';

--- a/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
@@ -1,5 +1,9 @@
 import type { StoredPromptBlockResponse } from '@mastra/client-js';
-import { DataList as EntityList, DataListSkeleton as EntityListSkeleton, truncateString } from '@mastra/playground-ui';
+import { truncateString } from '@mastra/playground-ui';
+import {
+  DataList as EntityList,
+  DataListSkeleton as EntityListSkeleton,
+} from '@mastra/playground-ui/components/DataList';
 import { CheckIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -1,6 +1,7 @@
-import { Button, DataList, Txt, Icon, cn } from '@mastra/playground-ui';
+import { Button, Txt, Icon, cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { DataList } from '@mastra/playground-ui/components/DataList';
 import {
   Dialog,
   DialogContent,

--- a/packages/playground/src/domains/schedules/components/schedule-triggers-list.tsx
+++ b/packages/playground/src/domains/schedules/components/schedule-triggers-list.tsx
@@ -1,5 +1,6 @@
 import type { ScheduleTriggerResponse } from '@mastra/client-js';
-import { DataList, DataListSkeleton, Txt } from '@mastra/playground-ui';
+import { Txt } from '@mastra/playground-ui';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { AlertTriangleIcon } from 'lucide-react';
 import { formatScheduleTimestamp, formatRelativeTime } from '../utils/format';

--- a/packages/playground/src/domains/schedules/components/schedules-list.tsx
+++ b/packages/playground/src/domains/schedules/components/schedules-list.tsx
@@ -1,5 +1,5 @@
 import type { ScheduleResponse } from '@mastra/client-js';
-import { DataList, DataListSkeleton } from '@mastra/playground-ui';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { useMemo } from 'react';
 import { formatScheduleTimestamp, formatRelativeTime } from '../utils/format';
 import { ScheduleStatusText } from './schedule-status-badge';

--- a/packages/playground/src/domains/scores/components/scorer-edit-page/scorer-edit-sidebar.tsx
+++ b/packages/playground/src/domains/scores/components/scorer-edit-page/scorer-edit-sidebar.tsx
@@ -1,7 +1,8 @@
-import { Button, ScrollArea, Icon } from '@mastra/playground-ui';
+import { Button, Icon } from '@mastra/playground-ui';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { RadioGroup, RadioGroupItem } from '@mastra/playground-ui/components/RadioGroup';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Check, Save } from 'lucide-react';

--- a/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
@@ -1,6 +1,10 @@
 import type { GetScorerResponse } from '@mastra/client-js';
-import { DataList as EntityList, DataListSkeleton as EntityListSkeleton, AgentIcon } from '@mastra/playground-ui';
+import { AgentIcon } from '@mastra/playground-ui';
 import { Chip } from '@mastra/playground-ui/components/Chip';
+import {
+  DataList as EntityList,
+  DataListSkeleton as EntityListSkeleton,
+} from '@mastra/playground-ui/components/DataList';
 import { WorkflowIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground/src/domains/scores/components/scores-list.tsx
+++ b/packages/playground/src/domains/scores/components/scores-list.tsx
@@ -1,6 +1,7 @@
 import type { ClientScoreRowData } from '@mastra/client-js';
 import type { ScoreRowData } from '@mastra/core/evals';
-import { ScoresDataList, DataListSkeleton, cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
+import { ScoresDataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScoreDataPanel } from '@/domains/traces/components/score-data-panel';
 

--- a/packages/playground/src/domains/tool-providers/components/integration-tools-section.tsx
+++ b/packages/playground/src/domains/tool-providers/components/integration-tools-section.tsx
@@ -1,5 +1,6 @@
-import { Entity, EntityContent, EntityName, EntityDescription, stringToColor } from '@mastra/playground-ui';
+import { stringToColor } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
+import { Entity, EntityContent, EntityName, EntityDescription } from '@mastra/playground-ui/components/Entity';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { Plug } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/domains/tool-providers/components/manage-connection-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/manage-connection-list.tsx
@@ -1,5 +1,6 @@
-import { Button, Entity, EntityContent, EntityName, Icon } from '@mastra/playground-ui';
+import { Button, Icon } from '@mastra/playground-ui';
 import { DialogBody, DialogFooter } from '@mastra/playground-ui/components/Dialog';
+import { Entity, EntityContent, EntityName } from '@mastra/playground-ui/components/Entity';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { ChevronRight, Plus } from 'lucide-react';
 

--- a/packages/playground/src/domains/tool-providers/components/selected-tool-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/selected-tool-list.tsx
@@ -1,5 +1,6 @@
-import { ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { Txt, cn } from '@mastra/playground-ui';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { useMemo } from 'react';
 
 interface SelectedToolListProps {

--- a/packages/playground/src/domains/tool-providers/components/tool-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/tool-list.tsx
@@ -1,6 +1,7 @@
-import { ScrollArea, Txt, cn } from '@mastra/playground-ui';
+import { Txt, cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar, SearchbarWrapper } from '@mastra/playground-ui/components/Searchbar';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { useState } from 'react';

--- a/packages/playground/src/domains/tool-providers/components/toolkit-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/toolkit-list.tsx
@@ -1,4 +1,5 @@
-import { ScrollArea, transitions, cn } from '@mastra/playground-ui';
+import { transitions, cn } from '@mastra/playground-ui';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { useToolkits } from '../hooks/use-toolkits';
 

--- a/packages/playground/src/domains/tools/components/tools-list/tools-list.tsx
+++ b/packages/playground/src/domains/tools/components/tools-list/tools-list.tsx
@@ -1,10 +1,9 @@
 import type { GetAgentResponse, GetToolResponse } from '@mastra/client-js';
+import { AgentIcon, truncateString } from '@mastra/playground-ui';
 import {
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
-  AgentIcon,
-  truncateString,
-} from '@mastra/playground-ui';
+} from '@mastra/playground-ui/components/DataList';
 import { useMemo } from 'react';
 import { prepareToolsTable } from '@/domains/tools/utils/prepareToolsTable';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground/src/domains/traces/components/span-feedback-list.tsx
+++ b/packages/playground/src/domains/traces/components/span-feedback-list.tsx
@@ -1,5 +1,5 @@
 import type { FeedbackRecord, ListFeedbackResponse } from '@mastra/core/storage';
-import { DataList, DataListSkeleton } from '@mastra/playground-ui';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { format } from 'date-fns';
 import { useState } from 'react';
 import { FeedbackDialog } from './feedback-dialog';

--- a/packages/playground/src/domains/traces/components/span-scores-list.tsx
+++ b/packages/playground/src/domains/traces/components/span-scores-list.tsx
@@ -1,5 +1,5 @@
 import type { ListScoresResponse, ScoreRowData } from '@mastra/core/evals';
-import { DataList, DataListSkeleton } from '@mastra/playground-ui';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { getShortId } from '@mastra/playground-ui/components/Text';
 import { isToday, format } from 'date-fns';
 

--- a/packages/playground/src/domains/workflows/components/workflow-information.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-information.tsx
@@ -1,5 +1,6 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
-import { Button, Icon, ScrollArea, toast } from '@mastra/playground-ui';
+import { Button, Icon, toast } from '@mastra/playground-ui';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Plus } from 'lucide-react';
 import type { ContextType, ReactNode } from 'react';
 import { useState, useEffect, useContext } from 'react';

--- a/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
+++ b/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
@@ -1,5 +1,9 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
-import { DataList as EntityList, DataListSkeleton as EntityListSkeleton, truncateString } from '@mastra/playground-ui';
+import { truncateString } from '@mastra/playground-ui';
+import {
+  DataList as EntityList,
+  DataListSkeleton as EntityListSkeleton,
+} from '@mastra/playground-ui/components/DataList';
 import { useMemo } from 'react';
 import { useLinkComponent } from '@/lib/framework';
 

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-condition-card-view.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-condition-card-view.tsx
@@ -1,4 +1,5 @@
-import { Collapsible, CollapsibleContent, CollapsibleTrigger, Icon, Txt, cn } from '@mastra/playground-ui';
+import { Icon, Txt, cn } from '@mastra/playground-ui';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { ChevronDown } from 'lucide-react';
 import { Fragment } from 'react';
 

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-condition-code.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-condition-code.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea, cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui';
 import {
   Dialog,
   DialogBody,
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@mastra/playground-ui/components/Dialog';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Highlight, themes } from 'prism-react-renderer';
 
 import type { WorkflowConditionCodeCondition } from './types';

--- a/packages/playground/src/domains/workflows/workflow/workflow-after-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-after-node.tsx
@@ -1,5 +1,6 @@
-import { Collapsible, CollapsibleContent, CollapsibleTrigger, Txt, Icon, cn } from '@mastra/playground-ui';
+import { Txt, Icon, cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps, Node } from '@xyflow/react';
 import { ChevronDown, Footprints } from 'lucide-react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-condition-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-condition-node.tsx
@@ -1,5 +1,6 @@
-import { Collapsible, CollapsibleContent, CollapsibleTrigger, ScrollArea, Txt, Icon, cn } from '@mastra/playground-ui';
+import { Txt, Icon, cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import {
   Dialog,
   DialogContent,
@@ -8,6 +9,7 @@ import {
   DialogDescription,
   DialogBody,
 } from '@mastra/playground-ui/components/Dialog';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps, Node } from '@xyflow/react';
 import { ChevronDown } from 'lucide-react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-input-data.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-input-data.tsx
@@ -1,5 +1,6 @@
-import { Button, Collapsible, CollapsibleContent, CollapsibleTrigger, Icon, Txt, cn } from '@mastra/playground-ui';
+import { Button, Icon, Txt, cn } from '@mastra/playground-ui';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { ChevronRight, Loader2, Play } from 'lucide-react';
 import type { ReactNode } from 'react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-suspended-steps.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-suspended-steps.tsx
@@ -1,7 +1,8 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger, Icon, Txt, cn } from '@mastra/playground-ui';
+import { Icon, Txt, cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { ChevronRight, CirclePause, MoveDownLeft, MoveUpRight, Play } from 'lucide-react';
 import { useState } from 'react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
@@ -1,15 +1,7 @@
 import { jsonLanguage } from '@codemirror/lang-json';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-  Txt,
-  Icon,
-  formatJSON,
-  isValidJson,
-  cn,
-} from '@mastra/playground-ui';
+import { Txt, Icon, formatJSON, isValidJson, cn } from '@mastra/playground-ui';
 import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';

--- a/packages/playground/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -1,8 +1,9 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
 import type { WorkflowRunStatus } from '@mastra/core/workflows';
-import { ScrollArea, Txt, Icon, WorkflowIcon, toast } from '@mastra/playground-ui';
+import { Txt, Icon, WorkflowIcon, toast } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Loader2 } from 'lucide-react';

--- a/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
+++ b/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
@@ -1,4 +1,4 @@
-import { Button, ScrollArea, SkillIcon, cn } from '@mastra/playground-ui';
+import { Button, SkillIcon, cn } from '@mastra/playground-ui';
 import {
   Dialog,
   DialogContent,
@@ -9,6 +9,7 @@ import {
 } from '@mastra/playground-ui/components/Dialog';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Search, Download, ExternalLink, Loader2, Package, Github, Check, Folder } from 'lucide-react';
 import { useState, useCallback, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';

--- a/packages/playground/src/domains/workspace/components/skills-table.tsx
+++ b/packages/playground/src/domains/workspace/components/skills-table.tsx
@@ -1,4 +1,5 @@
-import { Button, DataList, DataListSkeleton, Icon, SkillIcon } from '@mastra/playground-ui';
+import { Button, Icon, SkillIcon } from '@mastra/playground-ui';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { AlertTriangle, BookOpen, Plus } from 'lucide-react';
 import type { SkillMetadata } from '../types';
 import { SkillRemoveButton, SkillUpdateButton } from './skill-actions';

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -1,8 +1,9 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
-import { Button, cn, ScrollArea } from '@mastra/playground-ui';
+import { Button, cn } from '@mastra/playground-ui';
 import { Avatar } from '@mastra/playground-ui/components/Avatar';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { PendingIndicator } from '@mastra/playground-ui/components/PendingIndicator';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { useAutoscroll } from '@mastra/playground-ui/hooks/use-autoscroll';
 import type { MessageFactoryPart } from '@mastra/react';
 import { CLIENT_MESSAGE_ID_KEY, useSpeechRecognition } from '@mastra/react';

--- a/packages/playground/src/lib/command/navigation-command.tsx
+++ b/packages/playground/src/lib/command/navigation-command.tsx
@@ -1,4 +1,4 @@
-import { AgentIcon, McpServerIcon, ScrollArea, ToolsIcon, WorkflowIcon } from '@mastra/playground-ui';
+import { AgentIcon, McpServerIcon, ToolsIcon, WorkflowIcon } from '@mastra/playground-ui';
 import {
   CommandDialog,
   CommandEmpty,
@@ -10,6 +10,7 @@ import {
 } from '@mastra/playground-ui/components/Command';
 import { Kbd } from '@mastra/playground-ui/components/Kbd';
 import { useMaybeSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { useKeyboardShortcutLabel } from '@mastra/playground-ui/hooks/use-keyboard-shortcut-label';
 import {
   Cpu,

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -1,9 +1,10 @@
 import type { ListStoredAgentsParams } from '@mastra/client-js';
-import { AgentIcon, Button, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { AgentIcon, Button, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { PlusIcon } from 'lucide-react';

--- a/packages/playground/src/pages/agent-builder/favorite/index.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/index.tsx
@@ -1,9 +1,10 @@
 import type { ListStoredAgentsParams, StoredSkillResponse } from '@mastra/client-js';
-import { PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { SparklesIcon, StarIcon } from 'lucide-react';

--- a/packages/playground/src/pages/agent-builder/infrastructure/index.tsx
+++ b/packages/playground/src/pages/agent-builder/infrastructure/index.tsx
@@ -1,6 +1,7 @@
 import type { InfrastructureStatusResponse } from '@mastra/client-js';
-import { PageLayout, Txt } from '@mastra/playground-ui';
+import { Txt } from '@mastra/playground-ui';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { SectionCard } from '@mastra/playground-ui/components/SectionCard';
 
 import { useInfrastructureStatus } from '@/domains/agent-builder/hooks/use-infrastructure-status';

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -1,9 +1,10 @@
 import type { ListStoredAgentsParams } from '@mastra/client-js';
-import { PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { LibraryIcon, SparklesIcon } from 'lucide-react';

--- a/packages/playground/src/pages/agent-builder/skills/index.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/index.tsx
@@ -1,9 +1,10 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
-import { Button, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { Button, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { DownloadIcon, PlusIcon, SparklesIcon } from 'lucide-react';

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -1,6 +1,7 @@
-import { NoDataPageLayout, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { useState } from 'react';

--- a/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
@@ -1,12 +1,7 @@
-import {
-  Button,
-  PageLayout,
-  is401UnauthorizedError,
-  is403ForbiddenError,
-  is404NotFoundError,
-} from '@mastra/playground-ui';
+import { Button, is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { ArrowLeft, PlayCircle } from 'lucide-react';

--- a/packages/playground/src/pages/datasets/dataset/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/index.tsx
@@ -1,15 +1,10 @@
-import {
-  Button,
-  PageLayout,
-  is401UnauthorizedError,
-  is403ForbiddenError,
-  is404NotFoundError,
-} from '@mastra/playground-ui';
+import { Button, is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';

--- a/packages/playground/src/pages/datasets/index.tsx
+++ b/packages/playground/src/pages/datasets/index.tsx
@@ -1,5 +1,6 @@
-import { NoDataPageLayout, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { useCallback, useMemo, useState } from 'react';

--- a/packages/playground/src/pages/evaluation/index.tsx
+++ b/packages/playground/src/pages/evaluation/index.tsx
@@ -1,6 +1,7 @@
-import { NoDataPageLayout, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { MetricsFlexGrid } from '@mastra/playground-ui/components/MetricsFlexGrid';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { useMemo } from 'react';

--- a/packages/playground/src/pages/experiments/experiment/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/index.tsx
@@ -1,12 +1,7 @@
-import {
-  Button,
-  PageLayout,
-  is401UnauthorizedError,
-  is403ForbiddenError,
-  is404NotFoundError,
-} from '@mastra/playground-ui';
+import { Button, is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { ArrowLeft, PlayCircle } from 'lucide-react';

--- a/packages/playground/src/pages/experiments/index.tsx
+++ b/packages/playground/src/pages/experiments/index.tsx
@@ -1,5 +1,6 @@
-import { NoDataPageLayout, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/pages/logs/index.tsx
+++ b/packages/playground/src/pages/logs/index.tsx
@@ -5,7 +5,6 @@ import {
   LogsListView,
   LogsToolbar,
   NoLogsInfo,
-  PageLayout,
   SpanDetailsView,
   TraceDetailsView,
   buildLogsListFilters,
@@ -23,6 +22,7 @@ import {
   useTraceLightSpans,
 } from '@mastra/playground-ui';
 import { DateTimeRangePicker } from '@mastra/playground-ui/components/DateTimeRangePicker';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PropertyFilterCreator } from '@mastra/playground-ui/components/PropertyFilter';
 import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';

--- a/packages/playground/src/pages/mcps/index.tsx
+++ b/packages/playground/src/pages/mcps/index.tsx
@@ -1,6 +1,7 @@
-import { NoDataPageLayout, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { useState } from 'react';

--- a/packages/playground/src/pages/metrics/index.tsx
+++ b/packages/playground/src/pages/metrics/index.tsx
@@ -3,8 +3,6 @@ import {
   Button,
   DateRangeSelector,
   MetricsProvider,
-  NoDataPageLayout,
-  PageLayout,
   applyMetricsPropertyFilterTokens,
   clearSavedMetricsFilters,
   createMetricsPropertyFilterFields,
@@ -27,6 +25,7 @@ import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { MetricsFlexGrid } from '@mastra/playground-ui/components/MetricsFlexGrid';
 import { Notice } from '@mastra/playground-ui/components/Notice';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { PropertyFilterCreator } from '@mastra/playground-ui/components/PropertyFilter';
 import type { PropertyFilterToken } from '@mastra/playground-ui/components/PropertyFilter';

--- a/packages/playground/src/pages/processors/index.tsx
+++ b/packages/playground/src/pages/processors/index.tsx
@@ -1,6 +1,7 @@
-import { NoDataPageLayout, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { useState } from 'react';

--- a/packages/playground/src/pages/prompt-blocks/index.tsx
+++ b/packages/playground/src/pages/prompt-blocks/index.tsx
@@ -1,12 +1,7 @@
-import {
-  Button,
-  NoDataPageLayout,
-  PageLayout,
-  is401UnauthorizedError,
-  is403ForbiddenError,
-} from '@mastra/playground-ui';
+import { Button, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Plus } from 'lucide-react';

--- a/packages/playground/src/pages/request-context/index.tsx
+++ b/packages/playground/src/pages/request-context/index.tsx
@@ -1,4 +1,4 @@
-import { PageLayout } from '@mastra/playground-ui';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { RequestContext, RequestContextWrapper } from '@/domains/agents/components/request-context';
 
 export default function RequestContextPage() {

--- a/packages/playground/src/pages/resources/index.tsx
+++ b/packages/playground/src/pages/resources/index.tsx
@@ -1,4 +1,4 @@
-import { PageLayout } from '@mastra/playground-ui';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { BookIcon, EarthIcon, MessageSquareIcon, ExternalLinkIcon, CloudUploadIcon, BuildingIcon } from 'lucide-react';
 
 const resources = [

--- a/packages/playground/src/pages/scorers/index.tsx
+++ b/packages/playground/src/pages/scorers/index.tsx
@@ -1,5 +1,6 @@
-import { NoDataPageLayout, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { useState } from 'react';

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -1,5 +1,6 @@
-import { Button, PageLayout, is401UnauthorizedError, is403ForbiddenError, toast } from '@mastra/playground-ui';
+import { Button, is401UnauthorizedError, is403ForbiddenError, toast } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { PencilIcon } from 'lucide-react';

--- a/packages/playground/src/pages/settings/index.tsx
+++ b/packages/playground/src/pages/settings/index.tsx
@@ -1,4 +1,4 @@
-import { PageLayout } from '@mastra/playground-ui';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { SectionCard } from '@mastra/playground-ui/components/SectionCard';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';

--- a/packages/playground/src/pages/tools/index.tsx
+++ b/packages/playground/src/pages/tools/index.tsx
@@ -1,6 +1,7 @@
-import { NoDataPageLayout, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { useState } from 'react';

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -2,7 +2,6 @@ import { EntityType } from '@mastra/core/observability';
 import {
   Button,
   NoTracesInfo,
-  PageLayout,
   SpanDataPanelView,
   TraceDataPanelView,
   TracesErrorContent,
@@ -29,6 +28,7 @@ import type { SpanTab } from '@mastra/playground-ui';
 import { DateTimeRangePicker } from '@mastra/playground-ui/components/DateTimeRangePicker';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { Notice } from '@mastra/playground-ui/components/Notice';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PropertyFilterCreator } from '@mastra/playground-ui/components/PropertyFilter';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { CircleSlash2, RefreshCw } from 'lucide-react';

--- a/packages/playground/src/pages/traces/trace/index.tsx
+++ b/packages/playground/src/pages/traces/trace/index.tsx
@@ -2,7 +2,6 @@ import type { ScoreRowData } from '@mastra/core/evals';
 import { EntityType } from '@mastra/core/observability';
 import {
   Button,
-  PageLayout,
   SpanDataPanelView,
   TraceDataPanelView,
   TraceKeysAndValues,
@@ -14,6 +13,7 @@ import {
 } from '@mastra/playground-ui';
 import type { SpanTab } from '@mastra/playground-ui';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { CircleGaugeIcon, SaveIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';

--- a/packages/playground/src/pages/workflows/index.tsx
+++ b/packages/playground/src/pages/workflows/index.tsx
@@ -1,12 +1,7 @@
-import {
-  Button,
-  NoDataPageLayout,
-  PageLayout,
-  is401UnauthorizedError,
-  is403ForbiddenError,
-} from '@mastra/playground-ui';
+import { Button, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { CalendarClockIcon } from 'lucide-react';

--- a/packages/playground/src/pages/workflows/schedule.tsx
+++ b/packages/playground/src/pages/workflows/schedule.tsx
@@ -1,12 +1,6 @@
-import {
-  Button,
-  NoDataPageLayout,
-  PageLayout,
-  Txt,
-  is401UnauthorizedError,
-  is403ForbiddenError,
-} from '@mastra/playground-ui';
+import { Button, Txt, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { ArrowLeftIcon, PauseIcon, PlayIcon } from 'lucide-react';

--- a/packages/playground/src/pages/workflows/schedules.tsx
+++ b/packages/playground/src/pages/workflows/schedules.tsx
@@ -1,4 +1,5 @@
-import { NoDataPageLayout, PageLayout, is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { useSearchParams } from 'react-router';

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -1,12 +1,6 @@
-import {
-  Button,
-  NoDataPageLayout,
-  PageLayout,
-  is401UnauthorizedError,
-  is403ForbiddenError,
-  toast,
-} from '@mastra/playground-ui';
+import { Button, is401UnauthorizedError, is403ForbiddenError, toast } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
+import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';


### PR DESCRIPTION
This is mechanical import hygiene for packages/playground. It moves PageLayout, Collapsible, Entity, DataList, and ScrollArea usages from the @mastra/playground-ui root barrel to direct component subpaths so these paths do not accidentally pull through the root barrel and regress import or build performance.

It also adds package ESLint restricted specifiers for the migrated symbols to keep them from being reintroduced. No changeset is needed because this has no public API or behavior change.

Validated with the scoped zero-import script, pnpm prettier:changed, pnpm --filter ./packages/playground lint, pnpm --filter ./packages/playground typecheck, pnpm --filter ./packages/playground build, and pnpm lint. CodeRabbit local review was skipped because the CLI is installed but not signed in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the playground app stop grabbing lots of UI pieces from one big doorway and instead import each piece directly from where it lives. That helps keep imports cleaner and avoids pulling in more than needed, which can make builds and maintenance better.

## Summary
- Swapped `packages/playground` usages of `PageLayout`, `Collapsible`, `Entity`, `DataList`, and `ScrollArea` from the `@mastra/playground-ui` root barrel to direct component subpaths.
- Added ESLint restricted specifiers so those symbols can’t be re-imported from the root barrel.
- Left runtime behavior unchanged; this is import-hygiene only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->