### PR TITLE
feat(core): add mode tool allowlists

### DIFF
--- a/.changeset/mode-available-tools-core.md
+++ b/.changeset/mode-available-tools-core.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added an optional `availableTools` allowlist to `HarnessModeBase` so each mode can declare one unified list of visible tool names. When set, the harness resolves `activeTools` at LLM-call time and hides any tool not in the list — including workspace tools, which are matched by their exposed names. Per-tool and category `deny` permission rules still take precedence over the allowlist. `undefined` means no mode-level restriction (existing behavior). This moves mode-based tool visibility out of workspace construction and into a single, serializable contract.

--- a/.changeset/mode-available-tools-core.md
+++ b/.changeset/mode-available-tools-core.md
@@ -3,3 +3,22 @@
 ---
 
 Added an optional `availableTools` allowlist to `HarnessModeBase` so each mode can declare one unified list of visible tool names. When set, the harness resolves `activeTools` at LLM-call time and hides any tool not in the list — including workspace tools, which are matched by their exposed names. Per-tool and category `deny` permission rules still take precedence over the allowlist. `undefined` means no mode-level restriction (existing behavior). This moves mode-based tool visibility out of workspace construction and into a single, serializable contract.
+
+**Example**
+
+Declare a mode that only exposes read and plan-writing tools:
+
+```ts
+import type { HarnessMode } from '@mastra/core/harness';
+
+const planMode: HarnessMode = {
+  id: 'plan',
+  // Only these tools are visible to the model in plan mode.
+  // Workspace tools are matched by their exposed (renamed) names.
+  availableTools: ['view', 'find_files', 'search_content', 'write_file', 'submit_plan'],
+  // ...other mode config
+};
+
+// Omitting availableTools (or setting undefined) leaves all tools visible.
+// Set to [] to hide every tool for this mode.
+```

--- a/.changeset/mode-available-tools-mastracode.md
+++ b/.changeset/mode-available-tools-mastracode.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Updated plan and explore modes to declare `availableTools` allowlists so tool visibility is gated at LLM-call time instead of workspace construction. Plan mode includes read-only tools plus plan-file editing and delivery tools; explore mode includes only read-only tools. Build mode remains unrestricted. Workspace creation no longer branches on mode for tool visibility — all modes now share the same workspace instance.

--- a/mastracode/src/agents/__tests__/mode-available-tools.test.ts
+++ b/mastracode/src/agents/__tests__/mode-available-tools.test.ts
@@ -4,9 +4,14 @@ import { MC_TOOLS } from '../../tool-names.js';
 import { buildMode } from '../modes/build.js';
 import { fastMode } from '../modes/explore.js';
 import { planMode } from '../modes/plan.js';
