### PR TITLE
fix(mcp): use get-port for test port allocation to fix CI flakiness

### DIFF
--- a/.changeset/legal-lizards-smash.md
+++ b/.changeset/legal-lizards-smash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed flaky MCP server tests that used hardcoded random port ranges by binding to OS-assigned ephemeral ports instead.

--- a/.changeset/legal-lizards-smash.md
+++ b/.changeset/legal-lizards-smash.md
@@ -1,5 +1,0 @@
----
-'@mastra/mcp': patch
----
-
-Fixed flaky MCP server tests that used hardcoded random port ranges by binding to OS-assigned ephemeral ports instead.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -58,6 +58,7 @@
     "@vitest/ui": "catalog:",
     "ai": "^5.0.185",
     "eslint": "^10.4.1",
+    "get-port": "^7.1.0",
     "hono": "^4.12.8",
     "hono-mcp-server-sse-transport": "0.0.7",
     "tsup": "^8.5.1",

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -29,7 +29,41 @@ import { MCPClient } from '../client/configuration';
 import { MCPServer } from './server';
 import type { MastraPrompt, MCPServerResources, MCPServerResourceContent, MCPRequestHandlerExtra } from './types';
 
-const PORT = 9100 + Math.floor(Math.random() * 1000);
+// Helper: bind to OS-assigned port (port 0) and resolve to the actual port.
+// Avoids random-port collisions that flake tests on CI.
+const listenOnEphemeralPort = (server: http.Server): Promise<number> =>
+  new Promise<number>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, () => {
+      const address = server.address();
+      if (address && typeof address === 'object') {
+        resolve(address.port);
+      } else {
+        reject(new Error('Failed to obtain ephemeral port'));
+      }
+    });
+  });
+
+// Helper: resolve the port of a server that is already listening (e.g. started by Hono serve()).
+const getServerPort = (server: http.Server): Promise<number> =>
+  new Promise<number>((resolve, reject) => {
+    const address = server.address();
+    if (address && typeof address === 'object') {
+      resolve(address.port);
+    } else {
+      server.once('error', reject);
+      server.once('listening', () => {
+        const address = server.address();
+        if (address && typeof address === 'object') {
+          resolve(address.port);
+        } else {
+          reject(new Error('Failed to obtain ephemeral port'));
+        }
+      });
+    }
+  });
+
+let PORT: number;
 let server: MCPServer;
 let httpServer: http.Server;
 
