### PR TITLE
test(mastracode): cover browser tool availability

### DIFF
--- a/.changeset/witty-tires-say.md
+++ b/.changeset/witty-tires-say.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Add MastraCode browser tool availability scenarios

--- a/mastracode/e2e/fixtures/browser-tool-unavailable.json
+++ b/mastracode/e2e/fixtures/browser-tool-unavailable.json
@@ -1,0 +1,35 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "userMessage": "Open https://openclaw.ai in the browser.",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_tui_browser_goto",
+            "name": "browser_goto",
+            "arguments": {
+              "url": "https://openclaw.ai",
+              "waitUntil": "domcontentloaded"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "toolCallId": "call_tui_browser_goto",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Browser TUI navigation complete."
+      }
+    }
+  ]
+}

--- a/mastracode/e2e/tui/browser-tool-unavailable.ts
+++ b/mastracode/e2e/tui/browser-tool-unavailable.ts
@@ -1,0 +1,133 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { AgentBrowser } from '@mastra/agent-browser';
+import type { InputProcessor, ProcessInputArgs } from '@mastra/core/processors';
+import { expect } from './expect.js';
+import { createGlobalPatchScope } from './global-patches.js';
+import type { McE2eScenario } from './types.js';
+
+const cdpUrl = 'ws://127.0.0.1:65535/devtools/browser/browser-tool-unavailable-e2e';
+
+type AgentBrowserEnsureReady = typeof AgentBrowser.prototype.ensureReady;
+type AgentBrowserGetInputProcessors = typeof AgentBrowser.prototype.getInputProcessors;
+type AgentBrowserGoto = typeof AgentBrowser.prototype.goto;
+
+function hasBrowserContextProcessor(processor: InputProcessor): boolean {
+  return 'id' in processor && processor.id === 'browser-context';
+}
+
+function getRequestBodies(requests: unknown[]): string {
+  return JSON.stringify(
+    requests.map(request =>
+      typeof request === 'object' && request !== null && 'body' in request ? request.body : undefined,
+    ),
+  );
+}
+
+export const browserToolUnavailableScenario = {
+  name: 'browser-tool-unavailable',
+  description: 'Executes a browser tool call in the TUI to catch browser-tool unavailable regressions.',
+  testName: 'executes configured browser tools from TUI agent turns',
+  useOpenAIModel: true,
+  aimockFixture: 'browser-tool-unavailable.json',
+  prepare({ appDataDir }) {
+    const settingsPath = join(appDataDir, 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+    settings.onboarding = {
+      ...((typeof settings.onboarding === 'object' && settings.onboarding !== null
+        ? settings.onboarding
+        : {}) as Record<string, unknown>),
+      completedAt: new Date(0).toISOString(),
+      skippedAt: null,
+      version: 1,
+      quietModePreferenceSelected: true,
+    };
+    settings.browser = {
+      enabled: true,
+      provider: 'agent-browser',
+      headless: true,
+      viewport: { width: 1280, height: 720 },
+      cdpUrl,
+      agentBrowser: {},
+    };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  },
+  async inProcessApp({ startMastraCodeApp }) {
+    const patches = createGlobalPatchScope();
+    patches.setProperty(
+      AgentBrowser.prototype,
+      'ensureReady',
+      async function ensureReady(): Promise<void> {} satisfies AgentBrowserEnsureReady,
+    );
+    patches.setProperty(AgentBrowser.prototype, 'goto', async function goto(input) {
+      return {
+        success: true,
+        url: input.url,
+        title: 'OpenClaw',
+        hint: 'Browser TUI navigation succeeded',
+      };
+    } satisfies AgentBrowserGoto);
+    patches.setProperty(AgentBrowser.prototype, 'getInputProcessors', function getInputProcessors(
+      configuredProcessors: InputProcessor[] = [],
+    ) {
+      if (configuredProcessors.some(hasBrowserContextProcessor)) return [];
+      return [
+        {
+          id: 'browser-context',
+          processInput(args: ProcessInputArgs) {
+            const ctx = args.requestContext?.get('browser') as { provider?: string } | undefined;
+            if (!ctx) return args.messageList;
+            return {
+              messages: args.messages,
+              systemMessages: [
+                ...args.systemMessages,
+                {
+                  role: 'system',
+                  content: `You have access to browser tools (${ctx.provider}). Browser tool unavailable E2E active.`,
+                },
+              ],
+            };
+          },
+        } satisfies InputProcessor,
+      ];
+    } satisfies AgentBrowserGetInputProcessors);
+
+    try {
+      const app = await startMastraCodeApp();
+      return { stop: () => patches.stopApp(app.stop) };
+    } catch (error) {
+      patches.restore();
+      throw error;
+    }
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Project:\s+mastra/i, terminal);
+
+    terminal.submit('/browser status');
+    await runtime.waitForScreenText(/Browser: enabled/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Provider: AgentBrowser \(deterministic\)/i, terminal, 8_000);
+
+    terminal.submit('Open https://openclaw.ai in the browser.');
+    await runtime.waitForScreenText(/browser_goto/i, terminal, 10_000);
+    await runtime.waitForScreenText(/Browser TUI navigation complete\./i, terminal, 15_000);
+    await runtime.waitForScreenTextAbsent(/NoSuchToolError|ToolNotFoundError|No such tool/i, terminal, 1_000);
+
+    terminal.keyCtrlC();
+  },
+  verifyAimockRequests(requests) {
+    if (requests.length !== 2) {
+      throw new Error(
+        `Expected browser tool unavailable scenario to make 2 AIMock requests, received ${requests.length}`,
+      );
+    }
+    const serialized = getRequestBodies(requests);
+    expect(serialized).toContain('Open https://openclaw.ai in the browser.');
+    expect(serialized).toContain('browser_goto');
+    expect(serialized).toContain('call_tui_browser_goto');
+    expect(serialized).toContain('Browser TUI navigation succeeded');
+    if (/NoSuchToolError|ToolNotFoundError|No such tool/i.test(serialized)) {
+      throw new Error('Browser tool call failed as unavailable in the TUI scenario');
+    }
+  },
+} satisfies McE2eScenario;

