### PR TITLE
chore(docs): Add missing harness redirects

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -824,6 +824,16 @@
       "source": "/docs/harness/tool-approvals",
       "destination": "/docs/agent-controller/tool-approvals",
       "permanent": true
+    },
+    {
+      "source": "/reference/harness/harness-class",
+      "destination": "/reference/agent-controller/agent-controller-class",
+      "permanent": true
+    },
+    {
+      "source": "/reference/harness/session",
+      "destination": "/reference/agent-controller/session",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This update adds a couple of “send people to the right page” rules in the docs site, so old Harness links now go to the newer Agent Controller pages instead of breaking. It helps readers find the right reference pages without needing to update every old link.

## Summary
- Added permanent redirects in `docs/vercel.json` for:
  - `/reference/harness/harness-class` → `/reference/agent-controller/agent-controller-class`
  - `/reference/harness/session` → `/reference/agent-controller/session`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->