### PR TITLE
Improve gh-triage - Add merge confidence to maintainers notes

### DIFF
--- a/.mastracode/commands/gh-triage.md
+++ b/.mastracode/commands/gh-triage.md
@@ -60,7 +60,7 @@ Use this compact lifecycle template and update it after each major step with con
 
 ### Confidence basis
 
-<For PR branches: what supports the score, and what keeps it below 5/5.>
+<For PR branches: 1-2 bullets supporting the score, then 1-3 explicit confidence limits. Each limit must name the missing evidence or unresolved risk, explain why it matters for merge readiness, and say blocking or non-blocking.>
 
 ### Evidence
 
@@ -81,7 +81,7 @@ Use this compact lifecycle template and update it after each major step with con
 ### Comment style, only when preparing comments
 
 - Author pre-review: tag the PR author when known, be concise/action-oriented, and request only concrete changes the author needs to make. Do not ask authors to confirm tests, verification, or maintainer review readiness.
-- Maintainer notes: start with `## 🟠 High: Maintainer notes`, then `Merge confidence - <x>/5`. Keep the usual concise `Scope`, `Context`, `Confidence basis`, `Evidence checked`, and `Observations` sections; confidence basis should add supports/limits, not replace the rest. Do not count missing human approval or unapproved remote CI checks as confidence limits; mention approval/review/remote-check status separately only if useful. If maintainer notes already exist, update that comment instead of preparing a new one.
+- Maintainer notes: start with `## 🟠 High: Maintainer notes`, then `Merge confidence - <x>/5`. Keep the usual concise `Scope`, `Context`, `Confidence basis`, `Evidence checked`, and `Observations` sections; confidence basis should use short bullets with explicit reasons, not vague caveats. For each confidence limit, state: `Limit: <specific missing evidence or unresolved risk> — Why it matters: <merge-readiness impact> — Blocking: <yes/no>`. Do not count missing human approval or unapproved remote CI checks as confidence limits; mention approval/review/remote-check status separately only if useful. If maintainer notes already exist, update that comment instead of preparing a new one.
 - For PR branches, always prepare or update maintainer notes. Do not write `Maintainer notes: Not needed.` for Branch B or Branch C.
 - Do not present maintainer notes as final approval or rejection.
 
@@ -158,7 +158,8 @@ For Branch B/C PRs, assign a merge confidence score after reviewing context. Thi
 - [ ] Base the score on: problem/solution fit, regression risk, test quality, changed-code correctness, integration with existing patterns, unresolved review comments, local verification, approved/required remote checks that actually ran, and release/user impact.
 - [ ] Do not include unapproved remote CI checks in the score. Treat them as neutral and list them separately only if useful.
 - [ ] Save the score, confidence basis, confidence gaps, and required-to-merge actions in the triage file before preparing comments.
-- [ ] Explain what prevents full confidence and whether each gap is blocking or non-blocking.
+- [ ] Confidence gaps must be concise and explicit: name the missing evidence or unresolved risk, explain why it matters for merge readiness, and mark it blocking or non-blocking.
+- [ ] Do not write generic limits like "needs maintainer review" or "tests not run" without saying which evidence is missing, why that evidence matters for this PR, and whether it changes the merge recommendation.
 - [ ] If author action is needed to raise confidence, prepare an author pre-review comment with concrete requested changes.
 
 ### Repo/history context

--- a/.mastracode/commands/gh-triage.md
+++ b/.mastracode/commands/gh-triage.md
@@ -14,9 +14,13 @@ Triage one open GitHub issue or active PR into the next action. Keep the top-lev
 
 - [ ] Do not post comments, label, assign, close, tag, coordinate externally, implement fixes, or commit without explicit user approval.
 
+- [ ] When posting/updating comments from a file, pass file contents, not `@file` as the literal body.
+
 - [ ] Non-open issues, non-open PRs, and draft PRs stop with no triage file and no `ask_user`.
 
 - [ ] Successful triage ends by updating the triage file, then immediately calling branch-specific `ask_user`. Do not end with `Completed`, `Verdict`, `Key findings`, or a prose-only summary.
