### PR TITLE
fix(mastracode): stabilize queued follow-up e2e tests

### DIFF
--- a/.changeset/eleven-jobs-poke.md
+++ b/.changeset/eleven-jobs-poke.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed MastraCode queued follow-up E2E tests to wait for stable terminal output.

--- a/mastracode/e2e/tui/ctrlf-queued-custom-slash.ts
+++ b/mastracode/e2e/tui/ctrlf-queued-custom-slash.ts
@@ -28,7 +28,7 @@ export const ctrlfQueuedCustomSlashScenario = {
     await runtime.waitForScreenText(/Project: project/i, terminal);
 
     terminal.submit(START_PROMPT);
-    await runtime.waitForScreenText(/Start a slow Ctrl F custom slash queue run\./i, terminal);
+    await runtime.waitForScreenText(/Initial Ctrl F custom slash run is still streaming/i, terminal, 8_000);
 
     terminal.write('/queue-au');
     await runtime.waitForScreenText(/Queue command selected from autocomplete/i, terminal, 8_000);

--- a/mastracode/e2e/tui/ctrlf-queued-image-followup.ts
+++ b/mastracode/e2e/tui/ctrlf-queued-image-followup.ts
@@ -49,7 +49,7 @@ export const ctrlfQueuedImageFollowupScenario = {
     await runtime.waitForScreenText(/Project: mastra/i, terminal);
 
     terminal.submit(START_PROMPT);
-    await runtime.waitForScreenText(/Start a slow Ctrl F queue run\./i, terminal);
+    await runtime.waitForScreenText(/Initial Ctrl F queue run is still streaming/i, terminal, 8_000);
 
     terminal.write(`${QUEUED_PROMPT} `);
     terminal.write(`${PASTE_START}${imagePath}${PASTE_END}`);

--- a/mastracode/e2e/tui/github-signals-polling-inbox.ts
+++ b/mastracode/e2e/tui/github-signals-polling-inbox.ts
@@ -240,9 +240,11 @@ values
     terminal.submit('/threads');
     await runtime.waitForScreenText(/E2E GitHub polling inbox fixture/i, terminal, 8_000);
     terminal.write('polling inbox');
+    await terminal.flushInput?.();
     await runtime.waitForScreenText(/E2E GitHub polling inbox fixture/i, terminal, 8_000);
     terminal.write('\r');
-    await runtime.waitForScreenText(/Switched to: E2E GitHub polling inbox fixture/i, terminal, 8_000);
+    await terminal.flushInput?.();
+    await runtime.waitForScreenText(/Switched to: E2E GitHub polling inbox fixture/i, terminal, 15_000);
 
     await runtime.waitForScreenText(/notification from github/i, terminal, 60_000);
     await runtime.waitForScreenText(/mastra-ai\/mastra#17640 CI recovered/i, terminal, 60_000);


### PR DESCRIPTION
This makes the MastraCode terminal E2E tests less timing-sensitive.

The Ctrl+F queue tests now wait until the initial response is actually streaming before queueing a follow-up. Before, they could press Ctrl+F while the run was still starting, which took the idle submit path instead of the queue path.

The GitHub polling inbox test also flushes terminal input before selecting the fixture thread and gives the switch confirmation a bit more time, which should make that flow less flaky.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR tweaks a few “type and wait” end-to-end tests so they don’t press the next key too early. By waiting for the terminal UI to confirm it’s actually ready (and clearing any leftover input when needed), the tests stop failing randomly from timing quirks.

### What changed
- Updated the Ctrl+F queued follow-up tests to wait for a clear “still streaming / initial streaming” message (with an explicit timeout) before sending the follow-up action, instead of syncing on a slower-start text that could arrive too late.
- Adjusted the GitHub polling inbox test to flush terminal input around the fixture switch and then wait for the “switched to” confirmation with a more patient flow.

### Files touched
- `mastracode/e2e/tui/ctrlf-queued-custom-slash.ts`
- `mastracode/e2e/tui/ctrlf-queued-image-followup.ts`
- `mastracode/e2e/tui/github-signals-polling-inbox.ts`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->