### PR TITLE
feat(stores): implement missing bulk deleteVectors across vector store adapters

### DIFF
--- a/stores/astra/src/vector/index.ts
+++ b/stores/astra/src/vector/index.ts
@@ -354,15 +354,33 @@ export class AstraVector extends MastraVector<AstraVectorFilter> {
   }
 
   async deleteVectors({ indexName, filter, ids }: DeleteVectorsParams): Promise<void> {
+    if (ids) {
+      if (ids.length === 0) return;
+      try {
+        const collection = this.#db.collection(indexName);
+        await collection.deleteMany({ id: { $in: ids } });
+        return;
+      } catch (error: any) {
+        throw new MastraError(
+          {
+            id: createVectorErrorId('ASTRA', 'DELETE_VECTORS', 'FAILED'),
+            domain: ErrorDomain.MASTRA_VECTOR,
+            category: ErrorCategory.THIRD_PARTY,
+            details: { indexName, idsCount: ids.length },
+          },
+          error,
+        );
+      }
+    }
+
     throw new MastraError({
       id: createVectorErrorId('ASTRA', 'DELETE_VECTORS', 'NOT_SUPPORTED'),
-      text: 'deleteVectors is not yet implemented for Astra vector store',
+      text: 'deleteVectors by filter is not yet implemented for Astra vector store',
       domain: ErrorDomain.MASTRA_VECTOR,
       category: ErrorCategory.SYSTEM,
       details: {
         indexName,
         ...(filter && { filter: JSON.stringify(filter) }),
-        ...(ids && { idsCount: ids.length }),
       },
     });
   }

--- a/stores/couchbase/src/vector/index.ts
+++ b/stores/couchbase/src/vector/index.ts
@@ -507,15 +507,47 @@ export class CouchbaseVector extends MastraVector {
   }
 
   async deleteVectors({ indexName, filter, ids }: DeleteVectorsParams): Promise<void> {
+    if (ids) {
+      if (ids.length === 0) return;
+      try {
+        const collection = await this.getCollection();
+        // Process in chunks to avoid saturating the KV client
+        const BATCH_SIZE = 50;
+        for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+          const chunk = ids.slice(i, i + BATCH_SIZE);
+          const promises = chunk.map(id =>
+            collection.remove(id).catch((err: any) => {
+              // Ignore document not found errors for bulk deletion to be idempotent
+              if (err.code === 13 || err.message?.includes('document not found')) {
+                return;
+              }
+              throw err;
+            }),
+          );
+          await Promise.all(promises);
+        }
+        return;
+      } catch (error) {
+        throw new MastraError(
+          {
+            id: createVectorErrorId('COUCHBASE', 'DELETE_VECTORS', 'FAILED'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.THIRD_PARTY,
+            details: { indexName, idsCount: ids.length },
+          },
+          error,
+        );
+      }
+    }
+
     throw new MastraError({
       id: createVectorErrorId('COUCHBASE', 'DELETE_VECTORS', 'NOT_SUPPORTED'),
-      text: 'deleteVectors is not yet implemented for Couchbase vector store',
+      text: 'deleteVectors by filter is not yet implemented for Couchbase vector store',
       domain: ErrorDomain.STORAGE,
       category: ErrorCategory.SYSTEM,
       details: {
         indexName,
         ...(filter && { filter: JSON.stringify(filter) }),
-        ...(ids && { idsCount: ids.length }),
       },
     });
   }

