### PR TITLE
chore(playground): debarrel cn imports

### DIFF
--- a/.changeset/gold-buttons-shop.md
+++ b/.changeset/gold-buttons-shop.md
@@ -2,4 +2,8 @@
 '@mastra/playground-ui': patch
 ---
 
-Added a direct utility import for cn.
+Added a direct utility import for the class name helper so applications can avoid the root Playground UI barrel.
+
+```ts
+import { cn } from '@mastra/playground-ui/utils/cn';
+```

--- a/.changeset/gold-buttons-shop.md
+++ b/.changeset/gold-buttons-shop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added a direct utility import for cn.

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -43,6 +43,16 @@
         "default": "./dist/utils.cjs.js"
       }
     },
+    "./utils/*": {
+      "import": {
+        "types": "./dist/utils/*.d.ts",
+        "default": "./dist/utils/*.es.js"
+      },
+      "require": {
+        "types": "./dist/utils/*.d.ts",
+        "default": "./dist/utils/*.cjs.js"
+      }
+    },
     "./hooks/*": {
       "import": {
         "types": "./dist/hooks/*.d.ts",

--- a/packages/playground-ui/src/utils/cn.ts
+++ b/packages/playground-ui/src/utils/cn.ts
@@ -1,0 +1,1 @@
+export { cn } from '../lib/utils';

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -40,6 +40,22 @@ const hookEntries = Object.fromEntries(
     }),
 );
 
+// Public utility subpath entries, exposed as
+// `@mastra/playground-ui/utils/<utility-file>` via the `./utils/*` package export.
+const utilsDir = resolve(__dirname, 'src/utils');
+const utilityEntries = Object.fromEntries(
+  readdirSync(utilsDir, { withFileTypes: true })
+    .filter(dirent => dirent.isFile())
+    .map(dirent => dirent.name)
+    .filter(
+      fileName => /\.(ts|tsx)$/.test(fileName) && !fileName.endsWith('.test.tsx') && !fileName.endsWith('.test.ts'),
+    )
+    .map(fileName => {
+      const entryName = fileName.replace(/\.(ts|tsx)$/, '');
+      return [`utils/${entryName}`, resolve(utilsDir, fileName)] as const;
+    }),
+);
+
 const baseConfig: UserConfig = {
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -76,6 +92,7 @@ const libConfig: UserConfig = {
         utils: resolve(__dirname, 'src/utils.ts'),
         tokens: resolve(__dirname, 'src/ds/tokens/index.ts'),
         // Slashed keys make Rollup emit nested output: dist/components/<Name>.<format>.js
+        ...utilityEntries,
         ...componentEntries,
         ...hookEntries,
       },

--- a/packages/playground/eslint.config.js
+++ b/packages/playground/eslint.config.js
@@ -27,6 +27,10 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import keyboard shortcut hooks from @mastra/playground-ui/hooks/use-keyboard-shortcut-label.',
   },
   {
+    importNames: ['cn'],
+    message: 'Import cn from @mastra/playground-ui/utils/cn.',
+  },
+  {
     importNames: ['AlertDialog'],
     message: 'Import AlertDialog from @mastra/playground-ui/components/AlertDialog.',
   },

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -1,8 +1,8 @@
-import { cn } from '@mastra/playground-ui';
 import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { MainSidebar, useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import type { NavLink } from '@mastra/playground-ui/components/MainSidebar';
 import { useKeyboardShortcutLabel } from '@mastra/playground-ui/hooks/use-keyboard-shortcut-label';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Search, Wrench } from 'lucide-react';
 import { useLocation } from 'react-router';
 import { useAgentBuilderSidebarVisibility } from '@/domains/agent-builder/hooks/use-agent-builder-sidebar-visibility';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-details.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-details.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { AgentBuilderEditFormValues } from '../../../schemas';
 

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
@@ -1,5 +1,6 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ArrowLeftIcon } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
 import { useNavigate, useParams } from 'react-router';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/filterable-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/filterable-list.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@mastra/playground-ui';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { CSSProperties, ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { useAgentColor } from '../../../contexts/agent-color-context';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tool-grid.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tool-grid.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { CSSProperties, ReactNode } from 'react';
 import { useAgentColor } from '../../../contexts/agent-color-context';
 import type { AgentTool } from '../../../types/agent-tool';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-filter-pane.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-filter-pane.tsx
@@ -1,8 +1,8 @@
-import { cn } from '@mastra/playground-ui';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { memo, useMemo, useState } from 'react';
 import { useToolkits } from '../../../../tool-providers/hooks/use-toolkits';
 import { useAgentColor } from '../../../contexts/agent-color-context';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-selectable-card.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-selectable-card.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Check } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
 import { useAgentColor } from '../../contexts/agent-color-context';

