### PR TITLE
fix(pg): use ELSE NULL in numeric filter guard so $not excludes missing fields

### DIFF
--- a/.changeset/thick-months-report.md
+++ b/.changeset/thick-months-report.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed numeric range filters ($gt, $gte, $lt, $lte) returning incorrect results when negated with $not on rows where the field is missing or non-numeric. The CASE guard introduced in #18430 used ELSE FALSE, which made NOT(FALSE)=TRUE incorrectly include those rows. Changed to ELSE NULL so NOT(NULL)=NULL correctly excludes them.

--- a/.changeset/thick-months-report.md
+++ b/.changeset/thick-months-report.md
@@ -2,4 +2,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed numeric range filters ($gt, $gte, $lt, $lte) returning incorrect results when negated with $not on rows where the field is missing or non-numeric. The CASE guard introduced in #18430 used ELSE FALSE, which made NOT(FALSE)=TRUE incorrectly include those rows. Changed to ELSE NULL so NOT(NULL)=NULL correctly excludes them.
+Negated numeric range filters (`$not` with `$gt`, `$gte`, `$lt`, `$lte`) now correctly exclude rows where the filtered field is missing or non-numeric. Previously these rows were incorrectly included in results.

--- a/stores/pg/src/vector/sql-builder.test.ts
+++ b/stores/pg/src/vector/sql-builder.test.ts
@@ -22,7 +22,7 @@ describe('buildFilterQuery - numeric range operators', () => {
       expect(values).toEqual([0, 10, 50]);
       expect(sql).toContain(`jsonb_typeof(metadata#>'{price}') = 'number'`);
       expect(sql).toContain(`(metadata#>>'{price}')::numeric ${symbol} $3::numeric`);
-      expect(sql).toContain('ELSE FALSE');
+      expect(sql).toContain('ELSE NULL');
       // The bare, unguarded cast must no longer appear on its own.
       expect(sql).not.toMatch(/(?<!THEN )\(metadata#>>'\{price\}'\)::numeric/);
     });

--- a/stores/pg/src/vector/sql-builder.ts
+++ b/stores/pg/src/vector/sql-builder.ts
@@ -58,7 +58,7 @@ const createNumericOperator = (symbol: string) => {
       // number-typed rows are compared and everything else is excluded, mirroring the
       // $size/$in pattern already used in this file and MongoDB-style range semantics.
       return {
-        sql: `(CASE WHEN jsonb_typeof(metadata#>'{${jsonPathKey}}') = 'number' THEN (metadata#>>'{${jsonPathKey}}')::numeric ${symbol} $${paramIndex}::numeric ELSE FALSE END)`,
+        sql: `(CASE WHEN jsonb_typeof(metadata#>'{${jsonPathKey}}') = 'number' THEN (metadata#>>'{${jsonPathKey}}')::numeric ${symbol} $${paramIndex}::numeric ELSE NULL END)`,
         needsValue: true,
       };
     } else {


### PR DESCRIPTION
## Description

Fixes PG vector `$not` filter returning incorrect results when negating numeric range operators (`$gt`, `$gte`, `$lt`, `$lte`) on rows where the target field is missing or non-numeric.

- PR #18430 introduced a `CASE WHEN jsonb_typeof(...) = 'number' ... ELSE FALSE END` guard to prevent query crashes on mixed-type metadata. The `ELSE FALSE` is correct for positive filters, but wrong under negation: `NOT(FALSE) = TRUE` incorrectly includes rows where the field doesn't exist.
- Changed `ELSE FALSE` to `ELSE NULL`. In SQL, `NULL` in a WHERE clause behaves identically to `FALSE` for positive filters (row excluded), but `NOT(NULL) = NULL` (still excluded), which is the correct behavior under `$not`.
- Updated the corresponding unit test assertion from `ELSE FALSE` to `ELSE NULL`.

## Related Issue(s)

Fixes the `Combined Store Tests / test (pg)` CI failure: `PgVector > Filter Operators > Advanced $not Combinations > should handle $not in nested field paths` (regression from #18430)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR fixes a bug where a “not this number rule” could match rows even when the row didn’t have a usable number. It changes the SQL so missing or non-numeric values are treated as “unknown” (not “false”), which makes the negated filter behave correctly.

## Summary
- Updated PostgreSQL vector numeric range filter SQL so the numeric `CASE` fallback uses `ELSE NULL` instead of `ELSE FALSE` when the JSONB value isn’t numeric.
- Prevents `$not` combinations with `$gt/$gte/$lt/$lte` from incorrectly matching rows where the target field is missing or non-numeric (including in nested field paths).
- Updated `stores/pg/src/vector/sql-builder.test.ts` to assert the new `ELSE NULL` SQL behavior.
- Added a changeset (`.changeset/thick-months-report.md`) for `@mastra/pg` to publish a patch fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->