### PR TITLE
docs(reference): add LeaseProvider page and document RedisStreamsPubSub leasing

### DIFF
--- a/docs/src/content/en/reference/pubsub/lease-provider.mdx
+++ b/docs/src/content/en/reference/pubsub/lease-provider.mdx
@@ -11,7 +11,7 @@ packages:
 
 Leasing is a distinct concern from pub/sub. A backend implements `LeaseProvider` only when it can genuinely coordinate a lock, such as Redis via atomic `SET`/Lua, or an in-memory map for single-process. Backends that cannot lease omit it; the signals runtime feature-detects the capability and falls back to a no-op provider, preserving single-process behavior.
 
-The built-in [`RedisStreamsPubSub`](/reference/pubsub/redis-streams) implements `LeaseProvider`, which is what enables channels and signals to coordinate across instances in distributed and serverless deployments.
+The built-in [`RedisStreamsPubSub`](/reference/pubsub/redis-streams) implements `LeaseProvider`, which is what enables signals to coordinate across instances in distributed and serverless deployments.
 
 ## Usage example
 

--- a/docs/src/content/en/reference/pubsub/lease-provider.mdx
+++ b/docs/src/content/en/reference/pubsub/lease-provider.mdx
@@ -1,0 +1,154 @@
+---
+title: "Reference: LeaseProvider | PubSub"
+description: "API reference for LeaseProvider, the distributed leasing contract Mastra's signals layer uses to elect a single owner across processes."
+packages:
+  - "@mastra/core"
+---
+
+# LeaseProvider
+
+`LeaseProvider` is the distributed leasing contract, separate from event delivery ([`PubSub`](/reference/pubsub/base)). Mastra's signals layer uses it to elect a single owner across multiple processes — for example, serverless invocations — for a given resource, most commonly a thread key. The owner is the process that wakes and runs the agent stream, so other processes route follow-up work to it instead of starting a competing run.
+
+Leasing is a distinct concern from pub/sub. A backend implements `LeaseProvider` only when it can genuinely coordinate a lock — Redis via atomic `SET`/Lua, or an in-memory map for single-process. Backends that cannot lease omit it; the signals runtime feature-detects the capability and falls back to a no-op provider, preserving single-process behavior.
+
+The built-in [`RedisStreamsPubSub`](/reference/pubsub/redis-streams) implements `LeaseProvider`, which is what enables channels and signals to coordinate across instances in distributed and serverless deployments.
+
+## Usage example
+
+You don't construct a `LeaseProvider` directly. Configure a pub/sub backend that implements it (such as `RedisStreamsPubSub`) on the `Mastra` constructor, and the signals runtime uses it automatically for cross-process coordination.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { RedisStreamsPubSub } from '@mastra/redis-streams'
+
+export const mastra = new Mastra({
+  // RedisStreamsPubSub implements both PubSub and LeaseProvider
+  pubsub: new RedisStreamsPubSub({
+    url: process.env.REDIS_URL,
+  }),
+})
+```
+
+To implement leasing in a custom backend, implement the methods below. The signals runtime detects the capability structurally (so it works across package boundaries) and only uses it when all methods are present.
+
+```typescript title="src/mastra/pubsub.ts"
+import { PubSub } from '@mastra/core/events'
+import type { LeaseProvider } from '@mastra/core/events'
+
+export class CustomPubSub extends PubSub implements LeaseProvider {
+  async acquireLease(key: string, owner: string, ttlMs: number) {
+    // Atomically claim the lease, or report the current holder.
+    return { acquired: true, owner }
+  }
+
+  // ...getLeaseOwner, releaseLease, renewLease, transferLease
+}
+```
+
+## Methods
+
+### Leasing
+
+#### `acquireLease(key, owner, ttlMs)`
+
+Atomically tries to acquire a lease on a key. Returns `{ acquired: true, owner }` if the caller claimed the lease, or `{ acquired: false, owner }` where `owner` is the current holder, so the caller can route follow-up work to them. The same owner can call `acquireLease` idempotently to renew or re-claim.
+
+```typescript
+const result = await pubsub.acquireLease('thread:abc', runId, 15000)
+
+if (result.acquired) {
+  // This process owns the thread — wake and run the agent.
+} else {
+  // result.owner holds the lease — route the signal to them.
+}
+```
+
+Returns: `Promise<{ acquired: boolean; owner?: string }>`
+
+<PropertiesTable
+  content={[
+  {
+    name: 'key',
+    type: 'string',
+    description: 'The lease key, such as a thread key.',
+  },
+  {
+    name: 'owner',
+    type: 'string',
+    description:
+      'Identifier for the owner, such as a `runId`. The same owner can call `acquireLease` idempotently to renew or release.',
+  },
+  {
+    name: 'ttlMs',
+    type: 'number',
+    description: 'Time-to-live in milliseconds for the lease.',
+  },
+]}
+/>
+
+#### `getLeaseOwner(key)`
+
+Reads the current owner of a lease, or `undefined` if no lease is held.
+
+```typescript
+const owner = await pubsub.getLeaseOwner('thread:abc')
+```
+
+Returns: `Promise<string | undefined>`
+
+#### `releaseLease(key, owner)`
+
+Releases a lease. This is a no-op if the caller is not the current owner — implementations check ownership atomically before releasing, so a concurrent renewal by another owner is never clobbered.
+
+```typescript
+await pubsub.releaseLease('thread:abc', runId)
+```
+
+Returns: `Promise<void>`
+
+#### `renewLease(key, owner, ttlMs)`
+
+Renews an existing lease owned by `owner`, extending its TTL. Returns `true` if the renewal succeeded and the caller still owns the lease, or `false` if the lease was lost (TTL expired or another owner took it).
+
+```typescript
+const stillOwned = await pubsub.renewLease('thread:abc', runId, 15000)
+
+if (!stillOwned) {
+  // Lost the lease — stop renewing and let the new owner take over.
+}
+```
+
+Returns: `Promise<boolean>`
+
+#### `transferLease(key, fromOwner, toOwner, ttlMs)`
+
+Atomically hands a held lease from `fromOwner` to `toOwner`, refreshing its TTL, without releasing the key in between. This is the gap-free primitive used when one owner finishes but a follow-up owner must take over the same key immediately — for example, when a thread run completes and a queued follow-up run drains on the same thread. A naive release-then-acquire would briefly leave the key empty, letting a racing process win the freed lease and start a competing run.
+
+Returns `true` if `fromOwner` still held the lease and ownership moved to `toOwner`, or `false` if the lease was already lost, in which case the caller should fall back to a fresh `acquireLease`.
+
+```typescript
+const transferred = await pubsub.transferLease('thread:abc', currentRunId, nextRunId, 15000)
+
+if (!transferred) {
+  // Lease was lost — acquire fresh instead.
+  await pubsub.acquireLease('thread:abc', nextRunId, 15000)
+}
+```
+
+Returns: `Promise<boolean>`
+
+:::warning
+Backends that cannot perform the transfer atomically must still implement it as a best-effort `releaseLease(fromOwner)` followed by `acquireLease(toOwner)`, and document that the swap is non-atomic — a racing process can win the key in the gap. Keeping the method required means callers have a single code path and atomicity is an explicit per-backend decision.
+:::
+
+## Capability detection
+
+The signals runtime detects `LeaseProvider` structurally rather than with `instanceof`, so detection works even when a separately published backend resolves a different copy of `@mastra/core`. A value is treated as a `LeaseProvider` when it exposes all five methods (`acquireLease`, `getLeaseOwner`, `releaseLease`, `renewLease`, `transferLease`).
+
+When the configured pub/sub backend does not implement `LeaseProvider`, the runtime falls back to an always-win no-op provider. Every caller wins its own lease race and release, renew, and transfer are inert — which preserves the expected single-process behavior.
+
+## Related
+
+- [PubSub](/reference/pubsub/base): The event delivery contract, separate from leasing
+- [RedisStreamsPubSub](/reference/pubsub/redis-streams): The built-in backend that implements `LeaseProvider`
+- [Channels](/docs/agents/channels): Uses leasing to coordinate agent runs across instances

--- a/docs/src/content/en/reference/pubsub/lease-provider.mdx
+++ b/docs/src/content/en/reference/pubsub/lease-provider.mdx
@@ -7,9 +7,9 @@ packages:
 
 # LeaseProvider
 
-`LeaseProvider` is the distributed leasing contract, separate from event delivery ([`PubSub`](/reference/pubsub/base)). Mastra's signals layer uses it to elect a single owner across multiple processes — for example, serverless invocations — for a given resource, most commonly a thread key. The owner is the process that wakes and runs the agent stream, so other processes route follow-up work to it instead of starting a competing run.
+`LeaseProvider` is the distributed leasing contract, separate from event delivery ([`PubSub`](/reference/pubsub/base)). Mastra's signals layer uses it to elect a single owner across multiple processes (for example, serverless invocations) for a given resource, most commonly a thread key. The owner is the process that wakes and runs the agent stream, so other processes route follow-up work to it instead of starting a competing run.
 
-Leasing is a distinct concern from pub/sub. A backend implements `LeaseProvider` only when it can genuinely coordinate a lock — Redis via atomic `SET`/Lua, or an in-memory map for single-process. Backends that cannot lease omit it; the signals runtime feature-detects the capability and falls back to a no-op provider, preserving single-process behavior.
+Leasing is a distinct concern from pub/sub. A backend implements `LeaseProvider` only when it can genuinely coordinate a lock, such as Redis via atomic `SET`/Lua, or an in-memory map for single-process. Backends that cannot lease omit it; the signals runtime feature-detects the capability and falls back to a no-op provider, preserving single-process behavior.
 
 The built-in [`RedisStreamsPubSub`](/reference/pubsub/redis-streams) implements `LeaseProvider`, which is what enables channels and signals to coordinate across instances in distributed and serverless deployments.
 
@@ -57,9 +57,9 @@ Atomically tries to acquire a lease on a key. Returns `{ acquired: true, owner }
 const result = await pubsub.acquireLease('thread:abc', runId, 15000)
 
 if (result.acquired) {
-  // This process owns the thread — wake and run the agent.
+  // This process owns the thread, so wake and run the agent.
 } else {
-  // result.owner holds the lease — route the signal to them.
+  // result.owner holds the lease, so route the signal to them.
 }
 ```
 
@@ -98,7 +98,7 @@ Returns: `Promise<string | undefined>`
 
 #### `releaseLease(key, owner)`
 
-Releases a lease. This is a no-op if the caller is not the current owner — implementations check ownership atomically before releasing, so a concurrent renewal by another owner is never clobbered.
+Releases a lease. This is a no-op if the caller is not the current owner: implementations check ownership atomically before releasing, so a concurrent renewal by another owner is never clobbered.
 
 ```typescript
 await pubsub.releaseLease('thread:abc', runId)
