### PR TITLE
fix(core): add timeoutMs to tool execution in CoreToolBuilder

### DIFF
--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -739,7 +739,7 @@ describe('CoreToolBuilder requestContext merge', () => {
       id: 'slow',
       description: 'always slow',
       inputSchema: z.object({}),
-      execute: () => new Promise(r => setTimeout(r, 5_000)),
+      execute: () => new Promise(() => {}),
     });
 
     const built = new CoreToolBuilder({

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -734,4 +734,45 @@ describe('CoreToolBuilder requestContext merge', () => {
     // With no exec RC, closure RC is used directly
     expect(receivedCtx.requestContext!.get('controller')).toEqual({ controllerId: 'c-1' });
   });
+  it('rejects with TOOL_EXECUTION_TIMEOUT when tool exceeds timeoutMs', async () => {
+    const slowTool = createTool({
+      id: 'slow',
+      description: 'always slow',
+      inputSchema: z.object({}),
+      execute: () => new Promise(r => setTimeout(r, 5_000)),
+    });
+
+    const built = new CoreToolBuilder({
+      originalTool: slowTool,
+      options: {
+        name: 'slow',
+        requestContext: new RequestContext(),
+        timeoutMs: 100,
+      },
+    }).build();
+
+    await expect(built.execute?.({}, {} as any)).rejects.toMatchObject({
+      id: 'TOOL_EXECUTION_TIMEOUT',
+    });
+  }, 3_000);
+
+  it('resolves normally when tool finishes within timeoutMs', async () => {
+    const fastTool = createTool({
+      id: 'fast',
+      description: 'fast',
+      inputSchema: z.object({}),
+      execute: async () => ({ ok: true }),
+    });
+
+    const built = new CoreToolBuilder({
+      originalTool: fastTool,
+      options: {
+        name: 'fast',
+        requestContext: new RequestContext(),
+        timeoutMs: 2_000,
+      },
+    }).build();
+
+    await expect(built.execute?.({}, {} as any)).resolves.toMatchObject({ ok: true });
+  });
 });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -852,8 +852,10 @@ export class CoreToolBuilder extends MastraBase {
         });
         return await withTimeout(execPromise, options.timeoutMs ?? 0, options.name);
       } catch (err) {
-        // Re-throw timeout errors directly
+        // Re-throw timeout errors directly but still emit telemetry
         if (err instanceof MastraError && (err as any).id === 'TOOL_EXECUTION_TIMEOUT') {
+          toolSpan?.error({ error: err, attributes: { success: false } });
+          logger.trackException(err, { ...logData, ...rest, model: logModelObject, args });
           throw err;
         }
         const mastraError = new MastraError(

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -43,6 +43,24 @@ import type {
 import { noopObserve } from '../types';
 import { validateToolInput, validateToolOutput, validateToolSuspendData } from '../validation';
 
+function withTimeout<T>(promise: Promise<T>, ms: number, toolName: string): Promise<T> {
+  if (!ms || ms <= 0) return promise;
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new MastraError({
+          id: 'TOOL_EXECUTION_TIMEOUT',
+          domain: ErrorDomain.TOOL,
+          category: ErrorCategory.USER,
+          details: { toolName, timeoutMs: ms },
+        }),
+      );
+    }, ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 /**
  * Merge two RequestContexts so non-serializable values survive the evented
  * workflow engine's toJSON/reconstruct cycle.
@@ -822,7 +840,7 @@ export class CoreToolBuilder extends MastraBase {
         }
 
         // there is a small delay in stream output so we add an immediate to ensure the stream is ready
-        return await new Promise((resolve, reject) => {
+        const execPromise = new Promise((resolve, reject) => {
           setImmediate(async () => {
             try {
               const result = await execFunction(args, execOptions!, toolSpan);
@@ -832,7 +850,12 @@ export class CoreToolBuilder extends MastraBase {
             }
           });
         });
+        return await withTimeout(execPromise, options.timeoutMs ?? 0, options.name);
       } catch (err) {
+        // Re-throw timeout errors directly
+        if (err instanceof MastraError && (err as any).id === 'TOOL_EXECUTION_TIMEOUT') {
+          throw err;
+        }
         const mastraError = new MastraError(
           {
             id: 'TOOL_EXECUTION_FAILED',

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -369,6 +369,12 @@ export interface ToolOptions extends Partial<ObservabilityContext> {
    * browser capabilities for web automation, screenshots, and data extraction.
    */
   browser?: MastraBrowser;
+
+  /**
+   * Max milliseconds a tool execute() may run before rejecting.
+   * 0 or omitted = no timeout (preserves existing behavior).
+   */
+  timeoutMs?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `timeoutMs` field to `ToolOptions` and wraps the
`setImmediate` execution promise in `CoreToolBuilder.createExecute()`
with a `Promise.race` timeout guard.

Closes #18594

## Problem

`createExecute()` wraps every tool's `execute()` call with no deadline.
A tool that stalls blocks the agent loop indefinitely with no error,
no log, and no way to recover without killing the process.

## Solution

- Added `timeoutMs?: number` to `ToolOptions` (`utils.ts` line 332)
- Added `withTimeout()` helper using `Promise.race` + `MastraError`
- Wrapped execution promise at `builder.ts` lines 825–834
- Re-throws `TOOL_EXECUTION_TIMEOUT` errors directly so they are not
  swallowed by the outer `TOOL_EXECUTION_FAILED` catch block
- Added two unit tests covering timeout and no-timeout paths

## Backward Compatibility

Fully backward-compatible. Omitting `timeoutMs` or setting `0`
preserves existing behavior exactly - the helper returns the original
promise unchanged.

## Prior Art in This Codebase

- Background tasks: `background-tasks/resolve-config.ts` lines 65–69
- Code Mode tools: `tools/code-mode/transport.ts` lines 159–167

Both already use this same `Promise.race` timeout pattern.

## Test Results

21/21 tests passing including 2 new tests:
- `rejects with TOOL_EXECUTION_TIMEOUT when tool exceeds timeoutMs`
- `resolves normally when tool finishes within timeoutMs`
<img width="1021" height="792" alt="Screenshot 2026-06-29 125819" src="https://github.com/user-attachments/assets/ca6c859f-519b-4aed-a3d3-9dba5ccc9bb2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a timeout “stopwatch” around tool execution, so a stuck tool can’t block the agent forever. If the stopwatch runs out, the tool fails with a clear, dedicated timeout error.

### What changed
- Added optional `timeoutMs?: number` to `ToolOptions` (`0` or omitted preserves existing behavior—no timeout).
- Implemented a `withTimeout()` helper in `CoreToolBuilder` that uses `Promise.race` against a timer and clears the timer after completion.
- Updated `CoreToolBuilder.createExecute()` to wrap tool execution with `withTimeout(execPromise, options.timeoutMs ?? 0, options.name)`.
- When the timeout triggers, the code throws a `MastraError` with `id: 'TOOL_EXECUTION_TIMEOUT'` directly (so it isn’t converted into `TOOL_EXECUTION_FAILED`), while keeping the existing error-handling path for other failures.
- Added unit tests:
  - Rejects with `TOOL_EXECUTION_TIMEOUT` when the tool exceeds `timeoutMs`.
  - Resolves normally when the tool finishes within `timeoutMs`.

### Notes
- The change is opt-in and keeps the prior execution/error behavior for `timeoutMs` unset or `0`.
- Existing support for passing cancellation signals into tools remains unaffected; `timeoutMs` is an additional guard rather than a replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->