### PR TITLE
test(core): add unit tests for channels/stream-helpers pure functions

### DIFF
--- a/.changeset/spicy-rules-fly.md
+++ b/.changeset/spicy-rules-fly.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Added unit test coverage for `channels/stream-helpers.ts` pure functions. No behaviour changes — purely additive test coverage.

--- a/packages/core/src/channels/stream-helpers.test.ts
+++ b/packages/core/src/channels/stream-helpers.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for packages/core/src/channels/stream-helpers.ts
+ *
+ * `extractErrorMessage`, `chunkToFallbackMessage`, and `renderBuiltInToolEvent`
+ * are pure functions — no I/O, no async behaviour, no mocking required.
+ * `renderBuiltInToolEvent` delegates to the already-tested `formatTool*`
+ * helpers in `./formatting`, so these tests verify correct routing rather
+ * than re-testing the formatting output itself.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { ToolDisplayEvent } from './types';
+import { chunkToFallbackMessage, extractErrorMessage, renderBuiltInToolEvent } from './stream-helpers';
+
+// ---------------------------------------------------------------------------
+// extractErrorMessage
+// ---------------------------------------------------------------------------
+
+describe('extractErrorMessage', () => {
+  it('returns null unchanged', () => {
+    expect(extractErrorMessage(null)).toBeNull();
+  });
+
+  it('returns undefined unchanged', () => {
+    expect(extractErrorMessage(undefined)).toBeUndefined();
+  });
+
+  it('returns a string unchanged', () => {
+    expect(extractErrorMessage('plain error string')).toBe('plain error string');
+  });
+
+  it('extracts message from an Error instance', () => {
+    expect(extractErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('extracts message from a plain object with a message field', () => {
+    expect(extractErrorMessage({ message: 'something failed' })).toBe('something failed');
+  });
+
+  it('ignores an empty message field and falls through', () => {
+    const result = extractErrorMessage({ message: '' });
+    expect(result).toEqual({ message: '' });
+  });
+
+  it('extracts details.errorMessage when message is absent', () => {
+    const result = extractErrorMessage({ details: { errorMessage: 'nested error' } });
+    expect(result).toBe('nested error');
+  });
+
+  it('prefers top-level message over details.errorMessage', () => {
+    const result = extractErrorMessage({
+      message: 'top-level',
+      details: { errorMessage: 'nested' },
+    });
+    expect(result).toBe('top-level');
+  });
+
+  it('returns the raw object when neither message nor details.errorMessage exist', () => {
+    const obj = { code: 500, foo: 'bar' };
+    expect(extractErrorMessage(obj)).toBe(obj);
+  });
+
+  it('returns a number unchanged', () => {
+    expect(extractErrorMessage(42)).toBe(42);
+  });
+
+  it('returns a non-string message field unchanged at top level', () => {
+    const obj = { message: 42 };
+    expect(extractErrorMessage(obj)).toBe(obj);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chunkToFallbackMessage
+// ---------------------------------------------------------------------------
+
+describe('chunkToFallbackMessage', () => {
+  it('returns text for a markdown_text chunk with content', () => {
+    const chunk = { type: 'markdown_text', text: 'Hello world' } as any;
+    expect(chunkToFallbackMessage(chunk)).toBe('Hello world');
+  });
+
+  it('returns null for a markdown_text chunk with empty text', () => {
+    const chunk = { type: 'markdown_text', text: '' } as any;
+    expect(chunkToFallbackMessage(chunk)).toBeNull();
+  });
+
+  it('returns null for a markdown_text chunk with non-string text', () => {
+    const chunk = { type: 'markdown_text', text: undefined } as any;
+    expect(chunkToFallbackMessage(chunk)).toBeNull();
+  });
+
+  it('formats a task_update with title and status', () => {
+    const chunk = { type: 'task_update', title: 'Searching', status: 'running' } as any;
+    expect(chunkToFallbackMessage(chunk)).toBe('Searching · running');
+  });
+
+  it('formats a task_update with title, status, and details', () => {
+    const chunk = {
+      type: 'task_update',
+      title: 'Searching',
+      status: 'done',
+      details: 'Found 5 results',
+    } as any;
+    expect(chunkToFallbackMessage(chunk)).toBe('Searching · done\nFound 5 results');
+  });
+
+  it('falls back to output when details is absent', () => {
+    const chunk = { type: 'task_update', title: 'Task', output: 'output text' } as any;
+    expect(chunkToFallbackMessage(chunk)).toBe('Task\noutput text');
+  });
+
+  it('returns null for a task_update with no title, status, details, or output', () => {
+    const chunk = { type: 'task_update' } as any;
+    expect(chunkToFallbackMessage(chunk)).toBeNull();
+  });
+
+  it('formats a task_update with only status (no title)', () => {
+    const chunk = { type: 'task_update', status: 'pending' } as any;
+    expect(chunkToFallbackMessage(chunk)).toBe('· pending');
+  });
+
+  it('returns title for a plan_update chunk', () => {
+    const chunk = { type: 'plan_update', title: 'My Plan' } as any;
+    expect(chunkToFallbackMessage(chunk)).toBe('My Plan');
+  });
+
+  it('returns null for a plan_update chunk with empty title', () => {
+    const chunk = { type: 'plan_update', title: '' } as any;
+    expect(chunkToFallbackMessage(chunk)).toBeNull();
+  });
+
+  it('returns null for an unrecognised chunk type', () => {
+    const chunk = { type: 'text-delta', textDelta: 'hi' } as any;
+    expect(chunkToFallbackMessage(chunk)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderBuiltInToolEvent
+// ---------------------------------------------------------------------------
+
+describe('renderBuiltInToolEvent', () => {
+  const runningEvent: ToolDisplayEvent = {
+    kind: 'running',
+    toolCallId: 'call-1',
+    toolName: 'search',
+    displayName: 'search',
+    argsSummary: 'cats',
+    args: { query: 'cats' },
+  };
+
+  const resultEvent: ToolDisplayEvent = {
+    kind: 'result',
+    toolCallId: 'call-1',
+    toolName: 'search',
+    displayName: 'search',
+    argsSummary: 'cats',
+    args: { query: 'cats' },
+    result: { count: 5 },
+    resultText: '5 results',
+    durationMs: 120,
+    isError: false,
+  };
+
+  const errorEvent: ToolDisplayEvent = {
+    kind: 'error',
+    toolCallId: 'call-1',
+    toolName: 'search',
+    displayName: 'search',
+    argsSummary: 'cats',
+    args: { query: 'cats' },
+    error: new Error('timeout'),
+    errorText: 'timeout',
+    durationMs: 50,
+  };
+
+  const approvalEvent: ToolDisplayEvent = {
+    kind: 'approval',
+    toolCallId: 'call-1',
+    toolName: 'run_code',
+    displayName: 'run_code',
+    argsSummary: 'print()',
+    args: { code: 'print()' },
+  };
+
+  it('renders a "running" event in text mode', () => {
+    const result = renderBuiltInToolEvent(runningEvent, 'text') as string;
+    expect(result).toContain('search');
+    expect(result).toContain('cats');
+  });
+
+  it('renders a "result" event in text mode', () => {
+    const result = renderBuiltInToolEvent(resultEvent, 'text') as string;
+    expect(result).toContain('search');
+    expect(result).toContain('5 results');
+  });
+
+  it('renders an "error" event in text mode using errorText', () => {
+    const result = renderBuiltInToolEvent(errorEvent, 'text') as string;
+    expect(result).toContain('timeout');
+  });
+
+  it('passes isError=true for error events regardless of mode', () => {
+    const result = renderBuiltInToolEvent(errorEvent, 'text') as string;
+    expect(result).toContain('✗');
+  });
+
+  it('always renders approval events as cards-eligible even in text mode', () => {
+    // formatToolApproval is called with useCards=true unconditionally
+    const result = renderBuiltInToolEvent(approvalEvent, 'text');
+    expect(result).toBeDefined();
+  });
+
+  it('renders a "running" event identically in shape across modes', () => {
+    const textResult = renderBuiltInToolEvent(runningEvent, 'text');
+    const cardsResult = renderBuiltInToolEvent(runningEvent, 'cards');
+    expect(textResult).toBeDefined();
+    expect(cardsResult).toBeDefined();
+  });
+});

--- a/packages/core/src/channels/stream-helpers.test.ts
+++ b/packages/core/src/channels/stream-helpers.test.ts
@@ -2,15 +2,24 @@
  * Tests for packages/core/src/channels/stream-helpers.ts
  *
  * `extractErrorMessage`, `chunkToFallbackMessage`, and `renderBuiltInToolEvent`
- * are pure functions — no I/O, no async behaviour, no mocking required.
- * `renderBuiltInToolEvent` delegates to the already-tested `formatTool*`
- * helpers in `./formatting`, so these tests verify correct routing rather
- * than re-testing the formatting output itself.
+ * are pure functions. `renderBuiltInToolEvent` delegates to the already-tested
+ * `formatTool*` helpers in `./formatting`, so these tests verify correct routing
+ * rather than re-testing the formatting output itself.
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import type { ToolDisplayEvent } from './types';
+vi.mock('./chat-lazy', () => ({
+  chatModule: () => ({
+    Actions: (props: unknown) => ({ type: 'Actions', props }),
+    Button: (props: unknown) => ({ type: 'Button', props }),
+    Card: (props: unknown) => ({ type: 'Card', props }),
+    CardText: (text: string, options?: unknown) => ({ type: 'CardText', text, options }),
+  }),
+}));
+
+import { formatToolApproval, formatToolResult, formatToolRunning } from './formatting';
 import { chunkToFallbackMessage, extractErrorMessage, renderBuiltInToolEvent } from './stream-helpers';
+import type { ToolDisplayEvent } from './types';
 
 // ---------------------------------------------------------------------------
 // extractErrorMessage
@@ -184,38 +193,28 @@ describe('renderBuiltInToolEvent', () => {
     args: { code: 'print()' },
   };
 
-  it('renders a "running" event in text mode', () => {
-    const result = renderBuiltInToolEvent(runningEvent, 'text') as string;
-    expect(result).toContain('search');
-    expect(result).toContain('cats');
+  it('routes a "running" event to the text formatter in text mode', () => {
+    const result = renderBuiltInToolEvent(runningEvent, 'text');
+    expect(result).toBe(formatToolRunning('search', 'cats', false));
   });
 
-  it('renders a "result" event in text mode', () => {
-    const result = renderBuiltInToolEvent(resultEvent, 'text') as string;
-    expect(result).toContain('search');
-    expect(result).toContain('5 results');
+  it('routes a "result" event to the text formatter', () => {
+    const result = renderBuiltInToolEvent(resultEvent, 'text');
+    expect(result).toBe(formatToolResult('search', 'cats', '5 results', false, 120, false));
   });
 
-  it('renders an "error" event in text mode using errorText', () => {
-    const result = renderBuiltInToolEvent(errorEvent, 'text') as string;
-    expect(result).toContain('timeout');
+  it('routes an "error" event using errorText and isError=true', () => {
+    const result = renderBuiltInToolEvent(errorEvent, 'text');
+    expect(result).toBe(formatToolResult('search', 'cats', 'timeout', true, 50, false));
   });
 
-  it('passes isError=true for error events regardless of mode', () => {
-    const result = renderBuiltInToolEvent(errorEvent, 'text') as string;
-    expect(result).toContain('✗');
-  });
-
-  it('always renders approval events as cards-eligible even in text mode', () => {
-    // formatToolApproval is called with useCards=true unconditionally
+  it('routes approval events to the card formatter even in text mode', () => {
     const result = renderBuiltInToolEvent(approvalEvent, 'text');
-    expect(result).toBeDefined();
+    expect(result).toEqual(formatToolApproval('run_code', 'print()', 'call-1', true));
   });
 
-  it('renders a "running" event identically in shape across modes', () => {
-    const textResult = renderBuiltInToolEvent(runningEvent, 'text');
-    const cardsResult = renderBuiltInToolEvent(runningEvent, 'cards');
-    expect(textResult).toBeDefined();
-    expect(cardsResult).toBeDefined();
+  it('routes a "running" event to mode-specific formatters', () => {
+    expect(renderBuiltInToolEvent(runningEvent, 'text')).toBe(formatToolRunning('search', 'cats', false));
+    expect(renderBuiltInToolEvent(runningEvent, 'cards')).toEqual(formatToolRunning('search', 'cats', true));
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds unit test coverage for three pure functions in `packages/core/src/channels/stream-helpers.ts` used by both the streaming and static chat channel drivers.

Closes #18662

## Why this matters

A regression in `extractErrorMessage` would surface as `[object Object]` error messages to users in Slack/Discord. A bug in `chunkToFallbackMessage` would silently drop tool status updates for adapters without native streaming support.

## Coverage (28 tests, 1 file)

| Function | Tests | What is covered |
|---|---|---|
| `extractErrorMessage` | 11 | null/undefined passthrough, plain string, Error instance, object with message field, empty message falls through, nested `details.errorMessage`, message takes precedence over details, raw object when nothing extractable, number passthrough, non-string message field passthrough |
| `chunkToFallbackMessage` | 11 | `markdown_text` with/without content, non-string text, `task_update` with title+status, with details, falls back to output, no renderable fields → null, status-only formatting, `plan_update` with/without title, unrecognised chunk type |
| `renderBuiltInToolEvent` | 6 | running/result/error events render expected content in text mode, error indicator shown, approval events always render (cards path hardcoded regardless of mode param), shape consistency across cards/text modes |

All `ToolDisplayEvent` fixtures match the exact discriminated union shape in `channels/types.ts`. The approval-event behaviour (`formatToolApproval(..., true)` hardcoded) was verified directly against the `formatToolApproval` signature in `formatting.ts`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Test coverage improvement
- [ ] Documentation update

## Changeset

Patch changeset added for `@mastra/core`.

## Notes

Purely additive — 1 new test file, 226 lines, zero behaviour changes, zero new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds unit tests for a few “helper” functions used when chat messages stream in or when tools produce status updates. It helps ensure errors and tool updates don’t turn into unreadable `[object Object]` text or get dropped in channel adapters.

## Summary by CodeRabbit
* **Tests**
  * Added a new `stream-helpers.test.ts` suite (28 tests) for `extractErrorMessage`, `chunkToFallbackMessage`, and `renderBuiltInToolEvent` in `packages/core/src/channels/stream-helpers.ts`.
  * Verified error-shape handling (null/undefined/strings/objects/numbers) to ensure readable error messages.
  * Checked stream chunk flattening into fallback text, including special formatting for task/plan-style updates and returning `null` for empty/unrecognized inputs.
  * Confirmed built-in tool event rendering routes to the correct renderer in both `text` and `cards` modes, including error handling via `errorText` (with an error marker) and approval events being treated as cards-eligible even when in text mode.

* **Chores**
  * Added a changeset for `@mastra/core` with a `patch` bump noting test-only coverage with no behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->