--- a/stores/s3vectors/src/vector/index.ts
+++ b/stores/s3vectors/src/vector/index.ts
@@ -510,15 +510,42 @@ export class S3Vectors extends MastraVector<S3VectorsFilter> {
   }
 
   async deleteVectors({ indexName, filter, ids }: DeleteVectorsParams): Promise<void> {
+    if (ids) {
+      if (ids.length === 0) return;
+      indexName = normalizeIndexName(indexName);
+      try {
+        await this.client.send(
+          new DeleteVectorsCommand({
+            ...this.bucketParams(),
+            indexName,
+            keys: ids,
+          }),
+        );
+        return;
+      } catch (error) {
+        throw new MastraError(
+          {
+            id: createVectorErrorId('S3VECTORS', 'DELETE_VECTORS', 'FAILED'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.THIRD_PARTY,
+            details: {
+              indexName,
+              idsCount: ids.length,
+            },
+          },
+          error,
+        );
+      }
+    }
+
     throw new MastraError({
       id: createVectorErrorId('S3VECTORS', 'DELETE_VECTORS', 'NOT_SUPPORTED'),
-      text: 'deleteVectors is not yet implemented for S3Vectors vector store',
+      text: 'deleteVectors by filter is not yet implemented for S3Vectors vector store',
       domain: ErrorDomain.STORAGE,
       category: ErrorCategory.SYSTEM,
       details: {
         indexName,
         ...(filter && { filter: JSON.stringify(filter) }),
-        ...(ids && { idsCount: ids.length }),
       },
     });
   }

--- a/stores/vectorize/src/vector/index.ts
+++ b/stores/vectorize/src/vector/index.ts
@@ -387,15 +387,35 @@ export class CloudflareVector extends MastraVector<VectorizeVectorFilter> {
   }
 
   async deleteVectors({ indexName, filter, ids }: DeleteVectorsParams): Promise<void> {
+    if (ids) {
+      if (ids.length === 0) return;
+      try {
+        await this.client.vectorize.indexes.deleteByIds(indexName, {
+          ids,
+          account_id: this.accountId,
+        });
+        return;
+      } catch (error) {
+        throw new MastraError(
+          {
+            id: createVectorErrorId('VECTORIZE', 'DELETE_VECTORS', 'FAILED'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.THIRD_PARTY,
+            details: { indexName, idsCount: ids.length },
+          },
+          error,
+        );
+      }
+    }
+
     throw new MastraError({
       id: createVectorErrorId('VECTORIZE', 'DELETE_VECTORS', 'NOT_SUPPORTED'),
-      text: 'deleteVectors is not yet implemented for Vectorize vector store',
+      text: 'deleteVectors by filter is not yet implemented for Vectorize vector store',
       domain: ErrorDomain.STORAGE,
       category: ErrorCategory.SYSTEM,
       details: {
         indexName,
         ...(filter && { filter: JSON.stringify(filter) }),
-        ...(ids && { idsCount: ids.length }),
       },
     });
   }


### PR DESCRIPTION
## Description

This PR implements the previously unsupported `deleteVectors` method for the `vectorize`, `s3vectors`, `couchbase`, and `astra` vector stores. Previously, these stores unconditionally threw a `NOT_SUPPORTED` error, even though their respective underlying drivers supported deleting by IDs natively.

This change brings feature parity and API consistency across the vector store adapters by allowing bulk deletion of vectors by their IDs (which acts as a significant performance optimization by pushing batching down to the database level). 

*(Note: deletion by `filter` is still explicitly marked as `NOT_SUPPORTED` for stores whose drivers do not natively support it, preserving API integrity).*

## Related issue(s)

Fixes #18590

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR lets certain vector databases delete many vectors at once when you provide a list of vector IDs. Previously they rejected that request even though they already supported deleting by ID internally, so this makes bulk deletes faster and consistent.

### What changed
- Added/implemented bulk `deleteVectors` support for:
  - `vectorize`
  - `s3vectors`
  - `couchbase`
  - `astra`
- When `ids` is provided:
  - If `ids` is empty, the method returns immediately (no error).
  - If `ids` is non-empty, each adapter uses its backend’s native bulk delete-by-ID capability.
- Failures are wrapped in backend-specific `MastraError` variants for `DELETE_VECTORS/FAILED`, typically including `indexName` and `idsCount`.
- Deletion by `filter` remains `NOT_SUPPORTED` (with `filter` serialized into `details`), since the underlying drivers do not implement that behavior.

### Behavior updates by adapter
- **vectorize**: uses `indexes.deleteByIds(indexName, { ids, account_id })`.
- **s3vectors**: sends `DeleteVectorsCommand` with `keys: ids`.
- **couchbase**: deletes IDs in chunks (batch size 50), runs removals in parallel within each chunk, and ignores Couchbase “document not found” errors to keep deletes idempotent.
- **astra**: uses `collection.deleteMany({ id: { $in: ids } })`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->