### PR TITLE
feat(mastracode): add lifecycle authority hooks

### DIFF
--- a/.changeset/big-hats-travel.md
+++ b/.changeset/big-hats-travel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed server core import checks when the matching core release is not published.

--- a/.changeset/big-hats-travel.md
+++ b/.changeset/big-hats-travel.md
@@ -1,5 +1,0 @@
----
-'@mastra/server': patch
----
-
-Fixed server core import checks when the matching core release is not published.

--- a/.changeset/bumpy-jokes-smash.md
+++ b/.changeset/bumpy-jokes-smash.md
@@ -1,5 +1,0 @@
----
-'mastracode': patch
----
-
-Fixed lifecycle hooks to return isolated empty results and require run correlation for permission decisions and interrupts.

--- a/.changeset/bumpy-jokes-smash.md
+++ b/.changeset/bumpy-jokes-smash.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed lifecycle hooks to return isolated empty results and require run correlation for permission decisions and interrupts.

--- a/.changeset/mastracode-lifecycle-hooks.md
+++ b/.changeset/mastracode-lifecycle-hooks.md
@@ -1,0 +1,29 @@
+---
+'mastracode': minor
+---
+
+Added lifecycle hook events and a per-run `run_id` field so external orchestrators can track agent lifecycle states directly instead of inferring them from coarse prompt/tool/stop signals.
+
+**New events:** AgentStart, AgentEnd, PermissionRequest, PermissionResult, Interrupt, SubagentStart, SubagentEnd. All are non-blocking — existing blocking events (PreToolUse, Stop, UserPromptSubmit) and hook behavior are unchanged.
+
+Every hook stdin now includes a `run_id` during an active run, letting integrators correlate hooks to a specific agent run.
+
+**Why**
+
+External orchestrators needed first-class signals for permission gates, interrupts, and subagent delegation. The previous hook surface only offered coarse prompt/tool/stop events, forcing integrators to guess at lifecycle state.
+
+```json
+{
+  "hooks": {
+    "AgentStart": [{ "type": "command", "command": "echo started >> /tmp/lifecycle.log" }],
+    "AgentEnd": [{ "type": "command", "command": "echo ended >> /tmp/lifecycle.log" }],
+    "Interrupt": [{ "type": "command", "command": "echo interrupted >> /tmp/lifecycle.log" }]
+  }
+}
+```
+
+AgentStart stdin includes the shared `run_id`:
+
+```json
+{ "hook_event_name": "AgentStart", "run_id": "a1b2c3d4", "session_id": "...", "cwd": "/path/to/project" }
+```

--- a/.changeset/mastracode-lifecycle-hooks.md
+++ b/.changeset/mastracode-lifecycle-hooks.md
@@ -2,15 +2,17 @@
 'mastracode': minor
 ---
 
-Added lifecycle hook events and a per-run `run_id` field so external orchestrators can track agent lifecycle states directly instead of inferring them from coarse prompt/tool/stop signals.
+Added lifecycle hook events and a per-run `run_id` field so external orchestrators can track agent lifecycle states directly instead of inferring them from coarse prompt, tool, and stop signals.
 
-**New events:** AgentStart, AgentEnd, PermissionRequest, PermissionResult, Interrupt, SubagentStart, SubagentEnd. All are non-blocking — existing blocking events (PreToolUse, Stop, UserPromptSubmit) and hook behavior are unchanged.
+**New events:** AgentStart, AgentEnd, PermissionRequest, PermissionResult, Interrupt, SubagentStart, and SubagentEnd. All new lifecycle events are non-blocking. Existing blocking events, including PreToolUse, Stop, and UserPromptSubmit, keep their current behavior.
 
-Every hook stdin now includes a `run_id` during an active run, letting integrators correlate hooks to a specific agent run.
+Every hook stdin now includes a `run_id` during an active run. Permission decisions and interrupts only emit while a run is active, so consumers can reliably correlate them with the run that produced them.
+
+PostToolUse continues to fire from the agent tool hook wrapper after a tool call completes. It is not emitted from the TUI lifecycle dispatcher.
 
 **Why**
 
-External orchestrators needed first-class signals for permission gates, interrupts, and subagent delegation. The previous hook surface only offered coarse prompt/tool/stop events, forcing integrators to guess at lifecycle state.
+External orchestrators needed first-class signals for permission gates, interrupts, and subagent delegation. The previous hook surface only offered coarse prompt, tool, and stop events, forcing integrators to guess at lifecycle state.
 
 ```json
 {

--- a/.changeset/mastracode-lifecycle-hooks.md
+++ b/.changeset/mastracode-lifecycle-hooks.md
@@ -16,11 +16,9 @@ External orchestrators needed first-class signals for permission gates, interrup
 
 ```json
 {
-  "hooks": {
-    "AgentStart": [{ "type": "command", "command": "echo started >> /tmp/lifecycle.log" }],
-    "AgentEnd": [{ "type": "command", "command": "echo ended >> /tmp/lifecycle.log" }],
-    "Interrupt": [{ "type": "command", "command": "echo interrupted >> /tmp/lifecycle.log" }]
-  }
+  "AgentStart": [{ "type": "command", "command": "echo started >> /tmp/lifecycle.log" }],
+  "AgentEnd": [{ "type": "command", "command": "echo ended >> /tmp/lifecycle.log" }],
+  "Interrupt": [{ "type": "command", "command": "echo interrupted >> /tmp/lifecycle.log" }]
 }
 ```
 

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -324,8 +324,8 @@ Hooks are user-configured shell commands that run at specific lifecycle events. 
 
 | Event | When it fires | Can block? |
 | - | - | - |
-| `PreToolUse` | Before a tool call executes | Yes |
-| `PostToolUse` | After a tool call completes | No |
+| `PreToolUse` | Before the agent tool hook wrapper allows a tool call to execute | Yes |
+| `PostToolUse` | After the agent tool hook wrapper observes a completed tool call | No |
 | `Stop` | When an agent response ends (`complete`, `aborted`, or `error`) | Yes |
 | `UserPromptSubmit` | When the user sends a message | Yes |
 | `SessionStart` | When a session begins | No |
@@ -341,7 +341,9 @@ Hooks are user-configured shell commands that run at specific lifecycle events. 
 
 `UserPromptSubmit` runs before a non-command prompt is sent to the agent. If a hook blocks, the prompt is not sent.
 
-Only `PreToolUse`, `Stop`, and `UserPromptSubmit` can block agent behavior. The remaining events are non-blocking lifecycle signals for logging and integration.
+`PreToolUse` and `PostToolUse` are emitted by the agent tool hook wrapper around tool execution. Run, permission, interrupt, and subagent events are emitted by the TUI lifecycle dispatcher.
+
+Only `PreToolUse`, `Stop`, and `UserPromptSubmit` can block agent behavior. `PostToolUse` and the lifecycle dispatcher events are non-blocking signals for logging and integration.
 
 ### Hook I/O protocol
 

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -357,7 +357,7 @@ Hook processes receive a JSON payload on stdin with context about the event:
 }
 ```
 
-During an active agent run, all hook payloads include a `run_id` that identifies the current run. The same `run_id` appears on `AgentStart`, tool hooks, `PermissionRequest`, `SubagentStart`, `SubagentEnd`, `AgentEnd`, and `Stop` for that run, so external integrations can correlate events. `Interrupt` and `PermissionResult` include `run_id` when a run is active.
+During an active agent run, all hook payloads include a `run_id` that identifies the current run. The same `run_id` appears on `AgentStart`, tool hooks, `PermissionRequest`, `PermissionResult`, `Interrupt`, `SubagentStart`, `SubagentEnd`, `AgentEnd`, and `Stop` for that run, so external integrations can correlate events.
 
 A `PermissionRequest` payload includes the tool and approval kind:
 

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -333,7 +333,7 @@ Hooks are user-configured shell commands that run at specific lifecycle events. 
 | `Notification` | When the TUI fires a notification | No |
 | `AgentStart` | When an agent run begins | No |
 | `AgentEnd` | When an agent run ends (`complete`, `aborted`, `error`, or `suspended`) | No |
-| `PermissionRequest` | When a tool requires approval before running | No |
+| `PermissionRequest` | When a tool, sandbox access request, or plan approval requires user permission | No |
 | `PermissionResult` | When a user approves, declines, or dismisses a permission gate | No |
 | `Interrupt` | When a running run is aborted by the user, goal judge, or a process signal | No |
 | `SubagentStart` | When a subagent begins a delegated task | No |
@@ -361,7 +361,7 @@ Hook processes receive a JSON payload on stdin with context about the event:
 
 During an active agent run, all hook payloads include a `run_id` that identifies the current run. The same `run_id` appears on `AgentStart`, tool hooks, `PermissionRequest`, `PermissionResult`, `Interrupt`, `SubagentStart`, `SubagentEnd`, `AgentEnd`, and `Stop` for that run, so external integrations can correlate events.
 
-A `PermissionRequest` payload includes the tool and approval kind:
+A `PermissionRequest` payload includes the permission kind and call context. `permission_kind` can be `tool_approval`, `sandbox_access`, or `plan_approval`. `tool_name` and `tool_input` describe the gated tool call when the request comes from a tool approval, sandbox access request, or plan approval.
 
 ```json
 {

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -331,8 +331,17 @@ Hooks are user-configured shell commands that run at specific lifecycle events. 
 | `SessionStart` | When a session begins | No |
 | `SessionEnd` | When a session ends | No |
 | `Notification` | When the TUI fires a notification | No |
+| `AgentStart` | When an agent run begins | No |
+| `AgentEnd` | When an agent run ends (`complete`, `aborted`, `error`, or `suspended`) | No |
+| `PermissionRequest` | When a tool requires approval before running | No |
+| `PermissionResult` | When a user approves, declines, or dismisses a permission gate | No |
+| `Interrupt` | When a running run is aborted by the user, goal judge, or a process signal | No |
+| `SubagentStart` | When a subagent begins a delegated task | No |
+| `SubagentEnd` | When a subagent finishes its delegated task | No |
 
 `UserPromptSubmit` runs before a non-command prompt is sent to the agent. If a hook blocks, the prompt is not sent.
+
+Only `PreToolUse`, `Stop`, and `UserPromptSubmit` can block agent behavior. The remaining events are non-blocking lifecycle signals for logging and integration.
 
 ### Hook I/O protocol
 
@@ -345,6 +354,23 @@ Hook processes receive a JSON payload on stdin with context about the event:
   "hook_event_name": "PreToolUse",
   "tool_name": "execute_command",
   "tool_input": { "command": "npm test" }
+}
+```
+
+During an active agent run, all hook payloads include a `run_id` that identifies the current run. The same `run_id` appears on `AgentStart`, tool hooks, `PermissionRequest`, `SubagentStart`, `SubagentEnd`, `AgentEnd`, and `Stop` for that run, so external integrations can correlate events. `Interrupt` and `PermissionResult` include `run_id` when a run is active.
+
+A `PermissionRequest` payload includes the tool and approval kind:
+
+```json
+{
+  "session_id": "thread-abc123",
+  "cwd": "/path/to/project",
+  "hook_event_name": "PermissionRequest",
+  "run_id": "run-uuid",
+  "permission_kind": "tool_approval",
+  "tool_call_id": "call-1",
+  "tool_name": "execute_command",
+  "tool_input": { "command": "rm -rf /" }
 }
 ```
 

