### PR TITLE
Auto-provision per-tenant Turso databases in deployed environments

### DIFF
--- a/.changeset/turso-tenant-bootstrap-mastracode.md
+++ b/.changeset/turso-tenant-bootstrap-mastracode.md
@@ -1,0 +1,18 @@
+---
+'mastracode': minor
+---
+
+Auto-provision a per-tenant Turso database in deployed MastraCode Web environments.
+
+Previously, hosting per-`(org, user)` agent state on Turso required each tenant's database to already exist at the URL produced by `MASTRACODE_TENANT_DB_URL_TEMPLATE`. There was no way to create those databases on demand, so the only zero-setup option was server-local libSQL files — which are ephemeral and not shared across replicas.
+
+Setting `MASTRACODE_TURSO_PLATFORM_TOKEN` and `MASTRACODE_TURSO_ORG` now enables a third tenant-storage mode: the first time a tenant is seen, its own Turso database is created via the Turso Platform API (idempotent — an "already exists" race recovers the hostname via `databases.get`), a scoped auth token is minted, and the stable database-name/hostname mapping is persisted in the app Postgres (`tenant_databases` table, requires `APP_DATABASE_URL`). All replicas converge on the same database and cold starts never re-create it. Only the durable mapping is stored; the auth token is minted fresh per resolution, so no long-lived credential is persisted.
+
+Resolution priority is: explicit `MASTRACODE_TENANT_DB_URL_TEMPLATE` → Turso auto-provisioning → local libSQL files. Turso provisioning also satisfies `MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1`. The `@tursodatabase/api` client is loaded dynamically, so deployments that don't use Turso never pull it in at runtime.
+
+```bash
+MASTRACODE_TURSO_PLATFORM_TOKEN=...    # Turso Platform API token
+MASTRACODE_TURSO_ORG=my-org            # org that owns provisioned databases
+MASTRACODE_TURSO_GROUP=default         # optional group (default "default")
+APP_DATABASE_URL=postgres://...        # required for the mapping table
+```

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -331,12 +331,25 @@ client-supplied paths); users without an org fall back to a user-only key.
 # Local files (default): one isolated DB dir per tenant under this root
 export MASTRACODE_TENANT_DB_ROOT=~/.mastracode/web/tenants    # optional
 
-# Or remote libSQL/Turso per tenant ({id} = hashed (orgId, userId))
+# Or remote libSQL/Turso per tenant ({id} = hashed (orgId, userId)). This mode
+# assumes each tenant DB already exists at the templated URL.
 export MASTRACODE_TENANT_DB_URL_TEMPLATE=libsql://{id}-org.turso.io        # optional
 export MASTRACODE_TENANT_VECTOR_URL_TEMPLATE=libsql://{id}-vec-org.turso.io # optional
 export MASTRACODE_TENANT_DB_AUTH_TOKEN=...                                  # optional
 export MASTRACODE_TENANT_VECTOR_AUTH_TOKEN=...                              # optional
+
+# Or auto-provision a Turso database per tenant on first access via the Turso
+# Platform API (no pre-created DBs needed). Requires APP_DATABASE_URL: the
+# stable db-name/hostname mapping is persisted there so replicas converge on
+# one DB and cold starts don't re-create it. A scoped token is minted fresh per
+# resolution, so no long-lived credential is stored.
+export MASTRACODE_TURSO_PLATFORM_TOKEN=...    # optional
+export MASTRACODE_TURSO_ORG=my-org            # optional
+export MASTRACODE_TURSO_GROUP=default         # optional (default "default")
 ```
+
+Resolution priority: explicit `MASTRACODE_TENANT_DB_URL_TEMPLATE` → Turso
+auto-provisioning (when the platform token + org are set) → local libSQL files.
 
 When web auth is disabled the server uses a single shared store, exactly as before.
 
@@ -356,7 +369,8 @@ export GITHUB_APP_WEBHOOK_SECRET=...
 export MASTRACODE_DISTRIBUTED_LOCK=1
 
 # Persist/share tenant DBs across replicas — fail/warn at startup if no remote
-# tenant DB template is set (local-file DBs don't survive restarts or sharing).
+# tenant DB backend (URL template OR Turso auto-provisioning) is configured
+# (local-file DBs don't survive restarts or sharing).
 export MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1
 
 # Bound in-memory tenant caches as the team grows.

--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -112,6 +112,7 @@
     "@octokit/auth-app": "^8.0.0",
     "@octokit/rest": "^22.0.1",
     "@tanstack/react-query": "^5.90.21",
+    "@tursodatabase/api": "2.0.4",
     "ai": "^6.0.176",
     "chalk": "^5.5.0",
     "cli-highlight": "^2.1.11",

--- a/mastracode/src/web/.env.example
+++ b/mastracode/src/web/.env.example
@@ -108,8 +108,24 @@ MASTRACODE_TENANT_VECTOR_URL_TEMPLATE=
 MASTRACODE_TENANT_DB_AUTH_TOKEN=
 # optional — auth token for the remote tenant vector DB
 MASTRACODE_TENANT_VECTOR_AUTH_TOKEN=
-# optional — set to 1 to fail/warn at startup when no remote tenant DB template
-# is configured (local-file tenant DBs do not persist or share across replicas)
+# ---------------------------------------------------------------------------
+# Turso auto-provisioning (optional, alternative to the URL templates above).
+# When both a platform token and org are set, each tenant's own Turso database
+# is created on first access via the Turso Platform API, a scoped token is
+# minted per resolution, and the stable db-name/hostname mapping is persisted
+# in the app Postgres (APP_DATABASE_URL) so all replicas converge on one DB.
+# Requires APP_DATABASE_URL. Takes priority over local files but not over an
+# explicit MASTRACODE_TENANT_DB_URL_TEMPLATE.
+# ---------------------------------------------------------------------------
+# optional — Turso Platform API token (https://app.turso.tech, platform scope)
+MASTRACODE_TURSO_PLATFORM_TOKEN=
+# optional — Turso organization slug/name that owns the provisioned databases
+MASTRACODE_TURSO_ORG=
+# optional — Turso group new databases are created in (default "default")
+MASTRACODE_TURSO_GROUP=
+# optional — set to 1 to fail/warn at startup when no remote tenant DB backend
+# (URL template OR Turso provisioning) is configured (local-file tenant DBs do
+# not persist or share across replicas)
 MASTRACODE_REQUIRE_REMOTE_TENANT_DB=
 # optional — idle minutes before an inactive tenant's in-memory Mastra stack is
 # evicted from the dispatcher cache (default 30; 0 disables idle eviction)

--- a/mastracode/src/web/github/schema.ts
+++ b/mastracode/src/web/github/schema.ts
@@ -124,6 +124,23 @@ export const githubWorktrees = pgTable(
   ],
 );
 
+/**
+ * Stable mapping from a tenant key (the sha256 of an `(org, user)` identity, see
+ * `tenant-storage.ts`) to the Turso database provisioned for that tenant. Only
+ * the durable `db_name`/`hostname` are persisted — never the auth token, which
+ * is minted fresh per resolution. The row is written once, on first provision,
+ * with `onConflictDoNothing` so concurrent replicas converge on a single DB.
+ */
+export const tenantDatabases = pgTable('tenant_databases', {
+  /** sha256 hex of the `(org, user)` identity (the tenant key). */
+  tenantKey: text('tenant_key').primaryKey(),
+  /** Turso database name (deterministic, derived from the tenant key). */
+  dbName: text('db_name').notNull(),
+  /** Turso database hostname, e.g. `<db>-<org>.turso.io`. */
+  hostname: text('hostname').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
 export type GithubInstallationRow = typeof githubInstallations.$inferSelect;
 export type GithubProjectRow = typeof githubProjects.$inferSelect;
 export type GithubProjectSandboxRow = typeof githubProjectSandboxes.$inferSelect;
@@ -132,6 +149,8 @@ export type NewGithubInstallationRow = typeof githubInstallations.$inferInsert;
 export type NewGithubProjectRow = typeof githubProjects.$inferInsert;
 export type NewGithubProjectSandboxRow = typeof githubProjectSandboxes.$inferInsert;
 export type NewGithubWorktreeRow = typeof githubWorktrees.$inferInsert;
+export type TenantDatabaseRow = typeof tenantDatabases.$inferSelect;
+export type NewTenantDatabaseRow = typeof tenantDatabases.$inferInsert;
 
 /**
  * Idempotent DDL run on boot when the feature is enabled. We keep migrations
@@ -204,4 +223,11 @@ ALTER TABLE github_worktrees ADD COLUMN IF NOT EXISTS org_id text;
 
 CREATE UNIQUE INDEX IF NOT EXISTS github_worktrees_project_user_branch_unique
   ON github_worktrees (github_project_id, user_id, branch);
+
+CREATE TABLE IF NOT EXISTS tenant_databases (
+  tenant_key text PRIMARY KEY,
+  db_name text NOT NULL,
+  hostname text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
 `;

