### PR TITLE
fix(spanner): resolve silent exception swallowing in rollback handlers

### DIFF
--- a/.changeset/fix-spanner-silent-errors.md
+++ b/.changeset/fix-spanner-silent-errors.md
@@ -1,0 +1,5 @@
+---
+"@mastra/spanner": patch
+---
+
+resolve silent exception swallowing in rollback handlers

--- a/stores/spanner/src/storage/db/index.ts
+++ b/stores/spanner/src/storage/db/index.ts
@@ -370,7 +370,9 @@ export class SpannerDB extends MastraBase {
         } catch (err) {
           // The Spanner client does NOT auto-rollback when the runFn throws
           // explicitly release the transaction so its row locks are freed.
-          await tx.rollback();
+          await tx.rollback().catch(rollbackErr => {
+            throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+          });
           throw err;
         }
       });
@@ -394,7 +396,11 @@ export class SpannerDB extends MastraBase {
         return await fn();
       } catch (error: any) {
         attempt++;
-        const aborted = error && (error.code === 10 || /ABORTED/i.test(String(error?.message ?? '')));
+        let checkError = error;
+        if (checkError instanceof AggregateError && checkError.errors.length > 0) {
+          checkError = checkError.errors[0];
+        }
+        const aborted = checkError && (checkError.code === 10 || /ABORTED/i.test(String(checkError?.message ?? '')));
         if (!aborted || attempt >= maxAttempts) {
           throw error;
         }
@@ -961,7 +967,9 @@ export class SpannerDB extends MastraBase {
           } catch (err) {
             // The Spanner client does NOT auto-rollback when the runFn throws
             // explicitly release the transaction so its row locks are freed.
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -996,7 +1004,9 @@ export class SpannerDB extends MastraBase {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -1034,7 +1044,9 @@ export class SpannerDB extends MastraBase {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/db/index.ts
+++ b/stores/spanner/src/storage/db/index.ts
@@ -370,7 +370,7 @@ export class SpannerDB extends MastraBase {
         } catch (err) {
           // The Spanner client does NOT auto-rollback when the runFn throws
           // explicitly release the transaction so its row locks are freed.
-          await tx.rollback().catch(() => {});
+          await tx.rollback();
           throw err;
         }
       });
@@ -961,7 +961,7 @@ export class SpannerDB extends MastraBase {
           } catch (err) {
             // The Spanner client does NOT auto-rollback when the runFn throws
             // explicitly release the transaction so its row locks are freed.
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -996,7 +996,7 @@ export class SpannerDB extends MastraBase {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -1034,7 +1034,7 @@ export class SpannerDB extends MastraBase {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/db/runWithAbortRetry.test.ts
+++ b/stores/spanner/src/storage/db/runWithAbortRetry.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import { SpannerDB } from './index';
+
+/**
+ * Unit tests for runWithAbortRetry's AggregateError handling.
+ *
+ * These tests verify that when a transaction fails with an ABORTED error and the
+ * subsequent rollback also fails, the AggregateError wrapping both errors is
+ * correctly unwrapped so the retry mechanism still recognises the original
+ * ABORTED signal and retries the operation.
+ *
+ * No Spanner emulator is required — we instantiate SpannerDB with a dummy
+ * database reference and only exercise the public `runWithAbortRetry` method
+ * with plain async functions.
+ */
+
+// Minimal stub: runWithAbortRetry only uses `this` for MastraBase fields and
+// the `database` property. We pass an empty object as the database handle since
+// the retry loop never touches it.
+function makeDb(): SpannerDB {
+  return new SpannerDB({ database: {} as any });
+}
+
+describe('runWithAbortRetry – AggregateError handling', () => {
+  it('retries when fn throws a plain ABORTED error (baseline)', async () => {
+    const db = makeDb();
+    let calls = 0;
+
+    const result = await db.runWithAbortRetry(async () => {
+      calls++;
+      if (calls < 3) {
+        const err: any = new Error('ABORTED');
+        err.code = 10;
+        throw err;
+      }
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(calls).toBe(3);
+  });
+
+  it('retries when fn throws an AggregateError whose first error is ABORTED', async () => {
+    const db = makeDb();
+    let calls = 0;
+
+    const result = await db.runWithAbortRetry(async () => {
+      calls++;
+      if (calls < 3) {
+        const abortedErr: any = new Error('ABORTED');
+        abortedErr.code = 10;
+        const rollbackErr = new Error('Rollback failed: session not found');
+        throw new AggregateError([abortedErr, rollbackErr], 'Transaction and rollback both failed');
+      }
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(calls).toBe(3);
+  });
+
+  it('throws the full AggregateError after exhausting retries', async () => {
+    const db = makeDb();
+    let calls = 0;
+
+    await expect(
+      db.runWithAbortRetry(async () => {
+        calls++;
+        const abortedErr: any = new Error('ABORTED');
+        abortedErr.code = 10;
+        const rollbackErr = new Error('Rollback also failed');
+        throw new AggregateError([abortedErr, rollbackErr], 'Transaction and rollback both failed');
+      }),
+    ).rejects.toBeInstanceOf(AggregateError);
+
+    // maxAttempts is 5
+    expect(calls).toBe(5);
+  });
+
+  it('does NOT retry a non-ABORTED AggregateError', async () => {
+    const db = makeDb();
+    let calls = 0;
+
+    await expect(
+      db.runWithAbortRetry(async () => {
+        calls++;
+        const originalErr = new Error('UNIQUE constraint violated');
+        const rollbackErr = new Error('Rollback failed');
+        throw new AggregateError([originalErr, rollbackErr], 'Transaction and rollback both failed');
+      }),
+    ).rejects.toBeInstanceOf(AggregateError);
+
+    // Should NOT retry — only 1 call
+    expect(calls).toBe(1);
+  });
+
+  it('preserves both errors inside the AggregateError', async () => {
+    const db = makeDb();
+
+    try {
+      await db.runWithAbortRetry(async () => {
+        const abortedErr: any = new Error('ABORTED');
+        abortedErr.code = 10;
+        const rollbackErr = new Error('Session expired');
+        throw new AggregateError([abortedErr, rollbackErr], 'Transaction and rollback both failed');
+      });
+      // Should not reach here
+      expect.unreachable('Expected an AggregateError to be thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      const agg = error as AggregateError;
+      expect(agg.errors).toHaveLength(2);
+      expect(agg.errors[0].message).toBe('ABORTED');
+      expect(agg.errors[1].message).toBe('Session expired');
+      expect(agg.message).toBe('Transaction and rollback both failed');
+    }
+  });
+});

--- a/stores/spanner/src/storage/domains/agents/index.ts
+++ b/stores/spanner/src/storage/domains/agents/index.ts
@@ -295,7 +295,9 @@ export class AgentsSpanner extends AgentsStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -396,7 +398,9 @@ export class AgentsSpanner extends AgentsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/agents/index.ts
+++ b/stores/spanner/src/storage/domains/agents/index.ts
@@ -295,7 +295,7 @@ export class AgentsSpanner extends AgentsStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -396,7 +396,7 @@ export class AgentsSpanner extends AgentsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/blobs/index.ts
+++ b/stores/spanner/src/storage/domains/blobs/index.ts
@@ -200,7 +200,9 @@ export class BlobsSpanner extends BlobStore {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/blobs/index.ts
+++ b/stores/spanner/src/storage/domains/blobs/index.ts
@@ -200,7 +200,7 @@ export class BlobsSpanner extends BlobStore {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/channels/index.ts
+++ b/stores/spanner/src/storage/domains/channels/index.ts
@@ -196,7 +196,9 @@ export class ChannelsSpanner extends ChannelsStorage {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/channels/index.ts
+++ b/stores/spanner/src/storage/domains/channels/index.ts
@@ -196,7 +196,7 @@ export class ChannelsSpanner extends ChannelsStorage {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/datasets/index.ts
+++ b/stores/spanner/src/storage/domains/datasets/index.ts
@@ -356,7 +356,9 @@ export class DatasetsSpanner extends DatasetsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -572,7 +574,9 @@ export class DatasetsSpanner extends DatasetsStorage {
               updatedAt: now,
             };
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -672,7 +676,9 @@ export class DatasetsSpanner extends DatasetsStorage {
               updatedAt: now,
             };
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -736,7 +742,9 @@ export class DatasetsSpanner extends DatasetsStorage {
             await this.insertVersionRow(tx, args.datasetId, newVersion, now);
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -1047,7 +1055,9 @@ export class DatasetsSpanner extends DatasetsStorage {
               updatedAt: now,
             }));
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -1110,7 +1120,9 @@ export class DatasetsSpanner extends DatasetsStorage {
             await this.insertVersionRow(tx, input.datasetId, newVersion, now);
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/datasets/index.ts
+++ b/stores/spanner/src/storage/domains/datasets/index.ts
@@ -356,7 +356,7 @@ export class DatasetsSpanner extends DatasetsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -572,7 +572,7 @@ export class DatasetsSpanner extends DatasetsStorage {
               updatedAt: now,
             };
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -672,7 +672,7 @@ export class DatasetsSpanner extends DatasetsStorage {
               updatedAt: now,
             };
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -736,7 +736,7 @@ export class DatasetsSpanner extends DatasetsStorage {
             await this.insertVersionRow(tx, args.datasetId, newVersion, now);
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -1047,7 +1047,7 @@ export class DatasetsSpanner extends DatasetsStorage {
               updatedAt: now,
             }));
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -1110,7 +1110,7 @@ export class DatasetsSpanner extends DatasetsStorage {
             await this.insertVersionRow(tx, input.datasetId, newVersion, now);
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/experiments/index.ts
+++ b/stores/spanner/src/storage/domains/experiments/index.ts
@@ -404,7 +404,7 @@ export class ExperimentsSpanner extends ExperimentsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/experiments/index.ts
+++ b/stores/spanner/src/storage/domains/experiments/index.ts
@@ -404,7 +404,9 @@ export class ExperimentsSpanner extends ExperimentsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/favorites/index.ts
+++ b/stores/spanner/src/storage/domains/favorites/index.ts
@@ -146,7 +146,9 @@ export class FavoritesSpanner extends FavoritesStorage {
             favoriteCount = (await this.readEntityCount(tx, entityTable, entityId)) ?? 0;
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -205,7 +207,9 @@ export class FavoritesSpanner extends FavoritesStorage {
             favoriteCount = (await this.readEntityCount(tx, entityTable, entityId)) ?? 0;
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -333,7 +337,9 @@ export class FavoritesSpanner extends FavoritesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/favorites/index.ts
+++ b/stores/spanner/src/storage/domains/favorites/index.ts
@@ -146,7 +146,7 @@ export class FavoritesSpanner extends FavoritesStorage {
             favoriteCount = (await this.readEntityCount(tx, entityTable, entityId)) ?? 0;
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -205,7 +205,7 @@ export class FavoritesSpanner extends FavoritesStorage {
             favoriteCount = (await this.readEntityCount(tx, entityTable, entityId)) ?? 0;
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -333,7 +333,7 @@ export class FavoritesSpanner extends FavoritesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/mcp-clients/index.ts
+++ b/stores/spanner/src/storage/domains/mcp-clients/index.ts
@@ -234,7 +234,7 @@ export class MCPClientsSpanner extends MCPClientsStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -329,7 +329,7 @@ export class MCPClientsSpanner extends MCPClientsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/mcp-clients/index.ts
+++ b/stores/spanner/src/storage/domains/mcp-clients/index.ts
@@ -234,7 +234,9 @@ export class MCPClientsSpanner extends MCPClientsStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -329,7 +331,9 @@ export class MCPClientsSpanner extends MCPClientsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/mcp-servers/index.ts
+++ b/stores/spanner/src/storage/domains/mcp-servers/index.ts
@@ -246,7 +246,7 @@ export class MCPServersSpanner extends MCPServersStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -341,7 +341,7 @@ export class MCPServersSpanner extends MCPServersStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/mcp-servers/index.ts
+++ b/stores/spanner/src/storage/domains/mcp-servers/index.ts
@@ -246,7 +246,9 @@ export class MCPServersSpanner extends MCPServersStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -341,7 +343,9 @@ export class MCPServersSpanner extends MCPServersStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/memory/index.ts
+++ b/stores/spanner/src/storage/domains/memory/index.ts
@@ -349,7 +349,7 @@ export class MemorySpanner extends MemoryStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -392,7 +392,7 @@ export class MemorySpanner extends MemoryStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -800,7 +800,7 @@ export class MemorySpanner extends MemoryStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -926,7 +926,7 @@ export class MemorySpanner extends MemoryStorage {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -996,7 +996,7 @@ export class MemorySpanner extends MemoryStorage {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -1139,7 +1139,7 @@ export class MemorySpanner extends MemoryStorage {
             updated = merged;
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/memory/index.ts
+++ b/stores/spanner/src/storage/domains/memory/index.ts
@@ -349,7 +349,9 @@ export class MemorySpanner extends MemoryStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -392,7 +394,9 @@ export class MemorySpanner extends MemoryStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -800,7 +804,9 @@ export class MemorySpanner extends MemoryStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -926,7 +932,9 @@ export class MemorySpanner extends MemoryStorage {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -996,7 +1004,9 @@ export class MemorySpanner extends MemoryStorage {
             }
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -1139,7 +1149,9 @@ export class MemorySpanner extends MemoryStorage {
             updated = merged;
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/observability/metrics.ts
+++ b/stores/spanner/src/storage/domains/observability/metrics.ts
@@ -810,7 +810,9 @@ export async function batchCreateMetrics(database: Database, args: BatchCreateMe
           tx.insert(TABLE_AI_METRICS, rows);
           await tx.commit();
         } catch (err) {
-          await tx.rollback();
+          await tx.rollback().catch(rollbackErr => {
+            throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+          });
           throw err;
         }
       });
@@ -836,10 +838,14 @@ async function runWithAbortRetry<T>(fn: () => Promise<T>): Promise<T> {
       return await fn();
     } catch (error: unknown) {
       attempt++;
+      let checkError = error;
+      if (checkError instanceof AggregateError && checkError.errors.length > 0) {
+        checkError = checkError.errors[0];
+      }
       const aborted =
-        !!error &&
-        ((error as { code?: number }).code === 10 ||
-          /ABORTED/i.test(String((error as { message?: unknown })?.message ?? '')));
+        !!checkError &&
+        ((checkError as { code?: number }).code === 10 ||
+          /ABORTED/i.test(String((checkError as { message?: unknown })?.message ?? '')));
       if (!aborted || attempt >= maxAttempts) throw error;
       await new Promise(resolve => setTimeout(resolve, delay + Math.random() * delay));
       delay *= 2;
@@ -1491,7 +1497,9 @@ export async function clearMetrics(database: Database): Promise<void> {
       });
       await tx.commit();
     } catch (err) {
-      await tx.rollback();
+      await tx.rollback().catch(rollbackErr => {
+        throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+      });
       throw err;
     }
   });

--- a/stores/spanner/src/storage/domains/observability/metrics.ts
+++ b/stores/spanner/src/storage/domains/observability/metrics.ts
@@ -810,7 +810,7 @@ export async function batchCreateMetrics(database: Database, args: BatchCreateMe
           tx.insert(TABLE_AI_METRICS, rows);
           await tx.commit();
         } catch (err) {
-          await tx.rollback().catch(() => {});
+          await tx.rollback();
           throw err;
         }
       });
@@ -1491,7 +1491,7 @@ export async function clearMetrics(database: Database): Promise<void> {
       });
       await tx.commit();
     } catch (err) {
-      await tx.rollback().catch(() => {});
+      await tx.rollback();
       throw err;
     }
   });

--- a/stores/spanner/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/spanner/src/storage/domains/prompt-blocks/index.ts
@@ -241,7 +241,9 @@ export class PromptBlocksSpanner extends PromptBlocksStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -338,7 +340,9 @@ export class PromptBlocksSpanner extends PromptBlocksStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/spanner/src/storage/domains/prompt-blocks/index.ts
@@ -241,7 +241,7 @@ export class PromptBlocksSpanner extends PromptBlocksStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -338,7 +338,7 @@ export class PromptBlocksSpanner extends PromptBlocksStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/schedules/index.ts
+++ b/stores/spanner/src/storage/domains/schedules/index.ts
@@ -243,7 +243,9 @@ export class SchedulesSpanner extends SchedulesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -485,7 +487,9 @@ export class SchedulesSpanner extends SchedulesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/schedules/index.ts
+++ b/stores/spanner/src/storage/domains/schedules/index.ts
@@ -243,7 +243,7 @@ export class SchedulesSpanner extends SchedulesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -485,7 +485,7 @@ export class SchedulesSpanner extends SchedulesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/scorer-definitions/index.ts
+++ b/stores/spanner/src/storage/domains/scorer-definitions/index.ts
@@ -248,7 +248,9 @@ export class ScorerDefinitionsSpanner extends ScorerDefinitionsStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -345,7 +347,9 @@ export class ScorerDefinitionsSpanner extends ScorerDefinitionsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/scorer-definitions/index.ts
+++ b/stores/spanner/src/storage/domains/scorer-definitions/index.ts
@@ -248,7 +248,7 @@ export class ScorerDefinitionsSpanner extends ScorerDefinitionsStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -345,7 +345,7 @@ export class ScorerDefinitionsSpanner extends ScorerDefinitionsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/skills/index.ts
+++ b/stores/spanner/src/storage/domains/skills/index.ts
@@ -258,7 +258,9 @@ export class SkillsSpanner extends SkillsStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -355,7 +357,9 @@ export class SkillsSpanner extends SkillsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/skills/index.ts
+++ b/stores/spanner/src/storage/domains/skills/index.ts
@@ -258,7 +258,7 @@ export class SkillsSpanner extends SkillsStorage {
             // the transaction (and its row locks) stay pending on the server
             // until explicitly released. Without this rollback, a failed
             // create() blocks subsequent reads/writes against the same rows.
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -355,7 +355,7 @@ export class SkillsSpanner extends SkillsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/workflows/index.ts
+++ b/stores/spanner/src/storage/domains/workflows/index.ts
@@ -251,7 +251,7 @@ export class WorkflowsSpanner extends WorkflowsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -368,7 +368,7 @@ export class WorkflowsSpanner extends WorkflowsStorage {
             mergedContext = snapshot.context;
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -436,7 +436,7 @@ export class WorkflowsSpanner extends WorkflowsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/workflows/index.ts
+++ b/stores/spanner/src/storage/domains/workflows/index.ts
@@ -251,7 +251,9 @@ export class WorkflowsSpanner extends WorkflowsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -368,7 +370,9 @@ export class WorkflowsSpanner extends WorkflowsStorage {
             mergedContext = snapshot.context;
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -436,7 +440,9 @@ export class WorkflowsSpanner extends WorkflowsStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/workspaces/index.ts
+++ b/stores/spanner/src/storage/domains/workspaces/index.ts
@@ -237,7 +237,7 @@ export class WorkspacesSpanner extends WorkspacesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),
@@ -389,7 +389,7 @@ export class WorkspacesSpanner extends WorkspacesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback().catch(() => {});
+            await tx.rollback();
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/domains/workspaces/index.ts
+++ b/stores/spanner/src/storage/domains/workspaces/index.ts
@@ -237,7 +237,9 @@ export class WorkspacesSpanner extends WorkspacesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),
@@ -389,7 +391,9 @@ export class WorkspacesSpanner extends WorkspacesStorage {
             });
             await tx.commit();
           } catch (err) {
-            await tx.rollback();
+            await tx.rollback().catch(rollbackErr => {
+              throw new AggregateError([err, rollbackErr], 'Transaction and rollback both failed');
+            });
             throw err;
           }
         }),

--- a/stores/spanner/src/storage/index.ts
+++ b/stores/spanner/src/storage/index.ts
@@ -328,7 +328,9 @@ export class SpannerStore extends MastraCompositeStore {
     // root throw below propagates to the current call. Attach a no-op catch
     // here so a rejected `pending` without other awaiters is not flagged as
     // an unhandled rejection.
-    pending.catch(() => {});
+    pending.catch(e => {
+      this.logger?.warn?.('Initialization failed', e);
+    });
 
     try {
       // Initialize domains sequentially to avoid concurrent DDL errors in Spanner.


### PR DESCRIPTION
## Description

Replaces all silent `.catch(() => {})` blocks on `tx.rollback()` across the Spanner storage adapter with proper error propagation using `AggregateError`.

- **Rollback failures are now surfaced:** When a transaction fails and the subsequent rollback also fails, both errors are wrapped in an `AggregateError([originalErr, rollbackErr])` so neither is lost.
- **`runWithAbortRetry` updated:** Both instances (in `db/index.ts` and `observability/metrics.ts`) now unwrap `AggregateError` before checking for Spanner's `ABORTED` code, so automatic transaction retries continue to work correctly even when a rollback fails.
- **Initialization handler:** Updated the `SpannerStore.init()` rejection handler to log initialization failures via `this.logger?.warn?.(...)` instead of silently swallowing them.
- **Targeted test coverage:** Added unit tests for the `runWithAbortRetry` + `AggregateError` edge case — verifying that an `ABORTED` error wrapped inside an `AggregateError` is still correctly detected for retry, and that both errors are preserved after retries are exhausted.

No existing `this.logger?.warn?.(...)` calls were modified — this PR **only** touches previously silent empty catch blocks.

Includes a changeset for `@mastra/spanner`.

## Related issue(s)

Fixes #18603

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops the Spanner storage code from quietly hiding errors when a rollback or startup fails. Instead, it now tells you both what went wrong first and what went wrong during cleanup, while still keeping retry behavior working the same way.

## Summary
- Replaced swallowed rollback failures across `@mastra/spanner` with `AggregateError` so both the original error and rollback error are preserved.
- Updated retry logic in `db/index.ts` and `observability/metrics.ts` to unwrap `AggregateError` before checking for Spanner `ABORTED`, so automatic retries still happen.
- Changed `SpannerStore.init()` to warn on initialization failure instead of silently ignoring rejected startup work.
- Added targeted tests covering `runWithAbortRetry` with `AggregateError`, including the case where retries still occur and both errors are retained when attempts are exhausted.
- Added a changeset for the patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->