### PR TITLE
fix(core): in-memory getWorkflowRunById matches by runId when workflowName omitted

### DIFF
--- a/.changeset/fix-inmemory-getworkflowrunbyid-optional-name.md
+++ b/.changeset/fix-inmemory-getworkflowrunbyid-optional-name.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix in-memory workflow storage `getWorkflowRunById` returning `null` when `workflowName` is omitted. `workflowName` is optional in the storage contract and the pg/libsql adapters match by `runId` alone when it is not provided, but the in-memory store always compared `workflow_name === workflowName`, which never matched for an undefined name. It now matches by `runId`, only filters by `workflowName` when provided, and returns the most recent run for parity with the persistent adapters. Closes #18585.

--- a/packages/core/src/storage/domains/workflows/inmemory-get-by-id.test.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory-get-by-id.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkflowRunState } from '../../../workflows';
+import { InMemoryStore } from '../../mock';
+
+const makeSnapshot = (runId: string, status: WorkflowRunState['status']): WorkflowRunState =>
+  ({
+    runId,
+    status,
+    value: {},
+    context: {},
+    activePaths: [],
+    activeStepsPath: {},
+    suspendedPaths: {},
+    resumeLabels: {},
+    serializedStepGraph: [],
+    waitingPaths: {},
+    timestamp: Date.now(),
+  }) as WorkflowRunState;
+
+describe('WorkflowsInMemory getWorkflowRunById', () => {
+  it('finds a run by runId when workflowName is omitted', async () => {
+    const store = new InMemoryStore();
+    const workflows = (await store.getStore('workflows'))!;
+
+    await workflows.persistWorkflowSnapshot({
+      workflowName: 'wf-A',
+      runId: 'run-1',
+      snapshot: makeSnapshot('run-1', 'running'),
+    });
+
+    // workflowName is optional in the storage contract; the pg/libsql adapters
+    // match by runId alone when it is omitted. The in-memory store must match.
+    const run = await workflows.getWorkflowRunById({ runId: 'run-1' });
+
+    expect(run).not.toBeNull();
+    expect(run!.runId).toBe('run-1');
+    expect(run!.workflowName).toBe('wf-A');
+  });
+
+  it('still filters by workflowName when one is provided', async () => {
+    const store = new InMemoryStore();
+    const workflows = (await store.getStore('workflows'))!;
+
+    await workflows.persistWorkflowSnapshot({
+      workflowName: 'wf-A',
+      runId: 'run-1',
+      snapshot: makeSnapshot('run-1', 'running'),
+    });
+
+    expect(await workflows.getWorkflowRunById({ runId: 'run-1', workflowName: 'wf-A' })).not.toBeNull();
+    expect(await workflows.getWorkflowRunById({ runId: 'run-1', workflowName: 'wf-other' })).toBeNull();
+  });
+
+  it('returns null for an unknown runId', async () => {
+    const store = new InMemoryStore();
+    const workflows = (await store.getStore('workflows'))!;
+
+    expect(await workflows.getWorkflowRunById({ runId: 'missing' })).toBeNull();
+  });
+});

--- a/packages/core/src/storage/domains/workflows/inmemory.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory.ts
@@ -413,8 +413,12 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     runId: string;
     workflowName?: string;
   }): Promise<WorkflowRun | null> {
-    const runs = Array.from(this.db.workflows.values()).filter((r: any) => r.run_id === runId);
-    let run = runs.find((r: any) => r.workflow_name === workflowName);
+    // `workflowName` is optional in the storage contract. The pg/libsql adapters
+    // match by `runId` alone when it is omitted and return the most recent run
+    // (ORDER BY createdAt DESC LIMIT 1), so mirror that here.
+    const run = Array.from(this.db.workflows.values())
+      .filter((r: any) => r.run_id === runId && (!workflowName || r.workflow_name === workflowName))
+      .sort((a: any, b: any) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
 
     if (!run) return null;
 


### PR DESCRIPTION
## What

`WorkflowsInMemory.getWorkflowRunById` returns `null` when `workflowName` is omitted, even though a run with the given `runId` exists.

`workflowName` is optional in the storage contract (`base.ts`: `getWorkflowRunById(args: { runId: string; workflowName?: string })`), and the persistent adapters honor that. The pg and libsql adapters only add the `workflow_name` condition `if (workflowName)` and otherwise match by `run_id` alone. The in-memory store instead always ran:

```ts
const runs = Array.from(this.db.workflows.values()).filter(r => r.run_id === runId);
let run = runs.find(r => r.workflow_name === workflowName);
```

When `workflowName` is `undefined`, `r.workflow_name === undefined` never matches a stored run (runs always carry a concrete name), so the method returns `null`. This makes the in-memory store behave differently from every persistent adapter for a contract-supported call.

## Change

Match by `runId`, only filter by `workflowName` when it is provided, and return the most recent run (`createdAt DESC`) to match the pg/libsql behavior (`ORDER BY createdAt DESC LIMIT 1`).

## Tests

Added unit tests covering the omitted-name case, the provided-name case (correct run and a wrong name returning null), and an unknown `runId`. I confirmed the new omitted-name test fails on the current code and passes after the fix.

The wider storage suite and `workflows/state-reader` tests pass. Two unrelated suites in `packages/core/src/storage` (`filesystem.test.ts` and `bundle.test.ts`) fail on a clean checkout as well, due to a Windows temp-dir lock and a build-dependent skip, so they are not from this change.

Closes #18585

---

cc @taofeeq-deru who owns most of this store. Small fix, happy to drop the createdAt ordering if you would rather keep the in-memory lookup minimal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a lookup bug in the in-memory workflow store. If you ask for a run by its ID and don’t give a workflow name, it now finds the right run instead of saying “not found,” just like the other storage backends.

### Summary
- Fixed `WorkflowsInMemory.getWorkflowRunById` so `workflowName` is optional as the storage contract expects.
- When `workflowName` is omitted, the lookup now matches by `runId` alone.
- When `workflowName` is provided, it still filters by both `runId` and `workflowName`.
- If multiple runs share the same `runId`, the most recent matching run is returned.
- Added tests covering:
  - omitted `workflowName`
  - provided `workflowName`
  - wrong `workflowName`
  - unknown `runId`
- Added a changeset documenting the behavior fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->