### PR TITLE
feat(core): reusable createCodingAgent factory and buildBasePrompt

### DIFF
--- a/.changeset/cold-tigers-move.md
+++ b/.changeset/cold-tigers-move.md
@@ -1,13 +1,12 @@
 ---
 '@mastra/core': minor
-'mastracode': patch
 ---
 
 Added `createCodingAgent` factory and a reusable `buildBasePrompt` so other projects can build a coding agent on top of the same defaults MastraCode uses.
 
 The factory wires sensible, portable defaults that you can override per field:
 
-- **Workspace** — a local filesystem + sandbox rooted at `process.cwd()` (set `workspaceBasePath`, pass your own `workspace`, or pass `workspace: undefined` to opt out entirely).
+- **Workspace** — a local filesystem + sandbox rooted at `process.cwd()` (set `basePath`, pass your own `workspace`, or pass `workspace: undefined` to opt out entirely).
 - **Task signals** — `TaskSignalProvider` so a task list persists across turns.
 - **Error handling** — retries on `ECONNRESET` and bad-request errors, plus prefill and provider-history compatibility processors.
 - **Goal judging** — the default goal judge prompt.
@@ -18,8 +17,11 @@ The factory wires sensible, portable defaults that you can override per field:
 import { createCodingAgent } from '@mastra/core/coding-agent';
 
 const agent = createCodingAgent({
+  id: 'my-coding-agent',
+  name: 'My Coding Agent',
+  model: 'openai/gpt-5',
   instructions: 'You help with my project.',
-  model: myModel,
-  workspaceBasePath: '/path/to/repo',
+  tools: {},
+  basePath: '/path/to/repo',
 });
 ```

--- a/.changeset/cold-tigers-move.md
+++ b/.changeset/cold-tigers-move.md
@@ -1,0 +1,25 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Added `createCodingAgent` factory and a reusable `buildBasePrompt` so other projects can build a coding agent on top of the same defaults MastraCode uses.
+
+The factory wires sensible, portable defaults that you can override per field:
+
+- **Workspace** — a local filesystem + sandbox rooted at `process.cwd()` (set `workspaceBasePath`, pass your own `workspace`, or pass `workspace: undefined` to opt out entirely).
+- **Task signals** — `TaskSignalProvider` so a task list persists across turns.
+- **Error handling** — retries on `ECONNRESET` and bad-request errors, plus prefill and provider-history compatibility processors.
+- **Goal judging** — the default goal judge prompt.
+
+`buildBasePrompt` is parameterized with `productName` and `coAuthorName` (both default to "Mastra Code"), so you can brand the system prompt without forking it.
+
+```ts
+import { createCodingAgent } from '@mastra/core/coding-agent';
+
+const agent = createCodingAgent({
+  instructions: 'You help with my project.',
+  model: myModel,
+  workspaceBasePath: '/path/to/repo',
+});
+```

--- a/.changeset/cold-tigers-move.md
+++ b/.changeset/cold-tigers-move.md
@@ -12,7 +12,7 @@ The factory wires sensible, portable defaults that you can override per field:
 - **Error handling** — retries on `ECONNRESET` and bad-request errors, plus prefill and provider-history compatibility processors.
 - **Goal judging** — the default goal judge prompt.
 
-`buildBasePrompt` is parameterized with `productName` and `coAuthorName` (both default to "Mastra Code"), so you can brand the system prompt without forking it.
+`buildBasePrompt` is parameterized with `productName`, `coAuthorName` (both default to "Mastra Code"), and `coAuthorEmail` (defaults to "noreply@mastra.ai"), so you can brand the system prompt and commit trailer without forking it.
 
 ```ts
 import { createCodingAgent } from '@mastra/core/coding-agent';

--- a/.changeset/mastracode-coding-agent-factory.md
+++ b/.changeset/mastracode-coding-agent-factory.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+MastraCode now builds its code agent through the new `createCodingAgent` factory from `@mastra/core/coding-agent` instead of constructing the `Agent` inline. No user-facing behavior changes — the system prompt and agent configuration are unchanged.

