### PR TITLE
fix(deployer): bundle local workspace deps in dev

### DIFF
--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -67,13 +67,21 @@ export class DevBundler extends Bundler {
     const bundlerOptions = await this.getUserBundlerOptions(entryFile, outputDirectory);
     const sourcemapEnabled = !!bundlerOptions?.sourcemap;
 
+    const devServerAnalysisEntry = `
+      import { scoreTracesWorkflow } from '@mastra/core/evals/scoreTraces';
+      import { createNodeServer, getToolExports } from '#server';
+      export { scoreTracesWorkflow, createNodeServer, getToolExports };
+    `;
     const inputOptions = await getWatcherInputOptions(
       entryFile,
       this.platform,
       {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
       },
-      { sourcemap: sourcemapEnabled },
+      {
+        sourcemap: sourcemapEnabled,
+        analysisEntries: [entryFile, devServerAnalysisEntry],
+      },
     );
     const toolsInputOptions = await this.listToolsInputOptions(toolsPaths);
 

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -381,6 +381,7 @@ export async function analyzeBundle(
       plugins: [detectPinoTransports(detectedPinoTransports)],
       configFile: false,
       babelrc: false,
+      code: false,
     });
 
     // Write the entry file to the output dir so that we can use it for workspace resolution stuff

--- a/packages/deployer/src/build/analyze/analyzeEntry.test.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.test.ts
@@ -273,13 +273,24 @@ describe('analyzeEntry', () => {
         sourcemapEnabled: false,
         workspaceMap,
         projectRoot: root,
+        initialDepsToOptimize: new Map([
+          [
+            '@internal/shared',
+            {
+              exports: ['shared'],
+              rootPath: `${root}/packages/shared`,
+              isWorkspace: true,
+              version: '1.0.0',
+            },
+          ],
+        ]),
       },
     );
 
-    expect(rollup).toHaveBeenCalledTimes(3);
+    expect(rollup).toHaveBeenCalledTimes(2);
     expect(result.dependencies.size).toBe(2);
     expect(result.dependencies.get('@internal/a')?.exports).toEqual(['a']);
-    expect(result.dependencies.get('@internal/shared')?.exports).toEqual(['shared']);
+    expect(result.dependencies.get('@internal/shared')?.exports).toEqual(['shared', 'shared2']);
     // Verify that the analyzer doesn't get stuck in infinite loops.
     // The initialDepsToOptimize map tracks already-analyzed dependencies to prevent re-analysis.
     // (Test will timeout if there's an infinite loop issue)

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 import { noopLogger } from '@mastra/core/logger';
 import type { IMastraLogger } from '@mastra/core/logger';
 import commonjs from '@rollup/plugin-commonjs';
@@ -9,6 +9,7 @@ import { resolveModule } from 'local-pkg';
 import { rollup } from 'rollup';
 import type { OutputChunk, Plugin, SourceMap } from 'rollup';
 import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
+import { mastraInternalAliasPlugin, mastraToolsAliasPlugin } from '../bundler';
 import { getPackageRootPath } from '../package-info';
 import { esbuild } from '../plugins/esbuild';
 import { protocolExternalResolver } from '../plugins/protocol-external-resolver';