@@ -114,7 +114,7 @@ Renews an existing lease owned by `owner`, extending its TTL. Returns `true` if 
 const stillOwned = await pubsub.renewLease('thread:abc', runId, 15000)
 
 if (!stillOwned) {
-  // Lost the lease — stop renewing and let the new owner take over.
+  // Lost the lease, so stop renewing and let the new owner take over.
 }
 ```
 
@@ -122,7 +122,7 @@ Returns: `Promise<boolean>`
 
 #### `transferLease(key, fromOwner, toOwner, ttlMs)`
 
-Atomically hands a held lease from `fromOwner` to `toOwner`, refreshing its TTL, without releasing the key in between. This is the gap-free primitive used when one owner finishes but a follow-up owner must take over the same key immediately — for example, when a thread run completes and a queued follow-up run drains on the same thread. A naive release-then-acquire would briefly leave the key empty, letting a racing process win the freed lease and start a competing run.
+Atomically hands a held lease from `fromOwner` to `toOwner`, refreshing its TTL, without releasing the key in between. This is the gap-free primitive used when one owner finishes but a follow-up owner must take over the same key immediately, for example when a thread run completes and a queued follow-up run drains on the same thread. A naive release-then-acquire would briefly leave the key empty, letting a racing process win the freed lease and start a competing run.
 
 Returns `true` if `fromOwner` still held the lease and ownership moved to `toOwner`, or `false` if the lease was already lost, in which case the caller should fall back to a fresh `acquireLease`.
 
@@ -130,7 +130,7 @@ Returns `true` if `fromOwner` still held the lease and ownership moved to `toOwn
 const transferred = await pubsub.transferLease('thread:abc', currentRunId, nextRunId, 15000)
 
 if (!transferred) {
-  // Lease was lost — acquire fresh instead.
+  // Lease was lost, so acquire fresh instead.
   await pubsub.acquireLease('thread:abc', nextRunId, 15000)
 }
 ```
@@ -138,14 +138,14 @@ if (!transferred) {
 Returns: `Promise<boolean>`
 
 :::warning
-Backends that cannot perform the transfer atomically must still implement it as a best-effort `releaseLease(fromOwner)` followed by `acquireLease(toOwner)`, and document that the swap is non-atomic — a racing process can win the key in the gap. Keeping the method required means callers have a single code path and atomicity is an explicit per-backend decision.
+Backends that cannot perform the transfer atomically must still implement it as a best-effort `releaseLease(fromOwner)` followed by `acquireLease(toOwner)`, and document that the swap is non-atomic, since a racing process can win the key in the gap. Keeping the method required means callers have a single code path and atomicity is an explicit per-backend decision.
 :::
 
 ## Capability detection
 
 The signals runtime detects `LeaseProvider` structurally rather than with `instanceof`, so detection works even when a separately published backend resolves a different copy of `@mastra/core`. A value is treated as a `LeaseProvider` when it exposes all five methods (`acquireLease`, `getLeaseOwner`, `releaseLease`, `renewLease`, `transferLease`).
 
-When the configured pub/sub backend does not implement `LeaseProvider`, the runtime falls back to an always-win no-op provider. Every caller wins its own lease race and release, renew, and transfer are inert — which preserves the expected single-process behavior.
+When the configured pub/sub backend does not implement `LeaseProvider`, the runtime falls back to an always-win no-op provider. Every caller wins its own lease race, and release, renew, and transfer are inert, which preserves the expected single-process behavior.
 
 ## Related
 

--- a/docs/src/content/en/reference/pubsub/lease-provider.mdx
+++ b/docs/src/content/en/reference/pubsub/lease-provider.mdx
@@ -151,4 +151,4 @@ When the configured pub/sub backend does not implement `LeaseProvider`, the runt
 
 - [PubSub](/reference/pubsub/base): The event delivery contract, separate from leasing
 - [RedisStreamsPubSub](/reference/pubsub/redis-streams): The built-in backend that implements `LeaseProvider`
-- [Channels](/docs/agents/channels): Uses leasing to coordinate agent runs across instances
+- [Channels](/docs/agents/channels): Uses leasing to coordinate agent runs in serverless and multi-instance deployments

--- a/docs/src/content/en/reference/pubsub/lease-provider.mdx
+++ b/docs/src/content/en/reference/pubsub/lease-provider.mdx
@@ -7,7 +7,7 @@ packages:
 
 # LeaseProvider
 
-`LeaseProvider` is the distributed leasing contract, separate from event delivery ([`PubSub`](/reference/pubsub/base)). Mastra's signals layer uses it to elect a single owner across multiple processes (for example, serverless invocations) for a given resource, most commonly a thread key. The owner is the process that wakes and runs the agent stream, so other processes route follow-up work to it instead of starting a competing run.
+`LeaseProvider` is the distributed leasing contract, separate from event delivery ([`PubSub`](/reference/pubsub/base)). Mastra's [signals layer](/docs/agents/signals) uses it to elect a single owner across multiple processes (for example, serverless invocations) for a given resource, most commonly a thread key. The owner is the process that wakes and runs the agent stream, so other processes route follow-up work to it instead of starting a competing run.
 
 Leasing is a distinct concern from pub/sub. A backend implements `LeaseProvider` only when it can genuinely coordinate a lock, such as Redis via atomic `SET`/Lua, or an in-memory map for single-process. Backends that cannot lease omit it; the signals runtime feature-detects the capability and falls back to a no-op provider, preserving single-process behavior.
 
@@ -151,4 +151,5 @@ When the configured pub/sub backend does not implement `LeaseProvider`, the runt
 
 - [PubSub](/reference/pubsub/base): The event delivery contract, separate from leasing
 - [RedisStreamsPubSub](/reference/pubsub/redis-streams): The built-in backend that implements `LeaseProvider`
+- [Signals](/docs/agents/signals): The runtime that uses leasing to coordinate thread runs across processes
 - [Channels](/docs/agents/channels): Uses leasing to coordinate agent runs in serverless and multi-instance deployments

--- a/docs/src/content/en/reference/pubsub/redis-streams.mdx
+++ b/docs/src/content/en/reference/pubsub/redis-streams.mdx
@@ -8,7 +8,7 @@ packages:
 
 # RedisStreamsPubSub
 
-`RedisStreamsPubSub` is a [`PubSub`](/reference/pubsub/base) implementation backed by [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/). It delivers events across processes and hosts, with persistence, consumer groups, and redelivery on failure. It also implements [`LeaseProvider`](/reference/pubsub/lease-provider), so the signals layer can elect a single owner per resource across instances, which is what lets channels and signals coordinate runs in distributed and serverless deployments.
+`RedisStreamsPubSub` is a [`PubSub`](/reference/pubsub/base) implementation backed by [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/). It delivers events across processes and hosts, with persistence, consumer groups, and redelivery on failure. It also implements [`LeaseProvider`](/reference/pubsub/lease-provider), so the signals layer can elect a single owner per resource across instances, which is what lets signals coordinate runs in distributed and serverless deployments.
 
 Use it for distributed deployments where several services share an event stream. For single-process delivery, use [`EventEmitterPubSub`](/reference/pubsub/event-emitter). For Google Cloud, use [`GoogleCloudPubSub`](/reference/pubsub/google-cloud-pubsub).
 
@@ -156,7 +156,7 @@ When a subscriber calls `nack`, the event is republished with an incremented `de
 
 ## Distributed leasing
 
