### PR TITLE
Ensure snapshot publishes include forced packages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -490,6 +490,18 @@ jobs:
         if: steps.check-snapshot-pre-json.outputs.files_exists == 'true'
         run: pnpm changeset-cli pre exit
 
+      - name: Add snapshot-only package bumps
+        run: |
+          cat > .changeset/snapshot-forced-packages.md <<'EOF'
+          ---
+          '@mastra/observability': patch
+          '@mastra/auth-studio': patch
+          '@mastra/core': patch
+          ---
+
+          Include observability, auth studio, and core in snapshot publishes.
+          EOF
+
       - name: Run Changeset Version Snapshot
         run: pnpm changeset-cli version --snapshot ${{ env.FINAL_TAG }}
         env:


### PR DESCRIPTION
## Summary
- add a snapshot-only changeset in the npm publish workflow
- force snapshot versioning for @mastra/observability, @mastra/auth-studio, and @mastra/core without affecting regular publishes

## Test plan
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-publish.yml"); puts "yaml ok"'\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes sure a few important packages get a small version bump when making snapshot releases, so they actually get included. It only affects snapshot publishes, not normal releases.

## Summary
- Added a snapshot-only Changesets file in the npm publish workflow.
- Forces patch version bumps for `@mastra/observability`, `@mastra/auth-studio`, and `@mastra/core` during snapshot publishes.
- Keeps regular publish behavior unchanged by applying this only in the snapshot job before snapshot versioning runs.

## Validation
- Parsed `.github/workflows/npm-publish.yml` with Ruby YAML parsing.
- Checked the diff with `git diff --check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->