### PR TITLE
Rename AgentController interval background-task API

### DIFF
--- a/.changeset/big-dogs-change.md
+++ b/.changeset/big-dogs-change.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Renamed the AgentController interval API. `heartbeatHandlers` is now `intervalHandlers`, the `HeartbeatHandler` type is now `IntervalHandler`, and the `removeHeartbeat()`/`stopHeartbeats()` methods are now `removeInterval()`/`stopIntervals()`. This better reflects that these are fixed-interval background tasks, not liveness pings, and is distinct from the unrelated `mastra.heartbeats` scheduled-agent feature.
+
+**Before**
+
+```ts
+const { controller } = await createMastraCode({
+  heartbeatHandlers: [{ id: 'sync', intervalMs: 60_000, handler: async () => {} }],
+});
+await controller.removeHeartbeat({ id: 'sync' });
+await controller.stopHeartbeats();
+```
+
+**After**
+
+```ts
+const { controller } = await createMastraCode({
+  intervalHandlers: [{ id: 'sync', intervalMs: 60_000, handler: async () => {} }],
+});
+await controller.removeInterval({ id: 'sync' });
+await controller.stopIntervals();
+```

--- a/docs/src/content/en/docs/agent-controller/overview.mdx
+++ b/docs/src/content/en/docs/agent-controller/overview.mdx
@@ -29,7 +29,7 @@ The AgentController gives you the runtime pieces to ship interactive agent appli
 - **Let users pick the right model for each step.** Per-mode [model management](/reference/agent-controller/agent-controller-class) switches models at runtime and tracks usage, which powers copilot UIs where users trade speed for capability.
 - **Delegate focused work to child agents.** [Subagents](/docs/agent-controller/subagents) run subtasks with constrained tools and can fork the parent conversation, so a research mode can spin off web search or code review without polluting the main thread.
 - **Drive a live UI from agent activity.** The [event system](/docs/agent-controller/session) emits typed events and coalesced display snapshots, so your TUI or web app reflects message updates, mode changes, and pending approvals in real time.
-- **Run long-lived autonomous agents.** Structured task lists, heartbeat handlers, and observational memory keep background task runners on track and let them learn across threads.
+- **Run long-lived autonomous agents.** Structured task lists, interval handlers, and observational memory keep background task runners on track and let them learn across threads.
 
 ## When to use the AgentController
 

