### PR TITLE
Preserve pnpm install policy in deployer output

### DIFF
--- a/.changeset/pnpm-policy-preserve.md
+++ b/.changeset/pnpm-policy-preserve.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Copy pnpm install policy from the source workspace into generated deployer output so pnpm 11 build-script approvals are preserved.

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -85,12 +85,6 @@ export abstract class Bundler extends MastraBundler {
         2,
       ),
     );
-
-    // pnpm v11 requires build policy via pnpm-workspace.yaml in the output directory
-    await writeFile(
-      join(outputDirectory, 'pnpm-workspace.yaml'),
-      "packages:\n  - '.'\nallowBuilds:\n  bcrypt: true\n  esbuild: true\n  sharp: true\n  protobufjs: true\n  workerd: true\n  bufferutil: true\n  utf-8-validate: true\n",
-    );
   }
 
   protected createBundler(inputOptions: InputOptions, outputOptions: Partial<OutputOptions> & { dir: string }) {

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { copyPnpmWorkspaceSettings } from './deps';
+
+describe('copyPnpmWorkspaceSettings', () => {
+  it('copies pnpm install policy without copying source workspace packages', () => {
+    const output = copyPnpmWorkspaceSettings(
+      `packages:\n  - packages/*\n\ncatalog:\n  react: ^19.0.0\n\nminimumReleaseAge: 1440\nminimumReleaseAgeExclude:\n  - '@mastra/*'\n\nallowBuilds:\n  onnxruntime-node: false\n  node-pty: true\n\npatchedDependencies:\n  foo@1.0.0: patches/foo.patch\n`,
+    );
+
+    expect(output).toBe(
+      `packages:\n  - '.'\n\nminimumReleaseAge: 1440\n\nminimumReleaseAgeExclude:\n  - '@mastra/*'\n\nallowBuilds:\n  onnxruntime-node: false\n  node-pty: true\n`,
+    );
+  });
+
+  it('uses requested architecture over source supportedArchitectures', () => {
+    const output = copyPnpmWorkspaceSettings(
+      `packages:\n  - packages/*\n\nsupportedArchitectures:\n  os: [\"linux\"]\n`,
+      { os: ['darwin'], cpu: ['arm64'] },
+    );
+
+    expect(output).toBe(`packages:\n  - '.'\n\nsupportedArchitectures:\n  os: [\"darwin\"]\n  cpu: [\"arm64\"]\n`);
+  });
+});

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -16,6 +16,69 @@ interface ArchitectureOptions {
   libc?: string[];
 }
 
+const PNPM_CONFIG_KEYS_TO_COPY = new Set([
+  'allowBuilds',
+  'onlyBuiltDependencies',
+  'ignoredBuiltDependencies',
+  'neverBuiltDependencies',
+  'minimumReleaseAge',
+  'minimumReleaseAgeExclude',
+  'trustPolicy',
+  'trustPolicyExclude',
+  'trustPolicyIgnoreAfter',
+  'supportedArchitectures',
+]);
+
+function getTopLevelYamlKey(line: string) {
+  const match = /^(?!\s)([\w-]+):/.exec(line);
+  return match?.[1];
+}
+
+export function copyPnpmWorkspaceSettings(source: string, options: ArchitectureOptions = {}) {
+  const hasArchitecture = Boolean(options.os?.length || options.cpu?.length || options.libc?.length);
+  const lines = source.split(/\r?\n/);
+  const blocks: string[] = [];
+
+  for (let index = 0; index < lines.length; ) {
+    const key = getTopLevelYamlKey(lines[index] ?? '');
+    if (!key) {
+      index += 1;
+      continue;
+    }
+
+    const start = index;
+    index += 1;
+    while (index < lines.length && !getTopLevelYamlKey(lines[index] ?? '')) {
+      index += 1;
+    }
+
+    if (!PNPM_CONFIG_KEYS_TO_COPY.has(key) || (key === 'supportedArchitectures' && hasArchitecture)) {
+      continue;
+    }
+
+    const block = lines.slice(start, index).join('\n').trimEnd();
+    if (block) {
+      blocks.push(block);
+    }
+  }
+
+  if (hasArchitecture) {
+    const architectureBlock = ['supportedArchitectures:'];
+    if (options.os?.length) {
+      architectureBlock.push(`  os: ${JSON.stringify(options.os)}`);
+    }
+    if (options.cpu?.length) {
+      architectureBlock.push(`  cpu: ${JSON.stringify(options.cpu)}`);
+    }
+    if (options.libc?.length) {
+      architectureBlock.push(`  libc: ${JSON.stringify(options.libc)}`);
+    }
+    blocks.push(architectureBlock.join('\n'));
+  }
+
+  return ["packages:\n  - '.'", ...blocks].join('\n\n') + '\n';
+}
+
 export class Deps extends MastraBase {
   private packageManager: PackageManager;
   private rootDir: string;
@@ -90,38 +153,31 @@ export class Deps extends MastraBase {
     });
   }
 