@@ -391,7 +425,7 @@ describe('MCPServer', () => {
     let resourceTestServerInstance: MCPServer;
     let localHttpServerForResources: http.Server;
     let resourceTestInternalClient: InternalMastraMCPClient;
-    const RESOURCE_TEST_PORT = 9200 + Math.floor(Math.random() * 1000);
+    let RESOURCE_TEST_PORT: number;
 
     const mockResourceContents: Record<string, MCPServerResourceContent> = {
       'weather://current': {
@@ -464,7 +498,7 @@ describe('MCPServer', () => {
         });
       });
 
-      await new Promise<void>(resolve => localHttpServerForResources.listen(RESOURCE_TEST_PORT, () => resolve()));
+      RESOURCE_TEST_PORT = await listenOnEphemeralPort(localHttpServerForResources);
 
       resourceTestInternalClient = new InternalMastraMCPClient({
         name: 'resource-test-internal-client',
@@ -738,7 +772,7 @@ describe('MCPServer', () => {
     let promptServer: MCPServer;
     let promptInternalClient: InternalMastraMCPClient;
     let promptHttpServer: http.Server;
-    const PROMPT_PORT = 9500 + Math.floor(Math.random() * 1000);
+    let PROMPT_PORT: number;
 
     let currentPrompts: (MastraPrompt & { getMessages?: (args: any) => Promise<any[]> })[] = [
       {
@@ -788,7 +822,7 @@ describe('MCPServer', () => {
           res,
         });
       });
-      await new Promise<void>(resolve => promptHttpServer.listen(PROMPT_PORT, () => resolve()));
+      PROMPT_PORT = await listenOnEphemeralPort(promptHttpServer);
       promptInternalClient = new InternalMastraMCPClient({
         name: 'prompt-test-internal-client',
         server: { url: new URL(`http://localhost:${PROMPT_PORT}/sse`) },
@@ -938,7 +972,7 @@ describe('MCPServer', () => {
         });
       });
 
-      await new Promise<void>(resolve => httpServer.listen(PORT, () => resolve()));
+      PORT = await listenOnEphemeralPort(httpServer);
     });
 
     afterAll(async () => {
@@ -1054,7 +1088,7 @@ describe('MCPServer', () => {
   describe('MCPServer HTTP Transport', () => {
     let server: MCPServer;
     let client: MCPClient;
-    const PORT = 9200 + Math.floor(Math.random() * 1000);
+    let PORT: number;
     const TOKEN = `<random-token>`;
 
     beforeAll(async () => {
@@ -1096,7 +1130,7 @@ describe('MCPServer', () => {
         });
       });
 
-      await new Promise<void>(resolve => httpServer.listen(PORT, () => resolve()));
+      PORT = await listenOnEphemeralPort(httpServer);
 
       client = new MCPClient({
         servers: {
@@ -1210,7 +1244,7 @@ describe('MCPServer', () => {
     let hono: Hono;
     let honoServer: ServerType;
     let client: MCPClient;
-    const PORT = 9300 + Math.floor(Math.random() * 1000);
+    let PORT: number;
 
     beforeAll(async () => {
       server = new MCPServer({
@@ -1242,7 +1276,8 @@ describe('MCPServer', () => {
         });
       });
 
-      honoServer = serve({ fetch: hono.fetch, port: PORT });
+      honoServer = serve({ fetch: hono.fetch, port: 0 });
+      PORT = await getServerPort(honoServer);
 
       // Initialize MCPClient with SSE endpoint
       client = new MCPClient({
@@ -1293,21 +1328,6 @@ describe('MCPServer', () => {
     let sessionServer: MCPServer;
     let sessionHttpServer: http.Server;
     let currentTestPort: number;
-
-    // Helper: bind to OS-assigned port (port 0) and resolve to the actual port.
-    // Avoids the random-port collisions that were flaking these tests on CI.
-    const listenOnEphemeralPort = (server: http.Server): Promise<number> =>
-      new Promise<number>((resolve, reject) => {
-        server.once('error', reject);
-        server.listen(0, () => {
-          const address = server.address();
-          if (address && typeof address === 'object') {
-            resolve(address.port);
-          } else {
-            reject(new Error('Failed to obtain ephemeral port'));
-          }
-        });
-      });
 
     afterEach(async () => {
       if (sessionHttpServer) {
@@ -2166,21 +2186,6 @@ describe('MCPServer - Elicitation', () => {
   let elicitationHttpServer: http.Server;
   let ELICITATION_PORT: number;
 
-  // Helper: bind to OS-assigned port (port 0) and resolve to the actual port.
-  // Avoids the random-port collisions that were flaking these tests on CI.
-  const listenOnEphemeralPort = (server: http.Server): Promise<number> =>
-    new Promise<number>((resolve, reject) => {
-      server.once('error', reject);
-      server.listen(0, () => {
-        const address = server.address();
-        if (address && typeof address === 'object') {
-          resolve(address.port);
-        } else {
-          reject(new Error('Failed to obtain ephemeral port'));
-        }
-      });
-    });
-
   beforeAll(async () => {
     elicitationServer = new MCPServer({
       name: 'ElicitationTestServer',
@@ -2555,7 +2560,7 @@ describe('MCPServer - Elicitation', () => {
       },
     };
 
-    const customTimeoutPort = 9600 + Math.floor(Math.random() * 1000);
+    let customTimeoutPort: number;
     const customTimeoutServer = new MCPServer({
       name: 'CustomTimeoutServer',
       version: '1.0.0',
@@ -2572,7 +2577,7 @@ describe('MCPServer - Elicitation', () => {
       });
     });
 
-    await new Promise<void>(resolve => customTimeoutHttpServer.listen(customTimeoutPort, () => resolve()));
+    customTimeoutPort = await listenOnEphemeralPort(customTimeoutHttpServer);
 
     try {
       // Create a client that responds after a delay but within the custom timeout
@@ -2634,7 +2639,7 @@ describe('MCPServer - Elicitation', () => {
 describe('MCPServer with Tool Output Schema', () => {
   let serverWithOutputSchema: MCPServer;
   let clientWithOutputSchema: MCPClient;
-  const PORT = 9600 + Math.floor(Math.random() * 1000);
+  let PORT: number;
   let httpServerWithOutputSchema: http.Server;
 
   const structuredTool: ToolsInput = {
@@ -2669,7 +2674,7 @@ describe('MCPServer with Tool Output Schema', () => {
       });
     });
 
-    await new Promise<void>(resolve => httpServerWithOutputSchema.listen(PORT, () => resolve()));
+    PORT = await listenOnEphemeralPort(httpServerWithOutputSchema);
 
     clientWithOutputSchema = new MCPClient({
       servers: {
@@ -2717,7 +2722,7 @@ describe('MCPServer - Tool Input Validation', () => {
   let validationClient: InternalMastraMCPClient;
   let httpValidationServer: ServerType;
   let tools: Record<string, Tool<any, any, any, any>>;
-  const VALIDATION_PORT = 9700 + Math.floor(Math.random() * 100);
+  let VALIDATION_PORT: number;
 
   const toolsWithValidation: ToolsInput = {
     stringTool: {
@@ -2787,8 +2792,9 @@ describe('MCPServer - Tool Input Validation', () => {
 
     httpValidationServer = serve({
       fetch: app.fetch,
-      port: VALIDATION_PORT,
+      port: 0,
     });
+    VALIDATION_PORT = await getServerPort(httpValidationServer);
 
     validationClient = new InternalMastraMCPClient({
       name: 'validation-test-client',
@@ -3068,7 +3074,7 @@ describe('MCPServer - Tool Input Validation', () => {
  * from both pre-parsed middleware (like express.json()) and raw streams.
  */
 describe('MCPServer readJsonBody compatibility', () => {
-  const READ_JSON_BODY_PORT = 9400 + Math.floor(Math.random() * 100);
+  let READ_JSON_BODY_PORT: number;
   let readJsonServer: MCPServer;
   let readJsonHttpServer: http.Server;
 
@@ -3098,9 +3104,7 @@ describe('MCPServer readJsonBody compatibility', () => {
       });
     });
 
-    await new Promise<void>(resolve => {
-      readJsonHttpServer.listen(READ_JSON_BODY_PORT, resolve);
-    });
+    READ_JSON_BODY_PORT = await listenOnEphemeralPort(readJsonHttpServer);
   });
 
   afterAll(async () => {
@@ -3131,7 +3135,7 @@ describe('MCPServer readJsonBody compatibility', () => {
   });
 
   describe('HTTP transport with pre-parsed body (simulating express.json())', () => {
-    const PREPARSED_PORT = 9500 + Math.floor(Math.random() * 100);
+    let PREPARSED_PORT: number;
     let preParsedServer: MCPServer;
     let preParsedHttpServer: http.Server;
 
@@ -3169,9 +3173,7 @@ describe('MCPServer readJsonBody compatibility', () => {
         });
       });
 
-      await new Promise<void>(resolve => {
-        preParsedHttpServer.listen(PREPARSED_PORT, resolve);
-      });
+      PREPARSED_PORT = await listenOnEphemeralPort(preParsedHttpServer);
     });
 
     afterAll(async () => {
@@ -3222,7 +3224,7 @@ describe('MCPServer readJsonBody compatibility', () => {
   });
 
   describe('SSE transport with pre-parsed body', () => {
-    const SSE_PORT = 9600 + Math.floor(Math.random() * 100);
+    let SSE_PORT: number;
     let sseServer: MCPServer;
     let sseHttpServer: http.Server;
 
@@ -3261,9 +3263,7 @@ describe('MCPServer readJsonBody compatibility', () => {
         });
       });
 
-      await new Promise<void>(resolve => {
-        sseHttpServer.listen(SSE_PORT, resolve);
-      });
+      SSE_PORT = await listenOnEphemeralPort(sseHttpServer);
     });
 
     afterAll(async () => {
@@ -3293,7 +3293,7 @@ describe('MCPServer readJsonBody compatibility', () => {
   });
 
   describe('SSE transport with raw stream (no middleware)', () => {
-    const SSE_RAW_PORT = 9700 + Math.floor(Math.random() * 100);
+    let SSE_RAW_PORT: number;
     let sseRawServer: MCPServer;
     let sseRawHttpServer: http.Server;
 
@@ -3316,9 +3316,7 @@ describe('MCPServer readJsonBody compatibility', () => {
         });
       });
 
-      await new Promise<void>(resolve => {
-        sseRawHttpServer.listen(SSE_RAW_PORT, resolve);
-      });
+      SSE_RAW_PORT = await listenOnEphemeralPort(sseRawHttpServer);
     });
 
     afterAll(async () => {

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -20,6 +20,7 @@ import type {
   Prompt,
 } from '@modelcontextprotocol/sdk/types.js';
 import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai/test';
+import getPort from 'get-port';
 import { Hono } from 'hono';
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi, beforeEach } from 'vitest';
 import { z } from 'zod/v3';
@@ -29,39 +30,17 @@ import { MCPClient } from '../client/configuration';
 import { MCPServer } from './server';
 import type { MastraPrompt, MCPServerResources, MCPServerResourceContent, MCPRequestHandlerExtra } from './types';
 
-// Helper: bind to OS-assigned port (port 0) and resolve to the actual port.
-// Avoids random-port collisions that flake tests on CI.
-const listenOnEphemeralPort = (server: http.Server): Promise<number> =>
-  new Promise<number>((resolve, reject) => {
+// Bind `server` to a free port found via the `get-port` package (the same approach the
+// mastra CLI uses for port allocation) and resolve to the assigned port.
+// Avoids hardcoded random port ranges that flake tests on CI when two suites pick the same port.
+const listenOnFreePort = async (server: http.Server): Promise<number> => {
+  const port = await getPort();
+  await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
-    server.listen(0, () => {
-      const address = server.address();
-      if (address && typeof address === 'object') {
-        resolve(address.port);
-      } else {
-        reject(new Error('Failed to obtain ephemeral port'));
-      }
-    });
+    server.listen(port, () => resolve());
   });
-
-// Helper: resolve the port of a server that is already listening (e.g. started by Hono serve()).
-const getServerPort = (server: http.Server): Promise<number> =>
-  new Promise<number>((resolve, reject) => {
-    const address = server.address();
-    if (address && typeof address === 'object') {
-      resolve(address.port);
-    } else {
-      server.once('error', reject);
-      server.once('listening', () => {
-        const address = server.address();
-        if (address && typeof address === 'object') {
-          resolve(address.port);
-        } else {
-          reject(new Error('Failed to obtain ephemeral port'));
-        }
-      });
-    }
-  });
+  return port;
+};
 
 let PORT: number;
 let server: MCPServer;
@@ -498,7 +477,7 @@ describe('MCPServer', () => {
         });
       });
 
-      RESOURCE_TEST_PORT = await listenOnEphemeralPort(localHttpServerForResources);
+      RESOURCE_TEST_PORT = await listenOnFreePort(localHttpServerForResources);
 
       resourceTestInternalClient = new InternalMastraMCPClient({
         name: 'resource-test-internal-client',
@@ -822,7 +801,7 @@ describe('MCPServer', () => {
           res,
         });
       });
-      PROMPT_PORT = await listenOnEphemeralPort(promptHttpServer);
+      PROMPT_PORT = await listenOnFreePort(promptHttpServer);
       promptInternalClient = new InternalMastraMCPClient({
         name: 'prompt-test-internal-client',
         server: { url: new URL(`http://localhost:${PROMPT_PORT}/sse`) },
@@ -972,7 +951,7 @@ describe('MCPServer', () => {
         });
       });
 
-      PORT = await listenOnEphemeralPort(httpServer);
+      PORT = await listenOnFreePort(httpServer);
     });
 
     afterAll(async () => {
@@ -1130,7 +1109,7 @@ describe('MCPServer', () => {
         });
       });
 
-      PORT = await listenOnEphemeralPort(httpServer);
+      PORT = await listenOnFreePort(httpServer);
 
       client = new MCPClient({
         servers: {
@@ -1276,8 +1255,8 @@ describe('MCPServer', () => {
         });
       });
 
-      honoServer = serve({ fetch: hono.fetch, port: 0 });
-      PORT = await getServerPort(honoServer);
+      PORT = await getPort();
+      honoServer = serve({ fetch: hono.fetch, port: PORT });
 
       // Initialize MCPClient with SSE endpoint
       client = new MCPClient({
@@ -1362,7 +1341,7 @@ describe('MCPServer', () => {
         });
       });
 
-      currentTestPort = await listenOnEphemeralPort(sessionHttpServer);
+      currentTestPort = await listenOnFreePort(sessionHttpServer);
 
       const client = new InternalMastraMCPClient({
         name: 'default-session-client',
@@ -1401,7 +1380,7 @@ describe('MCPServer', () => {
         });
       });
 
-      currentTestPort = await listenOnEphemeralPort(sessionHttpServer);
+      currentTestPort = await listenOnFreePort(sessionHttpServer);
 
       const client = new InternalMastraMCPClient({
         name: 'no-session-client',
@@ -1440,7 +1419,7 @@ describe('MCPServer', () => {
         });
       });
 
-      currentTestPort = await listenOnEphemeralPort(sessionHttpServer);
+      currentTestPort = await listenOnFreePort(sessionHttpServer);
 
       const client = new InternalMastraMCPClient({
         name: 'serverless-client',
@@ -1488,7 +1467,7 @@ describe('MCPServer', () => {
         });
       });
 
-      currentTestPort = await listenOnEphemeralPort(sessionHttpServer);
+      currentTestPort = await listenOnFreePort(sessionHttpServer);
 
       const client = new InternalMastraMCPClient({
         name: 'custom-session-client',
@@ -1528,7 +1507,7 @@ describe('MCPServer', () => {
         });
       });
 
-      currentTestPort = await listenOnEphemeralPort(sessionHttpServer);
+      currentTestPort = await listenOnFreePort(sessionHttpServer);
 
       const client = new InternalMastraMCPClient({
         name: 'override-test-client',
@@ -1564,7 +1543,7 @@ describe('MCPServer', () => {
         });
       });
 
-      currentTestPort = await listenOnEphemeralPort(sessionHttpServer);
+      currentTestPort = await listenOnFreePort(sessionHttpServer);
 
       // Send a POST request with a session ID that doesn't exist on the server
       const response = await fetch(`http://localhost:${currentTestPort}/http`, {
@@ -2247,7 +2226,7 @@ describe('MCPServer - Elicitation', () => {
       });
     });
 
-    ELICITATION_PORT = await listenOnEphemeralPort(elicitationHttpServer);
+    ELICITATION_PORT = await listenOnFreePort(elicitationHttpServer);
   });
 
   afterAll(async () => {
@@ -2577,7 +2556,7 @@ describe('MCPServer - Elicitation', () => {
       });
     });
 
-    customTimeoutPort = await listenOnEphemeralPort(customTimeoutHttpServer);
+    customTimeoutPort = await listenOnFreePort(customTimeoutHttpServer);
 
     try {
       // Create a client that responds after a delay but within the custom timeout
@@ -2674,7 +2653,7 @@ describe('MCPServer with Tool Output Schema', () => {
       });
     });
 
-    PORT = await listenOnEphemeralPort(httpServerWithOutputSchema);
+    PORT = await listenOnFreePort(httpServerWithOutputSchema);
 
     clientWithOutputSchema = new MCPClient({
       servers: {
@@ -2790,11 +2769,11 @@ describe('MCPServer - Tool Input Validation', () => {
       });
     });
 
+    VALIDATION_PORT = await getPort();
     httpValidationServer = serve({
       fetch: app.fetch,
-      port: 0,
+      port: VALIDATION_PORT,
     });
-    VALIDATION_PORT = await getServerPort(httpValidationServer);
 
     validationClient = new InternalMastraMCPClient({
       name: 'validation-test-client',
@@ -3104,7 +3083,7 @@ describe('MCPServer readJsonBody compatibility', () => {
       });
     });
 
-    READ_JSON_BODY_PORT = await listenOnEphemeralPort(readJsonHttpServer);
+    READ_JSON_BODY_PORT = await listenOnFreePort(readJsonHttpServer);
   });
 
   afterAll(async () => {
@@ -3173,7 +3152,7 @@ describe('MCPServer readJsonBody compatibility', () => {
         });
       });
 
-      PREPARSED_PORT = await listenOnEphemeralPort(preParsedHttpServer);
+      PREPARSED_PORT = await listenOnFreePort(preParsedHttpServer);
     });
 
     afterAll(async () => {
@@ -3263,7 +3242,7 @@ describe('MCPServer readJsonBody compatibility', () => {
         });
       });
 
-      SSE_PORT = await listenOnEphemeralPort(sseHttpServer);
+      SSE_PORT = await listenOnFreePort(sseHttpServer);
     });
 
     afterAll(async () => {
@@ -3316,7 +3295,7 @@ describe('MCPServer readJsonBody compatibility', () => {
         });
       });
 
-      SSE_RAW_PORT = await listenOnEphemeralPort(sseRawHttpServer);
+      SSE_RAW_PORT = await listenOnFreePort(sseRawHttpServer);
     });
 
     afterAll(async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,7 +558,7 @@ importers:
     dependencies:
       firebase-admin:
         specifier: ^13.7.0
-        version: 13.9.0(encoding@0.1.13)
+        version: 13.9.0
     devDependencies:
       '@internal/auth':
         specifier: workspace:*
@@ -1818,16 +1818,16 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: ^2.0.62
-        version: 2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^2.0.99
-        version: 2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: ^2.0.1
         version: 2.0.3
       '@ai-sdk/provider-utils':
         specifier: ^3.0.22
-        version: 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@huggingface/hub':
         specifier: ^0.15.2
         version: 0.15.2
@@ -1900,7 +1900,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   integrations/brightdata:
     devDependencies:
@@ -4472,6 +4472,9 @@ importers:
       eslint:
         specifier: ^10.4.1
         version: 10.5.0(jiti@2.7.0)
+      get-port:
+        specifier: ^7.1.0
+        version: 7.1.0
       hono:
         specifier: ^4.12.8
         version: 4.12.25
@@ -28901,10 +28904,10 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -29054,6 +29057,26 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
+
+  '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@types/node'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - typescript
+      - vite
 
   '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
@@ -34024,7 +34047,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/firestore@7.11.6(encoding@0.1.13)':
+  '@google-cloud/firestore@7.11.6':
     dependencies:
       '@opentelemetry/api': 1.9.1
       fast-deep-equal: 3.1.3
@@ -44450,7 +44473,7 @@ snapshots:
       pkg-types: 1.3.1
       yaml: 2.9.0
 
-  firebase-admin@13.9.0(encoding@0.1.13):
+  firebase-admin@13.9.0:
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0
@@ -44463,7 +44486,7 @@ snapshots:
       node-forge: 1.4.0
       uuid: 11.1.0
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
+      '@google-cloud/firestore': 7.11.6
       '@google-cloud/storage': 7.19.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
The MCP server tests were flaking on CI because each suite picked a random port from a hardcoded range (`9100 + Math.floor(Math.random() * 1000)`), and two suites occasionally landed on the same port.

This switches to the [`get-port`](https://www.npmjs.com/package/get-port) package for port allocation — the same approach the mastra CLI already uses.

Before:

```ts
const PORT = 9100 + Math.floor(Math.random() * 1000);
await new Promise<void>(resolve => httpServer.listen(PORT, () => resolve()));
```

After:

```ts
import getPort from 'get-port';

const listenOnFreePort = async (server: http.Server): Promise<number> => {
  const port = await getPort();
  await new Promise<void>((resolve, reject) => {
    server.once('error', reject);
    server.listen(port, () => resolve());
  });
  return port;
};

PORT = await listenOnFreePort(httpServer);
```

`get-port` checks whether a port is actually available before returning it, so the suites no longer collide. Adds `get-port@^7.1.0` as a devDependency of `@mastra/mcp`.

Test-only change — no source or published-package impact, so no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the MCP test suite stop “guessing” which network ports to use and instead picks ports that are actually free. That helps prevent flaky CI failures when two tests accidentally try to use the same port.

## Summary
- Added `get-port@^7.1.0` to `packages/mcp` as a dev dependency.
- Updated `packages/mcp/src/server/server.test.ts` to use `get-port`/free-port allocation for server startup in tests instead of hardcoded random port ranges.
- Removed the old ephemeral-port helper and standardized test setup across SSE, HTTP transport, session management, elicitation, timeout, schema validation, and body-parsing coverage.

## Notes
- Test-only change; no published source/output changes.
- No changeset included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->