### PR TITLE
feat(core): thread agent and thread identity through the processor surface

### DIFF
--- a/.changeset/two-papayas-taste.md
+++ b/.changeset/two-papayas-taste.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': minor
+---
+
+Added agent and thread identity to processors. Every processor method now receives `agentId`, `agentName`, `threadId`, and `resourceId` so processors can tell which agent, thread, and resource a run belongs to without inspecting `requestContext`. The same fields arrive identically whether the processor runs in-process or as a workflow.
+
+```ts
+const myProcessor: Processor = {
+  id: 'my-processor',
+  processOutputStream: async ({ part, agentId, threadId, resourceId }) => {
+    // agentId, threadId, resourceId now available here
+    return part;
+  },
+};
+```
+
+The fields are optional and undefined for non-agent or threadless pipelines, so existing processors keep working unchanged.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1306,6 +1306,7 @@ export class Agent<
       errorProcessors,
       logger: this.logger,
       agentName: this.name,
+      agentId: this.id,
       processorStates,
     });
   }

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -348,6 +348,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
         errorProcessors,
         logger: logger as any,
         agentName: agent.name,
+        agentId: agent.id,
         processorStates,
       });
       await runner.runInputProcessors(
@@ -355,6 +356,8 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
         createObservabilityContext({ currentSpan: agentSpan }),
         requestContext,
         0,
+        threadId,
+        resourceId,
       );
     } catch (error) {
       logger?.warn?.(`[DurableAgent] Error running input processors: ${error}`);

--- a/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
+++ b/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
@@ -359,6 +359,7 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
                 errorProcessors: registryEntry.errorProcessors ?? [],
                 logger: logger as any,
                 agentName: initData.agentName ?? initData.agentId,
+                agentId: initData.agentId,
                 processorStates: registryEntry.processorStates,
               });
               const outputMessageList = new MessageList();
@@ -370,6 +371,10 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
                 createObservabilityContext(tracingContext),
                 requestContext ?? new RequestContext(),
                 0,
+                undefined,
+                undefined,
+                initData.state?.threadId,
+                initData.state?.resourceId,
               );
             } catch (error) {
               logger?.warn?.(`[DurableAgent] Error running output processors: ${error}`);

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -262,6 +262,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 errorProcessors: registryEntry?.errorProcessors ?? [],
                 logger: logger as any,
                 agentName: typedInput.agentName ?? typedInput.agentId,
+                agentId: typedInput.agentId,
                 processorStates: registryEntry?.processorStates,
               });
               const processInputStepResult = await runner.runProcessInputStep({
@@ -700,6 +701,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   errorProcessors: registryEntry.errorProcessors,
                   logger: logger as any,
                   agentName: typedInput.agentName ?? typedInput.agentId,
+                  agentId: typedInput.agentId,
                   processorStates: registryEntry.processorStates,
                 });
                 const currentMessageList = new MessageList();
@@ -711,6 +713,8 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   stepNumber: (inputData as any).stepIndex ?? 0,
                   steps: [],
                   requestContext,
+                  threadId: typedInput.state?.threadId,
+                  resourceId: typedInput.state?.resourceId,
                 });
                 if (retry) {
                   logger?.debug?.(`processAPIError requested retry for model ${modelId}`, { runId });

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -593,6 +593,7 @@ export async function createNetworkLoop({
           inputProcessors: [],
           logger: agent.getMastraInstance()?.getLogger() || noopLogger,
           agentName: agent.name,
+          agentId: agent.id,
         })
       : null;
 

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -846,6 +846,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
   errorProcessors,
   logger,
   agentId,
+  agentName,
   downloadRetries,
   downloadConcurrency,
   processorStates,
@@ -876,6 +877,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       // Resolve run-scoped state from either the Mastra-managed RunScope or
       // the legacy `_internal` bag (back-compat for tests).
       const scopeCtx: RunScopeContext = { mastra, runId, _internal };
+      const scopedThreadId = readScoped(scopeCtx, THREAD_ID_KEY, 'threadId') as string | undefined;
+      const scopedResourceId = readScoped(scopeCtx, RESOURCE_ID_KEY, 'resourceId') as string | undefined;
 
       // Insert a step-start boundary between loop iterations so that
       // consecutive tool-only turns are not collapsed into a single block
@@ -996,7 +999,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               inputProcessors: inputStepProcessors,
               outputProcessors: [],
               logger: logger || new ConsoleLogger({ level: 'error' }),
-              agentName: agentId || 'unknown',
+              agentId,
+              agentName: agentName || agentId || 'unknown',
               processorStates,
             });
 