-  private async writePnpmConfig(dir: string, options: ArchitectureOptions) {
+  private findPnpmWorkspaceFile(dir: string): string | null {
     const workspaceYamlPath = path.join(dir, 'pnpm-workspace.yaml');
-
-    const lines: string[] = [
-      'packages:',
-      "  - '.'",
-      'allowBuilds:',
-      '  bcrypt: true',
-      '  esbuild: true',
-      '  sharp: true',
-      '  protobufjs: true',
-      '  workerd: true',
-      '  bufferutil: true',
-      '  utf-8-validate: true',
-      'minimumReleaseAge: 0',
-    ];
-    if (options.os?.length || options.cpu?.length || options.libc?.length) {
-      lines.push('');
-      lines.push('supportedArchitectures:');
-      if (options.os?.length) {
-        lines.push(`  os: ${JSON.stringify(options.os)}`);
-      }
-      if (options.cpu?.length) {
-        lines.push(`  cpu: ${JSON.stringify(options.cpu)}`);
-      }
-      if (options.libc?.length) {
-        lines.push(`  libc: ${JSON.stringify(options.libc)}`);
-      }
+    if (fs.existsSync(workspaceYamlPath)) {
+      return workspaceYamlPath;
     }
-    lines.push('');
 
-    await fsPromises.writeFile(workspaceYamlPath, lines.join('\n'), 'utf-8');
+    const parentDir = path.resolve(dir, '..');
+    if (parentDir !== dir) {
+      return this.findPnpmWorkspaceFile(parentDir);
+    }
+
+    return null;
+  }
+
+  private async writePnpmConfig(dir: string, options: ArchitectureOptions = {}) {
+    const sourceWorkspaceYamlPath = this.findPnpmWorkspaceFile(this.rootDir);
+    const sourceWorkspaceYaml = sourceWorkspaceYamlPath
+      ? await fsPromises.readFile(sourceWorkspaceYamlPath, 'utf-8')
+      : '';
+
+    await fsPromises.writeFile(
+      path.join(dir, 'pnpm-workspace.yaml'),
+      copyPnpmWorkspaceSettings(sourceWorkspaceYaml, options),
+      'utf-8',
+    );
   }
 
   private async writeYarnConfig(dir: string, options: ArchitectureOptions) {
@@ -181,9 +237,7 @@ export class Deps extends MastraBase {
 
     switch (pm) {
       case 'pnpm':
-        if (architecture) {
-          await this.writePnpmConfig(dir, architecture);
-        }
+        await this.writePnpmConfig(dir, architecture);
         break;
       case 'yarn':
         // similar to --ignore-workspace but for yarn


### PR DESCRIPTION
## Summary
- Copy pnpm install policy blocks from the source workspace into generated deployer output.
- Keep deployer output scoped to its own package while preserving pnpm 11 build-script approvals such as allowBuilds and supportedArchitectures.
- Remove the hardcoded generated pnpm build policy from package.json writing.

Fixes https://github.com/mastra-ai/mastra/issues/16613

## Test plan
- pnpm --filter @mastra/deployer exec vitest run src/services/deps.test.ts
- pnpm --filter @mastra/deployer build:lib
- pnpm --filter @mastra/deployer lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the deployer keep the same pnpm settings as the source project, so installs still follow the right rules and approved builds don’t get lost. It also stops the deployer from writing a one-size-fits-all pnpm policy and instead copies only the useful settings into the generated output.

## Summary
- Copies pnpm workspace install policy from the source workspace into deployer output.
- Preserves pnpm 11 build-script approvals like `allowBuilds` and `supportedArchitectures`.
- Forces the generated deployer workspace to stay scoped to `packages: ['.']`.
- Stops writing the hardcoded pnpm build policy block into generated `package.json` / workspace output.
- Adds tests covering copied pnpm settings and architecture overrides.
- Includes a patch changeset for `@mastra/deployer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->