### PR TITLE
fix(core): prevent RequestContext auth token leak in scorer spans

### DIFF
--- a/.changeset/common-hoops-shout.md
+++ b/.changeset/common-hoops-shout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed RequestContext leaking auth tokens onto scorer_run span input. Added serializeForSpan() to RequestContext so deepClean uses a safe snapshot instead of walking the internal registry Map. Also fixed the MastraScorer.run() call site to pass the serialized snapshot into the span input.

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -289,6 +289,35 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
   }
 
   /**
+   * Custom span serialization to prevent leaking internal state (like auth
+   * tokens stored in the private `registry` Map) into observability spans.
+   *
+   * `deepClean` in `@mastra/observability` calls this method before falling
+   * back to `Object.keys()` — which would walk the runtime-enumerable
+   * `registry` field and serialize its raw Map entries (including any
+   * bearer tokens) into exported spans.
+   */
+  serializeForSpan(): Record<string, unknown> {
+    const safe: Record<string, unknown> = {};
+    for (const [key, value] of this.registry.entries()) {
+      if (key === MASTRA_AUTH_TOKEN_KEY) {
+        safe[key] = '[REDACTED]';
+      } else if (
+        value === null ||
+        value === undefined ||
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean'
+      ) {
+        safe[key] = value;
+      } else {
+        safe[key] = `[${typeof value}]`;
+      }
+    }
+    return safe;
+  }
+
+  /**
    * Get all values as a typed object for destructuring.
    * Returns Record<string, any> when untyped, or the Values type when typed.
    *

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -562,7 +562,7 @@ class MastraScorer<
         output: prepared.output,
         groundTruth: prepared.groundTruth,
         expectedTrajectory: prepared.expectedTrajectory,
-        requestContext: normalizedRequestContext,
+        requestContext: normalizedRequestContext?.serializeForSpan(),
       },
       attributes: {
         scorerId: this.id,

--- a/packages/core/src/request-context/index.test.ts
+++ b/packages/core/src/request-context/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { RequestContext } from './index';
+import { MASTRA_AUTH_TOKEN_KEY, RequestContext } from './index';
 
 describe('RequestContext', () => {
   describe('constructor', () => {
@@ -243,6 +243,56 @@ describe('RequestContext', () => {
       expect(elapsed).toBeLessThan(2000);
       const parsed = JSON.parse(serialized);
       expect(parsed).toEqual({ serializable: 'value' });
+    });
+  });
+
+  describe('serializeForSpan', () => {
+    it('should redact the auth token key', () => {
+      const ctx = new RequestContext();
+      ctx.set(MASTRA_AUTH_TOKEN_KEY, 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.secret');
+      ctx.set('userId', 'user-123');
+
+      const result = ctx.serializeForSpan();
+
+      expect(result[MASTRA_AUTH_TOKEN_KEY]).toBe('[REDACTED]');
+      expect(result['userId']).toBe('user-123');
+    });
+
+    it('should include primitive values as-is', () => {
+      const ctx = new RequestContext();
+      ctx.set('str', 'hello');
+      ctx.set('num', 42);
+      ctx.set('bool', true);
+      ctx.set('nil', null);
+      ctx.set('undef', undefined);
+
+      const result = ctx.serializeForSpan();
+
+      expect(result).toEqual({
+        str: 'hello',
+        num: 42,
+        bool: true,
+        nil: null,
+        undef: undefined,
+      });
+    });
+
+    it('should replace non-primitive values with type placeholders', () => {
+      const ctx = new RequestContext();
+      ctx.set('obj', { nested: 'value' });
+      ctx.set('arr', [1, 2, 3]);
+      ctx.set('fn', () => {});
+
+      const result = ctx.serializeForSpan();
+
+      expect(result['obj']).toBe('[object]');
+      expect(result['arr']).toBe('[object]');
+      expect(result['fn']).toBe('[function]');
+    });
+
+    it('should return empty object for empty context', () => {
+      const ctx = new RequestContext();
+      expect(ctx.serializeForSpan()).toEqual({});
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes a security issue where `MastraScorer.run()` embedded a live `RequestContext` instance into the `scorer_run` span input. TypeScript's `private` keyword is compile-time only, so the internal `registry` Map (containing `MASTRA_AUTH_TOKEN_KEY` bearer tokens) was walked by `deepClean()` via `Object.keys()` and serialized into exported spans in plaintext, bypassing `SensitiveDataFilter`.

- Added `serializeForSpan()` to `RequestContext` — returns a safe plain object that redacts `MASTRA_AUTH_TOKEN_KEY` and replaces non-primitive values with type placeholders. `deepClean()` already calls this method on any object before falling back to `Object.keys()`, providing defense-in-depth for all current and future call sites.
- Changed `MastraScorer.run()` to call `normalizedRequestContext?.serializeForSpan()` instead of passing the raw instance into the span input.

Look upon RequestContext for example :

## Before
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/d59ebb55-9efd-4ec6-a8d6-38e780022c18" />

## After
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/5744efee-d11d-40c0-8be7-cdfa3d1fc399" />

## Related Issue(s)

Fixes #18775

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops private auth tokens from accidentally showing up in tracing data. Instead of handing the real `RequestContext` object to the span, the code now turns it into a safe snapshot that hides secrets and replaces complex values with simple placeholders.

## What changed
- Added `RequestContext.serializeForSpan()` to produce a safe, JSON-friendly snapshot.
- Redacts `MASTRA_AUTH_TOKEN_KEY` as `"[REDACTED]"`.
- Keeps primitive values, and turns non-primitive values into type placeholders.
- Updated `deepClean()`/observability cleanup to use the safe serializer when available.
- Changed `MastraScorer.run()` to pass the serialized request context into `SCORER_RUN` span input instead of the live instance.

## Tests
- Added coverage for token redaction, primitive preservation, non-primitive replacement, and empty contexts.
- Updated test setup to include `MASTRA_AUTH_TOKEN_KEY`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->