### PR TITLE
fix(deployer): inject Studio config values containing $ verbatim

### DIFF
--- a/.changeset/fix-deployer-studio-config-dollar.md
+++ b/.changeset/fix-deployer-studio-config-dollar.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix `injectStudioHtmlConfig` corrupting Studio config values that contain `$`. Values such as request context presets are now injected into the HTML verbatim instead of being mangled by `String.prototype.replace` special patterns (`$$`, `$&`, etc.). Closes #18685.

--- a/packages/deployer/src/build/inject-studio-config-dollar.test.ts
+++ b/packages/deployer/src/build/inject-studio-config-dollar.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { injectStudioHtmlConfig } from './utils';
+
+function baseConfig(overrides: Record<string, string> = {}) {
+  return {
+    host: "'localhost'",
+    port: "'4111'",
+    protocol: "'http'",
+    apiPrefix: "'/api'",
+    basePath: '',
+    hideCloudCta: "'false'",
+    cloudApiEndpoint: "''",
+    experimentalFeatures: "'false'",
+    templates: "'false'",
+    telemetryDisabled: "''",
+    requestContextPresets: "''",
+    experimentalUI: "'false'",
+    agentSignals: "'false'",
+    signalsUI: "'false'",
+    autoDetectUrl: "'false'",
+    ...overrides,
+  } as any;
+}
+
+describe('injectStudioHtmlConfig $ handling', () => {
+  it('injects a value containing $$ verbatim', () => {
+    const html = "window.MASTRA_REQUEST_CONTEXT_PRESETS = '%%MASTRA_REQUEST_CONTEXT_PRESETS%%';";
+    const value = "'a$$b'";
+
+    const result = injectStudioHtmlConfig(html, baseConfig({ requestContextPresets: value }));
+
+    expect(result).toBe(`window.MASTRA_REQUEST_CONTEXT_PRESETS = ${value};`);
+  });
+
+  it('injects a value containing $& verbatim', () => {
+    const html = "window.MASTRA_REQUEST_CONTEXT_PRESETS = '%%MASTRA_REQUEST_CONTEXT_PRESETS%%';";
+    const value = "'a$&b'";
+
+    const result = injectStudioHtmlConfig(html, baseConfig({ requestContextPresets: value }));
+
+    expect(result).toBe(`window.MASTRA_REQUEST_CONTEXT_PRESETS = ${value};`);
+  });
+
+  it('injects a basePath containing $ verbatim', () => {
+    const html = "<base href='%%MASTRA_STUDIO_BASE_PATH%%'/> x %%MASTRA_STUDIO_BASE_PATH%%";
+
+    const result = injectStudioHtmlConfig(html, baseConfig({ basePath: '/a$$b' }));
+
+    expect(result).toBe("<base href='/a$$b'/> x /a$$b");
+  });
+});

--- a/packages/deployer/src/build/inject-studio-config-dollar.test.ts
+++ b/packages/deployer/src/build/inject-studio-config-dollar.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { injectStudioHtmlConfig } from './utils';
+import type { StudioInjectionConfig } from './utils';
 
