### PR TITLE
fix(core): createCodingAgent only includes TaskSignalProvider when memory is configured

### DIFF
--- a/.changeset/four-parks-change.md
+++ b/.changeset/four-parks-change.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+`createCodingAgent` now only includes the default `TaskSignalProvider` when `memory` is configured. Previously it always wired `TaskSignalProvider`, whose `TaskStateProcessor` requires a memory-backed thread — causing a hard error in memoryless contexts. The provider is merged into caller-provided signals when memory is present, so custom signal providers don't drop task tracking.

--- a/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
+++ b/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
@@ -99,6 +99,43 @@ describe('createCodingAgent', () => {
     );
     expect(agent).toBeInstanceOf(Agent);
   });
+
+  it('does not include TaskSignalProvider when no memory is configured', () => {
+    const agent = createCodingAgent(baseConfig());
+    const tools = agent.listTools();
+    expect(Object.keys(tools)).not.toContain('task_write');
+    expect(Object.keys(tools)).not.toContain('task_check');
+  });
+
+  it('includes TaskSignalProvider when memory is configured', () => {
+    const memory = {} as any;
+    const agent = createCodingAgent(baseConfig({ memory }));
+    const tools = agent.listTools();
+    expect(Object.keys(tools)).toContain('task_write');
+    expect(Object.keys(tools)).toContain('task_check');
+  });
+
+  it('merges TaskSignalProvider into caller-provided signals when memory is configured', () => {
+    const memory = {} as any;
+    const agent = createCodingAgent(
+      baseConfig({
+        memory,
+        signals: [],
+      }),
+    );
+    const tools = agent.listTools();
+    expect(Object.keys(tools)).toContain('task_write');
+  });
+
+  it('does not add TaskSignalProvider to caller-provided signals when no memory', () => {
+    const agent = createCodingAgent(
+      baseConfig({
+        signals: [],
+      }),
+    );
+    const tools = agent.listTools();
+    expect(Object.keys(tools)).not.toContain('task_write');
+  });
 });
 
 describe('buildBasePrompt', () => {

--- a/packages/core/src/coding-agent/index.ts
+++ b/packages/core/src/coding-agent/index.ts
@@ -103,8 +103,11 @@ export interface CreateCodingAgentConfig extends AgentConfig {
  * - `workspace` is used verbatim when provided; otherwise a {@link Workspace}
  *   backed by {@link LocalFilesystem}/{@link LocalSandbox} rooted at
  *   `basePath` (default `process.cwd()`) is built.
- * - `signals` is used verbatim when provided; otherwise it defaults to a single
- *   {@link TaskSignalProvider}.
+ * - `signals` are merged with a {@link TaskSignalProvider} when `memory` is
+ *   configured; otherwise the caller-provided signals are used verbatim (or
+ *   an empty array when none are provided). This avoids wiring
+ *   {@link TaskSignalProvider} — which requires a memory-backed thread — into
+ *   agents that have no memory.
  * - `errorProcessors` is used verbatim when provided; otherwise it defaults to
  *   the ECONNRESET/bad-request retry stack plus prefill + provider-history
  *   compatibility processors.
@@ -125,12 +128,18 @@ export interface CreateCodingAgentConfig extends AgentConfig {
  * ```
  */
 export function createCodingAgent(config: CreateCodingAgentConfig): Agent {
-  const { basePath, workspace: _workspace, signals, errorProcessors, goal, ...rest } = config;
+  const { basePath, workspace: _workspace, signals, errorProcessors, goal, memory, ...rest } = config;
 
   // Distinguish an absent `workspace` key (build the default) from an explicit
   // `workspace: undefined` (caller opts out — e.g. when the workspace is wired
   // elsewhere, such as at a controller/request-context level).
   const workspace = 'workspace' in config ? config.workspace : defaultWorkspace(basePath ?? process.cwd());
+
+  // TaskSignalProvider needs a memory-backed thread to function. Only include
+  // it when the caller has configured memory; merge it into caller-provided
+  // signals so custom signal providers don't drop task tracking.
+  const taskSignals = memory ? [new TaskSignalProvider()] : [];
+  const resolvedSignals = signals ? [...signals, ...taskSignals] : taskSignals;
 
   // Treat an explicit `prompt: undefined` the same as an omitted prompt so the
   // documented default is preserved.
@@ -138,8 +147,9 @@ export function createCodingAgent(config: CreateCodingAgentConfig): Agent {
 
   return new Agent({
     ...rest,
+    memory,
     workspace,
-    signals: signals ?? [new TaskSignalProvider()],
+    signals: resolvedSignals,
     errorProcessors: errorProcessors ?? defaultErrorProcessors(),
     ...(resolvedGoal ? { goal: resolvedGoal } : {}),
   });


### PR DESCRIPTION
## Summary

`createCodingAgent` previously always wired the default `TaskSignalProvider`, whose `TaskStateProcessor` requires a memory-backed thread (`threadId` + `resourceId`). This caused a hard error in memoryless contexts — e.g. running a coding agent from the CLI or any one-shot invocation without a Mastra memory instance.

Rather than silently swallowing the error in the processor (which would mask real misconfigurations where memory *is* expected but a thread context is missing), this PR makes the decision at **configuration time**: `TaskSignalProvider` is only included when `memory` is present in the `createCodingAgent` config.

### Behavior

- **No memory** → no `TaskSignalProvider` → no throw, no silent degradation. The agent still has full filesystem/sandbox workspace access.
- **Memory configured** → `TaskSignalProvider` is merged in alongside any caller-provided signals, so task tracking is not lost.
- **Memory configured but runtime call missing threadId/resourceId** → the processor still throws (correct usage error).

## Test plan

- [x] `createCodingAgent` does not include task tools (`task_write`, `task_check`) when no memory is configured
- [x] `createCodingAgent` includes task tools when memory is configured
- [x] Caller-provided signals are merged with `TaskSignalProvider` when memory is present
- [x] `TaskSignalProvider` is not added when no memory but custom signals are provided
- [x] Existing `ProcessorRunner` throw test intact (processor still throws for real misconfigurations)
- [x] Typecheck passes
- [x] 163 tests pass across runner, signals, task-state-processor, task-signal-provider, and coding-agent test suites