+
+- [ ] If the PR already has a previous maintainer-notes comment, treat it as prior lifecycle context: read it, compare it with the current PR state, and prepare an updated maintainer-notes comment that explains what changed in merge confidence.
 
 - [ ] Use shared context files for code-accurate evidence: `.mastracode/shared/pr-review-context.md` for PR context and `.mastracode/shared/issue-debug-context.md` for issue debug context.
 
@@ -41,6 +45,7 @@ Use this compact lifecycle template and update it after each major step with con
 ## GitHub Triage: <issue|PR> #<number> <title>
 
 **Severity:** <🔴 critical|🟠 high|🟡 medium|🟢 low|pending>
+**Merge confidence:** <0-5>/5 — <ready to merge|mergeable with non-blocking follow-up|needs review changes|blocked|not applicable|pending>
 **Scope:** <affected package/API/feature or `Pending.`>
 **Assessment:** <concise assessment or `Pending.`>
 **Linked issue/PR:** <issue #|closing/fixing PR #|multiple #s|none|pending>
@@ -52,6 +57,10 @@ Use this compact lifecycle template and update it after each major step with con
 - Input: <short issue/PR summary>
 - Linked context: <closing/fixing PR or linked issue; mention-only PRs only if useful for debugging>
 - Repo/history: <relevant files, APIs, tests, commits, or `Not inspected.`>
+
+### Confidence basis
+
+<For PR branches: what supports the score, and what keeps it below 5/5.>
 
 ### Evidence
 
@@ -72,8 +81,8 @@ Use this compact lifecycle template and update it after each major step with con
 ### Comment style, only when preparing comments
 
 - Author pre-review: tag the PR author when known, be concise/action-oriented, and request only concrete changes the author needs to make. Do not ask authors to confirm tests, verification, or maintainer review readiness.
-- Maintainer notes: start with a severity-titled heading like `## 🟠 High: Maintainer notes`; use short sections such as `Scope`, `Context`, `Evidence checked`, and `Observations`; keep observations declarative and keep author actions out of maintainer notes.
-- For PR branches, always prepare maintainer notes. Do not write `Maintainer notes: Not needed.` for Branch B or Branch C.
+- Maintainer notes: start with `## 🟠 High: Maintainer notes`, then `Merge confidence - <x>/5`. Keep the usual concise `Scope`, `Context`, `Confidence basis`, `Evidence checked`, and `Observations` sections; confidence basis should add supports/limits, not replace the rest. Do not count missing human approval or unapproved remote CI checks as confidence limits; mention approval/review/remote-check status separately only if useful. If maintainer notes already exist, update that comment instead of preparing a new one.
+- For PR branches, always prepare or update maintainer notes. Do not write `Maintainer notes: Not needed.` for Branch B or Branch C.
 - Do not present maintainer notes as final approval or rejection.
 
 ## Step 1: Resolve and check input
@@ -136,10 +145,21 @@ gh pr view "$PR" --json number,title,state,isDraft,url,author,body,comments,revi
 
 For Branch B/C PRs, do this before branch output or `ask_user`. Do not modify branches, apply suggestions, resolve conflicts, or run broad checks without approval.
 
-- [ ] Check conflicts, failed `statusCheckRollup` lint/typecheck/format/test/CI, and applicable inline suggestions/review nits; ignore unrelated Vercel failures.
-- [ ] If a relevant failure is unclear or stale and the affected package is obvious, run only the narrowest local check needed to confirm it.
+- [ ] Check conflicts, approved/required `statusCheckRollup` failures, and applicable inline suggestions/review nits; ignore unrelated Vercel failures and unapproved remote CI checks.
+- [ ] Do not reduce merge confidence for unapproved remote CI checks that did not run; rely on narrow local lint/typecheck/test/build checks you ran, or approved/required remote checks that actually ran.
+- [ ] If a relevant approved/required failure is unclear or stale, or if remote checks are unapproved, run only the narrowest local check needed for the affected package when practical.
 - [ ] Record concise results in `Context gathered` and `Evidence`, using `None found.` when nothing applies.
 - [ ] If a small low/medium-severity fix-up is found, set `Recommended next step` to `maintainer PR fix-up` and include matching final `ask_user` option(s).
