### PR TITLE
fix(deployer): write file-based agents wrapper after bundler.prepare()

### DIFF
--- a/.changeset/fix-fs-agents-dev-entry-write-order.md
+++ b/.changeset/fix-fs-agents-dev-entry-write-order.md
@@ -1,0 +1,12 @@
+---
+'@mastra/deployer': patch
+'mastra': patch
+---
+
+Fix `ENOENT: .mastra-fs-agents-entry.mjs` when running `mastra dev`/`mastra build` in a project that uses file-based agents. The generated fs-agents wrapper entry was written before `bundler.prepare()` emptied the output directory, so it was wiped before the bundler could read it. Wrapper generation is now split: `prepareFsAgentsEntry` returns the generated source without writing, and the new `writeFsAgentsEntry` writes it after `prepare()` runs.
+
+```ts
+const fsAgents = await prepareFsAgentsEntry({ entryFile, mastraDir, outputDirectory });
+await bundler.prepare(outputDirectory); // empties output dir
+await writeFsAgentsEntry(fsAgents); // wrapper now survives for the bundler
+```

--- a/examples/agent/src/mastra/agents/weather-fs/skills/units.md
+++ b/examples/agent/src/mastra/agents/weather-fs/skills/units.md
@@ -1,3 +1,8 @@
+---
+name: units
+description: Use when reporting temperatures so values are shown in both Celsius and Fahrenheit.
+---
+
 Always report temperatures in both Celsius and Fahrenheit, with Celsius first.
 
 Convert with `F = C * 9/5 + 32` and round both values to whole numbers.

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { getDeployer } from '@mastra/deployer';
-import { prepareFsAgentsEntry, mirrorFsAgentWorkspaces } from '@mastra/deployer/build';
+import { prepareFsAgentsEntry, writeFsAgentsEntry, mirrorFsAgentWorkspaces } from '@mastra/deployer/build';
 import { FileService } from '../../services/service.file';
 import { checkMastraPeerDeps, logPeerDepWarnings } from '../../utils/check-peer-deps';
 import { createLogger } from '../../utils/logger';