-`RedisStreamsPubSub` implements the [`LeaseProvider`](/reference/pubsub/lease-provider) contract on top of the same Redis connection. The signals runtime uses it to elect a single owner (usually per thread key) so that across instances only one process wakes and runs the agent, and others route follow-up work to the holder. This is what makes channels and signals work on serverless and multi-instance deployments; without a shared lease, each instance would start its own competing run.
+`RedisStreamsPubSub` implements the [`LeaseProvider`](/reference/pubsub/lease-provider) contract on top of the same Redis connection. The signals runtime uses it to elect a single owner (usually per thread key) so that across instances only one process wakes and runs the agent, and others route follow-up work to the holder. This is what makes signals work on serverless and multi-instance deployments; without a shared lease, each instance would start its own competing run.
 
 Lease keys are namespaced under the same `keyPrefix` as topics, as `<keyPrefix>:lease:<key>`. All operations are atomic: `acquireLease` uses `SET NX PX` and refreshes its own TTL idempotently, while `releaseLease`, `renewLease`, and `transferLease` use Lua scripts that check ownership before mutating, so a concurrent renewal from another owner is never clobbered.
 

--- a/docs/src/content/en/reference/pubsub/redis-streams.mdx
+++ b/docs/src/content/en/reference/pubsub/redis-streams.mdx
@@ -156,7 +156,7 @@ When a subscriber calls `nack`, the event is republished with an incremented `de
 
 ## Distributed leasing
 
-`RedisStreamsPubSub` implements the [`LeaseProvider`](/reference/pubsub/lease-provider) contract on top of the same Redis connection. The signals runtime uses it to elect a single owner (usually per thread key) so that across instances only one process wakes and runs the agent, and others route follow-up work to the holder. This is what makes signals work on serverless and multi-instance deployments; without a shared lease, each instance would start its own competing run.
+`RedisStreamsPubSub` implements the [`LeaseProvider`](/reference/pubsub/lease-provider) contract on top of the same Redis connection. The [signals runtime](/docs/agents/signals) uses it to elect a single owner (usually per thread key) so that across instances only one process wakes and runs the agent, and others route follow-up work to the holder. This is what makes signals work on serverless and multi-instance deployments; without a shared lease, each instance would start its own competing run.
 
 Lease keys are namespaced under the same `keyPrefix` as topics, as `<keyPrefix>:lease:<key>`. All operations are atomic: `acquireLease` uses `SET NX PX` and refreshes its own TTL idempotently, while `releaseLease`, `renewLease`, and `transferLease` use Lua scripts that check ownership before mutating, so a concurrent renewal from another owner is never clobbered.
 

--- a/docs/src/content/en/reference/pubsub/redis-streams.mdx
+++ b/docs/src/content/en/reference/pubsub/redis-streams.mdx
@@ -8,7 +8,7 @@ packages:
 
 # RedisStreamsPubSub
 
-`RedisStreamsPubSub` is a [`PubSub`](/reference/pubsub/base) implementation backed by [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/). It delivers events across processes and hosts, with persistence, consumer groups, and redelivery on failure. It also implements [`LeaseProvider`](/reference/pubsub/lease-provider), so the signals layer can elect a single owner per resource across instances — which is what lets channels and signals coordinate runs in distributed and serverless deployments.
+`RedisStreamsPubSub` is a [`PubSub`](/reference/pubsub/base) implementation backed by [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/). It delivers events across processes and hosts, with persistence, consumer groups, and redelivery on failure. It also implements [`LeaseProvider`](/reference/pubsub/lease-provider), so the signals layer can elect a single owner per resource across instances, which is what lets channels and signals coordinate runs in distributed and serverless deployments.
 
 Use it for distributed deployments where several services share an event stream. For single-process delivery, use [`EventEmitterPubSub`](/reference/pubsub/event-emitter). For Google Cloud, use [`GoogleCloudPubSub`](/reference/pubsub/google-cloud-pubsub).
 
@@ -156,8 +156,8 @@ When a subscriber calls `nack`, the event is republished with an incremented `de
 
 ## Distributed leasing
 
