### PR TITLE
fix(mastracode): recognize OAuth logins for model auth and provider status

### DIFF
--- a/.changeset/fancy-nights-fall.md
+++ b/.changeset/fancy-nights-fall.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added an optional `handlesModel` hook to the model gateway interface so a gateway can claim bare provider model IDs (like `__GATEWAY_ANTHROPIC_MODEL_OPUS__`) it is able to authenticate, before routing falls back to the default models.dev catalog. This lets gateways that hold credentials (for example OAuth-backed logins) be selected for auth resolution and availability checks instead of being bypassed.

--- a/.changeset/loose-turtles-judge.md
+++ b/.changeset/loose-turtles-judge.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed OAuth logins (such as Anthropic and OpenAI sign-in) not being recognized for the selected model. The model status bar no longer shows a false "missing API key" error, and the `/api-keys` command and web settings panel now display a distinct "oauth" status for providers you are signed into instead of treating them as unset.

--- a/mastracode/src/agents/mastracode-gateway.test.ts
+++ b/mastracode/src/agents/mastracode-gateway.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Scenario tests for MastraCodeGateway auth resolution and model claiming.
+ *
+ * The gateway uses a module-level AuthStorage that reads auth.json from the app
+ * data dir. We point MASTRA_APP_DATA_DIR at a temp dir, write credentials, and
+ * call reloadAuthStorage() so the module instance picks them up.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The gateway constructs a module-level AuthStorage at import time, binding its
+// auth.json path from MASTRA_APP_DATA_DIR. Set the env var (in a hoisted block
+// that runs before the import below) so that instance reads from a temp dir we
+// control, isolating the test from the developer's real credentials.
+const { appDataDir } = vi.hoisted(() => {
+  const dir = `${process.env.TMPDIR ?? '/tmp'}/mastracode-gateway-appdata-${process.pid}-${Date.now()}`;
+  process.env.MASTRA_APP_DATA_DIR = dir;
+  return { appDataDir: dir };
+});
+
+import { MastraCodeGateway, reloadAuthStorage } from './mastracode-gateway.js';
+
+mkdirSync(appDataDir, { recursive: true });
+
+function writeAuthJson(data: Record<string, unknown>): void {
+  writeFileSync(join(appDataDir, 'auth.json'), JSON.stringify(data), 'utf8');
+  reloadAuthStorage();
+}
+
+function createGateway(): MastraCodeGateway {
+  return new MastraCodeGateway({
+    mastraGatewayBaseUrl: 'https://gateway.example.com',
+    routeThroughMastraGateway: false,
+    customProviders: [],
+    settingsPath: join(tmpdir(), 'nonexistent-settings.json'),
+  });
+}
+
+describe('MastraCodeGateway', () => {
+  const prevAnthropicKey = process.env.ANTHROPIC_API_KEY;
+  const prevOpenAIKey = process.env.OPENAI_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    writeAuthJson({});
+  });
+
+  afterEach(() => {
+    if (prevAnthropicKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = prevAnthropicKey;
+    if (prevOpenAIKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = prevOpenAIKey;
+  });
+
+  afterAll(() => {
+    rmSync(appDataDir, { recursive: true, force: true });
+  });
+
+  describe('handlesModel', () => {
+    it('claims a bare anthropic model id when logged in via OAuth', () => {
+      writeAuthJson({
+        anthropic: { type: 'oauth', access: 'a', refresh: 'r', expires: Date.now() + 1_000_000 },
+      });
+
+      expect(createGateway().handlesModel('anthropic/claude-opus-4-8')).toBe(true);
+    });
+
+    it('claims a prefixed mastracode/anthropic id via OAuth', () => {
+      writeAuthJson({
+        anthropic: { type: 'oauth', access: 'a', refresh: 'r', expires: Date.now() + 1_000_000 },
+      });
+
+      expect(createGateway().handlesModel('mastracode/anthropic/claude-opus-4-8')).toBe(true);
+    });
+
+    it('claims a bare openai model id when the openai-codex OAuth slot is set', () => {
+      writeAuthJson({
+        'openai-codex': { type: 'oauth', access: 'a', refresh: 'r', expires: Date.now() + 1_000_000 },
+      });
+
+      expect(createGateway().handlesModel('openai/gpt-5.5')).toBe(true);
+    });
+
+    it('claims a model when a stored api key exists', () => {
+      writeAuthJson({
+        'apikey:anthropic': { type: 'api_key', key: 'sk-test' },
+      });
+
+      expect(createGateway().handlesModel('anthropic/claude-opus-4-8')).toBe(true);
+    });
+
+    it('does not claim a model with no credentials', () => {
+      writeAuthJson({});
+
+      expect(createGateway().handlesModel('anthropic/claude-opus-4-8')).toBe(false);
+    });
+
+    it('does not claim an id without a provider and model', () => {
+      writeAuthJson({
+        anthropic: { type: 'oauth', access: 'a', refresh: 'r', expires: Date.now() + 1_000_000 },
+      });
+
+      expect(createGateway().handlesModel('anthropic')).toBe(false);
+    });
+  });
+
+  describe('resolveProviderAuth', () => {
+    it('returns an oauth bearer token for an OAuth-logged-in provider', () => {
+      writeAuthJson({
+        anthropic: { type: 'oauth', access: 'a', refresh: 'r', expires: Date.now() + 1_000_000 },
+      });
+
+      const auth = MastraCodeGateway.resolveProviderAuth({
+        gatewayId: 'mastracode',
+        providerId: 'anthropic',
+        modelId: 'claude-opus-4-8',
+        routerId: 'anthropic/claude-opus-4-8',
+      });
+      expect(auth?.bearerToken).toBe('oauth');
+    });
+
+    it('returns undefined when the provider has no credentials', () => {
+      writeAuthJson({});
+
+      const auth = MastraCodeGateway.resolveProviderAuth({
+        gatewayId: 'mastracode',
+        providerId: 'anthropic',
+        modelId: 'claude-opus-4-8',
+        routerId: 'anthropic/claude-opus-4-8',
+      });
+      expect(auth).toBeUndefined();
+    });
+  });
+});

