### PR TITLE
feat(core/harness): move workspace and browser ownership to sessions

### DIFF
--- a/.changeset/strict-feet-tan.md
+++ b/.changeset/strict-feet-tan.md
@@ -1,10 +1,8 @@
 ---
-'@mastra/core': major
+'@mastra/core': minor
 ---
 
-Moved workspace and browser ownership from the Harness to individual sessions.
-
-`createSession` now accepts optional `workspace` and `browser` overrides that are passed directly to the `Session` constructor. These overrides are static instances only — use the Harness-level `DynamicArgument` config for per-request factory functions. When no override is provided, the Harness-level config is used as a fallback. Workspace is now required at session construction time — the `Session` constructor validates it is a `Workspace` instance and throws if missing.
+Moved workspace and browser ownership from the Harness to individual sessions. `createSession` now accepts optional `workspace` and `browser` overrides that are passed directly to the `Session` constructor. When no override is provided, the Harness-level config is used as a fallback.
 
 **Breaking changes:**
 

--- a/.changeset/strict-feet-tan.md
+++ b/.changeset/strict-feet-tan.md
@@ -11,7 +11,8 @@ Moved workspace and browser ownership from the Harness to individual sessions.
 - `Session` constructor now requires `workspace: Workspace` and accepts optional `browser?: MastraBrowser`
 - `HarnessConfig.workspace` no longer accepts a `WorkspaceConfig` object — pass a `Workspace` instance or a dynamic factory function
 - `createSession` overrides accept static `Workspace` / `MastraBrowser` instances only (not `DynamicArgument`)
-- Removed `Harness.getWorkspace()`, `Harness.resolveWorkspace()`, `Harness.hasWorkspace()`, `Harness.isWorkspaceReady()`, and `Harness.destroyWorkspace()` — workspace is now accessed via the session
+- Removed `Harness.getWorkspace()`, `Harness.resolveWorkspace()`, `Harness.hasWorkspace()`, `Harness.isWorkspaceReady()`, and `Harness.destroyWorkspace()` — workspace lifecycle is now driven by per-session `workspace_status_changed`, `workspace_ready`, and `workspace_error` events emitted after `workspace.init()` completes
+- The `SessionBus` replays the last workspace lifecycle event group to subscribers that attach after session creation, so late listeners always learn the current workspace status
 
 **Before:**
 

--- a/.changeset/strict-feet-tan.md
+++ b/.changeset/strict-feet-tan.md
@@ -4,12 +4,13 @@
 
 Moved workspace and browser ownership from the Harness to individual sessions.
 
-`createSession` now accepts optional `workspace` and `browser` overrides that are resolved per-session and passed directly to the `Session` constructor. When no override is provided, the Harness-level config is used as a fallback. Workspace is now required at session construction time — the `Session` constructor validates it is a `Workspace` instance and throws if missing.
+`createSession` now accepts optional `workspace` and `browser` overrides that are passed directly to the `Session` constructor. These overrides are static instances only — use the Harness-level `DynamicArgument` config for per-request factory functions. When no override is provided, the Harness-level config is used as a fallback. Workspace is now required at session construction time — the `Session` constructor validates it is a `Workspace` instance and throws if missing.
 
 **Breaking changes:**
 
 - `Session` constructor now requires `workspace: Workspace` and accepts optional `browser?: MastraBrowser`
 - `HarnessConfig.workspace` no longer accepts a `WorkspaceConfig` object — pass a `Workspace` instance or a dynamic factory function
+- `createSession` overrides accept static `Workspace` / `MastraBrowser` instances only (not `DynamicArgument`)
 - Removed `Harness.getWorkspace()`, `Harness.resolveWorkspace()`, `Harness.hasWorkspace()`, `Harness.isWorkspaceReady()`, and `Harness.destroyWorkspace()` — workspace is now accessed via the session
 
 **Before:**
@@ -40,12 +41,17 @@ const harness = new Harness({
   workspace: new Workspace({ name: 'my-workspace' }),
 });
 
-// workspace can be overridden per session
+// workspace can be overridden per session with a static instance
 const session = await harness.createSession({
   resourceId: 'user-1',
   ownerId: 'owner-1',
   id: 'session-1',
-  workspace: ({ requestContext, mastra }) =>
-    new Workspace({ name: `ws-${session.id}` }),
+  workspace: new Workspace({ name: 'ws-1' }),
+});
+
+// for dynamic per-request workspaces, use the harness-level config
+const harness2 = new Harness({
+  name: 'my-harness',
+  workspace: ({ requestContext, mastra }) => new Workspace({ name: `ws-${requestContext.session.id}` }),
 });
 ```

--- a/.changeset/strict-feet-tan.md
+++ b/.changeset/strict-feet-tan.md
@@ -1,0 +1,51 @@
+---
+'@mastra/core': major
+---
+
+Moved workspace and browser ownership from the Harness to individual sessions.
+
+`createSession` now accepts optional `workspace` and `browser` overrides that are resolved per-session and passed directly to the `Session` constructor. When no override is provided, the Harness-level config is used as a fallback. Workspace is now required at session construction time — the `Session` constructor validates it is a `Workspace` instance and throws if missing.
+
+**Breaking changes:**
+
+- `Session` constructor now requires `workspace: Workspace` and accepts optional `browser?: MastraBrowser`
+- `HarnessConfig.workspace` no longer accepts a `WorkspaceConfig` object — pass a `Workspace` instance or a dynamic factory function
+- Removed `Harness.getWorkspace()`, `Harness.resolveWorkspace()`, `Harness.hasWorkspace()`, `Harness.isWorkspaceReady()`, and `Harness.destroyWorkspace()` — workspace is now accessed via the session
+
+**Before:**
+
+```ts
+const harness = new Harness({
+  name: 'my-harness',
+  workspace: { name: 'my-workspace' }, // WorkspaceConfig shorthand
+});
+
+const session = await harness.createSession({
+  resourceId: 'user-1',
+  ownerId: 'owner-1',
+  id: 'session-1',
+});
+
+// workspace resolved lazily by the harness
+const ws = harness.getWorkspace();
+```
+
+**After:**
+
+```ts
+import { Workspace } from '@mastra/core';
+
+const harness = new Harness({
+  name: 'my-harness',
+  workspace: new Workspace({ name: 'my-workspace' }),
+});
+
+// workspace can be overridden per session
+const session = await harness.createSession({
+  resourceId: 'user-1',
+  ownerId: 'owner-1',
+  id: 'session-1',
+  workspace: ({ requestContext, mastra }) =>
+    new Workspace({ name: `ws-${session.id}` }),
+});
+```

--- a/.changeset/strict-feet-tan.md
+++ b/.changeset/strict-feet-tan.md
@@ -11,7 +11,9 @@ Moved workspace and browser ownership from the Harness to individual sessions.
 - `Session` constructor now requires `workspace: Workspace` and accepts optional `browser?: MastraBrowser`
 - `HarnessConfig.workspace` no longer accepts a `WorkspaceConfig` object — pass a `Workspace` instance or a dynamic factory function
 - `createSession` overrides accept static `Workspace` / `MastraBrowser` instances only (not `DynamicArgument`)
-- Removed `Harness.getWorkspace()`, `Harness.resolveWorkspace()`, `Harness.hasWorkspace()`, `Harness.isWorkspaceReady()`, and `Harness.destroyWorkspace()` — workspace lifecycle is now driven by per-session `workspace_status_changed`, `workspace_ready`, and `workspace_error` events emitted after `workspace.init()` completes
+- Removed `Harness.destroyWorkspace()` — workspace lifecycle is now driven by per-session `workspace_status_changed`, `workspace_ready`, and `workspace_error` events emitted after `workspace.init()` completes
+- `Harness.getWorkspace()` returns the static workspace instance only (returns `undefined` for dynamic factory configs); use `resolveWorkspace({ session })` to resolve and cache a factory outside the request flow
+- `Harness.resolveWorkspace()` now requires a `session` parameter to resolve dynamic factories against the session's request context
 - The `SessionBus` replays the last workspace lifecycle event group to subscribers that attach after session creation, so late listeners always learn the current workspace status
 
 **Before:**

--- a/docs/src/content/en/docs/harness/session.mdx
+++ b/docs/src/content/en/docs/harness/session.mdx
@@ -37,7 +37,7 @@ const threadId = harness.session.thread.getId()
 
 The session `id` and `ownerId` are stable for the life of the session — they don't change when the resource ID is switched. They mirror the `id` and `ownerId` fields on `SessionRecord` in storage, so storage layers can key sessions by a stable identifier rather than the mutable resource ID.
 
-The resource ID is set when creating a session via [`harness.createSession()`](/reference/harness/harness-class#createsession-id-ownerid-resourceid-) and defaults to the harness `id`. See [Resource IDs](/docs/harness/threads-and-state#resource-ids) for how it scopes threads.
+The resource ID is set when creating a session via [`harness.createSession()`](/reference/harness/harness-class#createsession-id-ownerid-resourceid-tags-workspace-browser-requestcontext-) and defaults to the harness `id`. See [Resource IDs](/docs/harness/threads-and-state#resource-ids) for how it scopes threads.
 
 ## Thread
 

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -529,6 +529,48 @@ Return the internal `Mastra` instance, or `undefined` before `init()`. Useful fo
 const mastra = harness.getMastra()
 ```
 
