### PR TITLE
fix(core): resolve sandbox marker dir lazily so Studio boots in the browser

### DIFF
--- a/.changeset/empty-hoops-cross.md
+++ b/.changeset/empty-hoops-cross.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Studio failing to boot in the browser with `TypeError: os.tmpdir is not a function`. The local sandbox resolved its mount marker directory at module-load time via `os.tmpdir()`, which crashed the client bundle where `node:os` has no `tmpdir`. The directory is now resolved lazily, so importing the Agent runtime in the browser no longer throws.

--- a/packages/core/src/workspace/sandbox/local-sandbox.browser-safety.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.browser-safety.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/18519
+ *
+ * The Studio client bundle transitively imports the Agent runtime, which pulls
+ * in `local-sandbox.ts`. In the browser, `node:os` is shimmed to an (almost)
+ * empty object, so `os.tmpdir` is `undefined`. If `local-sandbox.ts` evaluates
+ * `os.tmpdir()` at module-load time, importing it throws
+ * `TypeError: os.tmpdir is not a function`, which crashes Studio boot before
+ * React can render.
+ *
+ * `os.tmpdir()` must only be invoked lazily (via `getMarkerDir()`), never at
+ * module load — so importing the module under a browser-like `os` shim must
+ * not throw.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+describe('local-sandbox browser safety (issue #18519)', () => {
+  afterEach(() => {
+    vi.doUnmock('node:os');
+    vi.resetModules();
+  });
+
+  it('does not call os.tmpdir() at module load (browser os shim has no tmpdir)', async () => {
+    // Simulate the browser `os` shim: an object without `tmpdir`.
+    vi.resetModules();
+    vi.doMock('node:os', () => ({ default: {} }));
+
+    await expect(import('./local-sandbox')).resolves.toHaveProperty('getMarkerDir');
+  });
+});

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -8,7 +8,7 @@ import { createSandboxTestSuite } from '../../../../../workspaces/_test-utils/sr
 import { RequestContext } from '../../request-context';
 import type { WorkspaceFilesystem } from '../filesystem/filesystem';
 import { IsolationUnavailableError } from './errors';
