### PR TITLE
feat(core): add TemperatureDeprecatedHandler for deprecated sampling params

### DIFF
--- a/.changeset/temperature-deprecated-handler.md
+++ b/.changeset/temperature-deprecated-handler.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Add `TemperatureDeprecatedHandler`, an opt-in processor that recovers from models which dropped support for `temperature`, `top_p`, or `top_k` (for example Anthropic's `claude-opus-4-7`, which returns a 400 when `temperature` is sent). On that rejection it strips the unsupported sampling parameters from the call settings and retries the same model once. Register the same instance in both `inputProcessors` and `errorProcessors` to enable it. Closes #16247.

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -948,6 +948,8 @@ export class ContextLengthHandler implements Processor {
 
 Mastra includes a built-in [`PrefillErrorHandler`](/reference/processors/prefill-error-handler) that automatically handles the Anthropic "assistant message prefill" error. This processor is auto-injected and requires no configuration.
 
+Mastra also ships a [`TemperatureDeprecatedHandler`](/reference/processors/temperature-deprecated-handler) for models that dropped support for `temperature` / `top_p` / `top_k` (such as `claude-opus-4-7`). It strips the rejected sampling parameters and retries. Register the same instance in both `inputProcessors` and `errorProcessors` to enable it.
+
 ## Related documentation
 
 - [Guardrails](/docs/agents/guardrails): Security and validation processors

--- a/docs/src/content/en/reference/processors/temperature-deprecated-handler.mdx
+++ b/docs/src/content/en/reference/processors/temperature-deprecated-handler.mdx
@@ -1,0 +1,83 @@
+---
+title: "Reference: TemperatureDeprecatedHandler | Processors"
+description: "Documentation for the TemperatureDeprecatedHandler processor in Mastra, which recovers from models that reject deprecated sampling parameters by stripping them and retrying."
+packages:
+  - "@mastra/core"
+---
+
+# TemperatureDeprecatedHandler
+
+The `TemperatureDeprecatedHandler` recovers from models that have dropped support for sampling parameters (`temperature`, `top_p`, `top_k`) within a previously-supported family. Some models reject any request that still carries these parameters with a hard `400` (for example, Anthropic's `claude-opus-4-7` returns `400 — temperature is deprecated for this model.`).
+
+When the error is detected, the processor strips the offending sampling parameters from `modelSettings` and retries the same model once. It is the sampling-parameter sibling of [`PrefillErrorHandler`](/reference/processors/prefill-error-handler).
+
+## How it works
+
+The handler uses two hooks that run from different processor lists, so it must be registered in both `inputProcessors` and `errorProcessors`:
+
+1. The LLM API call fails with a `400` that names a sampling parameter and an "unsupported"/"deprecated" reason.
+1. `processAPIError` (which runs for error processors) checks that this is the first retry attempt, flags shared state, and returns `{ retry: true }`.
+1. On the retry, `processInputStep` (which runs for input processors) reads that flag and removes `temperature`, `topP`, and `topK` from `modelSettings` before the request is dispatched.
+1. The flag stays set for the rest of the run, so later steps keep stripping the parameters.
+
+Both hooks share the same per-processor state, so register the **same instance in both lists**.
+
+## Usage example
+
+```typescript title="src/mastra/agents/my-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { TemperatureDeprecatedHandler } from '@mastra/core/processors'
+
+const temperatureDeprecatedHandler = new TemperatureDeprecatedHandler()
+
+export const agent = new Agent({
+  name: 'my-agent',
+  instructions: 'You are a helpful assistant.',
+  model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
+  inputProcessors: [temperatureDeprecatedHandler],
+  errorProcessors: [temperatureDeprecatedHandler],
+})
+```
+
+## Constructor parameters
+
+The `TemperatureDeprecatedHandler` takes no constructor parameters.
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: "'temperature-deprecated-handler'",
+    description: 'Processor identifier.',
+    isOptional: false,
+  },
+  {
+    name: 'name',
+    type: "'Temperature Deprecated Handler'",
+    description: 'Processor display name.',
+    isOptional: false,
+  },
+  {
+    name: 'processAPIError',
+    type: '(args: ProcessAPIErrorArgs) => Promise<ProcessAPIErrorResult | void>',
+    description:
+      'Detects a deprecated sampling-parameter rejection, flags shared state, and signals retry. Only triggers on the first retry attempt.',
+    isOptional: false,
+  },
+  {
+    name: 'processInputStep',
+    type: '(args: ProcessInputStepArgs) => ProcessInputStepResult | void',
+    description:
+      'On the retried step, strips temperature, topP, and topK from modelSettings once the deprecation has been detected.',
+    isOptional: false,
+  },
+]}
+/>
+
+## Related
+
+- [PrefillErrorHandler](/reference/processors/prefill-error-handler)
+- [Processor interface](/reference/processors/processor-interface)
+- [Guardrails](/docs/agents/guardrails)

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -492,6 +492,11 @@ const sidebars = {
           label: 'StreamErrorRetryProcessor',
         },
         { type: 'doc', id: 'processors/system-prompt-scrubber', label: 'SystemPromptScrubber' },
