### PR TITLE
Run a Harness inside a messaging channel as a full UI (V1: messaging + approvals)

### DIFF
--- a/.changeset/frank-aliens-fix.md
+++ b/.changeset/frank-aliens-fix.md
@@ -1,0 +1,28 @@
+---
+'@mastra/core': minor
+---
+
+Added channel support to the Harness, so you can run a Harness inside a messaging platform like Slack as a full UI — a peer of the terminal interface.
+
+Where an Agent channel is a thin pipe to a single agent loop, a Harness channel is the interface to the Harness itself. Each conversation drives a durable per-resource Session, and replies (including streamed text and tool-approval cards) render from that session's event stream — the same contract the terminal UI consumes. V1 covers messaging and tool approvals.
+
+**Usage**
+
+```ts
+import { Harness } from '@mastra/core/harness';
+import { createSlackAdapter } from '@chat-adapter/slack';
+
+const harness = new Harness({
+  id: 'coding-harness',
+  modes: [{ id: 'build', defaultModelId: 'openai/gpt-5.5' }],
+  channels: {
+    adapters: { slack: createSlackAdapter() },
+  },
+});
+
+// Or bind later:
+harness.setChannels(channels);
+harness.getChannels();
+```
+
+The Agent channel path is unchanged.

--- a/docs/src/content/en/docs/agents/channels.mdx
+++ b/docs/src/content/en/docs/agents/channels.mdx
@@ -180,5 +180,6 @@ See [Channels reference](/reference/agents/channels#inline-media) for all `inlin
 - [Guide: Building a Slack assistant](/guides/guide/slack-assistant)
 - [Agent overview](/docs/agents/overview)
 - [Tool approval](/docs/agents/agent-approval)
+- [Harness channels](/docs/harness/channels) — run a Harness in a channel as a full UI
 - [Channels reference](/reference/agents/channels)
 - [Chat SDK adapters](https://chat-sdk.dev/adapters)

--- a/docs/src/content/en/docs/harness/channels.mdx
+++ b/docs/src/content/en/docs/harness/channels.mdx
@@ -1,0 +1,100 @@
+---
+title: "Channels | Harness"
+description: "Run a Harness inside a messaging channel like Slack, turning the channel into a full Harness UI — a peer of the terminal interface."
+packages:
+  - "@mastra/core"
+---
+
+# Channels
+
+:::experimental
+
+The `Harness` feature is in beta stage and subject to breaking changes in minor versions until it graduates from its beta status.
+
+:::
+
+A channel turns a messaging platform like Slack into a **Harness UI** — a peer of the terminal interface ([Mastra Code](https://code.mastra.ai/)). Where an [Agent channel](/docs/agents/channels) is a thin pipe to a single agent loop, a Harness channel is the interface to the Harness itself: incoming messages drive a durable per-conversation [`Session`](/docs/harness/session), and replies render from that session's event stream — the same contract the terminal UI consumes.
+
+## How it differs from an Agent channel
+
+- **An Agent channel** routes each message through the agent loop and streams the reply back.
+- **A Harness channel** resolves a durable `Session` for the conversation, sends the message through `Session.sendMessage`, and renders the session's events (streamed text, tool calls, and approval cards) back to the channel.
+
+Because the channel consumes the Session, it surfaces Harness capabilities through the same seam the terminal UI uses. V1 covers **messaging and tool approvals**.
+
+## Quickstart
+
+Pass `channels` to your Harness, using adapters from the [Chat SDK](https://chat-sdk.dev/adapters):
+
+```typescript title="src/mastra/harness.ts"
+import { Harness } from '@mastra/core/harness'
+import { createSlackAdapter } from '@chat-adapter/slack'
+
+export const harness = new Harness({
+  id: 'coding-harness',
+  modes: [{ id: 'build', defaultModelId: '__GATEWAY_OPENAI_MODEL__' }],
+  channels: {
+    adapters: {
+      slack: createSlackAdapter(),
+    },
+  },
+})
+```
+
+You can also attach a pre-built `AgentChannels` instance, or bind one later with `setChannels`:
+
+```typescript
+import { AgentChannels } from '@mastra/core/channels'
+
+const channels = new AgentChannels({
+  adapters: { slack: createSlackAdapter() },
+})
+
+harness.setChannels(channels)
+```
+
+`harness.getChannels()` returns the bound `AgentChannels` instance, or `null` when no channels are configured.
+
+## Sessions and conversations
+
+Each channel conversation maps to one durable Harness `Session`, keyed by `resourceId` (by default `${platform}:${userId}`). The session is get-or-create, so the same user resumes their own conversation across messages and process restarts. State, mode, and thread binding persist exactly as they do in the terminal UI.
+
+## Messaging
+
+When a user sends a message, the Harness:
+
+1. Resolves (or creates) the `Session` for that conversation.
+1. Sends the message through the session.
+1. Renders the session's event stream back to the channel — streamed assistant text appears as an updating reply.
+
+## Tool approvals
+
+Tools with `requireApproval: true` render as interactive cards with Approve and Deny buttons, just like in the terminal UI. Clicking a button resumes the parked tool call through the owning `Session`:
+
+```typescript
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+const deleteFile = createTool({
+  id: 'delete-file',
+  description: 'Delete a file from the system',
+  inputSchema: z.object({
+    path: z.string().describe('Path to the file to delete'),
+  }),
+  requireApproval: true,
+  execute: async ({ path }) => {
+    await fs.unlink(path)
+    return { deleted: path }
+  },
+})
+```
+
+The approval card records the owning session so the button click resolves the exact `Session` to resume — even after a process restart, because sessions are durable and keyed by `resourceId`.
+
+## Related
+
+- [Harness overview](/docs/harness/overview)
+- [Session](/docs/harness/session)
+- [Tool approvals](/docs/harness/tool-approvals)
+- [Agent channels](/docs/agents/channels)
+- [Chat SDK adapters](https://chat-sdk.dev/adapters)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -397,6 +397,11 @@ const sidebars = {
           id: 'harness/tool-approvals',
           label: 'Tool Approvals',
         },
+        {
+          type: 'doc',
+          id: 'harness/channels',
+          label: 'Channels',
+        },
       ],
     },
     {

--- a/packages/core/src/channels/__tests__/integration.test.ts
+++ b/packages/core/src/channels/__tests__/integration.test.ts
@@ -2,6 +2,7 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-
 import { describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../../agent';
+import { Harness } from '../../harness/harness';
 import { ConsoleLogger } from '../../logger';
 import { Mastra } from '../../mastra';
 import { InMemoryStore } from '../../storage/mock';
@@ -86,6 +87,53 @@ describe('Mastra Channel Integration', () => {
       });
       const channels = agent.getChannels()!;
       expect(Object.keys(channels.adapters)).toEqual(['discord', 'slack']);
+    });
+  });
+
+  describe('harness-level channel registration', () => {
+    it('creates AgentChannels from a ChannelConfig and binds the Harness target', () => {
+      const harness = new Harness({
+        id: 'harness-bot',
+        modes: [{ id: 'build', defaultModelId: 'test/build-model' }],
+        channels: { adapters: { slack: createMockAdapter('slack') } },
+      });
+      const channels = harness.getChannels();
+      expect(channels).not.toBeNull();
+      // The Harness target must be bound so incoming messages drive a Session.
+      expect((channels as any).harness).toBe(harness);
+    });
+
+    it('returns null when no channels are configured', () => {
+      const harness = new Harness({
+        id: 'harness-no-channels',
+        modes: [{ id: 'build', defaultModelId: 'test/build-model' }],
+      });
+      expect(harness.getChannels()).toBeNull();
+    });
+
+    it('accepts a pre-built AgentChannels instance and exposes its adapters', () => {
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord'), slack: createMockAdapter('slack') },
+      });
+      const harness = new Harness({
+        id: 'harness-prebuilt',
+        modes: [{ id: 'build', defaultModelId: 'test/build-model' }],
+        channels,
+      });
+      expect(harness.getChannels()).toBe(channels);
+      expect(Object.keys(harness.getChannels()!.adapters)).toEqual(['discord', 'slack']);
+      expect((channels as any).harness).toBe(harness);
+    });
+
+    it('rebinds the Harness target via setChannels()', () => {
+      const harness = new Harness({
+        id: 'harness-rebind',
+        modes: [{ id: 'build', defaultModelId: 'test/build-model' }],
+      });
+      const channels = new AgentChannels({ adapters: { slack: createMockAdapter('slack') } });
+      harness.setChannels(channels);
+      expect(harness.getChannels()).toBe(channels);
+      expect((channels as any).harness).toBe(harness);
     });
   });
 

