### PR TITLE
feat(e2b): support sandbox network options

### DIFF
--- a/.changeset/e2b-network-options.md
+++ b/.changeset/e2b-network-options.md
@@ -1,0 +1,9 @@
+---
+'@mastra/e2b': minor
+---
+
+Add an E2B sandbox `network` option that is forwarded to `Sandbox.create`.
+
+This lets Mastra users configure E2B network controls and per-host request transforms, including `network.rules` header injection for brokered credentials, through `E2BSandbox` without wrapping or monkey-patching the E2B SDK.
+
+E2B docs: https://e2b.dev/docs/network/internet-access#per-host-request-transforms

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -270,6 +270,26 @@ describe('E2BSandbox', () => {
       );
     });
 
+    it('forwards network options to Sandbox.create', async () => {
+      const { Sandbox } = await import('e2b');
+      const network = {
+        rules: {
+          'api.example.com': [
+            {
+              transform: {
+                headers: { Authorization: 'Bearer token' },
+              },
+            },
+          ],
+        },
+      };
+      const sandbox = new E2BSandbox({ network });
+
+      await sandbox._start();
+
+      expect(Sandbox.create).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ network }));
+    });
+
     it('reconnects to existing sandbox by metadata', async () => {
       const { Sandbox } = await import('e2b');
 

--- a/workspaces/e2b/src/sandbox/index.ts
+++ b/workspaces/e2b/src/sandbox/index.ts
@@ -24,7 +24,7 @@ import type {
 type InstructionsOption = string | ((opts: { defaultInstructions: string; requestContext?: RequestContext }) => string);
 import { MastraSandbox, SandboxNotReadyError } from '@mastra/core/workspace';
 import { Sandbox, Template } from 'e2b';
-import type { TemplateBuilder, TemplateClass } from 'e2b';
+import type { SandboxNetworkOpts, TemplateBuilder, TemplateClass } from 'e2b';
 import { createDefaultMountableTemplate } from '../utils/template';
 import type { TemplateSpec } from '../utils/template';
 import { mountS3, mountGCS, mountAzure, LOG_PREFIX } from './mounts';
@@ -83,6 +83,8 @@ export interface E2BSandboxOptions extends Omit<MastraSandboxOptions, 'processes
   env?: Record<string, string>;
   /** Custom metadata */
   metadata?: Record<string, unknown>;
+  /** Network configuration to use when creating the E2B sandbox */
+  network?: SandboxNetworkOpts;
 
   /** Domain for self-hosted E2B. Falls back to E2B_DOMAIN env var. */
   domain?: string;
@@ -163,6 +165,7 @@ export class E2BSandbox extends MastraSandbox {
   private readonly templateSpec?: TemplateSpec;
   private readonly env: Record<string, string>;
   private readonly metadata: Record<string, unknown>;
+  private readonly network?: SandboxNetworkOpts;
   private readonly connectionOpts: Record<string, string>;
   private readonly _instructionsOverride?: InstructionsOption;
 
@@ -184,6 +187,7 @@ export class E2BSandbox extends MastraSandbox {
     this.templateSpec = options.template;
     this.env = options.env ?? {};
     this.metadata = options.metadata ?? {};
+    this.network = options.network;
     this.connectionOpts = {
       ...(options.domain && { domain: options.domain }),
       ...(options.apiUrl && { apiUrl: options.apiUrl }),
@@ -285,6 +289,7 @@ export class E2BSandbox extends MastraSandbox {
           ...this.metadata,
           'mastra-sandbox-id': this.id,
         },
+        ...(this.network && { network: this.network }),
         timeoutMs: this.timeout,
       });
     } catch (createError) {
@@ -303,6 +308,7 @@ export class E2BSandbox extends MastraSandbox {
             ...this.metadata,
             'mastra-sandbox-id': this.id,
           },
+          ...(this.network && { network: this.network }),
           timeoutMs: this.timeout,
         });
       } else {


### PR DESCRIPTION
## Summary
- add a `network?: SandboxNetworkOpts` option to `E2BSandboxOptions`
- forward the option to both `Sandbox.create` paths, including the template-rebuild retry path
- add a unit test covering forwarding to the E2B SDK
- document the E2B `network.rules` / per-host transform use case in the changeset

## Why
E2B supports sandbox network controls and per-host request transforms through `Sandbox.create({ network })`. This is required for use cases like brokered credentials via `network.rules` header injection, without putting real secrets in sandbox environment variables or wrapping `Sandbox.create`.

E2B docs: https://e2b.dev/docs/network/internet-access#per-host-request-transforms

## Test
- `pnpm --dir /workspaces/worktrees/gorkie-slack/mastra exec turbo build --filter @mastra/e2b`
- `pnpm --dir /workspaces/worktrees/gorkie-slack/mastra --filter @mastra/e2b test:unit`
- vendored the packed PR version of `@mastra/e2b` into a downstream Gorkie checkout, temporarily simplified its sandbox construction to `new E2BSandbox({ network, ... })`, and verified `bun run typecheck` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR lets Mastra pass “network settings” into an E2B sandbox when it’s created. That way you can control how the sandbox accesses the internet (like per-host request header transforms) without changing anything in the E2B SDK.

### What changed
- Added an optional `network?: SandboxNetworkOpts` field to `E2BSandboxOptions`
- Forwarded `network` into `Sandbox.create(...)` both for normal sandbox creation and the 404 “rebuild and retry” path
- Added a unit test that verifies `network` is passed through to `Sandbox.create` unchanged
- Added a changeset for a `@mastra/e2b` minor release documenting the new `network` option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->