+#### `getWorkspace()`
+
+Return the Harness-level workspace if it is a static `Workspace` instance. Dynamic factory workspaces are not resolved here — use [`resolveWorkspace()`](#resolveworkspace-session-requestcontext-) to resolve a factory against a session's request context.
+
+```typescript
+const workspace = harness.getWorkspace()
+```
+
+#### `resolveWorkspace({ session, requestContext? })`
+
+Eagerly resolve and cache the workspace. For dynamic workspaces (factory function), this triggers the factory against the given session's request context and caches the result so `getWorkspace()` returns it. Returns the resolved workspace or `undefined` if none is configured.
+
+```typescript
+const workspace = await harness.resolveWorkspace({ session })
+```
+
+```typescript
+// With an explicit request context
+const requestContext = new RequestContext()
+const workspace = await harness.resolveWorkspace({ session, requestContext })
+```
+
+#### `hasWorkspace()`
+
+Whether a workspace is configured on this Harness (static instance or dynamic factory). Sessions without an explicit workspace override fall back to this.
+
+```typescript
+if (harness.hasWorkspace()) {
+  // ...
+}
+```
+
+#### `isWorkspaceReady()`
+
+Whether the Harness-level static workspace has been initialized. Dynamic factory workspaces are resolved and initialized per-session during `createSession`, so this returns `false` for factory configs until a session is created.
+
+```typescript
+if (harness.isWorkspaceReady()) {
+  // ...
+}
+```
+
 ### Modes
 
 #### `listModes()`

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -211,16 +211,16 @@ await harness.sendMessage({ content: 'Hello!' })
   },
   {
     name: 'workspace',
-    type: 'Workspace | WorkspaceConfig | ((ctx) => Workspace)',
+    type: 'Workspace | ((ctx) => Workspace)',
     description:
-      'Workspace configuration. Accepts a pre-constructed Workspace, a WorkspaceConfig for the harness to construct internally, or a dynamic factory function.',
+      'Workspace instance or a dynamic factory function. When omitted, each session created via createSession must provide its own workspace. The factory receives the request context and Mastra instance.',
     isOptional: true,
   },
   {
     name: 'browser',
     type: 'MastraBrowser | ((ctx) => MastraBrowser)',
     description:
-      "Browser automation configuration. Propagated to mode agents that don't have their own browser configured.",
+      'Browser automation instance or a dynamic factory function. When omitted, each session created via createSession can provide its own browser.',
     isOptional: true,
   },
   {
@@ -425,19 +425,21 @@ await harness.sendMessage({ content: 'Hello!' })
 
 #### `init()`
 
-Initialize the harness. Loads storage, initializes the workspace, propagates memory and workspace to mode agents, and starts heartbeat handlers. Call this before using the harness.
+Initialize the harness. Loads storage, initializes a static workspace (dynamic factory workspaces are resolved per-session during `createSession`), propagates memory and workspace to mode agents, and starts heartbeat handlers. Call this before using the harness.
 
 ```typescript
 await harness.init()
 ```
 
-#### `createSession({ id, ownerId, resourceId? })`
+#### `createSession({ id, ownerId, resourceId?, tags?, workspace?, browser?, requestContext? })`
 
-Create a new, fully-wired `Session` and bring it online. The session starts in the default mode with the seeded model, connects to the Harness's shared machinery (agent, storage/lock, config catalog), and has a current thread (the most recent thread for the resource, or a freshly created one). Call `init()` once before creating sessions so shared storage and workspace are ready.
+Create a new, fully-wired `Session` and bring it online. The session starts in the default mode with the seeded model, connects to the Harness's shared machinery (agent, storage/lock, config catalog), and has a current thread (the most recent thread for the resource, or a freshly created one). Call `init()` once before creating sessions so shared storage is ready.
 
 The Harness owns no session of its own — every consumer creates its own session and drives all work through it. In a server or multiplayer setting, each request, thread, or user gets its own session, isolated from every other: independent event bus, mode, model, state, and current thread.
 
 `id` and `ownerId` are required — they mirror `SessionRecord.id` and `SessionRecord.ownerId` and are stable for the life of the session. `resourceId` is optional and defaults to `config.resourceId` then `config.id`.
+
+Each session owns its own `Workspace` and `Browser` instance. When `workspace` is omitted, the Harness resolves its configured workspace (a static instance or a dynamic factory) and passes it to the session. Pass a `workspace` override to give a specific session a different workspace than the Harness default. The workspace is initialized during session creation; `workspace_ready` and `workspace_status_changed` events are emitted on the session bus after `init()` completes, and late subscribers receive a replay of the last workspace status.
 
 ```typescript
 const session = await harness.createSession({
@@ -455,6 +457,19 @@ const session = await harness.createSession({
   resourceId: 'project-abc',
 })
 ```
+
+Override the workspace and browser for a specific session:
+
+```typescript
+const session = await harness.createSession({
+  id: 'session-xyz',
+  ownerId: 'user-123',
+  workspace: myWorkspace,
+  browser: myBrowser,
+})
+```
+
+`tags` scopes initial thread selection: a thread is a resume candidate only when its metadata matches every provided tag. This lets worktrees sharing a resourceId each resume their own thread (via a `projectPath` tag).
 
 Switching the resource ID via `harness.setResourceId()` changes only the resource ID, not `id` or `ownerId`. Read them through `session.identity.getId()` and `session.identity.getOwnerId()`.
 
@@ -732,52 +747,6 @@ Resolve a tool's category using the configured `toolCategoryResolver`.
 ```typescript
 const category = harness.getToolCategory({ toolName: 'mastra_workspace_write_file' })
 // 'edit'
-```
-
-### Workspace
-
-#### `getWorkspace()`
-
-Return the current workspace instance, or `undefined` if no workspace is configured or it hasn't been resolved yet.
-
-```typescript
-const workspace = harness.getWorkspace()
-```
-
-#### `resolveWorkspace({ requestContext? })`
-
-Eagerly resolve and cache the workspace. For dynamic workspaces (factory function), this triggers the factory and caches the result so `getWorkspace()` returns it. Returns the resolved workspace or `undefined` if none is configured.
-
-```typescript
-const workspace = await harness.resolveWorkspace()
-```
-
-#### `hasWorkspace()`
-
-Return whether a workspace is configured (static, config-based, or dynamic).
-
-```typescript
-if (harness.hasWorkspace()) {
-  const workspace = await harness.resolveWorkspace()
-}
-```
-
-#### `isWorkspaceReady()`
-
-Return whether the workspace is ready to use. For dynamic workspaces (factory function), always returns `true`. For static workspaces, returns `true` after `init()` succeeds.
-
-```typescript
-if (harness.isWorkspaceReady()) {
-  const workspace = harness.getWorkspace()
-}
-```
-
-#### `destroyWorkspace()`
-
-Destroy the workspace and release resources. Only applies to static workspaces — dynamic workspaces aren't destroyed.
-
-```typescript
-await harness.destroyWorkspace()
 ```
 
 ### Observational Memory

--- a/docs/src/content/en/reference/harness/session.mdx
+++ b/docs/src/content/en/reference/harness/session.mdx
@@ -97,6 +97,12 @@ The session is organized into sub-objects, each owning one domain of per-convers
     type: 'SessionState<TState>',
     description: 'The schema-validated, session-owned Harness state. See state methods below.',
   },
+  {
+    name: 'browser',
+    type: 'MastraBrowser | undefined',
+    description:
+      'The browser automation instance for this session. Set at creation via createSession, or from the Harness config default. Undefined when no browser is configured.',
+  },
 ]}
 />
 
@@ -610,6 +616,19 @@ const added = await harness.session.state.update(current => ({
   updates: { count: (current.count ?? 0) + 1 },
   result: (current.count ?? 0) + 1,
 }))
