### PR TITLE
fix(ci): skip tests when no source files changed

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -105,8 +105,8 @@ jobs:
             || true)
 
           if [ -z "$CHANGED" ]; then
-            echo "No src/ changes detected — running full suite."
-            echo "run_full=true" >> $GITHUB_OUTPUT
+            echo "No source file changes found — skipping unit and E2E test selection."
+            echo "run_full=false" >> $GITHUB_OUTPUT
             echo "test_files=" >> $GITHUB_OUTPUT
             echo "affected_store_tests=false" >> $GITHUB_OUTPUT
             echo "affected_workspace_tests=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,7 +31,7 @@ permissions: {}
 jobs:
   unit-test:
     name: UNIT Test (Shard ${{ matrix.shard }})
-    if: inputs.has_code == 'true'
+    if: inputs.has_code == 'true' && inputs.run_full != 'false'
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -147,7 +147,7 @@ jobs:
 
   e2e-test:
     name: E2E Test (${{ matrix.project }})
-    if: inputs.has_code == 'true'
+    if: inputs.has_code == 'true' && (inputs.run_full != 'false' || inputs.test_files != '')
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -220,23 +220,23 @@ jobs:
       contents: read
 
     steps:
-      - name: Skip tests for non-code changes
-        if: inputs.has_code != 'true'
-        run: echo "No code changes detected; skipping unit and E2E tests."
+      - name: Skip tests when no test selection is needed
+        if: inputs.has_code != 'true' || (inputs.run_full == 'false' && inputs.test_files == '')
+        run: echo "No unit or E2E tests selected; skipping report merge."
 
       - name: Checkout repo
-        if: inputs.has_code == 'true'
+        if: inputs.has_code == 'true' && (inputs.run_full != 'false' || inputs.test_files != '')
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 1
           ref: ${{ inputs.head_sha }}
 
       - name: Setup pnpm and Node.js
-        if: inputs.has_code == 'true'
+        if: inputs.has_code == 'true' && (inputs.run_full != 'false' || inputs.test_files != '')
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Download test results
-        if: inputs.has_code == 'true'
+        if: inputs.has_code == 'true' && (inputs.run_full != 'false' || inputs.test_files != '')
         uses: actions/download-artifact@v6
         with:
           pattern: vitest-blob-*
@@ -244,5 +244,5 @@ jobs:
           merge-multiple: true
 
       - name: Merge reports
-        if: inputs.has_code == 'true'
+        if: inputs.has_code == 'true' && (inputs.run_full != 'false' || inputs.test_files != '')
         run: pnpm vitest --merge-reports --reporter=default --reporter=github-actions --passWithNoTests


### PR DESCRIPTION
This fixes the affected-test fallback for changes that do not touch source files. Previously, when the detector found no `/src/` TypeScript changes, it set `run_full=true`, so docs-only and agent-instruction-only PRs still ran the full unit and workflow E2E path.

Before:
```sh
No src/ changes detected — running full suite.
run_full=true
```

After:
```sh
No source file changes found — skipping unit and E2E test selection.
run_full=false
```

I also gated the reusable test-suite workflow so full unit shards, workflow E2E, and report merging only run when either a full run is selected or affected test files exist.

Tested with:
- `pnpm prettier --check .github/workflows/prebuild.yml .github/workflows/test-suite.yml`
- `git diff --check`
- a small Node assertion script for the expected workflow conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change teaches CI to be smarter about when it runs tests. If a PR only changes docs or agent instructions, it won’t waste time running the big unit and end-to-end test suites anymore.

## Summary
- Updated affected-test detection so “no source-file TypeScript changes” now skips unit/E2E test selection instead of falling back to a full test run.
- Adjusted the reusable test-suite workflow so:
  - unit tests only run when code changes are present and a full run hasn’t been disabled,
  - E2E tests only run when they’re needed by full-run selection or explicit test-file selection,
  - report merging only happens when a full run is selected or test files exist.
- Kept the workflow gating aligned with docs-only and agent-instruction-only PRs so they can bypass unnecessary test work cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->