### PR TITLE
feat(core): strip unsupported sampling params via capability registry

### DIFF
--- a/.changeset/twelve-candles-love.md
+++ b/.changeset/twelve-candles-love.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': minor
+---
+
+Agents using models that dropped support for `temperature`, `topP`, or `topK` (such as `claude-opus-4-7` or `gpt-5-pro`) no longer crash with a 400 error. The model router now automatically strips unsupported sampling parameters before the request is sent — no configuration or processors needed.
+
+```ts
+const agent = new Agent({
+  model: 'anthropic/claude-opus-4-7',
+  instructions: 'You are a helpful assistant.',
+});
+
+// temperature is stripped automatically — no 400 error
+await agent.generate('hello', { modelSettings: { temperature: 0.7 } });
+```

--- a/packages/core/scripts/generate-providers.ts
+++ b/packages/core/scripts/generate-providers.ts
@@ -10,7 +10,8 @@ const __dirname = path.dirname(__filename);
 
 async function generateProviderRegistry(gateways: MastraModelGateway[]) {
   // Fetch providers from all gateways
-  const { providers, models, attachmentCapabilities, failedGateways } = await fetchProvidersFromGateways(gateways);
+  const { providers, models, attachmentCapabilities, temperatureCapabilities, failedGateways } =
+    await fetchProvidersFromGateways(gateways);
 
   if (failedGateways.length > 0) {
     console.warn(
@@ -23,12 +24,26 @@ async function generateProviderRegistry(gateways: MastraModelGateway[]) {
   const srcDir = path.join(__dirname, '..', 'src', 'llm', 'model');
   const srcJsonPath = path.join(srcDir, 'provider-registry.json');
   const srcTypesPath = path.join(srcDir, 'provider-types.generated.d.ts');
-  await writeRegistryFiles(srcJsonPath, srcTypesPath, providers, models, attachmentCapabilities);
+  await writeRegistryFiles(
+    srcJsonPath,
+    srcTypesPath,
+    providers,
+    models,
+    attachmentCapabilities,
+    temperatureCapabilities,
+  );
 
   // Write registry files to dist/ (for build output)
   const distJsonPath = path.join(__dirname, '..', 'dist', 'provider-registry.json');
   const distTypesPath = path.join(__dirname, '..', 'dist', 'llm', 'model', 'provider-types.generated.d.ts');
-  await writeRegistryFiles(distJsonPath, distTypesPath, providers, models, attachmentCapabilities);
+  await writeRegistryFiles(
+    distJsonPath,
+    distTypesPath,
+    providers,
+    models,
+    attachmentCapabilities,
+    temperatureCapabilities,
+  );
 
   // Log summary
   console.info(`\nRegistered providers:`);
@@ -38,6 +53,9 @@ async function generateProviderRegistry(gateways: MastraModelGateway[]) {
   const capProviderCount = Object.keys(attachmentCapabilities).length;
   const capModelCount = Object.values(attachmentCapabilities).reduce((sum, models) => sum + models.length, 0);
   console.info(`\nAttachment-capable: ${capModelCount} models across ${capProviderCount} providers`);
+  const tempProviderCount = Object.keys(temperatureCapabilities).length;
+  const tempModelCount = Object.values(temperatureCapabilities).reduce((sum, models) => sum + models.length, 0);
+  console.info(`Temperature-capable: ${tempModelCount} models across ${tempProviderCount} providers`);
 }
 
 // Main execution

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -83,6 +83,7 @@ export {
   parseModelString,
   getProviderConfig,
   modelSupportsAttachments,
+  modelSupportsTemperature,
 } from './model/provider-registry.js';
 export type {
   ModelRouterModelId,

--- a/packages/core/src/llm/model/capabilities/anthropic.json
+++ b/packages/core/src/llm/model/capabilities/anthropic.json
@@ -18,5 +18,21 @@
     "claude-sonnet-4-5-20250929",
     "claude-sonnet-4-6",
     "claude-sonnet-5"
+  ],
+  "temperature": [
+    "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001",
+    "claude-opus-4-0",
+    "claude-opus-4-1",
+    "claude-opus-4-1-20250805",
+    "claude-opus-4-20250514",
+    "claude-opus-4-5",
+    "claude-opus-4-5-20251101",
+    "claude-opus-4-6",
+    "claude-sonnet-4-0",
+    "claude-sonnet-4-20250514",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-6"
   ]
 }

--- a/packages/core/src/llm/model/capabilities/openai.json
+++ b/packages/core/src/llm/model/capabilities/openai.json
@@ -45,5 +45,20 @@
     "o3-pro",
     "o4-mini",
     "o4-mini-deep-research"
+  ],
+  "temperature": [
+    "gpt-3.5-turbo",
+    "gpt-4",
+    "gpt-4-turbo",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4.1-nano",
+    "gpt-4o",
+    "gpt-4o-2024-05-13",
+    "gpt-4o-2024-08-06",
+    "gpt-4o-2024-11-20",
+    "gpt-4o-mini",
+    "gpt-5-chat-latest",
+    "gpt-5.3-chat-latest"
   ]
 }

--- a/packages/core/src/llm/model/gateways/base.ts
+++ b/packages/core/src/llm/model/gateways/base.ts
@@ -22,9 +22,10 @@ export interface ProviderConfig {
 
 /**
  * Compact capability data collected from gateways during generation.
- * Each provider maps to a list of model IDs that support attachments.
+ * Each provider maps to a list of model IDs that support a capability.
  */
 export type AttachmentCapabilities = Record<string, string[]>;
+export type TemperatureCapabilities = Record<string, string[]>;
 
 /**
  * Union type for language models that can be returned by gateways.

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -15,7 +15,7 @@ import { createGateway } from '@internal/ai-v6';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider-v5';
 import { parseModelRouterId } from '../gateway-resolver.js';
 import { MastraModelGateway } from './base.js';
-import type { AttachmentCapabilities, GatewayLanguageModel, ProviderConfig } from './base.js';
+import type { AttachmentCapabilities, GatewayLanguageModel, ProviderConfig, TemperatureCapabilities } from './base.js';
 import { EXCLUDED_PROVIDERS, MASTRA_USER_AGENT, PROVIDERS_WITH_INSTALLED_PACKAGES } from './constants.js';
 
 interface ModelsDevModelInfo {
@@ -24,6 +24,7 @@ interface ModelsDevModelInfo {
   status?: string;
   modalities?: { input?: string[]; output?: string[] };
   attachment?: boolean;
+  temperature?: boolean;
   [key: string]: unknown;
 }
 
@@ -110,6 +111,7 @@ export class ModelsDevGateway extends MastraModelGateway {
 
   private providerConfigs: Record<string, ProviderConfig> = {};
   private attachmentCapabilities: AttachmentCapabilities = {};
+  private temperatureCapabilities: TemperatureCapabilities = {};
 
   constructor(providerConfigs?: Record<string, ProviderConfig>) {
     super();
@@ -123,6 +125,10 @@ export class ModelsDevGateway extends MastraModelGateway {
     }
 
     const data = (await response.json()) as ModelsDevResponse;
+
+    // Reset capability maps so removed providers/models are not retained across syncs
+    this.attachmentCapabilities = {};
+    this.temperatureCapabilities = {};
 
     const providerConfigs: Record<string, ProviderConfig> = {};
 
@@ -158,6 +164,12 @@ export class ModelsDevGateway extends MastraModelGateway {
         // Collect model IDs that support attachments
         const attachmentModels = activeModels
           .filter(([, modelInfo]) => modelInfo?.attachment === true)
+          .map(([modelId]) => modelId)
+          .sort();
+
+        // Collect model IDs that support temperature sampling
+        const temperatureModels = activeModels
+          .filter(([, modelInfo]) => modelInfo?.temperature === true)
           .map(([modelId]) => modelId)
           .sort();
 
@@ -203,6 +215,9 @@ export class ModelsDevGateway extends MastraModelGateway {
         if (attachmentModels.length > 0) {
           this.attachmentCapabilities[normalizedId] = attachmentModels;
         }
+        if (temperatureModels.length > 0) {
+          this.temperatureCapabilities[normalizedId] = temperatureModels;
+        }
       }
     }
 
@@ -218,6 +233,10 @@ export class ModelsDevGateway extends MastraModelGateway {
    */
   getAttachmentCapabilities(): AttachmentCapabilities {
     return this.attachmentCapabilities;
+  }
+
+  getTemperatureCapabilities(): TemperatureCapabilities {
+    return this.temperatureCapabilities;
   }
 
   buildUrl(routerId: string, envVars?: typeof process.env): string | undefined {

--- a/packages/core/src/llm/model/index.ts
+++ b/packages/core/src/llm/model/index.ts
@@ -6,6 +6,7 @@ export {
   type ModelForProvider,
   type AttachmentCapabilities,
   modelSupportsAttachments,
+  modelSupportsTemperature,
 } from './provider-registry.js';
 export { resolveModelConfig, isOpenAICompatibleObjectConfig } from './resolve-model';
 export { resolveModelAuth, type ResolveModelAuthArgs } from './model-auth-resolver';

--- a/packages/core/src/llm/model/provider-registry.test.ts
+++ b/packages/core/src/llm/model/provider-registry.test.ts
@@ -6,10 +6,16 @@ import type { ProviderConfig } from './gateways/base.js';
 import { MastraGateway } from './gateways/mastra.js';
 import { ModelsDevGateway } from './gateways/models-dev.js';
 import { NetlifyGateway } from './gateways/netlify.js';
-import { GatewayRegistry, modelSupportsAttachments } from './provider-registry.js';
+import {
+  GatewayRegistry,
+  modelSupportsAttachments,
+  modelSupportsTemperature,
+  _resetCapabilityCaches,
+} from './provider-registry.js';
 
 describe('modelSupportsAttachments', () => {
   afterEach(() => {
+    _resetCapabilityCaches();
     vi.restoreAllMocks();
   });
 
@@ -32,6 +38,35 @@ describe('modelSupportsAttachments', () => {
     expect(modelSupportsAttachments('mastra/openrouter/deepseek/deepseek-v4-flash')).toBe(false);
     expect(modelSupportsAttachments('openrouter/openai/gpt-4o')).toBe(true);
     expect(modelSupportsAttachments('mastra/openrouter/openai/gpt-4o')).toBe(true);
+  });
+});
+
+describe('modelSupportsTemperature', () => {
+  beforeEach(() => {
+    _resetCapabilityCaches();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true for models listed in the temperature capability', () => {
+    expect(modelSupportsTemperature('openai/gpt-4o')).toBe(true);
+    expect(modelSupportsTemperature('anthropic/claude-sonnet-4-6')).toBe(true);
+  });
+
+  it('returns false for models whose provider is known but model is not in temperature list', () => {
+    // gpt-5-pro is in the openai attachment list but NOT in the temperature list
+    expect(modelSupportsTemperature('openai/gpt-5-pro')).toBe(false);
+  });
+
+  it('returns undefined for unknown providers', () => {
+    expect(modelSupportsTemperature('unknown-provider/some-model')).toBeUndefined();
+  });
+
+  it('resolves nested provider model IDs through the fallback path', () => {
+    // openrouter/anthropic/claude-sonnet-4-6 should resolve via the nested provider fallback
+    expect(modelSupportsTemperature('openrouter/anthropic/claude-sonnet-4-6')).toBe(true);
+    expect(modelSupportsTemperature('openrouter/openai/gpt-5-pro')).toBe(false);
   });
 });
 

--- a/packages/core/src/llm/model/provider-registry.ts
+++ b/packages/core/src/llm/model/provider-registry.ts
@@ -434,10 +434,16 @@ export function getRegisteredProviders(): string[] {
 // ---------------------------------------------------------------------------
 
 interface ProviderCapabilityFile {
-  attachment: string[];
+  attachment?: string[];
+  temperature?: string[];
 }
 
-const providerCapCache = new Map<string, string[] | null>();
+type CapabilityDimension = keyof ProviderCapabilityFile;
+
+const providerCapCaches: Record<CapabilityDimension, Map<string, string[] | null>> = {
+  attachment: new Map(),
+  temperature: new Map(),
+};
 
 function isDirectory(dir: string): boolean {
   try {
@@ -476,8 +482,11 @@ function findCapabilitiesDirs(useDynamicLoading: boolean): string[] {
 
 let capabilitiesDirCache: string[] | undefined;
 
-function loadProviderAttachmentModels(provider: string, useDynamicLoading: boolean): string[] | null {
-  if (providerCapCache.has(provider)) return providerCapCache.get(provider)!;
+/** Parsed capability file cache — avoids re-reading JSON per dimension. */
+const parsedCapFileCache = new Map<string, ProviderCapabilityFile | null>();
+
+function loadProviderCapabilityFile(provider: string, useDynamicLoading: boolean): ProviderCapabilityFile | null {
+  if (parsedCapFileCache.has(provider)) return parsedCapFileCache.get(provider)!;
 
   if (capabilitiesDirCache === undefined) {
     capabilitiesDirCache = findCapabilitiesDirs(useDynamicLoading);
@@ -488,53 +497,93 @@ function loadProviderAttachmentModels(provider: string, useDynamicLoading: boole
     try {
       const content = fs.readFileSync(filePath, 'utf-8');
       const data = JSON.parse(content) as ProviderCapabilityFile;
-      providerCapCache.set(provider, data.attachment);
-      return data.attachment;
+      parsedCapFileCache.set(provider, data);
+      return data;
     } catch {
       continue;
     }
   }
 
-  providerCapCache.set(provider, null);
+  parsedCapFileCache.set(provider, null);
   return null;
 }
 
-/**
- * Check whether a model supports image/file attachments.
- * Reads only the per-provider capability file for the given model's provider.
- * Returns `true` if the model is listed, `false` if the provider is known but
- * the model isn't listed, or `undefined` when no data exists for the provider.
- */
-function getProviderAttachmentSupport(
+function loadProviderCapability(
+  provider: string,
+  dimension: CapabilityDimension,
+  useDynamicLoading: boolean,
+): string[] | null {
+  const cache = providerCapCaches[dimension];
+  if (cache.has(provider)) return cache.get(provider)!;
+
+  const file = loadProviderCapabilityFile(provider, useDynamicLoading);
+  const models = file?.[dimension] ?? null;
+  cache.set(provider, models);
+  return models;
+}
+
+function getProviderCapabilitySupport(
   provider: string,
   modelId: string,
+  dimension: CapabilityDimension,
   useDynamicLoading: boolean,
 ): boolean | undefined {
-  const models = loadProviderAttachmentModels(provider, useDynamicLoading);
+  const models = loadProviderCapability(provider, dimension, useDynamicLoading);
   if (!models) return undefined;
   return models.includes(modelId);
 }
 
-export function modelSupportsAttachments(modelRouterId: string): boolean | undefined {
+function modelSupportsCapability(modelRouterId: string, dimension: CapabilityDimension): boolean | undefined {
   const { provider, modelId } = parseModelString(modelRouterId);
   if (!provider) return undefined;
 
   const registry = GatewayRegistry.getInstance();
   const useDynamicLoading = registry['useDynamicLoading'];
-  const directSupport = getProviderAttachmentSupport(provider, modelId, useDynamicLoading);
-  if (directSupport !== undefined) return directSupport;
+  const directSupport = getProviderCapabilitySupport(provider, modelId, dimension, useDynamicLoading);
 
+  // Positive direct match wins immediately.
+  if (directSupport === true) return true;
+
+  // For nested model IDs (e.g. `openrouter/anthropic/claude-sonnet-4-6`), the
+  // outer gateway's capability list may not enumerate every nested model. Fall
+  // back to the underlying provider's authoritative capability file before
+  // trusting a `false` from the gateway.
   const nestedProviderDelimiter = modelId.indexOf('/');
   if (nestedProviderDelimiter !== -1) {
     const nestedProvider = modelId.substring(0, nestedProviderDelimiter);
     const nestedModelId = modelId.substring(nestedProviderDelimiter + 1);
     if (nestedProvider && nestedModelId) {
-      const nestedSupport = getProviderAttachmentSupport(nestedProvider, nestedModelId, useDynamicLoading);
+      const nestedSupport = getProviderCapabilitySupport(nestedProvider, nestedModelId, dimension, useDynamicLoading);
       if (nestedSupport !== undefined) return nestedSupport;
     }
   }
 
   return directSupport;
+}
+
+/** @internal Reset capability caches. For testing only. */
+export function _resetCapabilityCaches(): void {
+  for (const cache of Object.values(providerCapCaches)) cache.clear();
+  parsedCapFileCache.clear();
+  capabilitiesDirCache = undefined;
+}
+
+/**
+ * Check whether a model supports image/file attachments.
+ * Returns `true` if the model is listed, `false` if the provider is known but
+ * the model isn't listed, or `undefined` when no data exists for the provider.
+ */
+export function modelSupportsAttachments(modelRouterId: string): boolean | undefined {
+  return modelSupportsCapability(modelRouterId, 'attachment');
+}
+
+/**
+ * Check whether a model supports the `temperature` sampling parameter.
+ * Returns `true` if the model is listed, `false` if the provider is known but
+ * the model isn't listed, or `undefined` when no data exists for the provider.
+ */
+export function modelSupportsTemperature(modelRouterId: string): boolean | undefined {
+  return modelSupportsCapability(modelRouterId, 'temperature');
 }
 
 /**
@@ -647,7 +696,8 @@ export class GatewayRegistry {
       const gateways = [...defaultGateways, ...this.customGateways];
 
       // Fetch provider data
-      const { providers, models, attachmentCapabilities, failedGateways } = await fetchProvidersFromGateways(gateways);
+      const { providers, models, attachmentCapabilities, temperatureCapabilities, failedGateways } =
+        await fetchProvidersFromGateways(gateways);
 
       // If any gateway failed, skip writing to prevent partial results from
       // overwriting the complete bundled registry. The existing static registry
@@ -670,6 +720,7 @@ export class GatewayRegistry {
           providers,
           models,
           attachmentCapabilities,
+          temperatureCapabilities,
         );
         // console.debug(`[GatewayRegistry] ✅ Updated global cache at ${CACHE_DIR()}`);
       } catch (error) {
@@ -680,7 +731,14 @@ export class GatewayRegistry {
       const distJsonPath = path.join(packageRoot, 'dist', 'provider-registry.json');
       const distTypesPath = path.join(packageRoot, 'dist', 'llm', 'model', 'provider-types.generated.d.ts');
 
-      await writeRegistryFiles(distJsonPath, distTypesPath, providers, models, attachmentCapabilities);
+      await writeRegistryFiles(
+        distJsonPath,
+        distTypesPath,
+        providers,
+        models,
+        attachmentCapabilities,
+        temperatureCapabilities,
+      );
       // console.debug(`[GatewayRegistry] ✅ Updated registry files in dist/`);
 
       // Copy to src/ only when explicitly requested (e.g., running the generation script)
@@ -708,7 +766,8 @@ export class GatewayRegistry {
       // Clear the in-memory cache to force reload (dynamic loading only)
       if (this.useDynamicLoading) {
         registryData = null;
-        providerCapCache.clear();
+        for (const cache of Object.values(providerCapCaches)) cache.clear();
+        parsedCapFileCache.clear();
         capabilitiesDirCache = undefined;
       }
 

--- a/packages/core/src/llm/model/registry-generator.ts
+++ b/packages/core/src/llm/model/registry-generator.ts
@@ -5,11 +5,20 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import type { AttachmentCapabilities, MastraModelGatewayInterface, ProviderConfig } from './gateways/base.js';
+import type {
+  AttachmentCapabilities,
+  MastraModelGatewayInterface,
+  ProviderConfig,
+  TemperatureCapabilities,
+} from './gateways/base.js';
 import { getGatewayId, shouldEnableGateway } from './gateways/index.js';
 
 interface GatewayWithAttachmentCapabilities {
   getAttachmentCapabilities(): AttachmentCapabilities;
+}
+
+interface GatewayWithTemperatureCapabilities {
+  getTemperatureCapabilities(): TemperatureCapabilities;
 }
 
 function hasAttachmentCapabilities(
@@ -18,6 +27,15 @@ function hasAttachmentCapabilities(
   return (
     'getAttachmentCapabilities' in gateway &&
     typeof (gateway as { getAttachmentCapabilities?: unknown }).getAttachmentCapabilities === 'function'
+  );
+}
+
+function hasTemperatureCapabilities(
+  gateway: MastraModelGatewayInterface,
+): gateway is MastraModelGatewayInterface & GatewayWithTemperatureCapabilities {
+  return (
+    'getTemperatureCapabilities' in gateway &&
+    typeof (gateway as { getTemperatureCapabilities?: unknown }).getTemperatureCapabilities === 'function'
   );
 }
 
@@ -71,6 +89,7 @@ export async function fetchProvidersFromGateways(gateways: MastraModelGatewayInt
   providers: Record<string, ProviderConfig>;
   models: Record<string, string[]>;
   attachmentCapabilities: AttachmentCapabilities;
+  temperatureCapabilities: TemperatureCapabilities;
   failedGateways: string[];
 }> {
   const enabledGateways: MastraModelGatewayInterface[] = [];
@@ -84,6 +103,7 @@ export async function fetchProvidersFromGateways(gateways: MastraModelGatewayInt
   const allProviders: Record<string, ProviderConfig> = {};
   const allModels: Record<string, string[]> = {};
   const allAttachmentCapabilities: AttachmentCapabilities = {};
+  const allTemperatureCapabilities: TemperatureCapabilities = {};
   const failedGateways: string[] = [];
 
   const maxRetries = 3;
@@ -112,8 +132,11 @@ export async function fetchProvidersFromGateways(gateways: MastraModelGatewayInt
     // models.dev is a provider registry, not a true gateway - don't prefix its providers
     const isProviderRegistry = gatewayId === 'models.dev';
 
-    // Collect attachment capabilities if the gateway exposes them
+    // Collect capabilities if the gateway exposes them
     const gatewayAttachmentCaps = hasAttachmentCapabilities(gateway) ? gateway.getAttachmentCapabilities() : undefined;
+    const gatewayTemperatureCaps = hasTemperatureCapabilities(gateway)
+      ? gateway.getTemperatureCapabilities()
+      : undefined;
 
     for (const [providerId, config] of Object.entries(providers)) {
       // For true gateways, use gateway id as prefix (e.g., "netlify/anthropic")
@@ -129,9 +152,12 @@ export async function fetchProvidersFromGateways(gateways: MastraModelGatewayInt
       // Sort models alphabetically for consistent ordering
       allModels[typeProviderId] = config.models.sort();
 
-      // Merge attachment capabilities for this provider if available
+      // Merge capabilities for this provider if available
       if (gatewayAttachmentCaps?.[providerId]) {
         allAttachmentCapabilities[typeProviderId] = gatewayAttachmentCaps[providerId];
+      }
+      if (gatewayTemperatureCaps?.[providerId]) {
+        allTemperatureCapabilities[typeProviderId] = gatewayTemperatureCaps[providerId];
       }
     }
   }
@@ -140,6 +166,7 @@ export async function fetchProvidersFromGateways(gateways: MastraModelGatewayInt
     providers: allProviders,
     models: allModels,
     attachmentCapabilities: allAttachmentCapabilities,
+    temperatureCapabilities: allTemperatureCapabilities,
     failedGateways,
   };
 }
@@ -231,6 +258,7 @@ export async function writeRegistryFiles(
   providers: Record<string, ProviderConfig>,
   models: Record<string, string[]>,
   attachmentCapabilities?: AttachmentCapabilities,
+  temperatureCapabilities?: TemperatureCapabilities,
 ): Promise<void> {
   // 0. Ensure directories exist
   const jsonDir = path.dirname(jsonPath);
@@ -252,7 +280,10 @@ export async function writeRegistryFiles(
   await atomicWriteFile(typesPath, typeContent, 'utf-8');
 
   // 3. Write per-provider capability files into a capabilities/ directory
-  if (attachmentCapabilities && Object.keys(attachmentCapabilities).length > 0) {
+  const hasCapabilities =
+    (attachmentCapabilities && Object.keys(attachmentCapabilities).length > 0) ||
+    (temperatureCapabilities && Object.keys(temperatureCapabilities).length > 0);
+  if (hasCapabilities) {
     const capDir = path.join(jsonDir, 'capabilities');
     await fs.mkdir(capDir, { recursive: true });
 
@@ -268,9 +299,19 @@ export async function writeRegistryFiles(
       // Directory may not exist yet — ignore
     }
 
-    for (const [provider, models] of Object.entries(attachmentCapabilities)) {
+    // Build a merged capability object per provider
+    const allProviderIds = new Set([
+      ...(attachmentCapabilities ? Object.keys(attachmentCapabilities) : []),
+      ...(temperatureCapabilities ? Object.keys(temperatureCapabilities) : []),
+    ]);
+
+    for (const provider of allProviderIds) {
+      const capData: Record<string, string[]> = {};
+      if (attachmentCapabilities?.[provider]) capData.attachment = attachmentCapabilities[provider];
+      if (temperatureCapabilities?.[provider]) capData.temperature = temperatureCapabilities[provider];
+
       const providerFile = path.join(capDir, `${provider}.json`);
-      await atomicWriteFile(providerFile, JSON.stringify({ attachment: models }, null, 2), 'utf-8');
+      await atomicWriteFile(providerFile, JSON.stringify(capData, null, 2), 'utf-8');
     }
   }
 }

--- a/packages/core/src/llm/model/router-custom-provider.test.ts
+++ b/packages/core/src/llm/model/router-custom-provider.test.ts
@@ -210,4 +210,122 @@ describe('ModelRouter - Custom Provider Support', () => {
       }).rejects.toThrow(/Could not find config for provider unknown-provider/);
     });
   });
+
+  describe('Temperature stripping via capability registry', () => {
+    it('strips temperature from doGenerate when model does not support it', async () => {
+      const receivedOptions: any[] = [];
+      vi.mocked(createOpenAICompatible).mockReturnValue({
+        chatModel: vi.fn(() =>
+          createMockModel({
+            mockText: 'ok',
+            spyGenerate: props => receivedOptions.push(props),
+          }),
+        ),
+      } as any);
+
+      const agent = new Agent({
+        id: 'test-strip-temp',
+        name: 'test',
+        instructions: 'Reply ok',
+        model: {
+          id: 'openai/gpt-5-pro',
+          url: 'http://fake.local:9999/v1',
+          apiKey: 'test-key',
+        },
+      });
+
+      await agent.generate('hi', { maxSteps: 1, modelSettings: { temperature: 0.7, topP: 0.9 } });
+
+      expect(receivedOptions).toHaveLength(1);
+      expect(receivedOptions[0].temperature).toBeUndefined();
+      expect(receivedOptions[0].topP).toBeUndefined();
+    });
+
+    it('preserves temperature for models that support it', async () => {
+      const receivedOptions: any[] = [];
+      vi.mocked(createOpenAICompatible).mockReturnValue({
+        chatModel: vi.fn(() =>
+          createMockModel({
+            mockText: 'ok',
+            spyGenerate: props => receivedOptions.push(props),
+          }),
+        ),
+      } as any);
+
+      const agent = new Agent({
+        id: 'test-keep-temp',
+        name: 'test',
+        instructions: 'Reply ok',
+        model: {
+          id: 'openai/gpt-4o',
+          url: 'http://fake.local:9999/v1',
+          apiKey: 'test-key',
+        },
+      });
+
+      await agent.generate('hi', { maxSteps: 1, modelSettings: { temperature: 0.7 } });
+
+      expect(receivedOptions).toHaveLength(1);
+      expect(receivedOptions[0].temperature).toBe(0.7);
+    });
+
+    it('strips temperature from doStream when model does not support it', async () => {
+      const receivedOptions: any[] = [];
+      vi.mocked(createOpenAICompatible).mockReturnValue({
+        chatModel: vi.fn(() =>
+          createMockModel({
+            mockText: 'ok',
+            spyStream: props => receivedOptions.push(props),
+          }),
+        ),
+      } as any);
+
+      const agent = new Agent({
+        id: 'test-strip-temp-stream',
+        name: 'test',
+        instructions: 'Reply ok',
+        model: {
+          id: 'openai/gpt-5-pro',
+          url: 'http://fake.local:9999/v1',
+          apiKey: 'test-key',
+        },
+      });
+
+      const result = await agent.stream('hi', { maxSteps: 1, modelSettings: { temperature: 0.7, topK: 40 } });
+      await result.text;
+
+      expect(receivedOptions).toHaveLength(1);
+      expect(receivedOptions[0].temperature).toBeUndefined();
+      expect(receivedOptions[0].topK).toBeUndefined();
+    });
+
+    it('preserves temperature for unknown providers (registry returns undefined)', async () => {
+      const receivedOptions: any[] = [];
+      vi.mocked(createOpenAICompatible).mockReturnValue({
+        chatModel: vi.fn(() =>
+          createMockModel({
+            mockText: 'ok',
+            spyGenerate: props => receivedOptions.push(props),
+          }),
+        ),
+      } as any);
+
+      const agent = new Agent({
+        id: 'test-unknown-provider',
+        name: 'test',
+        instructions: 'Reply ok',
+        model: {
+          id: 'my-custom-provider/my-model',
+          url: 'http://fake.local:9999/v1',
+          apiKey: 'test-key',
+        },
+      });
+
+      await agent.generate('hi', { maxSteps: 1, modelSettings: { temperature: 0.5, topP: 0.8 } });
+
+      expect(receivedOptions).toHaveLength(1);
+      expect(receivedOptions[0].temperature).toBe(0.5);
+      expect(receivedOptions[0].topP).toBe(0.8);
+    });
+  });
 });

--- a/packages/core/src/llm/model/router.ts
+++ b/packages/core/src/llm/model/router.ts
@@ -24,6 +24,7 @@ import { createOpenAIWebSocketFetch } from './openai-websocket-fetch.js';
 import type { OpenAIWebSocketFetch } from './openai-websocket-fetch.js';
 import type { OpenAITransport, ProviderOptions, ResponsesWebSocketOptions } from './provider-options.js';
 import type { ModelRouterModelId } from './provider-registry.js';
+import { modelSupportsTemperature } from './provider-registry.js';
 import type { MastraLanguageModelV2, OpenAICompatibleConfig } from './shared.types';
 
 export { defaultGateways, gateways } from './gateways/defaults.js';
@@ -355,6 +356,15 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     this.setStreamTransportHandle({ resolvedTransport, transport, responsesWebSocket });
   }
 
+  private stripUnsupportedSamplingParams(options: LanguageModelV2CallOptions): LanguageModelV2CallOptions {
+    const supports = modelSupportsTemperature(this.config.routerId);
+    if (supports !== false) return options;
+
+    const { temperature, topP, topK, ...rest } = options;
+    if (temperature === undefined && topP === undefined && topK === undefined) return options;
+    return rest;
+  }
+
   async doGenerate(options: LanguageModelV2CallOptions): Promise<StreamResult> {
     const resolved = this.#manager.resolveModelId(this.config.routerId);
     let auth: GatewayAuthResult;
@@ -377,6 +387,8 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       };
     }
 
+    const sanitizedOptions = this.stripUnsupportedSamplingParams(options);
+
     const model = await this.resolveLanguageModel({
       apiKey: auth.apiKey ?? '',
       auth,
@@ -387,16 +399,14 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     // Handle V2, V3, and V4 models
     if (isLanguageModelV4(model)) {
       const aiSDKV7Model = new AISDKV7LanguageModel(model);
-      // Cast V4 stream result to V2 format - the stream contents are compatible at runtime
-      return aiSDKV7Model.doGenerate(options as any) as unknown as Promise<StreamResult>;
+      return aiSDKV7Model.doGenerate(sanitizedOptions as any) as unknown as Promise<StreamResult>;
     }
     if (isLanguageModelV3(model)) {
       const aiSDKV6Model = new AISDKV6LanguageModel(model);
-      // Cast V3 stream result to V2 format - the stream contents are compatible at runtime
-      return aiSDKV6Model.doGenerate(options as any) as unknown as Promise<StreamResult>;
+      return aiSDKV6Model.doGenerate(sanitizedOptions as any) as unknown as Promise<StreamResult>;
     }
     const aiSDKV5Model = new AISDKV5LanguageModel(model);
-    return aiSDKV5Model.doGenerate(options);
+    return aiSDKV5Model.doGenerate(sanitizedOptions);
   }
 
   async doStream(options: LanguageModelV2CallOptions): Promise<StreamResult> {
@@ -422,8 +432,10 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       };
     }
 
+    const sanitizedOptions = this.stripUnsupportedSamplingParams(options);
+
     const { transport, websocket } = getOpenAITransport(
-      options.providerOptions as ProviderOptions | undefined,
+      sanitizedOptions.providerOptions as ProviderOptions | undefined,
       resolved.providerId,
     );
     const requestedTransport: OpenAITransport = transport === 'auto' ? 'websocket' : transport;
@@ -448,19 +460,19 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     if (isLanguageModelV4(model)) {
       const aiSDKV7Model = new AISDKV7LanguageModel(model);
       // Cast V4 stream result to V2 format - the stream contents are compatible at runtime
-      const streamResult = (await aiSDKV7Model.doStream(options as any)) as unknown as StreamResult;
+      const streamResult = (await aiSDKV7Model.doStream(sanitizedOptions as any)) as unknown as StreamResult;
       attachModelStreamTransport(streamResult, streamTransport);
       return streamResult;
     }
     if (isLanguageModelV3(model)) {
       const aiSDKV6Model = new AISDKV6LanguageModel(model);
       // Cast V3 stream result to V2 format - the stream contents are compatible at runtime
-      const streamResult = (await aiSDKV6Model.doStream(options as any)) as unknown as StreamResult;
+      const streamResult = (await aiSDKV6Model.doStream(sanitizedOptions as any)) as unknown as StreamResult;
       attachModelStreamTransport(streamResult, streamTransport);
       return streamResult;
     }
     const aiSDKV5Model = new AISDKV5LanguageModel(model);
-    const streamResult = await aiSDKV5Model.doStream(options);
+    const streamResult = await aiSDKV5Model.doStream(sanitizedOptions);
     attachModelStreamTransport(streamResult, streamTransport);
     return streamResult;
   }


### PR DESCRIPTION
## Description

Extends the model capability registry to include a `temperature` dimension so the model router can proactively strip unsupported sampling parameters (`temperature`, `topP`, `topK`) before dispatching requests. Models like `claude-opus-4-7` and `gpt-5-pro` that report `temperature: false` on models.dev now have these parameters silently removed, preventing 400 errors with zero user configuration.

- Generalized the attachment-only capability loader into a multi-dimension system (`CapabilityDimension`) that reads both `attachment` and `temperature` from per-provider JSON files
- Added `modelSupportsTemperature()` public lookup function following the same pattern as `modelSupportsAttachments()`
- Added `stripUnsupportedSamplingParams()` in `ModelRouterLanguageModel` that checks the registry before every `doGenerate` and `doStream` call
- Extended `ModelsDevGateway.fetchProviders()` to collect `temperature` capability data from models.dev alongside attachments
- Updated `registry-generator` and `generate-providers` script to write merged capability files with both dimensions
- Added temperature data to `anthropic.json` and `openai.json` capability files sourced from the live models.dev API

## Related Issue(s)

Fixes #16247

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Some AI models only accept certain “settings” (like how random the output should be). This PR teaches Mastra to check whether a model supports `temperature`/`topP`/`topK` and automatically removes unsupported ones so requests don’t fail with 400 errors.

## Summary
- Extended the model capability registry to support a new `temperature` capability dimension (alongside existing `attachment` support), with a new `modelSupportsTemperature()` lookup exported from core.
- Generalized the registry/capability loader/generator from attachment-only to multi-dimension capability files, merging `attachment` and `temperature` per provider.
- Updated `ModelsDevGateway.fetchProviders()` to collect temperature-capable model IDs from models.dev and include them when generating the registries.
- Updated the router (`ModelRouterLanguageModel`) to strip unsupported sampling parameters before dispatch:
  - removes `temperature` and `topP` when the target model doesn’t support temperature
  - additionally removes `topK` for streaming when unsupported
- Refreshed `anthropic.json` and `openai.json` capability lists to reflect temperature support from live models.dev.
- Added tests validating that the router strips or preserves these parameters depending on `modelSupportsTemperature()`.

## Notes / known limitations
- Capability matching won’t work for custom proxy aliases (capabilities are keyed to real model IDs).
- Support is treated as a simple on/off capability and can’t express conditional “only reject in certain scenarios” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->