### PR TITLE
chore: Fine-tune agent model ID instructions

### DIFF
--- a/.claude/skills/mastra-docs/references/STYLEGUIDE.md
+++ b/.claude/skills/mastra-docs/references/STYLEGUIDE.md
@@ -13,8 +13,7 @@ Use this file as the default writing guide for Mastra's documentation.
 
 ## Keep docs current
 
-- Use current model names for providers such as OpenAI and Claude.
-- Check `packages/core/src/llm/model/provider-registry.json` for the latest models supported by Mastra.
+- When adding a model name or ID to docs, use a placeholder token from docs/src/plugins/remark-model-tokens/models.ts (remark replaces them at docs build time)
 
 ## Scope
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ For work in packages read package local packages/<name>/AGENTS.md first
 turborepo pnpm workspace
 packages use strict TypeScript
 vitest tests are colocated with source
-When adding a model name or ID to docs, changesets, or comments, use a placeholder token from docs/src/plugins/remark-model-tokens/models.ts (remark replaces them at docs build time); in executable tests use a real provider/model value, not a bare token
+When adding a model name or ID to changesets or comments, use a literal value from docs/src/plugins/remark-model-tokens/models.ts (do not use placeholder tokens, remark does not replace them in changesets/comments)
 
 Prefer narrowest build test lint typecheck for packages
 when package splits unit integration or E2E coverage run narrowest suite first

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,6 +2,7 @@ Use @styleguides/STYLEGUIDE.md first. @styleguides/ also includes guides for doc
 
 When working check src/content/en/docs/ and src/content/en/reference/ update existing docs or create new docs
 @CONTRIBUTING.md for setup, local development, and components / frontmatter
+When adding a model name or ID to docs, use a placeholder token from src/plugins/remark-model-tokens/models.ts (remark replaces them at docs build time)
 
 main documentation src/content/en/docs/
 step by step guides src/content/en/guides/


### PR DESCRIPTION
## Description

Fine-tune AGENTS.md files so that agents do not put model name/ID placeholders into changesets

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR updates the guide for automated helpers so they handle model names and IDs the right way. It helps keep docs and change notes consistent by telling them when to use a real value and when to use a placeholder.

### Summary
- Updated `AGENTS.md` guidance to avoid putting model name/ID placeholders into changesets or comments.
- Updated `docs/AGENTS.md` and related docs guidance to use the shared model-token placeholder source so docs build can replace them correctly.
- Refined `STYLEGUIDE.md` language to match the new model token handling rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->