### PR TITLE
feat(sofya): add @mastra/sofya integration

### DIFF
--- a/.changeset/sofya-integration.md
+++ b/.changeset/sofya-integration.md
@@ -2,4 +2,11 @@
 '@mastra/sofya': minor
 ---
 
-Add @mastra/sofya integration with search, fetch, extract, and research tools for Mastra agents
+Added the `@mastra/sofya` integration. It provides four web tools for agents, backed by the [Sofya](https://sofya.co) API: search (full page content, not just snippets), fetch (URLs to clean markdown), extract (pull specific data from a page with a prompt), and research (multi-source, cited reports).
+
+```typescript
+import { createSofyaTools } from '@mastra/sofya';
+
+const tools = createSofyaTools(); // reads SOFYA_API_KEY from the environment
+// tools.sofyaSearch, tools.sofyaFetch, tools.sofyaExtract, tools.sofyaResearch
+```

--- a/.changeset/sofya-integration.md
+++ b/.changeset/sofya-integration.md
@@ -1,0 +1,5 @@
+---
+'@mastra/sofya': minor
+---
+
+Add @mastra/sofya integration with search, fetch, extract, and research tools for Mastra agents

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -657,6 +657,7 @@ const sidebars = {
         { type: 'doc', id: 'tools/mcp-client', label: 'MCPClient' },
         { type: 'doc', id: 'tools/mcp-server', label: 'MCPServer' },
         { type: 'doc', id: 'tools/perplexity', label: 'Perplexity Tools' },
+        { type: 'doc', id: 'tools/sofya', label: 'Sofya Tools' },
         { type: 'doc', id: 'tools/tavily', label: 'Tavily Tools' },
       ],
     },

--- a/docs/src/content/en/reference/tools/sofya.mdx
+++ b/docs/src/content/en/reference/tools/sofya.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Sofya tools
 
