### PR TITLE
File-based agents: memory.ts convention

### DIFF
--- a/.changeset/fs-agents-deployer.md
+++ b/.changeset/fs-agents-deployer.md
@@ -2,12 +2,13 @@
 '@mastra/deployer': minor
 ---
 
-You can now define agents by file convention instead of registering each one in code: drop a directory under `src/mastra/agents/<name>/`, run a Mastra build/dev, and the agent is bundled and registered onto your Mastra instance automatically. A directory becomes an agent when it has a `config.ts` or `instructions.md`; `tools/*.ts` add tools, `skills/` add skills (a `createSkill()` module, a packaged `SKILL.md` with its `references/`, or a flat `<skill>.md`), and `subagents/<childId>/` (one level deep) add delegatable subagents. Each agent gets a default workspace unless `workspace.ts` / `config.workspace` overrides it, and files committed under `agents/<name>/workspace/` are mirrored into the bundle to seed that workspace at runtime. Projects with no file-based agents are unaffected — the original entry is used unchanged.
+You can now define agents by file convention instead of registering each one in code: drop a directory under `src/mastra/agents/<name>/`, run a Mastra build/dev, and the agent is bundled and registered onto your Mastra instance automatically. A directory becomes an agent when it has a `config.ts` or `instructions.md`; `tools/*.ts` add tools, `skills/` add skills (a `createSkill()` module, a packaged `SKILL.md` with its `references/`, or a flat `<skill>.md`), a `memory.ts` default export supplies the agent's `memory`, and `subagents/<childId>/` (one level deep) add delegatable subagents. Each agent gets a default workspace unless `workspace.ts` / `config.workspace` overrides it, and files committed under `agents/<name>/workspace/` are mirrored into the bundle to seed that workspace at runtime. Projects with no file-based agents are unaffected — the original entry is used unchanged.
 
 ```text
 src/mastra/agents/weather/
   config.ts          # export default agentConfig({ model: 'openai/gpt-4o' })
   instructions.md
+  memory.ts          # export default new Memory()
   tools/get_weather.ts
   workspace/cities.json   # mirrored into the agent's workspace
 ```

--- a/.changeset/proud-zoos-enter.md
+++ b/.changeset/proud-zoos-enter.md
@@ -4,7 +4,7 @@
 
 Added file-based agents: define an agent by file convention under `src/mastra/agents/<name>/` alongside agents created with `new Agent()`.
 
-A directory becomes an agent when it has a `config.ts` or `instructions.md`. The directory name is the agent name. `instructions.md` supplies the instructions, `tools/*.ts` supply tools, and `skills/` supplies skills (a `createSkill()` module, a packaged `SKILL.md` directory, or a flat `<skill>.md`). Each file-based agent also gets a workspace by default (contained filesystem + shell sandbox rooted at a per-agent `workspace/` dir); customize it with a `workspace.ts` default export or `config.workspace`. Both styles register into the same Mastra instance and show up together in Studio, the server, and the bundler.
+A directory becomes an agent when it has a `config.ts` or `instructions.md`. The directory name is the agent name. `instructions.md` supplies the instructions, `tools/*.ts` supply tools, `skills/` supplies skills (a `createSkill()` module, a packaged `SKILL.md` directory, or a flat `<skill>.md`), and a `memory.ts` default export supplies the agent's `memory` (`config.memory` wins if both are set). Each file-based agent also gets a workspace by default (contained filesystem + shell sandbox rooted at a per-agent `workspace/` dir); customize it with a `workspace.ts` default export or `config.workspace`. Both styles register into the same Mastra instance and show up together in Studio, the server, and the bundler.
 
 **Before**
 
@@ -29,6 +29,11 @@ export default agentConfig({
   model: 'openai/gpt-4o',
   // instructions taken from instructions.md, tools from tools/*.ts
 });
