### PR TITLE
fix(core): fix lint formatting in session.ts

### DIFF
--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3490,8 +3490,7 @@ export class Session<TState = unknown> {
       // The resume data is the user's answer (a bare string), which the approval
       // re-check would reject because it cannot carry an `{ approved }` field.
       // Exempt these tools so the answer reaches the model as-is.
-      const isInteractive =
-        suspension.toolName === 'ask_user' || suspension.toolName === 'request_access';
+      const isInteractive = suspension.toolName === 'ask_user' || suspension.toolName === 'request_access';
       if (isInteractive) {
         sharedOptions.requireToolApproval = false;
       }


### PR DESCRIPTION
## Description

Fixes a recurring lint formatting issue in `session.ts` that causes CI failures across multiple PRs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

ELI5: This change is a tiny cleanup in `session.ts` that makes one boolean check easier for the linter to قبول, so CI stops failing on formatting. It doesn’t change how tool-call resuming works.

### What changed
- Simplified the `isInteractive` assignment in `Session.resumeToolCall` to a single-line boolean expression.
- Kept the existing behavior for detecting interactive built-in suspended tools (`ask_user` / `request_access`) unchanged.

### Impact
- No public API changes.
- Non-breaking bug fix.
- Helps prevent recurring lint formatting failures in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->