--- a/packages/core/src/channels/__tests__/session-renderer.test.ts
+++ b/packages/core/src/channels/__tests__/session-renderer.test.ts
@@ -1,0 +1,163 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { Session } from '../../harness/session';
+import type { HarnessEvent, HarnessEventListener, HarnessMessage } from '../../harness/types';
+import { getChatModule } from '../chat-lazy';
+import type { ChatChannelRenderContext } from '../output-processor';
+import { SessionChannelRenderer } from '../session-renderer';
+import type { PendingApprovalRecord } from '../stream-helpers';
+
+// The static/streaming drivers resolve Card/CardText/etc. via the lazily
+// loaded chat module at call time, so prime it before any driver runs.
+beforeAll(async () => {
+  await getChatModule();
+});
+
+/**
+ * Minimal fake of the Harness {@link Session} event bus: records subscribers
+ * and lets the test emit `HarnessEvent`s synchronously. Only the surface the
+ * renderer touches (`subscribe`) is implemented.
+ */
+function createFakeSession() {
+  const listeners = new Set<HarnessEventListener>();
+  const subscribe = vi.fn((listener: HarnessEventListener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  });
+  const emit = (event: HarnessEvent) => {
+    for (const l of listeners) void l(event);
+  };
+  const session = { subscribe } as unknown as Session;
+  return { session, emit, listeners };
+}
+
+function assistantMessage(id: string, text: string): HarnessMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+  } as unknown as HarnessMessage;
+}
+
+/**
+ * Build a real-shaped {@link ChatChannelRenderContext} backed by a recording
+ * adapter + thread, so the renderer drives the genuine render-pump + drivers.
+ * Streaming is disabled so the static driver produces deterministic posts.
+ */
+function createRenderContext(overrides?: Partial<ChatChannelRenderContext>) {
+  const posts: unknown[] = [];
+  const edits: Array<{ threadId: string; messageId: string; message: unknown }> = [];
+  const stash = new Map<string, PendingApprovalRecord>();
+
+  const chatThread = {
+    id: 'thread-1',
+    channelId: 'chan-1',
+    isDM: true,
+    post: vi.fn(async (message: unknown) => {
+      posts.push(message);
+      return { id: `posted-${posts.length}`, text: '' };
+    }),
+  } as any;
+
+  const adapter = {
+    name: 'discord',
+    editMessage: vi.fn(async (threadId: string, messageId: string, message: unknown) => {
+      edits.push({ threadId, messageId, message });
+    }),
+  } as any;
+
+  const render: ChatChannelRenderContext = {
+    adapter,
+    chatThread,
+    platform: 'discord',
+    streaming: { enabled: false },
+    toolDisplay: 'cards',
+    channelToolNames: new Set<string>(),
+    onApprovalPosted: (toolCallId, record) => {
+      stash.set(toolCallId, record);
+    },
+    getPendingApproval: id => stash.get(id),
+    takePendingApproval: id => {
+      const r = stash.get(id);
+      if (r) stash.delete(id);
+      return r;
+    },
+    wrapStream: stream => stream,
+    typingGate: { active: false },
+    ...overrides,
+  };
+
+  return { render, posts, edits, stash, chatThread, adapter };
+}
+
+describe('SessionChannelRenderer', () => {
+  it('renders streamed assistant text from session events to the channel', async () => {
+    const { session, emit } = createFakeSession();
+    const { render, posts } = createRenderContext();
+
+    const renderer = new SessionChannelRenderer({ session, render, runId: 'run-1' });
+    const drained = renderer.start();
+
+    emit({ type: 'message_start', message: assistantMessage('m1', '') });
+    emit({ type: 'message_update', message: assistantMessage('m1', 'Hel') });
+    emit({ type: 'message_update', message: assistantMessage('m1', 'Hello world') });
+    emit({ type: 'message_end', message: assistantMessage('m1', 'Hello world') });
+    emit({ type: 'agent_end', reason: 'complete' });
+
+    await drained;
+
+    const text = posts.map(p => (typeof p === 'string' ? p : JSON.stringify(p))).join('\n');
+    expect(text).toContain('Hello world');
+  });
+
+  it('completes a tool-approval round-trip: card stashed on suspend, resume renders result', async () => {
+    const { session, emit } = createFakeSession();
+    const { render, stash } = createRenderContext();
+
+    // --- Initial run: tool call → approval required → suspended -------------
+    const renderer = new SessionChannelRenderer({ session, render, runId: 'run-1' });
+    const drained = renderer.start();
+
+    emit({ type: 'tool_start', toolCallId: 'tc-1', toolName: 'mastra_fs_read', args: { path: 'a.txt' } });
+    emit({ type: 'tool_approval_required', toolCallId: 'tc-1', toolName: 'mastra_fs_read', args: { path: 'a.txt' } });
+    emit({ type: 'agent_end', reason: 'suspended' });
+
+    // The suspended run must drain so the incoming-message handler can return,
+    // and the approval card must be stashed for the later button click.
+    await drained;
+    expect(stash.has('tc-1')).toBe(true);
+
+    // --- Resume run (approval): a fresh renderer renders the tool-result ----
+    const { session: session2, emit: emit2 } = createFakeSession();
+    const resumeRender = createRenderContext();
+    const resumeRenderer = new SessionChannelRenderer({
+      session: session2,
+      render: resumeRender.render,
+      runId: 'run-1',
+    });
+    const resumeDrained = resumeRenderer.start();
+
+    emit2({ type: 'tool_end', toolCallId: 'tc-1', result: 'file contents', isError: false });
+    emit2({ type: 'message_update', message: assistantMessage('m2', 'Done reading the file.') });
+    emit2({ type: 'message_end', message: assistantMessage('m2', 'Done reading the file.') });
+    emit2({ type: 'agent_end', reason: 'complete' });
+
+    await resumeDrained;
+
+    const resumeText = resumeRender.posts.map(p => (typeof p === 'string' ? p : JSON.stringify(p))).join('\n');
+    expect(resumeText).toContain('Done reading the file.');
+  });
+
+  it('resolves drained on aborted runs without throwing', async () => {
+    const { session, emit } = createFakeSession();
+    const { render } = createRenderContext();
+
+    const renderer = new SessionChannelRenderer({ session, render, runId: 'run-1' });
+    const drained = renderer.start();
+
+    emit({ type: 'message_update', message: assistantMessage('m1', 'partial') });
+    emit({ type: 'agent_end', reason: 'aborted' });
+
+    await expect(drained).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import type { Agent } from '../agent/agent';
 import type { MastraProviderMetadata } from '../agent/message-list/state/types';
 import type { AgentSignalContents } from '../agent/signals';
+import type { Harness } from '../harness/harness';
 import type { IMastraLogger } from '../logger/logger';
 import type { Mastra } from '../mastra';
 import type { StorageThreadType } from '../memory/types';
@@ -34,6 +35,7 @@ import type { InlineLinkRule } from './inline-media';
 import { ChatChannelOutputProcessor, CHAT_CHANNEL_RENDER_CONTEXT_KEY } from './output-processor';
 import type { ChatChannelRenderContext } from './output-processor';
 import { ChatChannelProcessor } from './processor';
+import { SessionChannelRenderer } from './session-renderer';
 import { MastraStateAdapter } from './state-adapter';
 import type { PendingApprovalRecord } from './stream-helpers';
 import type {
@@ -66,6 +68,15 @@ export class AgentChannels {
   /** Stored initialization promise so webhook handlers can await readiness on serverless cold starts. */
   private initPromise: Promise<void> | null = null;
   private agent!: Agent<any, any, any, any>;
+  /**
+   * Optional Harness target. When set, incoming channel messages drive a
+   * Harness {@link Session} instead of the agent directly: the channel becomes
+   * a full Harness UI (a peer of the TUI) rather than a thin pipe to one agent
+   * loop. The Agent path (`__setAgent` + `agent.sendMessage`) is untouched;
+   * this is purely additive. Mutually exclusive with the Agent target in
+   * practice — whichever was bound last wins on the send tail.
+   */
+  private harness?: Harness<any>;
   private logger?: IMastraLogger;
   private customState: StateAdapter | undefined;
   private stateAdapter!: StateAdapter;
@@ -160,6 +171,16 @@ export class AgentChannels {
    */
   __setAgent(agent: Agent<any, any, any, any>): void {
     this.agent = agent;
+  }
+
+  /**
+   * Bind this AgentChannels to a Harness, turning the channel into a full
+   * Harness UI. Mirrors {@link __setAgent} for the Agent path. Called by
+   * `Harness.setChannels`. Additive — does not affect the Agent send path.
+   * @internal
+   */
+  __setHarness(harness: Harness<any>): void {
+    this.harness = harness;
   }
 
   /**
@@ -335,12 +356,14 @@ export class AgentChannels {
           let runId: string | undefined;
           let toolName: string | undefined;
           let toolArgs: Record<string, unknown> | undefined;
+          let sessionResourceId: string | undefined;
 
           const stashed = this.pendingApprovalCards.get(toolCallId);
           if (stashed?.runId) {
             runId = stashed.runId;
             toolName = stashed.toolName;
             toolArgs = stashed.args;
+            sessionResourceId = stashed.sessionResourceId;
           } else {
             const storage = mastra.getStorage();
             const memoryStore = storage ? await storage.getStore('memory') : undefined;
@@ -376,6 +399,14 @@ export class AgentChannels {
             this.log('info', `No pending approval found for toolCallId=${toolCallId}`);
             return;
           }
+
+          // Harness target: resume the parked tool call through the durable
+          // Session that owns it rather than the agent. Prefer the resourceId
+          // stashed on the approval card; fall back to the thread's resourceId
+          // for the process-restart case (the Session is durable and
+          // get-or-create by resourceId).
+          const harness = this.harness;
+          const harnessResourceId = harness ? (sessionResourceId ?? mastraThread.resourceId) : undefined;
 
           // Build the card header with tool name and args
           const displayName = toolName ? stripToolPrefix(toolName) : 'tool';
@@ -422,19 +453,30 @@ export class AgentChannels {
             requestContext.set(CHAT_CHANNEL_RENDER_CONTEXT_KEY, renderContext);
 
             try {
-              const resumed = await this.agent.declineToolCall({
-                runId,
-                toolCallId,
-                requestContext,
-                memory: {
-                  thread: mastraThread.id,
-                  resource: mastraThread.resourceId,
-                },
-              });
-              // Drive the run to completion so serverless runtimes don't kill it.
-              void resumed.consumeStream().catch(err => {
-                this.log('error', 'Error consuming resumed decline stream', err);
-              });
+              if (harness && harnessResourceId) {
+                // Harness path: decline through the durable Session that owns
+                // the parked tool call and render the resumed run's output
+                // (e.g. the agent's acknowledgement) via a SessionChannelRenderer.
+                const session = await harness.createSession({ resourceId: harnessResourceId });
+                const renderer = new SessionChannelRenderer({ session, render: renderContext });
+                const drained = renderer.start();
+                await session.declineToolCall({ toolCallId, requestContext });
+                await drained;
+              } else {
+                const resumed = await this.agent.declineToolCall({
+                  runId,
+                  toolCallId,
+                  requestContext,
+                  memory: {
+                    thread: mastraThread.id,
+                    resource: mastraThread.resourceId,
+                  },
+                });
+                // Drive the run to completion so serverless runtimes don't kill it.
+                void resumed.consumeStream().catch(err => {
+                  this.log('error', 'Error consuming resumed decline stream', err);
+                });
+              }
             } catch (err) {
               const isStaleApproval = err instanceof Error && err.message.includes('No snapshot found');
               if (isStaleApproval) {
@@ -472,6 +514,24 @@ export class AgentChannels {
 
           const renderContext = this._buildRenderContext(chatThread, platform, { toolCallId, messageId });
           requestContext.set(CHAT_CHANNEL_RENDER_CONTEXT_KEY, renderContext);
+
+          if (harness && harnessResourceId) {
+            // Harness path: approve through the durable Session that owns the
+            // parked tool call. The resumed run (tool-result + any follow-up
+            // text) is rendered inline via a SessionChannelRenderer. The
+            // session re-supplies the shared run budget on resume so the run
+            // doesn't stall on the agent's small default maxSteps.
+            const session = await harness.createSession({ resourceId: harnessResourceId });
+            const renderer = new SessionChannelRenderer({ session, render: renderContext });
+            const drained = renderer.start();
+            try {
+              await session.approveToolCall({ toolCallId, requestContext });
+              await drained;
+            } finally {
+              this.pendingApprovalCards.delete(toolCallId);
+            }
+            return;
+          }
 
           const resumed = await this.agent.approveToolCall({
             runId,
@@ -1033,6 +1093,20 @@ export class AgentChannels {
     // Otherwise pass the parts array directly — both shapes match AgentSignalContents.
     const signalContents: AgentSignalContents = parts.length === 1 && parts[0]?.type === 'text' ? parts[0].text : parts;
 
+    // Harness target: the channel is a full Harness UI. Drive a durable
+    // per-resource Session and render its event stream through the same
+    // channel drivers used by the Agent path. This branch is additive — the
+    // Agent path below is unchanged.
+    if (this.harness) {
+      await this.processHarnessMessage({
+        parts,
+        threadResourceId,
+        renderContext,
+        canRenderApprovalButtons,
+      });
+      return;
+    }
+
     const result = this.agent.sendMessage(
       {
         contents: signalContents,
@@ -1073,6 +1147,60 @@ export class AgentChannels {
       }
     } catch (err) {
       this.log('debug', 'accepted consume failed', err);
+    }
+  }
+
+  /**
+   * Harness send/render tail. Resolves (get-or-create) the durable per-resource
+   * Session for this conversation, starts a {@link SessionChannelRenderer} that
+   * translates the Session's event stream into channel chunks, then sends the
+   * message. The renderer drains when the run reaches a terminal `agent_end`.
+   *
+   * The Session is keyed by `resourceId` so each channel user/thread resumes
+   * its own durable Harness session across messages and process restarts.
+   *
+   * @internal
+   */
+  private async processHarnessMessage(args: {
+    parts: Exclude<AgentSignalContents, string>;
+    threadResourceId: string;
+    renderContext: ChatChannelRenderContext;
+    canRenderApprovalButtons: boolean;
+  }): Promise<void> {
+    const harness = this.harness;
+    if (!harness) return;
+
+    const session = await harness.createSession({ resourceId: args.threadResourceId });
+
+    // Stamp the owning Session's resourceId onto any approval card stashed
+    // during this run, so the approval-button handler can resolve the exact
+    // Session to resume (Harness path) instead of the agent (Agent path).
+    const baseOnApprovalPosted = args.renderContext.onApprovalPosted;
+    const renderContext: ChatChannelRenderContext = {
+      ...args.renderContext,
+      onApprovalPosted: (toolCallId, record) => {
+        baseOnApprovalPosted(toolCallId, { ...record, sessionResourceId: args.threadResourceId });
+      },
+    };
+
+    // Map channel parts → Session.sendMessage shape: a single text string plus
+    // an optional file array.
+    const content = args.parts
+      .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+      .map(p => p.text)
+      .join('\n\n');
+    const files = args.parts
+      .filter((p): p is { type: 'file'; data: string; mediaType: string; filename?: string } => p.type === 'file')
+      .map(p => ({ data: p.data, mediaType: p.mediaType, ...(p.filename ? { filename: p.filename } : {}) }));
+
+    const renderer = new SessionChannelRenderer({ session, render: renderContext });
+    // Start translating before sending so no early events are missed.
+    const drained = renderer.start();
+    try {
+      await session.sendMessage({ content, ...(files.length ? { files } : {}) });
+      await drained;
+    } catch (err) {
+      this.log('debug', 'harness session message failed', err);
     }
   }
 

--- a/packages/core/src/channels/output-processor.ts
+++ b/packages/core/src/channels/output-processor.ts
@@ -4,8 +4,8 @@ import type { IMastraLogger } from '../logger/logger';
 import type { ProcessOutputStreamArgs } from '../processors';
 import type { AgentChunkType, ChunkType } from '../stream/types';
 
-import { runStaticDriver } from './chat-driver-static';
-import { runStreamingDriver } from './chat-driver-streaming';
+import { openRenderSession } from './render-pump';
+import type { RenderSession } from './render-pump';
 import type { PendingApprovalRecord } from './stream-helpers';
 import type { ToolDisplay, ToolDisplayFn } from './types';
 
@@ -41,70 +41,6 @@ export interface ChatChannelRenderContext {
 
 /** Key the processor reads off `requestContext` to locate its render deps. */
 export const CHAT_CHANNEL_RENDER_CONTEXT_KEY = '__mastra_chat_channel_render';
-
-interface ChunkQueue {
-  iterable: AsyncIterable<AgentChunkType<any>>;
-  push: (chunk: AgentChunkType<any>) => void;
-  close: () => void;
-}
-
-/**
- * Single-producer / single-consumer async queue. The processor pushes chunks
- * synchronously from `processOutputStream`; the driver consumes them via the
- * async iterable. `close()` ends the iteration after pending items are drained.
- */
-function createChunkQueue(): ChunkQueue {
-  const buffer: AgentChunkType<any>[] = [];
-  const waiters: Array<(result: IteratorResult<AgentChunkType<any>>) => void> = [];
-  let closed = false;
-
-  const push = (chunk: AgentChunkType<any>) => {
-    if (closed) return;
-    const waiter = waiters.shift();
-    if (waiter) {
-      waiter({ value: chunk, done: false });
-    } else {
-      buffer.push(chunk);
-    }
-  };
-
-  const close = () => {
-    if (closed) return;
-    closed = true;
-    while (waiters.length > 0) {
-      waiters.shift()!({ value: undefined, done: true });
-    }
-  };
-
-  const iterable: AsyncIterable<AgentChunkType<any>> = {
-    [Symbol.asyncIterator]() {
-      return {
-        next() {
-          if (buffer.length > 0) {
-            return Promise.resolve({ value: buffer.shift()!, done: false });
-          }
-          if (closed) {
-            return Promise.resolve({ value: undefined as any, done: true });
-          }
-          return new Promise<IteratorResult<AgentChunkType<any>>>(resolve => {
-            waiters.push(resolve);
-          });
-        },
-        return() {
-          close();
-          return Promise.resolve({ value: undefined as any, done: true });
-        },
-      };
-    },
-  };
-
-  return { iterable, push, close };
-}
-
-interface RenderSession {
-  queue: ChunkQueue;
-  driverPromise: Promise<void>;
-}
 
 /**
  * Output processor that mirrors the agent's stream to the originating chat
@@ -144,7 +80,7 @@ export class ChatChannelOutputProcessor {
     let session = state.session as RenderSession | undefined;
 
     if (!session) {
-      session = this.#openSession(render);
+      session = openRenderSession(render);
       state.session = session;
     }
 
@@ -166,63 +102,5 @@ export class ChatChannelOutputProcessor {
     }
 
     return part;
-  }
-
-  #openSession(render: ChatChannelRenderContext): RenderSession {
-    const queue = createChunkQueue();
-    const wrapped = render.wrapStream(queue.iterable);
-
-    // Seed the approval-card stash on resumed runs so the driver can resolve
-    // `messageId` for the incoming `tool-result` even though it never saw the
-    // pre-suspension `tool-call`.
-    if (render.approvalContext) {
-      const existing = render.getPendingApproval(render.approvalContext.toolCallId);
-      render.onApprovalPosted(render.approvalContext.toolCallId, {
-        ...existing,
-        messageId: render.approvalContext.messageId,
-        displayName: existing?.displayName ?? '',
-        argsSummary: existing?.argsSummary ?? '',
-        startedAt: existing?.startedAt ?? Date.now(),
-      });
-    }
-
-    const driverPromise = (
-      render.streaming.enabled
-        ? runStreamingDriver({
-            stream: wrapped,
-            chatThread: render.chatThread,
-            adapter: render.adapter,
-            toolDisplay: render.toolDisplay as 'cards' | 'text' | 'timeline' | 'grouped' | 'hidden',
-            toolDisplayFn: render.toolDisplayFn,
-            streamingOptions: render.streaming.options,
-            channelToolNames: render.channelToolNames,
-            logger: render.logger,
-            onApprovalPosted: render.onApprovalPosted,
-            getPendingApproval: render.getPendingApproval,
-            takePendingApproval: render.takePendingApproval,
-            typingGate: render.typingGate,
-            formatError: render.formatError,
-          })
-        : runStaticDriver({
-            stream: wrapped,
-            chatThread: render.chatThread,
-            adapter: render.adapter,
-            toolDisplay: render.toolDisplay as 'cards' | 'text' | 'hidden',
-            toolDisplayFn: render.toolDisplayFn,
-            channelToolNames: render.channelToolNames,
-            logger: render.logger,
-            onApprovalPosted: render.onApprovalPosted,
-            getPendingApproval: render.getPendingApproval,
-            takePendingApproval: render.takePendingApproval,
-            formatError: render.formatError,
-          })
-    ).catch(err => {
-      // Prevent unhandled rejection if the driver fails before a terminal chunk
-      // reaches processOutputStream. The error is re-thrown when awaited at cleanup.
-      render.logger?.error?.(`[${render.platform}] channel render driver failed early`, { error: err });
-      throw err;
-    });
-
-    return { queue, driverPromise };
   }
 }

--- a/packages/core/src/channels/render-pump.ts
+++ b/packages/core/src/channels/render-pump.ts
@@ -1,0 +1,141 @@
+import type { AgentChunkType } from '../stream/types';
+
+import { runStaticDriver } from './chat-driver-static';
+import { runStreamingDriver } from './chat-driver-streaming';
+import type { ChatChannelRenderContext } from './output-processor';
+
+/**
+ * Single-producer / single-consumer async queue shared by the agent-path
+ * output processor (`ChatChannelOutputProcessor`) and the harness-path session
+ * renderer (`SessionChannelRenderer`). A producer pushes chunks synchronously;
+ * the driver consumes them via the async iterable. `close()` ends the
+ * iteration after pending items are drained.
+ */
+export interface ChunkQueue {
+  iterable: AsyncIterable<AgentChunkType<any>>;
+  push: (chunk: AgentChunkType<any>) => void;
+  close: () => void;
+}
+
+export function createChunkQueue(): ChunkQueue {
+  const buffer: AgentChunkType<any>[] = [];
+  const waiters: Array<(result: IteratorResult<AgentChunkType<any>>) => void> = [];
+  let closed = false;
+
+  const push = (chunk: AgentChunkType<any>) => {
+    if (closed) return;
+    const waiter = waiters.shift();
+    if (waiter) {
+      waiter({ value: chunk, done: false });
+    } else {
+      buffer.push(chunk);
+    }
+  };
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    while (waiters.length > 0) {
+      waiters.shift()!({ value: undefined, done: true });
+    }
+  };
+
+  const iterable: AsyncIterable<AgentChunkType<any>> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          if (buffer.length > 0) {
+            return Promise.resolve({ value: buffer.shift()!, done: false });
+          }
+          if (closed) {
+            return Promise.resolve({ value: undefined as any, done: true });
+          }
+          return new Promise<IteratorResult<AgentChunkType<any>>>(resolve => {
+            waiters.push(resolve);
+          });
+        },
+        return() {
+          close();
+          return Promise.resolve({ value: undefined as any, done: true });
+        },
+      };
+    },
+  };
+
+  return { iterable, push, close };
+}
+
+/**
+ * A live render session: a chunk queue plus the promise of the driver that is
+ * pumping that queue's iterable to the chat platform. Producers push chunks
+ * into `queue`, then `queue.close()` + `await driverPromise` once the run ends.
+ */
+export interface RenderSession {
+  queue: ChunkQueue;
+  driverPromise: Promise<void>;
+}
+
+/**
+ * Open a render session for a `ChatChannelRenderContext`: create a chunk queue,
+ * wrap its iterable with the typing-status wrapper, seed any resumed-approval
+ * stash entry, and launch the resolved streaming/static driver. Shared verbatim
+ * between the agent output processor and the session renderer so the driver and
+ * queue primitives stay identical across both paths.
+ */
+export function openRenderSession(render: ChatChannelRenderContext): RenderSession {
+  const queue = createChunkQueue();
+  const wrapped = render.wrapStream(queue.iterable);
+
+  // Seed the approval-card stash on resumed runs so the driver can resolve
+  // `messageId` for the incoming `tool-result` even though it never saw the
+  // pre-suspension `tool-call`.
+  if (render.approvalContext) {
+    const existing = render.getPendingApproval(render.approvalContext.toolCallId);
+    render.onApprovalPosted(render.approvalContext.toolCallId, {
+      ...existing,
+      messageId: render.approvalContext.messageId,
+      displayName: existing?.displayName ?? '',
+      argsSummary: existing?.argsSummary ?? '',
+      startedAt: existing?.startedAt ?? Date.now(),
+    });
+  }
+
+  const driverPromise = (
+    render.streaming.enabled
+      ? runStreamingDriver({
+          stream: wrapped,
+          chatThread: render.chatThread,
+          adapter: render.adapter,
+          toolDisplay: render.toolDisplay as 'cards' | 'text' | 'timeline' | 'grouped' | 'hidden',
+          toolDisplayFn: render.toolDisplayFn,
+          streamingOptions: render.streaming.options,
+          channelToolNames: render.channelToolNames,
+          logger: render.logger,
+          onApprovalPosted: render.onApprovalPosted,
+          getPendingApproval: render.getPendingApproval,
+          takePendingApproval: render.takePendingApproval,
+          typingGate: render.typingGate,
+          formatError: render.formatError,
+        })
+      : runStaticDriver({
+          stream: wrapped,
+          chatThread: render.chatThread,
+          adapter: render.adapter,
+          toolDisplay: render.toolDisplay as 'cards' | 'text' | 'hidden',
+          toolDisplayFn: render.toolDisplayFn,
+          channelToolNames: render.channelToolNames,
+          logger: render.logger,
+          onApprovalPosted: render.onApprovalPosted,
+          getPendingApproval: render.getPendingApproval,
+          takePendingApproval: render.takePendingApproval,
+          formatError: render.formatError,
+        })
+  ).catch((err: unknown) => {
+    // Prevent unhandled rejection if the driver fails before a terminal chunk
+    // reaches the producer. The error is re-thrown when awaited at cleanup.
+    render.logger?.error?.(`[${render.platform}] channel render driver failed early`, { error: err });
+    throw err;
+  });
+
+  return { queue, driverPromise };
+}

--- a/packages/core/src/channels/session-renderer.ts
+++ b/packages/core/src/channels/session-renderer.ts
@@ -1,0 +1,241 @@
+import type { Session } from '../harness/session';
+import type { HarnessEvent, HarnessMessage } from '../harness/types';
+import { ChunkFrom } from '../stream/types';
+import type { AgentChunkType } from '../stream/types';
+
+import type { ChatChannelRenderContext } from './output-processor';
+import { openRenderSession } from './render-pump';
+import type { RenderSession } from './render-pump';
+
+/**
+ * Translates a Harness {@link Session}'s event stream into the
+ * `AgentChunkType` chunks the existing channel drivers
+ * (`runStreamingDriver` / `runStaticDriver`) already understand, then pumps
+ * them through a shared render session (`openRenderSession`).
+ *
+ * This is the Harness-path peer of `ChatChannelOutputProcessor`: where the
+ * agent path taps the agent's own output-processor chunk stream, the Harness
+ * path consumes the **same contract the TUI consumes** — the Session event
+ * bus — and reconstructs the minimal chunk shapes the drivers need. The
+ * drivers, queue, and approval-card plumbing are reused verbatim; only the
+ * *source* of the chunks differs.
+ *
+ * V1 scope: messaging + approvals. Mode/model events and OM/subagent events
+ * are intentionally ignored — they don't map to a rendered channel output —
+ * but the seam (subscribe → translate → push) doesn't preclude adding them.
+ *
+ * @internal
+ */
+export class SessionChannelRenderer {
+  readonly #session: Session;
+  readonly #render: ChatChannelRenderContext;
+  readonly #runId: string;
+
+  #renderSession: RenderSession | undefined;
+  #unsubscribe: (() => void) | undefined;
+
+  /**
+   * Text already emitted to the driver for the in-flight assistant message,
+   * keyed by message id. The Session emits the full evolving message text on
+   * every `message_update`; the drivers want incremental `text-delta` pieces,
+   * so we diff each update against what we've already pushed.
+   */
+  readonly #emittedText = new Map<string, string>();
+
+  /** Resolves when the run reaches a terminal `agent_end` and the driver drains. */
+  readonly #done: Promise<void>;
+  #resolveDone!: () => void;
+
+  constructor(args: { session: Session; render: ChatChannelRenderContext; runId?: string }) {
+    this.#session = args.session;
+    this.#render = args.render;
+    // Channel drivers stamp `runId` onto nothing they render, but the chunk
+    // contract requires it; a stable per-renderer id keeps every chunk in one
+    // logical run.
+    this.#runId = args.runId ?? `channel-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    this.#done = new Promise<void>(resolve => {
+      this.#resolveDone = resolve;
+    });
+  }
+
+  /**
+   * Subscribe to the session and begin translating events. Returns a promise
+   * that resolves once the run ends and the driver has drained the queue.
+   */
+  start(): Promise<void> {
+    this.#unsubscribe = this.#session.subscribe(event => {
+      this.#onEvent(event);
+    });
+    return this.#done;
+  }
+
+  #ensureRenderSession(): RenderSession {
+    if (!this.#renderSession) {
+      this.#renderSession = openRenderSession(this.#render);
+    }
+    return this.#renderSession;
+  }
+
+  #push(chunk: AgentChunkType<any>): void {
+    this.#ensureRenderSession().queue.push(chunk);
+  }
+
+  #base() {
+    return { runId: this.#runId, from: ChunkFrom.AGENT } as const;
+  }
+
+  #onEvent(event: HarnessEvent): void {
+    switch (event.type) {
+      case 'message_start':
+      case 'message_update':
+        this.#onMessage(event.message);
+        return;
+      case 'message_end':
+        this.#onMessageEnd(event.message);
+        return;
+      case 'tool_start':
+        this.#push({
+          ...this.#base(),
+          type: 'tool-call',
+          payload: { toolCallId: event.toolCallId, toolName: event.toolName, args: event.args as any },
+        });
+        return;
+      case 'tool_approval_required':
+        // The drivers read `runId` off the approval chunk to stash it on the
+        // pending-approval record (used to resume the right run later).
+        this.#push({
+          ...this.#base(),
+          type: 'tool-call-approval',
+          payload: {
+            toolCallId: event.toolCallId,
+            toolName: event.toolName,
+            args: (event.args ?? {}) as Record<string, any>,
+            resumeSchema: '',
+          },
+        });
+        return;
+      case 'tool_end':
+        if (event.isError) {
+          this.#push({
+            ...this.#base(),
+            type: 'tool-error',
+            payload: {
+              toolCallId: event.toolCallId,
+              toolName: this.#toolNameFor(event.toolCallId),
+              error: event.result,
+            },
+          });
+        } else {
+          this.#push({
+            ...this.#base(),
+            type: 'tool-result',
+            payload: {
+              toolCallId: event.toolCallId,
+              toolName: this.#toolNameFor(event.toolCallId),
+              result: event.result,
+              isError: false,
+              providerMetadata: event.providerMetadata as any,
+            },
+          });
+        }
+        return;
+      case 'agent_end':
+        this.#onAgentEnd(event.reason);
+        return;
+      default:
+        // mode/model, OM, subagent, usage, info, task, goal, workspace, etc.
+        // are not rendered to the channel in V1.
+        return;
+    }
+  }
+
+  /**
+   * The Session models tool calls by id but `tool_end` carries no toolName.
+   * Track the name from `tool_start` so we can rebuild `tool-result`/`tool-error`
+   * payloads, which the drivers key on for channel-tool filtering and labels.
+   */
+  readonly #toolNames = new Map<string, string>();
+
+  #toolNameFor(toolCallId: string): string {
+    return this.#toolNames.get(toolCallId) ?? '';
+  }
+
+  #onMessage(message: HarnessMessage): void {
+    if (message.role !== 'assistant') return;
+    // Track tool names as they appear so later `tool_end` events can be labeled.
+    for (const part of message.content) {
+      if (part.type === 'tool_call') this.#toolNames.set(part.id, part.name);
+    }
+    const fullText = message.content
+      .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+      .map(p => p.text)
+      .join('');
+    if (!fullText) return;
+
+    const already = this.#emittedText.get(message.id) ?? '';
+    if (fullText === already) return;
+    // Only emit forward progress; if the message text shrank (shouldn't happen
+    // for an evolving assistant message), re-anchor without re-emitting.
+    const delta = fullText.startsWith(already) ? fullText.slice(already.length) : fullText;
+    this.#emittedText.set(message.id, fullText);
+    if (!delta) return;
+    this.#push({
+      ...this.#base(),
+      type: 'text-delta',
+      payload: { id: message.id, text: delta },
+    });
+  }
+
+  #onMessageEnd(message: HarnessMessage): void {
+    if (message.role !== 'assistant') return;
+    // Flush any remaining text first so the final piece renders.
+    this.#onMessage(message);
+    this.#push({ ...this.#base(), type: 'text-end', payload: { id: message.id } });
+  }
+
+  #onAgentEnd(reason: 'complete' | 'aborted' | 'error' | 'suspended' | undefined): void {
+    // A suspended run is parked on an approval. The approval card has already
+    // been posted by the driver (which closed its own internal render state on
+    // the `tool-call-approval` chunk), so there's nothing more to render for
+    // this run. Just drain the queue so the driver loop ends and `done`
+    // resolves, letting the incoming-message handler return. No terminal chunk
+    // is pushed — the driver already finalized its output. The eventual resume
+    // run is rendered by a fresh renderer + render session keyed off the
+    // resume action.
+    if (reason === 'suspended') {
+      void this.#finish();
+      return;
+    }
+
+    if (reason === 'aborted') {
+      this.#push({ ...this.#base(), type: 'abort', payload: {} });
+    } else if (reason === 'error') {
+      this.#push({
+        ...this.#base(),
+        type: 'error',
+        payload: { error: new Error('Run failed') },
+      });
+    } else {
+      this.#push({ ...this.#base(), type: 'finish', payload: {} as any });
+    }
+    void this.#finish();
+  }
+
+  async #finish(): Promise<void> {
+    this.#unsubscribe?.();
+    this.#unsubscribe = undefined;
+    const rs = this.#renderSession;
+    if (rs) {
+      rs.queue.close();
+      try {
+        await rs.driverPromise;
+      } catch (err) {
+        this.#render.logger?.error?.(`[${this.#render.platform}] session channel render driver failed`, {
+          error: err,
+        });
+      }
+    }
+    this.#renderSession = undefined;
+    this.#resolveDone();
+  }
+}