--- a/docs/src/content/en/reference/coding-agent/build-base-prompt.mdx
+++ b/docs/src/content/en/reference/coding-agent/build-base-prompt.mdx
@@ -27,7 +27,7 @@ const prompt = buildBasePrompt({
   platform: process.platform,
   date: new Date().toDateString(),
   mode: 'build',
-  modelId: 'openai/gpt-4o',
+  modelId: '__GATEWAY_OPENAI_MODEL_BASE__',
   toolGuidance: '',
 })
 ```

--- a/docs/src/content/en/reference/coding-agent/build-base-prompt.mdx
+++ b/docs/src/content/en/reference/coding-agent/build-base-prompt.mdx
@@ -1,0 +1,144 @@
+---
+title: "Reference: buildBasePrompt() | Coding Agent"
+description: "API reference for buildBasePrompt(), which builds the shared base system prompt for a coding agent from a PromptContext."
+packages:
+  - "@mastra/core"
+---
+
+# buildBasePrompt()
+
+`buildBasePrompt()` builds the shared base system prompt for a coding agent — the behavioral instructions that make the agent a good coding assistant. It takes a `PromptContext` describing the current environment (project, platform, git branch, mode, model) and returns the prompt as a string.
+
+Product-specific strings are parameterized through `productName`, `coAuthorName`, and `coAuthorEmail`, so you can rebrand the prompt and commit trailer without forking it. They default to `"Mastra Code"` / `"noreply@mastra.ai"`, so existing callers keep identical output.
+
+Use this with [`createCodingAgent()`](/reference/coding-agent/create-coding-agent) when you build dynamic instructions for the agent.
+
+## Usage example
+
+Build the base prompt from a `PromptContext`:
+
+```typescript title="src/mastra/prompt.ts"
+import { buildBasePrompt } from '@mastra/core/coding-agent'
+
+const prompt = buildBasePrompt({
+  projectPath: process.cwd(),
+  projectName: 'my-app',
+  gitBranch: 'main',
+  platform: process.platform,
+  date: new Date().toDateString(),
+  mode: 'build',
+  modelId: 'openai/gpt-4o',
+  toolGuidance: '',
+})
+```
+
+To rebrand the prompt, pass the product and co-author fields:
+
+```typescript
+const prompt = buildBasePrompt({
+  // ...environment fields
+  productName: 'Acme Coder',
+  coAuthorName: 'Acme Bot',
+  coAuthorEmail: 'bot@acme.dev',
+})
+```
+
+## Parameters
+
+`buildBasePrompt()` takes a single `PromptContext` object.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'projectPath',
+    type: 'string',
+    description: 'Absolute path to the project root.',
+  },
+  {
+    name: 'projectName',
+    type: 'string',
+    description: 'Display name of the project.',
+  },
+  {
+    name: 'gitBranch',
+    type: 'string',
+    description: 'Current git branch, if the project is a git repository.',
+    isOptional: true,
+  },
+  {
+    name: 'platform',
+    type: 'string',
+    description: 'Operating system platform (for example, the value of process.platform).',
+  },
+  {
+    name: 'commonBinaries',
+    type: '{ name: string; path: string | null }[]',
+    description: 'Common binaries detected on the system, each with a name and resolved path (or null when not found).',
+    isOptional: true,
+  },
+  {
+    name: 'date',
+    type: 'string',
+    description: 'Current date string injected into the prompt.',
+  },
+  {
+    name: 'mode',
+    type: 'string',
+    description: 'Active agent mode (for example, "build" or "plan").',
+  },
+  {
+    name: 'modelId',
+    type: 'string',
+    description: 'Identifier of the active model, included in the commit Co-Authored-By line when provided.',
+    isOptional: true,
+  },
+  {
+    name: 'activePlan',
+    type: '{ title: string; plan: string; approvedAt: string } | null',
+    description: 'The currently approved plan, if any.',
+    isOptional: true,
+  },
+  {
+    name: 'toolGuidance',
+    type: 'string',
+    description: 'Tool-usage guidance section appended to the prompt.',
+  },
+  {
+    name: 'productName',
+    type: 'string',
+    description: 'Display name used in the prompt header.',
+    isOptional: true,
+    defaultValue: 'Mastra Code',
+  },
+  {
+    name: 'coAuthorName',
+    type: 'string',
+    description: 'Name used in the commit Co-Authored-By line.',
+    isOptional: true,
+    defaultValue: 'Mastra Code',
+  },
+  {
+    name: 'coAuthorEmail',
+    type: 'string',
+    description: 'Email used in the commit Co-Authored-By line.',
+    isOptional: true,
+    defaultValue: 'noreply@mastra.ai',
+  },
+]}
+/>
+
+## Returns
+
+<PropertiesTable
+  content={[
+  {
+    name: 'prompt',
+    type: 'string',
+    description: 'The base system prompt for the coding agent.',
+  },
+]}
+/>
+
+## Related
+
+- [`createCodingAgent()`](/reference/coding-agent/create-coding-agent)

--- a/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
+++ b/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
@@ -17,12 +17,11 @@ Pass a model, instructions, and tools. The factory fills in the workspace, task 
 
 ```typescript title="src/mastra/coding-agent.ts"
 import { createCodingAgent } from '@mastra/core/coding-agent'
-import { openai } from '@ai-sdk/openai'
 
 const agent = createCodingAgent({
   id: 'my-coding-agent',
   name: 'My Coding Agent',
-  model: openai('gpt-4o'),
+  model: 'openai/gpt-5',
   instructions: 'You are a helpful coding assistant.',
   tools: {},
 })
