### PR TITLE
Preserve npm alias dependency specs in deployer output

### DIFF
--- a/.changeset/brave-aliases-push.md
+++ b/.changeset/brave-aliases-push.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Preserve npm alias dependency specs in generated deployer package.json files.

--- a/packages/deployer/src/build/analyze.test.ts
+++ b/packages/deployer/src/build/analyze.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { noopLogger } from '@mastra/core/logger';
@@ -29,6 +29,81 @@ describe('workspace path normalization (issue #13022)', () => {
     expect(rollupImport.startsWith(windowsPath)).toBe(false);
     expect(rollupImport.startsWith(slash(windowsPath))).toBe(true);
   });
+});
+
+describe('external dependency versions', () => {
+  it('resolves an external dependency version from the bundled workspace importer', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'mastra-importer-version-'));
+    tempDirs.push(tempDir);
+
+    const appDir = join(tempDir, 'apps', 'app');
+    const workspacePackageDir = join(tempDir, 'packages', 'workspace-package');
+    const externalPackageDir = join(workspacePackageDir, 'node_modules', 'external-only-from-workspace');
+    const entryFile = join(appDir, 'index.ts');
+    const outputDir = join(appDir, '.mastra', '.build');
+
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(join(appDir, 'node_modules', '@internal'), { recursive: true });
+    await mkdir(externalPackageDir, { recursive: true });
+    await mkdir(join(workspacePackageDir, 'src'), { recursive: true });
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test-workspace', version: '1.0.0' }));
+    await writeFile(join(tempDir, 'pnpm-workspace.yaml'), `packages:\n  - apps/*\n  - packages/*\n`);
+    await writeFile(join(appDir, 'package.json'), JSON.stringify({ name: 'app', version: '1.0.0', type: 'module' }));
+    await writeFile(
+      join(workspacePackageDir, 'package.json'),
+      JSON.stringify({
+        name: '@internal/workspace-package',
+        version: '1.0.0',
+        type: 'module',
+        main: './src/index.js',
+        dependencies: {
+          'external-only-from-workspace': '4.5.6',
+        },
+      }),
+    );
+    await writeFile(
+      join(externalPackageDir, 'package.json'),
+      JSON.stringify({ name: 'external-only-from-workspace', version: '4.5.6', type: 'module', main: './index.js' }),
+    );
+    await writeFile(join(externalPackageDir, 'index.js'), `export const externalValue = 'external';`);
+    await writeFile(
+      join(workspacePackageDir, 'src', 'index.js'),
+      `import { externalValue } from 'external-only-from-workspace';\nexport const workspaceValue = externalValue;`,
+    );
+    await symlink(workspacePackageDir, join(appDir, 'node_modules', '@internal', 'workspace-package'));
+    await writeFile(
+      entryFile,
+      `import { workspaceValue } from '@internal/workspace-package';\nexport const value = workspaceValue;`,
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      const result = await analyzeBundle(
+        [entryFile],
+        entryFile,
+        {
+          outputDir,
+          projectRoot: appDir,
+          platform: 'node',
+          isDev: true,
+          bundlerOptions: {
+            externals: ['external-only-from-workspace'],
+            enableSourcemap: false,
+          },
+        },
+        noopLogger,
+      );
+
+      expect(result.externalDependencies.get('external-only-from-workspace')).toEqual({
+        version: '4.5.6',
+        packageSpec: undefined,
+      });
+    } finally {
+      process.chdir(originalCwd);
+    }
+  }, 15000);
 });
 
 describe('protocol imports', () => {

--- a/packages/deployer/src/build/analyze.test.ts
+++ b/packages/deployer/src/build/analyze.test.ts
@@ -69,3 +69,111 @@ describe('protocol imports', () => {
     expect(result.externalDependencies.has('cloudflare:workers')).toBe(false);
   }, 15000);
 });
