### PR TITLE
fix(core): stop title generation propagating to ephemeral subagent threads

### DIFF
--- a/.changeset/yellow-games-go.md
+++ b/.changeset/yellow-games-go.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed subagent delegations wasting an LLM call on title generation. When a supervisor agent's Memory has generateTitle enabled and delegates to a subagent with no memory of its own, the subagent inherited the supervisor's Memory instance and its generateTitle setting, firing an extra title-generation call for every ephemeral delegation thread that no one ever sees. Title generation is now treated as a top-level thread concern and is suppressed for these ephemeral subagent threads. To generate titles for a subagent's own threads, give that subagent its own memory configuration.

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -175,7 +175,13 @@ Each delegation creates a fresh `threadId` and a deterministic `resourceId` for 
 
 - **Thread ID**: Unique per delegation. The subagent starts with a clean message history every time it's called.
 - **Resource ID**: Derived as `{parentResourceId}-{agentName}`. Because the resource ID is stable across delegations, resource-scoped memory persists between calls. A subagent remembers facts from previous delegations by the same user.
-- **Memory instance**: If a subagent has no memory configured, it inherits the supervisor's `Memory` instance. If the subagent defines its own, that takes precedence.
+- **Memory instance**: If a subagent has no memory configured, it inherits the supervisor's `Memory` instance, including all of its options. If the subagent defines its own, that takes precedence.
+
+:::note
+
+Title generation (`generateTitle`) is a top-level thread concern and is **not** applied to inherited subagent threads. Because each delegation creates an ephemeral thread that no one sees, running title generation for it would waste an LLM call per delegation. To generate titles for a subagent's own threads, give that subagent its own memory configuration.
+
+:::
 
 The supervisor forwards its conversation context to the subagent so it has enough background to complete the task. Only the delegation prompt and the subagent's response are saved — the full parent conversation isn't stored. You can control which messages reach the subagent with the [`messageFilter`](/docs/agents/supervisor-agents#message-filtering) callback.
 

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -2842,3 +2842,112 @@ function titleGenerationTests(version: 'v1' | 'v2') {
 
 titleGenerationTests('v1');
 titleGenerationTests('v2');
+
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/18738
+ *
+ * When a supervisor agent has a Memory instance with `generateTitle: true` and delegates to a
+ * subagent that has NO memory of its own, Mastra injects the supervisor's Memory instance into the
+ * subagent. That inherited instance carries `generateTitle: true`, so every ephemeral subagent
+ * delegation triggers an extra title-generation LLM call on a thread no one ever sees.
+ *
+ * Title generation is a top-level thread concern and must NOT propagate to ephemeral subagent
+ * delegations. The delegation path injects per-call memory options for the subagent, and those
+ * options must disable title generation for the ephemeral thread.
+ */
+describe('sub-agent title generation propagation (#18738)', () => {
+  function makeSubAgent() {
+    return new Agent({
+      id: 'helper',
+      name: 'helper',
+      description: 'A helper sub-agent.',
+      instructions: 'Say hello.',
+      model: new MockLanguageModelV2({
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'a1', modelId: 'mock', timestamp: new Date(0) },
+            { type: 'text-start', id: 'x' },
+            { type: 'text-delta', id: 'x', delta: 'Hello from the sub-agent.' },
+            { type: 'text-end', id: 'x' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ]),
+        }),
+      }),
+    });
+  }
+
+  function supervisorModel() {
+    let call = 0;
+    return new MockLanguageModelV2({
+      doStream: async () => {
+        call++;
+        if (call === 1) {
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 's1', modelId: 'mock', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'agent-helper',
+                input: JSON.stringify({ prompt: 'hi' }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              },
+            ]),
+          };
+        }
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 's2', modelId: 'mock', timestamp: new Date(0) },
+            { type: 'text-start', id: 't' },
+            { type: 'text-delta', id: 't', delta: 'done' },
+            { type: 'text-end', id: 't' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ]),
+        };
+      },
+    });
+  }
+
+  it('does not generate a title for the ephemeral subagent thread when the inherited memory has generateTitle enabled', async () => {
+    const memory = new MockMemory({ options: { generateTitle: true } });
+
+    const subAgent = makeSubAgent();
+    // Spy on the subagent's title generation — if the inherited generateTitle propagates, this fires.
+    const subAgentGenTitle = vi.spyOn(subAgent, 'genTitle');
+
+    const supervisor = new Agent({
+      id: 'supervisor',
+      name: 'supervisor',
+      instructions: 'Delegate to the helper sub-agent.',
+      model: supervisorModel(),
+      agents: { helper: subAgent },
+      memory,
+    });
+
+    const stream = await supervisor.stream('Please delegate.', {
+      maxSteps: 3,
+      memory: { thread: 'top-level-thread', resource: 'user-1' },
+    });
+    for await (const _ of stream.fullStream) {
+      // drain
+    }
+
+    // Let any async title-generation kick off.
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(subAgentGenTitle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4854,7 +4854,10 @@ export class Agent<
                             memory: {
                               resource: subAgentResourceId,
                               thread: subAgentThreadId,
-                              options: { lastMessages: false },
+                              // Title generation is a top-level thread concern. Ephemeral subagent
+                              // delegation threads are never surfaced, so suppress it here to avoid
+                              // an extra title-generation LLM call per delegation (issue #18738).
+                              options: { lastMessages: false, generateTitle: false },
                             },
                           }
                         : {}),
@@ -4873,7 +4876,10 @@ export class Agent<
                             memory: {
                               resource: subAgentResourceId,
                               thread: subAgentThreadId,
-                              options: { lastMessages: false },
+                              // Title generation is a top-level thread concern. Ephemeral subagent
+                              // delegation threads are never surfaced, so suppress it here to avoid
+                              // an extra title-generation LLM call per delegation (issue #18738).
+                              options: { lastMessages: false, generateTitle: false },
                             },
                           }
                         : {}),