-`RedisStreamsPubSub` implements the [`LeaseProvider`](/reference/pubsub/lease-provider) contract on top of the same Redis connection. The signals runtime uses it to elect a single owner — usually per thread key — so that across instances only one process wakes and runs the agent, and others route follow-up work to the holder. This is what makes channels and signals work on serverless and multi-instance deployments; without a shared lease, each instance would start its own competing run.
+`RedisStreamsPubSub` implements the [`LeaseProvider`](/reference/pubsub/lease-provider) contract on top of the same Redis connection. The signals runtime uses it to elect a single owner (usually per thread key) so that across instances only one process wakes and runs the agent, and others route follow-up work to the holder. This is what makes channels and signals work on serverless and multi-instance deployments; without a shared lease, each instance would start its own competing run.
 
 Lease keys are namespaced under the same `keyPrefix` as topics, as `<keyPrefix>:lease:<key>`. All operations are atomic: `acquireLease` uses `SET NX PX` and refreshes its own TTL idempotently, while `releaseLease`, `renewLease`, and `transferLease` use Lua scripts that check ownership before mutating, so a concurrent renewal from another owner is never clobbered.
 
-You don't call these methods directly — configuring `RedisStreamsPubSub` as the `pubsub` backend is enough for the runtime to detect and use the capability. See [`LeaseProvider`](/reference/pubsub/lease-provider) for the full method contract.
+You don't call these methods directly. Configuring `RedisStreamsPubSub` as the `pubsub` backend is enough for the runtime to detect and use the capability. See [`LeaseProvider`](/reference/pubsub/lease-provider) for the full method contract.

