### PR TITLE
docs(harness): document availableTools mode visibility allowlist

### DIFF
--- a/docs/src/content/en/docs/harness/modes.mdx
+++ b/docs/src/content/en/docs/harness/modes.mdx
@@ -88,6 +88,27 @@ const buildMode = { id: 'build', additionalTools: { deployTool } }
 
 You can't set both `tools` and `additionalTools` on the same mode.
 
+### Restricting tool visibility
+
+`tools` and `additionalTools` control which tools are **added** to a mode's run — they don't hide the backing agent's own tools. To restrict which of those tools the model can actually see and call, set `availableTools`:
+
+```typescript title="src/mastra/harness.ts"
+const reviewMode = {
+  id: 'review',
+  name: 'Review',
+  // Only these tools are visible to the model in this mode.
+  availableTools: ['view', 'find_files', 'search_content'],
+}
+```
+
+`availableTools` is a per-mode visibility allowlist that matches each tool by its final exposed name:
+
+- **`undefined`** (default): no mode-level restriction — every tool is visible.
+- **`[]`**: no tools are available for this mode.
+- A denied tool stays hidden even if it appears in the list. Per-tool and per-category `deny` rules in your permission config always take precedence.
+
+Workspace tools use the same list as every other tool — reference them by their exposed names (`view`, `write_file`, `find_files`, etc.). Visibility is enforced at LLM-call time, so the model never sees — and can't attempt to call — a tool outside the allowlist.
+
 ### Mode transitions
 
 A mode can declare a `transitionsTo` target. When the `submit_plan` built-in tool runs in that mode, the Harness transitions to the target mode on approval:

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -172,6 +172,13 @@ await harness.sendMessage({ content: 'Hello!' })
             isOptional: true,
           },
           {
+            name: 'availableTools',
+            type: 'string[]',
+            description:
+              "Per-mode tool visibility allowlist. When set, only tools whose final exposed names appear in this list are visible to the model and executable during this mode's runs. `undefined` = all tools visible; `[]` = no tools. Per-tool and per-category `deny` rules take precedence over this list. Workspace tools use the same list — reference them by exposed names (`view`, `write_file`, etc.).",
+            isOptional: true,
+          },
+          {
             name: 'agent',
             type: 'Agent',
             description:


### PR DESCRIPTION
## Summary

Documents the `availableTools` field on `HarnessMode` that was added in #18463. The feature itself is already merged; this PR adds the missing docs coverage so users can discover and use the per-mode tool visibility allowlist.

- **`docs/src/content/en/docs/harness/modes.mdx`** — New "Restricting tool visibility" subsection explaining that `availableTools` is a per-mode visibility allowlist (distinct from `tools`/`additionalTools` which control toolset composition), with semantics for `undefined` (all visible), `[]` (none), deny-rule precedence, and workspace tool exposed-name matching. Includes a code example.
- **`docs/src/content/en/reference/harness/harness-class.mdx`** — Added the `availableTools` parameter (`string[]`) to the `HarnessMode` PropertiesTable.

## Test plan

- [ ] Docs lint: prettier + remark pass on the two changed `.mdx` files.
