### PR TITLE
chore(docs): Improve internal agent hints for linting

### DIFF
--- a/.claude/skills/mastra-docs/SKILL.md
+++ b/.claude/skills/mastra-docs/SKILL.md
@@ -5,7 +5,7 @@ description: Documentation guidelines for Mastra. This skill should be used when
 
 # Mastra Documentation Guidelines
 
-Use this skill when you create or update Mastra docs. Keep the docs clear and consistent. Follow the most specific AGENTS.md for the area you change.
+Use this skill when you create or update Mastra docs. Keep the docs clear and consistent. Follow the most specific AGENTS.md for the area you change. After making your changes to the docs and sidebars, run the linters to check your work.
 
 ## Styleguides
 
@@ -32,3 +32,4 @@ Run these commands in docs/:
 - npm run format - Format files with Prettier
 - npm run lint:remark - Check markdown with Remark
 - npm run lint:vale:ai - Check prose with Vale using the error alert level
+- npm run validate - Check frontmatter values and if all sidebars are valid 

--- a/.claude/skills/mastra-docs/SKILL.md
+++ b/.claude/skills/mastra-docs/SKILL.md
@@ -32,4 +32,4 @@ Run these commands in docs/:
 - npm run format - Format files with Prettier
 - npm run lint:remark - Check markdown with Remark
 - npm run lint:vale:ai - Check prose with Vale using the error alert level
-- npm run validate - Check frontmatter values and if all sidebars are valid 
+- npm run validate - Check frontmatter values and if all sidebars are valid

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -27,4 +27,8 @@ pnpm test:smoke # Smoke tests only desktop
 pnpm test:og # OG image meta tag tests only desktop
 pnpm test:navigation # Navigation tests desktop + tablet + mobile
 
+Linting
+pnpm validate # Check frontmatter values and if all sidebars are valid
+pnpm lint:prose # Check prose with Vale and Remark
+
 Tests live in tests/ helpers in tests/helpers/ and playwright.config.ts starts pnpm serve

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -56,10 +56,10 @@ Before submitting a PR, make sure to:
 
 4. **Verify code examples** - If you've added code examples, test them if possible to ensure they work.
 
-5. **Run linters** to check for style issues:
+5. **Run linters**:
 
    ```shell
-   pnpm run lint:prose
+   pnpm run lint:prose && pnpm run validate
    ```
 
 ## Documentation structure

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,7 +27,7 @@
     "lint:vale": "scripts/vale/bin/vale src/content/en/docs src/content/en/guides src/content/en/reference src/learn/content",
     "lint:vale:ai": "pnpm lint:vale --minAlertLevel=error --output=line",
     "lint:remark": "remark --no-stdout --frail --quiet --ext mdx src/content/en/docs src/content/en/guides src/content/en/reference src/learn/content",
-    "lint:prose": "npm-run-all --parallel lint:vale lint:remark",
+    "lint:prose": "npm-run-all --parallel lint:vale:ai lint:remark",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "test:e2e": "pnpm exec playwright test",


### PR DESCRIPTION
## Description

Improve internal agent hints like AGENTS.md / skill to run linters after making changes to docs and sidebars.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds clearer “after you edit docs” reminders so contributors can quickly catch broken docs and sidebar/frontmatter issues. It updates the lint/validation steps to make the intended checks harder to miss.

### What changed
- Updated `.claude/skills/mastra-docs/SKILL.md` to expand the “Linting” guidance:
  - Added `npm run validate` to check frontmatter values and sidebar validity.
- Updated `docs/AGENTS.md` with a dedicated “Linting” section:
  - `pnpm validate` (frontmatter + sidebar validity)
  - `pnpm lint:prose` (Vale + Remark prose checks)
- Updated `docs/CONTRIBUTING.md` “Testing your changes” checklist:
  - Changed the step to run `pnpm run lint:prose && pnpm run validate`.
- Updated `docs/package.json`:
  - Adjusted `lint:prose` to run `lint:vale:ai` (instead of `lint:vale`) while still running `lint:remark`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->