### PR TITLE
chore(playground): debarrel utility helpers

### DIFF
--- a/.changeset/direct-utility-imports.md
+++ b/.changeset/direct-utility-imports.md
@@ -1,0 +1,11 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added direct Playground UI subpaths for shared helpers so apps can avoid the root barrel when importing existing utility and rule builder APIs.
+
+```ts
+import { is401UnauthorizedError } from '@mastra/playground-ui/utils/errors';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
+import { RuleBuilder } from '@mastra/playground-ui/components/RuleBuilder';
+```

--- a/packages/playground-ui/src/ds/components/RuleBuilder/index.ts
+++ b/packages/playground-ui/src/ds/components/RuleBuilder/index.ts
@@ -1,0 +1,2 @@
+export { RuleBuilder } from '@/lib/rule-engine/components';
+export type { RuleBuilderProps } from '@/lib/rule-engine/components';

--- a/packages/playground-ui/src/utils/colors.ts
+++ b/packages/playground-ui/src/utils/colors.ts
@@ -1,0 +1,1 @@
+export * from '../lib/colors';

--- a/packages/playground-ui/src/utils/errors.ts
+++ b/packages/playground-ui/src/utils/errors.ts
@@ -1,0 +1,2 @@
+export * from '../lib/errors';
+export * from '../lib/query-utils';

--- a/packages/playground-ui/src/utils/file.ts
+++ b/packages/playground-ui/src/utils/file.ts
@@ -1,0 +1,1 @@
+export * from '../lib/file';

--- a/packages/playground-ui/src/utils/formatting.ts
+++ b/packages/playground-ui/src/utils/formatting.ts
@@ -1,0 +1,1 @@
+export * from '../lib/formatting';

--- a/packages/playground-ui/src/utils/json-schema.ts
+++ b/packages/playground-ui/src/utils/json-schema.ts
@@ -1,0 +1,1 @@
+export * from '../lib/json-schema';

--- a/packages/playground-ui/src/utils/number.ts
+++ b/packages/playground-ui/src/utils/number.ts
@@ -1,0 +1,1 @@
+export * from '../lib/number';

--- a/packages/playground-ui/src/utils/query-utils.ts
+++ b/packages/playground-ui/src/utils/query-utils.ts
@@ -1,0 +1,1 @@
+export * from '../lib/query-utils';

--- a/packages/playground-ui/src/utils/rule-engine.ts
+++ b/packages/playground-ui/src/utils/rule-engine.ts
@@ -1,0 +1,2 @@
+export type { ConditionOperator, Rule, RuleGroup } from '../lib/rule-engine';
+export { countLeafRules, createDefaultRule, createDefaultRuleGroup, isRule, isRuleGroup } from '../lib/rule-engine';

--- a/packages/playground-ui/src/utils/string.ts
+++ b/packages/playground-ui/src/utils/string.ts
@@ -1,0 +1,1 @@
+export * from '../lib/string';

--- a/packages/playground-ui/src/utils/truncate-string.ts
+++ b/packages/playground-ui/src/utils/truncate-string.ts
@@ -1,0 +1,1 @@
+export * from '../lib/truncate-string';

--- a/packages/playground/eslint.config.js
+++ b/packages/playground/eslint.config.js
@@ -95,6 +95,60 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import cn from @mastra/playground-ui/utils/cn.',
   },
   {
+    importNames: [
+      'is401UnauthorizedError',
+      'is403ForbiddenError',
+      'is404NotFoundError',
+      'isBranchesNotSupportedError',
+      'isUnsupportedObservabilityOperationError',
+      'isNonRetryableError',
+      'parseError',
+    ],
+    message: 'Import error helpers from @mastra/playground-ui/utils/errors.',
+  },
+  {
+    importNames: ['shouldRetryQuery'],
+    message: 'Import query helpers from @mastra/playground-ui/utils/query-utils.',
+  },
+  {
+    importNames: ['JsonSchema', 'JsonSchemaProperty', 'JsonSchemaType'],
+    message: 'Import JSON schema types from @mastra/playground-ui/utils/json-schema.',
+  },
+  {
+    importNames: ['Rule', 'RuleGroup', 'ConditionOperator', 'countLeafRules'],
+    message: 'Import rule-engine types and helpers from @mastra/playground-ui/utils/rule-engine.',
+  },
+  {
+    importNames: ['truncateString'],
+    message: 'Import truncateString from @mastra/playground-ui/utils/truncate-string.',
+  },
+  {
+    importNames: ['stringToColor'],
+    message: 'Import stringToColor from @mastra/playground-ui/utils/colors.',
+  },
+  {
+    importNames: ['formatJSON', 'formatTypeScript', 'isValidJson'],
+    message: 'Import formatting helpers from @mastra/playground-ui/utils/formatting.',
+  },
+  {
+    importNames: [
+      'fileToBase64',
+      'getFileContentType',
+      'isRemoteUrl',
+      'isBrowserFetchableUrl',
+      'isNonFetchableRemoteUrl',
+    ],
+    message: 'Import file helpers from @mastra/playground-ui/utils/file.',
+  },
+  {
+    importNames: ['toSigFigs'],
+    message: 'Import toSigFigs from @mastra/playground-ui/utils/number.',
+  },
+  {
+    importNames: ['lodashTitleCase'],
+    message: 'Import lodashTitleCase from @mastra/playground-ui/utils/string.',
+  },
+  {
     importNames: ['toast'],
     message: 'Import toast from @mastra/playground-ui/utils/toast.',
   },
