### PR TITLE
fix(core): persist reasoning text in AIV4Adapter and stream chunk 

### DIFF
--- a/.changeset/late-crabs-like.md
+++ b/.changeset/late-crabs-like.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed reasoning text being lost in AIV4Adapter and stream-chunk assembly at the end of the turn

--- a/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
@@ -520,7 +520,7 @@ export class AIV4Adapter {
             {
               const part: MastraDBMessage['content']['parts'][number] = {
                 type: 'reasoning',
-                reasoning: '',
+                reasoning: aiV4Part.text,
                 details: [{ type: 'text', text: aiV4Part.text, signature: aiV4Part.signature }],
               };
               if (aiV4Part.providerOptions) {

--- a/packages/core/src/agent/message-list/tests/message-list.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list.test.ts
@@ -931,7 +931,7 @@ describe('MessageList', () => {
               expect.objectContaining({
                 type: 'reasoning',
                 createdAt: expect.any(Number),
-                reasoning: '',
+                reasoning: 'Step 1: Analyze',
                 details: [{ type: 'text', text: 'Step 1: Analyze', signature: 'sig-a' }],
               }),
               expect.objectContaining({
@@ -1011,7 +1011,7 @@ describe('MessageList', () => {
               expect.objectContaining({
                 type: 'reasoning',
                 createdAt: expect.any(Number),
-                reasoning: '',
+                reasoning: 'Analyzing data...',
                 details: [{ type: 'text', text: 'Analyzing data...', signature: 'sig-b' }],
               }),
               expect.objectContaining({
@@ -1225,7 +1225,7 @@ describe('MessageList', () => {
               expect.objectContaining({
                 type: 'reasoning',
                 createdAt: expect.any(Number),
-                reasoning: '',
+                reasoning: 'First, I need to gather some data.',
                 details: [{ type: 'text', text: 'First, I need to gather some data.', signature: 'sig-gather' }],
               }),
               expect.objectContaining({ type: 'text', text: 'Calling data tool...', createdAt: expect.any(Number) }),
@@ -1244,7 +1244,7 @@ describe('MessageList', () => {
               expect.objectContaining({
                 type: 'reasoning',
                 createdAt: expect.any(Number),
-                reasoning: '',
+                reasoning: 'Data gathered, now processing.',
                 details: [{ type: 'text', text: 'Data gathered, now processing.', signature: 'sig-process' }],
               }),
               expect.objectContaining({
@@ -1716,7 +1716,7 @@ describe('MessageList', () => {
             parts: [
               {
                 type: 'reasoning',
-                reasoning: '',
+                reasoning: 'First, I need to gather some data.',
                 details: [{ type: 'text', text: 'First, I need to gather some data.', signature: 'sig-gather' }],
               },
               { type: 'text', text: 'Gathering data...' },
@@ -1731,7 +1731,7 @@ describe('MessageList', () => {
               },
               {
                 type: 'reasoning',
-                reasoning: '',
+                reasoning: 'Data gathered, now I will process it.',
                 details: [{ type: 'text', text: 'Data gathered, now I will process it.', signature: 'sig-process' }],
               },
             ],
@@ -1893,13 +1893,13 @@ describe('MessageList', () => {
             parts: [
               {
                 type: 'reasoning',
-                reasoning: '',
+                reasoning: 'Thinking step 1...',
                 details: [{ type: 'text', text: 'Thinking step 1...', signature: 'sig-1' }],
               },
               { type: 'reasoning', reasoning: '', details: [{ type: 'redacted', data: 'some hidden data' }] },
               {
                 type: 'reasoning',
-                reasoning: '',
+                reasoning: 'Final thought.',
                 details: [{ type: 'text', text: 'Final thought.', signature: 'sig-2' }],
               },
             ],

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -120,6 +120,7 @@ describe('buildMessagesFromChunks', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: 'reasoning',
+      reasoning: 'Thinking...',
       details: [{ type: 'text', text: 'Thinking...' }],
     });
   });
@@ -132,6 +133,7 @@ describe('buildMessagesFromChunks', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: 'reasoning',
+      reasoning: '',
       details: [{ type: 'text', text: '' }],
     });
   });
@@ -144,7 +146,11 @@ describe('buildMessagesFromChunks', () => {
       { type: 'reasoning-delta', payload: { id: 'r1', text: 'think' } },
       { type: 'reasoning-end', payload: { id: 'r1', providerMetadata: endMeta } },
     ]);
-    expect(result[0]?.providerMetadata).toEqual(endMeta);
+    expect(result[0]).toMatchObject({
+      type: 'reasoning',
+      reasoning: 'think',
+      providerMetadata: endMeta,
+    });
   });
 
   it('should handle redacted reasoning', () => {
@@ -158,6 +164,7 @@ describe('buildMessagesFromChunks', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: 'reasoning',
+      reasoning: '',
       details: [{ type: 'redacted', data: '' }],
     });
   });
@@ -168,6 +175,7 @@ describe('buildMessagesFromChunks', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: 'reasoning',
+      reasoning: '',
       details: [{ type: 'redacted', data: '' }],
       providerMetadata: meta,
     });
@@ -184,8 +192,16 @@ describe('buildMessagesFromChunks', () => {
       { type: 'reasoning-end', payload: { id: 'r2' } },
     ]);
     expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ type: 'reasoning', details: [{ type: 'text', text: 'Thought A. More A.' }] });
-    expect(result[1]).toMatchObject({ type: 'reasoning', details: [{ type: 'text', text: 'Thought B.' }] });
+    expect(result[0]).toMatchObject({
+      type: 'reasoning',
+      reasoning: 'Thought A. More A.',
+      details: [{ type: 'text', text: 'Thought A. More A.' }],
+    });
+    expect(result[1]).toMatchObject({
+      type: 'reasoning',
+      reasoning: 'Thought B.',
+      details: [{ type: 'text', text: 'Thought B.' }],
+    });
   });
 
   // ── Tool calls ──────────────────────────────────────────────

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -162,6 +162,7 @@ export function buildMessagesFromChunks({
         if (detail && detail.type === 'text') {
           detail.text += p.text;
         }
+        ref.reasoning = (ref.reasoning || '') + p.text;
         if (p.providerMetadata) {
           ref.providerMetadata = p.providerMetadata;
         }


### PR DESCRIPTION

## Description

This PR fully resolves the issue where reasoning chunks completely vanish from Studio at the end of a turn by fixing the remaining adapters and streaming message-assembly paths:
- Updates `AIV4Adapter.ts` to populate the `reasoning` property with the actual text from the message parts, rather than hardcoding it to an empty string `''`.
- Updates `build-messages-from-chunks.ts` (stream assembler) to accumulate incoming streaming reasoning deltas into the part's main `reasoning` text property.
- Updates outdated assertions in `message-list.test.ts` that were previously expecting the buggy empty string `''`.

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/18532

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When Studio shows a model “thinking,” that text used to get cleared when the turn finished. This PR keeps the real thinking text stored all the way through the end of the turn so Studio can keep displaying it.

## What changed
- Updated `AIV4Adapter.ts` to copy the actual AI V4 reasoning text into the message part’s top-level `reasoning` field (instead of an empty string).
- Updated `build-messages-from-chunks.ts` to accumulate streamed `reasoning-delta` text into the part’s `reasoning` field.
- Adjusted `message-list.test.ts` (and related chunk-assembly tests) to assert the corrected `reasoning` behavior after streaming completes.
- Added a changeset entry for `@mastra/core` with a patch release note about preserving reasoning text.

## Notes
- No public API changes; this restores reasoning persistence across the full turn lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->