### PR TITLE
feat(memory): add OM-managed working memory

### DIFF
--- a/.changeset/honest-llamas-dress.md
+++ b/.changeset/honest-llamas-dress.md
@@ -1,16 +1,22 @@
 ---
 '@mastra/memory': minor
-'@mastra/core': patch
+'@mastra/core': minor
 ---
 
-add working memory extractor and injectTools config
+add OM-managed working memory
 
-Adds a built-in WorkingMemoryExtractor for the observtional
-memory extractor pipeline. When included in observation or
-reflection config, the observer/reflector can update working
-memory through the normal extractor pipeline instead of
-requiring the main agent to call the working memory tool.
+Adds `observationalMemory.observation.manageWorkingMemory` so the Observer can update working memory automatically instead of requiring the main agent to call the working memory tool.
 
-Adds injectTools: boolean (default true) to BaseWorkingMemory.
-Set to false to prevent the working memory update tool from
-being injected into the main agent.
+```ts
+new Memory({
+  options: {
+    workingMemory: { enabled: true },
+    observationalMemory: {
+      enabled: true,
+      observation: { manageWorkingMemory: true },
+    },
+  },
+})
+```
+
+This option adds `WorkingMemoryExtractor`, defaults `workingMemory.agentManaged` to `false`, and defaults `workingMemory.useStateSignals` to `true` when working memory is enabled. Set `workingMemory.agentManaged: true` to keep the main agent's working memory tool and instructions enabled.

