### PR TITLE
fix(core): release leaked scorer hook when internal Mastra is torn down

### DIFF
--- a/.changeset/smart-vans-shake.md
+++ b/.changeset/smart-vans-shake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an internal Mastra instance leaking a scorer hook onto a shared, process-wide emitter. Agents that use a Workspace (or any unwired agent run) built a throwaway internal Mastra whose scorer hook was never removed, so it kept firing on every scorer run and flooded logs with "scorer not found" errors. The scorer still ran correctly on the real Mastra — the noise came from the orphaned handler, which is now released on teardown.

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -616,6 +616,15 @@ export class AgentController<TState = {}> {
    */
   __registerMastra(mastra: Mastra): void {
     this.#externalMastra = mastra;
+
+    // If `init()` already built an internal Mastra before we were wired to a
+    // parent, drop it: the parent now owns storage/agents/observability, but the
+    // orphaned internal instance still holds a global scorer hook that fires
+    // (and fails to resolve the scorer) on every scorer run. Release it.
+    if (this.#internalMastra) {
+      this.#internalMastra.__unregisterHooks();
+      this.#internalMastra = undefined;
+    }
   }
 
   /**

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3079,8 +3079,10 @@ export class Agent<
     this.#mastra = mastra;
 
     // Tear down any ephemeral Mastra: we now have a real one. Workers stop in
-    // the background — we don't await to keep this hot path sync-ish.
+    // the background — we don't await to keep this hot path sync-ish. Release
+    // its global scorer hook synchronously so it can't outlive the instance.
     if (this.#ephemeralMastra) {
+      this.#ephemeralMastra.__unregisterHooks();
       void this.#ephemeralMastra.stopWorkers().catch(() => {});
       this.#ephemeralMastra = undefined;
     }

--- a/packages/core/src/hooks/index.test.ts
+++ b/packages/core/src/hooks/index.test.ts
@@ -1,6 +1,6 @@
 import { vi, it, expect } from 'vitest';
 
-import { AvailableHooks, executeHook, registerHook } from './index';
+import { AvailableHooks, deregisterHook, executeHook, registerHook } from './index';
 
 const hookBody = {
   input: 'test',
@@ -32,4 +32,33 @@ it('should not block the main thread', async () => {
   executeHook(AvailableHooks.ON_EVALUATION, hookBody);
 
   expect(hook).not.toHaveBeenCalled();
+});
+
+it('should stop firing a hook after it is deregistered', async () => {
+  const hook = vi.fn();
+
+  registerHook(AvailableHooks.ON_SCORER_RUN, hook);
+  deregisterHook(AvailableHooks.ON_SCORER_RUN, hook);
+  executeHook(AvailableHooks.ON_SCORER_RUN, hookBody as any);
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(hook).not.toHaveBeenCalled();
+});
+
+it('should only deregister the given handler, leaving others intact', async () => {
+  const kept = vi.fn();
+  const dropped = vi.fn();
+
+  registerHook(AvailableHooks.ON_SCORER_RUN, kept);
+  registerHook(AvailableHooks.ON_SCORER_RUN, dropped);
+  deregisterHook(AvailableHooks.ON_SCORER_RUN, dropped);
+  executeHook(AvailableHooks.ON_SCORER_RUN, hookBody as any);
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(dropped).not.toHaveBeenCalled();
+  expect(kept).toHaveBeenCalledWith(hookBody);
+
+  deregisterHook(AvailableHooks.ON_SCORER_RUN, kept);
 });

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -16,6 +16,11 @@ export function registerHook(hook: `${AvailableHooks}`, action: Handler<any>): v
   hooks.on(hook, action);
 }
 
+export function deregisterHook(hook: AvailableHooks.ON_SCORER_RUN, action: Handler<ScoringHookInput>): void;
+export function deregisterHook(hook: `${AvailableHooks}`, action: Handler<any>): void {
+  hooks.off(hook, action);
+}
+
 export function executeHook(hook: AvailableHooks.ON_SCORER_RUN, action: ScoringHookInput): void;
 export function executeHook(hook: `${AvailableHooks}`, data: unknown): void {
   // do not block the main thread

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -22,7 +22,7 @@ import { EventEmitterPubSub } from '../events/event-emitter';
 import type { PubSub } from '../events/pubsub';
 import type { Event, EventCallback } from '../events/types';
 import type { Harness } from '../harness';
-import { AvailableHooks, registerHook } from '../hooks';
+import { AvailableHooks, deregisterHook, registerHook } from '../hooks';
 import { LicenseClient } from '../license';
 import type { MastraModelGatewayInterface } from '../llm/model/gateways';
 import { getGatewayId } from '../llm/model/gateways';
@@ -619,6 +619,7 @@ export class Mastra<
   #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
   #observability: ObservabilityEntrypoint;
+  #onScorerHook?: ReturnType<typeof createOnScorerHook>;
   #tts?: TTTS;
   #deployer?: MastraDeployer;
   #serverMiddleware: Array<{
@@ -1555,7 +1556,12 @@ export class Mastra<
       agentController.__registerMastra(this);
     }
 
-    registerHook(AvailableHooks.ON_SCORER_RUN, createOnScorerHook(this));
+    // `registerHook` adds to a module-level emitter that never drops handlers on
+    // its own. Keep the reference so short-lived internal/ephemeral Mastras can
+    // release it on teardown (see `__unregisterHooks`); otherwise their handler
+    // fires on every scorer run for the lifetime of the process.
+    this.#onScorerHook = createOnScorerHook(this);
+    registerHook(AvailableHooks.ON_SCORER_RUN, this.#onScorerHook);
 
     /*
       Initialize observability with Mastra context (after storage configured)
@@ -4905,6 +4911,21 @@ export class Mastra<
 
     await this.#pubsub.flush();
     this.#workersStarted = false;
+  }
+
+  /**
+   * Release the module-level hooks this instance registered in its constructor.
+   * The scorer hook is added to a shared emitter that never drops handlers on
+   * its own, so short-lived internal/ephemeral Mastras must call this on teardown
+   * or their handler keeps firing (and failing to resolve the scorer) on every
+   * scorer run for the rest of the process. Idempotent.
+   * @internal
+   */
+  __unregisterHooks(): void {
+    if (this.#onScorerHook) {
+      deregisterHook(AvailableHooks.ON_SCORER_RUN, this.#onScorerHook);
+      this.#onScorerHook = undefined;
+    }
   }
 
   /**

--- a/packages/core/src/mastra/scorer-hook-teardown.test.ts
+++ b/packages/core/src/mastra/scorer-hook-teardown.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { AvailableHooks, executeHook } from '../hooks';
+import { InMemoryStore } from '../storage/mock';
+
+import { Mastra } from './index';
+
+// A scorer run for an entity/scorer this Mastra does not own — exactly what an
+// empty internal/ephemeral Mastra sees when the real Mastra runs a scorer,
+// since the scorer hook lives on a shared, process-wide emitter.
+const foreignScorerRun = {
+  entity: { id: 'agent-owned-by-another-mastra' },
+  entityType: 'AGENT',
+  scorer: { id: 'a-scorer-this-mastra-never-registered' },
+  input: 'in',
+  output: 'out',
+} as any;
+
+async function flushHook() {
+  // executeHook defers via setImmediate and the handler awaits internally.
+  await new Promise(resolve => setTimeout(resolve, 20));
+}
+
+describe('scorer hook teardown', () => {
+  it('an empty Mastra logs a failed-hook error for a scorer it does not own', async () => {
+    const mastra = new Mastra({ storage: new InMemoryStore() });
+    const trackException = vi.spyOn(mastra.getLogger(), 'trackException');
+
+    executeHook(AvailableHooks.ON_SCORER_RUN, foreignScorerRun);
+    await flushHook();
+
+    // Reproduces the reported flooding: the handler fires and cannot resolve the
+    // scorer, so it logs an exception on every scorer run.
+    expect(trackException).toHaveBeenCalled();
+
+    mastra.__unregisterHooks();
+  });
+
+  it('does not fire the scorer hook after __unregisterHooks', async () => {
+    const mastra = new Mastra({ storage: new InMemoryStore() });
+    const trackException = vi.spyOn(mastra.getLogger(), 'trackException');
+
+    mastra.__unregisterHooks();
+
+    executeHook(AvailableHooks.ON_SCORER_RUN, foreignScorerRun);
+    await flushHook();
+
+    expect(trackException).not.toHaveBeenCalled();
+  });
+
+  it('__unregisterHooks is idempotent', () => {
+    const mastra = new Mastra({ storage: new InMemoryStore() });
+    expect(() => {
+      mastra.__unregisterHooks();
+      mastra.__unregisterHooks();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #18762. Agents that use a `Workspace` and have scorers attached flood the logs with `MASTRA_SCORER_FAILED_TO_RUN_HOOK` / "scorer not found" errors on every scorer run, even though the scorer itself runs fine.

The `onScorerRun` hook lives on a module-level `mitt` emitter, and `registerHook` only ever calls `.on` — nothing removes handlers. Every `Mastra` registers a handler in its constructor. The problem is the throwaway internal Mastra that `AgentController` builds during `init()` (and the ephemeral one in `Agent#getOrCreateEphemeralMastra`): it has no agents or scorers, and when the real Mastra takes over via `__registerMastra` the internal instance is dropped — but its handler stays on the shared emitter forever. `executeHook` fans out to all handlers, so that orphaned empty-registry handler fires on every scorer run, `getAgentById` throws (`agents: ""`), and the failure gets logged/exported through the app's observability.

Gave the emitter an `off` path (`deregisterHook`) and had each Mastra keep the reference to the handler it registered, exposed as `__unregisterHooks()`. Then I call it at the two spots where these short-lived instances are already being torn down — `Agent.__registerMastra` (ephemeral) and `AgentController.__registerMastra` (internal). The real Mastra's handler is untouched, so scoring keeps working; only the leaked one goes away.

Added unit tests for the deregister path and an integration test that reproduces the flood on an empty Mastra and confirms it stops after teardown (reverting the `__unregisterHooks` call fails that test). Full agent-controller + durable scorer e2e suites stay green (377 tests). Changeset included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops a “ghost” callback from hanging around after temporary agents are thrown away. That ghost callback was causing the app to keep complaining about missing scorers over and over, even though scoring still worked.

## Summary
- Added hook deregistration support so registered handlers can be removed from the shared emitter.
- Updated `Mastra` to store its scorer hook handler and unregister it during teardown via a new `__unregisterHooks()` method.
- Cleaned up leaked scorer hooks when internal/ephemeral `Mastra` instances are replaced or torn down in `AgentController` and `Agent`.
- Added tests covering hook removal, idempotent teardown, and the scorer-hook leak/noise scenario.
- Added a changeset for the `@mastra/core` patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->