### PR TITLE
fix(core): preserve custom model gateways and surface real gateway errors

### DIFF
--- a/.changeset/two-dancers-jam.md
+++ b/.changeset/two-dancers-jam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed custom model gateways being overridden by default gateways. GatewayManager now deduplicates gateways by ID (first-wins) so custom gateways take precedence over defaults. Narrowed the auth-availability check to only swallow expected missing-credential errors instead of all errors, so real gateway failures surface during debugging.

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -1141,8 +1141,9 @@ export class AgentController<TState = {}> {
   /**
    * Check if the current model's provider has authentication configured.
    * Delegates to the {@link GatewayManager} auth chain (the same resolution
-   * the model router uses at run time). Falls back to `hasAuth: true` when
-   * no model is selected or the chain cannot resolve auth.
+   * the model router uses at run time). Returns `hasAuth: true` only when no
+   * model is selected; gateway-chain failures return `hasAuth: false` so the
+   * auth-status endpoint stays stable instead of erroring.
    */
   async getCurrentModelAuthStatus(session: Session<TState>): Promise<ModelAuthStatus> {
     const modelId = session.model.get();

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -1148,7 +1148,16 @@ export class AgentController<TState = {}> {
     const modelId = session.model.get();
     if (!modelId) return { hasAuth: true };
 
-    const hasAuth = this.#gatewayManager ? await this.#gatewayManager.hasAuth(modelId) : true;
+    // hasAuth returns false for expected missing-auth/missing-gateway cases.
+    // It rethrows unexpected gateway failures (token exchange errors, network
+    // bugs) — catch those here so the UI auth-status endpoint stays stable
+    // and falls back to "no auth" instead of erroring.
+    let hasAuth = true;
+    try {
+      hasAuth = this.#gatewayManager ? await this.#gatewayManager.hasAuth(modelId) : true;
+    } catch {
+      hasAuth = false;
+    }
     if (hasAuth) return { hasAuth: true };
 
     // Surface the env-var hint from the catalog when available.

--- a/packages/core/src/agent-controller/list-available-models.test.ts
+++ b/packages/core/src/agent-controller/list-available-models.test.ts
@@ -180,4 +180,22 @@ describe('AgentController.listAvailableModels', () => {
     const status = await controller.getCurrentModelAuthStatus(session);
     expect(status).toEqual({ hasAuth: true });
   });
+
+  it('getCurrentModelAuthStatus falls back to hasAuth false when the gateway throws an unexpected error', async () => {
+    // resolveAuth throws a non-missing-auth error (e.g. a token-exchange failure).
+    // hasAuth rethrows it, but getCurrentModelAuthStatus should catch it so the
+    // UI auth-status endpoint stays stable instead of erroring.
+    const gateway = createFakeGateway({
+      resolveAuth: () => {
+        throw new Error('token exchange failed');
+      },
+    });
+    const controller = createController(gateway, 'test-gateway/acme/sonic-fast');
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    session.model.set({ modelId: 'test-gateway/acme/sonic-fast' });
+
+    const status = await controller.getCurrentModelAuthStatus(session);
+    expect(status.hasAuth).toBe(false);
+  });
 });

--- a/packages/core/src/llm/model/gateways/custom-gateway.test.ts
+++ b/packages/core/src/llm/model/gateways/custom-gateway.test.ts
@@ -453,4 +453,68 @@ describe('Custom Gateway Integration', () => {
       expect(model.modelId).toBe('model-1');
     });
   });