--- a/packages/core/src/channels/stream-helpers.ts
+++ b/packages/core/src/channels/stream-helpers.ts
@@ -25,6 +25,14 @@ export interface PendingApprovalRecord {
   runId?: string;
   toolName?: string;
   args?: Record<string, unknown>;
+  /**
+   * Set only for the Harness channel path: the `resourceId` of the durable
+   * Harness Session that owns this parked tool call. The approval-button
+   * handler uses it to resolve the exact Session to resume (via
+   * `session.approveToolCall` / `session.declineToolCall`) instead of going
+   * through the agent. Absent for the Agent path, which resumes by `runId`.
+   */
+  sessionResourceId?: string;
 }
 
 /**

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -5,6 +5,8 @@ import type { MastraDBMessage } from '../agent/message-list/state/types';
 import { mastraDBMessageToSignal } from '../agent/signals';
 import type { AgentInstructions, ToolsInput, ToolsetsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
+import { AgentChannels } from '../channels/agent-channels';
+import type { ChannelConfig } from '../channels/types';
 import { getErrorFromUnknown } from '../error';
 import { GatewayManager } from '../llm/model/gateways';
 import { defaultGateways } from '../llm/model/gateways/defaults';
@@ -218,6 +220,13 @@ export class Harness<TState = {}> {
   #externalMastra: Mastra | undefined = undefined;
   #gatewayManager: GatewayManager | undefined = undefined;
   #legacyAgentMode: Record<string, Agent<any, any, any, any>> = {};
+  /**
+   * Channels bound to this Harness. When set, the channel acts as a full
+   * Harness UI: incoming messages drive a durable per-resource {@link Session}
+   * and replies render from that session's event stream. Null when no channels
+   * are configured.
+   */
+  #channels: AgentChannels | null = null;
 
   constructor(config: HarnessConfig<TState>) {
     validateModes(config.modes);
@@ -256,6 +265,33 @@ export class Harness<TState = {}> {
     } else if (typeof config.browser === 'function') {
       this.browserFn = config.browser;
     }
+
+    // Bind channels: the channel becomes a full Harness UI (peer of the TUI).
+    if (config.channels) {
+      const channels =
+        config.channels instanceof AgentChannels
+          ? config.channels
+          : new AgentChannels(config.channels as ChannelConfig);
+      this.setChannels(channels);
+    }
+  }
+
+  /**
+   * Returns the AgentChannels instance bound to this Harness, or null if no
+   * channels are configured. Mirrors `Agent.getChannels()`.
+   */
+  getChannels(): AgentChannels | null {
+    return this.#channels;
+  }
+
+  /**
+   * Bind an AgentChannels instance to this Harness, turning configured channels
+   * into a full Harness UI. Mirrors `Agent.setChannels()`. Used both by the
+   * constructor and by ChannelProvider implementations that inject adapters.
+   */
+  setChannels(channels: AgentChannels): void {
+    this.#channels = channels;
+    channels.__setHarness(this);
   }
 
   /**

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -1,6 +1,8 @@
 import type { Agent } from '../agent';
 import type { AgentInstructions, ToolsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
+import type { AgentChannels } from '../channels/agent-channels';
+import type { ChannelConfig } from '../channels/types';
 import type { PubSub } from '../events/pubsub';
 import type { MastraModelGatewayInterface } from '../llm/model/gateways';
 import type { LoopOptions } from '../loop/types';
@@ -336,6 +338,16 @@ export interface HarnessConfig<TState = {}> {
    * observability backend so that agent runs produce trace spans.
    */
   observability?: ObservabilityEntrypoint;
