### PR TITLE
fix(core): unref scheduler interval to allow Node.js process exit

### DIFF
--- a/.changeset/ten-donuts-itch.md
+++ b/.changeset/ten-donuts-itch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Scripts using Mastra no longer hang after completing their work. The scheduler timer that polls for due schedules previously kept the Node.js event loop alive, preventing process exit even when all work was done. The timer now allows the process to exit naturally.

--- a/packages/core/src/workflows/scheduler/scheduler.test.ts
+++ b/packages/core/src/workflows/scheduler/scheduler.test.ts
@@ -272,6 +272,38 @@ describe('Scheduler', () => {
     expect(scheduler.isRunning).toBe(false);
   });
 
+  it('does not keep the event loop alive after stop (setInterval is unrefed)', async () => {
+    const origSetInterval = globalThis.setInterval;
+    const unref = vi.fn();
+    const setIntervalSpy = vi
+      .spyOn(globalThis, 'setInterval')
+      .mockImplementation((handler: any, ms?: number, ...args: any[]) => {
+        const handle = origSetInterval(handler, ms, ...args);
+        // Replace unref on the real handle with a spy so we can assert it's called
+        const origUnref = handle.unref.bind(handle);
+        handle.unref = () => {
+          unref();
+          return origUnref();
+        };
+        return handle;
+      });
+
+    const { store } = makeStore();
+    const pubsub = new EventEmitterPubSub();
+    const scheduler = new Scheduler({
+      schedulesStore: store,
+      pubsub,
+      config: { tickIntervalMs: 60_000 },
+    });
+
+    await scheduler.start();
+    expect(setIntervalSpy).toHaveBeenCalledOnce();
+    expect(unref).toHaveBeenCalled();
+
+    await scheduler.stop();
+    setIntervalSpy.mockRestore();
+  });
+
   it('skips firing when the target workflow is not registered', async () => {
     const { store } = makeStore();
     const pubsub = new EventEmitterPubSub();

--- a/packages/core/src/workflows/scheduler/scheduler.ts
+++ b/packages/core/src/workflows/scheduler/scheduler.ts
@@ -89,6 +89,14 @@ export class Scheduler extends MastraBase {
           this.logger.error('Scheduler tick crashed', { error: err });
         });
       }, this.#config.tickIntervalMs);
+
+      // Don't keep the process alive just because the scheduler is polling.
+      // The process should be able to exit when all other work is done.
+      // Without .unref(), the setInterval prevents clean shutdown in
+      // scripts that create a Mastra instance (which auto-creates the
+      // notification dispatch workflow with a cron schedule) and exit
+      // after a single agent.generate() call.
+      this.#intervalHandle.unref();
     } catch (err) {
       // Reset state so a future start() can retry. Without this, a failed
       // warm-up tick would leave #started=true with no interval armed and


### PR DESCRIPTION
The scheduler's `setInterval` timer was keeping the Node.js event loop alive. Any script that creates a Mastra instance (which auto-creates a notification dispatch workflow with a cron schedule) and exits after completing its work would hang forever.

Before — script hangs on exit:
```ts
const mastra = new Mastra(...);
const result = await agent.generate(...);
// process never exits here
```

After — process exits naturally:
```ts
const mastra = new Mastra(...);
const result = await agent.generate(...);
// process exits once all work is done
```

Calls `.unref()` on the interval handle. Long-running servers with other active handles (sockets, listeners) are unaffected — `unref()` only prevents the timer from keeping the loop alive, it doesn't stop the timer from firing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a “stuck” issue where Mastra could finish its work but still not let the program close. It does this by making the scheduler’s timer non-blocking, so Node.js can exit normally when there’s nothing else left to do.

### Summary
- Added a changeset for `@mastra/core` documenting the runtime fix.
- Updated the scheduler so its polling interval calls `.unref()`, preventing it from keeping the Node.js event loop alive.
- Added a test to confirm the scheduler unrefs its interval handle and doesn’t block shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->