+
+  describe('Custom gateway dedup regression', () => {
+    it('uses the custom gateway when it shadows a default gateway id (first-wins)', () => {
+      // A custom gateway with the same id as the default Netlify gateway.
+      // Before the GatewayManager dedup fix, the default would override the
+      // custom gateway, losing the user's override. Now first-wins dedup keeps
+      // the custom gateway.
+      const shadowGateway: MastraModelGatewayInterface = {
+        id: 'netlify',
+        name: 'custom-netlify-override',
+        shouldEnable: () => true,
+        fetchProviders: vi.fn(async () => ({
+          'shadow-provider': {
+            name: 'Shadow',
+            models: ['shadow-model'],
+            apiKeyEnvVar: 'SHADOW_KEY',
+            gateway: 'netlify',
+            url: 'https://shadow.example/v1',
+          },
+        })),
+        buildUrl: () => 'https://shadow.example/v1',
+        getApiKey: vi.fn(async () => 'shadow-key'),
+        resolveAuth: vi.fn(() => ({ apiKey: 'shadow-auth-key', source: 'gateway' as const })),
+        resolveLanguageModel: vi.fn(
+          () =>
+            ({
+              specificationVersion: 'v2',
+              doGenerate: vi.fn(),
+              doStream: vi.fn(),
+            }) as any,
+        ),
+      };
+
+      const model = new ModelRouterLanguageModel('netlify/shadow-provider/shadow-model', [shadowGateway]);
+
+      // The custom gateway wins over the default Netlify gateway.
+      expect(model.gatewayId).toBe('netlify');
+      expect(model.provider).toBe('shadow-provider');
+      expect(model.modelId).toBe('shadow-model');
+      expect(shadowGateway.resolveAuth).not.toHaveBeenCalled(); // not called at construction time
+    });
+
+    it('does not reserve a gateway id from a disabled custom gateway before an enabled default', () => {
+      // A disabled custom gateway with the same id as a default should not
+      // block the enabled default from being used.
+      const disabledGateway: MastraModelGatewayInterface = {
+        id: 'netlify',
+        name: 'disabled-netlify-override',
+        shouldEnable: () => false,
+        fetchProviders: vi.fn(async () => ({})),
+        buildUrl: () => '',
+        getApiKey: vi.fn(async () => 'should-not-be-used'),
+        resolveLanguageModel: vi.fn(() => ({}) as any),
+      };
+
+      // With the disabled custom gateway first, the default Netlify gateway
+      // should still be available (not blocked by the disabled id).
+      const model = new ModelRouterLanguageModel('openai/gpt-4o', [disabledGateway]);
+
+      expect(model).toBeDefined();
+      // Should resolve via models.dev (default) since the disabled gateway is filtered.
+      expect(model.provider).toBe('openai');
+    });
+  });
 });

--- a/packages/core/src/llm/model/gateways/custom-gateway.test.ts
+++ b/packages/core/src/llm/model/gateways/custom-gateway.test.ts
@@ -495,9 +495,11 @@ describe('Custom Gateway Integration', () => {
       expect(shadowGateway.resolveAuth).not.toHaveBeenCalled(); // not called at construction time
     });
 
-    it('does not reserve a gateway id from a disabled custom gateway before an enabled default', () => {
+    it('does not reserve a gateway id from a disabled custom gateway before an enabled default', async () => {
       // A disabled custom gateway with the same id as a default should not
-      // block the enabled default from being used.
+      // block the enabled default from being used. Use a netlify-prefixed id
+      // so resolution depends on the netlify gateway (openai/gpt-4o would
+      // fall back to models.dev and hide a regression here).
       const disabledGateway: MastraModelGatewayInterface = {
         id: 'netlify',
         name: 'disabled-netlify-override',
@@ -508,13 +510,33 @@ describe('Custom Gateway Integration', () => {
         resolveLanguageModel: vi.fn(() => ({}) as any),
       };
 
-      // With the disabled custom gateway first, the default Netlify gateway
-      // should still be available (not blocked by the disabled id).
-      const model = new ModelRouterLanguageModel('openai/gpt-4o', [disabledGateway]);
+      // Ensure the default Netlify gateway's getApiKey throws predictably
+      // (missing token) instead of attempting a network token exchange.
+      const prevToken = process.env['NETLIFY_TOKEN'];
+      const prevSiteId = process.env['NETLIFY_SITE_ID'];
+      delete process.env['NETLIFY_TOKEN'];
+      delete process.env['NETLIFY_SITE_ID'];
 
-      expect(model).toBeDefined();
-      // Should resolve via models.dev (default) since the disabled gateway is filtered.
-      expect(model.provider).toBe('openai');
+      try {
+        const model = new ModelRouterLanguageModel('netlify/openai/gpt-4o', [disabledGateway]);
+
+        expect(model).toBeDefined();
+        expect(model.gatewayId).toBe('netlify');
+
+        // Driving resolution: the default Netlify gateway is retained (its
+        // getApiKey throws on the missing token), so resolveLanguageModel is
+        // never reached. If the disabled gateway were incorrectly retained,
+        // its getApiKey would return 'should-not-be-used' and
+        // resolveLanguageModel would be called — failing this assertion.
+        await model.supportedUrls;
+        expect(disabledGateway.resolveLanguageModel).not.toHaveBeenCalled();
+        expect(disabledGateway.getApiKey).not.toHaveBeenCalled();
+      } finally {
+        if (prevToken !== undefined) process.env['NETLIFY_TOKEN'] = prevToken;
+        else delete process.env['NETLIFY_TOKEN'];
+        if (prevSiteId !== undefined) process.env['NETLIFY_SITE_ID'] = prevSiteId;
+        else delete process.env['NETLIFY_SITE_ID'];
+      }
     });
   });
 });