+
+describe('npm alias dependencies', () => {
+  it('preserves alias install specs in external dependency metadata', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'mastra-npm-alias-'));
+    tempDirs.push(tempDir);
+
+    const entryFile = join(tempDir, 'index.ts');
+    const outputDir = join(tempDir, '.mastra', '.build');
+    const aliasPackageDir = join(tempDir, 'node_modules', '@ai-sdk', 'provider-utils-v7');
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(aliasPackageDir, { recursive: true });
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'alias-test-project',
+        version: '1.0.0',
+        type: 'module',
+        dependencies: {
+          '@ai-sdk/provider-utils-v7': 'npm:@ai-sdk/provider-utils@5.0.0',
+        },
+      }),
+    );
+    await writeFile(
+      join(aliasPackageDir, 'package.json'),
+      JSON.stringify({ name: '@ai-sdk/provider-utils', version: '5.0.0', type: 'module', main: './index.js' }),
+    );
+    await writeFile(join(aliasPackageDir, 'index.js'), `export const aliasValue = 'alias';`);
+    await writeFile(
+      entryFile,
+      `
+        import { aliasValue } from '@ai-sdk/provider-utils-v7';
+
+        export const value = aliasValue;
+      `,
+    );
+
+    const result = await analyzeBundle(
+      [entryFile],
+      entryFile,
+      {
+        outputDir,
+        projectRoot: tempDir,
+        platform: 'node',
+        bundlerOptions: {
+          externals: ['@ai-sdk/provider-utils-v7'],
+          enableSourcemap: false,
+        },
+      },
+      noopLogger,
+    );
+
+    expect(result.externalDependencies.get('@ai-sdk/provider-utils-v7')).toEqual({
+      version: '5.0.0',
+      packageSpec: 'npm:@ai-sdk/provider-utils@5.0.0',
+    });
+  }, 15000);
+
+  it('resolves alias install specs for dynamic external dependency fallbacks', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'mastra-npm-alias-dynamic-'));
+    tempDirs.push(tempDir);
+
+    const entryFile = join(tempDir, 'index.ts');
+    const outputDir = join(tempDir, '.mastra', '.build');
+    const aliasPackageDir = join(tempDir, 'node_modules', '@ai-sdk', 'provider-utils-v5');
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(aliasPackageDir, { recursive: true });
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'alias-dynamic-test-project',
+        version: '1.0.0',
+        type: 'module',
+        dependencies: {
+          '@ai-sdk/provider-utils-v5': 'npm:@ai-sdk/provider-utils@3.0.25',
+        },
+      }),
+    );
+    await writeFile(
+      join(aliasPackageDir, 'package.json'),
+      JSON.stringify({ name: '@ai-sdk/provider-utils', version: '3.0.25', type: 'module', main: './index.js' }),
+    );
+    await writeFile(join(aliasPackageDir, 'index.js'), `export const aliasValue = 'alias';`);
+    await writeFile(entryFile, `export const value = 'entry';`);
+
+    const result = await analyzeBundle(
+      [entryFile],
+      entryFile,
+      {
+        outputDir,
+        projectRoot: tempDir,
+        platform: 'node',
+        bundlerOptions: {
+          externals: [],
+          dynamicPackages: ['@ai-sdk/provider-utils-v5'],
+          enableSourcemap: false,
+        },
+      },
+      noopLogger,
+    );
+
+    expect(result.externalDependencies.get('@ai-sdk/provider-utils-v5')).toEqual({
+      version: '3.0.25',
+      packageSpec: 'npm:@ai-sdk/provider-utils@3.0.25',
+    });
+  }, 15000);
+});

--- a/packages/deployer/src/build/analyze.test.ts
+++ b/packages/deployer/src/build/analyze.test.ts
@@ -104,6 +104,79 @@ describe('external dependency versions', () => {
       process.chdir(originalCwd);
     }
   }, 15000);
