### PR TITLE
fix(license): treat 'undefined' and 'null' string keys as unset

### DIFF
--- a/.changeset/fluffy-apes-jam.md
+++ b/.changeset/fluffy-apes-jam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an issue where configuring MASTRA_LICENSE_KEY or MASTRA_EE_LICENSE as 'undefined' or 'null' string literals caused license validation failure errors on startup.

--- a/packages/_internals/auth/src/ee/license.test.ts
+++ b/packages/_internals/auth/src/ee/license.test.ts
@@ -95,6 +95,42 @@ describe('license', () => {
       await startLicenseValidation();
       expect(isLicenseValid()).toBe(true);
     });
+
+    it('should treat "undefined" string key as unset', () => {
+      process.env['MASTRA_LICENSE_KEY'] = 'undefined';
+      expect(isLicenseValid()).toBe(false);
+    });
+
+    it('should treat "null" string key as unset', () => {
+      process.env['MASTRA_LICENSE_KEY'] = 'null';
+      expect(isLicenseValid()).toBe(false);
+    });
+
+    it('should treat legacy alias with "undefined" string key as unset', () => {
+      process.env['MASTRA_EE_LICENSE'] = 'undefined';
+      expect(isLicenseValid()).toBe(false);
+    });
+
+    it('should treat legacy alias with "null" string key as unset', () => {
+      process.env['MASTRA_EE_LICENSE'] = 'null';
+      expect(isLicenseValid()).toBe(false);
+    });
+
+    it('should prefer a valid legacy alias when the primary key is set to a sentinel value like "undefined"', async () => {
+      process.env['MASTRA_LICENSE_KEY'] = 'undefined';
+      process.env['MASTRA_EE_LICENSE'] = 'LIC-legacy-key';
+      vi.stubGlobal('fetch', mockValidateResponse(VALID_ENTERPRISE));
+      await startLicenseValidation();
+      expect(isLicenseValid()).toBe(true);
+    });
+
+    it('should prefer a valid legacy alias when the primary key is set to a sentinel value like "null"', async () => {
+      process.env['MASTRA_LICENSE_KEY'] = 'null';
+      process.env['MASTRA_EE_LICENSE'] = 'LIC-legacy-key';
+      vi.stubGlobal('fetch', mockValidateResponse(VALID_ENTERPRISE));
+      await startLicenseValidation();
+      expect(isLicenseValid()).toBe(true);
+    });
   });
 
   describe('validate request contract', () => {

--- a/packages/_internals/auth/src/ee/license.ts
+++ b/packages/_internals/auth/src/ee/license.ts
@@ -77,7 +77,8 @@ export class LicenseClient {
     this.logger = logger;
     // MASTRA_LICENSE_KEY is the primary env var; MASTRA_EE_LICENSE is a
     // supported legacy alias kept for backward compatibility.
-    this.licenseKey = process.env.MASTRA_LICENSE_KEY || process.env.MASTRA_EE_LICENSE;
+    const cleanKey = (val?: string) => (val && val !== 'undefined' && val !== 'null' ? val : undefined);
+    this.licenseKey = cleanKey(process.env.MASTRA_LICENSE_KEY) || cleanKey(process.env.MASTRA_EE_LICENSE);
     this.licenseUrl = process.env.MASTRA_LICENSE_URL || 'https://license.mastra.ai';
 
     if (this.licenseKey) {
@@ -343,7 +344,8 @@ export interface SafeLicenseSummary {
  * `MASTRA_LICENSE_KEY` is primary; `MASTRA_EE_LICENSE` is a supported legacy alias.
  */
 function getLicenseKey(): string | undefined {
-  return process.env['MASTRA_LICENSE_KEY'] || process.env['MASTRA_EE_LICENSE'];
+  const cleanKey = (val?: string) => (val && val !== 'undefined' && val !== 'null' ? val : undefined);
+  return cleanKey(process.env['MASTRA_LICENSE_KEY']) || cleanKey(process.env['MASTRA_EE_LICENSE']);
 }
 
 let validationStarted = false;

--- a/packages/core/src/license/index.ts
+++ b/packages/core/src/license/index.ts
@@ -52,7 +52,8 @@ export class LicenseClient {
     this.logger = logger;
     // MASTRA_LICENSE_KEY is the primary env var; MASTRA_EE_LICENSE is a
     // supported legacy alias kept for backward compatibility.
-    this.licenseKey = process.env.MASTRA_LICENSE_KEY || process.env.MASTRA_EE_LICENSE;
+    const cleanKey = (val?: string) => (val && val !== 'undefined' && val !== 'null' ? val : undefined);
+    this.licenseKey = cleanKey(process.env.MASTRA_LICENSE_KEY) || cleanKey(process.env.MASTRA_EE_LICENSE);
     this.licenseUrl = process.env.MASTRA_LICENSE_URL || 'https://license.mastra.ai';
 
     if (this.licenseKey) {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1266,7 +1266,9 @@ export class Mastra<
     // an enterprise license key is configured. Fire-and-forget: LicenseClient
     // caches the result, schedules revalidation, and fails open on network
     // errors, so this never blocks or throws during construction.
-    if (process.env.MASTRA_LICENSE_KEY || process.env.MASTRA_EE_LICENSE) {
+    const cleanKey = (val?: string) => (val && val !== 'undefined' && val !== 'null' ? val : undefined);
+    const licenseKey = cleanKey(process.env.MASTRA_LICENSE_KEY) || cleanKey(process.env.MASTRA_EE_LICENSE);
+    if (licenseKey) {
       LicenseClient.getInstance(this.#logger)
         .validate()
         .catch(() => {


### PR DESCRIPTION
## Description

Fixes a bug where setting the `MASTRA_LICENSE_KEY` or `MASTRA_EE_LICENSE` environment variables to string literals like `"undefined"` or `"null"` (common in containerized/serverless hosting environments) results in a `License validation failed: INVALID_KEY - Invalid license key` error logged on boot. 

The fix filters out `"undefined"` and `"null"` string values in the following entry points so Mastra correctly falls back to open-source mode without validation warnings:
- Core package `LicenseClient` constructor and `Mastra` class constructor background validation trigger.
- Relocated `@internal/auth` ee-license client and `getLicenseKey()` helper.
- Added comprehensive unit tests in the `@internal/auth` package to cover these conditions.

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/18361

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Sometimes environment variables meant to hold a real license key contain the *text* `"undefined"` or `"null"` instead. This PR makes Mastra treat those fake values as “no key,” so it skips license warnings on startup and falls back to open-source mode.

## Summary
- Ignores literal `"undefined"` and `"null"` values for `MASTRA_LICENSE_KEY` and `MASTRA_EE_LICENSE` so they’re treated as unset.
- Hardens license key resolution in `LicenseClient` (core) and the `getLicenseKey()` helper to prevent invalid-key validation warnings.
- Updates `Mastra` startup/background license validation to only run when a normalized, real `licenseKey` is present.
- Applies the same normalization logic to the relocated `@internal/auth` EE license client.
- Adds unit tests in `@internal/auth` covering both sentinel-string scenarios and alias/primary-key interactions.
- Adds a patch changeset for `@mastra/core` documenting the startup validation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->