-The `@mastra/sofya` package wraps the [Sofya](https://sofya.co) API as Mastra-compatible tools. It exposes factory functions for search, fetch, extract, and research — each returning a tool created with [`createTool()`](./create-tool) that includes full Zod input/output schemas.
+The `@mastra/sofya` package wraps the [Sofya](https://sofya.co) API as Mastra-compatible tools. It exposes factory functions for search, fetch, extract, and research. Each one returns a tool created with [`createTool()`](./create-tool) that includes full Zod input/output schemas.
 
 ## Installation
 

--- a/docs/src/content/en/reference/tools/sofya.mdx
+++ b/docs/src/content/en/reference/tools/sofya.mdx
@@ -1,0 +1,405 @@
+---
+title: "Reference: Sofya tools | Tools & MCP"
+description: "API reference for @mastra/sofya, which provides web search, fetch, extract, and research tools for Mastra agents."
+packages:
+  - "@mastra/sofya"
+---
+
+# Sofya tools
+
+The `@mastra/sofya` package wraps the [Sofya](https://sofya.co) API as Mastra-compatible tools. It exposes factory functions for search, fetch, extract, and research — each returning a tool created with [`createTool()`](./create-tool) that includes full Zod input/output schemas.
+
+## Installation
+
+```sh npm2yarn
+npm install @mastra/sofya zod
+```
+
+## Quick start
+
+Use `createSofyaTools()` to get all four tools with shared configuration:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createSofyaTools } from '@mastra/sofya'
+
+const tools = createSofyaTools()
+// Or pass an explicit API key:
+// const tools = createSofyaTools({ apiKey: 'ay_live_...' })
+```
+
+Each tool can also be created individually:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createSofyaSearchTool, createSofyaResearchTool } from '@mastra/sofya'
+
+const searchTool = createSofyaSearchTool()
+const researchTool = createSofyaResearchTool({ apiKey: 'ay_live_...' })
+```
+
+By default, all tools read `SOFYA_API_KEY` from the environment. You can pass `{ apiKey }` explicitly to override.
+
+## Configuration
+
+All factory functions accept `SofyaClientOptions`:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'apiKey',
+    type: 'string',
+    description: 'Sofya API key. Falls back to the `SOFYA_API_KEY` environment variable.',
+    isOptional: true,
+  },
+  {
+    name: 'baseUrl',
+    type: 'string',
+    description: 'Base URL for the Sofya API.',
+    isOptional: true,
+    defaultValue: "'https://sofya.co/v1'",
+  },
+  {
+    name: 'clientSource',
+    type: 'string',
+    description: 'Attribution string sent with each request.',
+    isOptional: true,
+    defaultValue: "'mastra'",
+  },
+]}
+/>
+
+## `createSofyaTools()`
+
+Returns an object containing all four tools with a shared configuration.
+
+```typescript
+import { createSofyaTools } from '@mastra/sofya'
+
+const tools = createSofyaTools({ apiKey: 'ay_live_...' })
+// tools.sofyaSearch, tools.sofyaFetch, tools.sofyaExtract, tools.sofyaResearch
+```
+
+**Returns:** `{ sofyaSearch, sofyaFetch, sofyaExtract, sofyaResearch }`
+
+## `createSofyaSearchTool()`
+
+Creates a tool that searches the web using Sofya. Returns relevant results with full page content rather than snippets, plus an optional AI-synthesized answer.
+
+**Tool ID:** `sofya-search`
+
+```typescript
+import { createSofyaSearchTool } from '@mastra/sofya'
+
+const searchTool = createSofyaSearchTool()
+```
+
+### Input
+
+<PropertiesTable
+  content={[
+  {
+    name: 'query',
+    type: 'string',
+    description: 'The search query.',
+  },
+  {
+    name: 'searchDepth',
+    type: "'snippets' | 'basic'",
+    description: "Search depth. 'snippets' is cheaper and returns short excerpts, 'basic' returns full page content.",
+    isOptional: true,
+  },
+  {
+    name: 'maxResults',
+    type: 'number',
+    description: 'Maximum number of results to return (1-20).',
+    isOptional: true,
+  },
+  {
+    name: 'includeAnswer',
+    type: 'boolean',
+    description: 'Include an AI-synthesized answer generated from the results.',
+    isOptional: true,
+  },
+  {
+    name: 'includeDomains',
+    type: 'string[]',
+    description: 'Only include results from these domains (max 10).',
+    isOptional: true,
+  },
+  {
+    name: 'excludeDomains',
+    type: 'string[]',
+    description: 'Exclude results from these domains (max 10).',
+    isOptional: true,
+  },
+  {
+    name: 'topic',
+    type: "'general' | 'news'",
+    description: "Search topic. 'general' for web search, 'news' for news articles.",
+    isOptional: true,
+  },
+  {
+    name: 'freshness',
+    type: 'string',
+    description: "Filter results by recency. One of 'day', 'week', 'month', 'year', or a 'YYYY-MM-DD' date.",
+    isOptional: true,
+  },
+]}
+/>
+
+### Output
+
+<PropertiesTable
+  content={[
+  {
+    name: 'query',
+    type: 'string',
+    description: 'The original search query.',
+  },
+  {
+    name: 'answer',
+    type: 'string',
+    description: 'AI-synthesized answer generated from the results.',
+    isOptional: true,
+  },
+  {
+    name: 'results',
+    type: 'SearchResult[]',
+    description: 'Array of search results.',
+    properties: [
+      {
+        type: 'SearchResult',
+        parameters: [
+          { name: 'title', type: 'string', description: 'Result title.' },
+          { name: 'url', type: 'string', description: 'Result URL.' },
+          { name: 'content', type: 'string', description: 'Page content for the result.' },
+          { name: 'description', type: 'string', description: 'Short description of the result.', isOptional: true },
+          { name: 'fetched', type: 'boolean', description: 'Whether full page content was fetched.', isOptional: true },
+          { name: 'publishedDate', type: 'string', description: 'Publication date when available.', isOptional: true },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'creditsUsed',
+    type: 'number',
+    description: 'Credits consumed by this request.',
+  },
+  {
+    name: 'creditsRemaining',
+    type: 'number',
+    description: 'Credits remaining on the account.',
+  },
+]}
+/>
+
+## `createSofyaFetchTool()`
+
+Creates a tool that fetches one or more URLs as clean markdown. Supports web pages, PDFs, and documents using 250+ site-specific parsers. Each result carries a per-url success flag, so partial failures do not fail the whole request.
+
+**Tool ID:** `sofya-fetch`
+
+```typescript
+import { createSofyaFetchTool } from '@mastra/sofya'
+
+const fetchTool = createSofyaFetchTool()
+```
+
+### Input
+
+<PropertiesTable
+  content={[
+  {
+    name: 'urls',
+    type: 'string[]',
+    description: 'URLs to fetch as clean markdown (1-10). Supports web pages, PDFs, and documents.',
+  },
+  {
+    name: 'includeRawHtml',
+    type: 'boolean',
+    description: 'Include the raw HTML source for each result.',
+    isOptional: true,
+  },
+]}
+/>
+
+### Output
+
+<PropertiesTable
+  content={[
+  {
+    name: 'results',
+    type: 'FetchResult[]',
+    description: 'Fetched pages, one entry per requested URL.',
+    properties: [
+      {
+        type: 'FetchResult',
+        parameters: [
+          { name: 'title', type: 'string', description: 'Page title.', isOptional: true },
+          { name: 'url', type: 'string', description: 'Page URL.' },
+          { name: 'content', type: 'string', description: 'Page content as markdown.' },
+          { name: 'rawHtml', type: 'string', description: 'Raw HTML source (when requested).', isOptional: true },
+          { name: 'publishedTime', type: 'string', description: 'Publication time when available.', isOptional: true },
+          { name: 'success', type: 'boolean', description: 'Whether this URL was fetched successfully.' },
+          { name: 'error', type: 'string', description: 'Error message when the fetch failed.', isOptional: true },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'creditsUsed',
+    type: 'number',
+    description: 'Credits consumed by this request.',
+  },
+  {
+    name: 'creditsRemaining',
+    type: 'number',
+    description: 'Credits remaining on the account.',
+  },
+]}
+/>
+
+## `createSofyaExtractTool()`
+
+Creates a tool that extracts specific information from a URL. Fetches the page and uses AI to pull out exactly what the prompt asks for, such as pricing tables, contact details, or specifications.
+
+**Tool ID:** `sofya-extract`
+
+```typescript
+import { createSofyaExtractTool } from '@mastra/sofya'
+
+const extractTool = createSofyaExtractTool()
+```
+
+### Input
+
+<PropertiesTable
+  content={[
+  {
+    name: 'url',
+    type: 'string',
+    description: 'The URL to extract information from.',
+  },
+  {
+    name: 'prompt',
+    type: 'string',
+    description: 'What information to extract, for example "list all pricing tiers and their prices".',
+  },
+]}
+/>
+
+### Output
+
+<PropertiesTable
+  content={[
+  {
+    name: 'url',
+    type: 'string',
+    description: 'The URL the content was extracted from.',
+  },
+  {
+    name: 'content',
+    type: 'string',
+    description: 'The extracted content as text.',
+  },
+  {
+    name: 'creditsUsed',
+    type: 'number',
+    description: 'Credits consumed by this request.',
+  },
+  {
+    name: 'creditsRemaining',
+    type: 'number',
+    description: 'Credits remaining on the account.',
+  },
+]}
+/>
+
+## `createSofyaResearchTool()`
+
+Creates a tool that runs deep research on a question. Breaks the question into sub-queries, searches multiple sources, and synthesizes a cited report.
+
+**Tool ID:** `sofya-research`
+
+```typescript
+import { createSofyaResearchTool } from '@mastra/sofya'
+
+const researchTool = createSofyaResearchTool()
+```
+
+### Input
+
+<PropertiesTable
+  content={[
+  {
+    name: 'query',
+    type: 'string',
+    description: 'The research question or topic.',
+  },
+  {
+    name: 'topic',
+    type: "'general' | 'news'",
+    description: "Research topic. 'general' for web search, 'news' for news articles.",
+    isOptional: true,
+  },
+  {
+    name: 'freshness',
+    type: 'string',
+    description: "Filter sources by recency. One of 'day', 'week', 'month', 'year', or a 'YYYY-MM-DD' date.",
+    isOptional: true,
+  },
+  {
+    name: 'maxSources',
+    type: 'number',
+    description: 'Maximum number of sources to use (1-30).',
+    isOptional: true,
+  },
+]}
+/>
+
+### Output
+
+<PropertiesTable
+  content={[
+  {
+    name: 'query',
+    type: 'string',
+    description: 'The original research question.',
+  },
+  {
+    name: 'report',
+    type: 'string',
+    description: 'The synthesized research report.',
+  },
+  {
+    name: 'sources',
+    type: 'ResearchSource[]',
+    description: 'Sources used to build the report.',
+    properties: [
+      {
+        type: 'ResearchSource',
+        parameters: [
+          { name: 'title', type: 'string', description: 'Source title.' },
+          { name: 'url', type: 'string', description: 'Source URL.' },
+          { name: 'fetched', type: 'boolean', description: 'Whether full page content was fetched.', isOptional: true },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'subQueries',
+    type: 'string[]',
+    description: 'Sub-queries the research was broken into.',
+    isOptional: true,
+  },
+  {
+    name: 'creditsUsed',
+    type: 'number',
+    description: 'Credits consumed by this request.',
+  },
+  {
+    name: 'creditsRemaining',
+    type: 'number',
+    description: 'Credits remaining on the account.',
+  },
+]}
+/>

--- a/integrations/sofya/CHANGELOG.md
+++ b/integrations/sofya/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @mastra/sofya

--- a/integrations/sofya/README.md
+++ b/integrations/sofya/README.md
@@ -1,0 +1,129 @@
+# @mastra/sofya
+
+Sofya web search, fetch, extract, and research tools for [Mastra](https://mastra.ai) agents.
+
+## Installation
+
+```bash
+npm install @mastra/sofya zod
+```
+
+## Quick Start
+
+Use `createSofyaTools()` to get all four tools with a shared configuration:
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { createSofyaTools } from '@mastra/sofya';
+
+const tools = createSofyaTools();
+// Or pass an explicit API key:
+// const tools = createSofyaTools({ apiKey: 'ay_live_...' });
+
+const agent = new Agent({
+  id: 'realtime-information-agent',
+  name: 'Realtime Information Agent',
+  instructions: 'You are a realtime information agent that can search the web and research topics for the user.',
+  model: 'anthropic/claude-sonnet-4-6',
+  tools,
+});
+```
+
+By default, the tools read `SOFYA_API_KEY` from your environment. You can also pass `{ apiKey }` explicitly. Get a key at [sofya.co](https://sofya.co).
+
+## Individual Tools
+
+Each tool can be created independently:
+
+```typescript
+import { createSofyaSearchTool, createSofyaResearchTool } from '@mastra/sofya';
+
+const searchTool = createSofyaSearchTool({ apiKey: 'ay_live_...' });
+const researchTool = createSofyaResearchTool(); // uses SOFYA_API_KEY env var
+```
+
+### Search
+
+```typescript
+import { createSofyaSearchTool } from '@mastra/sofya';
+
+const searchTool = createSofyaSearchTool();
+
+// When called by an agent, accepts:
+// - query (required)
+// - searchDepth: 'snippets' | 'basic'
+// - maxResults: 1-20
+// - includeAnswer: boolean
+// - includeDomains, excludeDomains
+// - topic: 'general' | 'news'
+// - freshness: 'day' | 'week' | 'month' | 'year' | 'YYYY-MM-DD'
+// Returns full page content per result, not just snippets.
+```
+
+### Fetch
+
+```typescript
+import { createSofyaFetchTool } from '@mastra/sofya';
+
+const fetchTool = createSofyaFetchTool();
+
+// Accepts: urls (1-10), includeRawHtml
+// Returns: results[] as clean markdown, each with a per-url success flag.
+// Supports web pages, PDFs, and documents via 250+ site-specific parsers.
+```
+
+### Extract
+
+```typescript
+import { createSofyaExtractTool } from '@mastra/sofya';
+
+const extractTool = createSofyaExtractTool();
+
+// Accepts: url, prompt
+// Returns: content extracted from the page based on the prompt.
+```
+
+### Research
+
+```typescript
+import { createSofyaResearchTool } from '@mastra/sofya';
+
+const researchTool = createSofyaResearchTool();
+
+// Accepts: query, topic, freshness, maxSources (1-30)
+// Returns: report (synthesized, cited) + sources[] + subQueries[]
+```
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `apiKey` | `string` | `process.env.SOFYA_API_KEY` | Your Sofya API key |
+| `baseUrl` | `string` | `https://sofya.co/v1` | Base URL for the Sofya API |
+| `clientSource` | `string` | `mastra` | Attribution string sent with each request |
+
+If no API key is found, the tool throws a clear error at execution time.
+
+## RAG Pairing Example
+
+Combine search and fetch for retrieval-augmented generation:
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { createSofyaSearchTool, createSofyaFetchTool } from '@mastra/sofya';
+
+const agent = new Agent({
+  id: 'rag-agent',
+  name: 'Research Assistant',
+  model: 'anthropic/claude-sonnet-4-6',
+  instructions: `You are a research assistant. Use sofya-search to find relevant pages, then use sofya-fetch to read the full content of the best results.`,
+  tools: {
+    search: createSofyaSearchTool(),
+    fetch: createSofyaFetchTool(),
+  },
+});
+```
+
+## License
+
+Apache-2.0

--- a/integrations/sofya/eslint.config.js
+++ b/integrations/sofya/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/integrations/sofya/lint-staged.config.js
+++ b/integrations/sofya/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/integrations/sofya/package.json
+++ b/integrations/sofya/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/sofya",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Sofya web search, fetch, extract, and research tools for Mastra agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/integrations/sofya/package.json
+++ b/integrations/sofya/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@mastra/sofya",
+  "version": "1.0.0",
+  "description": "Sofya web search, fetch, extract, and research tools for Mastra agents",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "mastra",
+    "sofya",
+    "web-search",
+    "research",
+    "tools",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "integrations/sofya"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "homepage": "https://mastra.ai",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "zod": ">=3.0.0 || >=4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/integrations/sofya/src/__tests__/client.test.ts
+++ b/integrations/sofya/src/__tests__/client.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { getSofyaClient } from '../client.js';
+
+const mockFetch = vi.fn();
+
+function jsonResponse(body: unknown, ok = true, status = 200, statusText = 'OK') {
+  return {
+    ok,
+    status,
+    statusText,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+describe('getSofyaClient', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+    delete process.env.SOFYA_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('throws when no API key is provided or set in env', () => {
+    expect(() => getSofyaClient()).toThrow(/SOFYA_API_KEY/);
+  });
+
+  it('reads the API key from the SOFYA_API_KEY env var', () => {
+    process.env.SOFYA_API_KEY = 'env-key';
+    expect(() => getSofyaClient()).not.toThrow();
+  });
+
+  it('sends auth header, attribution, and maps camelCase params to snake_case body', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ query: 'q', results: [], credits_used: 3, credits_remaining: 97 }));
+
+    const client = getSofyaClient({ apiKey: 'test-key' });
+    await client.search({ query: 'hello', maxResults: 5, searchDepth: 'basic', topic: 'news', includeAnswer: true });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://sofya.co/v1/search');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer test-key');
+    expect(init.headers['X-Client-Source']).toBe('mastra');
+    expect(JSON.parse(init.body)).toEqual({
+      query: 'hello',
+      max_results: 5,
+      search_depth: 'basic',
+      topic: 'news',
+      include_answer: true,
+    });
+  });
+
+  it('omits undefined params from the request body', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ results: [], credits_used: 1, credits_remaining: 9 }));
+
+    const client = getSofyaClient({ apiKey: 'test-key' });
+    await client.fetch({ urls: ['https://example.com'] });
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({ urls: ['https://example.com'] });
+  });
+
+  it('honors a custom baseUrl and clientSource', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ content: '', url: 'u', credits_used: 5, credits_remaining: 5 }));
+
+    const client = getSofyaClient({ apiKey: 'k', baseUrl: 'https://proxy.example/v1/', clientSource: 'custom' });
+    await client.extract({ url: 'https://example.com', prompt: 'x' });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://proxy.example/v1/extract');
+    expect(init.headers['X-Client-Source']).toBe('custom');
+  });
+
+  it('throws a descriptive error on a non-ok response', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ error: 'bad key' }, false, 401, 'Unauthorized'));
+
+    const client = getSofyaClient({ apiKey: 'k' });
+    await expect(client.search({ query: 'x' })).rejects.toThrow(/401 Unauthorized/);
+  });
+});

--- a/integrations/sofya/src/__tests__/extract.test.ts
+++ b/integrations/sofya/src/__tests__/extract.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExtract = vi.fn();
+
+vi.mock('../client.js', () => ({
+  getSofyaClient: vi.fn(() => ({
+    search: vi.fn(),
+    fetch: vi.fn(),
+    extract: mockExtract,
+    research: vi.fn(),
+  })),
+}));
+
+import { createSofyaExtractTool } from '../extract.js';
+
+describe('createSofyaExtractTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExtract.mockResolvedValue({
+      url: 'https://example.com/pricing',
+      content: 'Pro plan: $20/mo',
+      credits_used: 5,
+      credits_remaining: 95,
+      usage: { input_tokens: 100, output_tokens: 20 },
+    });
+  });
+
+  it('creates a tool with the correct id', () => {
+    const tool = createSofyaExtractTool({ apiKey: 'test-key' });
+    expect(tool.id).toBe('sofya-extract');
+  });
+
+  it('calls client.extract with the url and prompt', async () => {
+    const tool = createSofyaExtractTool({ apiKey: 'test-key' });
+
+    await tool.execute!({ url: 'https://example.com/pricing', prompt: 'list pricing' }, {} as any);
+
+    expect(mockExtract).toHaveBeenCalledWith({ url: 'https://example.com/pricing', prompt: 'list pricing' });
+  });
+
+  it('maps the response to the output schema', async () => {
+    const tool = createSofyaExtractTool({ apiKey: 'test-key' });
+
+    const result = (await tool.execute!({ url: 'https://example.com/pricing', prompt: 'list pricing' }, {} as any)) as any;
+
+    expect(result).toEqual({
+      url: 'https://example.com/pricing',
+      content: 'Pro plan: $20/mo',
+      creditsUsed: 5,
+      creditsRemaining: 95,
+    });
+  });
+});

--- a/integrations/sofya/src/__tests__/fetch.test.ts
+++ b/integrations/sofya/src/__tests__/fetch.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchMethod = vi.fn();
+
+vi.mock('../client.js', () => ({
+  getSofyaClient: vi.fn(() => ({
+    search: vi.fn(),
+    fetch: mockFetchMethod,
+    extract: vi.fn(),
+    research: vi.fn(),
+  })),
+}));
+
+import { createSofyaFetchTool } from '../fetch.js';
+
+describe('createSofyaFetchTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchMethod.mockResolvedValue({
+      results: [
+        { title: 'Example', url: 'https://example.com', content: '# Example', raw_html: null, published_time: null, success: true, error: null },
+        { title: null, url: 'https://bad.example', content: '', raw_html: null, published_time: null, success: false, error: 'not found' },
+      ],
+      credits_used: 2,
+      credits_remaining: 98,
+    });
+  });
+
+  it('creates a tool with the correct id', () => {
+    const tool = createSofyaFetchTool({ apiKey: 'test-key' });
+    expect(tool.id).toBe('sofya-fetch');
+  });
+
+  it('calls client.fetch with mapped parameters', async () => {
+    const tool = createSofyaFetchTool({ apiKey: 'test-key' });
+
+    await tool.execute!({ urls: ['https://example.com'], includeRawHtml: true }, {} as any);
+
+    expect(mockFetchMethod).toHaveBeenCalledWith({
+      urls: ['https://example.com'],
+      includeRawHtml: true,
+    });
+  });
+
+  it('maps results and preserves per-url success flags', async () => {
+    const tool = createSofyaFetchTool({ apiKey: 'test-key' });
+
+    const result = (await tool.execute!({ urls: ['https://example.com', 'https://bad.example'] }, {} as any)) as any;
+
+    expect(result.results).toEqual([
+      { title: 'Example', url: 'https://example.com', content: '# Example', rawHtml: undefined, publishedTime: undefined, success: true, error: undefined },
+      { title: undefined, url: 'https://bad.example', content: '', rawHtml: undefined, publishedTime: undefined, success: false, error: 'not found' },
+    ]);
+    expect(result.creditsUsed).toBe(2);
+    expect(result.creditsRemaining).toBe(98);
+  });
+});

--- a/integrations/sofya/src/__tests__/research.test.ts
+++ b/integrations/sofya/src/__tests__/research.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockResearch = vi.fn();
+
+vi.mock('../client.js', () => ({
+  getSofyaClient: vi.fn(() => ({
+    search: vi.fn(),
+    fetch: vi.fn(),
+    extract: vi.fn(),
+    research: mockResearch,
+  })),
+}));
+
+import { createSofyaResearchTool } from '../research.js';
+
+describe('createSofyaResearchTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResearch.mockResolvedValue({
+      query: 'what is mastra',
+      report: 'Mastra is a TypeScript AI framework.',
+      sources: [{ title: 'Mastra', url: 'https://mastra.ai', fetched: true }],
+      sub_queries: ['mastra overview', 'mastra features'],
+      credits_used: 25,
+      credits_remaining: 75,
+    });
+  });
+
+  it('creates a tool with the correct id', () => {
+    const tool = createSofyaResearchTool({ apiKey: 'test-key' });
+    expect(tool.id).toBe('sofya-research');
+  });
+
+  it('calls client.research with mapped parameters', async () => {
+    const tool = createSofyaResearchTool({ apiKey: 'test-key' });
+
+    await tool.execute!({ query: 'what is mastra', topic: 'general', maxSources: 10 }, {} as any);
+
+    expect(mockResearch).toHaveBeenCalledWith({
+      query: 'what is mastra',
+      topic: 'general',
+      freshness: undefined,
+      maxSources: 10,
+    });
+  });
+
+  it('maps the report, sources, and sub-queries to the output schema', async () => {
+    const tool = createSofyaResearchTool({ apiKey: 'test-key' });
+
+    const result = (await tool.execute!({ query: 'what is mastra' }, {} as any)) as any;
+
+    expect(result).toEqual({
+      query: 'what is mastra',
+      report: 'Mastra is a TypeScript AI framework.',
+      sources: [{ title: 'Mastra', url: 'https://mastra.ai', fetched: true }],
+      subQueries: ['mastra overview', 'mastra features'],
+      creditsUsed: 25,
+      creditsRemaining: 75,
+    });
+  });
+});

--- a/integrations/sofya/src/__tests__/search.test.ts
+++ b/integrations/sofya/src/__tests__/search.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSearch = vi.fn();
+
+vi.mock('../client.js', () => ({
+  getSofyaClient: vi.fn(() => ({
+    search: mockSearch,
+    fetch: vi.fn(),
+    extract: vi.fn(),
+    research: vi.fn(),
+  })),
+}));
+
+import { createSofyaSearchTool } from '../search.js';
+
+describe('createSofyaSearchTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearch.mockResolvedValue({
+      query: 'test query',
+      answer: 'Test answer',
+      results: [
+        {
+          title: 'Result 1',
+          url: 'https://example.com',
+          content: 'Full page content',
+          description: 'A description',
+          fetched: true,
+          published_date: '2026-01-01',
+        },
+      ],
+      credits_used: 3,
+      credits_remaining: 97,
+    });
+  });
+
+  it('creates a tool with the correct id and schemas', () => {
+    const tool = createSofyaSearchTool({ apiKey: 'test-key' });
+    expect(tool.id).toBe('sofya-search');
+    expect(tool.description).toBeDefined();
+    expect(tool.inputSchema).toBeDefined();
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  it('calls client.search with mapped parameters', async () => {
+    const tool = createSofyaSearchTool({ apiKey: 'test-key' });
+
+    await tool.execute!(
+      { query: 'test query', searchDepth: 'basic', maxResults: 5, includeAnswer: true, topic: 'news', freshness: 'week' },
+      {} as any,
+    );
+
+    expect(mockSearch).toHaveBeenCalledWith({
+      query: 'test query',
+      searchDepth: 'basic',
+      maxResults: 5,
+      includeAnswer: true,
+      includeDomains: undefined,
+      excludeDomains: undefined,
+      topic: 'news',
+      freshness: 'week',
+    });
+  });
+
+  it('maps the snake_case response to camelCase output', async () => {
+    const tool = createSofyaSearchTool({ apiKey: 'test-key' });
+
+    const result = (await tool.execute!({ query: 'test query' }, {} as any)) as any;
+
+    expect(result).toEqual({
+      query: 'test query',
+      answer: 'Test answer',
+      results: [
+        {
+          title: 'Result 1',
+          url: 'https://example.com',
+          content: 'Full page content',
+          description: 'A description',
+          fetched: true,
+          publishedDate: '2026-01-01',
+        },
+      ],
+      creditsUsed: 3,
+      creditsRemaining: 97,
+    });
+  });
+
+  it('handles empty and missing optional fields', async () => {
+    mockSearch.mockResolvedValue({ query: 'test', answer: null, results: undefined, credits_used: 1, credits_remaining: 9 });
+
+    const tool = createSofyaSearchTool({ apiKey: 'test-key' });
+    const result = (await tool.execute!({ query: 'test' }, {} as any)) as any;
+
+    expect(result.answer).toBeUndefined();
+    expect(result.results).toEqual([]);
+  });
+
+  it('lets errors propagate', async () => {
+    mockSearch.mockRejectedValue(new Error('rate limit exceeded'));
+
+    const tool = createSofyaSearchTool({ apiKey: 'test-key' });
+    await expect(tool.execute!({ query: 'test' }, {} as any)).rejects.toThrow('rate limit exceeded');
+  });
+});

--- a/integrations/sofya/src/__tests__/tools.test.ts
+++ b/integrations/sofya/src/__tests__/tools.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../client.js', () => ({
+  getSofyaClient: vi.fn(() => ({
+    search: vi.fn(),
+    fetch: vi.fn(),
+    extract: vi.fn(),
+    research: vi.fn(),
+  })),
+}));
+
+import { createSofyaTools } from '../tools.js';
+
+describe('createSofyaTools', () => {
+  it('returns all four tools with the expected ids', () => {
+    const tools = createSofyaTools({ apiKey: 'test-key' });
+
+    expect(Object.keys(tools)).toEqual(['sofyaSearch', 'sofyaFetch', 'sofyaExtract', 'sofyaResearch']);
+    expect(tools.sofyaSearch.id).toBe('sofya-search');
+    expect(tools.sofyaFetch.id).toBe('sofya-fetch');
+    expect(tools.sofyaExtract.id).toBe('sofya-extract');
+    expect(tools.sofyaResearch.id).toBe('sofya-research');
+  });
+});

--- a/integrations/sofya/src/client.ts
+++ b/integrations/sofya/src/client.ts
@@ -1,0 +1,172 @@
+const DEFAULT_BASE_URL = 'https://sofya.co/v1';
+
+export interface SofyaClientOptions {
+  /** Sofya API key. Falls back to the `SOFYA_API_KEY` environment variable. */
+  apiKey?: string;
+  /** Base URL for the Sofya API. Defaults to `https://sofya.co/v1`. */
+  baseUrl?: string;
+  /** Attribution string sent with each request. Defaults to `mastra`. */
+  clientSource?: string;
+}
+
+export interface SofyaSearchParams {
+  query: string;
+  searchDepth?: 'snippets' | 'basic';
+  maxResults?: number;
+  includeAnswer?: boolean;
+  includeDomains?: string[];
+  excludeDomains?: string[];
+  topic?: 'general' | 'news';
+  freshness?: string;
+}
+
+export interface SofyaSearchResult {
+  title: string;
+  url: string;
+  content: string;
+  description?: string | null;
+  fetched?: boolean;
+  published_date?: string | null;
+}
+
+export interface SofyaSearchResponse {
+  query: string;
+  answer?: string | null;
+  results: SofyaSearchResult[];
+  search_depth?: string;
+  topic?: string;
+  credits_used: number;
+  credits_remaining: number;
+}
+
+export interface SofyaFetchParams {
+  urls: string[];
+  includeRawHtml?: boolean;
+}
+
+export interface SofyaFetchResult {
+  title?: string | null;
+  url: string;
+  content: string;
+  raw_html?: string | null;
+  published_time?: string | null;
+  success: boolean;
+  error?: string | null;
+}
+
+export interface SofyaFetchResponse {
+  results: SofyaFetchResult[];
+  credits_used: number;
+  credits_remaining: number;
+}
+
+export interface SofyaExtractParams {
+  url: string;
+  prompt: string;
+}
+
+export interface SofyaExtractResponse {
+  content: string;
+  url: string;
+  credits_used: number;
+  credits_remaining: number;
+  usage?: Record<string, unknown>;
+}
+
+export interface SofyaResearchParams {
+  query: string;
+  topic?: 'general' | 'news';
+  freshness?: string;
+  maxSources?: number;
+}
+
+export interface SofyaResearchSource {
+  title: string;
+  url: string;
+  fetched?: boolean;
+}
+
+export interface SofyaResearchResponse {
+  query: string;
+  report: string;
+  sources: SofyaResearchSource[];
+  sub_queries?: string[];
+  credits_used: number;
+  credits_remaining: number;
+  usage?: Record<string, unknown>;
+}
+
+export interface SofyaClient {
+  search(params: SofyaSearchParams): Promise<SofyaSearchResponse>;
+  fetch(params: SofyaFetchParams): Promise<SofyaFetchResponse>;
+  extract(params: SofyaExtractParams): Promise<SofyaExtractResponse>;
+  research(params: SofyaResearchParams): Promise<SofyaResearchResponse>;
+}
+
+function dropUndefined(body: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(body).filter(([, value]) => value !== undefined));
+}
+
+export function getSofyaClient(config?: SofyaClientOptions): SofyaClient {
+  const apiKey = config?.apiKey ?? process.env.SOFYA_API_KEY;
+  if (!apiKey) {
+    throw new Error('Sofya API key is required. Pass { apiKey } or set SOFYA_API_KEY env var.');
+  }
+
+  const baseUrl = (config?.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+  const clientSource = config?.clientSource ?? 'mastra';
+
+  async function post<T>(path: string, body: Record<string, unknown>): Promise<T> {
+    const response = await fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+        'X-Client-Source': clientSource,
+      },
+      body: JSON.stringify(dropUndefined(body)),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(`Sofya request to ${path} failed: ${response.status} ${response.statusText}${detail ? ` - ${detail}` : ''}`);
+    }
+
+    return (await response.json()) as T;
+  }
+
+  return {
+    search(params) {
+      return post<SofyaSearchResponse>('/search', {
+        query: params.query,
+        search_depth: params.searchDepth,
+        max_results: params.maxResults,
+        include_answer: params.includeAnswer,
+        include_domains: params.includeDomains,
+        exclude_domains: params.excludeDomains,
+        topic: params.topic,
+        freshness: params.freshness,
+      });
+    },
+    fetch(params) {
+      return post<SofyaFetchResponse>('/fetch', {
+        urls: params.urls,
+        include_raw_html: params.includeRawHtml,
+      });
+    },
+    extract(params) {
+      return post<SofyaExtractResponse>('/extract', {
+        url: params.url,
+        prompt: params.prompt,
+      });
+    },
+    research(params) {
+      return post<SofyaResearchResponse>('/research', {
+        query: params.query,
+        topic: params.topic,
+        freshness: params.freshness,
+        max_sources: params.maxSources,
+      });
+    },
+  };
+}

--- a/integrations/sofya/src/extract.ts
+++ b/integrations/sofya/src/extract.ts
@@ -1,0 +1,49 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getSofyaClient } from './client.js';
+import type { SofyaClient, SofyaClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  url: z.string().describe('The URL to extract information from'),
+  prompt: z.string().describe('What information to extract, for example "list all pricing tiers and their prices"'),
+});
+
+const outputSchema = z.object({
+  url: z.string(),
+  content: z.string(),
+  creditsUsed: z.number(),
+  creditsRemaining: z.number(),
+});
+
+export function createSofyaExtractTool(config?: SofyaClientOptions) {
+  let client: SofyaClient | null = null;
+
+  function getClient(): SofyaClient {
+    if (!client) {
+      client = getSofyaClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'sofya-extract',
+    description:
+      'Extract specific information from a URL using Sofya. Fetches the page and uses AI to pull out exactly what the prompt asks for, such as pricing tables, contact details, or specifications. Returns the extracted content as text.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const response = await getClient().extract({
+        url: input.url,
+        prompt: input.prompt,
+      });
+
+      return {
+        url: response.url,
+        content: response.content,
+        creditsUsed: response.credits_used,
+        creditsRemaining: response.credits_remaining,
+      };
+    },
+  });
+}

--- a/integrations/sofya/src/fetch.ts
+++ b/integrations/sofya/src/fetch.ts
@@ -1,0 +1,65 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getSofyaClient } from './client.js';
+import type { SofyaClient, SofyaClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  urls: z.array(z.string()).min(1).max(10).describe('URLs to fetch as clean markdown (1-10). Supports web pages, PDFs, and documents'),
+  includeRawHtml: z.boolean().optional().describe('Include the raw HTML source for each result'),
+});
+
+const outputSchema = z.object({
+  results: z.array(
+    z.object({
+      title: z.string().optional(),
+      url: z.string(),
+      content: z.string(),
+      rawHtml: z.string().optional(),
+      publishedTime: z.string().optional(),
+      success: z.boolean(),
+      error: z.string().optional(),
+    }),
+  ),
+  creditsUsed: z.number(),
+  creditsRemaining: z.number(),
+});
+
+export function createSofyaFetchTool(config?: SofyaClientOptions) {
+  let client: SofyaClient | null = null;
+
+  function getClient(): SofyaClient {
+    if (!client) {
+      client = getSofyaClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'sofya-fetch',
+    description:
+      'Fetch one or more URLs as clean markdown using Sofya. Supports web pages, PDFs, and documents, using 250+ site-specific parsers. Returns content per URL with a success flag, so partial failures do not fail the whole request.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const response = await getClient().fetch({
+        urls: input.urls,
+        includeRawHtml: input.includeRawHtml,
+      });
+
+      return {
+        results: (response.results ?? []).map(r => ({
+          title: r.title || undefined,
+          url: r.url,
+          content: r.content,
+          rawHtml: r.raw_html || undefined,
+          publishedTime: r.published_time || undefined,
+          success: r.success,
+          error: r.error || undefined,
+        })),
+        creditsUsed: response.credits_used,
+        creditsRemaining: response.credits_remaining,
+      };
+    },
+  });
+}