+
+  it('resolves an external dependency version from a dynamic import in a bundled workspace package', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'mastra-dynamic-importer-version-'));
+    tempDirs.push(tempDir);
+
+    const appDir = join(tempDir, 'apps', 'app');
+    const workspacePackageDir = join(tempDir, 'packages', 'workspace-package');
+    const externalPackageDir = join(workspacePackageDir, 'node_modules', 'typescript');
+    const entryFile = join(appDir, 'index.ts');
+    const outputDir = join(appDir, '.mastra', '.build');
+
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(join(appDir, 'node_modules', '@internal'), { recursive: true });
+    await mkdir(externalPackageDir, { recursive: true });
+    await mkdir(join(workspacePackageDir, 'src'), { recursive: true });
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test-workspace', version: '1.0.0' }));
+    await writeFile(join(tempDir, 'pnpm-workspace.yaml'), `packages:\n  - apps/*\n  - packages/*\n`);
+    await writeFile(join(appDir, 'package.json'), JSON.stringify({ name: 'app', version: '1.0.0', type: 'module' }));
+    await writeFile(
+      join(workspacePackageDir, 'package.json'),
+      JSON.stringify({
+        name: '@internal/workspace-package',
+        version: '1.0.0',
+        type: 'module',
+        main: './src/index.js',
+        dependencies: {
+          typescript: '5.9.3',
+        },
+      }),
+    );
+    await writeFile(
+      join(externalPackageDir, 'package.json'),
+      JSON.stringify({ name: 'typescript', version: '5.9.3', type: 'module', main: './index.js' }),
+    );
+    await writeFile(join(externalPackageDir, 'index.js'), `export const version = '5.9.3';`);
+    await writeFile(
+      join(workspacePackageDir, 'src', 'index.js'),
+      `export async function loadTypescript() { return import('typescript'); }`,
+    );
+    await symlink(workspacePackageDir, join(appDir, 'node_modules', '@internal', 'workspace-package'));
+    await writeFile(
+      entryFile,
+      `import { loadTypescript } from '@internal/workspace-package';\nexport const value = loadTypescript;`,
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      const result = await analyzeBundle(
+        [entryFile],
+        entryFile,
+        {
+          outputDir,
+          projectRoot: appDir,
+          platform: 'node',
+          isDev: true,
+          bundlerOptions: {
+            externals: ['typescript'],
+            enableSourcemap: false,
+          },
+        },
+        noopLogger,
+      );
+
+      expect(result.externalDependencies.get('typescript')).toEqual({
+        version: '5.9.3',
+        packageSpec: undefined,
+      });
+    } finally {
+      process.chdir(originalCwd);
+    }
+  }, 15000);
 });
 
 describe('protocol imports', () => {

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
-import { basename, join, relative } from 'node:path';
+import { basename, isAbsolute, join, relative } from 'node:path';
 import * as babel from '@babel/core';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { IMastraLogger } from '@mastra/core/logger';
@@ -46,7 +46,7 @@ async function resolveDependencyInfo(
   existing: ExternalDependencyInfo | undefined,
   parentPaths: string[],
 ): Promise<ExternalDependencyInfo> {
-  if (existing?.version && existing.packageSpec) {
+  if (existing?.version || existing?.packageSpec) {
     return existing;
   }
 
@@ -62,7 +62,26 @@ async function resolveDependencyInfo(
     }
   }
 
+  for (const name of packageNames) {
+    const metadata = await getPackageMetadata(name);
+    if (metadata.version || metadata.packageSpec) {
+      return preferDependencyInfo(existing, metadata);
+    }
+  }
+
   return existing ?? {};
+}
+
+function importerParentPaths(importerId: string | undefined, base: string[]): string[] {
+  if (!importerId || importerId.startsWith('\x00') || !isAbsolute(importerId)) {
+    return base;
+  }
+
+  return [...new Set([importerId, ...base])];
+}
+
+function getLastConcreteModuleId(moduleIds: string[]): string | undefined {
+  return moduleIds.findLast(id => !id.startsWith('\x00') && isAbsolute(id));
 }
 
 function throwExternalDependencyError({
@@ -294,16 +313,20 @@ async function validateOutput(
   // store resolve map for validation
   // we should resolve the version of the deps
   for (const deps of Object.values(usedExternals)) {
-    for (const dep of Object.keys(deps)) {
+    for (const [dep, importerId] of Object.entries(deps)) {
       if (isExternalProtocolImport(dep)) {
         continue;
       }
 
       const pkgName = getPackageName(dep);
       if (pkgName) {
-        // Use version info from analysis if available, then resolve from project/workspace package locations.
+        // Use version info from analysis if available, then resolve from the module that imported the external.
         const versionInfo = depsVersionInfo.get(dep) || depsVersionInfo.get(pkgName);
-        const dependencyInfo = await resolveDependencyInfo(dep, versionInfo, externalMetadataParentPaths);
+        const dependencyInfo = await resolveDependencyInfo(
+          dep,
+          versionInfo,
+          importerParentPaths(importerId, externalMetadataParentPaths),
+        );
         result.externalDependencies.set(
           pkgName,
           preferDependencyInfo(result.externalDependencies.get(pkgName), dependencyInfo),
@@ -458,6 +481,21 @@ export async function analyzeBundle(
     }
   }
 
+  // Build a map of dependency versions from the full analysis result before dev/externalsPreset pruning.
+  // Non-workspace deps are removed from optimization below, but their resolved version/packageSpec metadata
+  // is still needed when they become externals.
+  const depsVersionInfo = new Map<string, ExternalDependencyInfo>();
+  for (const [dep, metadata] of depsToOptimize.entries()) {
+    const pkgName = getPackageName(dep);
+    if (pkgName && (metadata.version || metadata.packageSpec)) {
+      depsVersionInfo.set(pkgName, preferDependencyInfo(depsVersionInfo.get(pkgName), metadata));
+    }
+    // Also store by full import path for subpath imports
+    if (metadata.version || metadata.packageSpec) {
+      depsVersionInfo.set(dep, preferDependencyInfo(depsVersionInfo.get(dep), metadata));
+    }
+  }
+
   /**
    * Only during `mastra dev` we want to optimize workspace packages. In previous steps we might have added dependencies that are not workspace packages, so we gotta remove them again.
    */
@@ -492,23 +530,12 @@ export async function analyzeBundle(
     slash(relative(workspaceRoot || projectRoot, pkgInfo.location)),
   );
 
-  // Build a map of dependency versions from depsToOptimize for lookup
-  const depsVersionInfo = new Map<string, ExternalDependencyInfo>();
-  for (const [dep, metadata] of depsToOptimize.entries()) {
-    const pkgName = getPackageName(dep);
-    if (pkgName && (metadata.version || metadata.packageSpec)) {
-      depsVersionInfo.set(pkgName, preferDependencyInfo(depsVersionInfo.get(pkgName), metadata));
-    }
-    // Also store by full import path for subpath imports
-    if (metadata.version || metadata.packageSpec) {
-      depsVersionInfo.set(dep, preferDependencyInfo(depsVersionInfo.get(dep), metadata));
-    }
-  }
-
   for (const o of output) {
     if (o.type === 'asset') {
       continue;
     }
+
+    const importerId = getLastConcreteModuleId(o.moduleIds);
 
     for (const i of o.imports) {
       if (isBuiltinModule(i)) {
@@ -532,12 +559,16 @@ export async function analyzeBundle(
       const pkgName = getPackageName(i);
 
       if (pkgName) {
-        // Try to get version info from our tracked dependencies, then resolve from project/workspace package locations.
+        // Try to get version info from our tracked dependencies, then resolve from the chunk's source module.
         const versionInfo = depsVersionInfo.get(i) || depsVersionInfo.get(pkgName);
-        const dependencyInfo = await resolveDependencyInfo(i, versionInfo, [
-          projectRoot,
-          ...Array.from(workspaceMap.values()).map(pkgInfo => pkgInfo.location),
-        ]);
+        const dependencyInfo = await resolveDependencyInfo(
+          i,
+          versionInfo,
+          importerParentPaths(importerId, [
+            projectRoot,
+            ...Array.from(workspaceMap.values()).map(pkgInfo => pkgInfo.location),
+          ]),
+        );
         allUsedExternals.set(pkgName, preferDependencyInfo(allUsedExternals.get(pkgName), dependencyInfo));
       }
     }

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -608,7 +608,19 @@ export async function analyzeBundle(
   const externalMetadataParentPaths = [
     projectRoot,
     ...Array.from(workspaceMap.values()).map(pkgInfo => pkgInfo.location),
+    // Last resort: resolve from the deployer's own installed location. Some externals are
+    // discovered inside externalized packages (e.g. optional dynamic imports like
+    // `import('typescript')` in @mastra/core) without being installed in the user's project.
+    import.meta.dirname,
   ];
+
+  // Retry externals that were discovered without install metadata (e.g. from entry analysis
+  // where the package isn't resolvable from the entry's own location).
+  for (const [dep, info] of mergedExternalDeps) {
+    if (!info.version && !info.packageSpec) {
+      mergedExternalDeps.set(dep, await resolveDependencyInfo(dep, info, externalMetadataParentPaths));
+    }
+  }
 
   // Add pino transports and user dynamic packages
   for (const transport of detectedPinoTransports) {

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -14,6 +14,7 @@ import { bundleExternals } from './analyze/bundleExternals';
 import { DEPS_TO_IGNORE, GLOBAL_EXTERNALS } from './analyze/constants';
 import { checkConfigExport } from './babel/check-config-export';
 import { detectPinoTransports } from './babel/detect-pino-transports';
+import { getPackageMetadata } from './package-info';
 import type { BundlerOptions, DependencyMetadata, ExternalDependencyInfo } from './types';
 import {
   getPackageName,
@@ -29,6 +30,40 @@ type ErrorId =
   | 'DEPLOYER_ANALYZE_MODULE_NOT_FOUND'
   | 'DEPLOYER_ANALYZE_MISSING_NATIVE_BUILD'
   | 'DEPLOYER_ANALYZE_TYPE_ERROR';
+
+function preferDependencyInfo(
+  existing: ExternalDependencyInfo | undefined,
+  incoming: ExternalDependencyInfo,
+): ExternalDependencyInfo {
+  return {
+    version: incoming.version ?? existing?.version,
+    packageSpec: incoming.packageSpec ?? existing?.packageSpec,
+  };
+}
+
+async function resolveDependencyInfo(
+  dep: string,
+  existing: ExternalDependencyInfo | undefined,
+  parentPaths: string[],
+): Promise<ExternalDependencyInfo> {
+  if (existing?.version && existing.packageSpec) {
+    return existing;
+  }
+
+  const packageName = getPackageName(dep);
+  const packageNames = [...new Set([dep, packageName].filter(Boolean) as string[])];
+
+  for (const parentPath of parentPaths) {
+    for (const name of packageNames) {
+      const metadata = await getPackageMetadata(name, parentPath);
+      if (metadata.version || metadata.packageSpec) {
+        return preferDependencyInfo(existing, metadata);
+      }
+    }
+  }
+
+  return existing ?? {};
+}
 
 function throwExternalDependencyError({
   errorId,
@@ -251,6 +286,11 @@ async function validateOutput(
     workspaceMap,
   };
 
+  const externalMetadataParentPaths = [
+    projectRoot,
+    ...Array.from(workspaceMap.values()).map(pkgInfo => pkgInfo.location),
+  ];
+
   // store resolve map for validation
   // we should resolve the version of the deps
   for (const deps of Object.values(usedExternals)) {
@@ -261,9 +301,13 @@ async function validateOutput(
 
       const pkgName = getPackageName(dep);
       if (pkgName) {
-        // Use version info from analysis if available
-        const versionInfo = depsVersionInfo.get(dep) || depsVersionInfo.get(pkgName) || {};
-        result.externalDependencies.set(pkgName, versionInfo);
+        // Use version info from analysis if available, then resolve from project/workspace package locations.
+        const versionInfo = depsVersionInfo.get(dep) || depsVersionInfo.get(pkgName);
+        const dependencyInfo = await resolveDependencyInfo(dep, versionInfo, externalMetadataParentPaths);
+        result.externalDependencies.set(
+          pkgName,
+          preferDependencyInfo(result.externalDependencies.get(pkgName), dependencyInfo),
+        );
       }
     }
   }
@@ -393,10 +437,8 @@ export async function analyzeBundle(
       if (isPartOfExternals || (externalsPreset && !metadata.isWorkspace)) {
         // Add all packages coming from src/mastra with their version info
         const pkgName = getPackageName(dep);
-        if (pkgName && !allUsedExternals.has(pkgName)) {
-          allUsedExternals.set(pkgName, {
-            version: metadata.version,
-          });
+        if (pkgName) {
+          allUsedExternals.set(pkgName, preferDependencyInfo(allUsedExternals.get(pkgName), metadata));
         }
         continue;
       }
@@ -406,6 +448,8 @@ export async function analyzeBundle(
         const existingEntry = depsToOptimize.get(dep)!;
         depsToOptimize.set(dep, {
           ...existingEntry,
+          version: metadata.version ?? existingEntry.version,
+          packageSpec: metadata.packageSpec ?? existingEntry.packageSpec,
           exports: [...new Set([...existingEntry.exports, ...metadata.exports])],
         });
       } else {
@@ -452,16 +496,12 @@ export async function analyzeBundle(
   const depsVersionInfo = new Map<string, ExternalDependencyInfo>();
   for (const [dep, metadata] of depsToOptimize.entries()) {
     const pkgName = getPackageName(dep);
-    if (pkgName && metadata.version) {
-      depsVersionInfo.set(pkgName, {
-        version: metadata.version,
-      });
+    if (pkgName && (metadata.version || metadata.packageSpec)) {
+      depsVersionInfo.set(pkgName, preferDependencyInfo(depsVersionInfo.get(pkgName), metadata));
     }
     // Also store by full import path for subpath imports
-    if (metadata.version) {
-      depsVersionInfo.set(dep, {
-        version: metadata.version,
-      });
+    if (metadata.version || metadata.packageSpec) {
+      depsVersionInfo.set(dep, preferDependencyInfo(depsVersionInfo.get(dep), metadata));
     }
   }
 
@@ -491,10 +531,14 @@ export async function analyzeBundle(
 
       const pkgName = getPackageName(i);
 
-      if (pkgName && !allUsedExternals.has(pkgName)) {
-        // Try to get version info from our tracked dependencies
-        const versionInfo = depsVersionInfo.get(i) || depsVersionInfo.get(pkgName) || {};
-        allUsedExternals.set(pkgName, versionInfo);
+      if (pkgName) {
+        // Try to get version info from our tracked dependencies, then resolve from project/workspace package locations.
+        const versionInfo = depsVersionInfo.get(i) || depsVersionInfo.get(pkgName);
+        const dependencyInfo = await resolveDependencyInfo(i, versionInfo, [
+          projectRoot,
+          ...Array.from(workspaceMap.values()).map(pkgInfo => pkgInfo.location),
+        ]);
+        allUsedExternals.set(pkgName, preferDependencyInfo(allUsedExternals.get(pkgName), dependencyInfo));
       }
     }
   }
@@ -527,21 +571,23 @@ export async function analyzeBundle(
       continue;
     }
 
-    const existing = mergedExternalDeps.get(dep);
-    if (!existing || (!existing.version && info.version)) {
-      mergedExternalDeps.set(dep, info);
-    }
+    mergedExternalDeps.set(dep, preferDependencyInfo(mergedExternalDeps.get(dep), info));
   }
 
-  // Add pino transports and user dynamic packages (no version info needed)
+  const externalMetadataParentPaths = [
+    projectRoot,
+    ...Array.from(workspaceMap.values()).map(pkgInfo => pkgInfo.location),
+  ];
+
+  // Add pino transports and user dynamic packages
   for (const transport of detectedPinoTransports) {
     if (!mergedExternalDeps.has(transport)) {
-      mergedExternalDeps.set(transport, {});
+      mergedExternalDeps.set(transport, await resolveDependencyInfo(transport, undefined, externalMetadataParentPaths));
     }
   }
   for (const pkg of userDynamicPackages) {
     if (!mergedExternalDeps.has(pkg)) {
-      mergedExternalDeps.set(pkg, {});
+      mergedExternalDeps.set(pkg, await resolveDependencyInfo(pkg, undefined, externalMetadataParentPaths));
     }
   }
 

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -4,13 +4,12 @@ import type { IMastraLogger } from '@mastra/core/logger';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import virtual from '@rollup/plugin-virtual';
-import { readJSON } from 'fs-extra/esm';
 import { resolveModule } from 'local-pkg';
 import { rollup } from 'rollup';
 import type { OutputChunk, Plugin, SourceMap } from 'rollup';
 import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
 import { mastraInternalAliasPlugin, mastraToolsAliasPlugin } from '../bundler';
-import { getPackageRootPath } from '../package-info';
+import { getPackageMetadata, getPackageRootPath } from '../package-info';
 import { esbuild } from '../plugins/esbuild';
 import { protocolExternalResolver } from '../plugins/protocol-external-resolver';
 import { removeDeployer } from '../plugins/remove-deployer';
@@ -108,20 +107,14 @@ async function captureDependenciesToOptimize(
     let rootPath: string | null = null;
     let isWorkspace = false;
     let version: string | undefined;
+    let packageSpec: string | undefined;
 
     if (pkgName) {
-      rootPath = await getPackageRootPath(dependency, entryRootPath);
+      const metadata = await getPackageMetadata(dependency, entryRootPath);
+      rootPath = metadata.rootPath;
+      version = metadata.version;
+      packageSpec = metadata.packageSpec;
       isWorkspace = workspaceMap.has(pkgName);
-
-      // Read version from package.json when we have a valid rootPath
-      if (rootPath) {
-        try {
-          const pkgJson = await readJSON(`${rootPath}/package.json`);
-          version = pkgJson.version;
-        } catch {
-          // Failed to read package.json, version will remain undefined
-        }
-      }
     }
 
     const normalizedRootPath = rootPath ? slash(rootPath) : null;
@@ -131,6 +124,7 @@ async function captureDependenciesToOptimize(
       rootPath: normalizedRootPath,
       isWorkspace,
       version,
+      packageSpec,
     });
   }
 
@@ -229,18 +223,14 @@ async function captureDependenciesToOptimize(
         // Try to resolve version for dynamic imports as well
         const pkgName = getPackageName(dynamicImport);
         let version: string | undefined;
+        let packageSpec: string | undefined;
         let rootPath: string | null = null;
 
         if (pkgName) {
-          rootPath = await getPackageRootPath(dynamicImport, entryRootPath);
-          if (rootPath) {
-            try {
-              const pkgJson = await readJSON(`${rootPath}/package.json`);
-              version = pkgJson.version;
-            } catch {
-              // Failed to read package.json
-            }
-          }
+          const metadata = await getPackageMetadata(dynamicImport, entryRootPath);
+          rootPath = metadata.rootPath;
+          version = metadata.version;
+          packageSpec = metadata.packageSpec;
         }
 
         depsToOptimize.set(dynamicImport, {
@@ -248,6 +238,7 @@ async function captureDependenciesToOptimize(
           rootPath: rootPath ? slash(rootPath) : null,
           isWorkspace: false,
           version,
+          packageSpec,
         });
       }
     }

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -414,8 +414,18 @@ async function buildExternalDependencies(
  * Recursively searches through Rollup output chunks to find which module imports a specific external dependency.
  * Used to build the module resolution map for proper external dependency tracking.
  */
-function findExternalImporter(module: OutputChunk, external: string, allOutputs: OutputChunk[]): OutputChunk | null {
-  const capturedFiles = new Set();
+function findExternalImporter(
+  module: OutputChunk,
+  external: string,
+  allOutputs: OutputChunk[],
+  visited = new Set<string>(),
+): OutputChunk | null {
+  if (visited.has(module.fileName)) {
+    return null;
+  }
+
+  visited.add(module.fileName);
+  const capturedFiles = new Set<string>();
 
   for (const id of [...module.imports, ...module.dynamicImports]) {
     if (isDependencyPartOfPackage(id, external)) {
@@ -430,7 +440,7 @@ function findExternalImporter(module: OutputChunk, external: string, allOutputs:
   for (const file of capturedFiles) {
     const nextModule = allOutputs.find(o => o.fileName === file);
     if (nextModule) {
-      const importer = findExternalImporter(nextModule, external, allOutputs);
+      const importer = findExternalImporter(nextModule, external, allOutputs, visited);
 
       if (importer) {
         return importer;

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -417,7 +417,7 @@ async function buildExternalDependencies(
 function findExternalImporter(module: OutputChunk, external: string, allOutputs: OutputChunk[]): OutputChunk | null {
   const capturedFiles = new Set();
 
-  for (const id of module.imports) {
+  for (const id of [...module.imports, ...module.dynamicImports]) {
     if (isDependencyPartOfPackage(id, external)) {
       return module;
     } else {

--- a/packages/deployer/src/build/package-info.test.ts
+++ b/packages/deployer/src/build/package-info.test.ts
@@ -1,0 +1,32 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getPackageMetadata } from './package-info';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+});
+
+describe('getPackageMetadata', () => {
+  it('falls back from a package subpath to the package root metadata', async () => {
+    const tempRoot = join(process.cwd(), '.tmp');
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'package-metadata-'));
+    tempDirs.push(tempDir);
+
+    const packageDir = join(tempDir, 'node_modules', 'date-fns');
+    await mkdir(join(packageDir, 'esm', 'endOfDay'), { recursive: true });
+    await writeFile(
+      join(packageDir, 'package.json'),
+      JSON.stringify({ name: 'date-fns', version: '2.30.0', type: 'module', main: './index.js' }),
+    );
+    await writeFile(join(packageDir, 'esm', 'endOfDay', 'index.js'), `export const endOfDay = () => {};`);
+
+    await expect(getPackageMetadata('date-fns/esm/endOfDay/index.js', tempDir)).resolves.toMatchObject({
+      version: '2.30.0',
+      packageSpec: undefined,
+    });
+  });
+});

--- a/packages/deployer/src/build/package-info.ts
+++ b/packages/deployer/src/build/package-info.ts
@@ -35,20 +35,14 @@ export async function getPackageRootPath(packageName: string, parentPath?: strin
   return rootPath;
 }
 
-export async function getPackageMetadata(
-  packageName: string,
-  parentPath?: string,
-): Promise<{ rootPath: string | null; version?: string; packageSpec?: string }> {
-  const rootPath = await getPackageRootPath(packageName, parentPath);
-  if (!rootPath) {
-    return { rootPath };
-  }
-
+async function readPackageMetadata(
+  rootPath: string,
+  requestedPackageName: string | null,
+): Promise<{ rootPath: string; version?: string; packageSpec?: string }> {
   try {
     const pkgJson = await readJSON(`${rootPath}/package.json`);
     const version = pkgJson.version;
     const actualPackageName = pkgJson.name;
-    const requestedPackageName = getPackageName(packageName);
     const packageSpec =
       version && actualPackageName && requestedPackageName && requestedPackageName !== actualPackageName
         ? `npm:${actualPackageName}@${version}`
@@ -58,4 +52,28 @@ export async function getPackageMetadata(
   } catch {
     return { rootPath };
   }
+}
+
+export async function getPackageMetadata(
+  packageName: string,
+  parentPath?: string,
+): Promise<{ rootPath: string | null; version?: string; packageSpec?: string }> {
+  const requestedPackageName = getPackageName(packageName);
+  const packageNames = [...new Set([packageName, requestedPackageName].filter(Boolean) as string[])];
+  let firstRootPath: string | null = null;
+
+  for (const name of packageNames) {
+    const rootPath = await getPackageRootPath(name, parentPath);
+    firstRootPath ??= rootPath;
+    if (!rootPath) {
+      continue;
+    }
+
+    const metadata = await readPackageMetadata(rootPath, requestedPackageName ?? null);
+    if (metadata.version || metadata.packageSpec) {
+      return metadata;
+    }
+  }
+
+  return { rootPath: firstRootPath };
 }

--- a/packages/deployer/src/build/package-info.ts
+++ b/packages/deployer/src/build/package-info.ts
@@ -4,7 +4,9 @@
  */
 
 import { pathToFileURL } from 'node:url';
+import { readJSON } from 'fs-extra/esm';
 import { getPackageInfo } from 'local-pkg';
+import { getPackageName } from './utils';
 
 /**
  * Get package root path
@@ -31,4 +33,29 @@ export async function getPackageRootPath(packageName: string, parentPath?: strin
   }
 
   return rootPath;
+}
+
+export async function getPackageMetadata(
+  packageName: string,
+  parentPath?: string,
+): Promise<{ rootPath: string | null; version?: string; packageSpec?: string }> {
+  const rootPath = await getPackageRootPath(packageName, parentPath);
+  if (!rootPath) {
+    return { rootPath };
+  }
+
+  try {
+    const pkgJson = await readJSON(`${rootPath}/package.json`);
+    const version = pkgJson.version;
+    const actualPackageName = pkgJson.name;
+    const requestedPackageName = getPackageName(packageName);
+    const packageSpec =
+      version && actualPackageName && requestedPackageName && requestedPackageName !== actualPackageName
+        ? `npm:${actualPackageName}@${version}`
+        : undefined;
+
+    return { rootPath, version, packageSpec };
+  } catch {
+    return { rootPath };
+  }
 }

--- a/packages/deployer/src/build/types.ts
+++ b/packages/deployer/src/build/types.ts
@@ -18,6 +18,11 @@ export interface DependencyMetadata {
    * The resolved version of the dependency (exact version from package.json)
    */
   version?: string;
+  /**
+   * The package.json dependency value to install when it differs from the resolved version.
+   * For npm aliases, this uses npm alias syntax (e.g. npm:actual-package@1.0.0).
+   */
+  packageSpec?: string;
 }
 
 export interface BundlerOptions {
@@ -35,4 +40,9 @@ export interface ExternalDependencyInfo {
    * The resolved version of the dependency (exact version from package.json)
    */
   version?: string;
+  /**
+   * The package.json dependency value to install when it differs from the resolved version.
+   * For npm aliases, this uses npm alias syntax (e.g. npm:actual-package@1.0.0).
+   */
+  packageSpec?: string;
 }

--- a/packages/deployer/src/bundler/index.test.ts
+++ b/packages/deployer/src/bundler/index.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Bundler } from './index';
+
+const tempDirs: string[] = [];
+
+class TestBundler extends Bundler {
+  async bundle(): Promise<void> {}
+
+  getEnvFiles(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Bundler.writePackageJson', () => {
+  it('writes npm alias dependency specs using the alias import name as the key', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'mastra-bundler-package-json-'));
+    tempDirs.push(tempDir);
+
+    const bundler = new TestBundler('Test');
+    await bundler.writePackageJson(
+      tempDir,
+      new Map([
+        ['@ai-sdk/provider-utils-v7', { version: '5.0.0', packageSpec: 'npm:@ai-sdk/provider-utils@5.0.0' }],
+        ['regular-package/subpath', { version: '1.2.3' }],
+      ]),
+    );
+
+    const pkg = JSON.parse(await readFile(join(tempDir, 'package.json'), 'utf-8'));
+    expect(pkg.dependencies).toEqual({
+      '@ai-sdk/provider-utils-v7': 'npm:@ai-sdk/provider-utils@5.0.0',
+      'regular-package': '1.2.3',
+    });
+  });
+});

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -7,14 +7,13 @@ import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import type { Config } from '@mastra/core/mastra';
 import virtual from '@rollup/plugin-virtual';
 import * as pkg from 'empathic/package';
-import fsExtra, { copy, ensureDir, readJSON, emptyDir } from 'fs-extra/esm';
+import fsExtra, { copy, ensureDir, emptyDir } from 'fs-extra/esm';
 import type { InputOptions, OutputOptions } from 'rollup';
 import { glob } from 'tinyglobby';
 import { analyzeBundle } from '../build/analyze';
 import { createBundler as createBundlerUtil, getInputOptions } from '../build/bundler';
 import { getBundlerOptions } from '../build/bundlerOptions';
-import { getPackageRootPath } from '../build/package-info';
-import type { BundlerOptions } from '../build/types';
+import type { BundlerOptions, ExternalDependencyInfo } from '../build/types';
 import type { BundlerPlatform } from '../build/utils';
 import { isBareModuleSpecifier, slash } from '../build/utils';
 import { DepsService } from '../services/deps';
@@ -45,7 +44,7 @@ export abstract class Bundler extends MastraBundler {
 
   async writePackageJson(
     outputDirectory: string,
-    dependencies: Map<string, string>,
+    dependencies: Map<string, string | ExternalDependencyInfo>,
     resolutions?: Record<string, string>,
   ) {
     this.logger.debug("Writing project's package.json");
@@ -55,14 +54,15 @@ export abstract class Bundler extends MastraBundler {
 
     const dependenciesMap = new Map();
     for (const [key, value] of dependencies.entries()) {
+      const dependencyValue = typeof value === 'string' ? value : (value.packageSpec ?? value.version ?? 'latest');
       if (key.startsWith('@')) {
         // Handle scoped packages (e.g. @org/package)
         const pkgChunks = key.split('/');
-        dependenciesMap.set(`${pkgChunks[0]}/${pkgChunks[1]}`, value);
+        dependenciesMap.set(`${pkgChunks[0]}/${pkgChunks[1]}`, dependencyValue);
       } else {
         // For non-scoped packages, take only the first part before any slash
         const pkgName = key.split('/')[0] || key;
-        dependenciesMap.set(pkgName, value);
+        dependenciesMap.set(pkgName, dependencyValue);
       }
     }
 
@@ -353,52 +353,13 @@ export abstract class Bundler extends MastraBundler {
       );
     }
 
-    const dependenciesToInstall = new Map<string, string>();
+    const dependenciesToInstall = new Map<string, ExternalDependencyInfo>();
     for (const [dep, depInfo] of analyzedBundleInfo.externalDependencies) {
       if (analyzedBundleInfo.workspaceMap.has(dep) || !isBareModuleSpecifier(dep)) {
         continue;
       }
 
-      let version = depInfo.version;
-      let actualPackageName: string | undefined;
-
-      // Read package.json to get actual package name (for alias detection) and version if not pre-resolved
-      try {
-        // First try to resolve from the project root (provides correct context for monorepos)
-        let rootPath = await getPackageRootPath(dep, projectRoot);
-
-        // If not found in user's project, try resolving from deployer's location
-        // This handles packages like hono that are provided by @mastra/deployer
-        if (!rootPath) {
-          rootPath = await getPackageRootPath(dep, import.meta.dirname);
-        }
-
-        if (rootPath) {
-          const pkg = await readJSON(`${rootPath}/package.json`);
-          actualPackageName = pkg.name;
-          // Use pre-resolved version if available, otherwise use from package.json
-          if (!version) {
-            version = pkg.version;
-          }
-        }
-      } catch {
-        // Resolution failed, will use 'latest' for version
-      }
-
-      // Default to 'latest' if still no version
-      version = version || 'latest';
-
-      // Check if this is an npm alias (import name differs from actual package name)
-      // e.g., importing "ai-v5" which resolves to package "ai"
-      // or importing "@ai-sdk/openai-v5" which resolves to "@ai-sdk/openai"
-      // In this case, write npm alias syntax: "ai-v5": "npm:ai@5.0.93"
-      const isAlias = actualPackageName && dep !== actualPackageName;
-
-      if (isAlias) {
-        dependenciesToInstall.set(dep, `npm:${actualPackageName}@${version}`);
-      } else {
-        dependenciesToInstall.set(dep, version);
-      }
+      dependenciesToInstall.set(dep, depInfo);
     }
 
     try {


### PR DESCRIPTION
## Summary
- Track npm alias install specs through deployer dependency metadata.
- Preserve alias keys while writing generated package.json dependencies with npm: install values.
- Add regression coverage for analysis metadata and package.json generation.

## Test plan
- pnpm --filter @mastra/deployer exec vitest run src/build/analyze.test.ts src/bundler/index.test.ts
- pnpm --filter @mastra/deployer build:lib
- pnpm --filter @mastra/deployer lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This change helps the deployer remember the exact way a package was originally installed, even if it uses an npm alias like `npm:foo@1.2.3`. It also makes sure packages found through dynamic imports are detected correctly, so the generated app bundle doesn’t accidentally replace them with `latest`.

## Summary
- Preserves npm alias install specs through deployer metadata and `package.json` generation.
- Adds richer dependency metadata handling, including `packageSpec`, across analysis, package metadata lookup, and bundler output.
- Improves external dependency resolution for workspace packages, including dynamically imported externals.
- Updates external import tracking so dynamic imports are considered when mapping Rollup externals.
- Adds regression coverage for alias dependencies, external metadata resolution, `getPackageMetadata`, and `writePackageJson`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->