### PR TITLE
chore(qdrant): remove @ts-expect-error by strictly typing distance mapping keys

### DIFF
--- a/.changeset/fix-qdrant-ts-expect-error-18572.md
+++ b/.changeset/fix-qdrant-ts-expect-error-18572.md
@@ -1,0 +1,5 @@
+---
+"@mastra/qdrant": patch
+---
+
+Fix type error in qdrant metric assignment

--- a/.changeset/fix-qdrant-ts-expect-error-18572.md
+++ b/.changeset/fix-qdrant-ts-expect-error-18572.md
@@ -2,4 +2,4 @@
 "@mastra/qdrant": patch
 ---
 
-Fix type error in qdrant metric assignment
+Improve type safety for `describeIndex` metric field — removes compiler suppression so TypeScript can fully validate the returned `IndexStats` shape

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -449,8 +449,9 @@ export class QdrantVector extends MastraVector {
       return {
         dimension: config.params.vectors?.size as number,
         count: points_count || 0,
-        // @ts-expect-error - Object.keys returns string[] but DISTANCE_MAPPING keys are typed
-        metric: Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance),
+        metric: (Object.keys(DISTANCE_MAPPING) as (keyof typeof DISTANCE_MAPPING)[]).find(
+          key => DISTANCE_MAPPING[key] === distance,
+        ) as IndexStats['metric'],
       };
     } catch (error) {
       throw new MastraError(


### PR DESCRIPTION
## Description

Removes an unnecessary `@ts-expect-error` directive in `stores/qdrant/src/vector/index.ts` by properly casting the return type of `Object.keys()` and the `.find()` result.

The `DISTANCE_MAPPING` constant is typed as `Record<string, Schemas['Distance']>`, which causes `Object.keys()` to return `string[]`. This made TypeScript unable to verify the index access `DISTANCE_MAPPING[key]`, requiring a `@ts-expect-error` suppression. The fix casts the keys to `(keyof typeof DISTANCE_MAPPING)[]` and the final result to `IndexStats['metric']`, restoring full type safety.

## Related issue(s)

Fixes #18572

## Type of change

- [x] Code refactoring

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR removes a “TypeScript ignore this” comment by teaching the code to look up distance metrics using properly typed keys. That way, TypeScript can verify the returned `metric` value matches what `IndexStats` expects.

### Summary
- Removed the unnecessary `@ts-expect-error` in `stores/qdrant/src/vector/index.ts` (issue `#18572`).
- Tightened `DISTANCE_MAPPING` key handling by casting `Object.keys(DISTANCE_MAPPING)` to `(keyof typeof DISTANCE_MAPPING)[]`.
- Kept the `describeIndex` return type safe by casting the `.find(...)` result to `IndexStats['metric']`.
- Added a changeset (`@mastra/qdrant`) to publish a patch release with the TypeScript type-safety improvement.

### Notes
- No runtime behavior change; this is a typing/refactor-only fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->