### PR TITLE
fix(schema-compat): preserve unrecognized zod v4 string_format checks

### DIFF
--- a/.changeset/fix-schema-compat-v4-string-format-drop.md
+++ b/.changeset/fix-schema-compat-v4-string-format-drop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fix the Zod v4 string handler silently dropping unrecognized `string_format` checks. Formats without a textual description (such as `ipv4`, `ipv6`, `datetime`, `date`, `time`, `base64`, `cuid2`, `ulid`, `nanoid`, `jwt`) are now preserved as validation instead of being removed, so schemas using them keep rejecting invalid input. Closes #18634.

--- a/packages/schema-compat/src/schema-compatibility-v4-string-format.test.ts
+++ b/packages/schema-compat/src/schema-compatibility-v4-string-format.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { OpenAIReasoningSchemaCompatLayer } from './provider-compats/openai-reasoning';
+import type { ModelInformation } from './types';
+
+const modelInfo: ModelInformation = {
+  provider: 'openai',
+  modelId: 'o3-mini',
+  supportsStructuredOutputs: true,
+};
+
+describe('defaultZodStringHandler string_format preservation', () => {
+  const layer = new OpenAIReasoningSchemaCompatLayer(modelInfo);
+
+  it('keeps datetime validation (a string format the handler does not turn into a description)', () => {
+    const result = layer.defaultZodStringHandler(z.string().datetime());
+
+    // Valid datetime still passes.
+    expect(result.safeParse('2026-01-01T00:00:00.000Z').success).toBe(true);
+    // Invalid datetime must still be rejected: the format check should not be dropped.
+    expect(result.safeParse('not-a-datetime').success).toBe(false);
+  });
+
+  it('still passes through a plain min_length string', () => {
+    const result = layer.defaultZodStringHandler(z.string().min(3));
+    expect(result.safeParse('abcd').success).toBe(true);
+  });
+});

--- a/packages/schema-compat/src/schema-compatibility-v4.ts
+++ b/packages/schema-compat/src/schema-compatibility-v4.ts
@@ -496,6 +496,12 @@ export class SchemaCompatLayer {
                     // @ts-expect-error - fix later
                     constraints.push(`input must match this regex ${check._zod.def.pattern}`);
                     break;
+                  default:
+                    // Formats without a textual description (ipv4, datetime,
+                    // base64, etc.) must be preserved as real validation instead
+                    // of being silently dropped.
+                    newChecks.push(check);
+                    break;
                 }
               }
               break;


### PR DESCRIPTION
## What

The Zod v4 string handler (`defaultZodStringHandler` in `schema-compatibility-v4.ts`) silently drops every `string_format` check whose format it has no textual description for (`ipv4`, `ipv6`, `datetime`, `date`, `time`, `base64`, `cuid2`, `ulid`, `nanoid`, `jwt`, `e164`, `cidr`, ...).

The outer switch enters the `string_format` case for any of these (because `string_format` is in `ALL_STRING_CHECKS`), but the inner `switch (format)` only handles `email`/`url`/`emoji`/`uuid`/`cuid`/`regex` and has no `default`, so the check is neither described nor pushed onto `newChecks` and disappears. The validation is lost. The Zod v3 handler preserves these via its `else` branch, so the v4 port diverges.

## Change

Add a `default` arm to the inner format switch that pushes the check onto `newChecks`, preserving it as validation.

## Tests

Added unit tests (`z.string().datetime()` keeps rejecting non-datetime input) that run under both the v3 and v4 test projects: they fail on the current v4 code and pass after the fix. The full schema-compat suite (30 files) still passes.

Closes #18634

cc @TylerBarnes @wardpeet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes sure string rules like “must be a date/time” don’t get lost when converting Zod schemas. Before, some special string checks were ignored, so invalid strings could sneak through; now those checks stay active and still reject bad input.

## What changed
- Updated `defaultZodStringHandler` in `@mastra/schema-compat` so unhandled Zod v4 `string_format` checks are preserved as validation instead of being dropped.
- Kept formats like `datetime`, `date`, `time`, `base64`, `cuid2`, `ulid`, `nanoid`, `jwt`, `e164`, `cidr`, and similar working as actual constraints.
- Added tests covering `z.string().datetime()` behavior in the schema-compat v3 and v4 test projects.
- Added a changeset for the patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->