### PR TITLE
feat: show Mastra Code work and idle timing

### DIFF
--- a/.changeset/thick-readers-arrive.md
+++ b/.changeset/thick-readers-arrive.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved the Mastra Code status area to show active work time, completed work duration, and idle time.

--- a/mastracode/e2e/fixtures/work-idle-status.json
+++ b/mastracode/e2e/fixtures/work-idle-status.json
@@ -1,0 +1,19 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "Run a slow work idle status check.",
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat"
+      },
+      "chunkSize": 4,
+      "streamingProfile": {
+        "ttft": 500,
+        "tps": 4
+      },
+      "response": {
+        "content": "Work idle status response complete."
+      }
+    }
+  ]
+}

--- a/mastracode/e2e/terminal-backend.ts
+++ b/mastracode/e2e/terminal-backend.ts
@@ -379,6 +379,7 @@ async function startMastraCodeApp(
     terminal,
     ...(options?.tui ?? {}),
   });
+  await options?.onTuiCreated?.(tui);
 
   void tui.run().catch(error => {
     process.stderr.write(`[mc-e2e:terminal] TUI run failed: ${error instanceof Error ? error.stack : String(error)}\n`);

--- a/mastracode/e2e/tui/index.ts
+++ b/mastracode/e2e/tui/index.ts
@@ -132,6 +132,7 @@ import { updateCommandPromptScenario } from './update-command-prompt.js';
 import { updateStartupPromptScenario } from './update-startup-prompt.js';
 import { visibleCommandsScenario } from './visible-commands.js';
 import { webSearchRenderingScenario } from './web-search-rendering.js';
+import { workIdleStatusScenario } from './work-idle-status.js';
 import { workspaceCommandsScenario } from './workspace-commands.js';
 import { workspacePlanModeToolsScenario } from './workspace-plan-mode-tools.js';
 import { workspaceToolNamesScenario } from './workspace-tool-names.js';
@@ -275,6 +276,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'workspace-plan-mode-tools': workspacePlanModeToolsScenario,
   'workspace-tool-names': workspaceToolNamesScenario,
   'workspace-tool-output-rendering': workspaceToolOutputRenderingScenario,
+  'work-idle-status': workIdleStatusScenario,
   'resourceid-drift-prompt-accept': resourceidDriftPromptAcceptScenario,
   'resourceid-drift-prompt-decline': resourceidDriftPromptDeclineScenario,
   'worktree-cross-thread-resume': worktreeCrossThreadResumeScenario,

--- a/mastracode/e2e/tui/state-signal-browser-processor.ts
+++ b/mastracode/e2e/tui/state-signal-browser-processor.ts
@@ -61,6 +61,8 @@ class BrowserProcessorFixture extends MastraBrowser {
   }
 }
 
+let browserProcessorStatePath: string | undefined;
+
 function getRequestBody(request: unknown): unknown {
   if (request && typeof request === 'object' && 'body' in request) {
     return request.body;
@@ -78,9 +80,9 @@ export const stateSignalBrowserProcessorScenario = {
   aimockFixture: 'state-signal-browser-processor.json',
   prepare({ appDataDir, projectDir }) {
     mkdirSync(projectDir, { recursive: true });
-    const statePath = join(appDataDir, 'browser-state-processor.json');
+    browserProcessorStatePath = join(appDataDir, 'browser-state-processor.json');
     writeFileSync(
-      statePath,
+      browserProcessorStatePath,
       JSON.stringify({
         tabs: [{ url: 'https://example.test/browser-snapshot', title: 'Browser Snapshot E2E' }],
         activeTabIndex: 0,
@@ -109,11 +111,17 @@ export const stateSignalBrowserProcessorScenario = {
     await runtime.waitForScreenText(/Active tab URL: https:\/\/example\.test\/browser-snapshot/i, terminal, 10_000);
     await runtime.waitForScreenText(/Browser processor snapshot captured/i, terminal, 10_000);
 
-    terminal.submit(
-      `!node -e 'const fs=require("fs"); fs.writeFileSync(process.env.MASTRA_APP_DATA_DIR+"/browser-state-processor.json", JSON.stringify({tabs:[{url:"https://example.test/browser-delta",title:"Browser Delta E2E"},{url:"https://example.test/second-tab",title:"Second Tab"}],activeTabIndex:0})); console.log("BROWSER_PROCESSOR_STATE=delta-ready");'`,
+    if (!browserProcessorStatePath) throw new Error('Browser processor state path was not initialized');
+    writeFileSync(
+      browserProcessorStatePath,
+      JSON.stringify({
+        tabs: [
+          { url: 'https://example.test/browser-delta', title: 'Browser Delta E2E' },
+          { url: 'https://example.test/second-tab', title: 'Second Tab' },
+        ],
+        activeTabIndex: 0,
+      }),
     );
-    await runtime.waitForScreenText(/BROWSER_PROCESSOR_STATE=delta-ready/i, terminal, 8_000);
-    await runtime.waitForScreenText(/BROWSER_PROCESSOR_STATE=delta-ready[\s\S]*✓/i, terminal, 8_000);
 
     terminal.submit('Capture browser processor delta.');
     await runtime.waitForScreenText(/State delta: browser/i, terminal, 10_000);

--- a/mastracode/e2e/tui/types.ts
+++ b/mastracode/e2e/tui/types.ts
@@ -137,6 +137,7 @@ export type ScenarioName =
   | 'workspace-plan-mode-tools'
   | 'workspace-tool-names'
   | 'workspace-tool-output-rendering'
+  | 'work-idle-status'
   | 'worktree-cross-thread-resume'
   | 'worktree-thread-scoping'
   | 'resourceid-drift-prompt-accept'
@@ -176,6 +177,7 @@ export type McE2eMastraCodeAppResult = Awaited<ReturnType<typeof createMastraCod
 export type McE2eStartMastraCodeAppOptions = {
   config?: MastraCodeConfig;
   onCreated?: (result: McE2eMastraCodeAppResult) => Promise<void> | void;
+  onTuiCreated?: (tui: unknown) => Promise<void> | void;
   setupDebugLogging?: boolean;
   startupWarnings?: string[];
   tui?: Partial<Pick<MastraTUIOptions, 'appName' | 'initialMessage' | 'inlineQuestions' | 'verbose'>>;

--- a/mastracode/e2e/tui/work-idle-status.ts
+++ b/mastracode/e2e/tui/work-idle-status.ts
@@ -1,3 +1,4 @@
+import { updateStatusLine } from '../../src/tui/status-line.js';
 import { expect } from './expect.js';
 import type { McE2eScenario } from './types.js';
 
@@ -5,8 +6,8 @@ let tuiRef: any;
 
 export const workIdleStatusScenario: McE2eScenario = {
   name: 'work-idle-status',
-  description: 'Verifies the TUI active timer, completed activity label, and delayed idle suffix.',
-  testName: 'shows active timing by the model and completed timing above the editor',
+  description: 'Verifies the TUI active timer, completed status-line timing, and delayed idle line.',
+  testName: 'keeps completed timing beside the model and shows delayed idle above the editor',
   useOpenAIModel: true,
   aimockFixture: 'work-idle-status.json',
   async inProcessApp({ startMastraCodeApp }) {
@@ -42,15 +43,17 @@ export const workIdleStatusScenario: McE2eScenario = {
       throw new Error('Expected TUI timing state to be available after agent run');
     }
     state.lastAgentRunDurationMs = 61_000;
+    state.lastAgentRunEndReason = 'done';
+    updateStatusLine(state);
     state.idleCounter.setTimingState(state);
     state.ui.requestRender?.();
-    await runtime.waitForScreenText(/done in \d+(?:m\d+s|hr\d*m?)/i, terminal);
+    await runtime.waitForScreenText(/\d+m\d+s\s+✓/i, terminal);
 
     state.lastAgentRunEndedAt = Date.now() - 60_000;
     state.idleCounter.setTimingState(state);
     state.ui.requestRender?.();
 
-    await runtime.waitForScreenText(/done in .* · 1m idle/i, terminal, 5_000);
+    await runtime.waitForScreenText(/1m idle/i, terminal, 5_000);
 
     terminal.keyCtrlC();
   },

--- a/mastracode/e2e/tui/work-idle-status.ts
+++ b/mastracode/e2e/tui/work-idle-status.ts
@@ -1,0 +1,57 @@
+import { expect } from './expect.js';
+import type { McE2eScenario } from './types.js';
+
+let tuiRef: any;
+
+export const workIdleStatusScenario: McE2eScenario = {
+  name: 'work-idle-status',
+  description: 'Verifies the TUI active timer, completed activity label, and delayed idle suffix.',
+  testName: 'shows active timing by the model and completed timing above the editor',
+  useOpenAIModel: true,
+  aimockFixture: 'work-idle-status.json',
+  async inProcessApp({ startMastraCodeApp }) {
+    const app = await startMastraCodeApp({
+      onTuiCreated(tui) {
+        tuiRef = tui;
+      },
+    });
+    return {
+      stop() {
+        tuiRef = undefined;
+        return app.stop?.();
+      },
+    };
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+
+    await (
+      expect(terminal.getByText(/Mastra Code|Build|Plan|Fast|Type|Press|>/gi, { full: true, strict: false })) as any
+    ).toBeVisible();
+
+    terminal.submit('Run a slow work idle status check.');
+    await runtime.waitForScreenText(/\b1s\b/i, terminal, 10_000);
+    await runtime.waitForScreenText(/Work idle status response complete\./i, terminal);
+
+    let state = tuiRef?.state;
+    for (let i = 0; i < 20 && (!state?.lastAgentRunEndedAt || !state.idleCounter); i++) {
+      await runtime.sleep(100);
+      state = tuiRef?.state;
+    }
+    if (!state?.lastAgentRunEndedAt || !state.idleCounter) {
+      throw new Error('Expected TUI timing state to be available after agent run');
+    }
+    state.lastAgentRunDurationMs = 61_000;
+    state.idleCounter.setTimingState(state);
+    state.ui.requestRender?.();
+    await runtime.waitForScreenText(/done in \d+(?:m\d+s|hr\d*m?)/i, terminal);
+
+    state.lastAgentRunEndedAt = Date.now() - 60_000;
+    state.idleCounter.setTimingState(state);
+    state.ui.requestRender?.();
+
+    await runtime.waitForScreenText(/done in .* · 1m idle/i, terminal, 5_000);
+
+    terminal.keyCtrlC();
+  },
+};

--- a/mastracode/src/tui/__tests__/agent-lifecycle-goal-timer.test.ts
+++ b/mastracode/src/tui/__tests__/agent-lifecycle-goal-timer.test.ts
@@ -51,6 +51,23 @@ describe('agent lifecycle goal timing', () => {
     expect(state.goalManager.stopActiveTimer).toHaveBeenCalled();
   });
 
+  it('does not render redundant interrupted errors for user aborts', () => {
+    const updateContent = vi.fn();
+    const streamingMessage = { id: 'msg-1' } as any;
+    const state = createState({
+      userInitiatedAbort: true,
+      streamingComponent: { updateContent } as any,
+      streamingMessage,
+    });
+
+    handleAgentAborted(createContext(state));
+
+    expect(updateContent).not.toHaveBeenCalled();
+    expect(streamingMessage.errorMessage).toBeUndefined();
+    expect(state.streamingComponent).toBeUndefined();
+    expect(state.streamingMessage).toBeUndefined();
+  });
+
   it('stops active goal timing when an agent error ends the turn', () => {
     const state = createState();
 

--- a/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   showInfo: vi.fn(),
   showFormattedError: vi.fn(),
   notify: vi.fn(),
+  updateStatusLine: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({
@@ -26,6 +27,10 @@ vi.mock('../display.js', () => ({
   notify: mocks.notify,
 }));
 
+vi.mock('../status-line.js', () => ({
+  updateStatusLine: mocks.updateStatusLine,
+}));
+
 import { MastraTUI } from '../mastra-tui.js';
 
 function createHookResult(overrides: Record<string, unknown> = {}) {
@@ -40,6 +45,7 @@ function createHookResult(overrides: Record<string, unknown> = {}) {
 function createBareTui(hookManager?: Record<string, unknown>) {
   const tui = Object.create(MastraTUI.prototype) as {
     state: Record<string, unknown>;
+    statusTimingTimer: ReturnType<typeof setInterval> | null;
     caffeinateProcess: MockChildProcess | null;
     getEventContext: ReturnType<typeof vi.fn>;
     showHookWarnings: ReturnType<typeof vi.fn>;
@@ -48,7 +54,12 @@ function createBareTui(hookManager?: Record<string, unknown>) {
     stop: () => void;
   };
 
-  tui.state = { hookManager, ui: { stop: vi.fn() } };
+  tui.state = {
+    hookManager,
+    ui: { stop: vi.fn(), requestRender: vi.fn() },
+    idleCounter: { setTimingState: vi.fn(), update: vi.fn() },
+  };
+  tui.statusTimingTimer = null;
   tui.caffeinateProcess = null;
   tui.getEventContext = vi.fn(() => ({}));
   tui.showHookWarnings = vi.fn();
@@ -115,6 +126,45 @@ describe('MastraTUI hook wiring', () => {
     await tui.handleEvent({ type: 'agent_start' });
 
     expect(runStop).not.toHaveBeenCalled();
+  });
+
+  it('ticks idle status line every second while an agent run is active', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.dispatchEvent.mockImplementation(async (_event, _ctx, state) => {
+        state.agentRunStartedAt = Date.now();
+      });
+      const tui = createBareTui();
+
+      await tui.handleEvent({ type: 'agent_start' });
+      expect((tui.state.idleCounter as any).setTimingState).toHaveBeenCalledWith(tui.state, expect.any(Number));
+      (tui.state.idleCounter as any).setTimingState.mockClear();
+
+      vi.advanceTimersByTime(1_000);
+      expect((tui.state.idleCounter as any).setTimingState).toHaveBeenCalledWith(tui.state, expect.any(Number));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ticks idle status line every minute after an agent run ends', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.dispatchEvent.mockImplementation(async (_event, _ctx, state) => {
+        state.lastAgentRunDurationMs = 1_000;
+        state.lastAgentRunEndedAt = Date.now();
+      });
+      const tui = createBareTui();
+
+      await tui.handleEvent({ type: 'agent_end', reason: 'complete' });
+      expect((tui.state.idleCounter as any).setTimingState).toHaveBeenCalledWith(tui.state, expect.any(Number));
+      (tui.state.idleCounter as any).setTimingState.mockClear();
+
+      vi.advanceTimersByTime(60_000);
+      expect((tui.state.idleCounter as any).setTimingState).toHaveBeenCalledWith(tui.state, expect.any(Number));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('starts caffeinate on macOS agent_start', async () => {

--- a/mastracode/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/src/tui/__tests__/status-line.test.ts
@@ -157,6 +157,34 @@ describe('updateStatusLine', () => {
     expect(rendered).not.toContain('queued');
   });
 
+  it('shows active elapsed time directly after the model name', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(62_000);
+    const state = createState();
+    state.agentRunStartedAt = 1_000;
+    state.controller.session.model.get.mockReturnValue('openai/gpt-5');
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('openai/gpt-5 1m1s');
+    expect(rendered).not.toContain('worked for');
+    vi.useRealTimers();
+  });
+
+  it('does not show completed work timing in the footer status line', () => {
+    const state = createState();
+    state.lastAgentRunDurationMs = 61_000;
+    state.lastAgentRunEndedAt = 1_000;
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).not.toContain('done in');
+    expect(rendered).not.toContain('canceled after');
+    expect(rendered).not.toContain('errored after');
+  });
+
   it('shows the active GitHub PR subscription beside the thread path', () => {
     const state = createState();
     state.activeGithubPrSubscriptions = [

--- a/mastracode/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/src/tui/__tests__/status-line.test.ts
@@ -172,17 +172,42 @@ describe('updateStatusLine', () => {
     vi.useRealTimers();
   });
 
-  it('does not show completed work timing in the footer status line', () => {
+  it('keeps successful completed run timing beside the model with a checkmark', () => {
     const state = createState();
     state.lastAgentRunDurationMs = 61_000;
     state.lastAgentRunEndedAt = 1_000;
+    state.lastAgentRunEndReason = 'done';
+    state.controller.session.model.get.mockReturnValue('openai/gpt-5');
 
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('openai/gpt-5 1m1s ✓');
     expect(rendered).not.toContain('done in');
-    expect(rendered).not.toContain('canceled after');
-    expect(rendered).not.toContain('errored after');
+  });
+
+  it('keeps aborted timing beside the model without an icon and errored timing with an x', () => {
+    const aborted = createState();
+    aborted.lastAgentRunDurationMs = 61_000;
+    aborted.lastAgentRunEndedAt = 1_000;
+    aborted.lastAgentRunEndReason = 'aborted';
+    aborted.controller.session.model.get.mockReturnValue('openai/gpt-5');
+
+    updateStatusLine(aborted);
+
+    expect(aborted.statusLine.setText.mock.calls[0]?.[0]).toContain('openai/gpt-5 1m1s');
+    expect(aborted.statusLine.setText.mock.calls[0]?.[0]).not.toContain('1m1s ×');
+    expect(aborted.statusLine.setText.mock.calls[0]?.[0]).not.toContain('1m1s ✓');
+
+    const errored = createState();
+    errored.lastAgentRunDurationMs = 61_000;
+    errored.lastAgentRunEndedAt = 1_000;
+    errored.lastAgentRunEndReason = 'error';
+    errored.controller.session.model.get.mockReturnValue('openai/gpt-5');
+
+    updateStatusLine(errored);
+
+    expect(errored.statusLine.setText.mock.calls[0]?.[0]).toContain('openai/gpt-5 1m1s ×');
   });
 
   it('shows the active GitHub PR subscription beside the thread path', () => {

--- a/mastracode/src/tui/__tests__/tokens-per-sec.test.ts
+++ b/mastracode/src/tui/__tests__/tokens-per-sec.test.ts
@@ -80,7 +80,10 @@ async function decodeStep(
 ): Promise<void> {
   vi.setSystemTime(opts.startMs);
   await dispatchEvent(
-    { type: 'message_update', message: { content: [{ type: 'text', text: 'streaming...' }] } } as any,
+    {
+      type: 'message_update',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'streaming...' }] },
+    } as any,
     ectx,
     state,
   );
@@ -134,7 +137,7 @@ describe('tokens/sec decode-window calculation', () => {
     vi.setSystemTime(1000); // request issued; nothing streamed yet
     vi.setSystemTime(4000);
     await dispatchEvent(
-      { type: 'message_update', message: { content: [{ type: 'text', text: 'hello' }] } } as any,
+      { type: 'message_update', message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] } } as any,
       ectx,
       state,
     );
@@ -148,13 +151,16 @@ describe('tokens/sec decode-window calculation', () => {
     expect(state.tokensPerSec).toBe(20);
   });
 
-  it('records stream activity on message updates', async () => {
+  it('records stream activity on assistant message updates', async () => {
     const state = createMinimalState({ agentRunStartedAt: 1000, agentRunLastStreamPartAt: 1000 });
     const ectx = createEctx();
 
     vi.setSystemTime(4000);
     await dispatchEvent(
-      { type: 'message_update', message: { content: [{ type: 'text', text: 'streaming...' }] } } as any,
+      {
+        type: 'message_update',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'streaming...' }] },
+      } as any,
       ectx,
       state,
     );
@@ -162,6 +168,41 @@ describe('tokens/sec decode-window calculation', () => {
     expect(state.agentRunLastStreamPartAt).toBe(4000);
     expect(state.decodeStartedAt).toBe(4000);
     expect(ectx.updateStatusLine).toHaveBeenCalled();
+  });
+
+  it('does not open the decode window for non-assistant text updates', async () => {
+    const state = createMinimalState({ agentRunStartedAt: 1000, agentRunLastStreamPartAt: 1000 });
+    const ectx = createEctx();
+
+    vi.setSystemTime(4000);
+    await dispatchEvent(
+      { type: 'message_update', message: { role: 'user', content: [{ type: 'text', text: 'user text' }] } } as any,
+      ectx,
+      state,
+    );
+
+    expect(state.agentRunLastStreamPartAt).toBe(1000);
+    expect(state.decodeStartedAt).toBe(0);
+    expect(ectx.updateStatusLine).toHaveBeenCalled();
+  });
+
+  it('records tool and shell activity without opening the decode window', async () => {
+    const state = createMinimalState({ agentRunStartedAt: 1000, agentRunLastStreamPartAt: 1000 });
+    const ectx = createEctx();
+
+    vi.setSystemTime(4000);
+    await dispatchEvent(
+      { type: 'tool_update', toolCallId: 'tool-1', partialResult: { status: 'working' } } as any,
+      ectx,
+      state,
+    );
+    expect(state.agentRunLastStreamPartAt).toBe(4000);
+    expect(state.decodeStartedAt).toBe(0);
+
+    vi.setSystemTime(5000);
+    await dispatchEvent({ type: 'shell_output', toolCallId: 'tool-1', output: 'still working' } as any, ectx, state);
+    expect(state.agentRunLastStreamPartAt).toBe(5000);
+    expect(state.decodeStartedAt).toBe(0);
   });
 
   it('includes reasoning tokens in the decode rate', async () => {

--- a/mastracode/src/tui/__tests__/tokens-per-sec.test.ts
+++ b/mastracode/src/tui/__tests__/tokens-per-sec.test.ts
@@ -148,6 +148,22 @@ describe('tokens/sec decode-window calculation', () => {
     expect(state.tokensPerSec).toBe(20);
   });
 
+  it('records stream activity on message updates', async () => {
+    const state = createMinimalState({ agentRunStartedAt: 1000, agentRunLastStreamPartAt: 1000 });
+    const ectx = createEctx();
+
+    vi.setSystemTime(4000);
+    await dispatchEvent(
+      { type: 'message_update', message: { content: [{ type: 'text', text: 'streaming...' }] } } as any,
+      ectx,
+      state,
+    );
+
+    expect(state.agentRunLastStreamPartAt).toBe(4000);
+    expect(state.decodeStartedAt).toBe(4000);
+    expect(ectx.updateStatusLine).toHaveBeenCalled();
+  });
+
   it('includes reasoning tokens in the decode rate', async () => {
     const state = createMinimalState();
     const ectx = createEctx();
@@ -179,16 +195,39 @@ describe('tokens/sec decode-window calculation', () => {
     const state = createMinimalState({ tokensPerSec: 42, decodeStartedAt: 1000 });
     const ectx = createEctx();
 
-    // agent_end keeps the reading visible (so short turns stay readable) but
-    // clears the in-flight decode window.
-    await dispatchEvent({ type: 'agent_end', reason: 'done' } as any, ectx, state);
-    expect(state.tokensPerSec).toBe(42);
-    expect(state.decodeStartedAt).toBe(0);
-
-    // The next turn's agent_start clears it for a fresh measurement.
+    vi.setSystemTime(1000);
     await dispatchEvent({ type: 'agent_start' } as any, ectx, state);
     expect(state.tokensPerSec).toBe(0);
     expect(state.decodeStartedAt).toBe(0);
+    expect(state.agentRunStartedAt).toBe(1000);
+    expect(state.agentRunLastStreamPartAt).toBe(1000);
+    expect(state.lastAgentRunDurationMs).toBeUndefined();
+    expect(state.lastAgentRunEndedAt).toBeUndefined();
+    expect(state.lastAgentRunEndReason).toBeUndefined();
+
+    state.tokensPerSec = 42;
+    state.decodeStartedAt = 1500;
+
+    // agent_end keeps the reading visible (so short turns stay readable) but
+    // clears the in-flight decode window.
+    vi.setSystemTime(4000);
+    await dispatchEvent({ type: 'agent_end', reason: 'done' } as any, ectx, state);
+    expect(state.tokensPerSec).toBe(42);
+    expect(state.decodeStartedAt).toBe(0);
+    expect(state.agentRunStartedAt).toBeUndefined();
+    expect(state.agentRunLastStreamPartAt).toBeUndefined();
+    expect(state.lastAgentRunDurationMs).toBe(3000);
+    expect(state.lastAgentRunEndedAt).toBe(4000);
+    expect(state.lastAgentRunEndReason).toBe('done');
+
+    // The next turn's agent_start clears it for a fresh measurement.
+    vi.setSystemTime(5000);
+    await dispatchEvent({ type: 'agent_start' } as any, ectx, state);
+    expect(state.tokensPerSec).toBe(0);
+    expect(state.decodeStartedAt).toBe(0);
+    expect(state.agentRunStartedAt).toBe(5000);
+    expect(state.lastAgentRunDurationMs).toBeUndefined();
+    expect(state.lastAgentRunEndedAt).toBeUndefined();
   });
 
   it('does not compute a rate for a tool-only step with no streamed content', async () => {
@@ -253,5 +292,23 @@ describe('tokens/sec decode-window calculation', () => {
 
     // With the decode window never opened, tok/s should remain 0 — NOT 55,000.
     expect(state.tokensPerSec).toBe(0);
+  });
+
+  it('records aborted and error end reasons for run summaries', async () => {
+    const ectx = createEctx();
+
+    vi.setSystemTime(1000);
+    const abortedState = createMinimalState({ agentRunStartedAt: 1000 });
+    vi.setSystemTime(4000);
+    await dispatchEvent({ type: 'agent_end', reason: 'aborted' } as any, ectx, abortedState);
+    expect(abortedState.lastAgentRunDurationMs).toBe(3000);
+    expect(abortedState.lastAgentRunEndReason).toBe('aborted');
+
+    vi.setSystemTime(5000);
+    const errorState = createMinimalState({ agentRunStartedAt: 5000 });
+    vi.setSystemTime(9000);
+    await dispatchEvent({ type: 'agent_end', reason: 'error' } as any, ectx, errorState);
+    expect(errorState.lastAgentRunDurationMs).toBe(4000);
+    expect(errorState.lastAgentRunEndReason).toBe('error');
   });
 });

--- a/mastracode/src/tui/components/__tests__/idle-counter.test.ts
+++ b/mastracode/src/tui/components/__tests__/idle-counter.test.ts
@@ -1,35 +1,101 @@
 import { describe, expect, it } from 'vitest';
-import { IdleCounterComponent, formatIdleDuration } from '../idle-counter.js';
+import { IdleCounterComponent, formatIdleStatusTiming, formatStatusDuration } from '../idle-counter.js';
 
-describe('formatIdleDuration', () => {
-  it('formats idle time from whole minutes up through larger units', () => {
-    expect(formatIdleDuration(1)).toBe('1 minute');
-    expect(formatIdleDuration(15)).toBe('15 minutes');
-    expect(formatIdleDuration(60)).toBe('1 hour');
-    expect(formatIdleDuration(96)).toBe('1 hour 36 minutes');
-    expect(formatIdleDuration(24 * 60)).toBe('1 day');
-    expect(formatIdleDuration(31 * 24 * 60)).toBe('1 month 1 day');
-    expect(formatIdleDuration(365 * 24 * 60)).toBe('1 year');
+describe('formatStatusDuration', () => {
+  it('formats active durations with seconds below an hour', () => {
+    expect(formatStatusDuration(1_000, { includeSeconds: true })).toBe('1s');
+    expect(formatStatusDuration(59_000, { includeSeconds: true })).toBe('59s');
+    expect(formatStatusDuration(61_000, { includeSeconds: true })).toBe('1m1s');
+    expect(formatStatusDuration(59 * 60_000 + 59_000, { includeSeconds: true })).toBe('59m59s');
+  });
+
+  it('formats hour and day durations without seconds', () => {
+    expect(formatStatusDuration(60 * 60_000, { includeSeconds: true })).toBe('1hr');
+    expect(formatStatusDuration(61 * 60_000 + 1_000, { includeSeconds: true })).toBe('1hr1m');
+    expect(formatStatusDuration(24 * 60 * 60_000 + 61 * 60_000, { includeSeconds: true })).toBe('1d1hr1m');
+  });
+
+  it('floors idle durations to compact whole minutes', () => {
+    expect(formatStatusDuration(3 * 60_000 + 59_000)).toBe('3m');
+    expect(formatStatusDuration(61 * 60_000)).toBe('1hr1m');
+    expect(formatStatusDuration(24 * 60 * 60_000 + 61 * 60_000)).toBe('1d1hr1m');
+  });
+});
+
+describe('formatIdleStatusTiming', () => {
+  it('does not show active elapsed time while the agent is running', () => {
+    expect(formatIdleStatusTiming({ lastAgentRunDurationMs: undefined, lastAgentRunEndedAt: undefined }, 2_000)).toBe(
+      '',
+    );
+  });
+
+  it('shows successful activity over one minute and idle time after one minute', () => {
+    const state = {
+      lastAgentRunDurationMs: 61 * 60_000,
+      lastAgentRunEndedAt: 1_000,
+      lastAgentRunEndReason: 'done' as const,
+    };
+
+    expect(formatIdleStatusTiming(state, 60_999)).toBe('done in 1hr1m');
+    expect(formatIdleStatusTiming(state, 61_000)).toBe('done in 1hr1m · 1m idle');
+    expect(formatIdleStatusTiming(state, 181_000)).toBe('done in 1hr1m · 3m idle');
+  });
+
+  it('shows successful activity under one minute', () => {
+    const state = {
+      lastAgentRunDurationMs: 59_000,
+      lastAgentRunEndedAt: 1_000,
+      lastAgentRunEndReason: 'done' as const,
+    };
+
+    expect(formatIdleStatusTiming(state, 60_999)).toBe('done in 59s');
+    expect(formatIdleStatusTiming(state, 61_000)).toBe('done in 59s · 1m idle');
+  });
+
+  it('shows canceled and errored activity with explicit labels', () => {
+    expect(
+      formatIdleStatusTiming(
+        { lastAgentRunDurationMs: 61_000, lastAgentRunEndedAt: 1_000, lastAgentRunEndReason: 'aborted' },
+        2_000,
+      ),
+    ).toBe('canceled after 1m1s');
+    expect(
+      formatIdleStatusTiming(
+        { lastAgentRunDurationMs: 61_000, lastAgentRunEndedAt: 1_000, lastAgentRunEndReason: 'error' },
+        2_000,
+      ),
+    ).toBe('errored after 1m1s');
+  });
+
+  it('can show restored idle time without a known prior work duration', () => {
+    expect(formatIdleStatusTiming({ lastAgentRunEndedAt: 0 }, 3 * 60_000)).toBe('3m idle');
+  });
+
+  it('omits timing when no timing state is present', () => {
+    expect(formatIdleStatusTiming({})).toBe('');
   });
 });
 
 describe('IdleCounterComponent', () => {
-  it('reserves one stable line until one minute idle, then renders like a temporal-gap marker', () => {
+  it('reserves one stable line and renders work/idle timing above input', () => {
     const component = new IdleCounterComponent();
 
     expect(component.render(80)).toEqual(['']);
 
-    component.setIdleStartedAt(0, 59_999);
-    expect(component.render(80)).toEqual(['']);
+    component.setTimingState(
+      { lastAgentRunDurationMs: 61_000, lastAgentRunEndedAt: 1_000, lastAgentRunEndReason: 'done' },
+      60_999,
+    );
+    expect(component.render(80).join('\n')).toContain('done in 1m1s');
+    expect(component.render(80).join('\n')).not.toContain('idle');
 
-    component.update(60_000);
-    expect(component.render(80).join('\n')).toContain('1 minute idle');
-    expect(component.render(80).join('\n')).not.toContain('⏳');
+    component.update(181_000);
+    const renderedWithIdle = component.render(80).join('\n');
+    expect(renderedWithIdle).toContain('done in 1m1s');
+    expect(renderedWithIdle).toContain(' · ');
+    expect(renderedWithIdle).toContain('3m idle');
 
-    component.update(96 * 60_000);
-    expect(component.render(80).join('\n')).toContain('1 hour 36 minutes idle');
-
-    component.setIdleStartedAt(undefined);
+    component.setTimingState(undefined);
     expect(component.render(80)).toEqual(['']);
   });
 });

--- a/mastracode/src/tui/components/__tests__/idle-counter.test.ts
+++ b/mastracode/src/tui/components/__tests__/idle-counter.test.ts
@@ -29,42 +29,31 @@ describe('formatIdleStatusTiming', () => {
     );
   });
 
-  it('shows successful activity over one minute and idle time after one minute', () => {
+  it('shows only idle time after one minute', () => {
     const state = {
       lastAgentRunDurationMs: 61 * 60_000,
       lastAgentRunEndedAt: 1_000,
       lastAgentRunEndReason: 'done' as const,
     };
 
-    expect(formatIdleStatusTiming(state, 60_999)).toBe('done in 1hr1m');
-    expect(formatIdleStatusTiming(state, 61_000)).toBe('done in 1hr1m · 1m idle');
-    expect(formatIdleStatusTiming(state, 181_000)).toBe('done in 1hr1m · 3m idle');
+    expect(formatIdleStatusTiming(state, 60_999)).toBe('');
+    expect(formatIdleStatusTiming(state, 61_000)).toBe('1m idle');
+    expect(formatIdleStatusTiming(state, 181_000)).toBe('3m idle');
   });
 
-  it('shows successful activity under one minute', () => {
-    const state = {
-      lastAgentRunDurationMs: 59_000,
-      lastAgentRunEndedAt: 1_000,
-      lastAgentRunEndReason: 'done' as const,
-    };
-
-    expect(formatIdleStatusTiming(state, 60_999)).toBe('done in 59s');
-    expect(formatIdleStatusTiming(state, 61_000)).toBe('done in 59s · 1m idle');
-  });
-
-  it('shows canceled and errored activity with explicit labels', () => {
+  it('does not show completed activity labels above input', () => {
     expect(
       formatIdleStatusTiming(
         { lastAgentRunDurationMs: 61_000, lastAgentRunEndedAt: 1_000, lastAgentRunEndReason: 'aborted' },
         2_000,
       ),
-    ).toBe('canceled after 1m1s');
+    ).toBe('');
     expect(
       formatIdleStatusTiming(
         { lastAgentRunDurationMs: 61_000, lastAgentRunEndedAt: 1_000, lastAgentRunEndReason: 'error' },
-        2_000,
+        61_000,
       ),
-    ).toBe('errored after 1m1s');
+    ).toBe('1m idle');
   });
 
   it('can show restored idle time without a known prior work duration', () => {
@@ -77,7 +66,7 @@ describe('formatIdleStatusTiming', () => {
 });
 
 describe('IdleCounterComponent', () => {
-  it('reserves one stable line and renders work/idle timing above input', () => {
+  it('reserves one stable line and renders only idle timing above input', () => {
     const component = new IdleCounterComponent();
 
     expect(component.render(80)).toEqual(['']);
@@ -86,13 +75,12 @@ describe('IdleCounterComponent', () => {
       { lastAgentRunDurationMs: 61_000, lastAgentRunEndedAt: 1_000, lastAgentRunEndReason: 'done' },
       60_999,
     );
-    expect(component.render(80).join('\n')).toContain('done in 1m1s');
-    expect(component.render(80).join('\n')).not.toContain('idle');
+    expect(component.render(80)).toEqual(['']);
 
     component.update(181_000);
     const renderedWithIdle = component.render(80).join('\n');
-    expect(renderedWithIdle).toContain('done in 1m1s');
-    expect(renderedWithIdle).toContain(' · ');
+    expect(renderedWithIdle).not.toContain('done in');
+    expect(renderedWithIdle).not.toContain(' · ');
     expect(renderedWithIdle).toContain('3m idle');
 
     component.setTimingState(undefined);

--- a/mastracode/src/tui/components/idle-counter.ts
+++ b/mastracode/src/tui/components/idle-counter.ts
@@ -1,18 +1,18 @@
 /**
- * Live idle-time indicator shown above the user input after an agent run completes.
+ * Live work/idle-time indicator shown above the user input.
  */
 
 import { Container, Text } from '@earendil-works/pi-tui';
+import type { TUIState } from '../state.js';
+import { formatStatusDuration } from '../status-duration.js';
 import { BOX_INDENT, theme } from '../theme.js';
 
+export { formatStatusDuration } from '../status-duration.js';
+
 const MINUTE_MS = 60_000;
-const HOUR_MINUTES = 60;
-const DAY_MINUTES = HOUR_MINUTES * 24;
-const MONTH_MINUTES = DAY_MINUTES * 30;
-const YEAR_MINUTES = DAY_MINUTES * 365;
 
 export class IdleCounterComponent extends Container {
-  private idleStartedAt?: number;
+  private timingState?: Pick<TUIState, 'lastAgentRunDurationMs' | 'lastAgentRunEndedAt' | 'lastAgentRunEndReason'>;
   private textChild: Text;
 
   constructor() {
@@ -21,24 +21,30 @@ export class IdleCounterComponent extends Container {
     this.addChild(this.textChild);
   }
 
-  setIdleStartedAt(idleStartedAt: number | undefined, now = Date.now()): void {
-    this.idleStartedAt = idleStartedAt;
+  setTimingState(
+    timingState: Pick<TUIState, 'lastAgentRunDurationMs' | 'lastAgentRunEndedAt' | 'lastAgentRunEndReason'> | undefined,
+    now = Date.now(),
+  ): void {
+    this.timingState = timingState;
     this.update(now);
   }
 
   update(now = Date.now()): void {
-    if (this.idleStartedAt === undefined) {
+    const segments = this.timingState ? formatIdleStatusTimingSegments(this.timingState, now) : null;
+    if (!segments) {
       this.textChild.setText('');
       return;
     }
 
-    const idleMinutes = Math.floor((now - this.idleStartedAt) / MINUTE_MS);
-    if (idleMinutes < 1) {
-      this.textChild.setText('');
-      return;
-    }
-
-    this.textChild.setText(theme.fg('dim', `  ${formatIdleDuration(idleMinutes)} idle`));
+    const summaryColor =
+      this.timingState?.lastAgentRunEndReason === 'aborted'
+        ? 'warning'
+        : this.timingState?.lastAgentRunEndReason === 'error'
+          ? 'error'
+          : 'dim';
+    const summary = segments.summary ? theme.fg(summaryColor, segments.summary) : '';
+    const idle = segments.idle ? theme.fg('dim', `${summary ? ' · ' : ''}${segments.idle}`) : '';
+    this.textChild.setText(`  ${summary}${idle}`);
   }
 
   render(width: number): string[] {
@@ -47,32 +53,38 @@ export class IdleCounterComponent extends Container {
   }
 }
 
-export function formatIdleDuration(totalMinutes: number): string {
-  const minutes = Math.max(1, Math.floor(totalMinutes));
-  const units = [
-    { name: 'year', minutes: YEAR_MINUTES },
-    { name: 'month', minutes: MONTH_MINUTES },
-    { name: 'day', minutes: DAY_MINUTES },
-    { name: 'hour', minutes: HOUR_MINUTES },
-    { name: 'minute', minutes: 1 },
-  ];
+type IdleStatusTimingState = Pick<TUIState, 'lastAgentRunDurationMs' | 'lastAgentRunEndedAt' | 'lastAgentRunEndReason'>;
 
-  let remaining = minutes;
-  const parts: string[] = [];
-
-  for (const unit of units) {
-    const value = Math.floor(remaining / unit.minutes);
-    if (value === 0) continue;
-
-    parts.push(formatUnit(value, unit.name));
-    remaining %= unit.minutes;
-
-    if (parts.length === 2) break;
+export function formatIdleStatusTimingSegments(
+  state: IdleStatusTimingState,
+  now = Date.now(),
+): { summary: string; idle: string } | null {
+  if (state.lastAgentRunEndedAt === undefined) {
+    return null;
   }
 
-  return parts.join(' ');
+  const idleMs = now - state.lastAgentRunEndedAt;
+  const idle = idleMs >= MINUTE_MS ? `${formatStatusDuration(idleMs)} idle` : '';
+  if (state.lastAgentRunDurationMs === undefined) {
+    return idle ? { summary: '', idle } : null;
+  }
+
+  const verb =
+    state.lastAgentRunEndReason === 'aborted'
+      ? 'canceled after'
+      : state.lastAgentRunEndReason === 'error'
+        ? 'errored after'
+        : 'done in';
+  return {
+    summary: `${verb} ${formatStatusDuration(state.lastAgentRunDurationMs, { includeSeconds: true })}`,
+    idle,
+  };
 }
 
-function formatUnit(value: number, unit: string): string {
-  return `${value} ${unit}${value === 1 ? '' : 's'}`;
+export function formatIdleStatusTiming(state: IdleStatusTimingState, now = Date.now()): string {
+  const segments = formatIdleStatusTimingSegments(state, now);
+  if (!segments) return '';
+  return segments.summary && segments.idle
+    ? `${segments.summary} · ${segments.idle}`
+    : segments.summary || segments.idle;
 }

--- a/mastracode/src/tui/components/idle-counter.ts
+++ b/mastracode/src/tui/components/idle-counter.ts
@@ -36,15 +36,8 @@ export class IdleCounterComponent extends Container {
       return;
     }
 
-    const summaryColor =
-      this.timingState?.lastAgentRunEndReason === 'aborted'
-        ? 'warning'
-        : this.timingState?.lastAgentRunEndReason === 'error'
-          ? 'error'
-          : 'dim';
-    const summary = segments.summary ? theme.fg(summaryColor, segments.summary) : '';
-    const idle = segments.idle ? theme.fg('dim', `${summary ? ' · ' : ''}${segments.idle}`) : '';
-    this.textChild.setText(`  ${summary}${idle}`);
+    const idle = segments.idle ? theme.fg('dim', segments.idle) : '';
+    this.textChild.setText(idle ? `  ${idle}` : '');
   }
 
   render(width: number): string[] {
@@ -65,20 +58,7 @@ export function formatIdleStatusTimingSegments(
 
   const idleMs = now - state.lastAgentRunEndedAt;
   const idle = idleMs >= MINUTE_MS ? `${formatStatusDuration(idleMs)} idle` : '';
-  if (state.lastAgentRunDurationMs === undefined) {
-    return idle ? { summary: '', idle } : null;
-  }
-
-  const verb =
-    state.lastAgentRunEndReason === 'aborted'
-      ? 'canceled after'
-      : state.lastAgentRunEndReason === 'error'
-        ? 'errored after'
-        : 'done in';
-  return {
-    summary: `${verb} ${formatStatusDuration(state.lastAgentRunDurationMs, { includeSeconds: true })}`,
-    idle,
-  };
+  return idle ? { summary: '', idle } : null;
 }
 
 export function formatIdleStatusTiming(state: IdleStatusTimingState, now = Date.now()): string {

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -68,13 +68,28 @@ export async function dispatchEvent(
       // would otherwise zero it before it could be read.
       state.tokensPerSec = 0;
       state.decodeStartedAt = 0;
+      state.agentRunStartedAt = Date.now();
+      state.agentRunLastStreamPartAt = state.agentRunStartedAt;
+      state.lastAgentRunDurationMs = undefined;
+      state.lastAgentRunEndedAt = undefined;
+      state.lastAgentRunEndReason = undefined;
+      ectx.updateStatusLine();
       handleAgentStart(ectx);
       break;
 
     case 'agent_end':
       // Keep tokensPerSec as the last turn's reading; only clear the in-flight
       // decode window so a stale start can't bleed into the next turn.
+      if (state.agentRunStartedAt !== undefined) {
+        const now = Date.now();
+        state.lastAgentRunDurationMs = Math.max(0, now - state.agentRunStartedAt);
+        state.lastAgentRunEndedAt = now;
+        state.lastAgentRunEndReason = event.reason === 'aborted' || event.reason === 'error' ? event.reason : 'done';
+        state.agentRunStartedAt = undefined;
+        state.agentRunLastStreamPartAt = undefined;
+      }
       state.decodeStartedAt = 0;
+      ectx.updateStatusLine();
       if (event.reason === 'aborted') {
         handleAgentAborted(ectx);
       } else if (event.reason === 'error') {
@@ -88,19 +103,24 @@ export async function dispatchEvent(
       handleMessageStart(ectx, event.message);
       break;
 
-    case 'message_update':
+    case 'message_update': {
       // Only open the decode window when the message carries actual streamed
       // text — tool-result-only updates (e.g. plan approval resume) must not
       // count toward tokens/sec. This mirrors the web UI's hasAssistantText()
       // guard in transcriptReducer.
-      if (
-        state.decodeStartedAt === 0 &&
-        event.message.content.some(part => part.type === 'text' && 'text' in part && part.text.trim().length > 0)
-      ) {
-        state.decodeStartedAt = Date.now();
+      const hasAssistantText = event.message.content.some(
+        part => part.type === 'text' && 'text' in part && part.text.trim().length > 0,
+      );
+      if (hasAssistantText) {
+        state.agentRunLastStreamPartAt = Date.now();
+        if (state.decodeStartedAt === 0) {
+          state.decodeStartedAt = state.agentRunLastStreamPartAt;
+        }
       }
+      ectx.updateStatusLine();
       handleMessageUpdate(ectx, event.message);
       break;
+    }
 
     case 'message_end':
       handleMessageEnd(ectx, event.message);

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -104,13 +104,12 @@ export async function dispatchEvent(
       break;
 
     case 'message_update': {
-      // Only open the decode window when the message carries actual streamed
-      // text — tool-result-only updates (e.g. plan approval resume) must not
-      // count toward tokens/sec. This mirrors the web UI's hasAssistantText()
-      // guard in transcriptReducer.
-      const hasAssistantText = event.message.content.some(
-        part => part.type === 'text' && 'text' in part && part.text.trim().length > 0,
-      );
+      // Only open the decode window when an assistant message carries actual
+      // streamed text — tool-result-only updates (e.g. plan approval resume) and
+      // user/system message updates must not count toward tokens/sec.
+      const hasAssistantText =
+        event.message.role === 'assistant' &&
+        event.message.content.some(part => part.type === 'text' && 'text' in part && part.text.trim().length > 0);
       if (hasAssistantText) {
         state.agentRunLastStreamPartAt = Date.now();
         if (state.decodeStartedAt === 0) {
@@ -127,6 +126,7 @@ export async function dispatchEvent(
       break;
 
     case 'tool_start':
+      state.agentRunLastStreamPartAt = Date.now();
       handleToolStart(ectx, event.toolCallId, event.toolName, event.args);
       break;
 
@@ -140,10 +140,12 @@ export async function dispatchEvent(
       break;
 
     case 'tool_update':
+      state.agentRunLastStreamPartAt = Date.now();
       handleToolUpdate(ectx, event.toolCallId, event.partialResult);
       break;
 
     case 'shell_output':
+      state.agentRunLastStreamPartAt = Date.now();
       handleShellOutput(ectx, event.toolCallId, event.output, event.stream);
       break;
 
@@ -167,6 +169,7 @@ export async function dispatchEvent(
       break;
 
     case 'tool_end':
+      state.agentRunLastStreamPartAt = Date.now();
       handleToolEnd(ectx, event.toolCallId, event.result, event.isError);
       break;
 

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -8,7 +8,6 @@ import { getCurrentGitBranchAsync } from '../../utils/project.js';
 import { insertChatComponentWithBoundarySpacing } from '../chat-boundary-reconciliation.js';
 import { JudgeDisplayComponent } from '../components/judge-display.js';
 import { GradientAnimator } from '../components/obi-loader.js';
-import { showError } from '../display.js';
 import { pruneChatContainer } from '../prune-chat.js';
 import { clearPendingUserMessages, removePendingUserMessage } from '../render-messages.js';
 
@@ -143,22 +142,19 @@ export function handleAgentAborted(ctx: EventHandlerContext): void {
     state.gradientAnimator.fadeOut();
   }
 
-  // A plan "Request Changes" abort ends the run intentionally; clear any
-  // streaming state without surfacing an "Interrupted" error so the user can
-  // type revision feedback against a clean transcript.
-  if (state.planRejectionAbort) {
+  // User-initiated aborts and plan "Request Changes" aborts are intentional.
+  // The timing line already says "canceled after x", so don't also render a
+  // redundant "Error: Interrupted" message in the transcript.
+  if (state.planRejectionAbort || state.userInitiatedAbort) {
     state.streamingComponent = undefined;
     state.streamingMessage = undefined;
   } else if (state.streamingComponent && state.streamingMessage) {
-    // Update streaming message to show it was interrupted
+    // Update unexpected aborted streams to show they were interrupted.
     state.streamingMessage.stopReason = 'aborted';
     state.streamingMessage.errorMessage = 'Interrupted';
     state.streamingComponent.updateContent(state.streamingMessage);
     state.streamingComponent = undefined;
     state.streamingMessage = undefined;
-  } else if (state.userInitiatedAbort) {
-    // Show standalone "Interrupted" if user pressed Ctrl+C but no streaming component
-    showError(state, 'Interrupted');
   }
   state.userInitiatedAbort = false;
   state.planRejectionAbort = false;

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -153,7 +153,7 @@ export function consumePendingImages(
 export class MastraTUI {
   private state: TUIState;
   private updateCheckTimer: ReturnType<typeof setInterval> | null = null;
-  private idleCounterTimer: ReturnType<typeof setInterval> | null = null;
+  private statusTimingTimer: ReturnType<typeof setInterval> | null = null;
   private hasShownUpdateBanner = false;
   private caffeinateProcess: ChildProcess | null = null;
   private cleanupKeyHandlers?: () => void;
@@ -361,7 +361,7 @@ export class MastraTUI {
    * Errors are handled via controller events.
    */
   private fireMessage(content: string, images?: Array<{ data: string; mimeType: string }>): void {
-    this.clearIdleCounter();
+    this.clearStatusTimingTicker();
     const files = images?.map(img => ({ data: img.data, mediaType: img.mimeType }));
     this.state.session.sendMessage({ content, files }).catch(error => {
       showError(this.state, error instanceof Error ? error.message : 'Unknown error');
@@ -432,7 +432,7 @@ export class MastraTUI {
     pendingNewThread: boolean,
   ): void {
     const send = () => {
-      this.clearIdleCounter();
+      this.clearStatusTimingTicker();
       this.state.analytics?.capture('mastracode_prompt_submitted', {
         threadId: this.state.session.thread.getId(),
         resourceId: this.state.session.identity.getResourceId(),
@@ -469,7 +469,7 @@ export class MastraTUI {
     const hasActiveRun = this.state.session.stream.isActive();
 
     const send = () => {
-      this.clearIdleCounter();
+      this.clearStatusTimingTicker();
       if (hasActiveRun) {
         this.state.pendingApprovalDismiss?.(USER_MESSAGE_APPROVAL_INTERRUPT);
       }
@@ -543,10 +543,7 @@ export class MastraTUI {
       this.updateCheckTimer = null;
     }
 
-    if (this.idleCounterTimer) {
-      clearInterval(this.idleCounterTimer);
-      this.idleCounterTimer = null;
-    }
+    this.clearStatusTimingTicker();
 
     if (this.cleanupKeyHandlers) {
       this.cleanupKeyHandlers();
@@ -683,18 +680,34 @@ export class MastraTUI {
     updateStatusLine(this.state);
   }
 
-  private startIdleCounter(idleStartedAt = Date.now(), now = Date.now()): void {
-    this.state.idleStartedAt = idleStartedAt;
-    this.state.idleCounter?.setIdleStartedAt(idleStartedAt, now);
+  private updateIdleStatusLine(now = Date.now()): void {
+    this.state.idleCounter?.setTimingState(this.state, now);
     this.state.ui.requestRender?.();
+  }
 
-    if (this.idleCounterTimer) {
-      clearInterval(this.idleCounterTimer);
-    }
+  private updateActiveStatusTiming(now = Date.now()): void {
+    this.state.idleCounter?.setTimingState(this.state, now);
+    updateStatusLine(this.state);
+    this.state.ui.requestRender?.();
+  }
 
-    this.idleCounterTimer = setInterval(() => {
-      this.state.idleCounter?.update();
-      this.state.ui.requestRender?.();
+  private startActiveStatusTimingTicker(): void {
+    this.clearStatusTimingTicker();
+    this.updateActiveStatusTiming();
+    this.statusTimingTimer = setInterval(() => {
+      if (this.state.agentRunStartedAt === undefined) {
+        this.clearStatusTimingTicker(false);
+        return;
+      }
+      this.updateActiveStatusTiming();
+    }, 1_000);
+  }
+
+  private startIdleStatusTimingTicker(): void {
+    this.clearStatusTimingTicker();
+    this.updateIdleStatusLine();
+    this.statusTimingTimer = setInterval(() => {
+      this.updateIdleStatusLine();
     }, 60_000);
   }
 
@@ -702,26 +715,28 @@ export class MastraTUI {
     await renderExistingMessages(this.state);
 
     if (this.state.session.run.isRunning()) {
-      this.clearIdleCounter();
+      this.clearStatusTimingTicker();
       return;
     }
 
     if (this.state.lastRenderedMessageAt === undefined) {
-      this.clearIdleCounter();
+      this.clearStatusTimingTicker();
       return;
     }
 
-    this.startIdleCounter(this.state.lastRenderedMessageAt);
+    this.state.lastAgentRunEndedAt = this.state.lastRenderedMessageAt;
+    this.startIdleStatusTimingTicker();
   }
 
-  private clearIdleCounter(): void {
-    this.state.idleStartedAt = undefined;
-    this.state.idleCounter?.setIdleStartedAt(undefined);
-    if (this.idleCounterTimer) {
-      clearInterval(this.idleCounterTimer);
-      this.idleCounterTimer = null;
+  private clearStatusTimingTicker(clearDisplay = true): void {
+    if (this.statusTimingTimer) {
+      clearInterval(this.statusTimingTimer);
+      this.statusTimingTimer = null;
     }
-    this.state.ui.requestRender?.();
+    if (clearDisplay) {
+      this.state.idleCounter?.setTimingState(undefined);
+      this.state.ui.requestRender?.();
+    }
   }
 
   // ===========================================================================
@@ -740,7 +755,7 @@ export class MastraTUI {
 
   private async handleEvent(event: AgentControllerEvent): Promise<void> {
     if (event.type === 'agent_start') {
-      this.clearIdleCounter();
+      this.clearStatusTimingTicker();
       this.startCaffeinate();
       this.lastStreamError = null;
     }
@@ -764,9 +779,13 @@ export class MastraTUI {
         await this.syncThreadActivePackMetadata();
       }
 
+      if (event.type === 'agent_start' && this.state.agentRunStartedAt !== undefined) {
+        this.startActiveStatusTimingTicker();
+      }
+
       if (event.type === 'agent_end') {
         const stopReason = event.reason === 'aborted' ? 'aborted' : event.reason === 'error' ? 'error' : 'complete';
-        this.startIdleCounter();
+        this.startIdleStatusTimingTicker();
         await this.runStopHook(stopReason);
 
         if (event.reason === 'error' && this.lastStreamError) {

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -164,7 +164,6 @@ export interface TUIState {
   chatContainer: Container;
   editorContainer: Container;
   idleCounter?: IdleCounterComponent;
-  idleStartedAt?: number;
   lastRenderedMessageAt?: number;
   editor: CustomEditor;
   footer: Container;
@@ -256,6 +255,16 @@ export interface TUIState {
   modelAuthStatus: { hasAuth: boolean; apiKeyEnvVar?: string };
   githubPrGradientAnimator?: GradientAnimator;
   githubPrPollingActive: boolean;
+  /** Timestamp (ms) when the current agent run started. */
+  agentRunStartedAt?: number;
+  /** Timestamp (ms) when the current agent run last received streamed content. */
+  agentRunLastStreamPartAt?: number;
+  /** Duration (ms) of the most recently completed agent run. */
+  lastAgentRunDurationMs?: number;
+  /** Timestamp (ms) when the most recent agent run ended. */
+  lastAgentRunEndedAt?: number;
+  /** End state of the most recent agent run. */
+  lastAgentRunEndReason?: 'done' | 'aborted' | 'error';
 
   // ── Tokens/sec tracking ────────────────────────────────────────────────
   /**

--- a/mastracode/src/tui/status-duration.ts
+++ b/mastracode/src/tui/status-duration.ts
@@ -1,0 +1,22 @@
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export function formatStatusDuration(ms: number, opts: { includeSeconds?: boolean } = {}): string {
+  const safeMs = Math.max(0, ms);
+  const days = Math.floor(safeMs / DAY_MS);
+  const hours = Math.floor((safeMs % DAY_MS) / HOUR_MS);
+  const minutes = Math.floor((safeMs % HOUR_MS) / MINUTE_MS);
+  const seconds = Math.floor((safeMs % MINUTE_MS) / 1000);
+
+  if (days > 0) {
+    return `${days}d${hours > 0 ? `${hours}hr` : ''}${minutes > 0 ? `${minutes}m` : ''}`;
+  }
+  if (hours > 0) {
+    return `${hours}hr${minutes > 0 ? `${minutes}m` : ''}`;
+  }
+  if (opts.includeSeconds) {
+    return minutes > 0 ? `${minutes}m${seconds}s` : `${Math.max(1, seconds)}s`;
+  }
+  return `${Math.max(1, minutes)}m`;
+}

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 import { applyGradientSweep } from './components/obi-loader.js';
 import { formatObservationStatus, formatReflectionStatus } from './components/om-progress.js';
 import type { GithubPrSubscriptionBadge, TUIState } from './state.js';
+import { formatStatusDuration } from './status-duration.js';
 import { theme, mastra, tintHex, getTermWidth, extendedColors } from './theme.js';
 
 // Colors for OM modes — read from proxy at render time so they pick up contrast adaptation
@@ -271,6 +272,16 @@ export function updateStatusLine(state: TUIState): void {
     shortModeBadgeWidth = shortName.length + 2;
   }
 
+  const now = Date.now();
+  const activeTimingLabel =
+    state.agentRunStartedAt !== undefined
+      ? formatStatusDuration(now - state.agentRunStartedAt, { includeSeconds: true })
+      : '';
+  const activeTimingIsStale =
+    state.agentRunStartedAt !== undefined &&
+    state.agentRunLastStreamPartAt !== undefined &&
+    now - state.agentRunLastStreamPartAt > 3 * 60_000;
+
   const buildLine = (opts: {
     modelId: string;
     memCompact?: 'percentOnly' | 'noBuffer' | 'full';
@@ -283,9 +294,13 @@ export function updateStatusLine(state: TUIState): void {
   }): { plain: string; styled: string } | null => {
     const parts: Array<{ plain: string; styled: string }> = [];
     // Model ID (always present) — styleModelId adds padding spaces
+    const activeTimingPlain = activeTimingLabel ? ` ${activeTimingLabel}` : '';
+    const activeTimingStyled = activeTimingLabel
+      ? ` ${activeTimingIsStale ? theme.fg('error', activeTimingLabel) : modeColor ? chalk.hex(modeColor)(activeTimingLabel) : theme.fg('dim', activeTimingLabel)}`
+      : '';
     parts.push({
-      plain: `${opts.modelId}${tintBg ? ' ' : ''}`,
-      styled: styleModelId(opts.modelId),
+      plain: `${opts.modelId}${tintBg ? ' ' : ''}${activeTimingPlain}`,
+      styled: styleModelId(opts.modelId) + activeTimingStyled,
     });
     const useBadge = opts.badge === 'short' ? shortModeBadge : modeBadge;
     const useBadgeWidth = opts.badge === 'short' ? shortModeBadgeWidth : modeBadgeWidth;

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -281,6 +281,17 @@ export function updateStatusLine(state: TUIState): void {
     state.agentRunStartedAt !== undefined &&
     state.agentRunLastStreamPartAt !== undefined &&
     now - state.agentRunLastStreamPartAt > 3 * 60_000;
+  const completedTimingLabel =
+    !activeTimingLabel && state.lastAgentRunDurationMs !== undefined
+      ? formatStatusDuration(state.lastAgentRunDurationMs, { includeSeconds: true })
+      : '';
+  const completedTimingIcon =
+    state.lastAgentRunEndReason === 'error'
+      ? '×'
+      : completedTimingLabel && state.lastAgentRunEndReason !== 'aborted'
+        ? '✓'
+        : '';
+  const timingLabel = activeTimingLabel || completedTimingLabel;
 
   const buildLine = (opts: {
     modelId: string;
@@ -294,13 +305,30 @@ export function updateStatusLine(state: TUIState): void {
   }): { plain: string; styled: string } | null => {
     const parts: Array<{ plain: string; styled: string }> = [];
     // Model ID (always present) — styleModelId adds padding spaces
-    const activeTimingPlain = activeTimingLabel ? ` ${activeTimingLabel}` : '';
-    const activeTimingStyled = activeTimingLabel
-      ? ` ${activeTimingIsStale ? theme.fg('error', activeTimingLabel) : modeColor ? chalk.hex(modeColor)(activeTimingLabel) : theme.fg('dim', activeTimingLabel)}`
+    const timingPlain = timingLabel ? ` ${timingLabel}${completedTimingIcon ? ` ${completedTimingIcon}` : ''}` : '';
+    const timingColor = activeTimingIsStale
+      ? theme.fg('error', timingLabel)
+      : activeTimingLabel
+        ? modeColor
+          ? chalk.hex(modeColor)(timingLabel)
+          : theme.fg('dim', timingLabel)
+        : state.lastAgentRunEndReason === 'aborted'
+          ? theme.fg('warning', timingLabel)
+          : state.lastAgentRunEndReason === 'error'
+            ? theme.fg('error', timingLabel)
+            : theme.fg('success', timingLabel);
+    const timingIconColor =
+      state.lastAgentRunEndReason === 'aborted'
+        ? 'warning'
+        : state.lastAgentRunEndReason === 'error'
+          ? 'error'
+          : 'success';
+    const timingStyled = timingLabel
+      ? ` ${timingColor}${completedTimingIcon ? ` ${theme.fg(timingIconColor, completedTimingIcon)}` : ''}`
       : '';
     parts.push({
-      plain: `${opts.modelId}${tintBg ? ' ' : ''}${activeTimingPlain}`,
-      styled: styleModelId(opts.modelId) + activeTimingStyled,
+      plain: `${opts.modelId}${tintBg ? ' ' : ''}${timingPlain}`,
+      styled: styleModelId(opts.modelId) + timingStyled,
     });
     const useBadge = opts.badge === 'short' ? shortModeBadge : modeBadge;
     const useBadgeWidth = opts.badge === 'short' ? shortModeBadgeWidth : modeBadgeWidth;


### PR DESCRIPTION
Adds lightweight timing feedback to the Mastra Code TUI so it is easier to tell how long the agent has been working and how long it has been idle.

Added e2e test and also smoke tested manually in the TUI: active timing, completed timing, and delayed idle display all looked good.

<img width="343" height="129" alt="Screenshot 2026-06-29 at 10 27 52 AM" src="https://github.com/user-attachments/assets/adb2118f-37f2-468f-8186-9995ff853366" />
<img width="410" height="125" alt="Screenshot 2026-06-29 at 10 27 56 AM" src="https://github.com/user-attachments/assets/837dded7-9437-423b-8689-1dd12ea62ede" />
<img width="353" height="118" alt="Screenshot 2026-06-29 at 10 28 03 AM" src="https://github.com/user-attachments/assets/efd570c1-c37c-4bfd-acbc-daed76e781f7" />
<img width="449" height="205" alt="Screenshot 2026-06-29 at 10 28 45 AM" src="https://github.com/user-attachments/assets/5feb216d-dea7-4db3-820f-5f2ba311af7d" />
<img width="397" height="125" alt="Screenshot 2026-06-29 at 11 23 58 AM" src="https://github.com/user-attachments/assets/e3f46809-bdcd-4e1f-ac9d-013115221659" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds small “how long” timers to the Mastra Code terminal UI. You’ll see how long the agent has been working, how long the last run took when it finishes, and how long it’s been waiting/idle.

## Summary
- **Status line timing for agent runs**
  - Shows **active elapsed time** while the agent is running (with “stale”/delayed styling when the stream hasn’t updated recently).
  - Shows **completed duration** with a **✓** for success and **×** for errors (and no success icon for intentional/“aborted” outcomes).
- **Idle display driven by the last completed run**
  - Idle text now derives from **`lastAgentRunEndedAt`** (and minimum thresholds), rendering **“X idle”** after sufficient idle time.
- **Shared timing formatting utilities**
  - Added `formatStatusDuration(ms)` plus new idle formatting helpers to consistently render durations like **`1m1s`**, **`1m`**, and **`1m idle`**.
- **State/timer wiring updates in the TUI**
  - Added/used timing fields (`agentRunStartedAt`, `agentRunLastStreamPartAt`, `lastAgentRunDurationMs`, `lastAgentRunEndedAt`, `lastAgentRunEndReason`) and ensured the status line is re-rendered at the right event boundaries.
  - Replaced the prior idle-counter ticker with a unified **status timing timer** that updates both active and idle timing and pauses/resumes appropriately around message sending.
- **E2E/test support + scenario**
  - Added an E2E hook (`onTuiCreated`) so scenarios can access the created TUI instance.
  - Added a new `work-idle-status` scenario + fixture to verify:
    - active timing appears,
    - completed timing appears,
    - idle timing transitions to **“1m idle”** after advancing simulated time.
- **UI/behavior polish**
  - Adjusted agent-abort handling so intentional aborts don’t produce redundant “interrupted” error UI.

## Testing
- Manual smoke testing in the TUI (active timing, completed timing, and delayed idle display).
- Added/updated unit tests for status-line timing rendering, idle timing formatting/component API, stream-activity timing updates, and abort UI behavior.
- Added an end-to-end TUI terminal scenario (`work-idle-status`) with a new fixture to validate the timing labels and idle transition.
- Updated the `mastracode` changeset for a patch release describing the new status-area timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->