--- a/mastracode/e2e/tui/index.ts
+++ b/mastracode/e2e/tui/index.ts
@@ -13,6 +13,7 @@ import { browserProfileProviderMismatchScenario } from './browser-profile-provid
 import { browserSettingsPersistenceScenario } from './browser-settings-persistence.js';
 import { browserStartupRestoreScenario } from './browser-startup-restore.js';
 import { browserToggleAttachScenario } from './browser-toggle-attach.js';
+import { browserToolUnavailableScenario } from './browser-tool-unavailable.js';
 import { browserWizardBrowserbaseScenario } from './browser-wizard-browserbase.js';
 import { browserWizardExportScenario } from './browser-wizard-export.js';
 import { browserbaseStartupRestoreScenario } from './browserbase-startup-restore.js';
@@ -146,6 +147,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'browser-profile-provider-mismatch': browserProfileProviderMismatchScenario,
   'browser-settings-persistence': browserSettingsPersistenceScenario,
   'browser-startup-restore': browserStartupRestoreScenario,
+  'browser-tool-unavailable': browserToolUnavailableScenario,
   'browserbase-startup-restore': browserbaseStartupRestoreScenario,
   'browser-toggle-attach': browserToggleAttachScenario,
   'browser-wizard-browserbase': browserWizardBrowserbaseScenario,

--- a/mastracode/e2e/tui/types.ts
+++ b/mastracode/e2e/tui/types.ts
@@ -19,6 +19,7 @@ export type ScenarioName =
   | 'browser-profile-provider-mismatch'
   | 'browser-settings-persistence'
   | 'browser-startup-restore'
+  | 'browser-tool-unavailable'
   | 'browserbase-startup-restore'
   | 'browser-toggle-attach'
   | 'browser-wizard-browserbase'

--- a/mastracode/e2e/web/browser-tool-unavailable.scenario.test.ts
+++ b/mastracode/e2e/web/browser-tool-unavailable.scenario.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+
+import { runScenario } from './harness';
+
+/**
+ * Reproduces the browser-tool availability path in MastraCode web scenarios:
+ * when the harness is configured with browser support, model-selected browser
+ * tools should be executable instead of surfacing as unavailable tools.
+ */
+describe('web scenario: browser-tool-unavailable', () => {
+  it('executes stagehand browser tools when the scenario server enables a browser', async () => {
+    await runScenario({
+      name: 'browser-tool-unavailable',
+      description: 'Agent navigates with stagehand_navigate when browser tools are configured.',
+      aimockFixture: 'browser-tool-unavailable.json',
+      server: { browser: 'stagehand', workspace: true },
+      run: async ({ driver }) => {
+        await driver.submit('Open https://openclaw.ai in the browser');
+
+        await driver.waitForText('stagehand_navigate');
+        await driver.waitForText('Opened https://openclaw.ai in the browser.');
+
+        const text = driver.text();
+        expect(text).not.toContain('NoSuchToolError');
+        expect(text).not.toContain('ToolNotFoundError');
+        expect(text).not.toContain('available tools');
+      },
+      verifyAimockRequests: requests => {
+        expect(JSON.stringify(requests[0])).toContain('stagehand_navigate');
+      },
+    });
+  });
+});

--- a/mastracode/e2e/web/fixtures/browser-tool-unavailable.json
+++ b/mastracode/e2e/web/fixtures/browser-tool-unavailable.json
@@ -1,0 +1,32 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "userMessage": "Open https://openclaw.ai in the browser",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_navigate_openclaw",
+            "name": "stagehand_navigate",
+            "arguments": { "url": "https://openclaw.ai" }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "toolCallId": "call_navigate_openclaw",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Opened https://openclaw.ai in the browser."
+      }
+    }
+  ]
+}

