### PR TITLE
feat(meilisearch): add @mastra/meilisearch vector store

### DIFF
--- a/.changeset/ready-tables-sneeze.md
+++ b/.changeset/ready-tables-sneeze.md
@@ -1,0 +1,34 @@
+---
+'@mastra/meilisearch': minor
+---
+
+Added `@mastra/meilisearch`, a vector store for semantic recall and RAG backed by [Meilisearch](https://www.meilisearch.com/) (GA vector search, v1.13+).
+
+It implements the standard `MastraVector` interface, so it drops into the same places as the other vector stores:
+
+```typescript
+import { MeilisearchVector } from '@mastra/meilisearch';
+
+const store = new MeilisearchVector({
+  id: 'meilisearch',
+  host: process.env.MEILISEARCH_HOST, // e.g. 'http://localhost:7700'
+  apiKey: process.env.MEILISEARCH_API_KEY,
+});
+
+await store.createIndex({ indexName: 'docs', dimension: 1536 });
+
+await store.upsert({
+  indexName: 'docs',
+  vectors: embeddings,
+  metadata: chunks.map(chunk => ({ text: chunk.text })),
+});
+
+const results = await store.query({
+  indexName: 'docs',
+  queryVector: embedding,
+  topK: 5,
+  filter: { category: 'electronics' },
+});
+```
+
+Mastra supplies the embeddings, so the store configures each index with a `userProvided` embedder and never embeds text itself. Similarity is cosine, and each result's `score` is Meilisearch's `_rankingScore`. MongoDB-style metadata filters are supported (`$eq`, `$ne`, `$gt`/`$gte`/`$lt`/`$lte`, `$in`, `$nin`, `$all`, `$and`, `$or`, `$not`, `$nor`, `$exists`); operators Meilisearch can't express (`$regex`, `$contains`, `$elemMatch`, `$size`) are not supported.

--- a/docs/src/content/en/docs/rag/vector-databases.mdx
+++ b/docs/src/content/en/docs/rag/vector-databases.mdx
@@ -8,6 +8,7 @@ packages:
   - "@mastra/couchbase"
   - "@mastra/elasticsearch"
   - "@mastra/lance"
+  - "@mastra/meilisearch"
   - "@mastra/mongodb"
   - "@mastra/opensearch"
   - "@mastra/pg"
@@ -245,6 +246,29 @@ After generating embeddings, you need to store them in a database that supports 
     import { OpenSearchVector } from '@mastra/opensearch'
 
     const store = new OpenSearchVector({ id: 'opensearch', node: process.env.OPENSEARCH_URL })
+
+    await store.createIndex({
+      indexName: 'my-collection',
+      dimension: 1536,
+    })
+
+    await store.upsert({
+      indexName: 'my-collection',
+      vectors: embeddings,
+      metadata: chunks.map(chunk => ({ text: chunk.text })),
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="meilisearch" label="Meilisearch">
+    ```ts title="vector-store.ts"
+    import { MeilisearchVector } from '@mastra/meilisearch'
+
+    const store = new MeilisearchVector({
+      id: 'meilisearch',
+      host: process.env.MEILISEARCH_HOST,
+      apiKey: process.env.MEILISEARCH_API_KEY,
+    })
 
     await store.createIndex({
       indexName: 'my-collection',
@@ -504,6 +528,15 @@ Each vector database enforces specific naming conventions for indexes and collec
     - Example: `my-index-123` is valid
     - Example: `My_Index` is not valid (contains uppercase letters)
     - Example: `_myindex` is not valid (begins with underscore)
+  </TabItem>
+
+  <TabItem value="meilisearch" label="Meilisearch">
+    Index names (Meilisearch index UIDs) must:
+
+    - Contain only alphanumeric characters (`a-z`, `A-Z`, `0-9`), hyphens (`-`), and underscores (`_`)
+    - Not exceed 512 bytes
+    - Example: `my-index_123` is valid
+    - Example: `my index` is not valid (contains a space)
   </TabItem>
 
   <TabItem value="elasticsearch" label="Elasticsearch">

--- a/docs/src/content/en/reference/vectors/meilisearch.mdx
+++ b/docs/src/content/en/reference/vectors/meilisearch.mdx
@@ -1,0 +1,292 @@
+---
+title: "Reference: Meilisearch vector store | Vectors"
+description: Documentation for the MeilisearchVector class in Mastra, which provides vector search using Meilisearch.
+packages:
+  - "@mastra/meilisearch"
+---
+
+# Meilisearch vector store
+
+The `MeilisearchVector` class provides vector search using [Meilisearch](https://www.meilisearch.com/), a search engine with built-in vector search. It uses Meilisearch's GA vector store (available in v1.13 and later) to perform similarity search over embeddings you supply.
+
+Mastra generates the embeddings, so the store configures each index with a `userProvided` embedder and never embeds text itself. Meilisearch uses cosine similarity, and the query score returned for each result is Meilisearch's `_rankingScore`.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MeilisearchVector } from '@mastra/meilisearch'
+
+const store = new MeilisearchVector({
+  id: 'meilisearch',
+  host: process.env.MEILISEARCH_HOST, // e.g. 'http://localhost:7700'
+  apiKey: process.env.MEILISEARCH_API_KEY,
+})
+
+await store.createIndex({
+  indexName: 'my-collection',
+  dimension: 1536,
+})
+
+await store.upsert({
+  indexName: 'my-collection',
+  vectors: embeddings,
+  metadata: chunks.map(chunk => ({ text: chunk.text })),
+})
+```
+
+## Constructor options
+
+The constructor accepts all Meilisearch client [config options](https://github.com/meilisearch/meilisearch-js) plus a required `id` field.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Unique identifier for this vector store instance',
+  },
+  {
+    name: 'host',
+    type: 'string',
+    description: "The Meilisearch host URL (e.g., 'http://localhost:7700')",
+  },
+  {
+    name: 'apiKey',
+    type: 'string',
+    description: 'API key (master or admin key) used to authenticate requests',
+    isOptional: true,
+  },
+]}
+/>
+
+## Methods
+
+### `createIndex()`
+
+Creates a new index configured with a `userProvided` embedder of the given dimension. Meilisearch only supports cosine similarity, so a non-cosine `metric` logs a warning and is treated as `cosine`.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'indexName',
+    type: 'string',
+    description: 'The name of the index to create',
+  },
+  {
+    name: 'dimension',
+    type: 'number',
+    description: 'The dimension of the vectors to be stored in the index',
+  },
+  {
+    name: 'metric',
+    type: "'cosine' | 'euclidean' | 'dotproduct'",
+    description: 'The distance metric. Meilisearch supports cosine only; other values are treated as cosine.',
+    defaultValue: "'cosine'",
+    isOptional: true,
+  },
+]}
+/>
+
+### `listIndexes()`
+
+Lists all indexes in the Meilisearch instance.
+
+Returns: `Promise<string[]>`
+
+### `describeIndex()`
+
+Gets information about an index. The returned `metric` is always `cosine`.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'indexName',
+    type: 'string',
+    description: 'The name of the index to describe',
+  },
+]}
+/>
+
+Returns: `Promise<{ dimension: number; count: number; metric: 'cosine' }>`
+
+### `deleteIndex()`
+
+<PropertiesTable
+  content={[
+  {
+    name: 'indexName',
+    type: 'string',
+    description: 'The name of the index to delete',
+  },
+]}
+/>
+
+### `upsert()`
+
+Inserts or replaces vectors and metadata. New metadata keys are registered as filterable attributes automatically the first time they are upserted, so you can filter on them afterward.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'indexName',
+    type: 'string',
+    description: 'The name of the index to upsert vectors into',
+  },
+  {
+    name: 'vectors',
+    type: 'number[][]',
+    description: 'Array of vector embeddings to insert',
+  },
+  {
+    name: 'metadata',
+    type: 'Record<string, any>[]',
+    description: 'Array of metadata objects corresponding to each vector',
+    isOptional: true,
+  },
+  {
+    name: 'ids',
+    type: 'string[]',
+    description: 'Optional array of IDs for the vectors. If not provided, random IDs are generated',
+    isOptional: true,
+  },
+]}
+/>
+
+### `query()`
+
+Runs a vector similarity search. The `score` on each result is Meilisearch's `_rankingScore`.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'indexName',
+    type: 'string',
+    description: 'The name of the index to query',
+  },
+  {
+    name: 'queryVector',
+    type: 'number[]',
+    description: 'The query vector to find similar vectors for',
+  },
+  {
+    name: 'topK',
+    type: 'number',
+    description: 'The number of results to return',
+    defaultValue: '10',
+    isOptional: true,
+  },
+  {
+    name: 'filter',
+    type: 'VectorFilter',
+    description: 'Optional filter to apply to the query (MongoDB-style query syntax)',
+    isOptional: true,
+  },
+  {
+    name: 'includeVector',
+    type: 'boolean',
+    description: 'Whether to include the stored vector in each result',
+    defaultValue: 'false',
+    isOptional: true,
+  },
+]}
+/>
+
+### `updateVector()`
+
+Update a single vector by ID or by metadata filter. Either `id` or `filter` must be provided, but not both.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'indexName',
+    type: 'string',
+    description: 'The name of the index to update vectors in',
+  },
+  {
+    name: 'id',
+    type: 'string',
+    isOptional: true,
+    description: 'The ID of the vector to update (mutually exclusive with filter)',
+  },
+  {
+    name: 'filter',
+    type: 'Record<string, any>',
+    isOptional: true,
+    description: 'Metadata filter to identify vector(s) to update (mutually exclusive with id)',
+  },
+  {
+    name: 'update',
+    type: '{ vector?: number[]; metadata?: Record<string, any>; }',
+    description: 'Object containing the vector and/or metadata to update',
+  },
+]}
+/>
+
+### `deleteVector()`
+
+Deletes a single vector by its ID from the index.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'indexName',
+    type: 'string',
+    description: 'The name of the index to delete the vector from',
+  },
+  {
+    name: 'id',
+    type: 'string',
+    description: 'The ID of the vector to delete',
+  },
+]}
+/>
+
+### `deleteVectors()`
+
+Delete multiple vectors by IDs or by metadata filter. Either `ids` or `filter` must be provided, but not both.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'indexName',
+    type: 'string',
+    description: 'Name of the index containing the vectors to delete',
+  },
+  {
+    name: 'ids',
+    type: 'string[]',
+    isOptional: true,
+    description: 'Array of vector IDs to delete (mutually exclusive with filter)',
+  },
+  {
+    name: 'filter',
+    type: 'Record<string, any>',
+    isOptional: true,
+    description: 'Metadata filter to identify vectors to delete (mutually exclusive with ids)',
+  },
+]}
+/>
+
+## Metadata filtering
+
+`MeilisearchVector` translates MongoDB-style filters into Meilisearch filter expressions. You can filter on any metadata field once it has been upserted at least once.
+
+Supported operators:
+
+- Comparison: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`
+- Array: `$in`, `$nin`, `$all`
+- Logical: `$and`, `$or`, `$not`, `$nor`
+- Element: `$exists`
+
+The following operators are not supported because Meilisearch cannot express them:
+
+- `$regex` and `$options`: no regex filter
+- `$contains`: substring matching needs an experimental Meilisearch flag
+- `$elemMatch`: no per-element object matching
+- `$size`: no array-length filter
+
+For more detail on filter syntax, see [Metadata Filters](../rag/metadata-filters).
+
+## Related
+
+- [Metadata Filters](../rag/metadata-filters)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1858,16 +1858,16 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: ^2.0.62
-        version: 2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^2.0.99
-        version: 2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: ^2.0.1
         version: 2.0.3
       '@ai-sdk/provider-utils':
         specifier: ^3.0.22
-        version: 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@huggingface/hub':
         specifier: ^0.15.2
         version: 0.15.2
@@ -1940,7 +1940,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   integrations/brightdata:
     devDependencies:
@@ -6773,6 +6773,49 @@ importers:
       '@libsql/client':
         specifier: ^0.17.4
         version: 0.17.4(bufferutil@4.1.0)
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/storage-test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(vitest@4.1.8)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.8(vitest@4.1.8)
+      eslint:
+        specifier: ^10.4.1
+        version: 10.5.0(jiti@2.7.0)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.9(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+
+  stores/meilisearch:
+    dependencies:
+      meilisearch:
+        specifier: ^0.58.0
+        version: 0.58.0
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -23821,6 +23864,10 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  meilisearch@0.58.0:
+    resolution: {integrity: sha512-MXFlU+JVG2I3tDI4brS3UHxEv2fjOROP24TPP16c8dGHTulb1kxMgXvKP0x4ImvUcsVVJFi4QXP0JNDS/TaWaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   memfs@4.57.2:
     resolution: {integrity: sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==}
     peerDependencies:
@@ -29255,10 +29302,10 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -29414,6 +29461,26 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
+
+  '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@types/node'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - typescript
+      - vite
 
   '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
@@ -41227,7 +41294,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8)':
     dependencies:
@@ -41320,7 +41387,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -47341,6 +47408,8 @@ snapshots:
   media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
+
+  meilisearch@0.58.0: {}
 
   memfs@4.57.2(tslib@2.8.1):
     dependencies:

--- a/stores/meilisearch/AGENTS.md
+++ b/stores/meilisearch/AGENTS.md
@@ -1,0 +1,25 @@
+# `@mastra/meilisearch` - agent notes
+
+Vector-store adapter (`MeilisearchVector extends MastraVector`). Modelled on `stores/opensearch` + `stores/qdrant`.
+Run the narrowest suite: `pnpm --filter ./stores/meilisearch test` (`pretest` starts docker Meilisearch and waits on `/health`; `posttest` tears it down).
+
+## Non-obvious Meilisearch constraints baked into this adapter
+
+- **Everything mutating is async.** `createIndex`, `updateEmbedders`, `updateFilterableAttributes`, `addDocuments`, `updateDocuments`, `deleteDocument(s)`, `deleteIndex` all return a task and complete later. Always `await ....waitTask()` (see `awaitTask`) or read-after-write tests flake. This is the analogue of OpenSearch's `refresh: true`.
+- **You can only filter on declared `filterableAttributes`.** Recall keys (`metadata.thread_id`, `metadata.resource_id`, `metadata.message_id`) are registered at `createIndex`; arbitrary metadata keys are registered on `upsert`/filtered mutations via `ensureFilterable` (diffs against a per-index cache, then `updateFilterableAttributes([...union])`). Filtering an undeclared attribute errors.
+- **`userProvided` embedder only.** Mastra hands us ready vectors - never embed here. Vectors live under `_vectors.default.embeddings` with `regenerate: false`. Index dimension is read back from the embedder config (`getEmbedders`).
+- **Cosine only.** Non-cosine `metric` warns and is treated as cosine; `describeIndex` always reports `cosine`. Zero-magnitude vectors are rejected (cosine normalization) - the conformance suite runs with `supportsZeroVectors: false`.
+- **Score is `_rankingScore`** (pure-vector; `semanticRatio: 1.0`). Mastra's `query()` passes no query text, so native hybrid keyword search is not wired (possible future opt-in).
+- **Primary keys must match `^[A-Za-z0-9_-]+$`.** Caller ids are base64url-encoded into a `pk` field; the original id stays in `id`.
+
+## Filter translation gotcha (the one the conformance suite catches)
+
+A missing attribute makes an inner predicate **false**, so a bare `NOT (field < x)` _also matches documents lacking the field_. Field-level `$not` over a positive predicate therefore emits `(field EXISTS) AND NOT (...)` so negation only matches documents that have the field. Skip the `EXISTS` guard when the inner is `$exists` (it would be self-contradictory). `EXISTS` matches null-valued fields, so `$ne: null` negations are unaffected.
+
+## Disabled conformance domains (genuine limitations, not shortcuts)
+
+`supportsRegex: false` (no regex), `supportsContains: false` (`CONTAINS` needs the experimental `containsFilter` flag), `supportsElemMatch: false` (no per-element matching), `supportsSize: false` (no array-length filter), `supportsZeroVectors: false` (cosine).
+
+## Versions
+
+Server `getmeili/meilisearch:v1.13` (vector store is GA - no experimental flag). Client `meilisearch@^0.58.0`.

--- a/stores/meilisearch/README.md
+++ b/stores/meilisearch/README.md
@@ -1,0 +1,64 @@
+# @mastra/meilisearch
+
+Vector store implementation for [Meilisearch](https://www.meilisearch.com/), using its GA vector store (v1.13+) with a `userProvided` embedder. Mastra computes the embeddings; Meilisearch stores and searches them.
+
+## Installation
+
+```bash
+npm install @mastra/meilisearch
+```
+
+## Usage
+
+```typescript
+import { MeilisearchVector } from '@mastra/meilisearch';
+
+const vectorStore = new MeilisearchVector({
+  id: 'my-vector-store',
+  host: 'http://localhost:7700',
+  apiKey: 'masterKey',
+});
+
+// Create an index (dimension must match your embedder output)
+await vectorStore.createIndex({ indexName: 'my_index', dimension: 1536 });
+
+// Add vectors Mastra produced
+const ids = await vectorStore.upsert({
+  indexName: 'my_index',
+  vectors: [[0.1, 0.2 /* ... */]],
+  metadata: [{ text: 'document content', source: 'doc1.pdf' }],
+});
+
+// Query
+const results = await vectorStore.query({
+  indexName: 'my_index',
+  queryVector: [0.1, 0.2 /* ... */],
+  topK: 10,
+  filter: { source: 'doc1.pdf' },
+});
+```
+
+## Configuration
+
+`MeilisearchVector` accepts the full Meilisearch client `Config` plus a required `id`:
+
+- `id` (required): Identifier for this vector store instance.
+- `host` (required): URL of the Meilisearch instance.
+- `apiKey`: API key / master key.
+- Any other Meilisearch client option (`timeout`, `requestInit`, `defaultWaitOptions`, ...).
+
+## Notes and limitations
+
+- **Cosine only.** Meilisearch similarity is cosine. Requests for `euclidean`/`dotproduct` are accepted with a warning and treated as cosine.
+- **Filterable attributes.** A field must be declared filterable before it can be filtered. The recall keys (`metadata.thread_id`, `metadata.resource_id`, `metadata.message_id`) are declared on `createIndex`; any other metadata keys are declared automatically on first upsert.
+- **Unsupported filter operators:** `$regex`/`$options`, `$contains`, `$elemMatch`, `$size`. Supported: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$all`, `$exists`, `$and`, `$or`, `$not`, `$nor`, and null matching.
+- **Async tasks.** All mutating operations wait for the underlying Meilisearch task to finish so reads are immediately consistent.
+
+## Development
+
+Start a local Meilisearch instance and run the tests:
+
+```bash
+docker compose up -d
+pnpm test
+```

