### PR TITLE
Cloud MastraCode: org-tenant coding agent with PR write-back and deployment hardening

### DIFF
--- a/.changeset/cloud-coding-agent-prs.md
+++ b/.changeset/cloud-coding-agent-prs.md
@@ -1,0 +1,11 @@
+---
+'mastracode': minor
+---
+
+Extended GitHub-backed MastraCode web projects into a full cloud coding-agent write-back flow. From a connected repo project, signed-in users can now create a git worktree / feature branch inside the project's cloud sandbox, run the agent against that worktree (file edits + commands bind to the worktree path), and commit, push, and open a pull request — all from inside the sandbox via the `gh` CLI, authenticated with short-lived per-operation installation tokens that never reach the browser and are scrubbed from the remote afterward.
+
+A new "Branch / PR" panel in the project view surfaces this: pick or create a branch, then commit and open a PR with a title/body. The active branch and worktree path are persisted on the project so reopening rebinds the same worktree. The panel shows a clear "sandbox not configured" state when no sandbox provider is set.
+
+The sandbox base image must include both `git` and `gh`; the PR action preflights `gh --version` and surfaces an actionable error if it's missing (clone/open still work without `gh`). New per-project routes (`worktree`, `commit`, `push`, `pr`) are behind the WorkOS gate, scoped per user, re-verify repo ownership, and serialize concurrent git writes with an in-process per-project lock so tokenized remotes can't leak.
+
+Provisioned sandboxes are torn down by the provider after an idle window (`MASTRACODE_SANDBOX_IDLE_MINUTES`, default 30); the next open detects a stopped/dead VM, clears the stale sandbox id, and re-provisions automatically. Push/PR install tokens only ever live in a per-operation remote URL or a single-process `GH_TOKEN` env and are scrubbed in a `finally`, never persisted in the sandbox or sent to the browser.

--- a/.changeset/org-tenant-cloud-mastracode.md
+++ b/.changeset/org-tenant-cloud-mastracode.md
@@ -1,0 +1,34 @@
+---
+'mastracode': minor
+---
+
+Made the MastraCode web server a multi-org cloud service. The tenant boundary is now the WorkOS organization, with each user inside an org isolated from the others.
+
+**Org-owned GitHub projects**
+
+The GitHub App installation and each connected repository now belong to the organization, not an individual. Every user inside the org gets their own isolated sandbox, worktrees, branches, and pull requests against the org's repo. The same repository can be connected independently by different orgs, and they never see each other's projects, sandboxes, or state. Users without a WorkOS organization (personal accounts) can't connect GitHub projects but still get isolated agent state.
+
+**Per-(org,user) agent-state isolation**
+
+Agent state (threads, messages, memory, and recall vectors) is now isolated by the `(organization, user)` pair instead of by user alone. Two users in the same org are isolated from each other, and the same user across two orgs is isolated as well. The per-tenant database location is derived server-side from a hash of `(orgId, userId)`.
+
+**Multi-replica deployment hardening**
+
+- Per-(project,user) git write operations are serialized across replicas using Postgres advisory locks (`MASTRACODE_DISTRIBUTED_LOCK`, on by default; requires `APP_DATABASE_URL`). Set it to `0` for single-process local dev.
+- GitHub OAuth/install state signing now requires a replica-stable secret in multi-replica setups. Set `GITHUB_APP_WEBHOOK_SECRET` (or `WORKOS_COOKIE_PASSWORD`); otherwise startup fails loudly because per-replica random secrets break callbacks.
+- In-memory tenant stacks are now evicted by idle timeout and an LRU cap (`MASTRACODE_TENANT_IDLE_MINUTES`, `MASTRACODE_TENANT_MAX_APPS`) so memory stays bounded as a team grows.
+- Set `MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1` to fail/warn at startup when no remote tenant DB template is configured, since local-file tenant DBs don't persist or share across replicas.
+- A per-replica live-sandbox cap (`MASTRACODE_MAX_SANDBOXES`) prevents one replica from exhausting the sandbox provider's quota, plus a per-user `DELETE /api/web/github/projects/:id/sandbox` route to tear down a user's own sandbox.
+
+```bash
+# Multi-replica hosted deployment
+export GITHUB_APP_WEBHOOK_SECRET=...                     # replica-stable state signing
+export MASTRACODE_DISTRIBUTED_LOCK=1                     # cross-replica git write locks
+export MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1            # require shared remote tenant DBs
+export MASTRACODE_TENANT_DB_URL_TEMPLATE=libsql://{id}-org.turso.io
+export MASTRACODE_TENANT_IDLE_MINUTES=30                 # evict idle tenant stacks
+export MASTRACODE_TENANT_MAX_APPS=100                    # cap cached tenant stacks
+export MASTRACODE_MAX_SANDBOXES=50                       # per-replica sandbox cap
+```
+
+Still deferred: collaboration within a project (multiple users sharing one worktree/sandbox/branch), org admin/roles and membership management, and project deletion at the org level.

--- a/.changeset/tenant-libsql-isolation.md
+++ b/.changeset/tenant-libsql-isolation.md
@@ -1,0 +1,22 @@
+---
+'mastracode': minor
+---
+
+Isolated per-user agent-state storage for the MastraCode web server. When WorkOS web auth is enabled, every authenticated user now operates against their own dedicated libSQL database for all agent state (threads, messages, memory, working/observational memory, and recall vectors) instead of a single shared store. The server dispatches each authenticated request to a per-user Mastra controller bound to that user's storage, so no tenant can read another tenant's conversations or memory at the storage layer — not just by `resourceId` convention.
+
+The per-user database location is derived server-side from a hashed WorkOS user id (no client-supplied paths). By default each user gets local libSQL files (`storage.db` + `vectors.db`) under `MASTRACODE_TENANT_DB_ROOT` (default `~/.mastracode/web/tenants/<sha256(id)>/`). For hosted deployments, set `MASTRACODE_TENANT_DB_URL_TEMPLATE` (optionally with `MASTRACODE_TENANT_VECTOR_URL_TEMPLATE` and auth tokens) to point each tenant at a remote libSQL/Turso database via a `{id}` template.
+
+When web auth is disabled the server keeps using the single shared store exactly as before, and the local/TUI path is untouched.
+
+Optional hosted-deployment configuration:
+
+```bash
+# Local files (default): one isolated DB dir per user
+MASTRACODE_TENANT_DB_ROOT=/data/mastracode/tenants
+
+# Or remote libSQL/Turso per tenant ({id} = hashed WorkOS user id)
+MASTRACODE_TENANT_DB_URL_TEMPLATE=libsql://{id}-org.turso.io
+MASTRACODE_TENANT_VECTOR_URL_TEMPLATE=libsql://{id}-vec-org.turso.io
+MASTRACODE_TENANT_DB_AUTH_TOKEN=xxxxxxxx
+MASTRACODE_TENANT_VECTOR_AUTH_TOKEN=xxxxxxxx
+```

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -274,7 +274,13 @@ export WORKOS_COOKIE_PASSWORD=...                            # optional (recomme
 
 **GitHub projects** — when the GitHub App variables are set _and_ WorkOS auth is enabled,
 signed-in users can install the GitHub App, pick repositories, and turn each repo into a project.
-Repo and project metadata persist in a separate application Postgres (`APP_DATABASE_URL`):
+The tenant boundary is the **WorkOS organization**: the GitHub App installation and the connected
+project (repo) are owned by the org, while each user inside the org gets their own isolated
+sandbox, worktrees, branches, and PRs against that repo. The **same repo can be connected
+independently by different orgs** without ever seeing each other's projects, sandboxes, or state.
+Users without a WorkOS organization (personal accounts) can't use GitHub projects, but still get
+isolated agent state. Repo and project metadata persist in a separate application Postgres
+(`APP_DATABASE_URL`):
 
 ```bash
 export GITHUB_APP_ID=...
@@ -304,18 +310,20 @@ detects the stopped VM and re-provisions automatically.
 Without a sandbox provider, users can still connect GitHub and pick repos, but opening a repo
 project shows a clear "sandbox not configured" error.
 
-### Per-user storage isolation
+### Per-(org,user) storage isolation
 
-When WorkOS web auth is enabled, every authenticated user operates against their own dedicated
-libSQL database for all agent state (threads, messages, memory, observational memory, recall
-vectors) — no tenant can read another tenant's data at the storage layer. The database location
-is derived server-side from a hashed WorkOS user id (no client-supplied paths).
+When WorkOS web auth is enabled, the tenant boundary is the **(organization, user)** pair: each
+user in each org operates against their own dedicated libSQL database for all agent state (threads,
+messages, memory, observational memory, recall vectors) — no tenant can read another tenant's data
+at the storage layer. Two users in the same org are isolated, and the same user across two orgs is
+also isolated. The database location is derived server-side from a hash of `(orgId, userId)` (no
+client-supplied paths); users without an org fall back to a user-only key.
 
 ```bash
-# Local files (default): one isolated DB dir per user under this root
+# Local files (default): one isolated DB dir per tenant under this root
 export MASTRACODE_TENANT_DB_ROOT=~/.mastracode/web/tenants    # optional
 
-# Or remote libSQL/Turso per tenant ({id} = hashed WorkOS user id)
+# Or remote libSQL/Turso per tenant ({id} = hashed (orgId, userId))
 export MASTRACODE_TENANT_DB_URL_TEMPLATE=libsql://{id}-org.turso.io        # optional
 export MASTRACODE_TENANT_VECTOR_URL_TEMPLATE=libsql://{id}-vec-org.turso.io # optional
 export MASTRACODE_TENANT_DB_AUTH_TOKEN=...                                  # optional
@@ -323,6 +331,33 @@ export MASTRACODE_TENANT_VECTOR_AUTH_TOKEN=...                              # op
 ```
 
 When web auth is disabled the server uses a single shared store, exactly as before.
+
+### Multi-replica deployment
+
+The web server keeps each tenant's Mastra stack in an in-memory cache and serializes per-user git
+write operations. For hosted, multi-replica deployments a few settings make this safe and bounded:
+
+```bash
+# Replica-stable state signing — REQUIRED across replicas. Without an explicit
+# GITHUB_APP_WEBHOOK_SECRET (or WORKOS_COOKIE_PASSWORD) the OAuth/install state
+# is signed with a per-process random key and callbacks fail on other replicas.
+export GITHUB_APP_WEBHOOK_SECRET=...
+
+# Cross-replica serialization of per-(project,user) git writes via Postgres
+# advisory locks (default on, requires APP_DATABASE_URL). Set 0 for local dev.
+export MASTRACODE_DISTRIBUTED_LOCK=1
+
+# Persist/share tenant DBs across replicas — fail/warn at startup if no remote
+# tenant DB template is set (local-file DBs don't survive restarts or sharing).
+export MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1
+
+# Bound in-memory tenant caches as the team grows.
+export MASTRACODE_TENANT_IDLE_MINUTES=30    # idle eviction window (0 disables)
+export MASTRACODE_TENANT_MAX_APPS=100       # LRU cap on cached stacks (0 disables)
+
+# Per-replica cap on concurrently live sandboxes (0 / unset = unlimited).
+export MASTRACODE_MAX_SANDBOXES=50
+```
 
 ## Architecture
 

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -294,11 +294,35 @@ export RAILWAY_API_TOKEN=...
 export RAILWAY_ENVIRONMENT_ID=...
 export MASTRACODE_SANDBOX_PROVIDER=railway                  # optional (default when a token is set)
 export MASTRACODE_SANDBOX_WORKDIR=/workspace                # optional (path inside the sandbox)
+export MASTRACODE_SANDBOX_IDLE_MINUTES=30                   # optional (idle teardown window; default 30)
 ```
 
-The sandbox template must have `git` installed and outbound network access to `github.com`.
+The sandbox template must have `git` and `gh` (the GitHub CLI) installed and outbound network
+access to `github.com`. `gh` is only required to open pull requests; clone/open work without it.
+Idle sandboxes are stopped by the provider after `MASTRACODE_SANDBOX_IDLE_MINUTES`; the next open
+detects the stopped VM and re-provisions automatically.
 Without a sandbox provider, users can still connect GitHub and pick repos, but opening a repo
 project shows a clear "sandbox not configured" error.
+
+### Per-user storage isolation
+
+When WorkOS web auth is enabled, every authenticated user operates against their own dedicated
+libSQL database for all agent state (threads, messages, memory, observational memory, recall
+vectors) — no tenant can read another tenant's data at the storage layer. The database location
+is derived server-side from a hashed WorkOS user id (no client-supplied paths).
+
+```bash
+# Local files (default): one isolated DB dir per user under this root
+export MASTRACODE_TENANT_DB_ROOT=~/.mastracode/web/tenants    # optional
+
+# Or remote libSQL/Turso per tenant ({id} = hashed WorkOS user id)
+export MASTRACODE_TENANT_DB_URL_TEMPLATE=libsql://{id}-org.turso.io        # optional
+export MASTRACODE_TENANT_VECTOR_URL_TEMPLATE=libsql://{id}-vec-org.turso.io # optional
+export MASTRACODE_TENANT_DB_AUTH_TOKEN=...                                  # optional
+export MASTRACODE_TENANT_VECTOR_AUTH_TOKEN=...                              # optional
+```
+
+When web auth is disabled the server uses a single shared store, exactly as before.
 
 ## Architecture
 

--- a/mastracode/src/agents/__tests__/workspace-worktree-scenario.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-worktree-scenario.test.ts
@@ -1,0 +1,149 @@
+import { RequestContext } from '@mastra/core/request-context';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../onboarding/settings.js', () => ({
+  loadSettings: () => ({}),
+}));
+vi.mock('../../onboarding/settings.js', () => ({
+  loadSettings: () => ({}),
+}));
+
+// Capture the workdir each SandboxFilesystem is constructed with so we can
+// assert the workspace binds to the active worktree across re-opens.
+const sandboxFsCalls: Array<{ workdir: string }> = [];
+vi.mock('../../web/github/sandbox-filesystem.js', () => ({
+  SandboxFilesystem: class {
+    workdir: string;
+    constructor(opts: { workdir: string }) {
+      this.workdir = opts.workdir;
+      sandboxFsCalls.push({ workdir: opts.workdir });
+    }
+  },
+}));
+
+const reattachCalls: string[] = [];
+vi.mock('../../web/github/sandbox.js', () => ({
+  reattachProjectSandbox: vi.fn(async (sandboxId: string) => {
+    reattachCalls.push(sandboxId);
+    return { executeCommand: vi.fn(), getInfo: vi.fn() };
+  }),
+}));
+
+function createSandboxRequestContext(state: Record<string, unknown>) {
+  const requestContext = new RequestContext();
+  const getState = () => state;
+  requestContext.set('controller', {
+    modeId: 'build',
+    getState,
+    session: { state: { get: getState } },
+  });
+  return requestContext;
+}
+
+/**
+ * Minimal Mastra registry stand-in. `getDynamicWorkspace` reuses a workspace
+ * only when `mastra.getWorkspaceById(id)` returns one, so the test mirrors the
+ * real open/reopen lifecycle by registering each freshly-built workspace and
+ * serving it back on the next resolve with the same reuse key.
+ */
+function createWorkspaceRegistry() {
+  const registry = new Map<string, unknown>();
+  return {
+    getWorkspaceById: (id: string) => registry.get(id),
+    register: (ws: { id: string }) => registry.set(ws.id, ws),
+    size: () => registry.size,
+  };
+}
+
+const baseState = {
+  githubProjectId: 'proj-1',
+  sandboxId: 'sbx-1',
+  sandboxWorkdir: '/workspace/hello',
+  sandboxAllowedPaths: [],
+};
+
+afterEach(() => {
+  sandboxFsCalls.length = 0;
+  reattachCalls.length = 0;
+  vi.resetModules();
+});
+
+describe('S5 — worktree reattach round-trip through the workspace seam', () => {
+  it('binds, reuses on reopen, and rebuilds across a different worktree', async () => {
+    const { getDynamicWorkspace } = await import('../workspace.js');
+    const reg = createWorkspaceRegistry();
+
+    // Resolve helper that mimics how the server registers a newly-built
+    // workspace before the next request can reuse it.
+    const resolve = async (state: Record<string, unknown>) => {
+      const ws = await getDynamicWorkspace({
+        requestContext: createSandboxRequestContext(state) as any,
+        mastra: reg as any,
+      });
+      reg.register(ws as { id: string });
+      return ws;
+    };
+
+    // 1. First open on worktree feat-x: filesystem + sandbox bind to the
+    //    worktree path, not the repo root.
+    const first = await resolve({
+      ...baseState,
+      worktreePath: '/workspace/worktrees/feat-x',
+      branch: 'feat/x',
+    });
+    expect(sandboxFsCalls.at(-1)?.workdir).toBe('/workspace/worktrees/feat-x');
+    expect(first.id).toBe('mastra-code-workspace-gh-proj-1-sbx-1-/workspace/worktrees/feat-x');
+    expect(reattachCalls).toHaveLength(1);
+    const fsCallsAfterFirst = sandboxFsCalls.length;
+
+    // 2. Reopen with the SAME sandbox + worktree: the exact same Workspace
+    //    instance is reused (reuse key honors the worktree). No new sandbox
+    //    reattach and no new SandboxFilesystem are constructed.
+    const second = await resolve({
+      ...baseState,
+      worktreePath: '/workspace/worktrees/feat-x',
+      branch: 'feat/x',
+    });
+    expect(second).toBe(first);
+    expect(reattachCalls).toHaveLength(1);
+    expect(sandboxFsCalls.length).toBe(fsCallsAfterFirst);
+
+    // 3. Reopen with the SAME sandbox but a DIFFERENT worktree: a brand new
+    //    Workspace is built so no state leaks across feature branches.
+    const third = await resolve({
+      ...baseState,
+      worktreePath: '/workspace/worktrees/feat-y',
+      branch: 'feat/y',
+    });
+    expect(third).not.toBe(first);
+    expect(third.id).toBe('mastra-code-workspace-gh-proj-1-sbx-1-/workspace/worktrees/feat-y');
+    expect(sandboxFsCalls.at(-1)?.workdir).toBe('/workspace/worktrees/feat-y');
+    expect(reattachCalls).toHaveLength(2);
+    expect(reg.size()).toBe(2);
+  });
+
+  it('reuses a worktree workspace independently from the base-checkout workspace', async () => {
+    const { getDynamicWorkspace } = await import('../workspace.js');
+    const reg = createWorkspaceRegistry();
+    const resolve = async (state: Record<string, unknown>) => {
+      const ws = await getDynamicWorkspace({
+        requestContext: createSandboxRequestContext(state) as any,
+        mastra: reg as any,
+      });
+      reg.register(ws as { id: string });
+      return ws;
+    };
+
+    // Base checkout (no worktree active) and a worktree both register distinct
+    // workspaces on the same sandbox, and each reopen reuses its own instance.
+    const base = await resolve({ ...baseState });
+    const wt = await resolve({ ...baseState, worktreePath: '/workspace/worktrees/feat-x' });
+    expect(base).not.toBe(wt);
+
+    const baseAgain = await resolve({ ...baseState });
+    const wtAgain = await resolve({ ...baseState, worktreePath: '/workspace/worktrees/feat-x' });
+    expect(baseAgain).toBe(base);
+    expect(wtAgain).toBe(wt);
+    expect(reg.size()).toBe(2);
+  });
+});

--- a/mastracode/src/agents/__tests__/workspace-worktree.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-worktree.test.ts
@@ -1,0 +1,98 @@
+import { RequestContext } from '@mastra/core/request-context';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../onboarding/settings.js', () => ({
+  loadSettings: () => ({}),
+}));
+vi.mock('../../onboarding/settings.js', () => ({
+  loadSettings: () => ({}),
+}));
+
+// Capture the workdir the SandboxFilesystem is constructed with so we can assert
+// the workspace binds to the worktree path rather than the repo root.
+const sandboxFsCalls: Array<{ workdir: string }> = [];
+vi.mock('../../web/github/sandbox-filesystem.js', () => ({
+  SandboxFilesystem: class {
+    workdir: string;
+    constructor(opts: { workdir: string }) {
+      this.workdir = opts.workdir;
+      sandboxFsCalls.push({ workdir: opts.workdir });
+    }
+  },
+}));
+
+vi.mock('../../web/github/sandbox.js', () => ({
+  reattachProjectSandbox: vi.fn(async () => ({
+    executeCommand: vi.fn(),
+    getInfo: vi.fn(),
+  })),
+}));
+
+function createSandboxRequestContext(state: Record<string, unknown>) {
+  const requestContext = new RequestContext();
+  const getState = () => state;
+  requestContext.set('controller', {
+    modeId: 'build',
+    getState,
+    session: { state: { get: getState } },
+  });
+  return requestContext;
+}
+
+const baseState = {
+  githubProjectId: 'proj-1',
+  sandboxId: 'sbx-1',
+  sandboxWorkdir: '/workspace/hello',
+  sandboxAllowedPaths: [],
+};
+
+afterEach(() => {
+  sandboxFsCalls.length = 0;
+  vi.resetModules();
+});
+
+describe('getDynamicWorkspace sandbox worktree binding', () => {
+  it('binds the workspace to the repo root when no worktree is active', async () => {
+    const { getDynamicWorkspace } = await import('../workspace.js');
+    const workspace = await getDynamicWorkspace({
+      requestContext: createSandboxRequestContext({ ...baseState }) as any,
+    });
+
+    expect(sandboxFsCalls.at(-1)?.workdir).toBe('/workspace/hello');
+    // Reuse key embeds the bound workdir (repo root here).
+    expect(workspace.id).toBe('mastra-code-workspace-gh-proj-1-sbx-1-/workspace/hello');
+  });
+
+  it('binds the workspace to the worktree path when one is active', async () => {
+    const { getDynamicWorkspace } = await import('../workspace.js');
+    const workspace = await getDynamicWorkspace({
+      requestContext: createSandboxRequestContext({
+        ...baseState,
+        worktreePath: '/workspace/worktrees/feat-x',
+        branch: 'feat/x',
+      }) as any,
+    });
+
+    expect(sandboxFsCalls.at(-1)?.workdir).toBe('/workspace/worktrees/feat-x');
+    // Reuse key includes the worktree path, so a different worktree gets a fresh workspace.
+    expect(workspace.id).toBe('mastra-code-workspace-gh-proj-1-sbx-1-/workspace/worktrees/feat-x');
+  });
+
+  it('produces distinct reuse keys for different worktrees on the same sandbox', async () => {
+    const { getDynamicWorkspace } = await import('../workspace.js');
+    const a = await getDynamicWorkspace({
+      requestContext: createSandboxRequestContext({
+        ...baseState,
+        worktreePath: '/workspace/worktrees/feat-a',
+      }) as any,
+    });
+    const b = await getDynamicWorkspace({
+      requestContext: createSandboxRequestContext({
+        ...baseState,
+        worktreePath: '/workspace/worktrees/feat-b',
+      }) as any,
+    });
+
+    expect(a.id).not.toBe(b.id);
+  });
+});

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -139,17 +139,25 @@ async function getSandboxWorkspace({
   githubProjectId,
   sandboxId,
   workdir,
+  worktreePath,
   mastra,
 }: {
   githubProjectId: string;
   sandboxId: string;
   workdir: string;
+  worktreePath?: string;
   mastra?: Mastra;
 }): Promise<Workspace> {
-  // Include the sandbox id in the reuse key: if the project is re-provisioned
-  // onto a new sandbox (e.g. the previous one expired), the key changes so we
-  // build a fresh Workspace instead of reusing one bound to the dead sandbox.
-  const workspaceId = `${WORKSPACE_ID_PREFIX}-gh-${githubProjectId}-${sandboxId}`;
+  // Bind the workspace to the active worktree when one is set, so file tools and
+  // command tools operate inside the feature branch's working tree rather than
+  // the base checkout. Falls back to the repo root when no worktree is active.
+  const boundWorkdir = worktreePath || workdir;
+
+  // Include the sandbox id *and* worktree path in the reuse key: a new sandbox
+  // (e.g. the previous one expired) or a different worktree must each get a
+  // fresh Workspace/ProcessManager instead of reusing one bound to a stale
+  // sandbox or the wrong working tree.
+  const workspaceId = `${WORKSPACE_ID_PREFIX}-gh-${githubProjectId}-${sandboxId}-${boundWorkdir}`;
 
   // Reuse the existing remote workspace if already registered (preserves the
   // reattached sandbox + ProcessManager state across re-opens).
@@ -164,7 +172,7 @@ async function getSandboxWorkspace({
   }
 
   const sandbox = await reattachProjectSandbox(sandboxId);
-  const filesystem = new SandboxFilesystem({ sandbox, workdir });
+  const filesystem = new SandboxFilesystem({ sandbox, workdir: boundWorkdir });
 
   return new Workspace({
     id: workspaceId,
@@ -195,6 +203,7 @@ export async function getDynamicWorkspace({
       githubProjectId: state.githubProjectId,
       sandboxId: state.sandboxId,
       workdir: state.sandboxWorkdir,
+      worktreePath: state.worktreePath,
       mastra,
     });
   }

--- a/mastracode/src/schema.ts
+++ b/mastracode/src/schema.ts
@@ -22,6 +22,10 @@ export interface MastraCodeState {
   sandboxId?: string;
   /** Path inside the sandbox the repo is cloned into. */
   sandboxWorkdir?: string;
+  /** Active git worktree path inside the sandbox for the current unit of work. */
+  worktreePath?: string;
+  /** Active feature branch checked out in the worktree. */
+  branch?: string;
   configDir: string;
   homeDir?: string;
   gitBranch?: string;
@@ -83,6 +87,8 @@ export const stateSchema = z.object({
   githubProjectId: z.string().optional(),
   sandboxId: z.string().optional(),
   sandboxWorkdir: z.string().optional(),
+  worktreePath: z.string().optional(),
+  branch: z.string().optional(),
   configDir: z.string().default(DEFAULT_CONFIG_DIR),
   homeDir: z.string().optional(),
   gitBranch: z.string().optional(),

--- a/mastracode/src/utils/project.ts
+++ b/mastracode/src/utils/project.ts
@@ -252,6 +252,14 @@ export interface LibSQLStorageConfig {
   url: string;
   authToken?: string;
   isRemote: boolean;
+  /**
+   * Optional explicit url for the recall vector DB. When omitted, the factory
+   * uses the shared default vector file. Per-tenant storage sets this so each
+   * tenant's recall vectors live in their own isolated DB, not a shared file.
+   */
+  vectorUrl?: string;
+  /** Auth token for the vector DB when `vectorUrl` points at a remote libSQL. */
+  vectorAuthToken?: string;
 }
 
 /**

--- a/mastracode/src/utils/storage-factory.ts
+++ b/mastracode/src/utils/storage-factory.ts
@@ -13,10 +13,33 @@ import { PostgresStore } from '@mastra/pg';
 import type { StorageConfig, PgStorageConfig } from './project.js';
 import { getDatabasePath, getVectorDatabasePath } from './project.js';
 
-const MASTRA_CODE_LOCAL_PRAGMAS = {
+export const MASTRA_CODE_LOCAL_PRAGMAS = {
   cacheSize: -128000,
   mmapSize: 536870912,
 };
+
+/**
+ * Construct a LibSQL store for an arbitrary url/authToken, applying the same
+ * local pragmas the default factory uses. Shared so per-tenant storage
+ * (see `web/tenant-storage.ts`) doesn't duplicate the construction.
+ */
+export function buildLibSQLStore(opts: { id?: string; url: string; authToken?: string }): MastraCompositeStore {
+  return new LibSQLStore({
+    id: opts.id ?? 'mastra-code-storage',
+    url: opts.url,
+    ...(opts.authToken ? { authToken: opts.authToken } : {}),
+    localPragmas: MASTRA_CODE_LOCAL_PRAGMAS,
+  });
+}
+
+/** Construct a LibSQL vector store for an arbitrary url/authToken. */
+export function buildLibSQLVector(opts: { id?: string; url: string; authToken?: string }): MastraVector {
+  return new LibSQLVector({
+    id: opts.id ?? 'mastra-code-vectors',
+    url: opts.url,
+    ...(opts.authToken ? { authToken: opts.authToken } : {}),
+  });
+}
 
 export interface StorageResult {
   storage: MastraCompositeStore;
@@ -27,11 +50,7 @@ export interface StorageResult {
 }
 
 function createFallbackLibSQL(): MastraCompositeStore {
-  return new LibSQLStore({
-    id: 'mastra-code-storage',
-    url: `file:${getDatabasePath()}`,
-    localPragmas: MASTRA_CODE_LOCAL_PRAGMAS,
-  });
+  return buildLibSQLStore({ url: `file:${getDatabasePath()}` });
 }
 
 /**
@@ -47,12 +66,7 @@ export async function createStorage(config: StorageConfig): Promise<StorageResul
 
   // Default: LibSQL
   return {
-    storage: new LibSQLStore({
-      id: 'mastra-code-storage',
-      url: config.url,
-      ...(config.authToken ? { authToken: config.authToken } : {}),
-      localPragmas: MASTRA_CODE_LOCAL_PRAGMAS,
-    }),
+    storage: buildLibSQLStore({ url: config.url, authToken: config.authToken }),
     backend: 'libsql',
   };
 }
@@ -134,9 +148,12 @@ export async function createVectorStore(
     });
   }
 
-  // LibSQL: separate file for vectors
-  return new LibSQLVector({
-    id: 'mastra-code-vectors',
-    url: `file:${getVectorDatabasePath()}`,
+  // LibSQL: separate file for vectors. Per-tenant configs supply an explicit
+  // vectorUrl so each tenant's recall vectors are isolated; otherwise use the
+  // shared default file.
+  const libsqlConfig = config as { vectorUrl?: string; vectorAuthToken?: string };
+  return buildLibSQLVector({
+    url: libsqlConfig.vectorUrl ?? `file:${getVectorDatabasePath()}`,
+    authToken: libsqlConfig.vectorAuthToken,
   });
 }

--- a/mastracode/src/web/.env.example
+++ b/mastracode/src/web/.env.example
@@ -45,7 +45,10 @@ GITHUB_APP_SLUG=your-app-slug
 APP_DATABASE_URL=postgres://user:pass@localhost:54329/mastracode_web
 # optional — defaults to <MASTRACODE_PUBLIC_URL>/auth/github/callback
 GITHUB_APP_REDIRECT_URI=
-# optional — secret for install/uninstall webhooks
+# Secret for install/uninstall webhooks. Also used to sign GitHub OAuth/install
+# state. REQUIRED for multi-replica deployments: without an explicit secret
+# (this or WORKOS_COOKIE_PASSWORD), state is signed with a per-process random
+# key and callbacks fail on a replica that did not sign the state.
 GITHUB_APP_WEBHOOK_SECRET=
 
 # ---------------------------------------------------------------------------
@@ -67,14 +70,19 @@ MASTRACODE_SANDBOX_WORKDIR=/workspace
 # optional — idle teardown window in minutes (default 30); the next open
 # re-provisions automatically if the VM was stopped
 MASTRACODE_SANDBOX_IDLE_MINUTES=30
+# optional — per-replica cap on concurrently live sandboxes. New provisioning
+# beyond this returns an actionable error; 0 / unset means unlimited.
+MASTRACODE_MAX_SANDBOXES=
 
 # ---------------------------------------------------------------------------
-# Per-user storage isolation (multi-tenant)
-# When WorkOS web auth is enabled, each authenticated user gets their own
-# isolated libSQL database for all agent state. The DB location is derived
-# server-side from a hashed WorkOS user id. By default each user gets local
-# libSQL files; for hosted deployments use the remote URL templates below
-# ({id} is replaced with the hashed user id).
+# Per-(org,user) storage isolation (multi-tenant)
+# When WorkOS web auth is enabled, the tenant boundary is (organization, user):
+# each user in each org gets their own isolated libSQL database for all agent
+# state (threads/messages/memory/recall vectors). The DB location is derived
+# server-side from a hash of the (orgId, userId) pair; users without an org
+# fall back to a user-only key. By default each tenant gets local libSQL files;
+# for hosted deployments use the remote URL templates below ({id} is replaced
+# with the hashed tenant key).
 # ---------------------------------------------------------------------------
 # optional — root dir for local per-tenant libSQL files
 MASTRACODE_TENANT_DB_ROOT=
@@ -86,3 +94,21 @@ MASTRACODE_TENANT_VECTOR_URL_TEMPLATE=
 MASTRACODE_TENANT_DB_AUTH_TOKEN=
 # optional — auth token for the remote tenant vector DB
 MASTRACODE_TENANT_VECTOR_AUTH_TOKEN=
+# optional — set to 1 to fail/warn at startup when no remote tenant DB template
+# is configured (local-file tenant DBs do not persist or share across replicas)
+MASTRACODE_REQUIRE_REMOTE_TENANT_DB=
+# optional — idle minutes before an inactive tenant's in-memory Mastra stack is
+# evicted from the dispatcher cache (default 30; 0 disables idle eviction)
+MASTRACODE_TENANT_IDLE_MINUTES=30
+# optional — max number of tenant stacks kept in memory before LRU eviction
+# (default 100; 0 disables the cap)
+MASTRACODE_TENANT_MAX_APPS=100
+
+# ---------------------------------------------------------------------------
+# Multi-replica deployment
+# ---------------------------------------------------------------------------
+# optional — set to 0 to disable the Postgres advisory-lock layer used to
+# serialize per-(project,user) git write operations across replicas. When
+# enabled (default), it requires APP_DATABASE_URL. Use 0 for single-process
+# local dev.
+MASTRACODE_DISTRIBUTED_LOCK=

--- a/mastracode/src/web/.env.example
+++ b/mastracode/src/web/.env.example
@@ -54,8 +54,9 @@ GITHUB_APP_WEBHOOK_SECRET=
 # which requires a sandbox provider. Railway is the first supported backend.
 # Without a provider, users can still connect GitHub and pick repos, but
 # opening a repo project shows a clear "sandbox not configured" error.
-# The sandbox template must have `git` installed and outbound network access
-# to github.com.
+# The sandbox template must have `git` and `gh` (the GitHub CLI) installed and
+# outbound network access to github.com. `gh` is only needed to open pull
+# requests; clone/open work without it.
 # ---------------------------------------------------------------------------
 RAILWAY_API_TOKEN=
 RAILWAY_ENVIRONMENT_ID=
@@ -63,3 +64,25 @@ RAILWAY_ENVIRONMENT_ID=
 MASTRACODE_SANDBOX_PROVIDER=railway
 # optional (path inside the sandbox)
 MASTRACODE_SANDBOX_WORKDIR=/workspace
+# optional — idle teardown window in minutes (default 30); the next open
+# re-provisions automatically if the VM was stopped
+MASTRACODE_SANDBOX_IDLE_MINUTES=30
+
+# ---------------------------------------------------------------------------
+# Per-user storage isolation (multi-tenant)
+# When WorkOS web auth is enabled, each authenticated user gets their own
+# isolated libSQL database for all agent state. The DB location is derived
+# server-side from a hashed WorkOS user id. By default each user gets local
+# libSQL files; for hosted deployments use the remote URL templates below
+# ({id} is replaced with the hashed user id).
+# ---------------------------------------------------------------------------
+# optional — root dir for local per-tenant libSQL files
+MASTRACODE_TENANT_DB_ROOT=
+# optional — remote libSQL/Turso per tenant
+MASTRACODE_TENANT_DB_URL_TEMPLATE=
+# optional — separate remote vector DB per tenant
+MASTRACODE_TENANT_VECTOR_URL_TEMPLATE=
+# optional — auth token for the remote tenant storage DB
+MASTRACODE_TENANT_DB_AUTH_TOKEN=
+# optional — auth token for the remote tenant vector DB
+MASTRACODE_TENANT_VECTOR_AUTH_TOKEN=

--- a/mastracode/src/web/auth.test.ts
+++ b/mastracode/src/web/auth.test.ts
@@ -1,7 +1,14 @@
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getWebAuthUser, getWebAuthUserId, isWebAuthEnabled, mountWebAuth } from './auth.js';
+import {
+  getWebAuthOrgId,
+  getWebAuthUser,
+  getWebAuthUserId,
+  isWebAuthEnabled,
+  mountWebAuth,
+  webAuthTenant,
+} from './auth.js';
 
 // Mock @mastra/auth-workos so the tests exercise the gating/routing logic in
 // this module without constructing a real WorkOS client. `authenticateToken`'s
@@ -208,5 +215,56 @@ describe('mountWebAuth /auth routes (enabled)', () => {
     const res = await app.request('/auth/me');
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ authenticated: true, user: { email: 'user@example.com', name: 'User' } });
+  });
+
+  it('/auth/me surfaces the organization id to the SPA', async () => {
+    mockAuthenticate.mockResolvedValue({
+      workosId: 'user_1',
+      email: 'user@example.com',
+      name: 'User',
+      organizationId: 'org_a',
+    });
+    const { app } = buildApp();
+    const res = await app.request('/auth/me');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      authenticated: true,
+      user: { email: 'user@example.com', name: 'User', organizationId: 'org_a' },
+    });
+  });
+});
+
+describe('org-tenant identity', () => {
+  beforeEach(enableEnv);
+
+  it('getWebAuthOrgId reads the organization id from the user shape', () => {
+    expect(getWebAuthOrgId({ workosId: 'user_1', organizationId: 'org_a' })).toBe('org_a');
+    expect(getWebAuthOrgId({ workosId: 'user_1' })).toBeUndefined();
+    expect(getWebAuthOrgId(undefined)).toBeUndefined();
+  });
+
+  it('gate stashes organizationId and webAuthTenant returns { orgId, userId }', async () => {
+    mockAuthenticate.mockResolvedValue({ workosId: 'user_1', organizationId: 'org_a', email: 'u@e.com' });
+    const app = new Hono();
+    mountWebAuth(app, { redirectUri: 'http://localhost:4111/auth/callback' });
+    app.get('/api/web/whoami', c => c.json(webAuthTenant(c) ?? { tenant: null }));
+
+    const res = await app.request('/api/web/whoami', { headers: { Accept: 'application/json' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: 'org_a', userId: 'user_1' });
+  });
+
+  it('webAuthTenant omits orgId for personal (no-org) users but keeps userId', async () => {
+    mockAuthenticate.mockResolvedValue({ workosId: 'user_solo', email: 'solo@e.com' });
+    const app = new Hono();
+    mountWebAuth(app, { redirectUri: 'http://localhost:4111/auth/callback' });
+    app.get('/api/web/whoami', c => {
+      const tenant = webAuthTenant(c);
+      return c.json({ orgId: tenant?.orgId ?? null, userId: tenant?.userId ?? null });
+    });
+
+    const res = await app.request('/api/web/whoami', { headers: { Accept: 'application/json' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: null, userId: 'user_solo' });
   });
 });

--- a/mastracode/src/web/auth.ts
+++ b/mastracode/src/web/auth.ts
@@ -23,6 +23,24 @@ export interface WebAuthUser {
   id?: string;
   email?: string;
   name?: string;
+  /**
+   * WorkOS organization id. The org is the top-level tenant: it owns the GitHub
+   * App installation and connected projects, while each user inside the org gets
+   * isolated building instances. Absent for personal (no-org) accounts.
+   */
+  organizationId?: string;
+}
+
+/**
+ * Tenant identity: the org is the top-level tenant, and each user inside it is
+ * an isolated builder. Agent state, worktrees and sandboxes are scoped per
+ * `(orgId, userId)`. Personal (no-org) users have `orgId === undefined`.
+ */
+export interface WebAuthTenant {
+  /** WorkOS organization id, or `undefined` for personal (no-org) accounts. */
+  orgId?: string;
+  /** Stable WorkOS user id. */
+  userId: string;
 }
 
 /** Hono context variables set by the auth gate. */
@@ -45,6 +63,25 @@ export function getWebAuthUser(c: Context): WebAuthUser | undefined {
 /** Resolve the stable user id from a WorkOS user shape. */
 export function getWebAuthUserId(user: WebAuthUser | undefined): string | undefined {
   return user?.workosId ?? user?.id;
+}
+
+/** Resolve the WorkOS organization id from a user shape, if present. */
+export function getWebAuthOrgId(user: WebAuthUser | undefined): string | undefined {
+  return user?.organizationId;
+}
+
+/**
+ * Resolve the tenant identity `(orgId, userId)` from the authenticated user on
+ * the context. Returns `undefined` when there is no signed-in user (auth
+ * disabled or unauthenticated). `orgId` is `undefined` for personal accounts;
+ * callers gate org-scoped GitHub features on its presence while agent state
+ * falls back to a user-only tenant.
+ */
+export function webAuthTenant(c: Context): WebAuthTenant | undefined {
+  const user = getWebAuthUser(c);
+  const userId = getWebAuthUserId(user);
+  if (!userId) return undefined;
+  return { orgId: getWebAuthOrgId(user), userId };
 }
 
 /**
@@ -177,7 +214,10 @@ export function mountWebAuth(app: Hono<any>, options: MountWebAuthOptions = {}):
     if (!user) {
       return c.json({ authenticated: false, user: null });
     }
-    return c.json({ authenticated: true, user: { email: user.email, name: user.name } });
+    return c.json({
+      authenticated: true,
+      user: { email: user.email, name: user.name, organizationId: user.organizationId },
+    });
   });
 
   // ── Gate middleware ───────────────────────────────────────────────────

--- a/mastracode/src/web/github/config.ts
+++ b/mastracode/src/web/github/config.ts
@@ -26,36 +26,85 @@ export function isGithubFeatureEnabled(): boolean {
 let stateSecret: string | undefined;
 function getStateSecret(): string {
   if (stateSecret) return stateSecret;
-  stateSecret =
-    process.env.GITHUB_APP_WEBHOOK_SECRET || process.env.WORKOS_COOKIE_PASSWORD || randomBytes(32).toString('hex');
+  stateSecret = explicitStateSecret() ?? randomBytes(32).toString('hex');
   return stateSecret;
 }
 
+/**
+ * The explicit, deployment-stable state secret if one is configured. When
+ * undefined, `getStateSecret()` falls back to a per-process random secret, which
+ * is NOT stable across replicas: a `state` signed by one replica cannot be
+ * verified by another. Multi-replica deploys must set an explicit secret.
+ */
+function explicitStateSecret(): string | undefined {
+  return process.env.GITHUB_APP_WEBHOOK_SECRET || process.env.WORKOS_COOKIE_PASSWORD || undefined;
+}
+
+/**
+ * True when a deployment-stable state secret is configured. Startup uses this to
+ * fail loud when the GitHub feature is on but state signing would not be
+ * replica-stable.
+ */
+export function hasExplicitStateSecret(): boolean {
+  return explicitStateSecret() !== undefined;
+}
+
+/**
+ * Fail loud at startup if the GitHub feature is on but no replica-stable state
+ * secret is configured. A random per-process secret silently breaks the
+ * OAuth/install callback whenever it lands on a different replica than the one
+ * that signed the `state`. Returns without error when the feature is off (the
+ * random fallback is acceptable for single-process/local dev).
+ */
+export function assertReplicaStableStateSecret(): void {
+  if (!isGithubFeatureEnabled()) return;
+  if (hasExplicitStateSecret()) return;
+  throw new Error(
+    'GitHub App feature is enabled but no replica-stable state secret is set. ' +
+      'Set GITHUB_APP_WEBHOOK_SECRET (or WORKOS_COOKIE_PASSWORD) so OAuth/install ' +
+      '`state` can be verified across replicas. Without it, the install callback ' +
+      'fails whenever it lands on a different replica than the one that signed it.',
+  );
+}
+
 interface StatePayload {
+  orgId: string;
   userId: string;
   nonce: string;
   issuedAt: number;
+}
+
+/** Verified `(orgId, userId)` tenant carried by a signed install `state`. */
+export interface StateTenant {
+  orgId: string;
+  userId: string;
 }
 
 /** Signed `state` values expire after this window to bound the CSRF token. */
 const STATE_MAX_AGE_MS = 10 * 60 * 1000;
 
 /**
- * Build a signed `state` bound to the user id. The payload is base64url JSON
- * with an HMAC suffix so the callback can verify it was not tampered with and
- * belongs to the same user.
+ * Build a signed `state` bound to the `(orgId, userId)` tenant. The payload is
+ * base64url JSON with an HMAC suffix so the callback can verify it was not
+ * tampered with and belongs to the same org + user.
  */
-export function signState(userId: string): string {
-  const payload: StatePayload = { userId, nonce: randomBytes(8).toString('hex'), issuedAt: Date.now() };
+export function signState(orgId: string, userId: string): string {
+  const payload: StatePayload = {
+    orgId,
+    userId,
+    nonce: randomBytes(8).toString('hex'),
+    issuedAt: Date.now(),
+  };
   const body = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
   const sig = createHmac('sha256', getStateSecret()).update(body).digest('base64url');
   return `${body}.${sig}`;
 }
 
 /**
- * Verify a signed `state` and return the bound user id, or `null` if invalid.
+ * Verify a signed `state` and return the bound `(orgId, userId)` tenant, or
+ * `null` if invalid.
  */
-export function verifyState(state: string | undefined): string | null {
+export function verifyState(state: string | undefined): StateTenant | null {
   if (!state) return null;
   const dot = state.lastIndexOf('.');
   if (dot <= 0) return null;
@@ -69,9 +118,10 @@ export function verifyState(state: string | undefined): string | null {
   }
   try {
     const parsed = JSON.parse(Buffer.from(body, 'base64url').toString('utf8')) as StatePayload;
-    if (typeof parsed.userId !== 'string' || typeof parsed.issuedAt !== 'number') return null;
+    if (typeof parsed.orgId !== 'string' || typeof parsed.userId !== 'string') return null;
+    if (typeof parsed.issuedAt !== 'number') return null;
     if (Date.now() - parsed.issuedAt > STATE_MAX_AGE_MS) return null;
-    return parsed.userId;
+    return { orgId: parsed.orgId, userId: parsed.userId };
   } catch {
     return null;
   }

--- a/mastracode/src/web/github/db.ts
+++ b/mastracode/src/web/github/db.ts
@@ -65,6 +65,20 @@ export async function ensureAppDbReady(): Promise<void> {
 }
 
 /**
+ * Get the underlying pg `Pool`, lazily creating the client if needed. Used by
+ * the distributed project lock, which needs a single dedicated connection to
+ * hold a transaction-scoped advisory lock.
+ * @throws if `APP_DATABASE_URL` is not set.
+ */
+export function getAppDbPool(): pkg.Pool {
+  getAppDb();
+  if (!pool) {
+    throw new Error('APP_DATABASE_URL is not set; the GitHub App feature requires an application database.');
+  }
+  return pool;
+}
+
+/**
  * Close the pool. Primarily for tests / graceful shutdown.
  */
 export async function closeAppDb(): Promise<void> {

--- a/mastracode/src/web/github/org-isolation-scenario.test.ts
+++ b/mastracode/src/web/github/org-isolation-scenario.test.ts
@@ -1,0 +1,454 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Phase 2 org-isolation scenario tests ─────────────────────────────────
+// These prove the org-tenancy boundary end to end through the real GitHub
+// route handlers:
+//   1. The same repo connected by two different orgs never bleeds across orgs.
+//   2. Two users in one org each get their own per-(project,user) sandbox row,
+//      and one user's worktree is invisible to the other.
+//   3. A user cannot operate on another user's persisted worktree path.
+// They reuse the harness shape from `routes.test.ts`: mocked drizzle eq/and,
+// an in-memory fake DB, and mocked `./client` / `./sandbox` / `./config`.
+
+vi.mock('drizzle-orm', () => ({
+  eq: (column: any, value: any) => ({ kind: 'eq', column: column?.name, value }),
+  and: (...conds: any[]) => ({ kind: 'and', conds: conds.filter(Boolean) }),
+}));
+
+interface Tables {
+  installations: Array<{
+    orgId?: string;
+    userId: string;
+    installationId: number;
+    accountLogin: string | null;
+    accountType: string | null;
+  }>;
+  projects: Array<Record<string, any>>;
+  sandboxes: Array<Record<string, any>>;
+  worktrees: Array<Record<string, any>>;
+}
+const tables: Tables = { installations: [], projects: [], sandboxes: [], worktrees: [] };
+
+vi.mock('./db', () => {
+  const makeDb = () => ({
+    select: () => ({
+      from: (table: any) => ({
+        where: async (cond: any) => filterRows(table, cond),
+      }),
+    }),
+    insert: (table: any) => ({
+      values: (vals: any) => {
+        const chain = {
+          onConflictDoNothing: (opts?: any) => {
+            const ret = insertIfAbsent(table, vals, opts);
+            const promise: any = Promise.resolve(ret ? [ret] : []);
+            promise.returning = async () => (ret ? [ret] : []);
+            return promise;
+          },
+          onConflictDoUpdate: (opts: any) => {
+            const ret = upsertRow(table, vals, opts);
+            return { returning: async () => [ret] };
+          },
+          returning: async () => [insertRow(table, vals)],
+        };
+        return chain;
+      },
+    }),
+    update: (table: any) => ({
+      set: (vals: any) => ({ where: async () => updateRows(table, vals) }),
+    }),
+  });
+  return { getAppDb: () => makeDb() };
+});
+
+let mintCount = 0;
+vi.mock('./client', () => ({
+  buildInstallUrl: (state: string) => `https://github.com/apps/test/installations/new?state=${state}`,
+  buildOAuthIdentifyUrl: (state: string) => `https://github.com/login/oauth/authorize?state=${state}`,
+  exchangeOAuthCode: vi.fn(async () => 'user-token'),
+  listUserInstallations: vi.fn(async () => [{ installationId: 7, accountLogin: 'octo', accountType: 'User' }]),
+  listInstallationRepos: vi.fn(async () => []),
+  getInstallationRepo: vi.fn(async (installationId: number, fullName: string) =>
+    fullName === 'octo/hello'
+      ? {
+          id: 99,
+          fullName: 'octo/hello',
+          name: 'hello',
+          owner: 'octo',
+          defaultBranch: 'main',
+          private: false,
+          installationId,
+        }
+      : null,
+  ),
+  mintInstallationToken: vi.fn(async () => `install-token-${++mintCount}`),
+}));
+
+// Mirror production: provisioning persists a sandboxId onto the binding row so
+// the later git routes can reattach. We update the fake DB row in place.
+const ensureProjectSandbox = vi.fn(async (row: any) => {
+  const persisted = tables.sandboxes.find(s => s.id === row.id);
+  if (persisted && !persisted.sandboxId) persisted.sandboxId = `sb-${persisted.userId}`;
+  return { id: persisted?.sandboxId ?? 'sb' };
+});
+const materializeRepo = vi.fn(async () => {});
+const reattachProjectSandbox = vi.fn(async (_id: string) => ({ id: 'sb' }));
+const ensureWorktree = vi.fn(async (_sb: any, _workdir: string, opts: { branch: string; baseBranch: string }) => ({
+  worktreePath: `/workspace/hello/../worktrees/${opts.branch}`,
+  branch: opts.branch,
+  baseBranch: opts.baseBranch,
+}));
+const commitAll = vi.fn(async () => ({ committed: true }));
+const pushBranch = vi.fn(async () => {});
+const createPullRequest = vi.fn(async () => ({ url: 'https://github.com/octo/hello/pull/1' }));
+let sandboxEnabled = true;
+vi.mock('./sandbox', () => {
+  class MaterializeError extends Error {
+    code: string;
+    constructor(m: string, code: string) {
+      super(m);
+      this.code = code;
+    }
+  }
+  class WorktreeError extends Error {
+    code: string;
+    constructor(m: string, code: string) {
+      super(m);
+      this.code = code;
+    }
+  }
+  return {
+    computeSandboxWorkdir: (repo: string) => `/workspace/${repo.split('/').pop()}`,
+    getSandboxProvider: () => 'railway',
+    isSandboxEnabled: () => sandboxEnabled,
+    ensureProjectSandbox: (row: any) => ensureProjectSandbox(row),
+    materializeRepo: (...args: any[]) => materializeRepo(...(args as [])),
+    reattachProjectSandbox: (id: string) => reattachProjectSandbox(id),
+    ensureWorktree: (sb: any, workdir: string, opts: any) => ensureWorktree(sb, workdir, opts),
+    commitAll: (...args: any[]) => commitAll(...(args as [])),
+    pushBranch: (...args: any[]) => pushBranch(...(args as [])),
+    createPullRequest: (...args: any[]) => createPullRequest(...(args as [])),
+    isValidGitRef: (v: unknown): v is string =>
+      typeof v === 'string' && v.length > 0 && v.length <= 255 && /^[A-Za-z0-9_./-]+$/.test(v),
+    MaterializeError,
+    WorktreeError,
+  };
+});
+
+let featureEnabled = true;
+vi.mock('./config', () => ({
+  isGithubFeatureEnabled: () => featureEnabled,
+  signState: (orgId: string, userId: string) => `state.${orgId}.${userId}`,
+  verifyState: (state: string | undefined) => {
+    if (!state?.startsWith('state.')) return null;
+    const [orgId, userId] = state.slice('state.'.length).split('.');
+    if (!orgId || !userId) return null;
+    return { orgId, userId };
+  },
+}));
+
+import { mountGithubRoutes } from './routes';
+
+// ── Fake table helpers (mirrors routes.test.ts) ─────────────────────────
+function tableKind(table: any): keyof Tables {
+  if (table === installationsRef) return 'installations';
+  if (table === worktreesRef) return 'worktrees';
+  if (table === sandboxesRef) return 'sandboxes';
+  return 'projects';
+}
+let installationsRef: any;
+let worktreesRef: any;
+let sandboxesRef: any;
+
+function dbNameToJsKey(table: any, dbName: string): string {
+  for (const [jsKey, col] of Object.entries(table)) {
+    if ((col as any)?.name === dbName) return jsKey;
+  }
+  return dbName;
+}
+function matches(table: any, row: any, cond: any): boolean {
+  if (!cond) return true;
+  if (cond.kind === 'and') return cond.conds.every((c: any) => matches(table, row, c));
+  if (cond.kind === 'eq') return row[dbNameToJsKey(table, cond.column)] === cond.value;
+  return true;
+}
+function filterRows(table: any, cond?: any): any[] {
+  return tables[tableKind(table)].filter(row => matches(table, row, cond));
+}
+function insertRow(table: any, vals: any): any {
+  const kind = tableKind(table);
+  const row = { id: `id-${tables[kind].length + 1}`, ...vals };
+  tables[kind].push(row as any);
+  return row;
+}
+function upsertRow(table: any, vals: any, opts: any): any {
+  const kind = tableKind(table);
+  const targets: string[] = (opts?.target ?? [])
+    .map((col: any) => (col?.name ? dbNameToJsKey(table, col.name) : undefined))
+    .filter(Boolean);
+  const existing = tables[kind].find(row => targets.every(t => (row as any)[t] === vals[t]));
+  if (existing) {
+    Object.assign(existing, opts?.set ?? {});
+    return existing;
+  }
+  return insertRow(table, vals);
+}
+function insertIfAbsent(table: any, vals: any, opts: any): any | undefined {
+  const kind = tableKind(table);
+  const targets: string[] = (opts?.target ?? [])
+    .map((col: any) => (col?.name ? dbNameToJsKey(table, col.name) : undefined))
+    .filter(Boolean);
+  const existing = targets.length
+    ? tables[kind].find(row => targets.every(t => (row as any)[t] === vals[t]))
+    : undefined;
+  if (existing) return undefined;
+  return insertRow(table, vals);
+}
+function updateRows(table: any, vals: any): void {
+  for (const row of tables[tableKind(table)]) Object.assign(row, vals);
+}
+
+import { githubInstallations, githubProjectSandboxes, githubWorktrees } from './schema';
+installationsRef = githubInstallations;
+worktreesRef = githubWorktrees;
+sandboxesRef = githubProjectSandboxes;
+
+function buildApp(user: { workosId: string; organizationId?: string } | null) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (user) c.set('webAuthUser' as never, user as never);
+    await next();
+  });
+  mountGithubRoutes(app as any, { baseUrl: 'http://localhost:4111' });
+  return app;
+}
+
+function postJson(app: ReturnType<typeof buildApp>, path: string, body: unknown) {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  tables.installations = [];
+  tables.projects = [];
+  tables.sandboxes = [];
+  tables.worktrees = [];
+  featureEnabled = true;
+  sandboxEnabled = true;
+  // No Postgres in these scenario tests: keep the project lock in-process.
+  process.env.MASTRACODE_DISTRIBUTED_LOCK = '0';
+  mintCount = 0;
+  ensureProjectSandbox.mockClear();
+  materializeRepo.mockClear();
+  reattachProjectSandbox.mockClear();
+  ensureWorktree.mockClear();
+  commitAll.mockClear();
+  pushBranch.mockClear();
+  createPullRequest.mockClear();
+});
+
+afterEach(() => {
+  delete process.env.MASTRACODE_DISTRIBUTED_LOCK;
+  vi.clearAllMocks();
+});
+
+// ── Scenario 1: same repo, two orgs, no bleed ────────────────────────────
+describe('same repo connected by two orgs stays isolated', () => {
+  it('gives each org its own project row and forbids cross-org operations', async () => {
+    // Each org has its own installation for the same repo.
+    tables.installations.push({
+      orgId: 'orgA',
+      userId: 'a1',
+      installationId: 7,
+      accountLogin: 'octo',
+      accountType: 'User',
+    });
+    tables.installations.push({
+      orgId: 'orgB',
+      userId: 'b1',
+      installationId: 7,
+      accountLogin: 'octo',
+      accountType: 'User',
+    });
+
+    const appA = buildApp({ workosId: 'a1', organizationId: 'orgA' });
+    const appB = buildApp({ workosId: 'b1', organizationId: 'orgB' });
+
+    const resA = await postJson(appA, '/api/web/github/projects', { repoFullName: 'octo/hello', installationId: 7 });
+    const resB = await postJson(appB, '/api/web/github/projects', { repoFullName: 'octo/hello', installationId: 7 });
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
+    const projA = (await resA.json()).project.id as string;
+    const projB = (await resB.json()).project.id as string;
+
+    // The (org_id, repo_id) unique target means two orgs → two distinct rows.
+    expect(projA).not.toBe(projB);
+    expect(tables.projects).toHaveLength(2);
+    expect(tables.projects.find(p => p.id === projA)?.orgId).toBe('orgA');
+    expect(tables.projects.find(p => p.id === projB)?.orgId).toBe('orgB');
+
+    // Org A cannot ensure / worktree / push against Org B's project id.
+    expect((await postJson(appA, `/api/web/github/projects/${projB}/ensure`, {})).status).toBe(404);
+    expect((await postJson(appA, `/api/web/github/projects/${projB}/worktree`, { branch: 'feat/x' })).status).toBe(404);
+    expect((await postJson(appA, `/api/web/github/projects/${projB}/push`, { branch: 'feat/x' })).status).toBe(404);
+  });
+});
+
+// ── Scenario 2: two users, one org, own sandboxes ────────────────────────
+describe('two users in one org each get their own sandbox + worktree', () => {
+  function seedOrgProject() {
+    tables.projects.push({
+      id: 'p1',
+      orgId: 'orgA',
+      userId: 'a1',
+      installationId: 7,
+      repoFullName: 'octo/hello',
+      repoId: 99,
+      defaultBranch: 'main',
+      sandboxWorkdir: '/workspace/hello',
+    });
+  }
+
+  it('creates a distinct (project,user) sandbox row per user and hides worktrees across users', async () => {
+    seedOrgProject();
+    const user1 = buildApp({ workosId: 'a1', organizationId: 'orgA' });
+    const user2 = buildApp({ workosId: 'a2', organizationId: 'orgA' });
+
+    // Both users open (ensure) the same org-owned project.
+    expect((await postJson(user1, '/api/web/github/projects/p1/ensure', {})).status).toBe(200);
+    expect((await postJson(user2, '/api/web/github/projects/p1/ensure', {})).status).toBe(200);
+
+    // Each got their own per-(project,user) sandbox binding row.
+    expect(tables.sandboxes).toHaveLength(2);
+    expect(tables.sandboxes.filter(s => s.githubProjectId === 'p1' && s.userId === 'a1')).toHaveLength(1);
+    expect(tables.sandboxes.filter(s => s.githubProjectId === 'p1' && s.userId === 'a2')).toHaveLength(1);
+
+    // User 1 creates a worktree; it is owned by user 1 only.
+    const wt = await postJson(user1, '/api/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    expect(wt.status).toBe(200);
+    const wtPath = (await wt.json()).worktreePath as string;
+    expect(tables.worktrees).toHaveLength(1);
+    expect(tables.worktrees[0]).toMatchObject({ userId: 'a1', orgId: 'orgA', githubProjectId: 'p1' });
+
+    // User 2 cannot commit against user 1's worktree path (scoped to (p,user)).
+    const crossCommit = await postJson(user2, '/api/web/github/projects/p1/commit', {
+      message: 'sneaky',
+      worktreePath: wtPath,
+    });
+    expect(crossCommit.status).toBe(400);
+    expect((await crossCommit.json()).error).toBe('Invalid worktreePath');
+
+    // User 1 can commit against their own worktree path.
+    const ownCommit = await postJson(user1, '/api/web/github/projects/p1/commit', {
+      message: 'wip',
+      worktreePath: wtPath,
+    });
+    expect(ownCommit.status).toBe(200);
+    expect(await ownCommit.json()).toMatchObject({ committed: true });
+  });
+});
+
+// ── Scenario 3: cross-user worktree path rejected even with same branch ───
+describe('cross-user worktree paths are rejected', () => {
+  it('does not let user 2 push user 1 worktree path when both share a branch name', async () => {
+    tables.projects.push({
+      id: 'p1',
+      orgId: 'orgA',
+      userId: 'a1',
+      installationId: 7,
+      repoFullName: 'octo/hello',
+      repoId: 99,
+      defaultBranch: 'main',
+      sandboxWorkdir: '/workspace/hello',
+    });
+    // Both users have their own sandbox bindings + a worktree row on the same
+    // branch name; uniqueness is (project,user,branch) so both can coexist.
+    for (const userId of ['a1', 'a2']) {
+      tables.sandboxes.push({
+        id: `sbrow-${userId}`,
+        githubProjectId: 'p1',
+        userId,
+        sandboxId: `sb-${userId}`,
+        sandboxWorkdir: '/workspace/hello',
+        materializedAt: new Date(),
+      });
+      tables.worktrees.push({
+        id: `wt-${userId}`,
+        orgId: 'orgA',
+        userId,
+        githubProjectId: 'p1',
+        branch: 'feat/x',
+        baseBranch: 'main',
+        worktreePath: `/workspace/hello/../worktrees/${userId}/feat/x`,
+      });
+    }
+
+    const user2 = buildApp({ workosId: 'a2', organizationId: 'orgA' });
+
+    // User 2 supplies user 1's worktree path → rejected (path not owned).
+    const res = await postJson(user2, '/api/web/github/projects/p1/push', {
+      branch: 'feat/x',
+      worktreePath: '/workspace/hello/../worktrees/a1/feat/x',
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid worktreePath');
+    expect(pushBranch).not.toHaveBeenCalled();
+
+    // User 2 with their own worktree path succeeds.
+    const ok = await postJson(user2, '/api/web/github/projects/p1/push', {
+      branch: 'feat/x',
+      worktreePath: '/workspace/hello/../worktrees/a2/feat/x',
+    });
+    expect(ok.status).toBe(200);
+    expect(pushBranch).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Phase 4: org-scoped GitHub install flow ──────────────────────────────
+// The install `state` carries `(orgId, userId)`; the callback persists the
+// installation against the org and rejects a session whose org differs from
+// the signed state's org. A second user in the same org then sees the shared
+// org-level installation and can create projects from it.
+describe('install flow binds the installation to the org', () => {
+  it('persists an org-owned installation, then a second org user can use it', async () => {
+    // User 1 connects: state must encode their (org, user).
+    const connect = await buildApp({ workosId: 'a1', organizationId: 'orgA' }).request('/auth/github/connect');
+    expect(connect.status).toBe(302);
+    expect(connect.headers.get('location')).toContain('state=state.orgA.a1');
+
+    // Callback with a matching state persists the installation against orgA.
+    const cb = await buildApp({ workosId: 'a1', organizationId: 'orgA' }).request(
+      '/auth/github/callback?state=state.orgA.a1&code=abc',
+    );
+    expect(cb.headers.get('location')).toBe('/?github=connected');
+    expect(tables.installations).toHaveLength(1);
+    expect(tables.installations[0]).toMatchObject({ orgId: 'orgA', installationId: 7 });
+
+    // A different user in the same org sees the org-level installation and can
+    // create a project from it (no second install required).
+    const user2 = buildApp({ workosId: 'a2', organizationId: 'orgA' });
+    const status = await user2.request('/api/web/github/status');
+    expect((await status.json()).connected).toBe(true);
+
+    const proj = await postJson(user2, '/api/web/github/projects', {
+      repoFullName: 'octo/hello',
+      installationId: 7,
+    });
+    expect(proj.status).toBe(200);
+    expect(tables.projects).toHaveLength(1);
+    expect(tables.projects[0]).toMatchObject({ orgId: 'orgA', repoId: 99 });
+  });
+
+  it('rejects a callback whose session org differs from the signed state org', async () => {
+    // State was signed for orgA but the callback session is in orgB.
+    const res = await buildApp({ workosId: 'a1', organizationId: 'orgB' }).request(
+      '/auth/github/callback?state=state.orgA.a1&code=abc',
+    );
+    expect(res.headers.get('location')).toBe('/?github=error');
+    expect(tables.installations).toHaveLength(0);
+  });
+});

--- a/mastracode/src/web/github/project-lock-scenario.test.ts
+++ b/mastracode/src/web/github/project-lock-scenario.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { LockClient, LockPool } from './project-lock';
+import { __resetProjectLocksForTests, hashKey, withDbAdvisoryLock, withProjectLock } from './project-lock';
+
+// ── Phase 5 distributed project-lock scenario tests ──────────────────────
+// These prove cross-replica serialization on the same key using a fake pg
+// client that faithfully models transaction-scoped advisory-lock semantics:
+//   - pg_advisory_xact_lock(k1, k2) blocks while another transaction holds the
+//     same key,
+//   - the lock auto-releases when the holding transaction COMMITs or ROLLBACKs.
+// Two `withProjectLock` callers sharing one fake pool model two replicas
+// pointed at one Postgres.
+
+/**
+ * A fake Postgres modeling per-key advisory-lock queues. A key is "held" by at
+ * most one transaction at a time; `pg_advisory_xact_lock` waits for the holder
+ * to COMMIT/ROLLBACK before resolving.
+ */
+class FakePg implements LockPool {
+  /** key -> currently-holding client (or undefined when free). */
+  private held = new Map<string, FakeClient>();
+  /** key -> FIFO queue of waiters resolved when the lock frees. */
+  private waiters = new Map<string, Array<() => void>>();
+
+  connect(): Promise<LockClient> {
+    return Promise.resolve(new FakeClient(this));
+  }
+
+  async acquire(key: string, client: FakeClient): Promise<void> {
+    if (!this.held.has(key)) {
+      this.held.set(key, client);
+      return;
+    }
+    await new Promise<void>(resolve => {
+      const q = this.waiters.get(key) ?? [];
+      q.push(resolve);
+      this.waiters.set(key, q);
+    });
+    this.held.set(key, client);
+  }
+
+  releaseAll(client: FakeClient): void {
+    for (const [key, holder] of [...this.held.entries()]) {
+      if (holder !== client) continue;
+      this.held.delete(key);
+      const q = this.waiters.get(key);
+      const next = q?.shift();
+      if (next) next();
+    }
+  }
+
+  isHeld(key: string): boolean {
+    return this.held.has(key);
+  }
+}
+
+class FakeClient implements LockClient {
+  private heldKeys: string[] = [];
+  constructor(private readonly pg: FakePg) {}
+
+  async query(sql: string, params?: unknown[]): Promise<unknown> {
+    if (sql === 'BEGIN') return undefined;
+    if (sql === 'COMMIT' || sql === 'ROLLBACK') {
+      this.pg.releaseAll(this);
+      this.heldKeys = [];
+      return undefined;
+    }
+    if (sql.includes('pg_advisory_xact_lock')) {
+      const [k1, k2] = params as [number, number];
+      const key = `${k1}:${k2}`;
+      this.heldKeys.push(key);
+      await this.pg.acquire(key, this);
+      return undefined;
+    }
+    return undefined;
+  }
+
+  release(): void {
+    // Connection back to the pool; any held advisory locks would have been
+    // released by COMMIT/ROLLBACK already. Defensive cleanup mirrors pg.
+    this.pg.releaseAll(this);
+  }
+}
+
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>(r => (resolve = r));
+  return { promise, resolve };
+};
+
+beforeEach(() => {
+  __resetProjectLocksForTests();
+  process.env.MASTRACODE_DISTRIBUTED_LOCK = '1';
+});
+afterEach(() => {
+  delete process.env.MASTRACODE_DISTRIBUTED_LOCK;
+  __resetProjectLocksForTests();
+});
+
+// Two replicas share one Postgres but have *independent* in-process lock
+// chains. We model each replica's call as a direct advisory-lock acquisition
+// (`withDbAdvisoryLock`), since that is the only layer that serializes across
+// replicas; the in-process mutex only serializes within a single replica.
+describe('cross-replica serialization via advisory locks', () => {
+  it('serializes overlapping critical sections on the same key across two replicas', async () => {
+    const pg = new FakePg(); // one shared Postgres
+    const [k1, k2] = hashKey('proj1:user1');
+    const key = `${k1}:${k2}`;
+
+    const order: string[] = [];
+    const gateA = deferred();
+
+    // Replica A acquires the advisory lock first.
+    const a = withDbAdvisoryLock(
+      'proj1:user1',
+      async () => {
+        order.push('A:start');
+        await gateA.promise;
+        order.push('A:end');
+      },
+      pg,
+    );
+    // Let A's BEGIN + advisory-lock acquisition settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Replica B (separate process → no shared in-process chain) tries the same
+    // key and must block on the Postgres advisory lock.
+    const b = withDbAdvisoryLock(
+      'proj1:user1',
+      async () => {
+        order.push('B:start');
+        order.push('B:end');
+      },
+      pg,
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(['A:start']);
+
+    gateA.resolve();
+    await Promise.all([a, b]);
+
+    expect(order).toEqual(['A:start', 'A:end', 'B:start', 'B:end']);
+    expect(pg.isHeld(key)).toBe(false);
+  });
+
+  it('lets different keys interleave', async () => {
+    const pg = new FakePg();
+    const order: string[] = [];
+    const gate1 = deferred();
+
+    const [k1a, k1b] = hashKey('proj1:user1');
+    const key1 = `${k1a}:${k1b}`;
+
+    const op1 = withDbAdvisoryLock(
+      'proj1:user1',
+      async () => {
+        order.push('1:start');
+        await gate1.promise;
+        order.push('1:end');
+      },
+      pg,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // A different key should not be blocked by op1 holding key1.
+    const op2 = withDbAdvisoryLock(
+      'proj2:user1',
+      async () => {
+        order.push('2:start');
+        order.push('2:end');
+      },
+      pg,
+    );
+
+    await op2;
+    // op2 finished while op1 is still holding its lock.
+    expect(order).toEqual(['1:start', '2:start', '2:end']);
+    expect(pg.isHeld(key1)).toBe(true);
+
+    gate1.resolve();
+    await op1;
+    expect(order).toEqual(['1:start', '2:start', '2:end', '1:end']);
+    expect(pg.isHeld(key1)).toBe(false);
+  });
+});
+
+describe('lock released on failure', () => {
+  it('rolls back and frees the key so the next caller acquires (no deadlock)', async () => {
+    const pg = new FakePg();
+    __resetProjectLocksForTests();
+    const [k1, k2] = hashKey('proj1:user1');
+    const key = `${k1}:${k2}`;
+
+    await expect(
+      withProjectLock(
+        'proj1:user1',
+        async () => {
+          throw new Error('boom');
+        },
+        pg,
+      ),
+    ).rejects.toThrow('boom');
+
+    // Lock must be free after the failed (rolled-back) transaction.
+    expect(pg.isHeld(key)).toBe(false);
+
+    let ran = false;
+    await withProjectLock(
+      'proj1:user1',
+      async () => {
+        ran = true;
+      },
+      pg,
+    );
+    expect(ran).toBe(true);
+    expect(pg.isHeld(key)).toBe(false);
+  });
+});
+
+describe('disabled distributed lock falls back to in-process only', () => {
+  it('does not touch the pg pool when MASTRACODE_DISTRIBUTED_LOCK=0', async () => {
+    process.env.MASTRACODE_DISTRIBUTED_LOCK = '0';
+    let connects = 0;
+    const pg: LockPool = {
+      connect: () => {
+        connects++;
+        return Promise.resolve({ query: async () => undefined, release: () => {} });
+      },
+    };
+    let ran = false;
+    await withProjectLock(
+      'proj1:user1',
+      async () => {
+        ran = true;
+      },
+      pg,
+    );
+    expect(ran).toBe(true);
+    expect(connects).toBe(0);
+  });
+});

--- a/mastracode/src/web/github/project-lock.ts
+++ b/mastracode/src/web/github/project-lock.ts
@@ -1,0 +1,113 @@
+/**
+ * Per-(project, user) lock that serializes the worktree/commit/push/PR flows.
+ *
+ * The push/PR flows temporarily rewrite the sandbox git remote to a tokenized
+ * URL and scrub it again in a `finally`; two concurrent operations on the same
+ * `(project, user)` sandbox could interleave those rewrites and leak a tokenized
+ * remote. Serializing per `(project, user)` removes that race.
+ *
+ * There are two layers:
+ *  1. An **in-process** promise-chain mutex keyed by the lock key, so repeated
+ *     same-replica callers stay cheap and never touch Postgres for ordering.
+ *  2. A **Postgres transaction-level advisory lock** (`pg_advisory_xact_lock`)
+ *     so that *different replicas* operating on the same key also serialize.
+ *     Transaction-scoped advisory locks release automatically when the
+ *     transaction ends (commit, rollback, or connection loss), so a crashed
+ *     replica can never hold the lock forever.
+ *
+ * Set `MASTRACODE_DISTRIBUTED_LOCK=0` to disable the Postgres layer (local dev,
+ * single replica) and fall back to the pure in-process mutex.
+ */
+
+import { createHash } from 'node:crypto';
+import { getAppDbPool } from './db';
+
+/** Minimal pg pool surface used by the distributed lock (for testability). */
+export interface LockPool {
+  connect(): Promise<LockClient>;
+}
+export interface LockClient {
+  query(sql: string, params?: unknown[]): Promise<unknown>;
+  release(): void;
+}
+
+const inProcessLocks = new Map<string, Promise<unknown>>();
+
+/** True when the Postgres advisory-lock layer should be used. */
+export function isDistributedLockEnabled(): boolean {
+  return process.env.MASTRACODE_DISTRIBUTED_LOCK !== '0';
+}
+
+/**
+ * Hash a lock key into the two signed 32-bit integers that the two-arg form of
+ * `pg_advisory_xact_lock(int4, int4)` expects. Using two int4 args (rather than
+ * one int8) keeps the key inside the GitHub-feature advisory-lock namespace and
+ * avoids collisions with other single-int8 advisory locks.
+ */
+export function hashKey(key: string): [number, number] {
+  const digest = createHash('sha256').update(key).digest();
+  // Read two independent 32-bit halves as signed int4 values.
+  const a = digest.readInt32BE(0);
+  const b = digest.readInt32BE(4);
+  return [a, b];
+}
+
+/**
+ * Run `fn` while holding the lock for `key`. Same-replica callers serialize via
+ * the in-process mutex; cross-replica callers additionally serialize via a
+ * Postgres transaction-scoped advisory lock (unless disabled).
+ *
+ * The in-process chain swallows rejections so one failed operation does not
+ * poison the lock for subsequent callers.
+ */
+export function withProjectLock<T>(key: string, fn: () => Promise<T>, poolOverride?: LockPool): Promise<T> {
+  const prev = inProcessLocks.get(key) ?? Promise.resolve();
+  const run = () => withDbAdvisoryLock(key, fn, poolOverride);
+  const next = prev.then(run, run);
+  inProcessLocks.set(
+    key,
+    next.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return next;
+}
+
+/**
+ * Acquire only the Postgres transaction-scoped advisory lock for `key` and run
+ * `fn` inside that transaction. This is the cross-replica serialization layer;
+ * `withProjectLock` wraps it with an in-process mutex for same-replica callers.
+ * Exposed so the cross-replica behavior can be tested without the in-process
+ * chain (each replica has its own in-process state but shares one Postgres).
+ */
+export async function withDbAdvisoryLock<T>(key: string, fn: () => Promise<T>, poolOverride?: LockPool): Promise<T> {
+  if (!isDistributedLockEnabled()) {
+    return fn();
+  }
+
+  const pool: LockPool = poolOverride ?? (getAppDbPool() as unknown as LockPool);
+  const [k1, k2] = hashKey(key);
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    // Blocks until no other transaction holds this advisory key. Auto-released
+    // when the transaction ends below.
+    await client.query('SELECT pg_advisory_xact_lock($1, $2)', [k1, k2]);
+    try {
+      const result = await fn();
+      await client.query('COMMIT');
+      return result;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    }
+  } finally {
+    client.release();
+  }
+}
+
+/** For tests: clear the in-process lock chains. */
+export function __resetProjectLocksForTests(): void {
+  inProcessLocks.clear();
+}

--- a/mastracode/src/web/github/routes-scenario.test.ts
+++ b/mastracode/src/web/github/routes-scenario.test.ts
@@ -1,0 +1,417 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Scenario tests (S1, S2) ──────────────────────────────────────────────
+// These exercise the *composition* of the real Phase 4 git route handlers
+// across a full write-back journey, and the per-project mutex that serialises
+// concurrent remote-rewriting pushes. They reuse the exact harness shape from
+// `routes.test.ts`: mocked `drizzle-orm` eq/and, an in-memory fake DB, and
+// mocked `./client` / `./sandbox` / `./config` modules. No real network.
+
+vi.mock('drizzle-orm', () => ({
+  eq: (column: any, value: any) => ({ kind: 'eq', column: column?.name, value }),
+  and: (...conds: any[]) => ({ kind: 'and', conds: conds.filter(Boolean) }),
+}));
+
+interface Tables {
+  installations: Array<{
+    userId: string;
+    installationId: number;
+    accountLogin: string | null;
+    accountType: string | null;
+  }>;
+  projects: Array<Record<string, any>>;
+  worktrees: Array<Record<string, any>>;
+}
+const tables: Tables = { installations: [], projects: [], worktrees: [] };
+
+vi.mock('./db', () => {
+  const makeDb = () => ({
+    select: () => ({
+      from: (table: any) => ({
+        where: async (cond: any) => filterRows(table, cond),
+      }),
+    }),
+    insert: (table: any) => ({
+      values: (vals: any) => {
+        const chain = {
+          onConflictDoNothing: async () => insertRow(table, vals),
+          onConflictDoUpdate: (opts: any) => {
+            const ret = upsertRow(table, vals, opts);
+            return { returning: async () => [ret] };
+          },
+          returning: async () => [insertRow(table, vals)],
+        };
+        return chain;
+      },
+    }),
+    update: (table: any) => ({
+      set: (vals: any) => ({ where: async () => updateRows(table, vals) }),
+    }),
+  });
+  return { getAppDb: () => makeDb() };
+});
+
+vi.mock('./client', () => ({
+  buildInstallUrl: (state: string) => `https://github.com/apps/test/installations/new?state=${state}`,
+  buildOAuthIdentifyUrl: (state: string) => `https://github.com/login/oauth/authorize?state=${state}`,
+  exchangeOAuthCode: vi.fn(async () => 'user-token'),
+  listUserInstallations: vi.fn(async () => [{ installationId: 7, accountLogin: 'octo', accountType: 'User' }]),
+  listInstallationRepos: vi.fn(async () => [
+    {
+      id: 99,
+      fullName: 'octo/hello',
+      name: 'hello',
+      owner: 'octo',
+      defaultBranch: 'main',
+      private: false,
+      installationId: 7,
+    },
+  ]),
+  getInstallationRepo: vi.fn(async (installationId: number, fullName: string) =>
+    fullName === 'octo/hello'
+      ? {
+          id: 99,
+          fullName: 'octo/hello',
+          name: 'hello',
+          owner: 'octo',
+          defaultBranch: 'main',
+          private: false,
+          installationId,
+        }
+      : null,
+  ),
+  // A fresh token string per call so the scenario can prove per-op minting.
+  mintInstallationToken: vi.fn(async () => `install-token-${++mintCount}`),
+}));
+
+let mintCount = 0;
+
+const ensureProjectSandbox = vi.fn(async (_row: any) => ({ id: 'sb' }));
+const materializeRepo = vi.fn(async () => {});
+const reattachProjectSandbox = vi.fn(async (_id: string) => ({ id: 'sb' }));
+const ensureWorktree = vi.fn(async (_sb: any, _workdir: string, opts: { branch: string; baseBranch: string }) => ({
+  worktreePath: `/workspace/hello/../worktrees/${opts.branch}`,
+  branch: opts.branch,
+  baseBranch: opts.baseBranch,
+}));
+const commitAll = vi.fn(async () => ({ committed: true }));
+// pushBranch is overridable per-test so S2 can make it block on a deferred.
+let pushImpl: (...args: any[]) => Promise<void> = async () => {};
+const pushBranch = vi.fn((...args: any[]) => pushImpl(...args));
+const createPullRequest = vi.fn(async () => ({ url: 'https://github.com/octo/hello/pull/1' }));
+let sandboxEnabled = true;
+vi.mock('./sandbox', () => {
+  class MaterializeError extends Error {
+    code: string;
+    constructor(m: string, code: string) {
+      super(m);
+      this.code = code;
+    }
+  }
+  class WorktreeError extends Error {
+    code: string;
+    constructor(m: string, code: string) {
+      super(m);
+      this.code = code;
+    }
+  }
+  return {
+    computeSandboxWorkdir: (repo: string) => `/workspace/${repo.split('/').pop()}`,
+    getSandboxProvider: () => 'railway',
+    isSandboxEnabled: () => sandboxEnabled,
+    ensureProjectSandbox: (row: any) => ensureProjectSandbox(row),
+    materializeRepo: (...args: any[]) => materializeRepo(...(args as [])),
+    reattachProjectSandbox: (id: string) => reattachProjectSandbox(id),
+    ensureWorktree: (sb: any, workdir: string, opts: any) => ensureWorktree(sb, workdir, opts),
+    commitAll: (...args: any[]) => commitAll(...(args as [])),
+    pushBranch: (...args: any[]) => pushBranch(...(args as [])),
+    createPullRequest: (...args: any[]) => createPullRequest(...(args as [])),
+    isValidGitRef: (v: unknown): v is string =>
+      typeof v === 'string' && v.length > 0 && v.length <= 255 && /^[A-Za-z0-9_./-]+$/.test(v),
+    MaterializeError,
+    WorktreeError,
+  };
+});
+
+let featureEnabled = true;
+vi.mock('./config', () => ({
+  isGithubFeatureEnabled: () => featureEnabled,
+  signState: (userId: string) => `state.${userId}`,
+  verifyState: (state: string | undefined) => (state?.startsWith('state.') ? state.slice('state.'.length) : null),
+}));
+
+import { mountGithubRoutes } from './routes';
+
+// ── Fake table helpers (mirrors routes.test.ts) ─────────────────────────
+function tableKind(table: any): keyof Tables {
+  if (table === installationsRef) return 'installations';
+  if (table === worktreesRef) return 'worktrees';
+  return 'projects';
+}
+let installationsRef: any;
+let worktreesRef: any;
+
+function dbNameToJsKey(table: any, dbName: string): string {
+  for (const [jsKey, col] of Object.entries(table)) {
+    if ((col as any)?.name === dbName) return jsKey;
+  }
+  return dbName;
+}
+function matches(table: any, row: any, cond: any): boolean {
+  if (!cond) return true;
+  if (cond.kind === 'and') return cond.conds.every((c: any) => matches(table, row, c));
+  if (cond.kind === 'eq') return row[dbNameToJsKey(table, cond.column)] === cond.value;
+  return true;
+}
+function filterRows(table: any, cond?: any): any[] {
+  return tables[tableKind(table)].filter(row => matches(table, row, cond));
+}
+function insertRow(table: any, vals: any): any {
+  const kind = tableKind(table);
+  const row = { id: `id-${tables[kind].length + 1}`, ...vals };
+  tables[kind].push(row as any);
+  return row;
+}
+function upsertRow(table: any, vals: any, opts: any): any {
+  const kind = tableKind(table);
+  const targets: string[] = (opts?.target ?? [])
+    .map((col: any) => (col?.name ? dbNameToJsKey(table, col.name) : undefined))
+    .filter(Boolean);
+  const existing = tables[kind].find(row => targets.every(t => row[t] === vals[t]));
+  if (existing) {
+    Object.assign(existing, opts?.set ?? {});
+    return existing;
+  }
+  return insertRow(table, vals);
+}
+function updateRows(table: any, vals: any): void {
+  for (const row of tables[tableKind(table)]) Object.assign(row, vals);
+}
+
+import { githubInstallations, githubWorktrees } from './schema';
+installationsRef = githubInstallations;
+worktreesRef = githubWorktrees;
+
+// A tiny deferred so S2 can control when a push resolves.
+function deferred<T = void>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function buildApp(user: { workosId: string } | null) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (user) c.set('webAuthUser' as never, user as never);
+    await next();
+  });
+  mountGithubRoutes(app as any, { baseUrl: 'http://localhost:4111' });
+  return app;
+}
+
+function postJson(app: ReturnType<typeof buildApp>, path: string, body: unknown) {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  tables.installations = [];
+  tables.projects = [];
+  tables.worktrees = [];
+  featureEnabled = true;
+  sandboxEnabled = true;
+  mintCount = 0;
+  pushImpl = async () => {};
+  ensureProjectSandbox.mockClear();
+  materializeRepo.mockClear();
+  reattachProjectSandbox.mockClear();
+  ensureWorktree.mockClear();
+  commitAll.mockClear();
+  pushBranch.mockClear();
+  createPullRequest.mockClear();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+// ── S1: full write-back journey ──────────────────────────────────────────
+describe('S1: full write-back journey through the real route handlers', () => {
+  it('drives create → ensure → worktree → commit → push → pr for one user', async () => {
+    const mintModule = (await import('./client')) as unknown as {
+      mintInstallationToken: ReturnType<typeof vi.fn>;
+    };
+    const mint = mintModule.mintInstallationToken;
+    tables.installations.push({ userId: 'u1', installationId: 7, accountLogin: 'octo', accountType: 'User' });
+    const app = buildApp({ workosId: 'u1' });
+
+    // 1. Create the project from an owned installation.
+    const createRes = await postJson(app, '/api/web/github/projects', {
+      repoFullName: 'octo/hello',
+      installationId: 7,
+    });
+    expect(createRes.status).toBe(200);
+    const projectId = (await createRes.json()).project.id as string;
+    expect(tables.projects).toHaveLength(1);
+    expect(projectId).toBeTruthy();
+
+    // The project must be materializable: seed the sandbox binding the way
+    // `ensure` would persist it (the sandbox provisioning itself is mocked).
+    const projectRow = tables.projects[0];
+    projectRow.sandboxId = 'sb-1';
+    projectRow.sandboxWorkdir = '/workspace/hello';
+
+    // 2. Ensure → provisions the sandbox + materialises the repo.
+    const ensureRes = await postJson(app, `/api/web/github/projects/${projectId}/ensure`, {});
+    expect(ensureRes.status).toBe(200);
+    expect(ensureProjectSandbox).toHaveBeenCalledOnce();
+    expect(materializeRepo).toHaveBeenCalledOnce();
+
+    // 3. Worktree → persists a github_worktrees row for feat/x.
+    const wtRes = await postJson(app, `/api/web/github/projects/${projectId}/worktree`, { branch: 'feat/x' });
+    expect(wtRes.status).toBe(200);
+    const wtJson = await wtRes.json();
+    expect(wtJson.branch).toBe('feat/x');
+    expect(wtJson.baseBranch).toBe('main');
+    expect(tables.worktrees).toHaveLength(1);
+    expect(tables.worktrees[0]).toMatchObject({
+      githubProjectId: projectId,
+      branch: 'feat/x',
+      baseBranch: 'main',
+    });
+    const persistedWorktreePath = wtJson.worktreePath as string;
+    expect(tables.worktrees[0].worktreePath).toBe(persistedWorktreePath);
+
+    // 4. Commit in that exact worktree path → the round-trip is honoured:
+    // a path that only exists because step 3 persisted it now passes
+    // resolveWorktreePath (no client-path injection possible).
+    const commitRes = await postJson(app, `/api/web/github/projects/${projectId}/commit`, {
+      message: 'wip',
+      worktreePath: persistedWorktreePath,
+    });
+    expect(commitRes.status).toBe(200);
+    expect(await commitRes.json()).toMatchObject({ committed: true });
+    expect((commitAll.mock.calls[0] as unknown as any[])[1]).toBe(persistedWorktreePath);
+
+    // 5. Push that worktree → a fresh token is minted for *this* op.
+    const mintBeforePush = mint.mock.calls.length;
+    const pushRes = await postJson(app, `/api/web/github/projects/${projectId}/push`, {
+      branch: 'feat/x',
+      worktreePath: persistedWorktreePath,
+    });
+    expect(pushRes.status).toBe(200);
+    expect(await pushRes.json()).toMatchObject({ pushed: true, branch: 'feat/x' });
+    expect(mint.mock.calls.length).toBe(mintBeforePush + 1);
+    const pushCall = pushBranch.mock.calls[0] as unknown as any[];
+    // pushBranch(sandbox, workdir, branch, token, repoFullName)
+    expect(pushCall[1]).toBe(persistedWorktreePath);
+    expect(pushCall[2]).toBe('feat/x');
+    const pushToken = pushCall[3] as string;
+    expect(pushToken).toMatch(/^install-token-/);
+
+    // 6. Open a PR → another fresh token is minted (per-op, not reused).
+    const mintBeforePr = mint.mock.calls.length;
+    const prRes = await postJson(app, `/api/web/github/projects/${projectId}/pr`, {
+      branch: 'feat/x',
+      title: 'My PR',
+      body: 'Adds a thing',
+      worktreePath: persistedWorktreePath,
+    });
+    expect(prRes.status).toBe(200);
+    expect(await prRes.json()).toMatchObject({ url: 'https://github.com/octo/hello/pull/1' });
+    expect(mint.mock.calls.length).toBe(mintBeforePr + 1);
+    const prToken = (createPullRequest.mock.calls[0] as unknown as any[])[2].token as string;
+    expect(prToken).toMatch(/^install-token-/);
+    // The push and PR tokens are distinct mints (never reused across ops).
+    expect(prToken).not.toBe(pushToken);
+  });
+});
+
+// ── S2: concurrent push serialisation (per-project mutex) ─────────────────
+describe('S2: per-project mutex serialises concurrent pushes', () => {
+  function seed(id: string, userId = 'u1') {
+    tables.projects.push({
+      id,
+      userId,
+      installationId: 7,
+      repoFullName: 'octo/hello',
+      repoId: 99,
+      defaultBranch: 'main',
+      sandboxId: `sb-${id}`,
+      sandboxWorkdir: '/workspace/hello',
+    });
+  }
+
+  it('does not start the second push for the same project until the first resolves', async () => {
+    seed('p1');
+    const app = buildApp({ workosId: 'u1' });
+
+    const order: string[] = [];
+    const gate = deferred();
+    let active = 0;
+    let maxConcurrent = 0;
+    pushImpl = async () => {
+      active++;
+      maxConcurrent = Math.max(maxConcurrent, active);
+      order.push(`start:${active}`);
+      // First push blocks on the gate; both wait on the same deferred so the
+      // mutex (not wall-clock) determines ordering.
+      await gate.promise;
+      active--;
+      order.push('end');
+    };
+
+    const first = postJson(app, '/api/web/github/projects/p1/push', { branch: 'feat/a' });
+    const second = postJson(app, '/api/web/github/projects/p1/push', { branch: 'feat/b' });
+
+    // Let microtasks flush; only the first push body should have begun.
+    await new Promise(r => setTimeout(r, 10));
+    expect(pushBranch).toHaveBeenCalledTimes(1);
+    expect(maxConcurrent).toBe(1);
+
+    // Release the gate → both complete, second runs only after the first ends.
+    gate.resolve();
+    const [r1, r2] = await Promise.all([first, second]);
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(pushBranch).toHaveBeenCalledTimes(2);
+    // The mutex never let two push bodies overlap.
+    expect(maxConcurrent).toBe(1);
+    expect(order).toEqual(['start:1', 'end', 'start:1', 'end']);
+  });
+
+  it('allows pushes for different projects to overlap', async () => {
+    seed('p1');
+    seed('p2');
+    const app = buildApp({ workosId: 'u1' });
+
+    const gate = deferred();
+    let active = 0;
+    let maxConcurrent = 0;
+    pushImpl = async () => {
+      active++;
+      maxConcurrent = Math.max(maxConcurrent, active);
+      await gate.promise;
+      active--;
+    };
+
+    const first = postJson(app, '/api/web/github/projects/p1/push', { branch: 'feat/a' });
+    const second = postJson(app, '/api/web/github/projects/p2/push', { branch: 'feat/b' });
+
+    await new Promise(r => setTimeout(r, 10));
+    // Distinct project ids → distinct locks → both bodies run concurrently.
+    expect(pushBranch).toHaveBeenCalledTimes(2);
+    expect(maxConcurrent).toBe(2);
+
+    gate.resolve();
+    const [r1, r2] = await Promise.all([first, second]);
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+  });
+});

--- a/mastracode/src/web/github/routes-scenario.test.ts
+++ b/mastracode/src/web/github/routes-scenario.test.ts
@@ -15,15 +15,17 @@ vi.mock('drizzle-orm', () => ({
 
 interface Tables {
   installations: Array<{
+    orgId?: string;
     userId: string;
     installationId: number;
     accountLogin: string | null;
     accountType: string | null;
   }>;
   projects: Array<Record<string, any>>;
+  sandboxes: Array<Record<string, any>>;
   worktrees: Array<Record<string, any>>;
 }
-const tables: Tables = { installations: [], projects: [], worktrees: [] };
+const tables: Tables = { installations: [], projects: [], sandboxes: [], worktrees: [] };
 
 vi.mock('./db', () => {
   const makeDb = () => ({
@@ -35,7 +37,12 @@ vi.mock('./db', () => {
     insert: (table: any) => ({
       values: (vals: any) => {
         const chain = {
-          onConflictDoNothing: async () => insertRow(table, vals),
+          onConflictDoNothing: (opts?: any) => {
+            const ret = insertIfAbsent(table, vals, opts);
+            const promise: any = Promise.resolve(ret ? [ret] : []);
+            promise.returning = async () => (ret ? [ret] : []);
+            return promise;
+          },
           onConflictDoUpdate: (opts: any) => {
             const ret = upsertRow(table, vals, opts);
             return { returning: async () => [ret] };
@@ -137,8 +144,13 @@ vi.mock('./sandbox', () => {
 let featureEnabled = true;
 vi.mock('./config', () => ({
   isGithubFeatureEnabled: () => featureEnabled,
-  signState: (userId: string) => `state.${userId}`,
-  verifyState: (state: string | undefined) => (state?.startsWith('state.') ? state.slice('state.'.length) : null),
+  signState: (orgId: string, userId: string) => `state.${orgId}.${userId}`,
+  verifyState: (state: string | undefined) => {
+    if (!state?.startsWith('state.')) return null;
+    const [orgId, userId] = state.slice('state.'.length).split('.');
+    if (!orgId || !userId) return null;
+    return { orgId, userId };
+  },
 }));
 
 import { mountGithubRoutes } from './routes';
@@ -147,10 +159,12 @@ import { mountGithubRoutes } from './routes';
 function tableKind(table: any): keyof Tables {
   if (table === installationsRef) return 'installations';
   if (table === worktreesRef) return 'worktrees';
+  if (table === sandboxesRef) return 'sandboxes';
   return 'projects';
 }
 let installationsRef: any;
 let worktreesRef: any;
+let sandboxesRef: any;
 
 function dbNameToJsKey(table: any, dbName: string): string {
   for (const [jsKey, col] of Object.entries(table)) {
@@ -185,13 +199,25 @@ function upsertRow(table: any, vals: any, opts: any): any {
   }
   return insertRow(table, vals);
 }
+function insertIfAbsent(table: any, vals: any, opts: any): any | undefined {
+  const kind = tableKind(table);
+  const targets: string[] = (opts?.target ?? [])
+    .map((col: any) => (col?.name ? dbNameToJsKey(table, col.name) : undefined))
+    .filter(Boolean);
+  const existing = targets.length
+    ? tables[kind].find(row => targets.every(t => (row as any)[t] === vals[t]))
+    : undefined;
+  if (existing) return undefined;
+  return insertRow(table, vals);
+}
 function updateRows(table: any, vals: any): void {
   for (const row of tables[tableKind(table)]) Object.assign(row, vals);
 }
 
-import { githubInstallations, githubWorktrees } from './schema';
+import { githubInstallations, githubProjectSandboxes, githubWorktrees } from './schema';
 installationsRef = githubInstallations;
 worktreesRef = githubWorktrees;
+sandboxesRef = githubProjectSandboxes;
 
 // A tiny deferred so S2 can control when a push resolves.
 function deferred<T = void>() {
@@ -204,7 +230,7 @@ function deferred<T = void>() {
   return { promise, resolve, reject };
 }
 
-function buildApp(user: { workosId: string } | null) {
+function buildApp(user: { workosId: string; organizationId?: string } | null) {
   const app = new Hono();
   app.use('*', async (c, next) => {
     if (user) c.set('webAuthUser' as never, user as never);
@@ -225,9 +251,13 @@ function postJson(app: ReturnType<typeof buildApp>, path: string, body: unknown)
 beforeEach(() => {
   tables.installations = [];
   tables.projects = [];
+  tables.sandboxes = [];
   tables.worktrees = [];
   featureEnabled = true;
   sandboxEnabled = true;
+  // No Postgres in these scenario tests: keep the project lock in-process.
+  // The in-process mutex still serializes same-replica callers (S2).
+  process.env.MASTRACODE_DISTRIBUTED_LOCK = '0';
   mintCount = 0;
   pushImpl = async () => {};
   ensureProjectSandbox.mockClear();
@@ -239,7 +269,10 @@ beforeEach(() => {
   createPullRequest.mockClear();
 });
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  delete process.env.MASTRACODE_DISTRIBUTED_LOCK;
+  vi.clearAllMocks();
+});
 
 // ── S1: full write-back journey ──────────────────────────────────────────
 describe('S1: full write-back journey through the real route handlers', () => {
@@ -248,8 +281,14 @@ describe('S1: full write-back journey through the real route handlers', () => {
       mintInstallationToken: ReturnType<typeof vi.fn>;
     };
     const mint = mintModule.mintInstallationToken;
-    tables.installations.push({ userId: 'u1', installationId: 7, accountLogin: 'octo', accountType: 'User' });
-    const app = buildApp({ workosId: 'u1' });
+    tables.installations.push({
+      orgId: 'org1',
+      userId: 'u1',
+      installationId: 7,
+      accountLogin: 'octo',
+      accountType: 'User',
+    });
+    const app = buildApp({ workosId: 'u1', organizationId: 'org1' });
 
     // 1. Create the project from an owned installation.
     const createRes = await postJson(app, '/api/web/github/projects', {
@@ -261,11 +300,16 @@ describe('S1: full write-back journey through the real route handlers', () => {
     expect(tables.projects).toHaveLength(1);
     expect(projectId).toBeTruthy();
 
-    // The project must be materializable: seed the sandbox binding the way
-    // `ensure` would persist it (the sandbox provisioning itself is mocked).
-    const projectRow = tables.projects[0];
-    projectRow.sandboxId = 'sb-1';
-    projectRow.sandboxWorkdir = '/workspace/hello';
+    // The project must be materializable: seed the per-(project,user) sandbox
+    // binding the way `ensure` would persist it (provisioning itself is mocked).
+    tables.sandboxes.push({
+      id: 'sbrow-1',
+      githubProjectId: projectId,
+      userId: 'u1',
+      sandboxId: 'sb-1',
+      sandboxWorkdir: '/workspace/hello',
+      materializedAt: null,
+    });
 
     // 2. Ensure → provisions the sandbox + materialises the repo.
     const ensureRes = await postJson(app, `/api/web/github/projects/${projectId}/ensure`, {});
@@ -335,22 +379,30 @@ describe('S1: full write-back journey through the real route handlers', () => {
 
 // ── S2: concurrent push serialisation (per-project mutex) ─────────────────
 describe('S2: per-project mutex serialises concurrent pushes', () => {
-  function seed(id: string, userId = 'u1') {
+  function seed(id: string, userId = 'u1', orgId = 'org1') {
     tables.projects.push({
       id,
+      orgId,
       userId,
       installationId: 7,
       repoFullName: 'octo/hello',
       repoId: 99,
       defaultBranch: 'main',
+      sandboxWorkdir: '/workspace/hello',
+    });
+    tables.sandboxes.push({
+      id: `sbrow-${id}`,
+      githubProjectId: id,
+      userId,
       sandboxId: `sb-${id}`,
       sandboxWorkdir: '/workspace/hello',
+      materializedAt: new Date(),
     });
   }
 
   it('does not start the second push for the same project until the first resolves', async () => {
     seed('p1');
-    const app = buildApp({ workosId: 'u1' });
+    const app = buildApp({ workosId: 'u1', organizationId: 'org1' });
 
     const order: string[] = [];
     const gate = deferred();
@@ -389,7 +441,7 @@ describe('S2: per-project mutex serialises concurrent pushes', () => {
   it('allows pushes for different projects to overlap', async () => {
     seed('p1');
     seed('p2');
-    const app = buildApp({ workosId: 'u1' });
+    const app = buildApp({ workosId: 'u1', organizationId: 'org1' });
 
     const gate = deferred();
     let active = 0;

--- a/mastracode/src/web/github/routes.test.ts
+++ b/mastracode/src/web/github/routes.test.ts
@@ -2,6 +2,14 @@ import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Mocks ────────────────────────────────────────────────────────────────
+// Mock drizzle's `eq`/`and` so the fake DB below can honour `where` predicates.
+// Each `eq(col, val)` yields a `{ column, value }` descriptor (using the
+// column's `.name`), and `and(...)` wraps them so `filterRows` can apply them.
+vi.mock('drizzle-orm', () => ({
+  eq: (column: any, value: any) => ({ kind: 'eq', column: column?.name, value }),
+  and: (...conds: any[]) => ({ kind: 'and', conds: conds.filter(Boolean) }),
+}));
+
 // In-memory tables so route handlers exercise real query-builder call shapes
 // against a tiny fake. We only model the operations the routes actually use.
 interface Tables {
@@ -12,22 +20,26 @@ interface Tables {
     accountType: string | null;
   }>;
   projects: Array<Record<string, any>>;
+  worktrees: Array<Record<string, any>>;
 }
-const tables: Tables = { installations: [], projects: [] };
+const tables: Tables = { installations: [], projects: [], worktrees: [] };
 
 vi.mock('./db', () => {
   // Minimal chainable drizzle-like stub keyed off the table object identity.
   const makeDb = () => ({
     select: () => ({
       from: (table: any) => ({
-        where: async () => filterRows(table),
+        where: async (cond: any) => filterRows(table, cond),
       }),
     }),
     insert: (table: any) => ({
       values: (vals: any) => {
         const chain = {
           onConflictDoNothing: async () => insertRow(table, vals),
-          onConflictDoUpdate: () => ({ returning: async () => [insertRow(table, vals)] }),
+          onConflictDoUpdate: (opts: any) => {
+            const ret = upsertRow(table, vals, opts);
+            return { returning: async () => [ret] };
+          },
           returning: async () => [insertRow(table, vals)],
         };
         return chain;
@@ -74,21 +86,49 @@ vi.mock('./client', () => ({
 
 const ensureProjectSandbox = vi.fn(async (_row: any) => ({ id: 'sb' }));
 const materializeRepo = vi.fn(async () => {});
+const reattachProjectSandbox = vi.fn(async (_id: string) => ({ id: 'sb' }));
+const ensureWorktree = vi.fn(async (_sb: any, _workdir: string, opts: { branch: string; baseBranch: string }) => ({
+  worktreePath: `/workspace/hello/../worktrees/${opts.branch}`,
+  branch: opts.branch,
+  baseBranch: opts.baseBranch,
+}));
+const commitAll = vi.fn(async () => ({ committed: true }));
+const pushBranch = vi.fn(async () => {});
+const createPullRequest = vi.fn(async () => ({ url: 'https://github.com/octo/hello/pull/1' }));
 let sandboxEnabled = true;
-vi.mock('./sandbox', () => ({
-  computeSandboxWorkdir: (repo: string) => `/workspace/${repo.split('/').pop()}`,
-  getSandboxProvider: () => 'railway',
-  isSandboxEnabled: () => sandboxEnabled,
-  ensureProjectSandbox: (row: any) => ensureProjectSandbox(row),
-  materializeRepo: (...args: any[]) => materializeRepo(...(args as [])),
-  MaterializeError: class extends Error {
+vi.mock('./sandbox', () => {
+  class MaterializeError extends Error {
     code: string;
     constructor(m: string, code: string) {
       super(m);
       this.code = code;
     }
-  },
-}));
+  }
+  class WorktreeError extends Error {
+    code: string;
+    constructor(m: string, code: string) {
+      super(m);
+      this.code = code;
+    }
+  }
+  return {
+    computeSandboxWorkdir: (repo: string) => `/workspace/${repo.split('/').pop()}`,
+    getSandboxProvider: () => 'railway',
+    isSandboxEnabled: () => sandboxEnabled,
+    ensureProjectSandbox: (row: any) => ensureProjectSandbox(row),
+    materializeRepo: (...args: any[]) => materializeRepo(...(args as [])),
+    reattachProjectSandbox: (id: string) => reattachProjectSandbox(id),
+    ensureWorktree: (sb: any, workdir: string, opts: any) => ensureWorktree(sb, workdir, opts),
+    commitAll: (...args: any[]) => commitAll(...(args as [])),
+    pushBranch: (...args: any[]) => pushBranch(...(args as [])),
+    createPullRequest: (...args: any[]) => createPullRequest(...(args as [])),
+    // Match the real ref validator closely enough for route tests.
+    isValidGitRef: (v: unknown): v is string =>
+      typeof v === 'string' && v.length > 0 && v.length <= 255 && /^[A-Za-z0-9_./-]+$/.test(v),
+    MaterializeError,
+    WorktreeError,
+  };
+});
 
 let featureEnabled = true;
 vi.mock('./config', () => ({
@@ -101,13 +141,34 @@ import { mountGithubRoutes } from './routes';
 
 // ── Fake table helpers ──────────────────────────────────────────────────
 function tableKind(table: any): keyof Tables {
-  return table === installationsRef ? 'installations' : 'projects';
+  if (table === installationsRef) return 'installations';
+  if (table === worktreesRef) return 'worktrees';
+  return 'projects';
 }
 // We can't import the actual schema objects easily into the closure used by the
 // mock above, so resolve them lazily here for the helpers.
 let installationsRef: any;
-function filterRows(table: any): any[] {
-  return [...tables[tableKind(table)]];
+let worktreesRef: any;
+
+// Drizzle columns carry their snake_case DB `.name`, but our fake rows use the
+// camelCase JS keys. Build a DB-name → JS-key map per table so predicates match.
+function dbNameToJsKey(table: any, dbName: string): string {
+  for (const [jsKey, col] of Object.entries(table)) {
+    if ((col as any)?.name === dbName) return jsKey;
+  }
+  return dbName;
+}
+
+// Apply a mocked `eq`/`and` predicate to a row.
+function matches(table: any, row: any, cond: any): boolean {
+  if (!cond) return true;
+  if (cond.kind === 'and') return cond.conds.every((c: any) => matches(table, row, c));
+  if (cond.kind === 'eq') return row[dbNameToJsKey(table, cond.column)] === cond.value;
+  return true;
+}
+
+function filterRows(table: any, cond?: any): any[] {
+  return tables[tableKind(table)].filter(row => matches(table, row, cond));
 }
 function insertRow(table: any, vals: any): any {
   const kind = tableKind(table);
@@ -115,13 +176,28 @@ function insertRow(table: any, vals: any): any {
   tables[kind].push(row as any);
   return row;
 }
+function upsertRow(table: any, vals: any, opts: any): any {
+  const kind = tableKind(table);
+  // Conflict targets are columns; match an existing row on all of them (mapped
+  // back to JS keys since vals/rows are camelCase).
+  const targets: string[] = (opts?.target ?? [])
+    .map((col: any) => (col?.name ? dbNameToJsKey(table, col.name) : undefined))
+    .filter(Boolean);
+  const existing = tables[kind].find(row => targets.every(t => row[t] === vals[t]));
+  if (existing) {
+    Object.assign(existing, opts?.set ?? {});
+    return existing;
+  }
+  return insertRow(table, vals);
+}
 function updateRows(table: any, vals: any): void {
   for (const row of tables[tableKind(table)]) Object.assign(row, vals);
 }
 
 // Resolve schema refs after import.
-import { githubInstallations } from './schema';
+import { githubInstallations, githubWorktrees } from './schema';
 installationsRef = githubInstallations;
+worktreesRef = githubWorktrees;
 
 // ── Test harness ─────────────────────────────────────────────────────────
 function buildApp(user: { workosId: string } | null) {
@@ -137,10 +213,16 @@ function buildApp(user: { workosId: string } | null) {
 beforeEach(() => {
   tables.installations = [];
   tables.projects = [];
+  tables.worktrees = [];
   featureEnabled = true;
   sandboxEnabled = true;
   ensureProjectSandbox.mockClear();
   materializeRepo.mockClear();
+  reattachProjectSandbox.mockClear();
+  ensureWorktree.mockClear();
+  commitAll.mockClear();
+  pushBranch.mockClear();
+  createPullRequest.mockClear();
 });
 
 afterEach(() => vi.clearAllMocks());
@@ -280,5 +362,199 @@ describe('ensure (materialize)', () => {
       method: 'POST',
     });
     expect(res.status).toBe(404);
+  });
+});
+
+// ── Phase 4: worktree / commit / push / pr git routes ─────────────────────
+function seedMaterializedProject(userId = 'u1') {
+  tables.projects.push({
+    id: 'p1',
+    userId,
+    installationId: 7,
+    repoFullName: 'octo/hello',
+    repoId: 99,
+    defaultBranch: 'main',
+    sandboxId: 'sb-1',
+    sandboxWorkdir: '/workspace/hello',
+  });
+}
+
+function postJson(app: ReturnType<typeof buildApp>, path: string, body: unknown) {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('worktree route', () => {
+  it('401s without an authenticated user', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp(null), '/api/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    expect(res.status).toBe(401);
+  });
+
+  it('503s when the sandbox is not configured', async () => {
+    sandboxEnabled = false;
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/worktree', {
+      branch: 'feat/x',
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it('404s for a project owned by another user', async () => {
+    seedMaterializedProject('someone-else');
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/worktree', {
+      branch: 'feat/x',
+    });
+    expect(res.status).toBe(404);
+    expect(ensureWorktree).not.toHaveBeenCalled();
+  });
+
+  it('400s on an invalid branch name', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/worktree', {
+      branch: 'bad branch!',
+    });
+    expect(res.status).toBe(400);
+    expect(ensureWorktree).not.toHaveBeenCalled();
+  });
+
+  it('creates a worktree, persists a row, and returns the path', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/worktree', {
+      branch: 'feat/x',
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.branch).toBe('feat/x');
+    expect(json.baseBranch).toBe('main');
+    expect(json.resourceId).toBe('p1');
+    expect(reattachProjectSandbox).toHaveBeenCalledWith('sb-1');
+    expect(ensureWorktree).toHaveBeenCalledOnce();
+    expect(tables.worktrees).toHaveLength(1);
+    expect(tables.worktrees[0]).toMatchObject({ githubProjectId: 'p1', branch: 'feat/x', userId: 'u1' });
+  });
+
+  it('upserts the worktree row on conflict instead of duplicating', async () => {
+    seedMaterializedProject();
+    const app = buildApp({ workosId: 'u1' });
+    await postJson(app, '/api/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    await postJson(app, '/api/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    expect(tables.worktrees).toHaveLength(1);
+  });
+});
+
+describe('commit route', () => {
+  it('400s on an empty message', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/commit', {
+      message: '   ',
+    });
+    expect(res.status).toBe(400);
+    expect(commitAll).not.toHaveBeenCalled();
+  });
+
+  it('400s on an unknown worktreePath', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/commit', {
+      message: 'wip',
+      worktreePath: '/etc/passwd',
+    });
+    expect(res.status).toBe(400);
+    expect(commitAll).not.toHaveBeenCalled();
+  });
+
+  it('commits on the base checkout when no worktreePath is given', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/commit', {
+      message: 'wip',
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ committed: true });
+    expect(commitAll).toHaveBeenCalledOnce();
+    // The base repo workdir is used when worktreePath is omitted.
+    expect((commitAll.mock.calls[0] as unknown as any[])[1]).toBe('/workspace/hello');
+  });
+
+  it('commits in a persisted worktree path', async () => {
+    seedMaterializedProject();
+    tables.worktrees.push({
+      id: 'w1',
+      userId: 'u1',
+      githubProjectId: 'p1',
+      branch: 'feat/x',
+      baseBranch: 'main',
+      worktreePath: '/workspace/worktrees/feat-x',
+    });
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/commit', {
+      message: 'wip',
+      worktreePath: '/workspace/worktrees/feat-x',
+    });
+    expect(res.status).toBe(200);
+    expect((commitAll.mock.calls[0] as unknown as any[])[1]).toBe('/workspace/worktrees/feat-x');
+  });
+});
+
+describe('push route', () => {
+  it('400s on an invalid branch', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/push', {
+      branch: 'bad branch',
+    });
+    expect(res.status).toBe(400);
+    expect(pushBranch).not.toHaveBeenCalled();
+  });
+
+  it('mints a token and pushes the branch', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/push', {
+      branch: 'feat/x',
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ pushed: true, branch: 'feat/x' });
+    expect(pushBranch).toHaveBeenCalledOnce();
+    // pushBranch(sandbox, workdir, branch, token, repoFullName)
+    const call = pushBranch.mock.calls[0] as unknown as any[];
+    expect(call[2]).toBe('feat/x');
+    expect(call[3]).toBe('install-token');
+    expect(call[4]).toBe('octo/hello');
+  });
+});
+
+describe('pr route', () => {
+  it('400s on a missing title', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/pr', {
+      branch: 'feat/x',
+    });
+    expect(res.status).toBe(400);
+    expect(createPullRequest).not.toHaveBeenCalled();
+  });
+
+  it('400s on an invalid base branch', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/pr', {
+      branch: 'feat/x',
+      base: 'bad base',
+      title: 'My PR',
+    });
+    expect(res.status).toBe(400);
+    expect(createPullRequest).not.toHaveBeenCalled();
+  });
+
+  it('opens a PR and returns its URL', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/pr', {
+      branch: 'feat/x',
+      title: 'My PR',
+      body: 'Adds a thing',
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ url: 'https://github.com/octo/hello/pull/1' });
+    expect(createPullRequest).toHaveBeenCalledOnce();
+    const opts = (createPullRequest.mock.calls[0] as unknown as any[])[2];
+    expect(opts).toMatchObject({ token: 'install-token', base: 'main', head: 'feat/x', title: 'My PR' });
   });
 });

--- a/mastracode/src/web/github/routes.test.ts
+++ b/mastracode/src/web/github/routes.test.ts
@@ -14,15 +14,17 @@ vi.mock('drizzle-orm', () => ({
 // against a tiny fake. We only model the operations the routes actually use.
 interface Tables {
   installations: Array<{
+    orgId?: string;
     userId: string;
     installationId: number;
     accountLogin: string | null;
     accountType: string | null;
   }>;
   projects: Array<Record<string, any>>;
+  sandboxes: Array<Record<string, any>>;
   worktrees: Array<Record<string, any>>;
 }
-const tables: Tables = { installations: [], projects: [], worktrees: [] };
+const tables: Tables = { installations: [], projects: [], sandboxes: [], worktrees: [] };
 
 vi.mock('./db', () => {
   // Minimal chainable drizzle-like stub keyed off the table object identity.
@@ -35,7 +37,12 @@ vi.mock('./db', () => {
     insert: (table: any) => ({
       values: (vals: any) => {
         const chain = {
-          onConflictDoNothing: async () => insertRow(table, vals),
+          onConflictDoNothing: (opts?: any) => {
+            const ret = insertIfAbsent(table, vals, opts);
+            const promise: any = Promise.resolve(ret ? [ret] : []);
+            promise.returning = async () => (ret ? [ret] : []);
+            return promise;
+          },
           onConflictDoUpdate: (opts: any) => {
             const ret = upsertRow(table, vals, opts);
             return { returning: async () => [ret] };
@@ -133,8 +140,13 @@ vi.mock('./sandbox', () => {
 let featureEnabled = true;
 vi.mock('./config', () => ({
   isGithubFeatureEnabled: () => featureEnabled,
-  signState: (userId: string) => `state.${userId}`,
-  verifyState: (state: string | undefined) => (state?.startsWith('state.') ? state.slice('state.'.length) : null),
+  signState: (orgId: string, userId: string) => `state.${orgId}.${userId}`,
+  verifyState: (state: string | undefined) => {
+    if (!state?.startsWith('state.')) return null;
+    const [orgId, userId] = state.slice('state.'.length).split('.');
+    if (!orgId || !userId) return null;
+    return { orgId, userId };
+  },
 }));
 
 import { mountGithubRoutes } from './routes';
@@ -143,12 +155,14 @@ import { mountGithubRoutes } from './routes';
 function tableKind(table: any): keyof Tables {
   if (table === installationsRef) return 'installations';
   if (table === worktreesRef) return 'worktrees';
+  if (table === sandboxesRef) return 'sandboxes';
   return 'projects';
 }
 // We can't import the actual schema objects easily into the closure used by the
 // mock above, so resolve them lazily here for the helpers.
 let installationsRef: any;
 let worktreesRef: any;
+let sandboxesRef: any;
 
 // Drizzle columns carry their snake_case DB `.name`, but our fake rows use the
 // camelCase JS keys. Build a DB-name → JS-key map per table so predicates match.
@@ -190,20 +204,39 @@ function upsertRow(table: any, vals: any, opts: any): any {
   }
   return insertRow(table, vals);
 }
+// onConflictDoNothing: insert only when no row matches the conflict target;
+// returns the inserted row, or undefined when a conflicting row already exists.
+function insertIfAbsent(table: any, vals: any, opts: any): any | undefined {
+  const kind = tableKind(table);
+  const targets: string[] = (opts?.target ?? [])
+    .map((col: any) => (col?.name ? dbNameToJsKey(table, col.name) : undefined))
+    .filter(Boolean);
+  if (targets.length) {
+    const existing = tables[kind].find(row => targets.every(t => row[t] === vals[t]));
+    if (existing) return undefined;
+  }
+  return insertRow(table, vals);
+}
 function updateRows(table: any, vals: any): void {
   for (const row of tables[tableKind(table)]) Object.assign(row, vals);
 }
 
 // Resolve schema refs after import.
-import { githubInstallations, githubWorktrees } from './schema';
+import { githubInstallations, githubProjectSandboxes, githubWorktrees } from './schema';
 installationsRef = githubInstallations;
 worktreesRef = githubWorktrees;
+sandboxesRef = githubProjectSandboxes;
 
 // ── Test harness ─────────────────────────────────────────────────────────
-function buildApp(user: { workosId: string } | null) {
+function buildApp(user: { workosId: string; organizationId?: string } | null) {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    if (user) c.set('webAuthUser' as never, user as never);
+    if (user) {
+      // Default to an organization so org-scoped GitHub features are enabled;
+      // tests that need a personal (no-org) account pass `organizationId` null.
+      const withOrg = 'organizationId' in user ? user : { ...user, organizationId: 'org1' };
+      c.set('webAuthUser' as never, withOrg as never);
+    }
     await next();
   });
   mountGithubRoutes(app as any, { baseUrl: 'http://localhost:4111' });
@@ -213,9 +246,12 @@ function buildApp(user: { workosId: string } | null) {
 beforeEach(() => {
   tables.installations = [];
   tables.projects = [];
+  tables.sandboxes = [];
   tables.worktrees = [];
   featureEnabled = true;
   sandboxEnabled = true;
+  // No Postgres in these unit tests: keep the project lock purely in-process.
+  process.env.MASTRACODE_DISTRIBUTED_LOCK = '0';
   ensureProjectSandbox.mockClear();
   materializeRepo.mockClear();
   reattachProjectSandbox.mockClear();
@@ -225,7 +261,10 @@ beforeEach(() => {
   createPullRequest.mockClear();
 });
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  delete process.env.MASTRACODE_DISTRIBUTED_LOCK;
+  vi.clearAllMocks();
+});
 
 describe('status route', () => {
   it('reports disabled without the feature', async () => {
@@ -235,7 +274,13 @@ describe('status route', () => {
   });
 
   it('reports connected installations for the user', async () => {
-    tables.installations.push({ userId: 'u1', installationId: 7, accountLogin: 'octo', accountType: 'User' });
+    tables.installations.push({
+      orgId: 'org1',
+      userId: 'u1',
+      installationId: 7,
+      accountLogin: 'octo',
+      accountType: 'User',
+    });
     const res = await buildApp({ workosId: 'u1' }).request('/api/web/github/status');
     const json = await res.json();
     expect(json.enabled).toBe(true);
@@ -255,23 +300,33 @@ describe('connect + callback', () => {
   it('redirects connect to the install URL with a signed state', async () => {
     const res = await buildApp({ workosId: 'u1' }).request('/auth/github/connect');
     expect(res.status).toBe(302);
-    expect(res.headers.get('location')).toContain('state=state.u1');
+    expect(res.headers.get('location')).toContain('state=state.org1.u1');
   });
 
   it('rejects a callback whose state belongs to another user', async () => {
-    const res = await buildApp({ workosId: 'u1' }).request('/auth/github/callback?state=state.someone-else&code=x');
+    const res = await buildApp({ workosId: 'u1' }).request(
+      '/auth/github/callback?state=state.org1.someone-else&code=x',
+    );
+    expect(res.headers.get('location')).toBe('/?github=error');
+    expect(tables.installations).toHaveLength(0);
+  });
+
+  it('rejects a callback whose state belongs to another org', async () => {
+    const res = await buildApp({ workosId: 'u1' }).request('/auth/github/callback?state=state.org2.u1&code=x');
     expect(res.headers.get('location')).toBe('/?github=error');
     expect(tables.installations).toHaveLength(0);
   });
 
   it('persists installations on a valid callback', async () => {
-    const res = await buildApp({ workosId: 'u1' }).request('/auth/github/callback?state=state.u1&code=abc');
+    const res = await buildApp({ workosId: 'u1' }).request('/auth/github/callback?state=state.org1.u1&code=abc');
     expect(res.headers.get('location')).toBe('/?github=connected');
     expect(tables.installations).toHaveLength(1);
   });
 
   it('does not trust an unverified installation_id without a code', async () => {
-    const res = await buildApp({ workosId: 'u1' }).request('/auth/github/callback?state=state.u1&installation_id=999');
+    const res = await buildApp({ workosId: 'u1' }).request(
+      '/auth/github/callback?state=state.org1.u1&installation_id=999',
+    );
     // No code → bounce through OAuth identify, persist nothing.
     expect(res.status).toBe(302);
     expect(res.headers.get('location')).toContain('/login/oauth/authorize');
@@ -281,7 +336,13 @@ describe('connect + callback', () => {
 
 describe('create project', () => {
   it('inserts a github-sourced project for an owned installation', async () => {
-    tables.installations.push({ userId: 'u1', installationId: 7, accountLogin: 'octo', accountType: 'User' });
+    tables.installations.push({
+      orgId: 'org1',
+      userId: 'u1',
+      installationId: 7,
+      accountLogin: 'octo',
+      accountType: 'User',
+    });
     const res = await buildApp({ workosId: 'u1' }).request('/api/web/github/projects', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -295,7 +356,13 @@ describe('create project', () => {
   });
 
   it('rejects an invalid repo name', async () => {
-    tables.installations.push({ userId: 'u1', installationId: 7, accountLogin: 'octo', accountType: 'User' });
+    tables.installations.push({
+      orgId: 'org1',
+      userId: 'u1',
+      installationId: 7,
+      accountLogin: 'octo',
+      accountType: 'User',
+    });
     const res = await buildApp({ workosId: 'u1' }).request('/api/web/github/projects', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -305,7 +372,13 @@ describe('create project', () => {
   });
 
   it('404s when the repo is not accessible to the installation', async () => {
-    tables.installations.push({ userId: 'u1', installationId: 7, accountLogin: 'octo', accountType: 'User' });
+    tables.installations.push({
+      orgId: 'org1',
+      userId: 'u1',
+      installationId: 7,
+      accountLogin: 'octo',
+      accountType: 'User',
+    });
     const res = await buildApp({ workosId: 'u1' }).request('/api/web/github/projects', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -315,7 +388,13 @@ describe('create project', () => {
   });
 
   it('persists the server-returned defaultBranch, ignoring the client value', async () => {
-    tables.installations.push({ userId: 'u1', installationId: 7, accountLogin: 'octo', accountType: 'User' });
+    tables.installations.push({
+      orgId: 'org1',
+      userId: 'u1',
+      installationId: 7,
+      accountLogin: 'octo',
+      accountType: 'User',
+    });
     const res = await buildApp({ workosId: 'u1' }).request('/api/web/github/projects', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -342,19 +421,37 @@ describe('create project', () => {
 describe('ensure (materialize)', () => {
   it('503s when the sandbox is not configured', async () => {
     sandboxEnabled = false;
-    tables.projects.push({ id: 'p1', userId: 'u1', installationId: 7, repoFullName: 'octo/hello' });
+    tables.projects.push({
+      id: 'p1',
+      orgId: 'org1',
+      userId: 'u1',
+      installationId: 7,
+      repoFullName: 'octo/hello',
+      sandboxWorkdir: '/workspace/hello',
+    });
     const res = await buildApp({ workosId: 'u1' }).request('/api/web/github/projects/p1/ensure', { method: 'POST' });
     expect(res.status).toBe(503);
     expect((await res.json()).error).toBe('sandbox_not_configured');
   });
 
   it('provisions + materializes and returns a resourceId', async () => {
-    tables.projects.push({ id: 'p1', userId: 'u1', installationId: 7, repoFullName: 'octo/hello' });
+    tables.projects.push({
+      id: 'p1',
+      orgId: 'org1',
+      userId: 'u1',
+      installationId: 7,
+      repoFullName: 'octo/hello',
+      defaultBranch: 'main',
+      sandboxWorkdir: '/workspace/hello',
+    });
     const res = await buildApp({ workosId: 'u1' }).request('/api/web/github/projects/p1/ensure', { method: 'POST' });
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ resourceId: 'p1', githubProjectId: 'p1' });
     expect(ensureProjectSandbox).toHaveBeenCalledOnce();
     expect(materializeRepo).toHaveBeenCalledOnce();
+    // A per-user sandbox binding row was created for the caller.
+    expect(tables.sandboxes).toHaveLength(1);
+    expect(tables.sandboxes[0]).toMatchObject({ githubProjectId: 'p1', userId: 'u1' });
   });
 
   it('404s for a project the user does not own', async () => {
@@ -366,16 +463,26 @@ describe('ensure (materialize)', () => {
 });
 
 // ── Phase 4: worktree / commit / push / pr git routes ─────────────────────
-function seedMaterializedProject(userId = 'u1') {
+function seedMaterializedProject(opts: { orgId?: string; userId?: string } = {}) {
+  const orgId = opts.orgId ?? 'org1';
+  const userId = opts.userId ?? 'u1';
   tables.projects.push({
     id: 'p1',
+    orgId,
     userId,
     installationId: 7,
     repoFullName: 'octo/hello',
     repoId: 99,
     defaultBranch: 'main',
+    sandboxWorkdir: '/workspace/hello',
+  });
+  tables.sandboxes.push({
+    id: 'sbrow-1',
+    githubProjectId: 'p1',
+    userId,
     sandboxId: 'sb-1',
     sandboxWorkdir: '/workspace/hello',
+    materializedAt: new Date(),
   });
 }
 
@@ -403,8 +510,8 @@ describe('worktree route', () => {
     expect(res.status).toBe(503);
   });
 
-  it('404s for a project owned by another user', async () => {
-    seedMaterializedProject('someone-else');
+  it('404s for a project owned by another org', async () => {
+    seedMaterializedProject({ orgId: 'other-org' });
     const res = await postJson(buildApp({ workosId: 'u1' }), '/api/web/github/projects/p1/worktree', {
       branch: 'feat/x',
     });

--- a/mastracode/src/web/github/routes.ts
+++ b/mastracode/src/web/github/routes.ts
@@ -13,7 +13,8 @@
 
 import { and, eq } from 'drizzle-orm';
 import type { Context, Hono } from 'hono';
-import { getWebAuthUser, getWebAuthUserId } from '../auth';
+import { getWebAuthUser, webAuthTenant } from '../auth';
+import type { WebAuthTenant } from '../auth';
 import {
   buildInstallUrl,
   buildOAuthIdentifyUrl,
@@ -25,6 +26,7 @@ import {
 } from './client';
 import { isGithubFeatureEnabled, signState, verifyState } from './config';
 import { getAppDb } from './db';
+import { withProjectLock } from './project-lock';
 import {
   commitAll,
   computeSandboxWorkdir,
@@ -38,11 +40,13 @@ import {
   MaterializeError,
   pushBranch,
   reattachProjectSandbox,
+  SandboxBudgetError,
+  teardownProjectSandbox,
   WorktreeError,
 } from './sandbox';
 import type { GitIdentity, MaterializationSandbox } from './sandbox';
-import { githubInstallations, githubProjects, githubWorktrees } from './schema';
-import type { GithubProjectRow } from './schema';
+import { githubInstallations, githubProjects, githubProjectSandboxes, githubWorktrees } from './schema';
+import type { GithubProjectRow, GithubProjectSandboxRow } from './schema';
 
 export interface MountGithubRoutesOptions {
   /**
@@ -70,6 +74,30 @@ function isValidGitRef(value: unknown): value is string {
 }
 
 /**
+ * Resolve the org-scoped tenant for a GitHub request. GitHub project features
+ * are org-owned, so they require both a signed-in user and a WorkOS
+ * organization. Returns the `(orgId, userId)` tenant (with `orgId` narrowed to a
+ * non-null string) or a ready-to-return error response: 401 when unauthenticated,
+ * 403 when the user has no organization (personal account).
+ */
+function resolveOrgTenant(c: Context): { tenant: WebAuthTenant & { orgId: string } } | { response: Response } {
+  const tenant = webAuthTenant(c);
+  if (!tenant) return { response: c.json({ error: 'unauthorized' }, 401) };
+  if (!tenant.orgId) {
+    return {
+      response: c.json(
+        {
+          error: 'organization_required',
+          message: 'GitHub projects require a WorkOS organization. Personal accounts cannot connect repositories.',
+        },
+        403,
+      ),
+    };
+  }
+  return { tenant: { orgId: tenant.orgId, userId: tenant.userId } };
+}
+
+/**
  * Shape returned to the SPA for a GitHub-backed project, matching the front-end
  * `Project` model (`source: 'github'`).
  */
@@ -91,10 +119,22 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
     if (!isGithubFeatureEnabled()) {
       return c.json({ enabled: false, connected: false, installations: [] });
     }
-    const userId = getWebAuthUserId(getWebAuthUser(c));
-    if (!userId) return c.json({ error: 'unauthorized' }, 401);
+    const tenant = webAuthTenant(c);
+    if (!tenant) return c.json({ error: 'unauthorized' }, 401);
 
-    const rows = await getAppDb().select().from(githubInstallations).where(eq(githubInstallations.userId, userId));
+    // Org-scoped: personal (no-org) users have GitHub projects disabled. Report
+    // enabled (so the SPA can show the org-required hint) but never connected.
+    if (!tenant.orgId) {
+      return c.json({
+        enabled: true,
+        sandboxEnabled: isSandboxEnabled(),
+        organizationRequired: true,
+        connected: false,
+        installations: [],
+      });
+    }
+
+    const rows = await getAppDb().select().from(githubInstallations).where(eq(githubInstallations.orgId, tenant.orgId));
 
     return c.json({
       enabled: true,
@@ -116,22 +156,23 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
 
   // ── Connect: redirect to the GitHub App install URL ─────────────────────
   app.get('/auth/github/connect', c => {
-    const userId = getWebAuthUserId(getWebAuthUser(c));
-    if (!userId) return c.json({ error: 'unauthorized' }, 401);
-    const state = signState(userId);
+    const resolved = resolveOrgTenant(c);
+    if ('response' in resolved) return resolved.response;
+    const state = signState(resolved.tenant.orgId, resolved.tenant.userId);
     return c.redirect(buildInstallUrl(state));
   });
 
-  // ── Callback: confirm identity, persist the installation ────────────────
+  // ── Callback: confirm identity, persist the installation against the org ──
   app.get('/auth/github/callback', async c => {
-    const userId = getWebAuthUserId(getWebAuthUser(c));
-    if (!userId) return c.json({ error: 'unauthorized' }, 401);
+    const resolved = resolveOrgTenant(c);
+    if ('response' in resolved) return resolved.response;
+    const { orgId, userId } = resolved.tenant;
 
     const state = c.req.query('state');
-    const stateUserId = verifyState(state);
-    if (!stateUserId || stateUserId !== userId) {
-      // CSRF / cross-user linking protection: the signed state must belong to
-      // the same logged-in user.
+    const stateTenant = verifyState(state);
+    if (!stateTenant || stateTenant.userId !== userId || stateTenant.orgId !== orgId) {
+      // CSRF / cross-user/org linking protection: the signed state must belong
+      // to the same logged-in user *and* their current org.
       return c.redirect('/?github=error');
     }
 
@@ -142,7 +183,7 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
     // an arbitrary id — so when no code is present we bounce through the OAuth
     // identify flow to obtain a verified user token first.
     if (!code) {
-      return c.redirect(buildOAuthIdentifyUrl(signState(userId), redirectUri));
+      return c.redirect(buildOAuthIdentifyUrl(signState(orgId, userId), redirectUri));
     }
 
     try {
@@ -150,16 +191,18 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
       const installations = await listUserInstallations(userToken);
       const db = getAppDb();
       for (const inst of installations) {
+        // The installation is org-owned; `userId` records who connected it.
         await db
           .insert(githubInstallations)
           .values({
+            orgId,
             userId,
             installationId: inst.installationId,
             accountLogin: inst.accountLogin,
             accountType: inst.accountType,
           })
           .onConflictDoNothing({
-            target: [githubInstallations.userId, githubInstallations.installationId],
+            target: [githubInstallations.orgId, githubInstallations.installationId],
           });
       }
     } catch {
@@ -169,12 +212,15 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
     return c.redirect('/?github=connected');
   });
 
-  // ── List repos across the user's installations ──────────────────────────
+  // ── List repos across the org's installations ───────────────────────────
   app.get('/api/web/github/repos', async c => {
-    const userId = getWebAuthUserId(getWebAuthUser(c));
-    if (!userId) return c.json({ error: 'unauthorized' }, 401);
+    const resolved = resolveOrgTenant(c);
+    if ('response' in resolved) return resolved.response;
 
-    const installs = await getAppDb().select().from(githubInstallations).where(eq(githubInstallations.userId, userId));
+    const installs = await getAppDb()
+      .select()
+      .from(githubInstallations)
+      .where(eq(githubInstallations.orgId, resolved.tenant.orgId));
 
     const query = (c.req.query('q') ?? '').toLowerCase();
     const repos = [];
@@ -190,8 +236,9 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
 
   // ── Create a project from a repo (no sandbox, no clone yet) ──────────────
   app.post('/api/web/github/projects', async c => {
-    const userId = getWebAuthUserId(getWebAuthUser(c));
-    if (!userId) return c.json({ error: 'unauthorized' }, 401);
+    const resolved = resolveOrgTenant(c);
+    if ('response' in resolved) return resolved.response;
+    const { orgId, userId } = resolved.tenant;
 
     let body: { repoFullName?: unknown; installationId?: unknown };
     try {
@@ -208,13 +255,13 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
       return c.json({ error: 'Invalid installationId' }, 400);
     }
 
-    // The installation must belong to this user.
+    // The installation must belong to this org.
     const owned = await getAppDb()
       .select()
       .from(githubInstallations)
-      .where(and(eq(githubInstallations.userId, userId), eq(githubInstallations.installationId, installationId)));
+      .where(and(eq(githubInstallations.orgId, orgId), eq(githubInstallations.installationId, installationId)));
     if (owned.length === 0) {
-      return c.json({ error: 'Installation not found for user' }, 404);
+      return c.json({ error: 'Installation not found for organization' }, 404);
     }
 
     // Verify the repo is actually accessible to the installation and use the
@@ -230,6 +277,7 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
     const [row] = await getAppDb()
       .insert(githubProjects)
       .values({
+        orgId,
         userId,
         installationId,
         repoFullName: repo.fullName,
@@ -239,7 +287,7 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
         sandboxWorkdir,
       })
       .onConflictDoUpdate({
-        target: [githubProjects.userId, githubProjects.repoId],
+        target: [githubProjects.orgId, githubProjects.repoId],
         set: { installationId, repoFullName: repo.fullName, defaultBranch, sandboxWorkdir },
       })
       .returning();
@@ -247,39 +295,54 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
     return c.json({ project: toProjectPayload(row!) });
   });
 
-  // ── Materialize a project into its sandbox ──────────────────────────────
+  // ── Materialize a project into the caller's per-user sandbox ─────────────
   app.post('/api/web/github/projects/:id/ensure', async c => {
-    const userId = getWebAuthUserId(getWebAuthUser(c));
-    if (!userId) return c.json({ error: 'unauthorized' }, 401);
+    const resolved = resolveOrgTenant(c);
+    if ('response' in resolved) return resolved.response;
+    const { orgId, userId } = resolved.tenant;
 
     if (!isSandboxEnabled()) {
       return c.json({ error: 'sandbox_not_configured', message: 'No sandbox provider is configured.' }, 503);
     }
 
     const projectId = c.req.param('id');
-    const [row] = await getAppDb()
+    if (!projectId) return c.json({ error: 'Project not found' }, 404);
+    const [project] = await getAppDb()
       .select()
       .from(githubProjects)
-      .where(and(eq(githubProjects.id, projectId), eq(githubProjects.userId, userId)));
-    if (!row) {
+      .where(and(eq(githubProjects.id, projectId), eq(githubProjects.orgId, orgId)));
+    if (!project) {
       return c.json({ error: 'Project not found' }, 404);
     }
 
+    const sandboxRow = await loadOrCreateSandboxRow(project, userId);
+
     try {
-      const sandbox = await ensureProjectSandbox(row);
-      // Re-read the row so we have the freshly persisted sandboxId.
-      const [fresh] = await getAppDb().select().from(githubProjects).where(eq(githubProjects.id, row.id));
-      const token = await mintInstallationToken(row.installationId);
-      const finalRow = fresh ?? row;
-      await materializeRepo(finalRow, sandbox, token);
+      const sandbox = await ensureProjectSandbox(sandboxRow);
+      // Re-read the sandbox binding so we have the freshly persisted sandboxId.
+      const [fresh] = await getAppDb()
+        .select()
+        .from(githubProjectSandboxes)
+        .where(eq(githubProjectSandboxes.id, sandboxRow.id));
+      const token = await mintInstallationToken(project.installationId);
+      const finalRow = fresh ?? sandboxRow;
+      await materializeRepo(
+        finalRow,
+        { repoFullName: project.repoFullName, defaultBranch: project.defaultBranch },
+        sandbox,
+        token,
+      );
 
       return c.json({
-        resourceId: row.id,
-        githubProjectId: row.id,
+        resourceId: project.id,
+        githubProjectId: project.id,
         sandboxId: finalRow.sandboxId,
         sandboxWorkdir: finalRow.sandboxWorkdir,
       });
     } catch (err) {
+      if (err instanceof SandboxBudgetError) {
+        return c.json({ error: err.code, message: err.message }, 429);
+      }
       if (err instanceof MaterializeError) {
         return c.json({ error: err.code, message: err.message }, 502);
       }
@@ -293,47 +356,52 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
   return true;
 }
 
-/**
- * In-process per-project async mutex. The push/PR flows temporarily rewrite the
- * sandbox git remote to a tokenized URL and scrub it again in a `finally`; two
- * concurrent operations on the same project could interleave those rewrites and
- * leak a tokenized remote. Serializing per `githubProjectId` removes that race.
- *
- * This lock is in-process only; multi-replica deploys need a shared lock
- * (called out as out-of-scope follow-up in the plan).
- */
-const projectLocks = new Map<string, Promise<unknown>>();
-
-function withProjectLock<T>(projectId: string, fn: () => Promise<T>): Promise<T> {
-  const prev = projectLocks.get(projectId) ?? Promise.resolve();
-  const next = prev.then(fn, fn);
-  // Keep the chain alive but swallow rejections so one failure doesn't poison
-  // the lock for subsequent callers.
-  projectLocks.set(
-    projectId,
-    next.then(
-      () => undefined,
-      () => undefined,
-    ),
-  );
-  return next;
-}
-
 /** Derive a commit/author identity from the authenticated WorkOS user. */
 function identityFromUser(user: { name?: string; email?: string } | undefined): GitIdentity {
   return { name: user?.name ?? null, email: user?.email ?? null };
 }
 
 /**
- * Resolve a live, started sandbox for a project row. The project must already
- * have been materialized (`sandboxId` set) — the git write routes never clone,
- * they operate on the existing checkout.
+ * Resolve a live, started sandbox for the caller's per-user sandbox binding. The
+ * sandbox must already have been provisioned (`sandboxId` set) — the git write
+ * routes never clone, they operate on the existing checkout.
  */
-async function resolveProjectSandbox(row: GithubProjectRow): Promise<MaterializationSandbox> {
-  if (!row.sandboxId) {
+async function resolveProjectSandbox(sandboxRow: GithubProjectSandboxRow): Promise<MaterializationSandbox> {
+  if (!sandboxRow.sandboxId) {
     throw new MaterializeError('Project sandbox is not provisioned. Open the project first.', 'clone-failed');
   }
-  return reattachProjectSandbox(row.sandboxId);
+  return reattachProjectSandbox(sandboxRow.sandboxId);
+}
+
+/**
+ * Load (or create) the caller's per-(project,user) sandbox binding row. The
+ * binding inherits its workdir from the org-owned project, but `sandboxId` /
+ * `materializedAt` stay null until the user first opens the project.
+ */
+async function loadOrCreateSandboxRow(project: GithubProjectRow, userId: string): Promise<GithubProjectSandboxRow> {
+  const [existing] = await getAppDb()
+    .select()
+    .from(githubProjectSandboxes)
+    .where(and(eq(githubProjectSandboxes.githubProjectId, project.id), eq(githubProjectSandboxes.userId, userId)));
+  if (existing) return existing;
+
+  const [created] = await getAppDb()
+    .insert(githubProjectSandboxes)
+    .values({
+      githubProjectId: project.id,
+      userId,
+      sandboxWorkdir: project.sandboxWorkdir,
+    })
+    .onConflictDoNothing({ target: [githubProjectSandboxes.githubProjectId, githubProjectSandboxes.userId] })
+    .returning();
+  if (created) return created;
+
+  // Lost a race: another request inserted the binding first. Re-read it.
+  const [row] = await getAppDb()
+    .select()
+    .from(githubProjectSandboxes)
+    .where(and(eq(githubProjectSandboxes.githubProjectId, project.id), eq(githubProjectSandboxes.userId, userId)));
+  return row!;
 }
 
 /** Map a sandbox/worktree error to an actionable HTTP response. */
@@ -348,15 +416,21 @@ function gitErrorResponse(c: Context, err: unknown) {
 }
 
 /**
- * Look up a project row scoped to the authenticated user. Returns the userId and
- * row, or a ready-to-return error response. Centralizes the auth + ownership
- * checks every git route shares.
+ * Load the org-owned project and the caller's per-user sandbox binding for a git
+ * route. Centralizes the auth + org/ownership checks every git route shares:
+ * the project is scoped by `(id, orgId)`, the sandbox binding by
+ * `(githubProjectId, userId)`. Returns the tenant, project, and sandbox row, or
+ * a ready-to-return error response.
  */
 async function loadOwnedProject(
   c: Context,
-): Promise<{ userId: string; row: GithubProjectRow } | { response: Response }> {
-  const userId = getWebAuthUserId(getWebAuthUser(c));
-  if (!userId) return { response: c.json({ error: 'unauthorized' }, 401) };
+): Promise<
+  | { orgId: string; userId: string; project: GithubProjectRow; sandboxRow: GithubProjectSandboxRow }
+  | { response: Response }
+> {
+  const resolved = resolveOrgTenant(c);
+  if ('response' in resolved) return { response: resolved.response };
+  const { orgId, userId } = resolved.tenant;
 
   if (!isSandboxEnabled()) {
     return {
@@ -368,14 +442,15 @@ async function loadOwnedProject(
   if (!projectId) {
     return { response: c.json({ error: 'Project not found' }, 404) };
   }
-  const [row] = await getAppDb()
+  const [project] = await getAppDb()
     .select()
     .from(githubProjects)
-    .where(and(eq(githubProjects.id, projectId), eq(githubProjects.userId, userId)));
-  if (!row) {
+    .where(and(eq(githubProjects.id, projectId), eq(githubProjects.orgId, orgId)));
+  if (!project) {
     return { response: c.json({ error: 'Project not found' }, 404) };
   }
-  return { userId, row };
+  const sandboxRow = await loadOrCreateSandboxRow(project, userId);
+  return { orgId, userId, project, sandboxRow };
 }
 
 function mountProjectGitRoutes(app: Hono<any>): void {
@@ -383,7 +458,7 @@ function mountProjectGitRoutes(app: Hono<any>): void {
   app.post('/api/web/github/projects/:id/worktree', async c => {
     const owned = await loadOwnedProject(c);
     if ('response' in owned) return owned.response;
-    const { userId, row } = owned;
+    const { orgId, userId, project, sandboxRow } = owned;
 
     let body: { branch?: unknown; baseBranch?: unknown };
     try {
@@ -394,28 +469,29 @@ function mountProjectGitRoutes(app: Hono<any>): void {
     if (!isValidGitRefSandbox(body.branch)) {
       return c.json({ error: 'Invalid branch' }, 400);
     }
-    const baseBranch = body.baseBranch === undefined ? row.defaultBranch : body.baseBranch;
+    const baseBranch = body.baseBranch === undefined ? project.defaultBranch : body.baseBranch;
     if (!isValidGitRefSandbox(baseBranch)) {
       return c.json({ error: 'Invalid baseBranch' }, 400);
     }
     const branch = body.branch;
 
     try {
-      return await withProjectLock(row.id, async () => {
-        const sandbox = await resolveProjectSandbox(row);
-        const result = await ensureWorktree(sandbox, row.sandboxWorkdir, { branch, baseBranch });
+      return await withProjectLock(`${project.id}:${userId}`, async () => {
+        const sandbox = await resolveProjectSandbox(sandboxRow);
+        const result = await ensureWorktree(sandbox, sandboxRow.sandboxWorkdir, { branch, baseBranch });
 
         await getAppDb()
           .insert(githubWorktrees)
           .values({
+            orgId,
             userId,
-            githubProjectId: row.id,
+            githubProjectId: project.id,
             branch: result.branch,
             baseBranch: result.baseBranch,
             worktreePath: result.worktreePath,
           })
           .onConflictDoUpdate({
-            target: [githubWorktrees.githubProjectId, githubWorktrees.branch],
+            target: [githubWorktrees.githubProjectId, githubWorktrees.userId, githubWorktrees.branch],
             set: { baseBranch: result.baseBranch, worktreePath: result.worktreePath },
           });
 
@@ -423,7 +499,7 @@ function mountProjectGitRoutes(app: Hono<any>): void {
           worktreePath: result.worktreePath,
           branch: result.branch,
           baseBranch: result.baseBranch,
-          resourceId: row.id,
+          resourceId: project.id,
         });
       });
     } catch (err) {
@@ -435,7 +511,7 @@ function mountProjectGitRoutes(app: Hono<any>): void {
   app.post('/api/web/github/projects/:id/commit', async c => {
     const owned = await loadOwnedProject(c);
     if ('response' in owned) return owned.response;
-    const { row } = owned;
+    const { userId, project, sandboxRow } = owned;
 
     let body: { message?: unknown; worktreePath?: unknown };
     try {
@@ -446,14 +522,14 @@ function mountProjectGitRoutes(app: Hono<any>): void {
     if (typeof body.message !== 'string' || body.message.trim().length === 0 || body.message.length > 5000) {
       return c.json({ error: 'Invalid message' }, 400);
     }
-    const workdir = await resolveWorktreePath(row.id, body.worktreePath, row.sandboxWorkdir);
+    const workdir = await resolveWorktreePath(project.id, userId, body.worktreePath, sandboxRow.sandboxWorkdir);
     if (!workdir) {
       return c.json({ error: 'Invalid worktreePath' }, 400);
     }
 
     try {
-      return await withProjectLock(row.id, async () => {
-        const sandbox = await resolveProjectSandbox(row);
+      return await withProjectLock(`${project.id}:${userId}`, async () => {
+        const sandbox = await resolveProjectSandbox(sandboxRow);
         const result = await commitAll(sandbox, workdir, body.message as string, identityFromUser(getWebAuthUser(c)));
         return c.json({ committed: result.committed });
       });
@@ -466,7 +542,7 @@ function mountProjectGitRoutes(app: Hono<any>): void {
   app.post('/api/web/github/projects/:id/push', async c => {
     const owned = await loadOwnedProject(c);
     if ('response' in owned) return owned.response;
-    const { row } = owned;
+    const { userId, project, sandboxRow } = owned;
 
     let body: { branch?: unknown; worktreePath?: unknown };
     try {
@@ -478,16 +554,16 @@ function mountProjectGitRoutes(app: Hono<any>): void {
       return c.json({ error: 'Invalid branch' }, 400);
     }
     const branch = body.branch;
-    const workdir = await resolveWorktreePath(row.id, body.worktreePath, row.sandboxWorkdir);
+    const workdir = await resolveWorktreePath(project.id, userId, body.worktreePath, sandboxRow.sandboxWorkdir);
     if (!workdir) {
       return c.json({ error: 'Invalid worktreePath' }, 400);
     }
 
     try {
-      return await withProjectLock(row.id, async () => {
-        const sandbox = await resolveProjectSandbox(row);
-        const token = await mintInstallationToken(row.installationId);
-        await pushBranch(sandbox, workdir, branch, token, row.repoFullName);
+      return await withProjectLock(`${project.id}:${userId}`, async () => {
+        const sandbox = await resolveProjectSandbox(sandboxRow);
+        const token = await mintInstallationToken(project.installationId);
+        await pushBranch(sandbox, workdir, branch, token, project.repoFullName);
         return c.json({ pushed: true, branch });
       });
     } catch (err) {
@@ -499,7 +575,7 @@ function mountProjectGitRoutes(app: Hono<any>): void {
   app.post('/api/web/github/projects/:id/pr', async c => {
     const owned = await loadOwnedProject(c);
     if ('response' in owned) return owned.response;
-    const { row } = owned;
+    const { userId, project, sandboxRow } = owned;
 
     let body: { branch?: unknown; base?: unknown; title?: unknown; body?: unknown; worktreePath?: unknown };
     try {
@@ -510,7 +586,7 @@ function mountProjectGitRoutes(app: Hono<any>): void {
     if (!isValidGitRefSandbox(body.branch)) {
       return c.json({ error: 'Invalid branch' }, 400);
     }
-    const base = body.base === undefined ? row.defaultBranch : body.base;
+    const base = body.base === undefined ? project.defaultBranch : body.base;
     if (!isValidGitRefSandbox(base)) {
       return c.json({ error: 'Invalid base' }, 400);
     }
@@ -523,17 +599,42 @@ function mountProjectGitRoutes(app: Hono<any>): void {
     const head = body.branch;
     const title = body.title;
     const prBody = body.body as string | undefined;
-    const workdir = await resolveWorktreePath(row.id, body.worktreePath, row.sandboxWorkdir);
+    const workdir = await resolveWorktreePath(project.id, userId, body.worktreePath, sandboxRow.sandboxWorkdir);
     if (!workdir) {
       return c.json({ error: 'Invalid worktreePath' }, 400);
     }
 
     try {
-      return await withProjectLock(row.id, async () => {
-        const sandbox = await resolveProjectSandbox(row);
-        const token = await mintInstallationToken(row.installationId);
+      return await withProjectLock(`${project.id}:${userId}`, async () => {
+        const sandbox = await resolveProjectSandbox(sandboxRow);
+        const token = await mintInstallationToken(project.installationId);
         const result = await createPullRequest(sandbox, workdir, { token, base, head, title, body: prBody });
         return c.json({ url: result.url });
+      });
+    } catch (err) {
+      return gitErrorResponse(c, err);
+    }
+  });
+
+  // ── Tear down the caller's sandbox for a project ────────────────────────
+  // Per-user teardown only: drops the caller's `(project, user)` sandbox
+  // binding and stops the VM, freeing a slot in the per-replica budget. Project
+  // deletion at the org level is out of scope (org admin model is later).
+  app.delete('/api/web/github/projects/:id/sandbox', async c => {
+    const owned = await loadOwnedProject(c);
+    if ('response' in owned) return owned.response;
+    const { userId, project, sandboxRow } = owned;
+
+    if (!sandboxRow.sandboxId) {
+      // Nothing provisioned for this user — idempotent success.
+      return c.json({ tornDown: false });
+    }
+
+    try {
+      return await withProjectLock(`${project.id}:${userId}`, async () => {
+        const sandbox = await reattachProjectSandbox(sandboxRow.sandboxId!);
+        await teardownProjectSandbox(sandboxRow, sandbox);
+        return c.json({ tornDown: true });
       });
     } catch (err) {
       return gitErrorResponse(c, err);
@@ -550,6 +651,7 @@ function mountProjectGitRoutes(app: Hono<any>): void {
  */
 async function resolveWorktreePath(
   projectId: string,
+  userId: string,
   worktreePath: unknown,
   repoWorkdir: string,
 ): Promise<string | undefined> {
@@ -562,6 +664,12 @@ async function resolveWorktreePath(
   const [row] = await getAppDb()
     .select()
     .from(githubWorktrees)
-    .where(and(eq(githubWorktrees.githubProjectId, projectId), eq(githubWorktrees.worktreePath, worktreePath)));
+    .where(
+      and(
+        eq(githubWorktrees.githubProjectId, projectId),
+        eq(githubWorktrees.userId, userId),
+        eq(githubWorktrees.worktreePath, worktreePath),
+      ),
+    );
   return row ? row.worktreePath : undefined;
 }

--- a/mastracode/src/web/github/routes.ts
+++ b/mastracode/src/web/github/routes.ts
@@ -12,7 +12,7 @@
  */
 
 import { and, eq } from 'drizzle-orm';
-import type { Hono } from 'hono';
+import type { Context, Hono } from 'hono';
 import { getWebAuthUser, getWebAuthUserId } from '../auth';
 import {
   buildInstallUrl,
@@ -26,14 +26,22 @@ import {
 import { isGithubFeatureEnabled, signState, verifyState } from './config';
 import { getAppDb } from './db';
 import {
+  commitAll,
   computeSandboxWorkdir,
+  createPullRequest,
   ensureProjectSandbox,
+  ensureWorktree,
   getSandboxProvider,
   isSandboxEnabled,
+  isValidGitRef as isValidGitRefSandbox,
   materializeRepo,
   MaterializeError,
+  pushBranch,
+  reattachProjectSandbox,
+  WorktreeError,
 } from './sandbox';
-import { githubInstallations, githubProjects } from './schema';
+import type { GitIdentity, MaterializationSandbox } from './sandbox';
+import { githubInstallations, githubProjects, githubWorktrees } from './schema';
 import type { GithubProjectRow } from './schema';
 
 export interface MountGithubRoutesOptions {
@@ -279,5 +287,281 @@ export function mountGithubRoutes(app: Hono<any>, options: MountGithubRoutesOpti
     }
   });
 
+  // ── Worktree / branch / commit / push / PR ──────────────────────────────
+  mountProjectGitRoutes(app);
+
   return true;
+}
+
+/**
+ * In-process per-project async mutex. The push/PR flows temporarily rewrite the
+ * sandbox git remote to a tokenized URL and scrub it again in a `finally`; two
+ * concurrent operations on the same project could interleave those rewrites and
+ * leak a tokenized remote. Serializing per `githubProjectId` removes that race.
+ *
+ * This lock is in-process only; multi-replica deploys need a shared lock
+ * (called out as out-of-scope follow-up in the plan).
+ */
+const projectLocks = new Map<string, Promise<unknown>>();
+
+function withProjectLock<T>(projectId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = projectLocks.get(projectId) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  // Keep the chain alive but swallow rejections so one failure doesn't poison
+  // the lock for subsequent callers.
+  projectLocks.set(
+    projectId,
+    next.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return next;
+}
+
+/** Derive a commit/author identity from the authenticated WorkOS user. */
+function identityFromUser(user: { name?: string; email?: string } | undefined): GitIdentity {
+  return { name: user?.name ?? null, email: user?.email ?? null };
+}
+
+/**
+ * Resolve a live, started sandbox for a project row. The project must already
+ * have been materialized (`sandboxId` set) — the git write routes never clone,
+ * they operate on the existing checkout.
+ */
+async function resolveProjectSandbox(row: GithubProjectRow): Promise<MaterializationSandbox> {
+  if (!row.sandboxId) {
+    throw new MaterializeError('Project sandbox is not provisioned. Open the project first.', 'clone-failed');
+  }
+  return reattachProjectSandbox(row.sandboxId);
+}
+
+/** Map a sandbox/worktree error to an actionable HTTP response. */
+function gitErrorResponse(c: Context, err: unknown) {
+  if (err instanceof WorktreeError) {
+    return c.json({ error: err.code, message: err.message }, err.code === 'invalid-branch' ? 400 : 502);
+  }
+  if (err instanceof MaterializeError) {
+    return c.json({ error: err.code, message: err.message }, 502);
+  }
+  return c.json({ error: 'git_failed', message: err instanceof Error ? err.message : String(err) }, 500);
+}
+
+/**
+ * Look up a project row scoped to the authenticated user. Returns the userId and
+ * row, or a ready-to-return error response. Centralizes the auth + ownership
+ * checks every git route shares.
+ */
+async function loadOwnedProject(
+  c: Context,
+): Promise<{ userId: string; row: GithubProjectRow } | { response: Response }> {
+  const userId = getWebAuthUserId(getWebAuthUser(c));
+  if (!userId) return { response: c.json({ error: 'unauthorized' }, 401) };
+
+  if (!isSandboxEnabled()) {
+    return {
+      response: c.json({ error: 'sandbox_not_configured', message: 'No sandbox provider is configured.' }, 503),
+    };
+  }
+
+  const projectId = c.req.param('id');
+  if (!projectId) {
+    return { response: c.json({ error: 'Project not found' }, 404) };
+  }
+  const [row] = await getAppDb()
+    .select()
+    .from(githubProjects)
+    .where(and(eq(githubProjects.id, projectId), eq(githubProjects.userId, userId)));
+  if (!row) {
+    return { response: c.json({ error: 'Project not found' }, 404) };
+  }
+  return { userId, row };
+}
+
+function mountProjectGitRoutes(app: Hono<any>): void {
+  // ── Create / reuse a worktree + feature branch ──────────────────────────
+  app.post('/api/web/github/projects/:id/worktree', async c => {
+    const owned = await loadOwnedProject(c);
+    if ('response' in owned) return owned.response;
+    const { userId, row } = owned;
+
+    let body: { branch?: unknown; baseBranch?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+    if (!isValidGitRefSandbox(body.branch)) {
+      return c.json({ error: 'Invalid branch' }, 400);
+    }
+    const baseBranch = body.baseBranch === undefined ? row.defaultBranch : body.baseBranch;
+    if (!isValidGitRefSandbox(baseBranch)) {
+      return c.json({ error: 'Invalid baseBranch' }, 400);
+    }
+    const branch = body.branch;
+
+    try {
+      return await withProjectLock(row.id, async () => {
+        const sandbox = await resolveProjectSandbox(row);
+        const result = await ensureWorktree(sandbox, row.sandboxWorkdir, { branch, baseBranch });
+
+        await getAppDb()
+          .insert(githubWorktrees)
+          .values({
+            userId,
+            githubProjectId: row.id,
+            branch: result.branch,
+            baseBranch: result.baseBranch,
+            worktreePath: result.worktreePath,
+          })
+          .onConflictDoUpdate({
+            target: [githubWorktrees.githubProjectId, githubWorktrees.branch],
+            set: { baseBranch: result.baseBranch, worktreePath: result.worktreePath },
+          });
+
+        return c.json({
+          worktreePath: result.worktreePath,
+          branch: result.branch,
+          baseBranch: result.baseBranch,
+          resourceId: row.id,
+        });
+      });
+    } catch (err) {
+      return gitErrorResponse(c, err);
+    }
+  });
+
+  // ── Stage all + commit inside a worktree ────────────────────────────────
+  app.post('/api/web/github/projects/:id/commit', async c => {
+    const owned = await loadOwnedProject(c);
+    if ('response' in owned) return owned.response;
+    const { row } = owned;
+
+    let body: { message?: unknown; worktreePath?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+    if (typeof body.message !== 'string' || body.message.trim().length === 0 || body.message.length > 5000) {
+      return c.json({ error: 'Invalid message' }, 400);
+    }
+    const workdir = await resolveWorktreePath(row.id, body.worktreePath, row.sandboxWorkdir);
+    if (!workdir) {
+      return c.json({ error: 'Invalid worktreePath' }, 400);
+    }
+
+    try {
+      return await withProjectLock(row.id, async () => {
+        const sandbox = await resolveProjectSandbox(row);
+        const result = await commitAll(sandbox, workdir, body.message as string, identityFromUser(getWebAuthUser(c)));
+        return c.json({ committed: result.committed });
+      });
+    } catch (err) {
+      return gitErrorResponse(c, err);
+    }
+  });
+
+  // ── Push a branch back to GitHub ────────────────────────────────────────
+  app.post('/api/web/github/projects/:id/push', async c => {
+    const owned = await loadOwnedProject(c);
+    if ('response' in owned) return owned.response;
+    const { row } = owned;
+
+    let body: { branch?: unknown; worktreePath?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+    if (!isValidGitRefSandbox(body.branch)) {
+      return c.json({ error: 'Invalid branch' }, 400);
+    }
+    const branch = body.branch;
+    const workdir = await resolveWorktreePath(row.id, body.worktreePath, row.sandboxWorkdir);
+    if (!workdir) {
+      return c.json({ error: 'Invalid worktreePath' }, 400);
+    }
+
+    try {
+      return await withProjectLock(row.id, async () => {
+        const sandbox = await resolveProjectSandbox(row);
+        const token = await mintInstallationToken(row.installationId);
+        await pushBranch(sandbox, workdir, branch, token, row.repoFullName);
+        return c.json({ pushed: true, branch });
+      });
+    } catch (err) {
+      return gitErrorResponse(c, err);
+    }
+  });
+
+  // ── Open a pull request via the gh CLI ──────────────────────────────────
+  app.post('/api/web/github/projects/:id/pr', async c => {
+    const owned = await loadOwnedProject(c);
+    if ('response' in owned) return owned.response;
+    const { row } = owned;
+
+    let body: { branch?: unknown; base?: unknown; title?: unknown; body?: unknown; worktreePath?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+    if (!isValidGitRefSandbox(body.branch)) {
+      return c.json({ error: 'Invalid branch' }, 400);
+    }
+    const base = body.base === undefined ? row.defaultBranch : body.base;
+    if (!isValidGitRefSandbox(base)) {
+      return c.json({ error: 'Invalid base' }, 400);
+    }
+    if (typeof body.title !== 'string' || body.title.trim().length === 0 || body.title.length > 256) {
+      return c.json({ error: 'Invalid title' }, 400);
+    }
+    if (body.body !== undefined && (typeof body.body !== 'string' || body.body.length > 65536)) {
+      return c.json({ error: 'Invalid body' }, 400);
+    }
+    const head = body.branch;
+    const title = body.title;
+    const prBody = body.body as string | undefined;
+    const workdir = await resolveWorktreePath(row.id, body.worktreePath, row.sandboxWorkdir);
+    if (!workdir) {
+      return c.json({ error: 'Invalid worktreePath' }, 400);
+    }
+
+    try {
+      return await withProjectLock(row.id, async () => {
+        const sandbox = await resolveProjectSandbox(row);
+        const token = await mintInstallationToken(row.installationId);
+        const result = await createPullRequest(sandbox, workdir, { token, base, head, title, body: prBody });
+        return c.json({ url: result.url });
+      });
+    } catch (err) {
+      return gitErrorResponse(c, err);
+    }
+  });
+}
+
+/**
+ * Resolve and validate the worktree path a git write operation targets. The
+ * path is never trusted from the client verbatim: it must either be the
+ * project's repo workdir (committing/pushing on the base checkout) or match a
+ * persisted worktree row for this project. Returns the validated path or
+ * `undefined` when it isn't recognized.
+ */
+async function resolveWorktreePath(
+  projectId: string,
+  worktreePath: unknown,
+  repoWorkdir: string,
+): Promise<string | undefined> {
+  if (worktreePath === undefined || worktreePath === repoWorkdir) {
+    return repoWorkdir;
+  }
+  if (typeof worktreePath !== 'string') {
+    return undefined;
+  }
+  const [row] = await getAppDb()
+    .select()
+    .from(githubWorktrees)
+    .where(and(eq(githubWorktrees.githubProjectId, projectId), eq(githubWorktrees.worktreePath, worktreePath)));
+  return row ? row.worktreePath : undefined;
 }

--- a/mastracode/src/web/github/sandbox-fleet-scenario.test.ts
+++ b/mastracode/src/web/github/sandbox-fleet-scenario.test.ts
@@ -1,0 +1,300 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Phase 7 sandbox-fleet scenario tests ─────────────────────────────────
+// These prove the lightweight per-replica sandbox budget and the per-user
+// teardown path end to end:
+//   1. Cap enforcement + recovery: with a cap of 1, a second fresh provision is
+//      rejected, then succeeds once the first is torn down (counter decremented).
+//   2. Teardown clears the per-(project,user) binding and decrements the live
+//      counter, so the next open re-provisions a fresh sandbox.
+//   3. Cross-user teardown is structurally impossible: a DELETE only ever
+//      resolves the caller's own `(project, user)` binding, so one user can never
+//      tear down another user's sandbox.
+//
+// Parts 1 & 2 drive the real `ensureProjectSandbox` / `teardownProjectSandbox`
+// helpers; part 3 drives the real DELETE route. All share one in-memory fake DB.
+
+vi.mock('drizzle-orm', () => ({
+  eq: (column: any, value: any) => ({ kind: 'eq', column: column?.name, value }),
+  and: (...conds: any[]) => ({ kind: 'and', conds: conds.filter(Boolean) }),
+}));
+
+// Enable the GitHub feature so the project git routes (incl. DELETE) mount.
+vi.mock('./config', () => ({
+  isGithubFeatureEnabled: () => true,
+  signState: (orgId: string, userId: string) => `state.${orgId}.${userId}`,
+  verifyState: (state: string | undefined) => {
+    if (!state?.startsWith('state.')) return null;
+    const [orgId, userId] = state.slice('state.'.length).split('.');
+    if (!orgId || !userId) return null;
+    return { orgId, userId };
+  },
+}));
+
+// ── Shared in-memory DB shaped like routes.test.ts ────────────────────────
+interface Tables {
+  projects: Array<Record<string, any>>;
+  sandboxes: Array<Record<string, any>>;
+}
+const tables: Tables = { projects: [], sandboxes: [] };
+
+function dbNameToJsKey(name: string): string {
+  return name.replace(/_([a-z])/g, (_m, c) => c.toUpperCase());
+}
+
+function matches(row: Record<string, any>, cond: any): boolean {
+  if (!cond) return true;
+  if (cond.kind === 'and') return cond.conds.every((c: any) => matches(row, c));
+  if (cond.kind === 'eq') return row[dbNameToJsKey(cond.column)] === cond.value;
+  return true;
+}
+
+let sandboxesRef: any;
+function tableKind(table: any): keyof Tables {
+  return table === sandboxesRef ? 'sandboxes' : 'projects';
+}
+
+vi.mock('./db', () => ({
+  getAppDb: () => ({
+    select: () => ({
+      from: (table: any) => ({
+        where: async (cond: any) => tables[tableKind(table)].filter(r => matches(r, cond)),
+      }),
+    }),
+    insert: (table: any) => ({
+      values: (vals: any) => {
+        const kind = tableKind(table);
+        const push = () => {
+          const row = { id: `gen-${kind}-${tables[kind].length}`, ...vals };
+          tables[kind].push(row);
+          return row;
+        };
+        const chain: any = {
+          onConflictDoNothing: () => {
+            const row = push();
+            const p: any = Promise.resolve([row]);
+            p.returning = async () => [row];
+            return p;
+          },
+          returning: async () => [push()],
+        };
+        return chain;
+      },
+    }),
+    update: (table: any) => ({
+      set: (vals: any) => ({
+        where: async (cond: any) => {
+          for (const r of tables[tableKind(table)]) {
+            if (matches(r, cond)) Object.assign(r, vals);
+          }
+        },
+      }),
+    }),
+  }),
+}));
+
+import type * as RoutesModule from './routes';
+import {
+  __resetLiveSandboxCount,
+  ensureProjectSandbox,
+  getLiveSandboxCount,
+  resetSandboxFactory,
+  SandboxBudgetError,
+  setSandboxFactory,
+  teardownProjectSandbox,
+} from './sandbox';
+import type { MaterializationSandbox } from './sandbox';
+import { githubProjectSandboxes } from './schema';
+import type { GithubProjectSandboxRow } from './schema';
+
+sandboxesRef = githubProjectSandboxes;
+
+/** Minimal fake sandbox VM that records lifecycle calls. */
+class FakeSandbox implements MaterializationSandbox {
+  readonly id: string;
+  startCount = 0;
+  stopCount = 0;
+  constructor(id: string) {
+    this.id = id;
+  }
+  async start(): Promise<void> {
+    this.startCount += 1;
+  }
+  async stop(): Promise<void> {
+    this.stopCount += 1;
+  }
+  async getInfo() {
+    return { metadata: { railwaySandboxId: `vm-${this.id}` } };
+  }
+  async executeCommand() {
+    return { exitCode: 0, stdout: '', stderr: '' };
+  }
+}
+
+function makeBindingRow(id: string): GithubProjectSandboxRow {
+  const row = {
+    id,
+    githubProjectId: `proj-${id}`,
+    userId: 'u1',
+    sandboxId: null,
+    sandboxWorkdir: '/workspace/hello',
+    materializedAt: null,
+    createdAt: new Date(),
+  } satisfies GithubProjectSandboxRow;
+  tables.sandboxes.push(row as unknown as Record<string, any>);
+  return row;
+}
+
+afterEach(() => {
+  resetSandboxFactory();
+  __resetLiveSandboxCount(0);
+  tables.projects = [];
+  tables.sandboxes = [];
+  delete process.env.MASTRACODE_MAX_SANDBOXES;
+  vi.restoreAllMocks();
+});
+
+describe('S7 — sandbox fleet budget', () => {
+  it('cap=1: a second fresh provision is rejected, then succeeds after teardown frees a slot', async () => {
+    process.env.MASTRACODE_MAX_SANDBOXES = '1';
+    let made = 0;
+    setSandboxFactory(({ providerSandboxId }) => new FakeSandbox(providerSandboxId ?? `fresh-${++made}`));
+
+    const rowA = makeBindingRow('a');
+    const rowB = makeBindingRow('b');
+
+    // First fresh provision succeeds and consumes the single slot.
+    const sandboxA = (await ensureProjectSandbox(rowA)) as FakeSandbox;
+    expect(sandboxA.startCount).toBe(1);
+    expect(getLiveSandboxCount()).toBe(1);
+    expect(rowA.sandboxId).toBe('vm-fresh-1');
+
+    // Second fresh provision is over budget → rejected before spending quota.
+    const err = await ensureProjectSandbox(rowB).catch(e => e);
+    expect(err).toBeInstanceOf(SandboxBudgetError);
+    expect(err.max).toBe(1);
+    expect(getLiveSandboxCount()).toBe(1);
+    expect(rowB.sandboxId).toBeNull();
+
+    // Tear down A → frees the slot.
+    await teardownProjectSandbox(rowA, sandboxA);
+    expect(sandboxA.stopCount).toBe(1);
+    expect(getLiveSandboxCount()).toBe(0);
+    expect(rowA.sandboxId).toBeNull();
+
+    // Now B provisions successfully.
+    const sandboxB = (await ensureProjectSandbox(rowB)) as FakeSandbox;
+    expect(sandboxB.startCount).toBe(1);
+    expect(getLiveSandboxCount()).toBe(1);
+    expect(rowB.sandboxId).toBe('vm-fresh-2');
+  });
+
+  it('teardown clears the per-(project,user) binding and the next open re-provisions fresh', async () => {
+    let made = 0;
+    setSandboxFactory(({ providerSandboxId }) => new FakeSandbox(providerSandboxId ?? `fresh-${++made}`));
+
+    const row = makeBindingRow('a');
+
+    const first = (await ensureProjectSandbox(row)) as FakeSandbox;
+    expect(getLiveSandboxCount()).toBe(1);
+    expect(row.sandboxId).toBe('vm-fresh-1');
+
+    // Simulate a materialized binding so teardown clears that too.
+    (row as { materializedAt: Date | null }).materializedAt = new Date();
+
+    await teardownProjectSandbox(row, first);
+    expect(first.stopCount).toBe(1);
+    expect(getLiveSandboxCount()).toBe(0);
+    expect(row.sandboxId).toBeNull();
+    expect(row.materializedAt).toBeNull();
+
+    // Next open re-provisions a brand new sandbox (fresh provider id).
+    const second = (await ensureProjectSandbox(row)) as FakeSandbox;
+    expect(second).not.toBe(first);
+    expect(second.startCount).toBe(1);
+    expect(getLiveSandboxCount()).toBe(1);
+    expect(row.sandboxId).toBe('vm-fresh-2');
+  });
+
+  it('teardown of a never-provisioned binding is a no-op that does not underflow the counter', async () => {
+    const row = makeBindingRow('a'); // sandboxId stays null
+    await teardownProjectSandbox(row);
+    expect(getLiveSandboxCount()).toBe(0);
+    expect(row.sandboxId).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Part 3: route-level cross-user teardown isolation. The DELETE handler always
+// resolves the caller's own `(project, user)` binding, so user 2's teardown can
+// never touch user 1's sandbox.
+
+describe('S7 — cross-user teardown isolation (route level)', () => {
+  let mountGithubRoutes: (typeof RoutesModule)['mountGithubRoutes'];
+
+  beforeEach(async () => {
+    tables.projects = [
+      { id: 'p1', orgId: 'org1', installationId: 7, repoFullName: 'octo/hello', sandboxWorkdir: '/workspace/hello' },
+    ];
+    // Only user 1 has a provisioned sandbox binding.
+    tables.sandboxes = [
+      { id: 's1', githubProjectId: 'p1', userId: 'u1', sandboxId: 'vm-u1', sandboxWorkdir: '/workspace/hello' },
+    ];
+    process.env.MASTRACODE_DISTRIBUTED_LOCK = '0';
+    process.env.MASTRACODE_SANDBOX_PROVIDER = 'railway';
+    process.env.RAILWAY_API_TOKEN = 'test-token'; // makes isSandboxEnabled() true
+
+    // Real teardown/reattach run; the factory yields a fake VM so reattach starts
+    // a recordable sandbox instead of hitting Railway.
+    setSandboxFactory(({ providerSandboxId }) => new FakeSandbox(providerSandboxId ?? 'fresh'));
+
+    ({ mountGithubRoutes } = await import('./routes'));
+  });
+
+  afterEach(() => {
+    delete process.env.MASTRACODE_DISTRIBUTED_LOCK;
+    delete process.env.MASTRACODE_SANDBOX_PROVIDER;
+    delete process.env.RAILWAY_API_TOKEN;
+  });
+
+  function buildApp(workosId: string) {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      (c as any).set('webAuthUser', { id: workosId, workosId, organizationId: 'org1', name: 'Test', email: 't@e.co' });
+      await next();
+    });
+    mountGithubRoutes(app as any, {});
+    return app;
+  }
+
+  it("user 2's teardown never touches user 1's sandbox binding", async () => {
+    const app = buildApp('u2');
+    const res = await app.request('/api/web/github/projects/p1/sandbox', { method: 'DELETE' });
+
+    // u2 has no provisioned binding → idempotent no-op success.
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ tornDown: false });
+
+    // u1's sandbox row is untouched.
+    const u1Row = tables.sandboxes.find(r => r.userId === 'u1');
+    expect(u1Row?.sandboxId).toBe('vm-u1');
+    // u2's own (freshly created) binding has no sandbox.
+    const u2Row = tables.sandboxes.find(r => r.userId === 'u2');
+    expect(u2Row?.sandboxId ?? null).toBeNull();
+  });
+
+  it('user 1 can tear down their own sandbox', async () => {
+    __resetLiveSandboxCount(1); // u1 has one live sandbox
+    const app = buildApp('u1');
+    const res = await app.request('/api/web/github/projects/p1/sandbox', { method: 'DELETE' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ tornDown: true });
+
+    // The caller's own binding is cleared and the counter is decremented.
+    const u1Row = tables.sandboxes.find(r => r.userId === 'u1');
+    expect(u1Row?.sandboxId).toBeNull();
+    expect(getLiveSandboxCount()).toBe(0);
+  });
+});

--- a/mastracode/src/web/github/sandbox-scenario.test.ts
+++ b/mastracode/src/web/github/sandbox-scenario.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// `pushBranch` writes a DB row only on success paths in some flows; the unit
+// suite stubs `./db` the same way so the helpers can run without Postgres.
+vi.mock('./db', () => ({
+  getAppDb: () => ({
+    update: () => ({
+      set: () => ({
+        where: async () => {},
+      }),
+    }),
+  }),
+}));
+
+import { createPullRequest, MaterializeError, pushBranch } from './sandbox';
+import type { MaterializationSandbox, SandboxCommandResult } from './sandbox';
+
+type Responder = (script: string) => SandboxCommandResult;
+const OK: SandboxCommandResult = { exitCode: 0, stdout: '', stderr: '' };
+
+/**
+ * Records every shell script the helper runs so the scenario can assert the
+ * security invariant across the WHOLE operation, not a single command.
+ */
+class RecordingSandbox implements MaterializationSandbox {
+  readonly id = 'logical-id';
+  readonly calls: string[] = [];
+  startCount = 0;
+  private responder: Responder;
+
+  constructor(responder?: Responder) {
+    this.responder = responder ?? (() => OK);
+  }
+
+  async start(): Promise<void> {
+    this.startCount += 1;
+  }
+
+  async getInfo() {
+    return { metadata: { railwaySandboxId: 'railway-vm-123' } };
+  }
+
+  async executeCommand(command: string, args?: string[]): Promise<SandboxCommandResult> {
+    const script = command === 'sh' && args?.[0] === '-c' ? args[1]! : [command, ...(args ?? [])].join(' ');
+    this.calls.push(script);
+    return this.responder(script);
+  }
+}
+
+const TOKEN = 'ghs_supersecrettoken1234567890';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('S4 — token leak negative scenarios on failure paths', () => {
+  it('pushBranch: a failed git push still scrubs the remote and never leaves the token behind', async () => {
+    // The push itself fails; the finally-scrub must still run.
+    const sandbox = new RecordingSandbox(script =>
+      script.includes('push -u origin') ? { exitCode: 1, stdout: '', stderr: 'rejected: non-fast-forward' } : OK,
+    );
+
+    const err = await pushBranch(sandbox, '/workspace/hello', 'feat/x', TOKEN, 'octocat/hello').catch(e => e);
+
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('push-failed');
+
+    // Invariant 1: the FINAL remote rewrite restores the clean (scrubbed) URL.
+    const remoteRewrites = sandbox.calls.filter(c => c.includes('remote set-url origin'));
+    expect(remoteRewrites.length).toBeGreaterThanOrEqual(2);
+    const finalRewrite = remoteRewrites.at(-1)!;
+    expect(finalRewrite).toContain('https://github.com/octocat/hello.git');
+    expect(finalRewrite).not.toContain(TOKEN);
+
+    // Invariant 2: the token only ever appears in the tokenized-remote rewrite,
+    // and NEVER survives into the last command recorded against the sandbox.
+    const lastCommand = sandbox.calls.at(-1)!;
+    expect(lastCommand).not.toContain(TOKEN);
+
+    // Invariant 3: every command that carries the token is a tokenized
+    // `remote set-url` — the token is never smuggled into push/config/log.
+    const tokenCommands = sandbox.calls.filter(c => c.includes(TOKEN));
+    expect(tokenCommands.length).toBeGreaterThan(0);
+    for (const c of tokenCommands) {
+      expect(c).toContain('remote set-url origin');
+      expect(c).toContain(`https://x-access-token:${TOKEN}@github.com/octocat/hello.git`);
+    }
+  });
+
+  it('pushBranch: an egress failure during push is classified and still scrubs the token', async () => {
+    const sandbox = new RecordingSandbox(script =>
+      script.includes('push -u origin')
+        ? { exitCode: 128, stdout: '', stderr: 'fatal: unable to access: Could not resolve host: github.com' }
+        : OK,
+    );
+
+    const err = await pushBranch(sandbox, '/workspace/hello', 'feat/x', TOKEN, 'octocat/hello').catch(e => e);
+
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('egress-blocked');
+
+    // The scrub still runs after the egress failure.
+    const finalRewrite = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1)!;
+    expect(finalRewrite).toContain('https://github.com/octocat/hello.git');
+    expect(finalRewrite).not.toContain(TOKEN);
+    expect(sandbox.calls.at(-1)).not.toContain(TOKEN);
+  });
+
+  it('createPullRequest: a failed gh pr create keeps GH_TOKEN inside that single invocation only', async () => {
+    const sandbox = new RecordingSandbox(script => {
+      if (script === 'gh --version') return { exitCode: 0, stdout: 'gh version 2.0.0', stderr: '' };
+      if (script.includes('gh pr create')) {
+        return { exitCode: 1, stdout: '', stderr: 'pull request already exists' };
+      }
+      return OK;
+    });
+
+    const err = await createPullRequest(sandbox, '/workspace/worktrees/feat-x', {
+      token: TOKEN,
+      base: 'main',
+      head: 'feat/x',
+      title: 'Add feature',
+      body: 'body',
+    }).catch(e => e);
+
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('pr-failed');
+
+    // The token may appear ONLY in the single failing `gh pr create` command,
+    // as an inline env prefix — never in the preflight or any other command.
+    const tokenCommands = sandbox.calls.filter(c => c.includes(TOKEN));
+    expect(tokenCommands).toHaveLength(1);
+    expect(tokenCommands[0]).toContain(`GH_TOKEN='${TOKEN}' gh pr create`);
+
+    // The preflight ran but carried no token.
+    const preflight = sandbox.calls.find(c => c === 'gh --version')!;
+    expect(preflight).not.toContain(TOKEN);
+
+    // Token is never exported into the session or written to git config.
+    expect(sandbox.calls.some(c => c.includes('export GH_TOKEN'))).toBe(false);
+    expect(sandbox.calls.some(c => c.includes('git config') && c.includes(TOKEN))).toBe(false);
+  });
+
+  it('createPullRequest: an egress failure from gh is classified without leaking the token', async () => {
+    const sandbox = new RecordingSandbox(script => {
+      if (script === 'gh --version') return { exitCode: 0, stdout: 'gh version 2.0.0', stderr: '' };
+      if (script.includes('gh pr create')) {
+        return { exitCode: 1, stdout: '', stderr: 'could not resolve host: github.com' };
+      }
+      return OK;
+    });
+
+    const err = await createPullRequest(sandbox, '/workspace/hello', {
+      token: TOKEN,
+      base: 'main',
+      head: 'feat/x',
+      title: 't',
+    }).catch(e => e);
+
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('egress-blocked');
+
+    const tokenCommands = sandbox.calls.filter(c => c.includes(TOKEN));
+    expect(tokenCommands).toHaveLength(1);
+    expect(tokenCommands[0]).toContain('gh pr create');
+  });
+});

--- a/mastracode/src/web/github/sandbox.test.ts
+++ b/mastracode/src/web/github/sandbox.test.ts
@@ -35,8 +35,8 @@ import {
   withInstallToken,
   WorktreeError,
 } from './sandbox';
-import type { MaterializationSandbox, SandboxCommandResult } from './sandbox';
-import type { GithubProjectRow } from './schema';
+import type { MaterializationSandbox, RepoMaterializeInfo, SandboxCommandResult } from './sandbox';
+import type { GithubProjectSandboxRow } from './schema';
 
 type Responder = (script: string) => SandboxCommandResult;
 const OK: SandboxCommandResult = { exitCode: 0, stdout: '', stderr: '' };
@@ -67,21 +67,21 @@ class FakeSandbox implements MaterializationSandbox {
   }
 }
 
-function makeRow(overrides: Partial<GithubProjectRow> = {}): GithubProjectRow {
+function makeRow(overrides: Partial<GithubProjectSandboxRow> = {}): GithubProjectSandboxRow {
   return {
-    id: 'proj-1',
+    id: 'sbrow-1',
+    githubProjectId: 'proj-1',
     userId: 'user-1',
-    installationId: 42,
-    repoFullName: 'octocat/hello',
-    repoId: 99,
-    defaultBranch: 'main',
-    sandboxProvider: 'railway',
     sandboxId: null,
     sandboxWorkdir: '/workspace/hello',
     materializedAt: null,
     createdAt: new Date(),
     ...overrides,
   };
+}
+
+function makeRepoInfo(overrides: Partial<RepoMaterializeInfo> = {}): RepoMaterializeInfo {
+  return { repoFullName: 'octocat/hello', defaultBranch: 'main', ...overrides };
 }
 
 beforeEach(() => {
@@ -219,7 +219,7 @@ describe('getSandboxIdleMinutes', () => {
 describe('materializeRepo', () => {
   it('clones on first open, scrubs the token, and marks materialized', async () => {
     const sandbox = new FakeSandbox();
-    await materializeRepo(makeRow({ materializedAt: null }), sandbox, 'tok-123');
+    await materializeRepo(makeRow({ materializedAt: null }), makeRepoInfo(), sandbox, 'tok-123');
 
     const joined = sandbox.calls.join('\n');
     expect(sandbox.calls[0]).toBe('git --version');
@@ -234,7 +234,7 @@ describe('materializeRepo', () => {
 
   it('pulls (not clones) on re-open', async () => {
     const sandbox = new FakeSandbox();
-    await materializeRepo(makeRow({ materializedAt: new Date() }), sandbox, 'tok-xyz');
+    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok-xyz');
 
     const joined = sandbox.calls.join('\n');
     expect(joined).toContain('git -C ');
@@ -247,7 +247,7 @@ describe('materializeRepo', () => {
     const sandbox = new FakeSandbox(script =>
       script === 'git --version' ? { exitCode: 127, stdout: '', stderr: 'not found' } : OK,
     );
-    await expect(materializeRepo(makeRow(), sandbox, 'tok')).rejects.toMatchObject({
+    await expect(materializeRepo(makeRow(), makeRepoInfo(), sandbox, 'tok')).rejects.toMatchObject({
       code: 'git-missing',
     });
   });
@@ -260,14 +260,19 @@ describe('materializeRepo', () => {
       }
       return OK;
     });
-    const err = await materializeRepo(makeRow(), sandbox, 'tok').catch(e => e);
+    const err = await materializeRepo(makeRow(), makeRepoInfo(), sandbox, 'tok').catch(e => e);
     expect(err).toBeInstanceOf(MaterializeError);
     expect(err.code).toBe('egress-blocked');
   });
 
   it('refuses to run git when the default branch is not git-ref-safe', async () => {
     const sandbox = new FakeSandbox();
-    const err = await materializeRepo(makeRow({ defaultBranch: "main'; rm -rf /; '" }), sandbox, 'tok').catch(e => e);
+    const err = await materializeRepo(
+      makeRow(),
+      makeRepoInfo({ defaultBranch: "main'; rm -rf /; '" }),
+      sandbox,
+      'tok',
+    ).catch(e => e);
     expect(err).toBeInstanceOf(MaterializeError);
     // No git command should have been executed for an invalid branch.
     expect(sandbox.calls).toHaveLength(0);
@@ -275,7 +280,9 @@ describe('materializeRepo', () => {
 
   it('refuses to run git when the repo full name is not owner/name shaped', async () => {
     const sandbox = new FakeSandbox();
-    const err = await materializeRepo(makeRow({ repoFullName: 'evil; whoami' }), sandbox, 'tok').catch(e => e);
+    const err = await materializeRepo(makeRow(), makeRepoInfo({ repoFullName: 'evil; whoami' }), sandbox, 'tok').catch(
+      e => e,
+    );
     expect(err).toBeInstanceOf(MaterializeError);
     expect(sandbox.calls).toHaveLength(0);
   });
@@ -289,7 +296,12 @@ describe('materializeRepo', () => {
       return OK;
     });
 
-    const err = await materializeRepo(makeRow({ materializedAt: new Date() }), sandbox, 'tok-secret').catch(e => e);
+    const err = await materializeRepo(
+      makeRow({ materializedAt: new Date() }),
+      makeRepoInfo(),
+      sandbox,
+      'tok-secret',
+    ).catch(e => e);
 
     // The pull failure is surfaced...
     expect(err).toBeInstanceOf(MaterializeError);
@@ -312,7 +324,9 @@ describe('materializeRepo', () => {
       return OK;
     });
 
-    const err = await materializeRepo(makeRow({ materializedAt: new Date() }), sandbox, 'tok').catch(e => e);
+    const err = await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok').catch(
+      e => e,
+    );
     expect(err).toBeInstanceOf(MaterializeError);
     expect(err.code).toBe('pull-failed');
     expect(String(err.message)).toContain('scrub');

--- a/mastracode/src/web/github/sandbox.test.ts
+++ b/mastracode/src/web/github/sandbox.test.ts
@@ -17,12 +17,23 @@ vi.mock('./db', () => ({
 
 import {
   computeSandboxWorkdir,
+  computeWorktreePath,
+  configureGitIdentity,
+  createPullRequest,
   ensureProjectSandbox,
+  ensureWorktree,
+  getSandboxIdleMinutes,
   isSandboxEnabled,
+  isValidGitRef,
   materializeRepo,
   MaterializeError,
+  pushBranch,
   resetSandboxFactory,
+  resolveGitIdentity,
+  safeBranchDir,
   setSandboxFactory,
+  withInstallToken,
+  WorktreeError,
 } from './sandbox';
 import type { MaterializationSandbox, SandboxCommandResult } from './sandbox';
 import type { GithubProjectRow } from './schema';
@@ -82,6 +93,7 @@ afterEach(() => {
   delete process.env.RAILWAY_API_TOKEN;
   delete process.env.MASTRACODE_SANDBOX_PROVIDER;
   delete process.env.MASTRACODE_SANDBOX_WORKDIR;
+  delete process.env.MASTRACODE_SANDBOX_IDLE_MINUTES;
 });
 
 describe('isSandboxEnabled', () => {
@@ -141,6 +153,66 @@ describe('ensureProjectSandbox', () => {
 
     expect(factoryArgs?.providerSandboxId).toBe('railway-vm-existing');
     expect(dbUpdates).toEqual([]);
+  });
+
+  it('passes the idle timeout to the provider on provision', async () => {
+    process.env.MASTRACODE_SANDBOX_IDLE_MINUTES = '15';
+    const sandbox = new FakeSandbox();
+    let factoryArgs: { idleTimeoutMinutes?: number } | undefined;
+    setSandboxFactory(opts => {
+      factoryArgs = opts;
+      return sandbox;
+    });
+
+    await ensureProjectSandbox(makeRow({ sandboxId: null }));
+
+    expect(factoryArgs?.idleTimeoutMinutes).toBe(15);
+  });
+
+  it('re-provisions and clears the stale id when reattach to a dead sandbox fails', async () => {
+    const dead = new FakeSandbox();
+    dead.start = async () => {
+      throw new Error('sandbox not found');
+    };
+    const fresh = new FakeSandbox();
+    fresh.providerId = 'railway-vm-new';
+
+    const provided: Array<string | undefined> = [];
+    setSandboxFactory(opts => {
+      provided.push(opts.providerSandboxId);
+      return opts.providerSandboxId ? dead : fresh;
+    });
+
+    const result = await ensureProjectSandbox(makeRow({ sandboxId: 'railway-vm-dead' }));
+
+    // First call reattaches (dead), second provisions fresh.
+    expect(provided).toEqual(['railway-vm-dead', undefined]);
+    expect(result).toBe(fresh);
+    expect(fresh.startCount).toBe(1);
+    // The stale id is cleared, then the new provider id persisted.
+    expect(dbUpdates).toEqual([{ sandboxId: null }, { sandboxId: 'railway-vm-new' }]);
+  });
+});
+
+describe('getSandboxIdleMinutes', () => {
+  afterEach(() => {
+    delete process.env.MASTRACODE_SANDBOX_IDLE_MINUTES;
+  });
+
+  it('defaults to 30 minutes when unset', () => {
+    expect(getSandboxIdleMinutes()).toBe(30);
+  });
+
+  it('reads a positive integer from the env', () => {
+    process.env.MASTRACODE_SANDBOX_IDLE_MINUTES = '45';
+    expect(getSandboxIdleMinutes()).toBe(45);
+  });
+
+  it('falls back to 30 for non-positive or invalid values', () => {
+    process.env.MASTRACODE_SANDBOX_IDLE_MINUTES = '0';
+    expect(getSandboxIdleMinutes()).toBe(30);
+    process.env.MASTRACODE_SANDBOX_IDLE_MINUTES = 'nope';
+    expect(getSandboxIdleMinutes()).toBe(30);
   });
 });
 
@@ -244,5 +316,391 @@ describe('materializeRepo', () => {
     expect(err).toBeInstanceOf(MaterializeError);
     expect(err.code).toBe('pull-failed');
     expect(String(err.message)).toContain('scrub');
+  });
+});
+
+describe('isValidGitRef', () => {
+  it('accepts normal branch names', () => {
+    expect(isValidGitRef('main')).toBe(true);
+    expect(isValidGitRef('feat/cloud-agent')).toBe(true);
+    expect(isValidGitRef('release-1.2.3')).toBe(true);
+  });
+
+  it('rejects empty, oversized, and shell-unsafe values', () => {
+    expect(isValidGitRef('')).toBe(false);
+    expect(isValidGitRef('a'.repeat(256))).toBe(false);
+    expect(isValidGitRef("main'; rm -rf /; '")).toBe(false);
+    expect(isValidGitRef('has space')).toBe(false);
+    expect(isValidGitRef(123)).toBe(false);
+  });
+});
+
+describe('resolveGitIdentity', () => {
+  it('uses provided name and email verbatim', () => {
+    expect(resolveGitIdentity({ name: 'Ada Lovelace', email: 'ada@example.com' })).toEqual({
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+    });
+  });
+
+  it('derives a noreply identity from the login when name/email are absent', () => {
+    expect(resolveGitIdentity({ login: 'octocat' })).toEqual({
+      name: 'octocat',
+      email: 'octocat@users.noreply.github.com',
+    });
+  });
+
+  it('falls back to a stable default identity with no inputs', () => {
+    expect(resolveGitIdentity({})).toEqual({
+      name: 'Mastra Code',
+      email: 'mastra-code@users.noreply.github.com',
+    });
+  });
+});
+
+describe('configureGitIdentity', () => {
+  it('configures user.name and user.email in the workdir, quoted', async () => {
+    const sandbox = new FakeSandbox();
+    await configureGitIdentity(sandbox, '/workspace/hello', { name: 'Ada Lovelace', email: 'ada@example.com' });
+
+    const joined = sandbox.calls.join('\n');
+    expect(joined).toContain("git -C '/workspace/hello' config user.name 'Ada Lovelace'");
+    expect(joined).toContain("git -C '/workspace/hello' config user.email 'ada@example.com'");
+  });
+
+  it('surfaces a commit-failed error when config fails', async () => {
+    const sandbox = new FakeSandbox(script =>
+      script.includes('config user.name') ? { exitCode: 1, stdout: '', stderr: 'boom' } : OK,
+    );
+    const err = await configureGitIdentity(sandbox, '/workspace/hello', { login: 'octocat' }).catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('commit-failed');
+  });
+});
+
+describe('withInstallToken', () => {
+  it('rewrites origin to the tokenized URL, runs fn, then scrubs the token', async () => {
+    const sandbox = new FakeSandbox();
+    const order: string[] = [];
+
+    await withInstallToken(sandbox, '/workspace/hello', 'octocat/hello', 'tok-secret', async () => {
+      order.push('fn');
+    });
+
+    const setUrlCalls = sandbox.calls.filter(c => c.includes('remote set-url origin'));
+    // First rewrite carries the token, the final scrub restores the clean URL.
+    expect(setUrlCalls[0]).toContain('https://x-access-token:tok-secret@github.com/octocat/hello.git');
+    expect(setUrlCalls.at(-1)).toContain('https://github.com/octocat/hello.git');
+    expect(setUrlCalls.at(-1)).not.toContain('tok-secret');
+    // fn ran while the tokenized remote was set (between the two set-url calls).
+    expect(order).toEqual(['fn']);
+  });
+
+  it('scrubs the token even when fn throws', async () => {
+    const sandbox = new FakeSandbox();
+    const err = await withInstallToken(sandbox, '/workspace/hello', 'octocat/hello', 'tok-secret', async () => {
+      throw new Error('push exploded');
+    }).catch(e => e);
+
+    expect(String(err.message)).toContain('push exploded');
+    const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
+    expect(scrub).toContain('https://github.com/octocat/hello.git');
+    expect(scrub).not.toContain('tok-secret');
+  });
+
+  it('rejects a malformed repo full name before touching the remote', async () => {
+    const sandbox = new FakeSandbox();
+    const err = await withInstallToken(sandbox, '/workspace/hello', 'evil; whoami', 'tok', async () => undefined).catch(
+      e => e,
+    );
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('push-failed');
+    expect(sandbox.calls).toHaveLength(0);
+  });
+});
+
+describe('pushBranch', () => {
+  it('pushes the branch with -u origin using a tokenized remote, then scrubs', async () => {
+    const sandbox = new FakeSandbox();
+    await pushBranch(sandbox, '/workspace/hello', 'feat/cloud-agent', 'tok-secret', 'octocat/hello');
+
+    const joined = sandbox.calls.join('\n');
+    expect(joined).toContain("git -C '/workspace/hello' push -u origin 'feat/cloud-agent'");
+    // tokenized remote was used during the push...
+    expect(joined).toContain('https://x-access-token:tok-secret@github.com/octocat/hello.git');
+    // ...and scrubbed back afterwards.
+    const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
+    expect(scrub).toContain('https://github.com/octocat/hello.git');
+    expect(scrub).not.toContain('tok-secret');
+  });
+
+  it('rejects an unsafe branch name before running git', async () => {
+    const sandbox = new FakeSandbox();
+    const err = await pushBranch(sandbox, '/workspace/hello', "x'; rm -rf /; '", 'tok', 'octocat/hello').catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('push-failed');
+    expect(sandbox.calls).toHaveLength(0);
+  });
+
+  it('scrubs the token even when the push itself fails', async () => {
+    const sandbox = new FakeSandbox(script =>
+      script.includes('push -u origin') ? { exitCode: 1, stdout: '', stderr: 'rejected' } : OK,
+    );
+    const err = await pushBranch(sandbox, '/workspace/hello', 'feat/x', 'tok-secret', 'octocat/hello').catch(e => e);
+
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('push-failed');
+    const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
+    expect(scrub).toContain('https://github.com/octocat/hello.git');
+    expect(scrub).not.toContain('tok-secret');
+  });
+
+  it('classifies an egress failure during push', async () => {
+    const sandbox = new FakeSandbox(script =>
+      script.includes('push -u origin')
+        ? { exitCode: 128, stdout: '', stderr: 'fatal: unable to access: Could not resolve host: github.com' }
+        : OK,
+    );
+    const err = await pushBranch(sandbox, '/workspace/hello', 'feat/x', 'tok', 'octocat/hello').catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('egress-blocked');
+  });
+});
+
+describe('safeBranchDir', () => {
+  it('collapses slashes and unsafe chars to a single dir segment', () => {
+    expect(safeBranchDir('feat/cloud-agent')).toBe('feat-cloud-agent');
+    expect(safeBranchDir('release/1.2.3')).toBe('release-1.2.3');
+  });
+
+  it('never produces an empty segment', () => {
+    expect(safeBranchDir('///')).toBe('work');
+  });
+});
+
+describe('computeWorktreePath', () => {
+  it('places worktrees in a sibling worktrees/ dir of the repo checkout', () => {
+    expect(computeWorktreePath('/workspace/hello', 'feat/x')).toBe('/workspace/worktrees/feat-x');
+  });
+
+  it('tolerates a trailing slash on the repo workdir', () => {
+    expect(computeWorktreePath('/workspace/hello/', 'main')).toBe('/workspace/worktrees/main');
+  });
+});
+
+describe('ensureWorktree', () => {
+  // The default FakeSandbox responder returns OK for everything, which would
+  // make `test -e <path>/.git` look like the worktree already exists. Use a
+  // responder that fails the existence check so the create path runs.
+  const notExisting = (script: string): SandboxCommandResult =>
+    script.startsWith('test -e') ? { exitCode: 1, stdout: '', stderr: '' } : OK;
+
+  it('creates a branch + worktree from the base branch when none exists', async () => {
+    const sandbox = new FakeSandbox(notExisting);
+    const result = await ensureWorktree(sandbox, '/workspace/hello', { branch: 'feat/x', baseBranch: 'main' });
+
+    expect(result).toEqual({
+      worktreePath: '/workspace/worktrees/feat-x',
+      branch: 'feat/x',
+      baseBranch: 'main',
+      reused: false,
+    });
+    const joined = sandbox.calls.join('\n');
+    expect(joined).toContain("git -C '/workspace/hello' fetch origin 'main'");
+    expect(joined).toContain("git -C '/workspace/hello' worktree add -B 'feat/x' '/workspace/worktrees/feat-x' 'main'");
+  });
+
+  it('reuses an existing worktree without running git worktree add', async () => {
+    // Default responder => `test -e` returns OK => path exists => reuse.
+    const sandbox = new FakeSandbox();
+    const result = await ensureWorktree(sandbox, '/workspace/hello', { branch: 'feat/x', baseBranch: 'main' });
+
+    expect(result.reused).toBe(true);
+    expect(result.worktreePath).toBe('/workspace/worktrees/feat-x');
+    expect(sandbox.calls.some(c => c.includes('worktree add'))).toBe(false);
+  });
+
+  it('rejects an unsafe branch name before touching the sandbox', async () => {
+    const sandbox = new FakeSandbox(notExisting);
+    const err = await ensureWorktree(sandbox, '/workspace/hello', {
+      branch: "x'; rm -rf /; '",
+      baseBranch: 'main',
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(WorktreeError);
+    expect(err.code).toBe('invalid-branch');
+    expect(sandbox.calls).toHaveLength(0);
+  });
+
+  it('rejects an unsafe base branch name', async () => {
+    const sandbox = new FakeSandbox(notExisting);
+    const err = await ensureWorktree(sandbox, '/workspace/hello', {
+      branch: 'feat/x',
+      baseBranch: 'bad branch',
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(WorktreeError);
+    expect(err.code).toBe('invalid-branch');
+    expect(sandbox.calls).toHaveLength(0);
+  });
+
+  it('surfaces a worktree-failed error when git worktree add fails', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script.startsWith('test -e')) return { exitCode: 1, stdout: '', stderr: '' };
+      if (script.includes('worktree add')) return { exitCode: 1, stdout: '', stderr: 'fatal: branch in use' };
+      return OK;
+    });
+    const err = await ensureWorktree(sandbox, '/workspace/hello', { branch: 'feat/x', baseBranch: 'main' }).catch(
+      e => e,
+    );
+    expect(err).toBeInstanceOf(WorktreeError);
+    expect(err.code).toBe('worktree-failed');
+  });
+});
+
+describe('createPullRequest', () => {
+  const PR_URL = 'https://github.com/octocat/hello/pull/7';
+  // gh prints the PR URL to stdout on success.
+  const ghOk = (script: string): SandboxCommandResult => {
+    if (script === 'gh --version') return { exitCode: 0, stdout: 'gh version 2.0.0', stderr: '' };
+    if (script.includes('gh pr create')) return { exitCode: 0, stdout: `${PR_URL}\n`, stderr: '' };
+    return OK;
+  };
+
+  it('opens a PR and parses the URL from gh stdout', async () => {
+    const sandbox = new FakeSandbox(ghOk);
+    const result = await createPullRequest(sandbox, '/workspace/worktrees/feat-x', {
+      token: 'tok-123',
+      base: 'main',
+      head: 'feat/x',
+      title: 'Add feature',
+      body: 'Some body',
+    });
+
+    expect(result).toEqual({ url: PR_URL });
+    const ghCall = sandbox.calls.find(c => c.includes('gh pr create'))!;
+    expect(ghCall).toContain("cd '/workspace/worktrees/feat-x'");
+    expect(ghCall).toContain("--base 'main'");
+    expect(ghCall).toContain("--head 'feat/x'");
+    expect(ghCall).toContain("--title 'Add feature'");
+    expect(ghCall).toContain("--body 'Some body'");
+  });
+
+  it('passes GH_TOKEN only inline to the gh process, never persisted', async () => {
+    const sandbox = new FakeSandbox(ghOk);
+    await createPullRequest(sandbox, '/workspace/hello', {
+      token: 'tok-secret',
+      base: 'main',
+      head: 'feat/x',
+      title: 't',
+    });
+
+    const ghCall = sandbox.calls.find(c => c.includes('gh pr create'))!;
+    // Token appears exactly once, as an inline env prefix on the gh command.
+    expect(ghCall).toContain("GH_TOKEN='tok-secret' gh pr create");
+    // It is never written via git config or exported to the session.
+    expect(sandbox.calls.some(c => c.includes('export GH_TOKEN'))).toBe(false);
+    expect(sandbox.calls.some(c => c.includes('git config') && c.includes('tok-secret'))).toBe(false);
+  });
+
+  it('shell-quotes a malicious title so it cannot break out', async () => {
+    const sandbox = new FakeSandbox(ghOk);
+    await createPullRequest(sandbox, '/workspace/hello', {
+      token: 'tok',
+      base: 'main',
+      head: 'feat/x',
+      title: "evil'; rm -rf / #",
+    });
+    const ghCall = sandbox.calls.find(c => c.includes('gh pr create'))!;
+    expect(ghCall).toContain(`--title 'evil'\\''; rm -rf / #'`);
+  });
+
+  it('defaults body to an empty string when omitted', async () => {
+    const sandbox = new FakeSandbox(ghOk);
+    await createPullRequest(sandbox, '/workspace/hello', {
+      token: 'tok',
+      base: 'main',
+      head: 'feat/x',
+      title: 't',
+    });
+    const ghCall = sandbox.calls.find(c => c.includes('gh pr create'))!;
+    expect(ghCall).toContain("--body ''");
+  });
+
+  it('surfaces an actionable gh-missing error when gh is not installed', async () => {
+    const sandbox = new FakeSandbox(script =>
+      script === 'gh --version' ? { exitCode: 127, stdout: '', stderr: 'gh: not found' } : OK,
+    );
+    const err = await createPullRequest(sandbox, '/workspace/hello', {
+      token: 'tok',
+      base: 'main',
+      head: 'feat/x',
+      title: 't',
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('gh-missing');
+    // gh pr create must not run when the preflight fails.
+    expect(sandbox.calls.some(c => c.includes('gh pr create'))).toBe(false);
+  });
+
+  it('rejects an invalid base or head branch before touching the sandbox', async () => {
+    const sandbox = new FakeSandbox(ghOk);
+    const err = await createPullRequest(sandbox, '/workspace/hello', {
+      token: 'tok',
+      base: 'bad branch',
+      head: 'feat/x',
+      title: 't',
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('pr-failed');
+    expect(sandbox.calls).toHaveLength(0);
+  });
+
+  it('classifies an egress failure from gh', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script === 'gh --version') return { exitCode: 0, stdout: 'gh version 2.0.0', stderr: '' };
+      if (script.includes('gh pr create'))
+        return { exitCode: 1, stdout: '', stderr: 'could not resolve host: github.com' };
+      return OK;
+    });
+    const err = await createPullRequest(sandbox, '/workspace/hello', {
+      token: 'tok',
+      base: 'main',
+      head: 'feat/x',
+      title: 't',
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('egress-blocked');
+  });
+
+  it('surfaces a pr-failed error when gh exits non-zero for another reason', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script === 'gh --version') return { exitCode: 0, stdout: 'gh version 2.0.0', stderr: '' };
+      if (script.includes('gh pr create')) return { exitCode: 1, stdout: '', stderr: 'pull request already exists' };
+      return OK;
+    });
+    const err = await createPullRequest(sandbox, '/workspace/hello', {
+      token: 'tok',
+      base: 'main',
+      head: 'feat/x',
+      title: 't',
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('pr-failed');
+    expect(err.message).toContain('pull request already exists');
+  });
+
+  it('errors when gh succeeds but emits no PR URL', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script === 'gh --version') return { exitCode: 0, stdout: 'gh version 2.0.0', stderr: '' };
+      if (script.includes('gh pr create')) return { exitCode: 0, stdout: 'created\n', stderr: '' };
+      return OK;
+    });
+    const err = await createPullRequest(sandbox, '/workspace/hello', {
+      token: 'tok',
+      base: 'main',
+      head: 'feat/x',
+      title: 't',
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('pr-failed');
   });
 });

--- a/mastracode/src/web/github/sandbox.ts
+++ b/mastracode/src/web/github/sandbox.ts
@@ -19,8 +19,8 @@
 import { RailwaySandbox } from '@mastra/railway';
 import { eq } from 'drizzle-orm';
 import { getAppDb } from './db';
-import { githubProjects } from './schema';
-import type { GithubProjectRow } from './schema';
+import { githubProjectSandboxes } from './schema';
+import type { GithubProjectSandboxRow } from './schema';
 
 /** Minimal command result shape we depend on. */
 export interface SandboxCommandResult {
@@ -38,6 +38,8 @@ export interface MaterializationSandbox {
   start(): Promise<void>;
   getInfo(): Promise<{ metadata?: Record<string, unknown> }>;
   executeCommand(command: string, args?: string[], options?: { timeout?: number }): Promise<SandboxCommandResult>;
+  /** Tear down the underlying VM. Optional: providers without it are no-ops. */
+  stop?(): Promise<void>;
 }
 
 /**
@@ -100,6 +102,49 @@ export function getSandboxIdleMinutes(): number | undefined {
   return Math.floor(parsed);
 }
 
+/**
+ * Per-replica cap on concurrently *provisioned* sandboxes. Reads
+ * `MASTRACODE_MAX_SANDBOXES`; 0 / unset means unlimited. This is a lightweight
+ * per-process budget to keep a single replica from exhausting provider quota —
+ * it is not a global, cross-replica scheduler (that is a deferred follow-up).
+ */
+export function getMaxSandboxes(): number {
+  const raw = process.env.MASTRACODE_MAX_SANDBOXES;
+  if (raw === undefined || raw === '') return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
+}
+
+/**
+ * Count of sandboxes this replica has freshly provisioned and not yet torn
+ * down. Reattaches to existing VMs do not count (they reuse an already-billed
+ * sandbox). Used to enforce `getMaxSandboxes()`.
+ */
+let liveSandboxCount = 0;
+
+/** Current live (freshly provisioned, not torn down) sandbox count. */
+export function getLiveSandboxCount(): number {
+  return liveSandboxCount;
+}
+
+/** For tests: reset the live-sandbox counter to a known state. */
+export function __resetLiveSandboxCount(value = 0): void {
+  liveSandboxCount = value;
+}
+
+/** Raised when provisioning would exceed the per-replica sandbox budget. */
+export class SandboxBudgetError extends Error {
+  readonly code = 'sandbox-budget-exceeded' as const;
+  constructor(readonly max: number) {
+    super(
+      `Sandbox budget exceeded: this server already has ${max} active sandbox(es) ` +
+        `(MASTRACODE_MAX_SANDBOXES=${max}). Close an existing project's sandbox and try again.`,
+    );
+    this.name = 'SandboxBudgetError';
+  }
+}
+
 /** Default factory: a Railway sandbox, optionally reattaching by id. */
 const railwayFactory: SandboxFactory = ({ providerSandboxId, env, idleTimeoutMinutes }) =>
   new RailwaySandbox({
@@ -134,7 +179,7 @@ async function readProviderSandboxId(sandbox: MaterializationSandbox): Promise<s
  * Provision a new sandbox (persisting its provider id on first open) or
  * reattach to the stored one. Returns a started, live sandbox.
  */
-export async function ensureProjectSandbox(row: GithubProjectRow): Promise<MaterializationSandbox> {
+export async function ensureProjectSandbox(row: GithubProjectSandboxRow): Promise<MaterializationSandbox> {
   const idleTimeoutMinutes = getSandboxIdleMinutes();
 
   // Reattach path: if we have a stored sandbox id, try to reattach. The VM may
@@ -147,20 +192,62 @@ export async function ensureProjectSandbox(row: GithubProjectRow): Promise<Mater
       await reattached.start();
       return reattached;
     } catch {
-      await getAppDb().update(githubProjects).set({ sandboxId: null }).where(eq(githubProjects.id, row.id));
+      await getAppDb()
+        .update(githubProjectSandboxes)
+        .set({ sandboxId: null })
+        .where(eq(githubProjectSandboxes.id, row.id));
       // fall through to fresh provision below
     }
   }
 
+  // Fresh provision: enforce the per-replica budget before spending quota.
+  const max = getMaxSandboxes();
+  if (max > 0 && liveSandboxCount >= max) {
+    throw new SandboxBudgetError(max);
+  }
+
   const sandbox = sandboxFactory({ idleTimeoutMinutes });
   await sandbox.start();
+  liveSandboxCount += 1;
 
   const providerSandboxId = await readProviderSandboxId(sandbox);
   if (providerSandboxId) {
-    await getAppDb().update(githubProjects).set({ sandboxId: providerSandboxId }).where(eq(githubProjects.id, row.id));
+    await getAppDb()
+      .update(githubProjectSandboxes)
+      .set({ sandboxId: providerSandboxId })
+      .where(eq(githubProjectSandboxes.id, row.id));
   }
 
   return sandbox;
+}
+
+/**
+ * Tear down a user's sandbox for a project: stop the live VM (best-effort) and
+ * clear the persisted `sandboxId`/`materializedAt` on the per-(project,user)
+ * binding row so the next open re-provisions cleanly. Decrements the
+ * per-replica live-sandbox counter.
+ *
+ * @param row     the per-(project,user) sandbox binding to tear down
+ * @param sandbox an already-reattached live sandbox to stop, when available
+ */
+export async function teardownProjectSandbox(
+  row: GithubProjectSandboxRow,
+  sandbox?: MaterializationSandbox,
+): Promise<void> {
+  if (sandbox?.stop) {
+    try {
+      await sandbox.stop();
+    } catch {
+      // Best-effort: the VM may already be gone (idle GC). Still clear the row.
+    }
+  }
+  if (row.sandboxId) {
+    if (liveSandboxCount > 0) liveSandboxCount -= 1;
+    await getAppDb()
+      .update(githubProjectSandboxes)
+      .set({ sandboxId: null, materializedAt: null })
+      .where(eq(githubProjectSandboxes.id, row.id));
+  }
 }
 
 /**
@@ -223,22 +310,31 @@ function cleanUrl(repoFullName: string): string {
   return `https://github.com/${repoFullName}.git`;
 }
 
+/** Repo metadata needed to materialize, read from the org-owned project row. */
+export interface RepoMaterializeInfo {
+  repoFullName: string;
+  defaultBranch: string;
+}
+
 /**
- * Materialize the repo inside its sandbox. Clones on first open, pulls on
+ * Materialize the repo inside the user's sandbox. Clones on first open, pulls on
  * re-open. Always scrubs the install token from the remote afterwards and sets
- * `materialized_at` in the DB.
+ * `materialized_at` on the per-user sandbox binding row.
  *
- * @param row     the project row (already provisioned via `ensureProjectSandbox`)
- * @param sandbox the live sandbox to run git inside
- * @param token   a freshly minted, short-lived installation access token
+ * @param sandboxRow the per-(project,user) sandbox binding (provisioned via
+ *                   `ensureProjectSandbox`)
+ * @param repo       repo metadata from the org-owned project row
+ * @param sandbox    the live sandbox to run git inside
+ * @param token      a freshly minted, short-lived installation access token
  */
 export async function materializeRepo(
-  row: GithubProjectRow,
+  sandboxRow: GithubProjectSandboxRow,
+  repoInfo: RepoMaterializeInfo,
   sandbox: MaterializationSandbox,
   token: string,
 ): Promise<void> {
-  const workdir = row.sandboxWorkdir;
-  const repo = row.repoFullName;
+  const workdir = sandboxRow.sandboxWorkdir;
+  const repo = repoInfo.repoFullName;
 
   // 0. Defense in depth: never build a git command from values that aren't
   // strictly shaped, even if a malformed row reached the DB. Inputs are also
@@ -246,9 +342,9 @@ export async function materializeRepo(
   if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) {
     throw new MaterializeError(`Refusing to materialize: invalid repo full name '${repo}'.`, 'clone-failed');
   }
-  if (!/^[A-Za-z0-9_./-]+$/.test(row.defaultBranch)) {
+  if (!/^[A-Za-z0-9_./-]+$/.test(repoInfo.defaultBranch)) {
     throw new MaterializeError(
-      `Refusing to materialize: invalid default branch '${row.defaultBranch}'.`,
+      `Refusing to materialize: invalid default branch '${repoInfo.defaultBranch}'.`,
       'clone-failed',
     );
   }
@@ -265,11 +361,11 @@ export async function materializeRepo(
   const authUrl = tokenUrl(repo, token);
 
   try {
-    if (!row.materializedAt) {
+    if (!sandboxRow.materializedAt) {
       // 2a. First open: clone the default branch into the workdir.
       const clone = await sh(
         sandbox,
-        `git clone --branch ${shellQuote(row.defaultBranch)} ${shellQuote(authUrl)} ${shellQuote(workdir)}`,
+        `git clone --branch ${shellQuote(repoInfo.defaultBranch)} ${shellQuote(authUrl)} ${shellQuote(workdir)}`,
       );
       if (clone.exitCode !== 0) {
         throw classifyGitFailure(clone, 'clone-failed');
@@ -290,11 +386,14 @@ export async function materializeRepo(
     // git config, even when the clone/pull above failed partway through. This
     // is best-effort on the failure path (the workdir may not exist yet after a
     // failed clone); on the success path the scrub must succeed or we surface it.
-    await scrubRemote(sandbox, workdir, repo, Boolean(row.materializedAt));
+    await scrubRemote(sandbox, workdir, repo, Boolean(sandboxRow.materializedAt));
   }
 
   // 4. Mark materialized.
-  await getAppDb().update(githubProjects).set({ materializedAt: new Date() }).where(eq(githubProjects.id, row.id));
+  await getAppDb()
+    .update(githubProjectSandboxes)
+    .set({ materializedAt: new Date() })
+    .where(eq(githubProjectSandboxes.id, sandboxRow.id));
 }
 
 /**

--- a/mastracode/src/web/github/sandbox.ts
+++ b/mastracode/src/web/github/sandbox.ts
@@ -48,6 +48,8 @@ export interface MaterializationSandbox {
 export type SandboxFactory = (opts: {
   providerSandboxId?: string;
   env?: Record<string, string>;
+  /** Idle teardown window (minutes). The provider stops the VM after this idle period. */
+  idleTimeoutMinutes?: number;
 }) => MaterializationSandbox;
 
 /**
@@ -84,11 +86,26 @@ export function computeSandboxWorkdir(repoFullName: string): string {
   return `/workspace/${repoName}`;
 }
 
+/**
+ * Idle teardown window for provisioned sandboxes, in minutes. Read from
+ * `MASTRACODE_SANDBOX_IDLE_MINUTES`; defaults to 30. The provider stops an idle
+ * VM after this window so abandoned sandboxes don't linger (GC). A re-open
+ * detects the stopped VM and re-provisions cleanly.
+ */
+export function getSandboxIdleMinutes(): number | undefined {
+  const raw = process.env.MASTRACODE_SANDBOX_IDLE_MINUTES;
+  if (raw === undefined || raw === '') return 30;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 30;
+  return Math.floor(parsed);
+}
+
 /** Default factory: a Railway sandbox, optionally reattaching by id. */
-const railwayFactory: SandboxFactory = ({ providerSandboxId, env }) =>
+const railwayFactory: SandboxFactory = ({ providerSandboxId, env, idleTimeoutMinutes }) =>
   new RailwaySandbox({
     ...(providerSandboxId ? { sandboxId: providerSandboxId } : {}),
     ...(env ? { env } : {}),
+    ...(idleTimeoutMinutes !== undefined ? { idleTimeoutMinutes } : {}),
   });
 
 let sandboxFactory: SandboxFactory = railwayFactory;
@@ -118,17 +135,29 @@ async function readProviderSandboxId(sandbox: MaterializationSandbox): Promise<s
  * reattach to the stored one. Returns a started, live sandbox.
  */
 export async function ensureProjectSandbox(row: GithubProjectRow): Promise<MaterializationSandbox> {
-  const sandbox = sandboxFactory({ providerSandboxId: row.sandboxId ?? undefined });
+  const idleTimeoutMinutes = getSandboxIdleMinutes();
+
+  // Reattach path: if we have a stored sandbox id, try to reattach. The VM may
+  // have been torn down by the provider's idle GC (or otherwise died), in which
+  // case `start()` fails. Recover by clearing the stale id and provisioning a
+  // fresh sandbox so the next open succeeds instead of being permanently wedged.
+  if (row.sandboxId) {
+    const reattached = sandboxFactory({ providerSandboxId: row.sandboxId, idleTimeoutMinutes });
+    try {
+      await reattached.start();
+      return reattached;
+    } catch {
+      await getAppDb().update(githubProjects).set({ sandboxId: null }).where(eq(githubProjects.id, row.id));
+      // fall through to fresh provision below
+    }
+  }
+
+  const sandbox = sandboxFactory({ idleTimeoutMinutes });
   await sandbox.start();
 
-  if (!row.sandboxId) {
-    const providerSandboxId = await readProviderSandboxId(sandbox);
-    if (providerSandboxId) {
-      await getAppDb()
-        .update(githubProjects)
-        .set({ sandboxId: providerSandboxId })
-        .where(eq(githubProjects.id, row.id));
-    }
+  const providerSandboxId = await readProviderSandboxId(sandbox);
+  if (providerSandboxId) {
+    await getAppDb().update(githubProjects).set({ sandboxId: providerSandboxId }).where(eq(githubProjects.id, row.id));
   }
 
   return sandbox;
@@ -141,7 +170,7 @@ export async function ensureProjectSandbox(row: GithubProjectRow): Promise<Mater
  * round-trip is needed.
  */
 export async function reattachProjectSandbox(providerSandboxId: string): Promise<MaterializationSandbox> {
-  const sandbox = sandboxFactory({ providerSandboxId });
+  const sandbox = sandboxFactory({ providerSandboxId, idleTimeoutMinutes: getSandboxIdleMinutes() });
   await sandbox.start();
   return sandbox;
 }
@@ -167,7 +196,15 @@ async function sh(sandbox: MaterializationSandbox, script: string): Promise<Sand
 export class MaterializeError extends Error {
   constructor(
     message: string,
-    readonly code: 'git-missing' | 'egress-blocked' | 'clone-failed' | 'pull-failed',
+    readonly code:
+      | 'git-missing'
+      | 'egress-blocked'
+      | 'clone-failed'
+      | 'pull-failed'
+      | 'push-failed'
+      | 'commit-failed'
+      | 'gh-missing'
+      | 'pr-failed',
   ) {
     super(message);
     this.name = 'MaterializeError';
@@ -288,7 +325,10 @@ async function scrubRemote(
  * Turn a failed git command into an actionable error, detecting the common
  * "cannot reach github.com" egress failure.
  */
-function classifyGitFailure(result: SandboxCommandResult, fallback: 'clone-failed' | 'pull-failed'): MaterializeError {
+function classifyGitFailure(
+  result: SandboxCommandResult,
+  fallback: 'clone-failed' | 'pull-failed' | 'push-failed',
+): MaterializeError {
   const stderr = result.stderr || '';
   if (/could not resolve host|failed to connect|network is unreachable|Connection timed out/i.test(stderr)) {
     return new MaterializeError(
@@ -296,5 +336,381 @@ function classifyGitFailure(result: SandboxCommandResult, fallback: 'clone-faile
       'egress-blocked',
     );
   }
-  return new MaterializeError(`git ${fallback === 'clone-failed' ? 'clone' : 'pull'} failed: ${stderr}`, fallback);
+  const verb = fallback === 'clone-failed' ? 'clone' : fallback === 'pull-failed' ? 'pull' : 'push';
+  return new MaterializeError(`git ${verb} failed: ${stderr}`, fallback);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — git identity + token-scoped push primitive
+//
+// These helpers let the sandbox author and push commits safely. The install
+// token is short-lived, minted per-operation server-side, injected only into
+// the temporary remote URL inside the sandbox, and always scrubbed in a
+// `finally` so it never persists in `.git/config`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a git ref (branch) name. Server-side defense-in-depth: only allow a
+ * conservative character set so a branch can never be built into a shell
+ * command in a way that escapes quoting. Mirrors the route-layer check.
+ */
+export function isValidGitRef(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 255 && /^[A-Za-z0-9_./-]+$/.test(value);
+}
+
+/** Identity used to author commits inside the sandbox. */
+export interface GitIdentity {
+  name?: string | null;
+  email?: string | null;
+  /** GitHub login, used to derive a stable noreply identity when name/email are absent. */
+  login?: string | null;
+}
+
+/**
+ * Resolve a concrete `{ name, email }` for git authorship from a possibly-sparse
+ * identity. Falls back to a GitHub-style noreply identity so commits are never
+ * authored with an empty or host-derived identity.
+ */
+export function resolveGitIdentity(identity: GitIdentity): { name: string; email: string } {
+  const login = (identity.login || '').trim();
+  const name = (identity.name || '').trim() || login || 'Mastra Code';
+  const email =
+    (identity.email || '').trim() ||
+    (login ? `${login}@users.noreply.github.com` : 'mastra-code@users.noreply.github.com');
+  return { name, email };
+}
+
+/**
+ * Configure `user.name` / `user.email` for the given repo working tree inside
+ * the sandbox so commits are authored correctly. Values are shell-quoted.
+ */
+export async function configureGitIdentity(
+  sandbox: MaterializationSandbox,
+  workdir: string,
+  identity: GitIdentity,
+): Promise<void> {
+  const { name, email } = resolveGitIdentity(identity);
+  const setName = await sh(sandbox, `git -C ${shellQuote(workdir)} config user.name ${shellQuote(name)}`);
+  if (setName.exitCode !== 0) {
+    throw new MaterializeError(`Failed to set git user.name: ${setName.stderr.trim()}`, 'commit-failed');
+  }
+  const setEmail = await sh(sandbox, `git -C ${shellQuote(workdir)} config user.email ${shellQuote(email)}`);
+  if (setEmail.exitCode !== 0) {
+    throw new MaterializeError(`Failed to set git user.email: ${setEmail.stderr.trim()}`, 'commit-failed');
+  }
+}
+
+/**
+ * Temporarily rewrite `origin` to a tokenized URL, run `fn` (e.g. a push), and
+ * **always** scrub the remote back to the tokenless URL in a `finally`. The
+ * token therefore only ever lives in the remote URL for the duration of the
+ * operation and is never left in the VM's git config.
+ *
+ * On the success path the scrub must succeed (a leaked token is a hard error);
+ * if it fails we surface it. On the failure path the scrub is best-effort but
+ * still attempted, and the original operation error is rethrown.
+ */
+export async function withInstallToken<T>(
+  sandbox: MaterializationSandbox,
+  workdir: string,
+  repoFullName: string,
+  token: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!/^[\w.-]+\/[\w.-]+$/.test(repoFullName)) {
+    throw new MaterializeError(`Refusing to push: invalid repo full name '${repoFullName}'.`, 'push-failed');
+  }
+
+  const setUrl = await sh(
+    sandbox,
+    `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(tokenUrl(repoFullName, token))}`,
+  );
+  if (setUrl.exitCode !== 0) {
+    // Best-effort scrub even though set-url failed, then surface the failure.
+    await scrubRemote(sandbox, workdir, repoFullName, false);
+    throw new MaterializeError(`Failed to set git remote: ${setUrl.stderr.trim()}`, 'push-failed');
+  }
+
+  try {
+    return await fn();
+  } finally {
+    // Always restore the tokenless remote. The workdir has a `.git` (we just
+    // rewrote its remote) so a scrub failure means the token may still persist
+    // — surface it.
+    await scrubRemote(sandbox, workdir, repoFullName, true);
+  }
+}
+
+/**
+ * Push a branch back to GitHub from inside the sandbox using a short-lived
+ * installation token. The branch is ref-validated, the token is injected only
+ * into the remote URL via `withInstallToken`, and egress failures are
+ * classified into actionable errors.
+ */
+export async function pushBranch(
+  sandbox: MaterializationSandbox,
+  workdir: string,
+  branch: string,
+  token: string,
+  repoFullName: string,
+): Promise<void> {
+  if (!isValidGitRef(branch)) {
+    throw new MaterializeError(`Refusing to push: invalid branch name '${branch}'.`, 'push-failed');
+  }
+
+  await withInstallToken(sandbox, workdir, repoFullName, token, async () => {
+    const push = await sh(sandbox, `git -C ${shellQuote(workdir)} push -u origin ${shellQuote(branch)}`);
+    if (push.exitCode !== 0) {
+      throw classifyGitFailure(push, 'push-failed');
+    }
+  });
+}
+
+export interface CommitResult {
+  /** True when a commit was created; false when there was nothing to commit. */
+  committed: boolean;
+}
+
+/**
+ * Stage every change in the working tree and create a commit inside the
+ * sandbox. The git identity is configured first so authorship is correct. When
+ * there is nothing to commit this is a no-op (`committed: false`) rather than an
+ * error, so callers can safely commit-then-push without first diffing.
+ *
+ * @param sandbox  the live sandbox containing the checkout
+ * @param workdir  the worktree (or repo) path to commit in
+ * @param message  the commit message (quoted; arbitrary text is safe)
+ * @param identity authorship identity for the commit
+ */
+export async function commitAll(
+  sandbox: MaterializationSandbox,
+  workdir: string,
+  message: string,
+  identity: GitIdentity,
+): Promise<CommitResult> {
+  await configureGitIdentity(sandbox, workdir, identity);
+
+  const add = await sh(sandbox, `git -C ${shellQuote(workdir)} add -A`);
+  if (add.exitCode !== 0) {
+    throw new MaterializeError(`git add failed: ${add.stderr.trim() || add.stdout.trim()}`, 'commit-failed');
+  }
+
+  // Nothing staged → nothing to commit. `git diff --cached --quiet` exits 1 when
+  // there are staged changes, 0 when the index is clean.
+  const staged = await sh(sandbox, `git -C ${shellQuote(workdir)} diff --cached --quiet`);
+  if (staged.exitCode === 0) {
+    return { committed: false };
+  }
+
+  const commit = await sh(sandbox, `git -C ${shellQuote(workdir)} commit -m ${shellQuote(message)}`);
+  if (commit.exitCode !== 0) {
+    throw new MaterializeError(`git commit failed: ${commit.stderr.trim() || commit.stdout.trim()}`, 'commit-failed');
+  }
+
+  return { committed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — worktree / branch lifecycle
+//
+// Each unit of work gets its own branch + working tree inside the same sandbox
+// as the base checkout. The worktree path is always computed server-side from a
+// sanitized branch name; client input never reaches a filesystem path.
+// ---------------------------------------------------------------------------
+
+/** Error raised when a worktree cannot be created/reused inside the sandbox. */
+export class WorktreeError extends Error {
+  constructor(
+    message: string,
+    readonly code: 'invalid-branch' | 'worktree-failed',
+  ) {
+    super(message);
+    this.name = 'WorktreeError';
+  }
+}
+
+/**
+ * Reduce a (already ref-validated) branch name to a filesystem-safe directory
+ * segment for the worktree path: lowercase, slashes/dots/unsafe chars collapsed
+ * to `-`. This only affects the *directory name*, never the git branch itself.
+ */
+export function safeBranchDir(branch: string): string {
+  return (
+    branch
+      .replace(/[^A-Za-z0-9._-]+/g, '-')
+      .replace(/\/+/g, '-')
+      .replace(/^[-.]+|[-.]+$/g, '')
+      .slice(0, 100) || 'work'
+  );
+}
+
+/**
+ * Compute the absolute worktree path for a branch, server-side only. Worktrees
+ * live alongside the repo checkout under a sibling `worktrees/` directory so the
+ * repo's `.git` is shared. Never derived from client-supplied paths.
+ */
+export function computeWorktreePath(repoWorkdir: string, branch: string): string {
+  const parent = repoWorkdir.replace(/\/+$/, '').split('/').slice(0, -1).join('/') || '';
+  return `${parent}/worktrees/${safeBranchDir(branch)}`;
+}
+
+export interface EnsureWorktreeResult {
+  worktreePath: string;
+  branch: string;
+  baseBranch: string;
+  /** True when an existing worktree was reused rather than freshly created. */
+  reused: boolean;
+}
+
+/**
+ * Create (or reuse) a git worktree + branch inside the sandbox for a unit of
+ * work. Idempotent: if a worktree already exists at the computed path it is
+ * reused. The branch is created from `baseBranch` when it does not yet exist.
+ *
+ * @param sandbox      live sandbox containing the base checkout
+ * @param repoWorkdir  the base repo checkout path inside the sandbox
+ * @param branch       the feature branch (ref-validated server-side)
+ * @param baseBranch   the branch to fork from (ref-validated; default's repo branch)
+ */
+export async function ensureWorktree(
+  sandbox: MaterializationSandbox,
+  repoWorkdir: string,
+  { branch, baseBranch }: { branch: string; baseBranch: string },
+): Promise<EnsureWorktreeResult> {
+  if (!isValidGitRef(branch)) {
+    throw new WorktreeError(`Invalid branch name '${branch}'.`, 'invalid-branch');
+  }
+  if (!isValidGitRef(baseBranch)) {
+    throw new WorktreeError(`Invalid base branch name '${baseBranch}'.`, 'invalid-branch');
+  }
+
+  const worktreePath = computeWorktreePath(repoWorkdir, branch);
+
+  // Idempotent reuse: a worktree already checked out at this path has a `.git`
+  // file (worktrees use a gitfile, not a directory). Reuse it as-is.
+  const exists = await sh(sandbox, `test -e ${shellQuote(`${worktreePath}/.git`)}`);
+  if (exists.exitCode === 0) {
+    return { worktreePath, branch, baseBranch, reused: true };
+  }
+
+  // Make sure the base ref is present locally before forking from it.
+  await sh(sandbox, `git -C ${shellQuote(repoWorkdir)} fetch origin ${shellQuote(baseBranch)}`);
+
+  // Create the worktree. If the branch already exists, check it out into the
+  // worktree; otherwise create it from the base branch. `git worktree add -B`
+  // creates-or-resets the branch to the base, which keeps this idempotent for a
+  // fresh worktree while still working when the branch already exists remotely.
+  const add = await sh(
+    sandbox,
+    `git -C ${shellQuote(repoWorkdir)} worktree add -B ${shellQuote(branch)} ${shellQuote(worktreePath)} ${shellQuote(baseBranch)}`,
+  );
+  if (add.exitCode !== 0) {
+    throw new WorktreeError(`git worktree add failed: ${add.stderr.trim() || add.stdout.trim()}`, 'worktree-failed');
+  }
+
+  return { worktreePath, branch, baseBranch, reused: false };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 — `gh` CLI pull-request creation primitive
+//
+// PRs are opened from inside the sandbox with the GitHub CLI. `gh` must be
+// present in the sandbox template (preflighted only on the PR path so clone /
+// open still work when it is absent). The token is passed to `gh` via a
+// per-invocation `GH_TOKEN` env that is scoped to the single `gh` process and
+// never written to git config, a shell rc, or the VM's environment.
+// ---------------------------------------------------------------------------
+
+export interface CreatePullRequestArgs {
+  /** Short-lived installation token, injected only into the `gh` process env. */
+  token: string;
+  /** Base branch the PR merges into. Ref-validated. */
+  base: string;
+  /** Head branch the PR is opened from. Ref-validated. */
+  head: string;
+  /** PR title. */
+  title: string;
+  /** PR body (optional). */
+  body?: string;
+}
+
+export interface CreatePullRequestResult {
+  /** The PR URL parsed from `gh pr create` stdout. */
+  url: string;
+}
+
+/**
+ * Preflight that `gh` is installed in the sandbox. Only called on the PR path so
+ * a missing `gh` never blocks clone/open. Surfaces an actionable error naming
+ * the sandbox template requirement.
+ */
+async function assertGhAvailable(sandbox: MaterializationSandbox): Promise<void> {
+  const version = await sh(sandbox, 'gh --version');
+  if (version.exitCode !== 0) {
+    throw new MaterializeError(
+      'The GitHub CLI (gh) is not installed in the sandbox. The sandbox template must include gh to open pull requests.',
+      'gh-missing',
+    );
+  }
+}
+
+/** Match the first GitHub PR URL in `gh pr create` output. */
+function parsePullRequestUrl(stdout: string): string | undefined {
+  const match = stdout.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/);
+  return match?.[0];
+}
+
+/**
+ * Open a pull request from inside the sandbox via `gh pr create`. The token is
+ * passed only through a per-invocation `GH_TOKEN` env scoped to the single `gh`
+ * process (never persisted), all arguments are shell-quoted, and the resulting
+ * PR URL is parsed from stdout.
+ *
+ * @param sandbox live sandbox containing the checkout
+ * @param workdir the worktree (or repo) path the PR head branch is checked out in
+ */
+export async function createPullRequest(
+  sandbox: MaterializationSandbox,
+  workdir: string,
+  { token, base, head, title, body }: CreatePullRequestArgs,
+): Promise<CreatePullRequestResult> {
+  if (!isValidGitRef(base)) {
+    throw new MaterializeError(`Refusing to open PR: invalid base branch '${base}'.`, 'pr-failed');
+  }
+  if (!isValidGitRef(head)) {
+    throw new MaterializeError(`Refusing to open PR: invalid head branch '${head}'.`, 'pr-failed');
+  }
+
+  await assertGhAvailable(sandbox);
+
+  // GH_TOKEN is prefixed inline so it is exported only to the single `gh`
+  // process and never to the wider shell session, git config, or VM env. `gh`
+  // is run from inside the checkout so it targets the correct repo/head branch.
+  const ghCommand = [
+    `GH_TOKEN=${shellQuote(token)} gh pr create`,
+    `--base ${shellQuote(base)}`,
+    `--head ${shellQuote(head)}`,
+    `--title ${shellQuote(title)}`,
+    `--body ${shellQuote(body ?? '')}`,
+  ].join(' ');
+  const script = `cd ${shellQuote(workdir)} && ${ghCommand}`;
+
+  const result = await sh(sandbox, script);
+  if (result.exitCode !== 0) {
+    const classified = classifyGitFailure(result, 'push-failed');
+    if (classified.code === 'egress-blocked') {
+      throw classified;
+    }
+    throw new MaterializeError(`gh pr create failed: ${result.stderr.trim() || result.stdout.trim()}`, 'pr-failed');
+  }
+
+  const url = parsePullRequestUrl(result.stdout);
+  if (!url) {
+    throw new MaterializeError(
+      `gh pr create succeeded but no PR URL was found in its output: ${result.stdout.trim()}`,
+      'pr-failed',
+    );
+  }
+
+  return { url };
 }

--- a/mastracode/src/web/github/schema.ts
+++ b/mastracode/src/web/github/schema.ts
@@ -63,10 +63,36 @@ export const githubProjects = pgTable(
   table => [uniqueIndex('github_projects_user_repo_unique').on(table.userId, table.repoId)],
 );
 
+/**
+ * A git worktree / feature branch created inside a project's sandbox for a unit
+ * of work. The worktree path is always computed server-side; one row per
+ * `(githubProjectId, branch)` so re-opening a branch reattaches the same tree.
+ */
+export const githubWorktrees = pgTable(
+  'github_worktrees',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** Stable WorkOS user id. */
+    userId: text('user_id').notNull(),
+    /** Project the worktree belongs to. */
+    githubProjectId: uuid('github_project_id').notNull(),
+    /** The feature branch this worktree checks out. */
+    branch: text('branch').notNull(),
+    /** The branch this worktree's branch was forked from. */
+    baseBranch: text('base_branch').notNull(),
+    /** Absolute path of the worktree inside the sandbox (server-computed). */
+    worktreePath: text('worktree_path').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  table => [uniqueIndex('github_worktrees_project_branch_unique').on(table.githubProjectId, table.branch)],
+);
+
 export type GithubInstallationRow = typeof githubInstallations.$inferSelect;
 export type GithubProjectRow = typeof githubProjects.$inferSelect;
+export type GithubWorktreeRow = typeof githubWorktrees.$inferSelect;
 export type NewGithubInstallationRow = typeof githubInstallations.$inferInsert;
 export type NewGithubProjectRow = typeof githubProjects.$inferInsert;
+export type NewGithubWorktreeRow = typeof githubWorktrees.$inferInsert;
 
 /**
  * Idempotent DDL run on boot when the feature is enabled. We keep migrations
@@ -103,4 +129,17 @@ CREATE TABLE IF NOT EXISTS github_projects (
 
 CREATE UNIQUE INDEX IF NOT EXISTS github_projects_user_repo_unique
   ON github_projects (user_id, repo_id);
+
+CREATE TABLE IF NOT EXISTS github_worktrees (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id text NOT NULL,
+  github_project_id uuid NOT NULL,
+  branch text NOT NULL,
+  base_branch text NOT NULL,
+  worktree_path text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS github_worktrees_project_branch_unique
+  ON github_worktrees (github_project_id, branch);
 `;

--- a/mastracode/src/web/github/schema.ts
+++ b/mastracode/src/web/github/schema.ts
@@ -1,24 +1,34 @@
 /**
  * Drizzle schema for the separate application Postgres backing the GitHub App
  * integration. This database is distinct from Mastra's own storage: it holds
- * only the GitHub App installations a user has connected and the repos they have
+ * only the GitHub App installations an org has connected and the repos they have
  * turned into MastraCode Web projects. No agent memory or Mastra data lives here.
  *
- * Rows are always scoped by `user_id` (the stable WorkOS user id) so a user can
- * only ever see and operate on their own installations and projects.
+ * The tenancy model is **org-first**:
+ * - A GitHub App installation and the projects (connected repos) are owned by a
+ *   WorkOS **organization** (`org_id`). The same repo can be connected
+ *   independently by different orgs.
+ * - The per-user build artifacts — the sandbox a repo is materialized into and
+ *   the worktrees/branches created in it — are owned by `(org, user)`. Each user
+ *   in an org gets their own sandbox + worktrees for the org's project.
+ *
+ * `user_id` on the installation/project rows records *who connected it* (audit)
+ * and no longer scopes reads; org-scoped reads use `org_id`.
  */
 
 import { bigint, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
 
 /**
- * A GitHub App installation a user has connected. One user may have several
- * installations (e.g. one personal account + several orgs).
+ * A GitHub App installation an org has connected. The installation is org-owned:
+ * any user in the org can list repos and create projects from it.
  */
 export const githubInstallations = pgTable(
   'github_installations',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    /** Stable WorkOS user id (`workosId`/`id`). */
+    /** Owning WorkOS organization id. */
+    orgId: text('org_id').notNull(),
+    /** Stable WorkOS user id of whoever connected it (audit only). */
     userId: text('user_id').notNull(),
     /** GitHub numeric installation id. */
     installationId: bigint('installation_id', { mode: 'number' }).notNull(),
@@ -28,19 +38,21 @@ export const githubInstallations = pgTable(
     accountType: text('account_type'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  table => [uniqueIndex('github_installations_user_installation_unique').on(table.userId, table.installationId)],
+  table => [uniqueIndex('github_installations_org_installation_unique').on(table.orgId, table.installationId)],
 );
 
 /**
- * A repo a user has turned into a project. The repo is materialized lazily into
- * a per-project cloud sandbox (no local clone). `sandboxId` / `materializedAt`
- * are null until the project is first opened.
+ * A repo an org has turned into a project. The project is pure org-level repo
+ * metadata; the per-user sandbox the repo is materialized into lives in
+ * `github_project_sandboxes`. One project per repo per org.
  */
 export const githubProjects = pgTable(
   'github_projects',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    /** Stable WorkOS user id. */
+    /** Owning WorkOS organization id. */
+    orgId: text('org_id').notNull(),
+    /** Stable WorkOS user id of whoever created it (audit only). */
     userId: text('user_id').notNull(),
     /** Installation the repo is accessed through. */
     installationId: bigint('installation_id', { mode: 'number' }).notNull(),
@@ -52,6 +64,27 @@ export const githubProjects = pgTable(
     defaultBranch: text('default_branch').notNull().default('main'),
     /** Sandbox provider id, e.g. 'railway'. */
     sandboxProvider: text('sandbox_provider').notNull().default('railway'),
+    /** Path inside the sandbox the repo is cloned into. */
+    sandboxWorkdir: text('sandbox_workdir').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  table => [uniqueIndex('github_projects_org_repo_unique').on(table.orgId, table.repoId)],
+);
+
+/**
+ * The per-user sandbox a project's repo is materialized into. Each `(project,
+ * user)` gets its own sandbox + checkout, so two users in the same org work in
+ * isolation against the org's project. `sandboxId` / `materializedAt` are null
+ * until the user first opens the project.
+ */
+export const githubProjectSandboxes = pgTable(
+  'github_project_sandboxes',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** Project (org-owned) this sandbox materializes. */
+    githubProjectId: uuid('github_project_id').notNull(),
+    /** Owning WorkOS user id (the sandbox belongs to this user only). */
+    userId: text('user_id').notNull(),
     /** Provider sandbox id once provisioned; null until first open. */
     sandboxId: text('sandbox_id'),
     /** Path inside the sandbox the repo is cloned into. */
@@ -60,19 +93,21 @@ export const githubProjects = pgTable(
     materializedAt: timestamp('materialized_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  table => [uniqueIndex('github_projects_user_repo_unique').on(table.userId, table.repoId)],
+  table => [uniqueIndex('github_project_sandboxes_project_user_unique').on(table.githubProjectId, table.userId)],
 );
 
 /**
- * A git worktree / feature branch created inside a project's sandbox for a unit
- * of work. The worktree path is always computed server-side; one row per
- * `(githubProjectId, branch)` so re-opening a branch reattaches the same tree.
+ * A git worktree / feature branch created inside a user's sandbox for a unit of
+ * work. Owned by `(org, user)`; one row per `(githubProjectId, userId, branch)`
+ * so two users in an org can use the same branch name in their own trees.
  */
 export const githubWorktrees = pgTable(
   'github_worktrees',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    /** Stable WorkOS user id. */
+    /** Owning WorkOS organization id. */
+    orgId: text('org_id').notNull(),
+    /** Owning WorkOS user id (the worktree belongs to this user only). */
     userId: text('user_id').notNull(),
     /** Project the worktree belongs to. */
     githubProjectId: uuid('github_project_id').notNull(),
@@ -84,21 +119,31 @@ export const githubWorktrees = pgTable(
     worktreePath: text('worktree_path').notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  table => [uniqueIndex('github_worktrees_project_branch_unique').on(table.githubProjectId, table.branch)],
+  table => [
+    uniqueIndex('github_worktrees_project_user_branch_unique').on(table.githubProjectId, table.userId, table.branch),
+  ],
 );
 
 export type GithubInstallationRow = typeof githubInstallations.$inferSelect;
 export type GithubProjectRow = typeof githubProjects.$inferSelect;
+export type GithubProjectSandboxRow = typeof githubProjectSandboxes.$inferSelect;
 export type GithubWorktreeRow = typeof githubWorktrees.$inferSelect;
 export type NewGithubInstallationRow = typeof githubInstallations.$inferInsert;
 export type NewGithubProjectRow = typeof githubProjects.$inferInsert;
+export type NewGithubProjectSandboxRow = typeof githubProjectSandboxes.$inferInsert;
 export type NewGithubWorktreeRow = typeof githubWorktrees.$inferInsert;
 
 /**
  * Idempotent DDL run on boot when the feature is enabled. We keep migrations
  * inline (rather than drizzle-kit generated files) because the schema is small
  * and only ever grows additively; `CREATE TABLE IF NOT EXISTS` keeps boot safe
- * to re-run.
+ * to re-run. New org-scoping columns/indexes are added with
+ * `ADD COLUMN IF NOT EXISTS` / `CREATE UNIQUE INDEX IF NOT EXISTS` so existing
+ * deployments migrate forward without a separate migration step.
+ *
+ * Pre-GA note: existing rows predate `org_id` and are left NULL. Org-scoped
+ * reads require a non-null `org_id`, so legacy rows are simply not returned;
+ * this is acceptable while the feature is behind env flags and not yet GA.
  */
 export const MIGRATION_SQL = `
 CREATE TABLE IF NOT EXISTS github_installations (
@@ -110,8 +155,10 @@ CREATE TABLE IF NOT EXISTS github_installations (
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS github_installations_user_installation_unique
-  ON github_installations (user_id, installation_id);
+ALTER TABLE github_installations ADD COLUMN IF NOT EXISTS org_id text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS github_installations_org_installation_unique
+  ON github_installations (org_id, installation_id);
 
 CREATE TABLE IF NOT EXISTS github_projects (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -121,14 +168,27 @@ CREATE TABLE IF NOT EXISTS github_projects (
   repo_id bigint NOT NULL,
   default_branch text NOT NULL DEFAULT 'main',
   sandbox_provider text NOT NULL DEFAULT 'railway',
+  sandbox_workdir text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE github_projects ADD COLUMN IF NOT EXISTS org_id text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS github_projects_org_repo_unique
+  ON github_projects (org_id, repo_id);
+
+CREATE TABLE IF NOT EXISTS github_project_sandboxes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  github_project_id uuid NOT NULL,
+  user_id text NOT NULL,
   sandbox_id text,
   sandbox_workdir text NOT NULL,
   materialized_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS github_projects_user_repo_unique
-  ON github_projects (user_id, repo_id);
+CREATE UNIQUE INDEX IF NOT EXISTS github_project_sandboxes_project_user_unique
+  ON github_project_sandboxes (github_project_id, user_id);
 
 CREATE TABLE IF NOT EXISTS github_worktrees (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -140,6 +200,8 @@ CREATE TABLE IF NOT EXISTS github_worktrees (
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS github_worktrees_project_branch_unique
-  ON github_worktrees (github_project_id, branch);
+ALTER TABLE github_worktrees ADD COLUMN IF NOT EXISTS org_id text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS github_worktrees_project_user_branch_unique
+  ON github_worktrees (github_project_id, user_id, branch);
 `;

--- a/mastracode/src/web/github/state-secret-scenario.test.ts
+++ b/mastracode/src/web/github/state-secret-scenario.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetStateSecretForTests,
+  assertReplicaStableStateSecret,
+  hasExplicitStateSecret,
+  isGithubFeatureEnabled,
+  signState,
+  verifyState,
+} from './config';
+
+// ── Phase 6 state-secret deploy scenario ─────────────────────────────────
+// The OAuth/install `state` is HMAC-signed with a secret. With no explicit
+// secret it falls back to a per-process random one, which breaks across
+// replicas: a `state` signed by replica A cannot be verified by replica B.
+// These tests simulate a second replica via `__resetStateSecretForTests()`
+// (drops the cached secret, forcing a fresh resolution as a new process would).
+
+const GITHUB_ENV_KEYS = [
+  'GITHUB_APP_ID',
+  'GITHUB_APP_PRIVATE_KEY',
+  'GITHUB_APP_CLIENT_ID',
+  'GITHUB_APP_CLIENT_SECRET',
+  'GITHUB_APP_SLUG',
+  'WORKOS_API_KEY',
+  'WORKOS_CLIENT_ID',
+  'APP_DATABASE_URL',
+  'GITHUB_APP_WEBHOOK_SECRET',
+  'WORKOS_COOKIE_PASSWORD',
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+
+function enableGithubFeature(): void {
+  process.env.GITHUB_APP_ID = 'app-id';
+  process.env.GITHUB_APP_PRIVATE_KEY = 'pk';
+  process.env.GITHUB_APP_CLIENT_ID = 'client-id';
+  process.env.GITHUB_APP_CLIENT_SECRET = 'client-secret';
+  process.env.GITHUB_APP_SLUG = 'slug';
+  process.env.WORKOS_API_KEY = 'workos-key';
+  process.env.WORKOS_CLIENT_ID = 'workos-client';
+  process.env.APP_DATABASE_URL = 'postgres://localhost/app';
+}
+
+beforeEach(() => {
+  for (const k of GITHUB_ENV_KEYS) saved[k] = process.env[k];
+  for (const k of GITHUB_ENV_KEYS) delete process.env[k];
+  __resetStateSecretForTests();
+});
+
+afterEach(() => {
+  for (const k of GITHUB_ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  __resetStateSecretForTests();
+});
+
+describe('explicit secret verifies across replicas', () => {
+  it('state signed on replica A verifies on replica B when an explicit secret is set', () => {
+    process.env.GITHUB_APP_WEBHOOK_SECRET = 'shared-stable-secret';
+    __resetStateSecretForTests();
+
+    // Replica A signs.
+    const state = signState('orgA', 'user1');
+
+    // Replica B: simulate a fresh process by dropping the cached secret. Because
+    // the secret is read from env, B resolves the SAME secret.
+    __resetStateSecretForTests();
+    const tenant = verifyState(state);
+
+    expect(tenant).toEqual({ orgId: 'orgA', userId: 'user1' });
+  });
+
+  it('WORKOS_COOKIE_PASSWORD also provides a stable secret', () => {
+    process.env.WORKOS_COOKIE_PASSWORD = 'cookie-pw-stable';
+    __resetStateSecretForTests();
+    const state = signState('orgA', 'user1');
+    __resetStateSecretForTests();
+    expect(verifyState(state)).toEqual({ orgId: 'orgA', userId: 'user1' });
+  });
+});
+
+describe('random fallback fails across replicas', () => {
+  it('state signed on replica A fails to verify on replica B with no explicit secret', () => {
+    // No explicit secret → per-process random.
+    expect(hasExplicitStateSecret()).toBe(false);
+    const state = signState('orgA', 'user1');
+
+    // Replica B with a *different* random secret cannot verify.
+    __resetStateSecretForTests();
+    expect(verifyState(state)).toBeNull();
+  });
+
+  it('same process (no reset) still verifies its own random-signed state', () => {
+    const state = signState('orgA', 'user1');
+    // No reset → same in-process random secret → verifies.
+    expect(verifyState(state)).toEqual({ orgId: 'orgA', userId: 'user1' });
+  });
+});
+
+describe('startup guard', () => {
+  it('throws when the GitHub feature is on but no explicit secret is set', () => {
+    enableGithubFeature();
+    expect(isGithubFeatureEnabled()).toBe(true);
+    expect(hasExplicitStateSecret()).toBe(false);
+    expect(() => assertReplicaStableStateSecret()).toThrow(/replica-stable state secret/);
+  });
+
+  it('passes when the GitHub feature is on and an explicit secret is set', () => {
+    enableGithubFeature();
+    process.env.GITHUB_APP_WEBHOOK_SECRET = 'shared-stable-secret';
+    expect(() => assertReplicaStableStateSecret()).not.toThrow();
+  });
+
+  it('is a no-op when the GitHub feature is off (random fallback is fine locally)', () => {
+    // No GitHub env → feature off.
+    expect(isGithubFeatureEnabled()).toBe(false);
+    expect(() => assertReplicaStableStateSecret()).not.toThrow();
+  });
+});

--- a/mastracode/src/web/server.ts
+++ b/mastracode/src/web/server.ts
@@ -18,6 +18,7 @@ import { isGithubFeatureEnabled } from './github/config.js';
 import { ensureAppDbReady } from './github/db.js';
 import { mountGithubRoutes } from './github/routes.js';
 import { isSandboxEnabled } from './github/sandbox.js';
+import { TenantDispatcher } from './tenant-server.js';
 
 const CONTROLLER_ID = 'code';
 
@@ -95,6 +96,24 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   const webAuthEnabled = mountWebAuth(app, { redirectUri });
   process.stderr.write(`MastraCode web auth: ${webAuthEnabled ? 'enabled (WorkOS AuthKit)' : 'disabled'}\n`);
 
+  // Per-tenant isolation: when web auth is enabled, every authenticated user
+  // operates against their own Mastra bound to their own libSQL storage/vector
+  // pair so no tenant's threads/messages/memory/recall can leak into another's.
+  // The dispatcher intercepts the Mastra controller surface (`/api/*`), routes
+  // authenticated users to their isolated tenant app, and falls through to the
+  // shared adapter below for the auth-disabled / unauthenticated public path.
+  let tenantDispatcher: TenantDispatcher | undefined;
+  if (webAuthEnabled) {
+    tenantDispatcher = new TenantDispatcher({
+      baseConfig: mastraCodeConfig,
+      controllerId: CONTROLLER_ID,
+    });
+    app.use('/api/*', tenantDispatcher.middleware());
+    process.stderr.write('MastraCode web storage: per-tenant libSQL (isolated)\n');
+  } else {
+    process.stderr.write('MastraCode web storage: shared (single store)\n');
+  }
+
   const adapter = new MastraServer({ app, mastra });
   await adapter.init();
 
@@ -147,7 +166,11 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
     url: `http://localhost:${port}`,
     stop: async () => {
       await new Promise<void>(resolve => server.close(() => resolve()));
-      await Promise.allSettled([controller.getMastra()?.stopWorkers(), controller.stopHeartbeats()]);
+      await Promise.allSettled([
+        controller.getMastra()?.stopWorkers(),
+        controller.stopHeartbeats(),
+        tenantDispatcher?.stopAll(),
+      ]);
     },
   };
 }

--- a/mastracode/src/web/server.ts
+++ b/mastracode/src/web/server.ts
@@ -14,11 +14,12 @@ import type { MastraCodeConfig } from '../index.js';
 import { mountWebAuth } from './auth.js';
 import { mountConfigRoutes } from './config-routes.js';
 import { mountFsRoutes } from './fs-routes.js';
-import { isGithubFeatureEnabled } from './github/config.js';
+import { assertReplicaStableStateSecret, isGithubFeatureEnabled } from './github/config.js';
 import { ensureAppDbReady } from './github/db.js';
 import { mountGithubRoutes } from './github/routes.js';
 import { isSandboxEnabled } from './github/sandbox.js';
 import { TenantDispatcher } from './tenant-server.js';
+import { assertRemoteTenantDbIfRequired } from './tenant-storage.js';
 
 const CONTROLLER_ID = 'code';
 
@@ -104,6 +105,9 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   // shared adapter below for the auth-disabled / unauthenticated public path.
   let tenantDispatcher: TenantDispatcher | undefined;
   if (webAuthEnabled) {
+    // Fail loud if a remote tenant DB is required (multi-replica/ephemeral
+    // deploy) but only local-file tenant DBs are configured.
+    assertRemoteTenantDbIfRequired();
     tenantDispatcher = new TenantDispatcher({
       baseConfig: mastraCodeConfig,
       controllerId: CONTROLLER_ID,
@@ -133,6 +137,10 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   // if the app DB can't be reached we log and leave the feature disabled rather
   // than crashing the server.
   if (isGithubFeatureEnabled()) {
+    // Fail loud if state signing wouldn't be stable across replicas. A random
+    // per-process secret silently breaks the OAuth/install callback on a replica
+    // that didn't sign the `state`.
+    assertReplicaStableStateSecret();
     const baseUrl = publicOrigin;
     let githubReady = false;
     try {

--- a/mastracode/src/web/tenant-cache-scenario.test.ts
+++ b/mastracode/src/web/tenant-cache-scenario.test.ts
@@ -1,0 +1,224 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Phase 6 tenant-cache eviction scenario ───────────────────────────────
+// The TenantDispatcher caches a full Mastra stack per tenant. Left unbounded
+// it leaks memory as a team grows. These scenarios drive the idle-TTL sweep
+// and the LRU max-size cap end to end using an injected fake builder + clock,
+// so no real Mastra stack boots.
+
+const mockWebAuthTenant = vi.fn();
+vi.mock('./auth.js', () => ({
+  webAuthTenant: (c: unknown) => mockWebAuthTenant(c),
+}));
+
+interface TenantIdentity {
+  orgId?: string;
+  userId: string;
+}
+
+const mockGetUserStorage = vi.fn();
+vi.mock('./tenant-storage.js', () => ({
+  getUserStorage: (identity: TenantIdentity) => mockGetUserStorage(identity),
+}));
+
+import { TenantDispatcher } from './tenant-server.js';
+import type { TenantAppBuilder } from './tenant-server.js';
+
+function tenantKeyOf(identity: TenantIdentity): string {
+  return identity.orgId ? `${identity.orgId}:${identity.userId}` : identity.userId;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserStorage.mockImplementation((identity: TenantIdentity) => {
+    const key = tenantKeyOf(identity);
+    return { tenantKey: `key_${key}`, storageConfig: { tenant: key } };
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * A fake tenant-app builder that records the storage configs it was asked to
+ * build and the stop calls it received, with a per-app echo route proving the
+ * request was routed to the matching stack.
+ */
+function makeFakeBuilder() {
+  const builtTenants: string[] = [];
+  const stopped: string[] = [];
+  const builder: TenantAppBuilder = async storage => {
+    const tenant = (storage as unknown as { tenant: string }).tenant;
+    builtTenants.push(tenant);
+    const app = new Hono();
+    app.get('/api/echo', c => c.json({ tenant }));
+    return {
+      fetch: (request, ...rest) => app.fetch(request as Request, ...(rest as [])),
+      stop: async () => {
+        stopped.push(tenant);
+      },
+    };
+  };
+  return { builder, builtTenants, stopped };
+}
+
+function buildOuterApp(dispatcher: TenantDispatcher) {
+  const app = new Hono();
+  app.use('/api/*', dispatcher.middleware());
+  return app;
+}
+
+describe('idle eviction round-trip', () => {
+  it('evicts an idle tenant (stops it) then rebuilds it on the next request', async () => {
+    const { builder, builtTenants, stopped } = makeFakeBuilder();
+    let clock = 1_000;
+    const dispatcher = new TenantDispatcher({
+      baseConfig: {},
+      controllerId: 'code',
+      buildTenantApp: builder,
+      idleMs: 10 * 60_000, // 10 minutes
+      maxApps: 0, // disable LRU cap; isolate idle behavior
+      now: () => clock,
+    });
+    const app = buildOuterApp(dispatcher);
+
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_a', userId: 'user_a' });
+    const first = await app.request('/api/echo');
+    expect(await first.json()).toEqual({ tenant: 'org_a:user_a' });
+    expect(dispatcher.size()).toBe(1);
+    expect(builtTenants).toEqual(['org_a:user_a']);
+
+    // Advance past the idle window, then a request from a DIFFERENT tenant
+    // triggers the sweep that evicts the idle one.
+    clock += 11 * 60_000;
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_a', userId: 'user_b' });
+    await app.request('/api/echo');
+    // Allow the fire-and-forget stop() to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(stopped).toContain('org_a:user_a');
+    // user_a evicted, user_b cached.
+    expect(dispatcher.size()).toBe(1);
+
+    // user_a returns → rebuilt fresh.
+    clock += 1_000;
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_a', userId: 'user_a' });
+    const back = await app.request('/api/echo');
+    expect(await back.json()).toEqual({ tenant: 'org_a:user_a' });
+    // Built twice in total for user_a (original + rebuild).
+    expect(builtTenants.filter(t => t === 'org_a:user_a')).toHaveLength(2);
+  });
+
+  it('keeps a tenant alive while it is actively used', async () => {
+    const { builder, builtTenants } = makeFakeBuilder();
+    let clock = 0;
+    const dispatcher = new TenantDispatcher({
+      baseConfig: {},
+      controllerId: 'code',
+      buildTenantApp: builder,
+      idleMs: 10 * 60_000,
+      maxApps: 0,
+      now: () => clock,
+    });
+    const app = buildOuterApp(dispatcher);
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_a' });
+
+    await app.request('/api/echo');
+    // Repeated use within the idle window refreshes lastUsed each time.
+    for (let i = 0; i < 5; i++) {
+      clock += 5 * 60_000;
+      await app.request('/api/echo');
+    }
+    // Only one build despite 30 minutes elapsing, because each access refreshed.
+    expect(builtTenants).toEqual(['user_a']);
+    expect(dispatcher.size()).toBe(1);
+  });
+});
+
+describe('max-size LRU eviction', () => {
+  it('evicts the least-recently-used tenant when the cap is exceeded', async () => {
+    const { builder, builtTenants, stopped } = makeFakeBuilder();
+    let clock = 0;
+    const dispatcher = new TenantDispatcher({
+      baseConfig: {},
+      controllerId: 'code',
+      buildTenantApp: builder,
+      idleMs: 0, // disable idle sweep; isolate LRU behavior
+      maxApps: 2,
+      now: () => clock,
+    });
+    const app = buildOuterApp(dispatcher);
+
+    // Build user_a, then user_b.
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_a' });
+    clock = 1;
+    await app.request('/api/echo');
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_b' });
+    clock = 2;
+    await app.request('/api/echo');
+    expect(dispatcher.size()).toBe(2);
+
+    // Touch user_a so user_b becomes the LRU.
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_a' });
+    clock = 3;
+    await app.request('/api/echo');
+
+    // Build user_c → exceeds cap → user_b (LRU) evicted.
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_c' });
+    clock = 4;
+    await app.request('/api/echo');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(dispatcher.size()).toBe(2);
+    expect(stopped).toEqual(['user_b']);
+    expect(builtTenants).toEqual(['user_a', 'user_b', 'user_c']);
+  });
+});
+
+describe('no cross-tenant bleed under eviction', () => {
+  it('rebuilds an evicted tenant with its OWN storage config, never another tenant’s', async () => {
+    const { builder } = makeFakeBuilder();
+    const seenStorageForBuild: Array<{ identity: string; tenant: string }> = [];
+    const wrapped: TenantAppBuilder = async (storage, ctx) => {
+      seenStorageForBuild.push({
+        identity: 'n/a',
+        tenant: (storage as unknown as { tenant: string }).tenant,
+      });
+      return builder(storage, ctx);
+    };
+    let clock = 0;
+    const dispatcher = new TenantDispatcher({
+      baseConfig: {},
+      controllerId: 'code',
+      buildTenantApp: wrapped,
+      idleMs: 1, // tiny idle window so eviction is easy to trigger
+      maxApps: 0,
+      now: () => clock,
+    });
+    const app = buildOuterApp(dispatcher);
+
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_a', userId: 'user_a' });
+    clock = 10;
+    const a1 = await app.request('/api/echo');
+    expect(await a1.json()).toEqual({ tenant: 'org_a:user_a' });
+
+    // Advance to force eviction of user_a on the next (different) request.
+    clock = 100;
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_b', userId: 'user_a' });
+    const b1 = await app.request('/api/echo');
+    expect(await b1.json()).toEqual({ tenant: 'org_b:user_a' });
+
+    // user_a (org_a) comes back → rebuilt against org_a's storage, not org_b's.
+    clock = 200;
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_a', userId: 'user_a' });
+    const a2 = await app.request('/api/echo');
+    expect(await a2.json()).toEqual({ tenant: 'org_a:user_a' });
+
+    // Every build saw the storage config matching its own composite key.
+    expect(seenStorageForBuild.map(s => s.tenant)).toEqual(['org_a:user_a', 'org_b:user_a', 'org_a:user_a']);
+  });
+});

--- a/mastracode/src/web/tenant-isolation.test.ts
+++ b/mastracode/src/web/tenant-isolation.test.ts
@@ -1,0 +1,119 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { MastraCompositeStore } from '@mastra/core/storage';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildLibSQLStore } from '../utils/storage-factory.js';
+import { __clearTenantStorageCache, resolveTenantStorage } from './tenant-storage.js';
+
+// The composite store types `stores`/`stores.memory` as optionally undefined;
+// after `init()` the libSQL memory domain is always present, so narrow once.
+function memoryOf(store: MastraCompositeStore) {
+  const memory = store.stores?.memory;
+  if (!memory) throw new Error('libSQL memory domain not initialised');
+  return memory;
+}
+
+// ── S3: true cross-tenant DB isolation with real libSQL stores ───────────
+// `tenant-storage.test.ts` only proves the *resolved paths* differ. This
+// scenario goes a layer deeper: it constructs real `LibSQLStore` instances
+// from the resolved per-tenant `storageConfig.url` and proves the storage
+// backend itself is the tenant wall — user B cannot read a thread/messages
+// user A wrote, and the two tenants live in two distinct database files.
+
+// Strip the `file:` prefix the resolver puts on local urls to get a real path.
+function dbFilePath(url: string): string {
+  return url.startsWith('file:') ? url.slice('file:'.length) : url;
+}
+
+let root: string;
+const savedRoot = process.env.MASTRACODE_TENANT_DB_ROOT;
+const savedTemplate = process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE;
+
+beforeEach(() => {
+  // Force the local-file branch of the resolver into a throwaway temp dir.
+  delete process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE;
+  root = mkdtempSync(path.join(os.tmpdir(), 'mc-tenant-iso-'));
+  process.env.MASTRACODE_TENANT_DB_ROOT = root;
+  __clearTenantStorageCache();
+});
+
+afterEach(() => {
+  __clearTenantStorageCache();
+  if (savedRoot === undefined) delete process.env.MASTRACODE_TENANT_DB_ROOT;
+  else process.env.MASTRACODE_TENANT_DB_ROOT = savedRoot;
+  if (savedTemplate === undefined) delete process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE;
+  else process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = savedTemplate;
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+describe('S3: cross-tenant libSQL isolation', () => {
+  it('keeps one tenant from reading another tenant threads and messages', async () => {
+    const a = resolveTenantStorage('user_a');
+    const b = resolveTenantStorage('user_b');
+
+    // Different tenants → different hashed dirs → different db files.
+    expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
+
+    const storeA = buildLibSQLStore({ id: 'tenant-a', url: a.storageConfig.url });
+    const storeB = buildLibSQLStore({ id: 'tenant-b', url: b.storageConfig.url });
+    await storeA.init();
+    await storeB.init();
+    const memA = memoryOf(storeA);
+    const memB = memoryOf(storeB);
+
+    const threadId = 'thread-shared-id';
+    const resourceId = 'resource-shared-id';
+    const now = new Date();
+
+    // 1. User A writes a thread + a message.
+    await memA.saveThread({
+      thread: { id: threadId, resourceId, title: 'A secret', createdAt: now, updatedAt: now },
+    });
+    await memA.saveMessages({
+      messages: [
+        {
+          id: 'msg-1',
+          threadId,
+          resourceId,
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'tenant-a private content' }] },
+          createdAt: now,
+        } as never,
+      ],
+    });
+
+    // 2. User B queries the SAME ids → must see nothing (no cross-tenant read).
+    expect(await memB.getThreadById({ threadId })).toBeNull();
+    const bThreads = await memB.listThreads({ filter: { resourceId } });
+    expect(bThreads.threads).toHaveLength(0);
+    const bMessages = await memB.listMessagesById({ messageIds: ['msg-1'] });
+    expect(bMessages.messages).toHaveLength(0);
+
+    // 3. User A reads its own data back → present.
+    const aThread = await memA.getThreadById({ threadId });
+    expect(aThread?.id).toBe(threadId);
+    expect(aThread?.title).toBe('A secret');
+    const aThreads = await memA.listThreads({ filter: { resourceId } });
+    expect(aThreads.threads).toHaveLength(1);
+    const aMessages = await memA.listMessagesById({ messageIds: ['msg-1'] });
+    expect(aMessages.messages).toHaveLength(1);
+
+    // 4. Two distinct db files actually exist on disk under distinct dirs.
+    const fileA = dbFilePath(a.storageConfig.url);
+    const fileB = dbFilePath(b.storageConfig.url);
+    expect(fileA).not.toBe(fileB);
+    expect(path.dirname(fileA)).not.toBe(path.dirname(fileB));
+    expect(existsSync(fileA)).toBe(true);
+    expect(existsSync(fileB)).toBe(true);
+
+    await storeA.close?.();
+    await storeB.close?.();
+  });
+});

--- a/mastracode/src/web/tenant-isolation.test.ts
+++ b/mastracode/src/web/tenant-isolation.test.ts
@@ -53,10 +53,34 @@ afterEach(() => {
   }
 });
 
+// Write a private thread + message into a tenant store. Returns the ids used.
+async function seedPrivateThread(mem: ReturnType<typeof memoryOf>, marker: string) {
+  const threadId = `thread-${marker}`;
+  const resourceId = `resource-${marker}`;
+  const messageId = `msg-${marker}`;
+  const now = new Date();
+  await mem.saveThread({
+    thread: { id: threadId, resourceId, title: `${marker} secret`, createdAt: now, updatedAt: now },
+  });
+  await mem.saveMessages({
+    messages: [
+      {
+        id: messageId,
+        threadId,
+        resourceId,
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: `${marker} private content` }] },
+        createdAt: now,
+      } as never,
+    ],
+  });
+  return { threadId, resourceId, messageId };
+}
+
 describe('S3: cross-tenant libSQL isolation', () => {
   it('keeps one tenant from reading another tenant threads and messages', async () => {
-    const a = resolveTenantStorage('user_a');
-    const b = resolveTenantStorage('user_b');
+    const a = resolveTenantStorage({ userId: 'user_a' });
+    const b = resolveTenantStorage({ userId: 'user_b' });
 
     // Different tenants → different hashed dirs → different db files.
     expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
@@ -115,5 +139,84 @@ describe('S3: cross-tenant libSQL isolation', () => {
 
     await storeA.close?.();
     await storeB.close?.();
+  });
+});
+
+describe('S3: per-(org,user) libSQL isolation', () => {
+  it('isolates two users in the SAME org into distinct databases', async () => {
+    const a = resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
+    const b = resolveTenantStorage({ orgId: 'org_a', userId: 'user_2' });
+
+    expect(a.tenantKey).not.toBe(b.tenantKey);
+    expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
+
+    const storeA = buildLibSQLStore({ id: 'org-a-u1', url: a.storageConfig.url });
+    const storeB = buildLibSQLStore({ id: 'org-a-u2', url: b.storageConfig.url });
+    await storeA.init();
+    await storeB.init();
+    const memA = memoryOf(storeA);
+    const memB = memoryOf(storeB);
+
+    const { threadId, resourceId, messageId } = await seedPrivateThread(memA, 'orgA-u1');
+
+    // Same org, different user → no cross-read.
+    expect(await memB.getThreadById({ threadId })).toBeNull();
+    expect((await memB.listThreads({ filter: { resourceId } })).threads).toHaveLength(0);
+    expect((await memB.listMessagesById({ messageIds: [messageId] })).messages).toHaveLength(0);
+
+    // Owner reads its own data back.
+    expect((await memA.getThreadById({ threadId }))?.id).toBe(threadId);
+
+    // Distinct files on disk under distinct hashed dirs.
+    const fileA = dbFilePath(a.storageConfig.url);
+    const fileB = dbFilePath(b.storageConfig.url);
+    expect(path.dirname(fileA)).not.toBe(path.dirname(fileB));
+    expect(existsSync(fileA)).toBe(true);
+    expect(existsSync(fileB)).toBe(true);
+
+    await storeA.close?.();
+    await storeB.close?.();
+  });
+
+  it('isolates the SAME user across two orgs into distinct databases', async () => {
+    const a = resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
+    const b = resolveTenantStorage({ orgId: 'org_b', userId: 'user_1' });
+
+    expect(a.tenantKey).not.toBe(b.tenantKey);
+    expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
+
+    const storeA = buildLibSQLStore({ id: 'u1-org-a', url: a.storageConfig.url });
+    const storeB = buildLibSQLStore({ id: 'u1-org-b', url: b.storageConfig.url });
+    await storeA.init();
+    await storeB.init();
+    const memA = memoryOf(storeA);
+    const memB = memoryOf(storeB);
+
+    const { threadId, resourceId, messageId } = await seedPrivateThread(memA, 'u1-orgA');
+
+    // Same user, different org → no cross-read.
+    expect(await memB.getThreadById({ threadId })).toBeNull();
+    expect((await memB.listThreads({ filter: { resourceId } })).threads).toHaveLength(0);
+    expect((await memB.listMessagesById({ messageIds: [messageId] })).messages).toHaveLength(0);
+
+    expect((await memA.getThreadById({ threadId }))?.id).toBe(threadId);
+
+    await storeA.close?.();
+    await storeB.close?.();
+  });
+});
+
+describe('S3: remote URL template per-(org,user) isolation', () => {
+  it('produces distinct remote urls carrying each tenant composite key', () => {
+    process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}.turso.io';
+
+    const a = resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
+    const b = resolveTenantStorage({ orgId: 'org_b', userId: 'user_1' });
+
+    expect(a.storageConfig.isRemote).toBe(true);
+    expect(b.storageConfig.isRemote).toBe(true);
+    expect(a.storageConfig.url).toBe(`libsql://${a.tenantKey}.turso.io`);
+    expect(b.storageConfig.url).toBe(`libsql://${b.tenantKey}.turso.io`);
+    expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
   });
 });

--- a/mastracode/src/web/tenant-server.test.ts
+++ b/mastracode/src/web/tenant-server.test.ts
@@ -35,27 +35,32 @@ vi.mock('@mastra/hono', () => ({
   },
 }));
 
-const mockGetWebAuthUser = vi.fn();
+const mockWebAuthTenant = vi.fn();
 vi.mock('./auth.js', () => ({
-  getWebAuthUser: (c: unknown) => mockGetWebAuthUser(c),
-  getWebAuthUserId: (user: { workosId?: string; id?: string } | undefined) => user?.workosId ?? user?.id,
+  webAuthTenant: (c: unknown) => mockWebAuthTenant(c),
 }));
+
+interface TenantIdentity {
+  orgId?: string;
+  userId: string;
+}
 
 const mockGetUserStorage = vi.fn();
 vi.mock('./tenant-storage.js', () => ({
-  getUserStorage: (workosId: string) => mockGetUserStorage(workosId),
+  getUserStorage: (identity: TenantIdentity) => mockGetUserStorage(identity),
 }));
 
 import { TenantDispatcher } from './tenant-server.js';
 
-function tenantStorageFor(workosId: string) {
-  return { tenantKey: `key_${workosId}`, storageConfig: { tenant: workosId } };
+function tenantStorageFor(identity: TenantIdentity) {
+  const key = identity.orgId ? `${identity.orgId}:${identity.userId}` : identity.userId;
+  return { tenantKey: `key_${key}`, storageConfig: { tenant: key } };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   builtStorages.length = 0;
-  mockGetUserStorage.mockImplementation((workosId: string) => tenantStorageFor(workosId));
+  mockGetUserStorage.mockImplementation((identity: TenantIdentity) => tenantStorageFor(identity));
 });
 
 afterEach(() => {
@@ -77,7 +82,7 @@ describe('TenantDispatcher', () => {
     const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
     const app = buildApp(dispatcher);
 
-    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_a' });
     const res = await app.request('/api/echo');
     expect(await res.json()).toEqual({ tenant: 'user_a' });
   });
@@ -86,9 +91,9 @@ describe('TenantDispatcher', () => {
     const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
     const app = buildApp(dispatcher);
 
-    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_a' });
     const resA = await app.request('/api/echo');
-    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_b' });
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_b' });
     const resB = await app.request('/api/echo');
 
     expect(await resA.json()).toEqual({ tenant: 'user_a' });
@@ -97,11 +102,39 @@ describe('TenantDispatcher', () => {
     expect(builtStorages).toEqual([{ tenant: 'user_a' }, { tenant: 'user_b' }]);
   });
 
-  it('reuses the cached tenant app for repeated requests by the same user', async () => {
+  it('routes two users in the same org to two isolated tenant apps', async () => {
     const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
     const app = buildApp(dispatcher);
 
-    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_a', userId: 'user_a' });
+    const resA = await app.request('/api/echo');
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_a', userId: 'user_b' });
+    const resB = await app.request('/api/echo');
+
+    expect(await resA.json()).toEqual({ tenant: 'org_a:user_a' });
+    expect(await resB.json()).toEqual({ tenant: 'org_a:user_b' });
+    expect(builtStorages).toEqual([{ tenant: 'org_a:user_a' }, { tenant: 'org_a:user_b' }]);
+  });
+
+  it('routes the same user in two orgs to two isolated tenant apps', async () => {
+    const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
+    const app = buildApp(dispatcher);
+
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_a', userId: 'user_a' });
+    const resA = await app.request('/api/echo');
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_b', userId: 'user_a' });
+    const resB = await app.request('/api/echo');
+
+    expect(await resA.json()).toEqual({ tenant: 'org_a:user_a' });
+    expect(await resB.json()).toEqual({ tenant: 'org_b:user_a' });
+    expect(builtStorages).toEqual([{ tenant: 'org_a:user_a' }, { tenant: 'org_b:user_a' }]);
+  });
+
+  it('reuses the cached tenant app for repeated requests by the same identity', async () => {
+    const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
+    const app = buildApp(dispatcher);
+
+    mockWebAuthTenant.mockReturnValue({ orgId: 'org_a', userId: 'user_a' });
     await app.request('/api/echo');
     await app.request('/api/echo');
     expect(builtStorages).toHaveLength(1);
@@ -111,7 +144,7 @@ describe('TenantDispatcher', () => {
     const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
     const app = buildApp(dispatcher);
 
-    mockGetWebAuthUser.mockReturnValue(undefined);
+    mockWebAuthTenant.mockReturnValue(undefined);
     const res = await app.request('/api/echo');
     expect(await res.json()).toEqual({ tenant: 'SHARED' });
     expect(builtStorages).toHaveLength(0);
@@ -121,7 +154,7 @@ describe('TenantDispatcher', () => {
     const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
     const app = buildApp(dispatcher);
 
-    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_a' });
     const res = await app.request('/api/web/status');
     expect(await res.json()).toEqual({ route: 'web' });
     expect(builtStorages).toHaveLength(0);
@@ -130,7 +163,7 @@ describe('TenantDispatcher', () => {
   it('stops all tenant stacks on shutdown', async () => {
     const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
     const app = buildApp(dispatcher);
-    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    mockWebAuthTenant.mockReturnValue({ userId: 'user_a' });
     await app.request('/api/echo');
     await expect(dispatcher.stopAll()).resolves.toBeUndefined();
   });

--- a/mastracode/src/web/tenant-server.test.ts
+++ b/mastracode/src/web/tenant-server.test.ts
@@ -1,0 +1,137 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Track which tenant storage each built app was bound to so we can assert
+// isolation (distinct users -> distinct mounts).
+const builtStorages: unknown[] = [];
+
+vi.mock('../index.js', () => ({
+  mountAgentControllerOnMastra: vi.fn(async (config: { storage?: unknown }) => {
+    builtStorages.push(config.storage);
+    return {
+      mastra: { __storage: config.storage },
+      controller: {
+        getMastra: () => ({ stopWorkers: vi.fn(async () => {}) }),
+        stopHeartbeats: vi.fn(async () => {}),
+      },
+    };
+  }),
+}));
+
+// A fake MastraServer adapter: registers a single /api/echo route on the passed
+// Hono app that returns the tenant's storage marker, proving the request was
+// routed to the right per-tenant app.
+vi.mock('@mastra/hono', () => ({
+  MastraServer: class {
+    private app: Hono;
+    private mastra: { __storage?: { tenant?: string } };
+    constructor(opts: { app: Hono; mastra: { __storage?: { tenant?: string } } }) {
+      this.app = opts.app;
+      this.mastra = opts.mastra;
+    }
+    async init() {
+      this.app.get('/api/echo', c => c.json({ tenant: this.mastra.__storage?.tenant ?? null }));
+    }
+  },
+}));
+
+const mockGetWebAuthUser = vi.fn();
+vi.mock('./auth.js', () => ({
+  getWebAuthUser: (c: unknown) => mockGetWebAuthUser(c),
+  getWebAuthUserId: (user: { workosId?: string; id?: string } | undefined) => user?.workosId ?? user?.id,
+}));
+
+const mockGetUserStorage = vi.fn();
+vi.mock('./tenant-storage.js', () => ({
+  getUserStorage: (workosId: string) => mockGetUserStorage(workosId),
+}));
+
+import { TenantDispatcher } from './tenant-server.js';
+
+function tenantStorageFor(workosId: string) {
+  return { tenantKey: `key_${workosId}`, storageConfig: { tenant: workosId } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  builtStorages.length = 0;
+  mockGetUserStorage.mockImplementation((workosId: string) => tenantStorageFor(workosId));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function buildApp(dispatcher: TenantDispatcher) {
+  const app = new Hono();
+  app.use('/api/*', dispatcher.middleware());
+  // Shared fallback route (the "auth disabled" / shared adapter path).
+  app.get('/api/echo', c => c.json({ tenant: 'SHARED' }));
+  // A custom web route that must NOT be forwarded to tenant apps.
+  app.get('/api/web/status', c => c.json({ route: 'web' }));
+  return app;
+}
+
+describe('TenantDispatcher', () => {
+  it('forwards authenticated requests to the user-specific tenant app', async () => {
+    const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
+    const app = buildApp(dispatcher);
+
+    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    const res = await app.request('/api/echo');
+    expect(await res.json()).toEqual({ tenant: 'user_a' });
+  });
+
+  it('routes two different users to two isolated tenant apps', async () => {
+    const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
+    const app = buildApp(dispatcher);
+
+    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    const resA = await app.request('/api/echo');
+    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_b' });
+    const resB = await app.request('/api/echo');
+
+    expect(await resA.json()).toEqual({ tenant: 'user_a' });
+    expect(await resB.json()).toEqual({ tenant: 'user_b' });
+    // Two distinct tenant stacks were built with distinct storage configs.
+    expect(builtStorages).toEqual([{ tenant: 'user_a' }, { tenant: 'user_b' }]);
+  });
+
+  it('reuses the cached tenant app for repeated requests by the same user', async () => {
+    const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
+    const app = buildApp(dispatcher);
+
+    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    await app.request('/api/echo');
+    await app.request('/api/echo');
+    expect(builtStorages).toHaveLength(1);
+  });
+
+  it('falls through to the shared app when there is no authenticated user', async () => {
+    const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
+    const app = buildApp(dispatcher);
+
+    mockGetWebAuthUser.mockReturnValue(undefined);
+    const res = await app.request('/api/echo');
+    expect(await res.json()).toEqual({ tenant: 'SHARED' });
+    expect(builtStorages).toHaveLength(0);
+  });
+
+  it('does not forward /api/web/* custom routes to tenant apps', async () => {
+    const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
+    const app = buildApp(dispatcher);
+
+    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    const res = await app.request('/api/web/status');
+    expect(await res.json()).toEqual({ route: 'web' });
+    expect(builtStorages).toHaveLength(0);
+  });
+
+  it('stops all tenant stacks on shutdown', async () => {
+    const dispatcher = new TenantDispatcher({ baseConfig: {}, controllerId: 'code' });
+    const app = buildApp(dispatcher);
+    mockGetWebAuthUser.mockReturnValue({ workosId: 'user_a' });
+    await app.request('/api/echo');
+    await expect(dispatcher.stopAll()).resolves.toBeUndefined();
+  });
+});

--- a/mastracode/src/web/tenant-server.ts
+++ b/mastracode/src/web/tenant-server.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-tenant Mastra controller dispatch for the multi-tenant web server.
+ *
+ * When web auth is enabled, every authenticated WorkOS user must operate against
+ * their OWN Mastra instance bound to their OWN isolated libSQL storage/vector
+ * pair (see `tenant-storage.ts`). A single shared Mastra/controller would land
+ * all tenants' threads, messages, memory and recall vectors in one store — a
+ * hard privacy violation.
+ *
+ * The Hono adapter binds a single fixed `Mastra` into request context at
+ * construction time (`c.set('mastra', this.mastra)`), so outer middleware can't
+ * retarget a shared controller per request. Instead, each tenant gets its own
+ * fully isolated `MastraServer` adapter (its own Hono sub-app + Mastra +
+ * storage). This dispatcher lazily builds and caches one per WorkOS user and
+ * forwards `/api/*` requests to the right tenant app.
+ *
+ * Auth-disabled / local-dev keeps using the single shared adapter built by the
+ * caller — this module is only engaged when `webAuthUser` is present.
+ */
+
+import { MastraServer } from '@mastra/hono';
+import type { HonoBindings, HonoVariables } from '@mastra/hono';
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+
+import { mountAgentControllerOnMastra } from '../index.js';
+import type { MastraCodeConfig } from '../index.js';
+
+import { getWebAuthUser, getWebAuthUserId } from './auth.js';
+import { getUserStorage } from './tenant-storage.js';
+
+/** A fully isolated per-tenant controller stack. */
+interface TenantApp {
+  /** The tenant's Hono app with the Mastra surface mounted under `/api`. */
+  fetch: (request: Request, ...rest: unknown[]) => Response | Promise<Response>;
+  /** Stop the tenant's workers/heartbeats on eviction or shutdown. */
+  stop: () => Promise<void>;
+}
+
+export interface TenantDispatcherOptions {
+  /** Base controller config shared by every tenant (minus storage). */
+  baseConfig: MastraCodeConfig;
+  /** Controller id, matching the shared controller. */
+  controllerId: string;
+}
+
+/**
+ * Builds and caches per-tenant Mastra controller stacks and dispatches requests
+ * to them based on the authenticated WorkOS user.
+ */
+export class TenantDispatcher {
+  private readonly baseConfig: MastraCodeConfig;
+  private readonly controllerId: string;
+  /** tenantKey -> in-flight or resolved tenant app. */
+  private readonly apps = new Map<string, Promise<TenantApp>>();
+
+  constructor(options: TenantDispatcherOptions) {
+    this.baseConfig = options.baseConfig;
+    this.controllerId = options.controllerId;
+  }
+
+  /** Get-or-create the tenant app for a WorkOS user id. */
+  private getTenantApp(workosId: string): Promise<TenantApp> {
+    const { tenantKey, storageConfig } = getUserStorage(workosId);
+    const existing = this.apps.get(tenantKey);
+    if (existing) return existing;
+
+    const built = this.buildTenantApp(storageConfig).catch(err => {
+      // Don't cache failures — let the next request retry a clean build.
+      this.apps.delete(tenantKey);
+      throw err;
+    });
+    this.apps.set(tenantKey, built);
+    return built;
+  }
+
+  private async buildTenantApp(storage: MastraCodeConfig['storage']): Promise<TenantApp> {
+    const result = await mountAgentControllerOnMastra({
+      ...this.baseConfig,
+      storage,
+      controllerId: this.controllerId,
+    });
+
+    const app = new Hono<{ Bindings: HonoBindings; Variables: HonoVariables }>();
+    const adapter = new MastraServer({ app, mastra: result.mastra });
+    await adapter.init();
+
+    return {
+      fetch: (request, ...rest) => app.fetch(request as Request, ...(rest as [])),
+      stop: async () => {
+        await Promise.allSettled([result.controller.getMastra()?.stopWorkers(), result.controller.stopHeartbeats()]);
+      },
+    };
+  }
+
+  /**
+   * Hono middleware: when an authenticated user is present, forward the request
+   * to that user's isolated Mastra app and return its response. When no user is
+   * present (auth disabled), fall through to the shared adapter via `next()`.
+   */
+  middleware() {
+    return async (c: Context, next: () => Promise<void>): Promise<Response | void> => {
+      // Custom web-only routes (`/api/web/...`: config, fs, GitHub) live on the
+      // outer app and use the app DB + webAuthUser, not tenant Mastra storage.
+      // They must NOT be forwarded to the tenant app (which has no such routes).
+      if (c.req.path.startsWith('/api/web/')) {
+        return next();
+      }
+      const user = getWebAuthUser(c);
+      const workosId = getWebAuthUserId(user);
+      if (!workosId) {
+        // Auth disabled or unauthenticated public route — use the shared path.
+        return next();
+      }
+      const tenant = await this.getTenantApp(workosId);
+      return tenant.fetch(c.req.raw);
+    };
+  }
+
+  /** Tear down all cached tenant stacks (server shutdown). */
+  async stopAll(): Promise<void> {
+    const apps = [...this.apps.values()];
+    this.apps.clear();
+    await Promise.allSettled(
+      apps.map(async p => {
+        try {
+          const app = await p;
+          await app.stop();
+        } catch {
+          // ignore — already failed to build
+        }
+      }),
+    );
+  }
+}

--- a/mastracode/src/web/tenant-server.ts
+++ b/mastracode/src/web/tenant-server.ts
@@ -26,8 +26,9 @@ import type { Context } from 'hono';
 import { mountAgentControllerOnMastra } from '../index.js';
 import type { MastraCodeConfig } from '../index.js';
 
-import { getWebAuthUser, getWebAuthUserId } from './auth.js';
+import { webAuthTenant } from './auth.js';
 import { getUserStorage } from './tenant-storage.js';
+import type { TenantIdentity } from './tenant-storage.js';
 
 /** A fully isolated per-tenant controller stack. */
 interface TenantApp {
@@ -37,60 +38,167 @@ interface TenantApp {
   stop: () => Promise<void>;
 }
 
+/**
+ * Builds a fully isolated tenant app for a given storage config. Injectable so
+ * tests can exercise eviction/LRU behavior without booting a real Mastra stack.
+ */
+export type TenantAppBuilder = (
+  storage: MastraCodeConfig['storage'],
+  ctx: { baseConfig: MastraCodeConfig; controllerId: string },
+) => Promise<TenantApp>;
+
 export interface TenantDispatcherOptions {
   /** Base controller config shared by every tenant (minus storage). */
   baseConfig: MastraCodeConfig;
   /** Controller id, matching the shared controller. */
   controllerId: string;
+  /**
+   * Tenant app builder. Defaults to the real Mastra-backed builder; injected in
+   * tests to avoid booting a real Mastra stack.
+   */
+  buildTenantApp?: TenantAppBuilder;
+  /**
+   * Evict tenant apps idle for longer than this. Defaults to
+   * `MASTRACODE_TENANT_IDLE_MINUTES` (minutes) or 30 minutes. 0 disables
+   * idle-based eviction.
+   */
+  idleMs?: number;
+  /**
+   * Cap on cached tenant apps. When exceeded, the least-recently-used app is
+   * evicted. Defaults to `MASTRACODE_TENANT_MAX_APPS` or 100. 0 disables the cap.
+   */
+  maxApps?: number;
+  /** Clock injection for deterministic eviction tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/** Default real Mastra-backed tenant app builder. */
+const defaultBuildTenantApp: TenantAppBuilder = async (storage, { baseConfig, controllerId }) => {
+  const result = await mountAgentControllerOnMastra({
+    ...baseConfig,
+    storage,
+    controllerId,
+  });
+
+  const app = new Hono<{ Bindings: HonoBindings; Variables: HonoVariables }>();
+  const adapter = new MastraServer({ app, mastra: result.mastra });
+  await adapter.init();
+
+  return {
+    fetch: (request, ...rest) => app.fetch(request as Request, ...(rest as [])),
+    stop: async () => {
+      await Promise.allSettled([result.controller.getMastra()?.stopWorkers(), result.controller.stopHeartbeats()]);
+    },
+  };
+};
+
+function resolveIdleMs(option: number | undefined): number {
+  if (option !== undefined) return option;
+  const raw = process.env.MASTRACODE_TENANT_IDLE_MINUTES;
+  const minutes = raw ? Number(raw) : NaN;
+  if (Number.isFinite(minutes) && minutes >= 0) return minutes * 60_000;
+  return 30 * 60_000;
+}
+
+function resolveMaxApps(option: number | undefined): number {
+  if (option !== undefined) return option;
+  const raw = process.env.MASTRACODE_TENANT_MAX_APPS;
+  const max = raw ? Number(raw) : NaN;
+  if (Number.isFinite(max) && max >= 0) return max;
+  return 100;
+}
+
+/** Cache entry tracking the built app plus its last-used timestamp. */
+interface CacheEntry {
+  app: Promise<TenantApp>;
+  lastUsed: number;
 }
 
 /**
  * Builds and caches per-tenant Mastra controller stacks and dispatches requests
  * to them based on the authenticated WorkOS user.
+ *
+ * The cache is bounded: apps idle past `idleMs` are swept and evicted (their
+ * workers stopped), and an LRU `maxApps` cap prevents unbounded growth as a team
+ * grows. Evicted tenants are lazily rebuilt on their next request.
  */
 export class TenantDispatcher {
   private readonly baseConfig: MastraCodeConfig;
   private readonly controllerId: string;
-  /** tenantKey -> in-flight or resolved tenant app. */
-  private readonly apps = new Map<string, Promise<TenantApp>>();
+  private readonly build: TenantAppBuilder;
+  private readonly idleMs: number;
+  private readonly maxApps: number;
+  private readonly now: () => number;
+  /** tenantKey -> cache entry (in-flight or resolved tenant app + lastUsed). */
+  private readonly apps = new Map<string, CacheEntry>();
 
   constructor(options: TenantDispatcherOptions) {
     this.baseConfig = options.baseConfig;
     this.controllerId = options.controllerId;
+    this.build = options.buildTenantApp ?? defaultBuildTenantApp;
+    this.idleMs = resolveIdleMs(options.idleMs);
+    this.maxApps = resolveMaxApps(options.maxApps);
+    this.now = options.now ?? Date.now;
   }
 
-  /** Get-or-create the tenant app for a WorkOS user id. */
-  private getTenantApp(workosId: string): Promise<TenantApp> {
-    const { tenantKey, storageConfig } = getUserStorage(workosId);
+  /** Get-or-create the tenant app for an `(org, user)` identity. */
+  private getTenantApp(identity: TenantIdentity): Promise<TenantApp> {
+    this.sweepIdle();
+    const { tenantKey, storageConfig } = getUserStorage(identity);
     const existing = this.apps.get(tenantKey);
-    if (existing) return existing;
+    if (existing) {
+      existing.lastUsed = this.now();
+      return existing.app;
+    }
 
-    const built = this.buildTenantApp(storageConfig).catch(err => {
+    const built = this.build(storageConfig, {
+      baseConfig: this.baseConfig,
+      controllerId: this.controllerId,
+    }).catch(err => {
       // Don't cache failures — let the next request retry a clean build.
       this.apps.delete(tenantKey);
       throw err;
     });
-    this.apps.set(tenantKey, built);
+    this.apps.set(tenantKey, { app: built, lastUsed: this.now() });
+    this.enforceMaxApps();
     return built;
   }
 
-  private async buildTenantApp(storage: MastraCodeConfig['storage']): Promise<TenantApp> {
-    const result = await mountAgentControllerOnMastra({
-      ...this.baseConfig,
-      storage,
-      controllerId: this.controllerId,
-    });
+  /** Evict any tenant apps idle for longer than `idleMs`. */
+  private sweepIdle(): void {
+    if (this.idleMs <= 0) return;
+    const cutoff = this.now() - this.idleMs;
+    for (const [key, entry] of [...this.apps.entries()]) {
+      if (entry.lastUsed <= cutoff) {
+        this.evict(key, entry);
+      }
+    }
+  }
 
-    const app = new Hono<{ Bindings: HonoBindings; Variables: HonoVariables }>();
-    const adapter = new MastraServer({ app, mastra: result.mastra });
-    await adapter.init();
+  /** Evict the least-recently-used apps until within `maxApps`. */
+  private enforceMaxApps(): void {
+    if (this.maxApps <= 0) return;
+    while (this.apps.size > this.maxApps) {
+      let lruKey: string | undefined;
+      let lruEntry: CacheEntry | undefined;
+      for (const [key, entry] of this.apps) {
+        if (!lruEntry || entry.lastUsed < lruEntry.lastUsed) {
+          lruKey = key;
+          lruEntry = entry;
+        }
+      }
+      if (!lruKey || !lruEntry) break;
+      this.evict(lruKey, lruEntry);
+    }
+  }
 
-    return {
-      fetch: (request, ...rest) => app.fetch(request as Request, ...(rest as [])),
-      stop: async () => {
-        await Promise.allSettled([result.controller.getMastra()?.stopWorkers(), result.controller.stopHeartbeats()]);
-      },
-    };
+  /** Remove an entry from the cache and stop its workers (fire-and-forget). */
+  private evict(key: string, entry: CacheEntry): void {
+    this.apps.delete(key);
+    void entry.app.then(
+      app => app.stop(),
+      () => undefined,
+    );
   }
 
   /**
@@ -106,30 +214,34 @@ export class TenantDispatcher {
       if (c.req.path.startsWith('/api/web/')) {
         return next();
       }
-      const user = getWebAuthUser(c);
-      const workosId = getWebAuthUserId(user);
-      if (!workosId) {
+      const identity = webAuthTenant(c);
+      if (!identity) {
         // Auth disabled or unauthenticated public route — use the shared path.
         return next();
       }
-      const tenant = await this.getTenantApp(workosId);
+      const tenant = await this.getTenantApp(identity);
       return tenant.fetch(c.req.raw);
     };
   }
 
   /** Tear down all cached tenant stacks (server shutdown). */
   async stopAll(): Promise<void> {
-    const apps = [...this.apps.values()];
+    const entries = [...this.apps.values()];
     this.apps.clear();
     await Promise.allSettled(
-      apps.map(async p => {
+      entries.map(async entry => {
         try {
-          const app = await p;
+          const app = await entry.app;
           await app.stop();
         } catch {
           // ignore — already failed to build
         }
       }),
     );
+  }
+
+  /** For tests: number of currently cached tenant apps. */
+  size(): number {
+    return this.apps.size;
   }
 }

--- a/mastracode/src/web/tenant-storage.test.ts
+++ b/mastracode/src/web/tenant-storage.test.ts
@@ -1,0 +1,115 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { __clearTenantStorageCache, getUserStorage, resolveTenantStorage, tenantKeyFor } from './tenant-storage.js';
+
+const ORIGINAL_ENV = { ...process.env };
+let tmpRoot: string;
+
+beforeEach(() => {
+  __clearTenantStorageCache();
+  delete process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE;
+  delete process.env.MASTRACODE_TENANT_VECTOR_URL_TEMPLATE;
+  delete process.env.MASTRACODE_TENANT_DB_AUTH_TOKEN;
+  delete process.env.MASTRACODE_TENANT_VECTOR_AUTH_TOKEN;
+  tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'mc-tenant-'));
+  process.env.MASTRACODE_TENANT_DB_ROOT = tmpRoot;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('tenantKeyFor', () => {
+  it('produces a stable filesystem-safe sha256 hex key', () => {
+    const key = tenantKeyFor('user_workos_12345');
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+    expect(tenantKeyFor('user_workos_12345')).toBe(key);
+  });
+
+  it('produces distinct keys for distinct ids', () => {
+    expect(tenantKeyFor('user_a')).not.toBe(tenantKeyFor('user_b'));
+  });
+});
+
+describe('resolveTenantStorage (local libSQL)', () => {
+  it('creates a hashed per-tenant directory with separate storage and vector DBs', () => {
+    const { tenantKey, storageConfig } = resolveTenantStorage('user_a');
+    const dir = path.join(tmpRoot, tenantKey);
+    expect(existsSync(dir)).toBe(true);
+    expect(storageConfig.backend).toBe('libsql');
+    expect(storageConfig.isRemote).toBe(false);
+    expect(storageConfig.url).toBe(`file:${path.join(dir, 'storage.db')}`);
+    expect(storageConfig.vectorUrl).toBe(`file:${path.join(dir, 'vectors.db')}`);
+  });
+
+  it('gives distinct users distinct DB paths', () => {
+    const a = resolveTenantStorage('user_a');
+    const b = resolveTenantStorage('user_b');
+    expect(a.tenantKey).not.toBe(b.tenantKey);
+    expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
+    expect(a.storageConfig.vectorUrl).not.toBe(b.storageConfig.vectorUrl);
+  });
+
+  it('never uses the raw workos id as a path component', () => {
+    const rawId = 'user/with/../traversal';
+    const { tenantKey, storageConfig } = resolveTenantStorage(rawId);
+    expect(tenantKey).toMatch(/^[0-9a-f]{64}$/);
+    expect(storageConfig.url).not.toContain('..');
+    expect(storageConfig.url).toContain(tenantKey);
+  });
+
+  it('throws on an empty workos id', () => {
+    expect(() => resolveTenantStorage('')).toThrow();
+  });
+});
+
+describe('resolveTenantStorage (remote URL template)', () => {
+  it('expands the {id} placeholder for storage and vector urls', () => {
+    process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}-org.turso.io';
+    process.env.MASTRACODE_TENANT_VECTOR_URL_TEMPLATE = 'libsql://{id}-vec.turso.io';
+    process.env.MASTRACODE_TENANT_DB_AUTH_TOKEN = 'tok_storage';
+    process.env.MASTRACODE_TENANT_VECTOR_AUTH_TOKEN = 'tok_vector';
+
+    const { tenantKey, storageConfig } = resolveTenantStorage('user_a');
+    expect(storageConfig.isRemote).toBe(true);
+    expect(storageConfig.url).toBe(`libsql://${tenantKey}-org.turso.io`);
+    expect(storageConfig.vectorUrl).toBe(`libsql://${tenantKey}-vec.turso.io`);
+    expect(storageConfig.authToken).toBe('tok_storage');
+    expect(storageConfig.vectorAuthToken).toBe('tok_vector');
+  });
+
+  it('falls back to the storage url and token for vectors when no vector template is set', () => {
+    process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}.turso.io';
+    process.env.MASTRACODE_TENANT_DB_AUTH_TOKEN = 'tok_shared';
+
+    const { storageConfig } = resolveTenantStorage('user_a');
+    expect(storageConfig.vectorUrl).toBe(storageConfig.url);
+    expect(storageConfig.vectorAuthToken).toBe('tok_shared');
+  });
+
+  it('does not touch the local filesystem when a template is configured', () => {
+    process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}.turso.io';
+    const { tenantKey } = resolveTenantStorage('user_a');
+    expect(existsSync(path.join(tmpRoot, tenantKey))).toBe(false);
+  });
+});
+
+describe('getUserStorage caching', () => {
+  it('returns the same cached descriptor for the same user', () => {
+    const first = getUserStorage('user_a');
+    const second = getUserStorage('user_a');
+    expect(second).toBe(first);
+  });
+
+  it('returns distinct descriptors for distinct users', () => {
+    const a = getUserStorage('user_a');
+    const b = getUserStorage('user_b');
+    expect(a).not.toBe(b);
+    expect(a.tenantKey).not.toBe(b.tenantKey);
+  });
+});

--- a/mastracode/src/web/tenant-storage.test.ts
+++ b/mastracode/src/web/tenant-storage.test.ts
@@ -26,19 +26,39 @@ afterEach(() => {
 
 describe('tenantKeyFor', () => {
   it('produces a stable filesystem-safe sha256 hex key', () => {
-    const key = tenantKeyFor('user_workos_12345');
+    const key = tenantKeyFor({ userId: 'user_workos_12345' });
     expect(key).toMatch(/^[0-9a-f]{64}$/);
-    expect(tenantKeyFor('user_workos_12345')).toBe(key);
+    expect(tenantKeyFor({ userId: 'user_workos_12345' })).toBe(key);
   });
 
-  it('produces distinct keys for distinct ids', () => {
-    expect(tenantKeyFor('user_a')).not.toBe(tenantKeyFor('user_b'));
+  it('produces distinct keys for distinct users', () => {
+    expect(tenantKeyFor({ userId: 'user_a' })).not.toBe(tenantKeyFor({ userId: 'user_b' }));
+  });
+
+  it('produces distinct keys for the same user in different orgs', () => {
+    expect(tenantKeyFor({ orgId: 'org_a', userId: 'user_a' })).not.toBe(
+      tenantKeyFor({ orgId: 'org_b', userId: 'user_a' }),
+    );
+  });
+
+  it('produces distinct keys for different users in the same org', () => {
+    expect(tenantKeyFor({ orgId: 'org_a', userId: 'user_a' })).not.toBe(
+      tenantKeyFor({ orgId: 'org_a', userId: 'user_b' }),
+    );
+  });
+
+  it('falls back to a user-only key for personal (no-org) accounts', () => {
+    expect(tenantKeyFor({ orgId: undefined, userId: 'user_a' })).toBe(tenantKeyFor({ userId: 'user_a' }));
+  });
+
+  it('does not collide an org-scoped key with a user-only key', () => {
+    expect(tenantKeyFor({ orgId: 'org_a', userId: 'user_a' })).not.toBe(tenantKeyFor({ userId: 'user_a' }));
   });
 });
 
 describe('resolveTenantStorage (local libSQL)', () => {
   it('creates a hashed per-tenant directory with separate storage and vector DBs', () => {
-    const { tenantKey, storageConfig } = resolveTenantStorage('user_a');
+    const { tenantKey, storageConfig } = resolveTenantStorage({ userId: 'user_a' });
     const dir = path.join(tmpRoot, tenantKey);
     expect(existsSync(dir)).toBe(true);
     expect(storageConfig.backend).toBe('libsql');
@@ -48,8 +68,8 @@ describe('resolveTenantStorage (local libSQL)', () => {
   });
 
   it('gives distinct users distinct DB paths', () => {
-    const a = resolveTenantStorage('user_a');
-    const b = resolveTenantStorage('user_b');
+    const a = resolveTenantStorage({ userId: 'user_a' });
+    const b = resolveTenantStorage({ userId: 'user_b' });
     expect(a.tenantKey).not.toBe(b.tenantKey);
     expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
     expect(a.storageConfig.vectorUrl).not.toBe(b.storageConfig.vectorUrl);
@@ -57,14 +77,14 @@ describe('resolveTenantStorage (local libSQL)', () => {
 
   it('never uses the raw workos id as a path component', () => {
     const rawId = 'user/with/../traversal';
-    const { tenantKey, storageConfig } = resolveTenantStorage(rawId);
+    const { tenantKey, storageConfig } = resolveTenantStorage({ userId: rawId });
     expect(tenantKey).toMatch(/^[0-9a-f]{64}$/);
     expect(storageConfig.url).not.toContain('..');
     expect(storageConfig.url).toContain(tenantKey);
   });
 
-  it('throws on an empty workos id', () => {
-    expect(() => resolveTenantStorage('')).toThrow();
+  it('throws on an empty user id', () => {
+    expect(() => resolveTenantStorage({ userId: '' })).toThrow();
   });
 });
 
@@ -75,7 +95,7 @@ describe('resolveTenantStorage (remote URL template)', () => {
     process.env.MASTRACODE_TENANT_DB_AUTH_TOKEN = 'tok_storage';
     process.env.MASTRACODE_TENANT_VECTOR_AUTH_TOKEN = 'tok_vector';
 
-    const { tenantKey, storageConfig } = resolveTenantStorage('user_a');
+    const { tenantKey, storageConfig } = resolveTenantStorage({ userId: 'user_a' });
     expect(storageConfig.isRemote).toBe(true);
     expect(storageConfig.url).toBe(`libsql://${tenantKey}-org.turso.io`);
     expect(storageConfig.vectorUrl).toBe(`libsql://${tenantKey}-vec.turso.io`);
@@ -87,28 +107,35 @@ describe('resolveTenantStorage (remote URL template)', () => {
     process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}.turso.io';
     process.env.MASTRACODE_TENANT_DB_AUTH_TOKEN = 'tok_shared';
 
-    const { storageConfig } = resolveTenantStorage('user_a');
+    const { storageConfig } = resolveTenantStorage({ userId: 'user_a' });
     expect(storageConfig.vectorUrl).toBe(storageConfig.url);
     expect(storageConfig.vectorAuthToken).toBe('tok_shared');
   });
 
   it('does not touch the local filesystem when a template is configured', () => {
     process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}.turso.io';
-    const { tenantKey } = resolveTenantStorage('user_a');
+    const { tenantKey } = resolveTenantStorage({ userId: 'user_a' });
     expect(existsSync(path.join(tmpRoot, tenantKey))).toBe(false);
   });
 });
 
 describe('getUserStorage caching', () => {
-  it('returns the same cached descriptor for the same user', () => {
-    const first = getUserStorage('user_a');
-    const second = getUserStorage('user_a');
+  it('returns the same cached descriptor for the same identity', () => {
+    const first = getUserStorage({ orgId: 'org_a', userId: 'user_a' });
+    const second = getUserStorage({ orgId: 'org_a', userId: 'user_a' });
     expect(second).toBe(first);
   });
 
   it('returns distinct descriptors for distinct users', () => {
-    const a = getUserStorage('user_a');
-    const b = getUserStorage('user_b');
+    const a = getUserStorage({ userId: 'user_a' });
+    const b = getUserStorage({ userId: 'user_b' });
+    expect(a).not.toBe(b);
+    expect(a.tenantKey).not.toBe(b.tenantKey);
+  });
+
+  it('returns distinct descriptors for the same user in different orgs', () => {
+    const a = getUserStorage({ orgId: 'org_a', userId: 'user_a' });
+    const b = getUserStorage({ orgId: 'org_b', userId: 'user_a' });
     expect(a).not.toBe(b);
     expect(a.tenantKey).not.toBe(b.tenantKey);
   });

--- a/mastracode/src/web/tenant-storage.ts
+++ b/mastracode/src/web/tenant-storage.ts
@@ -8,9 +8,9 @@
  * convention. That is a hard multi-tenancy/privacy violation: a bug or a crafted
  * `resourceId` could read another tenant's conversations.
  *
- * This module resolves a dedicated, isolated libSQL database **per WorkOS user**
- * so the tenant boundary is the storage backend itself, not just a scoping
- * convention. The resolver is provider-agnostic in shape (mirroring
+ * This module resolves a dedicated, isolated libSQL database **per
+ * (org, user)** so the tenant boundary is the storage backend itself, not just a
+ * scoping convention. The resolver is provider-agnostic in shape (mirroring
  * `getStorageConfig`) so a hosted deployment can point at a network volume or
  * swap in remote libSQL/Turso per user via a URL template.
  *
@@ -21,12 +21,12 @@
  *      DB url comes from `MASTRACODE_TENANT_VECTOR_URL_TEMPLATE` (same `{id}`),
  *      falling back to the storage template when absent.
  *   2. Local libSQL files under `MASTRACODE_TENANT_DB_ROOT` (default
- *      `~/.mastracode/web/tenants/<sha256(workosId)>/`), with `storage.db` +
- *      `vectors.db`.
+ *      `~/.mastracode/web/tenants/<sha256(orgId\0userId)>/`), with `storage.db`
+ *      + `vectors.db`.
  *
- * The WorkOS user id is hashed (sha256, hex) to a filesystem-safe directory
- * name — the raw id is never used as a path component, and no client-supplied
- * path ever reaches the filesystem.
+ * The `(org, user)` identity is hashed (sha256, hex) to a filesystem-safe
+ * directory name — the raw ids are never used as a path component, and no
+ * client-supplied path ever reaches the filesystem.
  */
 
 import { createHash } from 'node:crypto';
@@ -43,15 +43,31 @@ import type { LibSQLStorageConfig } from '../utils/project.js';
  * domains, memory, recall vectors) is built per tenant with no duplication.
  */
 export interface TenantStorage {
-  /** Filesystem-safe key derived from the WorkOS user id (sha256 hex). */
+  /** Filesystem-safe key derived from the (org, user) identity (sha256 hex). */
   tenantKey: string;
   /** Storage config passed to the controller factory for this tenant. */
   storageConfig: LibSQLStorageConfig;
 }
 
-/** Hash a WorkOS user id to a filesystem-safe, collision-resistant dir name. */
-export function tenantKeyFor(workosId: string): string {
-  return createHash('sha256').update(workosId).digest('hex');
+/**
+ * The tenant identity for agent-state isolation: a WorkOS organization plus a
+ * user inside it. `orgId` is `undefined`/empty for personal (no-org) accounts,
+ * which fall back to a user-only key so single-user dev keeps working.
+ */
+export interface TenantIdentity {
+  orgId?: string;
+  userId: string;
+}
+
+/**
+ * Hash the `(orgId, userId)` identity to a filesystem-safe, collision-resistant
+ * dir name. Two users in the same org get distinct keys; the same user across
+ * two orgs gets distinct keys. Personal accounts (no org) hash the user id only,
+ * so they stay stable and isolated from any org-scoped tenant.
+ */
+export function tenantKeyFor(identity: TenantIdentity): string {
+  const composite = identity.orgId ? `${identity.orgId}\u0000${identity.userId}` : identity.userId;
+  return createHash('sha256').update(composite).digest('hex');
 }
 
 /** Root directory for local per-tenant libSQL files. */
@@ -71,11 +87,11 @@ function applyTemplate(template: string, tenantKey: string): string {
  * ensuring the local directory exists) so it is easy to unit test. Use
  * {@link getUserStorage} for the cached entry point.
  */
-export function resolveTenantStorage(workosId: string): TenantStorage {
-  if (!workosId) {
-    throw new Error('resolveTenantStorage requires a non-empty workosId');
+export function resolveTenantStorage(identity: TenantIdentity): TenantStorage {
+  if (!identity.userId) {
+    throw new Error('resolveTenantStorage requires a non-empty userId');
   }
-  const tenantKey = tenantKeyFor(workosId);
+  const tenantKey = tenantKeyFor(identity);
 
   // 1. Remote libSQL/Turso via URL template.
   const urlTemplate = process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE;
@@ -116,17 +132,39 @@ export function resolveTenantStorage(workosId: string): TenantStorage {
 const tenantCache = new Map<string, TenantStorage>();
 
 /**
- * Get-or-create the cached tenant storage descriptor for a WorkOS user. Same
- * user → same cached descriptor; distinct users → distinct descriptors backed
- * by distinct databases.
+ * Get-or-create the cached tenant storage descriptor for an `(org, user)`
+ * identity. Same identity → same cached descriptor; distinct identities →
+ * distinct descriptors backed by distinct databases.
  */
-export function getUserStorage(workosId: string): TenantStorage {
-  const tenantKey = tenantKeyFor(workosId);
+export function getUserStorage(identity: TenantIdentity): TenantStorage {
+  const tenantKey = tenantKeyFor(identity);
   const cached = tenantCache.get(tenantKey);
   if (cached) return cached;
-  const resolved = resolveTenantStorage(workosId);
+  const resolved = resolveTenantStorage(identity);
   tenantCache.set(resolved.tenantKey, resolved);
   return resolved;
+}
+
+/** True when a remote (network-backed) tenant DB template is configured. */
+export function hasRemoteTenantDb(): boolean {
+  return Boolean(process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE);
+}
+
+/**
+ * Fail loud at startup when a remote tenant DB is required but not configured.
+ * Local-file tenant DBs do not survive container restarts and are not shared
+ * across replicas, so a multi-replica/ephemeral deploy must set
+ * `MASTRACODE_TENANT_DB_URL_TEMPLATE`. Gated behind
+ * `MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1` so local dev is unaffected.
+ */
+export function assertRemoteTenantDbIfRequired(): void {
+  if (process.env.MASTRACODE_REQUIRE_REMOTE_TENANT_DB !== '1') return;
+  if (hasRemoteTenantDb()) return;
+  throw new Error(
+    'MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1 but no MASTRACODE_TENANT_DB_URL_TEMPLATE is set. ' +
+      'Local-file tenant databases do not persist across container restarts and are not ' +
+      'shared across replicas. Set MASTRACODE_TENANT_DB_URL_TEMPLATE to a remote libSQL/Turso URL.',
+  );
 }
 
 /** Clear the in-process tenant cache (test helper). */

--- a/mastracode/src/web/tenant-storage.ts
+++ b/mastracode/src/web/tenant-storage.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-user (tenant) storage resolution for the multi-tenant web server.
+ *
+ * The web server authenticates browser clients via WorkOS AuthKit (see
+ * `auth.ts`). Without per-tenant isolation, every authenticated user's agent
+ * state (threads, messages, memory, observational memory, recall vectors) lands
+ * in a single shared storage backend — only separated by `resourceId`
+ * convention. That is a hard multi-tenancy/privacy violation: a bug or a crafted
+ * `resourceId` could read another tenant's conversations.
+ *
+ * This module resolves a dedicated, isolated libSQL database **per WorkOS user**
+ * so the tenant boundary is the storage backend itself, not just a scoping
+ * convention. The resolver is provider-agnostic in shape (mirroring
+ * `getStorageConfig`) so a hosted deployment can point at a network volume or
+ * swap in remote libSQL/Turso per user via a URL template.
+ *
+ * Resolution strategy (highest priority first):
+ *   1. `MASTRACODE_TENANT_DB_URL_TEMPLATE` — remote libSQL/Turso. The template
+ *      may contain a `{id}` placeholder replaced with the filesystem-safe
+ *      tenant key. Auth token from `MASTRACODE_TENANT_DB_AUTH_TOKEN`. The vector
+ *      DB url comes from `MASTRACODE_TENANT_VECTOR_URL_TEMPLATE` (same `{id}`),
+ *      falling back to the storage template when absent.
+ *   2. Local libSQL files under `MASTRACODE_TENANT_DB_ROOT` (default
+ *      `~/.mastracode/web/tenants/<sha256(workosId)>/`), with `storage.db` +
+ *      `vectors.db`.
+ *
+ * The WorkOS user id is hashed (sha256, hex) to a filesystem-safe directory
+ * name — the raw id is never used as a path component, and no client-supplied
+ * path ever reaches the filesystem.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { LibSQLStorageConfig } from '../utils/project.js';
+
+/**
+ * A resolved per-tenant storage descriptor. This is a `StorageConfig`-shaped
+ * value that flows into the existing `mountAgentControllerOnMastra({ storage })`
+ * pipeline, so all the usual composition (composite store, observability
+ * domains, memory, recall vectors) is built per tenant with no duplication.
+ */
+export interface TenantStorage {
+  /** Filesystem-safe key derived from the WorkOS user id (sha256 hex). */
+  tenantKey: string;
+  /** Storage config passed to the controller factory for this tenant. */
+  storageConfig: LibSQLStorageConfig;
+}
+
+/** Hash a WorkOS user id to a filesystem-safe, collision-resistant dir name. */
+export function tenantKeyFor(workosId: string): string {
+  return createHash('sha256').update(workosId).digest('hex');
+}
+
+/** Root directory for local per-tenant libSQL files. */
+function tenantDbRoot(): string {
+  const fromEnv = process.env.MASTRACODE_TENANT_DB_ROOT;
+  if (fromEnv) return fromEnv;
+  return path.join(os.homedir(), '.mastracode', 'web', 'tenants');
+}
+
+/** Apply a `{id}` template, tolerating templates without the placeholder. */
+function applyTemplate(template: string, tenantKey: string): string {
+  return template.includes('{id}') ? template.replaceAll('{id}', tenantKey) : `${template}${tenantKey}`;
+}
+
+/**
+ * Resolve the storage descriptor for a tenant. Pure (no caching, no I/O beyond
+ * ensuring the local directory exists) so it is easy to unit test. Use
+ * {@link getUserStorage} for the cached entry point.
+ */
+export function resolveTenantStorage(workosId: string): TenantStorage {
+  if (!workosId) {
+    throw new Error('resolveTenantStorage requires a non-empty workosId');
+  }
+  const tenantKey = tenantKeyFor(workosId);
+
+  // 1. Remote libSQL/Turso via URL template.
+  const urlTemplate = process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE;
+  if (urlTemplate) {
+    const url = applyTemplate(urlTemplate, tenantKey);
+    const vectorTemplate = process.env.MASTRACODE_TENANT_VECTOR_URL_TEMPLATE;
+    const vectorUrl = vectorTemplate ? applyTemplate(vectorTemplate, tenantKey) : url;
+    const authToken = process.env.MASTRACODE_TENANT_DB_AUTH_TOKEN;
+    const vectorAuthToken = process.env.MASTRACODE_TENANT_VECTOR_AUTH_TOKEN ?? authToken;
+    return {
+      tenantKey,
+      storageConfig: {
+        backend: 'libsql',
+        url,
+        authToken,
+        isRemote: true,
+        vectorUrl,
+        vectorAuthToken,
+      },
+    };
+  }
+
+  // 2. Local libSQL files under a hashed per-tenant directory.
+  const dir = path.join(tenantDbRoot(), tenantKey);
+  mkdirSync(dir, { recursive: true });
+  return {
+    tenantKey,
+    storageConfig: {
+      backend: 'libsql',
+      url: `file:${path.join(dir, 'storage.db')}`,
+      isRemote: false,
+      vectorUrl: `file:${path.join(dir, 'vectors.db')}`,
+    },
+  };
+}
+
+/** In-process cache of resolved tenant descriptors, keyed by tenant key. */
+const tenantCache = new Map<string, TenantStorage>();
+
+/**
+ * Get-or-create the cached tenant storage descriptor for a WorkOS user. Same
+ * user → same cached descriptor; distinct users → distinct descriptors backed
+ * by distinct databases.
+ */
+export function getUserStorage(workosId: string): TenantStorage {
+  const tenantKey = tenantKeyFor(workosId);
+  const cached = tenantCache.get(tenantKey);
+  if (cached) return cached;
+  const resolved = resolveTenantStorage(workosId);
+  tenantCache.set(resolved.tenantKey, resolved);
+  return resolved;
+}
+
+/** Clear the in-process tenant cache (test helper). */
+export function __clearTenantStorageCache(): void {
+  tenantCache.clear();
+}

--- a/mastracode/src/web/ui/App.tsx
+++ b/mastracode/src/web/ui/App.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { fetchAuthState, redirectToLogin } from './auth';
 import type { WebAuthState } from './auth';
+import { BranchPanel } from './BranchPanel';
+import type { BranchBinding } from './BranchPanel';
 import { CommandPalette } from './CommandPalette';
 import { matchCommands, SLASH_COMMANDS } from './commands';
 import type { SlashCommand } from './commands';
@@ -366,10 +368,34 @@ export default function App() {
         githubProjectId: activeProject.githubProjectId,
         sandboxId: binding?.sandboxId ?? activeProject.sandboxId,
         sandboxWorkdir: binding?.sandboxWorkdir ?? activeProject.sandboxWorkdir,
+        // Bind the agent's workspace to the active worktree when one exists, so
+        // file edits + commands run against the feature branch, not the repo root.
+        worktreePath: activeProject.activeWorktreePath,
+        branch: activeProject.activeBranch,
       };
     }
     return { projectPath: activeProject?.path ?? '' };
   }, [activeProject]);
+
+  // Persist a freshly created worktree onto the active GitHub project and push
+  // it into session state so the workspace rebinds to the worktree path.
+  const handleWorktreeReady = useCallback(
+    (binding: BranchBinding) => {
+      if (!activeProject || activeProject.source !== 'github') return;
+      const updated: Project = {
+        ...activeProject,
+        activeBranch: binding.branch,
+        activeWorktreePath: binding.worktreePath,
+      };
+      updateProject(updated);
+      setProjects(loadProjects());
+      void session.setState({
+        worktreePath: binding.worktreePath,
+        branch: binding.branch,
+      });
+    },
+    [activeProject, session],
+  );
 
   // After the session connects for a new project, push its workspace binding.
   // Only advance the tracked resourceId once the session is actually ready and
@@ -741,6 +767,17 @@ export default function App() {
                 onPauseGoal={() => void session.pauseGoal()}
                 onResumeGoal={() => void session.resumeGoal()}
                 onClearGoal={() => void session.clearGoal()}
+              />
+            )}
+
+            {activeProject.source === 'github' && activeProject.githubProjectId && (
+              <BranchPanel
+                githubProjectId={activeProject.githubProjectId}
+                sandboxEnabled={githubStatus.sandboxEnabled ?? false}
+                activeBranch={activeProject.activeBranch}
+                activeWorktreePath={activeProject.activeWorktreePath}
+                onWorktreeReady={handleWorktreeReady}
+                onNotice={toast}
               />
             )}
 

--- a/mastracode/src/web/ui/BranchPanel-scenario.msw.test.tsx
+++ b/mastracode/src/web/ui/BranchPanel-scenario.msw.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../e2e/web-ui/msw-server';
+import { renderWithProviders } from '../../../e2e/web-ui/render';
+import { BranchPanel } from './BranchPanel';
+import type { BranchBinding } from './BranchPanel';
+
+const ORIGIN = 'http://localhost:3000';
+const PROJECT = 'proj-1';
+
+function gitOpUrl(action: string): string {
+  return `${ORIGIN}/api/web/github/projects/${PROJECT}/${action}`;
+}
+
+/**
+ * Mirrors how `App.tsx` hosts the panel: it persists the worktree binding from
+ * `onWorktreeReady` into local state and feeds it back as `activeBranch` /
+ * `activeWorktreePath`, which is what unlocks the commit/push/PR controls. This
+ * lets the scenario walk the whole create → commit → push → PR journey through
+ * a single mounted tree, the way a real user would.
+ */
+function HostedBranchPanel({ onNotice }: { onNotice: (m: string, k?: 'success' | 'error' | 'info') => void }) {
+  const [binding, setBinding] = useState<BranchBinding | null>(null);
+  return (
+    <BranchPanel
+      githubProjectId={PROJECT}
+      sandboxEnabled
+      activeBranch={binding?.branch}
+      activeWorktreePath={binding?.worktreePath}
+      onWorktreeReady={setBinding}
+      onNotice={onNotice}
+    />
+  );
+}
+
+describe('S6 — BranchPanel end-to-end write-back journey', () => {
+  it('walks create branch → commit → push → open PR in one mounted panel', async () => {
+    const onNotice = vi.fn();
+    server.use(
+      http.post(gitOpUrl('worktree'), () =>
+        HttpResponse.json({
+          worktreePath: '/workspace/worktrees/feat-x',
+          branch: 'feat-x',
+          baseBranch: 'main',
+          resourceId: 'res-1',
+        }),
+      ),
+      http.post(gitOpUrl('commit'), () => HttpResponse.json({ committed: true })),
+      http.post(gitOpUrl('push'), () => HttpResponse.json({ pushed: true, branch: 'feat-x' })),
+      http.post(gitOpUrl('pr'), () => HttpResponse.json({ url: 'https://github.com/o/r/pull/42' })),
+    );
+
+    renderWithProviders(<HostedBranchPanel onNotice={onNotice} />);
+
+    // Step 1: no branch yet — commit/push/PR controls are hidden.
+    expect(screen.getByText(/no feature branch yet/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^commit$/i })).not.toBeInTheDocument();
+
+    // Step 2: create the feature branch (worktree).
+    fireEvent.change(screen.getByLabelText('Branch name'), { target: { value: 'feat-x' } });
+    fireEvent.click(screen.getByRole('button', { name: /create branch/i }));
+
+    // The binding is persisted and the panel rebinds to show the active branch.
+    await waitFor(() => expect(screen.getByText(/on branch/i)).toBeInTheDocument());
+    expect(onNotice).toHaveBeenCalledWith('Branch feat-x ready', 'success');
+
+    // Step 3: enter a title, then commit.
+    fireEvent.change(screen.getByLabelText('Commit message or PR title'), { target: { value: 'Ship feature' } });
+    fireEvent.click(screen.getByRole('button', { name: /^commit$/i }));
+    await waitFor(() => expect(onNotice).toHaveBeenCalledWith('Changes committed', 'success'));
+
+    // Step 4: push.
+    fireEvent.click(screen.getByRole('button', { name: /^push$/i }));
+    await waitFor(() => expect(onNotice).toHaveBeenCalledWith('Pushed feat-x', 'success'));
+
+    // Step 5: open the PR — the link surfaces in the panel.
+    fireEvent.click(screen.getByRole('button', { name: /open pr/i }));
+    await waitFor(() => expect(screen.getByText(/view pull request/i)).toBeInTheDocument());
+    expect(screen.getByText(/view pull request/i)).toHaveAttribute('href', 'https://github.com/o/r/pull/42');
+    expect(onNotice).toHaveBeenCalledWith('Pull request opened', 'success');
+  });
+
+  it('surfaces an expired-session prompt when a git op returns 401 mid-flow', async () => {
+    const onNotice = vi.fn();
+    // Branch creation succeeds, but the later commit hits an expired session.
+    server.use(
+      http.post(gitOpUrl('worktree'), () =>
+        HttpResponse.json({
+          worktreePath: '/workspace/worktrees/feat-x',
+          branch: 'feat-x',
+          baseBranch: 'main',
+          resourceId: 'res-1',
+        }),
+      ),
+      http.post(gitOpUrl('commit'), () => HttpResponse.json({ error: 'unauthorized' }, { status: 401 })),
+    );
+
+    renderWithProviders(<HostedBranchPanel onNotice={onNotice} />);
+
+    fireEvent.change(screen.getByLabelText('Branch name'), { target: { value: 'feat-x' } });
+    fireEvent.click(screen.getByRole('button', { name: /create branch/i }));
+    await waitFor(() => expect(screen.getByText(/on branch/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /^commit$/i }));
+    await waitFor(() => expect(onNotice).toHaveBeenCalledWith('Your session expired — please sign in again.', 'error'));
+  });
+
+  it('keeps the whole journey hidden when no sandbox provider is configured', () => {
+    renderWithProviders(
+      <BranchPanel githubProjectId={PROJECT} sandboxEnabled={false} onWorktreeReady={vi.fn()} onNotice={vi.fn()} />,
+    );
+    expect(screen.getByText(/need a sandbox provider/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText('Branch name')).not.toBeInTheDocument();
+  });
+});

--- a/mastracode/src/web/ui/BranchPanel.msw.test.tsx
+++ b/mastracode/src/web/ui/BranchPanel.msw.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../e2e/web-ui/msw-server';
+import { renderWithProviders } from '../../../e2e/web-ui/render';
+import { BranchPanel } from './BranchPanel';
+
+const ORIGIN = 'http://localhost:3000';
+const PROJECT = 'proj-1';
+
+function gitOpUrl(action: string): string {
+  return `${ORIGIN}/api/web/github/projects/${PROJECT}/${action}`;
+}
+
+describe('BranchPanel', () => {
+  it('shows a disabled hint when no sandbox provider is configured', () => {
+    renderWithProviders(
+      <BranchPanel githubProjectId={PROJECT} sandboxEnabled={false} onWorktreeReady={vi.fn()} onNotice={vi.fn()} />,
+    );
+    expect(screen.getByText(/need a sandbox provider/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText('Branch name')).not.toBeInTheDocument();
+  });
+
+  it('creates a worktree and reports the binding back to the parent', async () => {
+    const onWorktreeReady = vi.fn();
+    const onNotice = vi.fn();
+    server.use(
+      http.post(gitOpUrl('worktree'), () =>
+        HttpResponse.json({
+          worktreePath: '/workspace/worktrees/feat-x',
+          branch: 'feat-x',
+          baseBranch: 'main',
+          resourceId: 'res-1',
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <BranchPanel githubProjectId={PROJECT} sandboxEnabled onWorktreeReady={onWorktreeReady} onNotice={onNotice} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Branch name'), { target: { value: 'feat-x' } });
+    fireEvent.click(screen.getByRole('button', { name: /create branch/i }));
+
+    await waitFor(() =>
+      expect(onWorktreeReady).toHaveBeenCalledWith({
+        branch: 'feat-x',
+        worktreePath: '/workspace/worktrees/feat-x',
+        baseBranch: 'main',
+      }),
+    );
+    expect(onNotice).toHaveBeenCalledWith('Branch feat-x ready', 'success');
+  });
+
+  it('opens a PR and renders the resulting link when a branch is active', async () => {
+    const onNotice = vi.fn();
+    server.use(http.post(gitOpUrl('pr'), () => HttpResponse.json({ url: 'https://github.com/o/r/pull/9' })));
+
+    renderWithProviders(
+      <BranchPanel
+        githubProjectId={PROJECT}
+        sandboxEnabled
+        activeBranch="feat-x"
+        activeWorktreePath="/workspace/worktrees/feat-x"
+        onWorktreeReady={vi.fn()}
+        onNotice={onNotice}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Commit message or PR title'), { target: { value: 'My PR' } });
+    fireEvent.click(screen.getByRole('button', { name: /open pr/i }));
+
+    await waitFor(() => expect(screen.getByText(/view pull request/i)).toBeInTheDocument());
+    expect(screen.getByText(/view pull request/i)).toHaveAttribute('href', 'https://github.com/o/r/pull/9');
+    expect(onNotice).toHaveBeenCalledWith('Pull request opened', 'success');
+  });
+
+  it('blocks opening a PR without a title', async () => {
+    const onNotice = vi.fn();
+    renderWithProviders(
+      <BranchPanel
+        githubProjectId={PROJECT}
+        sandboxEnabled
+        activeBranch="feat-x"
+        activeWorktreePath="/workspace/worktrees/feat-x"
+        onWorktreeReady={vi.fn()}
+        onNotice={onNotice}
+      />,
+    );
+
+    // Open PR button is disabled until a title is entered.
+    expect(screen.getByRole('button', { name: /open pr/i })).toBeDisabled();
+  });
+
+  it('surfaces a server error via onNotice', async () => {
+    const onNotice = vi.fn();
+    server.use(
+      http.post(gitOpUrl('worktree'), () =>
+        HttpResponse.json({ error: 'Invalid branch', message: 'branch name is invalid' }, { status: 400 }),
+      ),
+    );
+
+    renderWithProviders(
+      <BranchPanel githubProjectId={PROJECT} sandboxEnabled onWorktreeReady={vi.fn()} onNotice={onNotice} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Branch name'), { target: { value: 'bad-ref' } });
+    fireEvent.click(screen.getByRole('button', { name: /create branch/i }));
+
+    await waitFor(() => expect(onNotice).toHaveBeenCalledWith('branch name is invalid', 'error'));
+  });
+});

--- a/mastracode/src/web/ui/BranchPanel.tsx
+++ b/mastracode/src/web/ui/BranchPanel.tsx
@@ -1,0 +1,214 @@
+/**
+ * Branch / PR panel for a GitHub-backed project.
+ *
+ * Surfaces the cloud coding-agent write-back flow to the web user: pick or
+ * create a feature branch (a git worktree inside the project's sandbox), then
+ * commit the agent's changes and open a pull request via the sandbox `gh` CLI.
+ *
+ * All git work happens server-side inside the sandbox; this component only
+ * drives the `/api/web/github/projects/:id/*` endpoints via the `github.ts`
+ * helpers. Branch names and PR titles are validated server-side too — the UI
+ * just disables actions until the required inputs are present.
+ */
+
+import { useState } from 'react';
+
+import { commitChanges, createWorktree, openPullRequest, pushBranch } from './github';
+import type { GitOpError, WorktreeResult } from './github';
+import { TargetIcon } from './icons';
+
+export interface BranchBinding {
+  branch: string;
+  worktreePath: string;
+  baseBranch: string;
+}
+
+export function BranchPanel({
+  githubProjectId,
+  sandboxEnabled,
+  activeBranch,
+  activeWorktreePath,
+  onWorktreeReady,
+  onNotice,
+}: {
+  githubProjectId: string;
+  /** Whether the server has a sandbox provider configured. */
+  sandboxEnabled: boolean;
+  /** Persisted active branch for this project (rebinds on reopen). */
+  activeBranch?: string;
+  /** Persisted active worktree path for this project. */
+  activeWorktreePath?: string;
+  /** Called after a worktree is created so the parent can persist + rebind it. */
+  onWorktreeReady: (binding: BranchBinding) => void;
+  /** Surface a status / error message to the user (toast). */
+  onNotice: (message: string, kind?: 'success' | 'error' | 'info') => void;
+}) {
+  const [branchDraft, setBranchDraft] = useState('');
+  const [title, setTitle] = useState('');
+  const [prBody, setPrBody] = useState('');
+  const [busy, setBusy] = useState<null | 'worktree' | 'commit' | 'push' | 'pr'>(null);
+  const [prUrl, setPrUrl] = useState<string | null>(null);
+
+  const hasBranch = !!activeBranch && !!activeWorktreePath;
+
+  function describeError(e: unknown): string {
+    const err = e as GitOpError;
+    if (err?.authRequired) return 'Your session expired — please sign in again.';
+    return err instanceof Error ? err.message : String(e);
+  }
+
+  async function handleCreateBranch(e: { preventDefault: () => void }) {
+    e.preventDefault();
+    const branch = branchDraft.trim();
+    if (!branch) return;
+    setBusy('worktree');
+    try {
+      const result: WorktreeResult = await createWorktree(githubProjectId, branch);
+      onWorktreeReady({
+        branch: result.branch,
+        worktreePath: result.worktreePath,
+        baseBranch: result.baseBranch,
+      });
+      setBranchDraft('');
+      setPrUrl(null);
+      onNotice(`Branch ${result.branch} ready`, 'success');
+    } catch (err) {
+      onNotice(describeError(err), 'error');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleCommit() {
+    if (!activeBranch || !activeWorktreePath) return;
+    const message = title.trim() || `Update from Mastra Code on ${activeBranch}`;
+    setBusy('commit');
+    try {
+      const result = await commitChanges(githubProjectId, message, activeWorktreePath);
+      onNotice(result.committed ? 'Changes committed' : 'Nothing to commit', result.committed ? 'success' : 'info');
+    } catch (err) {
+      onNotice(describeError(err), 'error');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handlePush() {
+    if (!activeBranch || !activeWorktreePath) return;
+    setBusy('push');
+    try {
+      await pushBranch(githubProjectId, activeBranch, activeWorktreePath);
+      onNotice(`Pushed ${activeBranch}`, 'success');
+    } catch (err) {
+      onNotice(describeError(err), 'error');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleOpenPr() {
+    if (!activeBranch || !activeWorktreePath) return;
+    const prTitle = title.trim();
+    if (!prTitle) {
+      onNotice('A pull request title is required', 'error');
+      return;
+    }
+    setBusy('pr');
+    try {
+      const result = await openPullRequest(githubProjectId, {
+        branch: activeBranch,
+        title: prTitle,
+        body: prBody.trim() || undefined,
+        worktreePath: activeWorktreePath,
+      });
+      setPrUrl(result.url);
+      onNotice('Pull request opened', 'success');
+    } catch (err) {
+      onNotice(describeError(err), 'error');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (!sandboxEnabled) {
+    return (
+      <div className="branch-panel branch-panel-disabled" role="note">
+        <span className="branch-panel-icon">
+          <TargetIcon size={14} />
+        </span>
+        <span className="branch-panel-hint">
+          Branch &amp; PR actions need a sandbox provider configured on the server.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="branch-panel">
+      <div className="branch-panel-row">
+        <span className="branch-panel-icon">
+          <TargetIcon size={14} />
+        </span>
+        {hasBranch ? (
+          <span className="branch-panel-current" title={activeWorktreePath}>
+            On branch <strong>{activeBranch}</strong>
+          </span>
+        ) : (
+          <span className="branch-panel-current branch-panel-muted">No feature branch yet</span>
+        )}
+      </div>
+
+      <form className="branch-panel-row" onSubmit={handleCreateBranch}>
+        <input
+          className="input branch-panel-input"
+          value={branchDraft}
+          onChange={e => setBranchDraft(e.target.value)}
+          placeholder={hasBranch ? 'Switch to / create another branch…' : 'feature-branch-name'}
+          aria-label="Branch name"
+          disabled={busy !== null}
+        />
+        <button className="btn btn-sm" type="submit" disabled={busy !== null || !branchDraft.trim()}>
+          {busy === 'worktree' ? 'Creating…' : 'Create branch'}
+        </button>
+      </form>
+
+      {hasBranch && (
+        <div className="branch-panel-pr">
+          <input
+            className="input branch-panel-input"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder="Commit message / PR title"
+            aria-label="Commit message or PR title"
+            disabled={busy !== null}
+          />
+          <textarea
+            className="input branch-panel-textarea"
+            value={prBody}
+            onChange={e => setPrBody(e.target.value)}
+            placeholder="PR description (optional)"
+            aria-label="PR description"
+            rows={2}
+            disabled={busy !== null}
+          />
+          <div className="branch-panel-actions">
+            <button className="btn btn-sm" onClick={handleCommit} disabled={busy !== null}>
+              {busy === 'commit' ? 'Committing…' : 'Commit'}
+            </button>
+            <button className="btn btn-sm" onClick={handlePush} disabled={busy !== null}>
+              {busy === 'push' ? 'Pushing…' : 'Push'}
+            </button>
+            <button className="btn btn-primary btn-sm" onClick={handleOpenPr} disabled={busy !== null || !title.trim()}>
+              {busy === 'pr' ? 'Opening…' : 'Open PR'}
+            </button>
+          </div>
+          {prUrl && (
+            <a className="branch-panel-prlink" href={prUrl} target="_blank" rel="noreferrer noopener">
+              View pull request →
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mastracode/src/web/ui/github.msw.test.tsx
+++ b/mastracode/src/web/ui/github.msw.test.tsx
@@ -1,0 +1,92 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../e2e/web-ui/msw-server';
+import { commitChanges, createWorktree, openPullRequest, pushBranch } from './github';
+import type { GitOpError } from './github';
+
+/**
+ * The GitHub git-op helpers use raw relative `fetch('/api/web/github/...')`
+ * (not the injected ApiConfig base), so jsdom resolves them against its default
+ * origin. Match handlers against that origin.
+ */
+const ORIGIN = 'http://localhost:3000';
+const PROJECT = 'proj-1';
+
+function gitOpUrl(action: string): string {
+  return `${ORIGIN}/api/web/github/projects/${PROJECT}/${action}`;
+}
+
+describe('github git-op helpers', () => {
+  it('createWorktree posts branch/baseBranch and returns the worktree result', async () => {
+    let received: unknown;
+    server.use(
+      http.post(gitOpUrl('worktree'), async ({ request }) => {
+        received = await request.json();
+        return HttpResponse.json({
+          worktreePath: '/workspace/worktrees/feat-x',
+          branch: 'feat-x',
+          baseBranch: 'main',
+          resourceId: 'res-1',
+        });
+      }),
+    );
+
+    const result = await createWorktree(PROJECT, 'feat-x', 'main');
+
+    expect(received).toEqual({ branch: 'feat-x', baseBranch: 'main' });
+    expect(result.worktreePath).toBe('/workspace/worktrees/feat-x');
+    expect(result.branch).toBe('feat-x');
+    expect(result.baseBranch).toBe('main');
+  });
+
+  it('commitChanges reports committed=false when nothing changed', async () => {
+    server.use(http.post(gitOpUrl('commit'), () => HttpResponse.json({ committed: false })));
+    const result = await commitChanges(PROJECT, 'msg', '/workspace/worktrees/feat-x');
+    expect(result.committed).toBe(false);
+  });
+
+  it('pushBranch returns the pushed branch', async () => {
+    let received: unknown;
+    server.use(
+      http.post(gitOpUrl('push'), async ({ request }) => {
+        received = await request.json();
+        return HttpResponse.json({ pushed: true, branch: 'feat-x' });
+      }),
+    );
+    const result = await pushBranch(PROJECT, 'feat-x', '/workspace/worktrees/feat-x');
+    expect(received).toEqual({ branch: 'feat-x', worktreePath: '/workspace/worktrees/feat-x' });
+    expect(result.pushed).toBe(true);
+  });
+
+  it('openPullRequest returns the PR url', async () => {
+    server.use(http.post(gitOpUrl('pr'), () => HttpResponse.json({ url: 'https://github.com/o/r/pull/7' })));
+    const result = await openPullRequest(PROJECT, { branch: 'feat-x', title: 'My PR' });
+    expect(result.url).toBe('https://github.com/o/r/pull/7');
+  });
+
+  it('surfaces the server error code/message on failure', async () => {
+    server.use(
+      http.post(gitOpUrl('worktree'), () =>
+        HttpResponse.json({ error: 'Invalid branch', message: 'branch name is invalid' }, { status: 400 }),
+      ),
+    );
+    await expect(createWorktree(PROJECT, 'bad ref')).rejects.toMatchObject({
+      code: 'Invalid branch',
+      message: 'branch name is invalid',
+      status: 400,
+    });
+  });
+
+  it('flags authRequired on a 401', async () => {
+    server.use(http.post(gitOpUrl('push'), () => new HttpResponse(null, { status: 401 })));
+    let caught: GitOpError | undefined;
+    try {
+      await pushBranch(PROJECT, 'feat-x');
+    } catch (e) {
+      caught = e as GitOpError;
+    }
+    expect(caught?.authRequired).toBe(true);
+    expect(caught?.status).toBe(401);
+  });
+});

--- a/mastracode/src/web/ui/github.ts
+++ b/mastracode/src/web/ui/github.ts
@@ -125,3 +125,104 @@ export async function ensureRepoMaterialized(githubProjectId: string): Promise<M
   }
   return (await res.json()) as MaterializeResult;
 }
+
+/**
+ * An error from a git write operation (worktree/commit/push/pr) that carries the
+ * server's error code so the UI can distinguish actionable failures (e.g.
+ * `authRequired` for a 401, `Invalid branch` for a 400) from generic failures.
+ */
+export interface GitOpError extends Error {
+  code?: string;
+  status?: number;
+  authRequired?: boolean;
+}
+
+/**
+ * POST helper for the per-project git endpoints. Parses the server's JSON body,
+ * surfacing `error`/`message` codes on failure (and `authRequired` for 401) so
+ * callers can react without re-implementing the parsing dance each time.
+ */
+async function postProjectGitOp<T>(githubProjectId: string, action: string, payload: unknown): Promise<T> {
+  const res = await fetch(`/api/web/github/projects/${encodeURIComponent(githubProjectId)}/${action}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(payload ?? {}),
+  });
+  if (!res.ok) {
+    let code = `http_${res.status}`;
+    let message = `Request failed (${res.status})`;
+    try {
+      const body = (await res.json()) as { error?: string; message?: string };
+      if (body.error) code = body.error;
+      if (body.message) message = body.message;
+      else if (body.error) message = body.error;
+    } catch {
+      /* ignore non-JSON */
+    }
+    const err = new Error(message) as GitOpError;
+    err.code = code;
+    err.status = res.status;
+    if (res.status === 401) err.authRequired = true;
+    throw err;
+  }
+  return (await res.json()) as T;
+}
+
+export interface WorktreeResult {
+  worktreePath: string;
+  branch: string;
+  baseBranch: string;
+  resourceId: string;
+}
+
+/**
+ * Create (or reuse) a git worktree + feature branch for a unit of work inside
+ * the project's cloud sandbox. `baseBranch` defaults to the project's default
+ * branch server-side when omitted.
+ */
+export async function createWorktree(
+  githubProjectId: string,
+  branch: string,
+  baseBranch?: string,
+): Promise<WorktreeResult> {
+  return postProjectGitOp<WorktreeResult>(githubProjectId, 'worktree', { branch, baseBranch });
+}
+
+export interface CommitResult {
+  committed: boolean;
+}
+
+/**
+ * Stage all changes and commit them inside the given worktree. `worktreePath`
+ * is validated server-side against persisted worktrees; omit it to commit on the
+ * base checkout. Resolves with `committed: false` when there was nothing to commit.
+ */
+export async function commitChanges(
+  githubProjectId: string,
+  message: string,
+  worktreePath?: string,
+): Promise<CommitResult> {
+  return postProjectGitOp<CommitResult>(githubProjectId, 'commit', { message, worktreePath });
+}
+
+export interface PushResult {
+  pushed: boolean;
+  branch: string;
+}
+
+/** Push a branch back to GitHub from inside the sandbox (token minted server-side). */
+export async function pushBranch(githubProjectId: string, branch: string, worktreePath?: string): Promise<PushResult> {
+  return postProjectGitOp<PushResult>(githubProjectId, 'push', { branch, worktreePath });
+}
+
+export interface PullRequestResult {
+  url: string;
+}
+
+/** Open a pull request via the sandbox `gh` CLI. `base` defaults to the project default branch. */
+export async function openPullRequest(
+  githubProjectId: string,
+  args: { branch: string; title: string; body?: string; base?: string; worktreePath?: string },
+): Promise<PullRequestResult> {
+  return postProjectGitOp<PullRequestResult>(githubProjectId, 'pr', args);
+}

--- a/mastracode/src/web/ui/projects.ts
+++ b/mastracode/src/web/ui/projects.ts
@@ -36,6 +36,13 @@ export interface Project {
   sandboxId?: string;
   sandboxWorkdir?: string;
   /**
+   * Active feature branch + worktree for a GitHub project, persisted after a
+   * worktree is created so a re-opened project rebinds the same worktree
+   * workspace (the agent edits the worktree path, not the repo root).
+   */
+  activeBranch?: string;
+  activeWorktreePath?: string;
+  /**
    * Server-resolved resourceId (TUI-compatible). May be absent on projects
    * created before this field existed; `ensureResourceId` backfills it.
    */

--- a/mastracode/src/web/ui/styles.css
+++ b/mastracode/src/web/ui/styles.css
@@ -1155,6 +1155,76 @@ body::before {
 
 /* ── Goal panel ─────────────────────────────────────────────────────────── */
 
+.branch-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.branch-panel-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.branch-panel-icon {
+  display: inline-flex;
+  color: var(--accent);
+}
+
+.branch-panel-current {
+  font-size: 12.5px;
+}
+
+.branch-panel-muted {
+  color: var(--fg-dim);
+}
+
+.branch-panel-input {
+  flex: 1;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+.branch-panel-textarea {
+  width: 100%;
+  font-size: 12px;
+  padding: 4px 8px;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.branch-panel-pr {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.branch-panel-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.branch-panel-prlink {
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.branch-panel-disabled {
+  flex-direction: row;
+  align-items: center;
+  color: var(--fg-dim);
+}
+
+.branch-panel-hint {
+  font-size: 12px;
+}
+
 .goal-bar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Turns the MastraCode web server into a multi-org cloud coding agent. Signed-in members of a WorkOS organization can connect a GitHub repository, open it inside an isolated cloud sandbox, run the coding agent against a git worktree, and write the work back as commits, pushes, and pull requests — all while staying isolated from other members and other organizations.

The tenant boundary is the **WorkOS organization**: the GitHub App installation and the connected repository belong to the org, while **each user inside the org gets their own sandbox, worktrees, branches, PRs, and agent state** against that repo. The **same repository can be connected independently by different orgs** with no cross-org visibility. Users without an organization (personal accounts) still get isolated agent state but cannot connect GitHub projects.

It also hardens the server for hosted, multi-replica deployment so a whole team can use it concurrently.

## What's included

**Cloud coding agent (per user)**
- Connect a GitHub repo via the GitHub App, materialized into an isolated cloud sandbox (Railway) on open via in-sandbox `git clone` / `git pull`.
- In-sandbox git identity, per-operation tokenized remotes (scrubbed after use), branch worktrees, commit/push helpers, and `gh`-based pull-request creation.
- Per-user agent state (threads, messages, memory, recall vectors) in a dedicated libSQL database — no shared store.
- Branch/PR panel in the web UI for the create → commit → push → PR journey.

**Org tenancy**
- Organization is the top-level tenant; installation and project (repo) are org-owned; worktrees/sandboxes/branches/PRs and agent state are isolated per `(org, user)`.
- The same repo can be connected by multiple orgs (`(org_id, repo_id)` uniqueness).

**Deployment hardening (multi-replica)**
- Per-`(project,user)` git writes serialized across replicas via Postgres advisory locks (`MASTRACODE_DISTRIBUTED_LOCK`).
- Replica-stable OAuth/install state signing required in multi-replica setups (`GITHUB_APP_WEBHOOK_SECRET`).
- Bounded in-memory tenant caches with idle + LRU eviction (`MASTRACODE_TENANT_IDLE_MINUTES`, `MASTRACODE_TENANT_MAX_APPS`).
- Startup guard for shared remote tenant DBs (`MASTRACODE_REQUIRE_REMOTE_TENANT_DB`).
- Per-replica live-sandbox cap (`MASTRACODE_MAX_SANDBOXES`) plus a per-user sandbox teardown route.

All features are off by default; with the relevant env vars absent the web UI and local/TUI paths behave exactly as before.

## Test plan

- `pnpm --filter mastracode check` (tsc + check:ui) — clean
- `pnpm --filter mastracode lint` (eslint) — clean
- Targeted web/agent Vitest suite — 34 files / 315 tests green
- UI MSW Vitest suite — 15 files / 67 tests green
- Cross-seam scenario coverage added for each area: full write-back journey, real cross-tenant libSQL isolation, org isolation (same repo across orgs, per-user sandboxes, cross-user rejection), distributed lock semantics, state-secret replica stability, tenant cache eviction, and sandbox fleet budget/teardown.

## Deferred (follow-ups)

- Collaboration within a project (multiple users sharing one worktree/sandbox/branch).
- Org admin / roles / membership management UI and org-level project deletion.
- Secrets manager / GitHub App key rotation (documented requirement only).
- Global cross-replica sandbox scheduler/quota; rate limiting / audit log / per-tenant metrics.