-function baseConfig(overrides: Record<string, string> = {}) {
+function baseConfig(overrides: Partial<StudioInjectionConfig> = {}): StudioInjectionConfig {
   return {
     host: "'localhost'",
     port: "'4111'",
@@ -19,7 +20,7 @@ function baseConfig(overrides: Record<string, string> = {}) {
     signalsUI: "'false'",
     autoDetectUrl: "'false'",
     ...overrides,
-  } as any;
+  };
 }
 
 describe('injectStudioHtmlConfig $ handling', () => {

--- a/packages/deployer/src/build/utils.ts
+++ b/packages/deployer/src/build/utils.ts
@@ -287,23 +287,31 @@ export interface StudioInjectionConfig {
  * source HTML) with the provided expression verbatim.
  */
 export function injectStudioHtmlConfig(html: string, config: StudioInjectionConfig): string {
-  html = html.replace(`'%%MASTRA_SERVER_HOST%%'`, config.host);
-  html = html.replace(`'%%MASTRA_SERVER_PORT%%'`, config.port);
-  html = html.replace(`'%%MASTRA_SERVER_PROTOCOL%%'`, config.protocol);
-  html = html.replace(`'%%MASTRA_API_PREFIX%%'`, config.apiPrefix);
-  html = html.replace(`'%%MASTRA_HIDE_CLOUD_CTA%%'`, config.hideCloudCta);
-  html = html.replace(`'%%MASTRA_CLOUD_API_ENDPOINT%%'`, config.cloudApiEndpoint);
-  html = html.replace(`'%%MASTRA_EXPERIMENTAL_FEATURES%%'`, config.experimentalFeatures);
-  html = html.replace(`'%%MASTRA_TEMPLATES%%'`, config.templates);
-  html = html.replace(`'%%MASTRA_TELEMETRY_DISABLED%%'`, config.telemetryDisabled);
-  html = html.replace(`'%%MASTRA_REQUEST_CONTEXT_PRESETS%%'`, config.requestContextPresets);
-  html = html.replace(`'%%MASTRA_EXPERIMENTAL_UI%%'`, config.experimentalUI);
-  html = html.replace(`'%%MASTRA_AGENT_SIGNALS%%'`, config.agentSignals);
-  html = html.replace(`'%%MASTRA_SIGNALS_UI%%'`, config.signalsUI);
+  // `String.prototype.replace`/`replaceAll` treat `$` sequences ($$, $&, $`,
+  // $', $n) in the replacement string as special patterns. Config values are
+  // dynamic (e.g. request context presets), so use a replacement function to
+  // insert them verbatim.
+  const replace = (token: string, value: string) => {
+    html = html.replace(token, () => value);
+  };
+
+  replace(`'%%MASTRA_SERVER_HOST%%'`, config.host);
+  replace(`'%%MASTRA_SERVER_PORT%%'`, config.port);
+  replace(`'%%MASTRA_SERVER_PROTOCOL%%'`, config.protocol);
+  replace(`'%%MASTRA_API_PREFIX%%'`, config.apiPrefix);
+  replace(`'%%MASTRA_HIDE_CLOUD_CTA%%'`, config.hideCloudCta);
+  replace(`'%%MASTRA_CLOUD_API_ENDPOINT%%'`, config.cloudApiEndpoint);
+  replace(`'%%MASTRA_EXPERIMENTAL_FEATURES%%'`, config.experimentalFeatures);
+  replace(`'%%MASTRA_TEMPLATES%%'`, config.templates);
+  replace(`'%%MASTRA_TELEMETRY_DISABLED%%'`, config.telemetryDisabled);
+  replace(`'%%MASTRA_REQUEST_CONTEXT_PRESETS%%'`, config.requestContextPresets);
+  replace(`'%%MASTRA_EXPERIMENTAL_UI%%'`, config.experimentalUI);
+  replace(`'%%MASTRA_AGENT_SIGNALS%%'`, config.agentSignals);
+  replace(`'%%MASTRA_SIGNALS_UI%%'`, config.signalsUI);
   if (config.autoDetectUrl) {
-    html = html.replace(`'%%MASTRA_AUTO_DETECT_URL%%'`, config.autoDetectUrl);
+    replace(`'%%MASTRA_AUTO_DETECT_URL%%'`, config.autoDetectUrl);
   }
-  html = html.replaceAll('%%MASTRA_STUDIO_BASE_PATH%%', config.basePath);
+  html = html.replaceAll('%%MASTRA_STUDIO_BASE_PATH%%', () => config.basePath);
 
   return html;
 }


### PR DESCRIPTION
## What

`injectStudioHtmlConfig` injects each Studio config value with `html.replace(token, value)`. `String.prototype.replace`/`replaceAll` treat `$$`, `$&`, `` $` ``, `$'`, and `$n` in the replacement string as special patterns, so any config value containing `$` gets mangled instead of inserted verbatim, which contradicts the function's documented "verbatim" contract.

The realistic trigger is `requestContextPresets`: it is built from `process.env.MASTRA_REQUEST_CONTEXT_PRESETS`, and `escapeForHtml` escapes `\`, `'`, newlines, `<`, `>`, and U+2028/2029 but not `$`, so a `$`-containing preset reaches `replace` unescaped. A value with `$&` even expands to the whole placeholder token and corrupts the surrounding HTML.

## Change

Use a replacement function so values are inserted literally (same approach as the recent `FileEnvService.setEnvValue` fix).

## Tests

Added unit tests for `$$`, `$&`, and a `$`-containing `basePath`. They fail on the current code and pass after the fix. The existing `utils.test.ts` suite still passes.

Closes #18685

---

Hey @mfrachet, you touched this file last so tagging you. Small one, mind giving it a look when you have a minute? Thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Studio config values sometimes include dollar signs (`$`). Previously, when the deployer plugged those values into an HTML template, the dollar signs got “misread” and mangled. Now the deployer inserts them exactly as written.

### What changed
- Fixed `injectStudioHtmlConfig` to replace HTML placeholders using a replacement *function* instead of passing raw strings to `String.prototype.replace`/`replaceAll`, preventing `$` sequences (like `$$` and `$&`) from being interpreted specially.
- Ensured the Studio `basePath` placeholder replacement also uses the safer replacement approach.
- Added unit tests validating verbatim insertion for:
  - `$$`
  - `$&`
  - `$` inside `basePath`
- Added a changeset for a patch release of `@mastra/deployer` and referenced the fix for the reported issue.

### Why
`String.prototype.replace` treats certain `$` patterns as replacement directives (e.g., `$$`, `$&`, `$n`). Using a replacement function avoids that behavior, so values from sources like `MASTRA_REQUEST_CONTEXT_PRESETS` (which may include `$`) are injected literally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->