--- a/stores/meilisearch/docker-compose.yaml
+++ b/stores/meilisearch/docker-compose.yaml
@@ -1,0 +1,17 @@
+services:
+  meilisearch:
+    # v1.13+ ships the vector store as GA (no experimental flag needed).
+    image: getmeili/meilisearch:v1.13
+    ports:
+      - '7700:7700'
+    environment:
+      - MEILI_MASTER_KEY=masterKey
+      - MEILI_NO_ANALYTICS=true
+      - MEILI_ENV=development
+    volumes:
+      - meilisearch_data:/meili_data
+    restart: always
+
+volumes:
+  meilisearch_data:
+    driver: local

--- a/stores/meilisearch/eslint.config.js
+++ b/stores/meilisearch/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/stores/meilisearch/lint-staged.config.js
+++ b/stores/meilisearch/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['eslint --fix', 'prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/stores/meilisearch/package.json
+++ b/stores/meilisearch/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@mastra/meilisearch",
+  "version": "0.0.0",
+  "description": "Meilisearch vector store provider for Mastra",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "prepack": "tsx ../../scripts/generate-package-docs.ts",
+    "build:watch": "tsup --watch --silent --config tsup.config.ts",
+    "pretest": "docker compose up -d && (for i in $(seq 1 90); do curl -s http://localhost:7700/health | grep -q '\"status\"' && break || (sleep 1; [ $i -eq 90 ] && exit 1); done)",
+    "test": "vitest run",
+    "posttest": "docker compose down -v",
+    "pretest:watch": "docker compose up -d",
+    "test:watch": "vitest watch",
+    "posttest:watch": "docker compose down -v",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "meilisearch": "^0.58.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/storage-test-utils": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.19.21",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "eslint": "^10.4.1",
+    "tsup": "^8.5.1",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "stores/meilisearch"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/stores/meilisearch/src/index.ts
+++ b/stores/meilisearch/src/index.ts
@@ -1,0 +1,3 @@
+export * from './vector';
+export { MEILISEARCH_PROMPT } from './vector/prompt';
+export type { MeilisearchVectorFilter } from './vector/filter';

--- a/stores/meilisearch/src/vector/filter.test.ts
+++ b/stores/meilisearch/src/vector/filter.test.ts
@@ -106,11 +106,21 @@ describe('MeilisearchFilterTranslator', () => {
       );
     });
 
