### PR TITLE
fix(core): stream array textStream incrementally to keep JSON valid

### DIFF
--- a/.changeset/fix-array-textstream-invalid-json.md
+++ b/.changeset/fix-array-textstream-invalid-json.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix array `textStream` emitting invalid JSON when the first streamed object chunk already contains elements. The JSON text transformer wrote a fully-closed array on the first non-empty chunk and then appended more elements plus another closing bracket, producing unparseable output. It now always streams incrementally, so the array `textStream` concatenates to a single valid JSON array. Closes #18758.

--- a/packages/core/src/stream/base/json-text-stream-array.test.ts
+++ b/packages/core/src/stream/base/json-text-stream-array.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { toStandardSchema } from '../../schema';
+import { createJsonTextStreamTransformer } from './output-format-handlers';
+
+async function runTransformer(schema: any, objectChunks: any[]): Promise<string> {
+  const transformer = createJsonTextStreamTransformer(schema);
+  const writer = transformer.writable.getWriter();
+  const reader = transformer.readable.getReader();
+
+  const out: string[] = [];
+  const readAll = (async () => {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      out.push(value);
+    }
+  })();
+
+  for (const object of objectChunks) {
+    await writer.write({ type: 'object', object, runId: '1', from: 'AGENT' } as any);
+  }
+  await writer.close();
+  await readAll;
+
+  return out.join('');
+}
+
+describe('createJsonTextStreamTransformer array output', () => {
+  const schema = toStandardSchema(z.array(z.object({ a: z.number() }))) as any;
+
+  it('produces valid JSON when the first chunk already has elements', async () => {
+    const text = await runTransformer(schema, [[{ a: 1 }], [{ a: 1 }, { a: 2 }], [{ a: 1 }, { a: 2 }, { a: 3 }]]);
+
+    expect(() => JSON.parse(text)).not.toThrow();
+    expect(JSON.parse(text)).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }]);
+  });
+
+  it('produces valid JSON for fine-grained streaming (first chunk empty)', async () => {
+    const text = await runTransformer(schema, [[], [{ a: 1 }], [{ a: 1 }, { a: 2 }]]);
+
+    expect(JSON.parse(text)).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it('produces valid JSON for a single complete chunk', async () => {
+    const text = await runTransformer(schema, [[{ a: 1 }, { a: 2 }]]);
+
+    expect(JSON.parse(text)).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+});

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -706,7 +706,6 @@ export function createObjectStreamTransformer<OUTPUT = undefined>({
 export function createJsonTextStreamTransformer<OUTPUT = undefined>(schema?: StandardSchemaWithJSON<OUTPUT>) {
   let previousArrayLength = 0;
   let hasStartedArray = false;
-  let chunkCount = 0;
   const outputSchema = getTransformedSchema(schema);
 
   return new TransformStream<ChunkType<OUTPUT>, string>({
@@ -716,21 +715,11 @@ export function createJsonTextStreamTransformer<OUTPUT = undefined>(schema?: Sta
       }
 
       if (outputSchema?.outputFormat === 'array' && Array.isArray(chunk.object)) {
-        chunkCount++;
-
-        // If this is the first chunk, decide between complete vs incremental streaming
-        if (chunkCount === 1) {
-          // If the first chunk already has multiple elements or is complete,
-          // emit as single JSON string
-          if (chunk.object.length > 0) {
-            controller.enqueue(JSON.stringify(chunk.object));
-            previousArrayLength = chunk.object.length;
-            hasStartedArray = true;
-            return;
-          }
-        }
-
-        // Incremental streaming mode (multiple chunks)
+        // Object chunks carry the array-so-far. Always stream incrementally:
+        // open the bracket once, emit only the newly-added elements, and close
+        // the bracket on flush. Emitting a complete JSON.stringify on the first
+        // chunk (as before) produced invalid JSON when later chunks arrived,
+        // because it had already written the closing bracket.
         if (!hasStartedArray) {
           controller.enqueue('[');
           hasStartedArray = true;
@@ -752,8 +741,8 @@ export function createJsonTextStreamTransformer<OUTPUT = undefined>(schema?: Sta
       }
     },
     flush(controller) {
-      // Close the array when the stream ends (only for incremental streaming)
-      if (hasStartedArray && outputSchema?.outputFormat === 'array' && chunkCount > 1) {
+      // Close the array when the stream ends.
+      if (hasStartedArray && outputSchema?.outputFormat === 'array') {
         controller.enqueue(']');
       }
     },


### PR DESCRIPTION
## What

`createJsonTextStreamTransformer` emits invalid JSON for an array `textStream` when the first `object` chunk already contains elements. Object chunks carry the array-so-far and grow over time, but the transformer has a first-chunk fast path that assumes the first non-empty chunk is the complete array and writes a fully-closed `JSON.stringify(array)`. When later chunks arrive it appends more elements plus a closing `]` on flush, producing broken output.

Feeding progressive chunks `[{a:1}]`, `[{a:1},{a:2}]`, `[{a:1},{a:2},{a:3}]`:
- Actual: `[{"a":1}],{"a":2},{"a":3}]` → `JSON.parse` throws.
- Expected: `[{"a":1},{"a":2},{"a":3}]`.

This fires whenever the first parseable chunk already has an element (coarse/batched provider deltas). Fine-grained streaming (first chunk `[]`) and single-chunk generate mode avoid the fast path, so they were unaffected.

## Change

Drop the first-chunk fast path and always stream incrementally: open `[` once, emit only newly-added elements, close `]` on flush. Behavior-preserving for the empty-first-chunk and single-chunk cases (same final text), and valid for the broken case.

## Tests

Added unit tests driving the transformer with a `z.array(...)` schema for all three cases (first-chunk-nonempty, first-chunk-empty, single complete chunk). The first-chunk-nonempty case fails on the current code and passes after the fix. The full stream suite (13 files, 181 tests) still passes.

Closes #18758

---

Hey @epinzur, you were last in this file so tagging you. Happy to add a schema-level e2e test too if you'd prefer. Thanks for the look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This fix makes streamed JSON arrays stay valid while they’re being sent piece by piece. Before, if the first chunk already had items, the code could accidentally close the array too early and then keep adding more, which broke the JSON.

## Summary
- Changed `createJsonTextStreamTransformer` to always stream array outputs incrementally.
- Removed the first-chunk fast path that treated the first non-empty array chunk as complete JSON.
- Now it opens `[` once, emits only newly added items as chunks arrive, and closes `]` on flush.
- Added tests for:
  - first chunk already containing elements
  - first chunk being empty
  - a single complete chunk
- Updated the patch release note to document the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->