### PR TITLE
fix(example): point agent-v6 start script to existing entrypoint

### DIFF
--- a/examples/agent-v6/package.json
+++ b/examples/agent-v6/package.json
@@ -6,8 +6,7 @@
   "main": "index.js",
   "version": "0.0.1",
   "scripts": {
-    "start": "npx bun src/example.ts",
-    "processor-demo": "npx bun src/processor-demo.ts",
+    "start": "npx bun src/structured-output-example.ts",
     "mastra:build": "mastra build",
     "mastra:dev": "mastra dev"
   },


### PR DESCRIPTION
## Summary

Fixes the `examples/agent-v6` start script so it points to the existing structured output example entrypoint.

The previous scripts referenced files that are not present in this example:
- `src/example.ts`
- `src/processor-demo.ts`

## Changes

- Update `start` to run `src/structured-output-example.ts`
- Remove the stale `processor-demo` script

## Verification

- `corepack pnpm@10.29.3 -C examples\agent-v6 install --ignore-workspace --no-lockfile --prefer-offline --reporter append-only`
- Checked that package scripts referencing local TypeScript files point to existing files
- `git diff --check`

Note: `corepack pnpm@10.29.3 -C examples\agent-v6 exec tsc --noEmit` currently fails because linked local `@mastra/*` packages have not been built and their `dist/*.d.ts` type entries are unavailable.