+
+### Merge confidence for PR branches
+
+For Branch B/C PRs, assign a merge confidence score after reviewing context. This is the main output maintainers use to decide whether the PR can be merged.
+
+- [ ] Base the score on: problem/solution fit, regression risk, test quality, changed-code correctness, integration with existing patterns, unresolved review comments, local verification, approved/required remote checks that actually ran, and release/user impact.
+- [ ] Do not include unapproved remote CI checks in the score. Treat them as neutral and list them separately only if useful.
+- [ ] Save the score, confidence basis, confidence gaps, and required-to-merge actions in the triage file before preparing comments.
+- [ ] Explain what prevents full confidence and whether each gap is blocking or non-blocking.
+- [ ] If author action is needed to raise confidence, prepare an author pre-review comment with concrete requested changes.
 
 ### Repo/history context
 
@@ -148,6 +168,8 @@ For Branch B/C PRs, do this before branch output or `ask_user`. Do not modify br
 - [ ] Prefer narrow search and recent history over broad exploration.
 
 - [ ] Ignore Vercel CI failures unless directly relevant to the issue, PR, or deployment behavior.
+
+- [ ] Treat unapproved remote CI checks as neutral for merge confidence; do not count them as missing verification or as failures. Prefer narrow local checks/lint/typecheck/tests for confidence evidence.
 
 ```bash
 git grep -n "<error text|API|symbol>" -- '<likely/pathspec>'
@@ -195,15 +217,13 @@ Use when exactly one PR clearly closes/fixes the issue, or when the input itself
 
 - [ ] Immediately update the triage file's `Context gathered` and `Evidence` sections with the PR context findings before writing branch conclusions.
 
-- [ ] Write Branch output with severity/assessment/scope, issue summary, PR relevance, evidence checked, review observations, PR maintainer-fix check results, optional author pre-review, optional maintainer PR fix-up, and required maintainer notes.
+- [ ] Write Branch output with severity/assessment/scope, issue summary, PR relevance, evidence checked, merge confidence, review observations, optional author pre-review, optional maintainer fix-up, and required maintainer notes.
 
 - [ ] Update the triage file, then call `ask_user` with exactly the relevant Branch B options:
   - `Post author pre-review comment`
   - `Post maintainer notes comment`
   - `Post both comments`
-  - `Fix conflicts as maintainer, then post maintainer notes` (only if found)
-  - `Fix lint/CI failures as maintainer, then post maintainer notes` (only if found)
-  - `Apply inline suggestions as maintainer, then post maintainer notes` (only if found)
+  - `Fix up PR as maintainer, then post maintainer notes` (only if a small conflict/CI/suggestion fix was found)
   - `End triage`
 
 ### Branch C: Multiple linked PRs
@@ -214,13 +234,11 @@ Use when multiple PRs clearly close/fix the issue.
 
 - [ ] Immediately update the triage file's `Context gathered` and `Evidence` sections with each PR context finding before writing comparison conclusions.
 
-- [ ] Write Branch output with severity/assessment/scope, issue summary, PR list, evidence checked, comparison notes, PR maintainer-fix check results, optional maintainer PR fix-up, and required maintainer notes.
+- [ ] Write Branch output with severity/assessment/scope, issue summary, PR list, evidence checked, merge confidence for each PR, comparison notes, optional maintainer fix-up, and required maintainer notes.
 
 - [ ] Update the triage file, then call `ask_user` with exactly the relevant Branch C options:
   - `Post maintainer notes comment`
-  - `Fix conflicts as maintainer, then post maintainer notes` (only if found)
-  - `Fix lint/CI failures as maintainer, then post maintainer notes` (only if found)
-  - `Apply inline suggestions as maintainer, then post maintainer notes` (only if found)
+  - `Fix up PR as maintainer, then post maintainer notes` (only if a small conflict/CI/suggestion fix was found)
   - `End triage`
 
 ### Branch D: No linked PR

--- a/.mastracode/commands/gh-triage.md
+++ b/.mastracode/commands/gh-triage.md
@@ -81,7 +81,7 @@ Use this compact lifecycle template and update it after each major step with con
 ### Comment style, only when preparing comments
 
 - Author pre-review: tag the PR author when known, be concise/action-oriented, and request only concrete changes the author needs to make. Do not ask authors to confirm tests, verification, or maintainer review readiness.
-- Maintainer notes: start with `## 🟠 High: Maintainer notes`, then `Merge confidence - <x>/5`. Keep concise `Scope`, `Context`, `Confidence basis`, `Evidence checked`, and `Observations` sections. In `Confidence basis`, use short support/limit bullets; each limit should state the gap/risk, merge impact, and blocking yes/no. Do not count missing human approval or unapproved remote CI checks as confidence limits; mention approval/review/remote-check status separately only if useful. If maintainer notes already exist, update that comment instead of preparing a new one.
+- Maintainer notes: start with `## 🟠 High: Maintainer notes`, then `Merge confidence - <x>/5`. Keep concise `Scope`, `Context`, `Confidence basis`, `Checks`, `Evidence checked`, and `Observations` sections. In `Confidence basis`, use short support/limit bullets; each limit should state the gap/risk, merge impact, and blocking yes/no. `Checks` must state the checked-at time, required/approved failures, and other visible pending/failing checks with their score impact. Do not count missing human approval or unapproved remote CI checks as confidence limits. If maintainer notes already exist, update that comment instead of preparing a new one.
 - For PR branches, always prepare or update maintainer notes. Do not write `Maintainer notes: Not needed.` for Branch B or Branch C.
 - Do not present maintainer notes as final approval or rejection.
 
