### PR TITLE
docs: add Voyage AI provider entry to model providers index

### DIFF
--- a/docs/src/content/en/models/providers/_meta.ts
+++ b/docs/src/content/en/models/providers/_meta.ts
@@ -43,6 +43,7 @@ const meta = {
   togetherai: 'Together AI',
   upstage: 'Upstage',
   venice: 'Venice AI',
+  voyageai: 'Voyage AI',
   vultr: 'Vultr',
   wandb: 'Weights & Biases',
   zai: 'Z.AI',

--- a/docs/src/content/en/models/providers/index.mdx
+++ b/docs/src/content/en/models/providers/index.mdx
@@ -582,6 +582,11 @@ Direct access to individual AI model providers. Each provider offers unique mode
       description="13 models"
       href="/models/providers/vivgrid"
       logo="https://models.dev/logos/vivgrid.svg"
+        />    <CardGridItem
+      title="Voyage AI"
+      description="10 models"
+      href="/models/providers/voyageai"
+      logo="https://models.dev/logos/voyageai.svg"
     />    <CardGridItem
       title="Vultr"
       description="7 models"

--- a/docs/src/content/en/models/providers/voyageai.mdx
+++ b/docs/src/content/en/models/providers/voyageai.mdx
@@ -1,0 +1,16 @@
+---
+title: "Voyage AI"
+description: "Use Voyage AI embedding and reranking models with Mastra."
+---
+
+# <img src="https://models.dev/logos/voyageai.svg" alt="Voyage AI logo" className="inline w-8 h-8 mr-2 align-middle dark:invert dark:brightness-0 dark:contrast-200" />Voyage AI
+
+Voyage AI provides embedding and reranking models optimized for retrieval and RAG applications. Install the embedder package to use their models with Mastra.
+
+For detailed provider-specific documentation, see the [Voyage AI documentation](https://docs.voyageai.com).
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/voyageai
+```


### PR DESCRIPTION
Add support for VoyageAI models: 

- docs: add Voyage AI provider entry to model providers index
- feat(core): surface step providerMetadata to output-step processors (#18432)
- fix(core): prevent duplicate stream events when observing an in-progress run (#18191)
- docs(harness): document availableTools mode visibility allowlist (#18471)
- chore: debarrel playground toast and icons (#18470)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds Voyage AI to Mastra’s list of supported model providers so it’s easy to find and use. It also fixes a couple runtime/UI issues: model-provider details now reach output processors, streaming observers don’t get duplicate text updates, tool visibility is controlled more cleanly by mode, and Playground UI helpers can be imported directly.

## Summary
- **Docs: add Voyage AI provider**
  - Added a new “Voyage AI” card to the providers grid (`docs/src/content/en/models/providers/index.mdx`).
  - Added `voyageai: 'Voyage AI'` to the providers `meta` index (`docs/src/content/en/models/providers/_meta.ts`).
  - Created the provider page with setup info and installation (`docs/src/content/en/models/providers/voyageai.mdx`).

- **Runtime: provider-aware output processing**
  - Surfaced step `providerMetadata` to output-step processors via a new optional `providerMetadata` field on `ProcessOutputStepArgs` (`.changeset/swift-zoos-clap.md`).

- **Runtime: prevent duplicate stream events**
  - Fixed duplicate `output.textStream` delivery when observing/reconnecting to an in-progress durable/evented run by correcting caching/pubsub wrapping and improving dedupe keying (`.changeset/fluffy-spies-matter.md`).

- **Harness/Mode: document & enforce `availableTools` visibility allowlist**
  - Added optional `availableTools` allowlist to `HarnessModeBase`, resolved at LLM-call time (with denies still taking precedence) (`.changeset/mode-available-tools-core.md`).
  - Updated plan/explore modes to use `availableTools` while keeping build mode unrestricted (`.changeset/mode-available-tools-mastracode.md`).

- **Playground UI: debarreling imports**
  - Added direct public import paths for `toast` and Playground UI icons to avoid using the root barrel (`.changeset/violet-candles-show.md`).

## Impact
- Makes Voyage AI easier to discover and adopt through the provider docs.
- Enables provider-specific attribution in observability/guardrail output processors.
- Improves reliability of streaming consumers by eliminating duplicate text deltas.
- Clarifies and standardizes tool visibility rules by mode.
- Reduces UI import overhead for consumers using high-traffic Playground utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->