### PR TITLE
fix(schema-compat): escape discriminator key in generated discriminatedUnion

### DIFF
--- a/.changeset/escape-discriminated-union-key.md
+++ b/.changeset/escape-discriminated-union-key.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed invalid code being generated for a discriminated union when the discriminator property name contains a double quote. The property name was inserted into the `z.discriminatedUnion(...)` call without escaping, while object keys, descriptions, and defaults are serialized with `JSON.stringify`. As a result the serialized schema threw a SyntaxError when it was evaluated. The discriminator key is now escaped the same way as the object keys it refers to.

--- a/packages/schema-compat/src/json-to-zod.test.ts
+++ b/packages/schema-compat/src/json-to-zod.test.ts
@@ -283,6 +283,43 @@ describe('jsonSchemaToZod', () => {
       // Should use the first common discriminator (category)
       expect(result).toContain('"category"');
     });
+
+    it('should escape the discriminator property name so the generated code stays valid', () => {
+      // A JSON Schema property name can contain a double quote. Object keys, descriptions
+      // and defaults in the output are serialized with JSON.stringify, but the
+      // discriminatedUnion key was interpolated raw, producing code that throws a
+      // SyntaxError when evaluated at runtime with Function().
+      const schema: JsonSchema = {
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              'ty"pe': { const: 'cat' },
+              name: { type: 'string' },
+            },
+            required: ['ty"pe', 'name'],
+          },
+          {
+            type: 'object',
+            properties: {
+              'ty"pe': { const: 'dog' },
+              name: { type: 'string' },
+            },
+            required: ['ty"pe', 'name'],
+          },
+        ],
+      };
+
+      const result = jsonSchemaToZod(schema);
+      expect(result).toContain('z.discriminatedUnion');
+      // The discriminator key is escaped the same way as the object key.
+      expect(result).toContain(JSON.stringify('ty"pe'));
+
+      // The generated string is evaluated at runtime with Function(); it must not throw.
+      const build = () => new Function('z', `return ${result}`)(z);
+      expect(build).not.toThrow();
+      expect(build().safeParse({ 'ty"pe': 'cat', name: 'Tom' }).success).toBe(true);
+    });
   });
 
   describe('Object Parsing', () => {

--- a/packages/schema-compat/src/json-to-zod.ts
+++ b/packages/schema-compat/src/json-to-zod.ts
@@ -257,7 +257,7 @@ const parserOverride = (schema: JsonSchemaObject, refs: Refs) => {
         if (discriminators.length > 0) {
           const discriminator = discriminators[0];
           if (discriminator) {
-            parsed = `z.discriminatedUnion("${discriminator}", [${schema.anyOf
+            parsed = `z.discriminatedUnion(${JSON.stringify(discriminator)}, [${schema.anyOf
               .map((schema, i) =>
                 parseSchema(schema, {
                   ...refs,


### PR DESCRIPTION
## Problem

`@mastra/schema-compat`'s `jsonSchemaToZod` builds a Zod schema as a source string that is later evaluated at runtime with `Function()`. When it detects a discriminated union (an `anyOf` of objects that share a `const` property), it inserts the discriminator property name into the generated `z.discriminatedUnion(...)` call directly:

```ts
parsed = `z.discriminatedUnion("${discriminator}", [${schema.anyOf...}])`;
```

Every other string this generator emits is serialized with `JSON.stringify` (object keys, `.describe(...)`, `.default(...)`), but the discriminator key is interpolated raw. A JSON Schema property name may legally contain a double quote, so a name such as `ty"pe` produces:

```
z.discriminatedUnion("ty"pe", [z.object({ "ty\"pe": z.literal("cat"), ... }), ...])
```

The object key is escaped correctly (`"ty\"pe"`), but the `discriminatedUnion` argument is not, so the generated string throws `SyntaxError: missing ) after argument list` when it is evaluated. This is the same kind of runtime `Function()` failure that was fixed for `parseOneOf` in #11610.

## Solution

Serialize the discriminator key with `JSON.stringify`, the same helper already used for the object keys it refers to:

```ts
parsed = `z.discriminatedUnion(${JSON.stringify(discriminator)}, [${schema.anyOf...}])`;
```

For any ordinary property name this is byte-identical to the previous output, since `JSON.stringify("type") === '"type"'`, so existing schemas generate exactly the same code.

## Verification

I added a test in the `DiscriminatedUnion Detection` block that uses a discriminator name containing a double quote, evaluates the generated string with `Function()` the way the output is consumed, and asserts it no longer throws and parses a matching value.

- Before the change the new test fails: the generated code throws a SyntaxError when evaluated.
- After the change it passes.
- The existing discriminated-union tests are unaffected, because the generated code for their normal property names is identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a bug where a special character in a schema property name could break generated code. Now the property name is safely escaped before being put into the code, so schemas with quotes in their discriminator key work correctly.

### Changes
- Fixed `jsonSchemaToZod` to serialize discriminated-union keys with `JSON.stringify`, matching other generated strings.
- Added a test that uses a discriminator name containing a double quote and verifies the generated code runs and parses successfully.
- Added a changeset entry documenting the patch release for `@mastra/schema-compat`.

### Why
- Prevents runtime `SyntaxError` when JSON Schema discriminator keys contain double quotes.
- Keeps normal output unchanged for standard property names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->