@@ -145,9 +145,12 @@ gh pr view "$PR" --json number,title,state,isDraft,url,author,body,comments,revi
 
 For Branch B/C PRs, do this before branch output or `ask_user`. Do not modify branches, apply suggestions, resolve conflicts, or run broad checks without approval.
 
-- [ ] Check conflicts, approved/required `statusCheckRollup` failures, and applicable inline suggestions/review nits; ignore unrelated Vercel failures and unapproved remote CI checks.
-- [ ] Do not reduce merge confidence for unapproved remote CI checks that did not run; rely on narrow local lint/typecheck/test/build checks you ran, or approved/required remote checks that actually ran.
-- [ ] If a relevant approved/required failure is unclear or stale, or if remote checks are unapproved, run only the narrowest local check needed for the affected package when practical.
+- [ ] Check conflicts, approved/required `statusCheckRollup` failures, and applicable inline suggestions/review nits; ignore unrelated Vercel failures and unapproved remote CI checks for scoring.
+- [ ] Record check state at triage time: required/approved failures, other visible pending/failing checks, and whether each affects the score.
+- [ ] Run relevant local checks for the changed package(s) when practical: lint, typecheck, tests, and/or build, using the narrowest applicable package scripts.
+- [ ] If a relevant local check cannot be run, record why and how that affects merge confidence.
+- [ ] Do not reduce merge confidence for unapproved remote CI checks that did not run; rely on local checks you ran, or approved/required remote checks that actually ran.
+- [ ] If a relevant approved/required failure is unclear or stale, run the narrowest local check needed for the affected package when practical.
 - [ ] Record concise results in `Context gathered` and `Evidence`, using `None found.` when nothing applies.
 - [ ] If a small low/medium-severity fix-up is found, set `Recommended next step` to `maintainer PR fix-up` and include matching final `ask_user` option(s).
 

--- a/.mastracode/commands/gh-triage.md
+++ b/.mastracode/commands/gh-triage.md
@@ -60,7 +60,7 @@ Use this compact lifecycle template and update it after each major step with con
 
 ### Confidence basis
 
-<For PR branches: 1-2 score-support bullets plus concise limits: gap/risk, merge impact, blocking yes/no.>
+<For PR branches: 1-2 bullets supporting the score, then 1-3 explicit confidence limitations.>
 
 ### Evidence
 

--- a/.mastracode/commands/gh-triage.md
+++ b/.mastracode/commands/gh-triage.md
@@ -60,7 +60,7 @@ Use this compact lifecycle template and update it after each major step with con
 
 ### Confidence basis
 
-<For PR branches: 1-2 bullets supporting the score, then 1-3 explicit confidence limits. Each limit must name the missing evidence or unresolved risk, explain why it matters for merge readiness, and say blocking or non-blocking.>
+<For PR branches: 1-2 score-support bullets plus concise limits: gap/risk, merge impact, blocking yes/no.>
 
 ### Evidence
 