--- a/.changeset/honest-llamas-dress.md
+++ b/.changeset/honest-llamas-dress.md
@@ -1,0 +1,16 @@
+---
+'@mastra/memory': minor
+'@mastra/core': patch
+---
+
+add working memory extractor and injectTools config
+
+Adds a built-in WorkingMemoryExtractor for the observtional
+memory extractor pipeline. When included in observation or
+reflection config, the observer/reflector can update working
+memory through the normal extractor pipeline instead of
+requiring the main agent to call the working memory tool.
+
+Adds injectTools: boolean (default true) to BaseWorkingMemory.
+Set to false to prevent the working memory update tool from
+being injected into the main agent.

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -250,7 +250,7 @@ new Extractor({
 
 ### Working memory updates
 
-Use `observationalMemory.observation.manageWorkingMemory` when working memory should be managed automatically by the Observer. The main agent no longer needs to remember to call the working memory tool while it is handling the user request.
+Use `observationalMemory.observation.manageWorkingMemory` to let the Observer manage working memory automatically. The main agent no longer needs to call the working memory tool while it handles the user request, so working memory updates don't depend on the agent remembering to make them.
 
 This also keeps working memory prompt-cache friendly. Working memory normally lives in the system prompt, so updates can invalidate the prompt cache. OM-managed working memory defaults `workingMemory.useStateSignals` to `true`, which moves working memory into state signals instead.
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -248,6 +248,32 @@ new Extractor({
 })
 ```
 
+### Working memory updates
+
+Use `observationalMemory.observation.manageWorkingMemory` when working memory should be managed automatically by the Observer. The main agent no longer needs to remember to call the working memory tool while it is handling the user request.
+
+This also keeps working memory prompt-cache friendly. Working memory normally lives in the system prompt, so updates can invalidate the prompt cache. OM-managed working memory defaults `workingMemory.useStateSignals` to `true`, which moves working memory into state signals instead.
+
+```typescript title="src/mastra/agents/agent.ts"
+import { Memory } from '@mastra/memory'
+
+const memory = new Memory({
+  options: {
+    workingMemory: {
+      enabled: true,
+    },
+    observationalMemory: {
+      enabled: true,
+      observation: {
+        manageWorkingMemory: true,
+      },
+    },
+  },
+})
+```
+
+This setting adds `WorkingMemoryExtractor`, defaults `workingMemory.agentManaged` to `false`, and defaults `workingMemory.useStateSignals` to `true`. Set `workingMemory.agentManaged: true` if the main agent should still receive working memory tool and instruction injection.
+
 Use `onExtracted` to normalize or react to custom extracted values before they are persisted:
 
 ```typescript title="src/mastra/agents/agent.ts"

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -20,6 +20,8 @@ Think of it as the agent's active thoughts or scratchpad – the key information
 
 This is useful for maintaining ongoing state that's always relevant and should always be available to the agent.
 
+If you use [Observational Memory](/docs/memory/observational-memory), `observationalMemory.observation.manageWorkingMemory` lets OM update working memory for the agent.
+
 Working memory can persist at two different scopes:
 
 - **Resource-scoped** (default): Memory persists across all conversation threads for the same user

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -448,9 +448,35 @@ const memory = new Memory({
 - Schema-backed extractors add a follow-up structured output request.
 - Schema-less extractors are inline string extractors emitted directly in the Observer or Reflector output.
 - Dynamic extractor functions receive runtime context, including `source`, `threadId`, `resourceId`, `mainAgent`, `memory`, and `requestContext` when available.
+- `WorkingMemoryExtractor` uses the normal extractor pipeline to update working memory through the active `Memory` instance. It uses structured extraction when working memory has a JSON schema and skips OM metadata persistence, so the working memory payload isn't duplicated under OM extracted metadata.
+- `observationalMemory.observation.manageWorkingMemory` adds `WorkingMemoryExtractor`, defaults `workingMemory.agentManaged` to `false`, and defaults `workingMemory.useStateSignals` to `true` when working memory is enabled.
 - Extraction failures are reported in OM marker data and do not discard other successful extracted values.
 
 ## Examples
+
+### Working memory updates
+
+Use `observationalMemory.observation.manageWorkingMemory` when OM should update working memory.
+
+```typescript title="src/mastra/agents/agent.ts"
+import { Memory } from '@mastra/memory'
+
+const memory = new Memory({
+  options: {
+    workingMemory: {
+      enabled: true,
+    },
+    observationalMemory: {
+      enabled: true,
+      observation: {
+        manageWorkingMemory: true,
+      },
+    },
+  },
+})
+```
+
+Set `workingMemory.agentManaged: true` if the main agent should still receive working memory tool and instruction injection.
 
 ### Resource scope with custom thresholds (experimental)
 

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -237,7 +237,7 @@ export class MockMemory extends MastraMemory {
 
   public listTools(_config?: MemoryConfigInternal): Record<string, ToolAction<any, any, any>> {
     const mergedConfig = this.getMergedThreadConfig(_config);
-    if (!mergedConfig.workingMemory?.enabled) {
+    if (!mergedConfig.workingMemory?.enabled || mergedConfig.workingMemory.agentManaged === false) {
       return {};
     }
 

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -197,13 +197,13 @@ type BaseWorkingMemory = {
    */
   useStateSignals?: boolean;
   /**
-   * Whether to inject the working memory update tool into the main agent.
+   * Whether the main agent manages working memory directly through tool/instruction injection.
    * Set to false when another path, such as Observational Memory extractors,
    * owns working memory updates.
    *
    * @default true
    */
-  injectTools?: boolean;
+  agentManaged?: boolean;
   /** @deprecated The `use` option has been removed. Working memory always uses tool-call mode. */
   use?: never;
 };
@@ -443,6 +443,16 @@ export interface ObservationalMemoryObservationConfig {
    * @default 'google/gemini-2.5-flash'
    */
   model?: AgentConfig['model'];
+
+  /**
+   * Manage working memory through Observational Memory extraction.
+   * When enabled alongside `workingMemory.enabled`, Memory supplies defaults that
+   * disable main-agent working memory management and add the WorkingMemoryExtractor.
+   * Set `workingMemory.agentManaged: true` to keep main-agent tools/instructions enabled.
+   *
+   * @default false
+   */
+  manageWorkingMemory?: boolean;
 
   /**
    * Token count of unobserved messages that triggers observation.
@@ -1329,6 +1339,9 @@ export type SerializedObservationalMemoryConfig = {
 export type SerializedObservationalMemoryObservationConfig = {
   /** Observer model ID */
   model?: string;
+  /** Manage working memory through Observational Memory extraction. */
+  manageWorkingMemory?: boolean;
+
   /** Token count threshold that triggers observation */
   messageTokens?: number;
   /** Model settings (temperature, maxOutputTokens, etc.) */

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -196,6 +196,14 @@ type BaseWorkingMemory = {
    * @see docs/src/content/en/docs/agents/signals.mdx
    */
   useStateSignals?: boolean;
+  /**
+   * Whether to inject the working memory update tool into the main agent.
+   * Set to false when another path, such as Observational Memory extractors,
+   * owns working memory updates.
+   *
+   * @default true
+   */
+  injectTools?: boolean;
   /** @deprecated The `use` option has been removed. Working memory always uses tool-call mode. */
   use?: never;
 };

--- a/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
+++ b/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
@@ -6,8 +6,9 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-
 import type { MastraDBMessage } from '@mastra/core/agent';
 import { getThreadOMMetadata, setThreadOMMetadata } from '@mastra/core/memory';
 import { LibSQLStore } from '@mastra/libsql';
-import { Extractor, Memory } from '@mastra/memory';
+import { Extractor, Memory, WorkingMemoryExtractor } from '@mastra/memory';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 const createMessage = (
   threadId: string,
@@ -107,6 +108,157 @@ describe('Observational Memory extracted metadata persistence', () => {
         status: 'documented',
       },
     });
+  });
+
+  it('updates markdown working memory from an end-to-end LibSQL observation run', async () => {
+    const threadId = randomUUID();
+    const resourceId = randomUUID();
+    const observerOutput = `<observations>
+- User shared durable profile details.
+</observations>
+<working-memory># User Profile
+- Name: Tyler
+- Location: Seattle
+</working-memory>`;
+    const model = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'obs-wm-1', modelId: 'mock-observer', timestamp: new Date() },
+          { type: 'text-start', id: 'text-wm-1' },
+          { type: 'text-delta', id: 'text-wm-1', delta: observerOutput },
+          { type: 'text-end', id: 'text-wm-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 } },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const workingMemory = new Memory({
+      storage: memory.storage,
+      options: {
+        workingMemory: {
+          enabled: true,
+          template: '# User Profile\n- Name:\n- Location:',
+          agentManaged: false,
+        },
+        observationalMemory: {
+          enabled: true,
+          observation: {
+            model,
+            messageTokens: 1,
+            bufferTokens: false,
+            previousObserverTokens: 1000,
+            extract: [new WorkingMemoryExtractor()],
+          },
+        },
+      },
+    });
+
+    await workingMemory.createThread({ threadId, resourceId, title: 'Working Memory Markdown' });
+    await workingMemory.saveMessages({
+      messages: [
+        createMessage(
+          threadId,
+          resourceId,
+          'user',
+          'My name is Tyler and I live in Seattle.',
+          '2026-06-24T18:00:00.000Z',
+        ),
+      ],
+    });
+
+    const omEngine = await workingMemory.omEngine;
+    const result = await omEngine!.observe({ threadId, resourceId });
+
+    expect(result.observed).toBe(true);
+    await expect(workingMemory.getWorkingMemory({ threadId, resourceId })).resolves.toContain('Name: Tyler');
+    await expect(workingMemory.getWorkingMemory({ threadId, resourceId })).resolves.toContain('Location: Seattle');
+  });
+
+  it('replaces schema-backed working memory from an end-to-end LibSQL observation run', async () => {
+    const threadId = randomUUID();
+    const resourceId = randomUUID();
+    const observerOutput = `<observations>
+- User shared durable schema-backed profile details.
+</observations>`;
+    const model = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'obs-wm-2', modelId: 'mock-observer', timestamp: new Date() },
+          { type: 'text-start', id: 'text-wm-2' },
+          { type: 'text-delta', id: 'text-wm-2', delta: observerOutput },
+          { type: 'text-end', id: 'text-wm-2' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 } },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 80, outputTokens: 10, totalTokens: 90 },
+        warnings: [],
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ 'working-memory': { profile: { location: 'Seattle' }, preferences: ['weather'] } }),
+          },
+        ],
+      }),
+    });
+
+    const workingMemory = new Memory({
+      storage: memory.storage,
+      options: {
+        workingMemory: {
+          enabled: true,
+          schema: z.object({
+            profile: z.object({ name: z.string().optional(), location: z.string().optional() }).optional(),
+            preferences: z.array(z.string()).optional(),
+          }),
+          agentManaged: false,
+        },
+        observationalMemory: {
+          enabled: true,
+          observation: {
+            model,
+            messageTokens: 1,
+            bufferTokens: false,
+            previousObserverTokens: 1000,
+            extract: [new WorkingMemoryExtractor()],
+          },
+        },
+      },
+    });
+
+    await workingMemory.createThread({ threadId, resourceId, title: 'Working Memory Schema' });
+    await workingMemory.updateWorkingMemory({
+      threadId,
+      resourceId,
+      workingMemory: JSON.stringify({ profile: { name: 'Tyler' } }),
+    });
+    await workingMemory.saveMessages({
+      messages: [
+        createMessage(
+          threadId,
+          resourceId,
+          'user',
+          'I live in Seattle and like weather updates.',
+          '2026-06-24T18:05:00.000Z',
+        ),
+      ],
+    });
+
+    const omEngine = await workingMemory.omEngine;
+    const result = await omEngine!.observe({ threadId, resourceId });
+
+    expect(result.observed).toBe(true);
+    await expect(workingMemory.getWorkingMemory({ threadId, resourceId })).resolves.toBe(
+      JSON.stringify({ profile: { location: 'Seattle' }, preferences: ['weather'] }),
+    );
   });
 
   it('persists extracted values from an end-to-end LibSQL observation run', async () => {

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -54,6 +54,26 @@ describe('Memory', () => {
     });
   });
 
