### PR TITLE
fix(core): broadcast channel output for runs without inbound request context

### DIFF
--- a/.changeset/wide-signs-send.md
+++ b/.changeset/wide-signs-send.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed channel broadcasting so agent runs on a channel-backed thread post back to the channel even when they did not start from an inbound platform message. Previously only runs triggered by an incoming Slack/Discord/etc. message would render to the channel; heartbeat, Studio, and custom UI runs were silently dropped. The channels output processor now reconstructs the channel destination from the thread itself, so any run on a channel-backed thread delivers its output.

--- a/packages/core/src/channels/__tests__/output-processor.test.ts
+++ b/packages/core/src/channels/__tests__/output-processor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 
+import { InMemoryStore } from '../../storage/mock';
 import { AgentChannels } from '../agent-channels';
 import { getChatModule } from '../chat-lazy';
 import { ChatChannelOutputProcessor, CHAT_CHANNEL_RENDER_CONTEXT_KEY } from '../output-processor';
@@ -1586,5 +1587,146 @@ describe('ChatChannelOutputProcessor', () => {
       expect(postArgs[0]).toBe('here you go');
       expect(typeof postArgs[1]).toBe('object');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fallback render-context resolution (no inbound requestContext)
+// ---------------------------------------------------------------------------
+//
+// Runs that did NOT originate from a platform webhook (heartbeats, Studio,
+// custom UI, user code) have no `CHAT_CHANNEL_RENDER_CONTEXT_KEY` on
+// `requestContext`. When the processor is bound to its owning `AgentChannels`
+// and the run's thread carries channel coordinates, it must reconstruct the
+// render context from the thread and still broadcast.
+
+const FALLBACK_THREAD_ID = 'mastra-thread-1';
+const FALLBACK_EXTERNAL_ID = 'test:c1:t1';
+
+async function makeFallbackChannels(
+  threadMetadata?: Record<string, unknown> | null,
+): Promise<ReturnType<typeof createRecording> & { channels: AgentChannels }> {
+  const recording = createRecording();
+
+  const channels = new AgentChannels({
+    adapters: { test: { adapter: recording.adapter, streaming: false } as any },
+  });
+
+  const storage = new InMemoryStore();
+  if (threadMetadata !== null) {
+    const memory = await storage.getStore('memory');
+    await memory!.saveThread({
+      thread: {
+        id: FALLBACK_THREAD_ID,
+        resourceId: 'resource-1',
+        title: 'channel thread',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        metadata: threadMetadata ?? {
+          channel_platform: 'test',
+          channel_externalThreadId: FALLBACK_EXTERNAL_ID,
+        },
+      },
+    });
+  }
+
+  // Bind a minimal agent that exposes the Mastra storage, and a Chat stub that
+  // materializes the live Thread handle from the stored external id.
+  (channels as any).agent = { getMastraInstance: () => ({ getStorage: () => storage }) };
+  (channels as any).chat = {
+    thread: (id: string) => {
+      expect(id).toBe(FALLBACK_EXTERNAL_ID);
+      return recording.chatThread;
+    },
+  };
+
+  return { channels, ...recording };
+}
+
+async function driveFallback(
+  channels: AgentChannels,
+  chunks: any[],
+  opts: { threadId?: string; requestContext?: Map<string, unknown> } = {},
+) {
+  const processor = new ChatChannelOutputProcessor(channels);
+  const requestContext = opts.requestContext ?? new Map<string, unknown>();
+  const state: Record<string, unknown> = {};
+
+  const effective = [...chunks, { type: 'step-finish', payload: { stepResult: { isContinued: false } } }];
+
+  for (const chunk of effective) {
+    await processor.processOutputStream({
+      part: chunk,
+      state,
+      threadId: opts.threadId,
+      requestContext: { get: (key: string) => requestContext.get(key) } as any,
+    } as any);
+  }
+}
+
+describe('ChatChannelOutputProcessor fallback render context', () => {
+  beforeAll(async () => {
+    await getChatModule();
+  });
+
+  it('broadcasts on a channel-backed thread with no requestContext key', async () => {
+    const { channels, calls } = await makeFallbackChannels();
+    await driveFallback(channels, [{ type: 'text-delta', payload: { text: 'heartbeat says hi' } }], {
+      threadId: FALLBACK_THREAD_ID,
+    });
+
+    const posts = calls.filter(c => c.kind === 'post');
+    expect(posts).toEqual([{ kind: 'post', arg: 'heartbeat says hi' }]);
+  });
+
+  it('passes through when the thread has no channel metadata', async () => {
+    const { channels, calls } = await makeFallbackChannels({ some: 'other-metadata' });
+    await driveFallback(channels, [{ type: 'text-delta', payload: { text: 'no channel here' } }], {
+      threadId: FALLBACK_THREAD_ID,
+    });
+
+    expect(calls.filter(c => c.kind === 'post')).toHaveLength(0);
+  });
+
+  it('passes through when the thread does not exist in storage', async () => {
+    const { channels, calls } = await makeFallbackChannels(null);
+    await driveFallback(channels, [{ type: 'text-delta', payload: { text: 'orphan run' } }], {
+      threadId: 'unknown-thread',
+    });
+
+    expect(calls.filter(c => c.kind === 'post')).toHaveLength(0);
+  });
+
+  it('passes through when no threadId is provided', async () => {
+    const { channels, calls } = await makeFallbackChannels();
+    await driveFallback(channels, [{ type: 'text-delta', payload: { text: 'threadless' } }], {});
+
+    expect(calls.filter(c => c.kind === 'post')).toHaveLength(0);
+  });
+
+  it('prefers the inbound requestContext render context over the fallback', async () => {
+    const { channels, calls, chatThread } = await makeFallbackChannels();
+
+    // Inbound fast path: a render context is already on requestContext. The
+    // fallback must not run (and would post to the same chatThread anyway, so
+    // assert it posts exactly once via the fast path).
+    const render = (channels as any)._buildRenderContext(chatThread, 'test');
+    const requestContext = new Map<string, unknown>();
+    requestContext.set(CHAT_CHANNEL_RENDER_CONTEXT_KEY, render);
+
+    // Break the fallback so a single post proves the fast path was taken.
+    (channels as any).chat = {
+      thread: () => {
+        throw new Error('fallback should not run when requestContext render exists');
+      },
+    };
+
+    await driveFallback(channels, [{ type: 'text-delta', payload: { text: 'inbound message' } }], {
+      threadId: FALLBACK_THREAD_ID,
+      requestContext,
+    });
+
+    const posts = calls.filter(c => c.kind === 'post');
+    expect(posts).toEqual([{ kind: 'post', arg: 'inbound message' }]);
   });
 });

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -656,9 +656,11 @@ export class AgentChannels {
 
   /**
    * Returns channel output processors that render the agent's stream to the
-   * originating chat platform. The processor is a no-op for runs that didn't
-   * come in through the channels path (it keys off a marker on
-   * `requestContext` set by `processChatMessage`).
+   * originating chat platform. The processor resolves its render context from
+   * the inbound `requestContext` marker set by `processChatMessage` when
+   * present, and otherwise reconstructs it from the run's thread via the bound
+   * `AgentChannels` (so heartbeat / Studio / custom-UI runs on a channel-backed
+   * thread still post back). Non-channel runs pass through untouched.
    *
    * Skipped if the user already added a processor with the same id.
    */
@@ -673,7 +675,7 @@ export class AgentChannels {
   getOutputProcessors(configuredProcessors: OutputProcessorOrWorkflow[] = []): OutputProcessor[] {
     const hasProcessor = configuredProcessors.some(p => !isProcessorWorkflow(p) && p.id === 'chat-channel-render');
     if (hasProcessor) return [];
-    return [new ChatChannelOutputProcessor()];
+    return [new ChatChannelOutputProcessor(this)];
   }
 
   /**
@@ -1169,6 +1171,50 @@ export class AgentChannels {
       formatError: adapterConfig?.formatError,
       approvalContext,
     };
+  }
+
+  /**
+   * Reconstruct a {@link ChatChannelRenderContext} for a Mastra thread that is
+   * backed by a channel, without an inbound platform event.
+   *
+   * The inbound webhook paths (`processChatMessage`, approve/decline) stash a
+   * render context on `requestContext` because they already hold the live
+   * `Thread` handle from `event.thread`. Runs that did NOT originate from a
+   * platform message (heartbeats, Studio, custom UI, user code) have no such
+   * handle, so `ChatChannelOutputProcessor` calls this to rebuild it from the
+   * thread's persisted channel coordinates.
+   *
+   * Returns `null` when the thread is not channel-backed (no `channel_platform`
+   * metadata) or its platform adapter isn't configured on this instance — the
+   * processor then passes the run through untouched.
+   *
+   * Delegates to the same {@link _buildRenderContext} used by the inbound paths,
+   * so both paths produce an identical render context (single source of truth).
+   * The only per-fire inputs are `platform` (a persisted string) and the live
+   * `Thread` handle, which the Chat SDK materializes from the stored external id
+   * via `chat.thread(externalThreadId)`.
+   */
+  async buildRenderContextForThread(threadId: string): Promise<ChatChannelRenderContext | null> {
+    const mastra = this.agent?.getMastraInstance();
+    const storage = mastra?.getStorage();
+    if (!storage) return null;
+
+    const memoryStore = await storage.getStore('memory');
+    if (!memoryStore) return null;
+
+    const thread = await memoryStore.getThreadById({ threadId });
+    if (!thread) return null;
+
+    const platform = thread.metadata?.channel_platform as string | undefined;
+    const externalThreadId = thread.metadata?.channel_externalThreadId as string | undefined;
+    if (!platform || !externalThreadId) return null;
+    if (!this.adapters[platform]) return null;
+
+    const chat = this.chat;
+    if (!chat) return null;
+
+    const chatThread = chat.thread(externalThreadId);
+    return this._buildRenderContext(chatThread, platform);
   }
 
   /**

--- a/packages/core/src/channels/output-processor.ts
+++ b/packages/core/src/channels/output-processor.ts
@@ -4,6 +4,7 @@ import type { IMastraLogger } from '../logger/logger';
 import type { ProcessOutputStreamArgs } from '../processors';
 import type { AgentChunkType, ChunkType } from '../stream/types';
 
+import type { AgentChannels } from './agent-channels';
 import { runStaticDriver } from './chat-driver-static';
 import { runStreamingDriver } from './chat-driver-streaming';
 import type { PendingApprovalRecord } from './stream-helpers';
@@ -121,9 +122,19 @@ interface RenderSession {
  * awaited so the run doesn't end (and a serverless invocation isn't allowed
  * to freeze) before the last `chat.update` lands.
  *
- * Skips entirely when no `CHAT_CHANNEL_RENDER_CONTEXT_KEY` exists on
- * `requestContext` — runs that didn't come in through the channels path
- * (Studio, direct API, etc.) pass through untouched.
+ * Render context is resolved in two ways, in order:
+ *
+ * 1. Fast path — `CHAT_CHANNEL_RENDER_CONTEXT_KEY` on `requestContext`, stashed
+ *    by `AgentChannels` on inbound platform events (`processChatMessage`,
+ *    approve/decline). This is the original webhook path and is unchanged.
+ * 2. Fallback — when no render context is on `requestContext` (heartbeat,
+ *    Studio, custom UI, user code) but the processor is bound to its owning
+ *    `AgentChannels`, it reconstructs the render context from the run's
+ *    `threadId` via `agentChannels.buildRenderContextForThread(threadId)`,
+ *    which reads the thread's persisted channel coordinates.
+ *
+ * Runs that resolve no render context at all — non-channel threads, or an
+ * unbound processor with no `requestContext` key — pass through untouched.
  *
  * @internal
  */
@@ -133,12 +144,24 @@ export class ChatChannelOutputProcessor {
   /** Need data-* chunks because some drivers (`hidden`/`grouped`) inspect them. */
   readonly processDataParts = true;
 
+  /**
+   * The owning `AgentChannels`, bound at construction. Enables the fallback
+   * render-context reconstruction for runs without an inbound `requestContext`.
+   * Optional so the processor can still be constructed standalone in tests.
+   */
+  #agentChannels?: AgentChannels;
+
+  constructor(agentChannels?: AgentChannels) {
+    this.#agentChannels = agentChannels;
+  }
+
   async processOutputStream({
     part,
     state,
     requestContext,
+    threadId,
   }: ProcessOutputStreamArgs): Promise<ChunkType | null | undefined> {
-    const render = requestContext?.get(CHAT_CHANNEL_RENDER_CONTEXT_KEY) as ChatChannelRenderContext | undefined;
+    const render = await this.#resolveRenderContext(state, requestContext, threadId);
     if (!render) return part;
 
     let session = state.session as RenderSession | undefined;
@@ -166,6 +189,39 @@ export class ChatChannelOutputProcessor {
     }
 
     return part;
+  }
+
+  /**
+   * Resolve the render context for this run, built once and cached on `state`.
+   *
+   * Fast path: the inbound `requestContext` key. Fallback: reconstruct from the
+   * run's `threadId` via the bound `AgentChannels`. The resolved value (or
+   * `null` for non-channel runs) is cached on `state.render` so we don't reload
+   * thread metadata on every chunk.
+   */
+  async #resolveRenderContext(
+    state: Record<string, any>,
+    requestContext: ProcessOutputStreamArgs['requestContext'],
+    threadId: string | undefined,
+  ): Promise<ChatChannelRenderContext | undefined> {
+    if (state.render !== undefined) {
+      return state.render as ChatChannelRenderContext | undefined;
+    }
+
+    const fromRequest = requestContext?.get(CHAT_CHANNEL_RENDER_CONTEXT_KEY) as ChatChannelRenderContext | undefined;
+    if (fromRequest) {
+      state.render = fromRequest;
+      return fromRequest;
+    }
+
+    if (this.#agentChannels && threadId) {
+      const rebuilt = await this.#agentChannels.buildRenderContextForThread(threadId);
+      // Cache `null` too, so a non-channel thread isn't re-resolved per chunk.
+      state.render = rebuilt ?? null;
+      return rebuilt ?? undefined;
+    }
+
+    return undefined;
   }
 
   #openSession(render: ChatChannelRenderContext): RenderSession {


### PR DESCRIPTION
## What this ships

Agent runs on a channel-backed thread (Slack, Discord, etc.) now post their output back to the channel **even when the run did not start from an inbound platform message**. Heartbeat-triggered runs, Studio runs, and custom-UI / user-code runs against a channel thread previously produced no channel output at all — they were silently dropped.

## Why

`ChatChannelOutputProcessor` only rendered to the channel when `AgentChannels` stashed a render context on `requestContext` during an inbound webhook (`processChatMessage`, approve/decline). Any run that did not originate from a platform message had no such context, so the processor early-returned and nothing reached the channel. Channel delivery was effectively coupled to the inbound request path.

## How

- `ChatChannelOutputProcessor` is now bound to its owning `AgentChannels` at construction.
- When no inbound render context is present, the processor reconstructs it from the run's `threadId` (provided by the processor-identity work) via a new `AgentChannels.buildRenderContextForThread(threadId)`. That method reads the thread's persisted channel coordinates (`channel_platform`, `channel_externalThreadId`), materializes the live channel thread handle, and delegates to the **same** `_buildRenderContext` the inbound paths use — so both paths produce an identical render context (single source of truth).
- The inbound `requestContext` path is unchanged and still takes precedence (fast path).
- Non-channel threads pass through untouched. The resolved render context (or `null`) is cached on `state` so it is built once per run, not per chunk.

Nothing new is persisted: every non-serializable field (adapter, closures, logger) is rebuilt live from the bound `AgentChannels`.

## Stacking

Stacked on #18552 (processor context identity), which threads `threadId` to the output processor. This PR targets that branch and stays a draft until #18552 merges.

## Test plan

- `pnpm build:core`
- `pnpm --filter ./packages/core check` (typecheck clean)
- `pnpm --filter ./packages/core test -- src/channels/` — all 238 channels tests pass, including 5 new fallback tests in `output-processor.test.ts`:
  - broadcasts on a channel-backed thread with no `requestContext` key
  - passes through when the thread has no channel metadata
  - passes through when the thread does not exist in storage
  - passes through when no `threadId` is provided
  - prefers the inbound `requestContext` render context over the fallback (no regression)
