### PR TITLE
fix(core/harness): add required workspace to mode-tool-availability tests

### DIFF
--- a/packages/core/src/harness/__tests__/mode-tool-availability.test.ts
+++ b/packages/core/src/harness/__tests__/mode-tool-availability.test.ts
@@ -18,6 +18,7 @@ import { InMemoryStore } from '../../storage/mock';
 import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
 import { createTool } from '../../tools';
 import { Harness } from '../harness';
+import { createMockWorkspace } from '../test-utils';
 import type { HarnessMode } from '../types';
 
 vi.setConfig({ testTimeout: 30_000 });
@@ -124,6 +125,7 @@ async function setupHarness({
     storage,
     agent: registeredAgent,
     modes,
+    workspace: createMockWorkspace(),
     ...(toolCategoryResolver && { toolCategoryResolver }),
     ...(initialState && { initialState: initialState as any }),
   });


### PR DESCRIPTION
After workspace ownership moved to sessions (#18467), `Harness.createSession()` requires a valid `Workspace` instance. The `mode-tool-availability` tests still constructed the Harness without one, so all six tests threw `A session requires a valid workspace instance` before reaching their assertions.

This passes `createMockWorkspace()` to the Harness in `setupHarness`, matching every other harness test. Test-only change, no runtime behavior affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change gives the test harness a pretend workspace so it can start up correctly. Without it, the tests were trying to launch a session with nothing to attach to, which made them fail before they could check anything.

## Summary
- Updated `packages/core/src/harness/__tests__/mode-tool-availability.test.ts` to pass `createMockWorkspace()` into `setupHarness`.
- This aligns the test setup with the newer requirement that a session must have a valid `Workspace`.
- No test assertions or runtime code were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->