--- a/packages/playground/src/domains/agent-builder/components/agent-list/favorite-button.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/favorite-button.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Star } from 'lucide-react';
 import type { MouseEvent } from 'react';
 import { useBuilderAgentFeatures } from '@/domains/agent-builder';

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-textarea.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-textarea.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import type { TextareaProps } from '@mastra/playground-ui/components/Textarea';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { forwardRef } from 'react';
 
 export type ChatTextareaProps = Omit<TextareaProps, 'size' | 'variant' | 'rows'>;

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -1,11 +1,12 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
-import { cn, Icon } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Card } from '@mastra/playground-ui/components/Card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { MessageFactory } from '@mastra/react';
 import type {
   MastraDBMessageMetadata,

--- a/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
@@ -1,5 +1,5 @@
 import type { BuilderRegistrySkillSummary } from '@mastra/client-js';
-import { SkillIcon, cn } from '@mastra/playground-ui';
+import { SkillIcon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import {
   Dialog,
@@ -12,6 +12,7 @@ import {
 import { Input } from '@mastra/playground-ui/components/Input';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Check, Download, ExternalLink, Github, Loader2, Package, Search } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';

--- a/packages/playground/src/domains/agent-builder/components/skill-list/skill-favorite-button.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/skill-favorite-button.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Star } from 'lucide-react';
 import type { MouseEvent } from 'react';
 import { useBuilderAgentFeatures } from '@/domains/agent-builder';

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-edit-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-edit-layout.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { ReactNode } from 'react';
 
 export interface AgentBuilderEditLayoutProps {

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-sidebar.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-sidebar.tsx
@@ -1,7 +1,8 @@
-import { AgentIcon, cn } from '@mastra/playground-ui';
+import { AgentIcon } from '@mastra/playground-ui';
 import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { MainSidebar, useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import type { NavLink } from '@mastra/playground-ui/components/MainSidebar';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Blocks, LibraryIcon, ServerCogIcon, StarIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useLocation } from 'react-router';

--- a/packages/playground/src/domains/agent-builder/layouts/skill-workspace-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/skill-workspace-layout.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ArrowLeftIcon } from 'lucide-react';
 import { useState } from 'react';
 import type { ReactNode } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
@@ -1,6 +1,6 @@
 import type { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
 import type { RuleGroup, JsonSchema } from '@mastra/playground-ui';
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { ContentBlock } from '@mastra/playground-ui/components/ContentBlocks';
@@ -17,6 +17,7 @@ import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { GripVertical, X, BookmarkPlus } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
@@ -1,7 +1,8 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import type { JsonSchema } from '@mastra/playground-ui';
 import { ContentBlocks } from '@mastra/playground-ui/components/ContentBlocks';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { FileText, PenLine, PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import type { InstructionBlock } from '../agent-edit-page/utils/form-validation';

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
@@ -1,5 +1,5 @@
 import type { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import type { JsonSchema } from '@mastra/playground-ui';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { ContentBlock } from '@mastra/playground-ui/components/ContentBlocks';
@@ -7,6 +7,7 @@ import { Popover, PopoverTrigger, PopoverContent } from '@mastra/playground-ui/c
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { GripVertical, X, ExternalLink, ChevronDown } from 'lucide-react';
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/prompt-block-picker-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/prompt-block-picker-dialog.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@mastra/playground-ui';
 import {
   Dialog,
   DialogContent,
@@ -9,6 +8,7 @@ import {
 } from '@mastra/playground-ui/components/Dialog';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { FileText, Search } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/domains/agents/components/agent-cms-layout/agent-cms-layout.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-layout/agent-cms-layout.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { AgentCmsSidebar } from '../agent-cms-sidebar';
 import { AgentCmsBottomBar } from './agent-cms-bottom-bar';
 

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
@@ -1,10 +1,11 @@
-import { AgentIcon, cn } from '@mastra/playground-ui';
+import { AgentIcon } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
 import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { Switch } from '@mastra/playground-ui/components/Switch';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
@@ -1,4 +1,4 @@
-import { JudgeIcon, cn } from '@mastra/playground-ui';
+import { JudgeIcon } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
 import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
 import { Input } from '@mastra/playground-ui/components/Input';
@@ -8,6 +8,7 @@ import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { Switch } from '@mastra/playground-ui/components/Switch';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
@@ -1,4 +1,4 @@
-import { Icon, ToolsIcon, cn } from '@mastra/playground-ui';
+import { Icon, ToolsIcon } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
@@ -6,6 +6,7 @@ import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Popover, PopoverTrigger, PopoverContent } from '@mastra/playground-ui/components/Popover';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { PlusIcon, XIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
@@ -1,10 +1,11 @@
-import { WorkflowIcon, cn } from '@mastra/playground-ui';
+import { WorkflowIcon } from '@mastra/playground-ui';
 import type { RuleGroup } from '@mastra/playground-ui';
 import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
 import { Switch } from '@mastra/playground-ui/components/Switch';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agents/components/agent-cms-sidebar/agent-cms-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-sidebar/agent-cms-sidebar.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Check } from 'lucide-react';
 import { useMemo } from 'react';
 

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-list.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
 export interface AgentMetadataListProps {
   children: React.ReactNode;

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
@@ -1,4 +1,4 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import type { JsonSchema, JsonSchemaProperty } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
@@ -6,6 +6,7 @@ import { HoverPopover, PopoverTrigger, PopoverContent } from '@mastra/playground
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Braces, ChevronDown, ChevronRight, Wrench, Cpu, Eye, Pencil } from 'lucide-react';
 import { useState, useMemo } from 'react';
 

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
@@ -1,4 +1,4 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
@@ -8,6 +8,7 @@ import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import {

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
@@ -1,4 +1,4 @@
-import { Icon, toast, cn } from '@mastra/playground-ui';
+import { Icon, toast } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
@@ -17,6 +17,7 @@ import { Label } from '@mastra/playground-ui/components/Label';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMastraClient } from '@mastra/react';
 import {
   CheckCircle,

--- a/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -1,4 +1,4 @@
-import { Icon, toast, cn } from '@mastra/playground-ui';
+import { Icon, toast } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Chip } from '@mastra/playground-ui/components/Chip';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
@@ -8,6 +8,7 @@ import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useQueryClient } from '@tanstack/react-query';
 import { Play, Sparkles, Clock, ChevronRight, ChevronDown, Pencil, Save, X, Trash2 } from 'lucide-react';
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/scorer-mini-editor.tsx
@@ -1,4 +1,4 @@
-import { Icon, toast, cn } from '@mastra/playground-ui';
+import { Icon, toast } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Input } from '@mastra/playground-ui/components/Input';
@@ -7,6 +7,7 @@ import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMastraClient } from '@mastra/react';
 import { ArrowLeft, Play, Save, Plus, Trash2, CheckCircle2, XCircle, AlertCircle } from 'lucide-react';
 import { useState, useCallback, useEffect } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-settings/agent-memory-config.tsx
+++ b/packages/playground/src/domains/agents/components/agent-settings/agent-memory-config.tsx
@@ -1,6 +1,6 @@
 import type { SemanticRecall } from '@mastra/core/memory';
-import { cn } from '@mastra/playground-ui';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronRight, ChevronDown } from 'lucide-react';
 import { useState, useMemo } from 'react';
 import { useMemoryConfig } from '@/domains/memory/hooks';

--- a/packages/playground/src/domains/agents/components/agent-version-panel.tsx
+++ b/packages/playground/src/domains/agents/components/agent-version-panel.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useAgentVersions } from '../hooks/use-agent-versions';
 
 function formatTimestamp(isoString: string): string {

--- a/packages/playground/src/domains/agents/components/browser-view/browser-thumbnail.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-thumbnail.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Monitor, ChevronUp, ChevronDown, Maximize2, X } from 'lucide-react';
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useBrowserFrame, useBrowserSession } from '../../context/browser-session-context';

