### PR TITLE
fix(mastracode): repair AgentController unit test fallout from the Harness rename

### DIFF
--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -29,11 +29,11 @@ vi.mock('@mastra/core/agent', () => ({
 
 const agentConstructorMock = vi.fn();
 
-const controllerConstructorMock = vi.fn();
+const agentControllerConstructorMock = vi.fn();
 const loadSettingsMock = vi.fn();
 const getAvailableModePacksMock = vi.fn(() => []);
 const getAvailableOmPacksMock = vi.fn(() => []);
-const controllerSubscribeMock = vi.fn();
+const agentControllerSubscribeMock = vi.fn();
 const detectProjectMock = vi.fn(() => ({
   mode: 'none',
   rootPath: process.cwd(),
@@ -42,16 +42,16 @@ const detectProjectMock = vi.fn(() => ({
   hasGit: false,
   contextFiles: [],
 }));
-const controllerGetCurrentThreadIdMock = vi.fn();
-const controllerListThreadsMock = vi.fn();
-const controllerSetStateMock = vi.fn();
-const controllerSetThreadSettingMock = vi.fn();
+const agentControllerGetCurrentThreadIdMock = vi.fn();
+const agentControllerListThreadsMock = vi.fn();
+const agentControllerSetStateMock = vi.fn();
+const agentControllerSetThreadSettingMock = vi.fn();
 const createMcpManagerMock = vi.fn();
 const hookManagerConstructorMock = vi.fn();
 const getStorageConfigMock = vi.fn(() => ({ type: 'memory' }));
 const getResourceIdOverrideMock = vi.fn(() => undefined);
 const getDynamicWorkspaceMock = vi.fn();
-let controllerStateMock: Record<string, unknown> = { cavemanObservations: false };
+let agentControllerStateMock: Record<string, unknown> = { cavemanObservations: false };
 
 function createMockSettings() {
   return {
@@ -107,7 +107,7 @@ function createMockSettings() {
 vi.mock('@mastra/core/agent-controller', () => ({
   AgentController: class {
     constructor(config: unknown) {
-      controllerConstructorMock(config);
+      agentControllerConstructorMock(config);
     }
     async init() {}
     getMastra() {
@@ -115,33 +115,33 @@ vi.mock('@mastra/core/agent-controller', () => ({
     }
     async createSession() {
       return {
-        subscribe: (eventHandler: unknown) => controllerSubscribeMock(eventHandler),
+        subscribe: (eventHandler: unknown) => agentControllerSubscribeMock(eventHandler),
         identity: {
           getResourceId: () => 'project-resource',
         },
         thread: {
-          getId: () => controllerGetCurrentThreadIdMock(),
-          list: (options: unknown) => controllerListThreadsMock(options),
-          setSetting: (setting: unknown) => controllerSetThreadSettingMock(setting),
+          getId: () => agentControllerGetCurrentThreadIdMock(),
+          list: (options: unknown) => agentControllerListThreadsMock(options),
+          setSetting: (setting: unknown) => agentControllerSetThreadSettingMock(setting),
         },
         mode: { get: () => 'build' },
         model: { get: () => 'anthropic/claude-opus-4-6' },
         state: {
-          get: () => controllerStateMock,
-          set: (state: unknown) => controllerSetStateMock(state),
+          get: () => agentControllerStateMock,
+          set: (state: unknown) => agentControllerSetStateMock(state),
           update: async (updater: any) => {
-            const result = await updater(controllerStateMock);
-            if (result?.updates) controllerSetStateMock(result.updates);
+            const result = await updater(agentControllerStateMock);
+            if (result?.updates) agentControllerSetStateMock(result.updates);
             return result?.result;
           },
         },
       };
     }
     getState() {
-      return controllerStateMock;
+      return agentControllerStateMock;
     }
     setState(state: unknown) {
-      return controllerSetStateMock(state);
+      return agentControllerSetStateMock(state);
     }
   },
   taskWriteTool: {},

--- a/mastracode/src/headless-integration.test.ts
+++ b/mastracode/src/headless-integration.test.ts
@@ -1428,7 +1428,6 @@ describe('headless mode — thread control', () => {
         prompt: 'Hello',
         format: 'json',
         continue_: false,
-        model: 'anthropic/claude-haiku-4-5',
         cloneThread: true,
         thread: 'source-thread',
       });


### PR DESCRIPTION
## Summary

The Harness→AgentController canonical-API rename (#18510) left two `mastracode` unit tests broken, which fails the Unit test shard in CI (visible on the current alpha release PR #18472). This restores the suite to green. Test-only changes; no runtime behavior is affected.

### index.test.ts
The `@mastra/core/agent-controller` mock still declared its mocks with old `controller*` names while setup/assertions used `agentController*`. Startup-state cases referenced an undefined `agentControllerSubscribeMock` and threw before asserting. Renamed mock declarations and wiring to `agentController*`.

### headless-integration.test.ts
The thread-cloning test passed a `model` flag, but it builds its controller without gateways, so `listAvailableModels()` never returns that model. `runHeadless` failed early with "Unknown model" (exit 1) while the test expected 0. The test only asserts `thread_cloned` and sibling tests omit the flag, so the unused flag is removed.

## Test plan

- `cd mastracode && vitest run` -> 1424 passed / 135 files (with MASTRA_GATEWAY_URL/MASTRA_GATEWAY_API_KEY unset to mirror CI).
- Both previously failing tests now pass; no other tests changed.