--- a/docs/src/content/en/reference/pubsub/redis-streams.mdx
+++ b/docs/src/content/en/reference/pubsub/redis-streams.mdx
@@ -8,7 +8,7 @@ packages:
 
 # RedisStreamsPubSub
 
-`RedisStreamsPubSub` is a [`PubSub`](/reference/pubsub/base) implementation backed by [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/). It delivers events across processes and hosts, with persistence, consumer groups, and redelivery on failure.
+`RedisStreamsPubSub` is a [`PubSub`](/reference/pubsub/base) implementation backed by [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/). It delivers events across processes and hosts, with persistence, consumer groups, and redelivery on failure. It also implements [`LeaseProvider`](/reference/pubsub/lease-provider), so the signals layer can elect a single owner per resource across instances — which is what lets channels and signals coordinate runs in distributed and serverless deployments.
 
 Use it for distributed deployments where several services share an event stream. For single-process delivery, use [`EventEmitterPubSub`](/reference/pubsub/event-emitter). For Google Cloud, use [`GoogleCloudPubSub`](/reference/pubsub/google-cloud-pubsub).
 
@@ -153,3 +153,11 @@ await pubsub.close()
 ## Redelivery and reclaim
 
 When a subscriber calls `nack`, the event is republished with an incremented `deliveryAttempt` and the original is acknowledged. Once an event reaches `maxDeliveryAttempts`, it's dropped instead of redelivered. Separately, each subscription periodically reclaims events that an earlier consumer in the group read but never acknowledged, controlled by `reclaimIntervalMs` and `reclaimIdleMs`.
