### PR TITLE
fix(railway): stop double-building sandbox templates

### DIFF
--- a/.changeset/floppy-towns-notice.md
+++ b/.changeset/floppy-towns-notice.md
@@ -1,0 +1,5 @@
+---
+'@mastra/railway': patch
+---
+
+Fixed Railway sandbox templates so they are built once during sandbox creation.

--- a/workspaces/railway/README.md
+++ b/workspaces/railway/README.md
@@ -69,8 +69,8 @@ const sandbox = new RailwaySandbox({ sandboxId: 'existing-railway-sandbox-id' })
 ### Custom base image (templates)
 
 Pre-install packages and run setup steps so every sandbox starts ready. Pass a
-builder callback over the Railway template builder — it's built once on the
-first `start()`:
+builder callback over the Railway template builder — Railway builds the image
+when the sandbox is created during `start()`:
 
 ```typescript
 const sandbox = new RailwaySandbox({
@@ -78,8 +78,9 @@ const sandbox = new RailwaySandbox({
 });
 ```
 
-You can also pass a pre-built `SandboxTemplate` to reuse it across sandboxes
-without rebuilding. Templates are ignored when `sandboxId` is set (reattach).
+You can also pass a `SandboxTemplate` to reuse it across sandboxes. Railway
+builds the image during sandbox creation. Templates are ignored when
+`sandboxId` is set (reattach).
 
 ### Fork a running sandbox
 