-    it('maps field-level $not with nested operators (double negation)', () => {
+    it('maps field-level $not with nested operators (double negation), guarded by EXISTS', () => {
+      // A bare NOT(...) in Meilisearch also matches documents missing the field
+      // (the inner predicate is false for them). Negating a positive predicate
+      // should only match documents that have the field, so we AND in EXISTS.
       expect(translate({ category: { $not: { $ne: 'electronics' } } })).toBe(
-        'NOT (metadata.category != "electronics")',
+        '(metadata.category EXISTS) AND (NOT (metadata.category != "electronics"))',
       );
-      expect(translate({ price: { $not: { $gt: 50 } } })).toBe('NOT (metadata.price > 50)');
+      expect(translate({ price: { $not: { $gt: 50 } } })).toBe(
+        '(metadata.price EXISTS) AND (NOT (metadata.price > 50))',
+      );
+    });
+
+    it('does not add an EXISTS guard when $not wraps $exists', () => {
+      // Guarding existence-negation with EXISTS would be self-contradictory.
+      expect(translate({ description: { $not: { $exists: true } } })).toBe('NOT (metadata.description EXISTS)');
     });
   });
 

--- a/stores/meilisearch/src/vector/filter.test.ts
+++ b/stores/meilisearch/src/vector/filter.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { MeilisearchFilterTranslator, MEILISEARCH_MATCH_NONE } from './filter';
+
+const translate = (filter: any) => new MeilisearchFilterTranslator().translate(filter);
+
+describe('MeilisearchFilterTranslator', () => {
+  describe('empty / no-op filters', () => {
+    it('returns undefined for empty/nullish filters', () => {
+      expect(translate(undefined)).toBeUndefined();
+      expect(translate(null)).toBeUndefined();
+      expect(translate({})).toBeUndefined();
+    });
+
+    it('treats empty $and as match-all and empty $or as match-none', () => {
+      expect(translate({ $and: [] })).toBeUndefined();
+      expect(translate({ $or: [] })).toBe(MEILISEARCH_MATCH_NONE);
+    });
+
+    it('treats empty $nor as match-all', () => {
+      expect(translate({ $nor: [] })).toBeUndefined();
+    });
+  });
+
+  describe('equality', () => {
+    it('prefixes fields with metadata. and quotes strings', () => {
+      expect(translate({ category: 'electronics' })).toBe('metadata.category = "electronics"');
+    });
+
+    it('does not double-prefix metadata. fields', () => {
+      expect(translate({ 'metadata.thread_id': 't1' })).toBe('metadata.thread_id = "t1"');
+    });
+
+    it('formats numbers and booleans without quotes', () => {
+      expect(translate({ price: 10 })).toBe('metadata.price = 10');
+      expect(translate({ available: true })).toBe('metadata.available = true');
+    });
+
+    it('maps null equality to IS NULL', () => {
+      expect(translate({ price: { $eq: null } })).toBe('metadata.price IS NULL');
+      expect(translate({ price: { $ne: null } })).toBe('metadata.price IS NOT NULL');
+    });
+  });
+
+  describe('comparison', () => {
+    it('maps numeric operators', () => {
+      expect(translate({ price: { $gt: 50 } })).toBe('metadata.price > 50');
+      expect(translate({ price: { $gte: 50 } })).toBe('metadata.price >= 50');
+      expect(translate({ price: { $lt: 50 } })).toBe('metadata.price < 50');
+      expect(translate({ price: { $lte: 50 } })).toBe('metadata.price <= 50');
+    });
+
+    it('combines a range into AND', () => {
+      expect(translate({ price: { $gte: 20, $lte: 80 } })).toBe('(metadata.price >= 20) AND (metadata.price <= 80)');
+    });
+
+    it('throws for non-scalar comparison values', () => {
+      expect(() => translate({ price: { $gt: [10, 20] } })).toThrow();
+    });
+  });
+
+  describe('arrays', () => {
+    it('maps $in and $nin', () => {
+      expect(translate({ category: { $in: ['a', 'b'] } })).toBe('metadata.category IN ["a", "b"]');
+      expect(translate({ category: { $nin: ['a', 'b'] } })).toBe('NOT (metadata.category IN ["a", "b"])');
+    });
+
+    it('simulates $all via AND of equalities', () => {
+      expect(translate({ tags: { $all: ['premium', 'sale'] } })).toBe(
+        '(metadata.tags = "premium") AND (metadata.tags = "sale")',
+      );
+    });
+
+    it('empty $in -> match-none, empty $nin -> match-all', () => {
+      expect(translate({ category: { $in: [] } })).toBe(MEILISEARCH_MATCH_NONE);
+      expect(translate({ category: { $nin: [] } })).toBeUndefined();
+    });
+  });
+
+  describe('existence', () => {
+    it('maps $exists', () => {
+      expect(translate({ description: { $exists: true } })).toBe('metadata.description EXISTS');
+      expect(translate({ description: { $exists: false } })).toBe('NOT (metadata.description EXISTS)');
+    });
+  });
+
+  describe('logical', () => {
+    it('maps $and / $or', () => {
+      expect(translate({ $and: [{ category: 'a' }, { price: { $gt: 1 } }] })).toBe(
+        '(metadata.category = "a") AND (metadata.price > 1)',
+      );
+      expect(translate({ $or: [{ category: 'a' }, { category: 'b' }] })).toBe(
+        '(metadata.category = "a") OR (metadata.category = "b")',
+      );
+    });
+
+    it('maps implicit AND over multiple fields', () => {
+      expect(translate({ category: 'a', price: { $gte: 5 } })).toBe(
+        '(metadata.category = "a") AND (metadata.price >= 5)',
+      );
+    });
+
+    it('maps top-level $not and $nor', () => {
+      expect(translate({ $not: { category: 'a' } })).toBe('NOT (metadata.category = "a")');
+      expect(translate({ $nor: [{ category: 'a' }, { category: 'b' }] })).toBe(
+        'NOT ((metadata.category = "a") OR (metadata.category = "b"))',
+      );
+    });
+
+    it('maps field-level $not with nested operators (double negation)', () => {
+      expect(translate({ category: { $not: { $ne: 'electronics' } } })).toBe(
+        'NOT (metadata.category != "electronics")',
+      );
+      expect(translate({ price: { $not: { $gt: 50 } } })).toBe('NOT (metadata.price > 50)');
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects unsupported operators', () => {
+      expect(() => translate({ value: { $invalidOperator: 10 } })).toThrow(/unsupported|invalid|unknown/i);
+    });
+
+    it('rejects regex (unsupported by Meilisearch)', () => {
+      expect(() => translate({ name: { $regex: '^Product' } })).toThrow();
+    });
+  });
+});