--- a/mastracode/src/web/tenant-isolation-turso.test.ts
+++ b/mastracode/src/web/tenant-isolation-turso.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { __clearTenantStorageCache, resolveTenantStorage } from './tenant-storage.js';
+
+// Turso-mode isolation: distinct tenants resolve to distinct provisioned
+// databases, and the same tenant is stable. The provisioner is mocked so the
+// test never touches the network or the app Postgres; the mock derives a
+// deterministic db name from the tenant key, exactly as the real provisioner
+// does, so we can assert per-tenant uniqueness and stability.
+
+const isTursoProvisioningEnabled = vi.fn(() => true);
+const provisionTursoTenant = vi.fn();
+
+vi.mock('./tenant-provisioner.js', () => ({
+  isTursoProvisioningEnabled: () => isTursoProvisioningEnabled(),
+  // Mirror the real provisioner: derive a stable db name from the tenant key.
+  provisionTursoTenant: (tenantKey: string) => provisionTursoTenant(tenantKey),
+  tursoDbName: (tenantKey: string) => `mc-${tenantKey.slice(0, 40)}`,
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  __clearTenantStorageCache();
+  isTursoProvisioningEnabled.mockReset();
+  isTursoProvisioningEnabled.mockReturnValue(true);
+  provisionTursoTenant.mockReset();
+  provisionTursoTenant.mockImplementation(async (tenantKey: string) => {
+    const dbName = `mc-${tenantKey.slice(0, 40)}`;
+    const url = `libsql://${dbName}.turso.io`;
+    return { url, authToken: `jwt-${dbName}`, vectorUrl: url, vectorAuthToken: `jwt-${dbName}` };
+  });
+  delete process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  __clearTenantStorageCache();
+});
+
+describe('Turso-mode per-(org,user) isolation', () => {
+  it('gives two distinct tenants distinct provisioned databases', async () => {
+    const a = await resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
+    const b = await resolveTenantStorage({ orgId: 'org_b', userId: 'user_1' });
+
+    expect(a.tenantKey).not.toBe(b.tenantKey);
+    expect(a.storageConfig.isRemote).toBe(true);
+    expect(b.storageConfig.isRemote).toBe(true);
+    expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
+    // Each tenant's db name embeds its own tenant key.
+    expect(a.storageConfig.url).toContain(a.tenantKey.slice(0, 40));
+    expect(b.storageConfig.url).toContain(b.tenantKey.slice(0, 40));
+  });
+
+  it('is stable for the same tenant across resolutions', async () => {
+    const first = await resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
+    __clearTenantStorageCache();
+    const second = await resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
+
+    expect(first.tenantKey).toBe(second.tenantKey);
+    expect(first.storageConfig.url).toBe(second.storageConfig.url);
+  });
+});

--- a/mastracode/src/web/tenant-isolation.test.ts
+++ b/mastracode/src/web/tenant-isolation.test.ts
@@ -79,8 +79,8 @@ async function seedPrivateThread(mem: ReturnType<typeof memoryOf>, marker: strin
 
 describe('S3: cross-tenant libSQL isolation', () => {
   it('keeps one tenant from reading another tenant threads and messages', async () => {
-    const a = resolveTenantStorage({ userId: 'user_a' });
-    const b = resolveTenantStorage({ userId: 'user_b' });
+    const a = await resolveTenantStorage({ userId: 'user_a' });
+    const b = await resolveTenantStorage({ userId: 'user_b' });
 
     // Different tenants → different hashed dirs → different db files.
     expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
@@ -144,8 +144,8 @@ describe('S3: cross-tenant libSQL isolation', () => {
 
 describe('S3: per-(org,user) libSQL isolation', () => {
   it('isolates two users in the SAME org into distinct databases', async () => {
-    const a = resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
-    const b = resolveTenantStorage({ orgId: 'org_a', userId: 'user_2' });
+    const a = await resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
+    const b = await resolveTenantStorage({ orgId: 'org_a', userId: 'user_2' });
 
     expect(a.tenantKey).not.toBe(b.tenantKey);
     expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
@@ -179,8 +179,8 @@ describe('S3: per-(org,user) libSQL isolation', () => {
   });
 
   it('isolates the SAME user across two orgs into distinct databases', async () => {
-    const a = resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
-    const b = resolveTenantStorage({ orgId: 'org_b', userId: 'user_1' });
+    const a = await resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
+    const b = await resolveTenantStorage({ orgId: 'org_b', userId: 'user_1' });
 
     expect(a.tenantKey).not.toBe(b.tenantKey);
     expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
@@ -207,11 +207,11 @@ describe('S3: per-(org,user) libSQL isolation', () => {
 });
 
 describe('S3: remote URL template per-(org,user) isolation', () => {
-  it('produces distinct remote urls carrying each tenant composite key', () => {
+  it('produces distinct remote urls carrying each tenant composite key', async () => {
     process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}.turso.io';
 
-    const a = resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
-    const b = resolveTenantStorage({ orgId: 'org_b', userId: 'user_1' });
+    const a = await resolveTenantStorage({ orgId: 'org_a', userId: 'user_1' });
+    const b = await resolveTenantStorage({ orgId: 'org_b', userId: 'user_1' });
 
     expect(a.storageConfig.isRemote).toBe(true);
     expect(b.storageConfig.isRemote).toBe(true);

--- a/mastracode/src/web/tenant-provisioner.test.ts
+++ b/mastracode/src/web/tenant-provisioner.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock drizzle's eq() into a plain descriptor we can read in the fake DB.
+vi.mock('drizzle-orm', () => ({
+  eq: (_column: any, value: any) => ({ kind: 'eq', value }),
+}));
+
+// ── Fake app Postgres (tenant_databases mapping table) ──────────────────────
+// Mirrors the fake-DB harness used in routes-scenario.test.ts: a single
+// in-memory rows array, with select().from().where() filtering on tenant_key
+// and insert().values().onConflictDoNothing() honoring the primary key.
+interface TenantDbRow {
+  tenantKey: string;
+  dbName: string;
+  hostname: string;
+}
+let rows: TenantDbRow[] = [];
+let appDbConfigured = true;
+
+function filterByTenantKey(cond: any): TenantDbRow[] {
+  // The provisioner always queries `eq(tenantDatabases.tenantKey, key)`.
+  if (!cond || cond.kind !== 'eq') return [...rows];
+  return rows.filter(r => r.tenantKey === cond.value);
+}
+
+vi.mock('./github/db.js', () => ({
+  isAppDbConfigured: () => appDbConfigured,
+  getAppDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: async (cond: any) => filterByTenantKey(cond),
+      }),
+    }),
+    insert: () => ({
+      values: (vals: TenantDbRow) => ({
+        onConflictDoNothing: async () => {
+          if (!rows.some(r => r.tenantKey === vals.tenantKey)) rows.push({ ...vals });
+        },
+      }),
+    }),
+  }),
+}));
+
+// ── Mock Turso Platform API client ──────────────────────────────────────────
+const createDb = vi.fn();
+const getDb = vi.fn();
+const createToken = vi.fn();
+const createClient = vi.fn((_opts: unknown) => ({
+  databases: { create: createDb, get: getDb, createToken },
+}));
+
+vi.mock('@tursodatabase/api', () => ({ createClient: (opts: unknown) => createClient(opts) }));
+
+import {
+  __resetTursoClient,
+  isTursoProvisioningEnabled,
+  lookupTenantDb,
+  provisionTursoTenant,
+  recordTenantDb,
+  tursoDbName,
+} from './tenant-provisioner.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  rows = [];
+  appDbConfigured = true;
+  __resetTursoClient();
+  createDb.mockReset();
+  getDb.mockReset();
+  createToken.mockReset();
+  createClient.mockClear();
+  createToken.mockResolvedValue({ jwt: 'jwt-default' });
+  process.env.MASTRACODE_TURSO_PLATFORM_TOKEN = 'platform-token';
+  process.env.MASTRACODE_TURSO_ORG = 'my-org';
+  delete process.env.MASTRACODE_TURSO_GROUP;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  __resetTursoClient();
+});
+
+describe('tursoDbName', () => {
+  it('is deterministic and Turso-safe', () => {
+    const key = 'f'.repeat(64);
+    const name = tursoDbName(key);
+    expect(name).toMatch(/^mc-[a-z0-9-]+$/);
+    expect(name).not.toMatch(/[^a-z0-9-]/);
+    expect(tursoDbName(key)).toBe(name);
+  });
+
+  it('stays well under the length limit', () => {
+    expect(tursoDbName('a'.repeat(200)).length).toBeLessThanOrEqual(43);
+  });
+
+  it('produces distinct names for distinct tenant keys', () => {
+    expect(tursoDbName('a'.repeat(64))).not.toBe(tursoDbName('b'.repeat(64)));
+  });
+});
+
+describe('isTursoProvisioningEnabled', () => {
+  it('is true only when both the platform token and org are set', () => {
+    expect(isTursoProvisioningEnabled()).toBe(true);
+    delete process.env.MASTRACODE_TURSO_ORG;
+    expect(isTursoProvisioningEnabled()).toBe(false);
+    delete process.env.MASTRACODE_TURSO_PLATFORM_TOKEN;
+    expect(isTursoProvisioningEnabled()).toBe(false);
+  });
+});
+
+describe('provisionTursoTenant', () => {
+  const tenantKey = 'a'.repeat(64);
+
+  it('creates the database, persists the mapping, and mints a token', async () => {
+    createDb.mockResolvedValue({ hostname: 'mc-host.turso.io' });
+    createToken.mockResolvedValue({ jwt: 'jwt-fresh' });
+
+    const result = await provisionTursoTenant(tenantKey);
+
+    expect(createDb).toHaveBeenCalledWith(tursoDbName(tenantKey), { group: 'default' });
+    expect(result.url).toBe('libsql://mc-host.turso.io');
+    expect(result.authToken).toBe('jwt-fresh');
+    expect(result.vectorUrl).toBe('libsql://mc-host.turso.io');
+    expect(result.vectorAuthToken).toBe('jwt-fresh');
+    // Mapping was persisted.
+    const mapping = await lookupTenantDb(tenantKey);
+    expect(mapping).toEqual({ dbName: tursoDbName(tenantKey), hostname: 'mc-host.turso.io' });
+  });
+
+  it('honours MASTRACODE_TURSO_GROUP', async () => {
+    process.env.MASTRACODE_TURSO_GROUP = 'prod';
+    createDb.mockResolvedValue({ hostname: 'h.turso.io' });
+    await provisionTursoTenant(tenantKey);
+    expect(createDb).toHaveBeenCalledWith(tursoDbName(tenantKey), { group: 'prod' });
+  });
+
+  it('recovers from an "already exists" race via databases.get', async () => {
+    createDb.mockRejectedValue(new Error('database already exists'));
+    getDb.mockResolvedValue({ hostname: 'mc-existing.turso.io' });
+
+    const result = await provisionTursoTenant(tenantKey);
+
+    expect(getDb).toHaveBeenCalledWith(tursoDbName(tenantKey));
+    expect(result.url).toBe('libsql://mc-existing.turso.io');
+    const mapping = await lookupTenantDb(tenantKey);
+    expect(mapping?.hostname).toBe('mc-existing.turso.io');
+  });
+
+  it('reuses the persisted mapping and mints a fresh token without re-creating', async () => {
+    await recordTenantDb(tenantKey, tursoDbName(tenantKey), 'mc-known.turso.io');
+    createToken.mockResolvedValue({ jwt: 'jwt-known' });
+
+    const result = await provisionTursoTenant(tenantKey);
+
+    expect(createDb).not.toHaveBeenCalled();
+    expect(createToken).toHaveBeenCalledWith(tursoDbName(tenantKey));
+    expect(result.url).toBe('libsql://mc-known.turso.io');
+    expect(result.authToken).toBe('jwt-known');
+  });
+
+  it('mints a fresh token on every resolution', async () => {
+    await recordTenantDb(tenantKey, tursoDbName(tenantKey), 'mc-known.turso.io');
+    createToken.mockResolvedValueOnce({ jwt: 'jwt-1' }).mockResolvedValueOnce({ jwt: 'jwt-2' });
+
+    const first = await provisionTursoTenant(tenantKey);
+    const second = await provisionTursoTenant(tenantKey);
+
+    expect(first.authToken).toBe('jwt-1');
+    expect(second.authToken).toBe('jwt-2');
+    expect(createToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when the app database is not configured', async () => {
+    appDbConfigured = false;
+    await expect(provisionTursoTenant(tenantKey)).rejects.toThrow(/APP_DATABASE_URL/);
+    expect(createDb).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-"already exists" create error', async () => {
+    createDb.mockRejectedValue(new Error('rate limited'));
+    await expect(provisionTursoTenant(tenantKey)).rejects.toThrow('rate limited');
+    expect(getDb).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/src/web/tenant-provisioner.ts
+++ b/mastracode/src/web/tenant-provisioner.ts
@@ -1,0 +1,160 @@
+/**
+ * Turso auto-provisioning for per-tenant agent state.
+ *
+ * In a deployed environment each `(org, user)` tenant needs its own remote Turso
+ * database — server-local libSQL files are ephemeral and not shared across
+ * replicas. The `MASTRACODE_TENANT_DB_URL_TEMPLATE` mode assumes the tenant DB
+ * already exists at a predictable URL; this module instead *creates* the
+ * database (and a scoped auth token) via the Turso Platform API the first time a
+ * tenant is seen, then persists the stable `db_name`/`hostname` mapping in the
+ * app Postgres so all replicas converge on the same DB and no re-create happens
+ * on cold start.
+ *
+ * Only the durable mapping is persisted; the auth token is minted fresh per
+ * resolution so no long-lived credential is ever stored.
+ *
+ * The `@tursodatabase/api` client is imported dynamically so the dependency is
+ * only loaded when provisioning is actually used — local dev and tests that
+ * don't configure Turso never load it.
+ */
+
+import { eq } from 'drizzle-orm';
+import { getAppDb, isAppDbConfigured } from './github/db.js';
+import { tenantDatabases } from './github/schema.js';
+
+/** The remote libSQL descriptor produced for a provisioned tenant. */
+export interface ProvisionedTenantDb {
+  url: string;
+  authToken: string;
+  vectorUrl: string;
+  vectorAuthToken: string;
+}
+
+/** True when both the Turso platform token and org slug/id are configured. */
+export function isTursoProvisioningEnabled(): boolean {
+  return Boolean(process.env.MASTRACODE_TURSO_PLATFORM_TOKEN && process.env.MASTRACODE_TURSO_ORG);
+}
+
+/**
+ * Derive a deterministic, Turso-safe database name from a tenant key. Turso
+ * database names must be lowercase `[a-z0-9-]`, may not start/end with a dash,
+ * and are length-bounded. The tenant key is already a sha256 hex string, so it
+ * is safe to slice; we prefix `mc-` and bound the length to stay well under the
+ * limit while remaining unique per tenant.
+ */
+export function tursoDbName(tenantKey: string): string {
+  const safe = tenantKey.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return `mc-${safe.slice(0, 40)}`;
+}
+
+/** The minimal shape of the Turso Platform API client we depend on. */
+interface TursoClient {
+  databases: {
+    create(name: string, options?: { group?: string }): Promise<{ hostname: string; name?: string }>;
+    get(name: string): Promise<{ hostname: string; name?: string }>;
+    createToken(name: string): Promise<{ jwt: string }>;
+  };
+}
+
+let clientPromise: Promise<TursoClient> | undefined;
+
+/** Lazily construct (and memoize) the Turso Platform API client. */
+async function getTursoClient(): Promise<TursoClient> {
+  if (clientPromise) return clientPromise;
+  clientPromise = (async () => {
+    const token = process.env.MASTRACODE_TURSO_PLATFORM_TOKEN;
+    const org = process.env.MASTRACODE_TURSO_ORG;
+    if (!token || !org) {
+      throw new Error('Turso provisioning requires MASTRACODE_TURSO_PLATFORM_TOKEN and MASTRACODE_TURSO_ORG.');
+    }
+    const mod = await import('@tursodatabase/api');
+    return mod.createClient({ org, token }) as unknown as TursoClient;
+  })();
+  return clientPromise;
+}
+
+/** True when a Turso create error indicates the database already exists. */
+function isAlreadyExists(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /already exists|already in use|conflict/i.test(message);
+}
+
+/** The configured Turso group, defaulting to `default`. */
+function tursoGroup(): string {
+  return process.env.MASTRACODE_TURSO_GROUP || 'default';
+}
+
+/**
+ * Look up an existing tenant → Turso DB mapping. Returns `undefined` when the
+ * tenant has not yet been provisioned.
+ */
+export async function lookupTenantDb(tenantKey: string): Promise<{ dbName: string; hostname: string } | undefined> {
+  const [row] = await getAppDb().select().from(tenantDatabases).where(eq(tenantDatabases.tenantKey, tenantKey));
+  if (!row) return undefined;
+  return { dbName: row.dbName, hostname: row.hostname };
+}
+
+/**
+ * Persist a tenant → Turso DB mapping. Uses `onConflictDoNothing` so concurrent
+ * replicas provisioning the same tenant converge on the first writer's row.
+ */
+export async function recordTenantDb(tenantKey: string, dbName: string, hostname: string): Promise<void> {
+  await getAppDb().insert(tenantDatabases).values({ tenantKey, dbName, hostname }).onConflictDoNothing();
+}
+
+/** Build the remote libSQL descriptor from a hostname + freshly minted token. */
+function descriptorFor(hostname: string, jwt: string): ProvisionedTenantDb {
+  const url = `libsql://${hostname}`;
+  return { url, authToken: jwt, vectorUrl: url, vectorAuthToken: jwt };
+}
+
+/**
+ * Provision (or recover) the Turso database for a tenant and return a ready
+ * remote libSQL descriptor with a freshly minted scoped token.
+ *
+ * Resolution:
+ *   1. If a mapping already exists in Postgres, mint a token for the known DB
+ *      and return — no Turso create call.
+ *   2. Otherwise create the database (idempotent: an "already exists" race falls
+ *      back to `databases.get`), record the mapping, mint a token, return.
+ *
+ * @throws if the app database is not configured — Turso provisioning needs it
+ *   for the durable mapping table, and silently falling back to local files in a
+ *   deployed env would defeat the isolation guarantee.
+ */
+export async function provisionTursoTenant(tenantKey: string): Promise<ProvisionedTenantDb> {
+  if (!isAppDbConfigured()) {
+    throw new Error(
+      'Turso tenant provisioning requires APP_DATABASE_URL for the tenant_databases mapping table. ' +
+        'Set APP_DATABASE_URL, or unset MASTRACODE_TURSO_PLATFORM_TOKEN/MASTRACODE_TURSO_ORG to use local files.',
+    );
+  }
+
+  const dbName = tursoDbName(tenantKey);
+  const turso = await getTursoClient();
+
+  const existing = await lookupTenantDb(tenantKey);
+  if (existing) {
+    const { jwt } = await turso.databases.createToken(existing.dbName);
+    return descriptorFor(existing.hostname, jwt);
+  }
+
+  let hostname: string;
+  try {
+    const db = await turso.databases.create(dbName, { group: tursoGroup() });
+    hostname = db.hostname;
+  } catch (err) {
+    if (!isAlreadyExists(err)) throw err;
+    const db = await turso.databases.get(dbName);
+    hostname = db.hostname;
+  }
+
+  await recordTenantDb(tenantKey, dbName, hostname);
+  const { jwt } = await turso.databases.createToken(dbName);
+  return descriptorFor(hostname, jwt);
+}
+
+/** Reset the memoized Turso client (test helper). */
+export function __resetTursoClient(): void {
+  clientPromise = undefined;
+}

--- a/mastracode/src/web/tenant-server.ts
+++ b/mastracode/src/web/tenant-server.ts
@@ -142,9 +142,9 @@ export class TenantDispatcher {
   }
 
   /** Get-or-create the tenant app for an `(org, user)` identity. */
-  private getTenantApp(identity: TenantIdentity): Promise<TenantApp> {
+  private async getTenantApp(identity: TenantIdentity): Promise<TenantApp> {
     this.sweepIdle();
-    const { tenantKey, storageConfig } = getUserStorage(identity);
+    const { tenantKey, storageConfig } = await getUserStorage(identity);
     const existing = this.apps.get(tenantKey);
     if (existing) {
       existing.lastUsed = this.now();

--- a/mastracode/src/web/tenant-storage.test.ts
+++ b/mastracode/src/web/tenant-storage.test.ts
@@ -2,15 +2,26 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { __clearTenantStorageCache, getUserStorage, resolveTenantStorage, tenantKeyFor } from './tenant-storage.js';
+
+const provisionTursoTenant = vi.fn();
+const isTursoProvisioningEnabled = vi.fn(() => false);
+
+vi.mock('./tenant-provisioner.js', () => ({
+  provisionTursoTenant: (...args: unknown[]) => provisionTursoTenant(...args),
+  isTursoProvisioningEnabled: () => isTursoProvisioningEnabled(),
+}));
 
 const ORIGINAL_ENV = { ...process.env };
 let tmpRoot: string;
 
 beforeEach(() => {
   __clearTenantStorageCache();
+  provisionTursoTenant.mockReset();
+  isTursoProvisioningEnabled.mockReset();
+  isTursoProvisioningEnabled.mockReturnValue(false);
   delete process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE;
   delete process.env.MASTRACODE_TENANT_VECTOR_URL_TEMPLATE;
   delete process.env.MASTRACODE_TENANT_DB_AUTH_TOKEN;
@@ -57,8 +68,8 @@ describe('tenantKeyFor', () => {
 });
 
 describe('resolveTenantStorage (local libSQL)', () => {
-  it('creates a hashed per-tenant directory with separate storage and vector DBs', () => {
-    const { tenantKey, storageConfig } = resolveTenantStorage({ userId: 'user_a' });
+  it('creates a hashed per-tenant directory with separate storage and vector DBs', async () => {
+    const { tenantKey, storageConfig } = await resolveTenantStorage({ userId: 'user_a' });
     const dir = path.join(tmpRoot, tenantKey);
     expect(existsSync(dir)).toBe(true);
     expect(storageConfig.backend).toBe('libsql');
@@ -67,35 +78,35 @@ describe('resolveTenantStorage (local libSQL)', () => {
     expect(storageConfig.vectorUrl).toBe(`file:${path.join(dir, 'vectors.db')}`);
   });
 
-  it('gives distinct users distinct DB paths', () => {
-    const a = resolveTenantStorage({ userId: 'user_a' });
-    const b = resolveTenantStorage({ userId: 'user_b' });
+  it('gives distinct users distinct DB paths', async () => {
+    const a = await resolveTenantStorage({ userId: 'user_a' });
+    const b = await resolveTenantStorage({ userId: 'user_b' });
     expect(a.tenantKey).not.toBe(b.tenantKey);
     expect(a.storageConfig.url).not.toBe(b.storageConfig.url);
     expect(a.storageConfig.vectorUrl).not.toBe(b.storageConfig.vectorUrl);
   });
 
-  it('never uses the raw workos id as a path component', () => {
+  it('never uses the raw workos id as a path component', async () => {
     const rawId = 'user/with/../traversal';
-    const { tenantKey, storageConfig } = resolveTenantStorage({ userId: rawId });
+    const { tenantKey, storageConfig } = await resolveTenantStorage({ userId: rawId });
     expect(tenantKey).toMatch(/^[0-9a-f]{64}$/);
     expect(storageConfig.url).not.toContain('..');
     expect(storageConfig.url).toContain(tenantKey);
   });
 
-  it('throws on an empty user id', () => {
-    expect(() => resolveTenantStorage({ userId: '' })).toThrow();
+  it('rejects an empty user id', async () => {
+    await expect(resolveTenantStorage({ userId: '' })).rejects.toThrow();
   });
 });
 
 describe('resolveTenantStorage (remote URL template)', () => {
-  it('expands the {id} placeholder for storage and vector urls', () => {
+  it('expands the {id} placeholder for storage and vector urls', async () => {
     process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}-org.turso.io';
     process.env.MASTRACODE_TENANT_VECTOR_URL_TEMPLATE = 'libsql://{id}-vec.turso.io';
     process.env.MASTRACODE_TENANT_DB_AUTH_TOKEN = 'tok_storage';
     process.env.MASTRACODE_TENANT_VECTOR_AUTH_TOKEN = 'tok_vector';
 
-    const { tenantKey, storageConfig } = resolveTenantStorage({ userId: 'user_a' });
+    const { tenantKey, storageConfig } = await resolveTenantStorage({ userId: 'user_a' });
     expect(storageConfig.isRemote).toBe(true);
     expect(storageConfig.url).toBe(`libsql://${tenantKey}-org.turso.io`);
     expect(storageConfig.vectorUrl).toBe(`libsql://${tenantKey}-vec.turso.io`);
@@ -103,40 +114,95 @@ describe('resolveTenantStorage (remote URL template)', () => {
     expect(storageConfig.vectorAuthToken).toBe('tok_vector');
   });
 
-  it('falls back to the storage url and token for vectors when no vector template is set', () => {
+  it('falls back to the storage url and token for vectors when no vector template is set', async () => {
     process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}.turso.io';
     process.env.MASTRACODE_TENANT_DB_AUTH_TOKEN = 'tok_shared';
 
-    const { storageConfig } = resolveTenantStorage({ userId: 'user_a' });
+    const { storageConfig } = await resolveTenantStorage({ userId: 'user_a' });
     expect(storageConfig.vectorUrl).toBe(storageConfig.url);
     expect(storageConfig.vectorAuthToken).toBe('tok_shared');
   });
 
-  it('does not touch the local filesystem when a template is configured', () => {
+  it('does not touch the local filesystem when a template is configured', async () => {
     process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}.turso.io';
-    const { tenantKey } = resolveTenantStorage({ userId: 'user_a' });
+    const { tenantKey } = await resolveTenantStorage({ userId: 'user_a' });
     expect(existsSync(path.join(tmpRoot, tenantKey))).toBe(false);
+  });
+
+  it('prefers the explicit template over Turso provisioning', async () => {
+    process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE = 'libsql://{id}.turso.io';
+    isTursoProvisioningEnabled.mockReturnValue(true);
+
+    const { storageConfig } = await resolveTenantStorage({ userId: 'user_a' });
+    expect(storageConfig.url).toContain('.turso.io');
+    expect(provisionTursoTenant).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveTenantStorage (Turso auto-provisioning)', () => {
+  it('provisions the tenant DB and returns a remote libsql descriptor', async () => {
+    isTursoProvisioningEnabled.mockReturnValue(true);
+    provisionTursoTenant.mockResolvedValue({
+      url: 'libsql://mc-abc123.turso.io',
+      authToken: 'jwt_token',
+      vectorUrl: 'libsql://mc-abc123.turso.io',
+      vectorAuthToken: 'jwt_token',
+    });
+
+    const { tenantKey, storageConfig } = await resolveTenantStorage({ orgId: 'org_a', userId: 'user_a' });
+    expect(provisionTursoTenant).toHaveBeenCalledWith(tenantKey);
+    expect(storageConfig.backend).toBe('libsql');
+    expect(storageConfig.isRemote).toBe(true);
+    expect(storageConfig.url).toBe('libsql://mc-abc123.turso.io');
+    expect(storageConfig.authToken).toBe('jwt_token');
+    expect(storageConfig.vectorUrl).toBe('libsql://mc-abc123.turso.io');
+    expect(storageConfig.vectorAuthToken).toBe('jwt_token');
+    expect(existsSync(path.join(tmpRoot, tenantKey))).toBe(false);
+  });
+
+  it('propagates a provisioning failure instead of falling back to local files', async () => {
+    isTursoProvisioningEnabled.mockReturnValue(true);
+    provisionTursoTenant.mockRejectedValue(new Error('turso down'));
+
+    await expect(resolveTenantStorage({ userId: 'user_a' })).rejects.toThrow('turso down');
   });
 });
 
 describe('getUserStorage caching', () => {
-  it('returns the same cached descriptor for the same identity', () => {
-    const first = getUserStorage({ orgId: 'org_a', userId: 'user_a' });
-    const second = getUserStorage({ orgId: 'org_a', userId: 'user_a' });
+  it('returns the same cached descriptor for the same identity', async () => {
+    const first = await getUserStorage({ orgId: 'org_a', userId: 'user_a' });
+    const second = await getUserStorage({ orgId: 'org_a', userId: 'user_a' });
     expect(second).toBe(first);
   });
 
-  it('returns distinct descriptors for distinct users', () => {
-    const a = getUserStorage({ userId: 'user_a' });
-    const b = getUserStorage({ userId: 'user_b' });
+  it('returns distinct descriptors for distinct users', async () => {
+    const a = await getUserStorage({ userId: 'user_a' });
+    const b = await getUserStorage({ userId: 'user_b' });
     expect(a).not.toBe(b);
     expect(a.tenantKey).not.toBe(b.tenantKey);
   });
 
-  it('returns distinct descriptors for the same user in different orgs', () => {
-    const a = getUserStorage({ orgId: 'org_a', userId: 'user_a' });
-    const b = getUserStorage({ orgId: 'org_b', userId: 'user_a' });
+  it('returns distinct descriptors for the same user in different orgs', async () => {
+    const a = await getUserStorage({ orgId: 'org_a', userId: 'user_a' });
+    const b = await getUserStorage({ orgId: 'org_b', userId: 'user_a' });
     expect(a).not.toBe(b);
     expect(a.tenantKey).not.toBe(b.tenantKey);
+  });
+
+  it('provisions only once for concurrent first-hits of the same tenant', async () => {
+    isTursoProvisioningEnabled.mockReturnValue(true);
+    provisionTursoTenant.mockResolvedValue({
+      url: 'libsql://mc-x.turso.io',
+      authToken: 'jwt',
+      vectorUrl: 'libsql://mc-x.turso.io',
+      vectorAuthToken: 'jwt',
+    });
+
+    const [a, b] = await Promise.all([
+      getUserStorage({ orgId: 'org_a', userId: 'user_a' }),
+      getUserStorage({ orgId: 'org_a', userId: 'user_a' }),
+    ]);
+    expect(a).toBe(b);
+    expect(provisionTursoTenant).toHaveBeenCalledTimes(1);
   });
 });

--- a/mastracode/src/web/tenant-storage.ts
+++ b/mastracode/src/web/tenant-storage.ts
@@ -20,7 +20,12 @@
  *      tenant key. Auth token from `MASTRACODE_TENANT_DB_AUTH_TOKEN`. The vector
  *      DB url comes from `MASTRACODE_TENANT_VECTOR_URL_TEMPLATE` (same `{id}`),
  *      falling back to the storage template when absent.
- *   2. Local libSQL files under `MASTRACODE_TENANT_DB_ROOT` (default
+ *   2. Turso auto-provisioning — when `MASTRACODE_TURSO_PLATFORM_TOKEN` and
+ *      `MASTRACODE_TURSO_ORG` are set, the tenant's own Turso database is
+ *      created (and a scoped token minted) on first access via the Turso
+ *      Platform API, then the stable mapping is persisted in the app Postgres.
+ *      See `tenant-provisioner.ts`.
+ *   3. Local libSQL files under `MASTRACODE_TENANT_DB_ROOT` (default
  *      `~/.mastracode/web/tenants/<sha256(orgId\0userId)>/`), with `storage.db`
  *      + `vectors.db`.
  *
@@ -35,6 +40,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import type { LibSQLStorageConfig } from '../utils/project.js';
+import { isTursoProvisioningEnabled, provisionTursoTenant } from './tenant-provisioner.js';
 
 /**
  * A resolved per-tenant storage descriptor. This is a `StorageConfig`-shaped
@@ -87,7 +93,7 @@ function applyTemplate(template: string, tenantKey: string): string {
  * ensuring the local directory exists) so it is easy to unit test. Use
  * {@link getUserStorage} for the cached entry point.
  */
-export function resolveTenantStorage(identity: TenantIdentity): TenantStorage {
+export async function resolveTenantStorage(identity: TenantIdentity): Promise<TenantStorage> {
   if (!identity.userId) {
     throw new Error('resolveTenantStorage requires a non-empty userId');
   }
@@ -114,7 +120,23 @@ export function resolveTenantStorage(identity: TenantIdentity): TenantStorage {
     };
   }
 
-  // 2. Local libSQL files under a hashed per-tenant directory.
+  // 2. Turso auto-provisioning via the Turso Platform API.
+  if (isTursoProvisioningEnabled()) {
+    const provisioned = await provisionTursoTenant(tenantKey);
+    return {
+      tenantKey,
+      storageConfig: {
+        backend: 'libsql',
+        url: provisioned.url,
+        authToken: provisioned.authToken,
+        isRemote: true,
+        vectorUrl: provisioned.vectorUrl,
+        vectorAuthToken: provisioned.vectorAuthToken,
+      },
+    };
+  }
+
+  // 3. Local libSQL files under a hashed per-tenant directory.
   const dir = path.join(tenantDbRoot(), tenantKey);
   mkdirSync(dir, { recursive: true });
   return {
@@ -132,42 +154,67 @@ export function resolveTenantStorage(identity: TenantIdentity): TenantStorage {
 const tenantCache = new Map<string, TenantStorage>();
 
 /**
+ * In-flight resolution promises, keyed by tenant key. Guards against duplicate
+ * concurrent provisioning when several requests for the same brand-new tenant
+ * arrive before the first resolution finishes.
+ */
+const inFlight = new Map<string, Promise<TenantStorage>>();
+
+/**
  * Get-or-create the cached tenant storage descriptor for an `(org, user)`
  * identity. Same identity → same cached descriptor; distinct identities →
- * distinct descriptors backed by distinct databases.
+ * distinct descriptors backed by distinct databases. Concurrent first-hits for
+ * the same tenant share a single resolution (and thus a single provision call).
  */
-export function getUserStorage(identity: TenantIdentity): TenantStorage {
+export async function getUserStorage(identity: TenantIdentity): Promise<TenantStorage> {
   const tenantKey = tenantKeyFor(identity);
   const cached = tenantCache.get(tenantKey);
   if (cached) return cached;
-  const resolved = resolveTenantStorage(identity);
-  tenantCache.set(resolved.tenantKey, resolved);
-  return resolved;
+
+  const pending = inFlight.get(tenantKey);
+  if (pending) return pending;
+
+  const promise = resolveTenantStorage(identity)
+    .then(resolved => {
+      tenantCache.set(resolved.tenantKey, resolved);
+      return resolved;
+    })
+    .finally(() => {
+      inFlight.delete(tenantKey);
+    });
+  inFlight.set(tenantKey, promise);
+  return promise;
 }
 
-/** True when a remote (network-backed) tenant DB template is configured. */
+/**
+ * True when a remote (network-backed) tenant DB backend is configured — either
+ * an explicit URL template or Turso auto-provisioning.
+ */
 export function hasRemoteTenantDb(): boolean {
-  return Boolean(process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE);
+  return Boolean(process.env.MASTRACODE_TENANT_DB_URL_TEMPLATE) || isTursoProvisioningEnabled();
 }
 
 /**
  * Fail loud at startup when a remote tenant DB is required but not configured.
  * Local-file tenant DBs do not survive container restarts and are not shared
- * across replicas, so a multi-replica/ephemeral deploy must set
- * `MASTRACODE_TENANT_DB_URL_TEMPLATE`. Gated behind
+ * across replicas, so a multi-replica/ephemeral deploy must set either
+ * `MASTRACODE_TENANT_DB_URL_TEMPLATE` or Turso auto-provisioning
+ * (`MASTRACODE_TURSO_PLATFORM_TOKEN` + `MASTRACODE_TURSO_ORG`). Gated behind
  * `MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1` so local dev is unaffected.
  */
 export function assertRemoteTenantDbIfRequired(): void {
   if (process.env.MASTRACODE_REQUIRE_REMOTE_TENANT_DB !== '1') return;
   if (hasRemoteTenantDb()) return;
   throw new Error(
-    'MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1 but no MASTRACODE_TENANT_DB_URL_TEMPLATE is set. ' +
+    'MASTRACODE_REQUIRE_REMOTE_TENANT_DB=1 but no remote tenant DB backend is configured. ' +
       'Local-file tenant databases do not persist across container restarts and are not ' +
-      'shared across replicas. Set MASTRACODE_TENANT_DB_URL_TEMPLATE to a remote libSQL/Turso URL.',
+      'shared across replicas. Set MASTRACODE_TENANT_DB_URL_TEMPLATE to a remote libSQL/Turso URL, ' +
+      'or set MASTRACODE_TURSO_PLATFORM_TOKEN + MASTRACODE_TURSO_ORG to auto-provision Turso databases.',
   );
 }
 
 /** Clear the in-process tenant cache (test helper). */
 export function __clearTenantStorageCache(): void {
   tenantCache.clear();
+  inFlight.clear();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2150,6 +2150,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.6)
+      '@tursodatabase/api':
+        specifier: 2.0.4
+        version: 2.0.4
       ai:
         specifier: ^6.0.176
         version: 6.0.177(zod@4.4.3)
@@ -18110,6 +18113,9 @@ packages:
   '@turbopuffer/turbopuffer@0.10.18':
     resolution: {integrity: sha512-3AuyjumzcQ0iLNU6hRTbOt8OeZoVJaHqNQOzIMzM6h290OGEtdCJ6L0L5Hs9gmrpANlaTPN1kUC2fe+/BMpRDw==}
 
+  '@tursodatabase/api@2.0.4':
+    resolution: {integrity: sha512-jgWNzy9kmOqZDaTblWUb3fqhl9qfmB2GuTLq7DVL8xQ5AAEkwKR2W6A/XZsqt8kS/CZ6qCH9yeDy2PhQvOYoDg==}
+
   '@tursodatabase/database-common@0.4.4':
     resolution: {integrity: sha512-iuSYWgBQEETjwfWOmi3E4Q++jQTb+VOPXeaKozQqW8fXtgU6ZaYUMmWbqQVMGSS9sAWZlZi9qyPVz0rkT8zoqQ==}
 
@@ -28852,6 +28858,9 @@ packages:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -40575,6 +40584,10 @@ snapshots:
     dependencies:
       pako: 2.1.0
       undici: 7.25.0
+
+  '@tursodatabase/api@2.0.4':
+    dependencies:
+      whatwg-fetch: 3.6.20
 
   '@tursodatabase/database-common@0.4.4': {}
 
@@ -54020,6 +54033,8 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
+
+  whatwg-fetch@3.6.20: {}
 
   whatwg-mimetype@4.0.0: {}
 


### PR DESCRIPTION
## Summary

In a deployed multi-replica environment, each `(org, user)` tenant's agent state must live in its own remote database — server-local libSQL files are ephemeral and not shared across replicas. Previously the only remote option (`MASTRACODE_TENANT_DB_URL_TEMPLATE`) assumed the tenant database already existed at a predictable URL; nothing ever created it, so a brand-new tenant would hit a non-existent database and fail.

This change adds automatic provisioning: the first time a tenant is seen, its Turso database and a scoped auth token are created on demand via the Turso Platform API, and the stable database mapping is persisted so every replica converges on the same database without re-creating it on cold start.

## What changed

- **Tenant-database provisioner** (`tenant-provisioner.ts`): wraps the Turso Platform API with idempotent database creation (treats "already exists" as success and recovers the hostname), deterministic Turso-safe database naming, and fresh per-resolution token minting so no long-lived credential is ever stored. The Turso client is imported dynamically so the dependency is never loaded unless provisioning is actually used.
- **Persistence** (`tenant_databases` table + migration): durable `(org, user) → db_name/hostname` mapping in the app Postgres, written with conflict-tolerant inserts so concurrent replicas converge.
- **Async tenant-storage resolution**: `getUserStorage`/`resolveTenantStorage` are now async to support provisioning, with in-flight deduplication so concurrent first-hits for the same tenant share a single provision call.
- **Server wiring**: `getTenantApp` awaits the now-async resolver.

## Resolution priority (highest first)

1. `MASTRACODE_TENANT_DB_URL_TEMPLATE` — explicit remote libSQL/Turso URL (unchanged).
2. **Turso auto-provision (new)** — active **only** when both `MASTRACODE_TURSO_PLATFORM_TOKEN` and `MASTRACODE_TURSO_ORG` are set.
3. Local libSQL files — unchanged dev fallback.

Provisioning is strictly env-gated: with no Turso env vars set, the Turso branch is skipped entirely, the `@tursodatabase/api` dependency is never loaded, and resolution falls back to local files exactly as before.

## Docs & config

- Documented `MASTRACODE_TURSO_PLATFORM_TOKEN`, `MASTRACODE_TURSO_ORG`, `MASTRACODE_TURSO_GROUP` in `.env.example`.
- README deployment section explains auto-provision vs. URL template vs. local, plus the app-Postgres requirement for the mapping table.
- Added `@tursodatabase/api` dependency and a changeset.

## Test plan

- `pnpm vitest run src/web` — 244/244 passing, including new provisioner and Turso-isolation suites.
- New/updated tests: `tenant-provisioner.test.ts` (idempotent create + already-exists recovery, deterministic naming, env gating, mapping round-trip), `tenant-isolation-turso.test.ts` (distinct DBs per tenant, stable DB per tenant), and async updates to `tenant-isolation.test.ts` / `tenant-storage.test.ts`.
- Offline no-op path confirmed: with no Turso env set, the provisioner is never invoked and local libSQL fallback runs.
- `tsc --noEmit` clean, `eslint` clean.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-8) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change teaches the app how to automatically create a separate Turso database for each tenant the first time they need one. That means multiple deployed copies of the app can all agree on the same tenant storage instead of relying on local files or pre-made databases.

### What changed
- Added automatic Turso tenant provisioning for multi-replica deployments
- Made tenant storage resolution async and added in-flight deduping so concurrent requests don’t create duplicate databases
- Persisted tenant DB name/hostname mappings in app Postgres so replicas converge on the same tenant database
- Updated tenant app startup flow to await async storage resolution
- Added tests for provisioning, caching, isolation, and race handling
- Updated docs, env examples, and added `@tursodatabase/api`
- Added a changeset for the new behavior

### Resolution order
1. `MASTRACODE_TENANT_DB_URL_TEMPLATE`
2. Turso auto-provisioning
3. Local libSQL files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->