@@ -81,7 +81,7 @@ Use this compact lifecycle template and update it after each major step with con
 ### Comment style, only when preparing comments
 
 - Author pre-review: tag the PR author when known, be concise/action-oriented, and request only concrete changes the author needs to make. Do not ask authors to confirm tests, verification, or maintainer review readiness.
-- Maintainer notes: start with `## 🟠 High: Maintainer notes`, then `Merge confidence - <x>/5`. Keep the usual concise `Scope`, `Context`, `Confidence basis`, `Evidence checked`, and `Observations` sections; confidence basis should use short bullets with explicit reasons, not vague caveats. For each confidence limit, state: `Limit: <specific missing evidence or unresolved risk> — Why it matters: <merge-readiness impact> — Blocking: <yes/no>`. Do not count missing human approval or unapproved remote CI checks as confidence limits; mention approval/review/remote-check status separately only if useful. If maintainer notes already exist, update that comment instead of preparing a new one.
+- Maintainer notes: start with `## 🟠 High: Maintainer notes`, then `Merge confidence - <x>/5`. Keep concise `Scope`, `Context`, `Confidence basis`, `Evidence checked`, and `Observations` sections. In `Confidence basis`, use short support/limit bullets; each limit should state the gap/risk, merge impact, and blocking yes/no. Do not count missing human approval or unapproved remote CI checks as confidence limits; mention approval/review/remote-check status separately only if useful. If maintainer notes already exist, update that comment instead of preparing a new one.
 - For PR branches, always prepare or update maintainer notes. Do not write `Maintainer notes: Not needed.` for Branch B or Branch C.
 - Do not present maintainer notes as final approval or rejection.
 
@@ -158,8 +158,8 @@ For Branch B/C PRs, assign a merge confidence score after reviewing context. Thi
 - [ ] Base the score on: problem/solution fit, regression risk, test quality, changed-code correctness, integration with existing patterns, unresolved review comments, local verification, approved/required remote checks that actually ran, and release/user impact.
 - [ ] Do not include unapproved remote CI checks in the score. Treat them as neutral and list them separately only if useful.
 - [ ] Save the score, confidence basis, confidence gaps, and required-to-merge actions in the triage file before preparing comments.
-- [ ] Confidence gaps must be concise and explicit: name the missing evidence or unresolved risk, explain why it matters for merge readiness, and mark it blocking or non-blocking.
-- [ ] Do not write generic limits like "needs maintainer review" or "tests not run" without saying which evidence is missing, why that evidence matters for this PR, and whether it changes the merge recommendation.
+- [ ] Confidence gaps must name the gap/risk, merge impact, and blocking yes/no.
+- [ ] Avoid generic limits like "needs maintainer review" or "tests not run" unless tied to specific missing evidence and impact.
 - [ ] If author action is needed to raise confidence, prepare an author pre-review comment with concrete requested changes.
 
 ### Repo/history context

--- a/.mastracode/shared/pr-review-context.md
+++ b/.mastracode/shared/pr-review-context.md
@@ -37,9 +37,15 @@ gh pr diff <PR>
    - Check integration points with existing code.
    - Note patterns, conventions, tests, docs, changesets, package-local instructions, or dependency/build requirements.
    - Confirm line numbers before citing `path:line` evidence.
-8. Compare the PR title and description against the actual diff; record mismatches.
-9. Check status checks, but ignore Vercel CI failures unless directly relevant to the issue, PR, or deployment behavior.
-10. Before relying on tests, builds, or checks, verify they were actually run or are present in CI. Do not claim they passed from expectation alone.
+8. Gather merge-confidence evidence without assigning the final score:
+   - Problem/solution fit: whether the diff plausibly fixes the linked issue or stated goal.
+   - Regression risk: affected runtime paths, compatibility concerns, and edge cases.
+   - Test quality: whether regression coverage exercises the reported failure shape and relevant integration point.
+   - Review state: unresolved blocking comments, stale suggestions, or prior maintainer notes.
+   - Verification state: narrow local lint/typecheck/test/build checks actually run, plus approved/required remote checks that actually ran. Treat unapproved remote CI checks as neutral, not as missing verification or failures.
+9. Compare the PR title and description against the actual diff; record mismatches.
+10. Check status checks, but ignore Vercel CI failures unless directly relevant to the issue, PR, or deployment behavior. Record unapproved remote CI checks separately from confidence evidence.
+11. Before relying on tests, builds, or checks, verify they were actually run locally or are approved/required CI checks that actually ran. Do not claim they passed from expectation alone.
 
 ## Return only context
 
