### PR TITLE
docs(voyageai): note voyage-context-4 in contextualized config model field

### DIFF
--- a/embedders/voyageai/src/types.ts
+++ b/embedders/voyageai/src/types.ts
@@ -153,7 +153,7 @@ export interface VoyageMultimodalEmbeddingConfig {
  * Configuration for VoyageAI contextualized chunk embedding models
  */
 export interface VoyageContextualizedEmbeddingConfig {
-  /** The model to use (voyage-context-3) */
+  /** The model to use (voyage-context-3 or voyage-context-4) */
   model: VoyageContextModel;
   /** API key (defaults to VOYAGE_API_KEY env var) */
   apiKey?: string;


### PR DESCRIPTION
Update VoyageContextualizedEmbeddingConfig docs to note voyage-context-4 model support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change updates the docs so they say the embedding config can use either `voyage-context-3` or the newer `voyage-context-4`. It’s just a wording update to keep the documentation accurate.

## Summary
- Updated the `VoyageContextualizedEmbeddingConfig` documentation comment in `embedders/voyageai/src/types.ts`
- Noted support for `voyage-context-4` in the configurable model field
- No type, interface, or runtime behavior changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->