+
+  /**
+   * Channel configuration. When provided, the Harness becomes reachable through
+   * messaging channels (e.g. Slack) as a full Harness UI — a peer of the TUI.
+   * Each incoming channel message drives a durable per-resource Harness
+   * {@link Session}; replies (and tool-approval cards) are rendered from that
+   * session's event stream. Accepts a `ChannelConfig` or a pre-built
+   * `AgentChannels` instance (the same shapes the Agent accepts).
+   */
+  channels?: ChannelConfig | AgentChannels;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR lets you run a **Harness inside a messaging channel** (e.g. Slack), turning the channel into a full Harness UI — a peer of the terminal interface (Mastra Code).

The distinction matters:

- **An Agent channel** is a thin pipe to a single agent loop: each message runs the agent and streams the reply back.
- **A Harness channel** is the interface to the Harness itself: each conversation drives a durable per-resource `Session`, and replies render from that session's event stream — the same contract the terminal UI consumes.

Because the channel consumes the `Session`, Harness capabilities surface through the same seam the terminal UI uses. **V1 covers messaging and tool approvals.**

## What's in here

- **`render-pump.ts`** — extracts the shared chunk-queue / driver pump (`openRenderSession`) out of `output-processor.ts`. Pure internal refactor; the streaming/static drivers are unchanged and `output-processor.ts` now delegates to it.
- **`session-renderer.ts`** — `SessionChannelRenderer` subscribes to a `Session` event bus and translates harness events into the existing `AgentChunkType` stream the drivers already consume (`message_update` → diffed `text-delta`, `tool_start` → `tool-call`, `tool_approval_required` → `tool-call-approval`, `tool_end` → `tool-result`/`tool-error`, `agent_end` → terminal finish/abort/error).
- **`agent-channels.ts`** — additive `processHarnessMessage` send path plus Harness branches in `onAction`. Approvals resume through `session.approveToolCall` / `session.declineToolCall`, resolved by the `resourceId` stamped onto the approval record (so it survives process restarts).
- **`harness.ts` / `types.ts`** — a `channels` config field plus `getChannels()` / `setChannels()`, mirroring the Agent channels API.
- **Docs** — new `harness/channels.mdx` framing the channel as a Harness UI peer of the terminal interface, wired into the sidebar and cross-linked from the Agent channels guide.

