### PR TITLE
Fix (playground) preserve composer provider/model selection after hydration

### DIFF
--- a/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
@@ -36,11 +36,18 @@ export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) =
 
   const providers = dataProviders?.providers || [];
 
-  // Update local state when agent data changes
+  // Only hydrate from agent defaults while the local picker is still empty.
+  // This avoids clobbering the first manual selection when the initial agent
+  // details query resolves slightly after the user interacts.
   useEffect(() => {
-    setSelectedModel(defaultModel);
-    setSelectedProvider(defaultProvider);
-  }, [defaultModel, defaultProvider]);
+    if (!selectedProvider && defaultProvider) {
+      setSelectedProvider(defaultProvider);
+    }
+
+    if (!selectedModel && defaultModel) {
+      setSelectedModel(defaultModel);
+    }
+  }, [defaultModel, defaultProvider, selectedModel, selectedProvider]);
 
   const currentModelProvider = cleanProviderId(selectedProvider);
 


### PR DESCRIPTION
## Description

Prevents the Studio composer model picker from overwriting the user's first manual provider/model selection when agent details hydrate after the picker has already been used.

This keeps the initial default provider/model behavior intact, but only applies those defaults while the local picker state is still empty.

## Related issue(s)

No linked issue yet. This PR addresses a reproducible Studio bug in the composer hydration flow.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops the app from “changing its mind” after you’ve already picked a model and provider. If the page is still loading and your choice hasn’t been set yet, it can use the defaults—but once you pick something yourself, it leaves it alone.

## Summary
`ComposerModelSwitcher` now hydrates `selectedModel` and `selectedProvider` only when the local picker state is still empty. This preserves the existing default provider/model behavior while preventing agent detail hydration from overwriting a user’s first manual selection.

## Impact
- Fixes the Studio composer selection overwrite bug
- Keeps default hydration behavior intact
- No public API changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->