--- a/integrations/sofya/src/index.ts
+++ b/integrations/sofya/src/index.ts
@@ -1,0 +1,18 @@
+export {
+  getSofyaClient,
+  type SofyaClient,
+  type SofyaClientOptions,
+  type SofyaSearchParams,
+  type SofyaSearchResponse,
+  type SofyaFetchParams,
+  type SofyaFetchResponse,
+  type SofyaExtractParams,
+  type SofyaExtractResponse,
+  type SofyaResearchParams,
+  type SofyaResearchResponse,
+} from './client.js';
+export { createSofyaSearchTool } from './search.js';
+export { createSofyaFetchTool } from './fetch.js';
+export { createSofyaExtractTool } from './extract.js';
+export { createSofyaResearchTool } from './research.js';
+export { createSofyaTools } from './tools.js';

--- a/integrations/sofya/src/research.ts
+++ b/integrations/sofya/src/research.ts
@@ -11,7 +11,7 @@ const inputSchema = z.object({
     .string()
     .optional()
     .describe("Filter sources by recency. One of 'day', 'week', 'month', 'year', or a 'YYYY-MM-DD' date"),
-  maxSources: z.number().min(1).max(30).optional().describe('Maximum number of sources to use (1-30)'),
+  maxSources: z.number().int().min(1).max(30).optional().describe('Maximum number of sources to use (1-30)'),
 });
 
 const outputSchema = z.object({

--- a/integrations/sofya/src/research.ts
+++ b/integrations/sofya/src/research.ts
@@ -1,0 +1,70 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getSofyaClient } from './client.js';
+import type { SofyaClient, SofyaClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  query: z.string().describe('The research question or topic'),
+  topic: z.enum(['general', 'news']).optional().describe("Research topic. 'general' for web search, 'news' for news articles"),
+  freshness: z
+    .string()
+    .optional()
+    .describe("Filter sources by recency. One of 'day', 'week', 'month', 'year', or a 'YYYY-MM-DD' date"),
+  maxSources: z.number().min(1).max(30).optional().describe('Maximum number of sources to use (1-30)'),
+});
+
+const outputSchema = z.object({
+  query: z.string(),
+  report: z.string(),
+  sources: z.array(
+    z.object({
+      title: z.string(),
+      url: z.string(),
+      fetched: z.boolean().optional(),
+    }),
+  ),
+  subQueries: z.array(z.string()).optional(),
+  creditsUsed: z.number(),
+  creditsRemaining: z.number(),
+});
+
+export function createSofyaResearchTool(config?: SofyaClientOptions) {
+  let client: SofyaClient | null = null;
+
+  function getClient(): SofyaClient {
+    if (!client) {
+      client = getSofyaClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'sofya-research',
+    description:
+      'Run deep research on a question using Sofya. Breaks the question into sub-queries, searches multiple sources, and synthesizes a cited report. Returns the report text along with the list of sources used.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const response = await getClient().research({
+        query: input.query,
+        topic: input.topic,
+        freshness: input.freshness,
+        maxSources: input.maxSources,
+      });
+
+      return {
+        query: response.query,
+        report: response.report,
+        sources: (response.sources ?? []).map(s => ({
+          title: s.title,
+          url: s.url,
+          fetched: s.fetched,
+        })),
+        subQueries: response.sub_queries || undefined,
+        creditsUsed: response.credits_used,
+        creditsRemaining: response.credits_remaining,
+      };
+    },
+  });
+}

