### PR TITLE
fix(core): pass mastra and memory to makeCoreTool for processor-added tools

### DIFF
--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -44,7 +44,7 @@ import {
 import { findProviderToolByName, inferProviderExecuted } from '../../../tools/provider-tool-utils';
 import type { ToolToConvert } from '../../../tools/tool-builder/builder';
 import { getProviderToolName, isMastraTool, isProviderTool } from '../../../tools/toolchecks';
-import { makeCoreTool } from '../../../utils';
+import { createMastraProxy, makeCoreTool } from '../../../utils';
 import { createStep } from '../../../workflows/workflow';
 import type { Workspace } from '../../../workspace/workspace';
 import type { RunScopeContext } from '../../run-scope-access';
@@ -1098,6 +1098,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                         threadId: readScoped(scopeCtx, THREAD_ID_KEY, 'threadId'),
                         resourceId: readScoped(scopeCtx, RESOURCE_ID_KEY, 'resourceId'),
                         logger,
+                        mastra: mastra
+                          ? createMastraProxy({ mastra, logger: logger || new ConsoleLogger({ level: 'error' }) })
+                          : undefined,
+                        memory: readScoped(scopeCtx, MEMORY_KEY, 'memory'),
                         agentName: agentId,
                         requestContext: requestContext || new RequestContext(),
                         outputWriter,


### PR DESCRIPTION
When `processInputStep` returns `{ tools }`, the agentic execution loop re-converts each new tool via `makeCoreTool` before calling the model. The options object passed at that site omitted `mastra` and `memory`, so a tool added by a processor received `context.mastra === undefined` (and `context.memory === undefined`) in its `execute` callback — even when the agent is registered on a `Mastra` instance. Statically-declared agent tools receive both values correctly on the same run.

The static toolset path (`listInputProcessorLoadedTools` in `agent.ts`, line ~3713) already passes `mastra: createMastraProxy(...)` and `memory` at the equivalent `makeCoreTool` call. This change mirrors that pattern in `createLLMExecutionStep` where `processInputStepResult.tools` triggers re-conversion.

Root cause identified in the issue: `createMastraProxy` was simply missing from the import and from the options object at the re-conversion site.

**Changes**

- `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`: add `createMastraProxy` to the existing `'../../../utils'` import; pass `mastra` (wrapped in `createMastraProxy`) and `memory` (from run scope) into the `makeCoreTool` options block that runs when `processInputStepResult.tools` changes the toolset

**Verification**

The reporter's gist reproduces the bug with a mock model (no provider key needed) and confirms the fix with the existing `processor-tool-request-context.test.ts` suite staying green. The changed path is limited to the processor-supplied tools re-conversion block and does not touch the static or legacy toolset paths.

Fixes #18526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes sure tools added during input processing get the same “who am I working with?” information as tools that were set up earlier. That means they can now see both the app context and memory they need to work properly.

## Summary
- Updated the processor-added tool re-conversion path in `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`.
- Passed the Mastra proxy into `makeCoreTool` for tools returned from `processInputStepResult.tools`, matching the behavior already used for statically declared tools.
- Kept the change scoped to the processor-supplied tool path, with no public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->