+
+// src/mastra/agents/weather/memory.ts
+import { Memory } from '@mastra/memory';
+
+export default new Memory(); // wired in as the agent's memory
 ```
 
 A file-based agent can also declare **subagents** under `agents/<name>/subagents/<childId>/`, using the same directory layout as an agent (`config.ts`, `instructions.md`, `tools/`, `skills/`, `workspace.ts` / `workspace/`). Each subagent is assembled independently and wired into the parent's `agents` map, so the loop exposes it as a delegation tool named after the directory. A subagent's `config.ts` must set a non-empty `description` (build error otherwise), subagents inherit nothing from the parent, and they are one level deep (a nested `subagents/` directory is ignored with a warning). A subagent id colliding with a parent tool key or another subagent id is a build error; an id also present in `config.agents` keeps the `config.agents` entry with a warning.

--- a/docs/src/content/en/docs/agents/file-based-agents.mdx
+++ b/docs/src/content/en/docs/agents/file-based-agents.mdx
@@ -94,6 +94,7 @@ The following table shows the supported file-based agent surface:
 | `agents/<name>/skills/*.ts` | Each default-exported [`createSkill()`](/reference/agents/createSkill), added to the agent `skills`. |
 | `agents/<name>/skills/<skill>/SKILL.md` | A packaged skill. Frontmatter supplies `name` and `description`, the body is the instructions, and files under `references/` are inlined. |
 | `agents/<name>/skills/<skill>.md` | A flat skill. The filename is the skill name and the body is the instructions. |
+| `agents/<name>/memory.ts` | Default export: a [`Memory`](/reference/memory/memory-class) instance used as the agent `memory`. |
 | `agents/<name>/workspace.ts` | Default export: a [`Workspace`](/reference/workspace/workspace-class) for the agent. |
 | `agents/<name>/workspace/` | Seed files mirrored into the agent's default workspace at build time. |
 | `agents/<name>/subagents/<childId>/` | A declared subagent with the same layout as an agent directory. Wired into the parent as a delegation tool named `<childId>`. |
@@ -139,6 +140,18 @@ Add skills to a file-based agent by placing them under `agents/<name>/skills/`. 
 
 Discovered skills merge with any `skills` in `config.ts`. On a name collision, `config.skills` wins and a warning is logged. If `config.skills` is a function, discovered skills are ignored with a warning because they can't be statically merged.
 
+## Add memory
+
+Give a file-based agent [memory](/docs/memory/overview) by adding a `memory.ts` that default-exports a [`Memory`](/reference/memory/memory-class) instance:
+
+```typescript title="src/mastra/agents/weather/memory.ts"
+import { Memory } from '@mastra/memory'
+
+export default new Memory()
+```
+
+The exported instance becomes the agent's `memory`. You can also set `memory` directly in `config.ts`. `config.memory` wins over `memory.ts`, and a warning is logged when both are present. If neither is present, the agent has no memory, which is the default.
+
 ## Add a workspace
 
 When a file-based agent is discovered through `mastra dev` or `mastra build`, it gets a default workspace unless `config.workspace` or `workspace.ts` supplies one. The default workspace uses a contained filesystem and shell sandbox rooted at a per-agent `workspace/` directory in the bundle.
@@ -173,7 +186,7 @@ Seed files are copied into the bundle next to the running server. Commit the sta
 
 ## Add subagents
 
-A file-based agent can declare **subagents**, specialist child agents it can delegate to. Add a `subagents/` directory under the agent, with one directory per subagent. Each subagent directory has the same layout as a top-level agent: `config.ts`, `instructions.md`, `tools/`, `skills/`, `workspace.ts`, and `workspace/`.
+A file-based agent can declare **subagents**, specialist child agents it can delegate to. Add a `subagents/` directory under the agent, with one directory per subagent. Each subagent directory has the same layout as a top-level agent: `config.ts`, `instructions.md`, `tools/`, `skills/`, `memory.ts`, `workspace.ts`, and `workspace/`.
 
 ```text
 src/mastra/agents/
@@ -217,11 +230,12 @@ Naming rules:
 File-based and code-based agents coexist with deterministic rules:
 
 - **Code wins on name collisions:** If an agent name exists in both code and the filesystem, the code-registered agent is kept and a warning is logged.
-- **A folder can hold a code agent:** If `config.ts` exports `new Agent({...})`, that instance is used as-is. Sibling `instructions.md`, `tools/`, `skills/`, `workspace.ts`, and `subagents/` entries are ignored with warnings.
+- **A folder can hold a code agent:** If `config.ts` exports `new Agent({...})`, that instance is used as-is. Sibling `instructions.md`, `tools/`, `skills/`, `memory.ts`, `workspace.ts`, and `subagents/` entries are ignored with warnings.
 - **Instructions:** Dynamic function instructions in `config.ts` win over `instructions.md`. Otherwise, `instructions.md` wins over a static `instructions` string. If neither is present, the build fails for that agent.
 - **Model:** A missing `model` fails the build and names the agent directory.
 - **Tools:** Tools from `tools/*.ts` merge with `config.tools`. On a key collision, `config.tools` wins and a warning is logged. If `config.tools` is a function, discovered tools are ignored with a warning.
 - **Skills:** Skills from `skills/` merge with `config.skills`. On a name collision, `config.skills` wins and a warning is logged. If `config.skills` is a function, discovered skills are ignored with a warning.
+- **Memory:** `config.memory` wins over `memory.ts`, and a warning is logged when both are present. If neither is set, the agent has no memory.
 - **Workspace:** `config.workspace` wins over `workspace.ts`, which wins over the default workspace.
 - **Subagents:** Subagents from `subagents/` merge with `config.agents`. On an id collision, `config.agents` wins and a warning is logged. A subagent id that collides with a tool key, or a duplicate subagent id, is a build error.
 
@@ -254,10 +268,12 @@ export const mastra = new Mastra({
 - [Agents overview](/docs/agents/overview)
 - [Tools](/docs/agents/using-tools)
 - [Skills](/docs/agents/skills)
+- [Memory](/docs/memory/overview)
 - [Supervisor agents](/docs/agents/supervisor-agents)
 - [Workspace](/docs/workspace/overview)
 - [Studio overview](/docs/studio/overview)
 - [`Agent` reference](/reference/agents/agent)
 - [`createTool()` reference](/reference/tools/create-tool)
 - [`createSkill()` reference](/reference/agents/createSkill)
+- [`Memory` reference](/reference/memory/memory-class)
 - [`Workspace` reference](/reference/workspace/workspace-class)

--- a/examples/agent/src/mastra/agents/weather-fs/README.md
+++ b/examples/agent/src/mastra/agents/weather-fs/README.md
@@ -7,7 +7,7 @@ example (which are created with `new Agent()` and exported from
 automatically.
 
 It exercises every file-based capability: config, instructions, tools, skills,
-a default workspace with seed files, and a declared subagent.
+memory, a default workspace with seed files, and a declared subagent.
 
 ## Layout
 
@@ -15,6 +15,7 @@ a default workspace with seed files, and a declared subagent.
 weather-fs/
   config.ts                       # model + config overrides (uses agentConfig() for typing)
   instructions.md                 # the agent instructions
+  memory.ts                       # default-exported Memory instance, wired in as the agent memory
   tools/
     get_weather.ts                # default-exported tool, keyed by filename -> "get_weather"
   skills/
@@ -40,6 +41,7 @@ weather-fs/
 | -------------------------------- | ------------------------------------------------------------------------------- |
 | `config.ts`                      | merged agent config; `id`/`name` default to `weather-fs`.                       |
 | `instructions.md`                | the agent `instructions`.                                                       |
+| `memory.ts`                      | the agent `memory` (default export).                                            |
 | `tools/get_weather.ts`           | a tool keyed `get_weather`.                                                     |
 | `skills/units.md`                | a flat skill named `units`.                                                     |
 | `skills/severe-weather/SKILL.md` | a packaged skill; frontmatter supplies name/description, `references/` inlined. |

--- a/examples/agent/src/mastra/agents/weather-fs/memory.ts
+++ b/examples/agent/src/mastra/agents/weather-fs/memory.ts
@@ -1,0 +1,5 @@
+import { Memory } from '@mastra/memory';
+
+// Default-exported `Memory` instance is wired in as the agent's `memory`.
+// `config.memory` in config.ts would win over this file if both were set.
+export default new Memory();

--- a/packages/core/src/agent/fs-routing/index.test.ts
+++ b/packages/core/src/agent/fs-routing/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { MockMemory } from '../../memory/mock';
 import { RequestContext } from '../../request-context';
 import { createSkill } from '../../skills';
 import type { InlineSkill } from '../../skills/types';
@@ -493,6 +494,68 @@ describe('assembleAgentFromFsEntry', () => {
       expect(Object.keys(agents)).toEqual(['researcher']);
       const researcher = await (agents.researcher as Agent).listAgents();
       expect(Object.keys(researcher)).toEqual([]);
+    });
+  });
+
+  describe('memory', () => {
+    it('wires memory.ts onto the assembled agent', async () => {
+      const memory = new MockMemory();
+      const agent = assembleAgentFromFsEntry({
+        name: 'support',
+        config: { model: 'openai/gpt-4o' },
+        instructionsMd: 'hi',
+        memory,
+      });
+
+      expect(agent.hasOwnMemory()).toBe(true);
+      expect(await agent.getMemory()).toBe(memory);
+    });
+
+    it('config.memory wins over memory.ts and warns', async () => {
+      const onWarn = vi.fn();
+      const fromConfig = new MockMemory();
+      const fromFile = new MockMemory();
+
+      const agent = assembleAgentFromFsEntry(
+        {
+          name: 'support',
+          config: { model: 'openai/gpt-4o', memory: fromConfig },
+          instructionsMd: 'hi',
+          memory: fromFile,
+        },
+        { onWarn },
+      );
+
+      expect(await agent.getMemory()).toBe(fromConfig);
+      expect(onWarn).toHaveBeenCalledWith(expect.stringContaining('config.memory wins'));
+    });
+
+    it('warns and ignores memory.ts when config.ts exports a new Agent()', async () => {
+      const onWarn = vi.fn();
+      const coded = new Agent({
+        id: 'support',
+        name: 'support',
+        instructions: 'Code-defined.',
+        model: 'openai/gpt-4o',
+      });
+      const fromFile = new MockMemory();
+
+      const result = assembleAgentFromFsEntry({ name: 'support', config: coded, memory: fromFile }, { onWarn });
+
+      expect(result).toBe(coded);
+      expect(result.hasOwnMemory()).toBe(false);
+      expect(onWarn).toHaveBeenCalledWith(expect.stringContaining('memory.ts is ignored'));
+    });
+
+    it('leaves the agent without memory when none is provided', async () => {
+      const agent = assembleAgentFromFsEntry({
+        name: 'support',
+        config: { model: 'openai/gpt-4o' },
+        instructionsMd: 'hi',
+      });
+
+      expect(agent.hasOwnMemory()).toBe(false);
+      expect(await agent.getMemory()).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/agent/fs-routing/index.ts
+++ b/packages/core/src/agent/fs-routing/index.ts
@@ -1,4 +1,5 @@
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
+import type { MastraMemory } from '../../memory/memory';
 import type { InlineSkill, SkillInput } from '../../skills/types';
 import { Workspace, LocalFilesystem, LocalSandbox } from '../../workspace';
 import type { AnyWorkspace } from '../../workspace';
@@ -64,6 +65,12 @@ export interface FsAgentEntry {
    */
   workspace?: AnyWorkspace;
   /**
+   * Default export of `agents/<name>/memory.ts`, if present. A `MastraMemory`
+   * instance wired into the assembled agent as its `memory`. `config.memory`
+   * (from `config.ts`) takes precedence on conflict.
+   */
+  memory?: MastraMemory;
+  /**
    * Base path for the convention default workspace. When provided and neither
    * `config.workspace` nor `workspace.ts` supplies one, an FS agent gets a
    * default `Workspace` (a contained `LocalFilesystem` rooted here plus a
@@ -98,6 +105,9 @@ export interface FsAgentEntry {
  *   collision `config.skills` wins (a warning is surfaced via `onWarn`). A
  *   dynamic (function) `config.skills` wins wholesale and discovered skills are
  *   ignored with a warning.
+ * - `memory`: `memory.ts`'s default export is used unless `config.memory` is
+ *   set, in which case `config.memory` wins (a warning is surfaced via
+ *   `onWarn`). Missing both leaves the agent without memory.
  *
  * If `config` is already an `Agent` instance (the author wrote
  * `export default new Agent({...})` in `config.ts`), it is used as-is — no
@@ -113,6 +123,7 @@ export function assembleAgentFromFsEntry(entry: FsAgentEntry, options?: { onWarn
     tools = [],
     skills = [],
     workspace,
+    memory,
     defaultWorkspaceBasePath,
     subagents = [],
   } = entry;
@@ -138,6 +149,11 @@ export function assembleAgentFromFsEntry(entry: FsAgentEntry, options?: { onWarn
         `Agent "${name}": config.ts exports a new Agent(), so agents/${name}/workspace.ts is ignored. Set the workspace in the Agent config instead.`,
       );
     }
+    if (memory !== undefined) {
+      onWarn(
+        `Agent "${name}": config.ts exports a new Agent(), so agents/${name}/memory.ts is ignored. Set the memory in the Agent config instead.`,
+      );
+    }
     if (subagents.length > 0) {
       onWarn(
         `Agent "${name}": config.ts exports a new Agent(), so discovered subagents under agents/${name}/subagents/ are ignored. Set 'agents' in the Agent config instead.`,
@@ -161,6 +177,7 @@ export function assembleAgentFromFsEntry(entry: FsAgentEntry, options?: { onWarn
   const mergedTools = mergeTools(name, tools, config.tools, onWarn);
   const mergedSkills = mergeSkills(name, skills, config.skills, onWarn);
   const mergedWorkspace = mergeWorkspace(name, workspace, config.workspace, defaultWorkspaceBasePath, onWarn);
+  const mergedMemory = mergeMemory(name, memory, config.memory, onWarn);
   const mergedAgents = mergeSubAgents(name, subagents, config.agents, mergedTools, options);
 
   const assembled = {
@@ -171,6 +188,7 @@ export function assembleAgentFromFsEntry(entry: FsAgentEntry, options?: { onWarn
     ...(mergedTools !== undefined ? { tools: mergedTools } : {}),
     ...(mergedSkills !== undefined ? { skills: mergedSkills } : {}),
     ...(mergedWorkspace !== undefined ? { workspace: mergedWorkspace } : {}),
+    ...(mergedMemory !== undefined ? { memory: mergedMemory } : {}),
     ...(mergedAgents !== undefined ? { agents: mergedAgents } : {}),
   } as AgentConfig;
 
@@ -411,4 +429,33 @@ function createDefaultWorkspace(name: string, basePath: string): AnyWorkspace {
     filesystem: new LocalFilesystem({ basePath }),
     sandbox: new LocalSandbox({ workingDirectory: basePath }),
   });
+}
+
+/**
+ * Resolve the memory for a file-based agent.
+ *
+ * Precedence (explicit > convention):
+ * - `config.memory` (from `config.ts`) wins over `memory.ts`. A function
+ *   `config.memory` is carried through wholesale (it is an opaque value).
+ * - Otherwise `memory.ts`'s default export is used.
+ * - Otherwise returns `undefined` (no memory; current behavior).
+ */
+function mergeMemory(
+  name: string,
+  fsMemory: MastraMemory | undefined,
+  configMemory: FsAgentConfig['memory'],
+  onWarn: (message: string) => void,
+): FsAgentConfig['memory'] | undefined {
+  if (configMemory !== undefined) {
+    if (fsMemory !== undefined) {
+      onWarn(`Agent "${name}": memory defined in both config.ts and memory.ts; config.memory wins.`);
+    }
+    return configMemory;
+  }
+
+  if (fsMemory !== undefined) {
+    return fsMemory;
+  }
+
+  return undefined;
 }

