### PR TITLE
fix(e2b): use per-mount credentials file for S3 and GCS mounts

### DIFF
--- a/.changeset/e2b-per-mount-credential-files.md
+++ b/.changeset/e2b-per-mount-credential-files.md
@@ -1,0 +1,15 @@
+---
+'@mastra/e2b': patch
+---
+
+Fix concurrent S3/GCS mounts racing on a shared credentials file
+
+`mountS3` and `mountGCS` wrote credentials to a single fixed path
+(`/tmp/.passwd-s3fs`, `/tmp/gcs-key.json`) and rewrote it (`rm` → `write` →
+`chmod`) on every mount. When two mounts run concurrently in the same sandbox
+(e.g. mounting several buckets, or re-establishing mounts after a pause/resume),
+their rewrites interleave — one mount's `write`/`chmod` races another's `rm` —
+causing `EACCES` and a failed mount, or a mount reading another mount's
+credentials. Each mount now derives a per-mount path from a hash of its mount
+point (the same approach `mountAzure` already uses), removing the shared
+resource. Azure was already unaffected.

--- a/.changeset/e2b-per-mount-credential-files.md
+++ b/.changeset/e2b-per-mount-credential-files.md
@@ -2,14 +2,6 @@
 '@mastra/e2b': patch
 ---
 
-Fix concurrent S3/GCS mounts racing on a shared credentials file
+Make concurrent S3 and GCS mounts reliable in the same sandbox
 
-`mountS3` and `mountGCS` wrote credentials to a single fixed path
-(`/tmp/.passwd-s3fs`, `/tmp/gcs-key.json`) and rewrote it (`rm` → `write` →
-`chmod`) on every mount. When two mounts run concurrently in the same sandbox
-(e.g. mounting several buckets, or re-establishing mounts after a pause/resume),
-their rewrites interleave — one mount's `write`/`chmod` races another's `rm` —
-causing `EACCES` and a failed mount, or a mount reading another mount's
-credentials. Each mount now derives a per-mount path from a hash of its mount
-point (the same approach `mountAzure` already uses), removing the shared
-resource. Azure was already unaffected.
+Mounting several buckets at once, or restoring mounts after a pause/resume, could previously fail or pick up the wrong credentials because every mount shared one temporary credentials file and overwrote each other's. Each mount now gets its own credentials file, so they no longer interfere. (Azure already worked this way.)

--- a/workspaces/e2b/src/sandbox/mounts/gcs.ts
+++ b/workspaces/e2b/src/sandbox/mounts/gcs.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
@@ -69,8 +71,11 @@ export async function mountGCS(mountPath: string, config: E2BGCSMountConfig, ctx
   let mountCmd: string;
 
   if (hasCredentials) {
-    // Write service account key with root ownership so sudo gcsfuse can read it
-    const keyPath = '/tmp/gcs-key.json';
+    // Write service account key with root ownership so sudo gcsfuse can read it.
+    // Per-mount path (hashed mountPath) so concurrent mounts don't race on a single
+    // shared rm -> write -> chmod sequence (same approach as azure.ts).
+    const mountHash = createHash('md5').update(mountPath).digest('hex').slice(0, 8);
+    const keyPath = `/tmp/gcs-key-${mountHash}.json`;
     await sandbox.commands.run(`sudo rm -f ${keyPath}`);
     await sandbox.files.write(keyPath, config.serviceAccountKey!);
     // Make readable by root (sudo gcsfuse runs as root)

--- a/workspaces/e2b/src/sandbox/mounts/s3.ts
+++ b/workspaces/e2b/src/sandbox/mounts/s3.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
@@ -81,7 +83,13 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
 
   // Determine if we have credentials or using public bucket mode
   const hasCredentials = config.accessKeyId && config.secretAccessKey;
-  const credentialsPath = '/tmp/.passwd-s3fs';
+  // Use a per-mount credentials file. s3fs reads `passwd_file` at mount time, so a
+  // single shared path (rewritten rm -> write -> chmod on every mount) lets
+  // concurrent mounts race: one mount's write/chmod interleaves with another's rm,
+  // causing EACCES or a mount reading another mount's credentials. Hashing the
+  // mountPath gives each mount a unique, stable file (same approach as azure.ts).
+  const mountHash = createHash('md5').update(mountPath).digest('hex').slice(0, 8);
+  const credentialsPath = `/tmp/.passwd-s3fs-${mountHash}`;
 
   // S3-compatible services (R2, MinIO, etc.) require credentials
   // public_bucket=1 only works for truly public AWS S3 buckets


### PR DESCRIPTION
Closes #18513

## What

`mountS3` and `mountGCS` write the mount credentials to a single fixed path
(`/tmp/.passwd-s3fs` and `/tmp/gcs-key.json`) and rewrite it with a non-atomic
`sudo rm -f` → `files.write` → `chmod` sequence on **every** mount.

## Why

When two mounts run concurrently in the same sandbox — e.g. mounting several
buckets at once, or re-establishing FUSE mounts after a pause/resume — those
rewrites interleave. One mount's `write`/`chmod` races another's `rm -f`, which
yields an `EACCES` and a failed mount, or (worse) a mount that ends up reading
another mount's credentials.

`mountAzure` already avoids this by deriving a per-mount path from a hash of the
mount point:

```ts
const mountHash = createHash('md5').update(mountPath).digest('hex').slice(0, 8);
const configPath = `/tmp/.blobfuse2-config-${mountHash}.yaml`;
```

## What this PR does

Applies the same per-mount pattern to S3 and GCS, so each mount gets its own
credentials file and the shared resource (and the race) is gone:

- `/tmp/.passwd-s3fs` → `/tmp/.passwd-s3fs-${mountHash}`
- `/tmp/gcs-key.json` → `/tmp/gcs-key-${mountHash}.json`

`mountHash` is deterministic per mount point, so re-mounting the same path reuses
the same file. Azure is unchanged (already correct).

## Testing

The mount helpers need a live E2B sandbox and have no unit-test harness in the
repo, so this was verified by reasoning through the rewrite sequence and by
matching the existing `mountAzure` implementation. A changeset (`@mastra/e2b`
patch) is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When the sandbox mounts S3 or GCS, it temporarily writes credential files to `/tmp`. This PR makes those files unique per mount point, so two mounts running at the same time can’t overwrite each other’s credentials and cause failures.

## Summary
- Updated `mountS3` to write credentials to a deterministic per-mount temp path derived from `mountPath` (replacing `/tmp/.passwd-s3fs` with `/tmp/.passwd-s3fs-${mountHash}`).
- Updated `mountGCS` to write service account keys to a deterministic per-mount temp path derived from `mountPath` (replacing `/tmp/gcs-key.json` with `/tmp/gcs-key-${mountHash}.json`).
- Added a changeset for a `patch` release of `@mastra/e2b` documenting the concurrency/race fix.
- Left `mountAzure` unchanged since it already uses per-mount hashed config paths.

## Why
Previously, concurrent mounts could interleave the `rm -f` → write → `chmod` steps on shared credential files, leading to `EACCES`, failed mounts, or credentials being read from the wrong mount. Using per-mount credential file paths removes that shared-file contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->