+        {
+          type: 'doc',
+          id: 'processors/temperature-deprecated-handler',
+          label: 'TemperatureDeprecatedHandler',
+        },
         { type: 'doc', id: 'processors/token-limiter-processor', label: 'TokenLimiterProcessor' },
         { type: 'doc', id: 'processors/tool-call-filter', label: 'ToolCallFilter' },
         { type: 'doc', id: 'processors/tool-search-processor', label: 'ToolSearchProcessor' },

--- a/packages/core/src/agent/__tests__/temperature-deprecated-recovery.test.ts
+++ b/packages/core/src/agent/__tests__/temperature-deprecated-recovery.test.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from 'node:crypto';
+import { APICallError } from '@internal/ai-sdk-v5';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { MockMemory } from '../../memory/mock';
+import { TemperatureDeprecatedHandler } from '../../processors/temperature-deprecated-handler';
+import { Agent } from '../agent';
+
+/**
+ * Integration test for TemperatureDeprecatedHandler recovery.
+ *
+ * Simulates a model (e.g. Anthropic's `claude-opus-4-7`) that dropped support
+ * for `temperature`:
+ * - The mock model rejects the first call with a 400 whenever `temperature` is
+ *   present in the call settings.
+ * - TemperatureDeprecatedHandler catches it, strips `temperature` from
+ *   modelSettings, and signals retry.
+ * - On retry the same model receives no `temperature` and succeeds.
+ *
+ * Related: https://github.com/mastra-ai/mastra/issues/16247
+ */
+function createTemperatureDeprecatedModel(responseText: string) {
+  const errorMessage = '`temperature` is deprecated for this model.';
+
+  const reject = () => {
+    throw new APICallError({
+      message: errorMessage,
+      url: 'https://api.anthropic.com/v1/messages',
+      requestBodyValues: {},
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: errorMessage },
+      }),
+      isRetryable: false,
+    });
+  };
+
+  const model = new MockLanguageModelV2({
+    modelId: 'mock-temperature-deprecated',
+    doGenerate: async ({ temperature }) => {
+      if (temperature !== undefined) reject();
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        content: [{ type: 'text' as const, text: responseText }],
+        warnings: [],
+      };
+    },
+    doStream: async ({ temperature }) => {
+      if (temperature !== undefined) reject();
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-temperature-deprecated', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: responseText },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+        ]),
+      };
+    },
+  });
+
+  return model;
+}
+
+describe('TemperatureDeprecatedHandler Recovery', () => {
+  describe('generate()', () => {
+    it('strips temperature and retries when the model rejects it', async () => {
+      const model = createTemperatureDeprecatedModel('Recovery successful!');
+      const handler = new TemperatureDeprecatedHandler();
+
+      const agent = new Agent({
+        id: 'temperature-deprecated-generate',
+        name: 'Temperature Deprecated Test Agent',
+        instructions: 'You are a test agent',
+        model: [{ model, maxRetries: 0 }],
+        inputProcessors: [handler],
+        errorProcessors: [handler],
+      });
+
+      const result = await agent.generate('Hello', { modelSettings: { temperature: 0.7 } });
+
+      expect(result.text).toBe('Recovery successful!');
+      // First call carried temperature and failed; retry dropped it and succeeded.
+      expect(model.doGenerateCalls).toHaveLength(2);
+      expect(model.doGenerateCalls[0]?.temperature).toBe(0.7);
+      expect(model.doGenerateCalls[1]?.temperature).toBeUndefined();
+    });
+
+    it('does not retry when no error processor is registered', async () => {
+      const model = createTemperatureDeprecatedModel('unused');
+
+      const agent = new Agent({
+        id: 'temperature-deprecated-no-handler',
+        name: 'Temperature Deprecated No Handler',
+        instructions: 'You are a test agent',
+        model: [{ model, maxRetries: 0 }],
+      });
+
+      await expect(agent.generate('Hello', { modelSettings: { temperature: 0.7 } })).rejects.toThrow(
+        /temperature.*deprecated/i,
+      );
+    });
+  });
+
+  describe('stream()', () => {
+    it('strips temperature and retries when the model rejects it', async () => {
+      const mockMemory = new MockMemory();
+      const threadId = randomUUID();
+      const resourceId = randomUUID();
+      await mockMemory.createThread({ threadId, resourceId });
+
+      const model = createTemperatureDeprecatedModel('Stream recovery!');
+      const handler = new TemperatureDeprecatedHandler();
+
+      const agent = new Agent({
+        id: 'temperature-deprecated-stream',
+        name: 'Temperature Deprecated Stream Agent',
+        instructions: 'You are a test agent',
+        model: [{ model, maxRetries: 0 }],
+        memory: mockMemory,
+        inputProcessors: [handler],
+        errorProcessors: [handler],
+      });
+
+      const result = await agent.stream('Hello', {
+        modelSettings: { temperature: 0.7 },
+        memory: { thread: threadId, resource: resourceId },
+      });
+
+      const fullText = await result.text;
+
+      expect(fullText).toBe('Stream recovery!');
+      expect(model.doStreamCalls).toHaveLength(2);
+      expect(model.doStreamCalls[0]?.temperature).toBe(0.7);
+      expect(model.doStreamCalls[1]?.temperature).toBeUndefined();
+    });
+
+    it('also strips top_p and top_k alongside temperature', async () => {
+      const model = createTemperatureDeprecatedModel('Recovery successful!');
+      const handler = new TemperatureDeprecatedHandler();
+
+      const agent = new Agent({
+        id: 'temperature-deprecated-topp-topk',
+        name: 'Temperature Deprecated TopP TopK Agent',
+        instructions: 'You are a test agent',
+        model: [{ model, maxRetries: 0 }],
+        inputProcessors: [handler],
+        errorProcessors: [handler],
+      });
+
+      const result = await agent.generate('Hello', {
+        modelSettings: { temperature: 0.7, topP: 0.9, topK: 40 },
+      });
+
+      expect(result.text).toBe('Recovery successful!');
+      expect(model.doGenerateCalls).toHaveLength(2);
+      expect(model.doGenerateCalls[1]?.temperature).toBeUndefined();
+      expect(model.doGenerateCalls[1]?.topP).toBeUndefined();
+      expect(model.doGenerateCalls[1]?.topK).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -834,6 +834,7 @@ export { isProcessorWorkflow } from './is-processor-workflow';
 
 export * from './processors';
 export { PrefillErrorHandler } from './prefill-error-handler';
+export { TemperatureDeprecatedHandler } from './temperature-deprecated-handler';
 export { ProviderHistoryCompat, anthropicToolIdFormat, cerebrasStripReasoningContent } from './provider-history-compat';
 export {
   isBadRequestError,

--- a/packages/core/src/processors/temperature-deprecated-handler.test.ts
+++ b/packages/core/src/processors/temperature-deprecated-handler.test.ts
@@ -1,0 +1,230 @@
+import { APICallError } from '@internal/ai-sdk-v5';
+import { describe, expect, it } from 'vitest';
+import { MessageList } from '../agent/message-list';
+import { TemperatureDeprecatedHandler } from './temperature-deprecated-handler';
+import type { ProcessAPIErrorArgs, ProcessInputStepArgs } from './index';
+
+function createTemperatureDeprecatedError() {
+  return new APICallError({
+    message: '`temperature` is deprecated for this model.',
+    url: 'https://api.anthropic.com/v1/messages',
+    requestBodyValues: {},
+    statusCode: 400,
+    responseBody: JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: '`temperature` is deprecated for this model.',
+      },
+    }),
+    isRetryable: false,
+  });
+}
+
+function createTopPUnsupportedError() {
+  return new APICallError({
+    message: 'top_p is not supported for this model.',
+    url: 'https://api.anthropic.com/v1/messages',
+    requestBodyValues: {},
+    statusCode: 400,
+    responseBody: JSON.stringify({ error: { message: 'top_p is not supported for this model.' } }),
+    isRetryable: false,
+  });
+}
+
+function createDeprecatedInBodyOnlyError() {
+  return new APICallError({
+    message: 'Bad request',
+    url: 'https://api.anthropic.com/v1/messages',
+    requestBodyValues: {},
+    statusCode: 400,
+    responseBody: JSON.stringify({
+      error: {
+        type: 'invalid_request_error',
+        message: 'The temperature parameter is no longer supported.',
+      },
+    }),
+    isRetryable: false,
+  });
+}
+
+function createOtherError() {
+  return new APICallError({
+    message: 'Rate limit exceeded',
+    url: 'https://api.anthropic.com/v1/messages',
+    requestBodyValues: {},
+    statusCode: 429,
+    responseBody: JSON.stringify({ error: { message: 'Rate limit exceeded' } }),
+    isRetryable: true,
+  });
+}
+
+function makeErrorArgs(overrides: Partial<ProcessAPIErrorArgs> = {}): ProcessAPIErrorArgs {
+  const messageList = new MessageList({ threadId: 'test-thread' });
+
+  return {
+    error: createTemperatureDeprecatedError(),
+    messages: messageList.get.all.db(),
+    messageList,
+    stepNumber: 0,
+    steps: [],
+    state: {},
+    retryCount: 0,
+    abort: (() => {
+      throw new Error('abort');
+    }) as any,
+    ...overrides,
+  } as unknown as ProcessAPIErrorArgs;
+}
+
+function makeInputStepArgs(overrides: Partial<ProcessInputStepArgs> = {}): ProcessInputStepArgs {
+  const messageList = new MessageList({ threadId: 'test-thread' });
+
+  return {
+    messageList,
+    messages: messageList.get.all.db(),
+    systemMessages: [],
+    stepNumber: 0,
+    steps: [],
+    state: {},
+    retryCount: 0,
+    model: {} as any,
+    modelSettings: { temperature: 0.7, topP: 0.9, maxOutputTokens: 100 },
+    abort: (() => {
+      throw new Error('abort');
+    }) as any,
+    ...overrides,
+  } as unknown as ProcessInputStepArgs;
+}
+
+describe('TemperatureDeprecatedHandler', () => {
+  describe('processAPIError', () => {
+    it('returns { retry: true } and flags state for a temperature-deprecated 400', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+      const state: Record<string, unknown> = {};
+
+      const result = await handler.processAPIError(makeErrorArgs({ state }));
+
+      expect(result).toEqual({ retry: true });
+      // State is flagged so the next processInputStep strips the sampling params.
+      expect(Object.values(state).some(Boolean)).toBe(true);
+    });
+
+    it('returns { retry: true } for a top_p unsupported 400', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+
+      const result = await handler.processAPIError(makeErrorArgs({ error: createTopPUnsupportedError() }));
+
+      expect(result).toEqual({ retry: true });
+    });
+
+    it('matches the deprecation message when it is only in the response body', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+
+      const result = await handler.processAPIError(makeErrorArgs({ error: createDeprecatedInBodyOnlyError() }));
+
+      expect(result).toEqual({ retry: true });
+    });
+
+    it('returns { retry: true } for plain Error objects containing a deprecation message', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+
+      const result = await handler.processAPIError(
+        makeErrorArgs({ error: new Error('temperature is deprecated for this model') }),
+      );
+
+      expect(result).toEqual({ retry: true });
+    });
+
+    it('returns undefined for unrelated errors', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+
+      const result = await handler.processAPIError(makeErrorArgs({ error: createOtherError() }));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined for plain Error objects without a deprecation message', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+
+      const result = await handler.processAPIError(makeErrorArgs({ error: new Error('Something else went wrong') }));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('does not flag state for unrelated errors', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+      const state: Record<string, unknown> = {};
+
+      await handler.processAPIError(makeErrorArgs({ error: createOtherError(), state }));
+
+      expect(Object.keys(state)).toHaveLength(0);
+    });
+
+    it('returns undefined when retryCount > 0 (only retries once)', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+
+      const result = await handler.processAPIError(makeErrorArgs({ retryCount: 1 }));
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('processInputStep', () => {
+    it('does nothing before a deprecation error has been seen', () => {
+      const handler = new TemperatureDeprecatedHandler();
+
+      const result = handler.processInputStep(makeInputStepArgs({ state: {} }));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('strips temperature, topP, and topK once the state flag is set', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+      const state: Record<string, unknown> = {};
+
+      // The error handler flags the shared state first.
+      await handler.processAPIError(makeErrorArgs({ state }));
+
+      const result = handler.processInputStep(
+        makeInputStepArgs({ state, modelSettings: { temperature: 0.7, topP: 0.9, topK: 40, maxOutputTokens: 100 } }),
+      );
+
+      expect(result).toBeDefined();
+      const modelSettings = (result as { modelSettings: Record<string, unknown> }).modelSettings;
+      expect(modelSettings).not.toHaveProperty('temperature');
+      expect(modelSettings).not.toHaveProperty('topP');
+      expect(modelSettings).not.toHaveProperty('topK');
+      // Unrelated settings are preserved.
+      expect(modelSettings.maxOutputTokens).toBe(100);
+    });
+
+    it('returns undefined when the flag is set but no sampling params are present', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+      const state: Record<string, unknown> = {};
+
+      await handler.processAPIError(makeErrorArgs({ state }));
+
+      const result = handler.processInputStep(makeInputStepArgs({ state, modelSettings: { maxOutputTokens: 100 } }));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when the flag is set but modelSettings is undefined', async () => {
+      const handler = new TemperatureDeprecatedHandler();
+      const state: Record<string, unknown> = {};
+
+      await handler.processAPIError(makeErrorArgs({ state }));
+
+      const result = handler.processInputStep(makeInputStepArgs({ state, modelSettings: undefined }));
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  it('has correct id and name', () => {
+    const handler = new TemperatureDeprecatedHandler();
+    expect(handler.id).toBe('temperature-deprecated-handler');
+    expect(handler.name).toBe('Temperature Deprecated Handler');
+  });
+});

--- a/packages/core/src/processors/temperature-deprecated-handler.ts
+++ b/packages/core/src/processors/temperature-deprecated-handler.ts
@@ -1,0 +1,133 @@
+import { APICallError } from '@internal/ai-sdk-v5';
+
+import type {
+  Processor,
+  ProcessAPIErrorArgs,
+  ProcessAPIErrorResult,
+  ProcessInputStepArgs,
+  ProcessInputStepResult,
+} from './index';
+
+/**
+ * Matches an API rejection that complains about a sampling parameter the model
+ * no longer accepts. Both a parameter name *and* an "unsupported" phrasing must
+ * be present so unrelated 400s (e.g. a bad message body that happens to mention
+ * "temperature") are not misclassified.
+ *
+ * Example that triggers this: Anthropic's `claude-opus-4-7` family returns
+ * `400 — temperature is deprecated for this model.`
+ */
+const SAMPLING_PARAM_PATTERN = /\b(?:temperature|top[_\s-]?p|top[_\s-]?k)\b/i;
+const UNSUPPORTED_PATTERN =
+  /\b(?:deprecated|no longer supported|not supported|unsupported|not allowed|not permitted|cannot be (?:set|used|specified)|is not a (?:valid|supported)|removed)\b/i;
+
+/**
+ * Shared-state flag set by `processAPIError` and read by `processInputStep` on
+ * the retried step. The processor state object is the same instance across all
+ * method calls within a single request.
+ */
+const STRIP_SAMPLING_PARAMS_STATE_KEY = 'temperature-deprecated-handler:strip-sampling-params';
+
+function getErrorCandidates(error: APICallError | Error): string[] {
+  const candidates = [error.message];
+
+  if (APICallError.isInstance(error) && typeof error.responseBody === 'string') {
+    candidates.push(error.responseBody);
+  }
+
+  return candidates.filter(Boolean);
+}
+
+/**
+ * Checks whether an error is a known "sampling parameter is no longer accepted"
+ * rejection (`temperature`, `top_p`, or `top_k`).
+ */
+function isSamplingParamDeprecatedError(error: unknown): boolean {
+  const matchesDeprecation = (message: string) =>
+    SAMPLING_PARAM_PATTERN.test(message) && UNSUPPORTED_PATTERN.test(message);
+
+  if (APICallError.isInstance(error)) {
+    return getErrorCandidates(error).some(matchesDeprecation);
+  }
+
+  if (error instanceof Error) {
+    return getErrorCandidates(error).some(matchesDeprecation);
+  }
+
+  return false;
+}
+
+/**
+ * Handles "sampling parameter is deprecated" API errors reactively.
+ *
+ * Some models drop support for `temperature` / `top_p` / `top_k` within a
+ * previously-supported family (e.g. Anthropic's `claude-opus-4-7`), and reject
+ * any request that still carries them with a hard `400`. Mastra forwards the
+ * default (or user-configured) `temperature` straight through to the provider,
+ * so the run fails mid-stream with no automatic recovery.
+ *
+ * This processor catches that rejection, strips the offending sampling
+ * parameters from `modelSettings`, and retries the same model once. It is the
+ * sampling-parameter sibling of {@link PrefillErrorHandler}.
+ *
+ * It uses two hooks that run from different processor lists: `processAPIError`
+ * (which fires for error processors) detects the rejection and signals a retry,
+ * and `processInputStep` (which fires for input processors) strips the params
+ * before the retried request. Register the **same instance in both lists** so
+ * the two hooks share state:
+ *
+ * ```ts
+ * const handler = new TemperatureDeprecatedHandler();
+ *
+ * const agent = new Agent({
+ *   // ...
+ *   inputProcessors: [handler],
+ *   errorProcessors: [handler],
+ * });
+ * ```
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/16247
+ */
+export class TemperatureDeprecatedHandler implements Processor<'temperature-deprecated-handler'> {
+  readonly id = 'temperature-deprecated-handler' as const;
+  readonly name = 'Temperature Deprecated Handler';
+
+  processInputStep({ modelSettings, state }: ProcessInputStepArgs): ProcessInputStepResult | void {
+    // Only act once a previous call has been rejected for these params.
+    if (!state[STRIP_SAMPLING_PARAMS_STATE_KEY] || !modelSettings) return;
+
+    const next = { ...modelSettings };
+    let changed = false;
+
+    if (next.temperature !== undefined) {
+      delete next.temperature;
+      changed = true;
+    }
+    if (next.topP !== undefined) {
+      delete next.topP;
+      changed = true;
+    }
+    if (next.topK !== undefined) {
+      delete next.topK;
+      changed = true;
+    }
+
+    if (!changed) return;
+
+    return { modelSettings: next };
+  }
+
+  async processAPIError({ error, retryCount, state }: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
+    // Only handle on first attempt — if it fails again after our fix, don't loop.
+    if (retryCount > 0) return;
+
+    if (!isSamplingParamDeprecatedError(error)) return;
+
+    // Tell processInputStep (which shares this state object) to drop the
+    // unsupported sampling params before the retried request is dispatched.
+    // The flag stays set for the rest of the run so later steps keep stripping.
+    state[STRIP_SAMPLING_PARAMS_STATE_KEY] = true;
+
+    return { retry: true };
+  }
+}


### PR DESCRIPTION
## What

Some models drop support for `temperature` (and `top_p` / `top_k`) within a previously supported family. `claude-opus-4-7` is the current example: it returns `400 temperature is deprecated for this model` when the parameter is sent. Mastra passes the default or configured temperature straight through to the provider, so the run fails mid stream with no way to recover short of forking or sanitising call settings outside the framework.

## Change

Adds `TemperatureDeprecatedHandler`, an opt-in processor that recovers from this automatically. It is the sampling parameter sibling of `PrefillErrorHandler`.

How it works:

1. `processAPIError` detects a 400 that names a sampling parameter together with a deprecated or unsupported reason, flags shared processor state, and signals a retry. It only acts on the first attempt, so it never loops.
2. On the retry, `processInputStep` reads that flag and strips `temperature`, `topP`, and `topK` from `modelSettings` before the request is dispatched. The flag stays set for the rest of the run so later steps keep stripping.

The two hooks run from different processor lists, so register the same instance in both `inputProcessors` and `errorProcessors`. They share state by processor id.

```ts
const handler = new TemperatureDeprecatedHandler()

new Agent({
  // ...
  inputProcessors: [handler],
  errorProcessors: [handler],
})
```

This needs no changes to the core loop or the processor interfaces. It only uses existing hooks.

## Tests

- Unit tests for error detection, retry signalling, the retry once guard, and the `modelSettings` stripping.
- Integration tests that drive a real agent through `generate()` and `stream()` with a mock model that rejects `temperature`, asserting the retried call has the sampling params removed and succeeds, including the `top_p` / `top_k` case.

All new tests pass, and typecheck and lint are clean. The two unrelated failing suites in `packages/core/src/processors` (agents-md autoload and tool-result-reminder) already fail on a clean checkout and are not touched by this change.

## Docs and changeset

- New reference page with a sidebar entry, plus a short mention on the processors overview.
- Minor changeset for `@mastra/core`.

Closes #16247

---

cc @TylerBarnes since this follows the `PrefillErrorHandler` pattern from #14435, and @mikhael28 who is assigned the issue. Happy to adjust the shape if you would prefer auto injection or single list registration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This adds a helper that notices when a model says “I don’t accept those settings” for things like `temperature`, `top_p`, or `top_k`. If that happens, it removes those settings and tries again so requests can still succeed instead of failing.

### What changed
- Added `TemperatureDeprecatedHandler` to detect 400 errors for deprecated/unsupported sampling parameters and retry once after stripping them.
- The handler removes `temperature`, `topP`, and `topK` from `modelSettings` on the retry.
- It must be registered in both `inputProcessors` and `errorProcessors` so the retry state is shared.
- Exported the new processor from the core processors index.
- Added unit tests and integration tests covering error detection, retry behavior, and streamed/non-streamed recovery.
- Updated processor docs, added a reference page, updated the sidebar, and included a changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->