--- a/packages/core/src/llm/model/gateways/gateway-manager.test.ts
+++ b/packages/core/src/llm/model/gateways/gateway-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { MastraError } from '../../../error/index.js';
 import type {
   GatewayAuthRequest,
   GatewayAuthResult,
@@ -75,6 +76,33 @@ describe('GatewayManager', () => {
       const manager = new GatewayManager([enabled, disabled]);
       expect(manager.gateways.map(g => g.id)).not.toContain('off-gateway');
       expect(manager.gateways.map(g => g.id)).toContain('on-gateway');
+    });
+
+    it('deduplicates by gateway id — first (custom) gateway wins', () => {
+      const custom = createFakeGateway({ id: 'netlify', provider: 'openai', models: ['custom-model'] });
+      const defaultLike = createFakeGateway({ id: 'netlify', provider: 'openai', models: ['default-model'] });
+      const manager = new GatewayManager([custom, defaultLike]);
+      expect(manager.gateways).toHaveLength(1);
+      expect(manager.gateways[0]).toBe(custom);
+    });
+
+    it('removes later duplicates when custom appears before defaults', () => {
+      const custom = createFakeGateway({ id: 'netlify', provider: 'openai', models: ['custom-model'] });
+      const other = createFakeGateway({ id: 'models.dev', provider: 'openai' });
+      const duplicate = createFakeGateway({ id: 'netlify', provider: 'openai', models: ['dup-model'] });
+      const manager = new GatewayManager([custom, other, duplicate]);
+      expect(manager.gateways.map(g => g.id)).toEqual(['netlify', 'models.dev']);
+      expect(manager.gateways[0]).toBe(custom);
+    });
+
+    it('does not reserve a gateway id from a disabled gateway before an enabled duplicate', () => {
+      const disabled = createFakeGateway({ id: 'shared', enabled: false, models: ['disabled-model'] });
+      const enabled = createFakeGateway({ id: 'shared', models: ['enabled-model'] });
+      const manager = new GatewayManager([disabled, enabled]);
+      // The disabled gateway is filtered out before dedup, so the enabled
+      // duplicate is kept — not removed by the disabled one's id.
+      expect(manager.gateways).toHaveLength(1);
+      expect(manager.gateways[0]).toBe(enabled);
     });
   });
 
