### PR TITLE
feat(mastracode): read MCP servers from a project root .mcp.json

### DIFF
--- a/.changeset/mastracode-root-mcp-json.md
+++ b/.changeset/mastracode-root-mcp-json.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Read MCP server config from a project root `.mcp.json` (the file Claude Code uses). Projects that already keep their MCP servers there no longer need a duplicate under `.mastracode/`. The root file sits below `.mastracode/mcp.json` in priority, so project-specific config still wins.

--- a/.changeset/mastracode-root-mcp-json.md
+++ b/.changeset/mastracode-root-mcp-json.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Read MCP server config from a project root `.mcp.json` (the file Claude Code uses). Projects that already keep their MCP servers there no longer need a duplicate under `.mastracode/`. The root file sits below `.mastracode/mcp.json` in priority, so project-specific config still wins.
+Added support for reading MCP server config from a project root `.mcp.json` (the file Claude Code uses). Projects that already keep their MCP servers there no longer need a duplicate under `.mastracode/`. The root file sits below `.mastracode/mcp.json` in priority, so project-specific config still wins.

--- a/mastracode/src/mcp/__tests__/config.test.ts
+++ b/mastracode/src/mcp/__tests__/config.test.ts
@@ -375,4 +375,39 @@ describe('loadMcpConfig', () => {
 
     expect(Object.keys(config.mcpServers!).sort()).toEqual(['fromProject', 'fromRoot']);
   });
+
+  it('lets a root .mcp.json override the global ~/.mastracode/mcp.json by server name', () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-home-'));
+    const previousHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    try {
+      writeJson(path.join(homeDir, '.mastracode', 'mcp.json'), {
+        mcpServers: { shared: { command: 'global-cmd' } },
+      });
+      writeJson(path.join(projectDir, '.mcp.json'), {
+        mcpServers: { shared: { command: 'root-cmd' } },
+      });
+
+      const config = loadMcpConfig(projectDir);
+
+      expect(config.mcpServers!['shared']).toEqual({ command: 'root-cmd', args: undefined, env: undefined });
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('lets a root .mcp.json override .claude/settings.local.json by server name', () => {
+    writeJson(path.join(projectDir, '.claude', 'settings.local.json'), {
+      mcpServers: { shared: { command: 'claude-cmd' } },
+    });
+    writeJson(path.join(projectDir, '.mcp.json'), {
+      mcpServers: { shared: { command: 'root-cmd' } },
+    });
+
+    const config = loadMcpConfig(projectDir);
+
+    expect(config.mcpServers!['shared']).toEqual({ command: 'root-cmd', args: undefined, env: undefined });
+  });
 });

