### PR TITLE
fix(deployer): preserve $ in env values when updating an existing key

### DIFF
--- a/.changeset/fix-deployer-env-dollar-corruption.md
+++ b/.changeset/fix-deployer-env-dollar-corruption.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix `FileEnvService.setEnvValue` corrupting env values that contain `$` when updating an existing key. Values such as database URLs and passwords that include `$&`, `$$`, or `$1` are now written exactly as provided instead of being mangled by `String.prototype.replace` special patterns. Closes #18633.

--- a/packages/deployer/src/services/env.test.ts
+++ b/packages/deployer/src/services/env.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FileEnvService } from './env';
+
+describe('FileEnvService.setEnvValue', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'mastra-env-'));
+    file = join(dir, '.env');
+  });
+
+  afterEach(async () => {
+    // Cleanup is best-effort; Windows can transiently lock the temp dir.
+    try {
+      await rm(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('preserves $ sequences in the value when replacing an existing key', async () => {
+    await writeFile(file, 'PWD=old\n', 'utf8');
+    const svc = new FileEnvService(file);
+
+    // Values like DB URLs or passwords commonly contain $.
+    const value = 'a$&b_$$_$1_end';
+    await svc.setEnvValue('PWD', value);
+
+    const content = await readFile(file, 'utf8');
+    expect(content).toContain(`PWD=${value}`);
+    expect(await svc.getEnvValue('PWD')).toBe(value);
+  });
+
+  it('writes value literally when the key is new', async () => {
+    await writeFile(file, 'OTHER=1\n', 'utf8');
+    const svc = new FileEnvService(file);
+
+    const value = 'x$&y$$z';
+    await svc.setEnvValue('NEWKEY', value);
+
+    expect(await svc.getEnvValue('NEWKEY')).toBe(value);
+  });
+});

--- a/packages/deployer/src/services/env.ts
+++ b/packages/deployer/src/services/env.ts
@@ -44,7 +44,10 @@ export class FileEnvService extends EnvService {
   }): Promise<string> {
     const regex = new RegExp(`^${key}=.*$`, 'm');
     if (data.match(regex)) {
-      data = data.replace(regex, `${key}=${value}`);
+      // Use a replacement function so `$` sequences in the value (e.g. `$&`,
+      // `$$`) are written literally instead of being interpreted as
+      // String.prototype.replace special patterns.
+      data = data.replace(regex, () => `${key}=${value}`);
     } else {
       data += `\n${key}=${value}`;
     }


### PR DESCRIPTION
## What

`FileEnvService.setEnvValue` corrupts any env value containing `$` when the key already exists in the file. `updateEnvData` replaces the line with:

```ts
data = data.replace(regex, `${key}=${value}`);
```

`String.prototype.replace` treats `$&`, `$$`, `` $` ``, `$'`, and `$n` as special patterns in the replacement string, so a value with `$` is mangled. For `.env` containing `PWD=old` and `setEnvValue('PWD', 'a$&b_$$_end')`, the line becomes `PWD=aPWD=oldb_$_end` instead of `PWD=a$&b_$$_end`. This hits real secrets (database URLs, passwords) that commonly contain `$`. The new-key branch writes the value literally via concatenation, so the two paths disagree.

## Change

Pass a replacement function to `replace` so the value is written literally.

## Tests

Added unit tests with a temp `.env`: replacing an existing key with a `$`-containing value preserves it byte for byte, and the new-key path is also covered. The existing-key test fails on the current code and passes after the fix.

Closes #18633

---

cc @wardpeet who last touched this file. One-line change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a bug where putting special `$` characters into an env value could get mangled when saving it back to an existing `.env` key. Now the value is written exactly as typed, so things like `a$&b_$$_end` stay unchanged.

## Summary
- Fixed `FileEnvService.setEnvValue` in `@mastra/deployer` so existing env values containing `$` are preserved literally during updates.
- Switched the replacement logic to use a callback, avoiding `String.prototype.replace` special `$` expansion behavior.
- Added tests covering:
  - updating an existing key with `$`-containing values
  - creating a new key with the same values
- Added a changeset for the `@mastra/deployer` patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->