--- a/integrations/sofya/src/search.ts
+++ b/integrations/sofya/src/search.ts
@@ -10,10 +10,10 @@ const inputSchema = z.object({
     .enum(['snippets', 'basic'])
     .optional()
     .describe("Search depth. 'snippets' is cheaper and returns short excerpts, 'basic' returns full page content"),
-  maxResults: z.number().min(1).max(20).optional().describe('Maximum number of results to return (1-20)'),
+  maxResults: z.number().int().min(1).max(20).optional().describe('Maximum number of results to return (1-20)'),
   includeAnswer: z.boolean().optional().describe('Include an AI-synthesized answer generated from the results'),
-  includeDomains: z.array(z.string()).optional().describe('Only include results from these domains (max 10)'),
-  excludeDomains: z.array(z.string()).optional().describe('Exclude results from these domains (max 10)'),
+  includeDomains: z.array(z.string()).max(10).optional().describe('Only include results from these domains (max 10)'),
+  excludeDomains: z.array(z.string()).max(10).optional().describe('Exclude results from these domains (max 10)'),
   topic: z.enum(['general', 'news']).optional().describe("Search topic. 'general' for web search, 'news' for news articles"),
   freshness: z
     .string()

--- a/integrations/sofya/src/search.ts
+++ b/integrations/sofya/src/search.ts
@@ -1,0 +1,85 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getSofyaClient } from './client.js';
+import type { SofyaClient, SofyaClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  query: z.string().describe('The search query'),
+  searchDepth: z
+    .enum(['snippets', 'basic'])
+    .optional()
+    .describe("Search depth. 'snippets' is cheaper and returns short excerpts, 'basic' returns full page content"),
+  maxResults: z.number().min(1).max(20).optional().describe('Maximum number of results to return (1-20)'),
+  includeAnswer: z.boolean().optional().describe('Include an AI-synthesized answer generated from the results'),
+  includeDomains: z.array(z.string()).optional().describe('Only include results from these domains (max 10)'),
+  excludeDomains: z.array(z.string()).optional().describe('Exclude results from these domains (max 10)'),
+  topic: z.enum(['general', 'news']).optional().describe("Search topic. 'general' for web search, 'news' for news articles"),
+  freshness: z
+    .string()
+    .optional()
+    .describe("Filter results by recency. One of 'day', 'week', 'month', 'year', or a 'YYYY-MM-DD' date"),
+});
+
+const outputSchema = z.object({
+  query: z.string(),
+  answer: z.string().optional(),
+  results: z.array(
+    z.object({
+      title: z.string(),
+      url: z.string(),
+      content: z.string(),
+      description: z.string().optional(),
+      fetched: z.boolean().optional(),
+      publishedDate: z.string().optional(),
+    }),
+  ),
+  creditsUsed: z.number(),
+  creditsRemaining: z.number(),
+});
+
+export function createSofyaSearchTool(config?: SofyaClientOptions) {
+  let client: SofyaClient | null = null;
+
+  function getClient(): SofyaClient {
+    if (!client) {
+      client = getSofyaClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'sofya-search',
+    description:
+      'Search the web using Sofya. Returns relevant results with full page content rather than snippets, plus an optional AI-synthesized answer. Supports filtering by domain, topic, and recency.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const response = await getClient().search({
+        query: input.query,
+        searchDepth: input.searchDepth,
+        maxResults: input.maxResults,
+        includeAnswer: input.includeAnswer,
+        includeDomains: input.includeDomains,
+        excludeDomains: input.excludeDomains,
+        topic: input.topic,
+        freshness: input.freshness,
+      });
+
+      return {
+        query: response.query,
+        answer: response.answer || undefined,
+        results: (response.results ?? []).map(r => ({
+          title: r.title,
+          url: r.url,
+          content: r.content,
+          description: r.description || undefined,
+          fetched: r.fetched,
+          publishedDate: r.published_date || undefined,
+        })),
+        creditsUsed: response.credits_used,
+        creditsRemaining: response.credits_remaining,
+      };
+    },
+  });
+}

