### PR TITLE
Improve gh-triage to support maintainer fixes

### DIFF
--- a/.mastracode/commands/gh-triage.md
+++ b/.mastracode/commands/gh-triage.md
@@ -134,11 +134,12 @@ gh pr view "$PR" --json number,title,state,isDraft,url,author,body,comments,revi
 
 ### PR maintainer-fix checks
 
-For Branch B/C PRs, check once for small maintainer-applicable fixes before finalizing the branch output. Do not modify branches, apply suggestions, resolve conflicts, or run broad checks without explicit user approval.
+For Branch B/C PRs, do this before branch output or `ask_user`. Do not modify branches, apply suggestions, resolve conflicts, or run broad checks without approval.
 
-- [ ] Check merge/conflict status, failing lint/typecheck/format/test checks, and applicable inline suggestions/review nits.
-- [ ] Write concise results to the triage file `Context gathered` and `Evidence` sections, using `None found.` when nothing applies.
-- [ ] If any small low/medium-severity fix-up is found, set `Recommended next step` to `maintainer PR fix-up` and include the matching final `ask_user` option(s).
+- [ ] Check conflicts, failed `statusCheckRollup` lint/typecheck/format/test/CI, and applicable inline suggestions/review nits; ignore unrelated Vercel failures.
+- [ ] If a relevant failure is unclear or stale and the affected package is obvious, run only the narrowest local check needed to confirm it.
+- [ ] Record concise results in `Context gathered` and `Evidence`, using `None found.` when nothing applies.
+- [ ] If a small low/medium-severity fix-up is found, set `Recommended next step` to `maintainer PR fix-up` and include matching final `ask_user` option(s).
 
 ### Repo/history context
 
@@ -201,7 +202,7 @@ Use when exactly one PR clearly closes/fixes the issue, or when the input itself
   - `Post maintainer notes comment`
   - `Post both comments`
   - `Fix conflicts as maintainer, then post maintainer notes` (only if found)
-  - `Fix lint/check failures as maintainer, then post maintainer notes` (only if found)
+  - `Fix lint/CI failures as maintainer, then post maintainer notes` (only if found)
   - `Apply inline suggestions as maintainer, then post maintainer notes` (only if found)
   - `End triage`
 
@@ -218,7 +219,7 @@ Use when multiple PRs clearly close/fix the issue.
 - [ ] Update the triage file, then call `ask_user` with exactly the relevant Branch C options:
   - `Post maintainer notes comment`
   - `Fix conflicts as maintainer, then post maintainer notes` (only if found)
-  - `Fix lint/check failures as maintainer, then post maintainer notes` (only if found)
+  - `Fix lint/CI failures as maintainer, then post maintainer notes` (only if found)
   - `Apply inline suggestions as maintainer, then post maintainer notes` (only if found)
   - `End triage`
 

