### PR TITLE
feat(examples): add Dakera persistent memory agent example

### DIFF
--- a/examples/dakera-memory/README.md
+++ b/examples/dakera-memory/README.md
@@ -1,0 +1,79 @@
+# Dakera Persistent Memory with Mastra
+
+A Mastra agent with cross-session memory backed by [Dakera](https://dakera.ai) — a self-hosted, decay-weighted vector memory server.
+
+## What this demonstrates
+
+- **Persistent memory across sessions** — the agent recalls context from prior conversations, even after a process restart.
+- **Decay-weighted recall** — Dakera scores memories by recency, access frequency, and semantic relevance, so important context stays accessible while stale data fades.
+- **Agent-driven memory lifecycle** — the agent decides what to store (via `dakera-store` tool) and when to recall (via `dakera-recall` tool), guided by its system prompt.
+
+## Prerequisites
+
+### 1. Start Dakera
+
+```bash
+docker run -d -p 3300:3300 \
+  -e DAKERA_API_KEY=demo \
+  ghcr.io/dakera-ai/dakera:latest
+```
+
+See [dakera.ai](https://dakera.ai) for more deployment options (bare metal, Kubernetes, etc.).
+
+### 2. Environment variables
+
+```bash
+export OPENAI_API_KEY=sk-your-key
+export DAKERA_API_URL=http://localhost:3300
+export DAKERA_API_KEY=demo         # match DAKERA_API_KEY above
+export DAKERA_AGENT_ID=my-agent   # namespace for stored memories
+```
+
+## Run
+
+```bash
+npm install
+npm run dev
+```
+
+Run it twice — on the second run the agent recalls everything stored during the first run.
+
+## Architecture
+
+The agent uses two lightweight tools:
+
+| Tool | Purpose | Dakera endpoint |
+|------|---------|-----------------|
+| `dakera-recall` | Semantic search over all prior memories | `POST /v1/memory/search` |
+| `dakera-store` | Persist a new memory for future recall | `POST /v1/memory/store` |
+
+The agent's system prompt instructs it when to call each tool, giving it automatic memory behaviour without any hardcoded application logic.
+
+### Files
+
+```
+src/
+├── mastra/
+│   ├── index.ts          # Mastra + Agent setup
+│   └── dakera-tools.ts   # dakeraRecallTool + dakeraStoreTool
+└── index.ts              # Example conversation driver
+```
+
+## Customise
+
+### Use a different LLM
+
+Replace `openai.languageModel('gpt-4o-mini')` in `src/mastra/index.ts` with any Mastra-supported model.
+
+### Multi-user isolation
+
+Pass a `sessionId` in the tool calls to isolate each user's memories. Dakera scopes memories by `agent_id + session_id`, so different users never see each other's data.
+
+### Combine with Mastra's built-in memory
+
+Mastra's thread/message memory and Dakera serve complementary roles:
+
+- **Mastra memory** — recent conversation history within a thread (short-term, structured)
+- **Dakera memory** — semantic long-term memory across all threads and sessions (persistent, decay-weighted)
+
+Both can be active simultaneously.

--- a/examples/dakera-memory/package.json
+++ b/examples/dakera-memory/package.json
@@ -18,5 +18,8 @@
     "@types/node": "22.19.21",
     "tsx": "catalog:",
     "typescript": "catalog:"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/examples/dakera-memory/package.json
+++ b/examples/dakera-memory/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dakera-memory-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Mastra agent with Dakera self-hosted persistent memory",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^1.3.22",
+    "@mastra/core": "workspace:*",
+    "ai": "^4.3.16",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.21",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/dakera-memory/src/index.ts
+++ b/examples/dakera-memory/src/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Mastra + Dakera persistent memory example.
+ *
+ * Prerequisites:
+ *   # 1. Start Dakera locally
+ *   docker run -d -p 3300:3300 \
+ *     -e DAKERA_API_KEY=demo \
+ *     ghcr.io/dakera-ai/dakera:latest
+ *
+ *   # 2. Set env vars
+ *   export OPENAI_API_KEY=sk-...
+ *   export DAKERA_API_URL=http://localhost:3300
+ *   export DAKERA_API_KEY=demo
+ *
+ *   # 3. Run
+ *   npm run dev
+ */
+
+import { mastra } from './mastra';
+
+async function main() {
+  const agent = mastra.getAgent('memoryAgent');
+
+  // -----------------------------------------------------------------------
+  // Session 1: user tells the agent their preferences
+  // -----------------------------------------------------------------------
+  console.log('\n=== Session 1 ===\n');
+
+  const r1 = await agent.generate(
+    "Hi! I'm Alice. I'm a backend engineer who loves Rust and hates verbose Java code. " +
+      'I prefer concise, type-safe APIs over fluent builders.',
+  );
+  console.log('Agent:', r1.text, '\n');
+
+  const r2 = await agent.generate(
+    "I'm currently building a distributed key-value store in Rust. " +
+      "The hardest part so far is managing the RAFT consensus log — it's getting complex.",
+  );
+  console.log('Agent:', r2.text, '\n');
+
+  // -----------------------------------------------------------------------
+  // Session 2: fresh conversation — agent should recall Alice's context
+  // -----------------------------------------------------------------------
+  console.log('\n=== Session 2 (new conversation) ===\n');
+
+  const r3 = await agent.generate(
+    "Hey, I need some advice on database indexing strategies for high write throughput.",
+  );
+  console.log('Agent:', r3.text, '\n');
+
+  // The agent should recall that Alice is building a Rust KV store and tailor advice accordingly.
+  // Memories survive across Node.js process restarts — run the script twice to see full recall.
+}
+
+main().catch(console.error);

--- a/examples/dakera-memory/src/mastra/dakera-tools.ts
+++ b/examples/dakera-memory/src/mastra/dakera-tools.ts
@@ -19,6 +19,25 @@ const DAKERA_URL = process.env.DAKERA_API_URL ?? 'http://localhost:3300';
 const DAKERA_KEY = process.env.DAKERA_API_KEY ?? '';
 const AGENT_ID = process.env.DAKERA_AGENT_ID ?? 'mastra-agent';
 
+// Zod schemas for Dakera API responses — parse at runtime to catch schema drift early
+const dakeraMemoryItemSchema = z.object({
+  memory: z.object({
+    id: z.string(),
+    content: z.string(),
+  }),
+  score: z.number(),
+});
+
+const dakeraSearchResponseSchema = z.object({
+  memories: z.array(dakeraMemoryItemSchema).default([]),
+});
+
+const dakeraStoreResponseSchema = z.object({
+  memory: z.object({
+    id: z.string(),
+  }),
+});
+
 function dakeraHeaders(): Record<string, string> {
   const h: Record<string, string> = { 'Content-Type': 'application/json' };
   if (DAKERA_KEY) h['Authorization'] = `Bearer ${DAKERA_KEY}`;
@@ -71,8 +90,12 @@ export const dakeraRecallTool = createTool({
       return { memories: [] };
     }
 
-    const data = (await resp.json()) as { memories?: Array<{ memory: { id: string; content: string }; score: number }> };
-    const memories = (data.memories ?? []).map((r) => ({
+    const parsed = dakeraSearchResponseSchema.safeParse(await resp.json());
+    if (!parsed.success) {
+      console.warn('[dakera-recall] Unexpected response shape:', parsed.error.message);
+      return { memories: [] };
+    }
+    const memories = parsed.data.memories.map((r) => ({
       id: r.memory.id,
       content: r.memory.content,
       score: r.score,
@@ -127,7 +150,11 @@ export const dakeraStoreTool = createTool({
       return { id: '', stored: false };
     }
 
-    const data = (await resp.json()) as { memory: { id: string } };
-    return { id: data.memory?.id ?? '', stored: true };
+    const parsed = dakeraStoreResponseSchema.safeParse(await resp.json());
+    if (!parsed.success) {
+      console.warn('[dakera-store] Unexpected response shape:', parsed.error.message);
+      return { id: '', stored: true }; // stored successfully but ID not parseable
+    }
+    return { id: parsed.data.memory.id, stored: true };
   },
 });

--- a/examples/dakera-memory/src/mastra/dakera-tools.ts
+++ b/examples/dakera-memory/src/mastra/dakera-tools.ts
@@ -1,0 +1,133 @@
+/**
+ * Dakera memory tools for Mastra agents.
+ *
+ * Dakera (https://dakera.ai) is a self-hosted, decay-weighted vector memory
+ * server. These tools let a Mastra agent store and recall memories from Dakera,
+ * giving agents cross-session, semantically-searchable memory without any cloud
+ * dependency.
+ *
+ * Self-host Dakera:
+ *   docker run -d -p 3300:3300 \
+ *     -e DAKERA_API_KEY=demo \
+ *     ghcr.io/dakera-ai/dakera:latest
+ */
+
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+const DAKERA_URL = process.env.DAKERA_API_URL ?? 'http://localhost:3300';
+const DAKERA_KEY = process.env.DAKERA_API_KEY ?? '';
+const AGENT_ID = process.env.DAKERA_AGENT_ID ?? 'mastra-agent';
+
+function dakeraHeaders(): Record<string, string> {
+  const h: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (DAKERA_KEY) h['Authorization'] = `Bearer ${DAKERA_KEY}`;
+  return h;
+}
+
+/**
+ * Tool: recall relevant memories from Dakera using semantic search.
+ *
+ * The agent calls this tool when it needs context from prior conversations or
+ * stored knowledge. Dakera uses decay-weighted scoring so recently-accessed,
+ * high-importance memories rank higher.
+ */
+export const dakeraRecallTool = createTool({
+  id: 'dakera-recall',
+  description:
+    'Recall relevant memories from long-term storage. Use this when you need context about prior ' +
+    'conversations, user preferences, or domain knowledge that may have been stored in earlier sessions.',
+  inputSchema: z.object({
+    query: z.string().describe('Natural-language description of what you want to recall'),
+    topK: z.number().int().min(1).max(20).optional().default(5).describe('Number of memories to retrieve'),
+    sessionId: z.string().optional().describe('Restrict recall to a specific session'),
+  }),
+  outputSchema: z.object({
+    memories: z.array(
+      z.object({
+        content: z.string(),
+        score: z.number(),
+        id: z.string(),
+      }),
+    ),
+  }),
+  execute: async ({ context }) => {
+    const { query, topK, sessionId } = context;
+    const body: Record<string, unknown> = {
+      agent_id: AGENT_ID,
+      query,
+      top_k: topK ?? 5,
+    };
+    if (sessionId) body['session_id'] = sessionId;
+
+    const resp = await fetch(`${DAKERA_URL}/v1/memory/search`, {
+      method: 'POST',
+      headers: dakeraHeaders(),
+      body: JSON.stringify(body),
+    });
+
+    if (!resp.ok) {
+      console.warn(`[dakera-recall] HTTP ${resp.status}`);
+      return { memories: [] };
+    }
+
+    const data = (await resp.json()) as { memories?: Array<{ memory: { id: string; content: string }; score: number }> };
+    const memories = (data.memories ?? []).map((r) => ({
+      id: r.memory.id,
+      content: r.memory.content,
+      score: r.score,
+    }));
+
+    return { memories };
+  },
+});
+
+/**
+ * Tool: store a new memory in Dakera for future recall.
+ *
+ * The agent calls this after learning something worth remembering — user
+ * preferences, decisions made, facts learned, or key context for future sessions.
+ */
+export const dakeraStoreTool = createTool({
+  id: 'dakera-store',
+  description:
+    'Store a memory in long-term storage for future recall. Use this when you learn something ' +
+    'important about the user, make a decision you should remember, or encounter information ' +
+    'that will be useful in future conversations.',
+  inputSchema: z.object({
+    content: z.string().describe('The memory to store — be specific and self-contained'),
+    sessionId: z.string().optional().describe('Tag this memory with a session ID'),
+    tags: z
+      .array(z.string())
+      .optional()
+      .default([])
+      .describe('Optional tags for categorizing this memory (e.g. ["preference", "decision"])'),
+  }),
+  outputSchema: z.object({
+    id: z.string(),
+    stored: z.boolean(),
+  }),
+  execute: async ({ context }) => {
+    const { content, sessionId, tags } = context;
+    const body: Record<string, unknown> = {
+      content,
+      agent_id: AGENT_ID,
+      tags: tags ?? [],
+    };
+    if (sessionId) body['session_id'] = sessionId;
+
+    const resp = await fetch(`${DAKERA_URL}/v1/memory/store`, {
+      method: 'POST',
+      headers: dakeraHeaders(),
+      body: JSON.stringify(body),
+    });
+
+    if (!resp.ok) {
+      console.warn(`[dakera-store] HTTP ${resp.status}`);
+      return { id: '', stored: false };
+    }
+
+    const data = (await resp.json()) as { memory: { id: string } };
+    return { id: data.memory?.id ?? '', stored: true };
+  },
+});

--- a/examples/dakera-memory/src/mastra/index.ts
+++ b/examples/dakera-memory/src/mastra/index.ts
@@ -1,0 +1,44 @@
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { createOpenAI } from '@ai-sdk/openai';
+import { dakeraRecallTool, dakeraStoreTool } from './dakera-tools';
+
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+/**
+ * A Mastra agent with Dakera-backed persistent memory.
+ *
+ * The agent has two tools:
+ *   - dakera-recall: semantic search across all prior stored memories
+ *   - dakera-store:  persist important context for future sessions
+ *
+ * The system prompt tells the agent when to use each tool so it behaves
+ * like a memory-aware assistant by default.
+ */
+export const memoryAgent = new Agent({
+  name: 'memory-agent',
+  instructions: `You are a helpful assistant with access to persistent long-term memory.
+
+At the START of every conversation:
+1. Call the dakera-recall tool with a summary of the user's first message to retrieve relevant prior context.
+2. If memories are found, briefly acknowledge them so the user knows their history is available.
+
+During the conversation:
+- When the user shares preferences, goals, decisions, or facts about themselves, call dakera-store to persist them.
+- When the user asks about something they've discussed before, call dakera-recall before answering.
+- Be explicit when you're using recalled memories ("Based on what I remember from last time...")
+
+At the END of an important exchange:
+- Store a short summary of any key decisions or context from this session so it is available next time.
+
+Keep stored memories concise and factual. Prefer specific, self-contained statements over vague summaries.`,
+  model: openai.languageModel('gpt-4o-mini'),
+  tools: {
+    dakeraRecall: dakeraRecallTool,
+    dakeraStore: dakeraStoreTool,
+  },
+});
+
+export const mastra = new Mastra({
+  agents: { memoryAgent },
+});


### PR DESCRIPTION
Closes https://github.com/mastra-ai/mastra/issues/18730

## Summary

Adds a complete, runnable example showing how to give Mastra agents **persistent cross-session memory** via [Dakera](https://dakera.ai) — a self-hosted, decay-weighted vector memory server.

Mastra's built-in `@mastra/memory` is great for in-session context. This example shows the complementary pattern: **long-term memory that survives across sessions, process restarts, and devices**.

### What's included

| File | Purpose |
|------|---------|
| `examples/dakera-memory/src/mastra/dakera-tools.ts` | `dakeraRecallTool` + `dakeraStoreTool` wired to Dakera's REST API |
| `examples/dakera-memory/src/mastra/index.ts` | Mastra agent with memory system prompt + both tools |
| `examples/dakera-memory/src/index.ts` | Two-session demo: store in session 1, recall in session 2 |
| `examples/dakera-memory/package.json` | Dependencies (`@mastra/core`, `zod`) |
| `examples/dakera-memory/README.md` | Full setup guide |

### How it works

```typescript
// Semantic recall — agent calls this to retrieve prior context
export const dakeraRecallTool = createTool({
  id: 'dakera-recall',
  inputSchema: z.object({ query: z.string(), topK: z.number().default(5) }),
  execute: async ({ context }) => {
    const resp = await fetch(`${DAKERA_URL}/v1/memory/search`, {
      method: 'POST',
      body: JSON.stringify({ agent_id: 'mastra-agent', query: context.query, top_k: context.topK }),
    });
    return { memories };
  },
});

// Store — agent writes facts for future sessions
export const dakeraStoreTool = createTool({ id: 'dakera-store', ... });
```

### Quick start

```bash
# Self-host Dakera (single container)
docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest

# Run the example
cd examples/dakera-memory
cp .env.example .env  # fill in LLM key + DAKERA_URL
npm install && npx tsx src/index.ts
```

## Test plan

- [ ] `docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest`
- [ ] `cd examples/dakera-memory && npm install && npx tsx src/index.ts`
- [ ] Confirm session 2 recalls preferences stored in session 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a small “example chat app” that remembers things forever. It uses Dakera (a self-hosted memory database) so Mastra can save what you say in one run and automatically recall it in the next run—even after restarting.

## Summary
- Added `examples/dakera-memory/` demonstrating Mastra + Dakera for persistent, cross-session long-term memory (survives restarts).
- Implemented two Dakera-backed Mastra tools:
  - `dakeraRecallTool` → `POST /v1/memory/search` for semantic recall (with Zod-validated response parsing and graceful failure)
  - `dakeraStoreTool` → `POST /v1/memory/store` for saving memories (with Zod validation and safe failure handling)
- Wired both tools into a `memoryAgent` with a system prompt that:
  - recalls relevant context at the start of conversations
  - stores user preferences/decisions/facts during the chat
- Added a two-session demo (`src/index.ts`) where Session 1 stores user/proj context and Session 2 recalls it in a fresh conversation.
- Included setup docs and run instructions (`README.md`), plus example dependencies and Node 18+ requirement (`package.json`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->