+  describe('listTools', () => {
+    it('omits working memory tools when injectTools is false', () => {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        options: { workingMemory: { enabled: true, injectTools: false } },
+      });
+
+      expect(memory.listTools()).not.toHaveProperty('updateWorkingMemory');
+    });
+
+    it('includes working memory tools by default when working memory is enabled', () => {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        options: { workingMemory: { enabled: true } },
+      });
+
+      expect(memory.listTools()).toHaveProperty('updateWorkingMemory');
+    });
+  });
+
   describe('updateMessageToHideWorkingMemoryV2', () => {
     const memory = new TestableMemory();
 

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -55,10 +55,10 @@ describe('Memory', () => {
   });
 
   describe('listTools', () => {
-    it('omits working memory tools when injectTools is false', () => {
+    it('omits working memory tools when agentManaged is false', () => {
       const memory = new Memory({
         storage: new InMemoryStore(),
-        options: { workingMemory: { enabled: true, injectTools: false } },
+        options: { workingMemory: { enabled: true, agentManaged: false } },
       });
 
       expect(memory.listTools()).not.toHaveProperty('updateWorkingMemory');
@@ -71,6 +71,90 @@ describe('Memory', () => {
       });
 
       expect(memory.listTools()).toHaveProperty('updateWorkingMemory');
+    });
+
+    it('uses manageWorkingMemory to add the working memory extractor and disable agent-managed tools by default', () => {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        options: {
+          workingMemory: { enabled: true },
+          observationalMemory: { enabled: true, observation: { manageWorkingMemory: true } },
+        },
+      });
+
+      const config = memory.getMergedThreadConfig() as MemoryConfig & {
+        workingMemory: MemoryConfig['workingMemory'] & { agentManaged?: boolean; useStateSignals?: boolean };
+      };
+      const omConfig = config.observationalMemory as Extract<MemoryConfig['observationalMemory'], object> & {
+        observation?: { extract?: Array<{ slug: string }> };
+      };
+      expect(config.workingMemory.agentManaged).toBe(false);
+      expect(config.workingMemory.useStateSignals).toBe(true);
+      expect(memory.listTools()).not.toHaveProperty('updateWorkingMemory');
+      expect(omConfig.observation?.extract?.some(extractor => extractor.slug === 'working-memory')).toBe(true);
+    });
+
+    it('keeps explicit useStateSignals false when manageWorkingMemory supplies defaults', () => {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        options: {
+          workingMemory: { enabled: true, useStateSignals: false },
+          observationalMemory: { enabled: true, observation: { manageWorkingMemory: true } },
+        },
+      });
+
+      const config = memory.getMergedThreadConfig();
+
+      expect(config.workingMemory?.useStateSignals).toBe(false);
+    });
+
+    it('keeps agent-managed tools when agentManaged explicitly overrides manageWorkingMemory defaults', () => {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        options: {
+          workingMemory: { enabled: true, agentManaged: true, useStateSignals: false },
+          observationalMemory: { enabled: true, observation: { manageWorkingMemory: true } },
+        },
+      });
+
+      expect(memory.listTools()).toHaveProperty('updateWorkingMemory');
+    });
+  });
+
+  describe('getSystemMessage', () => {
+    it('renders working memory as context-only when agentManaged is false', async () => {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        options: { workingMemory: { enabled: true, agentManaged: false } },
+      });
+      const threadId = 'agent-managed-false-thread';
+      const resourceId = 'agent-managed-false-resource';
+      await memory.createThread({ threadId, resourceId });
+      await memory.updateWorkingMemory({ threadId, resourceId, workingMemory: '# User\n- Location: Sooke' });
+
+      const systemMessage = await memory.getSystemMessage({ threadId, resourceId });
+
+      expect(systemMessage).toContain('WORKING_MEMORY_SYSTEM_INSTRUCTION (READ-ONLY)');
+      expect(systemMessage).toContain('Location: Sooke');
+      expect(systemMessage).not.toContain('calling the updateWorkingMemory tool');
+    });
+
+    it('renders update instructions when agentManaged explicitly overrides manageWorkingMemory defaults', async () => {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        options: {
+          workingMemory: { enabled: true, agentManaged: true, useStateSignals: false },
+          observationalMemory: { enabled: true, observation: { manageWorkingMemory: true } },
+        },
+      });
+      const threadId = 'agent-managed-true-thread';
+      const resourceId = 'agent-managed-true-resource';
+      await memory.createThread({ threadId, resourceId });
+
+      const systemMessage = await memory.getSystemMessage({ threadId, resourceId });
+
+      expect(systemMessage).toContain('calling the updateWorkingMemory tool');
+      expect(systemMessage).not.toContain('WORKING_MEMORY_SYSTEM_INSTRUCTION (READ-ONLY)');
     });
   });
 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -55,6 +55,7 @@ export {
 } from './processors/observational-memory/model-by-input-tokens';
 export {
   Extractor,
+  WorkingMemoryExtractor,
   type ExtractorConfig,
   type ExtractorOnExtractedContext,
   type ExtractorRuntimeContext,
@@ -2149,7 +2150,11 @@ Notes:
     this.assertWorkingMemoryStateSignalsCompatibility(mergedConfig);
     const tools: Record<string, ToolAction<any, any, any>> = {};
 
-    if (mergedConfig.workingMemory?.enabled && !mergedConfig.readOnly) {
+    if (
+      mergedConfig.workingMemory?.enabled &&
+      mergedConfig.workingMemory.injectTools !== false &&
+      !mergedConfig.readOnly
+    ) {
       const { name, tool } = createWorkingMemoryTool(mergedConfig, {
         vNext: this.isVNextWorkingMemoryConfig(mergedConfig),
       });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -46,6 +46,7 @@ import type { JSONSchema7 } from 'json-schema';
 import { LRUCache } from 'lru-cache';
 import xxhash from 'xxhash-wasm';
 import type { ObservationalMemory, ObservationalMemoryConfig } from './processors/observational-memory';
+import { WorkingMemoryExtractor } from './processors/observational-memory/working-memory-extractor';
 import { recallTool } from './tools/om-tools';
 import { createWorkingMemoryTool, deepMergeWorkingMemory } from './tools/working-memory';
 
@@ -55,12 +56,12 @@ export {
 } from './processors/observational-memory/model-by-input-tokens';
 export {
   Extractor,
-  WorkingMemoryExtractor,
   type ExtractorConfig,
   type ExtractorOnExtractedContext,
   type ExtractorRuntimeContext,
   type ExtractorSource,
 } from './processors/observational-memory';
+export { WorkingMemoryExtractor } from './processors/observational-memory/working-memory-extractor';
 
 /**
  * Normalize a `boolean | object` observational memory config.
@@ -212,6 +213,12 @@ function normalizeObservationalMemoryConfig(
   return config as NormalizedObservationalMemoryConfig;
 }
 
+function hasWorkingMemoryExtractor(
+  extractors: NonNullable<NonNullable<ObservationalMemoryConfig['observation']>['extract']> | undefined,
+): boolean {
+  return !!extractors?.some(extractor => extractor.slug === 'working-memory');
+}
+
 // Re-export for testing purposes
 export { deepMergeWorkingMemory };
 
@@ -259,6 +266,40 @@ export class Memory extends MastraMemory {
     } else {
       void this._omEngine?.then(engine => engine?.__registerMastra(mastra));
     }
+  }
+
+  public override getMergedThreadConfig(config?: MemoryConfigInternal): MemoryConfigInternal {
+    return this.applyManagedWorkingMemoryDefaults(super.getMergedThreadConfig(config));
+  }
+
+  private applyManagedWorkingMemoryDefaults(config: MemoryConfigInternal): MemoryConfigInternal {
+    const omConfig = normalizeObservationalMemoryConfig(
+      config.observationalMemory as boolean | MemoryObservationalMemoryOptions | undefined,
+    );
+    if (!omConfig?.observation?.manageWorkingMemory || !config.workingMemory?.enabled) {
+      return config;
+    }
+
+    const currentWorkingMemory = config.workingMemory;
+    const workingMemory = {
+      ...currentWorkingMemory,
+      agentManaged: currentWorkingMemory.agentManaged ?? false,
+      useStateSignals: currentWorkingMemory.useStateSignals ?? true,
+    };
+    const observation = (omConfig.observation ?? {}) as NonNullable<ObservationalMemoryConfig['observation']>;
+    const extract = observation.extract ?? [];
+
+    return {
+      ...config,
+      workingMemory,
+      observationalMemory: {
+        ...omConfig,
+        observation: {
+          ...observation,
+          extract: hasWorkingMemoryExtractor(extract) ? extract : [...extract, new WorkingMemoryExtractor()],
+        },
+      },
+    } as MemoryConfigInternal;
   }
 
   constructor(config: MemoryConstructorConfig = {}) {
@@ -1427,8 +1468,10 @@ ${workingMemory}`;
       return null;
     }
 
-    // In readOnly mode, provide context without tool instructions
-    if (config?.readOnly) {
+    const workingMemoryConfig = config.workingMemory;
+
+    // In readOnly or non-agent-managed mode, provide context without tool instructions.
+    if (config?.readOnly || workingMemoryConfig.agentManaged === false) {
       return this.getReadOnlyWorkingMemoryInstruction({
         template: workingMemoryTemplate,
         data: workingMemoryData,
@@ -2150,11 +2193,9 @@ Notes:
     this.assertWorkingMemoryStateSignalsCompatibility(mergedConfig);
     const tools: Record<string, ToolAction<any, any, any>> = {};
 
-    if (
-      mergedConfig.workingMemory?.enabled &&
-      mergedConfig.workingMemory.injectTools !== false &&
-      !mergedConfig.readOnly
-    ) {
+    const workingMemoryConfig = mergedConfig.workingMemory;
+
+    if (workingMemoryConfig?.enabled && workingMemoryConfig.agentManaged !== false && !mergedConfig.readOnly) {
       const { name, tool } = createWorkingMemoryTool(mergedConfig, {
         vNext: this.isVNextWorkingMemoryConfig(mergedConfig),
       });

--- a/packages/memory/src/processors/observational-memory/__tests__/extractor.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/extractor.test.ts
@@ -221,10 +221,10 @@ describe('Extractor', () => {
       workingMemory: '# User\n- Existing fact\n- New fact',
       memoryConfig: undefined,
     });
-    expect(result.values).toBeUndefined();
+    expect(result.values).toEqual({ 'working-memory': '# User\n- Existing fact\n- New fact' });
   });
 
-  it('merges JSON working memory updates from the working memory extractor', async () => {
+  it('replaces JSON working memory from the working memory extractor', async () => {
     const memory = {
       getMergedThreadConfig: vi.fn(() => ({ workingMemory: { enabled: true, schema: {} } })),
       getWorkingMemoryTemplate: vi.fn(async () => ({ format: 'json', content: '{"type":"object"}' })),
@@ -242,6 +242,7 @@ describe('Extractor', () => {
     expect(resolved?.mode).toBe('structured');
     expect(resolved?.instructions).toContain('Working memory JSON schema:');
     expect(resolved?.schema.parse({ location: 'Toronto' })).toEqual({ location: 'Toronto' });
+    expect(resolved?.schema.parse(null)).toBeNull();
     expect(buildExtractorOutputSections([resolved!])).toBe('');
 
     const result = await applyExtractorHooks({
@@ -256,9 +257,37 @@ describe('Extractor', () => {
     expect(memory.updateWorkingMemory).toHaveBeenCalledWith({
       threadId: 'thread-1',
       resourceId: 'resource-1',
-      workingMemory: JSON.stringify({ name: 'Tyler', likes: ['dogs'], location: 'Toronto' }),
+      workingMemory: JSON.stringify({ location: 'Toronto' }),
       memoryConfig: undefined,
     });
+    expect(result.values).toEqual({ 'working-memory': { location: 'Toronto' } });
+  });
+
+  it('skips JSON working memory updates when the extractor returns null', async () => {
+    const memory = {
+      getMergedThreadConfig: vi.fn(() => ({ workingMemory: { enabled: true, schema: {} } })),
+      getWorkingMemoryTemplate: vi.fn(async () => ({ format: 'json', content: '{"type":"object"}' })),
+      getWorkingMemory: vi.fn(async () => '{"name":"Tyler"}'),
+      updateWorkingMemory: vi.fn(async () => undefined),
+    } as any;
+    const extractor = new WorkingMemoryExtractor();
+    const [resolved] = await resolveExtractors([extractor], {
+      source: 'observer',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      memory,
+    });
+
+    const result = await applyExtractorHooks({
+      source: 'observer',
+      extractors: [resolved!],
+      values: { 'working-memory': null },
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      memory,
+    });
+
+    expect(memory.updateWorkingMemory).not.toHaveBeenCalled();
     expect(result.values).toBeUndefined();
   });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/extractor.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/extractor.test.ts
@@ -18,6 +18,8 @@ import {
   stripExtractorSections,
   validateExtractorList,
 } from '../extractor';
+import { WorkingMemoryExtractor } from '../working-memory-extractor';
+
 describe('Extractor', () => {
   it('creates an inline string carry-forward extractor when no schema is provided', () => {
     const extractor = new Extractor({ name: 'Project Status', instructions: 'Extract the project status.' });
@@ -185,6 +187,79 @@ describe('Extractor', () => {
     });
 
     expect(onExtracted).toHaveBeenCalledWith(expect.objectContaining({ memory }));
+  });
+
+  it('updates markdown working memory from the working memory extractor without persisting OM metadata', async () => {
+    const memory = {
+      getMergedThreadConfig: vi.fn(() => ({ workingMemory: { enabled: true } })),
+      getWorkingMemoryTemplate: vi.fn(async () => ({ format: 'markdown', content: '# User\n' })),
+      getWorkingMemory: vi.fn(async () => '- Existing fact'),
+      updateWorkingMemory: vi.fn(async () => undefined),
+    } as any;
+    const extractor = new WorkingMemoryExtractor();
+    const [resolved] = await resolveExtractors([extractor], {
+      source: 'observer',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      memory,
+    });
+
+    expect(resolved?.instructions).toContain('Current working memory:\n- Existing fact');
+
+    const result = await applyExtractorHooks({
+      source: 'observer',
+      extractors: [resolved!],
+      values: { 'working-memory': '# User\n- Existing fact\n- New fact' },
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      memory,
+    });
+
+    expect(memory.updateWorkingMemory).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      workingMemory: '# User\n- Existing fact\n- New fact',
+      memoryConfig: undefined,
+    });
+    expect(result.values).toBeUndefined();
+  });
+
+  it('merges JSON working memory updates from the working memory extractor', async () => {
+    const memory = {
+      getMergedThreadConfig: vi.fn(() => ({ workingMemory: { enabled: true, schema: {} } })),
+      getWorkingMemoryTemplate: vi.fn(async () => ({ format: 'json', content: '{"type":"object"}' })),
+      getWorkingMemory: vi.fn(async () => '{"name":"Tyler","likes":["dogs"]}'),
+      updateWorkingMemory: vi.fn(async () => undefined),
+    } as any;
+    const extractor = new WorkingMemoryExtractor();
+    const [resolved] = await resolveExtractors([extractor], {
+      source: 'observer',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      memory,
+    });
+
+    expect(resolved?.mode).toBe('structured');
+    expect(resolved?.instructions).toContain('Working memory JSON schema:');
+    expect(resolved?.schema.parse({ location: 'Toronto' })).toEqual({ location: 'Toronto' });
+    expect(buildExtractorOutputSections([resolved!])).toBe('');
+
+    const result = await applyExtractorHooks({
+      source: 'observer',
+      extractors: [resolved!],
+      values: { 'working-memory': { location: 'Toronto' } },
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      memory,
+    });
+
+    expect(memory.updateWorkingMemory).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      workingMemory: JSON.stringify({ name: 'Tyler', likes: ['dogs'], location: 'Toronto' }),
+      memoryConfig: undefined,
+    });
+    expect(result.values).toBeUndefined();
   });
 
   it('returns extractor failures when the structured extraction call fails', async () => {

--- a/packages/memory/src/processors/observational-memory/index.ts
+++ b/packages/memory/src/processors/observational-memory/index.ts
@@ -38,6 +38,7 @@ export type {
   ExtractorRuntimeContext,
   ExtractorSource,
 } from './extractor';
+export { WorkingMemoryExtractor } from './working-memory-extractor';
 
 export type {
   ObservationalMemoryConfig,

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -198,6 +198,16 @@ export interface ObservationConfig {
   instruction?: string;
 
   /**
+   * Manage working memory through Observational Memory extraction.
+   * When enabled alongside `workingMemory.enabled`, Memory supplies defaults that
+   * disable main-agent working memory management and add the WorkingMemoryExtractor.
+   * Set `workingMemory.agentManaged: true` to keep main-agent tools/instructions enabled.
+   *
+   * @default false
+   */
+  manageWorkingMemory?: boolean;
+
+  /**
    * Additional values to extract from observer output. Built-in OM fields are registered automatically.
    * @experimental Extractors are experimental and may change in a future release.
    */

--- a/packages/memory/src/processors/observational-memory/working-memory-extractor.ts
+++ b/packages/memory/src/processors/observational-memory/working-memory-extractor.ts
@@ -1,41 +1,20 @@
 import { parseMemoryRequestContext } from '@mastra/core/memory';
 import { z } from 'zod';
 
-import type { Memory } from '../..';
-import { deepMergeWorkingMemory } from '../../tools/working-memory';
 import { Extractor } from './extractor';
 import type { ExtractorRuntimeContext } from './extractor';
 
-function parseJsonObject(value: unknown): Record<string, unknown> | null {
-  if (!value) return null;
-  if (typeof value === 'object' && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  if (typeof value !== 'string') return null;
-  try {
-    const parsed = JSON.parse(value);
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
 async function getWorkingMemoryDetails(context: ExtractorRuntimeContext): Promise<{
-  memory?: Memory;
   template?: string;
   current?: string | null;
   usesSchema: boolean;
 }> {
-  const memory = context.memory;
-  if (!memory) {
-    return { usesSchema: false };
-  }
-
+  const memory = context.memory!;
   const memoryConfig = parseMemoryRequestContext(context.requestContext)?.memoryConfig;
   const config = memory.getMergedThreadConfig(memoryConfig ?? {});
   const workingMemory = config.workingMemory;
   if (!workingMemory?.enabled) {
-    return { memory, usesSchema: false };
+    return { usesSchema: false };
   }
 
   const [template, current] = await Promise.all([
@@ -50,7 +29,6 @@ async function getWorkingMemoryDetails(context: ExtractorRuntimeContext): Promis
   ]);
 
   return {
-    memory,
     template: typeof template?.content === 'string' ? template.content : JSON.stringify(template?.content),
     current,
     usesSchema: Boolean(workingMemory.schema),
@@ -58,15 +36,11 @@ async function getWorkingMemoryDetails(context: ExtractorRuntimeContext): Promis
 }
 
 function buildWorkingMemoryInstructions(details: Awaited<ReturnType<typeof getWorkingMemoryDetails>>): string {
-  if (!details.memory) {
-    return 'Working memory is unavailable. Do not output this section.';
-  }
-
   if (details.usesSchema) {
     return [
       'Update working memory with durable facts from the observations you made.',
-      'Return only a JSON object containing fields to add or update. Omit unchanged fields.',
-      'Arrays replace existing arrays when provided, so include the complete array only when it changed.',
+      'Return the full updated JSON object when working memory should change.',
+      'Return null when no working memory update is needed.',
       details.template ? `Working memory JSON schema:\n${details.template}` : undefined,
       details.current ? `Current working memory JSON:\n${details.current}` : undefined,
     ]
@@ -84,7 +58,7 @@ function buildWorkingMemoryInstructions(details: Awaited<ReturnType<typeof getWo
     .join('\n\n');
 }
 
-export class WorkingMemoryExtractor extends Extractor<string | Record<string, unknown>> {
+export class WorkingMemoryExtractor extends Extractor<string | Record<string, unknown> | null> {
   constructor() {
     super({
       name: 'Working Memory',
@@ -92,37 +66,30 @@ export class WorkingMemoryExtractor extends Extractor<string | Record<string, un
       instructions: async context => buildWorkingMemoryInstructions(await getWorkingMemoryDetails(context)),
       schema: async context => {
         const details = await getWorkingMemoryDetails(context);
-        return details.usesSchema ? z.record(z.string(), z.unknown()) : undefined;
+        return details.usesSchema ? z.union([z.record(z.string(), z.unknown()), z.null()]) : undefined;
       },
       onExtracted: async ({ current, memory, threadId, resourceId, requestContext }) => {
-        if (!memory) {
-          throw new Error('Working memory extractor requires an active Memory instance.');
-        }
-
         const memoryConfig = parseMemoryRequestContext(requestContext)?.memoryConfig;
-        const config = memory.getMergedThreadConfig(memoryConfig ?? {});
-        if (!config.workingMemory?.enabled) {
-          throw new Error('Working memory is not enabled for this memory instance.');
+        const config = memory!.getMergedThreadConfig(memoryConfig ?? {});
+        const isSchemaWorkingMemory = Boolean(config.workingMemory?.schema);
+
+        if (isSchemaWorkingMemory && current === null) {
+          return undefined;
         }
 
-        let workingMemory = typeof current === 'string' ? current : (JSON.stringify(current) ?? '');
-        if (config.workingMemory.schema) {
-          const existing = parseJsonObject(await memory.getWorkingMemory({ threadId, resourceId, memoryConfig }));
-          const update = parseJsonObject(current);
-          if (!update) {
-            throw new Error('Working memory extractor expected a JSON object update.');
-          }
-          workingMemory = JSON.stringify(deepMergeWorkingMemory(existing, update));
+        const workingMemory = typeof current === 'string' ? current : (JSON.stringify(current) ?? '');
+        if (!workingMemory.trim()) {
+          return undefined;
         }
 
-        await memory.updateWorkingMemory({
+        await memory!.updateWorkingMemory({
           threadId,
           resourceId,
           workingMemory,
           memoryConfig,
         });
 
-        return undefined;
+        return current;
       },
     });
   }

--- a/packages/memory/src/processors/observational-memory/working-memory-extractor.ts
+++ b/packages/memory/src/processors/observational-memory/working-memory-extractor.ts
@@ -1,0 +1,129 @@
+import { parseMemoryRequestContext } from '@mastra/core/memory';
+import { z } from 'zod';
+
+import type { Memory } from '../..';
+import { deepMergeWorkingMemory } from '../../tools/working-memory';
+import { Extractor } from './extractor';
+import type { ExtractorRuntimeContext } from './extractor';
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (!value) return null;
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getWorkingMemoryDetails(context: ExtractorRuntimeContext): Promise<{
+  memory?: Memory;
+  template?: string;
+  current?: string | null;
+  usesSchema: boolean;
+}> {
+  const memory = context.memory;
+  if (!memory) {
+    return { usesSchema: false };
+  }
+
+  const memoryConfig = parseMemoryRequestContext(context.requestContext)?.memoryConfig;
+  const config = memory.getMergedThreadConfig(memoryConfig ?? {});
+  const workingMemory = config.workingMemory;
+  if (!workingMemory?.enabled) {
+    return { memory, usesSchema: false };
+  }
+
+  const [template, current] = await Promise.all([
+    memory.getWorkingMemoryTemplate({ memoryConfig }),
+    context.threadId
+      ? memory.getWorkingMemory({
+          threadId: context.threadId,
+          resourceId: context.resourceId,
+          memoryConfig,
+        })
+      : Promise.resolve(null),
+  ]);
+
+  return {
+    memory,
+    template: typeof template?.content === 'string' ? template.content : JSON.stringify(template?.content),
+    current,
+    usesSchema: Boolean(workingMemory.schema),
+  };
+}
+
+function buildWorkingMemoryInstructions(details: Awaited<ReturnType<typeof getWorkingMemoryDetails>>): string {
+  if (!details.memory) {
+    return 'Working memory is unavailable. Do not output this section.';
+  }
+
+  if (details.usesSchema) {
+    return [
+      'Update working memory with durable facts from the observations you made.',
+      'Return only a JSON object containing fields to add or update. Omit unchanged fields.',
+      'Arrays replace existing arrays when provided, so include the complete array only when it changed.',
+      details.template ? `Working memory JSON schema:\n${details.template}` : undefined,
+      details.current ? `Current working memory JSON:\n${details.current}` : undefined,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+  }
+
+  return [
+    'Update working memory with durable facts from the observations you made.',
+    'Return the full updated Markdown working memory. Preserve useful existing content and add or revise only what changed.',
+    details.template ? `Working memory template:\n${details.template}` : undefined,
+    details.current ? `Current working memory:\n${details.current}` : undefined,
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+export class WorkingMemoryExtractor extends Extractor<string | Record<string, unknown>> {
+  constructor() {
+    super({
+      name: 'Working Memory',
+      includePreviousExtraction: false,
+      instructions: async context => buildWorkingMemoryInstructions(await getWorkingMemoryDetails(context)),
+      schema: async context => {
+        const details = await getWorkingMemoryDetails(context);
+        return details.usesSchema ? z.record(z.string(), z.unknown()) : undefined;
+      },
+      onExtracted: async ({ current, memory, threadId, resourceId, requestContext }) => {
+        if (!memory) {
+          throw new Error('Working memory extractor requires an active Memory instance.');
+        }
+
+        const memoryConfig = parseMemoryRequestContext(requestContext)?.memoryConfig;
+        const config = memory.getMergedThreadConfig(memoryConfig ?? {});
+        if (!config.workingMemory?.enabled) {
+          throw new Error('Working memory is not enabled for this memory instance.');
+        }
+
+        let workingMemory = typeof current === 'string' ? current : (JSON.stringify(current) ?? '');
+        if (config.workingMemory.schema) {
+          const existing = parseJsonObject(await memory.getWorkingMemory({ threadId, resourceId, memoryConfig }));
+          const update = parseJsonObject(current);
+          if (!update) {
+            throw new Error('Working memory extractor expected a JSON object update.');
+          }
+          workingMemory = JSON.stringify(deepMergeWorkingMemory(existing, update));
+        }
+
+        await memory.updateWorkingMemory({
+          threadId,
+          resourceId,
+          workingMemory,
+          memoryConfig,
+        });
+
+        return undefined;
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Adds a built-in WorkingMemoryExtractor and a simpler OM-managed working memory setup.

With `manageWorkingMemory`, OM can extract working-memory updates from observations and apply them after the turn. The sugar defaults working memory to prompt-cache-friendly state signals and disables direct agent tool management unless the user opts back in.

```ts
new Memory({
  options: {
    observationalMemory: {
      enabled: true,
      observation: {
        manageWorkingMemory: true,
        // extractors: [new WorkingMemoryExtractor()] <- added internally by manageWorkingMemory: true
      },
    },
    workingMemory: {
      enabled: true,
      // these are configured internally by observation.manageWorkingMemory: true
      // agentManaged: false, <- disables the agent managing working memory via tool calls and removes system instructions saying to do so
      // useStateSignals: true,
    },
  },
});
```



Users who still want both paths can opt in explicitly:

```ts
workingMemory: {
  enabled: true,
  agentManaged: true
}
```

<img width="1013" height="889" alt="Screenshot 2026-06-29 at 3 54 07 PM" src="https://github.com/user-attachments/assets/cccb97dd-ac5c-4898-b78a-f84f6cdd3bb0" />
<img width="1015" height="871" alt="Screenshot 2026-06-29 at 3 25 57 PM" src="https://github.com/user-attachments/assets/7d06499f-45dc-443a-ac28-f1aa65f4ceb9" />


## Test plan

- `pnpm --filter ./packages/memory test:unit -- --run src/processors/observational-memory/__tests__/extractor.test.ts src/processors/observational-memory/__tests__/observational-memory-api.test.ts --reporter=dot --bail 1`
- `pnpm --filter ./packages/memory check`
- Stack rebase verified linear against #18653

## Stack

- Previous: #18653
- Next: #18655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR helps Observational Memory automatically “catch” what changed in your app’s working memory as it watches the conversation, then apply those updates for the agent after the turn. So the agent doesn’t have to remember to call the working-memory tool every time—and the default setup is tuned to stay friendly to prompt caching.

## Summary
- Added a built-in `WorkingMemoryExtractor` and re-exported it from the Observational Memory module.
- Introduced `observationalMemory.observation.manageWorkingMemory` to let Observational Memory extract working-memory updates and apply them after the turn.
- Added `workingMemory.agentManaged` to control whether the main agent still receives working-memory tool/instructions (`agentManaged` defaults to `true` when not overridden).
- When OM manages working memory (`manageWorkingMemory: true` with `workingMemory.enabled: true`), defaults change to:
  - `workingMemory.agentManaged: false` (OM applies updates instead of the agent)
  - `workingMemory.useStateSignals: true` (prompt-cache-friendly)
  - setting `workingMemory.agentManaged: true` preserves the “agent also manages it” path.
- Updated memory behavior for tool exposure, system-message/tool instruction wording, and merged thread config defaults to match the new working-memory management rules.
- Extended unit/integration tests to verify extraction and persistence for both markdown and JSON/schema-backed working memory modes, plus `listTools()`/`getSystemMessage()`/merged-config behavior under the new options.
- Updated documentation and a changeset to document the new configuration flow and defaults (`manageWorkingMemory`, `agentManaged`, and `useStateSignals`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->