### PR TITLE
fix(mysql): add missing PRIMARY KEY constraints for snapshot and spans tables

### DIFF
--- a/.changeset/cuddly-oranges-worry.md
+++ b/.changeset/cuddly-oranges-worry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mysql': patch
+---
+
+Fixed missing UNIQUE and PRIMARY KEY constraints on mastra_workflow_snapshot and mastra_ai_spans tables. Without these keys, ON DUPLICATE KEY UPDATE never fired, causing a new row per workflow step instead of updating in place.

--- a/.changeset/cuddly-oranges-worry.md
+++ b/.changeset/cuddly-oranges-worry.md
@@ -2,4 +2,4 @@
 '@mastra/mysql': patch
 ---
 
-Fixed missing UNIQUE and PRIMARY KEY constraints on mastra_workflow_snapshot and mastra_ai_spans tables. Without these keys, ON DUPLICATE KEY UPDATE never fired, causing a new row per workflow step instead of updating in place.
+Fixed workflow snapshots and AI spans creating duplicate records instead of updating in place. Each workflow step previously inserted a new row, causing unbounded table growth and degraded read performance.

--- a/stores/mysql/src/storage/domains/observability/index.ts
+++ b/stores/mysql/src/storage/domains/observability/index.ts
@@ -117,6 +117,7 @@ export class ObservabilityMySQL extends ObservabilityStorage {
       generateTableSQL({
         tableName: TABLE_SPANS,
         schema: TABLE_SCHEMAS[TABLE_SPANS],
+        compositePrimaryKey: ['traceId', 'spanId'],
       }),
     );
 

--- a/stores/mysql/src/storage/domains/operations/index.ts
+++ b/stores/mysql/src/storage/domains/operations/index.ts
@@ -154,6 +154,18 @@ export class StoreOperationsMySQL extends StoreOperations {
       extraConstraints.push(`PRIMARY KEY (${pkColumns})`);
     }
 
+    // Hard-coded constraints for tables that rely on upsert behavior
+    if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      extraConstraints.push(
+        `PRIMARY KEY (${quoteIdentifier('workflow_name', 'column name')}, ${quoteIdentifier('run_id', 'column name')})`,
+      );
+    }
+    if (tableName === TABLE_SPANS) {
+      extraConstraints.push(
+        `PRIMARY KEY (${quoteIdentifier('traceId', 'column name')}, ${quoteIdentifier('spanId', 'column name')})`,
+      );
+    }
+
     return `CREATE TABLE IF NOT EXISTS ${tableIdent} (${[...columns, ...extraConstraints].filter(Boolean).join(', ')}) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`;
   }
 

--- a/stores/mysql/src/storage/domains/workflows/index.ts
+++ b/stores/mysql/src/storage/domains/workflows/index.ts
@@ -65,7 +65,13 @@ export class WorkflowsMySQL extends WorkflowsStorage {
    * Exports DDL statements for all managed tables.
    */
   static getExportDDL(): string[] {
-    return [generateTableSQL({ tableName: TABLE_WORKFLOW_SNAPSHOT, schema: TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT] })];
+    return [
+      generateTableSQL({
+        tableName: TABLE_WORKFLOW_SNAPSHOT,
+        schema: TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT],
+        compositePrimaryKey: ['workflow_name', 'run_id'],
+      }),
+    ];
   }
 
   constructor({


### PR DESCRIPTION
## Description

Adds missing `PRIMARY KEY` constraints on `mastra_workflow_snapshot` and `mastra_ai_spans` tables in the MySQL store. Without these keys, `ON DUPLICATE KEY UPDATE` never fired, causing a new row per workflow step instead of updating in place — leading to unbounded table growth and degraded read performance.

- Added `PRIMARY KEY (workflow_name, run_id)` for `mastra_workflow_snapshot` in runtime table creation (`getCreateTableSQL`)
- Added `PRIMARY KEY (traceId, spanId)` for `mastra_ai_spans` in runtime table creation (`getCreateTableSQL`)
- Added `compositePrimaryKey` to both `getExportDDL` paths so exported DDL also includes the correct constraints
- Matches the pattern used by all other stores (PG, LibSQL, DSQL, Spanner), which hard-code these constraints in their own DDL

## Related Issue(s)

Fixes #18447

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
MySQL needs to know which columns make a row “the same” so that `ON DUPLICATE KEY UPDATE` updates an existing record instead of inserting a new one. This PR adds the missing composite primary keys for workflow snapshots and AI spans, stopping duplicate rows from being created forever.

## Summary
- Added missing composite `PRIMARY KEY` constraints so upserts work correctly:
  - `mastra_workflow_snapshot`: `(workflow_name, run_id)`
  - `mastra_ai_spans`: `(traceId, spanId)`
- Updated MySQL table creation logic to include these composite primary keys for the affected tables.
- Updated exported DDL generation so the emitted schema matches the actual table definitions (including the same composite primary keys).
- Added a changeset for `@mastra/mysql` documenting the fix for duplicate growth.

## Impact
- Fixes `ON DUPLICATE KEY UPDATE` behavior for workflow snapshots (prevents inserting a new row on every step).
- Prevents unbounded table growth and duplicate rows for both workflow snapshots and spans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->