--- a/integrations/sofya/src/tools.ts
+++ b/integrations/sofya/src/tools.ts
@@ -1,0 +1,14 @@
+import type { SofyaClientOptions } from './client.js';
+import { createSofyaExtractTool } from './extract.js';
+import { createSofyaFetchTool } from './fetch.js';
+import { createSofyaResearchTool } from './research.js';
+import { createSofyaSearchTool } from './search.js';
+
+export function createSofyaTools(config?: SofyaClientOptions) {
+  return {
+    sofyaSearch: createSofyaSearchTool(config),
+    sofyaFetch: createSofyaFetchTool(config),
+    sofyaExtract: createSofyaExtractTool(config),
+    sofyaResearch: createSofyaResearchTool(config),
+  };
+}

--- a/integrations/sofya/tsconfig.build.json
+++ b/integrations/sofya/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/sofya/tsconfig.json
+++ b/integrations/sofya/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/sofya/tsup.config.ts
+++ b/integrations/sofya/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/integrations/sofya/turbo.json
+++ b/integrations/sofya/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://v2-9-16.turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/integrations/sofya/vitest.config.ts
+++ b/integrations/sofya/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:integrations/sofya',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Closes #18555

## Description

Adds `@mastra/sofya`, a web tools integration for the [Sofya](https://sofya.co) API. It exposes four tools for agents, built with `createTool()` and full Zod input/output schemas:

- `sofya-search`: web search that returns full page content, not just snippets, with an optional AI-synthesized answer.
- `sofya-fetch`: fetch up to 10 URLs as clean markdown (web pages, PDFs, documents), with a per-url success flag.
- `sofya-extract`: pull specific information from a page using a prompt.
- `sofya-research`: multi-source deep research that returns a cited report plus the sources used.

It follows the existing integration package pattern (the `@mastra/tavily` layout): per-tool factory functions, a shared lazy client, and an `SOFYA_API_KEY` environment fallback. `createSofyaTools()` returns all four with one config.

```typescript
import { createSofyaTools } from '@mastra/sofya';

const tools = createSofyaTools(); // reads SOFYA_API_KEY from the environment
```

Notes:

- The client uses plain `fetch`, so the package adds no new runtime dependency.
- A reference docs page and a sidebar entry are included.
- A changeset is included (`minor`, net-new package).

## Verification

- `tsc --noEmit`, `tsup` (esm + cjs), and `vitest` all pass. 21 unit tests cover param mapping, response mapping, env fallback, and error propagation.
- Verified all four tools end to end against the live Sofya API: search, fetch, extract, and research each return and map correctly.
- `prettier --check` passes with the repo config.

## Related issue(s)

N/A. Net-new integration package, no existing issue.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a new “Sofya” web-tools integration for Mastra so agents can look up web pages, turn them into clean text, pull out specific details, and do multi-source research. It also adds the docs and tests to make sure the tools work reliably.

### What changed
- Added the new `@mastra/sofya` integration package, exposing four agent tools:
  - `sofya-search`: searches the web and can include an optional synthesized answer plus full page content
  - `sofya-fetch`: fetches up to 10 URLs and returns clean markdown per URL (with per-URL success/error)
  - `sofya-extract`: extracts specific information from a page using a prompt
  - `sofya-research`: performs multi-source “deep research” and returns a cited report with a source list
- Added `createSofyaTools()` to create all four tools from one config, following the existing `@mastra/tavily` integration pattern (lazy shared client, per-tool factory functions, and `SOFYA_API_KEY` fallback). Sofya API calls use Bearer auth.
- Implemented typed Zod input/output schemas and response field normalization (snake_case ↔ camelCase).
- Tightened/validated request parameters as documented:
  - `maxResults` / `maxSources` are treated as integers
  - `includeDomains` / `excludeDomains` are capped at the documented max
  - `freshness` stays a string to support supported presets and date ranges
- Added comprehensive unit tests for the client and each tool (including execute/mapping behavior).
- Added documentation + reference wiring:
  - Sidebar entry for `tools/sofya`
  - Full `tools/sofya` reference page with usage examples and schemas
  - `integrations/sofya/README.md` with quick-start and examples
- Added release/docs housekeeping for the new package (changeset and integration package setup/config).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->