--- a/stores/meilisearch/src/vector/filter.ts
+++ b/stores/meilisearch/src/vector/filter.ts
@@ -1,0 +1,230 @@
+import type {
+  BlacklistedRootOperators,
+  LogicalOperatorValueMap,
+  OperatorSupport,
+  OperatorValueMap,
+  VectorFilter,
+} from '@mastra/core/vector/filter';
+import { BaseFilterTranslator } from '@mastra/core/vector/filter';
+
+// Meilisearch cannot express regex (`$regex`/`$options`) or per-element object
+// matching (`$elemMatch`). Everything else in the Mongo-style operator set maps
+// onto Meilisearch's SQL-like filter syntax.
+type MeilisearchOperatorValueMap = Omit<OperatorValueMap, '$regex' | '$options' | '$elemMatch'>;
+
+type MeilisearchLogicalOperatorValueMap = LogicalOperatorValueMap;
+
+export type MeilisearchVectorFilter = VectorFilter<
+  keyof MeilisearchOperatorValueMap,
+  MeilisearchOperatorValueMap,
+  MeilisearchLogicalOperatorValueMap,
+  BlacklistedRootOperators
+>;
+
+/**
+ * Sentinel returned by {@link MeilisearchFilterTranslator.translate} to signal a
+ * filter that can never match any document (e.g. an empty `$or`). Meilisearch has
+ * no literal "false" filter expression, so the caller short-circuits to an empty
+ * result set / no-op instead of issuing a request.
+ */
+export const MEILISEARCH_MATCH_NONE = Symbol('meilisearch-match-none');
+
+/**
+ * Translated filter:
+ * - `undefined` -> match everything (no filter applied)
+ * - {@link MEILISEARCH_MATCH_NONE} -> match nothing (short-circuit)
+ * - `string` -> a Meilisearch filter expression
+ */
+export type MeilisearchTranslatedFilter = string | undefined | typeof MEILISEARCH_MATCH_NONE;
+
+// Internal three-valued representation used while building the expression so we
+// can fold empty/constant branches (ALL / NONE) before emitting a string.
+type Node = { kind: 'all' } | { kind: 'none' } | { kind: 'expr'; expr: string };
+
+const ALL: Node = { kind: 'all' };
+const NONE: Node = { kind: 'none' };
+const expr = (e: string): Node => ({ kind: 'expr', expr: e });
+
+/**
+ * Translator from Mongo-style filters to Meilisearch's filter expression syntax.
+ *
+ * Field names are prefixed with `metadata.` because adapter documents store user
+ * metadata under a `metadata` object. The corresponding nested attributes must be
+ * declared filterable on the index before they can be used here (handled by the
+ * vector store on `createIndex`/`upsert`).
+ */
+export class MeilisearchFilterTranslator extends BaseFilterTranslator<
+  MeilisearchVectorFilter,
+  MeilisearchTranslatedFilter
+> {
+  protected override getSupportedOperators(): OperatorSupport {
+    return {
+      ...BaseFilterTranslator.DEFAULT_OPERATORS,
+      logical: ['$and', '$or', '$not', '$nor'],
+      array: ['$in', '$nin', '$all'],
+      regex: [],
+      custom: [],
+    };
+  }
+
+  translate(filter?: MeilisearchVectorFilter): MeilisearchTranslatedFilter {
+    if (this.isEmpty(filter)) return undefined;
+    this.validateFilter(filter as MeilisearchVectorFilter);
+    const node = this.translateNode(filter as Record<string, any>);
+    if (node.kind === 'all') return undefined;
+    if (node.kind === 'none') return MEILISEARCH_MATCH_NONE;
+    return node.expr;
+  }
+
+  // ---- boolean algebra over ALL / NONE / expr ----
+
+  private and(parts: Node[]): Node {
+    if (parts.some(p => p.kind === 'none')) return NONE;
+    const exprs = parts.filter((p): p is { kind: 'expr'; expr: string } => p.kind === 'expr');
+    if (exprs.length === 0) return ALL;
+    if (exprs.length === 1) return exprs[0]!;
+    return expr(exprs.map(p => `(${p.expr})`).join(' AND '));
+  }
+
+  private or(parts: Node[]): Node {
+    if (parts.some(p => p.kind === 'all')) return ALL;
+    const exprs = parts.filter((p): p is { kind: 'expr'; expr: string } => p.kind === 'expr');
+    if (exprs.length === 0) return NONE;
+    if (exprs.length === 1) return exprs[0]!;
+    return expr(exprs.map(p => `(${p.expr})`).join(' OR '));
+  }
+
+  private not(part: Node): Node {
+    if (part.kind === 'all') return NONE;
+    if (part.kind === 'none') return ALL;
+    return expr(`NOT (${part.expr})`);
+  }
+
+  private translateNode(node: Record<string, any>): Node {
+    if (this.isEmpty(node)) return ALL;
+
+    const parts: Node[] = [];
+    for (const [key, value] of Object.entries(node)) {
+      if (key === '$and') {
+        parts.push(this.and(this.asArray('$and', value).map(v => this.translateNode(v))));
+      } else if (key === '$or') {
+        parts.push(this.or(this.asArray('$or', value).map(v => this.translateNode(v))));
+      } else if (key === '$nor') {
+        parts.push(this.not(this.or(this.asArray('$nor', value).map(v => this.translateNode(v)))));
+      } else if (key === '$not') {
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+          throw new Error('$not operator requires an object');
+        }
+        parts.push(this.not(this.translateNode(value)));
+      } else if (this.isOperator(key)) {
+        throw new Error(`Unsupported operator: ${key}`);
+      } else {
+        parts.push(this.translateField(key, value));
+      }
+    }
+    return this.and(parts);
+  }
+
+  private asArray(op: string, value: any): any[] {
+    if (!Array.isArray(value)) {
+      throw new Error(`Logical operator ${op} requires an array value`);
+    }
+    return value;
+  }
+
+  private field(name: string): string {
+    return name.startsWith('metadata.') ? name : `metadata.${name}`;
+  }
+
+  private translateField(name: string, value: any): Node {
+    const field = this.field(name);
+
+    // Operator object, e.g. { $gt: 5, $lte: 10 }
+    if (typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date)) {
+      return this.translateOperators(field, value);
+    }
+
+    // Bare array -> membership ($in semantics)
+    if (Array.isArray(value)) {
+      if (value.length === 0) return NONE;
+      return expr(`${field} IN [${value.map(v => this.formatValue(v)).join(', ')}]`);
+    }
+
+    // Primitive equality
+    if (value === null) return expr(`${field} IS NULL`);
+    return expr(`${field} = ${this.formatValue(value)}`);
+  }
+
+  private translateOperators(field: string, ops: Record<string, any>): Node {
+    const parts: Node[] = [];
+
+    for (const [op, raw] of Object.entries(ops)) {
+      const value = this.normalizeComparisonValue(raw);
+      switch (op) {
+        case '$eq':
+          parts.push(raw === null ? expr(`${field} IS NULL`) : expr(`${field} = ${this.formatValue(value)}`));
+          break;
+        case '$ne':
+          parts.push(raw === null ? expr(`${field} IS NOT NULL`) : expr(`${field} != ${this.formatValue(value)}`));
+          break;
+        case '$gt':
+        case '$gte':
+        case '$lt':
+        case '$lte': {
+          const symbol = { $gt: '>', $gte: '>=', $lt: '<', $lte: '<=' }[op]!;
+          parts.push(expr(`${field} ${symbol} ${this.formatComparison(op, value)}`));
+          break;
+        }
+        case '$in': {
+          const arr = this.asArray('$in', raw);
+          parts.push(arr.length === 0 ? NONE : expr(`${field} IN [${arr.map(v => this.formatValue(v)).join(', ')}]`));
+          break;
+        }
+        case '$nin': {
+          const arr = this.asArray('$nin', raw);
+          parts.push(
+            arr.length === 0 ? ALL : this.not(expr(`${field} IN [${arr.map(v => this.formatValue(v)).join(', ')}]`)),
+          );
+          break;
+        }
+        case '$all': {
+          // Meilisearch has no $all; array membership is plain equality, so
+          // require each value to be present (AND of equalities).
+          const arr = this.asArray('$all', raw);
+          parts.push(arr.length === 0 ? NONE : this.and(arr.map(v => expr(`${field} = ${this.formatValue(v)}`))));
+          break;
+        }
+        case '$exists':
+          parts.push(raw ? expr(`${field} EXISTS`) : this.not(expr(`${field} EXISTS`)));
+          break;
+        case '$not':
+          if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+            throw new Error('$not operator requires an object');
+          }
+          parts.push(this.not(this.translateOperators(field, raw)));
+          break;
+        default:
+          throw new Error(`Unsupported operator: ${op}`);
+      }
+    }
+
+    return this.and(parts);
+  }
+
+  private formatComparison(op: string, value: any): string {
+    if (typeof value === 'number') return String(value);
+    if (typeof value === 'string') return this.quote(value);
+    throw new Error(`Operator ${op} requires a number, string, or Date value`);
+  }
+
+  private formatValue(value: any): string {
+    if (value === null) return 'NULL';
+    if (typeof value === 'number') return String(value);
+    if (typeof value === 'boolean') return value ? 'true' : 'false';
+    return this.quote(String(value));
+  }
+
+  private quote(value: string): string {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+}