@@ -540,6 +594,10 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import RadioGroup exports from @mastra/playground-ui/components/RadioGroup.',
   },
   {
+    importNames: ['RuleBuilder', 'RuleBuilderProps'],
+    message: 'Import RuleBuilder exports from @mastra/playground-ui/components/RuleBuilder.',
+  },
+  {
     importNames: ['Searchbar', 'SearchbarWrapper', 'SearchbarProps'],
     message: 'Import Searchbar exports from @mastra/playground-ui/components/Searchbar.',
   },
@@ -696,10 +754,16 @@ const restrictedPlaygroundUiBarrelImportSpecifiers = [
     message: 'Import Truncate exports from @mastra/playground-ui/components/Truncate.',
   },
 ].flatMap(restriction =>
-  restriction.importNames.map(importName => ({
-    selector: `ImportDeclaration[source.value="@mastra/playground-ui"] > ImportSpecifier[imported.name="${importName}"]`,
-    message: restriction.message,
-  })),
+  restriction.importNames.flatMap(importName => [
+    {
+      selector: `ImportDeclaration[source.value="@mastra/playground-ui"] > ImportSpecifier[imported.name="${importName}"]`,
+      message: restriction.message,
+    },
+    {
+      selector: `ExportNamedDeclaration[source.value="@mastra/playground-ui"] > ExportSpecifier[local.name="${importName}"]`,
+      message: restriction.message,
+    },
+  ]),
 );
 
 // Enforce the playground testing contract (packages/playground/AGENTS.md + the

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/browser.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/browser.test.tsx
@@ -1,5 +1,5 @@
-import { stringToColor } from '@mastra/playground-ui';
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
+import { stringToColor } from '@mastra/playground-ui/utils/colors';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { afterEach, describe, expect, it } from 'vitest';

--- a/packages/playground/src/domains/agent-builder/contexts/__tests__/agent-color-context.test.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/__tests__/agent-color-context.test.tsx
@@ -1,4 +1,4 @@
-import { stringToColor } from '@mastra/playground-ui';
+import { stringToColor } from '@mastra/playground-ui/utils/colors';
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentColors } from '../agent-color-context';

--- a/packages/playground/src/domains/agent-builder/contexts/agent-color-context.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/agent-color-context.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import { stringToColor } from '@mastra/playground-ui';
+import { stringToColor } from '@mastra/playground-ui/utils/colors';
 import { createContext, useContext, useMemo } from 'react';
 import type { ReactNode } from 'react';
 

--- a/packages/playground/src/domains/agents/components/agent-advanced-settings.tsx
+++ b/packages/playground/src/domains/agents/components/agent-advanced-settings.tsx
@@ -1,11 +1,11 @@
 import { jsonLanguage } from '@codemirror/lang-json';
-import { formatJSON, isValidJson } from '@mastra/playground-ui';
 import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
