### PR TITLE
chore(docs): Add missing 'id' property to agent constructors

### DIFF
--- a/.claude/skills/mastra-docs/references/STYLEGUIDE.md
+++ b/.claude/skills/mastra-docs/references/STYLEGUIDE.md
@@ -15,6 +15,11 @@ Use this file as the default writing guide for Mastra's documentation.
 
 - When adding a model name or ID to docs, use a placeholder token from docs/src/plugins/remark-model-tokens/models.ts (remark replaces them at docs build time)
 
+## Accuracy
+
+- Ensure that code examples are validated against the available source code
+- When defining an agent through `new Agent()`, ensure that the agent at least has: `id`, `name`, `instructions`, and `model` properties
+
 ## Scope
 
 - Document how to use technologies with Mastra.

--- a/docs/src/content/en/docs/agent-controller/overview.mdx
+++ b/docs/src/content/en/docs/agent-controller/overview.mdx
@@ -65,6 +65,7 @@ import { AgentController } from '@mastra/core/agent-controller'
 import { LibSQLStore } from '@mastra/libsql'
 
 const agent = new Agent({
+  id: 'assistant',
   name: 'assistant',
   instructions: 'Help the user plan and complete tasks.',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/docs/agent-controller/subagents.mdx
+++ b/docs/src/content/en/docs/agent-controller/subagents.mdx
@@ -18,6 +18,7 @@ import { Agent } from '@mastra/core/agent'
 import { AgentController } from '@mastra/core/agent-controller'
 
 const agent = new Agent({
+  id: 'assistant',
   name: 'assistant',
   instructions: 'Use subagents when a focused task needs a narrower toolset.',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/docs/agent-controller/threads-and-state.mdx
+++ b/docs/src/content/en/docs/agent-controller/threads-and-state.mdx
@@ -91,6 +91,7 @@ import { AgentController } from '@mastra/core/agent-controller'
 import { z } from 'zod'
 
 const agent = new Agent({
+  id: 'assistant',
   name: 'assistant',
   instructions: 'Help the user manage a stateful session.',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/docs/agents/channels.mdx
+++ b/docs/src/content/en/docs/agents/channels.mdx
@@ -142,6 +142,7 @@ import { createDiscordAdapter } from '@chat-adapter/discord'
 import { google } from '@ai-sdk/google'
 
 export const visionAgent = new Agent({
+  id: 'vision-agent',
   name: 'Vision Agent',
   instructions: 'You can see images, watch videos, and listen to audio.',
   model: google('gemini-3.1-flash-image-preview'),
@@ -186,14 +187,18 @@ A channel webhook returns a `200` response right away, then the agent runs in th
 On Vercel, pass `waitUntil` from `@vercel/functions`:
 
 ```typescript
+import { Agent } from '@mastra/core/agent'
+import { createSlackAdapter } from '@chat-adapter/slack'
+// highlight-next-line
 import { waitUntil } from '@vercel/functions'
 
 export const agent = new Agent({
-  // ...
+  id: 'agent',
   channels: {
     adapters: {
       slack: createSlackAdapter(),
     },
+    // highlight-next-line
     waitUntil,
   },
 })

--- a/docs/src/content/en/docs/agents/code-mode.mdx
+++ b/docs/src/content/en/docs/agents/code-mode.mdx
@@ -70,6 +70,7 @@ const { tool, instructions } = createCodeMode({
 })
 
 const agent = new Agent({
+  id: 'shop-assistant',
   name: 'shop-assistant',
   instructions: ['You are a helpful shopping assistant.', instructions],
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -128,6 +129,7 @@ const inventory = createCodeMode({
 })
 
 const agent = new Agent({
+  id: 'ops-assistant',
   name: 'ops-assistant',
   instructions: ['You are an ops assistant.', sales.instructions, inventory.instructions],
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/docs/agents/file-based-agents.mdx
+++ b/docs/src/content/en/docs/agents/file-based-agents.mdx
@@ -230,7 +230,7 @@ Naming rules:
 File-based and code-based agents coexist with deterministic rules:
 
 - **Code wins on name collisions:** If an agent name exists in both code and the filesystem, the code-registered agent is kept and a warning is logged.
-- **A folder can hold a code agent:** If `config.ts` exports `new Agent({...})`, that instance is used as-is. Sibling `instructions.md`, `tools/`, `skills/`, `memory.ts`, `workspace.ts`, and `subagents/` entries are ignored with warnings.
+- **A folder can hold a code agent:** If `config.ts` exports a configured `new Agent({ id: 'file-based-agent', ... })`, that instance is used as-is. Sibling `instructions.md`, `tools/`, `skills/`, `memory.ts`, `workspace.ts`, and `subagents/` entries are ignored with warnings.
 - **Instructions:** Dynamic function instructions in `config.ts` win over `instructions.md`. Otherwise, `instructions.md` wins over a static `instructions` string. If neither is present, the build fails for that agent.
 - **Model:** A missing `model` fails the build and names the agent directory.
 - **Tools:** Tools from `tools/*.ts` merge with `config.tools`. On a key collision, `config.tools` wins and a warning is logged. If `config.tools` is a function, discovered tools are ignored with a warning.

--- a/docs/src/content/en/docs/agents/goals.mdx
+++ b/docs/src/content/en/docs/agents/goals.mdx
@@ -38,6 +38,7 @@ Goals require a configured [storage](/docs/memory/storage) backend and a memory-
 import { Agent } from '@mastra/core/agent'
 
 const worker = new Agent({
+  id: 'worker',
   name: 'worker',
   instructions: 'You complete software tasks end to end.',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -78,6 +79,7 @@ By default the step uses a built-in LLM-as-judge scorer that returns `1` when th
 
 ```typescript title="src/mastra/agents/worker.ts"
 const worker = new Agent({
+  id: 'worker',
   name: 'worker',
   instructions: 'You complete software tasks end to end.',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -44,6 +44,7 @@ import { Agent } from '@mastra/core/agent'
 import { ModerationProcessor } from '@mastra/core/processors'
 
 export const moderatedAgent = new Agent({
+  id: 'moderated-agent',
   name: 'moderated-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
@@ -99,6 +100,7 @@ import { Agent } from '@mastra/core/agent'
 import { PrefillErrorHandler, TokenLimiter, ModerationProcessor } from '@mastra/core/processors'
 
 const agent = new Agent({
+  id: 'support-agent',
   name: 'support-agent',
   model: '__GATEWAY_OPENAI_MODEL_BASE__',
   instructions: '...',
@@ -119,7 +121,7 @@ Each array also accepts a function that returns an array, so processors can be b
 
 ```typescript
 new Agent({
-  // ...
+  id: 'processors-agent',
   inputProcessors: ({ requestContext }) => {
     const limit = requestContext.get('tokenLimit') ?? 4000
     return [new TokenLimiter(limit)]
@@ -389,6 +391,7 @@ import { Agent } from '@mastra/core/agent'
 import { TokenLimiter } from '@mastra/core/processors'
 
 const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   model: '__GATEWAY_OPENAI_MODEL__',
   inputProcessors: [new TokenLimiter(127000)],
@@ -461,6 +464,7 @@ import { ResponseCache } from '@mastra/core/processors'
 const cache = new InMemoryServerCache()
 
 export const searchAgent = new Agent({
+  id: 'search-agent',
   name: 'Search Agent',
   instructions: 'You answer questions concisely.',
   model: '__GATEWAY_OPENAI_MODEL_BASE__',
@@ -506,7 +510,7 @@ Override explicitly when you need a different scope:
 
 ```typescript title="src/mastra/agents/scoped-agent.ts"
 new Agent({
-  // ...
+  id: 'processors-agent',
   inputProcessors: [
     new ResponseCache({
       cache,
@@ -530,6 +534,7 @@ import { RedisCache } from '@mastra/redis'
 const cache = new RedisCache({ url: process.env.REDIS_URL })
 
 export const agent = new Agent({
+  id: 'cached-agent',
   name: 'Cached Agent',
   instructions: '...',
   model: '__GATEWAY_OPENAI_MODEL_BASE__',
@@ -629,6 +634,7 @@ import { EnsureFinalResponseProcessor } from '../processors/ensure-final-respons
 const MAX_STEPS = 5
 
 const agent = new Agent({
+  id: 'agent',
   instructions: `You are a helpful assistant.
 
 Some messages you receive may contain <system-reminder>...</system-reminder> tags.

--- a/docs/src/content/en/docs/agents/supervisor-agents.mdx
+++ b/docs/src/content/en/docs/agents/supervisor-agents.mdx
@@ -371,6 +371,7 @@ Each subagent should have a clear `description` that explains what it does, what
 
 ```typescript
 const supervisor = new Agent({
+  id: 'supervisor',
   instructions: `You coordinate research and writing tasks.
 
 Available resources:

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -260,6 +260,7 @@ Use `hooks` to run custom logic before and after every tool call an agent makes.
 import { Agent } from '@mastra/core/agent'
 
 export const supportAgent = new Agent({
+  id: 'support-agent',
   name: 'support-agent',
   instructions: 'Help users with their questions.',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -280,6 +281,7 @@ export const supportAgent = new Agent({
 
 ```typescript
 const guardedAgent = new Agent({
+  id: 'guarded-agent',
   name: 'guarded-agent',
   instructions: 'Run shell commands for the user.',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -416,6 +418,7 @@ Subagents and workflows follow the same pattern. They're converted to tools with
 
 ```typescript
 const orchestrator = new Agent({
+  id: 'orchestrator',
   agents: {
     weather: weatherAgent, // toolName: "agent-weather"
   },

--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -195,6 +195,7 @@ Use the `editor` field on a code-defined agent to control which fields the edito
 import { Agent } from '@mastra/core/agent'
 
 export const supportAgent = new Agent({
+  id: 'support-agent',
   name: 'support-agent',
   model: '__GATEWAY_OPENAI_MODEL__',
   editor: { instructions: true, tools: { description: true } },

--- a/docs/src/content/en/docs/evals/overview.mdx
+++ b/docs/src/content/en/docs/evals/overview.mdx
@@ -43,6 +43,7 @@ import { Agent } from '@mastra/core/agent'
 import { createAnswerRelevancyScorer, createToxicityScorer } from '@mastra/evals/scorers/prebuilt'
 
 export const evaluatedAgent = new Agent({
+  id: 'evaluated-agent',
   scorers: {
     relevancy: {
       scorer: createAnswerRelevancyScorer({ model: '__GATEWAY_OPENAI_MODEL_MINI__' }),

--- a/docs/src/content/en/docs/evals/quick-checks.mdx
+++ b/docs/src/content/en/docs/evals/quick-checks.mdx
@@ -107,6 +107,7 @@ import { Agent } from '@mastra/core/agent'
 import { checks } from '@mastra/evals/checks'
 
 export const weatherAgent = new Agent({
+  id: 'weather-agent',
   name: 'Weather Agent',
   instructions: 'Answer weather questions using the get_weather tool.',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/docs/memory/memory-processors.mdx
+++ b/docs/src/content/en/docs/memory/memory-processors.mdx
@@ -259,6 +259,7 @@ const contentBlocker = {
 }
 
 const agent = new Agent({
+  id: 'safe-agent',
   name: 'safe-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -298,6 +299,7 @@ const inputValidator = {
 }
 
 const agent = new Agent({
+  id: 'validated-agent',
   name: 'validated-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -21,6 +21,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
@@ -73,6 +74,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
@@ -212,6 +214,7 @@ const memory = new Memory({
 })
 
 export const agent = new Agent({
+  id: 'assistant',
   name: 'assistant',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
@@ -297,6 +300,7 @@ If your Observer model is text-only or its API rejects multimodal input, set `ob
 
 ```typescript
 new Agent({
+  id: 'assistant',
   name: 'assistant',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',

--- a/docs/src/content/en/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/en/docs/memory/semantic-recall.mdx
@@ -145,6 +145,7 @@ The following options control semantic recall behavior:
 
 ```typescript {5-9}
 const agent = new Agent({
+  id: 'agent',
   memory: new Memory({
     options: {
       semanticRecall: {
@@ -170,6 +171,7 @@ The `filter` option restricts semantic recall results to messages with matching 
 
 ```typescript {5-10}
 const agent = new Agent({
+  id: 'agent',
   memory: new Memory({
     options: {
       semanticRecall: {
@@ -236,6 +238,7 @@ import { Agent } from '@mastra/core/agent'
 import { ModelRouterEmbeddingModel } from '@mastra/core/llm'
 
 const agent = new Agent({
+  id: 'agent',
   memory: new Memory({
     embedder: new ModelRouterEmbeddingModel('openai/text-embedding-3-small'),
     options: {
@@ -257,6 +260,7 @@ import { Memory } from '@mastra/memory'
 import { ModelRouterEmbeddingModel } from '@mastra/core/llm'
 
 const agent = new Agent({
+  id: 'agent',
   memory: new Memory({
     embedder: new ModelRouterEmbeddingModel({
       providerId: 'openrouter',
@@ -278,6 +282,7 @@ import { Agent } from '@mastra/core/agent'
 import { ModelRouterEmbeddingModel } from '@mastra/core/llm'
 
 const agent = new Agent({
+  id: 'agent',
   memory: new Memory({
     embedder: new ModelRouterEmbeddingModel('openai/text-embedding-3-small'),
   }),
@@ -300,6 +305,7 @@ import { Agent } from '@mastra/core/agent'
 import { fastembed } from '@mastra/fastembed'
 
 const agent = new Agent({
+  id: 'agent',
   memory: new Memory({
     embedder: fastembed,
   }),

--- a/docs/src/content/en/docs/observability/integrations/exporters/langfuse.mdx
+++ b/docs/src/content/en/docs/observability/integrations/exporters/langfuse.mdx
@@ -225,6 +225,7 @@ const exporter = new LangfuseExporter()
 const prompt = await exporter.client.prompt.get('customer-support', { type: 'text' })
 
 export const supportAgent = new Agent({
+  id: 'support-agent',
   name: 'support-agent',
   instructions: prompt.compile(), // Use the prompt text from Langfuse
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/guides/migrations/agentnetwork.mdx
+++ b/docs/src/content/en/guides/migrations/agentnetwork.mdx
@@ -97,6 +97,7 @@ import { Memory } from '@mastra/memory'
 const memory = new Memory()
 
 const agent = new Agent({
+  id: 'agent-network',
   name: 'agent-network',
   agents: { agent1, agent2 },
   workflows: { workflow1 },

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
@@ -294,6 +294,7 @@ To migrate, move processor configuration from Memory to Agent using `inputProces
   });
 
   const agent = new Agent({
+    id: 'agent',
     memory,
 +   inputProcessors: [
 +     new TokenLimiter({ limit: 4000 }), // Limits historical messages to fit context window

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/voice.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/voice.mdx
@@ -17,6 +17,7 @@ To migrate, update configuration property names when configuring agents with voi
 
 ```diff
   const agent = new Agent({
+    id: 'agent',
     voice: {
 -     speakProvider: murfVoice,
 -     listenProvider: deepgramVoice,

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -762,14 +762,14 @@ Returns an `AgentThreadSubscription` object with these members:
   {
     name: 'id',
     type: 'string',
-    isOptional: true,
-    description: 'Unique identifier for the agent. Defaults to `name` if not provided.',
+    isOptional: false,
+    description: 'Unique identifier for the agent.',
   },
   {
     name: 'name',
     type: 'string',
     isOptional: false,
-    description: 'Display name for the agent. Used as the identifier if `id` is not provided.',
+    description: 'Display name for the agent.',
   },
   {
     name: 'description',
@@ -958,6 +958,7 @@ Use `hooks` to run logic around every tool call the agent makes, including assig
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'support-agent',
   name: 'support-agent',
   instructions: 'Help users with their questions.',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -139,6 +139,7 @@ import { createDiscordAdapter } from '@chat-adapter/discord'
 import { createSlackAdapter } from '@chat-adapter/slack'
 
 const agent = new Agent({
+  id: 'example',
   name: 'Example',
   instructions: '...',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -262,6 +263,7 @@ import { Agent } from '@mastra/core/agent'
 import { createSlackAdapter } from '@chat-adapter/slack'
 
 const agent = new Agent({
+  id: 'streaming-agent',
   name: 'Streaming Agent',
   instructions: '...',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -293,6 +295,7 @@ import { defaultTypingStatus } from '@mastra/core/channels'
 import { createDiscordAdapter } from '@chat-adapter/discord'
 
 const agent = new Agent({
+  id: 'custom-typing-agent',
   name: 'Custom Typing Agent',
   instructions: '...',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -325,6 +328,7 @@ import { Agent } from '@mastra/core/agent'
 import { createSlackAdapter } from '@chat-adapter/slack'
 
 const agent = new Agent({
+  id: 'custom-handler-agent',
   name: 'Custom Handler Agent',
   instructions: '...',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -387,6 +391,7 @@ import { Agent } from '@mastra/core/agent'
 import { createSlackAdapter } from '@chat-adapter/slack'
 
 const agent = new Agent({
+  id: 'sso-agent',
   name: 'SSO Agent',
   instructions: '...',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/evals/hallucination.mdx
+++ b/docs/src/content/en/reference/evals/hallucination.mdx
@@ -213,6 +213,7 @@ const hallucinationScorer = createHallucinationScorer({
 })
 
 const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   model: '__GATEWAY_OPENAI_MODEL__',
   instructions: 'You are a helpful assistant.',

--- a/docs/src/content/en/reference/evals/prompt-alignment.mdx
+++ b/docs/src/content/en/reference/evals/prompt-alignment.mdx
@@ -267,6 +267,7 @@ Measure how well your AI agents follow user instructions:
 
 ```typescript
 const agent = new Agent({
+  id: 'coding-assistant',
   name: 'CodingAssistant',
   instructions: 'You are a helpful coding assistant. Always provide working code examples.',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -19,6 +19,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'test-agent',
   name: 'test-agent',
   instructions: 'You are an agent with memory.',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -19,6 +19,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
@@ -485,6 +486,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
@@ -514,6 +516,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
@@ -543,6 +546,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -564,6 +568,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -593,6 +598,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'health-assistant',
   name: 'health-assistant',
   instructions: 'You are a health and wellness assistant.',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -636,6 +642,7 @@ import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
@@ -970,6 +977,7 @@ const om = new ObservationalMemory({
 })
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',

--- a/docs/src/content/en/reference/observability/tracing/exporters/langfuse.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/langfuse.mdx
@@ -172,6 +172,7 @@ const exporter = new LangfuseExporter()
 const prompt = await exporter.client.prompt.get('customer-support', { type: 'text' })
 
 const agent = new Agent({
+  id: 'support-agent',
   name: 'support-agent',
   instructions: prompt.compile(),
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/batch-parts-processor.mdx
+++ b/docs/src/content/en/reference/processors/batch-parts-processor.mdx
@@ -101,6 +101,7 @@ import { Agent } from '@mastra/core/agent'
 import { BatchPartsProcessor } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'batched-agent',
   name: 'batched-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/cost-guard-processor.mdx
+++ b/docs/src/content/en/reference/processors/cost-guard-processor.mdx
@@ -62,6 +62,7 @@ costGuard.onViolation = ({ detail }) => {
 }
 
 const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   model: '__GATEWAY_OPENAI_MODEL_NANO__',
   processors: {

--- a/docs/src/content/en/reference/processors/message-history-processor.mdx
+++ b/docs/src/content/en/reference/processors/message-history-processor.mdx
@@ -96,6 +96,7 @@ const storage = new PostgresStorage({
 })
 
 export const agent = new Agent({
+  id: 'memory-agent',
   name: 'memory-agent',
   instructions: 'You are a helpful assistant with conversation memory',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/moderation-processor.mdx
+++ b/docs/src/content/en/reference/processors/moderation-processor.mdx
@@ -152,6 +152,7 @@ import { Agent } from '@mastra/core/agent'
 import { ModerationProcessor } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'moderated-agent',
   name: 'moderated-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -177,6 +178,7 @@ import { Agent } from '@mastra/core/agent'
 import { BatchPartsProcessor, ModerationProcessor } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'output-moderated-agent',
   name: 'output-moderated-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/pii-detector.mdx
+++ b/docs/src/content/en/reference/processors/pii-detector.mdx
@@ -160,6 +160,7 @@ import { Agent } from '@mastra/core/agent'
 import { PIIDetector } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'private-agent',
   name: 'private-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -188,6 +189,7 @@ import { Agent } from '@mastra/core/agent'
 import { BatchPartsProcessor, PIIDetector } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'output-pii-agent',
   name: 'output-pii-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/prefill-error-handler.mdx
+++ b/docs/src/content/en/reference/processors/prefill-error-handler.mdx
@@ -31,6 +31,7 @@ import { Agent } from '@mastra/core/agent'
 import { PrefillErrorHandler } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
@@ -52,6 +53,7 @@ const customErrorHandler: Processor = {
 }
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -1269,7 +1269,7 @@ Configure processors that implement `processAPIError` in `errorProcessors`:
 
 ```typescript
 const agent = new Agent({
-  // ...
+  id: 'agent',
   errorProcessors: [new PrefillErrorHandler()],
 })
 ```
@@ -1530,6 +1530,7 @@ import { Agent } from '@mastra/core/agent'
 import { PrefillErrorHandler } from '@mastra/core/processors'
 
 const agent = new Agent({
+  id: 'support-agent',
   name: 'support-agent',
   model: '__GATEWAY_OPENAI_MODEL_BASE__',
   instructions: '...',
@@ -1548,7 +1549,7 @@ Each array also accepts a function so processors can be built per-request from `
 
 ```typescript
 new Agent({
-  // ...
+  id: 'processor-interface-agent',
   inputProcessors: ({ requestContext }) => {
     const blockedWords = requestContext.get('blockedWords') ?? []
     return [new ContentFilter(blockedWords)]

--- a/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
+++ b/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
@@ -136,6 +136,7 @@ import { Agent } from '@mastra/core/agent'
 import { PromptInjectionDetector } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'secure-agent',
   name: 'secure-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/provider-history-compat.mdx
+++ b/docs/src/content/en/reference/processors/provider-history-compat.mdx
@@ -20,6 +20,7 @@ import { Agent } from '@mastra/core/agent'
 import { ProviderHistoryCompat } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: 'anthropic/claude-sonnet-4-5',
@@ -187,6 +188,7 @@ const stripUnsupportedAssistantMetadata: CompatRule = {
 }
 
 export const agent = new Agent({
+  id: 'custom-provider-agent',
   name: 'custom-provider-agent',
   instructions: 'You are a helpful assistant.',
   model: 'example-provider/model',

--- a/docs/src/content/en/reference/processors/regex-filter-processor.mdx
+++ b/docs/src/content/en/reference/processors/regex-filter-processor.mdx
@@ -55,6 +55,7 @@ import { Agent } from '@mastra/core/agent'
 import { RegexFilterProcessor } from '@mastra/core/processors'
 
 const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   model: '__GATEWAY_OPENAI_MODEL_NANO__',
   processors: {

--- a/docs/src/content/en/reference/processors/response-cache.mdx
+++ b/docs/src/content/en/reference/processors/response-cache.mdx
@@ -23,6 +23,7 @@ import { ResponseCache } from '@mastra/core/processors'
 const cache = new InMemoryServerCache()
 
 const agent = new Agent({
+  id: 'search-agent',
   name: 'Search Agent',
   instructions: 'You answer questions concisely.',
   model: '__GATEWAY_OPENAI_MODEL_BASE__',

--- a/docs/src/content/en/reference/processors/semantic-recall-processor.mdx
+++ b/docs/src/content/en/reference/processors/semantic-recall-processor.mdx
@@ -166,6 +166,7 @@ const semanticRecall = new SemanticRecall({
 })
 
 export const agent = new Agent({
+  id: 'semantic-memory-agent',
   name: 'semantic-memory-agent',
   instructions: 'You are a helpful assistant with semantic memory recall',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/skill-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/skill-search-processor.mdx
@@ -140,6 +140,7 @@ const skillSearch = new SkillSearchProcessor({
 })
 
 const agent = new Agent({
+  id: 'skill-agent',
   name: 'skill-agent',
   instructions:
     'You are a helpful assistant. Use search_skills to find relevant skills, then load_skill to load their instructions.',

--- a/docs/src/content/en/reference/processors/stream-error-retry-processor.mdx
+++ b/docs/src/content/en/reference/processors/stream-error-retry-processor.mdx
@@ -20,6 +20,7 @@ import { Agent } from '@mastra/core/agent'
 import { StreamErrorRetryProcessor } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'openai-agent',
   name: 'openai-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_BASE__',
@@ -56,6 +57,7 @@ const isECONNRESET = (error: unknown) => {
 }
 
 export const agent = new Agent({
+  id: 'resilient-agent',
   name: 'resilient-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_BASE__',

--- a/docs/src/content/en/reference/processors/system-prompt-scrubber.mdx
+++ b/docs/src/content/en/reference/processors/system-prompt-scrubber.mdx
@@ -141,6 +141,7 @@ import { Agent } from '@mastra/core/agent'
 import { BatchPartsProcessor, SystemPromptScrubber } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'scrubbed-agent',
   name: 'scrubbed-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/token-limiter-processor.mdx
+++ b/docs/src/content/en/reference/processors/token-limiter-processor.mdx
@@ -165,6 +165,7 @@ import { Memory } from '@mastra/memory'
 import { TokenLimiterProcessor } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'context-limited-agent',
   name: 'context-limited-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -186,6 +187,7 @@ import { Agent } from '@mastra/core/agent'
 import { TokenLimiterProcessor } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'multi-step-agent',
   name: 'multi-step-agent',
   instructions: 'You are a helpful research assistant with access to tools',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -209,6 +211,7 @@ import { Agent } from '@mastra/core/agent'
 import { TokenLimiterProcessor } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'response-limited-agent',
   name: 'response-limited-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/tool-call-filter.mdx
+++ b/docs/src/content/en/reference/processors/tool-call-filter.mdx
@@ -149,6 +149,7 @@ import { Agent } from '@mastra/core/agent'
 import { ToolCallFilter } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'filtered-agent',
   name: 'filtered-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -174,6 +175,7 @@ import { Agent } from '@mastra/core/agent'
 import { ToolCallFilter } from '@mastra/core/processors'
 
 export const agent = new Agent({
+  id: 'no-tools-context-agent',
   name: 'no-tools-context-agent',
   instructions: 'You are a helpful assistant',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/processors/tool-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/tool-search-processor.mdx
@@ -227,6 +227,7 @@ const toolSearch = new ToolSearchProcessor({
 })
 
 const agent = new Agent({
+  id: 'dynamic-tools-agent',
   name: 'dynamic-tools-agent',
   instructions:
     'You are a helpful assistant with access to many tools. Use search_tools to find relevant tools, then load_tool to make them available.',
@@ -308,6 +309,7 @@ import { Agent } from '@mastra/core/agent'
 import { ToolSearchProcessor, TokenLimiter } from '@mastra/core/processors'
 
 const agent = new Agent({
+  id: 'my-agent',
   name: 'my-agent',
   model: '__GATEWAY_OPENAI_MODEL__',
   inputProcessors: [

--- a/docs/src/content/en/reference/processors/working-memory-processor.mdx
+++ b/docs/src/content/en/reference/processors/working-memory-processor.mdx
@@ -157,6 +157,7 @@ const storage = new PostgresStorage({
 })
 
 export const agent = new Agent({
+  id: 'personalized-agent',
   name: 'personalized-agent',
   instructions: 'You are a helpful assistant that remembers user preferences',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/signals/signal-provider.mdx
+++ b/docs/src/content/en/reference/signals/signal-provider.mdx
@@ -51,6 +51,7 @@ Register with an agent:
 import { Agent } from '@mastra/core/agent'
 
 const agent = new Agent({
+  id: 'agent',
   signals: [new SlackSignals()],
 })
 ```

--- a/docs/src/content/en/reference/signals/task-signal-provider.mdx
+++ b/docs/src/content/en/reference/signals/task-signal-provider.mdx
@@ -20,6 +20,7 @@ import { Agent } from '@mastra/core/agent'
 import { TaskSignalProvider } from '@mastra/core/signals'
 
 const agent = new Agent({
+  id: 'coder',
   name: 'coder',
   instructions: '...',
   model,

--- a/docs/src/content/en/reference/signals/webhook-signal-provider.mdx
+++ b/docs/src/content/en/reference/signals/webhook-signal-provider.mdx
@@ -37,6 +37,7 @@ Register with an agent and subscribe a thread:
 import { Agent } from '@mastra/core/agent'
 
 const agent = new Agent({
+  id: 'agent',
   signals: [webhookProvider],
 })
 

--- a/docs/src/content/en/reference/templates/overview.mdx
+++ b/docs/src/content/en/reference/templates/overview.mdx
@@ -146,6 +146,7 @@ We recommend using OpenAI, Anthropic, or Google model providers for templates. C
 import { Agent } from '@mastra/core/agent'
 
 const agent = new Agent({
+  id: 'example-agent',
   name: 'example-agent',
   model: '__GATEWAY_OPENAI_MODEL__', // or other provider strings
   instructions: 'Your agent instructions here',

--- a/docs/src/content/en/reference/tools/create-code-mode.mdx
+++ b/docs/src/content/en/reference/tools/create-code-mode.mdx
@@ -47,6 +47,7 @@ const { tool, instructions } = createCodeMode({
 })
 
 export const shopAgent = new Agent({
+  id: 'shop-assistant',
   name: 'shop-assistant',
   instructions: ['You are a helpful shopping assistant.', instructions],
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -1168,6 +1168,7 @@ const mcpClient = new MCPClient({
 
 // Use with an agent — requestContext is automatically forwarded
 const agent = new Agent({
+  id: 'my-agent',
   name: 'My Agent',
   instructions: 'You are a helpful assistant.',
   model: openai('gpt-5.4'),

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -211,7 +211,7 @@ When you provide agents in the `agents` configuration property, `MCPServer` will
 
 The description for this generated tool will be: "Ask agent `<agent.name>` a question. Agent description: `<agent.description>`".
 
-**Important**: For an agent to be converted into a tool, it **must** have a non-empty `description` string property set in its configuration when it was instantiated (e.g., `new Agent({ name: 'myAgent', description: 'This agent does X.', ... })`). If an agent is passed to `MCPServer` with a missing or empty `description`, an error will be thrown when the `MCPServer` is instantiated, and server setup will fail.
+**Important**: For an agent to be converted into a tool, it **must** have a non-empty `description` string property set in its configuration when it was instantiated (e.g., `new Agent({ id: 'my-agent', name: 'myAgent', description: 'This agent does X.', ... })`). If an agent is passed to `MCPServer` with a missing or empty `description`, an error will be thrown when the `MCPServer` is instantiated, and server setup will fail.
 
 This allows you to quickly expose the generative capabilities of your agents through the MCP, enabling clients to "ask" your agents questions directly.
 

--- a/docs/src/content/en/reference/voice/voice.addInstructions.mdx
+++ b/docs/src/content/en/reference/voice/voice.addInstructions.mdx
@@ -26,6 +26,7 @@ const voice = new OpenAIRealtimeVoice({
 
 // Create an agent with the voice provider
 const agent = new Agent({
+  id: 'customer-support-agent',
   name: 'Customer Support Agent',
   instructions: 'You are a helpful customer support agent for a software company.',
   model: '__GATEWAY_OPENAI_MODEL__',

--- a/docs/src/content/en/reference/workspace/agentcore-runtime-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/agentcore-runtime-sandbox.mdx
@@ -47,6 +47,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'dev-agent',
   name: 'dev-agent',
   model: 'anthropic/claude-sonnet-4-6',
   instructions: 'You are a helpful development assistant.',

--- a/docs/src/content/en/reference/workspace/agentfs-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/agentfs-filesystem.mdx
@@ -37,6 +37,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'file-agent',
   name: 'file-agent',
   model: '__GATEWAY_OPENAI_MODEL__',
   workspace,

--- a/docs/src/content/en/reference/workspace/archil-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/archil-filesystem.mdx
@@ -39,6 +39,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'file-agent',
   name: 'file-agent',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,

--- a/docs/src/content/en/reference/workspace/azure-blob-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/azure-blob-filesystem.mdx
@@ -38,6 +38,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'file-agent',
   name: 'file-agent',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,

--- a/docs/src/content/en/reference/workspace/docker-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/docker-sandbox.mdx
@@ -39,6 +39,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'dev-agent',
   name: 'dev-agent',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,

--- a/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
@@ -38,6 +38,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'dev-agent',
   name: 'dev-agent',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,

--- a/docs/src/content/en/reference/workspace/files-sdk-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/files-sdk-filesystem.mdx
@@ -48,6 +48,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'file-agent',
   name: 'file-agent',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,

--- a/docs/src/content/en/reference/workspace/gcs-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/gcs-filesystem.mdx
@@ -39,6 +39,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'file-agent',
   name: 'file-agent',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,

--- a/docs/src/content/en/reference/workspace/mesa-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/mesa-filesystem.mdx
@@ -43,6 +43,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'file-agent',
   name: 'file-agent',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,

--- a/docs/src/content/en/reference/workspace/s3-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/s3-filesystem.mdx
@@ -40,6 +40,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'file-agent',
   name: 'file-agent',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,

--- a/docs/src/content/en/reference/workspace/vercel.mdx
+++ b/docs/src/content/en/reference/workspace/vercel.mdx
@@ -49,6 +49,7 @@ const workspace = new Workspace({
 })
 
 const agent = new Agent({
+  id: 'dev-agent',
   name: 'dev-agent',
   model: '__GATEWAY_ANTHROPIC_MODEL_SONNET__',
   workspace,


### PR DESCRIPTION
## Description

In some of our code examples the `new Agent()` constructor was missing the required `id` property.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This update fixes the docs so the example “Agent” code shows all the pieces it needs, including the missing `id`. That helps people copy examples that match how the code really works.

### What changed
- Added missing `id` properties to many `new Agent()` examples across the docs.
- Updated the Agent reference to mark `id` as required and remove the old idea that it defaults to `name`.
- Added a docs style guide note saying examples must be validated against source code and must include required `Agent` fields.

### Files updated
- Agent controller docs
- Agents docs
- Editor docs
- Evals docs
- Memory docs
- Observability docs
- Migration guides
- Processor references
- Signals references
- Tools references
- Voice docs
- Workspace docs
- Style guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->