--- a/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
+++ b/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
@@ -331,8 +331,8 @@ await agentController.sendMessage({ content: 'Hello!' })
     isOptional: true,
   },
   {
-    name: 'heartbeatHandlers',
-    type: 'HeartbeatHandler[]',
+    name: 'intervalHandlers',
+    type: 'IntervalHandler[]',
     description:
       'Periodic background tasks started during `init()`. Use for gateway sync, cache refresh, and similar tasks.',
     isOptional: true,
@@ -432,7 +432,7 @@ await agentController.sendMessage({ content: 'Hello!' })
 
 #### `init()`
 
-Initialize the agentController. Loads storage, initializes a static workspace (dynamic factory workspaces are resolved per-session during `createSession`), propagates memory and workspace to mode agents, and starts heartbeat handlers. Call this before using the agentController.
+Initialize the agentController. Loads storage, initializes a static workspace (dynamic factory workspaces are resolved per-session during `createSession`), propagates memory and workspace to mode agents, and starts interval handlers. Call this before using the agentController.
 
 ```typescript
 await agentController.init()
@@ -490,26 +490,26 @@ const thread = await agentController.selectOrCreateThread()
 
 #### `destroy()`
 
-Stop all heartbeat handlers and clean up resources.
+Stop all interval handlers and clean up resources.
 
 ```typescript
 await agentController.destroy()
 ```
 
-#### `removeHeartbeat({ id })`
+#### `removeInterval({ id })`
 
-Remove a specific heartbeat handler by ID. Calls the handler's `shutdown()` callback if defined.
+Remove a specific interval handler by ID. Calls the handler's `shutdown()` callback if defined.
 
 ```typescript
-await agentController.removeHeartbeat({ id: 'gateway-sync' })
+await agentController.removeInterval({ id: 'gateway-sync' })
 ```
 
-#### `stopHeartbeats()`
+#### `stopIntervals()`
 
-Stop and remove all heartbeat handlers.
+Stop and remove all interval handlers.
 
 ```typescript
-await agentController.stopHeartbeats()
+await agentController.stopIntervals()
 ```
 
 #### `getCurrentAgent()`

--- a/docs/src/mastra-code/customization.mdx
+++ b/docs/src/mastra-code/customization.mdx
@@ -148,15 +148,15 @@ const { controller } = await createMastraCode({
 
 This is equivalent to setting `.mastracode/database.json` but allows configuration at the code level.
 
-## Custom heartbeat handlers
+## Custom interval handlers
 
 Replace or extend the default background tasks:
 
-```typescript title="src/custom-heartbeats.ts"
+```typescript title="src/custom-intervals.ts"
 import { createMastraCode } from 'mastracode'
 
 const { controller } = await createMastraCode({
-  heartbeatHandlers: [
+  intervalHandlers: [
     {
       id: 'sync-config',
       intervalMs: 60_000,
@@ -168,7 +168,7 @@ const { controller } = await createMastraCode({
 })
 ```
 
-Heartbeat handlers run on a fixed interval. They start when `controller.init()` is called and stop when `controller.destroy()` is called.
+Interval handlers run on a fixed interval. They start when `controller.init()` is called and stop when `controller.destroy()` is called.
 
 ## Building a custom TUI
 

--- a/docs/src/mastra-code/reference.mdx
+++ b/docs/src/mastra-code/reference.mdx
@@ -55,7 +55,7 @@ const {
 | `subagents` | `AgentControllerSubagent[]` | Explore, Plan, Execute | Custom subagent definitions |
 | `storage` | `StorageConfig` | Local LibSQL | Database configuration |
 | `initialState` | `Partial<MastraCodeState>` | Default state | Initial controller state values |
-| `heartbeatHandlers` | `HeartbeatHandler[]` | Default handlers | Background task definitions |
+| `intervalHandlers` | `IntervalHandler[]` | Default handlers | Background task definitions |
 | `resolveModel` | `(modelId: string, options?: { thinkingLevel?: ThinkingLevel; remapForCodexOAuth?: boolean; requestContext?: RequestContext }) => ResolvedModel` | Default resolver | Custom model resolution function |
 
 #### `AgentControllerMode`
@@ -128,7 +128,7 @@ interface PermissionRules {
 }
 ```
 
-#### `HeartbeatHandler`
+#### `IntervalHandler`
 
 Background task definition.
 

--- a/mastracode/e2e/terminal-backend.ts
+++ b/mastracode/e2e/terminal-backend.ts
@@ -398,7 +398,7 @@ async function startMastraCodeApp(
       await Promise.allSettled([
         result.mcpManager?.disconnect(),
         result.controller.getMastra()?.stopWorkers(),
-        result.controller.stopHeartbeats(),
+        result.controller.stopIntervals(),
         closeSignalsPubSub?.(),
       ]);
     },

--- a/mastracode/src/acp/index.ts
+++ b/mastracode/src/acp/index.ts
@@ -46,7 +46,7 @@ export async function acpMain(options?: { dangerousAutoApprove?: boolean }): Pro
       await Promise.allSettled([
         mcpManager?.disconnect(),
         controller?.getMastra()?.stopWorkers(),
-        controller?.stopHeartbeats(),
+        controller?.stopIntervals(),
         closeSignalsPubSub?.(),
       ]);
 

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -649,7 +649,7 @@ export async function headlessMain(predrainedInput?: string | null): Promise<nev
   await Promise.allSettled([
     mcpManager?.disconnect(),
     controller.getMastra()?.stopWorkers(),
-    controller?.stopHeartbeats(),
+    controller?.stopIntervals(),
     closeSignalsPubSub?.(),
   ]);
 

--- a/mastracode/src/index.test.ts
+++ b/mastracode/src/index.test.ts
@@ -24,10 +24,10 @@ vi.mock('@mastra/core/agent-controller', () => ({
   AgentController: class {
     constructor(config: {
       resourceId?: string;
-      heartbeatHandlers?: Array<{ immediate?: boolean; handler: () => unknown }>;
+      intervalHandlers?: Array<{ immediate?: boolean; handler: () => unknown }>;
     }) {
-      for (const heartbeat of config.heartbeatHandlers ?? []) {
-        if (heartbeat.immediate !== false) void heartbeat.handler();
+      for (const interval of config.intervalHandlers ?? []) {
+        if (interval.immediate !== false) void interval.handler();
       }
     }
 

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { Agent } from '@mastra/core/agent';
 import { AgentController } from '@mastra/core/agent-controller';
 import type {
-  HeartbeatHandler,
+  IntervalHandler,
   AgentControllerConfig,
   AgentControllerEvent,
   AgentControllerMode,
@@ -176,8 +176,8 @@ export interface MastraCodeConfig {
   initialState?: Partial<MastraCodeState>;
   /** Override id generation for threads/messages. Primarily useful for deterministic tests. */
   idGenerator?: AgentControllerConfig<MastraCodeState>['idGenerator'];
-  /** Override heartbeat handlers. Default: gateway-sync */
-  heartbeatHandlers?: HeartbeatHandler[];
+  /** Override interval handlers. Default: gateway-sync */
+  intervalHandlers?: IntervalHandler[];
   /** Override the workspace. Default: local filesystem + local sandbox based on detected project */
   workspace?: AgentControllerConfig<MastraCodeState>['workspace'];
   /** Override the config directory name. Default: '.mastracode'. Replaces '.mastracode' in all project-level and global config paths (MCP, hooks, commands, database, skills, agent instructions). */
@@ -622,7 +622,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
     },
   ];
 
-  const defaultHeartbeatHandlers: HeartbeatHandler[] = [
+  const defaultIntervalHandlers: IntervalHandler[] = [
     {
       id: 'gateway-sync',
       intervalMs: 5 * 60 * 1000,
@@ -630,7 +630,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       handler: () => syncGateways(),
     },
   ];
-  const heartbeatHandlers = config?.heartbeatHandlers ?? defaultHeartbeatHandlers;
+  const intervalHandlers = config?.intervalHandlers ?? defaultIntervalHandlers;
 
   // Build lightweight provider access for resolving built-in packs at startup.
   // Anthropic/OpenAI use AuthStorage; other providers use env API keys.
@@ -765,7 +765,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       configDir,
     },
     modes,
-    heartbeatHandlers,
+    intervalHandlers,
     modelUseCountProvider: () => loadSettings().modelUseCounts,
     modelUseCountTracker: modelId => {
       try {

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -150,7 +150,7 @@ const asyncCleanup = async () => {
   await Promise.allSettled([
     mcpManager?.disconnect(),
     controller?.getMastra()?.stopWorkers(),
-    controller?.stopHeartbeats(),
+    controller?.stopIntervals(),
     closeSignalsPubSub?.(),
     analytics?.shutdown(),
   ]);

--- a/mastracode/src/web/server.ts
+++ b/mastracode/src/web/server.ts
@@ -103,7 +103,7 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
     url: `http://localhost:${port}`,
     stop: async () => {
       await new Promise<void>(resolve => server.close(() => resolve()));
-      await Promise.allSettled([controller.getMastra()?.stopWorkers(), controller.stopHeartbeats()]);
+      await Promise.allSettled([controller.getMastra()?.stopWorkers(), controller.stopIntervals()]);
     },
   };
 }

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -44,7 +44,7 @@ import {
 } from './tools';
 import type {
   AvailableModel,
-  HeartbeatHandler,
+  IntervalHandler,
   AgentControllerConfig,
   AgentControllerMessage,
   AgentControllerMessageContent,
@@ -181,7 +181,7 @@ export class AgentController<TState = {}> {
   private initPromise: Promise<void> | undefined = undefined;
   private browser: DynamicArgument<MastraBrowser | undefined> = undefined;
   private workspace: DynamicArgument<Workspace | undefined> = undefined;
-  private heartbeatTimers = new Map<string, { timer: NodeJS.Timeout; shutdown?: () => void | Promise<void> }>();
+  private intervalTimers = new Map<string, { timer: NodeJS.Timeout; shutdown?: () => void | Promise<void> }>();
   /**
    * The mode every new session starts in. Resolved once at construction from
    * `config.defaultModeId` (or the configured default/first mode) and reused by
@@ -747,7 +747,7 @@ export class AgentController<TState = {}> {
       this.propagateRuntimeServicesToAgent(agent);
     }
 
-    this.startHeartbeats();
+    this.startIntervals();
   }
 
   private async getMemoryStorage(): Promise<MemoryStorage> {
@@ -2155,42 +2155,42 @@ export class AgentController<TState = {}> {
   }
 
   // ===========================================================================
-  // Heartbeat Handlers
+  // Interval Handlers
   // ===========================================================================
 
-  private startHeartbeats(): void {
-    const handlers = [...(this.config.heartbeatHandlers ?? [])];
+  private startIntervals(): void {
+    const handlers = [...(this.config.intervalHandlers ?? [])];
     if (!handlers.length) return;
 
-    for (const hb of handlers) {
-      if (this.heartbeatTimers.has(hb.id)) continue;
+    for (const iv of handlers) {
+      if (this.intervalTimers.has(iv.id)) continue;
 
       const run = async () => {
         try {
-          await hb.handler();
+          await iv.handler();
         } catch (error) {
-          console.error(`[Heartbeat:${hb.id}] failed:`, error);
+          console.error(`[Interval:${iv.id}] failed:`, error);
         }
       };
 
-      if (hb.immediate !== false) {
+      if (iv.immediate !== false) {
         void run();
       }
 
-      const timer = setInterval(run, hb.intervalMs);
+      const timer = setInterval(run, iv.intervalMs);
       timer.unref();
-      this.heartbeatTimers.set(hb.id, { timer, shutdown: hb.shutdown });
+      this.intervalTimers.set(iv.id, { timer, shutdown: iv.shutdown });
     }
   }
 
-  registerHeartbeat(handler: HeartbeatHandler): void {
-    void this.removeHeartbeat({ id: handler.id });
+  registerInterval(handler: IntervalHandler): void {
+    void this.removeInterval({ id: handler.id });
 
     const run = async () => {
       try {
         await handler.handler();
       } catch (error) {
-        console.error(`[Heartbeat:${handler.id}] failed:`, error);
+        console.error(`[Interval:${handler.id}] failed:`, error);
       }
     };
 
@@ -2200,32 +2200,32 @@ export class AgentController<TState = {}> {
 
     const timer = setInterval(run, handler.intervalMs);
     timer.unref();
-    this.heartbeatTimers.set(handler.id, { timer, shutdown: handler.shutdown });
+    this.intervalTimers.set(handler.id, { timer, shutdown: handler.shutdown });
   }
 
-  async removeHeartbeat({ id }: { id: string }): Promise<void> {
-    const entry = this.heartbeatTimers.get(id);
+  async removeInterval({ id }: { id: string }): Promise<void> {
+    const entry = this.intervalTimers.get(id);
     if (entry) {
       clearInterval(entry.timer);
-      this.heartbeatTimers.delete(id);
+      this.intervalTimers.delete(id);
       try {
         await entry.shutdown?.();
       } catch (error) {
-        console.error(`[Heartbeat:${id}] shutdown failed:`, error);
+        console.error(`[Interval:${id}] shutdown failed:`, error);
       }
     }
   }
 
-  async stopHeartbeats(): Promise<void> {
-    const entries = [...this.heartbeatTimers.entries()];
-    this.heartbeatTimers.clear();
+  async stopIntervals(): Promise<void> {
+    const entries = [...this.intervalTimers.entries()];
+    this.intervalTimers.clear();
 
     for (const [id, entry] of entries) {
       clearInterval(entry.timer);
       try {
         await entry.shutdown?.();
       } catch (error) {
-        console.error(`[Heartbeat:${id}] shutdown failed:`, error);
+        console.error(`[Interval:${id}] shutdown failed:`, error);
       }
     }
   }
@@ -2238,7 +2238,7 @@ export class AgentController<TState = {}> {
     // The AgentController owns no session; per-session teardown (thread-subscription
     // cleanup) is the caller's responsibility via `session.thread.*`. Here we
     // only tear down AgentController-shared resources.
-    await this.stopHeartbeats();
+    await this.stopIntervals();
   }
 
   // ===========================================================================

--- a/packages/core/src/agent-controller/index.ts
+++ b/packages/core/src/agent-controller/index.ts
@@ -41,7 +41,7 @@ export type {
   AgentControllerSubagent,
   AgentControllerSubagentHistoryEntry,
   AgentControllerThread,
-  HeartbeatHandler,
+  IntervalHandler,
   ModelAuthStatus,
   ModelUseCountProvider,
   ModelUseCountTracker,

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -14,14 +14,14 @@ import type { Workspace, WorkspaceStatus } from '../workspace';
 import type { TaskItemSnapshot } from './tools';
 
 // =============================================================================
-// Heartbeat Handlers
+// Interval Handlers
 // =============================================================================
 
 /**
  * A periodic task that the AgentController runs on a timer.
- * Heartbeat handlers start during `init()` and are cleaned up on `stopHeartbeats()`.
+ * Interval handlers start during `init()` and are cleaned up on `stopIntervals()`.
  */
-export interface HeartbeatHandler {
+export interface IntervalHandler {
   /** Unique identifier for this handler (used for dedup and logging) */
   id: string;
   /** Interval in milliseconds between invocations */
@@ -30,7 +30,7 @@ export interface HeartbeatHandler {
   handler: () => void | Promise<void>;
   /** Whether to run the handler immediately on start (default: true) */
   immediate?: boolean;
-  /** Called when the handler is removed or all heartbeats are stopped */
+  /** Called when the handler is removed or all intervals are stopped */
   shutdown?: () => void | Promise<void>;
 }
 
@@ -276,10 +276,10 @@ export interface AgentControllerConfig<TState = {}> {
   browser?: DynamicArgument<MastraBrowser | undefined>;
 
   /**
-   * Periodic heartbeat handlers started during `init()`.
+   * Periodic interval handlers started during `init()`.
    * Use for background tasks like gateway sync, cache refresh, etc.
    */
-  heartbeatHandlers?: HeartbeatHandler[];
+  intervalHandlers?: IntervalHandler[];
 
   /**
    * Custom ID generator for AgentController-managed IDs such as threads and mode-run identifiers.

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -63,7 +63,7 @@ export type {
   AgentControllerSubagent,
   AgentControllerSubagentHistoryEntry,
   AgentControllerThread,
-  HeartbeatHandler,
+  IntervalHandler,
   ModelAuthStatus,
   ModelUseCountProvider,
   ModelUseCountTracker,

--- a/scripts/gh-dane-command/index.ts
+++ b/scripts/gh-dane-command/index.ts
@@ -122,7 +122,7 @@ async function main(): Promise<never> {
 
   // Cleanup
   releaseAllThreadLocks();
-  await Promise.allSettled([mcpManager?.disconnect(), controller?.stopHeartbeats()]);
+  await Promise.allSettled([mcpManager?.disconnect(), controller?.stopIntervals()]);
 
   process.exit(exitCode);
 }


### PR DESCRIPTION
## Summary

Renames the AgentController's periodic background-task API from "heartbeat" to "interval". These handlers run fixed-interval background work (gateway sync, cache refresh, etc.); the old "heartbeat" naming implied liveness pings and was easy to confuse with the unrelated `mastra.heartbeats` scheduled-agent feature. The new naming makes the public API self-explanatory.

The rename spans the `@mastra/core` AgentController, its harness re-export, the mastracode consumers, and the docs.

**Public API change (`@mastra/core`, minor):**

Before:

```ts
const { controller } = await createMastraCode({
  heartbeatHandlers: [{ id: 'sync', intervalMs: 60_000, handler: async () => {} }],
})
await controller.removeHeartbeat({ id: 'sync' })
await controller.stopHeartbeats()
```

After:

```ts
const { controller } = await createMastraCode({
  intervalHandlers: [{ id: 'sync', intervalMs: 60_000, handler: async () => {} }],
})
await controller.removeInterval({ id: 'sync' })
await controller.stopIntervals()
```

Identifier map:
- `heartbeatHandlers` → `intervalHandlers` (config)
- `HeartbeatHandler` → `IntervalHandler` (type)
- `registerHeartbeat()` → `registerInterval()`
- `removeHeartbeat()` → `removeInterval()`
- `startHeartbeats()` / `stopHeartbeats()` → `startIntervals()` / `stopIntervals()`
- log prefix `[Heartbeat:…]` → `[Interval:…]`

The unrelated `mastra.heartbeats` cron-scheduled-agent feature (in `packages/server` / `client-js` and its docs) is intentionally untouched.

## Test plan

- [x] `tsc --noEmit` clean for `@mastra/core` and `mastracode`
- [x] `@mastra/core` agent-controller suite passes (373/373)
- [x] `mastracode` `src/index.test.ts` passes (5/5)
- [x] eslint clean on changed mastracode files
- [x] No remaining `heartbeat` identifiers in renamed code paths or docs (verified the only remaining matches are the separate `mastra.heartbeats` feature)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change renames a background task feature from “heartbeat” to “interval” because these tasks run on a timer, not as a liveliness ping. It updates the core API, docs, tests, and cleanup code so everything uses the new name consistently.

### Summary
- Renamed `heartbeatHandlers` to `intervalHandlers` and `HeartbeatHandler` to `IntervalHandler` in `@mastra/core`
- Renamed controller methods:
  - `registerHeartbeat()` → `registerInterval()`
  - `removeHeartbeat()` → `removeInterval()`
  - `startHeartbeats()` / `stopHeartbeats()` → `startIntervals()` / `stopIntervals()`
- Updated internal timer storage and logging from `heartbeat` to `interval`
- Propagated the rename through:
  - harness re-exports
  - `mastracode` config, cleanup paths, and tests
  - docs and reference material
- Left the unrelated `mastra.heartbeats` scheduled-agent feature unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->