--- a/mastracode/src/mcp/__tests__/config.test.ts
+++ b/mastracode/src/mcp/__tests__/config.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
-import { classifyServerEntry, expandEnvVars, validateConfig } from '../config.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { classifyServerEntry, expandEnvVars, loadMcpConfig, validateConfig } from '../config.js';
 
 describe('classifyServerEntry', () => {
   it('classifies stdio entry', () => {
@@ -315,5 +319,60 @@ describe('expandEnvVars', () => {
 
   it('does not treat $ followed by a non-identifier as a reference', () => {
     expect(expandEnvVars('it costs $5 today', env)).toBe('it costs $5 today');
+  });
+});
+
+describe('loadMcpConfig', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-config-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeJson(filePath: string, data: unknown): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(data));
+  }
+
+  it('reads MCP servers from a root .mcp.json (Claude Code compatible)', () => {
+    writeJson(path.join(projectDir, '.mcp.json'), {
+      mcpServers: { root: { url: 'https://root.example.com/mcp' } },
+    });
+
+    const config = loadMcpConfig(projectDir);
+
+    expect(config.mcpServers).toEqual({
+      root: { url: 'https://root.example.com/mcp', headers: undefined },
+    });
+  });
+
+  it('lets .mastracode/mcp.json override root .mcp.json by server name', () => {
+    writeJson(path.join(projectDir, '.mcp.json'), {
+      mcpServers: { shared: { command: 'root-cmd' } },
+    });
+    writeJson(path.join(projectDir, '.mastracode', 'mcp.json'), {
+      mcpServers: { shared: { command: 'project-cmd' } },
+    });
+
+    const config = loadMcpConfig(projectDir);
+
+    expect(config.mcpServers!['shared']).toEqual({ command: 'project-cmd', args: undefined, env: undefined });
+  });
+
+  it('merges distinct servers from root .mcp.json and .mastracode/mcp.json', () => {
+    writeJson(path.join(projectDir, '.mcp.json'), {
+      mcpServers: { fromRoot: { command: 'a' } },
+    });
+    writeJson(path.join(projectDir, '.mastracode', 'mcp.json'), {
+      mcpServers: { fromProject: { command: 'b' } },
+    });
+
+    const config = loadMcpConfig(projectDir);
+
+    expect(Object.keys(config.mcpServers!).sort()).toEqual(['fromProject', 'fromRoot']);
   });
 });

--- a/mastracode/src/mcp/config.ts
+++ b/mastracode/src/mcp/config.ts
@@ -3,9 +3,12 @@
  * Loads from:
  *   1. .claude/settings.local.json  (Claude Code compat — lowest priority)
  *   2. ~/.mastracode/mcp.json       (global)
- *   3. .mastracode/mcp.json         (project — highest priority)
+ *   3. .mcp.json                    (project root — Claude Code compatible)
+ *   4. .mastracode/mcp.json         (project — highest priority)
  *
- * Project overrides global by server name. Claude Code config is lowest priority.
+ * Higher-priority configs override lower ones by server name. The project root
+ * `.mcp.json` is read so a project that already keeps MCP servers there for
+ * Claude Code does not need to duplicate them under `.mastracode/`.
  */
 
 import * as fs from 'node:fs';
@@ -17,13 +20,18 @@ import type { McpConfig, McpHttpOAuthConfig, McpServerConfig, McpSkippedServer }
 export function loadMcpConfig(projectDir: string, configDirName = DEFAULT_CONFIG_DIR): McpConfig {
   const claudeConfig = loadClaudeSettings(projectDir);
   const globalConfig = loadSingleConfig(getGlobalMcpPath(configDirName));
+  const rootConfig = loadSingleConfig(getRootMcpPath(projectDir));
   const projectConfig = loadSingleConfig(getProjectMcpPath(projectDir, configDirName));
 
-  return mergeConfigs(claudeConfig, globalConfig, projectConfig);
+  return mergeConfigs(claudeConfig, globalConfig, rootConfig, projectConfig);
 }
 
 export function getProjectMcpPath(projectDir: string, configDirName = DEFAULT_CONFIG_DIR): string {
   return path.join(projectDir, configDirName, 'mcp.json');
+}
+
+export function getRootMcpPath(projectDir: string): string {
+  return path.join(projectDir, '.mcp.json');
 }
 
 export function getGlobalMcpPath(configDirName = DEFAULT_CONFIG_DIR): string {


### PR DESCRIPTION
## Description

Mastracode reads MCP server config from `.mastracode/mcp.json`, the global `~/.mastracode/mcp.json`, and `.claude/settings.local.json`, but not from a project root `.mcp.json`. Claude Code reads MCP servers from a root `.mcp.json`, so a project that uses both tools has to keep the same servers in two files.

This adds `.mcp.json` to the lookup chain. It sits below `.mastracode/mcp.json` so it does not override project-specific config, and above the global file:

1. `.mastracode/mcp.json` — project (highest priority)
2. `.mcp.json` — project root (Claude Code compatible)
3. `~/.mastracode/mcp.json` — global
4. `.claude/settings.local.json` — fallback (lowest priority)

The root file uses the same `{ "mcpServers": { ... } }` shape that the existing loader already validates, so a project can point both tools at one shared file.

## Related issue(s)

Closes #18176

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Tests

Added a `loadMcpConfig` suite that writes real files into a temp project dir and checks that a root `.mcp.json` is read, that `.mastracode/mcp.json` overrides it by server name, and that distinct servers from both files are merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Mastra Code can now read your MCP server settings from a project’s root `.mcp.json` file—just like Claude Code—so you don’t have to duplicate config. Your project’s `.mastracode/mcp.json` still wins if there are conflicts.

## Summary
- Added support for loading MCP server config from a project root `.mcp.json` in the MCP config lookup chain.
- Updated precedence to:
  1. `.mastracode/mcp.json` (highest priority)
  2. `.mcp.json` (project root, Claude Code compatible)
  3. `~/.mastracode/mcp.json` (global)
  4. `.claude/settings.local.json` (fallback, lowest priority)
- Added `getRootMcpPath(projectDir)` to compute the root `.mcp.json` path.
- Strengthened `loadMcpConfig` tests to verify:
  - root `.mcp.json` is read
  - `.mastracode/mcp.json` overrides root entries by server name
  - distinct servers from root and `.mastracode` are merged
  - root `.mcp.json` overrides both global (`~/.mastracode/mcp.json`) and Claude (`.claude/settings.local.json`) layers by server name
- Added a patch changeset for the `mastracode` package documenting the behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->