### PR TITLE
fix(client-js): send page/perPage in logs queries when they are 0

### DIFF
--- a/.changeset/fix-client-js-logs-pagination-zero.md
+++ b/.changeset/fix-client-js-logs-pagination-zero.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fix `listLogs` and `getLogForRun` dropping the `page` and `perPage` query parameters when they are `0`. Requesting the first page with `page: 0` (or `perPage: 0`) now sends those values instead of falling back to the server defaults. Closes #18631.

--- a/client-sdks/client-js/src/client-logs-pagination.test.ts
+++ b/client-sdks/client-js/src/client-logs-pagination.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, beforeEach, it, vi } from 'vitest';
+import { MastraClient } from './client';
+
+global.fetch = vi.fn();
+
+function mockJsonResponse() {
+  (global.fetch as any).mockResolvedValueOnce({
+    ok: true,
+    headers: { get: () => 'application/json' },
+    json: async () => ({}),
+  });
+}
+
+function lastFetchUrl(): string {
+  const calls = (global.fetch as any).mock.calls;
+  return calls[calls.length - 1][0] as string;
+}
+
+describe('MastraClient logs pagination params', () => {
+  let client: MastraClient;
+
+  beforeEach(() => {
+    (global.fetch as any).mockClear();
+    client = new MastraClient({ baseUrl: 'http://localhost:3000' });
+  });
+
+  it('listLogs sends page and perPage even when they are 0', async () => {
+    mockJsonResponse();
+    await client.listLogs({ transportId: 't', page: 0, perPage: 0 });
+
+    const url = lastFetchUrl();
+    expect(url).toContain('page=0');
+    expect(url).toContain('perPage=0');
+  });
+
+  it('getLogForRun sends page and perPage even when they are 0', async () => {
+    mockJsonResponse();
+    await client.getLogForRun({ runId: 'r', transportId: 't', page: 0, perPage: 0 });
+
+    const url = lastFetchUrl();
+    expect(url).toContain('page=0');
+    expect(url).toContain('perPage=0');
+  });
+});

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -622,10 +622,10 @@ export class MastraClient extends BaseResource {
     if (logLevel) {
       searchParams.set('logLevel', logLevel);
     }
-    if (page) {
+    if (page !== undefined) {
       searchParams.set('page', String(page));
     }
-    if (perPage) {
+    if (perPage !== undefined) {
       searchParams.set('perPage', String(perPage));
     }
     if (_filters) {
@@ -670,10 +670,10 @@ export class MastraClient extends BaseResource {
     if (logLevel) {
       searchParams.set('logLevel', logLevel);
     }
-    if (page) {
+    if (page !== undefined) {
       searchParams.set('page', String(page));
     }
-    if (perPage) {
+    if (perPage !== undefined) {
       searchParams.set('perPage', String(perPage));
     }
 


### PR DESCRIPTION
## What

`client.listLogs` and `client.getLogForRun` drop the `page` and `perPage` query parameters when they are `0`, because they guard with a truthy check:

```ts
if (page) {
  searchParams.set('page', String(page));
}
if (perPage) {
  searchParams.set('perPage', String(perPage));
}
```

`page`/`perPage` are optional `number`s, so `if (page)` is falsy for `0`. Requesting the first page with `page: 0` (or `perPage: 0`) never sends those values and the server falls back to its own defaults, returning the wrong page.

Every other paginated method in the client guards with `!== undefined` (`listMemoryThreads`, `getMcpServers`, `listScoresByRunId`, the `resources/` methods, etc.). These two log methods are the only sites using a truthy check.

## Change

Change the four guards in `listLogs` and `getLogForRun` to `!== undefined`.

## Tests

Added unit tests asserting `listLogs` and `getLogForRun` include `page=0` and `perPage=0` in the request URL. Both fail on the current code and pass after the fix. The existing `client.test.ts` suite still passes.

Closes #18631

---

cc @abhiaiyer91 who last touched this file. One-line-per-site change, no behavior change for non-zero values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a bug where asking for the first page of logs could accidentally be ignored. Now, when `page` or `perPage` is set to `0`, the client still sends it properly instead of skipping it and using the server’s default.

### What changed
- Fixed `client.listLogs` and `client.getLogForRun` to keep `page=0` and `perPage=0` in query strings by checking for `!== undefined` instead of truthy values.
- Added unit tests to confirm both methods include zero-valued pagination parameters in the request URL.
- Added a changeset for `@mastra/client-js`.

### Notes
- This resolves the pagination bug for zero values and closes the referenced issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->