@@ -49,7 +55,8 @@ Return concise context for the calling command:
 - Linked issue summary, if any.
 - Changed files and affected areas.
 - Evidence checked, including important PR comments/review threads and `path:line` references.
+- Merge-confidence evidence: problem/solution fit, regression risk, test quality, review state, and verification state.
 - Test/build/check status that was actually verified.
 - Context gaps or uncertainty.
 
-Do not decide final maintainer action, post comments, assign severity, route triage branches, or create files from this shared checklist.
+Do not decide final maintainer action, post comments, assign severity, assign merge confidence, route triage branches, or create files from this shared checklist.

--- a/.mastracode/shared/pr-review-context.md
+++ b/.mastracode/shared/pr-review-context.md
@@ -42,10 +42,11 @@ gh pr diff <PR>
    - Regression risk: affected runtime paths, compatibility concerns, and edge cases.
    - Test quality: whether regression coverage exercises the reported failure shape and relevant integration point.
    - Review state: unresolved blocking comments, stale suggestions, or prior maintainer notes.
-   - Verification state: narrow local lint/typecheck/test/build checks actually run, plus approved/required remote checks that actually ran. Treat unapproved remote CI checks as neutral, not as missing verification or failures.
-9. Compare the PR title and description against the actual diff; record mismatches.
-10. Check status checks, but ignore Vercel CI failures unless directly relevant to the issue, PR, or deployment behavior. Record unapproved remote CI checks separately from confidence evidence.
-11. Before relying on tests, builds, or checks, verify they were actually run locally or are approved/required CI checks that actually ran. Do not claim they passed from expectation alone.
+   - Verification state: relevant local lint/typecheck/test/build checks actually run for the changed package(s), plus approved/required remote checks that actually ran. Treat unapproved remote CI checks as neutral, not as missing verification or failures.
+9. Record check state at triage time: checked-at timestamp, local checks run or why they could not be run, required/approved failures, other visible pending/failing checks, and score impact.
+10. Compare the PR title and description against the actual diff; record mismatches.
+11. Check status checks, but ignore Vercel CI failures unless directly relevant to the issue, PR, or deployment behavior. Record unapproved remote CI checks separately from confidence evidence.
+12. Before relying on tests, builds, or checks, verify they were actually run locally or are approved/required CI checks that actually ran. Do not claim they passed from expectation alone.
 
 ## Return only context
 


### PR DESCRIPTION
## Summary
- add merge-confidence guidance to gh-triage PR branches
- require maintainer notes to include merge readiness, confidence basis, gaps, and required-to-merge actions
- update shared PR review context to gather confidence evidence without assigning the score

## Test plan
- git diff --check
- searched gh-triage/pr-review-context for stale /10 confidence wording

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR makes the triage guide better at judging whether a pull request is ready to merge. It asks maintainers to write down what they checked, what looks safe, and what still needs work so the team can make clearer decisions.

## Summary
- Updated `gh-triage` guidance to require maintainer notes that include merge readiness, confidence basis, remaining gaps, and any merge-blocking actions.
- Expanded the maintainer-notes template with a more structured format for scope, context, evidence checked, observations, and confidence details.
- Added clearer merge-confidence guidance for checking conflicts, reviewing local verification, and recording what was actually checked during triage.
- Clarified that unapproved remote CI failures should be treated as neutral for confidence rather than lowering it.
- Revised the shared PR review context to capture merge-confidence evidence and check state without assigning a numeric score.
- Simplified the `ask_user` branching options so maintainer follow-up paths are more focused.
- Updated test-plan guidance to include `git diff --check` and removal of stale `/10 confidence` wording from `gh-triage/pr-review-context`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->