@@ -1269,7 +1273,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             inputProcessors: getRequestInputProcessors({ inputProcessors, llmRequestInputProcessors }),
             outputProcessors: [],
             logger: logger || new ConsoleLogger({ level: 'error' }),
-            agentName: agentId || 'unknown',
+            agentId,
+            agentName: agentName || agentId || 'unknown',
             processorStates,
           });
           const requestStepWriter: ProcessorStreamWriter | undefined = outputWriter
@@ -1448,6 +1453,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             messageId: currentStep.messageId,
             options: {
               runId,
+              agentId,
+              agentName: agentName || agentId,
+              threadId: scopedThreadId,
+              resourceId: scopedResourceId,
               toolCallStreaming,
               includeRawChunks,
               structuredOutput: currentStep.structuredOutput,
@@ -1630,7 +1639,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                 outputProcessors: outputProcessors || [],
                 errorProcessors: errorProcessors || [],
                 logger: logger || new ConsoleLogger({ level: 'error' }),
-                agentName: agentId || 'unknown',
+                agentId,
+                agentName: agentName || agentId || 'unknown',
                 processorStates,
               });
 
@@ -1652,6 +1662,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                 steps: inputData.output?.steps || [],
                 retryCount: currentRetryCount,
                 requestContext,
+                threadId: scopedThreadId,
+                resourceId: scopedResourceId,
                 writer: apiErrorWriter,
                 abortSignal: options?.abortSignal,
                 messageId: currentMessageId,
@@ -1771,7 +1783,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           outputProcessors: outputProcessors || [],
           errorProcessors: errorProcessors || [],
           logger: logger || new ConsoleLogger({ level: 'error' }),
-          agentName: agentId || 'unknown',
+          agentId,
+          agentName: agentName || agentId || 'unknown',
           processorStates,
         });
 
@@ -1790,6 +1803,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           steps: inputData.output?.steps || [],
           retryCount: currentRetryCount,
           requestContext,
+          threadId: scopedThreadId,
+          resourceId: scopedResourceId,
           writer: apiErrorWriter2,
           abortSignal: options?.abortSignal,
           messageId: currentMessageId,
@@ -1893,7 +1908,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           inputProcessors: [],
           outputProcessors,
           logger: logger || new ConsoleLogger({ level: 'error' }),
-          agentName: agentId || 'unknown',
+          agentId,
+          agentName: agentName || agentId || 'unknown',
           processorStates,
         });
 
@@ -1938,6 +1954,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             ...createObservabilityContext(outputStepTracingContext),
             requestContext,
             retryCount: currentRetryCount,