@@ -58,7 +57,7 @@ const agent = createCodingAgent({
     isOptional: true,
   },
   {
-    name: 'workspaceBasePath',
+    name: 'basePath',
     type: 'string',
     description: 'Base path for the default workspace built when workspace is omitted.',
     isOptional: true,
@@ -112,7 +111,7 @@ The factory only fills a default when you do not provide the corresponding field
 
 ### Workspace
 
-When the `workspace` key is omitted, the factory builds a local workspace rooted at `workspaceBasePath` (default `process.cwd()`):
+When the `workspace` key is omitted, the factory builds a local workspace rooted at `basePath` (default `process.cwd()`):
 
 ```typescript
 import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace'
@@ -128,7 +127,8 @@ To opt out — for example when the workspace is injected at the [`AgentControll
 ```typescript
 const agent = createCodingAgent({
   id: 'my-coding-agent',
-  model: openai('gpt-4o'),
+  name: 'My Coding Agent',
+  model: 'openai/gpt-5',
   instructions: 'You are a helpful coding assistant.',
   tools: {},
   workspace: undefined, // opt out of the default workspace

--- a/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
+++ b/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
@@ -21,7 +21,7 @@ import { createCodingAgent } from '@mastra/core/coding-agent'
 const agent = createCodingAgent({
   id: 'my-coding-agent',
   name: 'My Coding Agent',
-  model: 'openai/gpt-5',
+  model: '__GATEWAY_OPENAI_MODEL_BASE__',
   instructions: 'You are a helpful coding assistant.',
   tools: {},
 })
@@ -128,7 +128,7 @@ To opt out — for example when the workspace is injected at the [`AgentControll
 const agent = createCodingAgent({
   id: 'my-coding-agent',
   name: 'My Coding Agent',
-  model: 'openai/gpt-5',
+  model: '__GATEWAY_OPENAI_MODEL_BASE__',
   instructions: 'You are a helpful coding assistant.',
   tools: {},
   workspace: undefined, // opt out of the default workspace

--- a/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
+++ b/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
@@ -1,0 +1,151 @@
+---
+title: "Reference: createCodingAgent() | Coding Agent"
+description: "API reference for createCodingAgent(), a factory that builds a coding agent with portable defaults for workspace, task signal, error retries, and goal judge."
+packages:
+  - "@mastra/core"
+---
+
+# createCodingAgent()
+
+`createCodingAgent()` builds a coding [`Agent`](/reference/agents/agent) with portable defaults for the pieces a coding agent always needs: a local workspace, the task-list signal provider, network-retry error processors, and the goal judge prompt. Supply only `model`, `instructions`, and `tools` to get a working agent, or override any default.
+
+The returned value is a standard `Agent`, so it works anywhere an `Agent` does — including as the agent passed to an [`AgentController`](/reference/agent-controller/agent-controller-class).
+
+## Usage example
+
+Pass a model, instructions, and tools. The factory fills in the workspace, task signal, error processors, and goal prompt:
+
+```typescript title="src/mastra/coding-agent.ts"
+import { createCodingAgent } from '@mastra/core/coding-agent'
+import { openai } from '@ai-sdk/openai'
+
+const agent = createCodingAgent({
+  id: 'my-coding-agent',
+  name: 'My Coding Agent',
+  model: openai('gpt-4o'),
+  instructions: 'You are a helpful coding assistant.',
+  tools: {},
+})
+```
+
+## Parameters
+
+`createCodingAgent()` accepts every field of [`AgentConfig`](/reference/agents/agent#constructor-parameters) plus the fields below. Fields you provide always take precedence over the factory defaults.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'model',
+    type: 'MastraLanguageModel | DynamicArgument<MastraLanguageModel>',
+    description: 'The language model the agent uses. Passed straight through to Agent.',
+  },
+  {
+    name: 'instructions',
+    type: 'string | DynamicArgument<string>',
+    description: 'System instructions for the agent. Passed straight through to Agent.',
+  },
+  {
+    name: 'tools',
+    type: 'ToolsInput | DynamicArgument<ToolsInput>',
+    description: 'Tools available to the agent. Passed straight through to Agent.',
+    isOptional: true,
+  },
+  {
+    name: 'workspace',
+    type: 'AnyWorkspace | undefined',
+    description:
+      'The workspace backing the agent. When the key is omitted, a default local workspace is built. When set explicitly to undefined, the factory builds no default — opt out when the workspace is wired elsewhere (for example at the AgentController level).',
+    isOptional: true,
+  },
+  {
+    name: 'workspaceBasePath',
+    type: 'string',
+    description: 'Base path for the default workspace built when workspace is omitted.',
+    isOptional: true,
+    defaultValue: 'process.cwd()',
+  },
+  {
+    name: 'signals',
+    type: 'SignalProvider[]',
+    description: 'Signal providers for the agent. When omitted, defaults to a single TaskSignalProvider.',
+    isOptional: true,
+  },
+  {
+    name: 'errorProcessors',
+    type: 'Processor[]',
+    description:
+      'Error processors for the agent. When omitted, defaults to the ECONNRESET/bad-request retry stack plus PrefillErrorHandler and ProviderHistoryCompat.',
+    isOptional: true,
+  },
+  {
+    name: 'goal',
+    type: 'AgentGoalConfig',
+    description:
+      'Goal configuration. When provided without a prompt, the prompt defaults to DEFAULT_GOAL_JUDGE_PROMPT.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Returns
+
+<PropertiesTable
+  content={[
+  {
+    name: 'agent',
+    type: 'Agent',
+    description: 'A coding agent with the resolved workspace, signals, error processors, and goal applied.',
+  },
+]}
+/>
+
+## Defaults
+
+The factory only fills a default when you do not provide the corresponding field. Caller-provided values always win.
+
+| Field | Default when omitted |
+| - | - |
+| `workspace` | A [`Workspace`](/reference/workspace/workspace-class) backed by `LocalFilesystem` and `LocalSandbox` rooted at the base path. |
+| `signals` | A single [`TaskSignalProvider`](/reference/signals/task-signal-provider). |
+| `errorProcessors` | ECONNRESET and bad-request retry processors plus `PrefillErrorHandler` and `ProviderHistoryCompat`. |
+| `goal.prompt` | `DEFAULT_GOAL_JUDGE_PROMPT` (only when a `goal` is configured). |
+
+### Workspace
+
+When the `workspace` key is omitted, the factory builds a local workspace rooted at `workspaceBasePath` (default `process.cwd()`):
+
+```typescript
+import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace'
+
+new Workspace({
+  filesystem: new LocalFilesystem({ basePath }),
+  sandbox: new LocalSandbox({ workingDirectory: basePath }),
+})
+```
+
+To opt out — for example when the workspace is injected at the [`AgentController`](/reference/agent-controller/agent-controller-class) level — pass `workspace: undefined` explicitly:
+
+```typescript
+const agent = createCodingAgent({
+  id: 'my-coding-agent',
+  model: openai('gpt-4o'),
+  instructions: 'You are a helpful coding assistant.',
+  tools: {},
+  workspace: undefined, // opt out of the default workspace
+})
+```
+
+### Error processors
+
+The default error processors apply a retry policy for transient failures:
+
+- Network resets (`ECONNRESET` / `socket hang up`) retry up to twice with exponential backoff (`1000ms * 2^retryCount`, capped at `30000ms`).
+- Bad-request errors retry once after `2000ms`.
+
+`PrefillErrorHandler` and `ProviderHistoryCompat` are also included for provider compatibility.
+
+## Related
+
+- [`buildBasePrompt()`](/reference/coding-agent/build-base-prompt)
+- [`Agent`](/reference/agents/agent)
+- [`AgentController`](/reference/agent-controller/agent-controller-class)

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -171,8 +171,8 @@ const sidebars = {
       label: 'Coding Agent',
       collapsed: true,
       items: [
-        { type: 'doc', id: 'coding-agent/create-coding-agent', label: 'createCodingAgent()' },
         { type: 'doc', id: 'coding-agent/build-base-prompt', label: 'buildBasePrompt()' },
+        { type: 'doc', id: 'coding-agent/create-coding-agent', label: 'createCodingAgent()' },
       ],
     },
     {

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -168,6 +168,15 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Coding Agent',
+      collapsed: true,
+      items: [
+        { type: 'doc', id: 'coding-agent/create-coding-agent', label: 'createCodingAgent()' },
+        { type: 'doc', id: 'coding-agent/build-base-prompt', label: 'buildBasePrompt()' },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Core',
       collapsed: true,
       items: [

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -28,6 +28,16 @@ vi.mock('@mastra/core/agent', () => ({
   SignalProvider: class {},
 }));
 
+// The code agent is built via the core `createCodingAgent` factory. Forward the
+// config mastracode passes to the same constructor spy the tests assert against,
+// returning a mocked Agent instance.
+vi.mock('@mastra/core/coding-agent', () => ({
+  createCodingAgent: (config: unknown) => {
+    agentConstructorMock(config);
+    return {};
+  },
+}));
+
 const agentConstructorMock = vi.fn();
 
 const controllerConstructorMock = vi.fn();

--- a/mastracode/src/agents/prompts/index.ts
+++ b/mastracode/src/agents/prompts/index.ts
@@ -2,15 +2,15 @@
  * Prompt system — exports the prompt builder and mode-specific prompts.
  */
 
-export { buildBasePrompt } from './base.js';
+export { buildBasePrompt } from '@mastra/core/coding-agent';
 export { buildModePrompt, buildModePromptFn } from './build.js';
 export { planModePrompt } from './plan.js';
 export { fastModePrompt } from './fast.js';
 
+import { buildBasePrompt } from '@mastra/core/coding-agent';
+import type { PromptContext as BasePromptContext } from '@mastra/core/coding-agent';
 import { hasTavilyKey } from '../../tools/index.js';
 import { loadAgentInstructions, formatAgentInstructions } from './agent-instructions.js';
-import { buildBasePrompt } from './base.js';
-import type { PromptContext as BasePromptContext } from './base.js';
 import { buildModePromptFn } from './build.js';
 import { fastModePrompt } from './fast.js';
 import { modelSpecificPrompts } from './model.js';

--- a/mastracode/src/agents/prompts/index.ts
+++ b/mastracode/src/agents/prompts/index.ts
@@ -2,7 +2,6 @@
  * Prompt system — exports the prompt builder and mode-specific prompts.
  */
 
-export { buildBasePrompt } from '@mastra/core/coding-agent';
 export { buildModePrompt, buildModePromptFn } from './build.js';
 export { planModePrompt } from './plan.js';
 export { fastModePrompt } from './fast.js';

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { hostname } from 'node:os';
 import path from 'node:path';
 
-import { Agent } from '@mastra/core/agent';
+import type { Agent } from '@mastra/core/agent';
 import { AgentController } from '@mastra/core/agent-controller';
 import type {
   IntervalHandler,
@@ -13,6 +13,7 @@ import type {
   AgentControllerRequestContext,
   Session,
 } from '@mastra/core/agent-controller';
+import { createCodingAgent } from '@mastra/core/coding-agent';
 import type { PubSub } from '@mastra/core/events';
 import { PROVIDER_REGISTRY } from '@mastra/core/llm';
 import type { ProviderConfig } from '@mastra/core/llm';
@@ -518,9 +519,14 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
         },
       })
     : undefined;
-  const codeAgent: Agent = new Agent({
+  const codeAgent: Agent = createCodingAgent({
     id: CODE_AGENT_ID,
     name: 'Code Agent',
+    // Workspace is wired per-request at the AgentController level (see
+    // `config.workspace` below), so opt out of the factory's default local
+    // workspace. An explicit `undefined` is required: the factory only builds a
+    // default when the `workspace` key is absent.
+    workspace: undefined,
     instructions: getDynamicInstructions,
     model: getDynamicModel,
     tools: createDynamicTools(mcpManager, config?.extraTools, config?.disabledTools, storage),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -161,6 +161,16 @@
         "default": "./dist/channels/index.cjs"
       }
     },
+    "./coding-agent": {
+      "import": {
+        "types": "./dist/coding-agent/index.d.ts",
+        "default": "./dist/coding-agent/index.js"
+      },
+      "require": {
+        "types": "./dist/coding-agent/index.d.ts",
+        "default": "./dist/coding-agent/index.cjs"
+      }
+    },
     "./datasets": {
       "import": {
         "types": "./dist/datasets/index.d.ts",

--- a/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
+++ b/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
@@ -109,4 +109,9 @@ describe('buildBasePrompt', () => {
     const prompt = buildBasePrompt(promptContext({ modelId: 'openai/gpt-4o' }));
     expect(prompt).toContain('Co-Authored-By: Mastra Code (openai/gpt-4o) <noreply@mastra.ai>');
   });
+
+  it('parameterizes the Co-Authored-By email', () => {
+    const prompt = buildBasePrompt(promptContext({ coAuthorName: 'Acme Bot', coAuthorEmail: 'bot@acme.dev' }));
+    expect(prompt).toContain('Co-Authored-By: Acme Bot <bot@acme.dev>');
+  });
 });

--- a/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
+++ b/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Agent } from '../../agent/agent';
+import { DEFAULT_GOAL_JUDGE_PROMPT } from '../../agent/goal/objective';
 import { LocalFilesystem, LocalSandbox, Workspace } from '../../workspace';
 import type { PromptContext } from '../index';
 import { buildBasePrompt, createCodingAgent } from '../index';
@@ -45,8 +46,8 @@ describe('createCodingAgent', () => {
     expect(workspace?.sandbox).toBeInstanceOf(LocalSandbox);
   });
 
-  it('roots the default workspace at workspaceBasePath', async () => {
-    const agent = createCodingAgent(baseConfig({ workspaceBasePath: '/custom/base' }));
+  it('roots the default workspace at basePath', async () => {
+    const agent = createCodingAgent(baseConfig({ basePath: '/custom/base' }));
     const workspace = await agent.getWorkspace();
 
     expect((workspace?.sandbox as LocalSandbox).workingDirectory).toBe('/custom/base');
@@ -71,13 +72,22 @@ describe('createCodingAgent', () => {
     expect(workspace).toBe(custom);
   });
 
-  it('does not throw when goal is configured (prompt defaulted)', () => {
+  it('defaults the goal prompt when a goal is configured without one', () => {
     const agent = createCodingAgent(
       baseConfig({
         goal: { judge: MODEL, maxRuns: 5 },
       }),
     );
-    expect(agent).toBeInstanceOf(Agent);
+    expect(agent.__getGoalConfig()?.prompt).toBe(DEFAULT_GOAL_JUDGE_PROMPT);
+  });
+
+  it('defaults the goal prompt when prompt is explicitly undefined', () => {
+    const agent = createCodingAgent(
+      baseConfig({
+        goal: { judge: MODEL, maxRuns: 5, prompt: undefined },
+      }),
+    );
+    expect(agent.__getGoalConfig()?.prompt).toBe(DEFAULT_GOAL_JUDGE_PROMPT);
   });
 
   it('accepts caller-provided signals and error processors', () => {

--- a/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
+++ b/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { Agent } from '../../agent/agent';
+import { LocalFilesystem, LocalSandbox, Workspace } from '../../workspace';
+import type { PromptContext } from '../index';
+import { buildBasePrompt, createCodingAgent } from '../index';
+
+const MODEL = 'openai/gpt-4o-mini';
+
+function baseConfig(overrides: Partial<Parameters<typeof createCodingAgent>[0]> = {}) {
+  return {
+    id: 'test-coding-agent',
+    name: 'Test Coding Agent',
+    model: MODEL,
+    instructions: 'You are a helpful coding assistant.',
+    tools: {},
+    ...overrides,
+  };
+}
+
+function promptContext(overrides: Partial<PromptContext> = {}): PromptContext {
+  return {
+    projectPath: '/repo',
+    projectName: 'repo',
+    platform: 'darwin',
+    date: '2026-06-30',
+    mode: 'build',
+    toolGuidance: '',
+    ...overrides,
+  };
+}
+
+describe('createCodingAgent', () => {
+  it('returns an Agent', () => {
+    const agent = createCodingAgent(baseConfig());
+    expect(agent).toBeInstanceOf(Agent);
+    expect(agent.id).toBe('test-coding-agent');
+  });
+
+  it('builds a default local workspace when none is provided', async () => {
+    const agent = createCodingAgent(baseConfig());
+    const workspace = await agent.getWorkspace();
+
+    expect(workspace).toBeInstanceOf(Workspace);
+    expect(workspace?.filesystem).toBeInstanceOf(LocalFilesystem);
+    expect(workspace?.sandbox).toBeInstanceOf(LocalSandbox);
+  });
+
+  it('roots the default workspace at workspaceBasePath', async () => {
+    const agent = createCodingAgent(baseConfig({ workspaceBasePath: '/custom/base' }));
+    const workspace = await agent.getWorkspace();
+
+    expect((workspace?.sandbox as LocalSandbox).workingDirectory).toBe('/custom/base');
+  });
+
+  it('builds no default workspace when workspace is explicitly undefined', async () => {
+    const agent = createCodingAgent(baseConfig({ workspace: undefined }));
+    const workspace = await agent.getWorkspace();
+
+    expect(workspace).toBeUndefined();
+  });
+
+  it('uses a caller-provided workspace verbatim', async () => {
+    const custom = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: '/somewhere' }),
+      sandbox: new LocalSandbox({ workingDirectory: '/somewhere' }),
+    });
+
+    const agent = createCodingAgent(baseConfig({ workspace: custom }));
+    const workspace = await agent.getWorkspace();
+
+    expect(workspace).toBe(custom);
+  });
+
+  it('does not throw when goal is configured (prompt defaulted)', () => {
+    const agent = createCodingAgent(
+      baseConfig({
+        goal: { judge: MODEL, maxRuns: 5 },
+      }),
+    );
+    expect(agent).toBeInstanceOf(Agent);
+  });
+
+  it('accepts caller-provided signals and error processors', () => {
+    const agent = createCodingAgent(
+      baseConfig({
+        signals: [],
+        errorProcessors: [],
+      }),
+    );
+    expect(agent).toBeInstanceOf(Agent);
+  });
+});
+
+describe('buildBasePrompt', () => {
+  it('defaults the product name to "Mastra Code"', () => {
+    const prompt = buildBasePrompt(promptContext());
+    expect(prompt).toContain('You are Mastra Code, an interactive CLI coding agent');
+    expect(prompt).toContain('Co-Authored-By: Mastra Code <noreply@mastra.ai>');
+  });
+
+  it('parameterizes productName and coAuthorName', () => {
+    const prompt = buildBasePrompt(promptContext({ productName: 'Acme Coder', coAuthorName: 'Acme Bot' }));
+    expect(prompt).toContain('You are Acme Coder, an interactive CLI coding agent');
+    expect(prompt).toContain('Acme Coder has a goal mode');
+    expect(prompt).toContain('Co-Authored-By: Acme Bot <noreply@mastra.ai>');
+  });
+
+  it('includes the model id in the Co-Authored-By line when provided', () => {
+    const prompt = buildBasePrompt(promptContext({ modelId: 'openai/gpt-4o' }));
+    expect(prompt).toContain('Co-Authored-By: Mastra Code (openai/gpt-4o) <noreply@mastra.ai>');
+  });
+});

--- a/packages/core/src/coding-agent/index.ts
+++ b/packages/core/src/coding-agent/index.ts
@@ -1,0 +1,145 @@
+import { Agent } from '../agent';
+import { DEFAULT_GOAL_JUDGE_PROMPT } from '../agent/goal/objective';
+import type { AgentConfig } from '../agent/types';
+import {
+  isBadRequestError,
+  PrefillErrorHandler,
+  ProviderHistoryCompat,
+  StreamErrorRetryProcessor,
+} from '../processors';
+import { TaskSignalProvider } from '../signals';
+import { LocalFilesystem, LocalSandbox, Workspace } from '../workspace';
+
+export { buildBasePrompt, type PromptContext } from './prompt';
+
+/**
+ * Retry policy for transient network resets (e.g. provider sockets dropping
+ * mid-stream). Applied centrally to every model call via the default
+ * `StreamErrorRetryProcessor` so all modes/subagents benefit from a short wait
+ * before retrying an ECONNRESET. Delay uses exponential backoff:
+ * `initialDelay * 2^retryCount`, capped at `maxDelay`.
+ */
+const ECONNRESET_MAX_RETRIES = 2;
+const ECONNRESET_RETRY_INITIAL_DELAY_MS = 1000;
+const ECONNRESET_RETRY_MAX_DELAY_MS = 30000;
+
+const ECONNRESET_MESSAGE_PATTERN = /econnreset|socket hang up/i;
+
+/**
+ * Matcher for transient network-reset failures. Checks the immediate error for
+ * an `ECONNRESET` code or a `socket hang up` message. Cause-chain traversal is
+ * handled by `StreamErrorRetryProcessor.isRetryableStreamError`, which calls
+ * each matcher at every level of the cause chain.
+ */
+function isECONNRESETError(error: unknown): boolean {
+  if (!error) return false;
+
+  const code = typeof error === 'object' && 'code' in error ? (error as { code?: unknown }).code : undefined;
+  if (typeof code === 'string' && code.toUpperCase() === 'ECONNRESET') return true;
+
+  const message = error instanceof Error ? error.message : undefined;
+  if (typeof message === 'string' && ECONNRESET_MESSAGE_PATTERN.test(message)) return true;
+
+  return false;
+}
+
+/**
+ * Builds the portable default error processors: an ECONNRESET + bad-request
+ * retry policy, prefill-error recovery, and provider-history compatibility.
+ */
+function defaultErrorProcessors(): NonNullable<AgentConfig['errorProcessors']> {
+  return [
+    new StreamErrorRetryProcessor({
+      matchers: [
+        { match: isBadRequestError, maxRetries: 1, delayMs: 2000 },
+        {
+          match: isECONNRESETError,
+          maxRetries: ECONNRESET_MAX_RETRIES,
+          delayMs: ({ retryCount }) =>
+            Math.min(ECONNRESET_RETRY_INITIAL_DELAY_MS * Math.pow(2, retryCount), ECONNRESET_RETRY_MAX_DELAY_MS),
+        },
+      ],
+    }),
+    new PrefillErrorHandler(),
+    new ProviderHistoryCompat(),
+  ];
+}
+
+/**
+ * Builds a portable default workspace from core's local primitives, rooted at
+ * `basePath` (defaults to `process.cwd()`). Used when the caller passes no
+ * `workspace`.
+ */
+function defaultWorkspace(basePath: string): Workspace {
+  return new Workspace({
+    filesystem: new LocalFilesystem({ basePath }),
+    sandbox: new LocalSandbox({ workingDirectory: basePath }),
+  });
+}
+
+/**
+ * Configuration for {@link createCodingAgent}.
+ *
+ * Most fields are passed straight through to the underlying `Agent`. The
+ * factory fills portable defaults for the pieces a coding agent always needs —
+ * a local workspace, the task-list signal provider, network-retry error
+ * processors, and the goal judge prompt — so a caller can get a working coding
+ * agent by supplying only `model`, `instructions`, and `tools`.
+ */
+export interface CreateCodingAgentConfig extends AgentConfig {
+  /**
+   * Base path for the default workspace built when `workspace` is omitted.
+   * @default process.cwd()
+   */
+  workspaceBasePath?: string;
+}
+
+/**
+ * Creates a coding agent as a Mastra {@link Agent}, applying portable defaults
+ * for the workspace, task-list signal, network-retry error processors, and goal
+ * judge prompt.
+ *
+ * Caller-provided values always win:
+ * - `workspace` is used verbatim when provided; otherwise a {@link Workspace}
+ *   backed by {@link LocalFilesystem}/{@link LocalSandbox} rooted at
+ *   `workspaceBasePath` (default `process.cwd()`) is built.
+ * - `signals` is used verbatim when provided; otherwise it defaults to a single
+ *   {@link TaskSignalProvider}.
+ * - `errorProcessors` is used verbatim when provided; otherwise it defaults to
+ *   the ECONNRESET/bad-request retry stack plus prefill + provider-history
+ *   compatibility processors.
+ * - `goal.prompt` defaults to {@link DEFAULT_GOAL_JUDGE_PROMPT} when a goal is
+ *   configured without one.
+ *
+ * @example
+ * ```typescript
+ * import { createCodingAgent } from '@mastra/core/coding-agent';
+ * import { openai } from '@ai-sdk/openai';
+ *
+ * const agent = createCodingAgent({
+ *   id: 'my-coding-agent',
+ *   name: 'My Coding Agent',
+ *   model: openai('gpt-4o'),
+ *   instructions: 'You are a helpful coding assistant.',
+ *   tools: {},
+ * });
+ * ```
+ */
+export function createCodingAgent(config: CreateCodingAgentConfig): Agent {
+  const { workspaceBasePath, workspace: _workspace, signals, errorProcessors, goal, ...rest } = config;
+
+  // Distinguish an absent `workspace` key (build the default) from an explicit
+  // `workspace: undefined` (caller opts out — e.g. when the workspace is wired
+  // elsewhere, such as at a controller/request-context level).
+  const workspace = 'workspace' in config ? config.workspace : defaultWorkspace(workspaceBasePath ?? process.cwd());
+
+  const resolvedGoal = goal ? { prompt: DEFAULT_GOAL_JUDGE_PROMPT, ...goal } : undefined;
+
+  return new Agent({
+    ...rest,
+    workspace,
+    signals: signals ?? [new TaskSignalProvider()],
+    errorProcessors: errorProcessors ?? defaultErrorProcessors(),
+    ...(resolvedGoal ? { goal: resolvedGoal } : {}),
+  });
+}

--- a/packages/core/src/coding-agent/index.ts
+++ b/packages/core/src/coding-agent/index.ts
@@ -91,7 +91,7 @@ export interface CreateCodingAgentConfig extends AgentConfig {
    * Base path for the default workspace built when `workspace` is omitted.
    * @default process.cwd()
    */
-  workspaceBasePath?: string;
+  basePath?: string;
 }
 
 /**
@@ -102,7 +102,7 @@ export interface CreateCodingAgentConfig extends AgentConfig {
  * Caller-provided values always win:
  * - `workspace` is used verbatim when provided; otherwise a {@link Workspace}
  *   backed by {@link LocalFilesystem}/{@link LocalSandbox} rooted at
- *   `workspaceBasePath` (default `process.cwd()`) is built.
+ *   `basePath` (default `process.cwd()`) is built.
  * - `signals` is used verbatim when provided; otherwise it defaults to a single
  *   {@link TaskSignalProvider}.
  * - `errorProcessors` is used verbatim when provided; otherwise it defaults to
@@ -114,26 +114,27 @@ export interface CreateCodingAgentConfig extends AgentConfig {
  * @example
  * ```typescript
  * import { createCodingAgent } from '@mastra/core/coding-agent';
- * import { openai } from '@ai-sdk/openai';
  *
  * const agent = createCodingAgent({
  *   id: 'my-coding-agent',
  *   name: 'My Coding Agent',
- *   model: openai('gpt-4o'),
+ *   model: 'openai/gpt-5',
  *   instructions: 'You are a helpful coding assistant.',
  *   tools: {},
  * });
  * ```
  */
 export function createCodingAgent(config: CreateCodingAgentConfig): Agent {
-  const { workspaceBasePath, workspace: _workspace, signals, errorProcessors, goal, ...rest } = config;
+  const { basePath, workspace: _workspace, signals, errorProcessors, goal, ...rest } = config;
 
   // Distinguish an absent `workspace` key (build the default) from an explicit
   // `workspace: undefined` (caller opts out — e.g. when the workspace is wired
   // elsewhere, such as at a controller/request-context level).
-  const workspace = 'workspace' in config ? config.workspace : defaultWorkspace(workspaceBasePath ?? process.cwd());
+  const workspace = 'workspace' in config ? config.workspace : defaultWorkspace(basePath ?? process.cwd());
 
-  const resolvedGoal = goal ? { prompt: DEFAULT_GOAL_JUDGE_PROMPT, ...goal } : undefined;
+  // Treat an explicit `prompt: undefined` the same as an omitted prompt so the
+  // documented default is preserved.
+  const resolvedGoal = goal ? { ...goal, prompt: goal.prompt ?? DEFAULT_GOAL_JUDGE_PROMPT } : undefined;
 
   return new Agent({
     ...rest,

--- a/packages/core/src/coding-agent/prompt.ts
+++ b/packages/core/src/coding-agent/prompt.ts
@@ -22,12 +22,15 @@ export interface PromptContext {
   productName?: string;
   /** Name used in the commit `Co-Authored-By` line. Default: "Mastra Code". */
   coAuthorName?: string;
+  /** Email used in the commit `Co-Authored-By` line. Default: "noreply@mastra.ai". */
+  coAuthorEmail?: string;
 }
 
 export function buildBasePrompt(ctx: PromptContext): string {
   const commonBinaries = formatCommonBinaries(ctx.commonBinaries);
   const productName = ctx.productName ?? 'Mastra Code';
   const coAuthorName = ctx.coAuthorName ?? 'Mastra Code';
+  const coAuthorEmail = ctx.coAuthorEmail ?? 'noreply@mastra.ai';
 
   return `You are ${productName}, an interactive CLI coding agent that helps users with software engineering tasks.
 
@@ -82,7 +85,7 @@ ${ctx.toolGuidance}
 Don't commit files likely to contain secrets (\`.env\`, \`*.key\`, \`credentials.json\`). Warn if asked.
 
 ## Commits
-Write commit messages that explain WHY, not just WHAT. Match the repo's existing style. Include \`Co-Authored-By: ${coAuthorName}${ctx.modelId ? ` (${ctx.modelId})` : ''} <noreply@mastra.ai>\` in the message body.
+Write commit messages that explain WHY, not just WHAT. Match the repo's existing style. Include \`Co-Authored-By: ${coAuthorName}${ctx.modelId ? ` (${ctx.modelId})` : ''} <${coAuthorEmail}>\` in the message body.
 
 ## Pull Requests
 Use \`gh pr create\`. Include a summary of what changed and a test plan. Word the pull request title/description to explain the entire unit of work being shipped, worded to explain it to someone who doesn't know anything about the work being shipped. Do not add details of fixes that were needed along the way.

--- a/packages/core/src/coding-agent/prompt.ts
+++ b/packages/core/src/coding-agent/prompt.ts
@@ -1,6 +1,10 @@
 /**
- * Base system prompt — shared behavioral instructions for all modes.
+ * Base system prompt — shared behavioral instructions for a coding agent.
  * This is the "brain" that makes the agent a good coding assistant.
+ *
+ * Product-specific strings (the agent's display name and the commit
+ * `Co-Authored-By` name) are parameterized via `productName` / `coAuthorName`
+ * and default to "Mastra Code" so existing callers keep identical output.
  */
 
 export interface PromptContext {
@@ -14,12 +18,18 @@ export interface PromptContext {
   modelId?: string;
   activePlan?: { title: string; plan: string; approvedAt: string } | null;
   toolGuidance: string;
+  /** Display name used in the prompt header. Default: "Mastra Code". */
+  productName?: string;
+  /** Name used in the commit `Co-Authored-By` line. Default: "Mastra Code". */
+  coAuthorName?: string;
 }
 
 export function buildBasePrompt(ctx: PromptContext): string {
   const commonBinaries = formatCommonBinaries(ctx.commonBinaries);
+  const productName = ctx.productName ?? 'Mastra Code';
+  const coAuthorName = ctx.coAuthorName ?? 'Mastra Code';
 
-  return `You are Mastra Code, an interactive CLI coding agent that helps users with software engineering tasks.
+  return `You are ${productName}, an interactive CLI coding agent that helps users with software engineering tasks.
 
 # Environment
 Working directory: ${ctx.projectPath}
@@ -45,7 +55,7 @@ ${ctx.toolGuidance}
 - Identify existing conventions (naming, structure, error handling) and follow them.
 
 ## Goal Mode Awareness
-- Mastra Code has a goal mode for longer-running work. A goal is a persistent objective that the agent continues pursuing across turns until a judge decides the goal is complete, should continue, should pause, or should wait for user input.
+- ${productName} has a goal mode for longer-running work. A goal is a persistent objective that the agent continues pursuing across turns until a judge decides the goal is complete, should continue, should pause, or should wait for user input.
 - Users can start goal mode directly with /goal <objective>. In plan mode, plans submitted with the submit_plan tool may also be started as a goal if the user selects that option in the approval UI.
 - Help users create good goals by making objectives concrete, outcome-focused, verifiable, and bounded. Prefer goals that state the desired end state, relevant constraints, and what proof or verification should be produced.
 - When writing implementation plans, make them goal-ready: structure steps so they can be carried out autonomously after approval, include clear verification criteria, call out risks/blockers, and avoid vague instructions that would leave the goal judge unable to determine completion.
@@ -72,7 +82,7 @@ ${ctx.toolGuidance}
 Don't commit files likely to contain secrets (\`.env\`, \`*.key\`, \`credentials.json\`). Warn if asked.
 
 ## Commits
-Write commit messages that explain WHY, not just WHAT. Match the repo's existing style. Include \`Co-Authored-By: Mastra Code${ctx.modelId ? ` (${ctx.modelId})` : ''} <noreply@mastra.ai>\` in the message body.
+Write commit messages that explain WHY, not just WHAT. Match the repo's existing style. Include \`Co-Authored-By: ${coAuthorName}${ctx.modelId ? ` (${ctx.modelId})` : ''} <noreply@mastra.ai>\` in the message body.
 
 ## Pull Requests
 Use \`gh pr create\`. Include a summary of what changed and a test plan. Word the pull request title/description to explain the entire unit of work being shipped, worded to explain it to someone who doesn't know anything about the work being shipped. Do not add details of fixes that were needed along the way.


### PR DESCRIPTION
## Summary

Adds a reusable `createCodingAgent` factory and a parameterized `buildBasePrompt` under `@mastra/core/coding-agent`, so any project can stand up a coding agent on top of the same defaults MastraCode uses — without copying MastraCode internals or forking its system prompt.

The factory fills portable, per-field-overridable defaults so a caller can get a working coding agent by supplying only `model`, `instructions`, and `tools`:

- **Workspace** — a local filesystem + sandbox rooted at `process.cwd()`. Override with `workspaceBasePath`, pass your own `workspace`, or pass `workspace: undefined` to opt out entirely (e.g. when the workspace is wired at a controller/request level).
- **Task signals** — `TaskSignalProvider`, so the task list persists across turns.
- **Error handling** — retries on `ECONNRESET` (exponential backoff) and bad-request errors, plus prefill and provider-history compatibility processors.
- **Goal judging** — the default goal judge prompt.

`buildBasePrompt` gains optional `productName` / `coAuthorName` parameters (both default to `"Mastra Code"`), so the system prompt can be rebranded without forking it.

MastraCode now consumes the factory and imports `buildBasePrompt` from core directly; its local `prompts/base.ts` is removed. MastraCode passes `workspace: undefined` to opt out of the default workspace, so the controller keeps injecting its GitHub/sandbox-aware workspace at request time (`agent.__setWorkspace` only fires when the agent has no own workspace).

## Key design point

The factory distinguishes an **absent** `workspace` key (build the default) from an **explicit `workspace: undefined`** (opt out). This is what lets a fresh consumer get a working workspace out of the box while MastraCode preserves its controller-level workspace wiring.

## Test plan

- `pnpm build:core` — builds clean
- `pnpm --filter ./packages/core test -- coding-agent` — 10/10 factory tests pass (default workspace, opt-out, signal/error-processor defaults, prompt parameterization)
- `pnpm --filter ./mastracode web:test` — 89 passed / 1 skipped scenario tests
- `pnpm --filter ./mastracode check` — typecheck clean
- `pnpm --filter ./mastracode lint` — lint clean
- System prompt verified byte-identical to pre-change output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes it easier for other projects to reuse Mastra’s “coding agent” by providing a ready-made factory with sensible defaults. It also lets you tweak the agent’s public-facing prompt wording (like “Mastra Code” branding) without changing how the agent works.

## Summary
- Added a reusable `createCodingAgent` factory in `@mastra/core/coding-agent` with portable defaults:
  - workspace rooted at `process.cwd()` (configurable via `basePath`, a provided `workspace`, or by explicitly passing `workspace: undefined` to opt out)
  - `TaskSignalProvider` for persistent task lists
  - default error/retry processing (including `ECONNRESET` and bad-request handling) plus prefill/provider-history compatibility
  - default goal judge prompt initialization
- Added/parameterized `buildBasePrompt` to support branding by accepting optional `productName` and `coAuthorName` (defaulting to `"Mastra Code"`), and to include `coAuthorEmail` with a default of `noreply@mastra.ai`.
- Updated MastraCode to use the shared core factory and to import `buildBasePrompt` from `@mastra/core/coding-agent`; removed MastraCode’s local `prompts/base.ts` and passed `workspace: undefined` so the workspace can still be injected later per request. System prompt output remains byte-identical.
- Added tests for `createCodingAgent` (workspace defaulting/opt-out behavior, goal/judge prompt defaults, and prompt parameterization) and for `buildBasePrompt` output details.
- Exposed a new `@mastra/core/coding-agent` subpath export and added new reference docs for `createCodingAgent` and `buildBasePrompt`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->