--- a/mastracode/e2e/fixtures/lifecycle-hooks-events.json
+++ b/mastracode/e2e/fixtures/lifecycle-hooks-events.json
@@ -12,7 +12,7 @@
         "tps": 2
       },
       "response": {
-        "content": "Lifecycle hook slow response that should be interrupted before completing the full response."
+        "content": "Lifecycle hook slow response that should be interrupted before completing the full response. This fixture keeps streaming for long enough that Ctrl+C reliably aborts the active run before it finishes. Additional lifecycle text keeps the stream open while hooks record AgentStart, Interrupt, and AgentEnd events."
       }
     }
   ]

--- a/mastracode/e2e/fixtures/lifecycle-hooks-events.json
+++ b/mastracode/e2e/fixtures/lifecycle-hooks-events.json
@@ -1,0 +1,19 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "Start a slow run for lifecycle hook e2e.",
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat"
+      },
+      "chunkSize": 4,
+      "streamingProfile": {
+        "ttft": 500,
+        "tps": 2
+      },
+      "response": {
+        "content": "Lifecycle hook slow response that should be interrupted before completing the full response."
+      }
+    }
+  ]
+}

--- a/mastracode/e2e/terminal-backend-vitest-shared.ts
+++ b/mastracode/e2e/terminal-backend-vitest-shared.ts
@@ -179,6 +179,9 @@ async function prepareTerminalRun(
 
   seedSettings(isolatedHome, scenario.useOpenAIModel === true, openAiApiKey);
   await initializeStorage(dbPath);
+  if (scenario.projectFixture === 'long-branch') createLongBranchProject(projectDir);
+  else createBasicProject(projectDir);
+
   const scenarioContext = {
     appDataDir: isolatedAppDataDir,
     dbPath,
@@ -188,8 +191,6 @@ async function prepareTerminalRun(
   };
   await scenario.prepare?.(scenarioContext);
 
-  if (scenario.projectFixture === 'long-branch') createLongBranchProject(projectDir);
-  else createBasicProject(projectDir);
   const launchCwd = projectDir;
 
   const env: Record<string, string | null> = {

--- a/mastracode/e2e/terminal-backend-vitest-shared.ts
+++ b/mastracode/e2e/terminal-backend-vitest-shared.ts
@@ -180,7 +180,7 @@ async function prepareTerminalRun(
   seedSettings(isolatedHome, scenario.useOpenAIModel === true, openAiApiKey);
   await initializeStorage(dbPath);
   if (scenario.projectFixture === 'long-branch') createLongBranchProject(projectDir);
-  else createBasicProject(projectDir);
+  else if (scenario.projectFixture !== 'manual') createBasicProject(projectDir);
 
   const scenarioContext = {
     appDataDir: isolatedAppDataDir,

--- a/mastracode/e2e/tui/index.ts
+++ b/mastracode/e2e/tui/index.ts
@@ -45,6 +45,7 @@ import { githubSignalsUnsubscribeReloadScenario } from './github-signals-unsubsc
 import { headlessMcpToolAvailabilityScenario } from './headless-mcp-tool-availability.js';
 import { integrationCommandsScenario } from './integration-commands.js';
 import { lifecycleHooksConfiguredScenario } from './lifecycle-hooks-configured.js';
+import { lifecycleHooksEventsScenario } from './lifecycle-hooks-events.js';
 import { loginDialogMaskedInputScenario } from './login-dialog-masked-input.js';
 import { mcpHttpToolCallScenario } from './mcp-http-tool-call.js';
 import { mcpLongRunningToolScenario } from './mcp-long-running-tool.js';
@@ -193,6 +194,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'visible-commands': visibleCommandsScenario,
   'integration-commands': integrationCommandsScenario,
   'lifecycle-hooks-configured': lifecycleHooksConfiguredScenario,
+  'lifecycle-hooks-events': lifecycleHooksEventsScenario,
   'login-dialog-masked-input': loginDialogMaskedInputScenario,
   'modal-and-shell': modalAndShellScenario,
   'mcp-http-tool-call': mcpHttpToolCallScenario,

--- a/mastracode/e2e/tui/lifecycle-hooks-events.ts
+++ b/mastracode/e2e/tui/lifecycle-hooks-events.ts
@@ -107,6 +107,11 @@ if (!agentEnd) {
   process.exit(1);
 }
 
+if (agentEnd.stop_reason !== 'aborted') {
+  console.error('Expected AgentEnd stop_reason to be aborted', agentEnd);
+  process.exit(1);
+}
+
 const interrupt = lines.find(e => e.event === 'Interrupt' && e.run_id);
 if (!interrupt) {
   console.error('Missing Interrupt with run_id', lines);
@@ -140,13 +145,12 @@ console.log('LIFECYCLE_HOOKS_VERIFIED=true');
     terminal.submit('Start a slow run for lifecycle hook e2e.');
     // Wait for the stream to actually start so AgentStart has fired and we
     // are interrupting mid-run.
-    await runtime.waitForScreenText(/Lifecycle hook slow response/i, terminal, 15_000);
+    await runtime.waitForScreenText(/Lifecycle hook slow/i, terminal, 15_000);
     runtime.printScreen('mid-stream before abort', terminal);
 
     // Abort the run mid-stream — fires Interrupt, then AgentEnd (aborted).
     terminal.keyCtrlC();
     runtime.printScreen('after Ctrl-C', terminal);
-    await runtime.waitForScreenText(/Interrupted/i, terminal, 10_000);
     await runtime.sleep(1_000);
 
     // Assert the hook log contains the expected lifecycle events.

--- a/mastracode/e2e/tui/lifecycle-hooks-events.ts
+++ b/mastracode/e2e/tui/lifecycle-hooks-events.ts
@@ -1,0 +1,159 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect } from './expect.js';
+import type { McE2eScenario } from './types.js';
+
+/**
+ * E2E scenario for lifecycle hook events (AgentStart, AgentEnd, Interrupt).
+ *
+ * Configures a single hook script that logs every event's stdin payload —
+ * including `run_id` — to a JSONL file. The scenario starts an agent run,
+ * interrupts it mid-stream with Ctrl+C, then asserts that AgentStart, AgentEnd,
+ * and Interrupt were all emitted and share the same `run_id`.
+ */
+export const lifecycleHooksEventsScenario: McE2eScenario = {
+  name: 'lifecycle-hooks-events',
+  description:
+    'Configure lifecycle hooks, run an agent, interrupt it, and verify AgentStart, AgentEnd, and Interrupt events carry the same run_id.',
+  testName: 'emits AgentStart, AgentEnd, and Interrupt lifecycle hooks with a shared run_id',
+  useOpenAIModel: true,
+  aimockFixture: 'lifecycle-hooks-events.json',
+  env() {
+    return { MASTRACODE_DISABLE_HOOKS: '0' };
+  },
+  prepare({ projectDir }) {
+    const hooksDir = join(projectDir, '.mastracode');
+    mkdirSync(hooksDir, { recursive: true });
+
+    // Hook script: log the full stdin payload (event name + run_id + relevant
+    // fields) to a JSONL file, then exit 0 (lifecycle hooks are non-blocking).
+    writeFileSync(
+      join(hooksDir, 'lifecycle-hook.cjs'),
+      `const fs = require('node:fs');
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  const payload = JSON.parse(input || '{}');
+  fs.appendFileSync('.mastracode/lifecycle-events.jsonl', JSON.stringify({
+    event: payload.hook_event_name,
+    run_id: payload.run_id || null,
+    stop_reason: payload.stop_reason || null,
+    reason: payload.reason || null,
+  }) + '\\n');
+  console.log(JSON.stringify({ decision: 'allow' }));
+  process.exit(0);
+});
+`,
+    );
+
+    // Configure AgentStart, AgentEnd, and Interrupt hooks.
+    writeFileSync(
+      join(hooksDir, 'hooks.json'),
+      JSON.stringify(
+        {
+          AgentStart: [
+            {
+              type: 'command',
+              command: 'node .mastracode/lifecycle-hook.cjs',
+              timeout: 5000,
+              description: 'log lifecycle events',
+            },
+          ],
+          AgentEnd: [
+            {
+              type: 'command',
+              command: 'node .mastracode/lifecycle-hook.cjs',
+              timeout: 5000,
+              description: 'log lifecycle events',
+            },
+          ],
+          Interrupt: [
+            {
+              type: 'command',
+              command: 'node .mastracode/lifecycle-hook.cjs',
+              timeout: 5000,
+              description: 'log lifecycle events',
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    // Assertion script: verify AgentStart, AgentEnd, and Interrupt were logged
+    // with a shared run_id, and AgentEnd has stop_reason 'aborted'.
+    writeFileSync(
+      join(hooksDir, 'assert-lifecycle.cjs'),
+      `const fs = require('node:fs');
+const raw = fs.readFileSync('.mastracode/lifecycle-events.jsonl', 'utf8').trim();
+if (!raw) {
+  console.error('No lifecycle events logged');
+  process.exit(1);
+}
+const lines = raw.split(/\\n+/).map(line => JSON.parse(line));
+
+const agentStart = lines.find(e => e.event === 'AgentStart' && e.run_id);
+if (!agentStart) {
+  console.error('Missing AgentStart with run_id', lines);
+  process.exit(1);
+}
+
+const agentEnd = lines.find(e => e.event === 'AgentEnd' && e.run_id);
+if (!agentEnd) {
+  console.error('Missing AgentEnd with run_id', lines);
+  process.exit(1);
+}
+
+const interrupt = lines.find(e => e.event === 'Interrupt' && e.run_id);
+if (!interrupt) {
+  console.error('Missing Interrupt with run_id', lines);
+  process.exit(1);
+}
+
+if (agentStart.run_id !== agentEnd.run_id) {
+  console.error('run_id mismatch: AgentStart vs AgentEnd', { agentStart: agentStart.run_id, agentEnd: agentEnd.run_id });
+  process.exit(1);
+}
+
+if (agentStart.run_id !== interrupt.run_id) {
+  console.error('run_id mismatch: AgentStart vs Interrupt', { agentStart: agentStart.run_id, interrupt: interrupt.run_id });
+  process.exit(1);
+}
+
+console.log('LIFECYCLE_HOOKS_VERIFIED=true');
+`,
+    );
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    runtime.printScreen('spawned', terminal);
+
+    await (
+      expect(terminal.getByText(/Mastra Code|Build|Plan|Fast|Type|Press|>/gi, { full: true, strict: false })) as any
+    ).toBeVisible();
+    runtime.printScreen('after startup', terminal);
+
+    // Start a slow run that will be interrupted.
+    terminal.submit('Start a slow run for lifecycle hook e2e.');
+    // Wait for the stream to actually start so AgentStart has fired and we
+    // are interrupting mid-run.
+    await runtime.waitForScreenText(/Lifecycle hook slow response/i, terminal, 15_000);
+    runtime.printScreen('mid-stream before abort', terminal);
+
+    // Abort the run mid-stream — fires Interrupt, then AgentEnd (aborted).
+    terminal.keyCtrlC();
+    runtime.printScreen('after Ctrl-C', terminal);
+    await runtime.waitForScreenText(/Interrupted/i, terminal, 10_000);
+    await runtime.sleep(1_000);
+
+    // Assert the hook log contains the expected lifecycle events.
+    terminal.submit('!node .mastracode/assert-lifecycle.cjs');
+    await runtime.waitForScreenText(/LIFECYCLE_HOOKS_VERIFIED=true/i, terminal, 10_000);
+    runtime.printScreen('after lifecycle hook verification', terminal);
+
+    terminal.keyCtrlC();
+    runtime.printScreen('after final Ctrl-C', terminal);
+  },
+};

--- a/mastracode/e2e/tui/lifecycle-hooks-events.ts
+++ b/mastracode/e2e/tui/lifecycle-hooks-events.ts
@@ -16,6 +16,7 @@ export const lifecycleHooksEventsScenario: McE2eScenario = {
   description:
     'Configure lifecycle hooks, run an agent, interrupt it, and verify AgentStart, AgentEnd, and Interrupt events carry the same run_id.',
   testName: 'emits AgentStart, AgentEnd, and Interrupt lifecycle hooks with a shared run_id',
+  projectFixture: 'long-branch',
   useOpenAIModel: true,
   aimockFixture: 'lifecycle-hooks-events.json',
   env() {

--- a/mastracode/e2e/tui/types.ts
+++ b/mastracode/e2e/tui/types.ts
@@ -199,7 +199,7 @@ export type McE2eScenario = {
   description: string;
   testName: string;
   skipReason?: string;
-  projectFixture?: 'long-branch';
+  projectFixture?: 'long-branch' | 'manual';
   useOpenAIModel?: boolean;
   disableMemory?: boolean;
   aimockFixture?: string;

--- a/mastracode/e2e/tui/types.ts
+++ b/mastracode/e2e/tui/types.ts
@@ -73,6 +73,7 @@ export type ScenarioName =
   | 'visible-commands'
   | 'integration-commands'
   | 'lifecycle-hooks-configured'
+  | 'lifecycle-hooks-events'
   | 'login-dialog-masked-input'
   | 'modal-and-shell'
   | 'mcp-http-tool-call'

--- a/mastracode/e2e/tui/worktree-cross-thread-resume.ts
+++ b/mastracode/e2e/tui/worktree-cross-thread-resume.ts
@@ -32,6 +32,7 @@ export const worktreeCrossThreadResumeScenario: McE2eScenario = {
   name: 'worktree-cross-thread-resume',
   description: 'Verify that MC in a worktree does NOT auto-resume a thread tagged for a different worktree.',
   testName: 'does not auto-resume a thread from a different worktree',
+  projectFixture: 'manual',
   env() {
     return { MASTRA_RESOURCE_ID: RESOURCE_ID };
   },

--- a/mastracode/e2e/tui/worktree-thread-scoping.ts
+++ b/mastracode/e2e/tui/worktree-thread-scoping.ts
@@ -17,6 +17,7 @@ export const worktreeThreadScopingScenario: McE2eScenario = {
   description:
     'Verify that starting MC in a git worktree does NOT auto-resume untagged threads or threads tagged for a different path.',
   testName: 'worktree filters out untagged and mismatched-path threads on startup',
+  projectFixture: 'manual',
   env() {
     return { MASTRA_RESOURCE_ID: RESOURCE_ID };
   },

--- a/mastracode/src/hooks/config.ts
+++ b/mastracode/src/hooks/config.ts
@@ -10,7 +10,7 @@ import * as path from 'node:path';
 import { DEFAULT_CONFIG_DIR } from '../constants.js';
 import type { HooksConfig, HookDefinition, HookEventName } from './types.js';
 
-const VALID_EVENTS: HookEventName[] = [
+export const VALID_EVENTS: HookEventName[] = [
   'PreToolUse',
   'PostToolUse',
   'Stop',
@@ -18,6 +18,13 @@ const VALID_EVENTS: HookEventName[] = [
   'SessionStart',
   'SessionEnd',
   'Notification',
+  'AgentStart',
+  'AgentEnd',
+  'PermissionRequest',
+  'PermissionResult',
+  'Interrupt',
+  'SubagentStart',
+  'SubagentEnd',
 ];
 
 export function loadHooksConfig(projectDir: string, configDirName = DEFAULT_CONFIG_DIR, homeDir?: string): HooksConfig {

--- a/mastracode/src/hooks/index.ts
+++ b/mastracode/src/hooks/index.ts
@@ -1,5 +1,5 @@
 export { HookManager } from './manager.js';
-export { loadHooksConfig, getProjectHooksPath, getGlobalHooksPath } from './config.js';
+export { loadHooksConfig, getProjectHooksPath, getGlobalHooksPath, VALID_EVENTS } from './config.js';
 export { executeHook, runHooksForEvent, matchesHook } from './executor.js';
 export { isBlockingEvent } from './types.js';
 export type {
@@ -14,8 +14,19 @@ export type {
   HookStdinStop,
   HookStdinSession,
   HookStdinNotification,
+  HookStdinAgentStart,
+  HookStdinAgentEnd,
+  HookStdinPermissionRequest,
+  HookStdinPermissionResult,
+  HookStdinInterrupt,
+  HookStdinSubagentStart,
+  HookStdinSubagentEnd,
   HookStdout,
   HookResult,
   HookEventResult,
   BlockingHookEvent,
+  LifecycleHookEvent,
+  PermissionKind,
+  PermissionDecision,
+  InterruptReason,
 } from './types.js';

--- a/mastracode/src/hooks/manager.test.ts
+++ b/mastracode/src/hooks/manager.test.ts
@@ -167,6 +167,31 @@ describe('HookManager run_id propagation', () => {
     expect(stdin.tool_input).toEqual({ command: 'rm -rf /' });
   });
 
+  it('skips AgentEnd when no run_id is active', async () => {
+    const mgr = createManager({
+      AgentEnd: [{ type: 'command', command: 'echo test' }],
+    });
+
+    const result = await mgr.runAgentEnd('complete');
+
+    expect(result.allowed).toBe(true);
+    expect(mocks.runHooksForEvent).not.toHaveBeenCalled();
+  });
+
+  it('fires AgentEnd with stop reason and run_id', async () => {
+    const mgr = createManager({
+      AgentEnd: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-agent-end');
+
+    await mgr.runAgentEnd('aborted');
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.hook_event_name).toBe('AgentEnd');
+    expect(stdin.run_id).toBe('run-uuid-agent-end');
+    expect(stdin.stop_reason).toBe('aborted');
+  });
+
   it('skips PermissionResult when no run_id is active', async () => {
     const mgr = createManager({
       PermissionResult: [{ type: 'command', command: 'echo test' }],

--- a/mastracode/src/hooks/manager.test.ts
+++ b/mastracode/src/hooks/manager.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runHooksForEvent: vi.fn(),
+  loadHooksConfig: vi.fn(),
+}));
+
+vi.mock('./executor.js', () => ({
+  runHooksForEvent: mocks.runHooksForEvent,
+}));
+
+vi.mock('./config.js', () => ({
+  loadHooksConfig: mocks.loadHooksConfig,
+  getProjectHooksPath: vi.fn(),
+  getGlobalHooksPath: vi.fn(),
+}));
+
+import { HookManager } from './manager.js';
+
+function createHookResult(overrides: Record<string, unknown> = {}) {
+  return {
+    allowed: true,
+    results: [],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function createManager(hooksConfig: Record<string, unknown> = {}) {
+  mocks.loadHooksConfig.mockReturnValue(hooksConfig);
+  mocks.runHooksForEvent.mockResolvedValue(createHookResult());
+  return new HookManager('/project', 'session-1');
+}
+
+describe('HookManager run_id propagation', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach(mockFn => mockFn.mockReset());
+  });
+
+  it('includes run_id in PreToolUse stdin when a run is active', async () => {
+    const mgr = createManager({
+      PreToolUse: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-1');
+
+    await mgr.runPreToolUse('execute_command', { command: 'ls' });
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.run_id).toBe('run-uuid-1');
+    expect(stdin.hook_event_name).toBe('PreToolUse');
+    expect(stdin.tool_name).toBe('execute_command');
+  });
+
+  it('includes run_id in PostToolUse stdin when a run is active', async () => {
+    const mgr = createManager({
+      PostToolUse: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-2');
+
+    await mgr.runPostToolUse('write_file', { path: 'x' }, undefined, false);
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.run_id).toBe('run-uuid-2');
+    expect(stdin.hook_event_name).toBe('PostToolUse');
+  });
+
+  it('includes run_id in Stop stdin when a run is active', async () => {
+    const mgr = createManager({
+      Stop: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-3');
+
+    await mgr.runStop(undefined, 'complete');
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.run_id).toBe('run-uuid-3');
+    expect(stdin.hook_event_name).toBe('Stop');
+    expect(stdin.stop_reason).toBe('complete');
+  });
+
+  it('omits run_id from stdin when no run is active', async () => {
+    const mgr = createManager({
+      PreToolUse: [{ type: 'command', command: 'echo test' }],
+    });
+
+    await mgr.runPreToolUse('execute_command', { command: 'ls' });
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.run_id).toBeUndefined();
+  });
+
+  it('clears run_id so subsequent hooks no longer carry it', async () => {
+    const mgr = createManager({
+      Stop: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-4');
+    mgr.clearRunId();
+
+    await mgr.runStop(undefined, 'complete');
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.run_id).toBeUndefined();
+  });
+
+  it('returns empty result and skips executor when no hooks configured for AgentStart', async () => {
+    const mgr = createManager();
+    mgr.setRunId('run-uuid-5');
+
+    const result = await mgr.runAgentStart();
+
+    expect(result.allowed).toBe(true);
+    expect(mocks.runHooksForEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns empty result when AgentStart has hooks but no run_id set', async () => {
+    const mgr = createManager({
+      AgentStart: [{ type: 'command', command: 'echo test' }],
+    });
+
+    const result = await mgr.runAgentStart();
+
+    expect(result.allowed).toBe(true);
+    expect(mocks.runHooksForEvent).not.toHaveBeenCalled();
+  });
+
+  it('fires AgentStart with run_id when hooks and run_id are both present', async () => {
+    const mgr = createManager({
+      AgentStart: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-6');
+
+    await mgr.runAgentStart();
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.run_id).toBe('run-uuid-6');
+    expect(stdin.hook_event_name).toBe('AgentStart');
+  });
+
+  it('fires PermissionRequest with tool context and run_id', async () => {
+    const mgr = createManager({
+      PermissionRequest: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-7');
+
+    await mgr.runPermissionRequest('tool_approval', 'call-1', 'execute_command', { command: 'rm -rf /' });
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.run_id).toBe('run-uuid-7');
+    expect(stdin.hook_event_name).toBe('PermissionRequest');
+    expect(stdin.permission_kind).toBe('tool_approval');
+    expect(stdin.tool_call_id).toBe('call-1');
+    expect(stdin.tool_name).toBe('execute_command');
+    expect(stdin.tool_input).toEqual({ command: 'rm -rf /' });
+  });
+
+  it('fires Interrupt with reason', async () => {
+    const mgr = createManager({
+      Interrupt: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-8');
+
+    await mgr.runInterrupt('user_interrupt');
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.hook_event_name).toBe('Interrupt');
+    expect(stdin.reason).toBe('user_interrupt');
+    expect(stdin.run_id).toBe('run-uuid-8');
+  });
+
+  it('fires SubagentStart and SubagentEnd with delegation context', async () => {
+    const mgr = createManager({
+      SubagentStart: [{ type: 'command', command: 'echo test' }],
+      SubagentEnd: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-9');
+
+    await mgr.runSubagentStart('call-2', 'execute', 'run tests', 'gpt-4o', true);
+    await mgr.runSubagentEnd('call-2', 'execute', 'done', false, 500);
+
+    const startStdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(startStdin.hook_event_name).toBe('SubagentStart');
+    expect(startStdin.run_id).toBe('run-uuid-9');
+    expect(startStdin.agent_type).toBe('execute');
+    expect(startStdin.task).toBe('run tests');
+    expect(startStdin.model_id).toBe('gpt-4o');
+    expect(startStdin.forked).toBe(true);
+
+    const endStdin = mocks.runHooksForEvent.mock.calls[1][1];
+    expect(endStdin.hook_event_name).toBe('SubagentEnd');
+    expect(endStdin.run_id).toBe('run-uuid-9');
+    expect(endStdin.agent_type).toBe('execute');
+    expect(endStdin.result).toBe('done');
+    expect(endStdin.is_error).toBe(false);
+    expect(endStdin.duration_ms).toBe(500);
+  });
+});

--- a/mastracode/src/hooks/manager.test.ts
+++ b/mastracode/src/hooks/manager.test.ts
@@ -123,6 +123,20 @@ describe('HookManager run_id propagation', () => {
     expect(mocks.runHooksForEvent).not.toHaveBeenCalled();
   });
 
+  it('returns a fresh empty result for each skipped hook call', async () => {
+    const mgr = createManager();
+
+    const first = await mgr.runAgentStart();
+    first.results.push({ hook: { type: 'command', command: 'mutated' }, exitCode: 0, timedOut: false, durationMs: 0 });
+    first.warnings.push('mutated');
+
+    const second = await mgr.runAgentStart();
+
+    expect(second.results).toEqual([]);
+    expect(second.warnings).toEqual([]);
+    expect(second).not.toBe(first);
+  });
+
   it('fires AgentStart with run_id when hooks and run_id are both present', async () => {
     const mgr = createManager({
       AgentStart: [{ type: 'command', command: 'echo test' }],
@@ -153,18 +167,58 @@ describe('HookManager run_id propagation', () => {
     expect(stdin.tool_input).toEqual({ command: 'rm -rf /' });
   });
 
-  it('fires Interrupt with reason', async () => {
+  it('skips PermissionResult when no run_id is active', async () => {
+    const mgr = createManager({
+      PermissionResult: [{ type: 'command', command: 'echo test' }],
+    });
+
+    const result = await mgr.runPermissionResult('tool_approval', 'call-1', 'execute_command', 'approved');
+
+    expect(result.allowed).toBe(true);
+    expect(mocks.runHooksForEvent).not.toHaveBeenCalled();
+  });
+
+  it('fires PermissionResult with decision context and run_id', async () => {
+    const mgr = createManager({
+      PermissionResult: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-8');
+
+    await mgr.runPermissionResult('tool_approval', 'call-1', 'execute_command', 'approved', { command: 'npm test' });
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.hook_event_name).toBe('PermissionResult');
+    expect(stdin.run_id).toBe('run-uuid-8');
+    expect(stdin.permission_kind).toBe('tool_approval');
+    expect(stdin.tool_call_id).toBe('call-1');
+    expect(stdin.tool_name).toBe('execute_command');
+    expect(stdin.decision).toBe('approved');
+    expect(stdin.tool_input).toEqual({ command: 'npm test' });
+  });
+
+  it('skips Interrupt when no run_id is active', async () => {
     const mgr = createManager({
       Interrupt: [{ type: 'command', command: 'echo test' }],
     });
-    mgr.setRunId('run-uuid-8');
+
+    const result = await mgr.runInterrupt('user_interrupt');
+
+    expect(result.allowed).toBe(true);
+    expect(mocks.runHooksForEvent).not.toHaveBeenCalled();
+  });
+
+  it('fires Interrupt with reason and run_id', async () => {
+    const mgr = createManager({
+      Interrupt: [{ type: 'command', command: 'echo test' }],
+    });
+    mgr.setRunId('run-uuid-9');
 
     await mgr.runInterrupt('user_interrupt');
 
     const stdin = mocks.runHooksForEvent.mock.calls[0][1];
     expect(stdin.hook_event_name).toBe('Interrupt');
     expect(stdin.reason).toBe('user_interrupt');
-    expect(stdin.run_id).toBe('run-uuid-8');
+    expect(stdin.run_id).toBe('run-uuid-9');
   });
 
   it('fires SubagentStart and SubagentEnd with delegation context', async () => {

--- a/mastracode/src/hooks/manager.ts
+++ b/mastracode/src/hooks/manager.ts
@@ -26,7 +26,7 @@ import type {
   InterruptReason,
 } from './types.js';
 
-const EMPTY_RESULT: HookEventResult = { allowed: true, results: [], warnings: [] };
+const emptyResult = (): HookEventResult => ({ allowed: true, results: [], warnings: [] });
 
 export class HookManager {
   private config: HooksConfig;
@@ -113,7 +113,7 @@ export class HookManager {
   async runPreToolUse(toolName: string, toolInput: unknown): Promise<HookEventResult> {
     const hooks = this.config.PreToolUse;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinToolEvent = {
@@ -133,7 +133,7 @@ export class HookManager {
   ): Promise<HookEventResult> {
     const hooks = this.config.PostToolUse;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinToolEvent = {
@@ -150,7 +150,7 @@ export class HookManager {
   async runUserPromptSubmit(userMessage: string): Promise<HookEventResult> {
     const hooks = this.config.UserPromptSubmit;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinUserPrompt = {
@@ -167,7 +167,7 @@ export class HookManager {
   ): Promise<HookEventResult> {
     const hooks = this.config.Stop;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinStop = {
@@ -182,7 +182,7 @@ export class HookManager {
   async runSessionStart(): Promise<HookEventResult> {
     const hooks = this.config.SessionStart;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinSession = {
@@ -194,7 +194,7 @@ export class HookManager {
   async runSessionEnd(): Promise<HookEventResult> {
     const hooks = this.config.SessionEnd;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinSession = {
@@ -229,11 +229,11 @@ export class HookManager {
   async runAgentStart(): Promise<HookEventResult> {
     const hooks = this.config.AgentStart;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
     const runId = this.runId;
     if (!runId) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinAgentStart = {
@@ -247,11 +247,11 @@ export class HookManager {
   async runAgentEnd(stopReason: 'complete' | 'aborted' | 'error' | 'suspended'): Promise<HookEventResult> {
     const hooks = this.config.AgentEnd;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
     const runId = this.runId;
     if (!runId) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinAgentEnd = {
@@ -271,11 +271,11 @@ export class HookManager {
   ): Promise<HookEventResult> {
     const hooks = this.config.PermissionRequest;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
     const runId = this.runId;
     if (!runId) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinPermissionRequest = {
@@ -299,11 +299,17 @@ export class HookManager {
   ): Promise<HookEventResult> {
     const hooks = this.config.PermissionResult;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
+    }
+
+    const runId = this.runId;
+    if (!runId) {
+      return emptyResult();
     }
 
     const stdin: HookStdinPermissionResult = {
       ...this.baseStdinFields('PermissionResult'),
+      run_id: runId,
       permission_kind: permissionKind,
       tool_call_id: toolCallId,
       tool_name: toolName,
@@ -317,11 +323,17 @@ export class HookManager {
   async runInterrupt(reason: InterruptReason): Promise<HookEventResult> {
     const hooks = this.config.Interrupt;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
+    }
+
+    const runId = this.runId;
+    if (!runId) {
+      return emptyResult();
     }
 
     const stdin: HookStdinInterrupt = {
       ...this.baseStdinFields('Interrupt'),
+      run_id: runId,
       reason,
     };
 
@@ -337,11 +349,11 @@ export class HookManager {
   ): Promise<HookEventResult> {
     const hooks = this.config.SubagentStart;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
     const runId = this.runId;
     if (!runId) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinSubagentStart = {
@@ -366,11 +378,11 @@ export class HookManager {
   ): Promise<HookEventResult> {
     const hooks = this.config.SubagentEnd;
     if (!hooks || hooks.length === 0) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
     const runId = this.runId;
     if (!runId) {
-      return EMPTY_RESULT;
+      return emptyResult();
     }
 
     const stdin: HookStdinSubagentEnd = {

--- a/mastracode/src/hooks/manager.ts
+++ b/mastracode/src/hooks/manager.ts
@@ -8,12 +8,25 @@ import { runHooksForEvent } from './executor.js';
 import type {
   HooksConfig,
   HookEventResult,
+  HookEventName,
   HookStdinToolEvent,
   HookStdinUserPrompt,
   HookStdinStop,
   HookStdinSession,
   HookStdinNotification,
+  HookStdinAgentStart,
+  HookStdinAgentEnd,
+  HookStdinPermissionRequest,
+  HookStdinPermissionResult,
+  HookStdinInterrupt,
+  HookStdinSubagentStart,
+  HookStdinSubagentEnd,
+  PermissionKind,
+  PermissionDecision,
+  InterruptReason,
 } from './types.js';
+
+const EMPTY_RESULT: HookEventResult = { allowed: true, results: [], warnings: [] };
 
 export class HookManager {
   private config: HooksConfig;
@@ -21,6 +34,7 @@ export class HookManager {
   private sessionId: string;
   private configDirName: string;
   private homeDir?: string;
+  private runId?: string;
 
   constructor(projectDir: string, sessionId: string, configDirName = DEFAULT_CONFIG_DIR, homeDir?: string) {
     this.projectDir = projectDir;
@@ -36,6 +50,20 @@ export class HookManager {
 
   setSessionId(sessionId: string): void {
     this.sessionId = sessionId;
+  }
+
+  /** Set the active agent run id. Included as `run_id` in all hook stdin while a run is active. */
+  setRunId(runId: string): void {
+    this.runId = runId;
+  }
+
+  /** Clear the active run id. Call only after end-of-run hooks (AgentEnd, Stop) have been dispatched. */
+  clearRunId(): void {
+    this.runId = undefined;
+  }
+
+  getRunId(): string | undefined {
+    return this.runId;
   }
 
   hasHooks(): boolean {
@@ -54,19 +82,42 @@ export class HookManager {
   }
 
   // =========================================================================
-  // Event Methods
+  // Stdin Helpers
+  // =========================================================================
+
+  /**
+   * Build the common stdin base fields. `run_id` is included when an active run
+   * is set, so every event dispatched during a run carries the same identifier.
+   */
+  private baseStdinFields<T extends HookEventName>(
+    hook_event_name: T,
+  ): {
+    session_id: string;
+    cwd: string;
+    hook_event_name: T;
+    run_id?: string;
+  } {
+    const base: { session_id: string; cwd: string; hook_event_name: T; run_id?: string } = {
+      session_id: this.sessionId,
+      cwd: this.projectDir,
+      hook_event_name,
+    };
+    if (this.runId) base.run_id = this.runId;
+    return base;
+  }
+
+  // =========================================================================
+  // Blocking Event Methods (decisions enforced by callers)
   // =========================================================================
 
   async runPreToolUse(toolName: string, toolInput: unknown): Promise<HookEventResult> {
     const hooks = this.config.PreToolUse;
     if (!hooks || hooks.length === 0) {
-      return { allowed: true, results: [], warnings: [] };
+      return EMPTY_RESULT;
     }
 
     const stdin: HookStdinToolEvent = {
-      session_id: this.sessionId,
-      cwd: this.projectDir,
-      hook_event_name: 'PreToolUse',
+      ...this.baseStdinFields('PreToolUse'),
       tool_name: toolName,
       tool_input: toolInput,
     };
@@ -82,13 +133,11 @@ export class HookManager {
   ): Promise<HookEventResult> {
     const hooks = this.config.PostToolUse;
     if (!hooks || hooks.length === 0) {
-      return { allowed: true, results: [], warnings: [] };
+      return EMPTY_RESULT;
     }
 
     const stdin: HookStdinToolEvent = {
-      session_id: this.sessionId,
-      cwd: this.projectDir,
-      hook_event_name: 'PostToolUse',
+      ...this.baseStdinFields('PostToolUse'),
       tool_name: toolName,
       tool_input: toolInput,
       tool_output: toolOutput,
@@ -101,13 +150,11 @@ export class HookManager {
   async runUserPromptSubmit(userMessage: string): Promise<HookEventResult> {
     const hooks = this.config.UserPromptSubmit;
     if (!hooks || hooks.length === 0) {
-      return { allowed: true, results: [], warnings: [] };
+      return EMPTY_RESULT;
     }
 
     const stdin: HookStdinUserPrompt = {
-      session_id: this.sessionId,
-      cwd: this.projectDir,
-      hook_event_name: 'UserPromptSubmit',
+      ...this.baseStdinFields('UserPromptSubmit'),
       user_message: userMessage,
     };
 
@@ -120,13 +167,11 @@ export class HookManager {
   ): Promise<HookEventResult> {
     const hooks = this.config.Stop;
     if (!hooks || hooks.length === 0) {
-      return { allowed: true, results: [], warnings: [] };
+      return EMPTY_RESULT;
     }
 
     const stdin: HookStdinStop = {
-      session_id: this.sessionId,
-      cwd: this.projectDir,
-      hook_event_name: 'Stop',
+      ...this.baseStdinFields('Stop'),
       assistant_message: assistantMessage,
       stop_reason: stopReason,
     };
@@ -137,13 +182,11 @@ export class HookManager {
   async runSessionStart(): Promise<HookEventResult> {
     const hooks = this.config.SessionStart;
     if (!hooks || hooks.length === 0) {
-      return { allowed: true, results: [], warnings: [] };
+      return EMPTY_RESULT;
     }
 
     const stdin: HookStdinSession = {
-      session_id: this.sessionId,
-      cwd: this.projectDir,
-      hook_event_name: 'SessionStart',
+      ...this.baseStdinFields('SessionStart'),
     };
 
     return runHooksForEvent(hooks, stdin);
@@ -151,13 +194,11 @@ export class HookManager {
   async runSessionEnd(): Promise<HookEventResult> {
     const hooks = this.config.SessionEnd;
     if (!hooks || hooks.length === 0) {
-      return { allowed: true, results: [], warnings: [] };
+      return EMPTY_RESULT;
     }
 
     const stdin: HookStdinSession = {
-      session_id: this.sessionId,
-      cwd: this.projectDir,
-      hook_event_name: 'SessionEnd',
+      ...this.baseStdinFields('SessionEnd'),
     };
 
     return runHooksForEvent(hooks, stdin);
@@ -172,14 +213,176 @@ export class HookManager {
     if (!hooks || hooks.length === 0) return;
 
     const stdin: HookStdinNotification = {
-      session_id: this.sessionId,
-      cwd: this.projectDir,
-      hook_event_name: 'Notification',
+      ...this.baseStdinFields('Notification'),
       reason,
       message,
     };
 
     // Fire-and-forget — don't await
     runHooksForEvent(hooks, stdin).catch(() => {});
+  }
+
+  // =========================================================================
+  // Lifecycle Event Methods (non-blocking: observe behavior, never enforce)
+  // =========================================================================
+
+  async runAgentStart(): Promise<HookEventResult> {
+    const hooks = this.config.AgentStart;
+    if (!hooks || hooks.length === 0) {
+      return EMPTY_RESULT;
+    }
+    const runId = this.runId;
+    if (!runId) {
+      return EMPTY_RESULT;
+    }
+
+    const stdin: HookStdinAgentStart = {
+      ...this.baseStdinFields('AgentStart'),
+      run_id: runId,
+    };
+
+    return runHooksForEvent(hooks, stdin);
+  }
+
+  async runAgentEnd(stopReason: 'complete' | 'aborted' | 'error' | 'suspended'): Promise<HookEventResult> {
+    const hooks = this.config.AgentEnd;
+    if (!hooks || hooks.length === 0) {
+      return EMPTY_RESULT;
+    }
+    const runId = this.runId;
+    if (!runId) {
+      return EMPTY_RESULT;
+    }
+
+    const stdin: HookStdinAgentEnd = {
+      ...this.baseStdinFields('AgentEnd'),
+      run_id: runId,
+      stop_reason: stopReason,
+    };
+
+    return runHooksForEvent(hooks, stdin);
+  }
+
+  async runPermissionRequest(
+    permissionKind: PermissionKind,
+    toolCallId: string,
+    toolName: string,
+    toolInput?: unknown,
+  ): Promise<HookEventResult> {
+    const hooks = this.config.PermissionRequest;
+    if (!hooks || hooks.length === 0) {
+      return EMPTY_RESULT;
+    }
+    const runId = this.runId;
+    if (!runId) {
+      return EMPTY_RESULT;
+    }
+
+    const stdin: HookStdinPermissionRequest = {
+      ...this.baseStdinFields('PermissionRequest'),
+      run_id: runId,
+      permission_kind: permissionKind,
+      tool_call_id: toolCallId,
+      tool_name: toolName,
+      ...(toolInput !== undefined ? { tool_input: toolInput } : {}),
+    };
+
+    return runHooksForEvent(hooks, stdin);
+  }
+
+  async runPermissionResult(
+    permissionKind: PermissionKind,
+    toolCallId: string,
+    toolName: string,
+    decision: PermissionDecision,
+    toolInput?: unknown,
+  ): Promise<HookEventResult> {
+    const hooks = this.config.PermissionResult;
+    if (!hooks || hooks.length === 0) {
+      return EMPTY_RESULT;
+    }
+
+    const stdin: HookStdinPermissionResult = {
+      ...this.baseStdinFields('PermissionResult'),
+      permission_kind: permissionKind,
+      tool_call_id: toolCallId,
+      tool_name: toolName,
+      decision,
+      ...(toolInput !== undefined ? { tool_input: toolInput } : {}),
+    };
+
+    return runHooksForEvent(hooks, stdin);
+  }
+
+  async runInterrupt(reason: InterruptReason): Promise<HookEventResult> {
+    const hooks = this.config.Interrupt;
+    if (!hooks || hooks.length === 0) {
+      return EMPTY_RESULT;
+    }
+
+    const stdin: HookStdinInterrupt = {
+      ...this.baseStdinFields('Interrupt'),
+      reason,
+    };
+
+    return runHooksForEvent(hooks, stdin);
+  }
+
+  async runSubagentStart(
+    toolCallId: string,
+    agentType: string,
+    task: string,
+    modelId?: string,
+    forked?: boolean,
+  ): Promise<HookEventResult> {
+    const hooks = this.config.SubagentStart;
+    if (!hooks || hooks.length === 0) {
+      return EMPTY_RESULT;
+    }
+    const runId = this.runId;
+    if (!runId) {
+      return EMPTY_RESULT;
+    }
+
+    const stdin: HookStdinSubagentStart = {
+      ...this.baseStdinFields('SubagentStart'),
+      run_id: runId,
+      tool_call_id: toolCallId,
+      agent_type: agentType,
+      task,
+      ...(modelId !== undefined ? { model_id: modelId } : {}),
+      ...(forked !== undefined ? { forked } : {}),
+    };
+
+    return runHooksForEvent(hooks, stdin);
+  }
+
+  async runSubagentEnd(
+    toolCallId: string,
+    agentType: string,
+    result: unknown,
+    isError: boolean,
+    durationMs: number,
+  ): Promise<HookEventResult> {
+    const hooks = this.config.SubagentEnd;
+    if (!hooks || hooks.length === 0) {
+      return EMPTY_RESULT;
+    }
+    const runId = this.runId;
+    if (!runId) {
+      return EMPTY_RESULT;
+    }
+
+    const stdin: HookStdinSubagentEnd = {
+      ...this.baseStdinFields('SubagentEnd'),
+      run_id: runId,
+      tool_call_id: toolCallId,
+      agent_type: agentType,
+      result,
+      is_error: isError,
+      duration_ms: durationMs,
+    };
+
+    return runHooksForEvent(hooks, stdin);
   }
 }

--- a/mastracode/src/hooks/types.ts
+++ b/mastracode/src/hooks/types.ts
@@ -13,9 +13,26 @@ export type HookEventName =
   | 'UserPromptSubmit'
   | 'SessionStart'
   | 'SessionEnd'
-  | 'Notification';
+  | 'Notification'
+  | 'AgentStart'
+  | 'AgentEnd'
+  | 'PermissionRequest'
+  | 'PermissionResult'
+  | 'Interrupt'
+  | 'SubagentStart'
+  | 'SubagentEnd';
 
 export type BlockingHookEvent = 'PreToolUse' | 'Stop' | 'UserPromptSubmit';
+
+/** Lifecycle hook events are non-blocking: they observe behavior without changing it. */
+export type LifecycleHookEvent =
+  | 'AgentStart'
+  | 'AgentEnd'
+  | 'PermissionRequest'
+  | 'PermissionResult'
+  | 'Interrupt'
+  | 'SubagentStart'
+  | 'SubagentEnd';
 
 export function isBlockingEvent(event: HookEventName): event is BlockingHookEvent {
   return event === 'PreToolUse' || event === 'Stop' || event === 'UserPromptSubmit';
@@ -50,6 +67,13 @@ export interface HooksConfig {
   SessionStart?: HookDefinition[];
   SessionEnd?: HookDefinition[];
   Notification?: HookDefinition[];
+  AgentStart?: HookDefinition[];
+  AgentEnd?: HookDefinition[];
+  PermissionRequest?: HookDefinition[];
+  PermissionResult?: HookDefinition[];
+  Interrupt?: HookDefinition[];
+  SubagentStart?: HookDefinition[];
+  SubagentEnd?: HookDefinition[];
 }
 
 // =============================================================================
@@ -60,6 +84,12 @@ export interface HookStdinBase {
   session_id: string;
   cwd: string;
   hook_event_name: HookEventName;
+  /**
+   * Stable MastraCode-generated id for the active agent run. Present on events
+   * emitted while a run is active (AgentStart..AgentEnd, tool hooks, Stop).
+   * Absent outside a run (SessionStart, SessionEnd, Notification fired idle).
+   */
+  run_id?: string;
 }
 
 export interface HookStdinToolEvent extends HookStdinBase {
@@ -92,12 +122,81 @@ export interface HookStdinNotification extends HookStdinBase {
   message?: string;
 }
 
+export interface HookStdinAgentStart extends HookStdinBase {
+  hook_event_name: 'AgentStart';
+  run_id: string;
+}
+
+export interface HookStdinAgentEnd extends HookStdinBase {
+  hook_event_name: 'AgentEnd';
+  run_id: string;
+  stop_reason: 'complete' | 'aborted' | 'error' | 'suspended';
+}
+
+export type PermissionKind = 'tool_approval' | 'sandbox_access' | 'plan_approval';
+
+export interface HookStdinPermissionRequest extends HookStdinBase {
+  hook_event_name: 'PermissionRequest';
+  run_id: string;
+  permission_kind: PermissionKind;
+  tool_call_id: string;
+  tool_name: string;
+  tool_input?: unknown;
+}
+
+export type PermissionDecision = 'approved' | 'declined' | 'dismissed' | 'auto_approved' | 'auto_declined';
+
+export interface HookStdinPermissionResult extends HookStdinBase {
+  hook_event_name: 'PermissionResult';
+  run_id?: string;
+  permission_kind: PermissionKind;
+  tool_call_id: string;
+  tool_name: string;
+  tool_input?: unknown;
+  decision: PermissionDecision;
+}
+
+export type InterruptReason = 'user_interrupt' | 'goal_judge_interrupt' | 'process_sigint';
+
+export interface HookStdinInterrupt extends HookStdinBase {
+  hook_event_name: 'Interrupt';
+  run_id?: string;
+  reason: InterruptReason;
+}
+
+export interface HookStdinSubagentStart extends HookStdinBase {
+  hook_event_name: 'SubagentStart';
+  run_id: string;
+  tool_call_id: string;
+  agent_type: string;
+  task: string;
+  model_id?: string;
+  forked?: boolean;
+}
+
+export interface HookStdinSubagentEnd extends HookStdinBase {
+  hook_event_name: 'SubagentEnd';
+  run_id: string;
+  tool_call_id: string;
+  agent_type: string;
+  result: unknown;
+  is_error: boolean;
+  duration_ms: number;
+}
+
 export type HookStdin =
   | HookStdinToolEvent
   | HookStdinUserPrompt
   | HookStdinStop
   | HookStdinSession
-  | HookStdinNotification;
+  | HookStdinNotification
+  | HookStdinAgentStart
+  | HookStdinAgentEnd
+  | HookStdinPermissionRequest
+  | HookStdinPermissionResult
+  | HookStdinInterrupt
+  | HookStdinSubagentStart
+  | HookStdinSubagentEnd;
 
 // =============================================================================
 // Stdout Protocol (JSON read from hook process)

--- a/mastracode/src/hooks/types.ts
+++ b/mastracode/src/hooks/types.ts
@@ -148,7 +148,7 @@ export type PermissionDecision = 'approved' | 'declined' | 'dismissed' | 'auto_a
 
 export interface HookStdinPermissionResult extends HookStdinBase {
   hook_event_name: 'PermissionResult';
-  run_id?: string;
+  run_id: string;
   permission_kind: PermissionKind;
   tool_call_id: string;
   tool_name: string;
@@ -160,7 +160,7 @@ export type InterruptReason = 'user_interrupt' | 'goal_judge_interrupt' | 'proce
 
 export interface HookStdinInterrupt extends HookStdinBase {
   hook_event_name: 'Interrupt';
-  run_id?: string;
+  run_id: string;
   reason: InterruptReason;
 }
 

--- a/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
@@ -291,6 +291,53 @@ describe('MastraTUI hook wiring', () => {
     });
   });
 
+  it('fires PermissionRequest on sandbox access suspension with suspend payload', async () => {
+    const runPermissionRequest = vi.fn().mockResolvedValue(createHookResult());
+    const tui = createBareTui({ runPermissionRequest });
+    const suspendPayload = { kind: 'sandbox_access_request', path: '/tmp/project', reason: 'read files' };
+
+    await tui.handleEvent({
+      type: 'tool_suspended',
+      toolCallId: 'call-2',
+      toolName: 'request_access',
+      args: { path: '/tmp/project', reason: 'read files' },
+      suspendPayload,
+    });
+
+    expect(runPermissionRequest).toHaveBeenCalledWith('sandbox_access', 'call-2', 'request_access', suspendPayload);
+  });
+
+  it('fires PermissionRequest on plan approval suspension with suspend payload', async () => {
+    const runPermissionRequest = vi.fn().mockResolvedValue(createHookResult());
+    const tui = createBareTui({ runPermissionRequest });
+    const suspendPayload = { path: '.mastracode/plans/change.md' };
+
+    await tui.handleEvent({
+      type: 'tool_suspended',
+      toolCallId: 'call-3',
+      toolName: 'submit_plan',
+      args: { path: '.mastracode/plans/change.md' },
+      suspendPayload,
+    });
+
+    expect(runPermissionRequest).toHaveBeenCalledWith('plan_approval', 'call-3', 'submit_plan', suspendPayload);
+  });
+
+  it('does not fire PermissionRequest on ask_user suspension', async () => {
+    const runPermissionRequest = vi.fn().mockResolvedValue(createHookResult());
+    const tui = createBareTui({ runPermissionRequest });
+
+    await tui.handleEvent({
+      type: 'tool_suspended',
+      toolCallId: 'call-4',
+      toolName: 'ask_user',
+      args: { question: 'Continue?' },
+      suspendPayload: { question: 'Continue?' },
+    });
+
+    expect(runPermissionRequest).not.toHaveBeenCalled();
+  });
+
   it('fires SubagentStart on subagent_start with delegation context', async () => {
     const runSubagentStart = vi.fn().mockResolvedValue(createHookResult());
     const tui = createBareTui({ runSubagentStart });

--- a/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
@@ -111,21 +111,29 @@ describe('MastraTUI hook wiring', () => {
     [undefined, 'complete'],
   ] as const)('runs Stop hook on agent_end reason=%s', async (reason, expectedStopReason) => {
     const runStop = vi.fn().mockResolvedValue(createHookResult());
-    const tui = createBareTui({ runStop });
+    const runAgentEnd = vi.fn().mockResolvedValue(createHookResult());
+    const clearRunId = vi.fn();
+    const tui = createBareTui({ runStop, runAgentEnd, clearRunId });
 
     await tui.handleEvent({ type: 'agent_end', reason });
 
     expect(mocks.dispatchEvent).toHaveBeenCalledWith({ type: 'agent_end', reason }, {}, tui.state);
+    expect(runAgentEnd).toHaveBeenCalledWith(reason ?? 'complete');
     expect(runStop).toHaveBeenCalledWith(undefined, expectedStopReason);
+    expect(clearRunId).toHaveBeenCalledTimes(1);
   });
 
   it('does not run Stop hook for non-agent_end events', async () => {
     const runStop = vi.fn().mockResolvedValue(createHookResult());
-    const tui = createBareTui({ runStop });
+    const runAgentStart = vi.fn().mockResolvedValue(createHookResult());
+    const setRunId = vi.fn();
+    const tui = createBareTui({ runStop, runAgentStart, setRunId });
 
     await tui.handleEvent({ type: 'agent_start' });
 
     expect(runStop).not.toHaveBeenCalled();
+    expect(setRunId).toHaveBeenCalledTimes(1);
+    expect(runAgentStart).toHaveBeenCalledTimes(1);
   });
 
   it('ticks idle status line every second while an agent run is active', async () => {
@@ -238,5 +246,98 @@ describe('MastraTUI hook wiring', () => {
 
     expect(mocks.mockSpawn).not.toHaveBeenCalled();
     expect(tui.caffeinateProcess).toBeNull();
+  });
+
+  it('generates a run_id and sets it before firing AgentStart on agent_start', async () => {
+    const setRunId = vi.fn();
+    const runAgentStart = vi.fn().mockResolvedValue(createHookResult());
+    const tui = createBareTui({ setRunId, runAgentStart });
+
+    await tui.handleEvent({ type: 'agent_start' });
+
+    expect(setRunId).toHaveBeenCalledTimes(1);
+    const runId = setRunId.mock.calls[0][0] as string;
+    expect(runId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(runAgentStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires AgentEnd before clearing run_id on agent_end', async () => {
+    const runAgentEnd = vi.fn().mockResolvedValue(createHookResult());
+    const runStop = vi.fn().mockResolvedValue(createHookResult());
+    const clearRunId = vi.fn();
+    const tui = createBareTui({ runAgentEnd, runStop, clearRunId });
+
+    await tui.handleEvent({ type: 'agent_end', reason: 'suspended' });
+
+    expect(runAgentEnd).toHaveBeenCalledWith('suspended');
+    expect(runStop).toHaveBeenCalledWith(undefined, 'complete');
+    // AgentEnd must be called before clearRunId
+    expect(runAgentEnd.mock.invocationCallOrder[0]).toBeLessThan(clearRunId.mock.invocationCallOrder[0]);
+  });
+
+  it('fires PermissionRequest on tool_approval_required with tool context', async () => {
+    const runPermissionRequest = vi.fn().mockResolvedValue(createHookResult());
+    const tui = createBareTui({ runPermissionRequest });
+
+    await tui.handleEvent({
+      type: 'tool_approval_required',
+      toolCallId: 'call-1',
+      toolName: 'execute_command',
+      args: { command: 'rm -rf /' },
+    });
+
+    expect(runPermissionRequest).toHaveBeenCalledWith('tool_approval', 'call-1', 'execute_command', {
+      command: 'rm -rf /',
+    });
+  });
+
+  it('fires SubagentStart on subagent_start with delegation context', async () => {
+    const runSubagentStart = vi.fn().mockResolvedValue(createHookResult());
+    const tui = createBareTui({ runSubagentStart });
+
+    await tui.handleEvent({
+      type: 'subagent_start',
+      toolCallId: 'call-2',
+      agentType: 'execute',
+      task: 'run tests',
+      modelId: 'gpt-4o',
+      forked: true,
+    });
+
+    expect(runSubagentStart).toHaveBeenCalledWith('call-2', 'execute', 'run tests', 'gpt-4o', true);
+  });
+
+  it('fires SubagentEnd on subagent_end with result context', async () => {
+    const runSubagentEnd = vi.fn().mockResolvedValue(createHookResult());
+    const tui = createBareTui({ runSubagentEnd });
+
+    await tui.handleEvent({
+      type: 'subagent_end',
+      toolCallId: 'call-2',
+      agentType: 'execute',
+      result: 'all tests passed',
+      isError: false,
+      durationMs: 1234,
+    });
+
+    expect(runSubagentEnd).toHaveBeenCalledWith('call-2', 'execute', 'all tests passed', false, 1234);
+  });
+
+  it('does not fire lifecycle hooks when no hookManager is configured', async () => {
+    const tui = createBareTui();
+
+    await tui.handleEvent({ type: 'tool_approval_required', toolCallId: 'c', toolName: 't', args: {} });
+    await tui.handleEvent({ type: 'subagent_start', toolCallId: 'c', agentType: 'a', task: 't' });
+    await tui.handleEvent({
+      type: 'subagent_end',
+      toolCallId: 'c',
+      agentType: 'a',
+      result: '',
+      isError: false,
+      durationMs: 0,
+    });
+
+    // Should not throw — no hookManager means no lifecycle hook calls
+    expect(mocks.dispatchEvent).toHaveBeenCalledTimes(3);
   });
 });

--- a/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
@@ -338,6 +338,25 @@ describe('MastraTUI hook wiring', () => {
     expect(runPermissionRequest).not.toHaveBeenCalled();
   });
 
+  it('does not fire PostToolUse from TUI tool_end events', async () => {
+    const runPostToolUse = vi.fn().mockResolvedValue(createHookResult());
+    const tui = createBareTui({ runPostToolUse });
+
+    await tui.handleEvent({
+      type: 'tool_end',
+      toolCallId: 'call-5',
+      result: { ok: true },
+      isError: false,
+    });
+
+    expect(runPostToolUse).not.toHaveBeenCalled();
+    expect(mocks.dispatchEvent).toHaveBeenCalledWith(
+      { type: 'tool_end', toolCallId: 'call-5', result: { ok: true }, isError: false },
+      {},
+      tui.state,
+    );
+  });
+
   it('fires SubagentStart on subagent_start with delegation context', async () => {
     const runSubagentStart = vi.fn().mockResolvedValue(createHookResult());
     const tui = createBareTui({ runSubagentStart });

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -59,7 +59,7 @@ vi.mock('../status-line.js', () => ({
 
 import { showError, showInfo } from '../display.js';
 import { GOAL_JUDGE_INPUT_LOCK_MESSAGE } from '../goal-input-lock.js';
-import { refreshSkillsAutocomplete, setupAutocomplete, setupKeyboardShortcuts } from '../setup.js';
+import { refreshSkillsAutocomplete, setupAutocomplete, setupKeyHandlers, setupKeyboardShortcuts } from '../setup.js';
 import { createMockState } from './agent-controller-mock.js';
 
 const originalPlatform = process.platform;
@@ -125,6 +125,73 @@ function createState(isRunning: boolean) {
 
   return { state, editor, actions };
 }
+
+describe('setupKeyHandlers', () => {
+  function registerSigintHandler(state: any) {
+    let handler: (() => void) | undefined;
+    const onSpy = vi
+      .spyOn(process, 'on')
+      .mockImplementation((event: string | symbol, listener: (...args: any[]) => void) => {
+        if (event === 'SIGINT') {
+          handler = listener as () => void;
+        }
+        return process;
+      });
+    const offSpy = vi.spyOn(process, 'off').mockImplementation(() => process);
+
+    const cleanup = setupKeyHandlers(state, { stop: vi.fn(), doubleCtrlCMs: 500 });
+
+    expect(onSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+    expect(handler).toBeDefined();
+    return { handler: handler!, cleanup, offSpy };
+  }
+
+  it('only dismisses an active approval prompt on process SIGINT', () => {
+    const { state } = createState(false);
+    const pendingApprovalDismiss = vi.fn();
+    const runInterrupt = vi.fn().mockResolvedValue(undefined);
+    state.pendingApprovalDismiss = pendingApprovalDismiss;
+    state.hookManager = { runInterrupt };
+
+    const { handler, cleanup } = registerSigintHandler(state);
+
+    handler();
+    cleanup();
+
+    expect(pendingApprovalDismiss).toHaveBeenCalledTimes(1);
+    expect(runInterrupt).not.toHaveBeenCalled();
+    expect(state.session.abort).not.toHaveBeenCalled();
+  });
+
+  it('does not emit process_sigint when no run is active', () => {
+    const { state } = createState(false);
+    const runInterrupt = vi.fn().mockResolvedValue(undefined);
+    state.hookManager = { runInterrupt };
+
+    const { handler, cleanup } = registerSigintHandler(state);
+
+    handler();
+    cleanup();
+
+    expect(runInterrupt).not.toHaveBeenCalled();
+    expect(state.session.abort).not.toHaveBeenCalled();
+  });
+
+  it('emits process_sigint while aborting an active run', () => {
+    const { state } = createState(true);
+    const runInterrupt = vi.fn().mockResolvedValue(undefined);
+    state.hookManager = { runInterrupt };
+
+    const { handler, cleanup } = registerSigintHandler(state);
+
+    handler();
+    cleanup();
+
+    expect(runInterrupt).toHaveBeenCalledWith('process_sigint');
+    expect(state.session.abort).toHaveBeenCalledTimes(1);
+    expect(state.userInitiatedAbort).toBe(true);
+  });
+});
 
 describe('setupKeyboardShortcuts', () => {
   it('defaults slash-command autocomplete to the first visible built-in command before custom commands', () => {

--- a/mastracode/src/tui/commands/hooks.ts
+++ b/mastracode/src/tui/commands/hooks.ts
@@ -1,3 +1,4 @@
+import { VALID_EVENTS } from '../../hooks/index.js';
 import type { SlashCommandContext } from './types.js';
 
 export function handleHooksCommand(ctx: SlashCommandContext, args: string[]): void {
@@ -40,15 +41,7 @@ export function handleHooksCommand(ctx: SlashCommandContext, args: string[]): vo
   lines.push(`  Global:  ${paths.global}`);
   lines.push('');
 
-  const eventNames = [
-    'PreToolUse',
-    'PostToolUse',
-    'Stop',
-    'UserPromptSubmit',
-    'SessionStart',
-    'SessionEnd',
-    'Notification',
-  ] as const;
+  const eventNames = VALID_EVENTS;
 
   for (const event of eventNames) {
     const hooks = hookConfig[event];

--- a/mastracode/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/prompts.test.ts
@@ -6,7 +6,7 @@ import { getLocalPlansDir, getPlanFilename, getSuggestedPlanRelativePath } from 
 import { createMockState } from '../../__tests__/agent-controller-mock.js';
 import { PlanApprovalInlineComponent } from '../../components/plan-approval-inline.js';
 import type { TUIState } from '../../state.js';
-import { handleAskQuestion, handlePlanApproval } from '../prompts.js';
+import { handleAskQuestion, handlePlanApproval, handleSandboxAccessRequest } from '../prompts.js';
 import type { EventHandlerContext } from '../types.js';
 
 const tmpProjects: string[] = [];
@@ -67,6 +67,23 @@ function createCtx() {
 
   return { ctx, state, answerQuestion };
 }
+
+describe('handleSandboxAccessRequest', () => {
+  it('includes the requested path and reason in PermissionResult tool_input', async () => {
+    const { ctx, state } = createCtx();
+    const runPermissionResult = vi.fn().mockResolvedValue(undefined);
+    (state as any).hookManager = { runPermissionResult };
+
+    const promise = handleSandboxAccessRequest(ctx, 'sandbox-1', '/tmp/project', 'Read workspace files');
+    state.activeInlineQuestion!.handleInput('\r');
+    await promise;
+
+    expect(runPermissionResult).toHaveBeenCalledWith('sandbox_access', 'sandbox-1', 'request_access', 'approved', {
+      path: '/tmp/project',
+      reason: 'Read workspace files',
+    });
+  });
+});
 
 describe('handleAskQuestion goal mode', () => {
   it('shows ask_user prompts to the user instead of answering with the goal judge', async () => {
@@ -238,6 +255,8 @@ describe('handlePlanApproval regular approval', () => {
   it('approves the plan without sending a handoff signal', async () => {
     const projectPath = createTmpProjectWithPlan(PLAN_TITLE, 'Build the feature');
     const { state, ctx, sendSignal } = createPlanApprovalCtx(projectPath);
+    const runPermissionResult = vi.fn().mockResolvedValue(undefined);
+    state.hookManager = { runPermissionResult };
 
     const { promise, component } = await renderPlanApproval(ctx, state, PLAN_PATH);
 
@@ -254,6 +273,9 @@ describe('handlePlanApproval regular approval', () => {
       },
     });
     expect(state.ui.setFocus).toHaveBeenLastCalledWith(state.editor);
+    expect(runPermissionResult).toHaveBeenCalledWith('plan_approval', 'plan-1', 'submit_plan', 'approved', {
+      path: PLAN_PATH,
+    });
     expect(ctx.addUserMessage).not.toHaveBeenCalled();
     expect(ctx.fireMessage).not.toHaveBeenCalled();
     expect(sendSignal).not.toHaveBeenCalled();

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -189,6 +189,9 @@ export async function handleSandboxAccessRequest(
 ): Promise<void> {
   const { state } = ctx;
   return new Promise(resolve => {
+    const firePermissionResult = (decision: 'approved' | 'declined' | 'dismissed') => {
+      state.hookManager?.runPermissionResult('sandbox_access', toolCallId, 'request_access', decision).catch(() => {});
+    };
     const activate = () => {
       const questionComponent = new AskQuestionInlineComponent(
         {
@@ -199,12 +202,14 @@ export async function handleSandboxAccessRequest(
           ],
           onSubmit: answer => {
             state.activeInlineQuestion = undefined;
+            firePermissionResult(answer.toLowerCase().startsWith('y') ? 'approved' : 'declined');
             state.session.respondToToolSuspension({ toolCallId, resumeData: answer });
             resolve();
             processNextInlineQuestion(state);
           },
           onCancel: () => {
             state.activeInlineQuestion = undefined;
+            firePermissionResult('dismissed');
             state.session.respondToToolSuspension({ toolCallId, resumeData: 'No' });
             resolve();
             processNextInlineQuestion(state);
@@ -333,6 +338,9 @@ export async function handlePlanApproval(
 
   return new Promise(resolve => {
     const planFilename = snapshotKey;
+    const firePermissionResult = (decision: 'approved' | 'declined') => {
+      state.hookManager?.runPermissionResult('plan_approval', toolCallId, 'submit_plan', decision).catch(() => {});
+    };
     const approvalOptions = {
       toolCallId,
       title: resolvedTitle,
@@ -342,12 +350,14 @@ export async function handlePlanApproval(
       onApprove: async () => {
         state.activeInlinePlanApproval = undefined;
         state.ui.setFocus(state.editor);
+        firePermissionResult('approved');
         await approvePlan(ctx, toolCallId, resolvedTitle, plan, planPath, snapshotKey);
         resolve();
       },
       onGoal: async () => {
         state.activeInlinePlanApproval = undefined;
         state.ui.setFocus(state.editor);
+        firePermissionResult('approved');
         await approvePlan(ctx, toolCallId, resolvedTitle, plan, planPath, snapshotKey);
 
         // `approvePlan` waits for plan mode to idle before `startGoal` sends
@@ -365,6 +375,7 @@ export async function handlePlanApproval(
       onReject: () => {
         state.activeInlinePlanApproval = undefined;
         state.ui.setFocus(state.editor);
+        firePermissionResult('declined');
         // Resume the tool with a rejection so the rejection result is persisted
         // in thread history (the next run sees it for context). For submit_plan,
         // respondToToolSuspension resolves at the resumed tool's `tool_end`

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -190,7 +190,9 @@ export async function handleSandboxAccessRequest(
   const { state } = ctx;
   return new Promise(resolve => {
     const firePermissionResult = (decision: 'approved' | 'declined' | 'dismissed') => {
-      state.hookManager?.runPermissionResult('sandbox_access', toolCallId, 'request_access', decision).catch(() => {});
+      state.hookManager
+        ?.runPermissionResult('sandbox_access', toolCallId, 'request_access', decision, { path: requestedPath, reason })
+        .catch(() => {});
     };
     const activate = () => {
       const questionComponent = new AskQuestionInlineComponent(
@@ -339,7 +341,9 @@ export async function handlePlanApproval(
   return new Promise(resolve => {
     const planFilename = snapshotKey;
     const firePermissionResult = (decision: 'approved' | 'declined') => {
-      state.hookManager?.runPermissionResult('plan_approval', toolCallId, 'submit_plan', decision).catch(() => {});
+      state.hookManager
+        ?.runPermissionResult('plan_approval', toolCallId, 'submit_plan', decision, { path: snapshotKey })
+        .catch(() => {});
     };
     const approvalOptions = {
       toolCallId,

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -235,6 +235,10 @@ export function handleToolApprovalRequired(
   // Send notification to alert the user
   ctx.notify('tool_approval', `Approve ${toolName}?`);
 
+  const firePermissionResult = (decision: 'approved' | 'declined' | 'dismissed' | 'auto_approved') => {
+    state.hookManager?.runPermissionResult('tool_approval', toolCallId, toolName, decision, args).catch(() => {});
+  };
+
   const dialog = new ToolApprovalDialogComponent({
     toolCallId,
     toolName,
@@ -244,13 +248,17 @@ export function handleToolApprovalRequired(
       state.ui.hideOverlay();
       state.pendingApprovalDismiss = null;
       if (action.type === 'approve') {
+        firePermissionResult('approved');
         state.session.respondToToolApproval({ decision: 'approve' });
       } else if (action.type === 'always_allow_category') {
+        firePermissionResult('approved');
         state.session.respondToToolApproval({ decision: 'always_allow_category' });
       } else if (action.type === 'yolo') {
+        firePermissionResult('auto_approved');
         void state.session.state.set({ yolo: true } as any);
         state.session.respondToToolApproval({ decision: 'approve' });
       } else {
+        firePermissionResult('declined');
         state.session.respondToToolApproval({ decision: 'decline' });
       }
     },
@@ -260,6 +268,7 @@ export function handleToolApprovalRequired(
   state.pendingApprovalDismiss = declineContext => {
     state.ui.hideOverlay();
     state.pendingApprovalDismiss = null;
+    firePermissionResult('dismissed');
     state.session.respondToToolApproval({ decision: 'decline', declineContext });
   };
 

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -1004,6 +1004,15 @@ export class MastraTUI {
       case 'tool_approval_required':
         hookMgr.runPermissionRequest('tool_approval', event.toolCallId, event.toolName, event.args).catch(() => {});
         break;
+      case 'tool_suspended': {
+        const payload = (event.suspendPayload ?? {}) as Record<string, unknown>;
+        if (event.toolName === 'request_access' || payload.kind === 'sandbox_access_request') {
+          hookMgr.runPermissionRequest('sandbox_access', event.toolCallId, event.toolName, payload).catch(() => {});
+        } else if (event.toolName === 'submit_plan') {
+          hookMgr.runPermissionRequest('plan_approval', event.toolCallId, event.toolName, payload).catch(() => {});
+        }
+        break;
+      }
       case 'subagent_start':
         hookMgr
           .runSubagentStart(event.toolCallId, event.agentType, event.task, event.modelId, event.forked)

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -791,7 +791,6 @@ export class MastraTUI {
         this.startIdleStatusTimingTicker();
         await this.runAgentEndHook(event.reason ?? 'complete');
         await this.runStopHook(stopReason);
-        this.endLifecycleRun();
 
         if (event.reason === 'error' && this.lastStreamError) {
           this.emitErrorFeedback(this.lastStreamError);
@@ -801,6 +800,7 @@ export class MastraTUI {
     } finally {
       if (event.type === 'agent_end') {
         this.stopCaffeinate();
+        this.endLifecycleRun();
       }
     }
   }

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -4,6 +4,7 @@
  */
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import type { Component } from '@earendil-works/pi-tui';
 import type { AgentSignalAttributes } from '@mastra/core/agent';
 import type { AgentControllerEvent, AgentControllerMessage } from '@mastra/core/agent-controller';
@@ -758,6 +759,7 @@ export class MastraTUI {
       this.clearStatusTimingTicker();
       this.startCaffeinate();
       this.lastStreamError = null;
+      this.beginLifecycleRun();
     }
 
     if (event.type === 'error' && 'error' in event && !event.retryable) {
@@ -770,6 +772,7 @@ export class MastraTUI {
     }
 
     try {
+      this.fireLifecycleHooksForEvent(event);
       await dispatchEvent(event, this.getEventContext(), this.state);
       this.captureAgentControllerAnalytics(event);
 
@@ -786,7 +789,9 @@ export class MastraTUI {
       if (event.type === 'agent_end') {
         const stopReason = event.reason === 'aborted' ? 'aborted' : event.reason === 'error' ? 'error' : 'complete';
         this.startIdleStatusTimingTicker();
+        await this.runAgentEndHook(event.reason ?? 'complete');
         await this.runStopHook(stopReason);
+        this.endLifecycleRun();
 
         if (event.reason === 'error' && this.lastStreamError) {
           this.emitErrorFeedback(this.lastStreamError);
@@ -982,6 +987,49 @@ export class MastraTUI {
     for (const warning of warnings) {
       showInfo(this.state, `[${event}] ${warning}`);
     }
+  }
+
+  private beginLifecycleRun(): void {
+    const hookMgr = this.state.hookManager;
+    if (!hookMgr) return;
+    const runId = randomUUID();
+    hookMgr.setRunId(runId);
+    hookMgr.runAgentStart().catch(() => {});
+  }
+
+  private fireLifecycleHooksForEvent(event: AgentControllerEvent): void {
+    const hookMgr = this.state.hookManager;
+    if (!hookMgr) return;
+    switch (event.type) {
+      case 'tool_approval_required':
+        hookMgr.runPermissionRequest('tool_approval', event.toolCallId, event.toolName, event.args).catch(() => {});
+        break;
+      case 'subagent_start':
+        hookMgr
+          .runSubagentStart(event.toolCallId, event.agentType, event.task, event.modelId, event.forked)
+          .catch(() => {});
+        break;
+      case 'subagent_end':
+        hookMgr
+          .runSubagentEnd(event.toolCallId, event.agentType, event.result, event.isError, event.durationMs)
+          .catch(() => {});
+        break;
+    }
+  }
+
+  private async runAgentEndHook(reason: 'complete' | 'aborted' | 'error' | 'suspended'): Promise<void> {
+    const hookMgr = this.state.hookManager;
+    if (!hookMgr) return;
+    try {
+      const result = await hookMgr.runAgentEnd(reason);
+      this.showHookWarnings('AgentEnd', result.warnings);
+    } catch (error) {
+      showError(this.state, `AgentEnd hook failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  private endLifecycleRun(): void {
+    const hookMgr = this.state.hookManager;
+    hookMgr?.clearRunId();
   }
 
   private async runStopHook(stopReason: 'complete' | 'aborted' | 'error'): Promise<void> {

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -527,14 +527,21 @@ export function setupKeyHandlers(
     }
     if (state.pendingApprovalDismiss) {
       state.pendingApprovalDismiss();
+      state.activeInlinePlanApproval = undefined;
+      state.activeInlineQuestion = undefined;
+      state.pendingInlineQuestions.length = 0;
+      return;
     }
-    state.activeInlinePlanApproval = undefined;
-    state.activeInlineQuestion = undefined;
-    state.pendingInlineQuestions.length = 0;
-    state.pendingAskUserComponents?.clear();
-    state.userInitiatedAbort = true;
-    state.hookManager?.runInterrupt('process_sigint').catch(() => {});
-    state.session.abort();
+
+    if (state.session.run.isRunning() || state.session.suspensions.hasPending()) {
+      state.activeInlinePlanApproval = undefined;
+      state.activeInlineQuestion = undefined;
+      state.pendingInlineQuestions.length = 0;
+      state.pendingAskUserComponents?.clear();
+      state.userInitiatedAbort = true;
+      state.hookManager?.runInterrupt('process_sigint').catch(() => {});
+      state.session.abort();
+    }
   };
   process.on('SIGINT', sigintHandler);
 

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -66,6 +66,7 @@ export function setupKeyboardShortcuts(
       state.pendingInlineQuestions.length = 0;
       state.pendingAskUserComponents?.clear();
       state.userInitiatedAbort = true;
+      state.hookManager?.runInterrupt('user_interrupt').catch(() => {});
       state.session.abort();
     } else {
       const current = state.editor.getText();
@@ -214,6 +215,7 @@ function abortActiveGoalJudge(state: TUIState): boolean {
   if (!activeGoalJudge) return false;
 
   state.userInitiatedAbort = true;
+  state.hookManager?.runInterrupt('goal_judge_interrupt').catch(() => {});
   activeGoalJudge.abortController.abort();
   activeGoalJudge.component.setInterrupted();
   // Esc during an in-loop goal evaluation pauses the goal so it does not
@@ -531,6 +533,7 @@ export function setupKeyHandlers(
     state.pendingInlineQuestions.length = 0;
     state.pendingAskUserComponents?.clear();
     state.userInitiatedAbort = true;
+    state.hookManager?.runInterrupt('process_sigint').catch(() => {});
     state.session.abort();
   };
   process.on('SIGINT', sigintHandler);


### PR DESCRIPTION
Adds first-class lifecycle hooks so external integrations can track agent runs without guessing from prompt, tool, and stop events. The new non-blocking events are AgentStart, AgentEnd, PermissionRequest, PermissionResult, Interrupt, SubagentStart, and SubagentEnd. Hook payloads during an active run share the same run_id.

Example hooks config:

```json
{
  "hooks": {
    "AgentStart": [{ "type": "command", "command": "echo started" }],
    "PermissionRequest": [{ "type": "command", "command": "echo blocked" }],
    "AgentEnd": [{ "type": "command", "command": "echo idle" }]
  }
}
```

I also fixed the lifecycle E2E setup so hook configs are loaded from the detected project root, and tightened PermissionResult/Interrupt so they only fire with an active run_id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds “milestones” to Mastra agent runs (start, end, interruptions, permission asks/decisions, and subagent start/end) so outside tools can track what’s happening without trying to guess from prompts or tool behavior. It also tags all those milestones with the same `run_id` while a run is active, so everything related to one run can be grouped together.

## Summary
- Added seven new **non-blocking** lifecycle hook events: `AgentStart`, `AgentEnd`, `PermissionRequest`, `PermissionResult`, `Interrupt`, `SubagentStart`, `SubagentEnd` (keeping existing blocking behavior for `PreToolUse`, `Stop`, and `UserPromptSubmit`).
- Introduced a shared per-run **`run_id`** in hook stdin payloads during an active run to make correlating events across the same run straightforward.
- Extended hook **types**, **public exports**, and **configuration validation** (`VALID_EVENTS`) to recognize the new events and payload shapes.
- Updated the TUI lifecycle orchestration to:
  - create and set a `runId` when `agent_start` begins lifecycle handling,
  - fire hook events for permission requests/results, interrupts, and subagent lifecycle,
  - ensure `AgentEnd` happens before normal `Stop`,
  - clear the `runId` in a `finally` block so lifecycle state is cleaned up reliably.
- Tightened `PermissionResult` and `Interrupt` so they only fire when an active `run_id` is present.
- Added/updated documentation and example hook configuration demonstrating handlers for the new events.
- Added E2E coverage (new TUI scenario + fixture) verifying `AgentStart`, `Interrupt`, `AgentEnd` all share the same `run_id` and that lifecycle assertions pass; updated lifecycle E2E setup to load hook configurations from the detected project root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->