## Usage

```ts
import { Harness } from '@mastra/core/harness'
import { createSlackAdapter } from '@chat-adapter/slack'

const harness = new Harness({
  id: 'coding-harness',
  modes: [{ id: 'build', defaultModelId: 'openai/gpt-5.5' }],
  channels: {
    adapters: { slack: createSlackAdapter() },
  },
})
```

## The Agent path is unchanged

The Harness path is additive-only — gated behind `if (harness && harnessResourceId)` branches. The Agent channel send/approval flow and all existing tests are untouched, and no TUI/CLI files are touched.

## Test plan

- [x] `pnpm --filter ./packages/core check` — `tsc --noEmit` clean.
- [x] `pnpm vitest run src/channels src/harness` — 46 files / 596 tests pass, 0 type errors.
- [x] New `session-renderer.test.ts` covers a streamed reply and a tool-approval round-trip via the static driver.
- [x] Existing `agent-channels.test.ts` / `integration.test.ts` stay green, proving the Agent path is unchanged.
- [ ] **Live Slack round-trip not runnable in CI/sandbox** — DM, channel-mention, and a real approval-card click should be smoke-tested against a live Slack workspace before merge.

## Notes for review

- The approval record now carries `sessionResourceId` (set only on the Harness path) so a button click resolves the exact durable `Session` to resume. The Agent path still resumes by `runId`.
- A changeset is included (`@mastra/core`, minor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR lets a Harness run directly inside a chat app like Slack, so the chat becomes the main interface instead of just sending messages to an agent. It also adds the plumbing to keep each conversation’s state safely saved, so replies and approval buttons keep working even after restarts.

### What changed
- Added shared render plumbing in `render-pump.ts` and moved `output-processor.ts` to use it.
- Added `SessionChannelRenderer` to turn Harness session events into the existing channel chunk stream.
- Extended `AgentChannels` to handle Harness-backed messages and tool approvals using durable `Session` state.
- Added `channels` support to `Harness` and updated related config/types.
- Added tests for Harness channel binding and session rendering behavior.
- Added documentation for Harness channels and linked it from the docs sidebar and channel guide.

### Notes
- The existing Agent channel flow is unchanged.
- The new Harness channel flow is additive and gated behind Harness channel configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->