--- a/stores/meilisearch/src/vector/filter.ts
+++ b/stores/meilisearch/src/vector/filter.ts
@@ -197,12 +197,23 @@ export class MeilisearchFilterTranslator extends BaseFilterTranslator<
         case '$exists':
           parts.push(raw ? expr(`${field} EXISTS`) : this.not(expr(`${field} EXISTS`)));
           break;
-        case '$not':
+        case '$not': {
           if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
             throw new Error('$not operator requires an object');
           }
-          parts.push(this.not(this.translateOperators(field, raw)));
+          const negated = this.not(this.translateOperators(field, raw));
+          // In Meilisearch a missing attribute makes the inner predicate false,
+          // so a bare `NOT (...)` would also match documents that lack the field
+          // entirely. The conformance contract (and Mongo intuition for these
+          // cases) is that negating a positive predicate only matches documents
+          // that actually have the field. Guard with `field EXISTS`, unless the
+          // inner predicate is itself about existence (then the guard would be
+          // contradictory). Note: `EXISTS` matches null-valued fields too, so
+          // `$ne: null`-style negations are unaffected.
+          const aboutExistence = Object.prototype.hasOwnProperty.call(raw, '$exists');
+          parts.push(aboutExistence ? negated : this.and([expr(`${field} EXISTS`), negated]));
           break;
+        }
         default:
           throw new Error(`Unsupported operator: ${op}`);
       }

