### PR TITLE
fix(cli): add minimumReleaseAgeExclude to pnpm workspace config

### DIFF
--- a/.changeset/pretty-comics-feel.md
+++ b/.changeset/pretty-comics-feel.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Added minimumReleaseAgeExclude for mastra packages in CLI pnpm-workspace.yaml template to resolve pnpm v11 upgrade issues.

--- a/packages/cli/src/commands/create/pnpm11-packagemanager.test.ts
+++ b/packages/cli/src/commands/create/pnpm11-packagemanager.test.ts
@@ -149,6 +149,15 @@ describe('pnpm v11 packageManager normalization', () => {
     // because corepack ≤0.35.0 rejects ranges in both fields
     expect(written.packageManager).toBeUndefined();
     expect(written.devEngines).toBeUndefined();
+
+    // Verify that the pnpm-workspace.yaml configuration is correctly generated and includes excludes
+    const workspaceWrite = writeFileCalls.find(
+      (call: any[]) => typeof call[0] === 'string' && call[0] === 'pnpm-workspace.yaml',
+    );
+    expect(workspaceWrite).toBeDefined();
+    expect(workspaceWrite![1]).toContain('minimumReleaseAgeExclude:');
+    expect(workspaceWrite![1]).toContain('- mastra');
+    expect(workspaceWrite![1]).toContain('- "@mastra/*"');
   });
 
   it('should remove legacy packageManager field with range', async () => {

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -278,6 +278,9 @@ export const createMastraProject = async ({
         'pnpm-workspace.yaml',
         `packages:
   - '.'
+minimumReleaseAgeExclude:
+  - mastra
+  - "@mastra/*"
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
## Description

This PR resolves a Developer Experience (DX) blocker where users on `pnpm v11` projects are unable to upgrade Mastra dependencies due to pnpm's default security configuration. 

By default, `pnpm v11` enforces a `minimumReleaseAge` of 24 hours (1440 minutes) on package installations to prevent zero-day package takeovers. This causes `pnpm add @mastra/core@latest` (and other updates) to resolve back to older cached versions if a new Mastra version was published less than 24 hours ago.

We resolved this by adding `minimumReleaseAgeExclude` for `mastra` and `@mastra/*` directly to the `pnpm-workspace.yaml` template generated during project initialization. A unit test was added to verify the generated workspace contents.

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/18737

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When new Mastra packages are released, pnpm v11 sometimes waits too long before letting projects upgrade to them. This change tells pnpm to skip that waiting rule for `mastra` and `@mastra/*`, so new Mastra updates can be installed right away.

## Summary
- Added `minimumReleaseAgeExclude` entries for `mastra` and `@mastra/*` in the generated `pnpm-workspace.yaml` template.
- Added a unit test to verify the workspace file includes the new exclusions.
- Added a changeset entry for the patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->