### PR TITLE
fix(schema-compat): correct inverted zod v4 date min/max descriptions

### DIFF
--- a/.changeset/fix-zod-v4-date-constraint-descriptions.md
+++ b/.changeset/fix-zod-v4-date-constraint-descriptions.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fix inverted date constraint descriptions in the Zod v4 schema handler. `z.date().min()` and `z.date().max()` were described with their bounds swapped (a lower bound was labelled "older than" and an upper bound "newer than"), so the schema sent to the model stated the opposite and impossible constraint. The handler now matches Zod semantics and the existing v3 handler. Closes #18581.

--- a/packages/schema-compat/src/schema-compatibility-v4.test.ts
+++ b/packages/schema-compat/src/schema-compatibility-v4.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { OpenAIReasoningSchemaCompatLayer } from './provider-compats/openai-reasoning';
+import type { ModelInformation } from './types';
+
+const modelInfo: ModelInformation = {
+  provider: 'openai',
+  modelId: 'o3-mini',
+  supportsStructuredOutputs: true,
+};
+
+describe('defaultZodDateHandler (zod v4)', () => {
+  const layer = new OpenAIReasoningSchemaCompatLayer(modelInfo);
+
+  it('describes a min() bound as "newer than" and a max() bound as "older than"', () => {
+    const schema = z.date().min(new Date('2020-01-01')).max(new Date('2030-01-01'));
+
+    const result = layer.defaultZodDateHandler(schema);
+    const description = result.description ?? '';
+
+    // z.date().min(d) means the date must be >= d, i.e. newer than d.
+    expect(description).toContain('Date must be newer than 2020-01-01T00:00:00.000Z (ISO)');
+    // z.date().max(d) means the date must be <= d, i.e. older than d.
+    expect(description).toContain('Date must be older than 2030-01-01T00:00:00.000Z (ISO)');
+
+    // The inverted (buggy) descriptions must not appear.
+    expect(description).not.toContain('Date must be older than 2020-01-01T00:00:00.000Z (ISO)');
+    expect(description).not.toContain('Date must be newer than 2030-01-01T00:00:00.000Z (ISO)');
+  });
+
+  it('handles a lower bound only (min)', () => {
+    const schema = z.date().min(new Date('2020-01-01'));
+
+    const description = layer.defaultZodDateHandler(schema).description ?? '';
+
+    expect(description).toContain('Date must be newer than 2020-01-01T00:00:00.000Z (ISO)');
+    expect(description).not.toContain('older than 2020-01-01T00:00:00.000Z');
+  });
+
+  it('handles an upper bound only (max)', () => {
+    const schema = z.date().max(new Date('2030-01-01'));
+
+    const description = layer.defaultZodDateHandler(schema).description ?? '';
+
+    expect(description).toContain('Date must be older than 2030-01-01T00:00:00.000Z (ISO)');
+    expect(description).not.toContain('newer than 2030-01-01T00:00:00.000Z');
+  });
+});

--- a/packages/schema-compat/src/schema-compatibility-v4.ts
+++ b/packages/schema-compat/src/schema-compatibility-v4.ts
@@ -611,18 +611,20 @@ export class SchemaCompatLayer {
     if (checks) {
       for (const check of checks) {
         switch (check._zod.def.check) {
+          // `.max(d)` lowers the upper bound, stored as a `less_than` check: the date must be older than `d`.
           case 'less_than':
-            // @ts-expect-error - fix later
-            const minDate = new Date(check._zod.def.value);
-            if (!isNaN(minDate.getTime())) {
-              constraints.push(`Date must be newer than ${minDate.toISOString()} (ISO)`);
-            }
-            break;
-          case 'greater_than':
             // @ts-expect-error - fix later
             const maxDate = new Date(check._zod.def.value);
             if (!isNaN(maxDate.getTime())) {
               constraints.push(`Date must be older than ${maxDate.toISOString()} (ISO)`);
+            }
+            break;
+          // `.min(d)` raises the lower bound, stored as a `greater_than` check: the date must be newer than `d`.
+          case 'greater_than':
+            // @ts-expect-error - fix later
+            const minDate = new Date(check._zod.def.value);
+            if (!isNaN(minDate.getTime())) {
+              constraints.push(`Date must be newer than ${minDate.toISOString()} (ISO)`);
             }
             break;
           default:


### PR DESCRIPTION
## What

The Zod v4 date handler in `@mastra/schema-compat` produces inverted descriptions for `z.date().min()` and `z.date().max()`. The text attached to the schema, which is sent to the model, states the opposite and impossible bound.

In Zod v4 a date bound is stored as a comparison check:

- `z.date().min(d)` becomes a `greater_than` check with value `d`, so the date must be newer than `d`.
- `z.date().max(d)` becomes a `less_than` check with value `d`, so the date must be older than `d`.

`defaultZodDateHandler` in `schema-compatibility-v4.ts` mapped these the wrong way around: the `less_than` branch emitted "newer than" and the `greater_than` branch emitted "older than". The v3 handler in `schema-compatibility-v3.ts` maps them correctly, so the v4 port had the two branches swapped.

For `z.date().min(new Date('2020-01-01')).max(new Date('2030-01-01'))`:

- Before: `Date must be older than 2020-01-01T00:00:00.000Z (ISO), Date must be newer than 2030-01-01T00:00:00.000Z (ISO)`
- After: `Date must be newer than 2020-01-01T00:00:00.000Z (ISO), Date must be older than 2030-01-01T00:00:00.000Z (ISO)`

## Change

Swap the two messages in the v4 `defaultZodDateHandler` so they match Zod semantics and the existing v3 handler, and rename the local variables to match their actual bound.

## Tests

Added unit tests for the lower bound, the upper bound, and the combined case, asserting both the correct phrasing and the absence of the inverted phrasing. The Zod v4 check kinds were verified at runtime (`min` yields `greater_than`, `max` yields `less_than`).

All new tests pass, the full `@mastra/schema-compat` suite passes (28 files), and typecheck and lint are clean.

Closes #18581

---

cc @TylerBarnes and @wardpeet who have worked on this file. Small fix, happy to adjust the wording if you prefer different phrasing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This update fixes date messages so they say the right thing. If a date has a minimum, it now says it must be **newer** than that date; if it has a maximum, it now says it must be **older** than that date.

### What changed
- Fixed `defaultZodDateHandler` in `schema-compatibility-v4.ts` so Zod v4 date checks use the correct wording:
  - `.min()` → “Date must be newer than …”
  - `.max()` → “Date must be older than …”
- Kept the existing `Date format is date-time` text in generated descriptions.
- Renamed local variables/comments to match the real lower/upper bound meaning.
- Added tests covering:
  - lower-bound-only dates
  - upper-bound-only dates
  - combined `min` + `max` dates
  - correct phrasing and no inverted wording
- Added a changeset documenting the patch fix for `@mastra/schema-compat`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->