### PR TITLE
feat(mastracode): create web sessions from git

### DIFF
--- a/.changeset/forty-years-appear.md
+++ b/.changeset/forty-years-appear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Pass harness session request context through server routes.

--- a/.changeset/hip-baboons-fold.md
+++ b/.changeset/hip-baboons-fold.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Add web sessions that start from Git repository URLs and clone into a selected folder.

--- a/.changeset/short-rockets-grin.md
+++ b/.changeset/short-rockets-grin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Allow harness sessions to include request context.

--- a/client-sdks/client-js/src/resources/harness.test.ts
+++ b/client-sdks/client-js/src/resources/harness.test.ts
@@ -75,6 +75,36 @@ describe('Harness Resource', () => {
     expect(JSON.parse(init.body as string)).toEqual({ resourceId: 'user-1' });
   });
 
+  it('sends tags and request context when creating a session', async () => {
+    mockJson({ harnessId: 'code', resourceId: 'user-1', threadId: 't-123' });
+    await client
+      .getHarness('code')
+      .session('user-1')
+      .create({
+        tags: { gitUrl: 'https://github.com/mastra-ai/mastra.git' },
+        requestContext: {
+          'mastracode.web.gitClone': {
+            gitUrl: 'https://github.com/mastra-ai/mastra.git',
+            cloneParentPath: '/Users/ward/projects',
+          },
+        },
+      });
+
+    const [url, init] = lastCall();
+    expect(url).toBe('http://localhost:4111/api/harness/code/sessions');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      resourceId: 'user-1',
+      tags: { gitUrl: 'https://github.com/mastra-ai/mastra.git' },
+      requestContext: {
+        'mastracode.web.gitClone': {
+          gitUrl: 'https://github.com/mastra-ai/mastra.git',
+          cloneParentPath: '/Users/ward/projects',
+        },
+      },
+    });
+  });
+
   it('sends a message to the resource-scoped session', async () => {
     mockJson({ ok: true });
     await client.getHarness('code').session('user-1').sendMessage('hello');

--- a/client-sdks/client-js/src/resources/harness.ts
+++ b/client-sdks/client-js/src/resources/harness.ts
@@ -1,3 +1,4 @@
+import type { RequestContext } from '@mastra/core/request-context';
 import type { ClientOptions } from '../types';
 
 import { BaseResource } from './base';
@@ -345,10 +346,13 @@ export class HarnessSession extends BaseResource {
    * using a `{ projectPath }` tag) so each resumes its own thread instead of the
    * most recent thread across the whole resource.
    */
-  create(options?: { tags?: Record<string, string> }): Promise<CreateHarnessSessionResponse> {
-    return this.request(`${this.pathPrefix}/${encodeURIComponent(this.harnessId)}/sessions`, {
+  create(options?: {
+    tags?: Record<string, string>;
+    requestContext?: RequestContext;
+  }): Promise<CreateHarnessSessionResponse> {
+    return this.request(`/harness/${encodeURIComponent(this.harnessId)}/sessions`, {
       method: 'POST',
-      body: { resourceId: this.resourceId, tags: options?.tags },
+      body: { resourceId: this.resourceId, tags: options?.tags, requestContext: options?.requestContext },
     });
   }
 

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -90301,6 +90301,11 @@ export type PostAgentControllerHarnessIdSessions_Body = {
         [key: string]: string;
       }
     | undefined;
+  requestContext?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
 };
 
 export type PostAgentControllerHarnessIdSessions_Response = {
@@ -91597,6 +91602,11 @@ export type PostHarnessHarnessIdSessions_Body = {
   tags?:
     | {
         [key: string]: string;
+      }
+    | undefined;
+  requestContext?:
+    | {
+        [key: string]: unknown;
       }
     | undefined;
 };

--- a/mastracode/src/agents/__tests__/workspace-env.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-env.test.ts
@@ -56,7 +56,7 @@ describe('mastracode workspace sandbox environment', () => {
     try {
       process.env.MASTRACODE_TEST_ENV = 'works';
       const { getDynamicWorkspace } = await import('../workspace.js');
-      const workspace = getDynamicWorkspace({ requestContext: createRequestContext(tempDir) as any });
+      const workspace = await getDynamicWorkspace({ requestContext: createRequestContext(tempDir) as any });
 
       const result = await workspace.sandbox!.executeCommand!('node -e "console.log(process.env.MASTRACODE_TEST_ENV)"');
 
@@ -80,7 +80,7 @@ describe('mastracode workspace sandbox environment', () => {
       };
       let callCount = 0;
       await fs.writeFile(path.join(tempDir, 'hooked.txt'), 'original');
-      const workspace = getDynamicWorkspace({ requestContext });
+      const workspace = await getDynamicWorkspace({ requestContext });
       const agent = new Agent({
         id: 'mc-workspace-hook-agent',
         name: 'MC Workspace Hook Agent',

--- a/mastracode/src/agents/__tests__/workspace-git-clone.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-git-clone.test.ts
@@ -1,0 +1,77 @@
+import { RequestContext } from '@mastra/core/request-context';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const ensureWebGitCloneMock = vi.fn(async () => '/tmp/mastracode-web-clones/test-checkout');
+const detectProjectMock = vi.fn(() => ({
+  resourceId: 'mastra-123',
+  name: 'mastra',
+  rootPath: '/tmp/mastracode-web-clones/test-checkout',
+  gitUrl: 'https://github.com/mastra-ai/mastra.git',
+  gitBranch: 'main',
+  isWorktree: false,
+}));
+
+vi.mock('../../onboarding/settings.js', () => ({
+  loadSettings: () => ({}),
+}));
+
+vi.mock('../../web/git-clone.js', () => ({
+  ensureWebGitClone: ensureWebGitCloneMock,
+}));
+
+vi.mock('../../utils/project.js', () => ({
+  detectProject: detectProjectMock,
+  getAppDataDir: () => '/tmp/mastracode-test-app-data',
+}));
+
+function createGitRequestContext() {
+  const requestContext = new RequestContext();
+  const state: Record<string, unknown> = { sandboxAllowedPaths: [] };
+  const setState = vi.fn(async (updates: Record<string, unknown>) => {
+    Object.assign(state, updates);
+  });
+
+  requestContext.set('mastracode.web.gitClone', {
+    gitUrl: 'https://github.com/mastra-ai/mastra.git',
+    cloneParentPath: '/Users/ward/projects',
+  });
+  requestContext.set('harness', {
+    modeId: 'build',
+    getState: () => state,
+    setState,
+    session: {
+      state: {
+        get: () => state,
+        set: setState,
+      },
+    },
+  });
+
+  return { requestContext, setState };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getDynamicWorkspace git clone context', () => {
+  it('clones a git URL and builds the workspace from the checkout', async () => {
+    const { getDynamicWorkspace } = await import('../workspace.js');
+    const { requestContext, setState } = createGitRequestContext();
+
+    const workspace = await getDynamicWorkspace({ requestContext });
+
+    expect(ensureWebGitCloneMock).toHaveBeenCalledWith(
+      'https://github.com/mastra-ai/mastra.git',
+      '/Users/ward/projects',
+    );
+    expect(detectProjectMock).toHaveBeenCalledWith('/tmp/mastracode-web-clones/test-checkout');
+    expect(setState).toHaveBeenCalledWith({
+      projectPath: '/tmp/mastracode-web-clones/test-checkout',
+      projectName: 'mastra',
+      gitBranch: 'main',
+    });
+    expect(workspace.id).toBe('mastra-code-workspace-/tmp/mastracode-web-clones/test-checkout');
+    expect(workspace.filesystem!.basePath).toBe('/tmp/mastracode-web-clones/test-checkout');
+  });
+});

--- a/mastracode/src/agents/__tests__/workspace-skill-activation.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-skill-activation.test.ts
@@ -63,7 +63,7 @@ describe('mastracode workspace skill activation', () => {
         },
       });
 
-      const workspace = getDynamicWorkspace({ requestContext });
+      const workspace = await getDynamicWorkspace({ requestContext });
 
       const agent = new Agent({
         id: 'mc-symlink-skill-agent',

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -12,6 +12,10 @@ import { DEFAULT_CONFIG_DIR } from '../constants.js';
 import { loadSettings } from '../onboarding/settings.js';
 import type { MastraCodeState } from '../schema';
 import { getPlansDir } from '../utils/plans.js';
+import { detectProject } from '../utils/project.js';
+import { MASTRACODE_WEB_GIT_CLONE_CONTEXT_KEY } from '../web/git-clone-context.js';
+import type { MastraCodeWebGitCloneContext } from '../web/git-clone-context.js';
+import { ensureWebGitClone } from '../web/git-clone.js';
 import { GOAL_JUDGE_READONLY_TOOLS, MASTRACODE_WORKSPACE_TOOLS } from './tool-availability.js';
 
 // =============================================================================
@@ -128,10 +132,42 @@ function detectPackageRunner(projectPath: string): string | undefined {
   return 'npx --yes';
 }
 
-export function getDynamicWorkspace({ requestContext, mastra }: { requestContext: RequestContext; mastra?: Mastra }) {
+function getGitCloneContext(requestContext: RequestContext): MastraCodeWebGitCloneContext | undefined {
+  const value = requestContext.get(MASTRACODE_WEB_GIT_CLONE_CONTEXT_KEY);
+  if (!value || typeof value !== 'object') return undefined;
+
+  const gitUrl = (value as { gitUrl?: unknown }).gitUrl;
+  const cloneParentPath = (value as { cloneParentPath?: unknown }).cloneParentPath;
+  if (typeof gitUrl !== 'string') return undefined;
+  return typeof cloneParentPath === 'string' ? { gitUrl, cloneParentPath } : { gitUrl };
+}
+
+export async function getDynamicWorkspace({
+  requestContext,
+  mastra,
+}: {
+  requestContext: RequestContext;
+  mastra?: Mastra;
+}) {
   const ctx = requestContext.get('harness') as HarnessRequestContext<MastraCodeState> | undefined;
   const state = ctx?.getState();
-  const rawProjectPath = state?.projectPath;
+  const gitClone = getGitCloneContext(requestContext);
+  let rawProjectPath = state?.projectPath;
+
+  if (gitClone) {
+    rawProjectPath = await ensureWebGitClone(gitClone.gitUrl, gitClone.cloneParentPath);
+    try {
+      const project = detectProject(rawProjectPath);
+      await ctx?.setState({
+        projectPath: project.rootPath,
+        projectName: project.name,
+        gitBranch: project.gitBranch,
+      });
+      rawProjectPath = project.rootPath;
+    } catch {
+      await ctx?.setState({ projectPath: rawProjectPath, projectName: path.basename(rawProjectPath) });
+    }
+  }
 
   if (!rawProjectPath) {
     throw new Error('Project path is required');
@@ -206,7 +242,7 @@ export async function getGoalJudgeTools({
 }): Promise<ToolsInput | undefined> {
   let workspace: Workspace<LocalFilesystem, LocalSandbox>;
   try {
-    workspace = getDynamicWorkspace({ requestContext, mastra });
+    workspace = await getDynamicWorkspace({ requestContext, mastra });
   } catch {
     return undefined;
   }

--- a/mastracode/src/web/__tests__/git-clone.test.ts
+++ b/mastracode/src/web/__tests__/git-clone.test.ts
@@ -1,0 +1,76 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.fn(
+  (
+    _file: string,
+    _args: string[],
+    _options: unknown,
+    callback: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    callback(null, '', '');
+  },
+);
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+describe('web git clone helpers', () => {
+  const cleanupDirs = new Set<string>();
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await Promise.all([...cleanupDirs].map(dir => fs.rm(dir, { recursive: true, force: true })));
+    cleanupDirs.clear();
+  });
+
+  it('normalizes and validates supported git URL forms', async () => {
+    const { normalizeWebGitUrl } = await import('../git-clone-context.js');
+
+    expect(normalizeWebGitUrl(' https://github.com/mastra-ai/mastra.git ')).toBe(
+      'https://github.com/mastra-ai/mastra.git',
+    );
+    expect(normalizeWebGitUrl('ssh://git@github.com/mastra-ai/mastra.git')).toBe(
+      'ssh://git@github.com/mastra-ai/mastra.git',
+    );
+    expect(normalizeWebGitUrl('git@github.com:mastra-ai/mastra.git')).toBe('git@github.com:mastra-ai/mastra.git');
+    expect(() => normalizeWebGitUrl('/Users/ward/project')).toThrow(/https:\/\//);
+    expect(() => normalizeWebGitUrl('file:///tmp/project')).toThrow(/Git URL/);
+  });
+
+  it('computes a deterministic clone path and reuses an existing checkout', async () => {
+    const { ensureWebGitClone, getWebGitClonePath } = await import('../git-clone.js');
+    const gitUrl = 'https://github.com/mastra-ai/mastra.git';
+    const cloneParentPath = path.join(process.cwd(), '.tmp-git-clone-test');
+    cleanupDirs.add(cloneParentPath);
+    const clonePath = getWebGitClonePath(gitUrl, cloneParentPath);
+
+    expect(getWebGitClonePath(gitUrl, cloneParentPath)).toBe(clonePath);
+    expect(clonePath.startsWith(cloneParentPath)).toBe(true);
+    await fs.mkdir(clonePath, { recursive: true });
+
+    await expect(ensureWebGitClone(gitUrl, cloneParentPath)).resolves.toBe(clonePath);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('clones with git into a deterministic temp directory', async () => {
+    const { ensureWebGitClone, getWebGitClonePath } = await import('../git-clone.js');
+    const gitUrl = 'https://github.com/mastra-ai/mastra.git';
+    const cloneParentPath = path.join(process.cwd(), '.tmp-git-clone-test');
+    cleanupDirs.add(cloneParentPath);
+    const clonePath = getWebGitClonePath(gitUrl, cloneParentPath);
+    await fs.rm(clonePath, { recursive: true, force: true });
+
+    await expect(ensureWebGitClone(gitUrl, cloneParentPath)).resolves.toBe(clonePath);
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [file, args, options] = execFileMock.mock.calls[0];
+    expect(file).toBe('git');
+    expect(args.slice(0, 4)).toEqual(['clone', '--depth', '1', gitUrl]);
+    expect(args[4]).toMatch(new RegExp(`${path.basename(clonePath)}-`));
+    expect(options).toMatchObject({ env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }) });
+    await expect(fs.stat(clonePath)).resolves.toMatchObject({});
+  });
+});

--- a/mastracode/src/web/git-clone-context.ts
+++ b/mastracode/src/web/git-clone-context.ts
@@ -1,0 +1,70 @@
+export const MASTRACODE_WEB_GIT_CLONE_CONTEXT_KEY = 'mastracode.web.gitClone';
+
+export interface MastraCodeWebGitCloneContext {
+  gitUrl: string;
+  cloneParentPath?: string;
+}
+
+const SCP_LIKE_GIT_URL_RE = /^git@([^:\s]+):(.+)$/;
+
+export function normalizeWebGitUrl(input: string): string {
+  const gitUrl = input.trim();
+
+  if (!gitUrl) {
+    throw new Error('Git URL is required');
+  }
+
+  if (/\p{C}/u.test(gitUrl)) {
+    throw new Error('Git URL contains invalid characters');
+  }
+
+  const scpLike = SCP_LIKE_GIT_URL_RE.exec(gitUrl);
+  if (scpLike) {
+    const [, host, repoPath] = scpLike;
+    if (!host || !repoPath || repoPath.startsWith('/') || repoPath.includes('..')) {
+      throw new Error('Invalid Git URL');
+    }
+    return gitUrl;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(gitUrl);
+  } catch {
+    throw new Error('Enter an https://, http://, ssh://, or git@host:org/repo.git URL');
+  }
+
+  if (!['https:', 'http:', 'ssh:'].includes(parsed.protocol)) {
+    throw new Error('Git URL must use https://, http://, ssh://, or git@host:org/repo.git');
+  }
+
+  if (!parsed.hostname || parsed.pathname === '/' || parsed.pathname.includes('..')) {
+    throw new Error('Invalid Git URL');
+  }
+
+  return parsed.toString();
+}
+
+export function getWebGitRepoName(gitUrl: string): string {
+  const normalizedGitUrl = normalizeWebGitUrl(gitUrl);
+  const tail = normalizedGitUrl.split(/[/:]/).filter(Boolean).pop() ?? 'repository';
+  return tail.replace(/\.git$/, '') || 'repository';
+}
+
+function shortHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function getWebGitCloneDirectoryName(gitUrl: string): string {
+  const normalizedGitUrl = normalizeWebGitUrl(gitUrl);
+  const repoName = getWebGitRepoName(normalizedGitUrl)
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `${repoName || 'repository'}-${shortHash(normalizedGitUrl)}`;
+}

--- a/mastracode/src/web/git-clone.ts
+++ b/mastracode/src/web/git-clone.ts
@@ -1,0 +1,74 @@
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { getWebGitCloneDirectoryName, normalizeWebGitUrl } from './git-clone-context.js';
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_WEB_CLONES_DIR = path.join(os.tmpdir(), 'mastracode-web-clones');
+
+function normalizeCloneParentPath(cloneParentPath?: string): string {
+  if (!cloneParentPath) return DEFAULT_WEB_CLONES_DIR;
+
+  const trimmed = cloneParentPath.trim();
+  if (!trimmed) throw new Error('Clone location is required');
+  if (/\p{C}/u.test(trimmed)) throw new Error('Clone location contains invalid characters');
+  if (!path.isAbsolute(trimmed)) throw new Error('Clone location must be an absolute path');
+
+  return path.resolve(trimmed);
+}
+
+export function getWebGitClonePath(gitUrl: string, cloneParentPath?: string): string {
+  const normalizedGitUrl = normalizeWebGitUrl(gitUrl);
+  const parentPath = normalizeCloneParentPath(cloneParentPath);
+  const finalDir = path.join(parentPath, getWebGitCloneDirectoryName(normalizedGitUrl));
+
+  if (path.relative(parentPath, finalDir).startsWith('..')) {
+    throw new Error('Clone path must stay inside the selected location');
+  }
+
+  return finalDir;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureWebGitClone(gitUrl: string, cloneParentPath?: string): Promise<string> {
+  const normalizedGitUrl = normalizeWebGitUrl(gitUrl);
+  const finalDir = getWebGitClonePath(normalizedGitUrl, cloneParentPath);
+  const parentPath = path.dirname(finalDir);
+
+  if (await pathExists(finalDir)) {
+    return finalDir;
+  }
+
+  await fs.mkdir(parentPath, { recursive: true });
+  const tempDir = await fs.mkdtemp(path.join(parentPath, `.${path.basename(finalDir)}-`));
+
+  try {
+    await execFileAsync('git', ['clone', '--depth', '1', normalizedGitUrl, tempDir], {
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+    try {
+      await fs.rename(tempDir, finalDir);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if ((code === 'EEXIST' || code === 'ENOTEMPTY') && (await pathExists(finalDir))) {
+        await fs.rm(tempDir, { recursive: true, force: true });
+        return finalDir;
+      }
+      throw error;
+    }
+    return finalDir;
+  } catch (error) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    throw error;
+  }
+}

--- a/mastracode/src/web/ui/App.tsx
+++ b/mastracode/src/web/ui/App.tsx
@@ -57,10 +57,17 @@ export default function App() {
   const resourceId = activeProject?.resourceId ?? DEFAULT_RESOURCE_ID;
   const sessionEnabled = !!activeProject?.resourceId;
 
+  const activeProjectGitUrl = activeProject?.source === 'git' ? activeProject.gitUrl : undefined;
+  const activeProjectCloneParentPath = activeProject?.source === 'git' ? activeProject.cloneParentPath : undefined;
+  const activeProjectPath = activeProject?.source === 'git' ? undefined : activeProject?.path;
+  const activeProjectLocation = activeProject?.path;
+
   const session = useHarnessSession({
     harnessId: 'code',
     resourceId,
-    projectPath: activeProject?.path,
+    projectPath: activeProjectPath,
+    gitUrl: activeProjectGitUrl,
+    cloneParentPath: activeProjectCloneParentPath,
     enabled: sessionEnabled,
   });
   const { transcript, status, modes, threads, send, steer, abort, approveTool, respondSuspension } = session;
@@ -251,25 +258,26 @@ export default function App() {
     setActiveProjectId(project.id);
   };
 
-  // After the session connects for a new project, set projectPath.
+  // After the session connects for a new local project, set projectPath. Git
+  // projects resolve their cloned path in the workspace factory.
   const prevResourceId = useRef(resourceId);
   useEffect(() => {
     if (resourceId !== prevResourceId.current) {
       prevResourceId.current = resourceId;
-      if (status === 'ready') {
-        void session.setState({ projectPath: activeProject?.path ?? '' });
+      if (status === 'ready' && activeProjectPath) {
+        void session.setState({ projectPath: activeProjectPath });
       }
     }
-  }, [resourceId, status, activeProject, session]);
+  }, [resourceId, status, activeProjectPath, session]);
 
-  // Also set projectPath on initial connection for the active project.
+  // Also set projectPath on initial connection for the active local project.
   const initialSet = useRef(false);
   useEffect(() => {
-    if (status === 'ready' && !initialSet.current && activeProject) {
+    if (status === 'ready' && !initialSet.current && activeProjectPath) {
       initialSet.current = true;
-      void session.setState({ projectPath: activeProject.path });
+      void session.setState({ projectPath: activeProjectPath });
     }
-  }, [status, activeProject, session]);
+  }, [status, activeProjectPath, session]);
 
   const onSubmit = (e: { preventDefault: () => void }) => {
     e.preventDefault();
@@ -339,7 +347,10 @@ export default function App() {
         case 'settings': {
           const lines = [
             `Project: ${activeProject?.name ?? '(none)'}`,
-            `Path: ${activeProject?.path ?? '(default workspace)'}`,
+            activeProject?.source === 'git'
+              ? `Repository: ${activeProject.gitUrl ?? '—'}`
+              : `Path: ${activeProjectLocation ?? '(default workspace)'}`,
+            ...(activeProject?.source === 'git' ? [`Clone path: ${activeProjectLocation ?? '—'}`] : []),
             `Mode: ${transcript.modeId ?? '—'}`,
             `Model: ${transcript.modelId ?? '—'}`,
             `Thread: ${transcript.threadId ?? '—'}`,
@@ -521,7 +532,7 @@ export default function App() {
           <button
             className="header-title"
             onClick={() => setProjectsOpen(true)}
-            title={activeProject ? `${activeProject.path} — switch project` : 'Select a project'}
+            title={activeProject ? `${activeProjectLocation} — switch project` : 'Select a project'}
           >
             <LogoMark size={24} className="logo-mark" />
             <span className="header-name">{activeProject ? activeProject.name : 'MastraCode'}</span>
@@ -560,8 +571,8 @@ export default function App() {
             </div>
             <h2>Welcome to MastraCode</h2>
             <p>
-              Open a project folder to start a coding session. Each project keeps its own threads, memory, and workspace
-              — shared with the terminal.
+              Open a project folder or clone a Git URL to start a coding session. Each project keeps its own threads,
+              memory, and workspace.
             </p>
             <button className="btn btn-primary no-project-cta" onClick={() => setProjectsOpen(true)}>
               Open a project
@@ -609,9 +620,15 @@ export default function App() {
                         <dd>{activeProject.gitBranch}</dd>
                       </div>
                     )}
+                    {activeProject.source === 'git' && (
+                      <div className="banner-row">
+                        <dt>Repository</dt>
+                        <dd>{activeProject.gitUrl}</dd>
+                      </div>
+                    )}
                     <div className="banner-row">
-                      <dt>Workspace</dt>
-                      <dd>{activeProject.path}</dd>
+                      <dt>{activeProject.source === 'git' ? 'Clone path' : 'Workspace'}</dt>
+                      <dd>{activeProjectLocation}</dd>
                     </div>
                   </dl>
                   <p className="banner-ready">Ready for new conversation</p>

--- a/mastracode/src/web/ui/ProjectsModal.tsx
+++ b/mastracode/src/web/ui/ProjectsModal.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { DirectoryBrowser } from './DirectoryPicker';
 import { CloseIcon, FolderIcon, LogoMark, PlusIcon } from './icons';
 import type { Project } from './projects';
-import { addProject, loadProjects, removeProject } from './projects';
+import { addGitProject, addProject, loadProjects, removeProject } from './projects';
 
 interface ProjectsModalProps {
   projects: Project[];
@@ -13,13 +13,16 @@ interface ProjectsModalProps {
   onClose: () => void;
 }
 
+type AddMode = 'git' | 'local';
+
 /**
  * App-level modal for managing projects — the primary entry point into a coding
  * session. A project binds a name to a filesystem path; its threads, memory,
  * and workspace are scoped to that directory (and shared with the terminal).
  *
- * Two views: the project list, and an "add" view that embeds the server-driven
- * directory browser. On first run (no projects) it opens straight into "add".
+ * Two views: the project list, and an "add" view for cloning a Git URL or
+ * browsing to an existing local folder. On first run (no projects) it opens
+ * straight into "add".
  */
 export function ProjectsModal({
   projects,
@@ -30,20 +33,25 @@ export function ProjectsModal({
 }: ProjectsModalProps) {
   const empty = projects.length === 0;
   const [adding, setAdding] = useState(empty);
+  const [addMode, setAddMode] = useState<AddMode>('git');
+  const [choosingCloneLocation, setChoosingCloneLocation] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [gitUrl, setGitUrl] = useState('');
+  const [cloneParentPath, setCloneParentPath] = useState('');
 
   // Close on Escape (but if browsing to add, Escape backs out to the list first
   // when there are existing projects).
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      if (adding && !empty) setAdding(false);
+      if (choosingCloneLocation) setChoosingCloneLocation(false);
+      else if (adding && !empty) setAdding(false);
       else onClose();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [adding, empty, onClose]);
+  }, [adding, choosingCloneLocation, empty, onClose]);
 
   const handlePick = async (path: string, name: string) => {
     setBusy(true);
@@ -60,6 +68,25 @@ export function ProjectsModal({
     } finally {
       setBusy(false);
     }
+  };
+
+  const handleGitSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const project = addGitProject(gitUrl, cloneParentPath);
+      onProjectsChange(loadProjects());
+      onSelectProject(project);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleCloneLocationPick = (path: string) => {
+    setCloneParentPath(path);
+    setChoosingCloneLocation(false);
+    setError(null);
   };
 
   const handleRemove = (e: React.MouseEvent, id: string) => {
@@ -90,15 +117,117 @@ export function ProjectsModal({
         {adding ? (
           <>
             <p className="projects-sub">
-              Choose a folder on this machine. Its threads, memory, and workspace stay scoped to that directory — and
-              are shared with the terminal.
+              Start from a Git repository URL, or choose an existing folder on this machine. Each project keeps its own
+              threads, memory, and workspace.
             </p>
-            <DirectoryBrowser
-              onPick={(p, n) => void handlePick(p, n)}
-              onCancel={() => (empty ? onClose() : setAdding(false))}
-              busy={busy}
-              error={error}
-            />
+            <div className="projects-add-tabs" role="tablist" aria-label="Project source">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={addMode === 'git'}
+                className={`projects-add-tab ${addMode === 'git' ? 'active' : ''}`}
+                onClick={() => {
+                  setAddMode('git');
+                  setChoosingCloneLocation(false);
+                  setError(null);
+                }}
+              >
+                Clone from Git
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={addMode === 'local'}
+                className={`projects-add-tab ${addMode === 'local' ? 'active' : ''}`}
+                onClick={() => {
+                  setAddMode('local');
+                  setChoosingCloneLocation(false);
+                  setError(null);
+                }}
+              >
+                Open local folder
+              </button>
+            </div>
+
+            {addMode === 'git' ? (
+              choosingCloneLocation ? (
+                <>
+                  <div className="projects-location-head">
+                    <span>Choose where to clone this repository</span>
+                    <button type="button" className="btn btn-sm" onClick={() => setChoosingCloneLocation(false)}>
+                      Back
+                    </button>
+                  </div>
+                  <DirectoryBrowser
+                    onPick={p => handleCloneLocationPick(p)}
+                    onCancel={() => setChoosingCloneLocation(false)}
+                    busy={busy}
+                    error={error}
+                  />
+                </>
+              ) : (
+                <form className="projects-git-form" onSubmit={handleGitSubmit}>
+                  <label className="projects-git-label" htmlFor="project-git-url">
+                    Git repository URL
+                  </label>
+                  <input
+                    id="project-git-url"
+                    className="input projects-git-input"
+                    value={gitUrl}
+                    onChange={e => setGitUrl(e.target.value)}
+                    placeholder="https://github.com/org/repo.git"
+                    disabled={busy}
+                  />
+
+                  <label className="projects-git-label" htmlFor="project-clone-location">
+                    Clone location
+                  </label>
+                  <div className="projects-git-row">
+                    <input
+                      id="project-clone-location"
+                      className="input projects-git-input"
+                      value={cloneParentPath}
+                      readOnly
+                      placeholder="Choose a folder…"
+                      disabled={busy}
+                    />
+                    <button
+                      type="button"
+                      className="btn projects-git-submit"
+                      onClick={() => setChoosingCloneLocation(true)}
+                    >
+                      Choose…
+                    </button>
+                  </div>
+                  <p className="projects-git-hint">
+                    MastraCode will clone into a repo-named subfolder inside this location and reuse it for future
+                    sessions.
+                  </p>
+                  {error && <div className="dirbrowser-msg dirbrowser-err projects-git-error">{error}</div>}
+                  <div className="projects-git-actions">
+                    {!empty && (
+                      <button type="button" className="btn" onClick={() => setAdding(false)} disabled={busy}>
+                        Cancel
+                      </button>
+                    )}
+                    <button
+                      className="btn btn-primary projects-git-submit"
+                      type="submit"
+                      disabled={busy || !gitUrl.trim() || !cloneParentPath.trim()}
+                    >
+                      Clone from URL
+                    </button>
+                  </div>
+                </form>
+              )
+            ) : (
+              <DirectoryBrowser
+                onPick={(p, n) => void handlePick(p, n)}
+                onCancel={() => (empty ? onClose() : setAdding(false))}
+                busy={busy}
+                error={error}
+              />
+            )}
           </>
         ) : (
           <>
@@ -120,6 +249,7 @@ export function ProjectsModal({
                       <span className="project-card-name">{p.name}</span>
                       <span className="project-card-path">{p.path}</span>
                     </span>
+                    {p.source === 'git' && <span className="project-card-badge secondary">Git</span>}
                     {active && <span className="project-card-badge">Active</span>}
                     <span
                       className="project-card-remove"

--- a/mastracode/src/web/ui/projects.ts
+++ b/mastracode/src/web/ui/projects.ts
@@ -12,6 +12,8 @@
  * workspace factory reads it to resolve the working directory.
  */
 
+import { getWebGitCloneDirectoryName, getWebGitRepoName, normalizeWebGitUrl } from '../git-clone-context';
+
 const STORAGE_KEY = 'mastracode-projects';
 const ACTIVE_KEY = 'mastracode-active-project';
 
@@ -20,6 +22,9 @@ export interface Project {
   id: string;
   name: string;
   path: string;
+  source?: 'local' | 'git';
+  gitUrl?: string;
+  cloneParentPath?: string;
   /**
    * Server-resolved resourceId (TUI-compatible). May be absent on projects
    * created before this field existed; `ensureResourceId` backfills it.
@@ -63,7 +68,8 @@ export function loadProjects(): Project[] {
         !!p &&
         typeof p === 'object' &&
         typeof (p as Project).id === 'string' &&
-        typeof (p as Project).path === 'string',
+        typeof (p as Project).path === 'string' &&
+        ((p as Project).source !== 'git' || typeof (p as Project).gitUrl === 'string'),
     );
   } catch {
     return [];
@@ -86,8 +92,52 @@ export async function addProject(name: string, path: string): Promise<Project> {
     id: crypto.randomUUID(),
     name: name.trim() || resolved.name,
     path: path.trim(),
+    source: 'local',
     resourceId: resolved.resourceId,
     gitBranch: resolved.gitBranch,
+    createdAt: Date.now(),
+  };
+  projects.push(project);
+  saveProjects(projects);
+  return project;
+}
+
+function shortHash(value: string): string {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = Math.imul(31, hash) + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+function joinPath(parentPath: string, childName: string): string {
+  const trimmed = parentPath.trim().replace(/[\\/]+$/, '');
+  if (!trimmed) throw new Error('Clone location is required');
+  return `${trimmed}/${childName}`;
+}
+
+export function addGitProject(gitUrl: string, cloneParentPath: string): Project {
+  const normalizedGitUrl = normalizeWebGitUrl(gitUrl);
+  const normalizedCloneParentPath = cloneParentPath.trim();
+  if (!normalizedCloneParentPath) throw new Error('Choose where to clone the repository');
+
+  const name = getWebGitRepoName(normalizedGitUrl);
+  const resourceId = `${
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || 'repository'
+  }-${shortHash(normalizedGitUrl)}`;
+  const projects = loadProjects();
+  const project: Project = {
+    id: crypto.randomUUID(),
+    name,
+    path: joinPath(normalizedCloneParentPath, getWebGitCloneDirectoryName(normalizedGitUrl)),
+    source: 'git',
+    gitUrl: normalizedGitUrl,
+    cloneParentPath: normalizedCloneParentPath,
+    resourceId,
     createdAt: Date.now(),
   };
   projects.push(project);
@@ -102,8 +152,19 @@ export async function addProject(name: string, path: string): Promise<Project> {
  */
 export async function ensureResourceId(project: Project): Promise<Project> {
   if (project.resourceId) return project;
+  if (project.source === 'git' && project.gitUrl) {
+    const cloneParentPath = project.cloneParentPath || project.path;
+    const updated = addGitProject(project.gitUrl, cloneParentPath);
+    removeProject(project.id);
+    return updated;
+  }
   const resolved = await resolveProjectPath(project.path);
-  const updated: Project = { ...project, resourceId: resolved.resourceId, gitBranch: resolved.gitBranch };
+  const updated: Project = {
+    ...project,
+    source: 'local',
+    resourceId: resolved.resourceId,
+    gitBranch: resolved.gitBranch,
+  };
   const projects = loadProjects().map(p => (p.id === project.id ? updated : p));
   saveProjects(projects);
   return updated;

--- a/mastracode/src/web/ui/styles.css
+++ b/mastracode/src/web/ui/styles.css
@@ -2054,6 +2054,10 @@ body::before {
   border-radius: 999px;
   flex-shrink: 0;
 }
+.project-card-badge.secondary {
+  color: var(--fg-dim);
+  background: var(--bg-surface3);
+}
 .project-card-remove {
   display: inline-flex;
   align-items: center;
@@ -2097,6 +2101,83 @@ body::before {
   background: var(--bg-surface2);
   color: var(--fg);
   border-color: var(--accent);
+}
+.projects-add-tabs {
+  display: flex;
+  gap: 8px;
+  padding: 10px 18px 8px;
+}
+.projects-add-tab {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-surface);
+  color: var(--fg-dim);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.projects-add-tab:hover {
+  background: var(--bg-surface3);
+  color: var(--fg);
+}
+.projects-add-tab.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.projects-git-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 18px 18px;
+}
+.projects-git-label {
+  display: block;
+  margin-bottom: -3px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+}
+.projects-git-row {
+  display: flex;
+  gap: 8px;
+}
+.projects-git-input {
+  flex: 1;
+  min-width: 0;
+}
+.projects-git-submit {
+  white-space: nowrap;
+}
+.projects-git-hint {
+  margin: -2px 0 2px;
+  color: var(--fg-muted);
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+.projects-git-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 2px;
+}
+.projects-git-error {
+  padding: 6px 0;
+  text-align: left;
+}
+.projects-location-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+  color: var(--fg-dim);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 /* ── Directory browser (embedded inside the Projects modal) ─────────── */

--- a/mastracode/src/web/ui/useHarnessSession.ts
+++ b/mastracode/src/web/ui/useHarnessSession.ts
@@ -11,6 +11,7 @@ import type {
 } from '@mastra/client-js';
 import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 
+import { MASTRACODE_WEB_GIT_CLONE_CONTEXT_KEY } from '../git-clone-context';
 import { initialTranscript, transcriptReducer } from './transcript';
 import type { TranscriptState } from './transcript';
 
@@ -20,6 +21,12 @@ export type ConnectionStatus = 'connecting' | 'ready' | 'reconnecting' | 'error'
 const THREAD_PAGE_SIZE = 20;
 
 type Session = ReturnType<ReturnType<MastraClient['getHarness']>['session']>;
+
+function sessionTags(projectPath?: string, gitUrl?: string): Record<string, string> | undefined {
+  if (gitUrl) return { gitUrl };
+  if (projectPath) return { projectPath };
+  return undefined;
+}
 
 function errorText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -34,6 +41,8 @@ interface UseHarnessSessionArgs {
    * the same repo. When omitted, all threads for the resource are listed.
    */
   projectPath?: string;
+  gitUrl?: string;
+  cloneParentPath?: string;
   /** Defaults to same-origin (Vite proxies /api → mastra dev). */
   baseUrl?: string;
   /**
@@ -93,6 +102,8 @@ export function useHarnessSession({
   harnessId,
   resourceId,
   projectPath,
+  gitUrl,
+  cloneParentPath,
   baseUrl = '',
   enabled = true,
 }: UseHarnessSessionArgs): HarnessSessionApi {
@@ -126,13 +137,13 @@ export function useHarnessSession({
       setThreads(
         await session.listThreads({
           limit: THREAD_PAGE_SIZE,
-          tags: projectPath ? { projectPath } : undefined,
+          tags: sessionTags(projectPath, gitUrl),
         }),
       );
     } catch {
       /* non-fatal */
     }
-  }, [projectPath]);
+  }, [projectPath, gitUrl]);
 
   useEffect(() => {
     if (!enabled) {
@@ -230,7 +241,12 @@ export function useHarnessSession({
         const [created, harnessModes] = await Promise.all([
           // Scope initial thread selection to the active project so worktrees
           // sharing a resourceId each resume their own thread.
-          session.create({ tags: projectPath ? { projectPath } : undefined }),
+          session.create({
+            tags: sessionTags(projectPath, gitUrl),
+            requestContext: gitUrl
+              ? { [MASTRACODE_WEB_GIT_CLONE_CONTEXT_KEY]: { gitUrl, cloneParentPath } }
+              : undefined,
+          }),
           harness.listModes(),
         ]);
         if (disposed) return;
@@ -291,7 +307,7 @@ export function useHarnessSession({
       unsubscribe?.();
       sessionRef.current = null;
     };
-  }, [harnessId, resourceId, baseUrl, refreshThreads, enabled]);
+  }, [harnessId, resourceId, projectPath, gitUrl, cloneParentPath, baseUrl, refreshThreads, enabled]);
 
   const send = useCallback(async (text: string) => {
     const session = sessionRef.current;

--- a/mastracode/src/web/vite.config.ts
+++ b/mastracode/src/web/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:4111',
+        target: 'http://127.0.0.1:4111',
         changeOrigin: true,
       },
     },

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -5746,6 +5746,7 @@ export const API_ROUTE_METADATA = {
     ],
     "queryParams": [],
     "bodyParams": [
+      "requestContext",
       "resourceId",
       "tags"
     ],
@@ -6307,6 +6308,7 @@ export const API_ROUTE_METADATA = {
     ],
     "queryParams": [],
     "bodyParams": [
+      "requestContext",
       "resourceId",
       "tags"
     ],

--- a/packages/server/src/server/handlers/harness.test.ts
+++ b/packages/server/src/server/handlers/harness.test.ts
@@ -1,6 +1,7 @@
 import { Agent } from '@mastra/core/agent';
 import { Harness } from '@mastra/core/harness';
 import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
 import { Workspace } from '@mastra/core/workspace';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -86,6 +87,31 @@ describe('harness routes', () => {
       } as any)) as { threadId?: string };
 
       expect(second.threadId).toBe(first.threadId);
+    });
+
+    it('passes request context to session workspace resolution', async () => {
+      const seen: unknown[] = [];
+      const harness = new Harness({
+        id: 'code',
+        storage: new InMemoryStore(),
+        workspace: ({ requestContext }) => {
+          seen.push(requestContext.get('mastracode.web.gitClone'));
+          return new Workspace({ name: 'test-workspace', skills: ['/tmp/test-skills'] });
+        },
+        modes: [{ id: 'build', name: 'Build', default: true, agent: makeAgent() }],
+      });
+      const scopedMastra = new Mastra({ harnesses: { code: harness }, storage: new InMemoryStore() });
+      const requestContext = new RequestContext();
+      requestContext.set('mastracode.web.gitClone', { gitUrl: 'https://github.com/mastra-ai/mastra.git' });
+
+      await CREATE_HARNESS_SESSION_ROUTE.handler({
+        mastra: scopedMastra,
+        harnessId: 'code',
+        resourceId: 'user-1',
+        requestContext,
+      } as any);
+
+      expect(seen).toEqual([{ gitUrl: 'https://github.com/mastra-ai/mastra.git' }]);
     });
 
     it('404s for an unknown harness id', async () => {

--- a/packages/server/src/server/handlers/harness.ts
+++ b/packages/server/src/server/handlers/harness.ts
@@ -1,6 +1,7 @@
 import type { Agent } from '@mastra/core/agent';
 import type { AgentController, Session } from '@mastra/core/agent-controller';
 import type { MastraFGAPermissionInput } from '@mastra/core/auth/ee';
+import type { RequestContext } from '@mastra/core/request-context';
 // Type-only import: erased at runtime, so this cannot crash against an older
 // @mastra/core that lacks the `./agent-controller` subpath export. Controller
 // resolution at runtime goes through mastra.getAgentController?.() with a
@@ -70,9 +71,16 @@ async function getSession(
   harness: AgentController<any>,
   resourceId: string,
   tags?: Record<string, string>,
+  requestContext?: RequestContext,
 ): Promise<Session<any>> {
   await harness.init();
-  return harness.createSession({ resourceId, id: resourceId, ownerId: harness.id, tags });
+  return harness.createSession({
+    resourceId,
+    id: resourceId,
+    ownerId: harness.id,
+    tags,
+    requestContext,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -85,6 +93,7 @@ const sessionPathParams = z.object({ harnessId: z.string(), resourceId: z.string
 const createSessionBodySchema = z.object({
   resourceId: z.string(),
   tags: z.record(z.string(), z.string()).optional(),
+  requestContext: z.record(z.string(), z.unknown()).optional(),
 });
 const sendMessageBodySchema = z.object({ message: z.string() });
 const steerBodySchema = z.object({ message: z.string() });
@@ -304,10 +313,10 @@ export const CREATE_HARNESS_SESSION_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, harnessId, resourceId, tags }) => {
+  handler: async ({ mastra, harnessId, resourceId, tags, requestContext }) => {
     try {
       const harness = getHarnessOrThrow(mastra, harnessId);
-      const session = await getSession(harness, resourceId, tags);
+      const session = await getSession(harness, resourceId, tags, requestContext);
       return {
         harnessId,
         resourceId,


### PR DESCRIPTION
Adds a Git repository option to the web project picker so users can start a session from a remote repo and choose where it should be cloned locally. The checkout path is deterministic under the selected folder, so reopening the same Git project reuses the existing clone.

Example:

```ts
await client.getHarness("code").session("repo-user").create({
  tags: { gitUrl: "https://github.com/mastra-ai/mastra.git" },
  requestContext: {
    "mastracode.web.gitClone": {
      gitUrl: "https://github.com/mastra-ai/mastra.git",
      cloneParentPath: "/Users/me/projects"
    }
  }
});
```

Verified with focused client, server, MastraCode workspace/git clone tests, server build, client build, MastraCode build, web UI build, and server core import checks.