+```
+
+## Scoping tags
+
+Sessions carry scoping tags (e.g. `{ projectPath }`) seeded at creation and stamped onto every thread the session creates. Thread listings can be filtered back to the session's scope using these tags.
+
+### `getTags()`
+
+Return a copy of the session's scoping tags. Empty object when the session is unscoped.
+
+```typescript
+const tags = harness.session.getTags()
+// { projectPath: '/my/project' }
 ```
 
 ## Related

--- a/mastracode/src/__tests__/tool-approval-libsql.test.ts
+++ b/mastracode/src/__tests__/tool-approval-libsql.test.ts
@@ -3,6 +3,7 @@ import { Harness } from '@mastra/core/harness';
 import { Mastra } from '@mastra/core/mastra';
 import { MastraLanguageModelV2Mock } from '@mastra/core/test-utils/llm-mock';
 import { createTool } from '@mastra/core/tools';
+import { Workspace } from '@mastra/core/workspace';
 import { LibSQLStore } from '@mastra/libsql';
 import { describe, it, expect, vi } from 'vitest';
 import z from 'zod';
@@ -101,6 +102,7 @@ describe('tool approval with LibSQLStore via Harness', () => {
     const harness = new Harness({
       id: 'test-harness',
       storage,
+      workspace: new Workspace({ name: 'test-workspace', skills: ['/tmp/test-skills'] }),
       modes: [
         {
           id: 'default',

--- a/mastracode/src/headless-integration.test.ts
+++ b/mastracode/src/headless-integration.test.ts
@@ -16,6 +16,7 @@ import { Mastra } from '@mastra/core/mastra';
 import { AgentsMDInjector } from '@mastra/core/processors';
 import { MastraLanguageModelV2Mock } from '@mastra/core/test-utils/llm-mock';
 import { createTool } from '@mastra/core/tools';
+import { Workspace } from '@mastra/core/workspace';
 import { LibSQLStore } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
@@ -187,6 +188,7 @@ function createHarnessWithAgent(opts: {
   const harness = new Harness({
     id: 'test-harness',
     storage,
+    workspace: new Workspace({ name: 'test-workspace', skills: ['/tmp/test-skills'] }),
     modes: [
       {
         id: 'default',
@@ -568,6 +570,7 @@ function createHarnessWithModels(opts: {
   const harness = new Harness({
     id: 'test-harness',
     storage,
+    workspace: new Workspace({ name: 'test-workspace', skills: ['/tmp/test-skills'] }),
     modes: [
       {
         id: 'default',
@@ -1386,6 +1389,7 @@ describe('headless mode — thread control', () => {
       id: 'test-harness',
       storage,
       memory,
+      workspace: new Workspace({ name: 'test-workspace', skills: ['/tmp/test-skills'] }),
       modes: [
         {
           id: 'default',

--- a/packages/core/src/harness/__tests__/harness-ask-user.test.ts
+++ b/packages/core/src/harness/__tests__/harness-ask-user.test.ts
@@ -16,6 +16,7 @@ import { askUserTool } from '../../tools/builtin/ask-user';
 
 import { Harness } from '../harness';
 import { SessionApproval } from '../session';
+import { createMockWorkspace } from '../test-utils';
 
 vi.setConfig({ testTimeout: 30_000 });
 
@@ -81,6 +82,7 @@ async function buildHarness(id: string, input: string) {
   const registeredAgent = mastra.getAgent(`agent-${id}`);
 
   const harness = new Harness({
+    workspace: createMockWorkspace(),
     id: `harness-${id}`,
     storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
@@ -337,6 +339,7 @@ describe('Harness: ask_user native suspension', () => {
     const mastra = new Mastra({ agents: { 'agent-serial': agent }, logger: false, storage });
     const registeredAgent = mastra.getAgent('agent-serial');
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'harness-serial',
       storage,
       modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],

--- a/packages/core/src/harness/__tests__/harness-finish-reason.test.ts
+++ b/packages/core/src/harness/__tests__/harness-finish-reason.test.ts
@@ -18,6 +18,7 @@ import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
 
 import { Harness } from '../harness';
 import { describeNonSuccessFinishReason } from '../stream-content';
+import { createMockWorkspace } from '../test-utils';
 
 vi.setConfig({ testTimeout: 30_000 });
 
@@ -55,6 +56,7 @@ async function buildHarness(id: string, stream: () => ReadableStream) {
   const registeredAgent = mastra.getAgent(`agent-${id}`);
 
   const harness = new Harness({
+    workspace: createMockWorkspace(),
     id: `harness-${id}`,
     storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],

--- a/packages/core/src/harness/__tests__/harness-notifications.test.ts
+++ b/packages/core/src/harness/__tests__/harness-notifications.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Harness } from '../harness';
+import { createMockWorkspace } from '../test-utils';
 
 function createSubscription() {
   return {
@@ -26,6 +27,7 @@ describe('Harness notification signals', () => {
   it('creates a thread and delegates notification signals with resource, thread, and idle stream options', async () => {
     const agent = createAgentMock();
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'harness-1',
       resourceId: 'resource-1',
       modes: [{ id: 'default', name: 'Default', default: true, agent: agent as any }],

--- a/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
+++ b/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
@@ -16,6 +16,7 @@ import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
 import { createTool } from '../../tools';
 
 import { Harness } from '../harness';
+import { createMockWorkspace } from '../test-utils';
 
 vi.setConfig({ testTimeout: 30_000 });
 
@@ -91,6 +92,7 @@ describe('Harness: tool suspension and resumption', () => {
     const streamSpy = vi.spyOn(registeredAgent, 'stream');
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness-default-model-settings',
       storage,
       modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
@@ -149,6 +151,7 @@ describe('Harness: tool suspension and resumption', () => {
     const registeredAgent = mastra.getAgent('test-agent');
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       storage,
       modes: [
@@ -225,6 +228,7 @@ describe('Harness: tool suspension and resumption', () => {
     const registeredAgent = mastra.getAgent('test-agent-ds');
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness-ds',
       storage,
       modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
@@ -288,6 +292,7 @@ describe('Harness: tool suspension and resumption', () => {
     const registeredAgent = mastra.getAgent('test-agent-resume');
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness-resume',
       storage,
       modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
@@ -373,6 +378,7 @@ describe('Harness: tool suspension and resumption', () => {
     const registeredAgent = mastra.getAgent('test-agent-yolo-resume');
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness-yolo-resume',
       storage,
       modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
@@ -451,6 +457,7 @@ describe('Harness: tool suspension and resumption', () => {
     const sendStreamResumeSpy = vi.spyOn(registeredAgent, 'sendStreamResume');
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness-budget-resume',
       storage,
       modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],

--- a/packages/core/src/harness/__tests__/signal-messages.test.ts
+++ b/packages/core/src/harness/__tests__/signal-messages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Harness } from '../harness';
+import { createMockWorkspace } from '../test-utils';
 
 function createSubscription(activeRunId: () => string | null) {
   return {
@@ -27,6 +28,7 @@ describe('Harness signal messages', () => {
     let activeRunId: string | null = 'run-1';
     const agent = createAgentMock(() => activeRunId);
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'harness-1',
       resourceId: 'resource-1',
       modes: [{ id: 'default', name: 'Default', default: true, agent: agent as any }],
@@ -66,6 +68,7 @@ describe('Harness signal messages', () => {
     let activeRunId: string | null = 'run-1';
     const agent = createAgentMock(() => activeRunId);
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'harness-approval-interrupt',
       resourceId: 'resource-1',
       modes: [{ id: 'default', name: 'Default', default: true, agent: agent as any }],
@@ -101,6 +104,7 @@ describe('Harness signal messages', () => {
       signal: { id: 'signal-1', type: 'user-message' },
     } as any);
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'harness-idle-signal-failure',
       resourceId: 'resource-1',
       modes: [{ id: 'default', name: 'Default', default: true, agent: agent as any }],

--- a/packages/core/src/harness/__tests__/trailing-guard-new-run.test.ts
+++ b/packages/core/src/harness/__tests__/trailing-guard-new-run.test.ts
@@ -17,6 +17,7 @@ import { Agent } from '../../agent';
 import { InMemoryStore } from '../../storage/mock';
 import { Harness } from '../harness';
 import type { Session } from '../session';
+import { createMockWorkspace } from '../test-utils';
 import type { HarnessEvent } from '../types';
 
 function createHarness() {
@@ -28,6 +29,7 @@ function createHarness() {
   });
 
   return new Harness({
+    workspace: createMockWorkspace(),
     id: 'trailing-guard-harness',
     storage: new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/clone-thread.test.ts
+++ b/packages/core/src/harness/clone-thread.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Agent } from '../agent';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 
 describe('Harness cloneThread', () => {
   it('resolves dynamic memory factory before cloning', async () => {
@@ -22,6 +23,7 @@ describe('Harness cloneThread', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       resourceId: 'harness-resource',
       memory: memoryFactory as any,
@@ -60,6 +62,7 @@ describe('Harness cloneThread', () => {
 
   it('throws when dynamic memory factory returns empty value', async () => {
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       memory: vi.fn().mockResolvedValue(undefined) as unknown as any,
       modes: [

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -1452,6 +1452,11 @@ describe('display_state_changed emission', () => {
     session.subscribe((event: HarnessEvent) => {
       events.push(event);
     });
+    // createSession emits workspace lifecycle events (workspace_status_changed,
+    // workspace_ready) during session creation, before this subscriber attaches.
+    // The bus replays them to late subscribers — clear them so the tests below
+    // only observe events they emit themselves.
+    events.length = 0;
   });
 
   it('emits display_state_changed after every non-display_state_changed event', () => {

--- a/packages/core/src/harness/fork-clone-metadata.test.ts
+++ b/packages/core/src/harness/fork-clone-metadata.test.ts
@@ -5,6 +5,7 @@ import { RequestContext } from '../request-context';
 import { SignalProvider } from '../signals/signal-provider';
 
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 import type * as Tools from './tools';
 import type { HarnessSubagent } from './types';
 
@@ -55,6 +56,7 @@ describe('Harness fork clone metadata wiring', () => {
     ];
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'parent-resource',
       memory: memoryFactory as unknown as never,
@@ -119,6 +121,7 @@ describe('Harness fork clone metadata wiring', () => {
     };
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'parent-resource',
       subagents,
@@ -171,6 +174,7 @@ describe('Harness fork clone metadata wiring', () => {
     ];
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'parent-resource',
       memory: memoryFactory as unknown as never,
@@ -219,6 +223,7 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'test-resource',
       memory: memoryFactory as unknown as never,
@@ -266,6 +271,7 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'test-resource',
       memory: memoryFactory as unknown as never,
@@ -313,6 +319,7 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'test-resource',
       memory: memoryFactory as unknown as never,
@@ -361,6 +368,7 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'test-resource',
       memory: memoryFactory as unknown as never,
@@ -420,6 +428,7 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'test-resource',
       memory: memoryFactory as unknown as never,
@@ -473,6 +482,7 @@ describe('Harness fork clone metadata wiring', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'test-resource',
       memory: memoryFactory as unknown as never,
@@ -532,6 +542,7 @@ describe('Harness fork clone metadata wiring', () => {
     expect(baseAgent.hasOwnMemory()).toBe(false);
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test',
       resourceId: 'test-resource',
       memory: memoryFactory as unknown as never,

--- a/packages/core/src/harness/get-om-record.test.ts
+++ b/packages/core/src/harness/get-om-record.test.ts
@@ -3,6 +3,7 @@ import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 import type { Session } from './session';
+import { createMockWorkspace } from './test-utils';
 
 function createHarness(storage: InMemoryStore) {
   const agent = new Agent({
@@ -12,6 +13,7 @@ function createHarness(storage: InMemoryStore) {
   });
 
   return new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1030,9 +1030,24 @@ export class Harness<TState = {}> {
     // otherwise the internal one). Re-bind when the agent currently has no
     // Mastra OR is bound to a different instance — e.g. an agent that built its
     // own internal Mastra before this Harness was registered on a parent.
+    // Done before workspace/browser propagation so that addAgent — which may
+    // resolve agent.getWorkspace() — does not prematurely invoke a workspace
+    // factory before the per-session request context is available.
     const mastra = this.getMastra();
     if (mastra && agent.getMastraInstance() !== mastra) {
       mastra.addAgent(agent);
+    }
+
+    if (this.workspace && typeof agent.hasOwnWorkspace === 'function' && !agent.hasOwnWorkspace()) {
+      agent.__setWorkspace(this.workspace);
+    }
+    if (
+      this.browser &&
+      typeof agent.hasOwnBrowser === 'function' &&
+      !agent.hasOwnBrowser() &&
+      typeof this.browser !== 'function'
+    ) {
+      agent.setBrowser(this.browser);
     }
 
     return agent;

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -523,6 +523,26 @@ export class Harness<TState = {}> {
   }
 
   /**
+   * Whether a workspace is configured on this Harness (static instance, dynamic
+   * factory, or config object). Sessions without an explicit workspace override
+   * fall back to this.
+   */
+  hasWorkspace(): boolean {
+    return this.workspace !== undefined;
+  }
+
+  /**
+   * Whether the Harness-level static workspace has been initialized. Dynamic
+   * factory workspaces are resolved and initialized per-session during
+   * `createSession`, so this returns `false` for factory configs until a
+   * session is created.
+   */
+  isWorkspaceReady(): boolean {
+    if (typeof this.workspace === 'function') return true;
+    return this.workspaceInitialized && this.workspace !== undefined;
+  }
+
+  /**
    * Register this Harness on a parent Mastra. Called by Mastra during
    * construction when a harness is passed in its config. Once registered, the
    * Harness uses the parent Mastra (its storage, agents, gateways, and

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -178,7 +178,6 @@ export class Harness<TState = {}> {
   private config: HarnessConfig<TState>;
   private workspaceInitialized = false;
   private initPromise: Promise<void> | undefined = undefined;
-  private workspaceError: Error | undefined = undefined;
   private browser: DynamicArgument<MastraBrowser | undefined> = undefined;
   private workspace: DynamicArgument<Workspace | undefined> = undefined;
   private heartbeatTimers = new Map<string, { timer: NodeJS.Timeout; shutdown?: () => void | Promise<void> }>();
@@ -446,6 +445,12 @@ export class Harness<TState = {}> {
     if (workspaceToConnect && workspaceToConnect instanceof Workspace) {
       try {
         await workspaceToConnect.init();
+        session.emit({ type: 'workspace_status_changed', status: 'ready' });
+        session.emit({
+          type: 'workspace_ready',
+          workspaceId: workspaceToConnect.id,
+          workspaceName: workspaceToConnect.name,
+        });
       } catch (error) {
         const initError = getErrorFromUnknown(error);
         session.emit({ type: 'workspace_status_changed', status: 'error', error: initError });
@@ -633,14 +638,11 @@ export class Harness<TState = {}> {
 
         await (this.workspace as Workspace).init();
         this.workspaceInitialized = true;
-        this.workspaceError = undefined;
-      } catch (error) {
-        const err = getErrorFromUnknown(error);
+      } catch {
         this.workspace = undefined;
         this.workspaceInitialized = false;
-        // Remember the failure so sessions created later can surface it; the
-        // Harness holds no session of its own to emit onto during init().
-        this.workspaceError = err;
+        // Sessions created later will call workspace.init() themselves and
+        // surface the error through workspace_error events on the session.
       }
     }
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -350,8 +350,8 @@ export class Harness<TState = {}> {
      * changing the API. Falls back to `initialState` when omitted.
      */
     tags?: Record<string, string>;
-    workspace?: DynamicArgument<Workspace | undefined>;
-    browser?: DynamicArgument<MastraBrowser | undefined>;
+    workspace?: Workspace;
+    browser?: MastraBrowser;
     requestContext?: RequestContext;
   } = {}): Promise<Session<TState>> {
     const effectiveResourceId = resourceId ?? this.config.resourceId ?? this.config.id;
@@ -391,8 +391,8 @@ export class Harness<TState = {}> {
     effectiveResourceId: string,
     tags?: Record<string, string>,
     overrides?: {
-      workspace?: DynamicArgument<Workspace | undefined>;
-      browser?: DynamicArgument<MastraBrowser | undefined>;
+      workspace?: Workspace;
+      browser?: MastraBrowser;
       requestContext?: RequestContext;
     },
   ): Promise<Session<TState>> {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -16,6 +16,7 @@ import { RequestContext } from '../request-context';
 import type { MastraCompositeStore } from '../storage/base';
 import type { MemoryStorage } from '../storage/domains/memory/base';
 import type { ObservationalMemoryRecord } from '../storage/types';
+import type { DynamicArgument } from '../types';
 import { Workspace } from '../workspace/workspace';
 import type { WorkspaceConfig } from '../workspace/workspace';
 
@@ -175,20 +176,11 @@ export class Harness<TState = {}> {
   readonly id: string;
 
   private config: HarnessConfig<TState>;
-  private workspace: Workspace | undefined = undefined;
-  private workspaceFn:
-    | ((ctx: {
-        requestContext: RequestContext;
-        mastra?: Mastra;
-      }) => Promise<Workspace | undefined> | Workspace | undefined)
-    | undefined = undefined;
   private workspaceInitialized = false;
   private initPromise: Promise<void> | undefined = undefined;
   private workspaceError: Error | undefined = undefined;
-  private browser: MastraBrowser | undefined = undefined;
-  private browserFn:
-    | ((ctx: { requestContext: RequestContext }) => Promise<MastraBrowser | undefined> | MastraBrowser | undefined)
-    | undefined = undefined;
+  private browser: DynamicArgument<MastraBrowser | undefined> = undefined;
+  private workspace: DynamicArgument<Workspace | undefined> = undefined;
   private heartbeatTimers = new Map<string, { timer: NodeJS.Timeout; shutdown?: () => void | Promise<void> }>();
   /**
    * The mode every new session starts in. Resolved once at construction from
@@ -243,19 +235,8 @@ export class Harness<TState = {}> {
 
     this.#defaultMode = defaultMode;
 
-    // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
-    if (config.workspace instanceof Workspace) {
-      this.workspace = config.workspace;
-    } else if (typeof config.workspace === 'function') {
-      this.workspaceFn = config.workspace;
-    }
-
-    // Store browser: pre-built instance or dynamic factory
-    if (config.browser && typeof config.browser !== 'function') {
-      this.browser = config.browser;
-    } else if (typeof config.browser === 'function') {
-      this.browserFn = config.browser;
-    }
+    this.workspace = config.workspace;
+    this.browser = config.browser;
   }
 
   /**
@@ -353,6 +334,9 @@ export class Harness<TState = {}> {
     ownerId,
     id,
     tags,
+    workspace,
+    browser,
+    requestContext,
   }: {
     resourceId?: string;
     id?: string;
@@ -366,6 +350,9 @@ export class Harness<TState = {}> {
      * changing the API. Falls back to `initialState` when omitted.
      */
     tags?: Record<string, string>;
+    workspace?: DynamicArgument<Workspace | undefined>;
+    browser?: DynamicArgument<MastraBrowser | undefined>;
+    requestContext?: RequestContext;
   } = {}): Promise<Session<TState>> {
     const effectiveResourceId = resourceId ?? this.config.resourceId ?? this.config.id;
     const effectiveSessionId = id ?? this.config.id;
@@ -381,7 +368,11 @@ export class Harness<TState = {}> {
       return existing;
     }
 
-    const creation = this.#createSessionForResource(effectiveOwnerId, effectiveSessionId, effectiveResourceId, tags);
+    const creation = this.#createSessionForResource(effectiveOwnerId, effectiveSessionId, effectiveResourceId, tags, {
+      workspace,
+      browser,
+      requestContext,
+    });
     this.#sessionsByResource.set(effectiveResourceId, creation);
     try {
       return await creation;
@@ -399,15 +390,43 @@ export class Harness<TState = {}> {
     id: string,
     effectiveResourceId: string,
     tags?: Record<string, string>,
+    overrides?: {
+      workspace?: DynamicArgument<Workspace | undefined>;
+      browser?: DynamicArgument<MastraBrowser | undefined>;
+      requestContext?: RequestContext;
+    },
   ): Promise<Session<TState>> {
     // Seed the session's tags into its state so thread tagging + the workspace
     // factory resolve against this session's scope (e.g. its `projectPath`), not
     // the harness-global default (which, on a multi-session server, may point at
     // a different repo).
-    const initialState =
-      tags && Object.keys(tags).length > 0
-        ? ({ ...(this.config.initialState as Record<string, unknown>), ...tags } as TState)
-        : this.config.initialState;
+    const requestContext = overrides?.requestContext ?? new RequestContext();
+    let initialState = structuredClone(this.config.initialState);
+    if (tags && Object.keys(tags).length > 0) {
+      initialState = { ...initialState, ...tags } as TState;
+    }
+    requestContext.set('harness', {
+      harnessId: this.id,
+      getState: () => initialState,
+      setState: (updates: Partial<TState>) => {
+        initialState = { ...initialState, ...updates };
+      },
+      session: {
+        id,
+        ownerId,
+        resourceId: effectiveResourceId,
+      },
+    });
+
+    let workspaceToConnect = overrides?.workspace ?? this.workspace;
+    if (typeof workspaceToConnect === 'function') {
+      workspaceToConnect = await workspaceToConnect({ requestContext, mastra: this.getMastra() });
+    }
+
+    let browserToConnect = overrides?.browser ?? this.browser;
+    if (typeof browserToConnect === 'function') {
+      browserToConnect = await browserToConnect({ requestContext, mastra: this.getMastra() });
+    }
 
     const session = this.#wireSession(
       new Session({
@@ -419,21 +438,19 @@ export class Harness<TState = {}> {
           initialState,
           stateSchema: this.config.stateSchema,
         },
+        workspace: workspaceToConnect as Workspace,
+        browser: browserToConnect,
       }),
     );
 
-    // Replay current workspace status onto the new session so a session created
-    // after init() still observes the shared workspace being ready (or failed).
-    if (this.workspace && this.workspaceInitialized) {
-      session.emit({ type: 'workspace_status_changed', status: 'ready' });
-      session.emit({
-        type: 'workspace_ready',
-        workspaceId: this.workspace.id,
-        workspaceName: this.workspace.name,
-      });
-    } else if (this.workspaceError) {
-      session.emit({ type: 'workspace_status_changed', status: 'error', error: this.workspaceError });
-      session.emit({ type: 'workspace_error', error: this.workspaceError });
+    if (workspaceToConnect && workspaceToConnect instanceof Workspace) {
+      try {
+        await workspaceToConnect.init();
+      } catch (error) {
+        const initError = getErrorFromUnknown(error);
+        session.emit({ type: 'workspace_status_changed', status: 'error', error: initError });
+        session.emit({ type: 'workspace_error', error: initError });
+      }
     }
 
     // Bring the session online with a current thread. Selection is tag-aware so
@@ -544,7 +561,6 @@ export class Harness<TState = {}> {
    */
   setBrowser(browser: MastraBrowser | undefined): void {
     this.browser = browser;
-    this.browserFn = undefined;
 
     // Collect unique agents: shared backing agent + any deprecated mode.agent
     // instances so all receive the browser (signal providers may be attached to
@@ -609,13 +625,13 @@ export class Harness<TState = {}> {
     }
 
     // Initialize workspace if configured (skip for dynamic factory — resolved per-request)
-    if (this.config.workspace && !this.workspaceInitialized && !this.workspaceFn) {
+    if (this.config.workspace && !this.workspaceInitialized && typeof this.workspace !== 'function') {
       try {
         if (!this.workspace) {
           this.workspace = new Workspace(this.config.workspace as WorkspaceConfig);
         }
 
-        await this.workspace.init();
+        await (this.workspace as Workspace).init();
         this.workspaceInitialized = true;
         this.workspaceError = undefined;
       } catch (error) {
@@ -909,18 +925,9 @@ export class Harness<TState = {}> {
     return this.config.modes;
   }
 
-  private propagateRuntimeServicesToAgent(agent: Agent): Agent {
-    const workspaceForAgents = this.workspaceFn ?? this.workspace;
-    const browserForAgents = this.browserFn ?? this.browser;
-
+  private propagateRuntimeServicesToAgent(agent: Agent, _session?: Session<TState>): Agent {
     if (this.config.memory && !agent.hasOwnMemory()) {
       agent.__setMemory(this.config.memory);
-    }
-    if (workspaceForAgents && !agent.hasOwnWorkspace()) {
-      agent.__setWorkspace(workspaceForAgents);
-    }
-    if (browserForAgents && !agent.hasOwnBrowser()) {
-      agent.setBrowser(browserForAgents as MastraBrowser);
     }
     if (this.config.pubsub && !agent.hasOwnPubSub()) {
       agent.__setPubSub(this.config.pubsub);
@@ -1023,7 +1030,7 @@ export class Harness<TState = {}> {
   getCurrentAgent(session: Session<TState>): Agent {
     const mode = session.mode.resolve();
 
-    return this.propagateRuntimeServicesToAgent(this.getAgentForMode(mode));
+    return this.propagateRuntimeServicesToAgent(this.getAgentForMode(mode), session);
   }
 
   /**
@@ -1915,25 +1922,11 @@ export class Harness<TState = {}> {
         },
       },
       abortSignal: session.run.getAbortSignal(),
-      workspace: this.workspace,
       emitEvent: event => session.emit(event),
       getSubagentModelId: params => session.subagents.model.get(params ?? {}),
     };
 
     requestContext.set('harness', harnessContext);
-
-    if (this.workspaceFn) {
-      // Pass the internal Mastra instance so the workspace factory can dedupe
-      // against the registered workspace (getWorkspaceById). Without it, a
-      // dynamic factory would build a *separate* Workspace/filesystem instance
-      // from the one the agent resolves and registers — leaving harness-side
-      // tools (e.g. request_access) mutating a different filesystem than the
-      // agent's workspace tools (e.g. view) read from.
-      const resolved = await Promise.resolve(this.workspaceFn({ requestContext, mastra: this.getMastra() }));
-      harnessContext.workspace = resolved;
-      // Cache for getWorkspace() so callers outside request flow (e.g. /skills) can access it
-      this.workspace = resolved;
-    }
 
     return requestContext;
   }
@@ -1979,59 +1972,6 @@ export class Harness<TState = {}> {
       }
     } catch {
       // Token persistence is not critical
-    }
-  }
-
-  // ===========================================================================
-  // Workspace
-  // ===========================================================================
-
-  getWorkspace(): Workspace | undefined {
-    return this.workspace;
-  }
-
-  /**
-   * Eagerly resolve the workspace. For dynamic workspaces (factory function),
-   * this triggers resolution and caches the result so getWorkspace() returns it.
-   * Useful for code paths outside the request flow (e.g. slash commands).
-   */
-  async resolveWorkspace({
-    session,
-    requestContext,
-  }: {
-    session: Session<TState>;
-    requestContext?: RequestContext;
-  }): Promise<Workspace | undefined> {
-    if (this.workspace) return this.workspace;
-    if (this.workspaceFn) {
-      // buildRequestContext resolves the workspace and caches it on this.workspace
-      await this.buildRequestContext(session, requestContext);
-      return this.workspace;
-    }
-    return undefined;
-  }
-
-  hasWorkspace(): boolean {
-    return this.config.workspace !== undefined;
-  }
-
-  isWorkspaceReady(): boolean {
-    if (this.workspaceFn) return true;
-    return this.workspaceInitialized && this.workspace !== undefined;
-  }
-
-  async destroyWorkspace(): Promise<void> {
-    if (this.workspaceFn) return;
-    if (this.workspace && this.workspaceInitialized) {
-      // The workspace is a Harness-shared resource torn down at Harness
-      // shutdown; there is no single session to emit lifecycle events onto.
-      try {
-        await this.workspace.destroy();
-      } catch (error) {
-        console.warn('Workspace destroy failed:', error);
-      } finally {
-        this.workspaceInitialized = false;
-      }
     }
   }
 
@@ -2120,7 +2060,6 @@ export class Harness<TState = {}> {
     // cleanup) is the caller's responsibility via `session.thread.*`. Here we
     // only tear down Harness-shared resources.
     await this.stopHeartbeats();
-    await this.destroyWorkspace();
   }
 
   // ===========================================================================

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -50,6 +50,7 @@ import type {
   HarnessMessageContent,
   HarnessMode,
   HarnessRequestContext,
+  HarnessRequestStateUpdater,
   HarnessThread,
   ModelAuthStatus,
   ToolCategory,
@@ -404,16 +405,49 @@ export class Harness<TState = {}> {
     if (tags && Object.keys(tags).length > 0) {
       initialState = { ...initialState, ...tags } as TState;
     }
+    const defaultMode = this.#defaultMode;
     requestContext.set('harness', {
       harnessId: this.id,
+      state: initialState,
       getState: () => initialState,
       setState: (updates: Partial<TState>) => {
         initialState = { ...initialState, ...updates };
       },
+      updateState: (updater: HarnessRequestStateUpdater<TState, unknown>) => {
+        return Promise.resolve(updater(initialState as Readonly<TState>)).then(result => {
+          if (result.updates) {
+            initialState = { ...initialState, ...result.updates };
+          }
+          return result.result;
+        });
+      },
+      threadId: null,
+      resourceId: effectiveResourceId,
       session: {
         id,
         ownerId,
         resourceId: effectiveResourceId,
+        modeId: defaultMode.id,
+        modelId: defaultMode.defaultModelId ?? '',
+        state: {
+          get: () => initialState as Readonly<TState>,
+          set: (updates: Partial<TState>) => {
+            initialState = { ...initialState, ...updates };
+            return Promise.resolve();
+          },
+          update: <TResult>(updater: HarnessRequestStateUpdater<TState, TResult>) => {
+            return Promise.resolve(updater(initialState as Readonly<TState>)).then(result => {
+              if (result.updates) {
+                initialState = { ...initialState, ...result.updates };
+              }
+              return result.result;
+            });
+          },
+        },
+      },
+      getSubagentModelId: (params?: { agentType?: string }) => {
+        const sub = this.config.subagents?.find(s => s.id === params?.agentType);
+        return sub?.defaultModelId ?? null;
       },
     });
 
@@ -540,6 +574,43 @@ export class Harness<TState = {}> {
   isWorkspaceReady(): boolean {
     if (typeof this.workspace === 'function') return true;
     return this.workspaceInitialized && this.workspace !== undefined;
+  }
+
+  /**
+   * The Harness-level workspace, if it is a static instance. Dynamic factory
+   * workspaces are not resolved here — use {@link resolveWorkspace} to resolve
+   * a factory against a session's request context.
+   */
+  getWorkspace(): Workspace | undefined {
+    return typeof this.workspace === 'function' ? undefined : (this.workspace ?? undefined);
+  }
+
+  /**
+   * Eagerly resolve the workspace. For dynamic workspaces (factory function),
+   * this triggers resolution against the given session's request context and
+   * caches the result so {@link getWorkspace} returns it. Useful for code paths
+   * outside the request flow (e.g. slash commands).
+   */
+  async resolveWorkspace({
+    session,
+    requestContext,
+  }: {
+    session: Session<TState>;
+    requestContext?: RequestContext;
+  }): Promise<Workspace | undefined> {
+    if (typeof this.workspace !== 'function') return this.workspace ?? undefined;
+    const ctx = requestContext ?? new RequestContext();
+    ctx.set('harness', {
+      harnessId: this.id,
+      session: {
+        id: session.identity.getId(),
+        ownerId: session.identity.getOwnerId(),
+        resourceId: session.identity.getResourceId(),
+      },
+    });
+    const resolved = await this.workspace({ requestContext: ctx, mastra: this.getMastra() });
+    this.workspace = resolved;
+    return resolved ?? undefined;
   }
 
   /**

--- a/packages/core/src/harness/list-available-models.test.ts
+++ b/packages/core/src/harness/list-available-models.test.ts
@@ -10,6 +10,7 @@ import type {
 } from '../llm/model/gateways';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 
 /**
  * Minimal in-memory gateway used to drive the Harness model catalog without
@@ -54,6 +55,7 @@ function createHarness(gateway: MastraModelGatewayInterface, defaultModelId?: st
   });
 
   return new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage: new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent, defaultModelId }],

--- a/packages/core/src/harness/list-threads-fork-filter.test.ts
+++ b/packages/core/src/harness/list-threads-fork-filter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 
 function createHarness(resourceId: string) {
   const agent = new Agent({
@@ -11,6 +12,7 @@ function createHarness(resourceId: string) {
   });
 
   return new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage: new InMemoryStore(),
     resourceId,

--- a/packages/core/src/harness/mode-model-persistence.test.ts
+++ b/packages/core/src/harness/mode-model-persistence.test.ts
@@ -3,6 +3,7 @@ import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 import type { Session } from './session';
+import { createMockWorkspace } from './test-utils';
 
 type HarnessTestState = { currentModelId?: string };
 
@@ -17,6 +18,7 @@ async function buildHarness(
   storage: InMemoryStore,
 ): Promise<{ harness: Harness<HarnessTestState>; session: Session<HarnessTestState> }> {
   const harness = new Harness<HarnessTestState>({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage,
     stateSchema: undefined,

--- a/packages/core/src/harness/om-failure-abort.test.ts
+++ b/packages/core/src/harness/om-failure-abort.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 import type { HarnessEvent } from './types';
 
 async function createSession() {
@@ -12,6 +13,7 @@ async function createSession() {
   });
 
   const harness = new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage: new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/om-threshold-persistence.test.ts
+++ b/packages/core/src/harness/om-threshold-persistence.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 
 function createHarness(storage: InMemoryStore, initialState: Record<string, unknown> = {}) {
   const agent = new Agent({
@@ -11,6 +12,7 @@ function createHarness(storage: InMemoryStore, initialState: Record<string, unkn
   });
 
   return new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage,
     initialState: initialState as any,

--- a/packages/core/src/harness/repro-mc-bug.test.ts
+++ b/packages/core/src/harness/repro-mc-bug.test.ts
@@ -21,6 +21,7 @@ import type { PubSubDeliveryMode } from '../events/pubsub';
 import type { RequestContext } from '../request-context';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 import type { HarnessEvent } from './types';
 
 /** Push-only wrapper around EventEmitterPubSub — mimics mc's SignalsPubSub. */
@@ -77,6 +78,7 @@ describe('mc send-message reproduction', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       storage,
       resourceId: 'test-resource',
@@ -122,6 +124,7 @@ describe('mc send-message reproduction', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       storage,
       resourceId: 'test-resource',
@@ -174,6 +177,7 @@ describe('mc send-message reproduction', () => {
     });
 
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       storage,
       pubsub: pushOnlyPubSub,

--- a/packages/core/src/harness/resource-id.test.ts
+++ b/packages/core/src/harness/resource-id.test.ts
@@ -3,6 +3,7 @@ import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 import type { Session } from './session';
+import { createMockWorkspace } from './test-utils';
 
 function createAgent() {
   return new Agent({
@@ -20,6 +21,7 @@ async function createSession(opts?: {
 }) {
   const agent = createAgent();
   const harness = new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage: opts?.storage ?? new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/session-bus.test.ts
+++ b/packages/core/src/harness/session-bus.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Session } from './session';
+import { createMockWorkspace } from './test-utils';
 import type { HarnessEvent } from './types';
 
 describe('Session event bus', () => {
   it('delivers emitted events to its own subscribers', () => {
-    const session = new Session({ resourceId: 'r1' });
+    const session = new Session({ resourceId: 'r1', id: 's1', ownerId: 'o1', workspace: createMockWorkspace() });
     const received: HarnessEvent[] = [];
     session.subscribe(event => {
       received.push(event);
@@ -17,8 +18,8 @@ describe('Session event bus', () => {
   });
 
   it("does not deliver one session's events to another session's subscribers", () => {
-    const a = new Session({ resourceId: 'a' });
-    const b = new Session({ resourceId: 'b' });
+    const a = new Session({ resourceId: 'a', id: 'sa', ownerId: 'oa', workspace: createMockWorkspace() });
+    const b = new Session({ resourceId: 'b', id: 'sb', ownerId: 'ob', workspace: createMockWorkspace() });
     const aReceived: HarnessEvent[] = [];
     const bReceived: HarnessEvent[] = [];
     a.subscribe(event => {
@@ -41,7 +42,7 @@ describe('Session event bus', () => {
   });
 
   it('stops delivering after unsubscribe', () => {
-    const session = new Session({ resourceId: 'r1' });
+    const session = new Session({ resourceId: 'r1', id: 's1', ownerId: 'o1', workspace: createMockWorkspace() });
     const listener = vi.fn();
     const unsubscribe = session.subscribe(listener);
 
@@ -55,7 +56,13 @@ describe('Session event bus', () => {
   });
 
   it('routes subsystem events (state_changed) through the session bus', async () => {
-    const session = new Session<{ count: number }>({ resourceId: 'r1', state: { initialState: { count: 0 } } });
+    const session = new Session<{ count: number }>({
+      resourceId: 'r1',
+      id: 's1',
+      ownerId: 'o1',
+      workspace: createMockWorkspace(),
+      state: { initialState: { count: 0 } },
+    });
     const received: HarnessEvent[] = [];
     session.subscribe(event => {
       received.push(event);

--- a/packages/core/src/harness/session-isolation.test.ts
+++ b/packages/core/src/harness/session-isolation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 import type { HarnessEvent } from './types';
 
 function createHarness(
@@ -15,6 +16,7 @@ function createHarness(
   });
 
   return new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     resourceId: options.resourceId,
     storage,
@@ -78,6 +80,7 @@ describe('Harness.createSession — cross-session isolation', () => {
       model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
     });
     const harness = new Harness<{ counter: number }>({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       storage,
       initialState: { counter: 0 },

--- a/packages/core/src/harness/session-om.test.ts
+++ b/packages/core/src/harness/session-om.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 import type { HarnessEvent, HarnessOMConfig } from './types';
 
 async function createSession(options: {
@@ -17,6 +18,7 @@ async function createSession(options: {
   });
 
   const harness = new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage: options.storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/session-permissions.test.ts
+++ b/packages/core/src/harness/session-permissions.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 
 async function createSession(storage: InMemoryStore) {
   const agent = new Agent({
@@ -12,6 +13,7 @@ async function createSession(storage: InMemoryStore) {
   });
 
   const harness = new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/session-state.test.ts
+++ b/packages/core/src/harness/session-state.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import { Harness } from './harness';
 import type { Session } from './session';
+import { createMockWorkspace } from './test-utils';
 import type { HarnessConfig, HarnessEvent } from './types';
 
 async function createSession<TState extends Record<string, unknown>>(
   config: Partial<HarnessConfig<TState>> = {},
 ): Promise<{ harness: Harness<TState>; session: Session<TState> }> {
   const harness = new Harness<TState>({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     modes: [{ id: 'build', defaultModelId: 'test-model' }],
     ...config,

--- a/packages/core/src/harness/session-subagents.test.ts
+++ b/packages/core/src/harness/session-subagents.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 import type { HarnessEvent } from './types';
 
 async function createSession(options: { storage: InMemoryStore; onEvent?: (event: HarnessEvent) => void }) {
@@ -13,6 +14,7 @@ async function createSession(options: { storage: InMemoryStore; onEvent?: (event
   });
 
   const harness = new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage: options.storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -3,6 +3,7 @@ import { createSignal } from '../agent/signals';
 import type { AgentSignalAttributes, AgentSignalContents, AgentSignalInput } from '../agent/signals';
 import type {
   AgentThreadSubscription,
+  MastraBrowser,
   SendAgentNotificationSignalOptions,
   SendAgentNotificationSignalResult,
   SendAgentSignalAccepted,
@@ -18,6 +19,7 @@ import type { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
 import type { PublicSchema, StandardSchemaWithJSON } from '../schema';
 import { safeStringify } from '../utils';
+import { Workspace } from '../workspace';
 
 import { SessionRunEngine } from './session-run-engine';
 import type { TaskItemSnapshot } from './tools';
@@ -2590,6 +2592,8 @@ export class Session<TState = unknown> {
    * filtered back to the session's scope. Empty when the session is unscoped.
    */
   readonly #tags: Record<string, string>;
+  readonly #workspace: Workspace;
+  browser?: MastraBrowser;
 
   constructor({
     resourceId,
@@ -2597,12 +2601,16 @@ export class Session<TState = unknown> {
     id,
     ownerId,
     tags,
+    workspace,
+    browser,
   }: {
     resourceId: string;
     state?: SessionStateOptions<TState>;
     id: string;
     ownerId: string;
     tags?: Record<string, string>;
+    workspace: Workspace;
+    browser?: MastraBrowser;
   }) {
     this.#tags = tags && Object.keys(tags).length > 0 ? { ...tags } : {};
     this.identity = new SessionIdentity({ resourceId, id, ownerId });
@@ -2615,6 +2623,23 @@ export class Session<TState = unknown> {
     });
     this.#bus.setDisplayState(this.displayState);
     this.state = new SessionState(state ?? { initialState: {} as TState }, this.#bus);
+
+    if (!workspace || !(workspace instanceof Workspace)) {
+      const error = new Error(`A session requires a valid workspace instance.`);
+      this.emit({ type: 'workspace_status_changed', status: 'error', error });
+      this.emit({ type: 'workspace_error', error });
+      throw error;
+    }
+
+    this.emit({ type: 'workspace_status_changed', status: 'ready' });
+    this.emit({
+      type: 'workspace_ready',
+      workspaceId: workspace.id,
+      workspaceName: workspace.name,
+    });
+
+    this.#workspace = workspace;
+    this.browser = browser;
   }
 
   /**

--- a/packages/core/src/harness/session.ts
+++ b/packages/core/src/harness/session.ts
@@ -2501,6 +2501,13 @@ export class SessionDisplayState {
 export class SessionBus {
   readonly #listeners: HarnessEventListener[] = [];
   #displayState: SessionDisplayState | undefined;
+  /**
+   * The last workspace lifecycle event group emitted on this bus, replayed to
+   * subscribers that attach after the workspace finished initializing. Without
+   * this, late listeners (the normal pattern: create a session, then subscribe)
+   * would never see the workspace ready/error status.
+   */
+  #lastWorkspaceEvents: HarnessEvent[] = [];
 
   /** Attach the display-state reducer the bus folds events into. Set once by the Session. */
   setDisplayState(displayState: SessionDisplayState): void {
@@ -2508,6 +2515,19 @@ export class SessionBus {
   }
 
   subscribe(listener: HarnessEventListener): () => void {
+    // Replay buffered workspace lifecycle events so late subscribers learn the
+    // current workspace status. The workspace is initialized during session
+    // creation, before any external caller can subscribe.
+    for (const event of this.#lastWorkspaceEvents) {
+      try {
+        const result = listener(event);
+        if (result && typeof result === 'object' && 'catch' in result) {
+          (result as Promise<void>).catch(err => console.error('Error in session event listener:', err));
+        }
+      } catch (err) {
+        console.error('Error in session event listener:', err);
+      }
+    }
     this.#listeners.push(listener);
     return () => {
       const index = this.#listeners.indexOf(listener);
@@ -2518,6 +2538,17 @@ export class SessionBus {
   }
 
   emit(event: HarnessEvent): void {
+    if (
+      event.type === 'workspace_status_changed' ||
+      event.type === 'workspace_ready' ||
+      event.type === 'workspace_error'
+    ) {
+      if (event.type === 'workspace_status_changed') {
+        this.#lastWorkspaceEvents = [event];
+      } else {
+        this.#lastWorkspaceEvents.push(event);
+      }
+    }
     this.#displayState?.apply(event);
     this.#dispatch(event);
     if (event.type !== 'display_state_changed' && this.#displayState) {
@@ -2625,18 +2656,8 @@ export class Session<TState = unknown> {
     this.state = new SessionState(state ?? { initialState: {} as TState }, this.#bus);
 
     if (!workspace || !(workspace instanceof Workspace)) {
-      const error = new Error(`A session requires a valid workspace instance.`);
-      this.emit({ type: 'workspace_status_changed', status: 'error', error });
-      this.emit({ type: 'workspace_error', error });
-      throw error;
+      throw new Error(`A session requires a valid workspace instance.`);
     }
-
-    this.emit({ type: 'workspace_status_changed', status: 'ready' });
-    this.emit({
-      type: 'workspace_ready',
-      workspaceId: workspace.id,
-      workspaceName: workspace.name,
-    });
 
     this.#workspace = workspace;
     this.browser = browser;

--- a/packages/core/src/harness/signal-history.test.ts
+++ b/packages/core/src/harness/signal-history.test.ts
@@ -4,6 +4,7 @@ import { getDummyResponseModel } from '../agent/__tests__/mock-model';
 import { signalToMastraDBMessage } from '../agent/signals';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 
 describe('Harness signal history rendering', () => {
   async function createHarnessWithThread() {
@@ -15,6 +16,7 @@ describe('Harness signal history rendering', () => {
       model: getDummyResponseModel('v2'),
     });
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       storage,
       modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/signal-messages.test.ts
+++ b/packages/core/src/harness/signal-messages.test.ts
@@ -5,6 +5,7 @@ import { createSignal } from '../agent/signals';
 import { RequestContext } from '../request-context';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 import type { HarnessEvent } from './types';
 
 function createTextStreamModel(responseText: string) {
@@ -46,6 +47,7 @@ async function createHarness(
   }),
 ) {
   const harness = new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
@@ -836,6 +838,7 @@ describe('Harness signal messages', () => {
       model: createTextStreamModel('unused'),
     });
     const harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'subscription-tool-harness',
       storage,
       modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/switch-model.test.ts
+++ b/packages/core/src/harness/switch-model.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 
 async function createSession(onModelUse?: (modelId: string) => void) {
   const agent = new Agent({
@@ -12,6 +13,7 @@ async function createSession(onModelUse?: (modelId: string) => void) {
   });
 
   const harness = new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage: new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/task-tools.test.ts
+++ b/packages/core/src/harness/task-tools.test.ts
@@ -6,6 +6,7 @@ import { RequestContext } from '../request-context';
 import { InMemoryStore } from '../storage/mock';
 
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 import { assignTaskIds, taskWriteTool } from './tools';
 import type { HarnessEvent } from './types';
 
@@ -17,6 +18,7 @@ async function createSession() {
   });
 
   const harness = new Harness<Record<string, unknown>>({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage: new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
@@ -195,6 +197,7 @@ describe('harness state transactions', () => {
     let validationCount = 0;
 
     const harness = new Harness<Record<string, unknown>>({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       storage: new InMemoryStore(),
       stateSchema: z
@@ -243,6 +246,7 @@ describe('harness state transactions', () => {
 describe('task tool permissions', () => {
   it('removes denied built-in and configured harness tools even when yolo is enabled', async () => {
     const harness = new Harness<Record<string, unknown>>({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       storage: new InMemoryStore(),
       initialState: {

--- a/packages/core/src/harness/test-utils.ts
+++ b/packages/core/src/harness/test-utils.ts
@@ -1,8 +1,17 @@
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
+import { Workspace } from '../workspace/workspace';
 import { Harness } from './harness';
 import type { Session } from './session';
 import type { HarnessConfig, HarnessMode } from './types';
+
+/**
+ * Create a minimal Workspace instance for testing.
+ * Uses a skills-only config so init() is a no-op (no fs/sandbox/search engine).
+ */
+export function createMockWorkspace(name = 'test-workspace'): Workspace {
+  return new Workspace({ name, skills: ['/tmp/test-skills'] });
+}
 
 /**
  * Shared test helpers for the Harness/Session suites.
@@ -37,7 +46,7 @@ export type TestHarnessConfig<TState = {}> = Partial<HarnessConfig<TState>> & {
  * mode list entirely.
  */
 export function createTestHarness<TState = {}>(config: TestHarnessConfig<TState> = {}): Harness<TState> {
-  const { agent, modes, storage, id, ...rest } = config;
+  const { agent, modes, storage, id, workspace, ...rest } = config;
 
   const defaultModes: HarnessMode[] = [
     { id: 'default', name: 'Default', default: true, agent: agent ?? createTestAgent() },
@@ -47,6 +56,7 @@ export function createTestHarness<TState = {}>(config: TestHarnessConfig<TState>
     id: id ?? 'test-harness',
     storage: storage ?? new InMemoryStore(),
     modes: modes ?? defaultModes,
+    workspace: workspace ?? createMockWorkspace(),
     ...rest,
   } as HarnessConfig<TState>);
 }

--- a/packages/core/src/harness/thread-locking.test.ts
+++ b/packages/core/src/harness/thread-locking.test.ts
@@ -3,6 +3,7 @@ import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 import type { Session } from './session';
+import { createMockWorkspace } from './test-utils';
 
 function createHarness(threadLock?: { acquire: (id: string) => void; release: (id: string) => void }) {
   const agent = new Agent({
@@ -12,6 +13,7 @@ function createHarness(threadLock?: { acquire: (id: string) => void; release: (i
   });
 
   return new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage: new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
@@ -188,6 +190,7 @@ describe('Harness thread locking', () => {
         model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
       });
       return new Harness({
+        workspace: createMockWorkspace(),
         id: 'test-harness',
         storage: store,
         modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/token-usage.test.ts
+++ b/packages/core/src/harness/token-usage.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import { createMockWorkspace } from './test-utils';
 import type { HarnessEvent } from './types';
 
 function createHarness(storage = new InMemoryStore()) {
@@ -12,6 +13,7 @@ function createHarness(storage = new InMemoryStore()) {
   });
 
   return new Harness({
+    workspace: createMockWorkspace(),
     id: 'test-harness',
     storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/tracing-propagation.test.ts
+++ b/packages/core/src/harness/tracing-propagation.test.ts
@@ -5,6 +5,7 @@ import type { TracingContext, TracingOptions } from '../observability';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 import type { Session } from './session';
+import { createMockWorkspace } from './test-utils';
 
 function createTextStreamModel(responseText: string) {
   return new MockLanguageModelV2({
@@ -55,6 +56,7 @@ describe('Harness tracing propagation', () => {
   beforeEach(async () => {
     agent = createAgent();
     harness = new Harness({
+      workspace: createMockWorkspace(),
       id: 'test-harness',
       storage: new InMemoryStore(),
       modes: [{ id: 'default', name: 'Default', default: true, agent }],

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -10,7 +10,7 @@ import type { PublicSchema } from '../schema';
 import type { MastraCompositeStore } from '../storage/base';
 import type { GoalEvaluationPayload } from '../stream/types';
 import type { DynamicArgument } from '../types';
-import type { Workspace, WorkspaceConfig, WorkspaceStatus } from '../workspace';
+import type { Workspace, WorkspaceStatus } from '../workspace';
 import type { TaskItemSnapshot } from './tools';
 
 // =============================================================================
@@ -239,11 +239,11 @@ export interface HarnessConfig<TState = {}> {
 
   /**
    * Workspace configuration.
-   * Accepts a pre-constructed Workspace instance, a WorkspaceConfig for
-   * Harness to construct internally, or a dynamic factory function that
-   * receives the request context and returns a Workspace per-request.
+   * Accepts a pre-constructed Workspace instance or a dynamic factory
+   * function that receives the request context and returns a Workspace
+   * per-request.
    */
-  workspace?: DynamicArgument<Workspace | undefined> | WorkspaceConfig;
+  workspace?: DynamicArgument<Workspace | undefined>;
 
   /**
    * Browser automation configuration.

--- a/packages/core/src/harness/workspace-resolution.test.ts
+++ b/packages/core/src/harness/workspace-resolution.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Agent } from '../agent';
+import type { MastraBrowser } from '../browser';
 import { InMemoryStore } from '../storage/mock';
 import { Workspace } from '../workspace/workspace';
 import { Harness } from './harness';
-import type { Session } from './session';
 
 /**
  * Create a minimal Workspace instance for testing.
@@ -11,6 +11,15 @@ import type { Session } from './session';
  */
 function createMockWorkspace(name = 'test-workspace'): Workspace {
   return new Workspace({ name, skills: ['/tmp/test-skills'] });
+}
+
+/**
+ * Create a minimal mock MastraBrowser for testing.
+ * Cast through `unknown` because MastraBrowser is abstract with many members
+ * we don't need to exercise in workspace/browser resolution tests.
+ */
+function createMockBrowser(id = 'mock-browser'): MastraBrowser {
+  return { id, provider: 'mock', providerType: 'sdk' } as unknown as MastraBrowser;
 }
 
 function createAgent() {
@@ -26,32 +35,9 @@ function createAgent() {
 // ===========================================================================
 
 describe('Harness workspace — static instance', () => {
-  it('getWorkspace() returns the workspace immediately', () => {
+  it('createSession succeeds with a static workspace and initializes it', async () => {
     const ws = createMockWorkspace();
-    const harness = new Harness({
-      id: 'test',
-      storage: new InMemoryStore(),
-      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
-      workspace: ws,
-    });
-
-    expect(harness.getWorkspace()).toBe(ws);
-  });
-
-  it('hasWorkspace() returns true', () => {
-    const ws = createMockWorkspace();
-    const harness = new Harness({
-      id: 'test',
-      storage: new InMemoryStore(),
-      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
-      workspace: ws,
-    });
-
-    expect(harness.hasWorkspace()).toBe(true);
-  });
-
-  it('resolveWorkspace() returns the existing workspace without calling workspaceFn', async () => {
-    const ws = createMockWorkspace();
+    const initSpy = vi.spyOn(ws, 'init');
     const harness = new Harness({
       id: 'test',
       storage: new InMemoryStore(),
@@ -59,10 +45,27 @@ describe('Harness workspace — static instance', () => {
       workspace: ws,
     });
     await harness.init();
-    const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
 
-    const resolved = await harness.resolveWorkspace({ session });
-    expect(resolved).toBe(ws);
+    const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    expect(session).toBeDefined();
+    expect(initSpy).toHaveBeenCalled();
+  });
+
+  it('createSession succeeds when workspace is provided as a session override', async () => {
+    const ws = createMockWorkspace('override-ws');
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+    });
+    await harness.init();
+
+    const session = await harness.createSession({
+      id: 'test-session',
+      ownerId: 'test-owner',
+      workspace: ws,
+    });
+    expect(session).toBeDefined();
   });
 });
 
@@ -71,70 +74,59 @@ describe('Harness workspace — static instance', () => {
 // ===========================================================================
 
 describe('Harness workspace — dynamic factory', () => {
-  let ws: Workspace;
-  let workspaceFn: ReturnType<typeof vi.fn>;
-  let harness: Harness;
-
-  beforeEach(async () => {
-    ws = createMockWorkspace('dynamic-ws');
-    workspaceFn = vi.fn().mockResolvedValue(ws);
-    harness = new Harness({
+  it('factory is called during createSession with requestContext and mastra', async () => {
+    const ws = createMockWorkspace('dynamic-ws');
+    const factory = vi.fn().mockResolvedValue(ws);
+    const harness = new Harness({
       id: 'test',
       storage: new InMemoryStore(),
       modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
-      workspace: workspaceFn,
+      workspace: factory,
     });
     await harness.init();
-  });
 
-  it('getWorkspace() returns undefined before resolution', () => {
-    // No session created yet, so the dynamic workspace has not been resolved.
-    expect(harness.getWorkspace()).toBeUndefined();
-  });
-
-  it('hasWorkspace() returns true (factory is configured)', () => {
-    expect(harness.hasWorkspace()).toBe(true);
-  });
-
-  it('resolveWorkspace() invokes the factory and caches the result', async () => {
     const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
-    // createSession resolves the workspace once; the explicit resolve below
-    // should hit the cache rather than re-invoking the factory.
-    workspaceFn.mockClear();
-
-    const resolved = await harness.resolveWorkspace({ session });
-
-    expect(resolved).toBe(ws);
-    expect(workspaceFn).not.toHaveBeenCalled();
-    // getWorkspace() returns the cached value
-    expect(harness.getWorkspace()).toBe(ws);
+    expect(session).toBeDefined();
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestContext: expect.anything(),
+        mastra: expect.anything(),
+      }),
+    );
   });
 
-  it('resolveWorkspace() returns cached workspace without re-invoking factory', async () => {
-    const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
-    workspaceFn.mockClear();
+  it('factory is invoked per-session, not cached across sessions', async () => {
+    const ws = createMockWorkspace('dynamic-ws');
+    const factory = vi.fn().mockResolvedValue(ws);
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      workspace: factory,
+    });
+    await harness.init();
 
-    await harness.resolveWorkspace({ session });
-    const resolved2 = await harness.resolveWorkspace({ session });
+    await harness.createSession({ id: 'session-a', ownerId: 'test-owner', resourceId: 'resource-a' });
+    await harness.createSession({ id: 'session-b', ownerId: 'test-owner', resourceId: 'resource-b' });
 
-    expect(resolved2).toBe(ws);
-    // Factory not called again — the workspace was cached at createSession time.
-    expect(workspaceFn).not.toHaveBeenCalled();
+    // Each session creation invokes the factory independently.
+    expect(factory).toHaveBeenCalledTimes(2);
   });
 
-  it('resolveWorkspace() returns undefined when factory returns undefined', async () => {
+  it('createSession throws when factory returns undefined', async () => {
     const nullFactory = vi.fn().mockResolvedValue(undefined);
-    const h = new Harness({
+    const harness = new Harness({
       id: 'test',
       storage: new InMemoryStore(),
       modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
       workspace: nullFactory,
     });
-    await h.init();
-    const session = await h.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    await harness.init();
 
-    const resolved = await h.resolveWorkspace({ session });
-    expect(resolved).toBeUndefined();
+    await expect(harness.createSession({ id: 'test-session', ownerId: 'test-owner' })).rejects.toThrow(
+      'A session requires a valid workspace instance.',
+    );
   });
 });
 
@@ -143,57 +135,282 @@ describe('Harness workspace — dynamic factory', () => {
 // ===========================================================================
 
 describe('Harness workspace — none configured', () => {
-  let harness: Harness;
-  let session: Session;
-
-  beforeEach(async () => {
-    harness = new Harness({
-      id: 'test',
-      storage: new InMemoryStore(),
-      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
-    });
-    await harness.init();
-    session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
-  });
-
-  it('getWorkspace() returns undefined', () => {
-    expect(harness.getWorkspace()).toBeUndefined();
-  });
-
-  it('hasWorkspace() returns false', () => {
-    expect(harness.hasWorkspace()).toBe(false);
-  });
-
-  it('resolveWorkspace() returns undefined', async () => {
-    const resolved = await harness.resolveWorkspace({ session });
-    expect(resolved).toBeUndefined();
-  });
-});
-
-// ===========================================================================
-// buildRequestContext caches workspace
-// ===========================================================================
-
-describe('buildRequestContext caches dynamic workspace', () => {
-  it('getWorkspace() returns the resolved workspace after buildRequestContext runs', async () => {
-    const ws = createMockWorkspace('ctx-ws');
-    const factory = vi.fn().mockResolvedValue(ws);
+  it('createSession throws when no workspace is configured', async () => {
     const harness = new Harness({
       id: 'test',
       storage: new InMemoryStore(),
       modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
-      workspace: factory,
+    });
+    await harness.init();
+
+    await expect(harness.createSession({ id: 'test-session', ownerId: 'test-owner' })).rejects.toThrow(
+      'A session requires a valid workspace instance.',
+    );
+  });
+});
+
+// ===========================================================================
+// Per-session workspace overrides via createSession({ workspace })
+// ===========================================================================
+
+describe('Harness createSession — workspace overrides', () => {
+  it('per-session workspace override factory is resolved at session creation', async () => {
+    const sessionWs = createMockWorkspace('factory-session-ws');
+    const workspaceFn = vi.fn().mockReturnValue(sessionWs);
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+    });
+    await harness.init();
+
+    const session = await harness.createSession({
+      id: 'test-session',
+      ownerId: 'test-owner',
+      workspace: workspaceFn,
     });
 
-    // Before — workspace is not resolved
-    expect(harness.getWorkspace()).toBeUndefined();
+    expect(workspaceFn).toHaveBeenCalledTimes(1);
+    expect(session).toBeDefined();
+  });
 
+  it('falls back to Harness-level workspace when no override is provided', async () => {
+    const harnessWs = createMockWorkspace('harness-ws');
+    const initSpy = vi.spyOn(harnessWs, 'init');
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      workspace: harnessWs,
+    });
     await harness.init();
-    const session = await harness.createSession({ id: 'test-session', ownerId: 'test-owner' });
-    // Trigger buildRequestContext indirectly via resolveWorkspace
-    await harness.resolveWorkspace({ session });
+    initSpy.mockClear();
 
-    // After — workspace is cached
-    expect(harness.getWorkspace()).toBe(ws);
+    const session = await harness.createSession({
+      id: 'test-session',
+      ownerId: 'test-owner',
+    });
+
+    expect(session).toBeDefined();
+    // The harness-level workspace is initialized for the session.
+    expect(initSpy).toHaveBeenCalled();
+  });
+
+  it('per-session workspace override takes precedence over harness-level', async () => {
+    const harnessWs = createMockWorkspace('harness-ws');
+    const sessionWs = createMockWorkspace('session-ws');
+    const harnessInitSpy = vi.spyOn(harnessWs, 'init');
+    const sessionInitSpy = vi.spyOn(sessionWs, 'init');
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      workspace: harnessWs,
+    });
+    await harness.init();
+    harnessInitSpy.mockClear();
+    sessionInitSpy.mockClear();
+
+    const session = await harness.createSession({
+      id: 'test-session',
+      ownerId: 'test-owner',
+      workspace: sessionWs,
+    });
+
+    expect(session).toBeDefined();
+    // The session-level workspace is initialized, not the harness-level one.
+    expect(sessionInitSpy).toHaveBeenCalled();
+    expect(harnessInitSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws when a workspace override factory resolves to undefined', async () => {
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+    });
+    await harness.init();
+
+    await expect(
+      harness.createSession({
+        id: 'test-session',
+        ownerId: 'test-owner',
+        workspace: () => undefined,
+      }),
+    ).rejects.toThrow('A session requires a valid workspace instance.');
+  });
+});
+
+// ===========================================================================
+// Per-session workspace isolation between sessions
+// ===========================================================================
+
+describe('Harness createSession — workspace isolation', () => {
+  it('two sessions with different resource IDs use different workspace overrides', async () => {
+    const wsA = createMockWorkspace('ws-a');
+    const wsB = createMockWorkspace('ws-b');
+    const initSpyA = vi.spyOn(wsA, 'init');
+    const initSpyB = vi.spyOn(wsB, 'init');
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+    });
+    await harness.init();
+
+    const sessionA = await harness.createSession({
+      id: 'session-a',
+      ownerId: 'test-owner',
+      resourceId: 'resource-a',
+      workspace: wsA,
+    });
+    const sessionB = await harness.createSession({
+      id: 'session-b',
+      ownerId: 'test-owner',
+      resourceId: 'resource-b',
+      workspace: wsB,
+    });
+
+    expect(sessionA).toBeDefined();
+    expect(sessionB).toBeDefined();
+    expect(initSpyA).toHaveBeenCalled();
+    expect(initSpyB).toHaveBeenCalled();
+    expect(wsA).not.toBe(wsB);
+  });
+
+  it('one session workspace override does not leak into another session', async () => {
+    const wsA = createMockWorkspace('ws-a');
+    const initSpyA = vi.spyOn(wsA, 'init');
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+    });
+    await harness.init();
+
+    // Session A has a workspace override
+    const sessionA = await harness.createSession({
+      id: 'session-a',
+      ownerId: 'test-owner',
+      resourceId: 'resource-a',
+      workspace: wsA,
+    });
+
+    // Session B has no workspace override — should throw because no workspace is available
+    await expect(
+      harness.createSession({
+        id: 'session-b',
+        ownerId: 'test-owner',
+        resourceId: 'resource-b',
+      }),
+    ).rejects.toThrow('A session requires a valid workspace instance.');
+
+    // Session A still has its own workspace (init was called)
+    expect(sessionA).toBeDefined();
+    expect(initSpyA).toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// Per-session browser overrides via createSession({ browser })
+// ===========================================================================
+
+describe('Harness createSession — browser overrides', () => {
+  it('uses the per-session browser instance instead of the Harness-level one', async () => {
+    const ws = createMockWorkspace();
+    const harnessBrowser = createMockBrowser('harness-browser');
+    const sessionBrowser = createMockBrowser('session-browser');
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      workspace: ws,
+      browser: harnessBrowser,
+    });
+    await harness.init();
+
+    const session = await harness.createSession({
+      id: 'test-session',
+      ownerId: 'test-owner',
+      browser: sessionBrowser,
+    });
+
+    expect(session.browser).toBe(sessionBrowser);
+    expect(session.browser).not.toBe(harnessBrowser);
+  });
+
+  it('per-session dynamic browser factory is resolved at session creation', async () => {
+    const ws = createMockWorkspace();
+    const sessionBrowser = createMockBrowser('factory-session-browser');
+    const browserFn = vi.fn().mockReturnValue(sessionBrowser);
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      workspace: ws,
+    });
+    await harness.init();
+
+    const session = await harness.createSession({
+      id: 'test-session',
+      ownerId: 'test-owner',
+      browser: browserFn,
+    });
+
+    expect(browserFn).toHaveBeenCalledTimes(1);
+    expect(session.browser).toBe(sessionBrowser);
+  });
+
+  it('falls back to Harness-level browser when no override is provided', async () => {
+    const ws = createMockWorkspace();
+    const harnessBrowser = createMockBrowser('harness-browser');
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      workspace: ws,
+      browser: harnessBrowser,
+    });
+    await harness.init();
+
+    const session = await harness.createSession({
+      id: 'test-session',
+      ownerId: 'test-owner',
+    });
+
+    expect(session.browser).toBe(harnessBrowser);
+  });
+
+  it('per-session browser override does not leak into another session', async () => {
+    const ws = createMockWorkspace();
+    const browserA = createMockBrowser('browser-a');
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      workspace: ws,
+    });
+    await harness.init();
+
+    // Session A has a browser override
+    const sessionA = await harness.createSession({
+      id: 'session-a',
+      ownerId: 'test-owner',
+      resourceId: 'resource-a',
+      browser: browserA,
+    });
+
+    // Session B has no browser override — should NOT see session A's browser
+    const sessionB = await harness.createSession({
+      id: 'session-b',
+      ownerId: 'test-owner',
+      resourceId: 'resource-b',
+    });
+
+    expect(sessionB.browser).toBeUndefined();
+    expect(sessionB.browser).not.toBe(browserA);
+
+    // Session A still has its own browser
+    expect(sessionA.browser).toBe(browserA);
   });
 });

--- a/packages/core/src/harness/workspace-resolution.test.ts
+++ b/packages/core/src/harness/workspace-resolution.test.ts
@@ -154,9 +154,9 @@ describe('Harness workspace — none configured', () => {
 // ===========================================================================
 
 describe('Harness createSession — workspace overrides', () => {
-  it('per-session workspace override factory is resolved at session creation', async () => {
-    const sessionWs = createMockWorkspace('factory-session-ws');
-    const workspaceFn = vi.fn().mockReturnValue(sessionWs);
+  it('per-session workspace override is resolved at session creation', async () => {
+    const sessionWs = createMockWorkspace('session-ws');
+    const initSpy = vi.spyOn(sessionWs, 'init');
     const harness = new Harness({
       id: 'test',
       storage: new InMemoryStore(),
@@ -167,10 +167,10 @@ describe('Harness createSession — workspace overrides', () => {
     const session = await harness.createSession({
       id: 'test-session',
       ownerId: 'test-owner',
-      workspace: workspaceFn,
+      workspace: sessionWs,
     });
 
-    expect(workspaceFn).toHaveBeenCalledTimes(1);
+    expect(initSpy).toHaveBeenCalledTimes(1);
     expect(session).toBeDefined();
   });
 
@@ -221,23 +221,6 @@ describe('Harness createSession — workspace overrides', () => {
     // The session-level workspace is initialized, not the harness-level one.
     expect(sessionInitSpy).toHaveBeenCalled();
     expect(harnessInitSpy).not.toHaveBeenCalled();
-  });
-
-  it('throws when a workspace override factory resolves to undefined', async () => {
-    const harness = new Harness({
-      id: 'test',
-      storage: new InMemoryStore(),
-      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
-    });
-    await harness.init();
-
-    await expect(
-      harness.createSession({
-        id: 'test-session',
-        ownerId: 'test-owner',
-        workspace: () => undefined,
-      }),
-    ).rejects.toThrow('A session requires a valid workspace instance.');
   });
 });
 
@@ -339,10 +322,9 @@ describe('Harness createSession — browser overrides', () => {
     expect(session.browser).not.toBe(harnessBrowser);
   });
 
-  it('per-session dynamic browser factory is resolved at session creation', async () => {
+  it('per-session browser override is used at session creation', async () => {
     const ws = createMockWorkspace();
-    const sessionBrowser = createMockBrowser('factory-session-browser');
-    const browserFn = vi.fn().mockReturnValue(sessionBrowser);
+    const sessionBrowser = createMockBrowser('session-browser');
     const harness = new Harness({
       id: 'test',
       storage: new InMemoryStore(),
@@ -354,10 +336,9 @@ describe('Harness createSession — browser overrides', () => {
     const session = await harness.createSession({
       id: 'test-session',
       ownerId: 'test-owner',
-      browser: browserFn,
+      browser: sessionBrowser,
     });
 
-    expect(browserFn).toHaveBeenCalledTimes(1);
     expect(session.browser).toBe(sessionBrowser);
   });
 

--- a/packages/memory/src/clone-thread-om.test.ts
+++ b/packages/memory/src/clone-thread-om.test.ts
@@ -3,6 +3,7 @@ import type { MastraDBMessage } from '@mastra/core/agent';
 import { Harness } from '@mastra/core/harness';
 import { InMemoryStore } from '@mastra/core/storage';
 import type { MemoryStorage, ObservationalMemoryRecord, BufferedObservationChunk } from '@mastra/core/storage';
+import { Workspace } from '@mastra/core/workspace';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Memory } from './index';
 
@@ -492,6 +493,7 @@ describe('cloneThread – Observational Memory', () => {
         id: 'clone-thread-dynamic-memory-test',
         resourceId,
         memory: memoryFactory,
+        workspace: new Workspace({ name: 'test-workspace', skills: ['/tmp/test-skills'] }),
         modes: [
           {
             id: 'default',

--- a/packages/server/src/server/handlers/harness.test.ts
+++ b/packages/server/src/server/handlers/harness.test.ts
@@ -2,6 +2,7 @@ import { Agent } from '@mastra/core/agent';
 import { Harness } from '@mastra/core/harness';
 import { Mastra } from '@mastra/core/mastra';
 import { InMemoryStore } from '@mastra/core/storage';
+import { Workspace } from '@mastra/core/workspace';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { HTTPException } from '../http-exception';
@@ -29,6 +30,7 @@ function makeMastra() {
   const harness = new Harness({
     id: 'code',
     storage: new InMemoryStore(),
+    workspace: new Workspace({ name: 'test-workspace', skills: ['/tmp/test-skills'] }),
     modes: [
       { id: 'build', name: 'Build', default: true, agent: makeAgent() },
       { id: 'plan', name: 'Plan', agent: makeAgent() },
@@ -135,12 +137,12 @@ describe('harness routes', () => {
       session.emit({ type: 'agent_start' } as any);
 
       // The route enqueues raw event objects (the server adapter is responsible
-      // for SSE framing). Read past any `:`-prefixed heartbeat comments until we
-      // see our event object.
+      // for SSE framing). Read past any `:`-prefixed heartbeat comments and
+      // workspace lifecycle events until we see our event object.
       let received: any;
-      for (let i = 0; i < 5 && received === undefined; i++) {
+      for (let i = 0; i < 10 && received === undefined; i++) {
         const { value } = await reader.read();
-        if (value && typeof value === 'object') received = value;
+        if (value && typeof value === 'object' && (value as any).type === 'agent_start') received = value;
       }
       await reader.cancel();
 


### PR DESCRIPTION
Moves workspace and browser from Harness-level shared resources to per-session ownership.

`createSession` now accepts optional `workspace` and `browser` overrides that are passed directly to the `Session` constructor. These overrides are static instances only — use the Harness-level `DynamicArgument` config for per-request factory functions. When no override is provided, the Harness-level config is used as a fallback. The `Session` constructor validates that `workspace` is a `Workspace` instance and throws if missing.

This is a breaking change — `HarnessConfig.workspace` no longer accepts a `WorkspaceConfig` shorthand, and the following `Harness` methods are removed: `getWorkspace`, `resolveWorkspace`, `hasWorkspace`, `isWorkspaceReady`, `destroyWorkspace`.

**Before:**
```ts
const harness = new Harness({
  name: 'my-harness',
  workspace: { name: 'my-workspace' }, // WorkspaceConfig shorthand
});
const session = await harness.createSession({ resourceId: 'user-1' });
const ws = harness.getWorkspace();
```

**After:**
```ts
const harness = new Harness({
  name: 'my-harness',
  workspace: new Workspace({ name: 'my-workspace' }),
});