--- a/stores/meilisearch/src/vector/index.test.ts
+++ b/stores/meilisearch/src/vector/index.test.ts
@@ -1,0 +1,97 @@
+// To set up a Meilisearch server, run the docker-compose file in this directory:
+//   docker compose up -d
+import { createVectorTestSuite } from '@internal/storage-test-utils';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { MeilisearchVector } from './index';
+
+const HOST = process.env.MEILISEARCH_HOST || 'http://localhost:7700';
+const API_KEY = process.env.MEILISEARCH_API_KEY || 'masterKey';
+
+describe('MeilisearchVector', () => {
+  let vectorDB: MeilisearchVector;
+
+  beforeAll(() => {
+    vectorDB = new MeilisearchVector({ id: 'meilisearch-test', host: HOST, apiKey: API_KEY });
+  });
+
+  afterAll(async () => {
+    try {
+      await vectorDB.deleteIndex({ indexName: 'duplicate-test' });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('Error Handling', () => {
+    it('should handle duplicate index creation gracefully', async () => {
+      const infoSpy = vi.spyOn(vectorDB['logger'], 'info');
+      const warnSpy = vi.spyOn(vectorDB['logger'], 'warn');
+
+      const duplicateIndexName = `duplicate-test`;
+      const dimension = 768;
+
+      try {
+        await vectorDB.createIndex({ indexName: duplicateIndexName, dimension, metric: 'cosine' });
+
+        // Same dimensions - should not throw
+        await expect(
+          vectorDB.createIndex({ indexName: duplicateIndexName, dimension, metric: 'cosine' }),
+        ).resolves.not.toThrow();
+
+        expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('already exists with'));
+
+        // Different dimensions - should throw
+        await expect(
+          vectorDB.createIndex({ indexName: duplicateIndexName, dimension: dimension + 1, metric: 'cosine' }),
+        ).rejects.toThrow(
+          `Index "${duplicateIndexName}" already exists with ${dimension} dimensions, but ${dimension + 1} dimensions were requested`,
+        );
+      } finally {
+        infoSpy.mockRestore();
+        warnSpy.mockRestore();
+        await vectorDB.deleteIndex({ indexName: duplicateIndexName });
+      }
+    }, 60000);
+
+    it('should warn when a non-cosine metric is requested', async () => {
+      const warnSpy = vi.spyOn(vectorDB['logger'], 'warn');
+      const indexName = `metric-warn-test-${Date.now()}`;
+      try {
+        await vectorDB.createIndex({ indexName, dimension: 3, metric: 'euclidean' });
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('only supports cosine'));
+        const stats = await vectorDB.describeIndex({ indexName });
+        expect(stats.metric).toBe('cosine');
+      } finally {
+        warnSpy.mockRestore();
+        await vectorDB.deleteIndex({ indexName });
+      }
+    }, 60000);
+  });
+});
+
+// Shared vector store conformance suite.
+const meilisearchVector = new MeilisearchVector({ id: 'meilisearch-shared-test', host: HOST, apiKey: API_KEY });
+
+createVectorTestSuite({
+  vector: meilisearchVector,
+  createIndex: async (indexName, options) => {
+    await meilisearchVector.createIndex({ indexName, dimension: 1536, metric: options?.metric });
+  },
+  deleteIndex: async (indexName: string) => {
+    await meilisearchVector.deleteIndex({ indexName });
+  },
+  waitForIndexing: async () => {
+    // Mutations already await their Meilisearch task (waitTask), so reads are
+    // consistent. A tiny buffer keeps parity with other store suites.
+    await new Promise(resolve => setTimeout(resolve, 50));
+  },
+  // --- Meilisearch capability profile ---
+  // Genuinely unsupported domains:
+  supportsRegex: false, // no regex filter
+  supportsContains: false, // CONTAINS needs the experimental containsFilter flag
+  supportsElemMatch: false, // no per-element object matching
+  supportsSize: false, // no array-length filter
+  // Cosine similarity rejects zero-magnitude vectors (division by zero).
+  supportsZeroVectors: false,
+});

--- a/stores/meilisearch/src/vector/index.ts
+++ b/stores/meilisearch/src/vector/index.ts
@@ -1,0 +1,643 @@
+import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
+import { createVectorErrorId } from '@mastra/core/storage';
+import type {
+  CreateIndexParams,
+  DeleteIndexParams,
+  DeleteVectorParams,
+  DescribeIndexParams,
+  IndexStats,
+  QueryResult,
+  QueryVectorParams,
+  UpdateVectorParams,
+  UpsertVectorParams,
+  DeleteVectorsParams,
+} from '@mastra/core/vector';
+import { MastraVector, validateUpsert, validateTopK } from '@mastra/core/vector';
+import { Meilisearch } from 'meilisearch';
+import type { Config, EnqueuedTaskPromise, Task } from 'meilisearch';
+import { MeilisearchFilterTranslator, MEILISEARCH_MATCH_NONE } from './filter';
+import type { MeilisearchVectorFilter } from './filter';
+
+/**
+ * Configuration for {@link MeilisearchVector}.
+ *
+ * Extends the Meilisearch client {@link Config} with a required `id`.
+ *
+ * @example
+ * ```typescript
+ * const vector = new MeilisearchVector({
+ *   id: 'my-vector',
+ *   host: 'http://localhost:7700',
+ *   apiKey: 'masterKey',
+ * });
+ * ```
+ */
+export type MeilisearchVectorConfig = Config & { id: string };
+
+// Embedder name used for the single user-provided embedder per index. Mastra
+// always hands us pre-computed vectors, so we never let Meilisearch embed.
+const EMBEDDER = 'default';
+
+// Document field that holds the (encoded) Meilisearch primary key. Meilisearch
+// primary keys must match /^[A-Za-z0-9_-]+$/, so we store a base64url-encoded
+// key here and keep the caller's original id in the `id` field.
+const PK = 'pk';
+
+// Recall keys the Memory system filters on. Declared filterable at createIndex.
+const RECALL_KEYS = ['metadata.thread_id', 'metadata.resource_id', 'metadata.message_id'];
+
+type MeilisearchQueryVectorParams = QueryVectorParams<MeilisearchVectorFilter>;
+
+export class MeilisearchVector extends MastraVector<MeilisearchVectorFilter> {
+  private client: Meilisearch;
+  // Per-index caches to avoid redundant settings round-trips.
+  private dimensionCache = new Map<string, number>();
+  private filterableCache = new Map<string, Set<string>>();
+
+  /**
+   * Creates a new MeilisearchVector client.
+   *
+   * @param config - Meilisearch client configuration plus a required id.
+   */
+  constructor({ id, ...config }: MeilisearchVectorConfig) {
+    super({ id });
+    // Generous default task timeout: large batches (1000+ vectors) can take a
+    // while to index and embed.
+    this.client = new Meilisearch({ defaultWaitOptions: { timeout: 120_000 }, ...config });
+  }
+
+  /** Encodes an arbitrary caller id into a Meilisearch-safe primary key. */
+  private encodeId(id: string): string {
+    return Buffer.from(String(id), 'utf-8').toString('base64url');
+  }
+
+  /** Awaits an enqueued task and throws a MastraError if it failed. */
+  private async awaitTask(enqueued: EnqueuedTaskPromise, op: string, indexName: string): Promise<Task> {
+    const task = await enqueued.waitTask();
+    if (task.status === 'failed') {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', op, 'TASK_FAILED'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.THIRD_PARTY,
+        text: task.error?.message || `Meilisearch task failed during ${op}`,
+        details: { indexName, code: task.error?.code || '', op },
+      });
+    }
+    return task;
+  }
+
+  async createIndex({ indexName, dimension, metric = 'cosine' }: CreateIndexParams): Promise<void> {
+    if (!Number.isInteger(dimension) || dimension <= 0) {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'CREATE_INDEX', 'INVALID_ARGS'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'Dimension must be a positive integer',
+        details: { indexName, dimension },
+      });
+    }
+
+    if (metric !== 'cosine') {
+      this.logger?.warn(
+        `Meilisearch only supports cosine similarity. Requested metric "${metric}" will be treated as "cosine".`,
+      );
+    }
+
+    try {
+      const task = await this.client.createIndex(indexName, { primaryKey: PK }).waitTask();
+      if (task.status === 'failed') {
+        if (task.error?.code === 'index_already_exists') {
+          await this.validateExistingIndex(indexName, dimension, metric);
+          return;
+        }
+        throw new MastraError({
+          id: createVectorErrorId('MEILISEARCH', 'CREATE_INDEX', 'TASK_FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          text: task.error?.message || 'Meilisearch index creation failed',
+          details: { indexName, code: task.error?.code || '' },
+        });
+      }
+
+      const index = this.client.index(indexName);
+      // userProvided embedder: Mastra supplies vectors; Meilisearch never embeds.
+      await this.awaitTask(
+        index.updateEmbedders({ [EMBEDDER]: { source: 'userProvided', dimensions: dimension } }),
+        'CREATE_INDEX',
+        indexName,
+      );
+      // Pre-declare recall keys so Memory semantic recall can filter immediately.
+      await this.awaitTask(index.updateFilterableAttributes([...RECALL_KEYS]), 'CREATE_INDEX', indexName);
+
+      this.dimensionCache.set(indexName, dimension);
+      this.filterableCache.set(indexName, new Set(RECALL_KEYS));
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'CREATE_INDEX', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName, dimension, metric },
+        },
+        error,
+      );
+    }
+  }
+
+  async listIndexes(): Promise<string[]> {
+    try {
+      const { results } = await this.client.getIndexes({ limit: 1000 });
+      return results.map(index => index.uid);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'LIST_INDEXES', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async describeIndex({ indexName }: DescribeIndexParams): Promise<IndexStats> {
+    try {
+      const index = this.client.index(indexName);
+      const [embedders, stats] = await Promise.all([index.getEmbedders(), index.getStats()]);
+      const embedder = embedders?.[EMBEDDER];
+      const dimension = embedder && 'dimensions' in embedder ? Number(embedder.dimensions) : 0;
+      if (dimension) this.dimensionCache.set(indexName, dimension);
+
+      return {
+        dimension,
+        count: stats.numberOfDocuments,
+        metric: 'cosine',
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'DESCRIBE_INDEX', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteIndex({ indexName }: DeleteIndexParams): Promise<void> {
+    try {
+      await this.awaitTask(this.client.deleteIndex(indexName), 'DELETE_INDEX', indexName);
+    } catch (error) {
+      const mastraError = new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'DELETE_INDEX', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName },
+        },
+        error,
+      );
+      this.logger?.error(mastraError.toString());
+      this.logger?.trackException(mastraError);
+    } finally {
+      this.dimensionCache.delete(indexName);
+      this.filterableCache.delete(indexName);
+    }
+  }
+
+  /** Returns the index's configured embedder dimension; throws if it doesn't exist. */
+  private async getDimension(indexName: string, op: string): Promise<number> {
+    const cached = this.dimensionCache.get(indexName);
+    if (cached) return cached;
+    try {
+      const embedders = await this.client.index(indexName).getEmbedders();
+      const embedder = embedders?.[EMBEDDER];
+      const dimension = embedder && 'dimensions' in embedder ? Number(embedder.dimensions) : 0;
+      if (!dimension) {
+        throw new Error(`Index "${indexName}" has no userProvided embedder configured`);
+      }
+      this.dimensionCache.set(indexName, dimension);
+      return dimension;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', op, 'INDEX_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          text: `Index "${indexName}" not found or not initialized`,
+          details: { indexName },
+        },
+        error,
+      );
+    }
+  }
+
+  private validateVectorDimensions(vectors: number[][], dimension: number) {
+    for (const vector of vectors) {
+      if (vector.length !== dimension) {
+        throw new MastraError({
+          id: createVectorErrorId('MEILISEARCH', 'UPSERT', 'DIMENSION_MISMATCH'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Vector dimension ${vector.length} does not match index dimension ${dimension}`,
+          details: { expected: dimension, actual: vector.length },
+        });
+      }
+    }
+  }
+
+  /** Declares any not-yet-filterable metadata keys on the index. */
+  private async ensureFilterable(indexName: string, metadataKeys: string[]): Promise<void> {
+    const needed = metadataKeys.map(key => (key.startsWith('metadata.') ? key : `metadata.${key}`));
+    if (needed.length === 0) return;
+
+    let known = this.filterableCache.get(indexName);
+    if (!known) {
+      const current = await this.client.index(indexName).getFilterableAttributes();
+      known = new Set([
+        ...RECALL_KEYS,
+        ...((current ?? []).filter((attr): attr is string => typeof attr === 'string') as string[]),
+      ]);
+      this.filterableCache.set(indexName, known);
+    }
+
+    const missing = needed.filter(key => !known!.has(key));
+    if (missing.length === 0) return;
+
+    const union = new Set([...known, ...needed]);
+    await this.awaitTask(
+      this.client.index(indexName).updateFilterableAttributes([...union]),
+      'UPDATE_FILTERABLE',
+      indexName,
+    );
+    this.filterableCache.set(indexName, union);
+  }
+
+  /** Collects top-level metadata field names referenced by a filter. */
+  private collectFilterFields(filter: any, out: Set<string> = new Set()): Set<string> {
+    if (!filter || typeof filter !== 'object') return out;
+    if (Array.isArray(filter)) {
+      filter.forEach(item => this.collectFilterFields(item, out));
+      return out;
+    }
+    for (const [key, value] of Object.entries(filter)) {
+      if (key === '$and' || key === '$or' || key === '$nor' || key === '$not') {
+        this.collectFilterFields(value, out);
+      } else if (!key.startsWith('$')) {
+        out.add(key);
+      }
+    }
+    return out;
+  }
+
+  async upsert({ indexName, vectors, metadata = [], ids }: UpsertVectorParams): Promise<string[]> {
+    validateUpsert('MEILISEARCH', vectors, metadata, ids, true);
+
+    try {
+      const dimension = await this.getDimension(indexName, 'UPSERT');
+      this.validateVectorDimensions(vectors, dimension);
+
+      const vectorIds = ids || vectors.map(() => crypto.randomUUID());
+
+      const metadataKeys = new Set<string>();
+      for (const meta of metadata) {
+        if (meta) Object.keys(meta).forEach(key => metadataKeys.add(key));
+      }
+      await this.ensureFilterable(indexName, [...metadataKeys]);
+
+      const documents = vectors.map((vector, i) => ({
+        [PK]: this.encodeId(vectorIds[i]!),
+        id: vectorIds[i],
+        metadata: metadata[i] ?? {},
+        _vectors: { [EMBEDDER]: { embeddings: vector, regenerate: false } },
+      }));
+
+      await this.awaitTask(
+        this.client.index(indexName).addDocuments(documents, { primaryKey: PK }),
+        'UPSERT',
+        indexName,
+      );
+
+      return vectorIds;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'UPSERT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName, vectorCount: vectors?.length || 0 },
+        },
+        error,
+      );
+    }
+  }
+
+  async query({
+    indexName,
+    queryVector,
+    filter,
+    topK = 10,
+    includeVector = false,
+  }: MeilisearchQueryVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'QUERY', 'MISSING_VECTOR'),
+        text: 'queryVector is required for Meilisearch queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
+    validateTopK('MEILISEARCH', topK);
+
+    try {
+      const dimension = await this.getDimension(indexName, 'QUERY');
+      if (queryVector.length !== dimension) {
+        throw new MastraError({
+          id: createVectorErrorId('MEILISEARCH', 'QUERY', 'DIMENSION_MISMATCH'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Query vector dimension ${queryVector.length} does not match index dimension ${dimension}`,
+          details: { expected: dimension, actual: queryVector.length },
+        });
+      }
+
+      const translatedFilter = this.transformFilter(filter);
+      if (translatedFilter === MEILISEARCH_MATCH_NONE) return [];
+
+      const response = await this.client.index(indexName).search(null, {
+        vector: queryVector,
+        hybrid: { embedder: EMBEDDER, semanticRatio: 1.0 },
+        limit: topK,
+        filter: translatedFilter,
+        showRankingScore: true,
+        retrieveVectors: includeVector,
+      });
+
+      return response.hits.map((hit: any) => {
+        const result: QueryResult = {
+          id: String(hit.id ?? ''),
+          score: typeof hit._rankingScore === 'number' ? hit._rankingScore : 0,
+          metadata: hit.metadata ?? {},
+        };
+        if (includeVector) {
+          const stored = hit._vectors?.[EMBEDDER];
+          result.vector = Array.isArray(stored) ? stored : stored?.embeddings;
+        }
+        return result;
+      });
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'QUERY', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName, topK },
+        },
+        error,
+      );
+    }
+  }
+
+  private transformFilter(filter?: MeilisearchVectorFilter) {
+    const translator = new MeilisearchFilterTranslator();
+    return translator.translate(filter);
+  }
+
+  async updateVector(params: UpdateVectorParams<MeilisearchVectorFilter>): Promise<void> {
+    const { indexName, update } = params;
+
+    if ('id' in params && 'filter' in params && params.id && params.filter) {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'UPDATE_VECTOR', 'MUTUALLY_EXCLUSIVE'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'id and filter are mutually exclusive',
+        details: { indexName },
+      });
+    }
+
+    if (!update || (!update.vector && !update.metadata)) {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'UPDATE_VECTOR', 'NO_UPDATES'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'No updates provided',
+        details: { indexName },
+      });
+    }
+
+    if ('filter' in params && params.filter && Object.keys(params.filter).length === 0) {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'UPDATE_VECTOR', 'EMPTY_FILTER'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'Cannot update with empty filter',
+        details: { indexName },
+      });
+    }
+
+    if ('id' in params && params.id) {
+      await this.updateVectorById(indexName, params.id, update);
+    } else if ('filter' in params && params.filter) {
+      await this.updateVectorsByFilter(indexName, params.filter, update);
+    } else {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'UPDATE_VECTOR', 'NO_TARGET'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'Either id or filter must be provided',
+        details: { indexName },
+      });
+    }
+  }
+
+  private buildPartialDocument(
+    update: { vector?: number[]; metadata?: Record<string, any> },
+    dimension: number,
+  ): Record<string, any> {
+    const doc: Record<string, any> = {};
+    if (update.vector) {
+      this.validateVectorDimensions([update.vector], dimension);
+      doc._vectors = { [EMBEDDER]: { embeddings: update.vector, regenerate: false } };
+    }
+    if (update.metadata) {
+      doc.metadata = update.metadata;
+    }
+    return doc;
+  }
+
+  private async updateVectorById(
+    indexName: string,
+    id: string,
+    update: { vector?: number[]; metadata?: Record<string, any> },
+  ): Promise<void> {
+    try {
+      const dimension = await this.getDimension(indexName, 'UPDATE_VECTOR');
+      if (update.metadata) {
+        await this.ensureFilterable(indexName, Object.keys(update.metadata));
+      }
+      const doc = { [PK]: this.encodeId(id), ...this.buildPartialDocument(update, dimension) };
+      // updateDocuments merges at the top-level field granularity, so omitting
+      // `_vectors` or `metadata` preserves the existing value.
+      await this.awaitTask(this.client.index(indexName).updateDocuments([doc]), 'UPDATE_VECTOR', indexName);
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'UPDATE_VECTOR', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName, id },
+        },
+        error,
+      );
+    }
+  }
+
+  private async updateVectorsByFilter(
+    indexName: string,
+    filter: MeilisearchVectorFilter,
+    update: { vector?: number[]; metadata?: Record<string, any> },
+  ): Promise<void> {
+    try {
+      const dimension = await this.getDimension(indexName, 'UPDATE_VECTOR');
+      await this.ensureFilterable(indexName, [...this.collectFilterFields(filter)]);
+      if (update.metadata) {
+        await this.ensureFilterable(indexName, Object.keys(update.metadata));
+      }
+
+      const translatedFilter = this.transformFilter(filter);
+      if (translatedFilter === MEILISEARCH_MATCH_NONE) return;
+
+      // Find the primary keys of all matching documents, then patch each.
+      const { results } = await this.client.index(indexName).getDocuments({
+        filter: translatedFilter,
+        fields: [PK],
+        limit: 100_000,
+      });
+      if (results.length === 0) return;
+
+      const partial = this.buildPartialDocument(update, dimension);
+      const docs = results.map((doc: any) => ({ [PK]: doc[PK], ...partial }));
+      await this.awaitTask(this.client.index(indexName).updateDocuments(docs), 'UPDATE_VECTOR', indexName);
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'UPDATE_VECTOR_BY_FILTER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName, filter: JSON.stringify(filter) },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVector({ indexName, id }: DeleteVectorParams): Promise<void> {
+    try {
+      await this.awaitTask(this.client.index(indexName).deleteDocument(this.encodeId(id)), 'DELETE_VECTOR', indexName);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'DELETE_VECTOR', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName, ...(id && { id }) },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVectors({ indexName, filter, ids }: DeleteVectorsParams<MeilisearchVectorFilter>): Promise<void> {
+    if (ids && filter) {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'DELETE_VECTORS', 'MUTUALLY_EXCLUSIVE'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'ids and filter are mutually exclusive',
+        details: { indexName },
+      });
+    }
+
+    if (!ids && !filter) {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'DELETE_VECTORS', 'NO_TARGET'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'Either filter or ids must be provided',
+        details: { indexName },
+      });
+    }
+
+    if (ids && ids.length === 0) {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'DELETE_VECTORS', 'EMPTY_IDS'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'Cannot delete with empty ids array',
+        details: { indexName },
+      });
+    }
+
+    if (filter && Object.keys(filter).length === 0) {
+      throw new MastraError({
+        id: createVectorErrorId('MEILISEARCH', 'DELETE_VECTORS', 'EMPTY_FILTER'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'Cannot delete with empty filter',
+        details: { indexName },
+      });
+    }
+
+    try {
+      // Ensure the index exists so deletes against a missing index throw.
+      await this.getDimension(indexName, 'DELETE_VECTORS');
+
+      if (ids) {
+        await this.awaitTask(
+          this.client.index(indexName).deleteDocuments(ids.map(id => this.encodeId(id))),
+          'DELETE_VECTORS',
+          indexName,
+        );
+      } else if (filter) {
+        await this.ensureFilterable(indexName, [...this.collectFilterFields(filter)]);
+        const translatedFilter = this.transformFilter(filter);
+        if (translatedFilter === MEILISEARCH_MATCH_NONE) return;
+        if (translatedFilter === undefined) {
+          await this.awaitTask(this.client.index(indexName).deleteAllDocuments(), 'DELETE_VECTORS', indexName);
+        } else {
+          await this.awaitTask(
+            this.client.index(indexName).deleteDocuments({ filter: translatedFilter }),
+            'DELETE_VECTORS',
+            indexName,
+          );
+        }
+      }
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createVectorErrorId('MEILISEARCH', 'DELETE_VECTORS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: {
+            indexName,
+            ...(filter && { filter: JSON.stringify(filter) }),
+            ...(ids && { idsCount: ids.length }),
+          },
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/meilisearch/src/vector/prompt.ts
+++ b/stores/meilisearch/src/vector/prompt.ts
@@ -1,0 +1,84 @@
+/**
+ * Vector store specific prompt that details supported operators and examples.
+ * This prompt helps users construct valid filters for Meilisearch Vector.
+ */
+export const MEILISEARCH_PROMPT = `When querying Meilisearch, you can ONLY use the operators listed below. Any other operators will be rejected.
+Important: Don't explain how to construct the filter - use the specified operators and fields to search the content and return relevant results.
+If a user tries to give an explicit operator that is not supported, reject the filter entirely and let them know that the operator is not supported.
+
+Basic Comparison Operators:
+- $eq: Exact match (default when using field: value)
+  Example: { "category": "electronics" }
+- $ne: Not equal
+  Example: { "category": { "$ne": "electronics" } }
+- $gt: Greater than (numeric fields)
+  Example: { "price": { "$gt": 100 } }
+- $gte: Greater than or equal
+  Example: { "price": { "$gte": 100 } }
+- $lt: Less than
+  Example: { "price": { "$lt": 100 } }
+- $lte: Less than or equal
+  Example: { "price": { "$lte": 100 } }
+
+Array Operators:
+- $in: Match any value in array
+  Example: { "category": { "$in": ["electronics", "books"] } }
+- $nin: Does not match any value in array
+  Example: { "category": { "$nin": ["electronics", "books"] } }
+- $all: Match values that contain all elements (array membership)
+  Example: { "tags": { "$all": ["premium", "sale"] } }
+
+Logical Operators:
+- $and: Logical AND (can be implicit or explicit)
+  Implicit Example: { "price": { "$gt": 100 }, "category": "electronics" }
+  Explicit Example: { "$and": [{ "price": { "$gt": 100 } }, { "category": "electronics" }] }
+- $or: Logical OR
+  Example: { "$or": [{ "price": { "$lt": 50 } }, { "category": "books" }] }
+- $not: Logical NOT
+  Example: { "$not": { "category": "electronics" } }
+- $nor: Logical NOR (none of the conditions match)
+  Example: { "$nor": [{ "category": "electronics" }, { "category": "books" }] }
+
+Element Operators:
+- $exists: Check if field exists
+  Example: { "rating": { "$exists": true } }
+
+Null Handling:
+- Match null values with $eq/$ne: null
+  Example: { "deletedAt": { "$eq": null } }
+
+Restrictions:
+- Regex patterns ($regex/$options) are NOT supported by Meilisearch.
+- Substring matching ($contains) and per-element array matching ($elemMatch) are NOT supported.
+- Array length filtering ($size) is NOT supported.
+- All similarity is cosine-based; euclidean/dotproduct metrics are not honoured.
+- Only $and, $or, $not, and $nor logical operators are supported at the top level.
+- Empty arrays in $in will return no results; empty $nin matches all.
+- Nested fields are supported using dot notation.
+- Multiple conditions on the same field are supported with both implicit and explicit $and.
+- At least one key-value pair is required in filter object.
+- Empty objects and undefined values are treated as no filter.
+- Invalid types in comparison operators will throw errors.
+- All non-logical operators must be used within a field condition.
+  Valid: { "field": { "$gt": 100 } }
+  Valid: { "$and": [...] }
+  Invalid: { "$gt": 100 }
+- Logical operators must contain field conditions, not direct operators.
+  Valid: { "$and": [{ "field": { "$gt": 100 } }] }
+  Invalid: { "$and": [{ "$gt": 100 }] }
+- The fields you filter on must be present in document metadata; new metadata
+  keys become filterable automatically the first time they are upserted.
+
+Example Complex Query:
+{
+  "$and": [
+    { "category": { "$in": ["electronics", "computers"] } },
+    { "price": { "$gte": 100, "$lte": 1000 } },
+    { "rating": { "$exists": true, "$gt": 4 } },
+    { "$or": [
+      { "stock": { "$gt": 0 } },
+      { "preorder": { "$eq": true } }
+    ]},
+    { "$not": { "status": "discontinued" } }
+  ]
+}`;

--- a/stores/meilisearch/tsconfig.build.json
+++ b/stores/meilisearch/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/stores/meilisearch/tsconfig.json
+++ b/stores/meilisearch/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/stores/meilisearch/tsup.config.ts
+++ b/stores/meilisearch/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/stores/meilisearch/turbo.json
+++ b/stores/meilisearch/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://v2-9-16.turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**", "!dist/docs/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/stores/meilisearch/vitest.config.ts
+++ b/stores/meilisearch/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'e2e:stores/meilisearch',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 60000,
+    hookTimeout: 120000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
Closes #18641

## What

Adds `@mastra/meilisearch`, a new vector store under `stores/meilisearch` that implements the `MastraVector` interface using [Meilisearch](https://www.meilisearch.com/)'s GA vector search (v1.13+). It mirrors the OpenSearch/Qdrant adapters and requires **no `packages/core` changes**.

Included:

- `MeilisearchVector` with all `MastraVector` methods (`createIndex`, `upsert`, `query`, `listIndexes`, `describeIndex`, `deleteIndex`, `updateVector`, `deleteVector`, `deleteVectors`).
- `MeilisearchFilterTranslator` (MongoDB-style filters → Meilisearch filter expressions) and `MEILISEARCH_PROMPT`.
- Package scaffolding (`package.json`, `tsup`/`vitest`/`tsconfig`/eslint configs, `docker-compose.yaml` pinned to `getmeili/meilisearch:v1.13`).
- Reference doc (`reference/vectors/meilisearch.mdx`) + entry in the RAG vector-databases page, and a changeset.

Design notes:

- **`userProvided` embedder.** Mastra supplies vectors, so each index uses a `userProvided` embedder and the adapter never embeds text itself.
- **Cosine only.** Non-cosine `metric` requests warn and are treated as cosine; `describeIndex` reports `cosine`. Each result's `score` is Meilisearch's `_rankingScore`.
- **Async task model.** Every mutating call awaits its Meilisearch task (`waitTask`) so read-after-write is consistent (the analogue of OpenSearch's `refresh: true`).
- **`filterableAttributes`.** Recall keys (`thread_id`, `resource_id`, `message_id`) are declared at `createIndex`; new metadata keys are registered automatically on first upsert so filters on them don't error.

## Conformance results

Run against a real Docker Meilisearch (**v1.13.3**) via Mastra's shared `createVectorTestSuite`:

```
Test Files  2 passed (2)
     Tests  166 passed (166)
```

**166/166 pass, 0 failed, 0 skipped.**

### One filter bug found and fixed

The suite caught a real semantics bug: in Meilisearch a missing attribute makes an inner predicate false, so a bare `NOT (rating < 4)` *also* matches documents that lack `rating` entirely - failing a `$not` negation case. Fix: field-level `$not` over a positive predicate now emits `(field EXISTS) AND NOT (...)`, so negation only matches documents that actually have the field (the guard is skipped when the inner predicate is `$exists`). `EXISTS` matches null-valued fields, so `$ne: null`-style negations are unaffected.

### Disabled domains (genuine Meilisearch limitations, not shortcuts)

Set via the suite's capability flags, each documented:

- `supportsRegex: false` - no regex filter (`$regex`/`$options`).
- `supportsContains: false` - `CONTAINS` needs the experimental `containsFilter` flag.
- `supportsElemMatch: false` - no per-element object matching.
- `supportsSize: false` - no array-length filter.
- `supportsZeroVectors: false` - cosine similarity is undefined for zero-magnitude vectors.

## Out of scope (future follow-ups)

- **Native hybrid keyword search**, Meilisearch's differentiator: `MastraVector.query()` exposes no query text, so default behavior is pure-vector (`semanticRatio: 1.0`). Could be added later as an adapter-specific option.
- **A storage (message) adapter**: semantic recall already uses the user's existing storage adapter for message bodies.

## Testing

```bash
pnpm --filter ./stores/meilisearch test   # pretest starts Docker Meilisearch, posttest tears it down
```

`lint`, `tsc --noEmit`, and `build:lib` (tsup esm+cjs + type generation) all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This adds a new way for Mastra to store and search vectors using Meilisearch. In simple terms, it lets Mastra save embeddings, search them by similarity, and filter them by metadata without changing the core package.

## What changed
- Added `@mastra/meilisearch` as a new vector store package under `stores/meilisearch`.
- Implemented `MeilisearchVector` with the full `MastraVector` API:
  - create/list/describe/delete indexes
  - upsert, query, update, and delete vectors
- Added `MeilisearchFilterTranslator` to convert MongoDB-style filters into Meilisearch filter expressions.
- Uses Mastra-provided embeddings via a `userProvided` embedder.
- Supports cosine similarity only; other metrics are warned about and treated as cosine.
- Waits for Meilisearch async tasks on writes for read-after-write consistency.
- Automatically manages filterable metadata keys.
- Added tests, including conformance coverage and a fix for `$not` behavior on missing fields.
- Added package scaffolding/config:
  - package metadata and exports
  - tsconfig/tsup/turbo/vitest/eslint/lint-staged setup
  - pinned Meilisearch Docker compose file
- Added docs for the new vector store and updated the vector database guide.
- Added a changeset for release tracking.

## Notes
- Unsupported Meilisearch capabilities are explicitly documented and disabled in conformance.
- No `packages/core` changes were needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->