@@ -51,6 +51,9 @@ export async function build({
       const discoveredTools = deployer.getAllToolPaths(mastraDir, [...(tools ?? []), ...fsAgents.toolPaths]);
 
       await deployer.prepare(outputDirectory);
+      // Write the fs-routed agents wrapper after prepare() empties the output
+      // directory, so it survives for the bundler. No-op when none are found.
+      await writeFsAgentsEntry(fsAgents);
       await deployer.bundle(bundleEntryFile, outputDirectory, {
         toolsPaths: discoveredTools,
         projectRoot: rootDir,
@@ -82,6 +85,9 @@ export async function build({
     const discoveredTools = platformDeployer.getAllToolPaths(mastraDir, [...(tools ?? []), ...fsAgents.toolPaths]);
 
     await platformDeployer.prepare(outputDirectory);
+    // Write the fs-routed agents wrapper after prepare() empties the output
+    // directory, so it survives for the bundler. No-op when none are found.
+    await writeFsAgentsEntry(fsAgents);
     await platformDeployer.bundle(bundleEntryFile, outputDirectory, {
       toolsPaths: discoveredTools,
       projectRoot: rootDir,

--- a/packages/cli/src/commands/dev/dev.test.ts
+++ b/packages/cli/src/commands/dev/dev.test.ts
@@ -41,6 +41,7 @@ vi.mock('@mastra/deployer/build', async importOriginal => {
       toolPaths: [],
       agentCount: 0,
     })),
+    writeFsAgentsEntry: vi.fn().mockResolvedValue(undefined),
     mirrorFsAgentWorkspaces: vi.fn().mockResolvedValue([]),
     getServerOptions: vi.fn().mockResolvedValue({
       port: 4111,

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -8,6 +8,7 @@ import {
   getServerOptions,
   normalizeStudioBase,
   prepareFsAgentsEntry,
+  writeFsAgentsEntry,
   mirrorFsAgentWorkspaces,
 } from '@mastra/deployer/build';
 import { execa } from 'execa';
@@ -534,6 +535,11 @@ export async function dev({
   };
 
   await bundler.prepare(dotMastraPath);
+
+  // Write the generated fs-routed agents wrapper entry. Runs after `prepare()`
+  // empties the output directory so the wrapper is not wiped before the watcher
+  // reads it. No-op when there are no fs-routed agents.
+  await writeFsAgentsEntry(fsAgents);
 
   // Mirror authored `agents/<name>/workspace/**` seeds into the bundled output
   // directory, where the generated entry resolves each agent's default

--- a/packages/deployer/src/build/fs-routing/fs-routing.test.ts
+++ b/packages/deployer/src/build/fs-routing/fs-routing.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { generateFsAgentsModule } from './codegen';
 import { discoverFsAgents } from './discover';
 import { mirrorFsAgentWorkspaces } from './mirror';
-import { prepareFsAgentsEntry } from './prepare';
+import { prepareFsAgentsEntry, writeFsAgentsEntry } from './prepare';
 
 let dir: string;
 
@@ -447,7 +447,7 @@ describe('prepareFsAgentsEntry', () => {
     expect(result).toEqual({ entryFile: '/project/index.ts', toolPaths: [], agentCount: 0 });
   });
 
-  it('writes a wrapper entry and tool paths when fs agents exist', async () => {
+  it('returns a wrapper entry path, tool paths, and deferred source without writing', async () => {
     await writeAgent('weather', {
       config: `export default { model: 'openai/gpt-4o' };`,
       instructions: 'hi',
@@ -459,6 +459,34 @@ describe('prepareFsAgentsEntry', () => {
     expect(result.agentCount).toBe(1);
     expect(result.entryFile).toMatch(/\.mastra-fs-agents-entry\.mjs$/);
     expect(result.toolPaths.some(p => p.includes('agents/*/tools'))).toBe(true);
+    expect(result.moduleSource).toBeTruthy();
+
+    // The wrapper must NOT be written by prepare(): the bundler empties the
+    // output dir between prepare() and the actual write.
+    await expect(access(result.entryFile)).rejects.toThrow();
+  });
+
+  it('writeFsAgentsEntry writes the wrapper after the output dir is emptied', async () => {
+    await writeAgent('weather', {
+      config: `export default { model: 'openai/gpt-4o' };`,
+      instructions: 'hi',
+    });
+    const out = join(dir, '.mastra');
+
+    const result = await prepareFsAgentsEntry(dir, join(dir, 'index.ts'), out);
+
+    // Simulate bundler.prepare() emptying the output directory.
+    await rm(out, { recursive: true, force: true });
+
+    await writeFsAgentsEntry(result);
+    const written = await readFile(result.entryFile, 'utf-8');
+    expect(written).toBe(result.moduleSource);
+  });
+
+  it('writeFsAgentsEntry is a no-op when there are no fs agents', async () => {
+    const out = join(dir, '.mastra');
+    const result = await prepareFsAgentsEntry(dir, '/project/index.ts', out);
+    await expect(writeFsAgentsEntry(result)).resolves.toBeUndefined();
   });
 });
 

--- a/packages/deployer/src/build/fs-routing/prepare.ts
+++ b/packages/deployer/src/build/fs-routing/prepare.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from 'node:fs/promises';
-import { join, posix } from 'node:path';
+import { dirname, join, posix } from 'node:path';
 import { slash } from '../utils';
 import { generateFsAgentsModule } from './codegen';
 import { discoverFsAgents } from './discover';
@@ -18,13 +18,24 @@ export interface PrepareFsAgentsEntryResult {
   toolPaths: string[];
   /** Number of fs-routed agents discovered. */
   agentCount: number;
+  /**
+   * Generated wrapper source to write to {@link entryFile}, or `undefined` when
+   * there are no fs-routed agents. The write is deferred so callers can run it
+   * *after* `bundler.prepare()` empties the output directory — otherwise the
+   * wrapper is wiped before the bundler reads it.
+   */
+  moduleSource?: string;
 }
 
 /**
  * Discover fs-routed agents under `<mastraDir>/agents/*` and, if any exist,
- * generate a wrapper entry module (written under `<outputDirectory>`) that
- * registers them onto the user's mastra instance. Returns the entry the bundler
- * should use plus extra tool glob paths so `agents/*\/tools` are bundled.
+ * generate a wrapper entry module that registers them onto the user's mastra
+ * instance. Returns the entry the bundler should use plus extra tool glob paths
+ * so `agents/*\/tools` are bundled.
+ *
+ * This does NOT write the wrapper to disk; call {@link writeFsAgentsEntry} with
+ * the result after `bundler.prepare()` so the generated file is not wiped when
+ * the output directory is emptied.
  *
  * When no fs-routed agents are present the original entry is returned unchanged,
  * so existing code-only projects are completely unaffected.
@@ -41,10 +52,7 @@ export async function prepareFsAgentsEntry(
   }
 
   const moduleSource = await generateFsAgentsModule(slash(entryFile), agents);
-
-  await mkdir(outputDirectory, { recursive: true });
   const generatedEntry = join(outputDirectory, '.mastra-fs-agents-entry.mjs');
-  await writeFile(generatedEntry, moduleSource, 'utf-8');
 
   const normalizedMastraDir = slash(mastraDir);
   const toolPaths = [
@@ -53,5 +61,20 @@ export async function prepareFsAgentsEntry(
     `!${posix.join(normalizedMastraDir, 'agents/*/tools/**/__tests__/**')}`,
   ];
 
-  return { entryFile: generatedEntry, toolPaths, agentCount: agents.length };
+  return { entryFile: generatedEntry, toolPaths, agentCount: agents.length, moduleSource };
+}
+
+/**
+ * Write the generated fs-agents wrapper produced by {@link prepareFsAgentsEntry}
+ * to its `entryFile`. No-op when there are no fs-routed agents. Call this AFTER
+ * `bundler.prepare()` (which empties the output directory) so the wrapper
+ * survives for the bundler/watcher to read.
+ */
+export async function writeFsAgentsEntry(result: PrepareFsAgentsEntryResult): Promise<void> {
+  if (!result.moduleSource) {
+    return;
+  }
+
+  await mkdir(dirname(result.entryFile), { recursive: true });
+  await writeFile(result.entryFile, result.moduleSource, 'utf-8');
 }

--- a/packages/deployer/src/build/index.ts
+++ b/packages/deployer/src/build/index.ts
@@ -10,6 +10,6 @@ export type { RuntimePlatform, BundlerPlatform, StudioInjectionConfig } from './
 export { discoverFsAgents } from './fs-routing/discover';
 export type { DiscoveredFsAgent } from './fs-routing/discover';
 export { generateFsAgentsModule } from './fs-routing/codegen';
-export { prepareFsAgentsEntry } from './fs-routing/prepare';
+export { prepareFsAgentsEntry, writeFsAgentsEntry } from './fs-routing/prepare';
 export type { PrepareFsAgentsEntryResult } from './fs-routing/prepare';
 export { mirrorFsAgentWorkspaces } from './fs-routing/mirror';


### PR DESCRIPTION
## Summary

Running `mastra dev` or `mastra build` in a project that uses file-based (fs-routed) agents crashed with:

```
ENOENT: no such file or directory, open '.mastra/.mastra-fs-agents-entry.mjs'
```

The generated fs-agents wrapper entry was written inside `prepareFsAgentsEntry`, which runs **before** `bundler.prepare()`. `prepare()` empties the output directory (`emptyDir`), so the wrapper was deleted before the bundler/watcher could read it.

This splits wrapper generation from writing:

- `prepareFsAgentsEntry` now returns the generated source (`moduleSource`) without writing to disk.
- A new `writeFsAgentsEntry` performs the deferred `mkdir` + `writeFile`, and is called **after** `prepare()` in both the dev and build CLI flows (matching the existing `mirrorFsAgentWorkspaces` ordering).

Also fixes the file-based agent example: the flat `units.md` skill had no frontmatter, so its empty `description` was rejected by `createSkill` at runtime. Added the required `name`/`description` frontmatter.

## Test plan

- `pnpm --filter ./packages/deployer exec vitest run src/build/fs-routing` — 42 passed (includes new deferred-write tests proving the wrapper survives an `emptyDir` between `prepareFsAgentsEntry` and `writeFsAgentsEntry`).
- `pnpm --filter ./packages/cli exec vitest run src/commands/dev` — 13 passed.
- `pnpm --filter ./packages/cli typecheck` — clean.
- Manual: `pnpm mastra dev` in `examples/agent` now boots cleanly (`✓ Initial bundle complete`); the file-based `weather-fs` agent registers with its tool, both skills, and the `forecaster` subagent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a “file missing” crash by making sure a helper file for file-based agents is written after the cleanup step that used to delete it. It also adds missing skill info to an example so it doesn’t fail at runtime.

## Summary
- Split fs-routed agent wrapper generation into two steps:
  - `prepareFsAgentsEntry` now returns the wrapper source instead of writing it immediately.
  - New `writeFsAgentsEntry` writes the file after `bundler.prepare()` / output cleanup.
- Updated both `mastra dev` and `mastra build` to write the wrapper at the safer point in the flow.
- Re-exported the new helper from the deployer build entrypoint.
- Added tests for the new write order, the no-fs-agents no-op case, and the updated mock in CLI dev tests.
- Fixed the file-based agent example by adding required `name` and `description` frontmatter to `units.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->