### PR TITLE
fix(core,schema-compat): resolve TS2589 type instantiation depth errors in workflows

### DIFF
--- a/.changeset/shy-radios-slide.md
+++ b/.changeset/shy-radios-slide.md
@@ -1,0 +1,6 @@
+---
+'@mastra/schema-compat': patch
+'@mastra/core': patch
+---
+
+Fixed 'Type instantiation is excessively deep' (TS2589) errors that occurred when defining workflows with Zod schemas. Workflow and step type inference is now significantly faster and no longer causes TypeScript to crash or report depth errors.

--- a/examples/agent-builder/package.json
+++ b/examples/agent-builder/package.json
@@ -12,7 +12,7 @@
     "mastra:dev": "mastra dev"
   },
   "dependencies": {
-    "zod": "^4.3.6",
+    "zod": "^4.4.3",
     "typescript": "^5.9.3",
     "@ai-sdk/openai": "^3.0.0",
     "@ai-sdk/provider": "^3.0.0",

--- a/examples/agent-builder/pnpm-lock.yaml
+++ b/examples/agent-builder/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^3.0.0
-        version: 3.0.0(zod@4.3.6)
+        version: 3.0.0(zod@4.4.3)
       '@ai-sdk/provider':
         specifier: ^3.0.0
         version: 3.0.0
@@ -82,7 +82,7 @@ importers:
         version: link:../../voice/openai
       ai:
         specifier: ^6.0.1
-        version: 6.0.1(zod@4.3.6)
+        version: 6.0.1(zod@4.4.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -90,8 +90,8 @@ importers:
         specifier: ^8.18.0
         version: 8.20.0
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       mastra:
         specifier: link:../../packages/cli
@@ -381,30 +381,30 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.0(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.0(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
-      '@ai-sdk/provider-utils': 4.0.0(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.0(zod@4.4.3)
       '@vercel/oidc': 3.0.5
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.0(zod@4.3.6)':
+  '@ai-sdk/openai@3.0.0(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
-      '@ai-sdk/provider-utils': 4.0.0(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 4.0.0(zod@4.4.3)
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.0(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.0(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@ai-sdk/provider@3.0.0':
     dependencies:
@@ -471,13 +471,13 @@ snapshots:
 
   '@vercel/oidc@3.0.5': {}
 
-  ai@6.0.1(zod@4.3.6):
+  ai@6.0.1(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.0(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.0(zod@4.4.3)
       '@ai-sdk/provider': 3.0.0
-      '@ai-sdk/provider-utils': 4.0.0(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.0(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   ansi-regex@5.0.1: {}
 
@@ -624,4 +624,4 @@ snapshots:
 
   yoctocolors-cjs@2.1.3: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}

--- a/examples/agent/package.json
+++ b/examples/agent/package.json
@@ -34,7 +34,7 @@
     "fetch-to-node": "^2.1.0",
     "mastra": "latest",
     "typescript": "^5.9.3",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "pnpm": {
     "overrides": {

--- a/examples/agent/pnpm-lock.yaml
+++ b/examples/agent/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.24
-        version: 1.3.24(zod@4.3.6)
+        version: 1.3.24(zod@4.4.3)
       '@ai-sdk/provider':
         specifier: ^2.0.0
         version: 2.0.1
@@ -95,13 +95,13 @@ importers:
         version: link:../../voice/openai
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
+        version: 1.29.0(zod@4.4.3)
       ai:
         specifier: ^4.3.19
-        version: 4.3.19(react@19.2.4)(zod@4.3.6)
+        version: 4.3.19(react@19.2.4)(zod@4.4.3)
       ai-v5:
         specifier: npm:ai@^5.0.93
-        version: ai@5.0.126(zod@4.3.6)
+        version: ai@5.0.126(zod@4.4.3)
       better-auth:
         specifier: ^1.2.8
         version: 1.5.3(react@19.2.4)
@@ -115,8 +115,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       concurrently:
         specifier: ^9.1.2
@@ -1166,37 +1166,37 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
-  '@ai-sdk/gateway@2.0.32(zod@4.3.6)':
+  '@ai-sdk/gateway@2.0.32(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.4.3)
       '@vercel/oidc': 3.1.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@ai-sdk/openai@1.3.24(zod@4.3.6)':
+  '@ai-sdk/openai@1.3.24(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
+  '@ai-sdk/provider-utils@2.2.8(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@3.0.20(zod@4.3.6)':
+  '@ai-sdk/provider-utils@3.0.20(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -1206,48 +1206,48 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.2.12(react@19.2.4)(zod@4.3.6)':
+  '@ai-sdk/react@1.2.12(react@19.2.4)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.3.6)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.4.3)
       react: 19.2.4
       swr: 2.4.0(react@19.2.4)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)':
+  '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
 
-  '@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)':
+  '@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)':
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.6)
+      better-call: 1.3.2(zod@4.4.3)
       jose: 6.2.0
       kysely: 0.28.11
       nanostores: 1.1.1
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@better-auth/kysely-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
+  '@better-auth/kysely-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
     dependencies:
-      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       kysely: 0.28.11
 
-  '@better-auth/memory-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
+  '@better-auth/memory-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/telemetry@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))':
+  '@better-auth/telemetry@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))':
     dependencies:
-      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
 
@@ -1359,7 +1359,7 @@ snapshots:
 
   '@inquirer/type@3.0.10': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.16)
       ajv: 8.20.0
@@ -1376,8 +1376,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -1418,25 +1418,25 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  ai@4.3.19(react@19.2.4)(zod@4.3.6):
+  ai@4.3.19(react@19.2.4)(zod@4.4.3):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      '@ai-sdk/react': 1.2.12(react@19.2.4)(zod@4.3.6)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.3.6)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      '@ai-sdk/react': 1.2.12(react@19.2.4)(zod@4.4.3)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       react: 19.2.4
 
-  ai@5.0.126(zod@4.3.6):
+  ai@5.0.126(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 2.0.32(zod@4.3.6)
+      '@ai-sdk/gateway': 2.0.32(zod@4.4.3)
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -1457,33 +1457,33 @@ snapshots:
 
   better-auth@1.5.3(react@19.2.4):
     dependencies:
-      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/kysely-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
-      '@better-auth/memory-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/telemetry': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))
+      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/kysely-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
+      '@better-auth/memory-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
+      '@better-auth/telemetry': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.6)
+      better-call: 1.3.2(zod@4.4.3)
       defu: 6.1.4
       jose: 6.2.0
       kysely: 0.28.11
       nanostores: 1.1.1
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       react: 19.2.4
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
 
-  better-call@1.3.2(zod@4.3.6):
+  better-call@1.3.2(zod@4.4.3):
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
       set-cookie-parser: 3.0.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   body-parser@2.2.2:
     dependencies:
@@ -2073,8 +2073,8 @@ snapshots:
 
   yoctocolors-cjs@2.1.3: {}
 
-  zod-to-json-schema@3.25.1(zod@4.3.6):
+  zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}

--- a/packages/core/src/workflows/create.ts
+++ b/packages/core/src/workflows/create.ts
@@ -13,9 +13,10 @@
  * By keeping the Workflow class in `workflow.ts` and the factories here,
  * neither module needs to import the other's runtime dependencies.
  */
+import type { InferPublicSchema, PublicSchema } from '../schema';
 import { createWorkflow as createEventedWorkflowImpl } from './evented/workflow';
 import type { Step } from './step';
-import type { DefaultEngineType, WorkflowConfig } from './types';
+import type { CreateWorkflowParams, DefaultEngineType, InferSchemaOutput } from './types';
 import { Workflow } from './workflow';
 
 /**
@@ -24,18 +25,34 @@ import { Workflow } from './workflow';
  */
 export function createWorkflow<
   TWorkflowId extends string = string,
-  TState = unknown,
-  TInput = unknown,
-  TOutput = unknown,
+  TInputSchema extends PublicSchema<any> = PublicSchema<any>,
+  TOutputSchema extends PublicSchema<any> = PublicSchema<any>,
+  TStateSchema extends PublicSchema<any> | undefined = undefined,
   TSteps extends Step<string, any, any, any, any, any, DefaultEngineType>[] = Step[],
-  TRequestContext extends Record<string, any> | unknown = unknown,
->(params: WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps, TRequestContext>) {
+  TRequestContextSchema extends PublicSchema<any> | undefined = undefined,
+>(params: CreateWorkflowParams<TWorkflowId, TStateSchema, TInputSchema, TOutputSchema, TSteps, TRequestContextSchema>) {
   if (params.schedule) {
-    return createEventedWorkflowImpl(
-      params as WorkflowConfig<TWorkflowId, TState, TInput, TOutput, Step[]>,
-    ) as unknown as Workflow<DefaultEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TInput, TRequestContext>;
+    return createEventedWorkflowImpl(params as any) as unknown as Workflow<
+      DefaultEngineType,
+      TSteps,
+      TWorkflowId,
+      InferSchemaOutput<TStateSchema>,
+      InferPublicSchema<TInputSchema>,
+      InferPublicSchema<TOutputSchema>,
+      InferPublicSchema<TInputSchema>,
+      InferSchemaOutput<TRequestContextSchema>
+    >;
   }
-  return new Workflow<DefaultEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TInput, TRequestContext>(params);
+  return new Workflow<
+    DefaultEngineType,
+    TSteps,
+    TWorkflowId,
+    InferSchemaOutput<TStateSchema>,
+    InferPublicSchema<TInputSchema>,
+    InferPublicSchema<TOutputSchema>,
+    InferPublicSchema<TInputSchema>,
+    InferSchemaOutput<TRequestContextSchema>
+  >(params as any);
 }
 
 /**
@@ -46,15 +63,22 @@ export function createWorkflow<
  */
 export function createEventedWorkflow<
   TWorkflowId extends string = string,
-  TState = unknown,
-  TInput = unknown,
-  TOutput = unknown,
+  TInputSchema extends PublicSchema<any> = PublicSchema<any>,
+  TOutputSchema extends PublicSchema<any> = PublicSchema<any>,
+  TStateSchema extends PublicSchema<any> | undefined = undefined,
   TSteps extends Step<string, any, any, any, any, any, DefaultEngineType>[] = Step[],
-  TRequestContext extends Record<string, any> | unknown = unknown,
->(params: WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps, TRequestContext>) {
-  return createEventedWorkflowImpl(
-    params as WorkflowConfig<TWorkflowId, TState, TInput, TOutput, Step[]>,
-  ) as unknown as Workflow<DefaultEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TInput, TRequestContext>;
+  TRequestContextSchema extends PublicSchema<any> | undefined = undefined,
+>(params: CreateWorkflowParams<TWorkflowId, TStateSchema, TInputSchema, TOutputSchema, TSteps, TRequestContextSchema>) {
+  return createEventedWorkflowImpl(params as any) as unknown as Workflow<
+    DefaultEngineType,
+    TSteps,
+    TWorkflowId,
+    InferSchemaOutput<TStateSchema>,
+    InferPublicSchema<TInputSchema>,
+    InferPublicSchema<TOutputSchema>,
+    InferPublicSchema<TInputSchema>,
+    InferSchemaOutput<TRequestContextSchema>
+  >;
 }
 
 export function cloneWorkflow<

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -64,6 +64,8 @@ import type {
   ToolStep,
   DefaultEngineType,
   StepMetadata,
+  CreateWorkflowParams,
+  InferSchemaOutput,
 } from '../../workflows/types';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from '../constants';
 import { validateCron } from '../scheduler/cron';
@@ -1502,9 +1504,9 @@ function createStepFromProcessor<TProcessorId extends string>(
 
 export function createWorkflow<
   TWorkflowId extends string = string,
-  TState = unknown,
-  TInput = unknown,
-  TOutput = unknown,
+  TInputSchema extends PublicSchema<any> = PublicSchema<any>,
+  TOutputSchema extends PublicSchema<any> = PublicSchema<any>,
+  TStateSchema extends PublicSchema<any> | undefined = undefined,
   TSteps extends Step<string, any, any, any, any, any, EventedEngineType>[] = Step<
     string,
     any,
@@ -1514,7 +1516,8 @@ export function createWorkflow<
     any,
     EventedEngineType
   >[],
->(params: WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps>) {
+  TRequestContextSchema extends PublicSchema<any> | undefined = undefined,
+>(params: CreateWorkflowParams<TWorkflowId, TStateSchema, TInputSchema, TOutputSchema, TSteps, TRequestContextSchema>) {
   if (params.schedule) {
     const schedules = Array.isArray(params.schedule) ? params.schedule : [params.schedule];
     if (Array.isArray(params.schedule)) {
@@ -1547,8 +1550,16 @@ export function createWorkflow<
       onError: params.options?.onError,
     },
   });
-  return new EventedWorkflow<EventedEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TInput>({
-    ...params,
+  return new EventedWorkflow<
+    EventedEngineType,
+    TSteps,
+    TWorkflowId,
+    InferSchemaOutput<TStateSchema>,
+    InferPublicSchema<TInputSchema>,
+    InferPublicSchema<TOutputSchema>,
+    InferPublicSchema<TInputSchema>
+  >({
+    ...(params as any),
     executionEngine,
   });
 }

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -606,9 +606,7 @@ export type StepWithComponent = Step<string, any, any, any, any, any> & {
   steps?: Record<string, StepWithComponent>;
 };
 
-type InferParsedPublicSchema<TSchema extends PublicSchema<any>> = TSchema extends { _output: infer Output }
-  ? Output
-  : InferPublicSchema<TSchema>;
+type InferParsedPublicSchema<TSchema extends PublicSchema<any>> = InferPublicSchema<TSchema>;
 
 /**
  * StepParams with schema-based inference for better type errors.
@@ -868,6 +866,50 @@ export type WorkflowConfig<
    * `requestContextSchema` respectively.
    */
   schedule?: WorkflowScheduleInput<NoInfer<TInput>, NoInfer<TState>, NoInfer<TRequestContext>>;
+};
+
+/**
+ * Infers the output type from a schema type that may be `undefined`.
+ * Returns `unknown` when no schema is provided.
+ */
+export type InferSchemaOutput<T> = T extends PublicSchema<any> ? InferPublicSchema<T> : unknown;
+
+/**
+ * Schema-typed variant of `WorkflowConfig` used by `createWorkflow` factories.
+ *
+ * Instead of inferring output types through the `PublicSchema<TOutput>` union
+ * (which forces TypeScript to distribute across 8+ union members and triggers
+ * TS2589 "Type instantiation is excessively deep"), this type infers the
+ * **schema type itself** (shallow inference) and defers output-type extraction
+ * to `InferSchemaOutput` / `InferPublicSchema` (which use `_output` / `_type`
+ * / `~standard` fast paths).
+ */
+export type CreateWorkflowParams<
+  TWorkflowId extends string = string,
+  TStateSchema extends PublicSchema<any> | undefined = undefined,
+  TInputSchema extends PublicSchema<any> = PublicSchema<any>,
+  TOutputSchema extends PublicSchema<any> = PublicSchema<any>,
+  TSteps extends Step[] = Step[],
+  TRequestContextSchema extends PublicSchema<any> | undefined = undefined,
+> = {
+  mastra?: Mastra;
+  id: TWorkflowId;
+  description?: string | undefined;
+  metadata?: Record<string, unknown> | undefined;
+  inputSchema: TInputSchema;
+  outputSchema: TOutputSchema;
+  stateSchema?: TStateSchema;
+  requestContextSchema?: TRequestContextSchema;
+  executionEngine?: ExecutionEngine;
+  steps?: TSteps;
+  retryConfig?: { attempts?: number; delay?: number };
+  options?: WorkflowOptions;
+  type?: WorkflowType;
+  schedule?: WorkflowScheduleInput<
+    NoInfer<InferSchemaOutput<TInputSchema>>,
+    NoInfer<InferSchemaOutput<TStateSchema>>,
+    NoInfer<InferSchemaOutput<TRequestContextSchema>>
+  >;
 };
 
 /**

--- a/packages/schema-compat/src/schema.types.ts
+++ b/packages/schema-compat/src/schema.types.ts
@@ -28,4 +28,12 @@ export type PublicSchema<Output = unknown, Input = Output> =
   | StandardSchemaWithJSON<Input, Output>
   | AISdkSchemaLike<Output>;
 
-export type InferPublicSchema<T extends PublicSchema> = T extends PublicSchema<infer Output> ? Output : never;
+export type InferPublicSchema<T extends PublicSchema> = T extends { _output: infer Output }
+  ? Output
+  : T extends { _type: infer Output }
+    ? Output
+    : T extends { '~standard': { types: { output: infer O } } }
+      ? O
+      : T extends PublicSchema<infer Output>
+        ? Output
+        : never;

--- a/renovate.json
+++ b/renovate.json
@@ -38,12 +38,23 @@
     "explorations/**",
     ".github/scripts",
     "templates/**",
-    "**/examples/**",
     "**/_examples/**",
     ".claude/skills/**/assets/**/package.json",
     "e2e-tests/**/template/package.json"
   ],
   "packageRules": [
+    {
+      "description": "Disable all dependency updates in examples (Renovate previously ignored these via ignorePaths)",
+      "matchFileNames": ["examples/**/package.json"],
+      "enabled": false
+    },
+    {
+      "description": "Keep zod in examples in sync with the catalog to prevent version collision with workspace-linked @mastra packages (TS2589/OOM)",
+      "matchFileNames": ["examples/**/package.json"],
+      "matchPackageNames": ["zod"],
+      "enabled": true,
+      "groupName": "Schema"
+    },
     {
       "matchDepTypes": ["engines"],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
       "enabled": false
     },
     {
-      "description": "Only allow zod updates in examples (kept in sync with the catalog to prevent version collision with workspace-linked @mastra packages that caused TS2589/OOM)",
+      "description": "Allow zod updates in examples (kept in sync with the catalog to prevent version collision with workspace-linked @mastra packages that caused TS2589/OOM)",
       "matchFileNames": ["examples/**/package.json"],
       "matchPackageNames": ["zod"],
       "enabled": true,
@@ -178,6 +178,13 @@
       "matchFileNames": ["**/package.json", "!examples/**", "!docs/**"],
       "matchSourceUrls": ["https://github.com/vercel/ai"],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "AI SDK Examples",
+      "description": "Allow all AI SDK update types in examples",
+      "matchFileNames": ["examples/**/package.json"],
+      "matchSourceUrls": ["https://github.com/vercel/ai"],
+      "enabled": true
     },
     {
       "groupName": "Assistant UI",

--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
       "enabled": false
     },
     {
-      "description": "Keep zod in examples in sync with the catalog to prevent version collision with workspace-linked @mastra packages (TS2589/OOM)",
+      "description": "Only allow zod updates in examples (kept in sync with the catalog to prevent version collision with workspace-linked @mastra packages that caused TS2589/OOM)",
       "matchFileNames": ["examples/**/package.json"],
       "matchPackageNames": ["zod"],
       "enabled": true,
@@ -178,12 +178,6 @@
       "matchFileNames": ["**/package.json", "!examples/**", "!docs/**"],
       "matchSourceUrls": ["https://github.com/vercel/ai"],
       "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "groupName": "AI SDK Examples",
-      "description": "Leave example apps eligible for all AI SDK update types",
-      "matchFileNames": ["examples/**/package.json"],
-      "matchSourceUrls": ["https://github.com/vercel/ai"]
     },
     {
       "groupName": "Assistant UI",


### PR DESCRIPTION
Fixes the `Type instantiation is excessively deep and possibly infinite` (TS2589) errors that crash TypeScript when defining workflows with Zod schemas.

Two layers to the fix:

**Type inference** — `InferPublicSchema` now short-circuits through `_output` (Zod), `_type` (AI SDK), and ``~standard` (Standard Schema) fast paths before distributing across the 8-member `PublicSchema` union. `createWorkflow` switched to a new `CreateWorkflowParams` type that infers schema types directly instead of resolving output types through the union during inference.

**Dependency collision** — examples declared `zod@^4.3.6` while workspace-linked `@mastra/*` packages brought `zod@4.4.3` (via catalog). TypeScript loaded both as separate module graphs, and structural comparison of two zod versions inside the `PublicSchema` union amplified depth past the OOM threshold. Bumped examples to `^4.4.3` to match the catalog, and updated renovate.json to keep zod in examples in sync going forward (it was previously excluded via `ignorePaths`).

Before: `tsc --noEmit` on `examples/agent` OOMs with 4GB heap.
After: completes in seconds, 0 TS2589 errors.

Co-Authored-By: Mastra Code (alibaba-token-plan/glm-5.2) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR makes workflow types much easier for TypeScript to understand, so it stops getting stuck and crashing when Zod schemas are used. It also keeps the example apps on the same Zod version as the main workspace so TypeScript doesn’t treat them like separate copies and do extra work.

## Summary
- Improved schema type inference in `@mastra/schema-compat` with faster paths for Zod, AI SDK, and Standard Schema shapes.
- Updated workflow factory types to infer directly from schema params instead of expanding through deeper generic unions.
- Added `InferSchemaOutput` and `CreateWorkflowParams` to support shallower workflow typing.
- Simplified parsed schema inference in workflow step params to reduce TypeScript depth.
- Bumped example packages to `zod@^4.4.3` to match the workspace and avoid duplicate type graphs.
- Adjusted Renovate rules so example Zod versions stay aligned going forward.
- Published patch releases for `@mastra/schema-compat` and `@mastra/core` to cover the TypeScript TS2589 fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->