@@ -236,6 +264,64 @@ describe('GatewayManager', () => {
     it('returns false instead of throwing on an unknown model', async () => {
       const manager = new GatewayManager([createFakeGateway({ id: 'test-gateway' })]);
       expect(await manager.hasAuth('unknown/garbage/model')).toBe(false);
+    });
+
+    it('returns false when resolveAuth throws a MastraError for a missing API key', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        resolveAuth: () => {
+          throw new MastraError({
+            id: 'MASTRA_GATEWAY_NO_API_KEY',
+            domain: 'LLM',
+            category: 'UNKNOWN',
+            text: 'Could not find API key',
+          });
+        },
+      });
+      const manager = new GatewayManager([gateway]);
+      expect(await manager.hasAuth('test-gateway/acme/sonic-fast')).toBe(false);
+    });
+
+    it('returns false when getApiKey throws a plain Error for a missing env var', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        apiKey: () => {
+          throw new Error('Missing OPENAI_API_KEY environment variable');
+        },
+      });
+      const manager = new GatewayManager([gateway]);
+      expect(await manager.hasAuth('test-gateway/acme/sonic-fast')).toBe(false);
+    });
+
+    it('re-throws unexpected gateway failures (e.g. token exchange)', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        resolveAuth: () => {
+          throw new Error('token exchange failed');
+        },
+      });
+      const manager = new GatewayManager([gateway]);
+      await expect(manager.hasAuth('test-gateway/acme/sonic-fast')).rejects.toThrow('token exchange failed');
+    });
+
+    it('re-throws unexpected MastraError IDs (e.g. token exchange error)', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        resolveAuth: () => {
+          throw new MastraError({
+            id: 'NETLIFY_GATEWAY_TOKEN_ERROR',
+            domain: 'LLM',
+            category: 'UNKNOWN',
+            text: 'token exchange failed',
+          });
+        },
+      });
+      const manager = new GatewayManager([gateway]);
+      await expect(manager.hasAuth('test-gateway/acme/sonic-fast')).rejects.toThrow('token exchange failed');
     });
   });
 

--- a/packages/core/src/llm/model/gateways/gateway-manager.ts
+++ b/packages/core/src/llm/model/gateways/gateway-manager.ts
@@ -1,6 +1,44 @@
+import { MastraError } from '../../../error/index.js';
 import { parseModelRouterId } from '../gateway-resolver.js';
 import type { GatewayAuthRequest, GatewayAuthResult, MastraModelGatewayInterface, ProviderConfig } from './base.js';
 import { findGatewayForModel, getGatewayId, shouldEnableGateway } from './gateway-helpers.js';