--- a/packages/deployer/src/build/fs-routing/codegen.ts
+++ b/packages/deployer/src/build/fs-routing/codegen.ts
@@ -36,6 +36,12 @@ async function emitAgentEntry(
     lines.push(`import ${workspaceIdent} from ${JSON.stringify(agent.workspacePath)};`);
   }
 
+  let memoryIdent: string | undefined;
+  if (agent.memoryPath) {
+    memoryIdent = sanitizeIdentifier(`${agent.name}_memory`, 'memory', idPath);
+    lines.push(`import ${memoryIdent} from ${JSON.stringify(agent.memoryPath)};`);
+  }
+
   for (let t = 0; t < agent.tools.length; t++) {
     const tool = agent.tools[t]!;
     const ident = sanitizeIdentifier(`${agent.name}_${tool.key}`, 'tool', `${idPath}_${t}`);
@@ -105,6 +111,9 @@ async function emitAgentEntry(
   if (workspaceIdent) {
     entryFields.push(`workspace: ${workspaceIdent}`);
   }
+  if (memoryIdent) {
+    entryFields.push(`memory: ${memoryIdent}`);
+  }
   // Default-on parity: every FS agent gets a default workspace (file + shell
   // tools) rooted at a per-agent `workspace/` dir next to the bundle, unless
   // config.ts or workspace.ts supplies one. Assembly applies the explicit >
@@ -118,8 +127,9 @@ async function emitAgentEntry(
 /**
  * Generate the source of a wrapper module that:
  * 1. imports the user's real Mastra entry,
- * 2. imports each discovered `config.ts`, `tools/*.ts`, and `skills/*.ts`
- *    (`createSkill(...)` modules), inlining packaged `SKILL.md` skills,
+ * 2. imports each discovered `config.ts`, `tools/*.ts`, `skills/*.ts`
+ *    (`createSkill(...)` modules), `workspace.ts`, and `memory.ts`, inlining
+ *    packaged `SKILL.md` skills,
  * 3. assembles `Agent` instances via `assembleAgentFromFsEntry`, wiring any
  *    declared `subagents/` into the parent (one level deep),
  * 4. registers them onto the user's `mastra` instance (code-registered agents

--- a/packages/deployer/src/build/fs-routing/discover.ts
+++ b/packages/deployer/src/build/fs-routing/discover.ts
@@ -19,6 +19,8 @@ export interface DiscoveredFsAgent {
   instructionsPath?: string;
   /** Absolute path to `workspace.ts`/`workspace.js`, if present. */
   workspacePath?: string;
+  /** Absolute path to `memory.ts`/`memory.js`, if present. */
+  memoryPath?: string;
   /**
    * Absolute, slash-normalized path to an authored `workspace/` directory of
    * seed files, if present. These are mirrored into the deployed workspace at
@@ -64,6 +66,7 @@ export type DiscoveredFsSkill =
 
 const CONFIG_BASENAMES = ['config.ts', 'config.js'];
 const WORKSPACE_BASENAMES = ['workspace.ts', 'workspace.js'];
+const MEMORY_BASENAMES = ['memory.ts', 'memory.js'];
 const INSTRUCTIONS_BASENAME = 'instructions.md';
 const TOOL_EXTENSIONS = ['.ts', '.js'];
 const SKILL_MODULE_EXTENSIONS = ['.ts', '.js'];
@@ -71,8 +74,8 @@ const SKILL_MD_BASENAME = 'SKILL.md';
 
 /**
  * Presence check that does NOT follow symlinks. Returns `false` for symlinks
- * (and broken links) so a symlinked `config.ts`/`instructions.md`/`workspace.ts`
- * is never inlined or imported into the generated bundle.
+ * (and broken links) so a symlinked `config.ts`/`instructions.md`/`workspace.ts`/
+ * `memory.ts` is never inlined or imported into the generated bundle.
  */
 async function exists(path: string): Promise<boolean> {
   try {
@@ -277,6 +280,7 @@ async function discoverAgentDir(
   }
 
   const workspacePath = await firstExisting(dir, WORKSPACE_BASENAMES);
+  const memoryPath = await firstExisting(dir, MEMORY_BASENAMES);
   const workspaceSeedDir = await directoryExists(join(dir, 'workspace'));
   const tools = await discoverTools(join(dir, 'tools'));
   const skills = await discoverSkills(join(dir, 'skills'));
@@ -288,6 +292,7 @@ async function discoverAgentDir(
     configPath,
     instructionsPath,
     workspacePath,
+    memoryPath,
     workspaceSeedDir,
     tools,
     skills,

--- a/packages/deployer/src/build/fs-routing/fs-routing.test.ts
+++ b/packages/deployer/src/build/fs-routing/fs-routing.test.ts
@@ -20,6 +20,7 @@ afterEach(async () => {
 interface AgentFiles {
   config?: string;
   instructions?: string;
+  memory?: string;
   workspace?: string;
   /** Map of relative path under `workspace/` to seed file content. */
   workspaceSeed?: Record<string, string>;
@@ -37,6 +38,9 @@ async function writeAgentDir(agentDir: string, files: AgentFiles) {
   }
   if (files.instructions !== undefined) {
     await writeFile(join(agentDir, 'instructions.md'), files.instructions);
+  }
+  if (files.memory !== undefined) {
+    await writeFile(join(agentDir, 'memory.ts'), files.memory);
   }
   if (files.workspace !== undefined) {
     await writeFile(join(agentDir, 'workspace.ts'), files.workspace);
@@ -251,6 +255,16 @@ describe('discoverFsAgents', () => {
     expect(agent.configPath).toBeUndefined();
   });
 
+  it('skips a symlinked memory.ts so it is not imported into the bundle', async () => {
+    const secret = join(dir, 'secret-memory.ts');
+    await writeFile(secret, `export default {};`);
+    await writeAgent('weather', { config: `export default { model: 'openai/gpt-4o' };`, instructions: 'hi' });
+    await symlink(secret, join(dir, 'agents', 'weather', 'memory.ts'));
+
+    const agent = (await discoverFsAgents(dir))[0]!;
+    expect(agent.memoryPath).toBeUndefined();
+  });
+
   it('discovers a flat markdown skill, defaulting name to the filename', async () => {
     await writeAgent('weather', {
       config: `export default { model: 'openai/gpt-4o' };`,
@@ -308,6 +322,42 @@ describe('discoverFsAgents', () => {
     });
 
     expect((await discoverFsAgents(dir))[0]!.workspacePath).toBeUndefined();
+  });
+
+  it('discovers memory.ts when present', async () => {
+    await writeAgent('weather', {
+      config: `export default { model: 'openai/gpt-4o' };`,
+      instructions: 'hi',
+      memory: `export default {};`,
+    });
+
+    expect((await discoverFsAgents(dir))[0]!.memoryPath).toMatch(/agents\/weather\/memory\.ts$/);
+  });
+
+  it('leaves memoryPath undefined when there is no memory file', async () => {
+    await writeAgent('weather', {
+      config: `export default { model: 'openai/gpt-4o' };`,
+      instructions: 'hi',
+    });
+
+    expect((await discoverFsAgents(dir))[0]!.memoryPath).toBeUndefined();
+  });
+
+  it('discovers a subagent memory.ts', async () => {
+    await writeAgent('supervisor', {
+      config: `export default { model: 'openai/gpt-4o' };`,
+      instructions: 'hi',
+      subagents: {
+        worker: {
+          config: `export default { model: 'openai/gpt-4o', description: 'worker' };`,
+          instructions: 'hi',
+          memory: `export default {};`,
+        },
+      },
+    });
+
+    const agent = (await discoverFsAgents(dir))[0]!;
+    expect(agent.subagents[0]!.memoryPath).toMatch(/subagents\/worker\/memory\.ts$/);
   });
 
   it('discovers an authored workspace/ seed directory', async () => {
@@ -437,6 +487,38 @@ describe('generateFsAgentsModule', () => {
     expect(source).toMatch(/import workspace_\d+_\w+ from "[^"]*workspace\.ts";/);
     expect(source).toMatch(/workspace: workspace_\d+_\w+/);
     expect(source).toContain('defaultWorkspaceBasePath:');
+  });
+
+  it('imports memory.ts and threads it into the entry when present', async () => {
+    await writeAgent('weather', {
+      config: `export default { model: 'openai/gpt-4o' };`,
+      instructions: 'hi',
+      memory: `export default {};`,
+    });
+    const agents = await discoverFsAgents(dir);
+
+    const source = await generateFsAgentsModule('/project/index.ts', agents);
+    expect(source).toMatch(/import memory_\w+ from "[^"]*memory\.ts";/);
+    expect(source).toMatch(/memory: memory_\w+/);
+  });
+
+  it('imports a subagent memory.ts and threads it into the nested entry', async () => {
+    await writeAgent('supervisor', {
+      config: `export default { model: 'openai/gpt-4o' };`,
+      instructions: 'hi',
+      subagents: {
+        worker: {
+          config: `export default { model: 'openai/gpt-4o', description: 'worker' };`,
+          instructions: 'hi',
+          memory: `export default {};`,
+        },
+      },
+    });
+    const agents = await discoverFsAgents(dir);
+
+    const source = await generateFsAgentsModule('/project/index.ts', agents);
+    expect(source).toMatch(/import memory_\w+ from "[^"]*subagents\/worker\/memory\.ts";/);
+    expect(source).toMatch(/memory: memory_\w+/);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a `memory.ts` file convention to file-system routed agents. A directory `agents/<name>/memory.ts` whose default export is a `Memory` instance is wired into the assembled agent as its `memory`, mirroring the existing `workspace.ts` convention.

```text
src/mastra/agents/support/
  config.ts
  instructions.md
  memory.ts          # export default new Memory({ ... })
```

Running `mastra dev` / `mastra build` produces an `Agent` whose `memory` is the instance exported from `memory.ts`. Projects without `memory.ts` are unchanged.

### Precedence
- `config.memory` (from `config.ts`) wins over `memory.ts`; on conflict a warning is emitted.
- Otherwise `memory.ts`'s default export is used; otherwise no memory.
- If `config.ts` exports a real `new Agent(...)`, `memory.ts` is ignored (with a warning), matching the existing sibling-file behavior.
- Subagents (`subagents/<child>/memory.ts`) support the convention too.

### Changes
- **core**: `memory?` added to `FsAgentEntry`; new `mergeMemory` helper handles precedence in `assembleAgentFromFsEntry`.
- **deployer**: `memory.ts|js` discovered into `DiscoveredFsAgent.memoryPath`; codegen imports the module and emits a `memory` field (recurses for subagents). Symlinked `memory.ts` rejected via the same `lstat`-based check as other config files.
- **docs**: new Memory section + conventions table entry in file-based agents docs.
- **example**: `weather-fs` gains a `memory.ts`.
- **changesets**: extended `@mastra/core` and `@mastra/deployer` entries.

## Test plan
- `pnpm build:core`
- `pnpm --filter ./packages/core exec vitest run src/agent/fs-routing` — 35 passed
- `pnpm --filter ./packages/deployer exec vitest run src/build/fs-routing` — 48 passed
- Memory AIMock scenarios (memory-history, multi-turn, recall-window, thread-switch, working-memory) pass on all engine variants including `fs` — 34 passed

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-8) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change lets file-based agents have a `memory.ts` file, just like they can already have `workspace.ts`. If both `config.ts` and `memory.ts` provide memory, the config wins and a warning is shown so it’s clear what happened.

### What changed
- Added `memory.ts` support to file-routed agents and subagents
- Updated core agent assembly to merge `memory.ts` with `config.memory`
- Added warnings for precedence conflicts and ignored memory on code-defined agents
- Extended deployer discovery/codegen to find, import, and emit `memory.ts`
- Rejected symlinked `memory.ts` files the same way as other config files
- Updated docs and the `weather-fs` example
- Added/updated tests for discovery, bundling, and memory precedence
- Bumped related changesets for `@mastra/core` and `@mastra/deployer`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->