### PR TITLE
fix(core): honor startExclusive/endExclusive in in-memory listTraces

### DIFF
--- a/.changeset/fix-inmemory-observability-exclusive-bounds.md
+++ b/.changeset/fix-inmemory-observability-exclusive-bounds.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix in-memory observability `listTraces` ignoring the `startExclusive` and `endExclusive` flags on `startedAt`/`endedAt` filters. Exclusive date-range bounds now drop a trace that sits exactly on the boundary, matching the pg/libsql adapters (and the in-memory log/metric filters). Closes #18635.

--- a/packages/core/src/storage/domains/observability/inmemory-trace-exclusive-filter.test.ts
+++ b/packages/core/src/storage/domains/observability/inmemory-trace-exclusive-filter.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { EntityType, SpanType } from '../../../observability/types';
+import { InMemoryStore } from '../../mock';
+
+function makeRootSpan(traceId: string, startedAt: Date) {
+  return {
+    traceId,
+    spanId: `${traceId}-root`,
+    parentSpanId: null,
+    name: 'agent-run',
+    spanType: SpanType.AGENT_RUN,
+    isEvent: false,
+    entityType: EntityType.AGENT,
+    entityId: 'agent-1',
+    entityName: 'myAgent',
+    userId: null,
+    organizationId: null,
+    resourceId: null,
+    runId: null,
+    sessionId: null,
+    threadId: null,
+    requestId: null,
+    environment: 'test',
+    source: null,
+    serviceName: 'test-service',
+    scope: null,
+    attributes: {},
+    metadata: {},
+    tags: [],
+    links: null,
+    input: null,
+    output: null,
+    error: null,
+    startedAt,
+    endedAt: null,
+  } as any;
+}
+
+const T0 = new Date('2026-01-01T00:00:00.000Z');
+const T1 = new Date('2026-01-02T00:00:00.000Z');
+
+async function seedTraces() {
+  const store = new InMemoryStore();
+  const obs = (await store.getStore('observability'))!;
+  await obs.createSpan({ span: makeRootSpan('trace-A', T0) });
+  await obs.createSpan({ span: makeRootSpan('trace-B', T1) });
+  return obs;
+}
+
+describe('ObservabilityInMemory listTraces startExclusive/endExclusive', () => {
+  it('startExclusive excludes a trace whose startedAt equals the boundary', async () => {
+    const obs = await seedTraces();
+
+    const inclusive = await obs.listTraces({ filters: { startedAt: { start: T1 } } });
+    expect(inclusive.spans.map((s: any) => s.traceId)).toContain('trace-B');
+
+    const exclusive = await obs.listTraces({ filters: { startedAt: { start: T1, startExclusive: true } } });
+    expect(exclusive.spans.map((s: any) => s.traceId)).not.toContain('trace-B');
+  });
+
+  it('endExclusive excludes a trace whose startedAt equals the end boundary', async () => {
+    const obs = await seedTraces();
+
+    const inclusive = await obs.listTraces({ filters: { startedAt: { end: T0 } } });
+    expect(inclusive.spans.map((s: any) => s.traceId)).toContain('trace-A');
+
+    const exclusive = await obs.listTraces({ filters: { startedAt: { end: T0, endExclusive: true } } });
+    expect(exclusive.spans.map((s: any) => s.traceId)).not.toContain('trace-A');
+  });
+});

--- a/packages/core/src/storage/domains/observability/inmemory.ts
+++ b/packages/core/src/storage/domains/observability/inmemory.ts
@@ -776,10 +776,20 @@ export class ObservabilityInMemory extends ObservabilityStorage {
 
     // Date range filters on startedAt (based on root span)
     if (filters.startedAt) {
-      if (filters.startedAt.start && rootSpan.startedAt < filters.startedAt.start) {
+      if (
+        filters.startedAt.start &&
+        (filters.startedAt.startExclusive
+          ? rootSpan.startedAt <= filters.startedAt.start
+          : rootSpan.startedAt < filters.startedAt.start)
+      ) {
         return false;
       }
-      if (filters.startedAt.end && rootSpan.startedAt > filters.startedAt.end) {
+      if (
+        filters.startedAt.end &&
+        (filters.startedAt.endExclusive
+          ? rootSpan.startedAt >= filters.startedAt.end
+          : rootSpan.startedAt > filters.startedAt.end)
+      ) {
         return false;
       }
     }
@@ -790,10 +800,20 @@ export class ObservabilityInMemory extends ObservabilityStorage {
       if (rootSpan.endedAt == null) {
         return false;
       }
-      if (filters.endedAt.start && rootSpan.endedAt < filters.endedAt.start) {
+      if (
+        filters.endedAt.start &&
+        (filters.endedAt.startExclusive
+          ? rootSpan.endedAt <= filters.endedAt.start
+          : rootSpan.endedAt < filters.endedAt.start)
+      ) {
         return false;
       }
-      if (filters.endedAt.end && rootSpan.endedAt > filters.endedAt.end) {
+      if (
+        filters.endedAt.end &&
+        (filters.endedAt.endExclusive
+          ? rootSpan.endedAt >= filters.endedAt.end
+          : rootSpan.endedAt > filters.endedAt.end)
+      ) {
         return false;
       }
     }


### PR DESCRIPTION
## What

The in-memory observability store ignores the `startExclusive`/`endExclusive` flags on `startedAt`/`endedAt` filters in `listTraces`. `traceMatchesFilters` always compares inclusively, so a trace whose root span sits exactly on an exclusive boundary is kept when it should be dropped (and it inflates `total`/`hasMore`).

These flags are part of the filter schema (`_internal-core/.../shared.ts`), the pg adapter honors them (`r."startedAt" ${startExclusive ? '>' : '>='}`), and the same in-memory file already honors them for logs and metrics. The trace path is the inconsistent one.

## Change

Use the exclusive operator when the flag is set, mirroring the existing log implementation.

## Tests

Added unit tests for `startExclusive` and `endExclusive` via `createSpan` + `listTraces`. Both fail on the current code and pass after the fix. The full observability suite (157 tests) still passes.

Closes #18635

cc @taofeeq-deru @epinzur. Note: spanMatchesBranchFilters and scoreMatchesFilters share the same inclusive-only pattern; happy to extend the fix to them here or in a follow-up.