@@ -4989,6 +4995,10 @@ export class Agent<
                               thread: subAgentThreadId,
                               options: {
                                 lastMessages: false,
+                                // Title generation is a top-level thread concern. Ephemeral subagent
+                                // delegation threads are never surfaced, so suppress it here to avoid
+                                // an extra title-generation LLM call per delegation (issue #18738).
+                                generateTitle: false,
                               },
                             },
                           }
@@ -5010,6 +5020,10 @@ export class Agent<
                               thread: subAgentThreadId,
                               options: {
                                 lastMessages: false,
+                                // Title generation is a top-level thread concern. Ephemeral subagent
+                                // delegation threads are never surfaced, so suppress it here to avoid
+                                // an extra title-generation LLM call per delegation (issue #18738).
+                                generateTitle: false,
                               },
                             },
                           }


### PR DESCRIPTION
Fixes #18738.

When a supervisor agent's `Memory` has `generateTitle` enabled and delegates to a subagent that has no memory of its own, the subagent inherits the supervisor's `Memory` instance — including `generateTitle`. That meant every ephemeral delegation fired an extra title-generation LLM call on a thread nobody ever sees.

Title generation is a top-level thread concern, so it's now suppressed on the per-call memory options injected for these ephemeral subagent threads. Nothing changes for a subagent that configures its own memory — it still controls `generateTitle`.

Before, delegating from this supervisor triggered a title-generation call for the subagent's throwaway thread:

```ts
const supervisor = new Agent({
  name: 'supervisor',
  model,
  agents: { helper },
  memory: new Memory({ options: { generateTitle: true } }),
});
// helper has no memory of its own -> inherited generateTitle: true -> wasted title call per delegation
```

After, the same setup runs the delegation with no extra title call. If you do want titles on a subagent's own threads, give that subagent its own memory config.

Added a regression test in `title-generation.test.ts` and a note in the memory docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When a supervisor asks a helper agent to do work, the helper was sometimes doing extra “name this conversation” work even though that conversation is temporary and never shown to users. This change stops that wasted work for delegated helper threads, while still letting agents with their own memory settings decide whether to name their own conversations.

## Summary
- Suppresses `generateTitle` for ephemeral subagent/delegation threads by passing it through per-call memory options alongside `lastMessages: false`.
- Keeps title generation enabled for subagents that define their own memory configuration.
- Adds a regression test covering delegated subagent title-generation propagation.
- Updates memory docs to clarify inheritance behavior and that `generateTitle` is a top-level thread concern.
- Adds a changeset entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->