### PR TITLE
fix(server-adapters): suppress error log for 4xx handler exceptions

### DIFF
--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -585,11 +585,16 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
           const result = await route.handler(handlerParams);
           await this.sendResponse(route, res, result, req, prefix);
         } catch (error) {
-          this.mastra.getLogger()?.error('Error calling handler', {
-            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
-            path: route.path,
-            method: route.method,
-          });
+          const httpStatus =
+            error && typeof error === 'object' && 'status' in error ? (error as any).status : undefined;
+          const isClientError = typeof httpStatus === 'number' && httpStatus >= 400 && httpStatus < 500;
+          if (!isClientError) {
+            this.mastra.getLogger()?.error('Error calling handler', {
+              error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+              path: route.path,
+              method: route.method,
+            });
+          }
           // Check if it's an HTTPException or MastraError with a status code
           let status = 500;
           if (error && typeof error === 'object') {

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -677,11 +677,16 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         const result = await route.handler(handlerParams);
         await this.sendResponse(route, reply, result, request, prefix);
       } catch (error) {
-        this.mastra.getLogger()?.error('Error calling handler', {
-          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
-          path: route.path,
-          method: route.method,
-        });
+        const httpStatus =
+          error && typeof error === 'object' && 'status' in error ? (error as any).status : undefined;
+        const isClientError = typeof httpStatus === 'number' && httpStatus >= 400 && httpStatus < 500;
+        if (!isClientError) {
+          this.mastra.getLogger()?.error('Error calling handler', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+            path: route.path,
+            method: route.method,
+          });
+        }
         // Check if it's an HTTPException or MastraError with a status code
         let status = 500;
         if (error && typeof error === 'object') {

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -677,8 +677,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         const result = await route.handler(handlerParams);
         await this.sendResponse(route, reply, result, request, prefix);
       } catch (error) {
-        const httpStatus =
-          error && typeof error === 'object' && 'status' in error ? (error as any).status : undefined;
+        const httpStatus = error && typeof error === 'object' && 'status' in error ? (error as any).status : undefined;
         const isClientError = typeof httpStatus === 'number' && httpStatus >= 400 && httpStatus < 500;
         if (!isClientError) {
           this.mastra.getLogger()?.error('Error calling handler', {

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -569,11 +569,19 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           const result = await route.handler(handlerParams);
           return this.sendResponse(route, c, result, prefix);
         } catch (error) {
-          this.mastra.getLogger()?.error('Error calling handler', {
-            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
-            path: route.path,
-            method: route.method,
-          });
+          // 4xx errors are client conditions (e.g. no session, expired token) and are
+          // already returned as structured HTTP responses below. Logging them as errors
+          // produces noise for callers — skip the logger call for those cases.
+          const httpStatus =
+            error && typeof error === 'object' && 'status' in error ? (error as any).status : undefined;
+          const isClientError = typeof httpStatus === 'number' && httpStatus >= 400 && httpStatus < 500;
+          if (!isClientError) {
+            this.mastra.getLogger()?.error('Error calling handler', {
+              error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+              path: route.path,
+              method: route.method,
+            });
+          }
           // Check if it's an HTTPException or MastraError with a status code
           if (error && typeof error === 'object') {
             // Check for direct status property (HTTPException)

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -504,11 +504,16 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       const result = await route.handler(handlerParams);
       await this.sendResponse(route, ctx, result, prefix);
     } catch (error) {
-      this.mastra.getLogger()?.error('Error calling handler', {
-        error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
-        path: route.path,
-        method: route.method,
-      });
+      const httpStatus =
+        error && typeof error === 'object' && 'status' in error ? (error as any).status : undefined;
+      const isClientError = typeof httpStatus === 'number' && httpStatus >= 400 && httpStatus < 500;
+      if (!isClientError) {
+        this.mastra.getLogger()?.error('Error calling handler', {
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          path: route.path,
+          method: route.method,
+        });
+      }
       // Attach status code to the error for upstream middleware
       if (error && typeof error === 'object') {
         if (!('status' in error)) {

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -504,8 +504,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       const result = await route.handler(handlerParams);
       await this.sendResponse(route, ctx, result, prefix);
     } catch (error) {
-      const httpStatus =
-        error && typeof error === 'object' && 'status' in error ? (error as any).status : undefined;
+      const httpStatus = error && typeof error === 'object' && 'status' in error ? (error as any).status : undefined;
       const isClientError = typeof httpStatus === 'number' && httpStatus >= 400 && httpStatus < 500;
       if (!isClientError) {
         this.mastra.getLogger()?.error('Error calling handler', {


### PR DESCRIPTION
Fixes #18420

When a route handler throws an `HTTPException` with a 4xx status the framework already converts it to a structured HTTP response with the correct status code. Logging it at the `error` level on top of that is misleading — it suggests a server fault when the condition is a normal client state (no session cookie, expired token, invalid request body).

The most visible symptom is `POST /auth/refresh` emitting a full `Error: No session` log entry every time a browser visits Mastra Studio with an expired session. The token refresh is expected to fail in that case and the client handles the 401 gracefully, but the error log pollutes production observability dashboards.

The fix guards the `logger.error('Error calling handler', ...)` call in all four server adapters (hono, express, fastify, koa): if the thrown error carries a `status` property in the 400-499 range the log is skipped. Genuine server errors (5xx) and any exception without a recognisable status continue to be logged as before.

The check is a duck-type on `.status` rather than an `instanceof HTTPException` import so it works regardless of which adapter or package version resolved the exception class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When your app code crashes, the server adapter currently logs it like a “real server error” even if the request was a normal client mistake (like “no session” or “expired token”). This change keeps those 4xx cases from being logged as errors while still returning the correct HTTP response.

## Summary
Updated the Hono, Express, Fastify, and Koa server adapters so the `catch` path only calls `logger.error('Error calling handler', ...)` when the thrown error is **not** a client error. Each adapter:
- Derives an HTTP status from `error.status` (or `error.details.status` where applicable).
- Treats **4xx (400–499)** as client errors and **skips** the error log.
- Continues to log **5xx** and errors without a recognizable status as before.
- Preserves the existing structured error response behavior (including the existing status code mapping for the response).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->