+
+## Distributed leasing
+
+`RedisStreamsPubSub` implements the [`LeaseProvider`](/reference/pubsub/lease-provider) contract on top of the same Redis connection. The signals runtime uses it to elect a single owner — usually per thread key — so that across instances only one process wakes and runs the agent, and others route follow-up work to the holder. This is what makes channels and signals work on serverless and multi-instance deployments; without a shared lease, each instance would start its own competing run.
+
+Lease keys are namespaced under the same `keyPrefix` as topics, as `<keyPrefix>:lease:<key>`. All operations are atomic: `acquireLease` uses `SET NX PX` and refreshes its own TTL idempotently, while `releaseLease`, `renewLease`, and `transferLease` use Lua scripts that check ownership before mutating, so a concurrent renewal from another owner is never clobbered.
+
+You don't call these methods directly — configuring `RedisStreamsPubSub` as the `pubsub` backend is enough for the runtime to detect and use the capability. See [`LeaseProvider`](/reference/pubsub/lease-provider) for the full method contract.

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -494,6 +494,7 @@ const sidebars = {
         { type: 'doc', id: 'pubsub/caching-pubsub', label: 'CachingPubSub' },
         { type: 'doc', id: 'pubsub/event-emitter', label: 'EventEmitterPubSub' },
         { type: 'doc', id: 'pubsub/google-cloud-pubsub', label: 'GoogleCloudPubSub' },
+        { type: 'doc', id: 'pubsub/lease-provider', label: 'LeaseProvider' },
         { type: 'doc', id: 'pubsub/base', label: 'PubSub' },
         { type: 'doc', id: 'pubsub/redis-streams', label: 'RedisStreamsPubSub' },
         { type: 'doc', id: 'pubsub/unix-socket-pubsub', label: 'UnixSocketPubSub' },


### PR DESCRIPTION
## What

Documents Mastra's distributed leasing layer:

- A new **`LeaseProvider`** reference page under PubSub. This is the contract the signals layer uses to elect a single owner per resource (usually a thread key) across processes, so only one instance wakes and runs the agent while others route follow-up work to the holder.
- Updates to the **`RedisStreamsPubSub`** page to document that it implements `LeaseProvider`.

## Page contents

**`LeaseProvider` (interface)**

- What leasing is and how it differs from event delivery (`PubSub`)
- All five methods with examples and return types: `acquireLease`, `getLeaseOwner`, `releaseLease`, `renewLease`, `transferLease`
- The gap-free `transferLease` handoff and why release-then-acquire isn't safe
- Structural capability detection (`isLeaseProvider`) and the `NoopLeaseProvider` always-win fallback for single-process

**`RedisStreamsPubSub`**

- Intro now notes it implements `LeaseProvider`
- New **Distributed leasing** section: lease key scheme (`<keyPrefix>:lease:<key>`), atomic `SET NX PX` acquire, and the ownership-checked Lua scripts for release/renew/transfer

## Sidebar

- New **LeaseProvider** entry under the **PubSub** category (alphabetical)

## Notes

Docs-only change, no changeset needed. Content audited against `packages/core/src/events/pubsub.ts` and `pubsub/redis-streams/src/index.ts`.

## Verification

- `prettier`, `remark`, and `pnpm validate` (frontmatter, reference sidebar sort, sidebar-docs linkage, new-tags) all pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change adds a new guide that explains how Mastra makes sure only one worker handles a shared task at a time. It also updates the Redis pub/sub docs to show how that “single owner” system works, and adds the new page to the docs menu.

### Summary
- Added a new `LeaseProvider` reference page under PubSub describing Mastra’s distributed leasing contract.
- Documented the five lease methods: `acquireLease`, `getLeaseOwner`, `releaseLease`, `renewLease`, and `transferLease`.
- Explained lease handoff behavior, capability detection via `isLeaseProvider`, and the `NoopLeaseProvider` fallback.
- Updated `RedisStreamsPubSub` docs to note `LeaseProvider` support and added a “Distributed leasing” section covering Redis lease keying and atomic/ownership-checked operations.
- Added `LeaseProvider` to the PubSub section in the sidebar.

### Validation
- `prettier`
- `remark`
- `pnpm validate`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->