### PR TITLE
feat(core, server, client-js, playground): add 'human-curation' to DatasetItemSource type

### DIFF
--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -85912,7 +85912,7 @@ export type GetDatasetsDatasetIdItems_Response = {
     source?:
       | {
           /** How this item was created */
-          type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+          type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
           /** Reference identifier (e.g., trace id, csv filename) */
           referenceId?: string | undefined;
         }
@@ -86241,7 +86241,7 @@ export type PostDatasetsDatasetIdItems_Body = {
   source?:
     | {
         /** How this item was created */
-        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
         /** Reference identifier (e.g., trace id, csv filename) */
         referenceId?: string | undefined;
       }
@@ -86284,7 +86284,7 @@ export type PostDatasetsDatasetIdItems_Response = {
   source?:
     | {
         /** How this item was created */
-        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
         /** Reference identifier (e.g., trace id, csv filename) */
         referenceId?: string | undefined;
       }
@@ -86603,7 +86603,7 @@ export type PostDatasetsDatasetIdItemsBatch_Body = {
     source?:
       | {
           /** How this item was created */
-          type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+          type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
           /** Reference identifier (e.g., trace id, csv filename) */
           referenceId?: string | undefined;
         }
@@ -86648,7 +86648,7 @@ export type PostDatasetsDatasetIdItemsBatch_Response = {
     source?:
       | {
           /** How this item was created */
-          type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+          type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
           /** Reference identifier (e.g., trace id, csv filename) */
           referenceId?: string | undefined;
         }
@@ -86764,7 +86764,7 @@ export type GetDatasetsDatasetIdItemsItemId_Response = {
   source?:
     | {
         /** How this item was created */
-        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
         /** Reference identifier (e.g., trace id, csv filename) */
         referenceId?: string | undefined;
       }
@@ -87086,7 +87086,7 @@ export type PatchDatasetsDatasetIdItemsItemId_Body = {
   source?:
     | {
         /** How this item was created */
-        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
         /** Reference identifier (e.g., trace id, csv filename) */
         referenceId?: string | undefined;
       }
@@ -87129,7 +87129,7 @@ export type PatchDatasetsDatasetIdItemsItemId_Response = {
   source?:
     | {
         /** How this item was created */
-        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
         /** Reference identifier (e.g., trace id, csv filename) */
         referenceId?: string | undefined;
       }
@@ -87347,7 +87347,7 @@ export type GetDatasetsDatasetIdItemsItemIdVersionsDatasetVersion_Response = {
   source?:
     | {
         /** How this item was created */
-        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+        type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
         /** Reference identifier (e.g., trace id, csv filename) */
         referenceId?: string | undefined;
       }

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -2592,7 +2592,7 @@ export class MastraClientError extends Error {
 // ============================================
 
 export interface DatasetItemSource {
-  type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+  type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
   referenceId?: string;
 }
 

--- a/packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts
+++ b/packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts
@@ -906,5 +906,16 @@ describe('DatasetsInMemory', () => {
       expect(item.source?.type).toBe('candidate-screener');
       expect(item.source?.referenceId).toBe('verdict-123');
     });
+
+    it('source.type accepts human-curation', async () => {
+      const dataset = await storage.createDataset({ name: 'd' });
+      const item = await storage.addItem({
+        datasetId: dataset.id,
+        input: { a: 1 },
+        source: { type: 'human-curation', referenceId: 'curator-456' },
+      });
+      expect(item.source?.type).toBe('human-curation');
+      expect(item.source?.referenceId).toBe('curator-456');
+    });
   });
 });

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -2404,7 +2404,7 @@ export interface DatasetRecord {
 }
 
 export interface DatasetItemSource {
-  type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+  type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
   referenceId?: string;
 }
 

--- a/packages/playground/src/domains/datasets/components/save-as-dataset-item-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/save-as-dataset-item-dialog.tsx
@@ -29,7 +29,7 @@ type SaveAsDatasetItemDialogProps = {
   onClose: () => void;
   level?: SideDialogRootProps['level'];
   source?: {
-    type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
+    type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener' | 'human-curation';
     referenceId?: string;
   };
 };

--- a/packages/server/src/server/schemas/datasets.ts
+++ b/packages/server/src/server/schemas/datasets.ts
@@ -175,7 +175,7 @@ const trajectoryExpectationSchema = z
 const datasetItemSourceSchema = z
   .object({
     type: z
-      .enum(['csv', 'json', 'trace', 'llm', 'experiment-result', 'candidate-screener'])
+      .enum(['csv', 'json', 'trace', 'llm', 'experiment-result', 'candidate-screener', 'human-curation'])
       .describe('How this item was created'),
     referenceId: z.string().optional().describe('Reference identifier (e.g., trace id, csv filename)'),
   })


### PR DESCRIPTION
## Summary

Extends `DatasetItemSource['type']` with `'human-curation'` so curators can add hand-authored dataset items (typed examples, edge cases, regression seeds) with provenance distinct from file upload (`'json'`), model generation (`'llm'`), or auto-materialized candidate-screener output.

The new discriminator lets scorers and curation UIs tell hand-authored seeds apart from other provenance without overloading the meaning of existing source types.

```ts
await mastra.datasets.addItem({
  datasetId,
  input: { question: 'edge case' },
  groundTruth: { answer: '…' },
  source: { type: 'human-curation', referenceId: 'curator-user-id' },
});
```

## Changes

- **`@mastra/core`**: extend `DatasetItemSource['type']` union at `packages/core/src/storage/types.ts:2407`.
- **`@mastra/server`**: extend `datasetItemSourceSchema` Zod enum so the HTTP boundary accepts the new value.
- **`@mastra/client-js`**: mirror enum extension in public `DatasetItemSource` type and regenerate `route-types.generated.ts`.
- **`@internal/playground`**: extend `SaveAsDatasetItemDialog`'s `source.type` prop union.
- **Test**: add `addItems` round-trip assertion for `source.type = 'human-curation'` in `packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts`.

## Out of scope

- Platform-side wiring of `POST /datasets/:id/items` — tracked by MASTRA-4399.
- DDL changes — `source` is stored as JSON, so this is a runtime/type-level change only. No schema migrations required across pg / libsql / mysql / mongodb adapters.

## Verification

- `pnpm vitest run packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts` — 63/63 ✅
- `pnpm --filter ./packages/core check` — ✅
- `tsc --noEmit` clean on `@mastra/server` and `@mastra/client-js` ✅
- `pnpm --filter ./packages/playground typecheck` — ✅

## Pattern reference

Follows the same enum-extension shape as PR #18314 (MASTRA-4383) which added `'candidate-screener'`.

Refs MASTRA-4430.