+            threadId: scopedThreadId,
+            resourceId: scopedResourceId,
             writer: processorWriter,
           });
         } catch (error) {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -15,7 +15,13 @@ import { findProviderToolByName } from '../../../tools/provider-tool-utils';
 import { createStep } from '../../../workflows/workflow';
 import { readScoped, writeScoped } from '../../run-scope-access';
 import type { RunScopeContext } from '../../run-scope-access';
-import { DELEGATION_BAILED_KEY, STEP_TOOLS_KEY, TOOL_PAYLOAD_TRANSFORM_KEY } from '../../run-scope-keys';
+import {
+  DELEGATION_BAILED_KEY,
+  RESOURCE_ID_KEY,
+  STEP_TOOLS_KEY,
+  THREAD_ID_KEY,
+  TOOL_PAYLOAD_TRANSFORM_KEY,
+} from '../../run-scope-keys';
 import type { OuterLLMRun } from '../../types';
 import { deserializeToolError } from '../errors';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
@@ -25,6 +31,8 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
   llmExecutionStep: any,
 ) {
   const scopeCtx: RunScopeContext = { mastra: rest.mastra, runId: rest.runId, _internal };
+  const scopedThreadId = readScoped(scopeCtx, THREAD_ID_KEY, 'threadId') as string | undefined;
+  const scopedResourceId = readScoped(scopeCtx, RESOURCE_ID_KEY, 'resourceId') as string | undefined;
   /**
    * Output processor handling for tool-result and tool-error chunks.
    *
@@ -46,7 +54,8 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           inputProcessors: [],
           outputProcessors: rest.outputProcessors,
           logger: rest.logger,
-          agentName: 'LLMMappingStep',
+          agentName: rest.agentName ?? 'LLMMappingStep',
+          agentId: rest.agentId,
           processorStates: rest.processorStates,
         })
       : undefined;
@@ -77,6 +86,8 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
         rest.messageList,
         0,
         streamWriter,
+        scopedThreadId,
+        scopedResourceId,
       );
 
       const enqueueTripwire = (r?: string, opts?: { retry?: boolean; metadata?: unknown }, pid?: string) => {

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -11,6 +11,9 @@ import { safeClose, safeEnqueue } from '../../stream/base';
 import type { ChunkType } from '../../stream/types';
 import { ChunkFrom } from '../../stream/types';
 import { hydrateRunScopeFromInternal } from '../hydrate-run-scope';
+import { readScoped } from '../run-scope-access';
+import type { RunScopeContext } from '../run-scope-access';
+import { RESOURCE_ID_KEY, THREAD_ID_KEY } from '../run-scope-keys';
 import type { LoopRun } from '../types';
 import { AGENTIC_EXECUTION_WORKFLOW_ID } from './agentic-execution';
 import { createAgenticLoopWorkflow } from './agentic-loop';
@@ -37,6 +40,10 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
       // Normalize requestContext so data-chunk processors and the agentic loop share the same instance
       const requestContext = rest.requestContext ?? new RequestContext();
 
+      const scopeCtx: RunScopeContext = { mastra: rest.mastra, runId, _internal };
+      const scopedThreadId = readScoped(scopeCtx, THREAD_ID_KEY, 'threadId') as string | undefined;
+      const scopedResourceId = readScoped(scopeCtx, RESOURCE_ID_KEY, 'resourceId') as string | undefined;
+
       // Create a ProcessorRunner for chunks routed through outputWriter (data-* custom
       // chunks plus lifecycle chunks like step-finish) so they go through output processors.
       // Share the loop's processorStates map so these chunks see the same per-processor state
@@ -50,7 +57,8 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
         ? new ProcessorRunner({
             outputProcessors: rest.outputProcessors,
             logger: rest.logger || new ConsoleLogger({ level: 'error' }),
-            agentName: agentId || 'unknown',
+            agentId,
+            agentName: rest.agentName || agentId || 'unknown',
             processorStates: dataChunkProcessorStates,
           })
         : undefined;
@@ -84,6 +92,8 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
               messageList,
               0,
               dataChunkStreamWriter,
+              scopedThreadId,
+              scopedResourceId,
             );
 
             if (blocked) {
@@ -158,6 +168,8 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
             messageList,
             0,
             dataChunkStreamWriter,
+            scopedThreadId,
+            scopedResourceId,
           );
 
           if (blocked) {

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -51,6 +51,26 @@ export interface ProcessorStreamWriter {
  */
 export interface ProcessorContext<TTripwireMetadata = unknown> extends Partial<ObservabilityContext> {
   /**
+   * Id of the agent this processor is running for, when the run is agent-scoped.
+   * Undefined for non-agent processor pipelines.
+   */
+  agentId?: string;
+  /**
+   * Name of the agent this processor is running for, when the run is agent-scoped.
+   * Undefined for non-agent processor pipelines.
+   */
+  agentName?: string;
+  /**
+   * Id of the thread this run is bound to, when the run is thread-scoped.
+   * Undefined for threadless runs.
+   */
+  threadId?: string;
+  /**
+   * Id of the resource (e.g. user) this run is bound to, when known.
+   * Undefined for resourceless runs.
+   */
+  resourceId?: string;
+  /**
    * Function to abort processing with an optional reason and options.
    * @param reason - The reason for aborting
    * @param options - Options including retry flag and metadata

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -3715,4 +3715,77 @@ describe('ProcessorRunner', () => {
       ]);
     });
   });
+
+  describe('Processor identity (cross-path symmetry)', () => {
+    it('passes identical agentId/agentName/threadId/resourceId on both in-process and workflow-as-processor paths', async () => {
+      const inProcess: Record<string, unknown> = {};
+      const viaWorkflow: Record<string, unknown> = {};
+
+      const inProcessProcessor: Processor = {
+        id: 'in-process',
+        processOutputResult: async ({ messages, agentId, agentName, threadId, resourceId }) => {
+          Object.assign(inProcess, { agentId, agentName, threadId, resourceId });
+          return messages;
+        },
+      };
+
+      const workflowProcessor: Processor = {
+        id: 'via-workflow',
+        processOutputResult: async ({ messages, agentId, agentName, threadId, resourceId }) => {
+          Object.assign(viaWorkflow, { agentId, agentName, threadId, resourceId });
+          return messages;
+        },
+      };
+      const workflow = createWorkflow({
+        id: 'identity-workflow',
+        inputSchema: ProcessorStepSchema,
+        outputSchema: ProcessorStepSchema,
+        type: 'processor',
+        options: { validateInputs: false },
+      })
+        .then(createStep(workflowProcessor as any))
+        .commit() as ProcessorWorkflow;
+
+      const list = new MessageList({ threadId: 'thread-xyz' });
+      list.add(
+        {
+          id: 'identity-msg',
+          role: 'assistant' as const,
+          content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'hello' }] },
+          createdAt: new Date(),
+          threadId: 'thread-xyz',
+        },
+        'response',
+      );
+
+      const identityRunner = new ProcessorRunner({
+        inputProcessors: [],
+        outputProcessors: [inProcessProcessor, workflow],
+        logger: mockLogger,
+        agentName: 'identity-agent',
+        agentId: 'agent-123',
+      });
+
+      await identityRunner.runOutputProcessors(
+        list,
+        undefined,
+        new RequestContext(),
+        0,
+        undefined,
+        undefined,
+        'thread-xyz',
+        'resource-abc',
+      );
+
+      const expected = {
+        agentId: 'agent-123',
+        agentName: 'identity-agent',
+        threadId: 'thread-xyz',
+        resourceId: 'resource-abc',
+      };
+      expect(inProcess).toEqual(expected);
+      expect(viaWorkflow).toEqual(expected);
+      expect(viaWorkflow).toEqual(inProcess);
+    });
+  });
 });

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -267,6 +267,7 @@ export class ProcessorRunner {
   public readonly errorProcessors: ErrorProcessorOrWorkflow[];
   private readonly logger: IMastraLogger;
   private readonly agentName: string;
+  private readonly agentId?: string;
   /**
    * Shared processor state that persists across loop iterations.
    * Used by all processor methods (input and output) to share state.
@@ -280,6 +281,7 @@ export class ProcessorRunner {
     errorProcessors,
     logger,
     agentName,
+    agentId,
     processorStates,
   }: {
     inputProcessors?: ProcessorOrWorkflow[];
@@ -287,6 +289,7 @@ export class ProcessorRunner {
     errorProcessors?: ErrorProcessorOrWorkflow[];
     logger: IMastraLogger;
     agentName: string;
+    agentId?: string;
     processorStates?: Map<string, ProcessorState>;
   }) {
     this.inputProcessors = inputProcessors ?? [];
@@ -294,6 +297,7 @@ export class ProcessorRunner {
     this.errorProcessors = errorProcessors ?? [];
     this.logger = logger;
     this.agentName = agentName;
+    this.agentId = agentId;
     this.processorStates = processorStates ?? new Map();
   }
 
@@ -396,6 +400,8 @@ export class ProcessorRunner {
       abortSignal,
       abort,
       retryCount,
+      agentId: this.agentId,
+      agentName: this.agentName,
       resourceId: resolvedResourceId,
       threadId: resolvedThreadId,
       activeStateSignals,
@@ -587,6 +593,8 @@ export class ProcessorRunner {
     retryCount: number = 0,
     writer?: ProcessorStreamWriter,
     result?: OutputResult,
+    threadId?: string,
+    resourceId?: string,
   ): Promise<MessageList> {
     for (const [index, processorOrWorkflow] of this.outputProcessors.entries()) {
       const allNewMessages = messageList.get.response.db();
@@ -604,6 +612,10 @@ export class ProcessorRunner {
             messageList,
             retryCount,
             result,
+            agentId: this.agentId,
+            agentName: this.agentName,
+            threadId,
+            resourceId,
           },
           observabilityContext,
           requestContext,
@@ -671,6 +683,10 @@ export class ProcessorRunner {
           requestContext,
           retryCount,
           writer,
+          agentId: this.agentId,
+          agentName: this.agentName,
+          threadId,
+          resourceId,
           sendSignal: createProcessorSendSignal({ messageList, writer }),
         });
 
@@ -755,6 +771,8 @@ export class ProcessorRunner {
     messageList?: MessageList,
     retryCount: number = 0,
     writer?: ProcessorStreamWriter,
+    threadId?: string,
+    resourceId?: string,
   ): Promise<{
     part: ChunkType<OUTPUT> | null | undefined;
     blocked: boolean;
@@ -796,6 +814,10 @@ export class ProcessorRunner {
                 state: state.customState,
                 messageList,
                 retryCount,
+                agentId: this.agentId,
+                agentName: this.agentName,
+                threadId,
+                resourceId,
               },
               observabilityContext,
               requestContext,
@@ -853,6 +875,10 @@ export class ProcessorRunner {
               messageList,
               retryCount,
               writer,
+              agentId: this.agentId,
+              agentName: this.agentName,
+              threadId,
+              resourceId,
             });
 
             // Track output chunk and update processedPart
@@ -1095,6 +1121,8 @@ export class ProcessorRunner {
     observabilityContext?: ObservabilityContext,
     requestContext?: RequestContext,
     retryCount: number = 0,
+    threadId?: string,
+    resourceId?: string,
   ): Promise<MessageList> {
     for (const [index, processorOrWorkflow] of this.inputProcessors.entries()) {
       let processableMessages: MastraDBMessage[] = messageList.get.input.db();
@@ -1112,6 +1140,10 @@ export class ProcessorRunner {
             messageList,
             systemMessages: currentSystemMessages,
             retryCount,
+            agentId: this.agentId,
+            agentName: this.agentName,
+            threadId,
+            resourceId,
           },
           observabilityContext,
           requestContext,
@@ -1170,6 +1202,10 @@ export class ProcessorRunner {
           messageList,
           requestContext,
           retryCount,
+          agentId: this.agentId,
+          agentName: this.agentName,
+          threadId,
+          resourceId,
           sendSignal: createProcessorSendSignal({ messageList }),
         });
 
@@ -1331,7 +1367,7 @@ export class ProcessorRunner {
    * @returns The processed MessageList
    */
   async runProcessInputStep(args: RunProcessInputStepArgs): Promise<RunProcessInputStepResult> {
-    const { messageList, stepNumber, steps, requestContext, writer } = args;
+    const { messageList, stepNumber, steps, requestContext, writer, threadId, resourceId } = args;
     const observabilityContext = resolveObservabilityContext(args);
 
     // Initialize with all provided values - processors will modify this object in order
@@ -1371,6 +1407,10 @@ export class ProcessorRunner {
             stepNumber,
             steps,
             systemMessages: currentSystemMessages,
+            agentId: this.agentId,
+            agentName: this.agentName,
+            threadId,
+            resourceId,
             rotateResponseMessageId: args.rotateResponseMessageId
               ? () => {
                   const nextMessageId = args.rotateResponseMessageId!();
@@ -1440,6 +1480,10 @@ export class ProcessorRunner {
         modelSettings: stepInput.modelSettings,
         structuredOutput: stepInput.structuredOutput,
         requestContext,
+        agentId: this.agentId,
+        agentName: this.agentName,
+        threadId,
+        resourceId,
       };
 
       // Use the current span (the step span) as the parent for processor spans
@@ -1820,6 +1864,8 @@ export class ProcessorRunner {
       requestContext?: RequestContext;
       retryCount?: number;
       writer?: ProcessorStreamWriter;
+      threadId?: string;
+      resourceId?: string;
     } & Partial<ObservabilityContext>,
   ): Promise<MessageList> {
     const {
@@ -1834,6 +1880,8 @@ export class ProcessorRunner {
       requestContext,
       retryCount = 0,
       writer,
+      threadId,
+      resourceId,
     } = args;
     const observabilityContext = resolveObservabilityContext(args);
 
@@ -1861,6 +1909,10 @@ export class ProcessorRunner {
             systemMessages: currentSystemMessages,
             steps,
             retryCount,
+            agentId: this.agentId,
+            agentName: this.agentName,
+            threadId,
+            resourceId,
           },
           observabilityContext,
           requestContext,
@@ -1934,6 +1986,10 @@ export class ProcessorRunner {
           requestContext,
           retryCount,
           writer,
+          agentId: this.agentId,
+          agentName: this.agentName,
+          threadId,
+          resourceId,
           sendSignal: createProcessorSendSignal({ messageList, writer }),
         });
 
@@ -2033,9 +2089,22 @@ export class ProcessorRunner {
       writer?: ProcessorStreamWriter;
       abortSignal?: AbortSignal;
       rotateResponseMessageId?: () => string;
+      threadId?: string;
+      resourceId?: string;
     } & Partial<ObservabilityContext>,
   ): Promise<{ retry: boolean }> {
-    const { error, messageList, stepNumber, steps, requestContext, retryCount = 0, writer, abortSignal } = args;
+    const {
+      error,
+      messageList,
+      stepNumber,
+      steps,
+      requestContext,
+      retryCount = 0,
+      writer,
+      abortSignal,
+      threadId,
+      resourceId,
+    } = args;
     const observabilityContext = resolveObservabilityContext(args);
 
     const allProcessors: ProcessorOrWorkflow[] = [
@@ -2114,6 +2183,10 @@ export class ProcessorRunner {
           retryCount,
           writer,
           abortSignal,
+          agentId: this.agentId,
+          agentName: this.agentName,
+          threadId,
+          resourceId,
           messageId: args.messageId,
           ...(rotateResponseMessageId ? { rotateResponseMessageId } : {}),
           sendSignal: createProcessorSendSignal({ messageList, writer, rotateResponseMessageId }),

--- a/packages/core/src/processors/step-schema.ts
+++ b/packages/core/src/processors/step-schema.ts
@@ -102,7 +102,19 @@ export type ProcessorStepModelConfig =
  */
 export type ProcessorStepToolsConfig = ToolSet | Record<string, unknown>;
 
-export type ProcessorInputPhaseType = {
+/**
+ * Agent/thread/resource identity threaded through every processor phase so
+ * processors can learn which agent run they belong to. All fields are plain
+ * strings, keeping the workflow-as-processor step schemas JSON-safe.
+ */
+export type ProcessorIdentityType = {
+  agentId?: string;
+  agentName?: string;
+  threadId?: string;
+  resourceId?: string;
+};
+
+export type ProcessorInputPhaseType = ProcessorIdentityType & {
   phase: 'input';
   messages: ProcessorMessageType[];
   messageList: MessageList;
@@ -110,7 +122,7 @@ export type ProcessorInputPhaseType = {
   retryCount?: number;
 };
 
-export type ProcessorInputStepPhaseType = {
+export type ProcessorInputStepPhaseType = ProcessorIdentityType & {
   phase: 'inputStep';
   messages: ProcessorMessageType[];
   messageList: MessageList;
@@ -129,7 +141,7 @@ export type ProcessorInputStepPhaseType = {
   rotateResponseMessageId?: () => string;
 };
 
-export type ProcessorOutputStreamPhaseType = {
+export type ProcessorOutputStreamPhaseType = ProcessorIdentityType & {
   phase: 'outputStream';
   part?: unknown | null;
   streamParts: unknown[];
@@ -150,7 +162,7 @@ export type SerializableOutputResult = {
   steps: unknown[];
 };
 
-export type ProcessorOutputResultPhaseType = {
+export type ProcessorOutputResultPhaseType = ProcessorIdentityType & {
   phase: 'outputResult';
   messages: ProcessorMessageType[];
   messageList: MessageList;
@@ -158,7 +170,7 @@ export type ProcessorOutputResultPhaseType = {
   result?: SerializableOutputResult;
 };
 
-export type ProcessorOutputStepPhaseType = {
+export type ProcessorOutputStepPhaseType = ProcessorIdentityType & {
   phase: 'outputStep';
   messages: ProcessorMessageType[];
   messageList: MessageList;
@@ -180,7 +192,7 @@ export type ProcessorStepInputType =
   | ProcessorOutputResultPhaseType
   | ProcessorOutputStepPhaseType;
 
-export type ProcessorStepOutputType = {
+export type ProcessorStepOutputType = ProcessorIdentityType & {
   phase: 'input' | 'inputStep' | 'outputStream' | 'outputResult' | 'outputStep';
   messages?: ProcessorMessageType[];
   messageList?: MessageList;
@@ -508,6 +520,18 @@ const toolCallSchema = z.object({
  */
 const retryCountSchema = z.number().optional();
 
+/**
+ * Agent/thread/resource identity fields shared across every processor phase
+ * schema. Spread into each phase object so identity survives the
+ * workflow-as-processor serialization boundary. All plain strings (JSON-safe).
+ */
+const identitySchema = {
+  agentId: z.string().optional(),
+  agentName: z.string().optional(),
+  threadId: z.string().optional(),
+  resourceId: z.string().optional(),
+};
+
 // =========================================================================
 // Phase-specific schemas (discriminated union)
 // =========================================================================
@@ -522,6 +546,7 @@ export const ProcessorInputPhaseSchema = z.object({
   messageList: messageListSchema,
   systemMessages: systemMessagesSchema.optional(),
   retryCount: retryCountSchema,
+  ...identitySchema,
 });
 
 /**
@@ -556,6 +581,7 @@ export const ProcessorInputStepPhaseSchema = z.object({
     .optional()
     .describe('Structured output configuration'),
   steps: z.custom<Array<StepResult<ToolSet>>>().optional().describe('Results from previous steps'),
+  ...identitySchema,
 });
 
 /**
@@ -569,6 +595,7 @@ export const ProcessorOutputStreamPhaseSchema = z.object({
   state: z.record(z.string(), z.unknown()).describe('Mutable state object that persists across chunks'),
   messageList: messageListSchema.optional(),
   retryCount: retryCountSchema,
+  ...identitySchema,
 });
 
 /**
@@ -588,6 +615,7 @@ export const ProcessorOutputResultPhaseSchema = z.object({
   messageList: messageListSchema,
   retryCount: retryCountSchema,
   result: outputResultSchema.optional(),
+  ...identitySchema,
 });
 
 /**
@@ -612,6 +640,7 @@ export const ProcessorOutputStepPhaseSchema = z.object({
     .describe('Token usage for the current step (inputTokens, outputTokens, totalTokens, etc.)'),
   systemMessages: systemMessagesSchema.optional(),
   retryCount: retryCountSchema,
+  ...identitySchema,
 });
 
 /**
@@ -684,6 +713,9 @@ export const ProcessorStepOutputSchema: z.ZodType<ProcessorStepOutputType> = z.o
   steps: z.custom<Array<StepResult<ToolSet>>>().optional(),
   messageId: z.string().optional(),
   rotateResponseMessageId: z.custom<() => string>().optional(),
+
+  // Agent/thread/resource identity (threaded through every phase)
+  ...identitySchema,
 });
 
 /**

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -323,7 +323,8 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
         inputProcessors: [],
         outputProcessors: options.outputProcessors,
         logger: this.logger,
-        agentName: 'MastraModelOutput',
+        agentId: options.agentId,
+        agentName: options.agentName || 'MastraModelOutput',
         processorStates: options.processorStates,
       });
     }
@@ -400,6 +401,8 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 self.messageList,
                 0,
                 streamWriter,
+                options.threadId,
+                options.resourceId,
               );
               const enqueueTripwire = (r?: string, opts?: { retry?: boolean; metadata?: unknown }, pid?: string) => {
                 controller.enqueue({
@@ -920,6 +923,8 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                     0,
                     outputResultWriter,
                     outputResult,
+                    options.threadId,
+                    options.resourceId,
                   );
 
                   // Get text from the latest response message (the last assistant message)

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -1089,6 +1089,10 @@ export type MastraOnFinishCallback<OUTPUT = undefined> = (
 
 export type MastraModelOutputOptions<OUTPUT = undefined> = {
   runId: string;
+  agentId?: string;
+  agentName?: string;
+  threadId?: string;
+  resourceId?: string;
   toolCallStreaming?: boolean;
   onFinish?: MastraOnFinishCallback<OUTPUT>;
   onStepFinish?: MastraOnStepFinishCallback<OUTPUT>;

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -810,6 +810,11 @@ function createStepFromProcessor<TProcessorId extends string>(
         usage,
         messageId,
         rotateResponseMessageId,
+        // Identity fields so processors know which agent/thread/resource they run for
+        agentId,
+        agentName,
+        threadId,
+        resourceId,
         // Shared processor states map for accessing persisted state
         processorStates,
         // Abort signal for cancelling in-flight processor work (e.g. OM observations)
@@ -1059,6 +1064,10 @@ function createStepFromProcessor<TProcessorId extends string>(
         abortSignal,
         messageId: currentMessageId,
         rotateResponseMessageId: rotateCurrentResponseMessageId,
+        agentId,
+        agentName,
+        threadId,
+        resourceId,
         ...(processorMessageList
           ? {
               sendSignal: createProcessorSendSignal({
@@ -1100,6 +1109,11 @@ function createStepFromProcessor<TProcessorId extends string>(
         usage,
         messageId: currentMessageId,
         rotateResponseMessageId: rotateCurrentResponseMessageId,
+        // Identity fields preserved so chained processors keep the same context
+        agentId,
+        agentName,
+        threadId,
+        resourceId,
       };
 
       // Helper to execute phase with proper span lifecycle management

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -769,6 +769,11 @@ function createStepFromProcessor<TProcessorId extends string>(
         usage,
         messageId,
         rotateResponseMessageId,
+        // Identity fields so processors know which agent/thread/resource they run for
+        agentId,
+        agentName,
+        threadId,
+        resourceId,
         // Shared processor states map for accessing persisted state
         processorStates,
         // Abort signal for cancelling in-flight processor work (e.g. OM observations)
@@ -1023,6 +1028,10 @@ function createStepFromProcessor<TProcessorId extends string>(
         abortSignal,
         messageId: currentMessageId,
         rotateResponseMessageId: rotateCurrentResponseMessageId,
+        agentId,
+        agentName,
+        threadId,
+        resourceId,
         ...(processorMessageList
           ? {
               sendSignal: createProcessorSendSignal({
@@ -1064,6 +1073,11 @@ function createStepFromProcessor<TProcessorId extends string>(
         usage,
         messageId: currentMessageId,
         rotateResponseMessageId: rotateCurrentResponseMessageId,
+        // Identity fields preserved so chained processors keep the same context
+        agentId,
+        agentName,
+        threadId,
+        resourceId,
       };
 
       // Helper to execute phase with proper span lifecycle management


### PR DESCRIPTION
## Summary

Processors today have no first-class way to learn which agent, thread, or resource a run belongs to. Consumers that need this (for example the channels output processor) are forced to depend on request-scoped side channels that are not always populated. This PR adds `agentId`, `agentName`, `threadId`, and `resourceId` as flat optional fields on `ProcessorContext`, so every processor method receives them directly.

The fields are optional and `undefined` for non-agent or threadless pipelines, so existing processors keep working unchanged.

```ts
const myProcessor: Processor = {
  id: 'my-processor',
  processOutputStream: async ({ part, agentId, threadId, resourceId }) => {
    // agentId, threadId, resourceId now available here
    return part;
  },
};
```

## What changed

- Added the four identity fields to `ProcessorContext` (propagates to all method arg types).
- Added `agentId` to the `ProcessorRunner` constructor alongside `agentName`; `threadId`/`resourceId` are passed per-call into the public entry methods.
- Injected the identity fields into every hand-built processor args object — both the in-process regular-processor objects and the workflow-as-processor inline objects.
- Added the identity fields to the workflow step schemas and types so they survive the workflow serialization boundary, and spread them into `baseContext` in both the default and evented workflow executors.
- Wired `agentId` (and proper `agentName`/`threadId`/`resourceId` where available) into all non-test `ProcessorRunner` construction sites.

All four fields are plain strings, so they cross the workflow step serialization boundary safely. No live handles or closures were added to any step schema.

## Test plan

- New cross-path symmetry test in `runner.test.ts`: a processor receives identical `agentId`/`agentName`/`threadId`/`resourceId` whether it runs in-process or as a workflow.
- `pnpm build:core` — passing.
- `pnpm --filter ./packages/core check` (typecheck) — passing.
- Focused processor tests (`src/processors/`, 38 files) — passing.
- Loop, agent, and workflow tests (125 files) — passing.

This is PR #1 of a stack. It is independently useful and unblocks a follow-up that makes the channels output processor self-sufficient.
