### PR TITLE
feat(fs-agents): support nested subagents up to three levels deep

### DIFF
--- a/.changeset/lemon-garlics-swim.md
+++ b/.changeset/lemon-garlics-swim.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': minor
+'@mastra/deployer': minor
+---
+
+File-based agents can now nest subagents up to three levels deep. A subagent directory can declare its own `subagents/`, and each level is assembled and wired into its parent as a delegation tool. Levels deeper than the cap are ignored with a warning.
+
+```text
+src/mastra/agents/
+  supervisor/            # depth 0
+    subagents/
+      researcher/        # depth 1
+        subagents/
+          summarizer/    # depth 2
+```

--- a/docs/src/content/en/docs/agents/file-based-agents.mdx
+++ b/docs/src/content/en/docs/agents/file-based-agents.mdx
@@ -216,7 +216,16 @@ export default agentConfig({
 
 Subagents are isolated. A subagent inherits nothing from its parent. Its tools, skills, and workspace come only from its own directory, and any absent slot falls back to the same framework defaults as a top-level agent.
 
-Subagents are one level deep. A `subagents/` directory nested inside a subagent is ignored with a warning.
+Subagents can declare their own `subagents/` directories, nesting up to three levels below the top-level agent. A `subagents/` directory deeper than that is ignored with a warning.
+
+```text
+src/mastra/agents/
+  supervisor/            # depth 0
+    subagents/
+      researcher/        # depth 1
+        subagents/
+          summarizer/    # depth 2
+```
 
 Naming rules:
 

--- a/examples/agent/src/mastra/agents/weather-fs/README.md
+++ b/examples/agent/src/mastra/agents/weather-fs/README.md
@@ -33,6 +33,12 @@ weather-fs/
       instructions.md
       tools/
         get_forecast.ts
+      subagents/
+        historian/                # a nested subagent (depth 2)
+          config.ts               # MUST set a description
+          instructions.md
+          tools/
+            get_climate_normals.ts
 ```
 
 ## How it maps
@@ -47,10 +53,12 @@ weather-fs/
 | `skills/severe-weather/SKILL.md` | a packaged skill; frontmatter supplies name/description, `references/` inlined. |
 | `workspace/`                     | seed files copied into the agent's default workspace.                           |
 | `subagents/forecaster/`          | a subagent the parent can delegate to via a tool named `forecaster`.            |
+| `.../forecaster/subagents/historian/` | a nested subagent `forecaster` can delegate to via a tool named `historian`. |
 
-Subagents are **one level deep** and each subagent's `config.ts` must set a
-non-empty `description` — that is what the parent model sees when deciding
-whether to delegate.
+Subagents can nest up to **`MAX_FS_SUBAGENT_DEPTH` (3) levels** below the
+top-level agent — deeper nesting is ignored with a warning. Each subagent's
+`config.ts` must set a non-empty `description` — that is what the parent model
+sees when deciding whether to delegate.
 
 ## Try it
 
@@ -65,6 +73,8 @@ agents. Try:
 
 - "what's the weather in Tokyo?" — calls `get_weather`, reports °C and °F.
 - "give me a 5-day forecast for London" — delegates to the `forecaster` subagent.
+- "how is the weather in Paris usually in April?" — `forecaster` delegates on to
+  the nested `historian` subagent.
 - Ask about a storm — the `severe-weather` skill prepends a safety note.
 
 See the full docs at `/docs/agents/file-based-agents`.

--- a/examples/agent/src/mastra/agents/weather-fs/subagents/forecaster/subagents/historian/config.ts
+++ b/examples/agent/src/mastra/agents/weather-fs/subagents/forecaster/subagents/historian/config.ts
@@ -1,0 +1,18 @@
+import { agentConfig } from '@mastra/core/agent';
+
+/**
+ * Nested subagent: `historian` (depth 2).
+ *
+ * Subagents can declare their own `subagents/` up to `MAX_FS_SUBAGENT_DEPTH`
+ * levels below the top-level agent. This one is wired into `forecaster` as a
+ * delegation tool named `historian`, so the chain is:
+ * `weather-fs` -> `forecaster` -> `historian`.
+ *
+ * Like any subagent, its `config.ts` MUST set a non-empty `description`.
+ */
+export default agentConfig({
+  model: 'openai/gpt-5.4-mini',
+  description: 'Looks up historical climate normals (typical temperatures and rainfall) for a city and month.',
+  // instructions omitted -> taken from instructions.md
+  // tools omitted -> taken from tools/*.ts
+});

--- a/examples/agent/src/mastra/agents/weather-fs/subagents/forecaster/subagents/historian/instructions.md
+++ b/examples/agent/src/mastra/agents/weather-fs/subagents/forecaster/subagents/historian/instructions.md
@@ -1,0 +1,5 @@
+You are a climate history specialist.
+
+When asked how the weather usually is somewhere, call the `get_climate_normals`
+tool for the named city and month and report the typical high, low, and rainy
+days in one short sentence. If no month is named, use the current month.

--- a/examples/agent/src/mastra/agents/weather-fs/subagents/forecaster/subagents/historian/tools/get_climate_normals.ts
+++ b/examples/agent/src/mastra/agents/weather-fs/subagents/forecaster/subagents/historian/tools/get_climate_normals.ts
@@ -1,0 +1,33 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+/**
+ * File-based tool for the nested `historian` subagent — discovered exactly the
+ * same way as at any other depth, keyed by filename -> `get_climate_normals`.
+ */
+export default createTool({
+  id: 'get-climate-normals',
+  description: 'Fetches historical climate normals for a city and month',
+  inputSchema: z.object({
+    city: z.string().describe('The city to look up'),
+    month: z.number().int().min(1).max(12).describe('Month as a number, 1-12'),
+  }),
+  outputSchema: z.object({
+    city: z.string(),
+    month: z.number(),
+    avgHighCelsius: z.number(),
+    avgLowCelsius: z.number(),
+    rainyDays: z.number(),
+  }),
+  execute: async ({ city, month }) => {
+    // Stubbed response — swap in a real climate API for production use.
+    const seasonal = Math.round(10 * Math.sin(((month - 1) / 12) * 2 * Math.PI - Math.PI / 2) + 15);
+    return {
+      city,
+      month,
+      avgHighCelsius: seasonal + 6,
+      avgLowCelsius: seasonal - 4,
+      rainyDays: ((month * 3) % 10) + 4,
+    };
+  },
+});

--- a/packages/core/src/agent/fs-routing/index.test.ts
+++ b/packages/core/src/agent/fs-routing/index.test.ts
@@ -6,8 +6,8 @@ import type { InlineSkill } from '../../skills/types';
 import { createTool } from '../../tools';
 import { Workspace, LocalFilesystem } from '../../workspace';
 import { Agent } from '../agent';
-import { assembleAgentFromFsEntry, agentConfig } from './index';
-import type { FsAgentToolEntry } from './index';
+import { assembleAgentFromFsEntry, agentConfig, MAX_FS_SUBAGENT_DEPTH } from './index';
+import type { FsAgentToolEntry, FsAgentEntry } from './index';
 
 function makeTool(id: string): FsAgentToolEntry {
   return {
@@ -477,7 +477,7 @@ describe('assembleAgentFromFsEntry', () => {
       expect(onWarn).toHaveBeenCalledWith(expect.stringContaining('subagents'));
     });
 
-    it('ignores a nested subagents/ inside a subagent (one level only)', async () => {
+    it('assembles nested subagents recursively', async () => {
       const parent = assembleAgentFromFsEntry({
         name: 'supervisor',
         config: { model: 'openai/gpt-4o' },
@@ -485,7 +485,7 @@ describe('assembleAgentFromFsEntry', () => {
         subagents: [
           {
             ...childEntry('researcher', 'Researches topics.'),
-            subagents: [childEntry('grandchild', 'Should be ignored.')],
+            subagents: [childEntry('grandchild', 'Summarizes findings.')],
           },
         ],
       });
@@ -493,7 +493,44 @@ describe('assembleAgentFromFsEntry', () => {
       const agents = await parent.listAgents();
       expect(Object.keys(agents)).toEqual(['researcher']);
       const researcher = await (agents.researcher as Agent).listAgents();
-      expect(Object.keys(researcher)).toEqual([]);
+      expect(Object.keys(researcher)).toEqual(['grandchild']);
+      const grandchild = await (researcher.grandchild as Agent).listAgents();
+      expect(Object.keys(grandchild)).toEqual([]);
+    });
+
+    it(`warns and ignores subagents nested deeper than MAX_FS_SUBAGENT_DEPTH (${MAX_FS_SUBAGENT_DEPTH})`, async () => {
+      const onWarn = vi.fn();
+
+      // Build a chain one level deeper than the cap: depth 1..MAX+1.
+      let entry: FsAgentEntry = childEntry(`level${MAX_FS_SUBAGENT_DEPTH + 1}`, 'Too deep.');
+      for (let depth = MAX_FS_SUBAGENT_DEPTH; depth >= 1; depth--) {
+        entry = { ...childEntry(`level${depth}`, `Level ${depth}.`), subagents: [entry] };
+      }
+
+      const parent = assembleAgentFromFsEntry(
+        {
+          name: 'supervisor',
+          config: { model: 'openai/gpt-4o' },
+          instructionsMd: 'hi',
+          subagents: [entry],
+        },
+        { onWarn },
+      );
+
+      // Walk down the chain: every level up to the cap is present.
+      let current = parent;
+      for (let depth = 1; depth <= MAX_FS_SUBAGENT_DEPTH; depth++) {
+        const agents = await current.listAgents();
+        expect(Object.keys(agents)).toEqual([`level${depth}`]);
+        current = agents[`level${depth}`] as Agent;
+      }
+
+      // The level past the cap was dropped with a warning.
+      const deepest = await current.listAgents();
+      expect(Object.keys(deepest)).toEqual([]);
+      expect(onWarn).toHaveBeenCalledWith(
+        expect.stringContaining(`nest ${MAX_FS_SUBAGENT_DEPTH} levels below a top-level agent`),
+      );
     });
   });
 

--- a/packages/core/src/agent/fs-routing/index.ts
+++ b/packages/core/src/agent/fs-routing/index.ts
@@ -82,11 +82,20 @@ export interface FsAgentEntry {
    * Declared subagents discovered under `agents/<name>/subagents/<childId>/`.
    * Each entry is assembled into its own `Agent` and wired into the parent's
    * `agents` map under its directory name, becoming a model-visible delegation
-   * tool. Subagents are one level deep — entries here carry no further
-   * `subagents` of their own.
+   * tool. Subagents may declare their own `subagents`, up to
+   * `MAX_FS_SUBAGENT_DEPTH` levels below the top-level agent; deeper entries
+   * are ignored with a warning.
    */
   subagents?: FsAgentEntry[];
 }
+
+/**
+ * Maximum nesting depth for declared subagents. A top-level agent is depth 0;
+ * its subagents are depth 1, and so on. Subagents declared deeper than this
+ * are ignored with a warning. The cap keeps delegation trees a sane size and
+ * guards `assembleAgentFromFsEntry` against cyclic entry objects.
+ */
+export const MAX_FS_SUBAGENT_DEPTH = 3;
 
 /**
  * Assemble a single `Agent` from already-loaded file-system entries for one
@@ -116,6 +125,10 @@ export interface FsAgentEntry {
  * `new Agent(...)` without the loader trying to re-wrap the latter.
  */
 export function assembleAgentFromFsEntry(entry: FsAgentEntry, options?: { onWarn?: (message: string) => void }): Agent {
+  return assembleAtDepth(entry, 0, options);
+}
+
+function assembleAtDepth(entry: FsAgentEntry, depth: number, options?: { onWarn?: (message: string) => void }): Agent {
   const {
     name,
     config = {},
@@ -178,7 +191,7 @@ export function assembleAgentFromFsEntry(entry: FsAgentEntry, options?: { onWarn
   const mergedSkills = mergeSkills(name, skills, config.skills, onWarn);
   const mergedWorkspace = mergeWorkspace(name, workspace, config.workspace, defaultWorkspaceBasePath, onWarn);
   const mergedMemory = mergeMemory(name, memory, config.memory, onWarn);
-  const mergedAgents = mergeSubAgents(name, subagents, config.agents, mergedTools, options);
+  const mergedAgents = mergeSubAgents(name, subagents, config.agents, mergedTools, depth, options);
 
   const assembled = {
     ...config,
@@ -294,9 +307,9 @@ function mergeSkills(
 /**
  * Assemble discovered subagents and merge them into the parent's `agents` map.
  *
- * Each discovered subagent is assembled independently via
- * `assembleAgentFromFsEntry` (one level deep — its own `subagents` are not
- * threaded further). Rules:
+ * Each discovered subagent is assembled independently, recursing into its own
+ * `subagents` up to `MAX_FS_SUBAGENT_DEPTH` levels below the top-level agent
+ * (deeper entries are ignored with a warning). Rules:
  * - Each subagent's `config.ts` must resolve a non-empty `description`;
  *   otherwise a dir-scoped build error is thrown.
  * - A subagent id that collides with a resolved tool key on the same parent, or
@@ -310,9 +323,17 @@ function mergeSubAgents(
   fsSubAgents: FsAgentEntry[],
   configAgents: FsAgentConfig['agents'],
   mergedTools: ToolsInput | undefined,
+  depth: number,
   options?: { onWarn?: (message: string) => void },
 ): FsAgentConfig['agents'] | undefined {
   const onWarn = options?.onWarn ?? (() => {});
+
+  if (fsSubAgents.length > 0 && depth >= MAX_FS_SUBAGENT_DEPTH) {
+    onWarn(
+      `Agent "${name}": ignoring its subagents — subagents may only nest ${MAX_FS_SUBAGENT_DEPTH} levels below a top-level agent.`,
+    );
+    fsSubAgents = [];
+  }
 
   // Dynamic config.agents (a function) can't be statically merged; it wins
   // wholesale and discovered subagents are ignored with a warning.
@@ -353,8 +374,7 @@ function mergeSubAgents(
       });
     }
 
-    // One level deep: a subagent's own `subagents` are not threaded further.
-    const child = assembleAgentFromFsEntry({ ...childEntry, subagents: undefined }, options);
+    const child = assembleAtDepth(childEntry, depth + 1, options);
 
     const description = child.getDescription();
     if (!description || description.trim() === '') {

--- a/packages/deployer/src/build/fs-routing/codegen.ts
+++ b/packages/deployer/src/build/fs-routing/codegen.ts
@@ -13,14 +13,13 @@ function sanitizeIdentifier(name: string, prefix: string, index: string): string
  * first top-level agent, `0_1` for its second subagent) used to keep generated
  * identifiers unique across the parent/child tree. `workspaceName` is the
  * slash-joined workspace key (`<parent>/<child>` for subagents) so seed files
- * don't collide. When `allowSubagents` is true the agent's discovered subagents
- * are emitted as a nested `subagents: [...]` field.
+ * don't collide. Discovered subagents are emitted recursively as a nested
+ * `subagents: [...]` field (discovery already enforces the depth cap).
  */
 async function emitAgentEntry(
   agent: DiscoveredFsAgent,
   idPath: string,
   workspaceName: string,
-  allowSubagents: boolean,
   lines: string[],
 ): Promise<string> {
   const configIdent = sanitizeIdentifier(agent.name, 'config', idPath);
@@ -80,15 +79,13 @@ async function emitAgentEntry(
     instructionsMd = await readFile(agent.instructionsPath, 'utf-8');
   }
 
-  // Declared subagents (one level deep). Each is itself an
-  // `assembleAgentFromFsEntry` entry object with no further `subagents`.
+  // Declared subagents. Each is itself an `assembleAgentFromFsEntry` entry
+  // object, recursively carrying its own `subagents`.
   const subagentExprs: string[] = [];
-  if (allowSubagents) {
-    for (let c = 0; c < agent.subagents.length; c++) {
-      const child = agent.subagents[c]!;
-      const childExpr = await emitAgentEntry(child, `${idPath}_${c}`, `${workspaceName}/${child.name}`, false, lines);
-      subagentExprs.push(childExpr);
-    }
+  for (let c = 0; c < agent.subagents.length; c++) {
+    const child = agent.subagents[c]!;
+    const childExpr = await emitAgentEntry(child, `${idPath}_${c}`, `${workspaceName}/${child.name}`, lines);
+    subagentExprs.push(childExpr);
   }
 
   const entryFields: string[] = [`name: ${JSON.stringify(agent.name)}`];
@@ -131,7 +128,7 @@ async function emitAgentEntry(
  *    (`createSkill(...)` modules), `workspace.ts`, and `memory.ts`, inlining
  *    packaged `SKILL.md` skills,
  * 3. assembles `Agent` instances via `assembleAgentFromFsEntry`, wiring any
- *    declared `subagents/` into the parent (one level deep),
+ *    declared `subagents/` into the parent (nested up to `MAX_FS_SUBAGENT_DEPTH`),
  * 4. registers them onto the user's `mastra` instance (code-registered agents
  *    win on name collisions), and
  * 5. re-exports everything from the user's entry so this module is a drop-in
@@ -146,9 +143,9 @@ async function emitAgentEntry(
 export async function generateFsAgentsModule(userEntry: string, agents: DiscoveredFsAgent[]): Promise<string> {
   const lines: string[] = [];
 
-  const hasInlineSkills = agents.some(a =>
-    [a, ...(a.subagents ?? [])].some(x => (x.skills ?? []).some(s => s.kind === 'packaged')),
-  );
+  const hasInlineSkills = (function check(list: DiscoveredFsAgent[]): boolean {
+    return list.some(a => (a.skills ?? []).some(s => s.kind === 'packaged') || check(a.subagents ?? []));
+  })(agents);
 
   lines.push(`import { assembleAgentFromFsEntry } from '@mastra/core/agent';`);
   if (hasInlineSkills) {
@@ -170,7 +167,7 @@ export async function generateFsAgentsModule(userEntry: string, agents: Discover
   const entryExprs: string[] = [];
   for (let i = 0; i < agents.length; i++) {
     const agent = agents[i]!;
-    const expr = await emitAgentEntry(agent, `${i}`, agent.name, true, lines);
+    const expr = await emitAgentEntry(agent, `${i}`, agent.name, lines);
     entryExprs.push(expr);
   }
 

--- a/packages/deployer/src/build/fs-routing/discover.ts
+++ b/packages/deployer/src/build/fs-routing/discover.ts
@@ -1,5 +1,6 @@
 import { lstat, readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { MAX_FS_SUBAGENT_DEPTH } from '@mastra/core/agent';
 import matter from 'gray-matter';
 import { slash } from '../utils';
 
@@ -33,8 +34,9 @@ export interface DiscoveredFsAgent {
   skills: DiscoveredFsSkill[];
   /**
    * Declared subagents discovered under `subagents/`, in stable (sorted) order.
-   * Subagents are one level deep only: a discovered subagent never carries its
-   * own `subagents` (nested `subagents/` directories are ignored with a warning).
+   * Subagents may declare their own `subagents/`, up to `MAX_FS_SUBAGENT_DEPTH`
+   * levels below the top-level agent; deeper `subagents/` directories are
+   * ignored with a warning.
    */
   subagents: DiscoveredFsAgent[];
 }
@@ -256,17 +258,18 @@ async function discoverSkills(skillsDir: string): Promise<DiscoveredFsSkill[]> {
 
 /**
  * Discover a single agent directory: its `config`/`instructions`/`workspace`
- * files plus `tools/`, `skills/`, and (when `allowSubagents`) one level of
- * declared `subagents/`. Returns `undefined` when `dir` is not an agent
- * directory (no `config.(ts|js)` and no `instructions.md`).
+ * files plus `tools/`, `skills/`, and declared `subagents/`. Returns
+ * `undefined` when `dir` is not an agent directory (no `config.(ts|js)` and no
+ * `instructions.md`).
  *
- * `allowSubagents` is `true` for top-level agents and `false` when discovering a
- * subagent, so nested `subagents/` directories are never recursed into.
+ * `depth` is the subagent nesting level (`0` for top-level agents). Discovery
+ * recurses into `subagents/` until `MAX_FS_SUBAGENT_DEPTH`; deeper directories
+ * are ignored with a warning.
  */
 async function discoverAgentDir(
   dir: string,
   name: string,
-  allowSubagents: boolean,
+  depth: number,
   onWarn?: (message: string) => void,
 ): Promise<DiscoveredFsAgent | undefined> {
   const configPath = await firstExisting(dir, CONFIG_BASENAMES);
@@ -284,7 +287,7 @@ async function discoverAgentDir(
   const workspaceSeedDir = await directoryExists(join(dir, 'workspace'));
   const tools = await discoverTools(join(dir, 'tools'));
   const skills = await discoverSkills(join(dir, 'skills'));
-  const subagents = await discoverSubagents(dir, allowSubagents, onWarn);
+  const subagents = await discoverSubagents(dir, depth, onWarn);
 
   return {
     name,
@@ -301,15 +304,14 @@ async function discoverAgentDir(
 }
 
 /**
- * Discover declared subagents under `<dir>/subagents/*`. Subagents are one level
- * deep only: each discovered subagent is scanned with `allowSubagents: false`,
- * so a nested `subagents/` directory inside a subagent is ignored with a warning.
- * When `allowSubagents` is `false` (we are already inside a subagent) the whole
- * `subagents/` directory is skipped and a warning is emitted if present.
+ * Discover declared subagents under `<dir>/subagents/*`. `parentDepth` is the
+ * parent agent's nesting level (`0` for top-level agents). Discovery recurses
+ * until `MAX_FS_SUBAGENT_DEPTH` levels of subagents; a `subagents/` directory
+ * that would exceed the cap is skipped with a warning.
  */
 async function discoverSubagents(
   parentDir: string,
-  allowSubagents: boolean,
+  parentDepth: number,
   onWarn?: (message: string) => void,
 ): Promise<DiscoveredFsAgent[]> {
   const subagentsDir = join(parentDir, 'subagents');
@@ -317,9 +319,9 @@ async function discoverSubagents(
     return [];
   }
 
-  if (!allowSubagents) {
+  if (parentDepth >= MAX_FS_SUBAGENT_DEPTH) {
     onWarn?.(
-      `Ignoring nested subagents in "${slash(subagentsDir)}": subagents are one level deep only, so a subagent cannot declare its own subagents.`,
+      `Ignoring subagents in "${slash(subagentsDir)}": subagents may only nest ${MAX_FS_SUBAGENT_DEPTH} levels below a top-level agent.`,
     );
     return [];
   }
@@ -337,7 +339,7 @@ async function discoverSubagents(
     if (!(await realDirectory(dir))) {
       continue;
     }
-    const child = await discoverAgentDir(dir, name, false, onWarn);
+    const child = await discoverAgentDir(dir, name, parentDepth + 1, onWarn);
     if (child) {
       subagents.push(child);
     }
@@ -349,10 +351,10 @@ async function discoverSubagents(
 /**
  * Scan `<mastraDir>/agents/*` for file-system routed agents. A directory is
  * treated as an agent only when it contains a `config.(ts|js)` or an
- * `instructions.md`; other directories are ignored. Each top-level agent may
- * declare one level of `subagents/`. Returns descriptors with absolute,
- * slash-normalized paths ready for codegen. Performs no module evaluation —
- * only filesystem inspection.
+ * `instructions.md`; other directories are ignored. Each agent may declare
+ * `subagents/` up to `MAX_FS_SUBAGENT_DEPTH` levels deep. Returns descriptors
+ * with absolute, slash-normalized paths ready for codegen. Performs no module
+ * evaluation — only filesystem inspection.
  */
 export async function discoverFsAgents(
   mastraDir: string,
@@ -376,7 +378,7 @@ export async function discoverFsAgents(
     if (!(await realDirectory(dir))) {
       continue;
     }
-    const agent = await discoverAgentDir(dir, name, true, onWarn);
+    const agent = await discoverAgentDir(dir, name, 0, onWarn);
     if (agent) {
       discovered.push(agent);
     }

--- a/packages/deployer/src/build/fs-routing/fs-routing.test.ts
+++ b/packages/deployer/src/build/fs-routing/fs-routing.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile, readFile, symlink, access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { MAX_FS_SUBAGENT_DEPTH } from '@mastra/core/agent';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { generateFsAgentsModule } from './codegen';
 import { discoverFsAgents } from './discover';
@@ -617,7 +618,7 @@ describe('mirrorFsAgentWorkspaces', () => {
 });
 
 describe('subagents', () => {
-  it('discovers one level of subagents under subagents/', async () => {
+  it('discovers subagents under subagents/', async () => {
     await writeAgent('supervisor', {
       config: `export default { model: 'openai/gpt-4o' };`,
       instructions: 'Delegate.',
@@ -655,7 +656,7 @@ describe('subagents', () => {
     expect(parent.subagents).toEqual([]);
   });
 
-  it('ignores nested subagents (one level only) with a warning', async () => {
+  it('discovers nested subagents recursively', async () => {
     await writeAgent('supervisor', {
       config: `export default { model: 'openai/gpt-4o' };`,
       instructions: 'hi',
@@ -676,9 +677,41 @@ describe('subagents', () => {
 
     const parent = (await discoverFsAgents(dir, m => warnings.push(m)))[0]!;
     const researcher = parent.subagents[0]!;
-    // The grandchild is dropped: a subagent never carries its own subagents.
-    expect(researcher.subagents).toEqual([]);
-    expect(warnings.some(w => /one level deep/.test(w))).toBe(true);
+    expect(researcher.subagents.map(s => s.name)).toEqual(['helper']);
+    expect(researcher.subagents[0]!.subagents).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it(`ignores subagents nested deeper than ${MAX_FS_SUBAGENT_DEPTH} levels with a warning`, async () => {
+    // Build a chain one level deeper than the cap: level1..level{MAX+1}.
+    let files: AgentFiles = {
+      config: `export default { model: 'openai/gpt-4o', description: 'Too deep' };`,
+      instructions: 'too deep',
+    };
+    for (let depth = MAX_FS_SUBAGENT_DEPTH; depth >= 1; depth--) {
+      files = {
+        config: `export default { model: 'openai/gpt-4o', description: 'Level ${depth}' };`,
+        instructions: `level ${depth}`,
+        subagents: { [`level${depth + 1}`]: files },
+      };
+    }
+    await writeAgent('supervisor', {
+      config: `export default { model: 'openai/gpt-4o' };`,
+      instructions: 'hi',
+      subagents: { level1: files },
+    });
+    const warnings: string[] = [];
+
+    const parent = (await discoverFsAgents(dir, m => warnings.push(m)))[0]!;
+    // Walk down the chain: every level up to the cap is present.
+    let current = parent;
+    for (let depth = 1; depth <= MAX_FS_SUBAGENT_DEPTH; depth++) {
+      expect(current.subagents.map(s => s.name)).toEqual([`level${depth}`]);
+      current = current.subagents[0]!;
+    }
+    // The level past the cap was dropped with a warning.
+    expect(current.subagents).toEqual([]);
+    expect(warnings.some(w => new RegExp(`nest ${MAX_FS_SUBAGENT_DEPTH} levels`).test(w))).toBe(true);
   });
 
   it('emits nested assembleAgentFromFsEntry entries for subagents with inlined instructions', async () => {
@@ -690,6 +723,12 @@ describe('subagents', () => {
           config: `export default { model: 'openai/gpt-4o', description: 'Writes' };`,
           instructions: 'You are the writer subagent.',
           tools: { 'draft.ts': `export default {};` },
+          subagents: {
+            editor: {
+              config: `export default { model: 'openai/gpt-4o', description: 'Edits' };`,
+              instructions: 'You are the editor subagent.',
+            },
+          },
         },
       },
     });
@@ -704,9 +743,14 @@ describe('subagents', () => {
     expect(source).toContain('name: "writer"');
     // Subagent workspace base path nests under <parent>/<child>.
     expect(source).toContain('defaultWorkspaceBasePath: __workspaceBasePath("supervisor/writer")');
-    // Generated identifiers are unique across parent/child.
+    // Nested subagents are emitted recursively with <parent>/<child>/<grandchild> workspace paths.
+    expect(source).toContain('name: "editor"');
+    expect(source).toContain(JSON.stringify('You are the editor subagent.'));
+    expect(source).toContain('defaultWorkspaceBasePath: __workspaceBasePath("supervisor/writer/editor")');
+    // Generated identifiers are unique across parent/child/grandchild.
     expect(source).toMatch(/import config_0_supervisor from /);
     expect(source).toMatch(/import config_0_0_writer from /);
+    expect(source).toMatch(/import config_0_0_0_editor from /);
   });
 
   it('mirrors subagent workspace seeds to <bundle>/workspace/<parent>/<child>', async () => {
@@ -719,14 +763,24 @@ describe('subagents', () => {
           config: `export default { model: 'openai/gpt-4o', description: 'Writes' };`,
           instructions: 'w',
           workspaceSeed: { 'child.txt': 'c' },
+          subagents: {
+            editor: {
+              config: `export default { model: 'openai/gpt-4o', description: 'Edits' };`,
+              instructions: 'e',
+              workspaceSeed: { 'grandchild.txt': 'g' },
+            },
+          },
         },
       },
     });
     const bundleDir = join(dir, 'output');
 
     const mirrored = await mirrorFsAgentWorkspaces(dir, bundleDir);
-    expect(mirrored.sort()).toEqual(['supervisor', 'supervisor/writer']);
+    expect(mirrored.sort()).toEqual(['supervisor', 'supervisor/writer', 'supervisor/writer/editor']);
     expect(await readFile(join(bundleDir, 'workspace', 'supervisor', 'parent.txt'), 'utf-8')).toBe('p');
     expect(await readFile(join(bundleDir, 'workspace', 'supervisor', 'writer', 'child.txt'), 'utf-8')).toBe('c');
+    expect(
+      await readFile(join(bundleDir, 'workspace', 'supervisor', 'writer', 'editor', 'grandchild.txt'), 'utf-8'),
+    ).toBe('g');
   });
 });


### PR DESCRIPTION
File-based agents can now nest subagents. Previously a `subagents/` directory inside a subagent was ignored with a warning — delegation trees were capped at one level. Now subagents can declare their own `subagents/` up to three levels below the top-level agent (`MAX_FS_SUBAGENT_DEPTH`, exported from `@mastra/core/agent`). Anything deeper is still ignored with a warning, which keeps delegation trees bounded and guards assembly against cyclic entry objects.

```text
src/mastra/agents/
  supervisor/            # depth 0
    subagents/
      researcher/        # depth 1
        subagents/
          summarizer/    # depth 2
```

Each level is assembled as its own agent and wired into its parent's `agents` map as a delegation tool, same as before. Workspace seeds mirror to nested paths (`workspace/supervisor/researcher/summarizer`). The discovery, codegen, and assembly layers now share a single depth counter instead of the hardcoded one-level boolean gates.

Tested with new unit tests in `@mastra/core` (recursive assembly, depth-cap warning) and `@mastra/deployer` (recursive discovery, codegen emission, workspace mirroring, depth-cap warning). Docs updated in `file-based-agents.mdx`.