--- a/mastracode/e2e/web/harness-server.ts
+++ b/mastracode/e2e/web/harness-server.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import { createOpenAI } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
+import type { MastraBrowser } from '@mastra/core/browser';
 import { Harness } from '@mastra/core/harness';
 import { Mastra } from '@mastra/core/mastra';
 import { InMemoryNotificationsStorage } from '@mastra/core/notifications';
@@ -38,6 +39,8 @@ export interface ScenarioServerOptions {
   yolo?: boolean;
   /** Attach a real sandboxed workspace + file/shell tools to the agent. */
   workspace?: boolean;
+  /** Attach lightweight browser tools to the agent, matching provider tool names. */
+  browser?: 'stagehand' | 'agent-browser' | false;
   /**
    * Build the Harness with no storage of its own and configure storage on the
    * parent Mastra instead, exercising Harness#resolveStorage inheritance (the
@@ -55,11 +58,51 @@ export interface ScenarioServer {
   stop: () => Promise<void>;
 }
 
+function createScenarioBrowser(provider: 'stagehand' | 'agent-browser'): MastraBrowser {
+  const currentUrl = 'https://openclaw.ai';
+  const toolName = provider === 'stagehand' ? 'stagehand_navigate' : 'browser_goto';
+  const tools = {
+    [toolName]: createTool({
+      id: toolName,
+      description: `Scenario ${provider} navigation tool.`,
+      inputSchema: z.object({ url: z.string().min(1) }),
+      outputSchema: z.object({ success: z.boolean(), url: z.string() }),
+      execute: async ({ url }: { url: string }) => ({ success: true, url }),
+    }),
+  };
+
+  return {
+    id: `scenario-${provider}-browser`,
+    provider,
+    providerType: 'sdk' as const,
+    headless: true,
+    getTools: () => tools,
+    getInputProcessors: () => [],
+    isBrowserRunning: () => true,
+    hasThreadSession: () => true,
+    getSessionId: (threadId?: string) => (threadId ? `scenario-browser:${threadId}` : 'scenario-browser'),
+    getCurrentUrl: async () => currentUrl,
+    getBrowserState: async () => ({
+      tabs: [{ url: currentUrl, title: 'OpenClaw' }],
+      activeTabIndex: 0,
+    }),
+    startScreencast: async () => ({ on: () => undefined, stop: () => undefined }),
+    startScreencastIfBrowserActive: async () => null,
+    injectMouseEvent: async () => undefined,
+    injectKeyboardEvent: async () => undefined,
+  } as unknown as MastraBrowser;
+}
+
 export async function startHarnessServer(
   aimockBaseUrl: string,
   options: ScenarioServerOptions = {},
 ): Promise<ScenarioServer> {
-  const { yolo = true, workspace: withWorkspace = false, inheritStorageFromMastra = false } = options;
+  const {
+    yolo = true,
+    workspace: withWorkspace = false,
+    browser: browserProvider = false,
+    inheritStorageFromMastra = false,
+  } = options;
   const openai = createOpenAI({ apiKey: 'scenario-key', baseURL: aimockBaseUrl });
 
   let workspace: Workspace | undefined;
@@ -108,12 +151,14 @@ export async function startHarnessServer(
     },
   } as any);
 
+  const browser = browserProvider ? createScenarioBrowser(browserProvider) : undefined;
   const agent = new Agent({
     id: 'code-agent',
     name: 'code-agent',
     instructions: 'You are a coding assistant for scenario tests.',
     model: openai('gpt-5.4-mini'),
     tools: { ...(tools ?? {}), request_access: requestAccessTool } as any,
+    ...(browser ? { browser } : {}),
   });
 
   // A registered Harness always reads storage through its parent Mastra


### PR DESCRIPTION
Adds focused MastraCode web and TUI scenarios for browser tool availability.

The scenarios cover the issue where the model can call a browser tool like `stagehand_navigate` or `browser_goto`, but the active tool set does not include it and the run fails with a missing-tool error.

After this change, configured browser support is exercised in both paths:

```text
Open https://openclaw.ai in the browser
→ stagehand_navigate / browser_goto executes
→ no NoSuchToolError or ToolNotFoundError
```

Verified with targeted web and TUI scenario runs, plus `pnpm --filter mastracode check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change adds tests to make sure the app can actually use browser tools when browser support is turned on. It helps catch bugs where the model tries to open a website, but the needed browser tool isn’t available, which would cause an error instead of working.

## Summary
- Added new browser-tool-availability scenarios for both web and TUI flows.
- Updated the web harness/server to optionally provide a browser stub so browser-enabled scenarios can run.
- Added new fixtures that simulate browser navigation requests and follow-up responses.
- Registered the new TUI scenario in the scenario map and scenario name types.
- Included a new changeset for a patch release of `mastracode`.

## Validation
- Verified with targeted web and TUI scenario runs.
- Verified with `pnpm --filter mastracode check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->