### PR TITLE
fix: add `.duckdb` and `.duckdb.wal` files to `.gitignore` if no template is passed

### DIFF
--- a/.changeset/good-bobcats-ring.md
+++ b/.changeset/good-bobcats-ring.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Add duckdb files to .gitignore for new projects

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -356,6 +356,8 @@ onlyBuiltDependencies:
       await exec(`echo *.db-* >> .gitignore`);
       await exec(`echo .netlify >> .gitignore`);
       await exec(`echo .vercel >> .gitignore`);
+      await exec(`echo *.duckdb >> .gitignore`);
+      await exec(`echo *.duckdb.wal >> .gitignore`);
     } catch (error) {
       throw new Error(`Failed to create .gitignore: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }


### PR DESCRIPTION
## Description

When no templates are passed, the cli installs packages manually. 
https://github.com/mastra-ai/mastra/blob/0f69865aced225d98eac812e22699dc445ee18cb/packages/cli/src/commands/create/create.ts#L37-L46

And in the process, the `@mastra/duckdb` is installed. But the `.duckdb` and `.duckdb.wal` files are not added to gitignore.
https://github.com/mastra-ai/mastra/blob/0f69865aced225d98eac812e22699dc445ee18cb/packages/cli/src/commands/init/init.ts#L103-L106

## Related issue(s)

fixes #18717 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When someone starts a new Mastra project without picking a template, the CLI now remembers to hide DuckDB’s extra data files from git. That means those automatic database files won’t show up as unwanted changes in the new project.

## Summary
- Updates `createMastraProject` so newly generated `.gitignore` files include DuckDB artifacts:
  - `*.duckdb`
  - `*.duckdb.wal`
- Adds a Changesets entry marking this as a patch release for `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->