### PR TITLE
fix(core): cache sub-agent tool schemas

### DIFF
--- a/.changeset/subagent-schema-cache.md
+++ b/.changeset/subagent-schema-cache.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Cache sub-agent tool schemas so repeated agent tool conversion does not rebuild the same Zod schemas.

--- a/.changeset/subagent-schema-cache.md
+++ b/.changeset/subagent-schema-cache.md
@@ -2,4 +2,4 @@
 "@mastra/core": patch
 ---
 
-Cache sub-agent tool schemas so repeated agent tool conversion does not rebuild the same Zod schemas.
+Reduce repeated schema work during sub-agent tool conversion for more stable memory usage.

--- a/packages/core/src/agent/__tests__/tools.test.ts
+++ b/packages/core/src/agent/__tests__/tools.test.ts
@@ -1716,4 +1716,62 @@ describe('sub-agent prompt input normalization (GitHub #14154)', () => {
     expect(subAgentTool).toBeDefined();
     expect(subAgentTool.description).toContain('subAgent');
   });
+
+  it('reuses sub-agent tool schemas across conversions', async () => {
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        text: 'ok',
+        content: [{ type: 'text', text: 'ok' }],
+        warnings: [],
+      }),
+    });
+
+    const subAgent = new Agent({
+      id: 'sub-agent',
+      name: 'Sub Agent',
+      instructions: 'You are a sub-agent',
+      model: mockModel,
+    });
+
+    const parentAgent = new Agent({
+      id: 'parent-agent',
+      name: 'Parent Agent',
+      instructions: 'You are a parent agent',
+      model: mockModel,
+      agents: { subAgent },
+    });
+
+    const getSubAgentToolSchemasSpy = vi.spyOn(parentAgent as any, 'getSubAgentToolSchemas');
+    let firstTools!: Record<string, any>;
+    let secondTools!: Record<string, any>;
+    let firstSchemas: any;
+    let secondSchemas: any;
+
+    try {
+      firstTools = await parentAgent['convertTools']({
+        requestContext: new RequestContext(),
+        methodType: 'generate',
+      });
+      secondTools = await parentAgent['convertTools']({
+        requestContext: new RequestContext(),
+        methodType: 'generate',
+      });
+
+      expect(getSubAgentToolSchemasSpy).toHaveBeenCalledTimes(2);
+      firstSchemas = getSubAgentToolSchemasSpy.mock.results[0]?.value;
+      secondSchemas = getSubAgentToolSchemasSpy.mock.results[1]?.value;
+    } finally {
+      getSubAgentToolSchemasSpy.mockRestore();
+    }
+
+    const firstSubAgentTool = firstTools['agent-subAgent'];
+    const secondSubAgentTool = secondTools['agent-subAgent'];
+
+    expect(secondSubAgentTool).not.toBe(firstSubAgentTool);
+    expect(secondSchemas.inputSchema).toBe(firstSchemas.inputSchema);
+    expect(secondSchemas.outputSchema).toBe(firstSchemas.outputSchema);
+  });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -178,6 +178,50 @@ import type { AgentCapabilities } from './workflows/prepare-stream/schema';
 
 export type MastraLLM = MastraLLMV1 | MastraLLMVNext;
 
+const createSubAgentInputSchema = () =>
+  z.object({
+    prompt: z.string().describe('The prompt to send to the agent'),
+    // Using .nullish() instead of .optional() because OpenAI sends null for unfilled optional fields
+    threadId: z.string().nullish().describe('Thread ID for conversation continuity for memory messages'),
+    resourceId: z.string().nullish().describe('Resource/user identifier for memory messages'),
+    instructions: z
+      .string()
+      .nullish()
+      .describe(
+        'Additional instructions to append to the agent instructions. Only provide if you have specific guidance beyond what the agent already knows. Leave empty in most cases.',
+      ),
+    maxSteps: z.number().min(3).nullish().describe('Maximum number of execution steps for the sub-agent'),
+    // using minimum of 3 to ensure if the agent has a tool call, the llm gets executed again after the tool call step, using the tool call result
+    // to return a proper llm response
+  });
+
+const createSubAgentOutputSchema = () =>
+  z.object({
+    text: z.string().describe('The response from the agent'),
+    subAgentThreadId: z.string().describe('The thread ID of the agent').optional(),
+    subAgentResourceId: z.string().describe('The resource ID of the agent').optional(),
+    subAgentToolResults: z
+      .array(
+        z.object({
+          toolName: z.string().describe('The name of the tool'),
+          toolCallId: z.string().describe('The ID of the tool call'),
+          result: z.unknown().describe('The result of the tool call'),
+          args: z.unknown().describe('The arguments of the tool call').optional(),
+          isError: z.boolean().describe('Whether the tool call resulted in an error').optional(),
+        }),
+      )
+      .describe("The results from the agent's tool calls")
+      .optional(),
+  });
+
+type SubAgentToolSchemas = {
+  inputSchema: StandardSchemaWithJSON<SubAgentToolInput>;
+  outputSchema: StandardSchemaWithJSON<SubAgentToolOutput>;
+};
+
+type SubAgentToolInput = z.infer<ReturnType<typeof createSubAgentInputSchema>>;
+type SubAgentToolOutput = z.infer<ReturnType<typeof createSubAgentOutputSchema>>;
+
 type ModelFallbacks = {
   id: string;
   model: DynamicArgument<MastraModelConfig>;
@@ -416,6 +460,7 @@ export class Agent<
   readonly #options?: AgentCreateOptions;
   #legacyHandler?: AgentLegacyHandler;
   #config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext, TEditor>;
+  #subAgentToolSchemas?: SubAgentToolSchemas;
 
   // This flag is for agent network messages. We should change the agent network formatting and remove this flag after.
   private _agentNetworkAppend = false;
@@ -4329,6 +4374,20 @@ export class Agent<
       .filter((message): message is MastraDBMessage => Boolean(message));
   }
 