--- a/packages/playground/src/domains/agents/components/browser-view/browser-tool-call-history.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-tool-call-history.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronDown } from 'lucide-react';
 import { useRef, useEffect, useState } from 'react';
 import { useBrowserToolCalls } from '../../context/browser-tool-calls-context';

--- a/packages/playground/src/domains/agents/components/browser-view/browser-tool-call-item.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-tool-call-item.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronRight, Check, X, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import type { BrowserToolCallEntry } from '../../context/browser-tool-calls-context';

--- a/packages/playground/src/domains/agents/components/browser-view/browser-view-frame.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-view-frame.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useBrowserFrame, useBrowserSession } from '../../context/browser-session-context';
 import type { StreamStatus } from '../../hooks/use-browser-stream';

--- a/packages/playground/src/domains/agents/components/browser-view/browser-view-header.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-view-header.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { X, ChevronDown, ChevronUp, Minus } from 'lucide-react';
 import type { StreamStatus } from '../../hooks/use-browser-stream';
 

--- a/packages/playground/src/domains/agents/components/browser-view/browser-view-panel.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-view-panel.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { X, Minimize2, ExternalLink, Globe } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { useBrowserSession } from '../../context/browser-session-context';

--- a/packages/playground/src/domains/agents/components/composer-model-settings.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-settings.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { Dialog, DialogBody, DialogContent, DialogHeader, DialogTitle } from '@mastra/playground-ui/components/Dialog';
@@ -10,6 +9,7 @@ import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Slider } from '@mastra/playground-ui/components/Slider';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Info, Sliders } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
@@ -1,5 +1,5 @@
 import type { UpdateModelParams } from '@mastra/client-js';
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Lock, TriangleAlert } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { useAgent } from '../hooks/use-agent';

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ExternalLink, Copy } from 'lucide-react';
 import { useCallback } from 'react';
 import { AgentObservationalMemory } from './agent-observational-memory';

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
@@ -1,10 +1,11 @@
-import { toast, cn } from '@mastra/playground-ui';
+import { toast } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { RefreshCcwIcon, ExternalLink } from 'lucide-react';
 import { useState } from 'react';
 import { useWorkingMemory } from '../../context/agent-working-memory-context';

--- a/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
@@ -1,9 +1,10 @@
 import type { StorageThreadType } from '@mastra/core/memory';
-import { MemoryIcon, cn } from '@mastra/playground-ui';
+import { MemoryIcon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronDown, ChevronUp, Eye, MessageSquare, NotebookPen, Search } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useLayoutEffect, useRef, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/request-context-run-options.tsx
+++ b/packages/playground/src/domains/agents/components/request-context-run-options.tsx
@@ -1,7 +1,8 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { FileJson, FormInput } from 'lucide-react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/request-context.tsx
+++ b/packages/playground/src/domains/agents/components/request-context.tsx
@@ -1,11 +1,12 @@
 import { jsonLanguage } from '@codemirror/lang-json';
-import { Icon, cn, formatJSON, isValidJson, toast } from '@mastra/playground-ui';
+import { Icon, formatJSON, isValidJson, toast } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import CodeMirror from '@uiw/react-codemirror';
 import { Braces, CopyIcon, ExternalLink, X } from 'lucide-react';
 import type { ReactNode } from 'react';

