### PR TITLE
chore(docs): Fix harness redirects

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -36,21 +36,6 @@
       "permanent": true
     },
     {
-      "source": "/docs/harness/overview",
-      "destination": "/docs/agent-controller/overview",
-      "permanent": true
-    },
-    {
-      "source": "/docs/harness/session",
-      "destination": "/docs/agent-controller/session",
-      "permanent": true
-    },
-    {
-      "source": "/docs/harness/threads-and-state",
-      "destination": "/docs/agent-controller/threads-and-state",
-      "permanent": true
-    },
-    {
       "source": "/docs/v1/:path*",
       "destination": "/docs/:path*",
       "permanent": true
@@ -808,6 +793,36 @@
     {
       "source": "/docs/streaming/background-task-streaming",
       "destination": "/docs/agents/background-tasks#subscribe-to-all-task-events",
+      "permanent": true
+    },
+    {
+      "source": "/docs/harness/modes",
+      "destination": "/docs/agent-controller/modes",
+      "permanent": true
+    },
+    {
+      "source": "/docs/harness/overview",
+      "destination": "/docs/agent-controller/overview",
+      "permanent": true
+    },
+    {
+      "source": "/docs/harness/session",
+      "destination": "/docs/agent-controller/session",
+      "permanent": true
+    },
+    {
+      "source": "/docs/harness/subagents",
+      "destination": "/docs/agent-controller/subagents",
+      "permanent": true
+    },
+    {
+      "source": "/docs/harness/threads-and-state",
+      "destination": "/docs/agent-controller/threads-and-state",
+      "permanent": true
+    },
+    {
+      "source": "/docs/harness/tool-approvals",
+      "destination": "/docs/agent-controller/tool-approvals",
       "permanent": true
     }
   ]


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes some broken links in the docs by sending old Harness page URLs to their new home. It also adds a few more redirects so people who use the old pages still end up in the right place.

## Summary
- Updated `docs/vercel.json` redirect rules for `/docs/harness/*` paths.
- Moved the existing redirects into a new block later in the array.
- Kept the redirects permanent and expanded coverage to include:
  - `/docs/harness/overview`
  - `/docs/harness/session`
  - `/docs/harness/threads-and-state`
  - `/docs/harness/modes`
  - `/docs/harness/subagents`
  - `/docs/harness/tool-approvals`
- All of these now point to the corresponding `/docs/agent-controller/*` pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->