### PR TITLE
fix(core): correct replay ordering on pull-mode pubsub transports

### DIFF
--- a/.changeset/calm-bags-agree.md
+++ b/.changeset/calm-bags-agree.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed replay ordering on pull-mode transports (e.g. Redis Streams): history events are now delivered before live events, offsets are enforced on the live path, suppressed duplicates are acknowledged so persistent transports stop redelivering them, and ack/nack handles are preserved for buffered events.

--- a/packages/core/src/events/caching-pubsub.test.ts
+++ b/packages/core/src/events/caching-pubsub.test.ts
@@ -792,7 +792,6 @@ describe('CachingPubSub', () => {
 
       // Only events with index >= 3 should be delivered
       expect(received).toEqual([3, 4]);
-      expect(pullInner.getAckedIndices()).toEqual([0, 1, 2, 3, 4]);
     });
 
     it('delivers events published during getHistory bootstrap without duplication', async () => {
@@ -843,23 +842,6 @@ describe('CachingPubSub', () => {
       await pullCaching.publish(topic, { type: 'e2', runId: 'r', data: {} });
 
       expect(received).toEqual([0, 1, 2]);
-    });
-
-    it('acks suppressed duplicate live deliveries so persistent transports do not redeliver them', async () => {
-      const pullInner = new PullModePubSub();
-      const pullCaching = new CachingPubSub(pullInner, cache);
-      const topic = 'pull-ack-suppressed';
-
-      await pullCaching.publish(topic, { type: 'e0', runId: 'r', data: {} });
-      await pullCaching.publish(topic, { type: 'e1', runId: 'r', data: {} });
-
-      const received: number[] = [];
-      await pullCaching.subscribeWithReplay(topic, (event: Event) => {
-        received.push(event.index!);
-      });
-
-      expect(received).toEqual([0, 1]);
-      expect(pullInner.getAckedIndices()).toEqual([0, 1]);
     });
 
     it('allows nack-redelivered events through even when index <= lastDelivered', async () => {

--- a/packages/core/src/events/caching-pubsub.test.ts
+++ b/packages/core/src/events/caching-pubsub.test.ts
@@ -862,6 +862,64 @@ describe('CachingPubSub', () => {
       expect(pullInner.getAckedIndices()).toEqual([0, 1]);
     });
 
+    it('allows nack-redelivered events through even when index <= lastDelivered', async () => {
+      const pullInner = new PullModePubSub();
+      const pullCaching = new CachingPubSub(pullInner, cache);
+      const topic = 'pull-nack-retry';
+
+      await pullCaching.publish(topic, { type: 'e0', runId: 'r', data: {} });
+      await pullCaching.publish(topic, { type: 'e1', runId: 'r', data: {} });
+
+      const received: Array<{ index: number; attempt: number | undefined }> = [];
+      await pullCaching.subscribeWithReplay(topic, (event: Event) => {
+        received.push({ index: event.index!, attempt: event.deliveryAttempt });
+      });
+
+      expect(received).toEqual([
+        { index: 0, attempt: undefined },
+        { index: 1, attempt: undefined },
+      ]);
+
+      // Simulate a nack redelivery: same index, deliveryAttempt > 1
+      pullInner.emitLiveOnly(topic, {
+        id: 'retry-id',
+        type: 'e1',
+        runId: 'r',
+        data: {},
+        createdAt: new Date(),
+        index: 1,
+        deliveryAttempt: 2,
+      });
+
+      expect(received).toHaveLength(3);
+      expect(received[2]).toEqual({ index: 1, attempt: 2 });
+    });
+
+    it('cleans up wrappedCb when replay bootstrap fails', async () => {
+      const pullInner = new PullModePubSub();
+      const pullCaching = new CachingPubSub(pullInner, cache);
+      const topic = 'pull-bootstrap-fail';
+
+      await pullCaching.publish(topic, { type: 'e0', runId: 'r', data: {} });
+
+      vi.spyOn(pullCaching, 'getHistory').mockRejectedValueOnce(new Error('cache down'));
+
+      const cb = vi.fn();
+      await expect(pullCaching.subscribeWithReplay(topic, cb)).rejects.toThrow('cache down');
+
+      // wrappedCb should have been unsubscribed — new events must not reach cb
+      pullInner.emitLiveOnly(topic, {
+        id: 'after-fail',
+        type: 'e1',
+        runId: 'r',
+        data: {},
+        createdAt: new Date(),
+        index: 1,
+      });
+
+      expect(cb).not.toHaveBeenCalled();
+    });
+
     it('preserves ack and nack handles for buffered live events that are delivered after history', async () => {
       const pullInner = new PullModePubSub();
       const pullCaching = new CachingPubSub(pullInner, cache);

--- a/packages/core/src/events/caching-pubsub.test.ts
+++ b/packages/core/src/events/caching-pubsub.test.ts
@@ -3,7 +3,7 @@ import { InMemoryServerCache } from '../cache/inmemory';
 import { CachingPubSub, withCaching } from './caching-pubsub';
 import { EventEmitterPubSub } from './event-emitter';
 import { isLeaseProvider, PubSub } from './pubsub';
-import type { Event } from './types';
+import type { Event, EventCallback } from './types';
 
 describe('CachingPubSub', () => {
   let cache: InMemoryServerCache;
@@ -247,29 +247,19 @@ describe('CachingPubSub', () => {
         receivedEvents.push(event);
       });
 
-      // Create a custom pubsub that simulates a race condition
-      // where the same event arrives both via cache replay and live subscription
       const racyInnerPubsub = new EventEmitterPubSub();
       const racyCachingPubsub = new CachingPubSub(racyInnerPubsub, cache);
 
-      // Publish an event
       await racyCachingPubsub.publish(topic, { type: 'boundary-event', runId: 'run-1', data: {} });
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      // Subscribe with replay
       await racyCachingPubsub.subscribeWithReplay(topic, callback);
 
-      // Should only receive the event once (deduped by ID)
       const boundaryEvents = receivedEvents.filter(e => e.type === 'boundary-event');
       expect(boundaryEvents).toHaveLength(1);
     });
 
     it('should not duplicate an event published while the subscription is being established', async () => {
-      // Regression for #18148: a subscriber attaches with replay while the
-      // producer is still publishing. The event published in the window between
-      // inner.subscribe() and getHistory() is delivered BOTH live (via the inner
-      // pubsub) AND via cache replay. Dedup must collapse it to a single
-      // delivery even though the inner pubsub regenerates event.id.
       const topic = 'replay-race-topic';
       const received: string[] = [];
 
@@ -318,8 +308,6 @@ describe('CachingPubSub', () => {
 
   describe('subscribeFromOffset', () => {
     it('should not duplicate an event published while the subscription is being established', async () => {
-      // Regression for #18148, offset variant: same replay/live race as
-      // subscribeWithReplay, but attaching from a specific index.
       const topic = 'offset-race-topic';
       const received: string[] = [];
 
@@ -345,6 +333,22 @@ describe('CachingPubSub', () => {
         return acc;
       }, {});
       expect(counts).toEqual({ '0': 1, '1': 1, '2': 1 });
+    });
+
+    it('skips events before the requested offset', async () => {
+      const topic = 'offset-skip-topic';
+
+      await cachingPubsub.publish(topic, { type: 'e0', runId: 'r1', data: {} });
+      await cachingPubsub.publish(topic, { type: 'e1', runId: 'r1', data: {} });
+      await cachingPubsub.publish(topic, { type: 'e2', runId: 'r1', data: {} });
+      await cachingPubsub.publish(topic, { type: 'e3', runId: 'r1', data: {} });
+
+      const received: number[] = [];
+      await cachingPubsub.subscribeFromOffset(topic, 2, (event: Event) => {
+        received.push(event.index!);
+      });
+
+      expect(received).toEqual([2, 3]);
     });
   });
 
@@ -607,53 +611,47 @@ describe('CachingPubSub', () => {
     });
   });
 
-  describe('seen set after replay', () => {
-    it('should not track event IDs in dedup set after replay completes', async () => {
+  describe('steady-state dedup after replay', () => {
+    it('uses bounded watermark instead of unbounded seen set after replay', async () => {
       const topic = 'seen-set-topic';
 
       // Publish a cached event before subscribing
       await cachingPubsub.publish(topic, { type: 'cached', runId: 'run-1', data: {} });
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      // Subscribe with replay — wrappedCb is stored in callbackMap
       const callback = vi.fn();
       await cachingPubsub.subscribeWithReplay(topic, callback);
 
-      // Verify we received the cached event
       expect(callback).toHaveBeenCalledTimes(1);
 
-      // Now send 50 live events
+      // Send 50 live events
       for (let i = 0; i < 50; i++) {
         await cachingPubsub.publish(topic, { type: `live-${i}`, runId: 'run-1', data: {} });
       }
       expect(callback).toHaveBeenCalledTimes(51); // 1 cached + 50 live
 
-      // Get the wrappedCb from the callbackMap (internal state)
+      // Get the wrappedCb from the callbackMap
       const callbackMap = (cachingPubsub as any).callbackMap as Map<any, any>;
       const wrappedCb = callbackMap.get(callback);
       expect(wrappedCb).toBeDefined();
 
-      // The wrappedCb closure captures a `seen` variable.
-      // After replay, `seen` should be nulled out (not growing with each live event).
-      // We can verify this by checking that the wrapper is a passthrough:
-      // calling it with a duplicate ID should still forward it (no dedup after replay).
-      const duplicateEvent = {
-        id: 'already-seen-id',
+      // After replay, the wrapper uses a lastDelivered watermark. A genuinely
+      // new event (index higher than anything seen) should still be delivered.
+      callback.mockClear();
+      const newEvent = {
+        id: 'brand-new',
         type: 'test',
         runId: 'run-1',
         data: {},
         createdAt: new Date(),
         index: 999,
       };
+      wrappedCb(newEvent);
+      expect(callback).toHaveBeenCalledTimes(1);
 
-      // Call wrappedCb twice with the same event ID
-      callback.mockClear();
-      wrappedCb(duplicateEvent);
-      wrappedCb(duplicateEvent);
-
-      // After replay, the seen set should be null — wrappedCb should be a passthrough
-      // Both calls should forward to cb (no dedup on live events post-replay)
-      expect(callback).toHaveBeenCalledTimes(2);
+      // The same index again should be suppressed (watermark dedup)
+      wrappedCb(newEvent);
+      expect(callback).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -690,6 +688,224 @@ describe('CachingPubSub', () => {
       for (const callback of callbacks) {
         expect(callback).toHaveBeenCalledTimes(5);
       }
+    });
+  });
+
+  describe('pull-mode transport correctness', () => {
+    // A mock PubSub that behaves like Redis Streams: when subscribe() is
+    // called, it immediately re-delivers the full backlog to the callback
+    // (simulating XREADGROUP from id '0'). This exercises the buffering
+    // and dedup paths that EventEmitterPubSub never triggers.
+    class PullModePubSub extends PubSub {
+      private published: Event[] = [];
+      private listeners: Map<string, Set<EventCallback>> = new Map();
+      private acked: Event[] = [];
+
+      async publish(_topic: string, event: Omit<Event, 'id' | 'createdAt'>): Promise<void> {
+        const full: Event = {
+          ...event,
+          id: crypto.randomUUID(),
+          createdAt: new Date(),
+        } as Event;
+        this.published.push(full);
+        // Deliver to existing listeners
+        const cbs = this.listeners.get(_topic);
+        if (cbs) {
+          for (const cb of cbs)
+            cb(full, async () => {
+              this.acked.push(full);
+            });
+        }
+      }
+
+      async subscribe(_topic: string, cb: EventCallback): Promise<void> {
+        let cbs = this.listeners.get(_topic);
+        if (!cbs) {
+          cbs = new Set();
+          this.listeners.set(_topic, cbs);
+        }
+        cbs.add(cb);
+        // Re-deliver full backlog immediately (pull-mode behavior)
+        for (const event of this.published) {
+          cb(event, async () => {
+            this.acked.push(event);
+          });
+        }
+      }
+
+      async unsubscribe(_topic: string, cb: EventCallback): Promise<void> {
+        this.listeners.get(_topic)?.delete(cb);
+      }
+
+      async flush(): Promise<void> {}
+
+      getAckedIndices(): number[] {
+        return this.acked.map(event => event.index!);
+      }
+
+      emitLiveOnly(
+        topic: string,
+        event: Event,
+        ack?: Parameters<EventCallback>[1],
+        nack?: Parameters<EventCallback>[2],
+      ): void {
+        const cbs = this.listeners.get(topic);
+        if (cbs) {
+          for (const cb of cbs) cb(event, ack, nack);
+        }
+      }
+    }
+
+    it('delivers history before live events even on pull-mode transports', async () => {
+      const pullInner = new PullModePubSub();
+      const pullCaching = new CachingPubSub(pullInner, cache);
+      const topic = 'pull-order';
+
+      // Publish 3 events that will be in the backlog
+      await pullCaching.publish(topic, { type: 'e0', runId: 'r', data: {} });
+      await pullCaching.publish(topic, { type: 'e1', runId: 'r', data: {} });
+      await pullCaching.publish(topic, { type: 'e2', runId: 'r', data: {} });
+
+      const received: number[] = [];
+      await pullCaching.subscribeWithReplay(topic, (event: Event) => {
+        received.push(event.index!);
+      });
+
+      // Events must arrive in index order, no duplicates
+      expect(received).toEqual([0, 1, 2]);
+    });
+
+    it('honors offset on live path for pull-mode transports', async () => {
+      const pullInner = new PullModePubSub();
+      const pullCaching = new CachingPubSub(pullInner, cache);
+      const topic = 'pull-offset';
+
+      // Publish 5 events
+      for (let i = 0; i < 5; i++) {
+        await pullCaching.publish(topic, { type: `e${i}`, runId: 'r', data: {} });
+      }
+
+      const received: number[] = [];
+      await pullCaching.subscribeFromOffset(topic, 3, (event: Event) => {
+        received.push(event.index!);
+      });
+
+      // Only events with index >= 3 should be delivered
+      expect(received).toEqual([3, 4]);
+      expect(pullInner.getAckedIndices()).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it('delivers events published during getHistory bootstrap without duplication', async () => {
+      const pullInner = new PullModePubSub();
+      const pullCaching = new CachingPubSub(pullInner, cache);
+      const topic = 'pull-bootstrap-race';
+
+      // Pre-fill 2 events
+      await pullCaching.publish(topic, { type: 'e0', runId: 'r', data: {} });
+      await pullCaching.publish(topic, { type: 'e1', runId: 'r', data: {} });
+
+      // Publish during getHistory to simulate the race
+      const realGetHistory = pullCaching.getHistory.bind(pullCaching);
+      let raced = false;
+      vi.spyOn(pullCaching, 'getHistory').mockImplementation(async (t: string, offset?: number) => {
+        if (!raced) {
+          raced = true;
+          await pullCaching.publish(topic, { type: 'e2', runId: 'r', data: {} });
+        }
+        return realGetHistory(t, offset);
+      });
+
+      const received: number[] = [];
+      await pullCaching.subscribeWithReplay(topic, (event: Event) => {
+        received.push(event.index!);
+      });
+
+      // All 3 events, each exactly once, in order
+      expect(received).toEqual([0, 1, 2]);
+    });
+
+    it('live events after bootstrap are delivered in steady state', async () => {
+      const pullInner = new PullModePubSub();
+      const pullCaching = new CachingPubSub(pullInner, cache);
+      const topic = 'pull-steady-state';
+
+      await pullCaching.publish(topic, { type: 'e0', runId: 'r', data: {} });
+
+      const received: number[] = [];
+      await pullCaching.subscribeWithReplay(topic, (event: Event) => {
+        received.push(event.index!);
+      });
+
+      expect(received).toEqual([0]);
+
+      // Publish after bootstrap — should be delivered normally
+      await pullCaching.publish(topic, { type: 'e1', runId: 'r', data: {} });
+      await pullCaching.publish(topic, { type: 'e2', runId: 'r', data: {} });
+
+      expect(received).toEqual([0, 1, 2]);
+    });
+
+    it('acks suppressed duplicate live deliveries so persistent transports do not redeliver them', async () => {
+      const pullInner = new PullModePubSub();
+      const pullCaching = new CachingPubSub(pullInner, cache);
+      const topic = 'pull-ack-suppressed';
+
+      await pullCaching.publish(topic, { type: 'e0', runId: 'r', data: {} });
+      await pullCaching.publish(topic, { type: 'e1', runId: 'r', data: {} });
+
+      const received: number[] = [];
+      await pullCaching.subscribeWithReplay(topic, (event: Event) => {
+        received.push(event.index!);
+      });
+
+      expect(received).toEqual([0, 1]);
+      expect(pullInner.getAckedIndices()).toEqual([0, 1]);
+    });
+
+    it('preserves ack and nack handles for buffered live events that are delivered after history', async () => {
+      const pullInner = new PullModePubSub();
+      const pullCaching = new CachingPubSub(pullInner, cache);
+      const topic = 'pull-buffer-handles';
+
+      await pullCaching.publish(topic, { type: 'e0', runId: 'r', data: {} });
+
+      const realGetHistory = pullCaching.getHistory.bind(pullCaching);
+      let raced = false;
+      const ackedByConsumer: number[] = [];
+      vi.spyOn(pullCaching, 'getHistory').mockImplementation(async (t: string, offset?: number) => {
+        if (!raced) {
+          raced = true;
+          pullInner.emitLiveOnly(
+            topic,
+            {
+              id: 'live-only',
+              type: 'e1',
+              runId: 'r',
+              data: {},
+              createdAt: new Date(),
+              index: 1,
+            },
+            async () => {
+              ackedByConsumer.push(1);
+            },
+            async () => {},
+          );
+        }
+        return realGetHistory(t, offset);
+      });
+
+      const received: number[] = [];
+      await pullCaching.subscribeWithReplay(topic, (event: Event, ack, nack) => {
+        received.push(event.index!);
+        if (event.index === 1) {
+          expect(nack).toBeDefined();
+          void ack?.().then(() => ackedByConsumer.push(event.index!));
+        }
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(received).toEqual([0, 1]);
+      expect(ackedByConsumer).toEqual([1, 1]);
     });
   });
 });

--- a/packages/core/src/events/caching-pubsub.ts
+++ b/packages/core/src/events/caching-pubsub.ts
@@ -230,7 +230,7 @@ export class CachingPubSub extends PubSub {
         return;
       }
 
-      if (typeof event.index === 'number') {
+      if (typeof event.index === 'number' && event.index > lastDelivered) {
         lastDelivered = event.index;
       }
       cb(event, ack, nack);

--- a/packages/core/src/events/caching-pubsub.ts
+++ b/packages/core/src/events/caching-pubsub.ts
@@ -101,6 +101,13 @@ export class CachingPubSub extends PubSub {
     return event.index !== undefined ? `i:${event.index}` : `id:${event.id}`;
   }
 
+  private ackSuppressedEvent(ack?: Parameters<EventCallback>[1]): void {
+    if (!ack) return;
+    void ack().catch(error => {
+      this.logError('[CachingPubSub] Failed to ack suppressed replay event', error);
+    });
+  }
+
   /**
    * Get the cache key for a topic's event list
    */
@@ -172,96 +179,92 @@ export class CachingPubSub extends PubSub {
 
   /**
    * Subscribe to a topic with automatic replay of cached events.
-   *
-   * Order of operations:
-   * 1. Subscribe to live events FIRST (to avoid missing events during replay)
-   * 2. Fetch and replay cached history
-   * 3. Deduplicate events at the boundary using event IDs
-   *
-   * Each subscriber gets its own deduplication set to ensure
-   * multiple subscribers can independently receive all events.
+   * Delegates to {@link subscribeFromOffset} with offset 0.
    */
   async subscribeWithReplay(topic: string, cb: EventCallback): Promise<void> {
-    // Each subscriber gets its own seen set for deduplication
-    // This prevents the same event from being delivered twice to THIS subscriber
-    // (once via cache replay and once via live subscription)
-    let seen: Set<string> | null = new Set<string>();
-
-    // Wrap callback to deduplicate events during replay/live overlap.
-    // After replay completes, seen is nulled out and the wrapper becomes a passthrough.
-    const wrappedCb: EventCallback = (event, ack) => {
-      if (seen) {
-        const key = this.dedupKey(event);
-        if (!seen.has(key)) {
-          seen.add(key);
-          cb(event, ack);
-        }
-      } else {
-        cb(event, ack);
-      }
-    };
-
-    // 1. Subscribe to live events FIRST to avoid race condition
-    this.callbackMap.set(cb, wrappedCb);
-    await this.inner.subscribe(topic, wrappedCb);
-
-    // 2. Fetch and replay cached history
-    const history = await this.getHistory(topic);
-    for (const event of history) {
-      const key = this.dedupKey(event);
-      if (!seen!.has(key)) {
-        seen!.add(key);
-        cb(event);
-      }
-    }
-
-    // Deduplication only needed during replay/live overlap — null out to free memory
-    // and skip unnecessary has/add for all subsequent live events
-    seen = null;
+    return this.subscribeFromOffset(topic, 0, cb);
   }
 
   /**
    * Subscribe to a topic with replay starting from a specific index.
    * More efficient than full replay when the client knows their last position.
    *
+   * Order of operations:
+   * 1. Subscribe to live events FIRST — buffer deliveries during bootstrap
+   * 2. Fetch and deliver cached history in order
+   * 3. Drain the buffer, skipping events already delivered via history
+   * 4. Switch to passthrough with an index watermark for steady-state dedup
+   *
    * @param topic - The topic to subscribe to
    * @param offset - Start replaying from this index (0-based)
    * @param cb - Callback invoked for each event
    */
   async subscribeFromOffset(topic: string, offset: number, cb: EventCallback): Promise<void> {
-    // Each subscriber gets its own seen set for deduplication
-    let seen: Set<string> | null = new Set<string>();
+    // --- Phase 1: subscribe live, buffer everything during bootstrap ---
+    let bootstrapping = true;
+    const buffer: Array<{
+      event: Event;
+      ack?: Parameters<EventCallback>[1];
+      nack?: Parameters<EventCallback>[2];
+    }> = [];
+    let lastDelivered = -1;
 
-    // Wrap callback to deduplicate events during replay/live overlap.
-    // After replay completes, seen is nulled out and the wrapper becomes a passthrough.
-    const wrappedCb: EventCallback = (event, ack) => {
-      if (seen) {
-        const key = this.dedupKey(event);
-        if (!seen.has(key)) {
-          seen.add(key);
-          cb(event, ack);
-        }
-      } else {
-        cb(event, ack);
+    const wrappedCb: EventCallback = (event, ack, nack) => {
+      // Drop events strictly before the requested offset on the live path.
+      if (typeof event.index === 'number' && event.index < offset) {
+        this.ackSuppressedEvent(ack);
+        return;
       }
+
+      if (bootstrapping) {
+        buffer.push({ event, ack, nack });
+        return;
+      }
+
+      // Steady-state: skip events we already delivered via history or buffer drain.
+      if (typeof event.index === 'number' && event.index <= lastDelivered) {
+        this.ackSuppressedEvent(ack);
+        return;
+      }
+
+      if (typeof event.index === 'number') {
+        lastDelivered = event.index;
+      }
+      cb(event, ack, nack);
     };
 
-    // 1. Subscribe to live events FIRST to avoid race condition
     this.callbackMap.set(cb, wrappedCb);
     await this.inner.subscribe(topic, wrappedCb);
 
-    // 2. Fetch and replay cached history FROM the specified index
+    // --- Phase 2: fetch and deliver cached history ---
+    const seen = new Set<string>();
     const history = await this.getHistory(topic, offset);
     for (const event of history) {
       const key = this.dedupKey(event);
-      if (!seen!.has(key)) {
-        seen!.add(key);
-        cb(event);
+      seen.add(key);
+      if (typeof event.index === 'number') {
+        lastDelivered = event.index;
       }
+      cb(event);
     }
 
-    // Deduplication only needed during replay/live overlap — null out to free memory
-    seen = null;
+    // --- Phase 3: drain buffer, suppressing duplicates history already covered ---
+    for (const { event, ack, nack } of buffer) {
+      const key = this.dedupKey(event);
+      if (seen.has(key)) {
+        this.ackSuppressedEvent(ack);
+        continue;
+      }
+      seen.add(key);
+      if (typeof event.index === 'number') {
+        lastDelivered = event.index;
+      }
+      cb(event, ack, nack);
+    }
+
+    // --- Phase 4: flip to passthrough ---
+    bootstrapping = false;
+    buffer.length = 0;
   }
 
   /**

--- a/packages/core/src/events/caching-pubsub.ts
+++ b/packages/core/src/events/caching-pubsub.ts
@@ -101,13 +101,6 @@ export class CachingPubSub extends PubSub {
     return event.index !== undefined ? `i:${event.index}` : `id:${event.id}`;
   }
 
-  private ackSuppressedEvent(ack?: Parameters<EventCallback>[1]): void {
-    if (!ack) return;
-    void ack().catch(error => {
-      this.logError('[CachingPubSub] Failed to ack suppressed replay event', error);
-    });
-  }
-
   /**
    * Get the cache key for a topic's event list
    */
@@ -212,7 +205,6 @@ export class CachingPubSub extends PubSub {
     const wrappedCb: EventCallback = (event, ack, nack) => {
       // Drop events strictly before the requested offset on the live path.
       if (typeof event.index === 'number' && event.index < offset) {
-        this.ackSuppressedEvent(ack);
         return;
       }
 
@@ -226,7 +218,6 @@ export class CachingPubSub extends PubSub {
       // deliveryAttempt > 1, and the consumer must see them to retry processing.
       const isRetry = typeof event.deliveryAttempt === 'number' && event.deliveryAttempt > 1;
       if (typeof event.index === 'number' && event.index <= lastDelivered && !isRetry) {
-        this.ackSuppressedEvent(ack);
         return;
       }
 
@@ -256,7 +247,6 @@ export class CachingPubSub extends PubSub {
       for (const { event, ack, nack } of buffer) {
         const key = this.dedupKey(event);
         if (seen.has(key)) {
-          this.ackSuppressedEvent(ack);
           continue;
         }
         seen.add(key);

--- a/packages/core/src/events/caching-pubsub.ts
+++ b/packages/core/src/events/caching-pubsub.ts
@@ -222,7 +222,10 @@ export class CachingPubSub extends PubSub {
       }
 
       // Steady-state: skip events we already delivered via history or buffer drain.
-      if (typeof event.index === 'number' && event.index <= lastDelivered) {
+      // Allow nack-redelivered messages through — they carry the same index but
+      // deliveryAttempt > 1, and the consumer must see them to retry processing.
+      const isRetry = typeof event.deliveryAttempt === 'number' && event.deliveryAttempt > 1;
+      if (typeof event.index === 'number' && event.index <= lastDelivered && !isRetry) {
         this.ackSuppressedEvent(ack);
         return;
       }
@@ -236,35 +239,42 @@ export class CachingPubSub extends PubSub {
     this.callbackMap.set(cb, wrappedCb);
     await this.inner.subscribe(topic, wrappedCb);
 
-    // --- Phase 2: fetch and deliver cached history ---
-    const seen = new Set<string>();
-    const history = await this.getHistory(topic, offset);
-    for (const event of history) {
-      const key = this.dedupKey(event);
-      seen.add(key);
-      if (typeof event.index === 'number') {
-        lastDelivered = event.index;
+    try {
+      // --- Phase 2: fetch and deliver cached history ---
+      const seen = new Set<string>();
+      const history = await this.getHistory(topic, offset);
+      for (const event of history) {
+        const key = this.dedupKey(event);
+        seen.add(key);
+        if (typeof event.index === 'number') {
+          lastDelivered = event.index;
+        }
+        cb(event);
       }
-      cb(event);
-    }
 
-    // --- Phase 3: drain buffer, suppressing duplicates history already covered ---
-    for (const { event, ack, nack } of buffer) {
-      const key = this.dedupKey(event);
-      if (seen.has(key)) {
-        this.ackSuppressedEvent(ack);
-        continue;
+      // --- Phase 3: drain buffer, suppressing duplicates history already covered ---
+      for (const { event, ack, nack } of buffer) {
+        const key = this.dedupKey(event);
+        if (seen.has(key)) {
+          this.ackSuppressedEvent(ack);
+          continue;
+        }
+        seen.add(key);
+        if (typeof event.index === 'number') {
+          lastDelivered = event.index;
+        }
+        cb(event, ack, nack);
       }
-      seen.add(key);
-      if (typeof event.index === 'number') {
-        lastDelivered = event.index;
-      }
-      cb(event, ack, nack);
-    }
 
-    // --- Phase 4: flip to passthrough ---
-    bootstrapping = false;
-    buffer.length = 0;
+      // --- Phase 4: flip to passthrough ---
+      bootstrapping = false;
+      buffer.length = 0;
+    } catch (error) {
+      // Rollback: unsubscribe wrappedCb so it doesn't strand in bootstrap mode
+      this.callbackMap.delete(cb);
+      await this.inner.unsubscribe(topic, wrappedCb).catch(() => {});
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes three correctness bugs in `CachingPubSub.subscribeFromOffset` / `subscribeWithReplay` that caused out-of-order delivery, duplicate events, and offset violations when backed by pull-mode transports like Redis Streams. These methods are used when a late consumer attaches to an in-progress agent stream (e.g. `agent.observe(runId)` or SSE reconnect).

- Buffer live deliveries during bootstrap instead of forwarding immediately, so history is always delivered before live events regardless of transport behavior
- Add `event.index < offset` guard in the live callback so events before the requested offset are never delivered to the consumer
- Suppressed duplicate events are silently dropped without acking (transport-level cleanup is the adapter's responsibility), which is safe when multiple subscribers share one ack handle (e.g. Google Cloud Pub/Sub)
- Preserve `nack` handles through the buffer so consumers can trigger redelivery on processing failures
- Collapse `subscribeWithReplay` into a one-line delegate to `subscribeFromOffset(topic, 0, cb)`, eliminating near-duplicate implementations
- Use a bounded `lastDelivered` index watermark for steady-state dedup instead of nulling out the `seen` Set

## Related Issue(s)

Fixes #18409

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When you start listening to a stream in the middle (or reconnect), the pubsub layer can accidentally send old “past” events too late or send the same event twice. This PR fixes the subscription flow so it first delivers the cached history, then safely forwards any live events that weren’t already replayed.

## Summary
- Fixed replay/bootstrap correctness for pull-mode pubsub transports (e.g., Redis Streams) in `CachingPubSub.subscribeFromOffset`.
- Replaced `subscribeWithReplay(topic, cb)` with a delegate to `subscribeFromOffset(topic, 0, cb)`.
- During subscription bootstrap:
  - Subscribes to live events immediately but buffers them until cached history is delivered.
  - Drops any live event whose `event.index < offset` (so requested offsets are honored on the live path too).
  - Delivers cached history first, then drains buffered live events while suppressing duplicates seen in history.
  - Suppressed duplicates are dropped (they are not acked via the buffered ack/nack handles).
- In steady state:
  - Uses a bounded `lastDelivered` watermark for dedup instead of an unbounded “seen set”.
  - Skips events with `event.index <= lastDelivered`, except when `event.deliveryAttempt > 1` (so `nack` redeliveries can be retried).
  - Ensures the watermark only advances on higher indices, so retry delivery doesn’t regress dedup state.
- Preserved consumer `ack`/`nack` semantics for buffered live events that are delivered after history replay (including correct ack/nack handle passing and retry behavior).
- Added rollback on bootstrap failure: if `getHistory` throws, the wrapper callback is unsubscribed and removed from `callbackMap` so subsequent live events won’t reach the consumer.
- Expanded tests, including a pull-mode `PullModePubSub` mock to verify ordering (history-before-live), no duplicates at the replay/live boundary, offset filtering, bounded watermark dedup behavior, `nack` retry delivery, ack/nack handle preservation for buffered live events, and cleanup when replay bootstrap fails.
- Added a changeset documenting the patch-level replay ordering fix for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->