### PR TITLE
fix(cli): respect --server-api-prefix for observability commands

### DIFF
--- a/.changeset/polite-toes-mix.md
+++ b/.changeset/polite-toes-mix.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed observability CLI commands (trace, log, score, metric) ignoring `--server-api-prefix` when `--url` is provided. Previously, all `/observability/` routes were unconditionally routed through the hosted observability endpoint, dropping the custom API prefix. Now, when `--url` is explicitly set, observability commands correctly use the provided URL and prefix, matching the behavior of agent, workflow, and thread commands.

--- a/packages/cli/src/commands/api/target.test.ts
+++ b/packages/cli/src/commands/api/target.test.ts
@@ -163,7 +163,7 @@ describe('resolveTarget', () => {
     expect(mocks.fetchServerProjects).not.toHaveBeenCalled();
   });
 
-  it('keeps explicit observability headers and URL overrides', async () => {
+  it('uses explicit --url for observability paths instead of hosted endpoint', async () => {
     process.env.MASTRA_PLATFORM_ACCESS_TOKEN = 'env-token';
     process.env.MASTRA_PROJECT_ID = 'env-project';
 
@@ -183,6 +183,25 @@ describe('resolveTarget', () => {
         'X-Mastra-Project-Id': 'custom-project',
       },
       timeoutMs: 30_000,
+    });
+  });
+
+  it('carries --server-api-prefix for observability paths when --url is set', async () => {
+    await expect(
+      resolveTarget(
+        options({
+          url: 'https://runtime.example.com',
+          serverApiPrefix: '/api/mastra-studio',
+          header: ['Authorization: Bearer token'],
+        }),
+        fetchMock as typeof fetch,
+        '/observability/traces',
+      ),
+    ).resolves.toEqual({
+      baseUrl: 'https://runtime.example.com',
+      headers: { Authorization: 'Bearer token' },
+      timeoutMs: 30_000,
+      apiPrefix: '/api/mastra-studio',
     });
   });
 

--- a/packages/cli/src/commands/api/target.ts
+++ b/packages/cli/src/commands/api/target.ts
@@ -44,7 +44,7 @@ export async function resolveTarget(
   }
 
   if (isObservabilityPath(path)) {
-    return resolveObservabilityTarget(options, customHeaders, timeoutMs);
+    return resolveObservabilityTarget(customHeaders, timeoutMs);
   }
 
   if (await canReachLocal(timeoutMs, fetchFn, apiPrefix)) {
@@ -86,7 +86,6 @@ export async function resolveTarget(
 }
 
 async function resolveObservabilityTarget(
-  options: ApiGlobalOptions,
   customHeaders: Record<string, string>,
   timeoutMs: number,
 ): Promise<ResolvedTarget> {
@@ -94,10 +93,10 @@ async function resolveObservabilityTarget(
   const explicitAuthorization = getHeader(customHeaders, AUTHORIZATION_HEADER);
   const explicitProjectId = getHeader(customHeaders, PROJECT_ID_HEADER);
   const envToken = process.env.MASTRA_PLATFORM_ACCESS_TOKEN || env.MASTRA_PLATFORM_ACCESS_TOKEN;
-  const cliToken = explicitAuthorization || options.url ? undefined : await getOptionalToken();
+  const cliToken = explicitAuthorization ? undefined : await getOptionalToken();
   const envProjectId = process.env.MASTRA_PROJECT_ID || env.MASTRA_PROJECT_ID;
   const configProjectId =
-    explicitProjectId || envProjectId || options.url ? undefined : (await loadProjectConfig(process.cwd()))?.projectId;
+    explicitProjectId || envProjectId ? undefined : (await loadProjectConfig(process.cwd()))?.projectId;
   const projectId = explicitProjectId || envProjectId || configProjectId;
   const headers = { ...customHeaders };
 
@@ -117,7 +116,7 @@ async function resolveObservabilityTarget(
       : undefined;
 
   return {
-    baseUrl: options.url ?? OBSERVABILITY_URL,
+    baseUrl: OBSERVABILITY_URL,
     headers,
     timeoutMs,
     fallbackHeaders,

--- a/packages/cli/src/commands/api/target.ts
+++ b/packages/cli/src/commands/api/target.ts
@@ -39,12 +39,12 @@ export async function resolveTarget(
   const customHeaders = parseHeaders(options.header);
   const apiPrefix = resolveApiPrefix(options);
 
-  if (isObservabilityPath(path)) {
-    return resolveObservabilityTarget(options, customHeaders, timeoutMs);
-  }
-
   if (options.url) {
     return { baseUrl: options.url, headers: customHeaders, timeoutMs, apiPrefix };
+  }
+
+  if (isObservabilityPath(path)) {
+    return resolveObservabilityTarget(options, customHeaders, timeoutMs);
   }
 
   if (await canReachLocal(timeoutMs, fetchFn, apiPrefix)) {


### PR DESCRIPTION
## Description

Observability CLI commands (`trace`, `log`, `score`, `metric`) ignored `--server-api-prefix` (and `MASTRA_API_PREFIX`) when `--url` was provided, always requesting `/api/observability/...` with the default prefix.

- Swapped the `isObservabilityPath` and `options.url` guards in `resolveTarget()` so that an explicit `--url` takes priority over the hosted-observability shortcut
- The hosted-observability path (`observability.mastra.ai`) still works when no `--url` is provided
- Added a test that verifies `apiPrefix` is carried through for observability paths with `--url` + `--server-api-prefix`

## Related Issue(s)

Fixes #18784

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The CLI used to ignore the API prefix you configured when you also gave it `--url`, so observability requests could hit the wrong path (and fail with 404s). Now it uses your `--url` (and keeps your `--server-api-prefix`) for `trace`, `log`, `score`, and `metric`.

## Summary
- Updated `resolveTarget()` so an explicit `--url` takes priority over the observability-path routing logic.
- Ensured observability targets preserve `--server-api-prefix` / `MASTRA_API_PREFIX` when `--url` is provided.
- Kept the existing behavior for observability routes when `--url` is not provided (still uses the hosted `observability.mastra.ai` endpoint).
- Added/updated tests covering observability resolution with both `--url` and `--server-api-prefix`.
- Added a patch changeset documenting the fix for observability CLI commands (`trace`, `log`, `score`, `metric`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->