### PR TITLE
fix(mastracode): restore sandbox grants per thread

### DIFF
--- a/mastracode/src/agents/thread-caveman-state.test.ts
+++ b/mastracode/src/agents/thread-caveman-state.test.ts
@@ -151,8 +151,17 @@ describe('restoreOMThreadStateForCurrentThread', () => {
     expect(session.thread.setSetting).not.toHaveBeenCalled();
   });
 
-  it('does not seed missing sandboxAllowedPaths metadata from current controller state', async () => {
+  it('clears sandboxAllowedPaths when the current thread has no sandbox metadata', async () => {
     const session = createSession({ metadata: {}, state: { sandboxAllowedPaths: ['/outside/project'] } });
+
+    await restoreOMThreadStateForCurrentThread(session as never);
+
+    expect(session.state.set).toHaveBeenCalledWith({ sandboxAllowedPaths: [] });
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
+  });
+
+  it('does not update sandboxAllowedPaths when missing metadata already matches the cleared state', async () => {
+    const session = createSession({ metadata: {}, state: { sandboxAllowedPaths: [] } });
 
     await restoreOMThreadStateForCurrentThread(session as never);
 

--- a/mastracode/src/agents/thread-caveman-state.test.ts
+++ b/mastracode/src/agents/thread-caveman-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { restoreOMThreadStateForCurrentThread } from './thread-caveman-state.js';
+import { attachOMThreadStatePersistence, restoreOMThreadStateForCurrentThread } from './thread-caveman-state.js';
 
 function createSession({
   currentThreadId = 'thread-1',
@@ -17,6 +17,7 @@ function createSession({
   const setState = vi.fn(async (nextState: Record<string, unknown>) => {
     Object.assign(state, nextState);
   });
+  let eventHandler: ((event: any) => void) | undefined;
   const session = {
     state: {
       get: vi.fn(() => state),
@@ -30,6 +31,13 @@ function createSession({
       }),
       setSetting: vi.fn(async () => {}),
     },
+    subscribe: vi.fn((handler: (event: any) => void) => {
+      eventHandler = handler;
+      return () => {
+        eventHandler = undefined;
+      };
+    }),
+    emit: (event: any) => eventHandler?.(event),
     switchCurrentThread: (threadId: string | undefined) => {
       activeThreadId = threadId;
     },
@@ -129,5 +137,42 @@ describe('restoreOMThreadStateForCurrentThread', () => {
 
     expect(session.state.set).not.toHaveBeenCalled();
     expect(session.thread.setSetting).toHaveBeenCalledWith({ key: 'observeAttachments', value: false });
+  });
+
+  it('mirrors persisted sandboxAllowedPaths metadata into controller state', async () => {
+    const session = createSession({
+      metadata: { sandboxAllowedPaths: ['/outside/project'] },
+      state: { sandboxAllowedPaths: [] },
+    });
+
+    await restoreOMThreadStateForCurrentThread(session as never);
+
+    expect(session.state.set).toHaveBeenCalledWith({ sandboxAllowedPaths: ['/outside/project'] });
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
+  });
+
+  it('does not seed missing sandboxAllowedPaths metadata from current controller state', async () => {
+    const session = createSession({ metadata: {}, state: { sandboxAllowedPaths: ['/outside/project'] } });
+
+    await restoreOMThreadStateForCurrentThread(session as never);
+
+    expect(session.state.set).not.toHaveBeenCalled();
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
+  });
+
+  it('persists sandboxAllowedPaths state changes back to the current thread', async () => {
+    const session = createSession({ metadata: {}, state: { sandboxAllowedPaths: ['/outside/project'] } });
+    attachOMThreadStatePersistence(session as never);
+
+    session.emit({
+      type: 'state_changed',
+      state: { sandboxAllowedPaths: ['/outside/project'] },
+      changedKeys: ['sandboxAllowedPaths'],
+    });
+
+    expect(session.thread.setSetting).toHaveBeenCalledWith({
+      key: 'sandboxAllowedPaths',
+      value: ['/outside/project'],
+    });
   });
 });

--- a/mastracode/src/agents/thread-caveman-state.ts
+++ b/mastracode/src/agents/thread-caveman-state.ts
@@ -4,6 +4,7 @@ interface ThreadStateSetting {
   key: string;
   isValid(value: unknown): boolean;
   seedMissingFromCurrentState?: boolean;
+  clearValueWhenMissing?: unknown;
 }
 
 const THREAD_STATE_SETTINGS: ThreadStateSetting[] = [
@@ -21,12 +22,20 @@ const THREAD_STATE_SETTINGS: ThreadStateSetting[] = [
     key: 'sandboxAllowedPaths',
     isValid: (value: unknown): value is string[] =>
       Array.isArray(value) && value.every(item => typeof item === 'string'),
+    clearValueWhenMissing: [],
   },
 ];
 
 function getStateValue(session: Session<Record<string, unknown>>, setting: ThreadStateSetting): unknown {
   const value = session.state.get()[setting.key];
   return setting.isValid(value) ? value : undefined;
+}
+
+function stateValuesEqual(left: unknown, right: unknown): boolean {
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((item, index) => item === right[index]);
+  }
+  return left === right;
 }
 
 async function findThread(
@@ -56,6 +65,14 @@ async function restoreSettingsForThread(session: Session<Record<string, unknown>
     if (setting.isValid(persisted)) {
       if (getStateValue(session, setting) !== persisted) {
         updates[setting.key] = persisted;
+      }
+      continue;
+    }
+
+    if (setting.clearValueWhenMissing !== undefined) {
+      const current = getStateValue(session, setting);
+      if (current !== undefined && !stateValuesEqual(current, setting.clearValueWhenMissing)) {
+        updates[setting.key] = setting.clearValueWhenMissing;
       }
       continue;
     }

--- a/mastracode/src/agents/thread-caveman-state.ts
+++ b/mastracode/src/agents/thread-caveman-state.ts
@@ -3,16 +3,24 @@ import type { AgentControllerThread, Session } from '@mastra/core/agent-controll
 interface ThreadStateSetting {
   key: string;
   isValid(value: unknown): boolean;
+  seedMissingFromCurrentState?: boolean;
 }
 
 const THREAD_STATE_SETTINGS: ThreadStateSetting[] = [
   {
     key: 'cavemanObservations',
     isValid: (value: unknown): value is boolean => typeof value === 'boolean',
+    seedMissingFromCurrentState: true,
   },
   {
     key: 'observeAttachments',
     isValid: (value: unknown): value is 'auto' | boolean => value === 'auto' || typeof value === 'boolean',
+    seedMissingFromCurrentState: true,
+  },
+  {
+    key: 'sandboxAllowedPaths',
+    isValid: (value: unknown): value is string[] =>
+      Array.isArray(value) && value.every(item => typeof item === 'string'),
   },
 ];
 
@@ -30,7 +38,7 @@ async function findThread(
 }
 
 /**
- * Restores MastraCode-owned per-thread OM settings for the given thread:
+ * Restores MastraCode-owned per-thread state for the given thread:
  * - If the thread already has a valid value in metadata, mirror it into controller state.
  * - Otherwise, persist the current session.state value to the thread so future
  *   sessions see the user's last-selected setting.
@@ -52,9 +60,11 @@ async function restoreSettingsForThread(session: Session<Record<string, unknown>
       continue;
     }
 
-    const current = getStateValue(session, setting);
-    if (current !== undefined) {
-      settingsToSeed.push({ key: setting.key, value: current });
+    if (setting.seedMissingFromCurrentState) {
+      const current = getStateValue(session, setting);
+      if (current !== undefined) {
+        settingsToSeed.push({ key: setting.key, value: current });
+      }
     }
   }
 
@@ -70,11 +80,11 @@ async function restoreSettingsForThread(session: Session<Record<string, unknown>
 }
 
 /**
- * Wires MastraCode-owned OM settings into controller thread events so they persist
+ * Wires MastraCode-owned state into controller thread events so it persists
  * per-thread and new threads inherit the most recent value.
  *
  * This is intentionally implemented in mastracode rather than core: these
- * settings are mastracode-specific OM concepts, so persistence stays scoped to
+ * settings are mastracode-specific concepts, so persistence stays scoped to
  * the host.
  */
 export function attachOMThreadStatePersistence(session: Session<Record<string, unknown>>): void {
@@ -84,6 +94,18 @@ export function attachOMThreadStatePersistence(session: Session<Record<string, u
       void restoreSettingsForThread(session, threadId).catch(() => {
         // Persistence is best-effort; don't crash the TUI if storage hiccups.
       });
+      return;
+    }
+
+    if (event.type === 'state_changed') {
+      for (const setting of THREAD_STATE_SETTINGS) {
+        if (!event.changedKeys.includes(setting.key)) continue;
+        const value = event.state[setting.key];
+        if (!setting.isValid(value)) continue;
+        void session.thread.setSetting({ key: setting.key, value }).catch(() => {
+          // Persistence is best-effort; don't crash the TUI if storage hiccups.
+        });
+      }
     }
   });
 }

--- a/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
+++ b/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
@@ -12,8 +12,8 @@ function createMockLocalFilesystem() {
   return { fs, setAllowedPaths: spy };
 }
 
-function createAgentControllerCtx() {
-  const getState = () => ({ sandboxAllowedPaths: [] });
+function createAgentControllerCtx(state: Record<string, unknown> = {}) {
+  const getState = () => ({ sandboxAllowedPaths: [], ...state });
   const setState = vi.fn();
   return {
     getState,

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -84,10 +84,12 @@ export const requestSandboxAccessTool = createTool({
         // filesystem allowlist from `sandboxAllowedPaths` on every call
         // (getDynamicWorkspace), so an unawaited setState would let that
         // rebuild clobber the in-turn widen below before the grant lands.
-        const currentAllowed = (agentControllerCtx?.getState()?.sandboxAllowedPaths as string[] | undefined) ?? [];
+        const controllerState = agentControllerCtx?.getState();
+        const currentAllowed = (controllerState?.sandboxAllowedPaths as string[] | undefined) ?? [];
+        const nextAllowed = currentAllowed.includes(absolutePath) ? currentAllowed : [...currentAllowed, absolutePath];
         if (!currentAllowed.includes(absolutePath)) {
           await agentControllerCtx?.setState({
-            sandboxAllowedPaths: [...currentAllowed, absolutePath],
+            sandboxAllowedPaths: nextAllowed,
           });
         }
 


### PR DESCRIPTION
Persists approved sandbox paths on the current thread instead of only keeping them in memory.
Before this change restarting would drop all previously approved sandbox access.

Now after approving access once the same thread can use that path again after a Mastra Code restart. New threads still start clean and need their own approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes “which folders are allowed” stick to the same conversation thread even after you restart. If a thread was previously approved for a path, it won’t need to ask again, while brand-new threads still start without permissions.

## Summary
- Persist approved sandbox paths in per-thread metadata (instead of only in memory), so restarts don’t wipe approvals.
- When restoring settings for a thread, repopulate controller `sandboxAllowedPaths` from persisted thread metadata (and clear it to `[]` when no persisted data exists).
- Added state-persistence behavior so `sandboxAllowedPaths` (and other MastraCode-owned settings) propagate from `state_changed` events back into the current thread via `thread.setSetting`.
- Extended thread setting restore logic with an optional `seedMissingFromCurrentState` flag to control which settings get seeded from current controller state when thread metadata is missing/invalid.
- Updated `request-sandbox-access` to build the next `sandboxAllowedPaths` based on cached controller state when updating approvals.
- Updated/expanded tests to cover persistence, restore edge-cases, and event-driven syncing through `attachOMThreadStatePersistence`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->