### PR TITLE
chore(docs): Link remote hosted MCP server

### DIFF
--- a/docs/src/content/en/docs/getting-started/build-with-ai.mdx
+++ b/docs/src/content/en/docs/getting-started/build-with-ai.mdx
@@ -83,7 +83,7 @@ In addition to the [context files](#context-files) each documentation page also 
 
 The `@mastra/mcp-docs-server` package provides direct local access to Mastra’s full documentation via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro). It works with Cursor, Windsurf, Cline, Claude Code, VS Code, Codex or any tool that supports MCP.
 
-These tools are designed to help agents retrieve precise, task-specific information. Whether you're adding a feature to an agent, scaffolding a new project, or exploring how something works.
+These tools are designed to help agents retrieve precise, task-specific information, whether you're adding a feature to an agent, scaffolding a new project, or exploring how something works.
 
 If you're unable to use a local MCP server and need to connect to a remote server, use this URL: `https://mastra.mcp.kapa.ai`. You need to authenticate with your Google Account (only an anonymous ID is transmitted) for rate limiting purposes. If possible, Mastra recommends using a local MCP server for better performance and reliability.
 

--- a/docs/src/content/en/docs/getting-started/build-with-ai.mdx
+++ b/docs/src/content/en/docs/getting-started/build-with-ai.mdx
@@ -85,7 +85,7 @@ The `@mastra/mcp-docs-server` package provides direct local access to Mastra’s
 
 These tools are designed to help agents retrieve precise, task-specific information, whether you're adding a feature to an agent, scaffolding a new project, or exploring how something works.
 
-If you're unable to use a local MCP server and need to connect to a remote server, use this URL: `https://mastra.mcp.kapa.ai`. You need to authenticate with your Google Account (only an anonymous ID is transmitted) for rate limiting purposes. If possible, Mastra recommends using a local MCP server for better performance and reliability.
+If you're unable to use a local MCP server and need to connect to a remote server, use this URL: `https://mastra.mcp.kapa.ai`. You need to authenticate with your Google Account (only an anonymous ID is transmitted) for rate-limiting purposes. If possible, Mastra recommends using a local MCP server for better performance and reliability.
 
 ### Installation
 

--- a/docs/src/content/en/docs/getting-started/build-with-ai.mdx
+++ b/docs/src/content/en/docs/getting-started/build-with-ai.mdx
@@ -81,13 +81,11 @@ In addition to the [context files](#context-files) each documentation page also 
 
 ## MCP docs server
 
-The `@mastra/mcp-docs-server` package provides direct access to Mastra’s full documentation via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro). It works with Cursor, Windsurf, Cline, Claude Code, VS Code, Codex or any tool that supports MCP.
+The `@mastra/mcp-docs-server` package provides direct local access to Mastra’s full documentation via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro). It works with Cursor, Windsurf, Cline, Claude Code, VS Code, Codex or any tool that supports MCP.
 
-These tools are designed to help agents retrieve precise, task-specific information — whether you're adding a feature to an agent, scaffolding a new project, or exploring how something works.
+These tools are designed to help agents retrieve precise, task-specific information. Whether you're adding a feature to an agent, scaffolding a new project, or exploring how something works.
 
-In this guide you'll learn how to add Mastra's MCP server to your AI tooling.
-
-<YouTube id="vciV57lF0og" />
+If you're unable to use a local MCP server and need to connect to a remote server, use this URL: `https://mastra.mcp.kapa.ai`. You need to authenticate with your Google Account (only an anonymous ID is transmitted) for rate limiting purposes. If possible, Mastra recommends using a local MCP server for better performance and reliability.
 
 ### Installation
 


### PR DESCRIPTION
## Description

Link remotely hosted MCP server powered by kapa.ai in our docs

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This change updates the docs so people can use a hosted MCP server instead of only a local one. It also explains how to connect to it and what account info is used, so getting started is easier.

## Summary
- Updated the “MCP docs server” introduction in `docs/src/content/en/docs/getting-started/build-with-ai.mdx`
- Added guidance for using the remote hosted MCP server at `https://mastra.mcp.kapa.ai`
- Clarified authentication/rate-limiting behavior, including that only an anonymous ID is transmitted
- Removed the older intro wording, the standalone “In this guide…” line, and the embedded YouTube block from that section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->