### PR TITLE
feat(examples): add Dakera persistent memory agent example

### DIFF
--- a/examples/dakera-memory/README.md
+++ b/examples/dakera-memory/README.md
@@ -1,0 +1,79 @@
+# Dakera Persistent Memory with Mastra
+
+A Mastra agent with cross-session memory backed by [Dakera](https://dakera.ai) — a self-hosted, decay-weighted vector memory server.
+
+## What this demonstrates
+
+- **Persistent memory across sessions** — the agent recalls context from prior conversations, even after a process restart.
+- **Decay-weighted recall** — Dakera scores memories by recency, access frequency, and semantic relevance, so important context stays accessible while stale data fades.
+- **Agent-driven memory lifecycle** — the agent decides what to store (via `dakera-store` tool) and when to recall (via `dakera-recall` tool), guided by its system prompt.
+
+## Prerequisites
+
+### 1. Start Dakera
+
+```bash
+docker run -d -p 3300:3300 \
+  -e DAKERA_API_KEY=demo \
+  ghcr.io/dakera-ai/dakera:latest
+```
+
+See [dakera.ai](https://dakera.ai) for more deployment options (bare metal, Kubernetes, etc.).
+
+### 2. Environment variables
+
+```bash
+export OPENAI_API_KEY=sk-your-key
+export DAKERA_API_URL=http://localhost:3300
+export DAKERA_API_KEY=demo         # match DAKERA_API_KEY above
+export DAKERA_AGENT_ID=my-agent   # namespace for stored memories
+```
+
+## Run
+
+```bash
+npm install
+npm run dev
+```
+
+Run it twice — on the second run the agent recalls everything stored during the first run.
+
+## Architecture
+
+The agent uses two lightweight tools:
+
+| Tool | Purpose | Dakera endpoint |
+|------|---------|-----------------|
+| `dakera-recall` | Semantic search over all prior memories | `POST /v1/memory/search` |
+| `dakera-store` | Persist a new memory for future recall | `POST /v1/memory/store` |
+
+The agent's system prompt instructs it when to call each tool, giving it automatic memory behaviour without any hardcoded application logic.
+
+### Files
+
+```
+src/
+├── mastra/
+│   ├── index.ts          # Mastra + Agent setup
+│   └── dakera-tools.ts   # dakeraRecallTool + dakeraStoreTool
+└── index.ts              # Example conversation driver
+```
+
+## Customise
+
+### Use a different LLM
+
+Replace `openai.languageModel('gpt-4o-mini')` in `src/mastra/index.ts` with any Mastra-supported model.
+
+### Multi-user isolation
+
+Pass a `sessionId` in the tool calls to isolate each user's memories. Dakera scopes memories by `agent_id + session_id`, so different users never see each other's data.
+
+### Combine with Mastra's built-in memory
+
+Mastra's thread/message memory and Dakera serve complementary roles:
+
+- **Mastra memory** — recent conversation history within a thread (short-term, structured)
+- **Dakera memory** — semantic long-term memory across all threads and sessions (persistent, decay-weighted)
+
+Both can be active simultaneously.

--- a/examples/dakera-memory/package.json
+++ b/examples/dakera-memory/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dakera-memory-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Mastra agent with Dakera self-hosted persistent memory",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^1.3.22",
+    "@mastra/core": "workspace:*",
+    "ai": "^4.3.16",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.21",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/dakera-memory/src/index.ts
+++ b/examples/dakera-memory/src/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Mastra + Dakera persistent memory example.
+ *
+ * Prerequisites:
+ *   # 1. Start Dakera locally
+ *   docker run -d -p 3300:3300 \
+ *     -e DAKERA_API_KEY=demo \
+ *     ghcr.io/dakera-ai/dakera:latest
+ *
+ *   # 2. Set env vars
+ *   export OPENAI_API_KEY=sk-...
+ *   export DAKERA_API_URL=http://localhost:3300
+ *   export DAKERA_API_KEY=demo
+ *
+ *   # 3. Run
+ *   npm run dev
+ */
+
+import { mastra } from './mastra';
+
+async function main() {
+  const agent = mastra.getAgent('memoryAgent');
+
+  // -----------------------------------------------------------------------
+  // Session 1: user tells the agent their preferences
+  // -----------------------------------------------------------------------
+  console.log('\n=== Session 1 ===\n');
+
+  const r1 = await agent.generate(
+    "Hi! I'm Alice. I'm a backend engineer who loves Rust and hates verbose Java code. " +
+      'I prefer concise, type-safe APIs over fluent builders.',
+  );
+  console.log('Agent:', r1.text, '\n');
+
+  const r2 = await agent.generate(
+    "I'm currently building a distributed key-value store in Rust. " +
+      "The hardest part so far is managing the RAFT consensus log — it's getting complex.",
+  );
+  console.log('Agent:', r2.text, '\n');
+
+  // -----------------------------------------------------------------------
+  // Session 2: fresh conversation — agent should recall Alice's context
+  // -----------------------------------------------------------------------
+  console.log('\n=== Session 2 (new conversation) ===\n');
+
+  const r3 = await agent.generate(
+    "Hey, I need some advice on database indexing strategies for high write throughput.",
+  );
+  console.log('Agent:', r3.text, '\n');
+
+  // The agent should recall that Alice is building a Rust KV store and tailor advice accordingly.
+  // Memories survive across Node.js process restarts — run the script twice to see full recall.
+}
+
+main().catch(console.error);

--- a/examples/dakera-memory/src/mastra/dakera-tools.ts
+++ b/examples/dakera-memory/src/mastra/dakera-tools.ts
@@ -1,0 +1,133 @@
+/**
+ * Dakera memory tools for Mastra agents.
+ *
+ * Dakera (https://dakera.ai) is a self-hosted, decay-weighted vector memory
+ * server. These tools let a Mastra agent store and recall memories from Dakera,
+ * giving agents cross-session, semantically-searchable memory without any cloud
+ * dependency.
+ *
+ * Self-host Dakera:
+ *   docker run -d -p 3300:3300 \
+ *     -e DAKERA_API_KEY=demo \
+ *     ghcr.io/dakera-ai/dakera:latest
+ */
+
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+const DAKERA_URL = process.env.DAKERA_API_URL ?? 'http://localhost:3300';
+const DAKERA_KEY = process.env.DAKERA_API_KEY ?? '';
+const AGENT_ID = process.env.DAKERA_AGENT_ID ?? 'mastra-agent';
+
+function dakeraHeaders(): Record<string, string> {
+  const h: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (DAKERA_KEY) h['Authorization'] = `Bearer ${DAKERA_KEY}`;
+  return h;
+}
+
+/**
+ * Tool: recall relevant memories from Dakera using semantic search.
+ *
+ * The agent calls this tool when it needs context from prior conversations or
+ * stored knowledge. Dakera uses decay-weighted scoring so recently-accessed,
+ * high-importance memories rank higher.
+ */
+export const dakeraRecallTool = createTool({
+  id: 'dakera-recall',
+  description:
+    'Recall relevant memories from long-term storage. Use this when you need context about prior ' +
+    'conversations, user preferences, or domain knowledge that may have been stored in earlier sessions.',
+  inputSchema: z.object({
+    query: z.string().describe('Natural-language description of what you want to recall'),
+    topK: z.number().int().min(1).max(20).optional().default(5).describe('Number of memories to retrieve'),
+    sessionId: z.string().optional().describe('Restrict recall to a specific session'),
+  }),
+  outputSchema: z.object({
+    memories: z.array(
+      z.object({
+        content: z.string(),
+        score: z.number(),
+        id: z.string(),
+      }),
+    ),
+  }),
+  execute: async ({ context }) => {
+    const { query, topK, sessionId } = context;
+    const body: Record<string, unknown> = {
+      agent_id: AGENT_ID,
+      query,
+      top_k: topK ?? 5,
+    };
+    if (sessionId) body['session_id'] = sessionId;
+
+    const resp = await fetch(`${DAKERA_URL}/v1/memory/search`, {
+      method: 'POST',
+      headers: dakeraHeaders(),
+      body: JSON.stringify(body),
+    });
+
+    if (!resp.ok) {
+      console.warn(`[dakera-recall] HTTP ${resp.status}`);
+      return { memories: [] };
+    }
+
+    const data = (await resp.json()) as { memories?: Array<{ memory: { id: string; content: string }; score: number }> };
+    const memories = (data.memories ?? []).map((r) => ({
+      id: r.memory.id,
+      content: r.memory.content,
+      score: r.score,
+    }));
+
+    return { memories };
+  },
+});
+
+/**
+ * Tool: store a new memory in Dakera for future recall.
+ *
+ * The agent calls this after learning something worth remembering — user
+ * preferences, decisions made, facts learned, or key context for future sessions.
+ */
+export const dakeraStoreTool = createTool({
+  id: 'dakera-store',
+  description:
+    'Store a memory in long-term storage for future recall. Use this when you learn something ' +
+    'important about the user, make a decision you should remember, or encounter information ' +
+    'that will be useful in future conversations.',
+  inputSchema: z.object({
+    content: z.string().describe('The memory to store — be specific and self-contained'),
+    sessionId: z.string().optional().describe('Tag this memory with a session ID'),
+    tags: z
+      .array(z.string())
+      .optional()
+      .default([])
+      .describe('Optional tags for categorizing this memory (e.g. ["preference", "decision"])'),
+  }),
+  outputSchema: z.object({
+    id: z.string(),
+    stored: z.boolean(),
+  }),
+  execute: async ({ context }) => {
+    const { content, sessionId, tags } = context;
+    const body: Record<string, unknown> = {
+      content,
+      agent_id: AGENT_ID,
+      tags: tags ?? [],
+    };
+    if (sessionId) body['session_id'] = sessionId;
+
+    const resp = await fetch(`${DAKERA_URL}/v1/memory/store`, {
+      method: 'POST',
+      headers: dakeraHeaders(),
+      body: JSON.stringify(body),
+    });
+
+    if (!resp.ok) {
+      console.warn(`[dakera-store] HTTP ${resp.status}`);
+      return { id: '', stored: false };
+    }
+
+    const data = (await resp.json()) as { memory: { id: string } };
+    return { id: data.memory?.id ?? '', stored: true };
+  },
+});

--- a/examples/dakera-memory/src/mastra/index.ts
+++ b/examples/dakera-memory/src/mastra/index.ts
@@ -1,0 +1,44 @@
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { createOpenAI } from '@ai-sdk/openai';
+import { dakeraRecallTool, dakeraStoreTool } from './dakera-tools';
+
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+/**
+ * A Mastra agent with Dakera-backed persistent memory.
+ *
+ * The agent has two tools:
+ *   - dakera-recall: semantic search across all prior stored memories
+ *   - dakera-store:  persist important context for future sessions
+ *
+ * The system prompt tells the agent when to use each tool so it behaves
+ * like a memory-aware assistant by default.
+ */
+export const memoryAgent = new Agent({
+  name: 'memory-agent',
+  instructions: `You are a helpful assistant with access to persistent long-term memory.
+
+At the START of every conversation:
+1. Call the dakera-recall tool with a summary of the user's first message to retrieve relevant prior context.
+2. If memories are found, briefly acknowledge them so the user knows their history is available.
+
+During the conversation:
+- When the user shares preferences, goals, decisions, or facts about themselves, call dakera-store to persist them.
+- When the user asks about something they've discussed before, call dakera-recall before answering.
+- Be explicit when you're using recalled memories ("Based on what I remember from last time...")
+
+At the END of an important exchange:
+- Store a short summary of any key decisions or context from this session so it is available next time.
+
+Keep stored memories concise and factual. Prefer specific, self-contained statements over vague summaries.`,
+  model: openai.languageModel('gpt-4o-mini'),
+  tools: {
+    dakeraRecall: dakeraRecallTool,
+    dakeraStore: dakeraStoreTool,
+  },
+});
+
+export const mastra = new Mastra({
+  agents: { memoryAgent },
+});


### PR DESCRIPTION
## Summary

Adds a complete, runnable Mastra agent example that gives agents **persistent, cross-session memory** via [Dakera](https://dakera.ai) — a self-hosted, decay-weighted vector memory server.

This fills the gap between Mastra's thread-scoped conversation memory (short-term, per-session) and the kind of long-term memory that survives across sessions, devices, and process restarts.

### What's included

| File | Purpose |
|------|---------|
| `examples/dakera-memory/src/mastra/dakera-tools.ts` | Two Mastra tools wired to Dakera's REST API |
| `examples/dakera-memory/src/mastra/index.ts` | Agent + Mastra setup |
| `examples/dakera-memory/src/index.ts` | Two-session demo script |
| `examples/dakera-memory/README.md` | Full setup guide |

### How it works

The agent has two tools:

```typescript
// Semantic recall — the agent calls this to retrieve relevant prior context
export const dakeraRecallTool = createTool({
  id: 'dakera-recall',
  // ...fetches from POST /v1/memory/search
});

// Persist important context for future sessions
export const dakeraStoreTool = createTool({
  id: 'dakera-store',
  // ...sends to POST /v1/memory/store
});
```

The system prompt instructs the agent to recall context at the start of each conversation and store key learnings at the end — no application-level orchestration needed.

### Complements Mastra's built-in memory

| | Mastra memory | Dakera memory |
|---|---|---|
| **Scope** | Per-thread, per-session | Cross-session, cross-thread |
| **Duration** | Until thread is deleted | Persistent with decay |
| **Retrieval** | Sequential message history | Semantic similarity search |
| **Ranking** | Chronological | Decay-weighted (recency + access) |

Both work simultaneously — Mastra handles the recent context window while Dakera provides deep long-term recall.

### Quick start

```bash
# Start Dakera (self-hosted, no external API)
docker run -d -p 3300:3300 \
  -e DAKERA_API_KEY=demo \
  ghcr.io/dakera-ai/dakera:latest

export OPENAI_API_KEY=sk-...
export DAKERA_API_URL=http://localhost:3300
export DAKERA_API_KEY=demo

cd examples/dakera-memory
npm install && npm run dev
```

Run it twice — on the second run the agent recalls everything stored in the first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds a small demo that helps a Mastra agent remember important things even after you close and reopen it. It saves useful details to a memory server and can look them up later, so the agent can keep learning across separate chats.

## Summary
- Added a complete `examples/dakera-memory` Mastra example for persistent, cross-session memory using Dakera.
- Introduced two tools:
  - `dakera-recall` for semantic search via `POST /v1/memory/search`
  - `dakera-store` for saving memories via `POST /v1/memory/store`
- Added a `memoryAgent` and Mastra setup that instructs the agent to recall context at the start of a chat and store key learnings at the end.
- Added a runnable demo script that shows the memory being reused across two sessions.
- Added setup and usage documentation, including local Dakera Docker instructions and environment variables.
- Added package metadata and scripts for running and building the example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->