+  private getSubAgentToolSchemas(): SubAgentToolSchemas {
+    if (!this.#subAgentToolSchemas) {
+      const inputSchema = createSubAgentInputSchema();
+      const outputSchema = createSubAgentOutputSchema();
+
+      this.#subAgentToolSchemas = {
+        inputSchema: toStandardSchema(inputSchema),
+        outputSchema: toStandardSchema(outputSchema),
+      };
+    }
+
+    return this.#subAgentToolSchemas;
+  }
+
   /**
    * Retrieves and converts agent tools to CoreTool format.
    * @internal
@@ -4359,43 +4418,11 @@ export class Agent<
 
     if (Object.keys(agents).length > 0) {
       for (const [agentName, agent] of Object.entries(agents)) {
-        const agentInputSchema = z.object({
-          prompt: z.string().describe('The prompt to send to the agent'),
-          // Using .nullish() instead of .optional() because OpenAI sends null for unfilled optional fields
-          threadId: z.string().nullish().describe('Thread ID for conversation continuity for memory messages'),
-          resourceId: z.string().nullish().describe('Resource/user identifier for memory messages'),
-          instructions: z
-            .string()
-            .nullish()
-            .describe(
-              'Additional instructions to append to the agent instructions. Only provide if you have specific guidance beyond what the agent already knows. Leave empty in most cases.',
-            ),
-          maxSteps: z.number().min(3).nullish().describe('Maximum number of execution steps for the sub-agent'),
-          // using minimum of 3 to ensure if the agent has a tool call, the llm gets executed again after the tool call step, using the tool call result
-          // to return a proper llm response
-        });
-
-        const agentOutputSchema = z.object({
-          text: z.string().describe('The response from the agent'),
-          subAgentThreadId: z.string().describe('The thread ID of the agent').optional(),
-          subAgentResourceId: z.string().describe('The resource ID of the agent').optional(),
-          subAgentToolResults: z
-            .array(
-              z.object({
-                toolName: z.string().describe('The name of the tool'),
-                toolCallId: z.string().describe('The ID of the tool call'),
-                result: z.unknown().describe('The result of the tool call'),
-                args: z.unknown().describe('The arguments of the tool call').optional(),
-                isError: z.boolean().describe('Whether the tool call resulted in an error').optional(),
-              }),
-            )
-            .describe("The results from the agent's tool calls")
-            .optional(),
-        });
+        const { inputSchema: agentInputSchema, outputSchema: agentOutputSchema } = this.getSubAgentToolSchemas();
 
         const toModelOutput = delegation?.includeSubAgentToolResultsInModelContext
           ? undefined
-          : (output: z.infer<typeof agentOutputSchema>) => ({
+          : (output: SubAgentToolOutput) => ({
               type: 'text' as const,
               value: output.text,
             });
@@ -4409,7 +4436,7 @@ export class Agent<
           ...(toModelOutput ? { toModelOutput } : {}),
           // manually wrap agent tools with tracing, so that we can pass the
           // current tool span onto the agent to maintain continuity of the trace
-          execute: async (inputData: z.infer<typeof agentInputSchema>, context) => {
+          execute: async (inputData: SubAgentToolInput, context) => {
             const invocationActor = getInvocationActor(context);
             const startTime = Date.now();
             const toolCallId = context?.agent?.toolCallId || randomUUID();


### PR DESCRIPTION
## Description

Cache the static sub-agent input/output tool schemas used by `listAgentTools()` and reuse their Standard Schema wrappers across repeated agent tool conversion.

`listAgentTools()` still creates a fresh tool wrapper on each conversion, so the `execute` closure continues to capture run-specific context such as `runId`, `threadId`, `requestContext`, delegation hooks, and observability state.

Root cause: `listAgentTools()` rebuilt Zod schemas with `.describe()` on every `generate()` / `stream()` call for each sub-agent. When `zod/v4` resolves to the `zod@3.25.x` compatibility layer, those described schemas are retained by the Zod global registry, causing repeated calls to pin schema graphs.

Validation:

- `corepack pnpm --filter ./packages/core test src/agent/__tests__/tools.test.ts -t "reuses sub-agent tool schemas across conversions"`
- `corepack pnpm --filter ./packages/core test src/agent/__tests__/tools.test.ts`
- `corepack pnpm --filter ./packages/core lint`
- `corepack pnpm --filter ./packages/core check`

## Related issue(s)

Fixes #18469

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR (none yet)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When the app creates “sub-agent tools,” it used to rebuild the same validation schemas every time. This PR makes those schemas get built once and reused, which avoids memory slowly growing and makes repeated tool setup faster.

## Summary
- Caches the static sub-agent input/output schemas used by `listAgentTools()` and reuses the same Standard Schema wrappers across repeated conversions.
- Refactors schema creation into shared `createSubAgentInputSchema()` / `createSubAgentOutputSchema()` helpers and stores the lazily-built results on `Agent` via a cached `#subAgentToolSchemas`.
- Updates sub-agent tool execution typing so the `execute` handler uses the shared inferred `SubAgentToolInput` type from the cached schema helper (instead of reusing inline Zod schema types).
- Adds a regression unit test ensuring repeated `convertTools` calls reuse the same schema object references (while creating new tool instances).
- Adds a changeset to publish a `@mastra/core` patch release with the memory-stability/memoization fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->