### PR TITLE
docs: fix AgentController PR checks

### DIFF
--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -20,6 +20,25 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'AgentController',
+      collapsed: true,
+      items: [
+        {
+          type: 'doc',
+          id: 'agent-controller/agent-controller-class',
+          label: 'AgentController Class',
+          customProps: { tags: ['beta'] },
+        },
+        {
+          type: 'doc',
+          id: 'agent-controller/session',
+          label: 'Session Class',
+          customProps: { tags: ['beta'] },
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Agents',
       collapsed: true,
       items: [
@@ -74,7 +93,11 @@ const sidebars = {
         { type: 'doc', id: 'ai-sdk/to-ai-sdk-v5-messages', label: 'toAISdkV5Messages()' },
         { type: 'doc', id: 'ai-sdk/with-mastra', label: 'withMastra()' },
         { type: 'doc', id: 'ai-sdk/workflow-route', label: 'workflowRoute()' },
-        { type: 'doc', id: 'ai-sdk/workflow-snapshot-to-stream', label: 'workflowSnapshotToStream()' },
+        {
+          type: 'doc',
+          id: 'ai-sdk/workflow-snapshot-to-stream',
+          label: 'workflowSnapshotToStream()',
+        },
       ],
     },
     {
@@ -303,25 +326,6 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'AgentController',
-      collapsed: true,
-      items: [
-        {
-          type: 'doc',
-          id: 'agent-controller/agent-controller-class',
-          label: 'AgentController Class',
-          customProps: { tags: ['beta'] },
-        },
-        {
-          type: 'doc',
-          id: 'agent-controller/session',
-          label: 'Session Class',
-          customProps: { tags: ['beta'] },
-        },
-      ],
-    },
-    {
-      type: 'category',
       label: 'Mastra platform',
       collapsed: true,
       items: [{ type: 'doc', id: 'mastra-platform/api', label: 'API Reference' }],
@@ -541,7 +545,12 @@ const sidebars = {
           label: 'createNotificationInboxTool()',
           customProps: { tags: ['beta'] },
         },
-        { type: 'doc', id: 'signals/signal-provider', label: 'SignalProvider', customProps: { tags: ['beta'] } },
+        {
+          type: 'doc',
+          id: 'signals/signal-provider',
+          label: 'SignalProvider',
+          customProps: { tags: ['beta'] },
+        },
         {
           type: 'doc',
           id: 'signals/task-signal-provider',
@@ -624,7 +633,12 @@ const sidebars = {
       collapsed: true,
       items: [
         { type: 'doc', id: 'tools/brightdata', label: 'Bright Data Tools' },
-        { type: 'doc', id: 'tools/create-code-mode', label: 'createCodeMode()', customProps: { tags: ['beta'] } },
+        {
+          type: 'doc',
+          id: 'tools/create-code-mode',
+          label: 'createCodeMode()',
+          customProps: { tags: ['beta'] },
+        },
         { type: 'doc', id: 'tools/document-chunker-tool', label: 'createDocumentChunkerTool()' },
         { type: 'doc', id: 'tools/graph-rag-tool', label: 'createGraphRAGTool()' },
         { type: 'doc', id: 'tools/create-tool', label: 'createTool()' },

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -36,6 +36,21 @@
       "permanent": true
     },
     {
+      "source": "/docs/harness/overview",
+      "destination": "/docs/agent-controller/overview",
+      "permanent": true
+    },
+    {
+      "source": "/docs/harness/session",
+      "destination": "/docs/agent-controller/session",
+      "permanent": true
+    },
+    {
+      "source": "/docs/harness/threads-and-state",
+      "destination": "/docs/agent-controller/threads-and-state",
+      "permanent": true
+    },
+    {
       "source": "/docs/v1/:path*",
       "destination": "/docs/:path*",
       "permanent": true


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes broken documentation links by sending old Harness page URLs to the new AgentController pages. It also moves AgentController to the right spot in the docs sidebar so the navigation looks correct again.

## Summary
- Added permanent redirects in `docs/vercel.json` from deleted Harness docs pages to the matching AgentController docs pages:
  - `/docs/harness/overview`
  - `/docs/harness/session`
  - `/docs/harness/threads-and-state`
- Updated `docs/src/content/en/reference/sidebars.js` to move the `AgentController` section earlier in the reference sidebar ordering.
- Reformatted a few sidebar entries for consistency without changing their meaning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->