+import { formatJSON, isValidJson } from '@mastra/playground-ui/utils/formatting';
 import CodeMirror from '@uiw/react-codemirror';
 import { Braces, CopyIcon, SaveIcon, CheckIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
@@ -1,5 +1,4 @@
 import type { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
-import type { RuleGroup, JsonSchema } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { ContentBlock } from '@mastra/playground-ui/components/ContentBlocks';
@@ -18,6 +17,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/c
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
+import type { RuleGroup } from '@mastra/playground-ui/utils/rule-engine';
 import type { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { GripVertical, X, BookmarkPlus } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
@@ -1,8 +1,8 @@
-import type { JsonSchema } from '@mastra/playground-ui';
 import { ContentBlocks } from '@mastra/playground-ui/components/ContentBlocks';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
 import { FileText, PenLine, PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import type { InstructionBlock } from '../agent-edit-page/utils/form-validation';

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
@@ -1,5 +1,4 @@
 import type { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
-import type { JsonSchema } from '@mastra/playground-ui';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { ContentBlock } from '@mastra/playground-ui/components/ContentBlocks';
 import { Popover, PopoverTrigger, PopoverContent } from '@mastra/playground-ui/components/Popover';
@@ -8,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/c
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
 import { GripVertical, X, ExternalLink, ChevronDown } from 'lucide-react';
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
@@ -1,4 +1,3 @@
-import type { RuleGroup } from '@mastra/playground-ui';
 import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
@@ -6,6 +5,7 @@ import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Sectio
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import type { RuleGroup } from '@mastra/playground-ui/utils/rule-engine';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
@@ -1,4 +1,3 @@
-import type { RuleGroup } from '@mastra/playground-ui';
 import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
@@ -9,6 +8,7 @@ import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Sectio
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { JudgeIcon } from '@mastra/playground-ui/icons/JudgeIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import type { RuleGroup } from '@mastra/playground-ui/utils/rule-engine';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
@@ -1,4 +1,3 @@
-import type { RuleGroup } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
 import { Notice } from '@mastra/playground-ui/components/Notice';
@@ -8,6 +7,7 @@ import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Sectio
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import type { RuleGroup } from '@mastra/playground-ui/utils/rule-engine';
 import { PlusIcon, XIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/variables-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/variables-page.tsx
@@ -1,7 +1,7 @@
-import type { JsonSchema } from '@mastra/playground-ui';
 import { JSONSchemaForm, jsonSchemaToFields } from '@mastra/playground-ui/components/JSONSchemaForm';
 import type { SchemaField } from '@mastra/playground-ui/components/JSONSchemaForm';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
 import { Plus, PlusIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
@@ -1,4 +1,3 @@
-import type { RuleGroup } from '@mastra/playground-ui';
 import { EntityName, EntityDescription, EntityContent, Entity } from '@mastra/playground-ui/components/Entity';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Searchbar } from '@mastra/playground-ui/components/Searchbar';
@@ -6,6 +5,7 @@ import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Sectio
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { WorkflowIcon } from '@mastra/playground-ui/icons/WorkflowIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import type { RuleGroup } from '@mastra/playground-ui/utils/rule-engine';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
@@ -1,4 +1,3 @@
-import type { JsonSchema } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { JSONSchemaForm, jsonSchemaToFields } from '@mastra/playground-ui/components/JSONSchemaForm';
@@ -12,6 +11,7 @@ import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
 import { VariablesIcon } from '@mastra/playground-ui/icons/VariablesIcon';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
 import { Check, PlusIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import type { RefObject } from 'react';

--- a/packages/playground/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from '@lukeed/uuid';
 import type { RuleGroup, RuleGroupDepth1, RuleGroupDepth2 } from '@mastra/core/storage';
-import type { JsonSchema } from '@mastra/playground-ui';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
 import { z } from 'zod';
 
 export type InMemoryFileNode = {

--- a/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
@@ -1,5 +1,4 @@
 import type { GetAgentResponse } from '@mastra/client-js';
-import { truncateString } from '@mastra/playground-ui';
 import {
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
@@ -8,6 +7,7 @@ import { TextAndIcon } from '@mastra/playground-ui/components/Text';
 import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
 import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
 import { WorkflowIcon } from '@mastra/playground-ui/icons/WorkflowIcon';
+import { truncateString } from '@mastra/playground-ui/utils/truncate-string';
 import { useMemo } from 'react';
 import { extractPrompt } from '../../utils/extractPrompt';
 import { ProviderLogo } from '../agent-metadata/provider-logo';

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
@@ -1,4 +1,3 @@
-import type { JsonSchema, JsonSchemaProperty } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { HoverPopover, PopoverTrigger, PopoverContent } from '@mastra/playground-ui/components/Popover';
@@ -7,6 +6,7 @@ import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import type { JsonSchema, JsonSchemaProperty } from '@mastra/playground-ui/utils/json-schema';
 import { Braces, ChevronDown, ChevronRight, Wrench, Cpu, Eye, Pencil } from 'lucide-react';
 import { useState, useMemo } from 'react';
 

--- a/packages/playground/src/domains/agents/components/request-context.tsx
+++ b/packages/playground/src/domains/agents/components/request-context.tsx
@@ -1,5 +1,4 @@
 import { jsonLanguage } from '@codemirror/lang-json';
-import { formatJSON, isValidJson } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
 import { Notice } from '@mastra/playground-ui/components/Notice';
@@ -8,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@mastr
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import { formatJSON, isValidJson } from '@mastra/playground-ui/utils/formatting';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import CodeMirror from '@uiw/react-codemirror';
 import { Braces, CopyIcon, ExternalLink, X } from 'lucide-react';

--- a/packages/playground/src/domains/cms/components/display-conditions/display-conditions-dialog.tsx
+++ b/packages/playground/src/domains/cms/components/display-conditions/display-conditions-dialog.tsx
@@ -1,5 +1,3 @@
-import type { JsonSchema, RuleGroup } from '@mastra/playground-ui';
-import { RuleBuilder, countLeafRules } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import {
   Dialog,
@@ -10,6 +8,10 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@mastra/playground-ui/components/Dialog';
+import { RuleBuilder } from '@mastra/playground-ui/components/RuleBuilder';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
+import type { RuleGroup } from '@mastra/playground-ui/utils/rule-engine';
+import { countLeafRules } from '@mastra/playground-ui/utils/rule-engine';
 import { Ruler } from 'lucide-react';
 
 interface DisplayConditionsDialogProps {

--- a/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
+++ b/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
@@ -1,10 +1,12 @@
-import { RuleBuilder, countLeafRules } from '@mastra/playground-ui';
-import type { JsonSchema, RuleGroup } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
+import { RuleBuilder } from '@mastra/playground-ui/components/RuleBuilder';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
+import type { RuleGroup } from '@mastra/playground-ui/utils/rule-engine';
+import { countLeafRules } from '@mastra/playground-ui/utils/rule-engine';
 import { ChevronRight, Ruler, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
@@ -1,5 +1,4 @@
 import type { StoredMCPServerConfig } from '@mastra/client-js';
-import { stringToColor } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Entity, EntityContent, EntityDescription, EntityName } from '@mastra/playground-ui/components/Entity';
@@ -7,6 +6,7 @@ import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Sectio
 import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { McpServerIcon } from '@mastra/playground-ui/icons/McpServerIcon';
+import { stringToColor } from '@mastra/playground-ui/utils/colors';
 import { LaptopMinimal, PlusIcon, XIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/mcps/components/mcps-list/mcps-list.tsx
+++ b/packages/playground/src/domains/mcps/components/mcps-list/mcps-list.tsx
@@ -1,5 +1,4 @@
 import type { McpServerListResponse } from '@mastra/client-js';
-import { truncateString } from '@mastra/playground-ui';
 import {
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
@@ -7,6 +6,7 @@ import {
 import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
 import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
 import { WorkflowIcon } from '@mastra/playground-ui/icons/WorkflowIcon';
+import { truncateString } from '@mastra/playground-ui/utils/truncate-string';
 import { useMastraClient } from '@mastra/react';
 import { useMemo } from 'react';
 import { useMCPServerTools } from '../../hooks/useMCPServerTools';

--- a/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
+++ b/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
@@ -1,8 +1,8 @@
-import { truncateString } from '@mastra/playground-ui';
 import {
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
 } from '@mastra/playground-ui/components/DataList';
+import { truncateString } from '@mastra/playground-ui/utils/truncate-string';
 import { CheckIcon, FileInput, FileOutput } from 'lucide-react';
 import { useMemo } from 'react';
 import type { ProcessorInfo, ProcessorPhase } from '../../hooks/use-processors';

--- a/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-main.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-main.tsx
@@ -1,5 +1,6 @@
-import type { JsonSchema, RuleGroup } from '@mastra/playground-ui';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
+import type { RuleGroup } from '@mastra/playground-ui/utils/rule-engine';
 import type { UseFormReturn } from 'react-hook-form';
 import { Controller, useWatch } from 'react-hook-form';
 

--- a/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-sidebar.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-sidebar.tsx
@@ -1,4 +1,3 @@
-import type { JsonSchema } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { JSONSchemaForm, jsonSchemaToFields } from '@mastra/playground-ui/components/JSONSchemaForm';
@@ -8,6 +7,7 @@ import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Textarea } from '@mastra/playground-ui/components/Textarea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
 import { Check, Plus, PlusIcon, Save } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';

--- a/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/utils/form-validation.ts
+++ b/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/utils/form-validation.ts
@@ -1,4 +1,4 @@
-import type { JsonSchema } from '@mastra/playground-ui';
+import type { JsonSchema } from '@mastra/playground-ui/utils/json-schema';
 import { z } from 'zod';
 
 export const promptBlockFormSchema = z.object({

--- a/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
@@ -1,9 +1,9 @@
 import type { StoredPromptBlockResponse } from '@mastra/client-js';
-import { truncateString } from '@mastra/playground-ui';
 import {
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
 } from '@mastra/playground-ui/components/DataList';
+import { truncateString } from '@mastra/playground-ui/utils/truncate-string';
 import { CheckIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground/src/domains/tool-providers/components/integration-tools-section.tsx
+++ b/packages/playground/src/domains/tool-providers/components/integration-tools-section.tsx
@@ -1,7 +1,7 @@
-import { stringToColor } from '@mastra/playground-ui';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Entity, EntityContent, EntityName, EntityDescription } from '@mastra/playground-ui/components/Entity';
 import { Section, SubSectionRoot } from '@mastra/playground-ui/components/Section';
+import { stringToColor } from '@mastra/playground-ui/utils/colors';
 import { Plug } from 'lucide-react';
 import { useMemo, useState } from 'react';
 

--- a/packages/playground/src/domains/tools/components/tools-list/tools-list.tsx
+++ b/packages/playground/src/domains/tools/components/tools-list/tools-list.tsx
@@ -1,10 +1,10 @@
 import type { GetAgentResponse, GetToolResponse } from '@mastra/client-js';
-import { truncateString } from '@mastra/playground-ui';
 import {
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
 } from '@mastra/playground-ui/components/DataList';
 import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
+import { truncateString } from '@mastra/playground-ui/utils/truncate-string';
 import { useMemo } from 'react';
 import { prepareToolsTable } from '@/domains/tools/utils/prepareToolsTable';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
+++ b/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
@@ -1,9 +1,9 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
-import { truncateString } from '@mastra/playground-ui';
 import {
   DataList as EntityList,
   DataListSkeleton as EntityListSkeleton,
 } from '@mastra/playground-ui/components/DataList';
+import { truncateString } from '@mastra/playground-ui/utils/truncate-string';
 import { useMemo } from 'react';
 import { useLinkComponent } from '@/lib/framework';
 

--- a/packages/playground/src/domains/workflows/workflow/workflow-clock.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-clock.tsx
@@ -1,5 +1,5 @@
-import { toSigFigs } from '@mastra/playground-ui';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { toSigFigs } from '@mastra/playground-ui/utils/number';
 import { useEffect, useState } from 'react';
 
 interface ClockProps {

--- a/packages/playground/src/domains/workflows/workflow/workflow-graph.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-graph.tsx
@@ -1,6 +1,6 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
-import { lodashTitleCase } from '@mastra/playground-ui';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { lodashTitleCase } from '@mastra/playground-ui/utils/string';
 import { ReactFlowProvider } from '@xyflow/react';
 import { AlertCircleIcon } from 'lucide-react';
 import { useContext } from 'react';

--- a/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
@@ -1,5 +1,4 @@
 import { jsonLanguage } from '@codemirror/lang-json';
-import { formatJSON, isValidJson } from '@mastra/playground-ui';
 import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
@@ -7,6 +6,7 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
+import { formatJSON, isValidJson } from '@mastra/playground-ui/utils/formatting';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import CodeMirror from '@uiw/react-codemirror';
 import { Braces, ChevronDown, CopyIcon, EyeIcon, EyeOffIcon } from 'lucide-react';

--- a/packages/playground/src/domains/workspace/compatibility.ts
+++ b/packages/playground/src/domains/workspace/compatibility.ts
@@ -1,6 +1,6 @@
 import type { MastraClient } from '@mastra/client-js';
 import { coreFeatures } from '@mastra/core/features';
-import { isNonRetryableError } from '@mastra/playground-ui';
+import { isNonRetryableError } from '@mastra/playground-ui/utils/errors';
 import { hasMethod } from './client-utils';
 
 /**

--- a/packages/playground/src/lib/ai-ui/attachments/attachment.tsx
+++ b/packages/playground/src/lib/ai-ui/attachments/attachment.tsx
@@ -1,8 +1,8 @@
-import { fileToBase64, isBrowserFetchableUrl } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
+import { fileToBase64, isBrowserFetchableUrl } from '@mastra/playground-ui/utils/file';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { X } from 'lucide-react';
 import { useEffect, useState } from 'react';

--- a/packages/playground/src/lib/ai-ui/attachments/composer-attachments.tsx
+++ b/packages/playground/src/lib/ai-ui/attachments/composer-attachments.tsx
@@ -1,5 +1,5 @@
 import type { CoreUserMessage } from '@mastra/core/llm';
-import { fileToBase64, getFileContentType, isRemoteUrl } from '@mastra/playground-ui';
+import { fileToBase64, getFileContentType, isRemoteUrl } from '@mastra/playground-ui/utils/file';
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 

--- a/packages/playground/src/lib/ai-ui/messages/renderers/user-file-part-renderer.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/user-file-part-renderer.tsx
@@ -1,4 +1,4 @@
-import { isBrowserFetchableUrl, isNonFetchableRemoteUrl } from '@mastra/playground-ui';
+import { isBrowserFetchableUrl, isNonFetchableRemoteUrl } from '@mastra/playground-ui/utils/file';
 import type { FilePart } from '@mastra/react';
 
 import { InMessageAttachment } from './in-message-attachment';

--- a/packages/playground/src/lib/ai-ui/tools/badges/background-task-metadata-dialog.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/background-task-metadata-dialog.tsx
@@ -1,4 +1,3 @@
-import { toSigFigs } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import {
@@ -10,6 +9,7 @@ import {
   DialogBody,
 } from '@mastra/playground-ui/components/Dialog';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { toSigFigs } from '@mastra/playground-ui/utils/number';
 import { Loader2Icon, Share2 } from 'lucide-react';
 import { useState } from 'react';
 import { useTimeDiff } from '../../hooks/use-time-diff';

--- a/packages/playground/src/lib/ai-ui/tools/badges/code-mode-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/code-mode-badge.tsx
@@ -1,7 +1,7 @@
-import { formatTypeScript } from '@mastra/playground-ui';
 import { CodeBlock } from '@mastra/playground-ui/components/CodeBlock';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { ToolCoinIcon } from '@mastra/playground-ui/icons/ToolCoinIcon';
+import { formatTypeScript } from '@mastra/playground-ui/utils/formatting';
 import { useEffect, useState } from 'react';
 import { BadgeWrapper } from './badge-wrapper';
 import type { ToolApprovalButtonsProps } from './tool-approval-buttons';

--- a/packages/playground/src/lib/tanstack-query.tsx
+++ b/packages/playground/src/lib/tanstack-query.tsx
@@ -1,4 +1,4 @@
-import { shouldRetryQuery } from '@mastra/playground-ui';
+import { shouldRetryQuery } from '@mastra/playground-ui/utils/query-utils';
 import type { QueryClientConfig } from '@tanstack/react-query';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 

--- a/packages/playground/src/lib/utils.ts
+++ b/packages/playground/src/lib/utils.ts
@@ -1,1 +1,1 @@
-export { cn } from '@mastra/playground-ui';
+export { cn } from '@mastra/playground-ui/utils/cn';

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -1,5 +1,4 @@
 import type { ListStoredAgentsParams } from '@mastra/client-js';
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
@@ -9,6 +8,7 @@ import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { PlusIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 

--- a/packages/playground/src/pages/agent-builder/favorite/index.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/index.tsx
@@ -1,5 +1,4 @@
 import type { ListStoredAgentsParams, StoredSkillResponse } from '@mastra/client-js';
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
@@ -7,6 +6,7 @@ import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { SparklesIcon, StarIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -1,5 +1,4 @@
 import type { ListStoredAgentsParams } from '@mastra/client-js';
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
@@ -7,6 +6,7 @@ import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { LibraryIcon, SparklesIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';

--- a/packages/playground/src/pages/agent-builder/skills/index.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/index.tsx
@@ -1,5 +1,4 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
@@ -8,6 +7,7 @@ import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { DownloadIcon, PlusIcon, SparklesIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';

--- a/packages/playground/src/pages/agents/agent-evaluate/index.tsx
+++ b/packages/playground/src/pages/agents/agent-evaluate/index.tsx
@@ -1,7 +1,7 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { AgentPlaygroundEvaluate } from '@/domains/agents/components/agent-playground/agent-playground-evaluate';

--- a/packages/playground/src/pages/agents/agent-playground/index.tsx
+++ b/packages/playground/src/pages/agents/agent-playground/index.tsx
@@ -1,7 +1,7 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { AgentPlaygroundView } from '@/domains/agents/components/agent-playground/agent-playground-view';

--- a/packages/playground/src/pages/agents/agent-review/index.tsx
+++ b/packages/playground/src/pages/agents/agent-review/index.tsx
@@ -1,7 +1,7 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useParams } from 'react-router';
 import { AgentPlaygroundReview } from '@/domains/agents/components/agent-playground';
 import { useAgent } from '@/domains/agents/hooks/use-agent';

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -1,7 +1,7 @@
 import { v4 as uuid } from '@lukeed/uuid';
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useEffect, useMemo } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { AgentSidebar } from '@/domains/agents/agent-sidebar';

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -1,9 +1,9 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useState } from 'react';
 import { AgentHeaderCreateAction } from '@/domains/agents/agent-header-actions';
 import { AgentsList } from '@/domains/agents/components/agent-list/agents-list';

--- a/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
@@ -1,10 +1,10 @@
-import { is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui/utils/errors';
 import { ArrowLeft, PlayCircle } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Link, useParams } from 'react-router';

--- a/packages/playground/src/pages/datasets/dataset/experiments/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiments/index.tsx
@@ -1,9 +1,9 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { MainContentContent, MainContentLayout } from '@mastra/playground-ui/components/MainContent';
 import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { GitCompare, ArrowLeft } from 'lucide-react';
 import { useParams, useSearchParams, Link } from 'react-router';
 import { DatasetExperimentsComparison } from '@/domains/datasets';

--- a/packages/playground/src/pages/datasets/dataset/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/index.tsx
@@ -1,4 +1,3 @@
-import { is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
@@ -9,6 +8,7 @@ import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
+import { is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui/utils/errors';
 import { format } from 'date-fns/format';
 import { ArrowLeft, Copy, DatabaseIcon, MoreVertical, Pencil, Play, Trash2 } from 'lucide-react';
 import type { ReactNode } from 'react';

--- a/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
@@ -1,5 +1,4 @@
 import type { DatasetItem } from '@mastra/client-js';
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { CodeDiff } from '@mastra/playground-ui/components/CodeDiff';
@@ -10,6 +9,7 @@ import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDen
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { TextAndIcon } from '@mastra/playground-ui/components/Text';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { ArrowLeft, GitCompareIcon, History, DiffIcon, ColumnsIcon } from 'lucide-react';
 import { Fragment, useState } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router';

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -1,5 +1,4 @@
 import type { DatasetItemToolMock } from '@mastra/client-js';
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
@@ -11,6 +10,7 @@ import { Notice } from '@mastra/playground-ui/components/Notice';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { TextAndIcon } from '@mastra/playground-ui/components/Text';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { format } from 'date-fns';
 import {

--- a/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
@@ -1,4 +1,3 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { Chip } from '@mastra/playground-ui/components/Chip';
@@ -10,6 +9,7 @@ import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDen
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { TextAndIcon } from '@mastra/playground-ui/components/Text';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { format } from 'date-fns';
 import { ArrowLeft, HistoryIcon, GitCompareIcon, ColumnsIcon, GitCompareArrowsIcon } from 'lucide-react';
 import { Fragment, useState } from 'react';

--- a/packages/playground/src/pages/datasets/dataset/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/versions/index.tsx
@@ -1,4 +1,3 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Column, Columns } from '@mastra/playground-ui/components/Columns';
 import { MainContentContent, MainContentLayout } from '@mastra/playground-ui/components/MainContent';
@@ -6,6 +5,7 @@ import { MainHeader } from '@mastra/playground-ui/components/MainHeader';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { TextAndIcon } from '@mastra/playground-ui/components/Text';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { ArrowLeft, ScaleIcon, HistoryIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useParams, useSearchParams, useNavigate, Link } from 'react-router';

--- a/packages/playground/src/pages/datasets/index.tsx
+++ b/packages/playground/src/pages/datasets/index.tsx
@@ -1,8 +1,8 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useCallback, useMemo, useState } from 'react';
 import { CreateDatasetDialog, DatasetsList, DatasetsToolbar, getDatasetTagOptions } from '@/domains/datasets';
 import { NoDatasetsInfo } from '@/domains/datasets/components/datasets-list/no-datasets-info';

--- a/packages/playground/src/pages/evaluation/index.tsx
+++ b/packages/playground/src/pages/evaluation/index.tsx
@@ -1,9 +1,9 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { MetricsFlexGrid } from '@mastra/playground-ui/components/MetricsFlexGrid';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useMemo } from 'react';
 import { DatasetHealthCard } from '@/domains/datasets';
 import { useDatasets } from '@/domains/datasets/hooks/use-datasets';

--- a/packages/playground/src/pages/experiments/experiment/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/index.tsx
@@ -1,10 +1,10 @@
-import { is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError, is404NotFoundError } from '@mastra/playground-ui/utils/errors';
 import { ArrowLeft, PlayCircle } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Link, useParams } from 'react-router';

--- a/packages/playground/src/pages/experiments/index.tsx
+++ b/packages/playground/src/pages/experiments/index.tsx
@@ -1,8 +1,8 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useMemo, useState } from 'react';
 import { useDatasets } from '@/domains/datasets/hooks/use-datasets';
 import { useExperiments } from '@/domains/datasets/hooks/use-experiments';

--- a/packages/playground/src/pages/mcps/index.tsx
+++ b/packages/playground/src/pages/mcps/index.tsx
@@ -1,9 +1,9 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useState } from 'react';
 import { McpServersList } from '@/domains/mcps/components/mcps-list/mcps-list';
 import { NoMCPServersInfo } from '@/domains/mcps/components/mcps-list/no-mcp-servers-info';

--- a/packages/playground/src/pages/metrics/index.tsx
+++ b/packages/playground/src/pages/metrics/index.tsx
@@ -7,8 +7,6 @@ import {
   createMetricsPropertyFilterFields,
   getMetricsPropertyFilterTokens,
   hasAnyMetricsFilterParams,
-  is401UnauthorizedError,
-  is403ForbiddenError,
   isValidPreset,
   loadMetricsFiltersFromStorage,
   saveMetricsFiltersToStorage,
@@ -29,6 +27,7 @@ import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDen
 import { PropertyFilterCreator } from '@mastra/playground-ui/components/PropertyFilter';
 import type { PropertyFilterToken } from '@mastra/playground-ui/components/PropertyFilter';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { CircleSlashIcon, ExternalLinkIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/playground/src/pages/processors/index.tsx
+++ b/packages/playground/src/pages/processors/index.tsx
@@ -1,9 +1,9 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useState } from 'react';
 import { NoProcessorsInfo } from '@/domains/processors/components/processors-list/no-processors-info';
 import { ProcessorsList } from '@/domains/processors/components/processors-list/processors-list';

--- a/packages/playground/src/pages/processors/processor/index.tsx
+++ b/packages/playground/src/pages/processors/processor/index.tsx
@@ -1,7 +1,7 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useParams, Navigate } from 'react-router';
 import { ProcessorPanel } from '@/domains/processors/components/processor-panel';
 import { useProcessor } from '@/domains/processors/hooks/use-processors';

--- a/packages/playground/src/pages/prompt-blocks/index.tsx
+++ b/packages/playground/src/pages/prompt-blocks/index.tsx
@@ -1,10 +1,10 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';

--- a/packages/playground/src/pages/scorers/index.tsx
+++ b/packages/playground/src/pages/scorers/index.tsx
@@ -1,8 +1,8 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useState } from 'react';
 import { ScorersToolbar, useScorers } from '@/domains/scores';
 import { NoScorersInfo } from '@/domains/scores/components/scorers-list/no-scorers-info';

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -1,9 +1,9 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { PencilIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';

--- a/packages/playground/src/pages/tools/index.tsx
+++ b/packages/playground/src/pages/tools/index.tsx
@@ -1,9 +1,9 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useState } from 'react';
 import { useAgents } from '@/domains/agents/hooks/use-agents';
 import { NoToolsInfo } from '@/domains/tools/components/tools-list/no-tools-info';

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -9,7 +9,6 @@ import {
   TracesToolbar,
   buildTraceListFilters,
   createTracePropertyFilterFields,
-  isBranchesNotSupportedError,
   neutralizeFilterTokens,
   useEntityNames,
   useEnvironments,
@@ -31,6 +30,7 @@ import { Notice } from '@mastra/playground-ui/components/Notice';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PropertyFilterCreator } from '@mastra/playground-ui/components/PropertyFilter';
 import { Switch } from '@mastra/playground-ui/components/Switch';
+import { isBranchesNotSupportedError } from '@mastra/playground-ui/utils/errors';
 import { CircleSlash2, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';

--- a/packages/playground/src/pages/workflows/index.tsx
+++ b/packages/playground/src/pages/workflows/index.tsx
@@ -1,10 +1,10 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { CalendarClockIcon } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';

--- a/packages/playground/src/pages/workflows/schedule.tsx
+++ b/packages/playground/src/pages/workflows/schedule.tsx
@@ -1,10 +1,10 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { ArrowLeftIcon, PauseIcon, PlayIcon } from 'lucide-react';
 import { Link, useParams } from 'react-router';
 import { ScheduleStatusText } from '@/domains/schedules/components/schedule-status-badge';

--- a/packages/playground/src/pages/workflows/schedules.tsx
+++ b/packages/playground/src/pages/workflows/schedules.tsx
@@ -1,7 +1,7 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useSearchParams } from 'react-router';
 import { SchedulesPage as SchedulesPageContent } from '@/domains/schedules/components/schedules-page';
 import { useSchedules } from '@/domains/schedules/hooks/use-schedules';

--- a/packages/playground/src/pages/workflows/workflow/index.tsx
+++ b/packages/playground/src/pages/workflows/workflow/index.tsx
@@ -1,7 +1,7 @@
 import type { GetWorkflowResponse } from '@mastra/client-js';
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useParams } from 'react-router';
 import { WorkflowStepDetailContent } from '@/domains/workflows/components/workflow-step-detail';
 import { useWorkflowStepDetail } from '@/domains/workflows/context/workflow-step-detail-context';

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -1,4 +1,3 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
@@ -6,6 +5,7 @@ import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDen
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tab, TabContent, TabList, Tabs } from '@mastra/playground-ui/components/Tabs';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { FileText, Wand2, Search, ChevronDown, Bot, Server } from 'lucide-react';
 import { useState, useCallback } from 'react';

--- a/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
+++ b/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
@@ -1,7 +1,7 @@
-import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui';
 import { MainContentLayout } from '@mastra/playground-ui/components/MainContent';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
+import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
 import { useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 


### PR DESCRIPTION
## Summary
- Mechanical import hygiene to reduce `@mastra/playground-ui` root barrel use in `packages/playground` and avoid accidental performance regressions.
- Adds direct public subpaths for existing helper APIs under `@mastra/playground-ui/utils/*` and `@mastra/playground-ui/components/RuleBuilder`.
- Migrates the in-scope playground imports and the lingering `cn` re-export to exact direct paths while preserving unrelated root imports.
- Adds ESLint restricted root specifiers for the migrated utility/schema/rule symbols and `RuleBuilder`, including named re-exports.

## Changeset
Needed: this adds public direct subpaths for existing `@mastra/playground-ui` APIs.

## Validation
- `pnpm prettier:changed`
- `pnpm build:playground-ui`
- `pnpm --filter ./packages/playground-ui typecheck`
- `pnpm --filter ./packages/playground-ui lint`
- `pnpm --filter ./packages/playground typecheck`
- `pnpm --filter ./packages/playground lint`
- `pnpm lint`
- TypeScript-parser audit: zero scoped named imports/re-exports from `@mastra/playground-ui`
- `git diff --check`
