### PR TITLE
Add browser-safe collect-tool-mocks subpath to @mastra/core

### DIFF
--- a/.changeset/shiny-rules-share.md
+++ b/.changeset/shiny-rules-share.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Added a browser-safe `@mastra/core/utils/collect-tool-mocks` export for `collectToolMocks`. The previous `@mastra/core/evals` barrel pulls in Node-only modules (`node:crypto`), which broke bundling in browser apps such as the Studio playground. Import the helper from the new subpath in browser code:
+
+```ts
+import { collectToolMocks } from '@mastra/core/utils/collect-tool-mocks';
+```
+
+The `@mastra/core/evals` export still works for Node-side callers.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -681,6 +681,16 @@
         "default": "./dist/zod-to-json.cjs"
       }
     },
+    "./utils/collect-tool-mocks": {
+      "import": {
+        "types": "./dist/utils/collect-tool-mocks.d.ts",
+        "default": "./dist/utils/collect-tool-mocks.js"
+      },
+      "require": {
+        "types": "./dist/utils/collect-tool-mocks.d.ts",
+        "default": "./dist/utils/collect-tool-mocks.cjs"
+      }
+    },
     "./loop/server": {
       "import": {
         "types": "./dist/loop/server.d.ts",

--- a/packages/core/src/utils/collect-tool-mocks.ts
+++ b/packages/core/src/utils/collect-tool-mocks.ts
@@ -1,0 +1,8 @@
+// Browser-safe re-export of `collectToolMocks`.
+//
+// The `@mastra/core/evals` barrel re-exports `evals/base.ts`, which imports
+// `node:crypto` and the full Agent/Mastra/scorer runtime. Consumers that run in
+// the browser (e.g. the playground trace dialogs) must not pull that in. This
+// standalone subpath entry exposes only `collectToolMocks`, whose own deps are
+// type-only, so the emitted chunk contains zero Node imports.
+export { collectToolMocks } from '../evals/collect-tool-mocks';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
     'src/a2a/client.ts',
     'src/processors/index.ts',
     'src/zod-to-json.ts',
+    'src/utils/collect-tool-mocks.ts',
     'src/evals/scoreTraces/index.ts',
     'src/agent/message-list/index.ts',
     'src/agent/durable/index.ts',

--- a/packages/playground/src/domains/observability/components/add-trace-mocks-to-item-dialog.tsx
+++ b/packages/playground/src/domains/observability/components/add-trace-mocks-to-item-dialog.tsx
@@ -1,5 +1,5 @@
 import type { DatasetItemToolMock } from '@mastra/client-js';
-import { collectToolMocks } from '@mastra/core/evals';
+import { collectToolMocks } from '@mastra/core/utils/collect-tool-mocks';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { Label } from '@mastra/playground-ui/components/Label';

--- a/packages/playground/src/domains/observability/components/trace-as-item-dialog.tsx
+++ b/packages/playground/src/domains/observability/components/trace-as-item-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { collectToolMocks } from '@mastra/core/evals';
 import type { SpanRecord } from '@mastra/core/storage';
+import { collectToolMocks } from '@mastra/core/utils/collect-tool-mocks';
 import { useSpanDetail } from '@mastra/playground-ui';
 import type { SideDialogRootProps } from '@mastra/playground-ui/components/SideDialog';
 import { TextAndIcon, getShortId } from '@mastra/playground-ui/components/Text';


### PR DESCRIPTION
## Summary

The Studio playground dev server stopped starting after the `collectToolMocks` helper was moved into `@mastra/core/evals`. The two playground trace dialogs import `collectToolMocks` from the `@mastra/core/evals` barrel, and that barrel re-exports `evals/base.ts`, which imports `node:crypto` (via `randomUUID`) along with the full Agent/Mastra/scorer runtime. As a result, `node:crypto` leaked into the browser bundle and broke Vite.

This change exposes `collectToolMocks` through a standalone, browser-safe subpath — `@mastra/core/utils/collect-tool-mocks` — mirroring the existing `@mastra/core/utils/zod-to-json` convention. `collectToolMocks` only has type-only dependencies, so the emitted chunk contains zero Node imports. The two playground dialogs now import from the new subpath. The `@mastra/core/evals` barrel re-export is kept intact for Node-side callers (datasets, evals, scripts).

## Changes
- New browser-safe re-export module `packages/core/src/utils/collect-tool-mocks.ts`
- New tsup entry + `./utils/collect-tool-mocks` export in `@mastra/core`
- Both playground observability dialogs import from the new subpath
- Patch changeset for `@mastra/core`

## Test plan
- `pnpm build:core` emits `dist/utils/collect-tool-mocks.{js,cjs,d.ts}`; emitted chunks contain no `node:crypto`/`require('crypto')`
- `pnpm --filter ./packages/core check` passes; colocated `collect-tool-mocks.test.ts` passes
- `pnpm --filter ./packages/playground` typechecks and production-builds successfully — the previous browser-bundle failure is gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes one helper available through a browser-safe path so the app can use it without accidentally loading Node-only code. It helps the Studio playground work in the browser again by keeping `node:crypto` out of the bundle.

## Summary
- Added a new `@mastra/core/utils/collect-tool-mocks` subpath that re-exports `collectToolMocks` without pulling in the `@mastra/core/evals` barrel.
- Updated `@mastra/core` package exports and tsup entries so the new utility is built and published.
- Switched the playground observability dialogs to import `collectToolMocks` from the new browser-safe path.
- Included a changeset documenting the new import path and the browser bundling issue it avoids.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->