--- a/.mastracode/commands/gh-triage.md
+++ b/.mastracode/commands/gh-triage.md
@@ -132,6 +132,14 @@ gh api "repos/$OWNER/$REPO/issues/$ISSUE/timeline" --paginate --jq '.[] | select
 gh pr view "$PR" --json number,title,state,isDraft,url,author,body,comments,reviewRequests,reviews,mergeStateStatus,statusCheckRollup,closingIssuesReferences,files
 ```
 
+### PR maintainer-fix checks
+
+For Branch B/C PRs, check once for small maintainer-applicable fixes before finalizing the branch output. Do not modify branches, apply suggestions, resolve conflicts, or run broad checks without explicit user approval.
+
+- [ ] Check merge/conflict status, failing lint/typecheck/format/test checks, and applicable inline suggestions/review nits.
+- [ ] Write concise results to the triage file `Context gathered` and `Evidence` sections, using `None found.` when nothing applies.
+- [ ] If any small low/medium-severity fix-up is found, set `Recommended next step` to `maintainer PR fix-up` and include the matching final `ask_user` option(s).
+
 ### Repo/history context
 
 - [ ] Inspect repo files/history only as needed for severity, scope, routing, or maintainer notes.
@@ -186,13 +194,15 @@ Use when exactly one PR clearly closes/fixes the issue, or when the input itself
 
 - [ ] Immediately update the triage file's `Context gathered` and `Evidence` sections with the PR context findings before writing branch conclusions.
 
-- [ ] Write Branch output with severity/assessment/scope, issue summary, PR relevance, evidence checked, review observations, optional author pre-review, optional maintainer PR fix-up if severity is low/medium and the fix is small, and required maintainer notes to post after any fix-up.
+- [ ] Write Branch output with severity/assessment/scope, issue summary, PR relevance, evidence checked, review observations, PR maintainer-fix check results, optional author pre-review, optional maintainer PR fix-up, and required maintainer notes.
 
-- [ ] Update the triage file, then call `ask_user` with exactly:
+- [ ] Update the triage file, then call `ask_user` with exactly the relevant Branch B options:
   - `Post author pre-review comment`
   - `Post maintainer notes comment`
   - `Post both comments`
-  - `Fix up PR as maintainer, then post maintainer notes` (only if severity is low/medium and the fix is small)
+  - `Fix conflicts as maintainer, then post maintainer notes` (only if found)
+  - `Fix lint/check failures as maintainer, then post maintainer notes` (only if found)
+  - `Apply inline suggestions as maintainer, then post maintainer notes` (only if found)
   - `End triage`
 
 ### Branch C: Multiple linked PRs
@@ -203,11 +213,13 @@ Use when multiple PRs clearly close/fix the issue.
 
 - [ ] Immediately update the triage file's `Context gathered` and `Evidence` sections with each PR context finding before writing comparison conclusions.
 
-- [ ] Write Branch output with severity/assessment/scope, issue summary, PR list, evidence checked, comparison notes, optional maintainer PR fix-up if severity is low/medium and the fix is small, and required maintainer notes to post after any fix-up.
+- [ ] Write Branch output with severity/assessment/scope, issue summary, PR list, evidence checked, comparison notes, PR maintainer-fix check results, optional maintainer PR fix-up, and required maintainer notes.
 
-- [ ] Update the triage file, then call `ask_user` with exactly:
+- [ ] Update the triage file, then call `ask_user` with exactly the relevant Branch C options:
   - `Post maintainer notes comment`
-  - `Fix up PR as maintainer, then post maintainer notes` (only if severity is low/medium and the fix is small)
+  - `Fix conflicts as maintainer, then post maintainer notes` (only if found)
+  - `Fix lint/check failures as maintainer, then post maintainer notes` (only if found)
+  - `Apply inline suggestions as maintainer, then post maintainer notes` (only if found)
   - `End triage`
 
 ### Branch D: No linked PR


### PR DESCRIPTION
## Summary
- Improve `gh-triage` so PR triage gathers maintainer-fix context before the final prompt.
- Record conflicts, failing lint/CI checks, and applicable inline suggestions in the triage file evidence.
- Add final Branch B/C options for maintainers to fix conflicts, lint/CI failures, or inline suggestions when those issues are found.

## Test plan
- Reviewed the updated command text manually.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR makes gh-triage do an extra quick “maintainer help” check for some pull requests before it tells the next step. That way, if there are merge/conflict issues or failing checks that maintainer can fix, the final prompt won’t miss them.

## Summary
- Added a shared **“PR maintainer-fix checks”** step for **Branch B/C** PRs to gather and record:
  - merge/conflict status,
  - failing **statusCheckRollup** checks (lint/typecheck/format/test/CI),
  - applicable inline suggestion/review nits (while ignoring unrelated Vercel failures),
  and to set **Recommended next step** to **maintainer PR fix-up** when a small low/medium fix-up is found.
- Updated **Branch B** to include **PR maintainer-fix check results** in the triage file/branch output and expanded the final `ask_user` options to allow maintainer actions when found:
  - `Fix conflicts as maintainer, then post maintainer notes`
  - `Fix lint/CI failures as maintainer, then post maintainer notes`
  - `Apply inline suggestions as maintainer, then post maintainer notes`
- Updated **Branch C** to include **PR maintainer-fix check results** in branch output and expanded the final `ask_user` options with the same maintainer fix actions (conflicts, lint/CI failures, inline suggestions) when found.
- Kept instructions that edited command text was manually verified and that `git diff --check` was run before committing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->