### PR TITLE
feat: add Scavio integration package

### DIFF
--- a/.changeset/add-scavio-integration.md
+++ b/.changeset/add-scavio-integration.md
@@ -1,0 +1,5 @@
+---
+"@mastra/scavio": minor
+---
+
+Add `@mastra/scavio` integration: real-time Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram search tools for Mastra agents, wrapping the official `scavio` SDK.

--- a/docs/src/content/en/reference/tools/scavio.mdx
+++ b/docs/src/content/en/reference/tools/scavio.mdx
@@ -1,0 +1,68 @@
+---
+title: "Reference: Scavio tools | Tools & MCP"
+description: "API reference for @mastra/scavio, which provides real-time Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram search tools for Mastra agents."
+packages:
+  - "@mastra/scavio"
+---
+
+# Scavio tools
+
+The `@mastra/scavio` package wraps the [Scavio](https://scavio.dev) search API as Mastra-compatible tools. Scavio is a real-time, multi-platform search API for AI agents. The package exposes factory functions for Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram — each returning a tool created with [`createTool()`](./create-tool) with Zod input/output schemas.
+
+## Installation
+
+```sh npm2yarn
+npm install @mastra/scavio scavio zod
+```
+
+## Quick start
+
+Use `createScavioTools()` to get all tools with shared configuration:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createScavioTools } from '@mastra/scavio'
+
+const tools = createScavioTools()
+// Or pass an explicit API key:
+// const tools = createScavioTools({ apiKey: 'sk_...' })
+```
+
+Each tool can also be created individually:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createScavioGoogleSearchTool, createScavioRedditSearchTool } from '@mastra/scavio'
+
+const googleSearch = createScavioGoogleSearchTool()
+const redditSearch = createScavioRedditSearchTool({ apiKey: 'sk_...' })
+```
+
+By default, all tools read `SCAVIO_API_KEY` from the environment. You can pass `{ apiKey }` explicitly to override. Get a key at the [Scavio Dashboard](https://dashboard.scavio.dev).
+
+## Configuration
+
+All factory functions accept `ScavioClientOptions`:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'apiKey',
+    type: 'string',
+    description: 'Scavio API key. Falls back to the `SCAVIO_API_KEY` environment variable.',
+    isOptional: true,
+  },
+  ]}
+/>
+
+## Tools
+
+`createScavioTools()` returns the following tools:
+
+- `scavioGoogleSearch` — Google web search
+- `scavioAmazonSearch`, `scavioAmazonProduct` — Amazon search and product lookup
+- `scavioWalmartSearch`, `scavioWalmartProduct` — Walmart search and product lookup
+- `scavioYoutubeSearch`, `scavioYoutubeMetadata` — YouTube search and video metadata
+- `scavioRedditSearch`, `scavioRedditPost` — Reddit search and post lookup
+- `scavioTiktokSearch`, `scavioTiktokProfile` — TikTok video search and profile lookup
+- `scavioInstagramSearch`, `scavioInstagramProfile` — Instagram user search and profile lookup
+
+Each tool returns the structured Scavio JSON response. The full Scavio API is also available via the [`scavio`](https://www.npmjs.com/package/scavio) SDK or the [Scavio MCP server](https://scavio.dev/docs).

--- a/integrations/scavio/CHANGELOG.md
+++ b/integrations/scavio/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @mastra/scavio

--- a/integrations/scavio/README.md
+++ b/integrations/scavio/README.md
@@ -1,0 +1,51 @@
+# @mastra/scavio
+
+[Scavio](https://scavio.dev) real-time search tools for [Mastra](https://mastra.ai) agents — Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram, with one API key.
+
+## Installation
+
+```bash
+npm install @mastra/scavio
+```
+
+## Setup
+
+Get a Scavio API key from the [Scavio Dashboard](https://dashboard.scavio.dev) (new accounts get free credits, no credit card). Set `SCAVIO_API_KEY` or pass `{ apiKey }`.
+
+## Usage
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { createScavioTools } from '@mastra/scavio';
+
+const agent = new Agent({
+  id: 'web-search-agent',
+  name: 'Web Search Agent',
+  model: 'anthropic/claude-sonnet-4-6',
+  instructions: 'Search the web, shopping sites, and social platforms with Scavio.',
+  tools: createScavioTools(), // reads SCAVIO_API_KEY
+});
+```
+
+Use a single tool instead of the full set:
+
+```typescript
+import { createScavioGoogleSearchTool } from '@mastra/scavio';
+
+const agent = new Agent({
+  id: 'search-agent',
+  model: 'anthropic/claude-sonnet-4-6',
+  instructions: 'Search Google with Scavio.',
+  tools: { googleSearch: createScavioGoogleSearchTool({ apiKey: process.env.SCAVIO_API_KEY }) },
+});
+```
+
+## Tools
+
+`createScavioTools()` returns: `scavioGoogleSearch`, `scavioAmazonSearch`, `scavioAmazonProduct`, `scavioWalmartSearch`, `scavioWalmartProduct`, `scavioYoutubeSearch`, `scavioYoutubeMetadata`, `scavioRedditSearch`, `scavioRedditPost`, `scavioTiktokSearch`, `scavioTiktokProfile`, `scavioInstagramSearch`, `scavioInstagramProfile`.
+
+Each tool returns the structured Scavio JSON response. The full Scavio API (33 endpoints) is also available directly via the [`scavio`](https://www.npmjs.com/package/scavio) SDK or the [MCP server](https://scavio.dev/docs).
+
+## Credits
+
+Most calls cost 1 credit. Reddit and Instagram cost 2 credits, and Google costs 2 unless `light_request` is set (1 credit). See [scavio.dev/docs](https://scavio.dev/docs).

--- a/integrations/scavio/eslint.config.js
+++ b/integrations/scavio/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/integrations/scavio/lint-staged.config.js
+++ b/integrations/scavio/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/integrations/scavio/package.json
+++ b/integrations/scavio/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@mastra/scavio",
+  "version": "1.0.0",
+  "description": "Scavio real-time search tools (Google, YouTube, Amazon, Walmart, Reddit, TikTok, Instagram) for Mastra agents",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "mastra",
+    "scavio",
+    "web-search",
+    "serp",
+    "tools",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "integrations/scavio"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "homepage": "https://mastra.ai",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "dependencies": {
+    "scavio": "^0.2.1"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "zod": ">=3.0.0 || >=4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/integrations/scavio/src/__tests__/client.test.ts
+++ b/integrations/scavio/src/__tests__/client.test.ts
@@ -1,0 +1,46 @@
+import { Scavio } from 'scavio';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { getScavioClient } from '../client.js';
+
+vi.mock('scavio', () => ({
+  Scavio: vi.fn(() => ({})),
+}));
+
+describe('getScavioClient', () => {
+  const originalEnv = process.env.SCAVIO_API_KEY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SCAVIO_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.SCAVIO_API_KEY = originalEnv;
+    } else {
+      delete process.env.SCAVIO_API_KEY;
+    }
+  });
+
+  it('should throw if no API key is provided and env var is not set', () => {
+    expect(() => getScavioClient()).toThrow('Scavio API key is required');
+  });
+
+  it('should use the API key from config', () => {
+    getScavioClient({ apiKey: 'test-key-123' });
+    expect(Scavio).toHaveBeenCalledWith({ apiKey: 'test-key-123' });
+  });
+
+  it('should fall back to SCAVIO_API_KEY env var', () => {
+    process.env.SCAVIO_API_KEY = 'env-key-456';
+    getScavioClient();
+    expect(Scavio).toHaveBeenCalledWith({ apiKey: 'env-key-456' });
+  });
+
+  it('should prefer config.apiKey over env var', () => {
+    process.env.SCAVIO_API_KEY = 'env-key-456';
+    getScavioClient({ apiKey: 'config-key-789' });
+    expect(Scavio).toHaveBeenCalledWith({ apiKey: 'config-key-789' });
+  });
+});

--- a/integrations/scavio/src/__tests__/tools.test.ts
+++ b/integrations/scavio/src/__tests__/tools.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGoogleSearch = vi.fn();
+const mockAmazonProduct = vi.fn();
+
+vi.mock('scavio', () => ({
+  Scavio: vi.fn(() => ({
+    google: { search: mockGoogleSearch },
+    amazon: { search: vi.fn(), product: mockAmazonProduct },
+    walmart: { search: vi.fn(), product: vi.fn() },
+    youtube: { search: vi.fn(), metadata: vi.fn() },
+    reddit: { search: vi.fn(), post: vi.fn() },
+    tiktok: { searchVideos: vi.fn(), profile: vi.fn() },
+    instagram: { searchUsers: vi.fn(), profile: vi.fn() },
+  })),
+}));
+
+import { createScavioGoogleSearchTool } from '../google.js';
+import { createScavioTools } from '../tools.js';
+
+describe('createScavioTools', () => {
+  it('returns all Scavio tools keyed by name', () => {
+    const tools = createScavioTools({ apiKey: 'test-key' });
+    expect(Object.keys(tools)).toEqual([
+      'scavioGoogleSearch',
+      'scavioAmazonSearch',
+      'scavioAmazonProduct',
+      'scavioWalmartSearch',
+      'scavioWalmartProduct',
+      'scavioYoutubeSearch',
+      'scavioYoutubeMetadata',
+      'scavioRedditSearch',
+      'scavioRedditPost',
+      'scavioTiktokSearch',
+      'scavioTiktokProfile',
+      'scavioInstagramSearch',
+      'scavioInstagramProfile',
+    ]);
+    expect(tools.scavioGoogleSearch.id).toBe('scavio-google-search');
+  });
+});
+
+describe('createScavioGoogleSearchTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGoogleSearch.mockResolvedValue({ results: [{ title: 'r1', url: 'https://example.com' }] });
+  });
+
+  it('has the correct id, description, and schemas', () => {
+    const tool = createScavioGoogleSearchTool({ apiKey: 'test-key' });
+    expect(tool.id).toBe('scavio-google-search');
+    expect(tool.description!.length).toBeGreaterThan(0);
+    expect(tool.inputSchema).toBeDefined();
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  it('calls client.google.search with the input and returns the response', async () => {
+    const tool = createScavioGoogleSearchTool({ apiKey: 'test-key' });
+    const input = { query: 'pydantic ai', light_request: true };
+    const result = await tool.execute!(input, {} as any);
+    expect(mockGoogleSearch).toHaveBeenCalledWith(input);
+    expect(result).toEqual({ results: [{ title: 'r1', url: 'https://example.com' }] });
+  });
+});

--- a/integrations/scavio/src/amazon.ts
+++ b/integrations/scavio/src/amazon.ts
@@ -1,0 +1,42 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getScavioClient } from './client.js';
+import type { ScavioClient, ScavioClientOptions } from './client.js';
+
+const outputSchema = z.record(z.string(), z.unknown());
+
+export function createScavioAmazonSearchTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-amazon-search',
+    description: 'Search Amazon for products via Scavio. Returns matching products as structured JSON.',
+    inputSchema: z.object({
+      query: z.string().describe('The product search query'),
+      domain: z.string().optional().describe('Amazon domain, e.g. "amazon.com"'),
+      country: z.string().optional().describe('Two-letter country code'),
+      sort_by: z.string().optional().describe('Sort order for results'),
+    }),
+    outputSchema,
+    execute: async input => getClient().amazon.search(input),
+  });
+}
+
+export function createScavioAmazonProductTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-amazon-product',
+    description: 'Fetch full Amazon product details by ASIN via Scavio.',
+    inputSchema: z.object({
+      asin: z.string().describe('Amazon Standard Identification Number (ASIN)'),
+      domain: z.string().optional().describe('Amazon domain, e.g. "amazon.com"'),
+      country: z.string().optional().describe('Two-letter country code'),
+    }),
+    outputSchema,
+    execute: async input => getClient().amazon.product(input),
+  });
+}

--- a/integrations/scavio/src/client.ts
+++ b/integrations/scavio/src/client.ts
@@ -1,0 +1,16 @@
+import { Scavio } from 'scavio';
+
+export interface ScavioClientOptions {
+  /** Scavio API key. Falls back to the `SCAVIO_API_KEY` environment variable. */
+  apiKey?: string;
+}
+
+export type ScavioClient = Scavio;
+
+export function getScavioClient(config?: ScavioClientOptions): ScavioClient {
+  const apiKey = config?.apiKey ?? process.env.SCAVIO_API_KEY;
+  if (!apiKey) {
+    throw new Error('Scavio API key is required. Pass { apiKey } or set SCAVIO_API_KEY env var.');
+  }
+  return new Scavio({ apiKey });
+}

--- a/integrations/scavio/src/google.ts
+++ b/integrations/scavio/src/google.ts
@@ -1,0 +1,34 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getScavioClient } from './client.js';
+import type { ScavioClient, ScavioClientOptions } from './client.js';
+
+const outputSchema = z.record(z.string(), z.unknown());
+
+export function createScavioGoogleSearchTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-google-search',
+    description:
+      'Search Google in real time via Scavio. Returns organic results, knowledge graph, related questions, news, and more as structured JSON.',
+    inputSchema: z.object({
+      query: z.string().describe('The search query'),
+      country_code: z.string().optional().describe('Two-letter country code, e.g. "us"'),
+      language: z.string().optional().describe('Two-letter language code, e.g. "en"'),
+      page: z.number().optional().describe('Result page number (1-based)'),
+      search_type: z
+        .enum(['classic', 'news', 'maps', 'images', 'lens'])
+        .optional()
+        .describe('The Google vertical to search'),
+      light_request: z
+        .boolean()
+        .optional()
+        .describe('Use the cheaper, lighter response (1 credit instead of 2)'),
+    }),
+    outputSchema,
+    execute: async input => getClient().google.search(input),
+  });
+}

--- a/integrations/scavio/src/index.ts
+++ b/integrations/scavio/src/index.ts
@@ -1,0 +1,9 @@
+export { getScavioClient, type ScavioClientOptions, type ScavioClient } from './client.js';
+export { createScavioGoogleSearchTool } from './google.js';
+export { createScavioAmazonSearchTool, createScavioAmazonProductTool } from './amazon.js';
+export { createScavioWalmartSearchTool, createScavioWalmartProductTool } from './walmart.js';
+export { createScavioYoutubeSearchTool, createScavioYoutubeMetadataTool } from './youtube.js';
+export { createScavioRedditSearchTool, createScavioRedditPostTool } from './reddit.js';
+export { createScavioTiktokSearchTool, createScavioTiktokProfileTool } from './tiktok.js';
+export { createScavioInstagramSearchTool, createScavioInstagramProfileTool } from './instagram.js';
+export { createScavioTools } from './tools.js';

--- a/integrations/scavio/src/instagram.ts
+++ b/integrations/scavio/src/instagram.ts
@@ -1,0 +1,38 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getScavioClient } from './client.js';
+import type { ScavioClient, ScavioClientOptions } from './client.js';
+
+const outputSchema = z.record(z.string(), z.unknown());
+
+export function createScavioInstagramSearchTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-instagram-search',
+    description: 'Search Instagram users by keyword via Scavio.',
+    inputSchema: z.object({
+      keyword: z.string().describe('Search keyword'),
+    }),
+    outputSchema,
+    execute: async input => getClient().instagram.searchUsers(input),
+  });
+}
+
+export function createScavioInstagramProfileTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-instagram-profile',
+    description: 'Fetch an Instagram profile by username via Scavio.',
+    inputSchema: z.object({
+      username: z.string().optional().describe('Instagram username'),
+      user_id: z.string().optional().describe('Instagram user id'),
+    }),
+    outputSchema,
+    execute: async input => getClient().instagram.profile(input),
+  });
+}

--- a/integrations/scavio/src/reddit.ts
+++ b/integrations/scavio/src/reddit.ts
@@ -1,0 +1,39 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getScavioClient } from './client.js';
+import type { ScavioClient, ScavioClientOptions } from './client.js';
+
+const outputSchema = z.record(z.string(), z.unknown());
+
+export function createScavioRedditSearchTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-reddit-search',
+    description: 'Search Reddit posts, subreddits, or users via Scavio.',
+    inputSchema: z.object({
+      query: z.string().describe('The Reddit search query'),
+      type: z.string().optional().describe('Search type, e.g. "posts", "subreddits", "users"'),
+      sort: z.string().optional().describe('Sort order, e.g. "relevance", "new", "top"'),
+    }),
+    outputSchema,
+    execute: async input => getClient().reddit.search(input),
+  });
+}
+
+export function createScavioRedditPostTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-reddit-post',
+    description: 'Fetch a Reddit post and its comment thread by URL via Scavio.',
+    inputSchema: z.object({
+      url: z.string().describe('Full URL of the Reddit post'),
+    }),
+    outputSchema,
+    execute: async input => getClient().reddit.post(input),
+  });
+}

--- a/integrations/scavio/src/tiktok.ts
+++ b/integrations/scavio/src/tiktok.ts
@@ -1,0 +1,40 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getScavioClient } from './client.js';
+import type { ScavioClient, ScavioClientOptions } from './client.js';
+
+const outputSchema = z.record(z.string(), z.unknown());
+
+export function createScavioTiktokSearchTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-tiktok-search',
+    description: 'Search TikTok videos by keyword via Scavio.',
+    inputSchema: z.object({
+      keyword: z.string().describe('Search keyword'),
+      count: z.number().optional().describe('Number of videos to return'),
+      sort_type: z.string().optional().describe('Sort order for results'),
+    }),
+    outputSchema,
+    execute: async input => getClient().tiktok.searchVideos(input),
+  });
+}
+
+export function createScavioTiktokProfileTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-tiktok-profile',
+    description: 'Fetch a TikTok user profile by username via Scavio.',
+    inputSchema: z.object({
+      username: z.string().optional().describe('TikTok username (without @)'),
+      sec_user_id: z.string().optional().describe('TikTok secUid'),
+    }),
+    outputSchema,
+    execute: async input => getClient().tiktok.profile(input),
+  });
+}

--- a/integrations/scavio/src/tools.ts
+++ b/integrations/scavio/src/tools.ts
@@ -1,0 +1,26 @@
+import type { ScavioClientOptions } from './client.js';
+import { createScavioAmazonProductTool, createScavioAmazonSearchTool } from './amazon.js';
+import { createScavioGoogleSearchTool } from './google.js';
+import { createScavioInstagramProfileTool, createScavioInstagramSearchTool } from './instagram.js';
+import { createScavioRedditPostTool, createScavioRedditSearchTool } from './reddit.js';
+import { createScavioTiktokProfileTool, createScavioTiktokSearchTool } from './tiktok.js';
+import { createScavioWalmartProductTool, createScavioWalmartSearchTool } from './walmart.js';
+import { createScavioYoutubeMetadataTool, createScavioYoutubeSearchTool } from './youtube.js';
+
+export function createScavioTools(config?: ScavioClientOptions) {
+  return {
+    scavioGoogleSearch: createScavioGoogleSearchTool(config),
+    scavioAmazonSearch: createScavioAmazonSearchTool(config),
+    scavioAmazonProduct: createScavioAmazonProductTool(config),
+    scavioWalmartSearch: createScavioWalmartSearchTool(config),
+    scavioWalmartProduct: createScavioWalmartProductTool(config),
+    scavioYoutubeSearch: createScavioYoutubeSearchTool(config),
+    scavioYoutubeMetadata: createScavioYoutubeMetadataTool(config),
+    scavioRedditSearch: createScavioRedditSearchTool(config),
+    scavioRedditPost: createScavioRedditPostTool(config),
+    scavioTiktokSearch: createScavioTiktokSearchTool(config),
+    scavioTiktokProfile: createScavioTiktokProfileTool(config),
+    scavioInstagramSearch: createScavioInstagramSearchTool(config),
+    scavioInstagramProfile: createScavioInstagramProfileTool(config),
+  };
+}

--- a/integrations/scavio/src/walmart.ts
+++ b/integrations/scavio/src/walmart.ts
@@ -1,0 +1,40 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getScavioClient } from './client.js';
+import type { ScavioClient, ScavioClientOptions } from './client.js';
+
+const outputSchema = z.record(z.string(), z.unknown());
+
+export function createScavioWalmartSearchTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-walmart-search',
+    description: 'Search Walmart for products via Scavio. Returns matching products as structured JSON.',
+    inputSchema: z.object({
+      query: z.string().describe('The product search query'),
+      sort_by: z.string().optional().describe('Sort order for results'),
+      min_price: z.number().optional().describe('Minimum price filter'),
+      max_price: z.number().optional().describe('Maximum price filter'),
+    }),
+    outputSchema,
+    execute: async input => getClient().walmart.search(input),
+  });
+}
+
+export function createScavioWalmartProductTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-walmart-product',
+    description: 'Fetch full Walmart product details by product id via Scavio.',
+    inputSchema: z.object({
+      product_id: z.string().describe('Walmart product id'),
+    }),
+    outputSchema,
+    execute: async input => getClient().walmart.product(input),
+  });
+}

--- a/integrations/scavio/src/youtube.ts
+++ b/integrations/scavio/src/youtube.ts
@@ -1,0 +1,40 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getScavioClient } from './client.js';
+import type { ScavioClient, ScavioClientOptions } from './client.js';
+
+const outputSchema = z.record(z.string(), z.unknown());
+
+export function createScavioYoutubeSearchTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-youtube-search',
+    description: 'Search YouTube for videos, channels, or playlists via Scavio.',
+    inputSchema: z.object({
+      query: z.string().describe('The video search query'),
+      upload_date: z.string().optional().describe('Upload date filter, e.g. "today", "week", "month"'),
+      type: z.string().optional().describe('Result type, e.g. "video", "channel", "playlist"'),
+      sort_by: z.string().optional().describe('Sort order for results'),
+    }),
+    outputSchema,
+    execute: async input => getClient().youtube.search(input),
+  });
+}
+
+export function createScavioYoutubeMetadataTool(config?: ScavioClientOptions) {
+  let client: ScavioClient | null = null;
+  const getClient = () => (client ??= getScavioClient(config));
+
+  return createTool({
+    id: 'scavio-youtube-metadata',
+    description: 'Fetch metadata for a YouTube video by id via Scavio.',
+    inputSchema: z.object({
+      video_id: z.string().describe('YouTube video id'),
+    }),
+    outputSchema,
+    execute: async input => getClient().youtube.metadata(input),
+  });
+}

--- a/integrations/scavio/tsconfig.build.json
+++ b/integrations/scavio/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/scavio/tsconfig.json
+++ b/integrations/scavio/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/scavio/tsup.config.ts
+++ b/integrations/scavio/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/integrations/scavio/turbo.json
+++ b/integrations/scavio/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://v2-9-16.turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/integrations/scavio/vitest.config.ts
+++ b/integrations/scavio/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:integrations/tavily',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Closes #18616

## What

Adds `@mastra/scavio` — real-time search tools for Mastra agents backed by [Scavio](https://scavio.dev), a multi-platform search API (a Tavily/SerpAPI alternative covering shopping and social as well as web). Mirrors the structure of `integrations/tavily` exactly.

Tools (13), via `createScavioTools()` or individual factories:
- Google search; Amazon search + product; Walmart search + product; YouTube search + metadata; Reddit search + post; TikTok search + profile; Instagram search + profile.

Each is a `createTool()` wrapping the official [`scavio`](https://www.npmjs.com/package/scavio) npm SDK; the client resolves the key from `{ apiKey }` or `SCAVIO_API_KEY`.

## Included

- `integrations/scavio/` package (mirrors `integrations/tavily/`: tsup build, vitest, eslint, Apache-2.0, peer-dep `@mastra/core`, dep `scavio`).
- Docs reference page `docs/src/content/en/reference/tools/scavio.mdx`.
- Changeset.
- Tests under `src/__tests__/` (client key-resolution + tools), mocking the SDK.

## Validation

- `tsc` clean, `vitest` green (7 tests), built with `tsup` — all run in a standalone harness against the published `@mastra/core` and `scavio`.
- Live-verified: the `scavio-google-search` tool's `execute()` was run against the live Scavio API and returned real results.

Follows the precedent of #15448 (add Tavily integration). Happy to adjust naming/scope.
