### PR TITLE
fix: exempt interactive builtins (ask_user, request_access) from appr…

### DIFF
--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3441,6 +3441,13 @@ export class Session<TState = unknown> {
    * Resume a suspended tool call through the active thread subscription.
    * Re-supplies the shared run budget so the resumed run doesn't stop mid-task
    * on the agent's small default maxSteps.
+   *
+   * Interactive builtins (`ask_user`, `request_access`) are exempted from the
+   * approval re-check on resume: their resume schema is `z.string()` /
+   * `z.array(z.string())` which cannot carry the `{ approved }` field the
+   * approval gate demands, so re-entering the approval branch would always
+   * reject the answer. The caller already handled approval (setForTool policy,
+   * yolo mode, or a prior explicit approval gate).
    */
   async resumeToolCall({
     resumeData,
@@ -3478,6 +3485,16 @@ export class Session<TState = unknown> {
 
     try {
       const resourceId = this.identity.getResourceId();
+      const sharedOptions = this.machinery.buildSharedRunOptions();
+      // Interactive builtins suspend to collect user input, not for approval.
+      // The resume data is the user's answer (a bare string), which the approval
+      // re-check would reject because it cannot carry an `{ approved }` field.
+      // Exempt these tools so the answer reaches the model as-is.
+      const isInteractive =
+        suspension.toolName === 'ask_user' || suspension.toolName === 'request_access';
+      if (isInteractive) {
+        sharedOptions.requireToolApproval = false;
+      }
       await agent.sendStreamResume({
         threadId,
         resourceId,
@@ -3485,7 +3502,7 @@ export class Session<TState = unknown> {
         toolCallId,
         resumeData,
         streamOptions: {
-          ...this.machinery.buildSharedRunOptions(),
+          ...sharedOptions,
           memory: { thread: threadId, resource: resourceId },
           abortSignal: this.run.ensureAbortController().signal,
           requestContext,


### PR DESCRIPTION

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->
The bug has been fixed in `packages/core/src/agent-controller/session.ts`. The change is in the `resumeToolCall` method (lines 3486-3497).

**Root Cause:** When a tool suspension is resumed via `respondToToolSuspension()`, the `resumeToolCall` method calls `agent.sendStreamResume()` with the shared run options from `buildSharedRunOptions()`, which hardcodes `requireToolApproval: !isYolo`. On resume, the agent's approval re-check sees `requireToolApproval: true` (non-yolo mode) and wraps the resumed tool execution in the approval gate. The approval gate then checks `resumeData.approved`, which fails because `ask_user`'s resume schema is `z.union([z.string(), z.array(z.string())])` — a bare string answer cannot carry an `{ approved }` field.

**Fix:** Before calling `sendStreamResume()`, the code now builds the shared options once, checks if the suspended tool is an interactive builtin (`ask_user` or `request_access`), and if so, overrides `requireToolApproval` to `false`. This exempts interactive builtins from the approval re-check on resume, just as `submit_plan` is already special-cased via a different path (`handlePlanApprovalResume`).

The fix addresses both symptoms:
1. **Bare string resume works:** `session.respondToToolSuspension({ toolCallId, resumeData: 'My answer' })` now delivers `"User answered: My answer"` to the model instead of `"Tool call was not approved by the user"`
2. **`setForTool({ policy: 'allow' })` now sufficient:** The per-tool allow policy still feeds through `resolveToolApproval` during the initial run, but the resume no longer re-enters the approval gate, so the answer passes through

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->
Closes #18564


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When a user pauses a chat to answer a question, the system used to “double-check” the answer in a way that rejected the normal simple response. This change tells the system not to do that extra check for `ask_user` and `request_access`, so those paused interactions can resume normally.

## Summary
- Updated `Session.resumeToolCall` to reuse shared run options once during resume.
- Disabled `requireToolApproval` for the interactive built-in tools `ask_user` and `request_access` when resuming.
- Preserved the existing approval flow for other tools while fixing the non-yolo resume path for string-based responses.
- Aligns the resume behavior with the existing special-case handling used for `submit_plan`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->