+import { EXPLORE_MODE_AVAILABLE_TOOLS, PLAN_MODE_AVAILABLE_TOOLS } from '../tool-availability.js';
 
 describe('mode availableTools configuration', () => {
   describe('plan mode', () => {
+    it('uses the shared plan availableTools allowlist', () => {
+      expect(planMode.availableTools).toEqual([...PLAN_MODE_AVAILABLE_TOOLS]);
+    });
+
     it('declares a unified availableTools allowlist', () => {
       expect(planMode.availableTools).toBeDefined();
       expect(Array.isArray(planMode.availableTools)).toBe(true);
@@ -46,6 +51,10 @@ describe('mode availableTools configuration', () => {
   });
 
   describe('explore (fast) mode', () => {
+    it('uses the shared explore availableTools allowlist', () => {
+      expect(fastMode.availableTools).toEqual([...EXPLORE_MODE_AVAILABLE_TOOLS]);
+    });
+
     it('declares a unified availableTools allowlist', () => {
       expect(fastMode.availableTools).toBeDefined();
       expect(Array.isArray(fastMode.availableTools)).toBe(true);

--- a/mastracode/src/agents/__tests__/mode-available-tools.test.ts
+++ b/mastracode/src/agents/__tests__/mode-available-tools.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { MC_TOOLS } from '../../tool-names.js';
+import { buildMode } from '../modes/build.js';
+import { fastMode } from '../modes/explore.js';
+import { planMode } from '../modes/plan.js';
+
+describe('mode availableTools configuration', () => {
+  describe('plan mode', () => {
+    it('declares a unified availableTools allowlist', () => {
+      expect(planMode.availableTools).toBeDefined();
+      expect(Array.isArray(planMode.availableTools)).toBe(true);
+      expect(planMode.availableTools!.length).toBeGreaterThan(0);
+    });
+
+    it('includes read-only exploration tools by exposed name', () => {
+      const tools = planMode.availableTools!;
+      expect(tools).toContain(MC_TOOLS.VIEW);
+      expect(tools).toContain(MC_TOOLS.FIND_FILES);
+      expect(tools).toContain(MC_TOOLS.SEARCH_CONTENT);
+      expect(tools).toContain(MC_TOOLS.FILE_STAT);
+      expect(tools).toContain(MC_TOOLS.LSP_INSPECT);
+    });
+
+    it('includes plan delivery tools', () => {
+      const tools = planMode.availableTools!;
+      expect(tools).toContain('submit_plan');
+      expect(tools).toContain('ask_user');
+    });
+
+    it('includes plan file editing tools', () => {
+      const tools = planMode.availableTools!;
+      expect(tools).toContain(MC_TOOLS.WRITE_FILE);
+      expect(tools).toContain(MC_TOOLS.STRING_REPLACE_LSP);
+    });
+
+    it('excludes mutating and execution tools', () => {
+      const tools = planMode.availableTools!;
+      expect(tools).not.toContain(MC_TOOLS.DELETE_FILE);
+      expect(tools).not.toContain(MC_TOOLS.MKDIR);
+      expect(tools).not.toContain(MC_TOOLS.AST_SMART_EDIT);
+      expect(tools).not.toContain(MC_TOOLS.EXECUTE_COMMAND);
+      expect(tools).not.toContain(MC_TOOLS.GET_PROCESS_OUTPUT);
+      expect(tools).not.toContain(MC_TOOLS.KILL_PROCESS);
+    });
+  });
+
+  describe('explore (fast) mode', () => {
+    it('declares a unified availableTools allowlist', () => {
+      expect(fastMode.availableTools).toBeDefined();
+      expect(Array.isArray(fastMode.availableTools)).toBe(true);
+      expect(fastMode.availableTools!.length).toBeGreaterThan(0);
+    });
+
+    it('includes only read-only tools', () => {
+      const tools = fastMode.availableTools!;
+      expect(tools).toContain(MC_TOOLS.VIEW);
+      expect(tools).toContain(MC_TOOLS.FIND_FILES);
+      expect(tools).toContain(MC_TOOLS.SEARCH_CONTENT);
+      expect(tools).toContain(MC_TOOLS.FILE_STAT);
+      expect(tools).toContain(MC_TOOLS.LSP_INSPECT);
+    });
+
+    it('excludes all write and execution tools', () => {
+      const tools = fastMode.availableTools!;
+      expect(tools).not.toContain(MC_TOOLS.WRITE_FILE);
+      expect(tools).not.toContain(MC_TOOLS.STRING_REPLACE_LSP);
+      expect(tools).not.toContain(MC_TOOLS.DELETE_FILE);
+      expect(tools).not.toContain(MC_TOOLS.MKDIR);
+      expect(tools).not.toContain(MC_TOOLS.AST_SMART_EDIT);
+      expect(tools).not.toContain(MC_TOOLS.EXECUTE_COMMAND);
+    });
+  });
+
+  describe('build mode', () => {
+    it('leaves availableTools unset for full access', () => {
+      expect(buildMode.availableTools).toBeUndefined();
+    });
+  });
+});

--- a/mastracode/src/agents/modes/explore.ts
+++ b/mastracode/src/agents/modes/explore.ts
@@ -6,7 +6,7 @@
  * the codebase, then returns a concise summary of its findings.
  */
 import type { HarnessMode } from '@mastra/core/harness';
-import { MC_TOOLS } from '../../tool-names.js';
+import { EXPLORE_MODE_AVAILABLE_TOOLS } from '../tool-availability.js';
 
 export const fastMode: HarnessMode = {
   id: 'fast',
@@ -41,12 +41,5 @@ End with a structured summary:
 
 Keep your summary under 300 words.`,
 
-  availableTools: [
-    MC_TOOLS.VIEW,
-    MC_TOOLS.FIND_FILES,
-    MC_TOOLS.SEARCH_CONTENT,
-    MC_TOOLS.FILE_STAT,
-    MC_TOOLS.LSP_INSPECT,
-    'ask_user',
-  ],
+  availableTools: [...EXPLORE_MODE_AVAILABLE_TOOLS],
 };

--- a/mastracode/src/agents/modes/explore.ts
+++ b/mastracode/src/agents/modes/explore.ts
@@ -6,6 +6,7 @@
  * the codebase, then returns a concise summary of its findings.
  */
 import type { HarnessMode } from '@mastra/core/harness';
+import { MC_TOOLS } from '../../tool-names.js';
 
 export const fastMode: HarnessMode = {
   id: 'fast',
@@ -39,4 +40,13 @@ End with a structured summary:
 . **Details**: Additional context if needed
 
 Keep your summary under 300 words.`,
+
+  availableTools: [
+    MC_TOOLS.VIEW,
+    MC_TOOLS.FIND_FILES,
+    MC_TOOLS.SEARCH_CONTENT,
+    MC_TOOLS.FILE_STAT,
+    MC_TOOLS.LSP_INSPECT,
+    'ask_user',
+  ],
 };

--- a/mastracode/src/agents/modes/plan.ts
+++ b/mastracode/src/agents/modes/plan.ts
@@ -2,6 +2,7 @@
  * Plan mode — read-only analysis and planning.
  */
 import type { HarnessMode } from '@mastra/core/harness';
+import { MC_TOOLS } from '../../tool-names.js';
 
 export const planMode: HarnessMode = {
   id: 'plan',
@@ -34,4 +35,26 @@ export const planMode: HarnessMode = {
   metadata: {
     default: false,
   },
+
+  availableTools: [
+    // Read-only exploration tools
+    MC_TOOLS.VIEW,
+    MC_TOOLS.FIND_FILES,
+    MC_TOOLS.SEARCH_CONTENT,
+    MC_TOOLS.FILE_STAT,
+    MC_TOOLS.LSP_INSPECT,
+    // Plan file writing (restricted to .mastracode/plans/ by workspace paths)
+    MC_TOOLS.WRITE_FILE,
+    MC_TOOLS.STRING_REPLACE_LSP,
+    // Plan delivery tools
+    'ask_user',
+    'submit_plan',
+    // Task tools for plan-stage tracking
+    'task_write',
+    'task_update',
+    'task_complete',
+    'task_check',
+    // Notification access
+    MC_TOOLS.NOTIFICATION_INBOX,
+  ],
 };

--- a/mastracode/src/agents/modes/plan.ts
+++ b/mastracode/src/agents/modes/plan.ts
@@ -2,7 +2,7 @@
  * Plan mode — read-only analysis and planning.
  */
 import type { HarnessMode } from '@mastra/core/harness';
-import { MC_TOOLS } from '../../tool-names.js';
+import { PLAN_MODE_AVAILABLE_TOOLS } from '../tool-availability.js';
 
 export const planMode: HarnessMode = {
   id: 'plan',
@@ -36,25 +36,5 @@ export const planMode: HarnessMode = {
     default: false,
   },
 
-  availableTools: [
-    // Read-only exploration tools
-    MC_TOOLS.VIEW,
-    MC_TOOLS.FIND_FILES,
-    MC_TOOLS.SEARCH_CONTENT,
-    MC_TOOLS.FILE_STAT,
-    MC_TOOLS.LSP_INSPECT,
-    // Plan file writing (restricted to .mastracode/plans/ by workspace paths)
-    MC_TOOLS.WRITE_FILE,
-    MC_TOOLS.STRING_REPLACE_LSP,
-    // Plan delivery tools
-    'ask_user',
-    'submit_plan',
-    // Task tools for plan-stage tracking
-    'task_write',
-    'task_update',
-    'task_complete',
-    'task_check',
-    // Notification access
-    MC_TOOLS.NOTIFICATION_INBOX,
-  ],
+  availableTools: [...PLAN_MODE_AVAILABLE_TOOLS],
 };

--- a/mastracode/src/agents/tool-availability.ts
+++ b/mastracode/src/agents/tool-availability.ts
@@ -1,0 +1,45 @@
+import type { WorkspaceToolsConfig } from '@mastra/core/workspace';
+import { MC_TOOLS, TOOL_NAME_OVERRIDES } from '../tool-names.js';
+
+export const MASTRACODE_WORKSPACE_TOOLS: WorkspaceToolsConfig = {
+  ...TOOL_NAME_OVERRIDES,
+};
+
+export const PLAN_MODE_AVAILABLE_TOOLS: readonly string[] = [
+  // Read-only exploration tools
+  MC_TOOLS.VIEW,
+  MC_TOOLS.FIND_FILES,
+  MC_TOOLS.SEARCH_CONTENT,
+  MC_TOOLS.FILE_STAT,
+  MC_TOOLS.LSP_INSPECT,
+  // Plan file writing (restricted to .mastracode/plans/ by workspace paths)
+  MC_TOOLS.WRITE_FILE,
+  MC_TOOLS.STRING_REPLACE_LSP,
+  // Plan delivery tools
+  'ask_user',
+  'submit_plan',
+  // Task tools for plan-stage tracking
+  'task_write',
+  'task_update',
+  'task_complete',
+  'task_check',
+  // Notification access
+  MC_TOOLS.NOTIFICATION_INBOX,
+];
+
+export const EXPLORE_MODE_AVAILABLE_TOOLS: readonly string[] = [
+  MC_TOOLS.VIEW,
+  MC_TOOLS.FIND_FILES,
+  MC_TOOLS.SEARCH_CONTENT,
+  MC_TOOLS.FILE_STAT,
+  MC_TOOLS.LSP_INSPECT,
+  'ask_user',
+];
+
+export const GOAL_JUDGE_READONLY_TOOLS: readonly string[] = [
+  MC_TOOLS.VIEW,
+  MC_TOOLS.SEARCH_CONTENT,
+  MC_TOOLS.FIND_FILES,
+  MC_TOOLS.FILE_STAT,
+  MC_TOOLS.LSP_INSPECT,
+];

--- a/mastracode/src/agents/tool-availability.ts
+++ b/mastracode/src/agents/tool-availability.ts
@@ -12,7 +12,9 @@ export const PLAN_MODE_AVAILABLE_TOOLS: readonly string[] = [
   MC_TOOLS.SEARCH_CONTENT,
   MC_TOOLS.FILE_STAT,
   MC_TOOLS.LSP_INSPECT,
-  // Plan file writing (restricted to .mastracode/plans/ by workspace paths)
+  // Plan file writing (visibility gated by availableTools; the shared workspace
+  // is mode-agnostic and does not path-restrict these — plan-mode instructions
+  // scope writes to .mastracode/plans/)
   MC_TOOLS.WRITE_FILE,
   MC_TOOLS.STRING_REPLACE_LSP,
   // Plan delivery tools

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -7,12 +7,12 @@ import type { HarnessRequestContext } from '@mastra/core/harness';
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
 import { Workspace, LocalFilesystem, LocalSandbox, createWorkspaceTools } from '@mastra/core/workspace';
-import type { LSPConfig, WorkspaceToolsConfig } from '@mastra/core/workspace';
+import type { LSPConfig } from '@mastra/core/workspace';
 import { DEFAULT_CONFIG_DIR } from '../constants.js';
 import { loadSettings } from '../onboarding/settings.js';
 import type { MastraCodeState } from '../schema';
-import { MC_TOOLS, TOOL_NAME_OVERRIDES } from '../tool-names.js';
 import { getPlansDir } from '../utils/plans.js';
+import { GOAL_JUDGE_READONLY_TOOLS, MASTRACODE_WORKSPACE_TOOLS } from './tool-availability.js';
 
 // =============================================================================
 // Sandbox Environment
@@ -147,9 +147,7 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
   // All modes share the same workspace tool configuration.  Per-mode tool
   // visibility is enforced at LLM-call time via `availableTools` /
   // `activeTools` on the Harness, not by mutating workspace capabilities.
-  const workspaceTools: WorkspaceToolsConfig = {
-    ...TOOL_NAME_OVERRIDES,
-  };
+  const workspaceTools = MASTRACODE_WORKSPACE_TOOLS;
 
   // Reuse existing workspace if already registered (preserves ProcessManager state)
   let existing: Workspace<LocalFilesystem, LocalSandbox> | undefined;
@@ -190,21 +188,6 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
     lsp: lspConfig,
   });
 }
-
-/**
- * Read-only workspace tools the goal judge is allowed to call to verify the
- * agent's work. Mirrors the original (pre-native-goal) MastraCode judge, which
- * could inspect the workspace before deciding `done`/`continue`/`waiting`
- * instead of grading the assistant's prose alone. Strictly read-only: no write,
- * edit, delete, mkdir, or command-execution tools.
- */
-const GOAL_JUDGE_READONLY_TOOLS: readonly string[] = [
-  MC_TOOLS.VIEW,
-  MC_TOOLS.SEARCH_CONTENT,
-  MC_TOOLS.FIND_FILES,
-  MC_TOOLS.FILE_STAT,
-  MC_TOOLS.LSP_INSPECT,
-];
 
 /**
  * Resolver for the agent's `goal.tools` config. Builds the request's workspace

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -131,7 +131,6 @@ function detectPackageRunner(projectPath: string): string | undefined {
 export function getDynamicWorkspace({ requestContext, mastra }: { requestContext: RequestContext; mastra?: Mastra }) {
   const ctx = requestContext.get('harness') as HarnessRequestContext<MastraCodeState> | undefined;
   const state = ctx?.session.state.get();
-  const modeId = ctx?.session?.modeId ?? 'build';
   const rawProjectPath = state?.projectPath;
 
   if (!rawProjectPath) {
@@ -144,17 +143,12 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
   const workspaceId = `${WORKSPACE_ID_PREFIX}-${projectPath}`;
   const sandboxPaths = state?.sandboxAllowedPaths ?? [];
   const allowedPaths = [...skillPaths, ...DEFAULT_ALLOWED_PATHS, ...sandboxPaths.map((p: string) => path.resolve(p))];
-  const isPlanMode = modeId === 'plan';
 
-  const planModeTools = {
-    // write_file stays enabled — the agent uses it to create the initial plan .md file.
-    // edit_file (string_replace_lsp) stays enabled for targeted plan revisions.
-    // ast_edit is disabled because plans are markdown, not code.
-    mastra_workspace_ast_edit: { ...TOOL_NAME_OVERRIDES.mastra_workspace_ast_edit, enabled: false },
-  };
-
+  // All modes share the same workspace tool configuration.  Per-mode tool
+  // visibility is enforced at LLM-call time via `availableTools` /
+  // `activeTools` on the Harness, not by mutating workspace capabilities.
   const workspaceTools: WorkspaceToolsConfig = {
-    ...(isPlanMode ? { ...TOOL_NAME_OVERRIDES, ...planModeTools } : TOOL_NAME_OVERRIDES),
+    ...TOOL_NAME_OVERRIDES,
   };
 
   // Reuse existing workspace if already registered (preserves ProcessManager state)

--- a/packages/core/src/harness/__tests__/mode-tool-availability.test.ts
+++ b/packages/core/src/harness/__tests__/mode-tool-availability.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for per-mode tool availability via `mode.availableTools`.
+ *
+ * When a mode declares `availableTools`, the harness resolves an
+ * `activeTools` allowlist at LLM-call time so that only the listed tools
+ * are visible to the model and executable at tool-call time.  This matches
+ * the existing execution-time enforcement in
+ * `packages/core/src/agent/durable/workflows/steps/tool-call.ts`.
+ *
+ * These tests cover the generic Harness behavior independently of Mastra
+ * Code's concrete mode definitions.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { Agent } from '../../agent';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage/mock';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { createTool } from '../../tools';
+import { Harness } from '../harness';
+import type { HarnessMode } from '../types';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+/** Stream that emits a single tool-call then a finish with `tool-calls`. */
+function createToolCallStream(toolName: string, toolCallId = 'call-1') {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({
+        type: 'response-metadata',
+        id: 'id-0',
+        modelId: 'mock',
+        timestamp: new Date(0),
+      });
+      controller.enqueue({
+        type: 'tool-call',
+        toolCallId,
+        toolName,
+        input: '{"value":"test"}',
+        providerExecuted: false,
+      });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      });
+      controller.close();
+    },
+  });
+}
+
+/** Stream that emits plain text then a finish with `stop`. */
+function createTextStream(text = 'Done.') {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({
+        type: 'response-metadata',
+        id: 'id-1',
+        modelId: 'mock',
+        timestamp: new Date(0),
+      });
+      controller.enqueue({ type: 'text-start', id: 'text-1' });
+      controller.enqueue({ type: 'text-delta', id: 'text-1', delta: text });
+      controller.enqueue({ type: 'text-end', id: 'text-1' });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      });
+      controller.close();
+    },
+  });
+}
+
+/** Build a mock model whose first call returns a tool-call and subsequent calls return text. */
+function createMockModel(toolName: string) {
+  let callCount = 0;
+  return new MastraLanguageModelV2Mock({
+    doStream: async () => {
+      callCount++;
+      return { stream: callCount === 1 ? createToolCallStream(toolName) : createTextStream() };
+    },
+  });
+}
+
+function makeTool(id: string, execute?: (...args: any[]) => any) {
+  return createTool({
+    id,
+    description: `Tool ${id}`,
+    inputSchema: z.object({ value: z.string() }),
+    execute: execute ?? vi.fn().mockResolvedValue(`${id} result`),
+  });
+}
+
+async function setupHarness({
+  modes,
+  tools,
+  model,
+  toolCategoryResolver,
+  initialState,
+}: {
+  modes: HarnessMode[];
+  tools: Record<string, ReturnType<typeof createTool>>;
+  model: MastraLanguageModelV2Mock;
+  toolCategoryResolver?: (toolName: string) => 'read' | 'edit' | 'execute' | 'mcp' | 'other' | null;
+  initialState?: Record<string, unknown>;
+}) {
+  const agent = new Agent({
+    id: 'test-agent',
+    name: 'test-agent',
+    instructions: 'You are a helpful assistant.',
+    model,
+    tools,
+  });
+
+  const storage = new InMemoryStore();
+  const mastra = new Mastra({ agents: { 'test-agent': agent }, logger: false, storage });
+  const registeredAgent = mastra.getAgent('test-agent');
+
+  const harness = new Harness({
+    id: 'test-harness',
+    storage,
+    agent: registeredAgent,
+    modes,
+    ...(toolCategoryResolver && { toolCategoryResolver }),
+    ...(initialState && { initialState: initialState as any }),
+  });
+
+  await harness.init();
+  const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
+  await session.thread.create();
+
+  return { harness, session, registeredAgent };
+}
+
+describe('Harness: mode availableTools allowlist', () => {
+  it('sets activeTools from mode.availableTools in stream options', async () => {
+    // Use a text-only stream so we don't trigger tool approval flow.
+    const model = new MastraLanguageModelV2Mock({
+      doStream: async () => ({ stream: createTextStream() }),
+    });
+
+    const { session, registeredAgent } = await setupHarness({
+      modes: [
+        {
+          id: 'restricted',
+          name: 'Restricted',
+          default: true,
+          availableTools: ['allowedTool', 'ask_user'],
+        },
+      ],
+      tools: {
+        allowedTool: makeTool('allowedTool'),
+        hiddenTool: makeTool('hiddenTool'),
+      },
+      model,
+    });
+
+    const streamSpy = vi.spyOn(registeredAgent, 'stream');
+    await session.sendMessage({ content: 'Hello' });
+
+    // stream was called with activeTools matching the mode's allowlist
+    const [, streamOptions] = streamSpy.mock.calls[0] as unknown as [any, any];
+    expect(streamOptions.activeTools).toEqual(['allowedTool', 'ask_user']);
+  });
+
+  it('hides tools not in availableTools at execution time', async () => {
+    const model = createMockModel('hiddenTool');
+    const hiddenExecute = vi.fn().mockResolvedValue('hidden result');
+
+    const { session } = await setupHarness({
+      modes: [
+        {
+          id: 'restricted',
+          name: 'Restricted',
+          default: true,
+          availableTools: ['allowedTool'],
+        },
+      ],
+      tools: {
+        allowedTool: makeTool('allowedTool'),
+        hiddenTool: makeTool('hiddenTool', hiddenExecute),
+      },
+      model,
+      // yolo so tool approval is auto-allowed — the hidden tool would execute if not blocked
+      initialState: { yolo: true },
+    });
+
+    await session.sendMessage({ content: 'Hello' });
+
+    // hiddenTool is not in availableTools → must NOT execute
+    expect(hiddenExecute).not.toHaveBeenCalled();
+  });
+
+  it('allows tools in availableTools to execute', async () => {
+    const model = createMockModel('allowedTool');
+    const allowedExecute = vi.fn().mockResolvedValue('allowed result');
+
+    const { session } = await setupHarness({
+      modes: [
+        {
+          id: 'restricted',
+          name: 'Restricted',
+          default: true,
+          availableTools: ['allowedTool'],
+        },
+      ],
+      tools: {
+        allowedTool: makeTool('allowedTool', allowedExecute),
+        hiddenTool: makeTool('hiddenTool'),
+      },
+      model,
+      initialState: { yolo: true },
+    });
+
+    await session.sendMessage({ content: 'Hello' });
+
+    expect(allowedExecute).toHaveBeenCalledOnce();
+  });
+
+  it('does not set activeTools when mode has no availableTools', async () => {
+    const model = createMockModel('tool1');
+    const tool1Execute = vi.fn().mockResolvedValue('result1');
+
+    const { session, registeredAgent } = await setupHarness({
+      modes: [{ id: 'open', name: 'Open', default: true }],
+      tools: {
+        tool1: makeTool('tool1', tool1Execute),
+        tool2: makeTool('tool2'),
+      },
+      model,
+      initialState: { yolo: true },
+    });
+
+    const streamSpy = vi.spyOn(registeredAgent, 'stream');
+    await session.sendMessage({ content: 'Hello' });
+
+    const [, streamOptions] = streamSpy.mock.calls[0] as unknown as [any, any];
+    expect(streamOptions.activeTools).toBeUndefined();
+  });
+
+  it('per-tool deny removes the tool even if it appears in availableTools', async () => {
+    const model = createMockModel('deniedTool');
+    const deniedExecute = vi.fn().mockResolvedValue('denied result');
+
+    const { session, registeredAgent } = await setupHarness({
+      modes: [
+        {
+          id: 'restricted',
+          name: 'Restricted',
+          default: true,
+          availableTools: ['allowedTool', 'deniedTool'],
+        },
+      ],
+      tools: {
+        allowedTool: makeTool('allowedTool'),
+        deniedTool: makeTool('deniedTool', deniedExecute),
+      },
+      model,
+      initialState: {
+        yolo: true,
+        permissionRules: {
+          categories: {},
+          tools: { deniedTool: 'deny' },
+        },
+      },
+    });
+
+    const streamSpy = vi.spyOn(registeredAgent, 'stream');
+    await session.sendMessage({ content: 'Hello' });
+
+    expect(streamSpy).toHaveBeenCalled();
+
+    // Per-tool deny is handled by buildToolsets — the denied tool is deleted
+    // from the toolsets entirely.  activeTools may still list the name, but
+    // the tool cannot execute because it doesn't exist in the toolsets.
+    // Verify the denied tool did NOT execute.
+    expect(deniedExecute).not.toHaveBeenCalled();
+  });
+
+  it('category deny filters tools from activeTools', async () => {
+    const model = createMockModel('editTool');
+    const editExecute = vi.fn().mockResolvedValue('edit result');
+
+    const { session, registeredAgent } = await setupHarness({
+      modes: [
+        {
+          id: 'restricted',
+          name: 'Restricted',
+          default: true,
+          availableTools: ['readTool', 'editTool'],
+        },
+      ],
+      tools: {
+        readTool: makeTool('readTool'),
+        editTool: makeTool('editTool', editExecute),
+      },
+      model,
+      toolCategoryResolver: (toolName: string) => {
+        if (toolName === 'readTool') return 'read' as const;
+        if (toolName === 'editTool') return 'edit' as const;
+        return 'other' as const;
+      },
+      initialState: {
+        yolo: true,
+        permissionRules: {
+          categories: { edit: 'deny' },
+          tools: {},
+        },
+      },
+    });
+
+    const streamSpy = vi.spyOn(registeredAgent, 'stream');
+    await session.sendMessage({ content: 'Hello' });
+
+    const [, streamOptions] = streamSpy.mock.calls[0] as unknown as [any, any];
+
+    // The 'edit' category is denied, so editTool must be filtered out of
+    // activeTools even though it appears in the mode's availableTools list.
+    expect(streamOptions.activeTools).toEqual(['readTool']);
+
+    // editTool must not execute
+    expect(editExecute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/harness/__tests__/mode-workspace-tool-availability.test.ts
+++ b/packages/core/src/harness/__tests__/mode-workspace-tool-availability.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for per-mode workspace tool visibility via `mode.availableTools`.
+ *
+ * These tests verify the core invariant: one shared workspace across modes,
+ * with tool visibility gated per LLM call via `activeTools`.  Workspace tools
+ * are treated as ordinary tools in the mode's unified `availableTools` list,
+ * matched by their exposed (renamed) names (e.g. `view`, `find_files`).
+ */
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Agent } from '../../agent';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage/mock';
+import { WORKSPACE_TOOLS } from '../../workspace/constants';
+import { LocalFilesystem } from '../../workspace/filesystem';
+import { Workspace } from '../../workspace/workspace';
+import { Harness } from '../harness';
+import type { HarnessMode } from '../types';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+/** Tool name overrides — matches Mastra Code's TOOL_NAME_OVERRIDES. */
+const TOOL_NAME_OVERRIDES: Record<string, { name: string }> = {
+  [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { name: 'view' },
+  [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: { name: 'write_file' },
+  [WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE]: { name: 'string_replace_lsp' },
+  [WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]: { name: 'find_files' },
+  [WORKSPACE_TOOLS.FILESYSTEM.DELETE]: { name: 'delete_file' },
+  [WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT]: { name: 'file_stat' },
+  [WORKSPACE_TOOLS.FILESYSTEM.MKDIR]: { name: 'mkdir' },
+  [WORKSPACE_TOOLS.FILESYSTEM.GREP]: { name: 'search_content' },
+  [WORKSPACE_TOOLS.FILESYSTEM.AST_EDIT]: { name: 'ast_smart_edit' },
+  [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: { name: 'execute_command' },
+  [WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT]: { name: 'get_process_output' },
+  [WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS]: { name: 'kill_process' },
+  [WORKSPACE_TOOLS.LSP.LSP_INSPECT]: { name: 'lsp_inspect' },
+};
+
+/** A text-only stream — no tool calls, so no approval flow needed. */
+function createTextStream(text = 'Done.') {
+  return convertArrayToReadableStream([
+    { type: 'stream-start', warnings: [] },
+    { type: 'response-metadata', id: 'id-1', modelId: 'mock', timestamp: new Date(0) },
+    { type: 'text-start', id: 'text-1' },
+    { type: 'text-delta', id: 'text-1', textDelta: text },
+    { type: 'text-end', id: 'text-1' },
+    { type: 'finish', finishReason: 'stop' as const, usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+  ]);
+}
+
+describe('Harness: mode availableTools with shared workspace', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mode-ws-'));
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  function createWorkspace() {
+    return new Workspace({
+      id: 'test-ws',
+      name: 'Test Workspace',
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: TOOL_NAME_OVERRIDES,
+    });
+  }
+
+  async function setupHarness({ modes, workspace }: { modes: HarnessMode[]; workspace: Workspace }) {
+    const model = new MockLanguageModelV2({
+      doStream: (async (_options: any) => ({ stream: createTextStream() })) as any,
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model: model as any,
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({ agents: { 'test-agent': agent }, logger: false, storage });
+    const registeredAgent = mastra.getAgent('test-agent');
+
+    const harness = new Harness({
+      id: 'test-harness',
+      storage,
+      agent: registeredAgent,
+      modes,
+      workspace,
+      initialState: { yolo: true } as any,
+    });
+
+    await harness.init();
+    const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    await session.thread.create();
+
+    return { harness, session, registeredAgent, workspace };
+  }
+
+  it('workspace tool names are matched by exposed names in availableTools', async () => {
+    const workspace = createWorkspace();
+    const planMode: HarnessMode = {
+      id: 'plan',
+      name: 'Plan',
+      default: true,
+      availableTools: [
+        'view',
+        'find_files',
+        'search_content',
+        'file_stat',
+        'lsp_inspect',
+        'write_file',
+        'string_replace_lsp',
+        'ask_user',
+        'submit_plan',
+      ],
+    };
+
+    const { session, registeredAgent } = await setupHarness({
+      modes: [planMode],
+      workspace,
+    });
+
+    const streamSpy = vi.spyOn(registeredAgent, 'stream');
+    await session.sendMessage({ content: 'Hello' });
+
+    const callArgs = streamSpy.mock.calls[0] as unknown as [any, any];
+    const streamOptions = callArgs[1];
+    // activeTools must contain the exposed (renamed) workspace tool names
+    expect(streamOptions.activeTools).toBeDefined();
+    expect(streamOptions.activeTools).toContain('view');
+    expect(streamOptions.activeTools).toContain('find_files');
+    expect(streamOptions.activeTools).toContain('search_content');
+    expect(streamOptions.activeTools).toContain('file_stat');
+    expect(streamOptions.activeTools).toContain('lsp_inspect');
+    // Write tools also included for plan files
+    expect(streamOptions.activeTools).toContain('write_file');
+    expect(streamOptions.activeTools).toContain('string_replace_lsp');
+    // Tools NOT in availableTools must not appear
+    expect(streamOptions.activeTools).not.toContain('execute_command');
+    expect(streamOptions.activeTools).not.toContain('delete_file');
+    expect(streamOptions.activeTools).not.toContain('ast_smart_edit');
+  });
+
+  it('mode switching changes activeTools without replacing the workspace instance', async () => {
+    const workspace = createWorkspace();
+    const planMode: HarnessMode = {
+      id: 'plan',
+      name: 'Plan',
+      default: true,
+      transitionsTo: 'build',
+      availableTools: ['view', 'find_files', 'search_content', 'ask_user', 'submit_plan'],
+    };
+    const buildMode: HarnessMode = {
+      id: 'build',
+      name: 'Build',
+      // No availableTools — full access
+    };
+
+    const {
+      session,
+      registeredAgent,
+      workspace: resolvedWorkspace,
+    } = await setupHarness({
+      modes: [planMode, buildMode],
+      workspace,
+    });
+
+    // --- Plan mode (default) ---
+    const streamSpy = vi.spyOn(registeredAgent, 'stream');
+    await session.sendMessage({ content: 'Hello in plan mode' });
+
+    let callArgs = streamSpy.mock.calls[0] as unknown as [any, any];
+    let streamOptions = callArgs[1];
+    expect(streamOptions.activeTools).toBeDefined();
+    expect(streamOptions.activeTools).toContain('view');
+    expect(streamOptions.activeTools).not.toContain('execute_command');
+
+    // Capture the workspace reference used in plan mode
+    const workspaceInPlanMode = resolvedWorkspace;
+
+    // --- Switch to build mode ---
+    await session.mode.switch({ modeId: 'build' });
+    streamSpy.mockClear();
+    await session.sendMessage({ content: 'Hello in build mode' });
+
+    callArgs = streamSpy.mock.calls[0] as unknown as [any, any];
+    streamOptions = callArgs[1];
+    // Build mode has no availableTools — activeTools must be undefined
+    expect(streamOptions.activeTools).toBeUndefined();
+
+    // The workspace instance must be the same object — mode switching
+    // must NOT create a new workspace.
+    expect(resolvedWorkspace).toBe(workspaceInPlanMode);
+  });
+
+  it('renamed workspace tools are matched by exposed name, not internal name', async () => {
+    const workspace = createWorkspace();
+    const readOnlyMode: HarnessMode = {
+      id: 'readonly',
+      name: 'Read Only',
+      default: true,
+      // Use exposed names (view, find_files) — not internal names
+      // (mastra_workspace_read_file, mastra_workspace_list_files)
+      availableTools: ['view', 'find_files'],
+    };
+
+    const { session, registeredAgent } = await setupHarness({
+      modes: [readOnlyMode],
+      workspace,
+    });
+
+    const streamSpy = vi.spyOn(registeredAgent, 'stream');
+    await session.sendMessage({ content: 'Hello' });
+
+    const callArgs = streamSpy.mock.calls[0] as unknown as [any, any];
+    const streamOptions = callArgs[1];
+    // The availableTools list uses exposed names. The model will call tools
+    // by their exposed names. activeTools must contain the exposed names,
+    // not the internal mastra_workspace_* names.
+    expect(streamOptions.activeTools).toEqual(['view', 'find_files']);
+    // Internal names must NOT appear in activeTools
+    expect(streamOptions.activeTools).not.toContain(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
+    expect(streamOptions.activeTools).not.toContain(WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES);
+  });
+});

--- a/packages/core/src/harness/__tests__/mode-workspace-tool-availability.test.ts
+++ b/packages/core/src/harness/__tests__/mode-workspace-tool-availability.test.ts
@@ -46,7 +46,7 @@ function createTextStream(text = 'Done.') {
     { type: 'stream-start', warnings: [] },
     { type: 'response-metadata', id: 'id-1', modelId: 'mock', timestamp: new Date(0) },
     { type: 'text-start', id: 'text-1' },
-    { type: 'text-delta', id: 'text-1', textDelta: text },
+    { type: 'text-delta', id: 'text-1', delta: text },
     { type: 'text-end', id: 'text-1' },
     { type: 'finish', finishReason: 'stop' as const, usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
   ]);

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1236,6 +1236,60 @@ export class Harness<TState = {}> {
   // Message Handling
   // ===========================================================================
 
+  /**
+   * Resolve the `activeTools` allowlist for the current mode's run.
+   *
+   * Returns `undefined` when the mode has no `availableTools` configured
+   * (no restriction — all tools visible). When the mode declares
+   * `availableTools`, returns that list filtered to remove tools whose
+   * permission category is denied.
+   *
+   * Per-tool `deny` is already handled by `buildToolsets` (denied tools are
+   * deleted from the toolsets), so those tools won't exist at execution time
+   * regardless of whether they appear in the allowlist.
+   *
+   * The returned list uses the same exposed tool names the execution pipeline
+   * checks against (e.g. `view`, `write_file`, `ask_user`), which matches the
+   * names workspace tools are renamed to via `TOOL_NAME_OVERRIDES`.
+   */
+  private resolveModeActiveTools(session: Session<TState>): string[] | undefined {
+    const currentMode = session.mode.resolve();
+    const availableTools = currentMode?.availableTools;
+    if (!availableTools) {
+      return undefined;
+    }
+    if (availableTools.length === 0) {
+      return [];
+    }
+
+    const permissionRules = session.permissions.getRules();
+    const deniedTools = new Set(
+      Object.entries(permissionRules.tools)
+        .filter(([, policy]) => policy === 'deny')
+        .map(([tool]) => tool),
+    );
+    const deniedCategories = new Set(
+      Object.entries(permissionRules.categories)
+        .filter(([, policy]) => policy === 'deny')
+        .map(([cat]) => cat),
+    );
+
+    if (deniedTools.size === 0 && deniedCategories.size === 0) {
+      return availableTools;
+    }
+
+    return availableTools.filter(toolName => {
+      // Per-tool deny always wins — even over the mode allowlist.
+      if (deniedTools.has(toolName)) {
+        return false;
+      }
+      // Category deny: tools with no category (null — always-allowed tools
+      // like ask_user) are not subject to category deny.
+      const category = this.getToolCategory({ toolName });
+      return !category || !deniedCategories.has(category);
+    });
+  }
+
   private async buildAgentMessageStreamOptions({
     session,
     requestContext: requestContextInput,
@@ -1282,6 +1336,15 @@ export class Harness<TState = {}> {
       ...(callTimeInstructions && { instructions: callTimeInstructions }),
     };
     streamOptions.toolsets = await this.buildToolsets(session, requestContext);
+
+    // Apply mode-level tool visibility via `activeTools` — the same mechanism
+    // the execution pipeline already enforces at tool-call time.  Only set
+    // when the helper returns a concrete list so modes without
+    // `availableTools` keep unrestricted behaviour.
+    const activeTools = this.resolveModeActiveTools(session);
+    if (activeTools !== undefined) {
+      streamOptions.activeTools = activeTools;
+    }
 
     return streamOptions;
   }

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -77,6 +77,26 @@ interface HarnessModeBase {
   transitionsTo?: string;
 
   /**
+   * Unified per-mode tool visibility allowlist. When set, only tools whose
+   * final exposed names appear in this list are visible to the model and
+   * executable during this mode's runs. Workspace tools use the same list
+   * as all other tools — configure them by exposed tool names such as
+   * `view`, `write_file`, `find_files`, etc. (after workspace tool renaming
+   * via `TOOL_NAME_OVERRIDES`).
+   *
+   * - `undefined` (default): no mode-level restriction; all tools are visible.
+   * - `[]`: no tools are available for this mode.
+   * - Per-tool permission `deny` and category `deny` still win — a denied
+   *   tool is hidden even if it appears in this list.
+   * - `tools` / `additionalTools` remain toolset composition inputs (which
+   *   tools are added to the run), not visibility gates.
+   *
+   * Enforced at LLM-call time via `activeTools`, matching the existing
+   * execution-time enforcement in the durable tool-call step.
+   */
+  availableTools?: string[];
+
+  /**
    * Arbitrary user-defined metadata. `metadata.default === true` is a
    * reserved harness hint for choosing the default mode when `defaultModeId`
    * is unset; all other metadata is pass-through and unvalidated. Use for UI
@@ -91,9 +111,11 @@ interface HarnessModeBase {
 type HarnessModeToolOverrides =
   | {
       /**
-       * The tool set this mode runs with. **Replaces** the backing agent's
-       * tools — the agent's own tools are hidden for the duration of the
-       * mode. Mutually exclusive with `additionalTools`.
+       * Mode-level tools added as a separate toolset alongside the backing
+       * agent's own tools. With a shared backing agent (`HarnessConfig.agent`),
+       * these are layered as an augment — the agent's own tools are **not**
+       * masked. To restrict which tools are visible, use `availableTools`
+       * instead. Mutually exclusive with `additionalTools`.
        */
       tools?: ToolsInput;
       additionalTools?: never;


### PR DESCRIPTION
Adds a mode-level `availableTools` allowlist so harness modes can decide which tools are visible to the model at call time. Workspace tools use the same list by their exposed names, so there is no separate workspace-specific config.

Example:

```ts
const planMode = {
  id: 'plan',
  name: 'Plan',
  availableTools: ['view', 'find_files', 'search_content', 'write_file', 'submit_plan'],
};
```

Mastracode now uses this for plan and explore modes, while build mode stays unrestricted. The workspace setup no longer branches by mode, so mode switching only changes the active tool list.

Tested with focused core harness tests and Mastracode mode/prompt tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This change lets each mode decide which tools the AI is allowed to see and use. That means plan mode, explore mode, and other modes can have different tool sets without rebuilding the workspace each time.

### What changed
- Added a new `availableTools` allowlist to harness modes.
- Applied that allowlist at LLM-call time through `activeTools`.
- Updated Mastracode modes to use shared allowlists:
  - plan mode: broader tool access for planning/editing
  - explore mode: read-only tools only
  - build mode: unchanged, unrestricted
- Simplified workspace setup so switching modes only changes the active tool list.
- Added tests covering:
  - mode tool allowlists
  - workspace tool visibility by exposed name
  - deny rules still overriding allowlists

### Additional updates
- Added a changeset documenting the new public API and behavior.
- Fixed related test fixtures and comments for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->