### PR TITLE
docs(channels): document serverless deployment with waitUntil and Redis Streams pub/sub

### DIFF
--- a/docs/src/content/en/docs/agents/channels.mdx
+++ b/docs/src/content/en/docs/agents/channels.mdx
@@ -199,11 +199,11 @@ export const agent = new Agent({
 })
 ```
 
-Cloudflare Workers and Netlify Functions are detected automatically from the request context, so they don't need `waitUntil`. AWS Lambda doesn't need it either, because it waits for the event loop to drain. For runtimes where `waitUntil` lives on the request context but isn't detected automatically, use `resolveWaitUntil`. See the [Channels reference](/reference/agents/channels#parameters) for details.
+Vercel and AWS Lambda require `waitUntil`, since they freeze the function as soon as the response is sent. Cloudflare Workers and Netlify Functions are detected automatically from the request context, so they don't need it. For runtimes where `waitUntil` lives on the request context but isn't detected automatically, use `resolveWaitUntil`. See the [Channels reference](/reference/agents/channels#parameters) for details.
 
 ### Coordinate instances with a shared pub/sub
 
-Channels route messages through the agent's signal pipeline, and each run acquires a lease on its thread. The default in-memory pub/sub can't cross instance boundaries, so on serverless a "stop" reply can land on a different instance than the one running the agent, and instances can re-process the same thread.
+Channels route messages through the agent's signal pipeline, and each run acquires a lease on its thread so a single run owns the conversation at a time. The default in-memory pub/sub can't cross instance boundaries, so on serverless a follow-up message can land on a different instance than the one running the agent. Without a shared pub/sub, that instance can't reach the active run and starts its own, leaving the original run untouched and the thread processed twice.
 
 Configure a shared pub/sub backed by Redis Streams on the `Mastra` instance so leases and signals coordinate across instances:
 

--- a/docs/src/content/en/docs/agents/channels.mdx
+++ b/docs/src/content/en/docs/agents/channels.mdx
@@ -175,6 +175,53 @@ See [Channels reference](/reference/agents/channels#inline-media) for all `inlin
 
 :::
 
+## Serverless deployment
+
+On serverless platforms like Vercel, each request runs in a separate, short-lived instance. Channels need two things to work reliably in that environment: a way to keep the function alive while the agent responds, and a shared pub/sub so instances can coordinate.
+
+### Keep the function alive with `waitUntil`
+
+A channel webhook returns a `200` response right away, then the agent runs in the background to post its reply. On most serverless platforms the function is frozen as soon as it responds, which kills the run before the agent answers. Pass a `waitUntil` function so the platform keeps the instance alive until the run finishes.
+
+On Vercel, pass `waitUntil` from `@vercel/functions`:
+
+```typescript
+import { waitUntil } from '@vercel/functions'
+
+export const agent = new Agent({
+  // ...
+  channels: {
+    adapters: {
+      slack: createSlackAdapter(),
+    },
+    waitUntil,
+  },
+})
+```
+
+Cloudflare Workers and Netlify Functions are detected automatically from the request context, so they don't need `waitUntil`. AWS Lambda doesn't need it either, because it waits for the event loop to drain. For runtimes where `waitUntil` lives on the request context but isn't detected automatically, use `resolveWaitUntil`. See the [Channels reference](/reference/agents/channels#parameters) for details.
+
+### Coordinate instances with a shared pub/sub
+
+Channels route messages through the agent's signal pipeline, and each run acquires a lease on its thread. The default in-memory pub/sub can't cross instance boundaries, so on serverless a "stop" reply can land on a different instance than the one running the agent, and instances can re-process the same thread.
+
+Configure a shared pub/sub backed by Redis Streams on the `Mastra` instance so leases and signals coordinate across instances:
+
+```typescript
+import { Mastra } from '@mastra/core'
+import { RedisStreamsPubSub } from '@mastra/redis-streams'
+
+export const mastra = new Mastra({
+  agents: { agent },
+  pubsub: new RedisStreamsPubSub({
+    url: process.env.REDIS_URL,
+    keyPrefix: 'mastra:my-app',
+  }),
+})
+```
+
+Vercel's one-click Redis integration and Upstash Redis both work well. For more on when a distributed pub/sub is needed, see the [PubSub guide](/docs/server/pubsub) and the [`RedisStreamsPubSub` reference](/reference/pubsub/redis-streams).
+
 ## Related
 
 - [Guide: Building a Slack assistant](/guides/guide/slack-assistant)


### PR DESCRIPTION
## What

Adds a **Serverless deployment** section to the Channels guide (`docs/src/content/en/docs/agents/channels.mdx`). The guide previously had no serverless coverage, even though running channels on platforms like Vercel requires two specific pieces of configuration that already shipped.

## Why

On serverless platforms each webhook runs in a short-lived instance. A channel webhook returns `200` immediately and the agent replies in the background, so without help the instance is frozen before the agent answers. Channels also route through the agent's signal pipeline and acquire a per-thread lease, which the default in-memory pub/sub can't coordinate across separate instances. Both gaps already have fixes in the framework, but they weren't documented in the channels guide, leading to repeated questions in issues.

## What's covered

- **`waitUntil`** — keeps the instance alive until the run finishes. Vercel example using `@vercel/functions`; notes that Cloudflare Workers and Netlify Functions are auto-detected, AWS Lambda doesn't need it, and `resolveWaitUntil` exists for other runtimes.
- **Shared pub/sub** — `RedisStreamsPubSub` on the `Mastra` instance so thread leases and signals coordinate across instances. Credits Vercel's one-click Redis integration and Upstash, and links the PubSub guide plus the `RedisStreamsPubSub` reference.

## Notes

- Docs-only change, no changeset.
- Links use existing anchors/pages (Channels reference `#parameters`, PubSub guide, `RedisStreamsPubSub` reference).

## Test plan

- `prettier --check` passes
- `remark --frail` passes (exit 0)
- Prose follows the docs styleguide (sentence-case headings, present tense, no banned/weak words)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
On serverless platforms, your channel webhook finishes fast and the server may stop before the agent replies. This guide shows how to keep it running long enough and how to coordinate with other instances so the same chat thread isn’t processed twice.

## Summary
- Added a **Serverless deployment** section to the Channels guide.
- Documented using `waitUntil` so a channel webhook can return `200` immediately while the agent finishes generating and sending the reply.
- Included platform guidance and a Vercel example using `waitUntil` from `@vercel/functions`, plus notes on Cloudflare Workers/Netlify auto-detection and using `resolveWaitUntil` for other runtimes.
- Added guidance to coordinate across instances with a shared distributed pub/sub on the `Mastra` instance, recommending **Redis Streams Pub/Sub** (`RedisStreamsPubSub`) to ensure thread leases/signals work correctly.
- Linked to the Pub/Sub guide and the `RedisStreamsPubSub` reference.
- Docs-only change (no changeset included).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->