@@ -27,7 +28,6 @@ function getInputPlugins(
   mastraEntry: string,
   { sourcemapEnabled }: { sourcemapEnabled: boolean },
 ): Plugin[] {
-  const normalizedMastraEntry = slash(mastraEntry);
   let virtualPlugin = null;
   if (isVirtualFile) {
     virtualPlugin = virtual({
@@ -43,22 +43,10 @@ function getInputPlugins(
 
   plugins.push(
     ...[
-      tsConfigPaths(),
       protocolExternalResolver(),
-      {
-        name: 'custom-alias-resolver',
-        resolveId(id: string) {
-          if (id === '#server') {
-            return slash(fileURLToPath(import.meta.resolve('@mastra/deployer/server')));
-          }
-          if (id === '#mastra') {
-            return normalizedMastraEntry;
-          }
-          if (id.startsWith('@mastra/server')) {
-            return fileURLToPath(import.meta.resolve(id));
-          }
-        },
-      } satisfies Plugin,
+      mastraInternalAliasPlugin(mastraEntry),
+      mastraToolsAliasPlugin(),
+      tsConfigPaths(),
       json(),
       esbuild(),
       commonjs({
@@ -197,17 +185,26 @@ async function captureDependenciesToOptimize(
         }
 
         for (const [innerDep, innerMeta] of analysis.dependencies) {
-          /**
-           * Only add to depsToOptimize if:
-           * - It's a workspace package
-           * - We haven't already processed it
-           * - We haven't already discovered it at the beginning
-           */
-          if (innerMeta.isWorkspace && !internalMap.has(innerDep) && !depsToOptimize.has(innerDep)) {
-            depsToOptimize.set(innerDep, innerMeta);
-            internalMap.set(innerDep, innerMeta);
-            hasAddedDeps = true;
+          if (!innerMeta.isWorkspace) {
+            continue;
           }
+
+          const existingMeta = depsToOptimize.get(innerDep);
+          if (existingMeta) {
+            depsToOptimize.set(innerDep, {
+              ...existingMeta,
+              exports: [...new Set([...existingMeta.exports, ...innerMeta.exports])],
+            });
+            continue;
+          }
+
+          if (internalMap.has(innerDep)) {
+            continue;
+          }
+
+          depsToOptimize.set(innerDep, innerMeta);
+          internalMap.set(innerDep, innerMeta);
+          hasAddedDeps = true;
         }
       } catch (err) {
         logger.error('Failed to resolve or analyze dependency', { dep, error: (err as Error).message });

--- a/packages/deployer/src/build/analyze/bundleExternals.test.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.test.ts
@@ -61,6 +61,31 @@ describe('createVirtualDependencies', () => {
     });
   });
 
+  it('should preserve merged workspace subpath exports in dev cache facades', () => {
+    const depsToOptimize = new Map<string, DependencyMetadata>([
+      [
+        '@mastra/core/llm',
+        {
+          exports: ['PROVIDER_REGISTRY', 'EMBEDDING_MODELS'],
+          rootPath: '/workspace/packages/core',
+          isWorkspace: true,
+        },
+      ],
+    ]);
+
+    const result = createVirtualDependencies(depsToOptimize, {
+      workspaceRoot: '/workspace',
+      projectRoot: '/workspace/apps/mastra',
+      outputDir: '/workspace/apps/mastra/.mastra/.build',
+      bundlerOptions: { isDev: true },
+    });
+
+    expect(result.optimizedDependencyEntries.get('@mastra/core/llm')).toEqual({
+      name: 'packages/core/node_modules/.cache/@mastra__core__llm',
+      virtual: "export { PROVIDER_REGISTRY, EMBEDDING_MODELS } from '@mastra/core/llm';",
+    });
+  });
+
   it('should handle default export only', () => {
     const depsToOptimize = new Map<string, DependencyMetadata>([
       [

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -19,6 +19,45 @@ import { tsConfigPaths } from './plugins/tsconfig-paths';
 import { getNodeResolveOptions, slash } from './utils';
 import type { BundlerPlatform } from './utils';
 
+export function mastraInternalAliasPlugin(entryFile: string): Plugin {
+  const normalizedEntryFile = slash(entryFile);
+
+  return alias({
+    entries: [
+      {
+        find: /^\#server$/,
+        replacement: slash(fileURLToPath(import.meta.resolve('@mastra/deployer/server'))),
+      },
+      {
+        find: /^\@mastra\/server\/(.*)/,
+        replacement: `@mastra/server/$1`,
+        customResolver: id => {
+          if (id.startsWith('@mastra/server')) {
+            return {
+              id: fileURLToPath(import.meta.resolve(id)),
+            };
+          }
+        },
+      },
+      { find: /^\#mastra$/, replacement: normalizedEntryFile },
+    ],
+  });
+}
+
+export function mastraToolsAliasPlugin(): Plugin {
+  return {
+    name: 'tools-rewriter',
+    resolveId(id: string) {
+      if (id === '#tools') {
+        return {
+          id: './tools.mjs',
+          external: true,
+        };
+      }
+    },
+  };
+}
+
 export async function getInputOptions(
   entryFile: string,
   analyzedBundleInfo: Awaited<ReturnType<typeof analyzeBundle>>,
@@ -45,7 +84,6 @@ export async function getInputOptions(
   const externalsCopy = new Set<string>(analyzedBundleInfo.externalDependencies.keys());
   const externals = externalsPreset ? [] : Array.from(externalsCopy);
 
-  const normalizedEntryFile = slash(entryFile);
   return {
     logLevel: process.env.MASTRA_BUNDLER_DEBUG === 'true' ? 'debug' : 'silent',
     treeshake: 'smallest',
@@ -79,38 +117,9 @@ export async function getInputOptions(
           };
         },
       } satisfies Plugin,
-      alias({
-        entries: [
-          {
-            find: /^\#server$/,
-            replacement: slash(fileURLToPath(import.meta.resolve('@mastra/deployer/server'))),
-          },
-          {
-            find: /^\@mastra\/server\/(.*)/,
-            replacement: `@mastra/server/$1`,
-            customResolver: id => {
-              if (id.startsWith('@mastra/server')) {
-                return {
-                  id: fileURLToPath(import.meta.resolve(id)),
-                };
-              }
-            },
-          },
-          { find: /^\#mastra$/, replacement: normalizedEntryFile },
-        ],
-      }),
+      mastraInternalAliasPlugin(entryFile),
       tsConfigPaths(),
-      {
-        name: 'tools-rewriter',
-        resolveId(id: string) {
-          if (id === '#tools') {
-            return {
-              id: './tools.mjs',
-              external: true,
-            };
-          }
-        },
-      } satisfies Plugin,
+      mastraToolsAliasPlugin(),
       esbuild({
         platform,
         define: env,

--- a/packages/deployer/src/build/watcher.ts
+++ b/packages/deployer/src/build/watcher.ts
@@ -24,14 +24,15 @@ export async function getInputOptions(
       enableEsmShim: true,
       externals: true,
     },
-  }: { sourcemap?: boolean; bundlerOptions?: BundlerOptions } = {},
+    analysisEntries = [entryFile],
+  }: { sourcemap?: boolean; bundlerOptions?: BundlerOptions; analysisEntries?: string[] } = {},
 ) {
   const closestPkgJson = pkg.up({ cwd: dirname(entryFile) });
   const projectRoot = closestPkgJson ? dirname(slash(closestPkgJson)) : slash(process.cwd());
   const { workspaceMap, workspaceRoot } = await getWorkspaceInformation({ mastraEntryFile: entryFile });
 
   const analyzeEntryResult = await analyzeBundle(
-    [entryFile],
+    analysisEntries,
     entryFile,
     {
       outputDir: posix.join(process.cwd(), '.mastra', '.build'),


### PR DESCRIPTION
## Summary
- Share Mastra internal alias handling between the production bundler and dev bundler.
- Preserve `#tools` as an external tools module through a reusable Rollup plugin.
- Allow watcher analysis to include additional entry points so local workspace dependencies are discovered and optimized correctly.
- Add coverage for local workspace dependency export merging and external package handling.

## Test plan
- `pnpm --filter @mastra/deployer test src/build/analyze/analyzeEntry.test.ts src/build/analyze/bundleExternals.test.ts` *(blocked: worktree lacked built `@mastra/core` artifacts; after building required internals, `@mastra/core build:lib` fails on existing TypeScript errors outside this change, including workflow generic errors and missing `@mastra/schema-compat/zod-to-json` types.)*

## Changeset
- Not included; this is local-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When developing, this PR makes the bundler treat your local workspace packages more like it does in production, so imports and exported helpers/tools resolve the same way. It also teaches the dev watcher to inspect a few extra starting files, helping it discover and optimize the right local dependencies.

## Summary
- Reused the same internal Mastra alias handling in both dev and production bundling by extracting it into reusable Rollup plugins.
- Preserved `#tools` as an external tools module via a dedicated Rollup plugin, rather than inline ad-hoc rewriting.
- Extended watcher/bundle analysis to include additional entry modules so local workspace dependency exports are discovered and optimized correctly.
- Updated transitive/workspace dependency analysis to merge export lists when the same workspace dependency is encountered again, reducing redundant processing and fixing export aggregation.
- Added dev-cache/virtual dependency test coverage for workspace export merging and external package handling.
- Adjusted the dev analysis Babel transform used for pino transport detection to avoid emitting transformed code (`code: false`), preventing monorepo e2e stderr deopt failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->