### PR TITLE
Default Agent Builder observational memory to OpenAI gpt-5.4-mini

### DIFF
--- a/.changeset/shaky-dingos-prove.md
+++ b/.changeset/shaky-dingos-prove.md
@@ -1,0 +1,18 @@
+---
+'@mastra/editor': patch
+---
+
+Agent Builder agents now default observational memory to `__GATEWAY_OPENAI_MODEL_MINI__` instead of `__GATEWAY_GOOGLE_MODEL__`. Set `OPENAI_API_KEY` in any environment where Builder agents run. Core (non-builder) agents are unaffected and keep the framework default. Admins can still override the model:
+
+```typescript
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        memory: { observationalMemory: { model: '__GATEWAY_OPENAI_MODEL_MINI__' } },
+      },
+    },
+  },
+});
+```

--- a/docs/src/content/en/docs/agent-builder/memory.mdx
+++ b/docs/src/content/en/docs/agent-builder/memory.mdx
@@ -35,9 +35,13 @@ Observational memory lets the agent learn long-lived facts from past conversatio
 
 ## Observational memory model
 
-Observational memory runs an Observer and Reflector model on top of every conversation. The default model is `__GATEWAY_GOOGLE_MODEL__`, which requires a `GOOGLE_API_KEY` environment variable in any environment where the Builder agent will run. Mastra also falls back to `GOOGLE_GENERATIVE_AI_API_KEY`.
+Observational memory runs an Observer and Reflector model on top of every conversation. For Agent Builder agents, the default model is `__GATEWAY_OPENAI_MODEL_MINI__`, which requires an `OPENAI_API_KEY` environment variable in any environment where the Builder agent will run.
 
-To use a different model, set `observationalMemory.model` to any model ID supported by the Mastra model router (and provide the matching provider credentials):
+:::note
+This default applies only to agents created through the Agent Builder. Core (non-builder) agents configured with `observationalMemory: true` keep the framework default `__GATEWAY_GOOGLE_MODEL__` (which uses `GOOGLE_API_KEY`, falling back to `GOOGLE_GENERATIVE_AI_API_KEY`).
+:::
+
+To use a different model, set `observationalMemory.model` to any model ID supported by the Mastra model router (and provide the matching provider credentials). An explicit model always wins over the Builder default:
 
 ```typescript title="src/mastra/index.ts"
 new MastraEditor({

--- a/packages/editor/src/editor.test.ts
+++ b/packages/editor/src/editor.test.ts
@@ -1723,6 +1723,43 @@ describe('agent.create with builder defaults', () => {
 
     const rawConfig = agent.toRawConfig?.();
     expect(rawConfig?.memory).toEqual({ observationalMemory: true });
+
+    const memory = await agent.getMemory();
+    const om = memory?.getConfig().observationalMemory;
+    expect(typeof om).not.toBe('boolean');
+    if (typeof om !== 'boolean' && om) {
+      expect(om.model).toBe('openai/gpt-5.4-mini');
+    }
+  });
+
+  it('passes an explicit observational memory model through unchanged (builder default does not override)', async () => {
+    const storage = new InMemoryStore();
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: {
+          agent: { memory: { observationalMemory: { model: 'openai/gpt-4o-mini' } } },
+        },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-explicit-om-model',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.memory).toEqual({ observationalMemory: { model: 'openai/gpt-4o-mini' } });
+
+    const memory = await agent.getMemory();
+    const om = memory?.getConfig().observationalMemory;
+    expect(typeof om).not.toBe('boolean');
+    if (typeof om !== 'boolean' && om) {
+      expect(om.model).toBe('openai/gpt-4o-mini');
+    }
   });
 
   it('applies baseline observational memory when admin pinned other defaults but not memory', async () => {

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -111,6 +111,9 @@ const BUILDER_BASELINE_DEFAULTS: Partial<Record<(typeof BUILDER_DEFAULT_FIELDS)[
   memory: { observationalMemory: true } satisfies SerializedMemoryConfig,
 };
 
+/** Model used for observational memory when a builder agent stores `observationalMemory: true`. */
+const BUILDER_DEFAULT_OM_MODEL = 'openai/gpt-5.4-mini';
+
 /**
  * Apply builder defaults to agent creation input.
  * Only applies for fields where input is `undefined` (not `null` — null is explicit disable).
@@ -1455,7 +1458,12 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
       if (memoryConfig.observationalMemory) {
         options = {
           ...options,
-          observationalMemory: memoryConfig.observationalMemory,
+          // A literal `true` means "use the builder default OM model"; an explicit
+          // object (user/admin choice) passes through untouched.
+          observationalMemory:
+            memoryConfig.observationalMemory === true
+              ? { model: BUILDER_DEFAULT_OM_MODEL }
+              : memoryConfig.observationalMemory,
         };
       }
 


### PR DESCRIPTION
## Summary

Agents created through the Agent Builder now default their observational memory (the Observer and Reflector models) to \`openai/gpt-5.4-mini\` instead of inheriting the framework-wide default \`google/gemini-2.5-flash\`.

The Agent Builder is an Enterprise feature, and its observational-memory default should be OpenAI-based. This change makes Builder-created agents use an OpenAI model by default while leaving every other agent in the framework untouched.

## How it works

- Builder agents continue to **store** \`{ observationalMemory: true }\` in their record. Nothing about the stored shape changes, so there is **no data migration**.
- The concrete model is resolved **at instantiation time**, from a single constant. Changing the default later automatically applies to all existing Builder agents the next time they are instantiated.
- An explicit \`observationalMemory.model\` (set by a user on create, or by an admin via \`configuration.agent.memory\`) always wins over the Builder default.
- Core (non-builder) agents are unaffected and keep \`google/gemini-2.5-flash\`.

### Resolution order
1. User-provided \`observationalMemory\` object on create → persisted, wins.
2. Admin \`configuration.agent.memory.observationalMemory.model\` → persisted, wins.
3. Neither → stored \`true\` → resolves to \`openai/gpt-5.4-mini\`.

## Operational note

Builder observational memory now requires \`OPENAI_API_KEY\` at runtime (previously \`GOOGLE_API_KEY\`). This is documented and called out in the changeset.

## Test plan

- \`pnpm --filter ./packages/editor test\` — full editor suite passes (502 passing). Added two focused cases:
  - stored \`{ observationalMemory: true }\` resolves to \`openai/gpt-5.4-mini\`.
  - an explicit \`observationalMemory.model\` passes through unchanged.
- \`pnpm --filter ./packages/editor typecheck\` — clean.
- Prettier check on changed files — clean.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-8) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

ELI5: This change makes Builder-created agents use a new default “memory brain” model, so they can remember things with OpenAI instead of Google. If someone already picked a specific model, that choice still wins.

### Summary
- Switched the default observational memory model for Agent Builder agents to `openai/gpt-5.4-mini`.
- Kept non-Builder/core agents unchanged.
- Preserved explicit `observationalMemory.model` settings from users or admins.
- Kept stored `{ observationalMemory: true }` records compatible by resolving the model at runtime.
- Documented that Builder observational memory now requires `OPENAI_API_KEY`.
- Updated tests to cover the new default resolution and explicit model passthrough.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->