### PR TITLE
fix(core): catch async title persistence failures in Agent

### DIFF
--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -1,6 +1,6 @@
 import { simulateReadableStream, MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { noopLogger } from '../../logger';
 import { MockMemory } from '../../memory/mock';
 import { RequestContext } from '../../request-context';
@@ -1964,6 +1964,106 @@ function titleGenerationTests(version: 'v1' | 'v2') {
       const thread = await mockMemory.getThreadById({ threadId: 'thread-instructions-error' });
       expect(thread).toBeDefined();
       expect(thread?.title).toBe(originalTitle);
+    });
+
+    it('should catch title persistence failures without causing an unhandled rejection', async () => {
+      if (version !== 'v2') {
+        return;
+      }
+
+      const titleText = 'Generated thread title';
+      const mockMemory = new MockMemory();
+      const originalSaveThread = mockMemory.saveThread.bind(mockMemory);
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn().mockReturnValue(new Map()),
+        listLogs: vi.fn().mockResolvedValue({ logs: [], total: 0, page: 1, perPage: 10, hasMore: false }),
+        listLogsByRunId: vi.fn().mockResolvedValue({ logs: [], total: 0, page: 1, perPage: 10, hasMore: false }),
+      };
+
+      vi.spyOn(mockMemory, 'saveThread').mockImplementation(async args => {
+        if (args.thread.title === titleText) {
+          throw new Error('sqlite write failed');
+        }
+
+        return originalSaveThread(args);
+      });
+
+      const titleModel = new MockLanguageModelV2({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: titleText,
+          content: [{ type: 'text', text: titleText }],
+          warnings: [],
+        }),
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: titleText },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+          ]),
+        }),
+      });
+
+      mockMemory.getMergedThreadConfig = () => {
+        return {
+          generateTitle: {
+            model: titleModel,
+          },
+        };
+      };
+
+      const agent = new Agent({
+        id: 'title-persist-error-agent',
+        name: 'Title Persist Error Agent',
+        instructions: 'test agent',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+      agent.__setLogger(logger as any);
+
+      let unhandledReason: unknown = null;
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledReason = reason;
+      };
+      process.once('unhandledRejection', onUnhandledRejection);
+
+      try {
+        await agent.generate('Test message', {
+          memory: {
+            resource: 'user-1',
+            thread: {
+              id: 'thread-title-persist-error',
+              title: '',
+            },
+          },
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+      } finally {
+        process.removeListener('unhandledRejection', onUnhandledRejection);
+      }
+
+      expect(unhandledReason).toBeNull();
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error persisting generated title:',
+        expect.objectContaining({ message: 'sqlite write failed' }),
+      );
+
+      const thread = await mockMemory.getThreadById({ threadId: 'thread-title-persist-error' });
+      expect(thread).toBeDefined();
+      expect(thread?.title).toBe('');
     });
 
     it('should handle empty or null instructions appropriately', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6845,13 +6845,17 @@ export class Agent<
             ).then(
               async title => {
                 if (title) {
-                  await memory.createThread({
-                    threadId: thread.id,
-                    resourceId,
-                    memoryConfig,
-                    title,
-                    metadata: thread.metadata,
-                  });
+                  try {
+                    await memory.createThread({
+                      threadId: thread.id,
+                      resourceId,
+                      memoryConfig,
+                      title,
+                      metadata: thread.metadata,
+                    });
+                  } catch (error) {
+                    this.logger.error('Error persisting generated title:', error);
+                  }
                 }
               },
               error => {


### PR DESCRIPTION
## Description

- catch errors from async generated-title persistence in `Agent`
- prevent background `memory.createThread()` failures from surfacing as unhandled rejections
- add a regression test for title persistence failure handling

`genTitle()` is kicked off in the background. If title generation succeeds but
the later `memory.createThread()` call fails, that rejection can escape the async
success handler unless it is caught locally.

Fixes #18617 

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [X] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
If the app makes up a nicer thread title later, it now won’t crash in the background if saving that title fails. Instead, it safely logs the problem and keeps going, and there’s a test to make sure this doesn’t happen again.

## Summary
- Wrapped async generated-title persistence in `Agent` with local `try/catch` so `memory.createThread()` failures are handled instead of becoming unhandled rejections.
- Added logging for title persistence failures with the underlying error message.
- Added a regression test covering failed title persistence, asserting no unhandled rejection occurs and the original thread title remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->