-import { LocalSandbox, MARKER_DIR } from './local-sandbox';
+import { LocalSandbox, getMarkerDir } from './local-sandbox';
 import { detectIsolation, isIsolationAvailable, isSeatbeltAvailable, isBwrapAvailable } from './native-sandbox';
 
 describe('LocalSandbox', () => {
@@ -1042,8 +1042,8 @@ describe('LocalSandbox', () => {
       // Write a matching marker file
       const markerFilename = mountSandbox.mounts.markerFilename(hostPath);
       const configHash = mountSandbox.mounts.computeConfigHash(config);
-      await fs.mkdir(MARKER_DIR, { recursive: true });
-      await fs.writeFile(path.join(MARKER_DIR, markerFilename), `${hostPath}|${configHash}`);
+      await fs.mkdir(getMarkerDir(), { recursive: true });
+      await fs.writeFile(path.join(getMarkerDir(), markerFilename), `${hostPath}|${configHash}`);
 
       try {
         const result = await mountSandbox.mount(makeMockLocalFs(basePath), mountPath);
@@ -1052,7 +1052,7 @@ describe('LocalSandbox', () => {
         const target = await fs.readlink(hostPath);
         expect(target).toBe(basePath);
       } finally {
-        await fs.unlink(path.join(MARKER_DIR, markerFilename)).catch(() => {});
+        await fs.unlink(path.join(getMarkerDir(), markerFilename)).catch(() => {});
         await fs.unlink(hostPath).catch(() => {});
       }
     });
@@ -1111,7 +1111,7 @@ describe('LocalSandbox', () => {
 
       // Read and verify marker file
       const markerFilename = mountSandbox.mounts.markerFilename(hostPath);
-      const markerPath = path.join(MARKER_DIR, markerFilename);
+      const markerPath = path.join(getMarkerDir(), markerFilename);
 
       try {
         const content = await fs.readFile(markerPath, 'utf-8');
@@ -1142,8 +1142,8 @@ describe('LocalSandbox', () => {
       await fs.symlink(oldBasePath, hostPath);
       const markerFilename = mountSandbox.mounts.markerFilename(hostPath);
       const oldHash = mountSandbox.mounts.computeConfigHash(oldConfig);
-      await fs.mkdir(MARKER_DIR, { recursive: true });
-      await fs.writeFile(path.join(MARKER_DIR, markerFilename), `${hostPath}|${oldHash}`);
+      await fs.mkdir(getMarkerDir(), { recursive: true });
+      await fs.writeFile(path.join(getMarkerDir(), markerFilename), `${hostPath}|${oldHash}`);
 
       try {
         const result = await mountSandbox.mount(makeMockLocalFs(newBasePath), mountPath);
@@ -1157,7 +1157,7 @@ describe('LocalSandbox', () => {
         const content = await fs.readFile(path.join(hostPath, 'new.txt'), 'utf-8');
         expect(content).toBe('new content');
       } finally {
-        await fs.unlink(path.join(MARKER_DIR, markerFilename)).catch(() => {});
+        await fs.unlink(path.join(getMarkerDir(), markerFilename)).catch(() => {});
         await fs.unlink(hostPath).catch(() => {});
       }
     });

--- a/packages/core/src/workspace/sandbox/local-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.ts
@@ -35,8 +35,18 @@ import type { SandboxInfo } from './types';
 // Mount Path Validation
 // =============================================================================
 
-/** Directory for mount marker files used to detect config changes across restarts. */
-export const MARKER_DIR = path.join(os.tmpdir(), '.mastra-mounts');
+/**
+ * Directory for mount marker files used to detect config changes across restarts.
+ *
+ * Resolved lazily so `os.tmpdir()` is never invoked at module-load time. The
+ * Agent/evals runtime (which transitively imports this module) is bundled into
+ * the Studio client, where `node:os` is shimmed to an empty object and
+ * `os.tmpdir` is `undefined`. Evaluating it at import time crashes Studio boot.
+ * See https://github.com/mastra-ai/mastra/issues/18519.
+ */
+export function getMarkerDir(): string {
+  return path.join(os.tmpdir(), '.mastra-mounts');
+}
 
 /** Allowlist pattern for mount paths — absolute path with safe characters only. */
 const SAFE_MOUNT_PATH = /^\/[a-zA-Z0-9_.\-/]+$/;
@@ -530,7 +540,7 @@ export class LocalSandbox extends MastraSandbox {
 
     // Clean up marker file
     const filename = this.mounts.markerFilename(hostPath);
-    const markerPath = path.join(MARKER_DIR, filename);
+    const markerPath = path.join(getMarkerDir(), filename);
     try {
       await fs.unlink(markerPath);
     } catch {
@@ -563,10 +573,10 @@ export class LocalSandbox extends MastraSandbox {
 
     const filename = this.mounts.markerFilename(hostPath);
     const markerContent = `${hostPath}|${entry.configHash}`;
-    const markerFilePath = path.join(MARKER_DIR, filename);
+    const markerFilePath = path.join(getMarkerDir(), filename);
 
     try {
-      await fs.mkdir(MARKER_DIR, { recursive: true });
+      await fs.mkdir(getMarkerDir(), { recursive: true });
       await fs.writeFile(markerFilePath, markerContent, 'utf-8');
     } catch {
       this.logger.debug('Could not write marker file', { markerFilePath });
@@ -611,7 +621,7 @@ export class LocalSandbox extends MastraSandbox {
    */
   private async hasMarkerFile(hostPath: string): Promise<boolean> {
     const filename = this.mounts.markerFilename(hostPath);
-    const markerPath = path.join(MARKER_DIR, filename);
+    const markerPath = path.join(getMarkerDir(), filename);
     try {
       await fs.access(markerPath);
       return true;
@@ -630,7 +640,7 @@ export class LocalSandbox extends MastraSandbox {
     newConfig: FilesystemMountConfig,
   ): Promise<'matching' | 'mismatched' | 'foreign'> {
     const filename = this.mounts.markerFilename(hostPath);
-    const markerPath = path.join(MARKER_DIR, filename);
+    const markerPath = path.join(getMarkerDir(), filename);
 
     try {
       const content = await fs.readFile(markerPath, 'utf-8');


### PR DESCRIPTION
Studio fails to boot in the browser starting with `mastra@1.16.0-alpha.5` because `LocalSandbox` resolved its mount marker directory at module-load time. The Agent runtime transitively imports that module and gets bundled into the Studio client, where `node:os` is shimmed and `tmpdir` is undefined, so the bundle throws `TypeError: os.tmpdir is not a function` before React can render.

The fix is to resolve the directory lazily so `os.tmpdir()` only runs at runtime, never at import time.

Before:

```ts
export const MARKER_DIR = path.join(os.tmpdir(), '.mastra-mounts');
```

After:

```ts
export function getMarkerDir(): string {
  return path.join(os.tmpdir(), '.mastra-mounts');
}
```

Added a regression test that imports the module under a browser-like `os` shim (no `tmpdir`) and asserts it no longer throws.

Fixes #18519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This fixes Studio so it can open in the browser again. A piece of code was trying to ask the computer for its temp folder too early, which breaks in browser builds, so it now waits until runtime before doing that.

## Summary
- Made `LocalSandbox` resolve its mount-marker directory lazily instead of at module load time.
- Removed the eagerly evaluated `MARKER_DIR` constant and switched marker-file operations to use `getMarkerDir()`.
- Added a browser-safety regression test that imports `local-sandbox` under an `node:os` shim without `tmpdir` and verifies it no longer throws.
- Updated existing sandbox tests to use the new lazy marker-directory helper.
- Added a changeset to publish the fix in `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->