### PR TITLE
fix(core): prune completed workflow step results

### DIFF
--- a/.changeset/few-candies-jog.md
+++ b/.changeset/few-candies-jog.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed storage snapshot size bloat by pruning completed step outputs and suspend payloads before persisting workflow snapshots.

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -138,6 +138,32 @@ export interface PersistStepUpdateParams {
   phase?: string;
 }
 
+function pruneStepResultsForSnapshot(stepResults: Record<string, StepResult<any, any, any, any>>): Record<string, any> {
+  const pruned: Record<string, any> = {};
+  for (const [stepId, result] of Object.entries(stepResults)) {
+    // Only prune completed or non-resumable terminal states
+    if (result.status === 'success' || result.status === 'failed' || result.status === 'skipped') {
+      const prunedResult: any = {
+        ...result,
+        payload: undefined,
+        suspendPayload: undefined,
+      };
+      if (prunedResult.output && typeof prunedResult.output === 'object') {
+        const out = prunedResult.output as any;
+        prunedResult.output = {
+          ...out,
+          steps: undefined,
+          messages: undefined,
+        };
+      }
+      pruned[stepId] = prunedResult;
+    } else {
+      pruned[stepId] = result;
+    }
+  }
+  return pruned;
+}
+
 export async function persistStepUpdate(
   engine: DefaultExecutionEngine,
   params: PersistStepUpdateParams,
@@ -177,7 +203,7 @@ export async function persistStepUpdate(
         runId,
         status: workflowStatus,
         value: executionContext.state,
-        context: stepResults as any,
+        context: pruneStepResultsForSnapshot(stepResults) as any,
         activePaths: executionContext.executionPath,
         stepExecutionPath: executionContext.stepExecutionPath,
         activeStepsPath: executionContext.activeStepsPath,


### PR DESCRIPTION
## Description

This PR fixes the issue where workflow snapshot sizes balloon excessively (often exceeding 1MB to 5MB+) during Human-In-The-Loop (HITL) tool approval or step suspensions.

We introduced a helper function `pruneStepResultsForSnapshot` in `packages/core/src/workflows/handlers/entry.ts` that strips out duplicate input `payload` objects, `suspendPayload` data, and massive AI SDK `steps` metadata from step results that have already succeeded or failed. Active or suspended steps remain untouched to ensure workflow resumption works correctly.

# Fixes https://github.com/mastra-ai/mastra/issues/18647

Addresses workflow snapshot storage bloat issues.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

