### PR TITLE
fix(playground): tighten E2E BDD follow-up

### DIFF
--- a/.claude/skills/e2e-tests-studio/SKILL.md
+++ b/.claude/skills/e2e-tests-studio/SKILL.md
@@ -32,7 +32,7 @@ model: claude-opus-4-5
 
 ## BDD Structure (REQUIRED)
 
-**Every E2E spec MUST follow the same BDD shape as the MSW tests.** This is lint-enforced for `packages/playground/e2e/tests/**/*.spec.ts` via `no-restricted-syntax` — a flat top-level `test()` will fail lint.
+**Every E2E spec MUST follow the same BDD shape as the MSW tests.** This is lint-enforced for `packages/playground/e2e/tests/**/*.spec.{js,jsx,ts,tsx}` via the custom `e2e-bdd/test-needs-when-describe` rule in `packages/playground/eslint.config.js` — a flat top-level `test()` will fail lint.
 
 The structure has exactly three levels:
 

--- a/.claude/skills/e2e-tests-studio/SKILL.md
+++ b/.claude/skills/e2e-tests-studio/SKILL.md
@@ -32,7 +32,7 @@ model: claude-opus-4-5
 
 ## BDD Structure (REQUIRED)
 
-**Every E2E spec MUST follow the same BDD shape as the MSW tests.** This is lint-enforced for `packages/playground/e2e/tests/**/*.spec.{js,jsx,ts,tsx}` via the custom `e2e-bdd/test-needs-when-describe` rule in `packages/playground/eslint.config.js` — a flat top-level `test()` will fail lint.
+**Every E2E spec MUST follow the same BDD shape as the MSW tests.** In `packages/playground`, `e2e-bdd/test-needs-when-describe` enforces this shape.
 
 The structure has exactly three levels:
 

--- a/packages/playground/AGENTS.md
+++ b/packages/playground/AGENTS.md
@@ -20,10 +20,8 @@ BDD-style, lint-enforced in `eslint.config.js`; MSW runs with
 - Each `it` = ONE outcome.
 
 The SAME BDD shape is required for both MSW tests (`src/**`) and Playwright E2E
-specs (`e2e/tests/**`). E2E specs are lint-enforced via the custom
-`e2e-bdd/test-needs-when-describe` rule. For E2E, outer `test.describe` = the
-unit, inner `test.describe('when …')` = ONE precondition, each `test` = ONE
-outcome — see the `e2e-tests-studio` skill.
+specs (`e2e/tests/**`). E2E uses `e2e-bdd/test-needs-when-describe`; see the
+`e2e-tests-studio` skill.
 
 Fixtures: nearby `__tests__/fixtures/`, typed with @mastra/client-js response
 types (no inline types, no `as any`). MSW is wired in `vitest.setup.ts`.

--- a/packages/playground/AGENTS.md
+++ b/packages/playground/AGENTS.md
@@ -12,17 +12,18 @@ Vitest + MSW + typed @mastra/client-js fixtures is the primary test strategy
 
 Test-first (TDD): RED failing MSW test → GREEN minimum code → REFACTOR.
 
-BDD-style, lint-enforced via `no-restricted-syntax` in `eslint.config.js`; MSW
-runs with `onUnhandledRequest: 'error'`:
+BDD-style, lint-enforced in `eslint.config.js`; MSW runs with
+`onUnhandledRequest: 'error'`:
 
 - Outer `describe` = the unit.
 - Inner `describe('when …')` = ONE precondition via a real MSW fixture.
 - Each `it` = ONE outcome.
 
 The SAME BDD shape is required for both MSW tests (`src/**`) and Playwright E2E
-specs (`e2e/tests/**`), each lint-enforced via `no-restricted-syntax`. For E2E,
-outer `test.describe` = the unit, inner `test.describe('when …')` = ONE
-precondition, each `test` = ONE outcome — see the `e2e-tests-studio` skill.
+specs (`e2e/tests/**`). E2E specs are lint-enforced via the custom
+`e2e-bdd/test-needs-when-describe` rule. For E2E, outer `test.describe` = the
+unit, inner `test.describe('when …')` = ONE precondition, each `test` = ONE
+outcome — see the `e2e-tests-studio` skill.
 
 Fixtures: nearby `__tests__/fixtures/`, typed with @mastra/client-js response
 types (no inline types, no `as any`). MSW is wired in `vitest.setup.ts`.