--- a/mastracode/src/agents/mastracode-gateway.ts
+++ b/mastracode/src/agents/mastracode-gateway.ts
@@ -269,6 +269,30 @@ export class MastraCodeGateway extends MastraModelGateway {
     return authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
   }
 
+  /**
+   * Claim an unprefixed model id (e.g. a bare `anthropic/...`) when this gateway
+   * can authenticate it via OAuth or a stored/env credential. This lets the
+   * shared gateway router select MastraCode for auth resolution, so the status
+   * bar and `/api-keys` reflect OAuth logins instead of only checking env vars.
+   */
+  handlesModel(modelId: string): boolean {
+    const parsed = parseGatewayRouterId(modelId, this);
+    if (!parsed.providerId || !parsed.modelId) return false;
+    if (this.#routeThroughMastraGateway && this.#mastraGatewayApiKey) return true;
+    const customProvider = this.#getCustomProviders().find(
+      provider => parsed.providerId === getCustomProviderId(provider.name),
+    );
+    if (customProvider?.apiKey) return true;
+    return hasResolvedAuth(
+      MastraCodeGateway.resolveProviderAuth({
+        gatewayId: this.id,
+        providerId: parsed.providerId,
+        modelId: parsed.modelId,
+        routerId: modelId,
+      }),
+    );
+  }
+
   static resolveProviderAuth(request: GatewayAuthRequest, memoryGatewayApiKey?: string): GatewayAuthResult | undefined {
     if (request.gatewayId === 'mastra' && memoryGatewayApiKey) {
       return { apiKey: memoryGatewayApiKey, source: 'gateway' };

--- a/mastracode/src/tui/commands/api-keys.test.ts
+++ b/mastracode/src/tui/commands/api-keys.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getProviderList } from './api-keys.js';
+import type { SlashCommandContext } from './types.js';
+
+type AuthStorageLike = NonNullable<SlashCommandContext['authStorage']>;
+
+function makeCtx(opts: { loggedIn?: string[]; storedKeys?: string[] }): SlashCommandContext {
+  const loggedIn = new Set(opts.loggedIn ?? []);
+  const storedKeys = new Set(opts.storedKeys ?? []);
+  const authStorage = {
+    isLoggedIn: (provider: string) => loggedIn.has(provider),
+    hasStoredApiKey: (provider: string) => storedKeys.has(provider),
+  } as unknown as AuthStorageLike;
+
+  return { authStorage } as unknown as SlashCommandContext;
+}
+
+describe('getProviderList', () => {
+  const prevAnthropicKey = process.env.ANTHROPIC_API_KEY;
+
+  afterEach(() => {
+    if (prevAnthropicKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = prevAnthropicKey;
+  });
+
+  it('labels an OAuth-logged-in provider as oauth (not stored)', () => {
+    const ctx = makeCtx({ loggedIn: ['anthropic'], storedKeys: ['anthropic'] });
+
+    const list = getProviderList(ctx, [{ provider: 'anthropic', hasApiKey: true, apiKeyEnvVar: 'ANTHROPIC_API_KEY' }]);
+
+    expect(list).toHaveLength(1);
+    expect(list[0]?.source).toBe('oauth');
+  });
+
+  it('maps the openai catalog provider to the openai-codex OAuth slot', () => {
+    const ctx = makeCtx({ loggedIn: ['openai-codex'] });
+
+    const list = getProviderList(ctx, [{ provider: 'openai', hasApiKey: false, apiKeyEnvVar: 'OPENAI_API_KEY' }]);
+
+    expect(list[0]?.source).toBe('oauth');
+  });
+
+  it('falls back to stored when not OAuth but a stored key exists', () => {
+    const ctx = makeCtx({ storedKeys: ['anthropic'] });
+
+    const list = getProviderList(ctx, [{ provider: 'anthropic', hasApiKey: false, apiKeyEnvVar: 'ANTHROPIC_API_KEY' }]);
+
+    expect(list[0]?.source).toBe('stored');
+  });
+
+  it('reports env when only the env var is set', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'sk-env';
+    const ctx = makeCtx({});
+
+    const list = getProviderList(ctx, [{ provider: 'anthropic', hasApiKey: false, apiKeyEnvVar: 'ANTHROPIC_API_KEY' }]);
+
+    expect(list[0]?.source).toBe('env');
+  });
+
+  it('reports none when no credentials are present', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const ctx = makeCtx({});
+
+    const list = getProviderList(ctx, [{ provider: 'anthropic', hasApiKey: false, apiKeyEnvVar: 'ANTHROPIC_API_KEY' }]);
+
+    expect(list[0]?.source).toBe('none');
+  });
+
+  it('dedupes repeated providers across models', () => {
+    const ctx = makeCtx({ loggedIn: ['anthropic'] });
+
+    const list = getProviderList(ctx, [
+      { provider: 'anthropic', hasApiKey: true, apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
+      { provider: 'anthropic', hasApiKey: true, apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
+    ]);
+
+    expect(list).toHaveLength(1);
+  });
+});

--- a/mastracode/src/tui/commands/api-keys.ts
+++ b/mastracode/src/tui/commands/api-keys.ts
@@ -14,14 +14,22 @@ import type { SlashCommandContext } from './types.js';
 interface ProviderInfo {
   provider: string;
   envVar?: string;
-  source: 'env' | 'stored' | 'none';
+  source: 'oauth' | 'env' | 'stored' | 'none';
+}
+
+/**
+ * OAuth credentials are stored under the auth provider id, which differs from
+ * the catalog provider id for OpenAI (stored as `openai-codex`).
+ */
+function getAuthProviderId(provider: string): string {
+  return provider === 'openai' ? 'openai-codex' : provider;
 }
 
 /**
  * Build a deduplicated list of providers from available models,
  * annotated with their current key source.
  */
-function getProviderList(
+export function getProviderList(
   ctx: SlashCommandContext,
   models: { provider: string; hasApiKey: boolean; apiKeyEnvVar?: string }[],
 ): ProviderInfo[] {
@@ -31,7 +39,9 @@ function getProviderList(
     if (seen.has(model.provider)) continue;
 
     let source: ProviderInfo['source'] = 'none';
-    if (ctx.authStorage?.hasStoredApiKey(model.provider)) {
+    if (ctx.authStorage?.isLoggedIn(getAuthProviderId(model.provider))) {
+      source = 'oauth';
+    } else if (ctx.authStorage?.hasStoredApiKey(model.provider)) {
       source = 'stored';
     } else if (model.apiKeyEnvVar && process.env[model.apiKeyEnvVar]) {
       source = 'env';
@@ -51,6 +61,8 @@ function getProviderList(
 
 function statusLabel(info: ProviderInfo): string {
   switch (info.source) {
+    case 'oauth':
+      return theme.fg('success', '✓') + theme.fg('dim', ' (oauth)');
     case 'env':
       return theme.fg('success', '✓') + theme.fg('dim', ' (env)');
     case 'stored':
@@ -89,7 +101,9 @@ export async function handleApiKeysCommand(ctx: SlashCommandContext): Promise<vo
     const updateDetail = (providerName: string) => {
       const info = providers.find(p => p.provider === providerName);
       if (!info) return;
-      if (info.source === 'env') {
+      if (info.source === 'oauth') {
+        detailText.setText(theme.fg('dim', '  Authenticated via OAuth. Press Enter to add an API key override.'));
+      } else if (info.source === 'env') {
         detailText.setText(
           theme.fg('dim', '  Key set via environment variable. Press Enter to store a local override.'),
         );

--- a/mastracode/src/web/config-routes.test.ts
+++ b/mastracode/src/web/config-routes.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AuthStorage } from '../auth/storage.js';
+import { listProviders } from './config-routes.js';
+
+function makeAuthStorage(opts: { loggedIn?: string[]; storedKeys?: string[] }): AuthStorage {
+  const loggedIn = new Set(opts.loggedIn ?? []);
+  const storedKeys = new Set(opts.storedKeys ?? []);
+  return {
+    isLoggedIn: (provider: string) => loggedIn.has(provider),
+    hasStoredApiKey: (provider: string) => storedKeys.has(provider),
+  } as unknown as AuthStorage;
+}
+
+function makeHarness(models: { provider: string; hasApiKey: boolean; apiKeyEnvVar?: string }[]) {
+  return { listAvailableModels: async () => models };
+}
+
+describe('listProviders', () => {
+  const prevAnthropicKey = process.env.ANTHROPIC_API_KEY;
+
+  afterEach(() => {
+    if (prevAnthropicKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = prevAnthropicKey;
+  });
+
+  it('labels an OAuth-logged-in provider as oauth (not stored)', async () => {
+    const auth = makeAuthStorage({ loggedIn: ['anthropic'], storedKeys: ['anthropic'] });
+
+    const list = await listProviders(
+      makeHarness([{ provider: 'anthropic', hasApiKey: true, apiKeyEnvVar: 'ANTHROPIC_API_KEY' }]),
+      auth,
+    );
+
+    expect(list).toHaveLength(1);
+    expect(list[0]?.source).toBe('oauth');
+  });
+
+  it('maps the openai catalog provider to the openai-codex OAuth slot', async () => {
+    const auth = makeAuthStorage({ loggedIn: ['openai-codex'] });
+
+    const list = await listProviders(
+      makeHarness([{ provider: 'openai', hasApiKey: false, apiKeyEnvVar: 'OPENAI_API_KEY' }]),
+      auth,
+    );
+
+    expect(list[0]?.source).toBe('oauth');
+  });
+
+  it('falls back to stored when not OAuth but a stored key exists', async () => {
+    const auth = makeAuthStorage({ storedKeys: ['anthropic'] });
+
+    const list = await listProviders(
+      makeHarness([{ provider: 'anthropic', hasApiKey: false, apiKeyEnvVar: 'ANTHROPIC_API_KEY' }]),
+      auth,
+    );
+
+    expect(list[0]?.source).toBe('stored');
+  });
+
+  it('reports env when only the env var is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-env';
+    const auth = makeAuthStorage({});
+
+    const list = await listProviders(
+      makeHarness([{ provider: 'anthropic', hasApiKey: false, apiKeyEnvVar: 'ANTHROPIC_API_KEY' }]),
+      auth,
+    );
+
+    expect(list[0]?.source).toBe('env');
+  });
+
+  it('reports none when no credentials are present', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const auth = makeAuthStorage({});
+
+    const list = await listProviders(
+      makeHarness([{ provider: 'anthropic', hasApiKey: false, apiKeyEnvVar: 'ANTHROPIC_API_KEY' }]),
+      auth,
+    );
+
+    expect(list[0]?.source).toBe('none');
+  });
+});

--- a/mastracode/src/web/config-routes.ts
+++ b/mastracode/src/web/config-routes.ts
@@ -31,7 +31,15 @@ export interface ProviderInfo {
   /** Env var the provider's key is read from, if any. */
   envVar?: string;
   /** Where the active credential comes from. */
-  source: 'stored' | 'env' | 'none';
+  source: 'oauth' | 'stored' | 'env' | 'none';
+}
+
+/**
+ * OAuth credentials are stored under the auth provider id, which differs from
+ * the catalog provider id for OpenAI (stored as `openai-codex`).
+ */
+function getAuthProviderId(provider: string): string {
+  return provider === 'openai' ? 'openai-codex' : provider;
 }
 
 /** Minimal session surface a pack activation touches. */
@@ -95,7 +103,9 @@ export async function listProviders(harness: ModelCatalog, authStorage?: AuthSto
     if (seen.has(model.provider)) continue;
 
     let source: ProviderInfo['source'] = 'none';
-    if (authStorage?.hasStoredApiKey(model.provider)) {
+    if (authStorage?.isLoggedIn(getAuthProviderId(model.provider))) {
+      source = 'oauth';
+    } else if (authStorage?.hasStoredApiKey(model.provider)) {
       source = 'stored';
     } else if (model.apiKeyEnvVar && process.env[model.apiKeyEnvVar]) {
       source = 'env';

--- a/mastracode/src/web/ui/ProvidersSection.tsx
+++ b/mastracode/src/web/ui/ProvidersSection.tsx
@@ -5,10 +5,11 @@ import { CheckIcon, SearchIcon } from './icons';
 interface ProviderInfo {
   provider: string;
   envVar?: string;
-  source: 'stored' | 'env' | 'none';
+  source: 'oauth' | 'stored' | 'env' | 'none';
 }
 
 const SOURCE_LABEL: Record<ProviderInfo['source'], string> = {
+  oauth: 'Signed in',
   stored: 'Key saved',
   env: 'From env',
   none: 'Not set',

--- a/mastracode/src/web/ui/styles.css
+++ b/mastracode/src/web/ui/styles.css
@@ -2760,6 +2760,7 @@ body::before {
 .provider-tick {
   flex-shrink: 0;
 }
+.provider-tick.oauth,
 .provider-tick.stored {
   color: var(--green);
 }
@@ -2783,6 +2784,7 @@ body::before {
   border-radius: 999px;
   flex-shrink: 0;
 }
+.provider-pill.oauth,
 .provider-pill.stored {
   background: color-mix(in oklch, var(--green) 18%, transparent);
   color: var(--green);

--- a/packages/core/src/llm/model/gateways/base.ts
+++ b/packages/core/src/llm/model/gateways/base.ts
@@ -83,6 +83,15 @@ export interface MastraModelGatewayInterface {
   shouldEnable?(): boolean;
 
   /**
+   * Whether this gateway claims the given model/router id even when the id is
+   * not prefixed with the gateway's own id (e.g. a bare `anthropic/...` id that
+   * this gateway can authenticate via OAuth/stored credentials).
+   * Checked after exact prefix matching but before the models.dev registry
+   * fallback. Optional; defaults to `false`.
+   */
+  handlesModel?(modelId: string): boolean;
+
+  /**
    * Fetch provider configurations from the gateway.
    * Should return providers in the standard format.
    */
@@ -135,6 +144,10 @@ export abstract class MastraModelGateway implements MastraModelGatewayInterface 
 
   shouldEnable(): boolean {
     return true;
+  }
+
+  handlesModel(_modelId: string): boolean {
+    return false;
   }
 
   abstract fetchProviders(): Promise<Record<string, ProviderConfig>>;

--- a/packages/core/src/llm/model/gateways/gateway-helpers.ts
+++ b/packages/core/src/llm/model/gateways/gateway-helpers.ts
@@ -33,6 +33,13 @@ export function findGatewayForModel(
     return prefixedGateway;
   }
 
+  // Then check gateways that explicitly claim this (possibly unprefixed) model
+  // id, e.g. a gateway that authenticates a bare `anthropic/...` id via OAuth.
+  const claimingGateway = gateways.find(g => getGatewayId(g) !== 'models.dev' && g.handlesModel?.(gatewayId) === true);
+  if (claimingGateway) {
+    return claimingGateway;
+  }
+
   // Then check models.dev (provider registry without prefix)
   const modelsDevGateway = gateways.find(g => getGatewayId(g) === 'models.dev');
   if (modelsDevGateway) {

--- a/packages/core/src/llm/model/gateways/gateway-manager.test.ts
+++ b/packages/core/src/llm/model/gateways/gateway-manager.test.ts
@@ -23,6 +23,7 @@ function createFakeGateway(options?: {
   resolveAuth?: (request: GatewayAuthRequest) => GatewayAuthResult | undefined;
   enabled?: boolean;
   provider?: string;
+  handlesModel?: (modelId: string) => boolean;
 }): MastraModelGatewayInterface {
   const id = options?.id ?? 'test-gateway';
   const provider = options?.provider ?? 'acme';
@@ -49,6 +50,7 @@ function createFakeGateway(options?: {
       return options?.apiKey ?? '';
     }),
     resolveAuth: options?.resolveAuth,
+    handlesModel: options?.handlesModel,
     resolveLanguageModel: () => ({}) as GatewayLanguageModel,
   };
 }
@@ -105,6 +107,70 @@ describe('GatewayManager', () => {
       expect(parsed.gatewayId).toBe('models.dev');
       expect(parsed.providerId).toBe('openai');
       expect(parsed.modelId).toBe('gpt-4o');
+    });
+  });
+
+  describe('handlesModel routing', () => {
+    it('routes an unprefixed model id to a gateway that claims it', () => {
+      const claiming = createFakeGateway({
+        id: 'mastracode',
+        provider: 'anthropic',
+        handlesModel: id => id.startsWith('anthropic/'),
+      });
+      const manager = new GatewayManager([claiming, ...defaultGateways]);
+
+      const gateway = manager.findGatewayForModel('anthropic/claude-sonnet-4-5');
+      expect(gateway.id).toBe('mastracode');
+    });
+
+    it('still prefers an exact prefix match over a claiming gateway', () => {
+      const claiming = createFakeGateway({
+        id: 'mastracode',
+        provider: 'anthropic',
+        handlesModel: () => true,
+      });
+      const prefixed = createFakeGateway({ id: 'netlify', provider: 'anthropic' });
+      const manager = new GatewayManager([claiming, prefixed]);
+
+      expect(manager.findGatewayForModel('netlify/anthropic/claude-sonnet-4-5').id).toBe('netlify');
+    });
+
+    it('falls back to models.dev when no gateway claims the model', () => {
+      const claiming = createFakeGateway({
+        id: 'mastracode',
+        provider: 'anthropic',
+        handlesModel: id => id.startsWith('anthropic/'),
+      });
+      const manager = new GatewayManager([claiming, ...defaultGateways]);
+
+      expect(manager.findGatewayForModel('openai/gpt-4o').id).toBe('models.dev');
+    });
+
+    it('parses a claimed unprefixed id as provider/model (not gateway-prefixed)', () => {
+      const claiming = createFakeGateway({
+        id: 'mastracode',
+        provider: 'anthropic',
+        handlesModel: id => id.startsWith('anthropic/'),
+      });
+      const manager = new GatewayManager([claiming]);
+
+      expect(manager.parseModelId('anthropic/claude-sonnet-4-5')).toEqual({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4-5',
+        gatewayId: 'mastracode',
+      });
+    });
+
+    it('resolves auth for a claimed unprefixed id via the claiming gateway', async () => {
+      const claiming = createFakeGateway({
+        id: 'mastracode',
+        provider: 'anthropic',
+        handlesModel: id => id.startsWith('anthropic/'),
+        resolveAuth: () => ({ bearerToken: 'oauth' }),
+      });
+      const manager = new GatewayManager([claiming, ...defaultGateways]);
+
+      expect(await manager.hasAuth('anthropic/claude-sonnet-4-5')).toBe(true);
     });
   });
 

--- a/packages/core/src/llm/model/gateways/gateway-manager.ts
+++ b/packages/core/src/llm/model/gateways/gateway-manager.ts
@@ -43,6 +43,20 @@ export class GatewayManager {
     return gatewayId === 'models.dev' ? undefined : gatewayId;
   }
 
+  /**
+   * Returns the prefix to use when parsing `routerId` for the given gateway.
+   * A gateway may claim an unprefixed id (e.g. `handlesModel` matching a bare
+   * `anthropic/...` id); in that case the gateway's prefix does not appear in
+   * the id, so parse it as an unprefixed `provider/model` id.
+   */
+  private static getPrefixForId(gatewayId: string, routerId: string): string | undefined {
+    const prefix = GatewayManager.getPrefix(gatewayId);
+    if (prefix && !routerId.startsWith(`${prefix}/`)) {
+      return undefined;
+    }
+    return prefix;
+  }
+
   /** Find the gateway that handles a given model/router id. */
   findGatewayForModel(routerId: string): MastraModelGatewayInterface {
     return findGatewayForModel(routerId, this.gateways);
@@ -52,7 +66,7 @@ export class GatewayManager {
   parseModelId(routerId: string): { providerId: string; modelId: string; gatewayId: string } {
     const gateway = this.findGatewayForModel(routerId);
     const gatewayId = getGatewayId(gateway);
-    const { providerId, modelId } = parseModelRouterId(routerId, GatewayManager.getPrefix(gatewayId));
+    const { providerId, modelId } = parseModelRouterId(routerId, GatewayManager.getPrefixForId(gatewayId, routerId));
     return { providerId, modelId, gatewayId };
   }
 
@@ -68,7 +82,7 @@ export class GatewayManager {
   async resolveAuth(routerId: string): Promise<GatewayAuthResult> {
     const gateway = this.findGatewayForModel(routerId);
     const gatewayId = getGatewayId(gateway);
-    const { providerId, modelId } = parseModelRouterId(routerId, GatewayManager.getPrefix(gatewayId));
+    const { providerId, modelId } = parseModelRouterId(routerId, GatewayManager.getPrefixForId(gatewayId, routerId));
     const request: GatewayAuthRequest = { gatewayId, providerId, modelId, routerId };
 
     const rawGatewayAuth = await gateway.resolveAuth?.(request);


### PR DESCRIPTION
## Summary

When a model is selected via an OAuth login (for example, signing into Anthropic or OpenAI), MastraCode failed to recognize the credential and reported the provider as having no API key. The model status bar showed a false "missing API key" error, and both the `/api-keys` command and the web settings panel listed signed-in providers as unset.

The root cause: a bare provider model ID like `anthropic/claude-opus-4-x` was routed to the default models.dev catalog, which only checks the provider's API key environment variable. The OAuth credential lived in `MastraCodeGateway`, which was never consulted for that bare ID.

## What changed

- **`@mastra/core`**: Added an optional `handlesModel(modelId)` hook to the gateway interface. `findGatewayForModel` now consults it between explicit gateway-prefix matching and the models.dev fallback, so a gateway can claim bare provider model IDs it is able to authenticate.
- **mastracode**: Implemented `handlesModel` on `MastraCodeGateway` to claim bare `anthropic/*` and `openai/*` IDs when it holds usable credentials (OAuth or stored/env key). Surfaced OAuth as a distinct status:
  - The model status bar no longer shows a false missing-key error for OAuth-backed models.
  - `/api-keys` now shows a distinct `oauth` status for providers you are signed into.
  - The web settings panel shows a "Signed in" status with matching styling.

## Test plan

- `pnpm check` (tsc) passes in mastracode — no type errors
- ESLint clean on all changed files
- New unit tests (19 total, all passing):
  - `mastracode/src/agents/mastracode-gateway.test.ts` — `handlesModel` routing + `/api-keys` OAuth label (8)
  - `mastracode/src/tui/commands/api-keys.test.ts` — provider list / status labels (6)
  - `mastracode/src/web/config-routes.test.ts` — web settings OAuth source classification (5)
- Core regression: `gateway-manager.test.ts` + `list-available-models.test.ts` — 28 passing, no type errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change helps the app notice when you’re already signed in with providers like Anthropic or OpenAI, so it won’t keep asking for an API key when you don’t need one. It also updates the provider list and settings UI to show “Signed in” instead of “missing” for OAuth logins.

## Summary
- Added gateway support for claiming bare model IDs before falling back to the default catalog lookup.
- Taught MastraCode to recognize OAuth-backed provider logins when resolving model auth and provider status.
- Updated `/api-keys` and the web settings panel to show `oauth` / “Signed in” for logged-in providers.
- Adjusted UI styling so OAuth providers match the configured-provider appearance.
- Added tests covering gateway routing, auth resolution, and provider classification for OAuth, stored keys, env vars, and missing credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->