// static override per session
const session = await harness.createSession({
  resourceId: 'user-1',
  workspace: new Workspace({ name: 'ws-1' }),
});

// dynamic per-request factory stays at the harness config level
const harness2 = new Harness({
  name: 'my-harness',
  workspace: ({ requestContext }) => new Workspace({ name: `ws-${requestContext.session.id}` }),
});
```

All 36 harness test files (359 tests) pass and `tsc --noEmit` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Before, the “Harness” picked and owned the `workspace`/`browser` that all sessions shared. Now, each `Session` is responsible for its own `workspace` (and optional `browser`), so setups don’t accidentally leak across sessions.

## Summary
- Shifted workspace/browser ownership from Harness-level shared state to per-session ownership.
- `Harness.createSession` now accepts optional per-call overrides:
  - `workspace?: Workspace` (static instance only)
  - `browser?: MastraBrowser`
  - `requestContext?: RequestContext`
  These are applied during session creation and passed into the `Session` constructor.
- Dynamic/per-request workspace factories are still supported, but only via the Harness-level `HarnessConfig.workspace` `DynamicArgument`; per-session overrides are static instances.
- `Session` now requires a valid `workspace: Workspace` at construction time and throws if it’s missing/invalid.
- Workspace lifecycle events are handled per session:
  - During session creation, if the resolved `workspace` is a `Workspace` instance, the harness calls `workspace.init()` and emits workspace lifecycle events on the session.
  - `SessionBus` buffers the latest workspace lifecycle event group and replays it to subscribers that attach after session creation.

## Breaking changes / API updates
- `HarnessConfig.workspace` no longer accepts a `WorkspaceConfig` shorthand; it is now limited to the `DynamicArgument<Workspace | undefined>` form.
- `Harness.destroyWorkspace()` was removed; `Harness.destroy()` no longer tears down the workspace.
- Workspace API behavior changes:
  - `getWorkspace()` returns only the Harness-level static workspace (dynamic factory setups don’t resolve via this method).
  - `resolveWorkspace()` now requires a `session` parameter and resolves dynamic workspace factories against that session’s request context (and is used to support code paths outside the normal request flow).

## Docs and tests
- Updated docs and reference pages to reflect the new session-level `workspace`/`browser` resolution model and the changed workspace APIs.
- Updated/expanded tests across Harness, Session, and server/SSE coverage to construct Harnesses with explicit mock `Workspace` instances where needed.
- `tsc --noEmit` passes, and the harness test suite runs cleanly.

## Changeset
- Added a breaking changeset documenting the workspace/browser ownership move from `Harness` to `Session`, including the revised `createSession` override behavior and workspace lifecycle expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->