--- a/workspaces/railway/src/sandbox/index.test.ts
+++ b/workspaces/railway/src/sandbox/index.test.ts
@@ -192,7 +192,7 @@ describe('RailwaySandbox', () => {
   });
 
   describe('template', () => {
-    it('builds a template from a builder callback and creates from it', async () => {
+    it('resolves a template from a builder callback and creates from it', async () => {
       const sandbox = new RailwaySandbox({
         token: 'tok',
         template: t => t.withPackages('git', 'curl').run('npm i -g pnpm'),
@@ -202,8 +202,8 @@ describe('RailwaySandbox', () => {
       expect(mockTemplateFactory).toHaveBeenCalledTimes(1);
       expect(mockTemplate.withPackages).toHaveBeenCalledWith('git', 'curl');
       expect(mockTemplate.run).toHaveBeenCalledWith('npm i -g pnpm');
-      expect(mockTemplate.build).toHaveBeenCalledTimes(1);
-      // create(template, options)
+      expect(mockTemplate.build).not.toHaveBeenCalled();
+      // create(template, options) — Railway builds the template during create
       expect(mockCreate).toHaveBeenCalledWith(mockTemplate, expect.objectContaining({ token: 'tok' }));
     });
 
@@ -212,7 +212,7 @@ describe('RailwaySandbox', () => {
       await sandbox._start();
 
       expect(mockTemplateFactory).not.toHaveBeenCalled();
-      expect(mockTemplate.build).toHaveBeenCalledTimes(1);
+      expect(mockTemplate.build).not.toHaveBeenCalled();
       expect(mockCreate).toHaveBeenCalledWith(mockTemplate, expect.objectContaining({ token: 'tok' }));
     });
 
@@ -225,6 +225,7 @@ describe('RailwaySandbox', () => {
       await sandbox._start();
 
       expect(mockConnect).toHaveBeenCalledWith('rw-existing', expect.anything());
+      expect(mockTemplateFactory).not.toHaveBeenCalled();
       expect(mockTemplate.build).not.toHaveBeenCalled();
       expect(mockCreate).not.toHaveBeenCalled();
     });

--- a/workspaces/railway/src/sandbox/index.ts
+++ b/workspaces/railway/src/sandbox/index.ts
@@ -61,13 +61,13 @@ export interface RailwaySandboxOptions extends Omit<MastraSandboxOptions, 'proce
    * every sandbox created from it starts ready.
    *
    * - Builder callback — receives the base `Sandbox.template()` and returns the
-   *   configured template. The template is built (`.build()`) on first
-   *   `start()` if not already built.
+   *   configured template. Railway builds the template when `Sandbox.create()`
+   *   runs during `start()`.
    *   ```ts
    *   template: t => t.withPackages('git', 'curl').run('npm i -g pnpm')
    *   ```
-   * - Pre-built `SandboxTemplate` — pass a template you built yourself to reuse
-   *   it across sandboxes without rebuilding.
+   * - Pre-built `SandboxTemplate` — pass a template to reuse it across
+   *   sandboxes. Railway still builds the image during sandbox creation.
    *
    * Ignored when `sandboxId` is set (reattach) or when forking.
    */
@@ -211,7 +211,7 @@ export class RailwaySandbox extends MastraSandbox {
       this.logger.debug(`${LOG_PREFIX} Reconnecting to Railway sandbox ${this._sandboxId}...`);
       this._sandbox = await Sandbox.connect(this._sandboxId, clientConfig);
     } else if (this._templateOption) {
-      const template = await this._resolveTemplate(clientConfig);
+      const template = this._resolveTemplate();
       this.logger.debug(`${LOG_PREFIX} Creating Railway sandbox from template for: ${this.id}`);
       this._sandbox = await Sandbox.create(template, createOptions);
     } else {
@@ -254,15 +254,13 @@ export class RailwaySandbox extends MastraSandbox {
   }
 
   /**
-   * Build the configured template into a ready-to-use base. Accepts either a
-   * pre-built `SandboxTemplate` or a builder callback over `Sandbox.template()`.
-   * Calls `.build()` so the recipe is materialised before `Sandbox.create()`.
+   * Resolve the configured template into a `SandboxTemplate` that Railway
+   * builds during `Sandbox.create()`. Accepts either a pre-built
+   * `SandboxTemplate` or a builder callback over `Sandbox.template()`.
    */
-  private async _resolveTemplate(buildOptions: { token?: string; environmentId?: string }): Promise<SandboxTemplate> {
+  private _resolveTemplate(): SandboxTemplate {
     const option = this._templateOption!;
-    const template = typeof option === 'function' ? option(Sandbox.template()) : option;
-    this.logger.debug(`${LOG_PREFIX} Building Railway sandbox template for: ${this.id}`);
-    return template.build(buildOptions);
+    return typeof option === 'function' ? option(Sandbox.template()) : option;
   }
 
   /**


### PR DESCRIPTION
`@mastra/railway` was building sandbox templates twice on every `start()`. `_resolveTemplate()` called `template.build()` and then passed the built template to `Sandbox.create()`, which builds it again internally.

Before:

```ts
private async _resolveTemplate(buildOptions) {
  const template = typeof option === 'function' ? option(Sandbox.template()) : option;
  return template.build(buildOptions); // build #1 (Mastra)
}
// start():
const template = await this._resolveTemplate(clientConfig);
this._sandbox = await Sandbox.create(template, createOptions); // build #2 (Railway)
```

After:

```ts
private _resolveTemplate(): SandboxTemplate {
  const option = this._templateOption!;
  return typeof option === 'function' ? option(Sandbox.template()) : option;
}
// start():
const template = this._resolveTemplate();
this._sandbox = await Sandbox.create(template, createOptions); // single build, owned by Railway
```

Mastra now just resolves the configured template (builder callback or pre-built `SandboxTemplate`) and hands it to `Sandbox.create()`, which owns the build. This also stops leaking build logs (e.g. tokens/env IDs) into SDK output before sandbox creation.

Tests updated to assert `build` is never called by Mastra, and the reattach test now also asserts the template factory isn't invoked. JSDoc and README updated to match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops Railway from “making the same sandbox twice” when it starts. Now it just picks the template once and lets sandbox creation do the building, which makes startup simpler and avoids extra work.

### What changed
- `@mastra/railway` no longer builds sandbox templates inside `_resolveTemplate()`.
- `Sandbox.create()` now handles the template build step entirely.
- Reattach flows skip the template factory when `sandboxId` is already set.
- Tests were updated to expect no extra `build()` call and no template factory call during reattach.
- README and JSDoc were updated to match the new behavior.
- Added a changeset for a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->