### PR TITLE
ci: make mastracode-e2e a reusable workflow called by prebuild

### DIFF
--- a/.github/workflows/mastracode-e2e.yml
+++ b/.github/workflows/mastracode-e2e.yml
@@ -1,26 +1,26 @@
 name: Mastra Code E2E
 
 on:
-  pull_request:
-    paths:
-      - 'mastracode/**'
-      - 'packages/core/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/mastracode-e2e.yml'
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      head_sha:
+        required: true
+        type: string
+    secrets:
+      TURBO_TOKEN:
+        required: false
+      TURBO_TEAM:
+        required: false
 
-concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   mastracode-e2e:
     name: Mastra Code E2E
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 20
+    permissions:
+      contents: read
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.head_sha }}
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -254,7 +254,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check for changes that require Mastra Code E2E
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           base: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -238,6 +238,48 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
+  mastracode-e2e-check-changes:
+    name: Detect Mastra Code E2E changes
+    if: github.repository == 'mastra-ai/mastra' && needs.changes.outputs.has_code == 'true'
+    needs: changes
+    runs-on: starsling-ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      mastracode-e2e-changed: ${{ steps.filter.outputs.mastracode_e2e }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes that require Mastra Code E2E
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          base: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          filters: |
+            mastracode_e2e:
+              - 'mastracode/**'
+              - 'packages/core/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/mastracode-e2e.yml'
+              - '!**/*.md'
+
+  mastracode-e2e:
+    name: Mastra Code E2E
+    needs: [changes, mastracode-e2e-check-changes, prebuild]
+    if: always() && github.repository == 'mastra-ai/mastra' && needs.mastracode-e2e-check-changes.outputs.mastracode-e2e-changed == 'true' && needs.prebuild.result == 'success'
+    uses: ./.github/workflows/mastracode-e2e.yml
+    permissions:
+      contents: read
+    with:
+      head_sha: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
   combined-stores-check-changes:
     name: Detect stores changes
     if: github.repository == 'mastra-ai/mastra' && needs.changes.outputs.has_code == 'true'


### PR DESCRIPTION
Converts the mastracode-e2e workflow into a reusable workflow triggered via workflow_call and adds a caller job in prebuild.yml that invokes it.

The caller is gated on mastracode/**, packages/core/**, and pnpm-lock.yaml changes (using dorny/paths-filter, same as the other subworkflows) and runs after the prebuild build succeeds. This matches how prebuild already orchestrates e2e-tests, test-suite, test-combined-stores, and test-workflows, consolidating CI orchestration into a single entry point.

No changeset — this is CI-only, no published packages are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR refactors the Mastra Code E2E GitHub Action so it can be “called” by another workflow instead of running independently. Then it teaches the main `prebuild` workflow to only run those E2E checks when changes touch Mastra Code–related files (saving CI time).

## Summary
- Converted `.github/workflows/mastracode-e2e.yml` into a reusable `workflow_call` workflow:
  - Added required `head_sha` input and optional `TURBO_TOKEN` / `TURBO_TEAM` secrets.
  - Removed PR/path-based and manual triggers (now only runs via `workflow_call`).
  - Set top-level permissions to `{}` and tightened job permissions to `contents: read`.
  - Updated checkout to use `actions/checkout` with `ref: ${{ inputs.head_sha }}`.
- Updated `.github/workflows/prebuild.yml` to orchestrate Mastra Code E2E tests:
  - Added `mastracode-e2e-check-changes` job using `dorny/paths-filter` to detect changes in:
    - `mastracode/**`, `packages/core/**`, `pnpm-lock.yaml`, `.github/workflows/mastracode-e2e.yml`
    - excluding markdown (`!**/*.md`)
  - Added `mastracode-e2e` job that runs after `prebuild` succeeds and only when `mastracode-e2e-changed` is `true`, invoking the reusable workflow and passing `head_sha` plus `TURBO_TOKEN` / `TURBO_TEAM`.

## Notes
- CI-only change.
- No changeset and no impact to published packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->