--- a/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
@@ -15,7 +15,7 @@ test.describe('Agent detail page', () => {
       await expect(page).toHaveTitle(/Mastra Studio/);
       await expectRouteDocsLink(page, 'Agents documentation', 'https://mastra.ai/en/docs/agents/overview');
       const breadcrumb = page.locator('header>nav');
-      expect(breadcrumb).toMatchAriaSnapshot();
+      await expect(breadcrumb).toMatchAriaSnapshot();
 
       // Thread history (with memory)
       const newChatButton = await page.locator('a:has-text("New Chat")');

--- a/packages/playground/e2e/tests/cms/agents/code-agent-override.spec.ts
+++ b/packages/playground/e2e/tests/cms/agents/code-agent-override.spec.ts
@@ -60,7 +60,9 @@ test.describe('code-mode agent override', () => {
       expect(download.suggestedFilename()).toBe('agents_code-override-editable.json');
       await expect(download.failure()).resolves.toBeNull();
     });
+  });
 
+  test.describe('when editable code-mode overrides are exported', () => {
     test('export endpoint returns a deterministic JSON payload for code-mode overrides', async ({ request }) => {
       // The Download JSON button calls /stored/agents/:id/export. Hit the endpoint
       // directly so we can assert on the actual exported payload — that is what
@@ -121,7 +123,9 @@ test.describe('code-mode agent override', () => {
       await expect(page.getByText(/Tools are owned by code/i)).toBeVisible();
       await expect(page.getByRole('button', { name: /Add Tools/i })).toHaveCount(0);
     });
+  });
 
+  test.describe('when locked code-mode overrides are exported', () => {
     test('locked code agent enforces editor: false on the server export endpoint', async ({ request }) => {
       // The server must refuse to bake overrides into an export for a code agent
       // that declared `editor: false`, even if the request body provides fields.

--- a/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
@@ -145,8 +145,8 @@ test.describe('CMS create agent page', () => {
     });
   });
 
-  test.describe('when required fields are partially filled', () => {
-    test('button stays disabled when only partial identity fields are filled', async ({ page }) => {
+  test.describe('when only agent name is filled', () => {
+    test('button stays disabled', async ({ page }) => {
       await page.goto('/cms/agents/create');
 
       const createButton = page.getByRole('button', { name: 'Create agent' });
@@ -156,15 +156,27 @@ test.describe('CMS create agent page', () => {
       await nameInput.fill('Test Agent');
 
       await expect(createButton).toBeDisabled();
+    });
+  });
 
-      // Fill provider but not model
+  test.describe('when agent name and provider are filled without a model', () => {
+    test('button stays disabled', async ({ page }) => {
+      await page.goto('/cms/agents/create');
+
+      const createButton = page.getByRole('button', { name: 'Create agent' });
+
+      const nameInput = page.locator('#agent-name');
+      await nameInput.fill('Test Agent');
+
       const providerCombobox = page.getByRole('combobox').nth(0);
       await providerCombobox.click();
       await page.getByRole('option', { name: 'OpenAI' }).click();
 
       await expect(createButton).toBeDisabled();
     });
+  });
 
+  test.describe('when identity fields are complete but instructions are empty', () => {
     test('button stays disabled when identity is complete but instructions are empty', async ({ page }) => {
       await page.goto('/cms/agents/create');
 
@@ -176,7 +188,9 @@ test.describe('CMS create agent page', () => {
       // Button should still be disabled because instructions are empty
       await expect(createButton).toBeDisabled();
     });
+  });
 
+  test.describe('when all required fields are filled', () => {
     test('button becomes enabled when all required fields are filled', async ({ page }) => {
       await page.goto('/cms/agents/create');
 
@@ -191,7 +205,9 @@ test.describe('CMS create agent page', () => {
       // Now enabled
       await expect(createButton).toBeEnabled();
     });
+  });
 
+  test.describe('when a required field is cleared after the form is enabled', () => {
     test('button becomes disabled again when required field is cleared', async ({ page }) => {
       await page.goto('/cms/agents/create');
 

--- a/packages/playground/e2e/tests/cms/scorers/create/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/scorers/create/page.spec.ts
@@ -123,7 +123,7 @@ test.describe('CMS create scorer page', () => {
     });
   });
 
-  test.describe('when required fields are left empty', () => {
+  test.describe('when the scorer name is empty', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/cms/scorers/create');
     });
@@ -140,6 +140,12 @@ test.describe('CMS create scorer page', () => {
 
       await expect(page.getByText('Name is required')).toBeVisible();
     });
+  });
+
+  test.describe('when the scorer provider is not selected', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/cms/scorers/create');
+    });
 
     test('shows validation error when provider is not selected', async ({ page }) => {
       await fillScorerFields(page, {
@@ -153,6 +159,12 @@ test.describe('CMS create scorer page', () => {
       await expect(page.getByText(/provider is required/i).or(page.getByText(/fill in all required/i))).toBeVisible({
         timeout: 5000,
       });
+    });
+  });
+
+  test.describe('when the scorer model is not selected', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/cms/scorers/create');
     });
 
     test('shows validation error when model is not selected', async ({ page }) => {
@@ -168,6 +180,12 @@ test.describe('CMS create scorer page', () => {
       await expect(page.getByText(/model is required/i).or(page.getByText(/fill in all required/i))).toBeVisible({
         timeout: 5000,
       });
+    });
+  });
+
+  test.describe('when the empty scorer form is submitted', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/cms/scorers/create');
     });
 
     test('shows error toast when submitting empty form', async ({ page }) => {

--- a/packages/playground/e2e/tests/observability/page.spec.ts
+++ b/packages/playground/e2e/tests/observability/page.spec.ts
@@ -63,7 +63,8 @@ test.describe('Observability traces page', () => {
 
       await scoreDialog.getByRole('link', { name: 'Response Quality Scorer' }).click();
 
-      const expectedUrl = new RegExp(`/scorers/response-quality\\?entity=.*&scoreId=${scoreId}`);
+      const escapedScoreId = scoreId!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const expectedUrl = new RegExp(`/scorers/response-quality\\?entity=.*&scoreId=${escapedScoreId}`);
       await expect(page).toHaveURL(expectedUrl);
       await expect(page.getByRole('dialog', { name: 'Scorer Score' })).toBeVisible();
       await expect(page.getByText(scoreId!, { exact: true })).toBeVisible();

--- a/packages/playground/e2e/tests/workflows/$workflowId/debug-step-by-step-conditional-run-page.spec.ts
+++ b/packages/playground/e2e/tests/workflows/$workflowId/debug-step-by-step-conditional-run-page.spec.ts
@@ -156,7 +156,9 @@ test.describe('Workflow debug conditional branch selection on the run-detail pag
       const skippedArmEdge = page.locator('[data-edge-to="short-text"]').first();
       await expect(skippedArmEdge).toHaveAttribute('data-edge-status', 'idle');
     });
+  });
 
+  test.describe('when the paused :runId page is reloaded before and after the conditional', () => {
     test('takes the condition-selected branch when the conditional is reloaded then advanced', async ({ page }) => {
       // The user's "even better" repro: pause right before the conditional, navigate to the run
       // page, HARD reload, advance once (long-text), then HARD reload AGAIN and advance once more.
@@ -214,7 +216,9 @@ test.describe('Workflow debug conditional branch selection on the run-detail pag
         timeout: 20000,
       });
     });
+  });
 
+  test.describe('when the conditional is advanced on the live graph page', () => {
     test('takes the condition-selected branch on the live graph page (no reload)', async ({ page }) => {
       // Same long input, but advance the conditional on the LIVE graph page without navigating
       // away. This isolates whether the conditional re-evaluation works in the live stream path,
@@ -251,8 +255,10 @@ test.describe('Workflow debug conditional branch selection on the run-detail pag
 
       await runNextStep(page);
     });
+  });
 
-    test('check edges', async ({ page }) => {
+  test.describe('when a debug run finishes after taking the condition-selected branch', () => {
+    test('marks branch and final edges successful', async ({ page }) => {
       // Drive complexWorkflow per-step all the way to a successful finish, then verify
       // both the post-branch map -> nested edge AND the boundary edge into the End node
       // are colored green. The End edge has no step ids, so it can only light once the

--- a/packages/playground/e2e/tests/workflows/$workflowId/page.spec.ts
+++ b/packages/playground/e2e/tests/workflows/$workflowId/page.spec.ts
@@ -18,7 +18,7 @@ test.describe('Workflow graph detail page', () => {
       await expect(page).toHaveTitle(/Mastra Studio/);
       await expectRouteDocsLink(page, 'Workflows documentation', 'https://mastra.ai/en/docs/workflows/overview');
       const breadcrumb = page.locator('header>nav');
-      expect(breadcrumb).toMatchAriaSnapshot();
+      await expect(breadcrumb).toMatchAriaSnapshot();
 
       // Information side panel
       await expect(page.getByText('complex-workflow').first()).toBeVisible();

--- a/packages/playground/e2e/tests/workflows/schedules.spec.ts
+++ b/packages/playground/e2e/tests/workflows/schedules.spec.ts
@@ -120,8 +120,8 @@ test.describe('Workflow schedules', () => {
     });
   });
 
-  test.describe('when a workflow graph header is rendered', () => {
-    test('shows the Schedules link only when the workflow has schedules', async ({ page }) => {
+  test.describe('when a workflow graph has one schedule', () => {
+    test('routes the Schedules link to the schedule detail page', async ({ page }) => {
       await page.goto('/workflows/scheduledWorkflow/graph');
 
       // scheduledWorkflow has exactly one schedule, so the header link goes straight
@@ -131,17 +131,22 @@ test.describe('Workflow schedules', () => {
 
       await scheduledHeaderLink.click();
       await expect(page).toHaveURL(/\/workflows\/schedules\/[^/]+$/);
+    });
+  });
 
-      // multiScheduledWorkflow has 2 schedules, so the header link goes to the
-      // filtered list view (?workflowId=...) instead of a detail page.
+  test.describe('when a workflow graph has multiple schedules', () => {
+    test('routes the Schedules link to the filtered schedules list', async ({ page }) => {
       await page.goto('/workflows/multiScheduledWorkflow/graph');
       const multiHeaderLink = page.getByRole('link', { name: /Schedules/ });
       await expect(multiHeaderLink).toBeVisible();
 
       await multiHeaderLink.click();
       await expect(page).toHaveURL(/\/workflows\/schedules\?workflowId=multiScheduledWorkflow$/);
+    });
+  });
 
-      // A workflow without any declared schedules should NOT render the link.
+  test.describe('when a workflow graph has no schedules', () => {
+    test('does not render the Schedules link', async ({ page }) => {
       await page.goto('/workflows/complexWorkflow/graph');
       await expect(page.getByRole('link', { name: /Schedules/ })).toHaveCount(0);
     });

--- a/packages/playground/eslint.config.js
+++ b/packages/playground/eslint.config.js
@@ -798,23 +798,47 @@ const prohibitedMockModulePatterns = [
 ];
 
 // BDD structure enforcement for Playwright E2E specs (e2e/tests/**).
-// Every leaf `test(...)` / `it(...)` MUST be nested inside a
-// `test.describe('when …')` (or `describe('when …')`) precondition block.
+// Every leaf `test(...)`, `it(...)`, or modifier form such as `test.skip(...)`
+// MUST be nested inside a `test.describe('when …')` (or `describe('when …')`)
+// precondition block.
 // A purely structural esquery selector cannot assert "nearest ancestor
 // describe title starts with 'when'", so this is implemented as a small custom
-// rule that walks the ancestor chain of each bare `test()` / `it()` call.
+// rule that walks the ancestor chain of each test declaration.
 const E2E_BDD_MESSAGE =
   "E2E BDD: every test()/it() must live inside a test.describe('when …') precondition block. " +
   "Outer test.describe = the unit, inner test.describe('when …') = ONE precondition, each test = ONE outcome. " +
   'See the e2e-tests-studio skill.';
 
-/** True when a CallExpression node is a bare `test(...)` / `it(...)` call. */
-function isBareTestCall(node) {
+const testFunctionNames = new Set(['test', 'it']);
+const testDeclarationModifiers = new Set(['skip', 'only', 'fixme', 'fail', 'slow']);
+
+function isStaticTestTitle(node) {
   return (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'Identifier' &&
-    (node.callee.name === 'test' || node.callee.name === 'it')
+    (node.type === 'Literal' && typeof node.value === 'string') ||
+    (node.type === 'TemplateLiteral' && node.quasis.length >= 1)
   );
+}
+
+/** True when a CallExpression node declares a `test(...)` / `it(...)` case. */
+function isTestDeclarationCall(node) {
+  if (node.type !== 'CallExpression') return false;
+
+  const callee = node.callee;
+  if (callee.type === 'Identifier' && testFunctionNames.has(callee.name)) return true;
+
+  if (
+    callee.type === 'MemberExpression' &&
+    callee.property.type === 'Identifier' &&
+    testDeclarationModifiers.has(callee.property.name) &&
+    callee.object.type === 'Identifier' &&
+    testFunctionNames.has(callee.object.name)
+  ) {
+    // Ignore suite/test annotations such as `test.skip(true, 'reason')` or
+    // `test.slow()`; only title-bearing modifier calls declare actual tests.
+    return isStaticTestTitle(node.arguments[0]);
+  }
+
+  return false;
 }
 
 /** True when a CallExpression is a `describe(...)`, `test.describe(...)`, or `it.describe(...)` call. */
@@ -858,7 +882,7 @@ const e2eBddPlugin = {
       create(context) {
         return {
           CallExpression(node) {
-            if (!isBareTestCall(node)) return;
+            if (!isTestDeclarationCall(node)) return;
             // Walk ancestors to find the nearest enclosing describe.
             const ancestors = context.sourceCode.getAncestors(node);
             let nearestDescribe = null;
@@ -942,7 +966,7 @@ export default [
     // e2e-tests-studio skill (every test()/it() nested in a describe('when …')).
     // These files are not part of the type-aware tsconfig program, so disable
     // the TypeScript project service here and only run the syntactic BDD rule.
-    files: ['e2e/tests/**/*.spec.ts'],
+    files: ['e2e/tests/**/*.spec.{js,jsx,ts,tsx}'],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/playground/eslint.config.js
+++ b/packages/playground/eslint.config.js
@@ -797,13 +797,7 @@ const prohibitedMockModulePatterns = [
   '^@mastra\\/react$',
 ];
 
-// BDD structure enforcement for Playwright E2E specs (e2e/tests/**).
-// Every leaf `test(...)`, `it(...)`, or modifier form such as `test.skip(...)`
-// MUST be nested inside a `test.describe('when …')` (or `describe('when …')`)
-// precondition block.
-// A purely structural esquery selector cannot assert "nearest ancestor
-// describe title starts with 'when'", so this is implemented as a small custom
-// rule that walks the ancestor chain of each test declaration.
+// Enforce the Playwright E2E BDD shape, including modifier forms like `test.skip('...')`.
 const E2E_BDD_MESSAGE =
   "E2E BDD: every test()/it() must live inside a test.describe('when …') precondition block. " +
   "Outer test.describe = the unit, inner test.describe('when …') = ONE precondition, each test = ONE outcome. " +
@@ -819,7 +813,6 @@ function isStaticTestTitle(node) {
   );
 }
 
-/** True when a CallExpression node declares a `test(...)` / `it(...)` case. */
 function isTestDeclarationCall(node) {
   if (node.type !== 'CallExpression') return false;
 
@@ -833,8 +826,7 @@ function isTestDeclarationCall(node) {
     callee.object.type === 'Identifier' &&
     testFunctionNames.has(callee.object.name)
   ) {
-    // Ignore suite/test annotations such as `test.skip(true, 'reason')` or
-    // `test.slow()`; only title-bearing modifier calls declare actual tests.
+    // Guard-style annotations like `test.skip(true, 'reason')` do not declare test cases.
     return isStaticTestTitle(node.arguments[0]);
   }
 


### PR DESCRIPTION
This stacks on #18514 and addresses the review issues around the E2E BDD cleanup.

It expands the custom BDD lint rule so modifier test declarations such as `test.skip('name', ...)` are enforced, while guard-style skips still stay valid. It also updates the guidance to name the real rule, awaits the ARIA snapshot assertions, escapes the score id URL regex, and splits the broad `when ...` groups called out in review.

Validated with `pnpm --filter ./packages/playground lint`, targeted Prettier check, `git diff --check`, and stdin ESLint probes for the new modifier handling. No changeset because this is test/docs/tooling only.