### PR TITLE
fix(playground): type workflow graph payloads

### DIFF
--- a/packages/playground/src/domains/workflows/context/use-current-run.tsx
+++ b/packages/playground/src/domains/workflows/context/use-current-run.tsx
@@ -1,3 +1,4 @@
+import type { WorkflowStepStatus } from '@mastra/core/workflows';
 import { useContext } from 'react';
 import { WorkflowRunContext } from './workflow-run-context';
 
@@ -24,12 +25,14 @@ export type ForeachProgress = {
   iterationOutput?: any;
 };
 
+type StepStatus = Extract<WorkflowStepStatus, 'running' | 'success' | 'failed' | 'suspended' | 'waiting' | 'skipped'>;
+
 export type Step = {
   error?: any;
   tripwire?: TripwireData;
   startedAt: number;
   endedAt?: number;
-  status: 'running' | 'success' | 'failed' | 'suspended' | 'waiting';
+  status: StepStatus;
   output?: any;
   input?: any;
   resumeData?: any;

--- a/packages/playground/src/domains/workflows/workflow/__tests__/workflow-debug-step-controls.test.tsx
+++ b/packages/playground/src/domains/workflows/workflow/__tests__/workflow-debug-step-controls.test.tsx
@@ -170,7 +170,7 @@ describe('WorkflowDebugStepControls', () => {
     const payload = timeTravelWorkflowStream.mock.calls[0][0];
     expect(payload.step).toBe('mapping_join');
     // Only the taken arm's output is forwarded as the join context.
-    expect(payload.context).toEqual({ 'short-text': { output: { text: 'AS' } } });
+    expect(payload.context).toEqual({ 'short-text': { status: 'success', output: { text: 'AS' } } });
     // A normal advance re-pauses, so per-step is explicitly enabled regardless of the
     // in-memory debug flag (which is false when landing on a paused run's :runId page).
     expect(payload.perStep).toBe(true);

--- a/packages/playground/src/domains/workflows/workflow/use-workflow-graph-runtime.tsx
+++ b/packages/playground/src/domains/workflows/workflow/use-workflow-graph-runtime.tsx
@@ -1,10 +1,11 @@
 import type { SerializedStepFlowEntry } from '@mastra/core/workflows';
-import type { Edge, EdgeProps, NodeProps } from '@xyflow/react';
+import type { EdgeProps, NodeProps } from '@xyflow/react';
 import { useContext, useMemo } from 'react';
 
 import { useCurrentRun } from '../context/use-current-run';
 import { WorkflowRunContext } from '../context/workflow-run-context';
 import { buildStepSuccessors, buildStepsFlow, collectGraphStepFlags, isBranchArmBypassed } from './utils';
+import type { WorkflowGraphEdge } from './utils';
 import { WorkflowBoundaryNode } from './workflow-boundary-node';
 import { WorkflowDataEdge, WORKFLOW_DATA_EDGE_TYPE } from './workflow-data-edge';
 import { WorkflowGraphNode } from './workflow-graph-node';
@@ -19,7 +20,7 @@ export const useWorkflowGraphRuntime = ({
   workflowName,
   stepGraph,
 }: {
-  edges: Edge[];
+  edges: WorkflowGraphEdge[];
   workflowName?: string;
   stepGraph?: SerializedStepFlowEntry[];
 }) => {
@@ -56,7 +57,7 @@ export const useWorkflowGraphRuntime = ({
   );
   const edgeTypes = useMemo(
     () => ({
-      [WORKFLOW_DATA_EDGE_TYPE]: (props: EdgeProps) => (
+      [WORKFLOW_DATA_EDGE_TYPE]: (props: EdgeProps<WorkflowGraphEdge>) => (
         <WorkflowDataEdge parentWorkflowName={workflowName} {...props} />
       ),
     }),
@@ -65,14 +66,14 @@ export const useWorkflowGraphRuntime = ({
   const styledEdges = useMemo(
     () =>
       edges.map(edge => {
-        const previousStepId = getScopedStepId(edge.data?.previousStepId as string | undefined, workflowName);
-        const nextStepId = getScopedStepId(edge.data?.nextStepId as string | undefined, workflowName);
+        const previousStepId = getScopedStepId(edge.data?.previousStepId, workflowName);
+        const nextStepId = getScopedStepId(edge.data?.nextStepId, workflowName);
         const previousStepSucceeded = steps[previousStepId ?? '']?.status === 'success';
-        const nextStepStatus = steps[nextStepId ?? '']?.status as string | undefined;
+        const nextStepStatus = steps[nextStepId ?? '']?.status;
         // A conditional arm that lost the branch decision never runs, so its status
         // stays `undefined`. Treat such a bypassed arm like an explicitly skipped step
         // so edges feeding it stay neutral.
-        const nextStepBypassed = isArmBypassed(edge.data?.nextStepId as string | undefined);
+        const nextStepBypassed = isArmBypassed(edge.data?.nextStepId);
         // The boundary edge into the End node carries no step ids; it should light
         // green once the whole workflow run has finished successfully.
         if (edge.data?.boundaryPayload === 'workflow-output') {

--- a/packages/playground/src/domains/workflows/workflow/use-workflow-trigger.ts
+++ b/packages/playground/src/domains/workflows/workflow/use-workflow-trigger.ts
@@ -1,4 +1,4 @@
-import type { GetWorkflowResponse } from '@mastra/client-js';
+import type { GetWorkflowResponse, TimeTravelParams } from '@mastra/client-js';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { useCallback, useContext, useMemo } from 'react';
 import { parse } from 'superjson';
@@ -73,9 +73,12 @@ export function useWorkflowSchemas(workflow?: GetWorkflowResponse) {
 function useWorkflowStepGraphInfo(stepGraph: GetWorkflowResponse['stepGraph'] | undefined) {
   return useMemo(() => {
     const { nodes, edges } = constructNodesAndEdges({ stepGraph });
-    const stepNodesInOrder = nodes
-      .filter(node => node.type === WORKFLOW_STEP_NODE_TYPE && node.data?.nodeRole !== 'condition' && node.data?.stepId)
-      .map(node => node.data.stepId as string);
+    const stepNodesInOrder = nodes.flatMap(node => {
+      if (node.type !== WORKFLOW_STEP_NODE_TYPE || node.data.nodeRole === 'condition' || !node.data.stepId) {
+        return [];
+      }
+      return [node.data.stepId];
+    });
 
     const stepsFlow = buildStepsFlow(edges);
     const stepSuccessors = buildStepSuccessors(stepsFlow);
@@ -204,12 +207,12 @@ export function useNextPerStep() {
         perStep: !runToFinish,
         ...(stepPayload.hasMultiSteps
           ? {
-              context: Object.keys(stepPayload.input).reduce(
+              context: Object.keys(stepPayload.input).reduce<NonNullable<TimeTravelParams['context']>>(
                 (acc, stepId) => {
-                  acc[stepId] = { output: stepPayload.input[stepId] };
+                  acc[stepId] = { status: 'success', output: stepPayload.input[stepId] };
                   return acc;
                 },
-                {} as Record<string, any>,
+                {},
               ),
             }
           : {}),

--- a/packages/playground/src/domains/workflows/workflow/utils.ts
+++ b/packages/playground/src/domains/workflows/workflow/utils.ts
@@ -1,12 +1,14 @@
 import Dagre from '@dagrejs/dagre';
 import type { Workflow, SerializedStepFlowEntry } from '@mastra/core/workflows';
-import type { Node, Edge } from '@xyflow/react';
+import type { Node } from '@xyflow/react';
 import { MarkerType } from '@xyflow/react';
+import type { WorkflowDataEdgeModel } from './workflow-data-edge';
 import {
   resolveWorkflowGraphStep,
   WORKFLOW_BOUNDARY_NODE_TYPE,
   WORKFLOW_STEP_NODE_TYPE,
 } from './workflow-step-node-utils';
+import type { WorkflowBoundaryNode, WorkflowStepNode } from './workflow-step-node-utils';
 
 const getWorkflowBoundaryNodeId = (role: 'start' | 'end') => `boundary-${role}`;
 const WORKFLOW_START_NODE_ID = getWorkflowBoundaryNodeId('start');
@@ -16,7 +18,10 @@ const getWorkflowNodeId = (stepId: string) => `node-${stepId}`;
 const getWorkflowConditionNodeId = (conditionId: string) => `condition-node-${conditionId}`;
 const getWorkflowEdgeId = (source: string, target: string, domain = 'step') => `edge-${domain}-${source}-${target}`;
 
-const normalizeDuplicateEdgeIds = (edges: Edge[]): Edge[] => {
+export type WorkflowGraphNode = WorkflowStepNode | WorkflowBoundaryNode;
+export type WorkflowGraphEdge = WorkflowDataEdgeModel;
+
+const normalizeDuplicateEdgeIds = (edges: WorkflowGraphEdge[]): WorkflowGraphEdge[] => {
   const usedEdgeIds = new Set<string>();
 
   return edges.map(edge => {
@@ -40,7 +45,7 @@ const normalizeDuplicateEdgeIds = (edges: Edge[]): Edge[] => {
   });
 };
 
-const getNodeSize = (node: Node): { width: number; height: number } => {
+const getNodeSize = (node: WorkflowGraphNode): { width: number; height: number } => {
   if (node.type === WORKFLOW_BOUNDARY_NODE_TYPE) {
     return {
       width: node.measured?.width ?? 56,
@@ -110,7 +115,7 @@ const formatMappingLabel = (stepId: string, prevStepIds: string[], nextStepIds: 
   return `${fromLabel} → ${toLabel} Map`;
 };
 
-const getLayoutedElements = (nodes: Node[], edges: Edge[]) => {
+const getLayoutedElements = (nodes: WorkflowGraphNode[], edges: WorkflowGraphEdge[]) => {
   const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
   g.setGraph({ rankdir: 'TB' });
 
@@ -191,7 +196,7 @@ const getStepNodeAndEdge = ({
   nextStepFlow?: SerializedStepFlowEntry;
   condition?: { id: string; fn: string };
   allPrevNodeIds: Set<string>;
-}): { nodes: Node[]; edges: Edge[]; nextPrevNodeIds: string[]; nextPrevStepIds: string[] } => {
+}): { nodes: WorkflowStepNode[]; edges: WorkflowGraphEdge[]; nextPrevNodeIds: string[]; nextPrevStepIds: string[] } => {
   let nextNodeIds: string[] = [];
   let nextStepIds: string[] = [];
   if (nextStepFlow?.type === 'step' || nextStepFlow?.type === 'foreach' || nextStepFlow?.type === 'loop') {
@@ -228,27 +233,28 @@ const getStepNodeAndEdge = ({
       ? `${stepFlow.step.id}-${yIndex}`
       : stepFlow.step.id;
     const nodeId = getWorkflowNodeId(rawNodeId);
-    const nodes = [
-      ...(condition
-        ? [
-            {
-              id: getWorkflowConditionNodeId(condition.id),
-              position: { x: xIndex * 300, y: yIndex * 100 },
-              type: WORKFLOW_STEP_NODE_TYPE,
-              data: {
-                label: condition.id,
-                workflowStep: conditionWorkflowStep(condition),
-                nodeRole: 'condition',
-                previousStepId: prevStepIds[prevStepIds.length - 1],
-                nextStepId: stepFlow.step.id,
-                withoutTopHandle: !prevNodeIds.length,
-                withoutBottomHandle: !nextNodeIds.length,
-                isLarge: true,
-                conditions: [{ type: 'when', fnString: condition.fn }],
-              },
+    const conditionNodes: WorkflowStepNode[] = condition
+      ? [
+          {
+            id: getWorkflowConditionNodeId(condition.id),
+            position: { x: xIndex * 300, y: yIndex * 100 },
+            type: WORKFLOW_STEP_NODE_TYPE,
+            data: {
+              label: condition.id,
+              workflowStep: conditionWorkflowStep(condition),
+              nodeRole: 'condition',
+              previousStepId: prevStepIds[prevStepIds.length - 1],
+              nextStepId: stepFlow.step.id,
+              withoutTopHandle: !prevNodeIds.length,
+              withoutBottomHandle: !nextNodeIds.length,
+              isLarge: true,
+              conditions: [{ type: 'when', fnString: condition.fn }],
             },
-          ]
-        : []),
+          },
+        ]
+      : [];
+    const nodes: WorkflowStepNode[] = [
+      ...conditionNodes,
       {
         id: nodeId,
         position: { x: xIndex * 300, y: (yIndex + (condition ? 1 : 0)) * 100 },
@@ -268,7 +274,7 @@ const getStepNodeAndEdge = ({
         },
       },
     ];
-    const edges = [
+    const edges: WorkflowGraphEdge[] = [
       ...(condition
         ? [
             ...(prevNodeIds || []).map((prevNodeId, i) => ({
@@ -311,27 +317,28 @@ const getStepNodeAndEdge = ({
   if (stepFlow.type === 'sleep' || stepFlow.type === 'sleepUntil') {
     const rawNodeId = allPrevNodeIds.has(getWorkflowNodeId(stepFlow.id)) ? `${stepFlow.id}-${yIndex}` : stepFlow.id;
     const nodeId = getWorkflowNodeId(rawNodeId);
-    const nodes = [
-      ...(condition
-        ? [
-            {
-              id: getWorkflowConditionNodeId(condition.id),
-              position: { x: xIndex * 300, y: yIndex * 100 },
-              type: WORKFLOW_STEP_NODE_TYPE,
-              data: {
-                label: condition.id,
-                workflowStep: conditionWorkflowStep(condition),
-                nodeRole: 'condition',
-                previousStepId: prevStepIds[prevStepIds.length - 1],
-                nextStepId: stepFlow.id,
-                withoutTopHandle: false,
-                withoutBottomHandle: !nextNodeIds.length,
-                isLarge: true,
-                conditions: [{ type: 'when', fnString: condition.fn }],
-              },
+    const conditionNodes: WorkflowStepNode[] = condition
+      ? [
+          {
+            id: getWorkflowConditionNodeId(condition.id),
+            position: { x: xIndex * 300, y: yIndex * 100 },
+            type: WORKFLOW_STEP_NODE_TYPE,
+            data: {
+              label: condition.id,
+              workflowStep: conditionWorkflowStep(condition),
+              nodeRole: 'condition',
+              previousStepId: prevStepIds[prevStepIds.length - 1],
+              nextStepId: stepFlow.id,
+              withoutTopHandle: false,
+              withoutBottomHandle: !nextNodeIds.length,
+              isLarge: true,
+              conditions: [{ type: 'when', fnString: condition.fn }],
             },
-          ]
-        : []),
+          },
+        ]
+      : [];
+    const nodes: WorkflowStepNode[] = [
+      ...conditionNodes,
       {
         id: nodeId,
         position: { x: xIndex * 300, y: (yIndex + (condition ? 1 : 0)) * 100 },
@@ -346,7 +353,7 @@ const getStepNodeAndEdge = ({
         },
       },
     ];
-    const edges = [
+    const edges: WorkflowGraphEdge[] = [
       ...(!prevNodeIds.length
         ? []
         : condition
@@ -394,7 +401,7 @@ const getStepNodeAndEdge = ({
     const { step: _step, serializedCondition, loopType } = stepFlow;
     const nodeId = getWorkflowNodeId(_step.id);
     const conditionNodeId = getWorkflowConditionNodeId(serializedCondition.id);
-    const nodes = [
+    const nodes: WorkflowStepNode[] = [
       {
         id: nodeId,
         position: { x: xIndex * 300, y: yIndex * 100 },
@@ -430,7 +437,7 @@ const getStepNodeAndEdge = ({
       },
     ];
 
-    const edges = [
+    const edges: WorkflowGraphEdge[] = [
       ...(!prevNodeIds.length
         ? []
         : prevNodeIds.map((prevNodeId, i) => ({
@@ -462,8 +469,8 @@ const getStepNodeAndEdge = ({
   }
 
   if (stepFlow.type === 'parallel') {
-    let nodes: Node[] = [];
-    let edges: Edge[] = [];
+    let nodes: WorkflowStepNode[] = [];
+    let edges: WorkflowGraphEdge[] = [];
     let nextPrevStepIds: string[] = [];
     stepFlow.steps.forEach((_stepFlow, index) => {
       const {
@@ -480,7 +487,7 @@ const getStepNodeAndEdge = ({
         allPrevNodeIds,
       });
       // Mark nodes as part of parallel execution
-      const markedNodes = _nodes.map(node => ({
+      const markedNodes: WorkflowStepNode[] = _nodes.map(node => ({
         ...node,
         data: {
           ...node.data,
@@ -496,8 +503,8 @@ const getStepNodeAndEdge = ({
   }
 
   if (stepFlow.type === 'conditional') {
-    let nodes: Node[] = [];
-    let edges: Edge[] = [];
+    let nodes: WorkflowStepNode[] = [];
+    let edges: WorkflowGraphEdge[] = [];
     let nextPrevStepIds: string[] = [];
     stepFlow.steps.forEach((_stepFlow, index) => {
       const {
@@ -534,7 +541,7 @@ export const constructNodesAndEdges = ({
   stepGraph,
 }: {
   stepGraph?: Workflow['serializedStepGraph'];
-}): { nodes: Node[]; edges: Edge[] } => {
+}): { nodes: WorkflowGraphNode[]; edges: WorkflowGraphEdge[] } => {
   if (!stepGraph) {
     return { nodes: [], edges: [] };
   }
@@ -543,8 +550,8 @@ export const constructNodesAndEdges = ({
     return { nodes: [], edges: [] };
   }
 
-  let nodes: Node[] = [];
-  let edges: Edge[] = [];
+  let nodes: WorkflowStepNode[] = [];
+  let edges: WorkflowGraphEdge[] = [];
 
   let prevNodeIds: string[] = [];
   let prevStepIds: string[] = [];
@@ -590,7 +597,7 @@ export const constructNodesAndEdges = ({
     },
   }));
 
-  nodes = [
+  const graphNodes: WorkflowGraphNode[] = [
     {
       id: WORKFLOW_START_NODE_ID,
       position: { x: 0, y: 0 },
@@ -606,46 +613,46 @@ export const constructNodesAndEdges = ({
     },
   ];
 
-  edges = [
-    ...sourceNodeIds.map(nodeId => ({
-      id: getWorkflowEdgeId(WORKFLOW_START_NODE_ID, nodeId, 'boundary'),
-      source: WORKFLOW_START_NODE_ID,
-      target: nodeId,
-      data: {
-        boundaryPayload: 'workflow-input',
-        nextStepId: (() => {
-          const targetNode = nodes.find(node => node.id === nodeId);
-          return targetNode?.data.stepId ?? targetNode?.data.nextStepId ?? nodeId;
-        })(),
-      },
-      ...defaultEdgeOptions,
-    })),
-    ...edges,
-    ...terminalNodeIds.map(nodeId => ({
-      id: getWorkflowEdgeId(nodeId, WORKFLOW_END_NODE_ID, 'boundary'),
-      source: nodeId,
-      target: WORKFLOW_END_NODE_ID,
-      data: { boundaryPayload: 'workflow-output' },
-      ...defaultEdgeOptions,
-    })),
-  ];
+  const sourceBoundaryEdges: WorkflowGraphEdge[] = sourceNodeIds.map(nodeId => ({
+    id: getWorkflowEdgeId(WORKFLOW_START_NODE_ID, nodeId, 'boundary'),
+    source: WORKFLOW_START_NODE_ID,
+    target: nodeId,
+    data: {
+      boundaryPayload: 'workflow-input',
+      nextStepId: (() => {
+        const targetNode = graphNodes.find(node => node.id === nodeId);
+        if (targetNode?.type !== WORKFLOW_STEP_NODE_TYPE) return nodeId;
+        return targetNode?.data.stepId ?? targetNode?.data.nextStepId ?? nodeId;
+      })(),
+    },
+    ...defaultEdgeOptions,
+  }));
+  const terminalBoundaryEdges: WorkflowGraphEdge[] = terminalNodeIds.map(nodeId => ({
+    id: getWorkflowEdgeId(nodeId, WORKFLOW_END_NODE_ID, 'boundary'),
+    source: nodeId,
+    target: WORKFLOW_END_NODE_ID,
+    data: { boundaryPayload: 'workflow-output' },
+    ...defaultEdgeOptions,
+  }));
+
+  edges = [...sourceBoundaryEdges, ...edges, ...terminalBoundaryEdges];
 
   edges = normalizeDuplicateEdgeIds(edges);
 
-  const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(nodes, edges);
+  const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(graphNodes, edges);
 
   return { nodes: layoutedNodes, edges: layoutedEdges };
 };
 
-export const buildStepsFlow = (edges: Edge[]): Record<string, string[]> =>
+export const buildStepsFlow = (edges: WorkflowGraphEdge[]): Record<string, string[]> =>
   edges.reduce(
     (acc, edge) => {
       if (!edge.data || edge.data.boundaryPayload) {
         return acc;
       }
 
-      const stepId = edge.data.nextStepId as string;
-      const prevStepId = edge.data.previousStepId as string;
+      const stepId = edge.data?.nextStepId;
+      const prevStepId = edge.data?.previousStepId;
 
       if (!stepId || !prevStepId) {
         return acc;
@@ -846,13 +853,10 @@ export const buildNextStepInput = ({
       hasMultiSteps: true,
       input: previousSteps
         .filter(stepId => steps?.[stepId]?.status === 'success')
-        .reduce(
-          (acc, stepId) => {
-            acc[stepId] = steps?.[stepId]?.output;
-            return acc;
-          },
-          {} as Record<string, any>,
-        ),
+        .reduce<Record<string, unknown>>((acc, stepId) => {
+          acc[stepId] = steps?.[stepId]?.output;
+          return acc;
+        }, {}),
     };
   }
 

--- a/packages/playground/src/domains/workflows/workflow/workflow-data-edge.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-data-edge.tsx
@@ -1,5 +1,5 @@
 import { BaseEdge, EdgeLabelRenderer, getBezierPath } from '@xyflow/react';
-import type { EdgeProps } from '@xyflow/react';
+import type { Edge, EdgeProps } from '@xyflow/react';
 import { memo, useContext } from 'react';
 
 import { useCurrentRun } from '../context/use-current-run';
@@ -9,6 +9,7 @@ import { WorkflowEdgeDataButton } from './components/workflow-edge-data-button';
 export const WORKFLOW_DATA_EDGE_TYPE = 'workflow-data-edge';
 
 export interface WorkflowDataEdgeData {
+  [key: string]: unknown;
   previousStepId?: string;
   nextStepId?: string;
   conditionNode?: boolean;
@@ -16,7 +17,9 @@ export interface WorkflowDataEdgeData {
   edgeStatus?: 'success' | 'idle';
 }
 
-export interface WorkflowDataEdgeProps extends EdgeProps {
+export type WorkflowDataEdgeModel = Edge<WorkflowDataEdgeData, typeof WORKFLOW_DATA_EDGE_TYPE>;
+
+export interface WorkflowDataEdgeProps extends EdgeProps<WorkflowDataEdgeModel> {
   parentWorkflowName?: string;
 }
 
@@ -26,7 +29,7 @@ const getScopedStepId = (stepId: string | undefined, workflowName?: string) =>
 const WorkflowDataEdgeComponent = (props: WorkflowDataEdgeProps) => {
   const { steps } = useCurrentRun();
   const workflowRun = useContext(WorkflowRunContext);
-  const data = props.data as WorkflowDataEdgeData | undefined;
+  const data = props.data;
   const previousStepKey = getScopedStepId(data?.previousStepId, props.parentWorkflowName);
   const previousStep = previousStepKey ? steps[previousStepKey] : undefined;
   const workflowInput = workflowRun.payload ?? workflowRun.result?.input;

--- a/packages/playground/src/domains/workflows/workflow/workflow-graph-inner.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-graph-inner.tsx
@@ -8,6 +8,7 @@ import { useWorkflowSelectedStep } from '../context/use-workflow-selected-step';
 import { useWorkflowGraphRuntime } from './use-workflow-graph-runtime';
 import { useSuspendedStepKey, useWaitingStepKey } from './use-workflow-trigger';
 import { constructNodesAndEdges, findFocusNode } from './utils';
+import type { WorkflowGraphEdge, WorkflowGraphNode } from './utils';
 import { ZoomSlider } from './zoom-slider';
 
 export interface WorkflowGraphInnerProps {
@@ -18,8 +19,8 @@ export interface WorkflowGraphInnerProps {
 
 export function WorkflowGraphInner({ workflow }: WorkflowGraphInnerProps) {
   const { nodes: initialNodes, edges: initialEdges } = constructNodesAndEdges(workflow);
-  const [nodes, _, onNodesChange] = useNodesState(initialNodes);
-  const [edges] = useEdgesState(initialEdges);
+  const [nodes, _, onNodesChange] = useNodesState<WorkflowGraphNode>(initialNodes);
+  const [edges] = useEdgesState<WorkflowGraphEdge>(initialEdges);
   const { edgeTypes, nodeTypes, styledEdges } = useWorkflowGraphRuntime({ edges });
 
   const graphRef = useRef<HTMLDivElement>(null);

--- a/packages/playground/src/domains/workflows/workflow/workflow-nested-graph.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-nested-graph.tsx
@@ -6,6 +6,7 @@ import '@xyflow/react/dist/style.css';
 import { useEffect, useState } from 'react';
 import { useWorkflowGraphRuntime } from './use-workflow-graph-runtime';
 import { constructNodesAndEdges } from './utils';
+import type { WorkflowGraphEdge, WorkflowGraphNode } from './utils';
 import { ZoomSlider } from './zoom-slider';
 
 export interface WorkflowNestedGraphProps {
@@ -19,8 +20,8 @@ export function WorkflowNestedGraph({ stepGraph, open, workflowName }: WorkflowN
     stepGraph,
   });
   const [isMounted, setIsMounted] = useState(false);
-  const [nodes, _, onNodesChange] = useNodesState(initialNodes);
-  const [edges] = useEdgesState(initialEdges);
+  const [nodes, _, onNodesChange] = useNodesState<WorkflowGraphNode>(initialNodes);
+  const [edges] = useEdgesState<WorkflowGraphEdge>(initialEdges);
   const { edgeTypes, nodeTypes, styledEdges } = useWorkflowGraphRuntime({ edges, workflowName, stepGraph });
 
   useEffect(() => {

--- a/packages/playground/src/domains/workflows/workflow/workflow-step-action-bar.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-step-action-bar.tsx
@@ -1,3 +1,4 @@
+import type { TimeTravelParams } from '@mastra/client-js';
 import type { WorkflowRunStatus } from '@mastra/core/workflows';
 import { Button } from '@mastra/playground-ui';
 import {
@@ -95,15 +96,12 @@ export const WorkflowStepActionBar = ({
     if (previousSteps.length > 1) {
       return {
         hasMultiSteps: true,
-        input: previousSteps.reduce(
-          (acc, stepId) => {
-            if (result?.steps?.[stepId]?.status === 'success') {
-              acc[stepId] = result?.steps?.[stepId].output;
-            }
-            return acc;
-          },
-          {} as Record<string, any>,
-        ),
+        input: previousSteps.reduce<Record<string, unknown>>((acc, stepId) => {
+          if (result?.steps?.[stepId]?.status === 'success') {
+            acc[stepId] = result?.steps?.[stepId].output;
+          }
+          return acc;
+        }, {}),
       };
     }
 
@@ -141,24 +139,24 @@ export const WorkflowStepActionBar = ({
   };
 
   const handleRunMapStep = (isContinueRun?: boolean) => {
+    if (!stepKey || !stepPayload) return;
+
     const payload = {
       runId: prevRunId,
       workflowId,
-      step: stepKey as string,
+      step: stepKey,
       inputData: stepPayload?.hasMultiSteps ? undefined : stepPayload?.input,
       requestContext: requestContext,
       ...(isContinueRun ? { perStep: false } : {}),
       ...(stepPayload?.hasMultiSteps
         ? {
-            context: Object.keys(stepPayload.input)?.reduce(
-              (acc, stepId) => {
-                acc[stepId] = {
-                  output: stepPayload.input[stepId],
-                };
-                return acc;
-              },
-              {} as Record<string, any>,
-            ),
+            context: Object.keys(stepPayload.input)?.reduce<NonNullable<TimeTravelParams['context']>>((acc, stepId) => {
+              acc[stepId] = {
+                status: 'success',
+                output: stepPayload.input[stepId],
+              };
+              return acc;
+            }, {}),
           }
         : {}),
     };

--- a/packages/playground/src/domains/workflows/workflow/workflow-timeline.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-timeline.tsx
@@ -27,6 +27,7 @@ const StepStatusIcon = ({ status }: { status: Step['status'] }) => (
     {status === 'failed' && <CrossIcon className="text-accent2" />}
     {status === 'suspended' && <CirclePause className="text-accent3" />}
     {status === 'waiting' && <HourglassIcon className="text-accent5" />}
+    {status === 'skipped' && <HourglassIcon className="text-icon3" />}
     {status === 'running' && <Loader2 className="text-accent6 animate-spin" />}
   </Icon>
 );
@@ -36,6 +37,7 @@ const BAR_TINT: Record<Step['status'], string> = {
   failed: 'bg-accent2',
   suspended: 'bg-accent3',
   waiting: 'bg-accent5',
+  skipped: 'bg-border1',
   running: 'bg-accent6',
 };
 


### PR DESCRIPTION
Stacks on #18228 and removes the workflow graph as casts by preserving typed React Flow node and edge data through graph construction and runtime rendering.

It also builds time-travel context payloads with explicit status: success, matching TimeTravelParams instead of asserting Record<string, any>.

Validated with pnpm --filter ./packages/playground typecheck and package-local Vitest workflow tests.