+
+/**
+ * MastraError IDs that represent expected "auth not available" states —
+ * missing credentials, missing gateway config, or no matching gateway.
+ * These are safe to surface as `hasAuth === false` for catalog/UI checks.
+ */
+const MISSING_AUTH_ERROR_IDS = new Set<string>([
+  'MODEL_ROUTER_NO_GATEWAY_FOUND',
+  'MASTRA_GATEWAY_NO_API_KEY',
+  'NETLIFY_GATEWAY_NO_TOKEN',
+  'NETLIFY_GATEWAY_NO_SITE_ID',
+  'AZURE_ENTRA_ID_AUTH_NOT_CONFIGURED',
+]);
+
+/**
+ * Returns true for errors that represent an expected "auth not available"
+ * state (no matching gateway, missing credentials/env vars, missing provider
+ * config). Real gateway failures (token exchange errors, network bugs,
+ * malformed auth hooks) are not matched here so {@link hasAuth} can re-throw
+ * them instead of silently hiding them.
+ */
+function isExpectedMissingAuthError(error: unknown): boolean {
+  if (error instanceof MastraError) {
+    return MISSING_AUTH_ERROR_IDS.has(error.id);
+  }
+  if (error instanceof Error) {
+    const msg = error.message;
+    return (
+      /Missing .+ environment variable/i.test(msg) ||
+      /Could not find API key/i.test(msg) ||
+      /no api key/i.test(msg) ||
+      /Could not find config for provider/i.test(msg) ||
+      /Could not identify provider/i.test(msg)
+    );
+  }
+  return false;
+}
 
 /**
  * A model entry in the gateway catalog (without use-count tracking).
@@ -32,7 +70,17 @@ export class GatewayManager {
   readonly gateways: MastraModelGatewayInterface[];
 
   constructor(gateways: MastraModelGatewayInterface[] = []) {
-    this.gateways = gateways.filter(shouldEnableGateway);
+    // Filter disabled gateways and deduplicate by gateway ID (first wins).
+    // Callers pass custom gateways before default gateways, so first-wins
+    // preserves custom-over-default precedence in a single place.
+    const seen = new Set<string>();
+    this.gateways = gateways.filter(gateway => {
+      if (!shouldEnableGateway(gateway)) return false;
+      const id = getGatewayId(gateway);
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
   }
 
   /**
@@ -62,11 +110,27 @@ export class GatewayManager {
     return findGatewayForModel(routerId, this.gateways);
   }
 
-  /** Parse a router id into its provider/model/gateway components. */
-  parseModelId(routerId: string): { providerId: string; modelId: string; gatewayId: string } {
+  /**
+   * Resolve the gateway and parsed provider/model components for a router id
+   * in a single pass. Centralises gateway selection + id parsing so callers
+   * (router constructor, doGenerate/doStream, supportedUrls) don't each
+   * re-derive the gateway and prefix separately.
+   */
+  resolveModelId(routerId: string): {
+    gateway: MastraModelGatewayInterface;
+    gatewayId: string;
+    providerId: string;
+    modelId: string;
+  } {
     const gateway = this.findGatewayForModel(routerId);
     const gatewayId = getGatewayId(gateway);
     const { providerId, modelId } = parseModelRouterId(routerId, GatewayManager.getPrefixForId(gatewayId, routerId));
+    return { gateway, gatewayId, providerId, modelId };
+  }
+
+  /** Parse a router id into its provider/model/gateway components. */
+  parseModelId(routerId: string): { providerId: string; modelId: string; gatewayId: string } {
+    const { gatewayId, providerId, modelId } = this.resolveModelId(routerId);
     return { providerId, modelId, gatewayId };
   }
 
@@ -80,9 +144,7 @@ export class GatewayManager {
    * from per-instance config on top of the result returned here.
    */
   async resolveAuth(routerId: string): Promise<GatewayAuthResult> {
-    const gateway = this.findGatewayForModel(routerId);
-    const gatewayId = getGatewayId(gateway);
-    const { providerId, modelId } = parseModelRouterId(routerId, GatewayManager.getPrefixForId(gatewayId, routerId));
+    const { gateway, gatewayId, providerId, modelId } = this.resolveModelId(routerId);
     const request: GatewayAuthRequest = { gatewayId, providerId, modelId, routerId };
 
     const rawGatewayAuth = await gateway.resolveAuth?.(request);
@@ -106,13 +168,22 @@ export class GatewayManager {
     };
   }
 
-  /** Convenience: whether auth is available for a model. Never throws. */
+  /**
+   * Convenience: whether auth is available for a model.
+   * Returns `false` for expected missing-auth states (no matching gateway,
+   * missing credentials/env vars) but re-throws unexpected errors (token
+   * exchange failures, network bugs, malformed auth hooks) so they surface
+   * instead of being silently hidden.
+   */
   async hasAuth(routerId: string): Promise<boolean> {
     try {
       const auth = await this.resolveAuth(routerId);
       return Boolean(auth.apiKey || auth.bearerToken || auth.headers);
-    } catch {
-      return false;
+    } catch (error) {
+      if (isExpectedMissingAuthError(error)) {
+        return false;
+      }
+      throw error;
     }
   }
 

--- a/packages/core/src/llm/model/router.ts
+++ b/packages/core/src/llm/model/router.ts
@@ -9,7 +9,6 @@ import type { StreamTransport } from '../../stream/types';
 import { AISDKV5LanguageModel } from './aisdk/v5/model';
 import { AISDKV6LanguageModel } from './aisdk/v6/model';
 import { AISDKV7LanguageModel } from './aisdk/v7/model';
-import { parseModelRouterId } from './gateway-resolver.js';
 import { MASTRA_GATEWAY_STREAM_TRANSPORT } from './gateways/base.js';
 import type {
   GatewayAuthResult,
@@ -19,7 +18,7 @@ import type {
   MastraModelGatewayInterface,
 } from './gateways/base.js';
 import { defaultGateways } from './gateways/defaults.js';
-import { GatewayManager, getGatewayId } from './gateways/index.js';
+import { GatewayManager } from './gateways/index.js';
 
 import { createOpenAIWebSocketFetch } from './openai-websocket-fetch.js';
 import type { OpenAIWebSocketFetch } from './openai-websocket-fetch.js';
@@ -173,19 +172,17 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       routerId: normalizedConfig.id,
     };
 
-    // Resolve gateway once using the normalized ID
-    const allGateways = [...(customGateways ?? []), ...defaultGateways];
-    this.#manager = new GatewayManager(allGateways);
-    this.gateway = this.#manager.findGatewayForModel(normalizedConfig.id);
-    this.gatewayId = getGatewayId(this.gateway);
-    // Extract provider from id if present
-    const gatewayPrefix = GatewayManager.getPrefix(this.gatewayId);
-    const parsed = parseModelRouterId(normalizedConfig.id, gatewayPrefix);
+    // Resolve gateway once using the normalized ID. The manager deduplicates
+    // the gateway chain (custom-before-default, first-wins) and centralises
+    // gateway selection + id parsing in a single resolveModelId call.
+    this.#manager = new GatewayManager([...(customGateways ?? []), ...defaultGateways]);
+    const resolved = this.#manager.resolveModelId(normalizedConfig.id);
+    this.gateway = resolved.gateway;
+    this.gatewayId = resolved.gatewayId;
+    this.provider = resolved.providerId || 'openai-compatible';
 
-    this.provider = parsed.providerId || 'openai-compatible';
-
-    if (parsed.providerId && parsed.modelId !== normalizedConfig.id) {
-      parsedConfig.id = parsed.modelId as `${string}/${string}`;
+    if (resolved.providerId && resolved.modelId !== normalizedConfig.id) {
+      parsedConfig.id = resolved.modelId as `${string}/${string}`;
     }
 
     this.modelId = parsedConfig.id;
@@ -226,15 +223,14 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
   private async _fetchSupportedUrls(): Promise<Record<string, RegExp[]>> {
     let apiKey: string;
     try {
-      const parsed = parseModelRouterId(this.config.routerId, GatewayManager.getPrefix(this.gatewayId));
-      const auth = await this.resolveAuth(parsed.providerId, parsed.modelId);
+      const resolved = this.#manager.resolveModelId(this.config.routerId);
+      const auth = await this.resolveAuth(resolved.providerId, resolved.modelId);
       apiKey = auth.apiKey ?? '';
-      const gatewayPrefix = GatewayManager.getPrefix(this.gatewayId);
       const model = await this.resolveLanguageModel({
         apiKey,
         auth,
         headers: mergeHeaders(this.config.headers, auth.headers),
-        ...parseModelRouterId(this.config.routerId, gatewayPrefix),
+        ...resolved,
       });
 
       // Get supportedUrls from the underlying model
@@ -360,12 +356,12 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
   }
 
   async doGenerate(options: LanguageModelV2CallOptions): Promise<StreamResult> {
+    const resolved = this.#manager.resolveModelId(this.config.routerId);
     let auth: GatewayAuthResult;
     try {
       // If custom URL is provided, skip gateway API key resolution
       // The provider might not be in the registry (e.g., custom providers like ollama)
-      const parsed = parseModelRouterId(this.config.routerId, GatewayManager.getPrefix(this.gatewayId));
-      auth = await this.resolveAuth(parsed.providerId, parsed.modelId);
+      auth = await this.resolveAuth(resolved.providerId, resolved.modelId);
     } catch (error) {
       // Return an error stream instead of throwing
       return {
@@ -381,12 +377,11 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       };
     }
 
-    const gatewayPrefix = GatewayManager.getPrefix(this.gatewayId);
     const model = await this.resolveLanguageModel({
       apiKey: auth.apiKey ?? '',
       auth,
       headers: mergeHeaders(this.config.headers, auth.headers),
-      ...parseModelRouterId(this.config.routerId, gatewayPrefix),
+      ...resolved,
     });
 
     // Handle V2, V3, and V4 models
@@ -406,12 +401,12 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
 
   async doStream(options: LanguageModelV2CallOptions): Promise<StreamResult> {
     // Validate API key and return error stream if validation fails
+    const resolved = this.#manager.resolveModelId(this.config.routerId);
     let auth: GatewayAuthResult;
     try {
       // If custom URL is provided, skip gateway API key resolution
       // The provider might not be in the registry (e.g., custom providers like ollama)
-      const parsed = parseModelRouterId(this.config.routerId, GatewayManager.getPrefix(this.gatewayId));
-      auth = await this.resolveAuth(parsed.providerId, parsed.modelId);
+      auth = await this.resolveAuth(resolved.providerId, resolved.modelId);
     } catch (error) {
       // Return an error stream instead of throwing
       return {
@@ -427,11 +422,9 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       };
     }
 
-    const gatewayPrefix = GatewayManager.getPrefix(this.gatewayId);
-    const parsedModelId = parseModelRouterId(this.config.routerId, gatewayPrefix);
     const { transport, websocket } = getOpenAITransport(
       options.providerOptions as ProviderOptions | undefined,
-      parsedModelId.providerId,
+      resolved.providerId,
     );
     const requestedTransport: OpenAITransport = transport === 'auto' ? 'websocket' : transport;
     const allowWebSocket =
@@ -447,7 +440,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       headers: mergeHeaders(this.config.headers, auth.headers),
       transport: resolvedTransport,
       responsesWebSocket: websocket,
-      ...parsedModelId,
+      ...resolved,
     });
 
     // Handle V2, V3, and V4 models


### PR DESCRIPTION
Custom model gateways registered before default gateways were being overridden by defaults that share the same ID, because neither `GatewayManager` nor its callers deduplicated the gateway chain. This broke the intended custom-over-default precedence when overriding a built-in gateway.

`GatewayManager` now deduplicates gateways by ID (first-wins) in its constructor, so the order callers already pass (custom, then defaults) is honored without each call site reimplementing the dedup:

```ts
// Before: custom gateway with id 'netlify' was shadowed by the default NetlifyGateway
new ModelRouterLanguageModel('netlify/my-provider/model-1', [customNetlifyGateway])
// customNetlifyGateway was ignored, default NetlifyGateway handled the model

// After: first-wins dedup keeps the custom gateway
new ModelRouterLanguageModel('netlify/my-provider/model-1', [customNetlifyGateway])
// customNetlifyGateway handles the model
```

Also narrowed the auth-availability check (`hasAuth`) so it only swallows expected missing-credential errors and re-throws real gateway failures (token exchange errors, network bugs) instead of hiding them behind a silent "no auth" result.

Test plan: focused gateway-manager, router, and AgentController auth-status tests all pass; `tsc --noEmit` is clean.

Co-Authored-By: Mastra Code (alibaba-token-plan/glm-5.2) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

ELI5: This change makes sure the app picks the right model gateway when two gateways have the same name, so a custom one can correctly override the default one. It also makes auth checks smarter: real gateway/auth problems now show up instead of being quietly treated like “no auth.”

### What changed
- `GatewayManager` now:
  - deduplicates gateways by ID using first-wins order
  - adds `resolveModelId()` to centralize model/gateway parsing and lookup
  - reuses that helper in `parseModelId()` and `resolveAuth()`
  - only treats expected missing-auth cases as “no auth”; unexpected failures are re-thrown
- `ModelRouterLanguageModel` now resolves routing info through `resolveModelId()` instead of repeatedly parsing IDs
- `AgentController` now safely falls back to `hasAuth: false` when auth lookup fails, while keeping the UI status flow intact

### Tests
- Added/updated coverage for:
  - gateway deduplication and custom-vs-default precedence
  - auth error handling in `hasAuth()`
  - router resolution behavior
  - agent controller auth status fallback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->