### PR TITLE
fix(mastracode): expand ${VAR} env references in MCP stdio server env values

### DIFF
--- a/.changeset/mcp-stdio-env-expansion.md
+++ b/.changeset/mcp-stdio-env-expansion.md
@@ -1,0 +1,17 @@
+---
+'mastracode': patch
+---
+
+MCP stdio servers now resolve `${VAR}` references in their `env` values from the host environment, matching the existing behavior for HTTP server headers. You can reference secrets from the environment instead of hardcoding them in `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "${GITHUB_TOKEN}" }
+    }
+  }
+}
+```

--- a/mastracode/src/mcp/__tests__/config.test.ts
+++ b/mastracode/src/mcp/__tests__/config.test.ts
@@ -109,6 +109,26 @@ describe('validateConfig', () => {
     }
   });
 
+  it('expands ${VAR} references in stdio env values from the environment', () => {
+    const previous = process.env.MC_TEST_MCP_KEY;
+    process.env.MC_TEST_MCP_KEY = 'secret-123';
+    try {
+      const result = validateConfig({
+        mcpServers: {
+          fs: { command: 'npx', args: ['-y', 'mcp-fs'], env: { API_KEY: '${MC_TEST_MCP_KEY}' } },
+        },
+      });
+      expect(result.mcpServers!['fs']).toEqual({
+        command: 'npx',
+        args: ['-y', 'mcp-fs'],
+        env: { API_KEY: 'secret-123' },
+      });
+    } finally {
+      if (previous === undefined) delete process.env.MC_TEST_MCP_KEY;
+      else process.env.MC_TEST_MCP_KEY = previous;
+    }
+  });
+
   it('accepts http server entry with OAuth config', () => {
     const result = validateConfig({
       mcpServers: {

--- a/mastracode/src/mcp/config.ts
+++ b/mastracode/src/mcp/config.ts
@@ -100,6 +100,19 @@ function expandHeaderEnvVars(headers: Record<string, unknown>): Record<string, s
 }
 
 /**
+ * Expand `${VAR}` and `$VAR` references in every string-valued environment
+ * variable passed to a stdio server, so that secrets can be referenced from the
+ * host environment instead of being hardcoded in `mcp.json`.
+ */
+function expandEnvValues(env: Record<string, unknown>): Record<string, string> {
+  const expanded: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === 'string') expanded[key] = expandEnvVars(value);
+  }
+  return expanded;
+}
+
+/**
  * Classify a raw server entry as stdio, http, or skip (with reason).
  */
 export function classifyServerEntry(raw: unknown): { kind: 'stdio' | 'http' | 'skip'; reason?: string } {
@@ -149,7 +162,8 @@ export function validateConfig(raw: unknown): McpConfig {
       servers[name] = {
         command: e.command as string,
         args: Array.isArray(e.args) ? (e.args as string[]) : undefined,
-        env: typeof e.env === 'object' && e.env !== null ? (e.env as Record<string, string>) : undefined,
+        env:
+          typeof e.env === 'object' && e.env !== null ? expandEnvValues(e.env as Record<string, unknown>) : undefined,
       };
     } else if (classification.kind === 'http') {
       const e = entry as Record<string, unknown>;


### PR DESCRIPTION
## Description

MCP stdio server `env` values were passed through verbatim, while HTTP server headers already resolved `${VAR}` references from the environment (#18240). This applies the same expansion to stdio `env`, so secrets can be referenced from the host environment instead of being hardcoded in `mcp.json`. The behavior now matches how Claude Code resolves values in `.mcp.json`, which the config loader already documents as its goal.

`expandEnvValues` mirrors the existing `expandHeaderEnvVars` helper and reuses `expandEnvVars`, so `${VAR}`, `${VAR:-default}`, and bare `$VAR` forms all resolve consistently.

## Related issue(s)

Fixes #18528

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change lets MCP stdio servers use secrets from your computer’s environment variables instead of typing them into config files. So if `mcp.json` says `"${GITHUB_TOKEN}"`, it now turns into the real token before the server starts, just like HTTP config already did.

## Summary
- Expanded `${VAR}`, `${VAR:-default}`, and `$VAR` references in stdio server `env` values using the host environment.
- Reused the existing environment expansion logic so stdio behavior now matches HTTP header handling.
- Added a test covering stdio `env` expansion and env cleanup/restoration.
- Added a changelog note describing the new stdio env interpolation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->