--- a/packages/playground/src/domains/agents/components/sidebar-panel.tsx
+++ b/packages/playground/src/domains/agents/components/sidebar-panel.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { ReactNode } from 'react';
 
 export function SidebarPanel({ children, className }: { children: ReactNode; className?: string }) {

--- a/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
+++ b/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
@@ -1,8 +1,9 @@
-import { Icon, RuleBuilder, countLeafRules, cn } from '@mastra/playground-ui';
+import { Icon, RuleBuilder, countLeafRules } from '@mastra/playground-ui';
 import type { JsonSchema, RuleGroup } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronRight, Ruler, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/domains/cms/components/section/section-header.tsx
+++ b/packages/playground/src/domains/cms/components/section/section-header.tsx
@@ -1,5 +1,6 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
 export type SectionHeaderProps = {
   title: React.ReactNode;

--- a/packages/playground/src/domains/cms/components/section/section-title.tsx
+++ b/packages/playground/src/domains/cms/components/section/section-title.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
 export type SectionTitleProps = {
   icon?: React.ReactNode;

--- a/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@mastra/playground-ui';
 import { CodeBlock } from '@mastra/playground-ui/components/CodeBlock';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import {
@@ -13,6 +12,7 @@ import {
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { MoveRight, ExternalLink, Info } from 'lucide-react';
 import { useState } from 'react';
 import { useMastraPackages } from '../hooks/use-mastra-packages';

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-upload-step.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-upload-step.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Upload } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 

--- a/packages/playground/src/domains/datasets/components/csv-import/validation-report.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/validation-report.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { AlertTriangleIcon, CheckCircleIcon } from 'lucide-react';
 import type { CsvValidationResult, RowValidationResult } from '../../utils/csv-validation';
 

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-comparison.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-comparison.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Chip, ChipsGroup } from '@mastra/playground-ui/components/Chip';
 import { Columns } from '@mastra/playground-ui/components/Columns';
@@ -6,6 +5,7 @@ import { ItemList } from '@mastra/playground-ui/components/ItemList';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useState, useMemo } from 'react';
 import { useCompareExperiments } from '../../hooks/use-compare-experiments';
 import { useDatasetExperiment } from '../../hooks/use-dataset-experiments';

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
@@ -1,9 +1,9 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { cn } from '@mastra/playground-ui';
 import { Chip } from '@mastra/playground-ui/components/Chip';
 import { DataList } from '@mastra/playground-ui/components/DataList';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { format, isThisYear, isToday } from 'date-fns';
 import { Play } from 'lucide-react';
 

--- a/packages/playground/src/domains/datasets/components/experiments/score-delta.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/score-delta.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Chip } from '@mastra/playground-ui/components/Chip';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ArrowDownIcon, ArrowUpIcon } from 'lucide-react';
 
 interface ScoreDeltaProps {

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-layout.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-layout.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { ReactNode } from 'react';
 
 export interface DatasetItemsLayoutProps {

--- a/packages/playground/src/domains/datasets/components/json-import/json-upload-step.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-upload-step.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { FileJson } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 

--- a/packages/playground/src/domains/datasets/components/schema-settings/schema-field.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-settings/schema-field.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { cn } from '@mastra/playground-ui';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { Switch } from '@mastra/playground-ui/components/Switch';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { JSONSchema7 } from 'json-schema';
 import { useState, useEffect, useRef } from 'react';
 

--- a/packages/playground/src/domains/datasets/components/versions/dataset-compare-versions-list.tsx
+++ b/packages/playground/src/domains/datasets/components/versions/dataset-compare-versions-list.tsx
@@ -1,8 +1,8 @@
 import type { DatasetItem } from '@mastra/client-js';
-import { cn } from '@mastra/playground-ui';
 import { Chip } from '@mastra/playground-ui/components/Chip';
 import { ItemList } from '@mastra/playground-ui/components/ItemList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { BanIcon, EqualIcon, PenIcon, PlusIcon } from 'lucide-react';
 import { useLinkComponent } from '@/lib/framework';
 

--- a/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
@@ -6,7 +6,6 @@ import {
   Icon,
   SpanDataPanelView,
   TraceDataPanelView,
-  cn,
   toast,
   useSpanDetail,
   useTraceSpanNavigation,
@@ -15,6 +14,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Chip } from '@mastra/playground-ui/components/Chip';
 import { Tabs, Tab, TabList, TabContent } from '@mastra/playground-ui/components/Tabs';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ClipboardCheck } from 'lucide-react';
 import { useState, useMemo, useCallback } from 'react';
 

--- a/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
@@ -1,7 +1,7 @@
 import type { ClientScoreRowData, DatasetExperimentResult } from '@mastra/client-js';
-import { cn } from '@mastra/playground-ui';
 import { DataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
 export type ExperimentResultsListProps = {
   results: DatasetExperimentResult[];

--- a/packages/playground/src/domains/experiments/components/experiment-stats.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-stats.tsx
@@ -1,5 +1,5 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { CheckIcon, ClockIcon, TimerIcon, XIcon } from 'lucide-react';
 
 export interface ExperimentStatsProps {

--- a/packages/playground/src/domains/experiments/components/experiment-trace-span-type-icon.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-span-type-icon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
 type ExperimentTraceSpanTypeIconProps = {
   icon: React.ReactNode;

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-expand-col.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-expand-col.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronDownIcon, ChevronsDownIcon, ChevronsUpIcon, ChevronUpIcon } from 'lucide-react';
 
 type ExperimentTraceTimelineExpandColProps = {

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-name-col.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-name-col.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { ExperimentUISpan, ExperimentUISpanStyle } from '../types';
 import { ExperimentTraceTimelineStructureSign } from './experiment-trace-timeline-structure-sign';
 

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-structure-sign.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-structure-sign.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { CircleChevronDownIcon, CircleChevronUpIcon } from 'lucide-react';
 
 type ExperimentTraceTimelineStructureSignProps = {

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-timing-col.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-timing-col.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { KeyValueList } from '@mastra/playground-ui/components/KeyValueList';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import * as HoverCard from '@radix-ui/react-hover-card';
 import { format } from 'date-fns/format';
 import { ChevronFirstIcon, ChevronLastIcon, ChevronsLeftRightIcon, ChevronsRightIcon, TimerIcon } from 'lucide-react';

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { ExperimentUISpan } from '../types';
 import { ExperimentTraceTimelineSpan } from './experiment-trace-timeline-span';
 

--- a/packages/playground/src/domains/llm/components/llm-providers.tsx
+++ b/packages/playground/src/domains/llm/components/llm-providers.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@mastra/playground-ui';
 import { Combobox } from '@mastra/playground-ui/components/Combobox';
 import type { ComboboxOption, ComboboxProps } from '@mastra/playground-ui/components/Combobox';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Info } from 'lucide-react';
 import type { MouseEvent } from 'react';
 import { useMemo } from 'react';

--- a/packages/playground/src/domains/llm/components/provider-logo.tsx
+++ b/packages/playground/src/domains/llm/components/provider-logo.tsx
@@ -1,4 +1,5 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useState } from 'react';
 import type { CSSProperties } from 'react';
 import { cleanProviderId as cleanProviderIdUtil } from '../utils';

--- a/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-tool-preview.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-tool-preview.tsx
@@ -1,4 +1,4 @@
-import { Icon, McpServerIcon, ToolsIcon, cn } from '@mastra/playground-ui';
+import { Icon, McpServerIcon, ToolsIcon } from '@mastra/playground-ui';
 import {
   Entity,
   EntityContent,
@@ -9,6 +9,7 @@ import {
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { TryConnectMcpMutation } from '../../hooks/use-try-connect-mcp';
 
 interface MCPClientToolPreviewProps {

--- a/packages/playground/src/domains/metrics/components/metrics-toolbar.tsx
+++ b/packages/playground/src/domains/metrics/components/metrics-toolbar.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import type { PropertyFilterField, PropertyFilterToken } from '@mastra/playground-ui/components/PropertyFilter';
 import { PropertyFilterActions, PropertyFilterApplied } from '@mastra/playground-ui/components/PropertyFilter';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
 type MetricsToolbarProps = {
   /** Keep all filter pills but reset each value to its neutral state

--- a/packages/playground/src/domains/observability/components/tracing-run-options.tsx
+++ b/packages/playground/src/domains/observability/components/tracing-run-options.tsx
@@ -1,7 +1,7 @@
 import { jsonLanguage } from '@codemirror/lang-json';
-import { cn } from '@mastra/playground-ui';
 import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import CodeMirror from '@uiw/react-codemirror';
 import { useTracingSettings } from '@/domains/observability/context/tracing-settings-context';
 import { WorkflowRunOptions } from '@/domains/workflows/workflow/workflow-run-options';

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -1,4 +1,4 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
@@ -16,6 +16,7 @@ import { Label } from '@mastra/playground-ui/components/Label';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMastraClient } from '@mastra/react';
 import {
   CheckCircle,

--- a/packages/playground/src/domains/review/components/review-item-card.tsx
+++ b/packages/playground/src/domains/review/components/review-item-card.tsx
@@ -1,9 +1,10 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ThumbsUp, ThumbsDown, Trash2, CheckCircle, GaugeIcon } from 'lucide-react';
 import { useState } from 'react';
 import { TagPicker } from './tag-picker';

--- a/packages/playground/src/domains/scores/components/scores-list.tsx
+++ b/packages/playground/src/domains/scores/components/scores-list.tsx
@@ -1,7 +1,7 @@
 import type { ClientScoreRowData } from '@mastra/client-js';
 import type { ScoreRowData } from '@mastra/core/evals';
-import { cn } from '@mastra/playground-ui';
 import { ScoresDataList, DataListSkeleton } from '@mastra/playground-ui/components/DataList';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScoreDataPanel } from '@/domains/traces/components/score-data-panel';
 

--- a/packages/playground/src/domains/shared/components/review-item-card.tsx
+++ b/packages/playground/src/domains/shared/components/review-item-card.tsx
@@ -1,9 +1,10 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ThumbsUp, ThumbsDown, Trash2, CheckCircle } from 'lucide-react';
 import { useState } from 'react';
 import { TagPicker } from './tag-picker';

--- a/packages/playground/src/domains/templates/shared.tsx
+++ b/packages/playground/src/domains/templates/shared.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
 export function getRepoName(githubUrl: string) {
   return githubUrl.replace(/\/$/, '').split('/').pop();

--- a/packages/playground/src/domains/templates/template-failure.tsx
+++ b/packages/playground/src/domains/templates/template-failure.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { FrownIcon, AlertTriangleIcon } from 'lucide-react';
 import { Container } from './shared';
 

--- a/packages/playground/src/domains/templates/template-form.tsx
+++ b/packages/playground/src/domains/templates/template-form.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { SelectFieldBlock, TextFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ArrowRightIcon, PackageOpenIcon } from 'lucide-react';
 import { Fragment } from 'react';
 import { AgentMetadataModelSwitcher } from '../agents/components/agent-metadata/agent-metadata-model-switcher';

--- a/packages/playground/src/domains/templates/template-info.tsx
+++ b/packages/playground/src/domains/templates/template-info.tsx
@@ -1,6 +1,7 @@
-import { GithubIcon, cn } from '@mastra/playground-ui';
+import { GithubIcon } from '@mastra/playground-ui';
 import { KeyValueList } from '@mastra/playground-ui/components/KeyValueList';
 import type { KeyValueListItemData } from '@mastra/playground-ui/components/KeyValueList';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { PackageIcon, GitBranchIcon, InfoIcon } from 'lucide-react';
 
 type TemplateInfoProps = {

--- a/packages/playground/src/domains/templates/template-installation.tsx
+++ b/packages/playground/src/domains/templates/template-installation.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@mastra/playground-ui';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { ProcessStepList, ProcessStepProgressBar } from '@mastra/playground-ui/components/Steps';
 import type { ProcessStep } from '@mastra/playground-ui/components/Steps';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { OctagonXIcon } from 'lucide-react';
 import { Container } from './shared';
 

--- a/packages/playground/src/domains/templates/template-success.tsx
+++ b/packages/playground/src/domains/templates/template-success.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import { KeyValueList } from '@mastra/playground-ui/components/KeyValueList';
 import type { KeyValueListItemData } from '@mastra/playground-ui/components/KeyValueList';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { PackageOpenIcon } from 'lucide-react';
 import type { ComponentType } from 'react';
 import { Container } from './shared';

--- a/packages/playground/src/domains/templates/templates-list.tsx
+++ b/packages/playground/src/domains/templates/templates-list.tsx
@@ -1,4 +1,5 @@
-import { AgentIcon, GithubIcon, McpServerIcon, ToolsIcon, cn } from '@mastra/playground-ui';
+import { AgentIcon, GithubIcon, McpServerIcon, ToolsIcon } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { NetworkIcon, WorkflowIcon } from 'lucide-react';
 import { getRepoName } from './shared';
 

--- a/packages/playground/src/domains/templates/templates-tools.tsx
+++ b/packages/playground/src/domains/templates/templates-tools.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { SearchFieldBlock, SelectFieldBlock } from '@mastra/playground-ui/components/FormFieldBlocks';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { XIcon } from 'lucide-react';
 
 type TemplatesToolsProps = {

--- a/packages/playground/src/domains/tool-providers/components/selected-tool-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/selected-tool-list.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@mastra/playground-ui';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMemo } from 'react';
 
 interface SelectedToolListProps {

--- a/packages/playground/src/domains/tool-providers/components/tool-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/tool-list.tsx
@@ -1,10 +1,10 @@
-import { cn } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar, SearchbarWrapper } from '@mastra/playground-ui/components/Searchbar';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useState } from 'react';
 
 import { useProviderTools } from '../hooks/use-provider-tools';

--- a/packages/playground/src/domains/tool-providers/components/toolkit-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/toolkit-list.tsx
@@ -1,6 +1,7 @@
-import { transitions, cn } from '@mastra/playground-ui';
+import { transitions } from '@mastra/playground-ui';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useToolkits } from '../hooks/use-toolkits';
 
 export const SELECTED_TOOLKIT_SENTINEL = '__selected__';

--- a/packages/playground/src/domains/tools/components/ToolExecutor.tsx
+++ b/packages/playground/src/domains/tools/components/ToolExecutor.tsx
@@ -1,10 +1,10 @@
 import { jsonLanguage } from '@codemirror/lang-json';
 import type { MCPToolType } from '@mastra/core/mcp';
-import { cn } from '@mastra/playground-ui';
 import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { MainContentContent } from '@mastra/playground-ui/components/MainContent';
 import { Tabs, Tab, TabList } from '@mastra/playground-ui/components/Tabs';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import CodeMirror from '@uiw/react-codemirror';
 import { useState } from 'react';
 import type { ZodType } from 'zod';

--- a/packages/playground/src/domains/traces/components/score-data-panel.tsx
+++ b/packages/playground/src/domains/traces/components/score-data-panel.tsx
@@ -1,9 +1,10 @@
 import type { ScoreRowData } from '@mastra/core/evals';
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
 import { DataPanel } from '@mastra/playground-ui/components/DataPanel';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { format } from 'date-fns/format';
 import { FileInputIcon, FileOutputIcon, GaugeIcon, ReceiptText, SaveIcon } from 'lucide-react';
 import { useState } from 'react';

--- a/packages/playground/src/domains/workflows/components/workflow-tracing-run-options.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-tracing-run-options.tsx
@@ -1,8 +1,8 @@
 import { jsonLanguage } from '@codemirror/lang-json';
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import CodeMirror from '@uiw/react-codemirror';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTracingSettings } from '@/domains/observability/context/tracing-settings-context';

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-card-badges.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-card-badges.tsx
@@ -1,5 +1,6 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
 import type { WorkflowCardIndicator } from './workflow-card-badge-utils';
 

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-condition-card-view.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-condition-card-view.tsx
@@ -1,6 +1,7 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronDown } from 'lucide-react';
 import { Fragment } from 'react';
 

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-condition-code.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-condition-code.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@mastra/playground-ui';
 import {
   Dialog,
   DialogBody,
@@ -8,6 +7,7 @@ import {
   DialogTitle,
 } from '@mastra/playground-ui/components/Dialog';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Highlight, themes } from 'prism-react-renderer';
 
 import type { WorkflowConditionCodeCondition } from './types';

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-step-card-view.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-step-card-view.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
 import { Clock } from '../workflow-clock';
 import type { WorkflowStepCardViewProps } from './types';

--- a/packages/playground/src/domains/workflows/workflow/workflow-after-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-after-node.tsx
@@ -1,7 +1,8 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps, Node } from '@xyflow/react';
 import { ChevronDown, Footprints } from 'lucide-react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-card.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-card.tsx
@@ -1,4 +1,5 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronDownIcon } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/domains/workflows/workflow/workflow-condition-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-condition-node.tsx
@@ -1,4 +1,4 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import {
@@ -11,6 +11,7 @@ import {
 } from '@mastra/playground-ui/components/Dialog';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps, Node } from '@xyflow/react';
 import { ChevronDown } from 'lucide-react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-default-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-default-node.tsx
@@ -1,6 +1,7 @@
-import { CheckIcon, CrossIcon, Icon, cn } from '@mastra/playground-ui';
+import { CheckIcon, CrossIcon, Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps, Node } from '@xyflow/react';
 import { CircleDashed, HourglassIcon, Loader2, PauseIcon, ShieldAlert } from 'lucide-react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-input-data.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-input-data.tsx
@@ -1,9 +1,10 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronRight, Loader2, Play } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-input-type-toggle.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-input-type-toggle.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Braces, FormInput } from 'lucide-react';
 
 export type WorkflowInputType = 'simple' | 'form' | 'json';

--- a/packages/playground/src/domains/workflows/workflow/workflow-loop-result-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-loop-result-node.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@mastra/playground-ui';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps, Node } from '@xyflow/react';
 import { CircleCheck, CircleX } from 'lucide-react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-nested-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-nested-node.tsx
@@ -1,7 +1,8 @@
 import type { SerializedStepFlowEntry } from '@mastra/core/workflows';
-import { CheckIcon, CrossIcon, Icon, cn } from '@mastra/playground-ui';
+import { CheckIcon, CrossIcon, Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeProps, Node } from '@xyflow/react';
 import { CircleDashed, HourglassIcon, Loader2, PauseIcon, ShieldAlert } from 'lucide-react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-suspended-steps.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-suspended-steps.tsx
@@ -1,9 +1,10 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { ChevronRight, CirclePause, MoveDownLeft, MoveUpRight, Play } from 'lucide-react';
 import { useState } from 'react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
@@ -1,10 +1,11 @@
 import { jsonLanguage } from '@codemirror/lang-json';
-import { Icon, formatJSON, isValidJson, cn } from '@mastra/playground-ui';
+import { Icon, formatJSON, isValidJson } from '@mastra/playground-ui';
 import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import CodeMirror from '@uiw/react-codemirror';
 import { Braces, ChevronDown, CopyIcon, EyeIcon, EyeOffIcon } from 'lucide-react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-timeline.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-timeline.tsx
@@ -1,8 +1,9 @@
-import { CheckIcon, CrossIcon, Icon, cn } from '@mastra/playground-ui';
+import { CheckIcon, CrossIcon, Icon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Dialog } from '@mastra/playground-ui/components/Dialog';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useAutoscroll } from '@mastra/playground-ui/hooks/use-autoscroll';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import {
   ChevronDown,
   CirclePause,

--- a/packages/playground/src/domains/workflows/workflow/zoom-slider.tsx
+++ b/packages/playground/src/domains/workflows/workflow/zoom-slider.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Slider } from '@mastra/playground-ui/components/Slider';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { PanelProps } from '@xyflow/react';
 import { Panel, useViewport, useReactFlow } from '@xyflow/react';
 import { Maximize, Minus, Plus } from 'lucide-react';

--- a/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
+++ b/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
@@ -1,4 +1,4 @@
-import { SkillIcon, cn } from '@mastra/playground-ui';
+import { SkillIcon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import {
   Dialog,
@@ -11,6 +11,7 @@ import {
 import { Input } from '@mastra/playground-ui/components/Input';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Search, Download, ExternalLink, Loader2, Package, Github, Check, Folder } from 'lucide-react';
 import { useState, useCallback, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';

--- a/packages/playground/src/lib/ai-ui/memory-search.tsx
+++ b/packages/playground/src/lib/ai-ui/memory-search.tsx
@@ -1,8 +1,8 @@
 import type { MemorySearchResult, MemorySearchResponse } from '@mastra/client-js';
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Search, X, ExternalLink } from 'lucide-react';
 import { useState, useCallback, useRef, useEffect } from 'react';
 

--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -1,7 +1,7 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { MessageFactory } from '@mastra/react';
 import type { MessageRenderers } from '@mastra/react';
 import { AudioLinesIcon, CheckIcon, CopyIcon, StopCircleIcon } from 'lucide-react';

--- a/packages/playground/src/lib/ai-ui/messages/observation-marker.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/observation-marker.tsx
@@ -6,7 +6,7 @@ import type {
   DataOmBufferingEndPart,
   DataOmBufferingFailedPart,
 } from '@mastra/memory/processors';
-import { cn } from '@mastra/playground-ui';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Brain, CheckCircle2, XCircle, Loader2, CloudCog } from 'lucide-react';
 import { useEffect } from 'react';
 

--- a/packages/playground/src/lib/ai-ui/messages/reasoning.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/reasoning.tsx
@@ -1,5 +1,6 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { BrainIcon, ChevronUpIcon } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
@@ -1,7 +1,8 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { Notice } from '@mastra/playground-ui/components/Notice';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { CheckCircleIcon, ChevronUpIcon } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -1,11 +1,11 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
-import { cn } from '@mastra/playground-ui';
 import { Avatar } from '@mastra/playground-ui/components/Avatar';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { PendingIndicator } from '@mastra/playground-ui/components/PendingIndicator';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { useAutoscroll } from '@mastra/playground-ui/hooks/use-autoscroll';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { MessageFactoryPart } from '@mastra/react';
 import { CLIENT_MESSAGE_ID_KEY, useSpeechRecognition } from '@mastra/react';
 import { ArrowUp, Mic } from 'lucide-react';

--- a/packages/playground/src/lib/ai-ui/tools/badges/badge-wrapper.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/badge-wrapper.tsx
@@ -1,5 +1,6 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronUpIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 

--- a/packages/playground/src/lib/ai-ui/tools/badges/file-tree-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/file-tree-badge.tsx
@@ -1,8 +1,9 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { ChevronUpIcon, CopyIcon, CheckIcon, FolderTree, HardDrive } from 'lucide-react';
 import { useState, useEffect, useMemo } from 'react';
 import type { DataMessagePart } from '../tool-card';

--- a/packages/playground/src/lib/ai-ui/tools/badges/observation-renderer.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/observation-renderer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { cn } from '@mastra/playground-ui';
 import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { useMemo } from 'react';
 
 // Priority emoji to color mapping

--- a/packages/playground/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
@@ -1,7 +1,8 @@
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { CheckIcon, ChevronUpIcon, CopyIcon, TerminalSquare } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { DataMessagePart } from '../tool-card';

--- a/packages/playground/src/lib/form/components/date-field.tsx
+++ b/packages/playground/src/lib/form/components/date-field.tsx
@@ -1,8 +1,8 @@
 import type { AutoFormFieldProps } from '@autoform/react';
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { DatePicker } from '@mastra/playground-ui/components/DateTimePicker';
 import { Popover, PopoverContent, PopoverTrigger } from '@mastra/playground-ui/components/Popover';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { format, isValid } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
 import React, { useState, useEffect } from 'react';

--- a/packages/playground/src/lib/form/components/object-wrapper.tsx
+++ b/packages/playground/src/lib/form/components/object-wrapper.tsx
@@ -1,7 +1,8 @@
 import type { ObjectWrapperProps } from '@autoform/react';
-import { Icon, cn } from '@mastra/playground-ui';
+import { Icon } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Braces, ChevronDownIcon } from 'lucide-react';
 import React, { useState } from 'react';
 

--- a/packages/playground/src/lib/form/dynamic-form.tsx
+++ b/packages/playground/src/lib/form/dynamic-form.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import type { ButtonProps } from '@mastra/playground-ui/components/Button';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { Loader2 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useCallback, useMemo } from 'react';

--- a/packages/playground/src/pages/traces/trace/index.tsx
+++ b/packages/playground/src/pages/traces/trace/index.tsx
@@ -5,7 +5,6 @@ import {
   TraceDataPanelView,
   TraceKeysAndValues,
   TracesErrorContent,
-  cn,
   useSpanDetail,
   useTraceLightSpans,
   useTraceSpanNavigation,
@@ -14,6 +13,7 @@ import type { SpanTab } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { CircleGaugeIcon, SaveIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';


### PR DESCRIPTION
## Summary
- Add a narrow `@mastra/playground-ui/utils/cn` public utility subpath and build/export wiring.
- Move existing `cn` imports in `packages/playground` from the root `@mastra/playground-ui` barrel to `@mastra/playground-ui/utils/cn`, preserving unrelated mixed root imports.
- Add the playground ESLint ratchet for `cn` and a patch changeset for `@mastra/playground-ui`.

## Why
This is mechanical import hygiene to reduce root barrel use and avoid accidental performance regressions.

## Validation
- `pnpm build:playground-ui`
- `pnpm --filter ./packages/playground-ui typecheck`
- `pnpm --filter ./packages/playground typecheck`
- `pnpm --filter ./packages/playground lint` (passes with 41 existing warnings)
- `pnpm prettier:changed` (passed; reverted out-of-scope example formatter spillover)
- `pnpm lint` (passes with existing warning baseline)
- Parser audit: zero `cn` imports remain from `@mastra/playground-ui` in `packages/playground/src`
- `npx -y react-doctor@latest . --verbose --diff` (exit 0; existing warnings only)
- `coderabbit doctor` (CLI is not signed in, so local review was not run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR lets you import the `cn` helper from a tiny, specific path (like `@mastra/playground-ui/utils/cn`) instead of grabbing it from the whole “playground UI” bundle. It keeps behavior the same, but makes the import targets more precise and prevents accidentally going back to the old path.

## Summary
- Added a public `@mastra/playground-ui/utils/cn` subpath export in `packages/playground-ui` and wired it into the build/export output.
- Updated `packages/playground-ui/src/utils/cn.ts` to re-export `cn` from the shared utils implementation.
- Enhanced `packages/playground-ui/vite.config.ts` to generate `src/utils`-based utility entrypoints so the new subpath is actually built and shipped.
- Switched `cn` imports throughout `packages/playground` from the root `@mastra/playground-ui` barrel to `@mastra/playground-ui/utils/cn`, while preserving unrelated root imports (e.g., `Icon`, other components).
- Added an ESLint restriction in `packages/playground/eslint.config.js` to ratchet against reintroducing `cn` imports from the root playground UI barrel.
- Updated the `@mastra/playground-ui` patch changeset to document the developer-facing import path: `import { cn } from '`@mastra/playground-ui/utils/cn`';`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->