### PR TITLE
chore(playground-ui): remove non-null assertions

### DIFF
--- a/packages/playground-ui/eslint.config.js
+++ b/packages/playground-ui/eslint.config.js
@@ -21,6 +21,12 @@ export default [
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
   },
+  {
+    files: ['**/*.ts?(x)'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'error',
+    },
+  },
   ...storybook.configs['flat/recommended'],
   {
     files: ['**/*.stories.tsx'],

--- a/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/log-details-view.tsx
@@ -39,6 +39,8 @@ export function LogDetailsView({
   const collapsed = controlledCollapsed ?? internalCollapsed;
   const setCollapsed = onCollapsedChange ?? setInternalCollapsed;
   const date = toDate(log.timestamp);
+  const traceId = log.traceId;
+  const spanId = log.spanId;
 
   return (
     <DataDetailsPanel collapsed={collapsed}>
@@ -74,35 +76,31 @@ export function LogDetailsView({
         <DataDetailsPanel.Content>
           <p className="text-ui-md text-neutral4 font-mono wrap-break-word whitespace-pre-wrap">{log.message}</p>
 
-          {(log.traceId || log.spanId) && (
+          {(traceId || spanId) && (
             <div className={cn('grid gap-2 my-8', '[&>button]:justify-between [&>button]:overflow-hidden')}>
-              {log.traceId && (
+              {traceId && (
                 <ButtonsGroup spacing="close" className="min-w-0 w-full">
-                  <Button
-                    size="md"
-                    className="min-w-0 flex-1 overflow-hidden"
-                    onClick={() => onTraceClick?.(log.traceId!)}
-                  >
+                  <Button size="md" className="min-w-0 flex-1 overflow-hidden" onClick={() => onTraceClick?.(traceId)}>
                     <ArrowRightIcon />
                     <span>Trace</span>
-                    <span className=" ml-auto text-ui-sm text-neutral2 min-w-0 truncate"># {log.traceId}</span>
+                    <span className=" ml-auto text-ui-sm text-neutral2 min-w-0 truncate"># {traceId}</span>
                   </Button>
-                  <CopyButton content={log.traceId!} size="md" tooltip="Copy Trace ID to clipboard" />
+                  <CopyButton content={traceId} size="md" tooltip="Copy Trace ID to clipboard" />
                 </ButtonsGroup>
               )}
-              {log.spanId && (
+              {spanId && (
                 <ButtonsGroup spacing="close" className="min-w-0 w-full">
                   <Button
                     size="md"
                     className="min-w-0 flex-1 overflow-hidden"
-                    disabled={!log.traceId || !onSpanClick}
-                    onClick={() => log.traceId && onSpanClick?.(log.traceId, log.spanId!)}
+                    disabled={!traceId || !onSpanClick}
+                    onClick={() => traceId && onSpanClick?.(traceId, spanId)}
                   >
                     <ArrowRightIcon />
                     <span>Span</span>
-                    <span className=" ml-auto text-ui-sm text-neutral2 min-w-0 truncate"># {log.spanId}</span>
+                    <span className=" ml-auto text-ui-sm text-neutral2 min-w-0 truncate"># {spanId}</span>
                   </Button>
-                  <CopyButton content={log.spanId!} size="md" tooltip="Copy Span ID to clipboard" />
+                  <CopyButton content={spanId} size="md" tooltip="Copy Span ID to clipboard" />
                 </ButtonsGroup>
               )}
             </div>

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs-list-navigation.tsx
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs-list-navigation.tsx
@@ -91,7 +91,8 @@ export function useLogsListNavigation(
     featuredLogIdx > 0
       ? () => {
           const prevLog = logs[featuredLogIdx - 1];
-          const id = logIdMap.get(prevLog)!;
+          const id = logIdMap.get(prevLog);
+          if (!id) return;
           if (featuredTraceId) {
             onFeaturedChange({ logId: id, traceId: prevLog.traceId ?? null, spanId: null });
           } else {
@@ -104,7 +105,8 @@ export function useLogsListNavigation(
     featuredLogIdx >= 0 && featuredLogIdx < logs.length - 1
       ? () => {
           const nextLog = logs[featuredLogIdx + 1];
-          const id = logIdMap.get(nextLog)!;
+          const id = logIdMap.get(nextLog);
+          if (!id) return;
           if (featuredTraceId) {
             onFeaturedChange({ logId: id, traceId: nextLog.traceId ?? null, spanId: null });
           } else {

--- a/packages/playground-ui/src/domains/memory/components/__tests__/flame-graph.test.tsx
+++ b/packages/playground-ui/src/domains/memory/components/__tests__/flame-graph.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { timestampsToTDomain } from '../../lib/timeline';
 import { FlameGraph } from '../flame-graph';
 import { memoryMessages, omHistoryRecords } from './fixtures/memory-studio';
-import { assertDefined } from '@/test-utils/assert';
 
 const tDomain = timestampsToTDomain(memoryMessages.map(m => new Date(m.createdAt).toISOString()));
 const markers: never[] = [];
@@ -54,9 +55,9 @@ describe('FlameGraph', () => {
     fireEvent.mouseUp(window);
 
     expect(onZoomRangeChange).toHaveBeenCalled();
-    const [lastRange] = assertDefined(onZoomRangeChange.mock.calls.at(-1), 'Expected zoom range change call') as [
-      { left: number; right: number },
-    ];
+    const lastCall = onZoomRangeChange.mock.calls.at(-1);
+    assert(lastCall, 'Expected zoom range change call');
+    const [lastRange] = lastCall as [{ left: number; right: number }];
     // Dragging the left handle to the middle of the track moves left toward the
     // midpoint of the domain, so it is now greater than the domain minimum.
     expect(lastRange.left).toBeGreaterThan(tDomain.tMin);

--- a/packages/playground-ui/src/domains/memory/components/__tests__/flame-graph.test.tsx
+++ b/packages/playground-ui/src/domains/memory/components/__tests__/flame-graph.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { timestampsToTDomain } from '../../lib/timeline';
 import { FlameGraph } from '../flame-graph';
 import { memoryMessages, omHistoryRecords } from './fixtures/memory-studio';
+import { assertDefined } from '@/test-utils/assert';
 
 const tDomain = timestampsToTDomain(memoryMessages.map(m => new Date(m.createdAt).toISOString()));
 const markers: never[] = [];
@@ -53,10 +54,9 @@ describe('FlameGraph', () => {
     fireEvent.mouseUp(window);
 
     expect(onZoomRangeChange).toHaveBeenCalled();
-    const lastCall = onZoomRangeChange.mock.calls.at(-1);
-    expect(lastCall).toBeDefined();
-    if (!lastCall) throw new Error('Expected zoom range change call');
-    const [lastRange] = lastCall as [{ left: number; right: number }];
+    const [lastRange] = assertDefined(onZoomRangeChange.mock.calls.at(-1), 'Expected zoom range change call') as [
+      { left: number; right: number },
+    ];
     // Dragging the left handle to the middle of the track moves left toward the
     // midpoint of the domain, so it is now greater than the domain minimum.
     expect(lastRange.left).toBeGreaterThan(tDomain.tMin);

--- a/packages/playground-ui/src/domains/memory/components/__tests__/flame-graph.test.tsx
+++ b/packages/playground-ui/src/domains/memory/components/__tests__/flame-graph.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { timestampsToTDomain } from '../../lib/timeline';
 import { FlameGraph } from '../flame-graph';

--- a/packages/playground-ui/src/domains/memory/components/__tests__/flame-graph.test.tsx
+++ b/packages/playground-ui/src/domains/memory/components/__tests__/flame-graph.test.tsx
@@ -53,11 +53,14 @@ describe('FlameGraph', () => {
     fireEvent.mouseUp(window);
 
     expect(onZoomRangeChange).toHaveBeenCalled();
-    const lastCall = onZoomRangeChange.mock.calls.at(-1)![0] as { left: number; right: number };
+    const lastCall = onZoomRangeChange.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    if (!lastCall) throw new Error('Expected zoom range change call');
+    const [lastRange] = lastCall as [{ left: number; right: number }];
     // Dragging the left handle to the middle of the track moves left toward the
     // midpoint of the domain, so it is now greater than the domain minimum.
-    expect(lastCall.left).toBeGreaterThan(tDomain.tMin);
-    expect(lastCall.right).toBe(tDomain.tMax);
+    expect(lastRange.left).toBeGreaterThan(tDomain.tMin);
+    expect(lastRange.right).toBe(tDomain.tMax);
   });
 
   it('fires onZoomRangeChange with the full domain when Reset zoom is clicked', () => {

--- a/packages/playground-ui/src/domains/memory/components/flame-graph.tsx
+++ b/packages/playground-ui/src/domains/memory/components/flame-graph.tsx
@@ -58,12 +58,13 @@ function toContextData(records: OMHistoryRecord[], markers: ExtractedOmMarker[],
     ts: String(getObservationTimestamp(r)),
     pendingMessageTokens: r.pendingMessageTokens,
   }));
-  const fromMarkers = markers
-    .filter(m => m.pendingTokens != null)
-    .map(m => ({
+  const fromMarkers = markers.flatMap(m => {
+    if (m.pendingTokens == null) return [];
+    return {
       ts: m.timestamp,
-      pendingMessageTokens: m.pendingTokens!,
-    }));
+      pendingMessageTokens: m.pendingTokens,
+    };
+  });
   return [...fromRecords, ...fromMarkers]
     .sort((a, b) => a.ts.localeCompare(b.ts))
     .map(d => ({ t: toT(d.ts, domain), pendingMessageTokens: d.pendingMessageTokens }));
@@ -75,12 +76,13 @@ function toActiveObservationData(records: OMHistoryRecord[], markers: ExtractedO
       ts: String(getObservationTimestamp(record)),
       observationTokenCount: record.observationTokenCount,
     })),
-    ...markers
-      .filter(marker => marker.type === 'status' && marker.observationTokens != null)
-      .map(marker => ({
+    ...markers.flatMap(marker => {
+      if (marker.type !== 'status' || marker.observationTokens == null) return [];
+      return {
         ts: marker.timestamp,
-        observationTokenCount: marker.observationTokens!,
-      })),
+        observationTokenCount: marker.observationTokens,
+      };
+    }),
   ].sort((a, b) => a.ts.localeCompare(b.ts));
 
   let runningTotal = 0;
@@ -92,14 +94,16 @@ function toActiveObservationData(records: OMHistoryRecord[], markers: ExtractedO
 
 function toBufferedObservationData(markers: ExtractedOmMarker[], domain: TDomain) {
   const points = markers
-    .filter(
-      marker => marker.observationTokens != null && (marker.type === 'buffering-end' || marker.type === 'activation'),
-    )
-    .map(marker => ({
-      ts: marker.timestamp,
-      bufferedObservationTokenCount:
-        marker.type === 'activation' ? -marker.observationTokens! : marker.observationTokens!,
-    }))
+    .flatMap(marker => {
+      if (marker.observationTokens == null || (marker.type !== 'buffering-end' && marker.type !== 'activation')) {
+        return [];
+      }
+      return {
+        ts: marker.timestamp,
+        bufferedObservationTokenCount:
+          marker.type === 'activation' ? -marker.observationTokens : marker.observationTokens,
+      };
+    })
     .sort((a, b) => a.ts.localeCompare(b.ts));
 
   let runningTotal = 0;

--- a/packages/playground-ui/src/domains/memory/hooks/__tests__/memory-hooks.test.tsx
+++ b/packages/playground-ui/src/domains/memory/hooks/__tests__/memory-hooks.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+import type {
+  GetMemoryStatusResponse,
+  GetObservationalMemoryResponse,
+  ListMemoryThreadMessagesResponse,
+} from '@mastra/client-js';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import type { ReactNode } from 'react';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { useMemoryStatus } from '../use-memory-status';
+import { useMemoryThreadMessages } from '../use-memory-thread-messages';
+import { useObservationalMemory } from '../use-observational-memory';
+
+const BASE_URL = 'http://localhost:4111';
+const ROOT = `${BASE_URL}/api`;
+
+const server = setupServer();
+
+const memoryStatusResponse: GetMemoryStatusResponse = {
+  result: true,
+  memoryType: 'local',
+  observationalMemory: { enabled: true, hasRecord: true },
+};
+
+const threadMessagesResponse: ListMemoryThreadMessagesResponse = {
+  messages: [
+    {
+      id: 'msg-1',
+      role: 'user',
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      content: {
+        format: 2,
+        content: 'Hello world',
+        parts: [{ type: 'text', text: 'Hello world' }],
+      },
+    },
+  ],
+};
+
+const observationalMemoryResponse: GetObservationalMemoryResponse = {
+  record: null,
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+
+afterEach(() => {
+  cleanup();
+  server.resetHandlers();
+});
+
+afterAll(() => server.close());
+
+describe('useMemoryStatus', () => {
+  describe('when agentId is present', () => {
+    it('fetches the memory status and forwards agentId/threadId', async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get(`${ROOT}/memory/status`, ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json(memoryStatusResponse);
+        }),
+      );
+
+      const { result } = renderHook(() => useMemoryStatus('agent-1', 'thread-1'), { wrapper: makeWrapper() });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(memoryStatusResponse);
+      expect(capturedUrl?.searchParams.get('agentId')).toBe('agent-1');
+      expect(capturedUrl?.searchParams.get('threadId')).toBe('thread-1');
+    });
+  });
+
+  describe('when agentId is undefined', () => {
+    it('stays idle and does not fetch', async () => {
+      const onStatus = vi.fn<() => void>();
+      server.use(
+        http.get(`${ROOT}/memory/status`, () => {
+          onStatus();
+          return HttpResponse.json(memoryStatusResponse);
+        }),
+      );
+
+      const { result } = renderHook(() => useMemoryStatus(undefined, 'thread-1'), { wrapper: makeWrapper() });
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(result.current.isPending).toBe(true);
+      expect(onStatus).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('useMemoryThreadMessages', () => {
+  describe('when threadId is present', () => {
+    it('fetches the messages and forwards page/perPage', async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get(`${ROOT}/memory/threads/:threadId/messages`, ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json(threadMessagesResponse);
+        }),
+      );
+
+      const { result } = renderHook(() => useMemoryThreadMessages('thread-1', { page: 2, perPage: 25 }), {
+        wrapper: makeWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.messages).toHaveLength(1);
+      expect(result.current.data?.messages[0]?.id).toBe('msg-1');
+      expect(capturedUrl?.pathname).toBe('/api/memory/threads/thread-1/messages');
+      expect(capturedUrl?.searchParams.get('page')).toBe('2');
+      expect(capturedUrl?.searchParams.get('perPage')).toBe('25');
+    });
+  });
+
+  describe('when threadId is undefined', () => {
+    it('stays idle and does not fetch', async () => {
+      const onMessages = vi.fn<() => void>();
+      server.use(
+        http.get(`${ROOT}/memory/threads/:threadId/messages`, () => {
+          onMessages();
+          return HttpResponse.json(threadMessagesResponse);
+        }),
+      );
+
+      const { result } = renderHook(() => useMemoryThreadMessages(undefined), { wrapper: makeWrapper() });
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(result.current.isPending).toBe(true);
+      expect(onMessages).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('useObservationalMemory', () => {
+  describe('when agentId and threadId are present', () => {
+    it('fetches the observational memory and forwards agentId/threadId', async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get(`${ROOT}/memory/observational-memory`, ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json(observationalMemoryResponse);
+        }),
+      );
+
+      const { result } = renderHook(() => useObservationalMemory('agent-1', 'thread-1', 'resource-1'), {
+        wrapper: makeWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(observationalMemoryResponse);
+      expect(capturedUrl?.searchParams.get('agentId')).toBe('agent-1');
+      expect(capturedUrl?.searchParams.get('threadId')).toBe('thread-1');
+      expect(capturedUrl?.searchParams.get('resourceId')).toBe('resource-1');
+    });
+  });
+
+  describe('when agentId is undefined', () => {
+    it('stays idle and does not fetch', async () => {
+      const onObservational = vi.fn<() => void>();
+      server.use(
+        http.get(`${ROOT}/memory/observational-memory`, () => {
+          onObservational();
+          return HttpResponse.json(observationalMemoryResponse);
+        }),
+      );
+
+      const { result } = renderHook(() => useObservationalMemory(undefined, 'thread-1'), { wrapper: makeWrapper() });
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(result.current.isPending).toBe(true);
+      expect(onObservational).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/playground-ui/src/domains/memory/hooks/use-memory-status.ts
+++ b/packages/playground-ui/src/domains/memory/hooks/use-memory-status.ts
@@ -1,14 +1,14 @@
 import { useMastraClient } from '@mastra/react';
 import { skipToken, useQuery } from '@tanstack/react-query';
 
-export const memoryStatusQueryKey = (agentId: string, threadId?: string) =>
-  ['memory', 'status', agentId, threadId ?? ''] as const;
+export const memoryStatusQueryKey = (agentId: string | undefined, threadId?: string) =>
+  ['memory', 'status', agentId, threadId] as const;
 
 export function useMemoryStatus(agentId: string | undefined, threadId?: string) {
   const client = useMastraClient();
 
   return useQuery({
-    queryKey: memoryStatusQueryKey(agentId ?? '', threadId),
+    queryKey: memoryStatusQueryKey(agentId, threadId),
     queryFn: agentId
       ? () =>
           client.getMemoryStatus(agentId, undefined, {

--- a/packages/playground-ui/src/domains/memory/hooks/use-memory-status.ts
+++ b/packages/playground-ui/src/domains/memory/hooks/use-memory-status.ts
@@ -1,5 +1,5 @@
 import { useMastraClient } from '@mastra/react';
-import { useQuery } from '@tanstack/react-query';
+import { skipToken, useQuery } from '@tanstack/react-query';
 
 export const memoryStatusQueryKey = (agentId: string, threadId?: string) =>
   ['memory', 'status', agentId, threadId ?? ''] as const;
@@ -8,11 +8,12 @@ export function useMemoryStatus(agentId: string | undefined, threadId?: string) 
   const client = useMastraClient();
 
   return useQuery({
-    queryKey: memoryStatusQueryKey(agentId!, threadId),
-    queryFn: () =>
-      client.getMemoryStatus(agentId!, undefined, {
-        threadId,
-      }),
-    enabled: !!agentId,
+    queryKey: memoryStatusQueryKey(agentId ?? '', threadId),
+    queryFn: agentId
+      ? () =>
+          client.getMemoryStatus(agentId, undefined, {
+            threadId,
+          })
+      : skipToken,
   });
 }

--- a/packages/playground-ui/src/domains/memory/hooks/use-memory-thread-messages.ts
+++ b/packages/playground-ui/src/domains/memory/hooks/use-memory-thread-messages.ts
@@ -1,5 +1,5 @@
 import { useMastraClient } from '@mastra/react';
-import { useQuery } from '@tanstack/react-query';
+import { skipToken, useQuery } from '@tanstack/react-query';
 
 export const memoryThreadMessagesQueryKey = (threadId: string, page?: number) =>
   ['memory', 'thread', threadId, 'messages', page ?? 0] as const;
@@ -10,8 +10,7 @@ export function useMemoryThreadMessages(threadId: string | undefined, opts?: { p
   const perPage = opts?.perPage ?? 100;
 
   return useQuery({
-    queryKey: memoryThreadMessagesQueryKey(threadId!, page),
-    queryFn: () => client.getMemoryThread({ threadId: threadId! }).listMessages({ page, perPage }),
-    enabled: !!threadId,
+    queryKey: memoryThreadMessagesQueryKey(threadId ?? '', page),
+    queryFn: threadId ? () => client.getMemoryThread({ threadId }).listMessages({ page, perPage }) : skipToken,
   });
 }

--- a/packages/playground-ui/src/domains/memory/hooks/use-memory-thread-messages.ts
+++ b/packages/playground-ui/src/domains/memory/hooks/use-memory-thread-messages.ts
@@ -1,7 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { skipToken, useQuery } from '@tanstack/react-query';
 
-export const memoryThreadMessagesQueryKey = (threadId: string, page?: number) =>
+export const memoryThreadMessagesQueryKey = (threadId: string | undefined, page?: number) =>
   ['memory', 'thread', threadId, 'messages', page ?? 0] as const;
 
 export function useMemoryThreadMessages(threadId: string | undefined, opts?: { page?: number; perPage?: number }) {
@@ -10,7 +10,7 @@ export function useMemoryThreadMessages(threadId: string | undefined, opts?: { p
   const perPage = opts?.perPage ?? 100;
 
   return useQuery({
-    queryKey: memoryThreadMessagesQueryKey(threadId ?? '', page),
+    queryKey: memoryThreadMessagesQueryKey(threadId, page),
     queryFn: threadId ? () => client.getMemoryThread({ threadId }).listMessages({ page, perPage }) : skipToken,
   });
 }

--- a/packages/playground-ui/src/domains/memory/hooks/use-observational-memory.ts
+++ b/packages/playground-ui/src/domains/memory/hooks/use-observational-memory.ts
@@ -1,14 +1,14 @@
 import { useMastraClient } from '@mastra/react';
 import { skipToken, useQuery } from '@tanstack/react-query';
 
-export const observationalMemoryQueryKey = (agentId: string, threadId: string) =>
+export const observationalMemoryQueryKey = (agentId: string | undefined, threadId: string | undefined) =>
   ['memory', 'observational-memory', agentId, threadId] as const;
 
 export function useObservationalMemory(agentId: string | undefined, threadId: string | undefined, resourceId?: string) {
   const client = useMastraClient();
 
   return useQuery({
-    queryKey: observationalMemoryQueryKey(agentId ?? '', threadId ?? ''),
+    queryKey: observationalMemoryQueryKey(agentId, threadId),
     queryFn:
       agentId && threadId
         ? () =>

--- a/packages/playground-ui/src/domains/memory/hooks/use-observational-memory.ts
+++ b/packages/playground-ui/src/domains/memory/hooks/use-observational-memory.ts
@@ -1,5 +1,5 @@
 import { useMastraClient } from '@mastra/react';
-import { useQuery } from '@tanstack/react-query';
+import { skipToken, useQuery } from '@tanstack/react-query';
 
 export const observationalMemoryQueryKey = (agentId: string, threadId: string) =>
   ['memory', 'observational-memory', agentId, threadId] as const;
@@ -8,13 +8,15 @@ export function useObservationalMemory(agentId: string | undefined, threadId: st
   const client = useMastraClient();
 
   return useQuery({
-    queryKey: observationalMemoryQueryKey(agentId!, threadId!),
-    queryFn: () =>
-      client.getObservationalMemory({
-        agentId: agentId!,
-        threadId: threadId!,
-        resourceId,
-      }),
-    enabled: !!agentId && !!threadId,
+    queryKey: observationalMemoryQueryKey(agentId ?? '', threadId ?? ''),
+    queryFn:
+      agentId && threadId
+        ? () =>
+            client.getObservationalMemory({
+              agentId,
+              threadId,
+              resourceId,
+            })
+        : skipToken,
   });
 }

--- a/packages/playground-ui/src/domains/metrics/components/token-usage-by-agent-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/token-usage-by-agent-card-view.tsx
@@ -41,7 +41,7 @@ export function TokenUsageByAgentCardView({
   const rows = data ?? [];
   const hasData = rows.length > 0;
   const totalTokens = rows.reduce((s, d) => s + d.total, 0);
-  const costRows = rows.filter(d => d.cost != null && d.cost > 0);
+  const costRows = rows.filter((d): d is TokenUsageByAgentRow & { cost: number } => d.cost != null && d.cost > 0);
   const uniqueCostUnits = new Set(costRows.map(d => d.costUnit ?? 'usd'));
   const hasSingleCostUnit = uniqueCostUnits.size <= 1;
   const costUnit = hasSingleCostUnit ? ([...uniqueCostUnits][0] ?? 'usd') : null;
@@ -107,7 +107,7 @@ export function TokenUsageByAgentCardView({
                     data={costRows
                       .slice()
                       .sort((a, b) => (b.cost ?? 0) - (a.cost ?? 0))
-                      .map(d => ({ name: d.name, values: [d.cost!], href: getRowHref?.(d) }))}
+                      .map(d => ({ name: d.name, values: [d.cost], href: getRowHref?.(d) }))}
                     segments={[{ label: 'Cost', color: CHART_COLORS.purple }]}
                     maxVal={Math.max(...costRows.map(d => d.cost ?? 0))}
                     fmt={v => formatCost(v, costUnit)}

--- a/packages/playground-ui/src/domains/metrics/hooks/use-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-metrics.tsx
@@ -15,11 +15,17 @@ const DATE_PRESETS = [
   { label: 'Last 30 days', value: '30d' },
 ] as const;
 
-export type DatePreset = (typeof DATE_PRESETS)[number]['value'] | 'custom';
+type FixedDatePreset = (typeof DATE_PRESETS)[number]['value'];
+
+export type DatePreset = FixedDatePreset | 'custom';
 
 export { DATE_PRESETS };
 
 const VALID_PRESETS = new Set<string>(DATE_PRESETS.map(p => p.value));
+const DATE_PRESET_LABELS = Object.fromEntries(DATE_PRESETS.map(preset => [preset.value, preset.label])) as Record<
+  FixedDatePreset,
+  string
+>;
 
 export function isValidPreset(value: string | null | undefined): value is DatePreset {
   return typeof value === 'string' && (VALID_PRESETS.has(value) || value === 'custom');
@@ -68,7 +74,7 @@ export function useMetrics() {
 
 function getDateRangeLabel(preset: DatePreset, customRange: DateRange | undefined) {
   if (preset !== 'custom') {
-    return DATE_PRESETS.find(p => p.value === preset)!.label;
+    return DATE_PRESET_LABELS[preset];
   }
   if (customRange?.from) {
     if (customRange.to) {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-metrics.tsx
@@ -15,17 +15,11 @@ const DATE_PRESETS = [
   { label: 'Last 30 days', value: '30d' },
 ] as const;
 
-type FixedDatePreset = (typeof DATE_PRESETS)[number]['value'];
-
-export type DatePreset = FixedDatePreset | 'custom';
+export type DatePreset = (typeof DATE_PRESETS)[number]['value'] | 'custom';
 
 export { DATE_PRESETS };
 
 const VALID_PRESETS = new Set<string>(DATE_PRESETS.map(p => p.value));
-const DATE_PRESET_LABELS = Object.fromEntries(DATE_PRESETS.map(preset => [preset.value, preset.label])) as Record<
-  FixedDatePreset,
-  string
->;
 
 export function isValidPreset(value: string | null | undefined): value is DatePreset {
   return typeof value === 'string' && (VALID_PRESETS.has(value) || value === 'custom');
@@ -74,7 +68,7 @@ export function useMetrics() {
 
 function getDateRangeLabel(preset: DatePreset, customRange: DateRange | undefined) {
   if (preset !== 'custom') {
-    return DATE_PRESET_LABELS[preset];
+    return DATE_PRESETS.find(p => p.value === preset)?.label ?? preset;
   }
   if (customRange?.from) {
     if (customRange.to) {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
@@ -2,6 +2,7 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { formatCompact } from '../components/metrics-utils';
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreateMapValue } from '@/lib/map';
 
 export interface ModelUsageRow {
   model: string;
@@ -51,10 +52,14 @@ export function useModelUsageCostMetrics() {
       const modelMap = new Map<string, ModelEntry>();
 
       const ensureModel = (model: string): ModelEntry => {
-        if (!modelMap.has(model)) {
-          modelMap.set(model, { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: null, costUnit: null });
-        }
-        return modelMap.get(model)!;
+        return getOrCreateMapValue(modelMap, model, () => ({
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          cost: null,
+          costUnit: null,
+        }));
       };
 
       // total_input/total_output estimatedCost already rolls up cache + other detail

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
@@ -2,6 +2,7 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { formatCompact } from '../components/metrics-utils';
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreate } from '@/lib/map';
 
 export interface ModelUsageRow {
   model: string;
@@ -50,21 +51,15 @@ export function useModelUsageCostMetrics() {
 
       const modelMap = new Map<string, ModelEntry>();
 
-      const ensureModel = (model: string): ModelEntry => {
-        const existing = modelMap.get(model);
-        if (existing) return existing;
-
-        const entry = {
+      const ensureModel = (model: string): ModelEntry =>
+        getOrCreate(modelMap, model, () => ({
           input: 0,
           output: 0,
           cacheRead: 0,
           cacheWrite: 0,
           cost: null,
           costUnit: null,
-        };
-        modelMap.set(model, entry);
-        return entry;
-      };
+        }));
 
       // total_input/total_output estimatedCost already rolls up cache + other detail
       // costs. The cache breakdowns are kept for their token counts only.

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
@@ -2,7 +2,6 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { formatCompact } from '../components/metrics-utils';
 import { useMetricsFilters } from './use-metrics-filters';
-import { getOrCreateMapValue } from '@/lib/map';
 
 export interface ModelUsageRow {
   model: string;
@@ -52,14 +51,19 @@ export function useModelUsageCostMetrics() {
       const modelMap = new Map<string, ModelEntry>();
 
       const ensureModel = (model: string): ModelEntry => {
-        return getOrCreateMapValue(modelMap, model, () => ({
+        const existing = modelMap.get(model);
+        if (existing) return existing;
+
+        const entry = {
           input: 0,
           output: 0,
           cacheRead: 0,
           cacheWrite: 0,
           cost: null,
           costUnit: null,
-        }));
+        };
+        modelMap.set(model, entry);
+        return entry;
       };
 
       // total_input/total_output estimatedCost already rolls up cache + other detail

--- a/packages/playground-ui/src/domains/metrics/hooks/use-scores-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-scores-metrics.tsx
@@ -1,6 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreate } from '@/lib/map';
 
 export interface ScorerSummary {
   scorer: string;
@@ -92,17 +93,8 @@ export function useScoresMetrics() {
               minute: '2-digit',
               hour12: false,
             });
-            let scorerMap = hourBuckets.get(hourKey);
-            if (!scorerMap) {
-              scorerMap = new Map();
-              hourBuckets.set(hourKey, scorerMap);
-            }
-
-            let acc = scorerMap.get(scorerId);
-            if (!acc) {
-              acc = { sum: 0, count: 0 };
-              scorerMap.set(scorerId, acc);
-            }
+            const scorerMap = getOrCreate(hourBuckets, hourKey, () => new Map());
+            const acc = getOrCreate(scorerMap, scorerId, () => ({ sum: 0, count: 0 }));
 
             acc.sum += point.value;
             acc.count += 1;

--- a/packages/playground-ui/src/domains/metrics/hooks/use-scores-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-scores-metrics.tsx
@@ -1,6 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreateMapValue } from '@/lib/map';
 
 export interface ScorerSummary {
   scorer: string;
@@ -92,14 +93,8 @@ export function useScoresMetrics() {
               minute: '2-digit',
               hour12: false,
             });
-            if (!hourBuckets.has(hourKey)) {
-              hourBuckets.set(hourKey, new Map());
-            }
-            const scorerMap = hourBuckets.get(hourKey)!;
-            if (!scorerMap.has(scorerId)) {
-              scorerMap.set(scorerId, { sum: 0, count: 0 });
-            }
-            const acc = scorerMap.get(scorerId)!;
+            const scorerMap = getOrCreateMapValue(hourBuckets, hourKey, () => new Map());
+            const acc = getOrCreateMapValue(scorerMap, scorerId, () => ({ sum: 0, count: 0 }));
             acc.sum += point.value;
             acc.count += 1;
           }

--- a/packages/playground-ui/src/domains/metrics/hooks/use-scores-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-scores-metrics.tsx
@@ -1,7 +1,6 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
-import { getOrCreateMapValue } from '@/lib/map';
 
 export interface ScorerSummary {
   scorer: string;
@@ -93,8 +92,18 @@ export function useScoresMetrics() {
               minute: '2-digit',
               hour12: false,
             });
-            const scorerMap = getOrCreateMapValue(hourBuckets, hourKey, () => new Map());
-            const acc = getOrCreateMapValue(scorerMap, scorerId, () => ({ sum: 0, count: 0 }));
+            let scorerMap = hourBuckets.get(hourKey);
+            if (!scorerMap) {
+              scorerMap = new Map();
+              hourBuckets.set(hourKey, scorerMap);
+            }
+
+            let acc = scorerMap.get(scorerId);
+            if (!acc) {
+              acc = { sum: 0, count: 0 };
+              scorerMap.set(scorerId, acc);
+            }
+
             acc.sum += point.value;
             acc.count += 1;
           }

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
@@ -1,7 +1,6 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
-import { getOrCreateMapValue } from '@/lib/map';
 
 export interface TokenUsageByAgentRow {
   name: string;
@@ -36,7 +35,12 @@ export function useTokenUsageByAgentMetrics() {
       const agentMap = new Map<string, AgentEntry>();
 
       const ensure = (name: string): AgentEntry => {
-        return getOrCreateMapValue(agentMap, name, () => ({ input: 0, output: 0, cost: null, costUnit: null }));
+        const existing = agentMap.get(name);
+        if (existing) return existing;
+
+        const entry = { input: 0, output: 0, cost: null, costUnit: null };
+        agentMap.set(name, entry);
+        return entry;
       };
 
       const addCost = (entry: AgentEntry, group: { estimatedCost?: number | null; costUnit?: string | null }) => {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
@@ -1,6 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreateMapValue } from '@/lib/map';
 
 export interface TokenUsageByAgentRow {
   name: string;
@@ -35,10 +36,7 @@ export function useTokenUsageByAgentMetrics() {
       const agentMap = new Map<string, AgentEntry>();
 
       const ensure = (name: string): AgentEntry => {
-        if (!agentMap.has(name)) {
-          agentMap.set(name, { input: 0, output: 0, cost: null, costUnit: null });
-        }
-        return agentMap.get(name)!;
+        return getOrCreateMapValue(agentMap, name, () => ({ input: 0, output: 0, cost: null, costUnit: null }));
       };
 
       const addCost = (entry: AgentEntry, group: { estimatedCost?: number | null; costUnit?: string | null }) => {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
@@ -1,6 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreate } from '@/lib/map';
 
 export interface TokenUsageByAgentRow {
   name: string;
@@ -34,14 +35,8 @@ export function useTokenUsageByAgentMetrics() {
 
       const agentMap = new Map<string, AgentEntry>();
 
-      const ensure = (name: string): AgentEntry => {
-        const existing = agentMap.get(name);
-        if (existing) return existing;
-
-        const entry = { input: 0, output: 0, cost: null, costUnit: null };
-        agentMap.set(name, entry);
-        return entry;
-      };
+      const ensure = (name: string): AgentEntry =>
+        getOrCreate(agentMap, name, () => ({ input: 0, output: 0, cost: null, costUnit: null }));
 
       const addCost = (entry: AgentEntry, group: { estimatedCost?: number | null; costUnit?: string | null }) => {
         if (group.estimatedCost != null) {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-timeseries.test.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-timeseries.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { EntityType } from '@mastra/core/observability';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -13,7 +15,6 @@ import { MetricsProvider } from './use-metrics';
 import type { DatePreset, DateRange } from './use-metrics';
 import { useTokenUsageTimeSeries } from './use-token-usage-timeseries';
 import type { PropertyFilterToken } from '@/ds/components/PropertyFilter/types';
-import { assertDefined } from '@/test-utils/assert';
 
 const BASE_URL = 'http://localhost:4111';
 const server = setupServer();
@@ -170,7 +171,9 @@ describe('useTokenUsageTimeSeries', () => {
       expect(onTimeseries).toHaveBeenCalledTimes(2);
     });
 
-    const [inputRequest] = assertDefined(onTimeseries.mock.calls[0], 'Expected first timeseries request');
+    const firstCall = onTimeseries.mock.calls[0];
+    assert(firstCall, 'Expected first timeseries request');
+    const [inputRequest] = firstCall;
     expect(inputRequest.name).toEqual(['mastra_model_total_input_tokens']);
     expect(inputRequest.aggregation).toBe('sum');
     expect(inputRequest.filters?.timestamp?.start).toBeDefined();

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-timeseries.test.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-timeseries.test.tsx
@@ -169,7 +169,10 @@ describe('useTokenUsageTimeSeries', () => {
       expect(onTimeseries).toHaveBeenCalledTimes(2);
     });
 
-    const [inputRequest] = onTimeseries.mock.calls[0]!;
+    const firstCall = onTimeseries.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    if (!firstCall) throw new Error('Expected first timeseries request');
+    const [inputRequest] = firstCall;
     expect(inputRequest.name).toEqual(['mastra_model_total_input_tokens']);
     expect(inputRequest.aggregation).toBe('sum');
     expect(inputRequest.filters?.timestamp?.start).toBeDefined();

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-timeseries.test.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-timeseries.test.tsx
@@ -13,6 +13,7 @@ import { MetricsProvider } from './use-metrics';
 import type { DatePreset, DateRange } from './use-metrics';
 import { useTokenUsageTimeSeries } from './use-token-usage-timeseries';
 import type { PropertyFilterToken } from '@/ds/components/PropertyFilter/types';
+import { assertDefined } from '@/test-utils/assert';
 
 const BASE_URL = 'http://localhost:4111';
 const server = setupServer();
@@ -169,10 +170,7 @@ describe('useTokenUsageTimeSeries', () => {
       expect(onTimeseries).toHaveBeenCalledTimes(2);
     });
 
-    const firstCall = onTimeseries.mock.calls[0];
-    expect(firstCall).toBeDefined();
-    if (!firstCall) throw new Error('Expected first timeseries request');
-    const [inputRequest] = firstCall;
+    const [inputRequest] = assertDefined(onTimeseries.mock.calls[0], 'Expected first timeseries request');
     expect(inputRequest.name).toEqual(['mastra_model_total_input_tokens']);
     expect(inputRequest.aggregation).toBe('sum');
     expect(inputRequest.filters?.timestamp?.start).toBeDefined();

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-timeseries.test.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-timeseries.test.tsx
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
 import { EntityType } from '@mastra/core/observability';
 import { MastraReactProvider } from '@mastra/react';
@@ -8,7 +7,7 @@ import { cleanup, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import type { ReactNode } from 'react';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { emptyTokenSeries, inputTokenSeries, outputTokenSeries } from './__tests__/fixtures/token-usage-timeseries';
 import { MetricsProvider } from './use-metrics';

--- a/packages/playground-ui/src/domains/metrics/hooks/use-top-active-threads-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-top-active-threads-metrics.tsx
@@ -2,6 +2,7 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreate } from '@/lib/map';
 
 export interface ActiveThreadRow {
   threadId: string;
@@ -62,14 +63,8 @@ export function useTopActiveThreadsMetrics() {
       type Entry = { tokens: number; cost: number | null; costUnit: string | null };
       const byThread = new Map<string, Entry>();
 
-      const ensure = (threadId: string): Entry => {
-        const existing = byThread.get(threadId);
-        if (existing) return existing;
-
-        const entry = { tokens: 0, cost: null, costUnit: null };
-        byThread.set(threadId, entry);
-        return entry;
-      };
+      const ensure = (threadId: string): Entry =>
+        getOrCreate(byThread, threadId, () => ({ tokens: 0, cost: null, costUnit: null }));
 
       const foldTokens = (groups: typeof inputRes.groups) => {
         for (const group of groups) {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-top-active-threads-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-top-active-threads-metrics.tsx
@@ -2,7 +2,6 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useMetricsFilters } from './use-metrics-filters';
-import { getOrCreateMapValue } from '@/lib/map';
 
 export interface ActiveThreadRow {
   threadId: string;
@@ -64,7 +63,12 @@ export function useTopActiveThreadsMetrics() {
       const byThread = new Map<string, Entry>();
 
       const ensure = (threadId: string): Entry => {
-        return getOrCreateMapValue(byThread, threadId, () => ({ tokens: 0, cost: null, costUnit: null }));
+        const existing = byThread.get(threadId);
+        if (existing) return existing;
+
+        const entry = { tokens: 0, cost: null, costUnit: null };
+        byThread.set(threadId, entry);
+        return entry;
       };
 
       const foldTokens = (groups: typeof inputRes.groups) => {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-top-active-threads-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-top-active-threads-metrics.tsx
@@ -2,6 +2,7 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreateMapValue } from '@/lib/map';
 
 export interface ActiveThreadRow {
   threadId: string;
@@ -63,8 +64,7 @@ export function useTopActiveThreadsMetrics() {
       const byThread = new Map<string, Entry>();
 
       const ensure = (threadId: string): Entry => {
-        if (!byThread.has(threadId)) byThread.set(threadId, { tokens: 0, cost: null, costUnit: null });
-        return byThread.get(threadId)!;
+        return getOrCreateMapValue(byThread, threadId, () => ({ tokens: 0, cost: null, costUnit: null }));
       };
 
       const foldTokens = (groups: typeof inputRes.groups) => {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-top-resources-by-threads-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-top-resources-by-threads-metrics.tsx
@@ -2,6 +2,7 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreateMapValue } from '@/lib/map';
 
 export interface ResourceThreadsRow {
   resourceId: string;
@@ -63,8 +64,7 @@ export function useTopResourcesByThreadsMetrics() {
       const byResource = new Map<string, Entry>();
 
       const ensure = (resourceId: string): Entry => {
-        if (!byResource.has(resourceId)) byResource.set(resourceId, { tokens: 0, cost: null, costUnit: null });
-        return byResource.get(resourceId)!;
+        return getOrCreateMapValue(byResource, resourceId, () => ({ tokens: 0, cost: null, costUnit: null }));
       };
 
       const foldTokens = (groups: typeof inputRes.groups) => {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-top-resources-by-threads-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-top-resources-by-threads-metrics.tsx
@@ -2,7 +2,6 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useMetricsFilters } from './use-metrics-filters';
-import { getOrCreateMapValue } from '@/lib/map';
 
 export interface ResourceThreadsRow {
   resourceId: string;
@@ -64,7 +63,12 @@ export function useTopResourcesByThreadsMetrics() {
       const byResource = new Map<string, Entry>();
 
       const ensure = (resourceId: string): Entry => {
-        return getOrCreateMapValue(byResource, resourceId, () => ({ tokens: 0, cost: null, costUnit: null }));
+        const existing = byResource.get(resourceId);
+        if (existing) return existing;
+
+        const entry = { tokens: 0, cost: null, costUnit: null };
+        byResource.set(resourceId, entry);
+        return entry;
       };
 
       const foldTokens = (groups: typeof inputRes.groups) => {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-top-resources-by-threads-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-top-resources-by-threads-metrics.tsx
@@ -2,6 +2,7 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreate } from '@/lib/map';
 
 export interface ResourceThreadsRow {
   resourceId: string;
@@ -62,14 +63,8 @@ export function useTopResourcesByThreadsMetrics() {
       type Entry = { tokens: number; cost: number | null; costUnit: string | null };
       const byResource = new Map<string, Entry>();
 
-      const ensure = (resourceId: string): Entry => {
-        const existing = byResource.get(resourceId);
-        if (existing) return existing;
-
-        const entry = { tokens: 0, cost: null, costUnit: null };
-        byResource.set(resourceId, entry);
-        return entry;
-      };
+      const ensure = (resourceId: string): Entry =>
+        getOrCreate(byResource, resourceId, () => ({ tokens: 0, cost: null, costUnit: null }));
 
       const foldTokens = (groups: typeof inputRes.groups) => {
         for (const group of groups) {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-trace-volume-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-trace-volume-metrics.tsx
@@ -1,6 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreate } from '@/lib/map';
 
 export interface VolumeRow {
   name: string;
@@ -26,11 +27,7 @@ async function fetchVolume(
   for (const group of res.groups) {
     const name = group.dimensions.entityName ?? 'unknown';
     const status = group.dimensions.status ?? 'ok';
-    let entry = map.get(name);
-    if (!entry) {
-      entry = { completed: 0, errors: 0 };
-      map.set(name, entry);
-    }
+    const entry = getOrCreate(map, name, () => ({ completed: 0, errors: 0 }));
 
     if (status === 'error') {
       entry.errors += group.value;

--- a/packages/playground-ui/src/domains/metrics/hooks/use-trace-volume-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-trace-volume-metrics.tsx
@@ -1,6 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
+import { getOrCreateMapValue } from '@/lib/map';
 
 export interface VolumeRow {
   name: string;
@@ -26,10 +27,7 @@ async function fetchVolume(
   for (const group of res.groups) {
     const name = group.dimensions.entityName ?? 'unknown';
     const status = group.dimensions.status ?? 'ok';
-    if (!map.has(name)) {
-      map.set(name, { completed: 0, errors: 0 });
-    }
-    const entry = map.get(name)!;
+    const entry = getOrCreateMapValue(map, name, () => ({ completed: 0, errors: 0 }));
     if (status === 'error') {
       entry.errors += group.value;
     } else {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-trace-volume-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-trace-volume-metrics.tsx
@@ -1,7 +1,6 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
-import { getOrCreateMapValue } from '@/lib/map';
 
 export interface VolumeRow {
   name: string;
@@ -27,7 +26,12 @@ async function fetchVolume(
   for (const group of res.groups) {
     const name = group.dimensions.entityName ?? 'unknown';
     const status = group.dimensions.status ?? 'ok';
-    const entry = getOrCreateMapValue(map, name, () => ({ completed: 0, errors: 0 }));
+    let entry = map.get(name);
+    if (!entry) {
+      entry = { completed: 0, errors: 0 };
+      map.set(name, entry);
+    }
+
     if (status === 'error') {
       entry.errors += group.value;
     } else {

--- a/packages/playground-ui/src/domains/traces/components/__tests__/format-hierarchical-spans.test.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/format-hierarchical-spans.test.ts
@@ -1,6 +1,4 @@
-import assert from 'node:assert';
-
-import { describe, it, expect } from 'vitest';
+import { assert, describe, it, expect } from 'vitest';
 import { formatHierarchicalSpans } from '../format-hierarchical-spans';
 
 type Span = Parameters<typeof formatHierarchicalSpans>[0][number];

--- a/packages/playground-ui/src/domains/traces/components/__tests__/format-hierarchical-spans.test.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/format-hierarchical-spans.test.ts
@@ -1,20 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { formatHierarchicalSpans } from '../format-hierarchical-spans';
+import { assertDefined } from '@/test-utils/assert';
 
 type Span = Parameters<typeof formatHierarchicalSpans>[0][number];
 type FormattedSpan = ReturnType<typeof formatHierarchicalSpans>[number];
 
 function getAt<T>(items: readonly T[], index: number): T {
-  const item = items[index];
-  expect(item).toBeDefined();
-  if (item === undefined) throw new Error(`Expected item at index ${index}`);
-  return item;
+  return assertDefined(items[index], `Expected item at index ${index}`);
 }
 
 function getChildren(span: FormattedSpan): FormattedSpan[] {
-  expect(span.spans).toBeDefined();
-  if (!span.spans) throw new Error(`Expected ${span.id} to have child spans`);
-  return span.spans;
+  return assertDefined(span.spans, `Expected ${span.id} to have child spans`);
 }
 
 function span(spanId: string, parentSpanId: string | null, overrides: Partial<Span> = {}): Span {

--- a/packages/playground-ui/src/domains/traces/components/__tests__/format-hierarchical-spans.test.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/format-hierarchical-spans.test.ts
@@ -1,16 +1,21 @@
+import assert from 'node:assert';
+
 import { describe, it, expect } from 'vitest';
 import { formatHierarchicalSpans } from '../format-hierarchical-spans';
-import { assertDefined } from '@/test-utils/assert';
 
 type Span = Parameters<typeof formatHierarchicalSpans>[0][number];
 type FormattedSpan = ReturnType<typeof formatHierarchicalSpans>[number];
 
 function getAt<T>(items: readonly T[], index: number): T {
-  return assertDefined(items[index], `Expected item at index ${index}`);
+  const item = items[index];
+  assert(item !== undefined, `Expected item at index ${index}`);
+  return item;
 }
 
 function getChildren(span: FormattedSpan): FormattedSpan[] {
-  return assertDefined(span.spans, `Expected ${span.id} to have child spans`);
+  const children = span.spans;
+  assert(children, `Expected ${span.id} to have child spans`);
+  return children;
 }
 
 function span(spanId: string, parentSpanId: string | null, overrides: Partial<Span> = {}): Span {

--- a/packages/playground-ui/src/domains/traces/components/__tests__/format-hierarchical-spans.test.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/format-hierarchical-spans.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect } from 'vitest';
 import { formatHierarchicalSpans } from '../format-hierarchical-spans';
 
 type Span = Parameters<typeof formatHierarchicalSpans>[0][number];
+type FormattedSpan = ReturnType<typeof formatHierarchicalSpans>[number];
+
+function getAt<T>(items: readonly T[], index: number): T {
+  const item = items[index];
+  expect(item).toBeDefined();
+  if (item === undefined) throw new Error(`Expected item at index ${index}`);
+  return item;
+}
+
+function getChildren(span: FormattedSpan): FormattedSpan[] {
+  expect(span.spans).toBeDefined();
+  if (!span.spans) throw new Error(`Expected ${span.id} to have child spans`);
+  return span.spans;
+}
 
 function span(spanId: string, parentSpanId: string | null, overrides: Partial<Span> = {}): Span {
   return {
@@ -26,17 +40,17 @@ describe('formatHierarchicalSpans', () => {
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('root');
       expect(result[0].spans).toHaveLength(1);
-      expect(result[0].spans![0].id).toBe('child');
+      expect(getAt(getChildren(result[0]), 0).id).toBe('child');
     });
 
     it('nests descendants under the correct parent across multiple levels', () => {
       const result = formatHierarchicalSpans([span('root', null), span('a', 'root'), span('b', 'a'), span('c', 'b')]);
       expect(result).toHaveLength(1);
-      const a = result[0].spans![0];
+      const a = getAt(getChildren(result[0]), 0);
       expect(a.id).toBe('a');
-      const b = a.spans![0];
+      const b = getAt(getChildren(a), 0);
       expect(b.id).toBe('b');
-      expect(b.spans![0].id).toBe('c');
+      expect(getAt(getChildren(b), 0).id).toBe('c');
     });
 
     it('surfaces orphans (parent not present in spans) as additional roots', () => {
@@ -56,7 +70,7 @@ describe('formatHierarchicalSpans', () => {
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('anchor');
       expect(result[0].spans).toHaveLength(1);
-      expect(result[0].spans![0].id).toBe('child');
+      expect(getAt(getChildren(result[0]), 0).id).toBe('child');
     });
 
     it('nests descendants of the anchor under it (multi-level subtree)', () => {
@@ -66,9 +80,13 @@ describe('formatHierarchicalSpans', () => {
       );
       const anchorRoot = result[0];
       expect(anchorRoot.id).toBe('anchor');
-      const a = anchorRoot.spans![0];
+      const a = getAt(getChildren(anchorRoot), 0);
       expect(a.id).toBe('a');
-      expect(a.spans!.map(s => s.id).sort()).toEqual(['b', 'c']);
+      expect(
+        getChildren(a)
+          .map(s => s.id)
+          .sort(),
+      ).toEqual(['b', 'c']);
     });
 
     it('does not promote a parentSpanId==null sibling to root when an anchor is specified', () => {

--- a/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
@@ -1,13 +1,10 @@
 import type { UsageStats } from '@mastra/core/observability';
 import { describe, expect, it } from 'vitest';
 import { getTokenUsageView } from '../span-token-usage.utils';
+import { assertDefined } from '@/test-utils/assert';
 
-const getRequiredTokenUsageView = (usage: UsageStats) => {
-  const view = getTokenUsageView(usage);
-  expect(view).not.toBeNull();
-  if (!view) throw new Error('Expected token usage view');
-  return view;
-};
+const getRequiredTokenUsageView = (usage: UsageStats) =>
+  assertDefined(getTokenUsageView(usage), 'Expected token usage view');
 
 describe('getTokenUsageView', () => {
   it('returns null when usage is undefined', () => {

--- a/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
@@ -1,7 +1,5 @@
-import assert from 'node:assert';
-
 import type { UsageStats } from '@mastra/core/observability';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { getTokenUsageView } from '../span-token-usage.utils';
 
 const getRequiredTokenUsageView = (usage: UsageStats) => {

--- a/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
@@ -2,6 +2,13 @@ import type { UsageStats } from '@mastra/core/observability';
 import { describe, expect, it } from 'vitest';
 import { getTokenUsageView } from '../span-token-usage.utils';
 
+const getRequiredTokenUsageView = (usage: UsageStats) => {
+  const view = getTokenUsageView(usage);
+  expect(view).not.toBeNull();
+  if (!view) throw new Error('Expected token usage view');
+  return view;
+};
+
 describe('getTokenUsageView', () => {
   it('returns null when usage is undefined', () => {
     expect(getTokenUsageView(undefined)).toBeNull();
@@ -24,78 +31,73 @@ describe('getTokenUsageView', () => {
   });
 
   it('renders both columns when only the input side is present, with output defaulting to 0', () => {
-    const view = getTokenUsageView({ inputTokens: 100 } as UsageStats);
-    expect(view).not.toBeNull();
-    expect(view!.inputValue).toBe(100);
-    expect(view!.outputValue).toBe(0);
-    expect(view!.total).toBe(100);
-    expect(view!.showSplit).toBe(true);
-    expect(view!.inputPct).toBe(100);
-    expect(view!.outputPct).toBe(0);
-    expect(view!.inputDetails).toBeUndefined();
-    expect(view!.outputDetails).toBeUndefined();
+    const view = getRequiredTokenUsageView({ inputTokens: 100 } as UsageStats);
+    expect(view.inputValue).toBe(100);
+    expect(view.outputValue).toBe(0);
+    expect(view.total).toBe(100);
+    expect(view.showSplit).toBe(true);
+    expect(view.inputPct).toBe(100);
+    expect(view.outputPct).toBe(0);
+    expect(view.inputDetails).toBeUndefined();
+    expect(view.outputDetails).toBeUndefined();
   });
 
   it('drops details on a side that has no top-level token count', () => {
-    const view = getTokenUsageView({
+    const view = getRequiredTokenUsageView({
       inputTokens: 100,
       outputDetails: { text: 50 },
     } as UsageStats);
-    expect(view).not.toBeNull();
-    expect(view!.outputValue).toBe(0);
-    expect(view!.outputDetails).toBeUndefined();
+    expect(view.outputValue).toBe(0);
+    expect(view.outputDetails).toBeUndefined();
   });
 
   it('keeps details on a side that has a top-level token count', () => {
-    const view = getTokenUsageView({
+    const view = getRequiredTokenUsageView({
       inputTokens: 100,
       inputDetails: { text: 80, cacheRead: 20 },
       outputTokens: 25,
     } as UsageStats);
-    expect(view).not.toBeNull();
-    expect(view!.inputDetails).toEqual({ text: 80, cacheRead: 20 });
-    expect(view!.outputDetails).toBeUndefined();
+    expect(view.inputDetails).toEqual({ text: 80, cacheRead: 20 });
+    expect(view.outputDetails).toBeUndefined();
   });
 
   it('treats a details object with no numeric values as absent', () => {
-    const view = getTokenUsageView({
+    const view = getRequiredTokenUsageView({
       inputTokens: 100,
       inputDetails: { text: undefined } as unknown as UsageStats['inputDetails'],
     } as UsageStats);
-    expect(view).not.toBeNull();
-    expect(view!.inputDetails).toBeUndefined();
+    expect(view.inputDetails).toBeUndefined();
   });
 
   it('renders both columns at 0 with no split bar when both totals are 0', () => {
-    const view = getTokenUsageView({ inputTokens: 0, outputTokens: 0 } as UsageStats);
-    expect(view).not.toBeNull();
-    expect(view!.inputValue).toBe(0);
-    expect(view!.outputValue).toBe(0);
-    expect(view!.total).toBe(0);
-    expect(view!.showSplit).toBe(false);
-    expect(view!.inputPct).toBe(0);
-    expect(view!.outputPct).toBe(0);
+    const view = getRequiredTokenUsageView({ inputTokens: 0, outputTokens: 0 } as UsageStats);
+    expect(view.inputValue).toBe(0);
+    expect(view.outputValue).toBe(0);
+    expect(view.total).toBe(0);
+    expect(view.showSplit).toBe(false);
+    expect(view.inputPct).toBe(0);
+    expect(view.outputPct).toBe(0);
   });
 
   it('splits 50/50 when input and output are equal', () => {
-    const view = getTokenUsageView({ inputTokens: 100, outputTokens: 100 } as UsageStats);
-    expect(view!.total).toBe(200);
-    expect(view!.inputPct).toBe(50);
-    expect(view!.outputPct).toBe(50);
+    const view = getRequiredTokenUsageView({ inputTokens: 100, outputTokens: 100 } as UsageStats);
+    expect(view.total).toBe(200);
+    expect(view.inputPct).toBe(50);
+    expect(view.outputPct).toBe(50);
   });
 
   it('produces percentages that always sum to 100 for asymmetric inputs', () => {
-    const view = getTokenUsageView({ inputTokens: 1000, outputTokens: 250 } as UsageStats);
-    expect(view!.total).toBe(1250);
-    expect(view!.inputPct).toBe(80);
-    expect(view!.outputPct).toBe(20);
-    expect(view!.inputPct + view!.outputPct).toBe(100);
+    const view = getRequiredTokenUsageView({ inputTokens: 1000, outputTokens: 250 } as UsageStats);
+    expect(view.total).toBe(1250);
+    expect(view.inputPct).toBe(80);
+    expect(view.outputPct).toBe(20);
+    expect(view.inputPct + view.outputPct).toBe(100);
   });
 
   it('handles one side at 0 with the other positive (100/0 split)', () => {
-    const view = getTokenUsageView({ inputTokens: 100, outputTokens: 0 } as UsageStats);
-    expect(view!.showSplit).toBe(true);
-    expect(view!.inputPct).toBe(100);
-    expect(view!.outputPct).toBe(0);
+    const view = getRequiredTokenUsageView({ inputTokens: 100, outputTokens: 0 } as UsageStats);
+    expect(view.showSplit).toBe(true);
+    expect(view.inputPct).toBe(100);
+    expect(view.outputPct).toBe(0);
   });
 });

--- a/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
@@ -1,10 +1,14 @@
+import assert from 'node:assert';
+
 import type { UsageStats } from '@mastra/core/observability';
 import { describe, expect, it } from 'vitest';
 import { getTokenUsageView } from '../span-token-usage.utils';
-import { assertDefined } from '@/test-utils/assert';
 
-const getRequiredTokenUsageView = (usage: UsageStats) =>
-  assertDefined(getTokenUsageView(usage), 'Expected token usage view');
+const getRequiredTokenUsageView = (usage: UsageStats) => {
+  const view = getTokenUsageView(usage);
+  assert(view, 'Expected token usage view');
+  return view;
+};
 
 describe('getTokenUsageView', () => {
   it('returns null when usage is undefined', () => {

--- a/packages/playground-ui/src/domains/traces/components/format-hierarchical-spans.ts
+++ b/packages/playground-ui/src/domains/traces/components/format-hierarchical-spans.ts
@@ -54,7 +54,8 @@ export const formatHierarchicalSpans = (spans: TimelineSpan[], anchorSpanId?: st
     anchorSpanId ? spanRecord.spanId === anchorSpanId : spanRecord?.parentSpanId == null;
 
   spans.forEach(spanRecord => {
-    const uiSpan = spanMap.get(spanRecord.spanId)!;
+    const uiSpan = spanMap.get(spanRecord.spanId);
+    if (!uiSpan) return;
 
     if (isAnchor(spanRecord)) {
       if (overallEndDate && uiSpan.endTime && overallEndDate > new Date(uiSpan.endTime)) {
@@ -67,7 +68,8 @@ export const formatHierarchicalSpans = (spans: TimelineSpan[], anchorSpanId?: st
     } else {
       const parent = spanRecord.parentSpanId ? spanMap.get(spanRecord.parentSpanId) : undefined;
       if (parent) {
-        parent.spans!.push(uiSpan);
+        parent.spans ??= [];
+        parent.spans.push(uiSpan);
       } else {
         // Orphan: either the parent isn't in the supplied set (branch subtree boundary), or
         // the span has no parent yet wasn't picked as the anchor (rare when `anchorSpanId`

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { SpanType } from '@mastra/core/observability';
 import type { TraceRecord } from '@mastra/core/storage';
 import { MastraReactProvider } from '@mastra/react';
@@ -9,7 +11,6 @@ import { setupServer } from 'msw/node';
 import type { ReactNode } from 'react';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDownloadTraceJson } from '../use-download-trace-json';
-import { assertDefined } from '@/test-utils/assert';
 
 // jsdom's Blob exposes no `.text()`, and the global `Response` doesn't recognize it.
 function readBlobText(blob: Blob): Promise<string> {
@@ -99,7 +100,9 @@ describe('useDownloadTraceJson', () => {
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
     expect(createObjectURL).toHaveBeenCalledTimes(1);
-    const [blob] = assertDefined(createObjectURL.mock.calls[0], 'Expected createObjectURL call') as [Blob];
+    const firstCall = createObjectURL.mock.calls[0];
+    assert(firstCall, 'Expected createObjectURL call');
+    const [blob] = firstCall as [Blob];
     await expect(readBlobText(blob)).resolves.toBe(JSON.stringify(traceFixture, null, 2));
     expect(clickedDownloadAttr).toBe(`trace-${TRACE_ID}.json`);
   });

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
@@ -9,6 +9,7 @@ import { setupServer } from 'msw/node';
 import type { ReactNode } from 'react';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDownloadTraceJson } from '../use-download-trace-json';
+import { assertDefined } from '@/test-utils/assert';
 
 // jsdom's Blob exposes no `.text()`, and the global `Response` doesn't recognize it.
 function readBlobText(blob: Blob): Promise<string> {
@@ -98,10 +99,7 @@ describe('useDownloadTraceJson', () => {
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
     expect(createObjectURL).toHaveBeenCalledTimes(1);
-    const firstCall = createObjectURL.mock.calls[0];
-    expect(firstCall).toBeDefined();
-    if (!firstCall) throw new Error('Expected createObjectURL call');
-    const [blob] = firstCall as [Blob];
+    const [blob] = assertDefined(createObjectURL.mock.calls[0], 'Expected createObjectURL call') as [Blob];
     await expect(readBlobText(blob)).resolves.toBe(JSON.stringify(traceFixture, null, 2));
     expect(clickedDownloadAttr).toBe(`trace-${TRACE_ID}.json`);
   });

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
@@ -98,7 +98,10 @@ describe('useDownloadTraceJson', () => {
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
     expect(createObjectURL).toHaveBeenCalledTimes(1);
-    const blob = createObjectURL.mock.calls[0]![0] as Blob;
+    const firstCall = createObjectURL.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    if (!firstCall) throw new Error('Expected createObjectURL call');
+    const [blob] = firstCall as [Blob];
     await expect(readBlobText(blob)).resolves.toBe(JSON.stringify(traceFixture, null, 2));
     expect(clickedDownloadAttr).toBe(`trace-${TRACE_ID}.json`);
   });

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-download-trace-json.test.tsx
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
 import { SpanType } from '@mastra/core/observability';
 import type { TraceRecord } from '@mastra/core/storage';
@@ -9,7 +8,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import type { ReactNode } from 'react';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDownloadTraceJson } from '../use-download-trace-json';
 
 // jsdom's Blob exposes no `.text()`, and the global `Response` doesn't recognize it.

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -94,10 +94,17 @@ const fetchTracesFn = async ({
   filters,
   listMode = 'traces',
 }: FetchTracesFnArgs) => {
-  const params =
-    mode === 'delta'
-      ? { mode: 'delta' as const, after, limit, filters }
-      : { pagination: { page: page!, perPage: perPage! }, filters };
+  const params = (() => {
+    if (mode === 'delta') {
+      return { mode: 'delta' as const, after, limit, filters };
+    }
+
+    if (page == null || perPage == null) {
+      throw new Error('page and perPage are required for traces page mode');
+    }
+
+    return { pagination: { page, perPage }, filters };
+  })();
 
   if (listMode === 'branches') {
     return client.listBranches(params as ListBranchesArgs);

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -77,34 +77,14 @@ function isHttp501(error: unknown): boolean {
 
 type FetchTracesFnArgs = TracesFilters & {
   client: ReturnType<typeof useMastraClient>;
-  mode?: 'page' | 'delta';
-  page?: number;
-  perPage?: number;
-  after?: string;
-  limit?: number;
-};
+} & ({ mode: 'delta'; after?: string; limit?: number } | { mode?: 'page'; page: number; perPage: number });
 
-const fetchTracesFn = async ({
-  client,
-  mode,
-  page,
-  perPage,
-  after,
-  limit,
-  filters,
-  listMode = 'traces',
-}: FetchTracesFnArgs) => {
-  const params = (() => {
-    if (mode === 'delta') {
-      return { mode: 'delta' as const, after, limit, filters };
-    }
-
-    if (page == null || perPage == null) {
-      throw new Error('page and perPage are required for traces page mode');
-    }
-
-    return { pagination: { page, perPage }, filters };
-  })();
+const fetchTracesFn = async (args: FetchTracesFnArgs) => {
+  const { client, filters, listMode = 'traces' } = args;
+  const params =
+    args.mode === 'delta'
+      ? { mode: 'delta' as const, after: args.after, limit: args.limit, filters }
+      : { pagination: { page: args.page, perPage: args.perPage }, filters };
 
   if (listMode === 'branches') {
     return client.listBranches(params as ListBranchesArgs);

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
@@ -7,24 +7,16 @@ import { DropdownMenu } from '../DropdownMenu';
 import { Input } from '../Input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
 import { ButtonsGroup } from './buttons-group';
+import { assertDefined } from '@/test-utils/assert';
 
 afterEach(() => {
   cleanup();
 });
 
-const getGroup = () => {
-  const group = document.querySelector<HTMLDivElement>('[data-slot="buttons-group"]');
-  expect(group).not.toBeNull();
-  if (!group) throw new Error('Expected buttons group');
-  return group;
-};
+const getGroup = () =>
+  assertDefined(document.querySelector<HTMLDivElement>('[data-slot="buttons-group"]'), 'Expected buttons group');
 
-const getButton = () => {
-  const button = document.querySelector('button');
-  expect(button).not.toBeNull();
-  if (!button) throw new Error('Expected button');
-  return button;
-};
+const getButton = () => assertDefined(document.querySelector('button'), 'Expected button');
 
 describe('ButtonsGroup', () => {
   it('close spacing keys the right-edge rounding off a visible next sibling (not :last-child)', () => {
@@ -156,9 +148,7 @@ describe('ButtonsGroup', () => {
       </ButtonsGroup>,
     );
     const group = getGroup();
-    const trigger = group.querySelector('[aria-label="More save options"]');
-    expect(trigger).not.toBeNull();
-    if (!trigger) throw new Error('Expected menu trigger');
+    const trigger = assertDefined(group.querySelector('[aria-label="More save options"]'), 'Expected menu trigger');
     // Closed: DropdownMenu renders no DOM of its own and the menu content is portaled out, so
     // the group has exactly the two button segments — the trigger is the last one (pill corner).
     expect(group.querySelectorAll(':scope > button').length).toBe(2);

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
 import { cleanup, fireEvent, render } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, assert, describe, expect, it } from 'vitest';
 
 import { Button } from '../Button';
 import { DropdownMenu } from '../DropdownMenu';

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -7,16 +9,22 @@ import { DropdownMenu } from '../DropdownMenu';
 import { Input } from '../Input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
 import { ButtonsGroup } from './buttons-group';
-import { assertDefined } from '@/test-utils/assert';
 
 afterEach(() => {
   cleanup();
 });
 
-const getGroup = () =>
-  assertDefined(document.querySelector<HTMLDivElement>('[data-slot="buttons-group"]'), 'Expected buttons group');
+const getGroup = () => {
+  const group = document.querySelector<HTMLDivElement>('[data-slot="buttons-group"]');
+  assert(group, 'Expected buttons group');
+  return group;
+};
 
-const getButton = () => assertDefined(document.querySelector('button'), 'Expected button');
+const getButton = () => {
+  const button = document.querySelector('button');
+  assert(button, 'Expected button');
+  return button;
+};
 
 describe('ButtonsGroup', () => {
   it('close spacing keys the right-edge rounding off a visible next sibling (not :last-child)', () => {
@@ -148,7 +156,8 @@ describe('ButtonsGroup', () => {
       </ButtonsGroup>,
     );
     const group = getGroup();
-    const trigger = assertDefined(group.querySelector('[aria-label="More save options"]'), 'Expected menu trigger');
+    const trigger = group.querySelector('[aria-label="More save options"]');
+    assert(trigger, 'Expected menu trigger');
     // Closed: DropdownMenu renders no DOM of its own and the menu content is portaled out, so
     // the group has exactly the two button segments — the trigger is the last one (pill corner).
     expect(group.querySelectorAll(':scope > button').length).toBe(2);

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
@@ -12,7 +12,19 @@ afterEach(() => {
   cleanup();
 });
 
-const getGroup = () => document.querySelector<HTMLDivElement>('[data-slot="buttons-group"]')!;
+const getGroup = () => {
+  const group = document.querySelector<HTMLDivElement>('[data-slot="buttons-group"]');
+  expect(group).not.toBeNull();
+  if (!group) throw new Error('Expected buttons group');
+  return group;
+};
+
+const getButton = () => {
+  const button = document.querySelector('button');
+  expect(button).not.toBeNull();
+  if (!button) throw new Error('Expected button');
+  return button;
+};
 
 describe('ButtonsGroup', () => {
   it('close spacing keys the right-edge rounding off a visible next sibling (not :last-child)', () => {
@@ -52,7 +64,7 @@ describe('ButtonsGroup', () => {
     );
 
     // Base UI appends a visually-hidden <input aria-hidden> right after the trigger.
-    const trigger = document.querySelector('button')!;
+    const trigger = getButton();
     const next = trigger.nextElementSibling;
     expect(next?.tagName).toBe('INPUT');
     expect(next?.getAttribute('aria-hidden')).toBe('true');
@@ -126,7 +138,7 @@ describe('ButtonsGroup', () => {
     // trigger's own `w-full`), so consumers don't need `shrink-0`/`w-fit`.
     expect(getGroup().className).toContain('[&>[data-slot=select-trigger]]:w-fit');
     // And the trigger actually carries the data-slot the rule targets.
-    expect(document.querySelector('button')!.getAttribute('data-slot')).toBe('select-trigger');
+    expect(getButton().getAttribute('data-slot')).toBe('select-trigger');
   });
 
   it('a DropdownMenu trigger composes as a real split-button segment, and the seam survives opening', () => {
@@ -144,7 +156,9 @@ describe('ButtonsGroup', () => {
       </ButtonsGroup>,
     );
     const group = getGroup();
-    const trigger = group.querySelector('[aria-label="More save options"]')!;
+    const trigger = group.querySelector('[aria-label="More save options"]');
+    expect(trigger).not.toBeNull();
+    if (!trigger) throw new Error('Expected menu trigger');
     // Closed: DropdownMenu renders no DOM of its own and the menu content is portaled out, so
     // the group has exactly the two button segments — the trigger is the last one (pill corner).
     expect(group.querySelectorAll(':scope > button').length).toBe(2);

--- a/packages/playground-ui/src/ds/components/Command/command.test.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, describe, expect, it, vi } from 'vitest';
 
 import { Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from './command';
 

--- a/packages/playground-ui/src/ds/components/Command/command.test.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.test.tsx
@@ -185,6 +185,9 @@ describe('Command', () => {
       expect(screen.queryByText('Weather Workflow')).toBeNull();
     });
 
-    expect(Boolean(beta?.compareDocumentPosition(alpha!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    expect(beta).not.toBeNull();
+    expect(alpha).not.toBeNull();
+    if (!beta || !alpha) throw new Error('Expected filtered command items');
+    expect(Boolean(beta.compareDocumentPosition(alpha) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
   });
 });

--- a/packages/playground-ui/src/ds/components/Command/command.test.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from './command';
-import { assertDefined } from '@/test-utils/assert';
 
 if (typeof globalThis.ResizeObserver === 'undefined') {
   class ResizeObserverPolyfill {
@@ -186,8 +187,10 @@ describe('Command', () => {
       expect(screen.queryByText('Weather Workflow')).toBeNull();
     });
 
-    const betaItem = assertDefined(beta, 'Expected filtered command items');
-    const alphaItem = assertDefined(alpha, 'Expected filtered command items');
+    assert(beta, 'Expected filtered command items');
+    assert(alpha, 'Expected filtered command items');
+    const betaItem = beta;
+    const alphaItem = alpha;
     expect(Boolean(betaItem.compareDocumentPosition(alphaItem) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
   });
 });

--- a/packages/playground-ui/src/ds/components/Command/command.test.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from './command';
+import { assertDefined } from '@/test-utils/assert';
 
 if (typeof globalThis.ResizeObserver === 'undefined') {
   class ResizeObserverPolyfill {
@@ -185,9 +186,8 @@ describe('Command', () => {
       expect(screen.queryByText('Weather Workflow')).toBeNull();
     });
 
-    expect(beta).not.toBeNull();
-    expect(alpha).not.toBeNull();
-    if (!beta || !alpha) throw new Error('Expected filtered command items');
-    expect(Boolean(beta.compareDocumentPosition(alpha) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    const betaItem = assertDefined(beta, 'Expected filtered command items');
+    const alphaItem = assertDefined(alpha, 'Expected filtered command items');
+    expect(Boolean(betaItem.compareDocumentPosition(alphaItem) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
   });
 });

--- a/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
@@ -3,24 +3,20 @@ import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from './input-group';
+import { assertDefined } from '@/test-utils/assert';
 
 afterEach(() => {
   cleanup();
 });
 
-const getWrapper = () => {
-  const wrapper = document.querySelector<HTMLDivElement>('[data-slot="input-group"]');
-  expect(wrapper).not.toBeNull();
-  if (!wrapper) throw new Error('Expected input group wrapper');
-  return wrapper;
-};
+const getWrapper = () =>
+  assertDefined(document.querySelector<HTMLDivElement>('[data-slot="input-group"]'), 'Expected input group wrapper');
 
-const getInput = () => {
-  const input = document.querySelector<HTMLInputElement>('[data-slot="input-group-control"]');
-  expect(input).not.toBeNull();
-  if (!input) throw new Error('Expected input group control');
-  return input;
-};
+const getInput = () =>
+  assertDefined(
+    document.querySelector<HTMLInputElement>('[data-slot="input-group-control"]'),
+    'Expected input group control',
+  );
 
 const inputGroupVariants = ['default', 'filled', 'outline'] as const;
 

--- a/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
@@ -8,8 +8,19 @@ afterEach(() => {
   cleanup();
 });
 
-const getWrapper = () => document.querySelector<HTMLDivElement>('[data-slot="input-group"]')!;
-const getInput = () => document.querySelector<HTMLInputElement>('[data-slot="input-group-control"]')!;
+const getWrapper = () => {
+  const wrapper = document.querySelector<HTMLDivElement>('[data-slot="input-group"]');
+  expect(wrapper).not.toBeNull();
+  if (!wrapper) throw new Error('Expected input group wrapper');
+  return wrapper;
+};
+
+const getInput = () => {
+  const input = document.querySelector<HTMLInputElement>('[data-slot="input-group-control"]');
+  expect(input).not.toBeNull();
+  if (!input) throw new Error('Expected input group control');
+  return input;
+};
 
 const inputGroupVariants = ['default', 'filled', 'outline'] as const;
 

--- a/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
@@ -1,22 +1,26 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from './input-group';
-import { assertDefined } from '@/test-utils/assert';
 
 afterEach(() => {
   cleanup();
 });
 
-const getWrapper = () =>
-  assertDefined(document.querySelector<HTMLDivElement>('[data-slot="input-group"]'), 'Expected input group wrapper');
+const getWrapper = () => {
+  const wrapper = document.querySelector<HTMLDivElement>('[data-slot="input-group"]');
+  assert(wrapper, 'Expected input group wrapper');
+  return wrapper;
+};
 
-const getInput = () =>
-  assertDefined(
-    document.querySelector<HTMLInputElement>('[data-slot="input-group-control"]'),
-    'Expected input group control',
-  );
+const getInput = () => {
+  const input = document.querySelector<HTMLInputElement>('[data-slot="input-group-control"]');
+  assert(input, 'Expected input group control');
+  return input;
+};
 
 const inputGroupVariants = ['default', 'filled', 'outline'] as const;
 

--- a/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
 import { cleanup, render } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, assert, describe, expect, it } from 'vitest';
 
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from './input-group';
 

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
@@ -6,12 +6,10 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { MainSidebarProvider } from './main-sidebar-context';
 import { MainSidebarNavLink } from './main-sidebar-nav-link';
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/ds/components/Tooltip';
+import { assertDefined } from '@/test-utils/assert';
 
-const getTooltipPopup = () => {
-  const popup = document.querySelector<HTMLElement>('.bg-surface3');
-  if (!popup) throw new Error('Expected tooltip popup');
-  return popup;
-};
+const getTooltipPopup = () =>
+  assertDefined(document.querySelector<HTMLElement>('.bg-surface3'), 'Expected tooltip popup');
 
 // MainSidebarProvider reads matchMedia at mount to decide mobile vs desktop.
 // jsdom does not implement it, so polyfill before any render.

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
@@ -1,9 +1,8 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
 import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { MainSidebarProvider } from './main-sidebar-context';
 import { MainSidebarNavLink } from './main-sidebar-nav-link';

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -6,10 +8,12 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { MainSidebarProvider } from './main-sidebar-context';
 import { MainSidebarNavLink } from './main-sidebar-nav-link';
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/ds/components/Tooltip';
-import { assertDefined } from '@/test-utils/assert';
 
-const getTooltipPopup = () =>
-  assertDefined(document.querySelector<HTMLElement>('.bg-surface3'), 'Expected tooltip popup');
+const getTooltipPopup = () => {
+  const popup = document.querySelector<HTMLElement>('.bg-surface3');
+  assert(popup, 'Expected tooltip popup');
+  return popup;
+};
 
 // MainSidebarProvider reads matchMedia at mount to decide mobile vs desktop.
 // jsdom does not implement it, so polyfill before any render.

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
@@ -7,6 +7,12 @@ import { MainSidebarProvider } from './main-sidebar-context';
 import { MainSidebarNavLink } from './main-sidebar-nav-link';
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/ds/components/Tooltip';
 
+const getTooltipPopup = () => {
+  const popup = document.querySelector<HTMLElement>('.bg-surface3');
+  if (!popup) throw new Error('Expected tooltip popup');
+  return popup;
+};
+
 // MainSidebarProvider reads matchMedia at mount to decide mobile vs desktop.
 // jsdom does not implement it, so polyfill before any render.
 beforeAll(() => {
@@ -114,11 +120,7 @@ describe('MainSidebarNavLink (collapsed) — tooltip regression', () => {
     // The Positioner and Popup both expose data-side. Target the Popup
     // specifically via its unique design-system class (bg-surface3) so the
     // assertions cannot accidentally pass against the Positioner wrapper.
-    const popup = await waitFor(() => {
-      const el = document.querySelector<HTMLElement>('.bg-surface3');
-      expect(el).not.toBeNull();
-      return el!;
-    });
+    const popup = await waitFor(getTooltipPopup);
 
     // Critical: no margin classes on the popup. Margins shift the popup AFTER
     // Floating UI calculated the arrow's anchor; use `sideOffset` instead.
@@ -140,11 +142,7 @@ describe('MainSidebarNavLink (collapsed) — tooltip regression', () => {
     // The Positioner and Popup both expose data-side. Target the Popup
     // specifically via its unique design-system class (bg-surface3) so the
     // assertions cannot accidentally pass against the Positioner wrapper.
-    const popup = await waitFor(() => {
-      const el = document.querySelector<HTMLElement>('.bg-surface3');
-      expect(el).not.toBeNull();
-      return el!;
-    });
+    const popup = await waitFor(getTooltipPopup);
 
     // jsdom has no layout, so Floating UI may flip the requested side away
     // from "right". Assert only that *some* side is set, which proves the
@@ -168,11 +166,7 @@ describe('MainSidebarNavLink (collapsed) — tooltip regression', () => {
       </TooltipProvider>,
     );
 
-    const popup = await waitFor(() => {
-      const el = document.querySelector<HTMLElement>('.bg-surface3');
-      expect(el).not.toBeNull();
-      return el!;
-    });
+    const popup = await waitFor(getTooltipPopup);
 
     expect(popup.getAttribute('role')).toBe('tooltip');
   });

--- a/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
@@ -33,8 +33,9 @@ export function PickMultiPanel({ field, tokens, onChange }: PickMultiPanelProps)
   // show their default option pre-selected before the user explicitly picks one.
   const selectedValue = typeof token?.value === 'string' ? token.value : !field.multi ? field.defaultValue : undefined;
   const selectedValues = useMemo<string[]>(() => {
-    if (Array.isArray(token?.value)) return token!.value as string[];
-    if (typeof token?.value === 'string') return [token.value];
+    const value = token?.value;
+    if (Array.isArray(value)) return value;
+    if (typeof value === 'string') return [value];
     return [];
   }, [token]);
 

--- a/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-actions.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-actions.tsx
@@ -26,8 +26,7 @@ export function PropertyFilterActions({
   onRemoveSaved,
 }: PropertyFilterActionsProps) {
   const hasMenuItems = !!(onRemoveAll || onSave || onRemoveSaved);
-  const showClear = onClear != null;
-  if (!showClear && !hasMenuItems) return null;
+  if (!onClear && !hasMenuItems) return null;
 
   return (
     <div className="flex items-center gap-2">

--- a/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-actions.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-actions.tsx
@@ -26,13 +26,13 @@ export function PropertyFilterActions({
   onRemoveSaved,
 }: PropertyFilterActionsProps) {
   const hasMenuItems = !!(onRemoveAll || onSave || onRemoveSaved);
-  const showClear = !!onClear;
+  const showClear = onClear != null;
   if (!showClear && !hasMenuItems) return null;
 
   return (
     <div className="flex items-center gap-2">
-      {showClear && (
-        <Button disabled={disabled} size="md" onClick={() => onClear!()}>
+      {onClear && (
+        <Button disabled={disabled} size="md" onClick={onClear}>
           <XIcon />
           Clear
         </Button>

--- a/packages/playground-ui/src/ds/components/PropertyFilter/property-filter.stories.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/property-filter.stories.tsx
@@ -160,15 +160,18 @@ export const PickMultiPanelMulti: Story = {
           tokens={tokens}
           onChange={(fieldId, value) => {
             const shouldRemove = value === undefined || (Array.isArray(value) && value.length === 0);
-            if (shouldRemove) setTokens(prev => prev.filter(t => t.fieldId !== fieldId));
-            else
-              setTokens(prev => {
-                const existing = prev.findIndex(t => t.fieldId === fieldId);
-                if (existing === -1) return [...prev, { fieldId, value: value! }];
-                const next = [...prev];
-                next[existing] = { fieldId, value: value! };
-                return next;
-              });
+            if (shouldRemove) {
+              setTokens(prev => prev.filter(t => t.fieldId !== fieldId));
+              return;
+            }
+
+            setTokens(prev => {
+              const existing = prev.findIndex(t => t.fieldId === fieldId);
+              if (existing === -1) return [...prev, { fieldId, value }];
+              const next = [...prev];
+              next[existing] = { fieldId, value };
+              return next;
+            });
           }}
         />
       </div>

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.test.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ScrollArea } from './scroll-area';
+import { assertDefined } from '@/test-utils/assert';
 
 afterEach(() => {
   cleanup();
@@ -10,12 +11,8 @@ afterEach(() => {
 
 const VIEWPORT_MARKER = 'test-viewport-marker';
 
-const getViewport = () => {
-  const viewport = document.querySelector<HTMLElement>(`.${VIEWPORT_MARKER}`);
-  expect(viewport).not.toBeNull();
-  if (!viewport) throw new Error('Expected scroll viewport');
-  return viewport;
-};
+const getViewport = () =>
+  assertDefined(document.querySelector<HTMLElement>(`.${VIEWPORT_MARKER}`), 'Expected scroll viewport');
 const getContent = (viewport: HTMLElement) => viewport.firstElementChild as HTMLElement;
 
 const renderArea = (props: Partial<React.ComponentProps<typeof ScrollArea>> = {}) =>

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.test.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ScrollArea } from './scroll-area';
-import { assertDefined } from '@/test-utils/assert';
 
 afterEach(() => {
   cleanup();
@@ -11,8 +12,11 @@ afterEach(() => {
 
 const VIEWPORT_MARKER = 'test-viewport-marker';
 
-const getViewport = () =>
-  assertDefined(document.querySelector<HTMLElement>(`.${VIEWPORT_MARKER}`), 'Expected scroll viewport');
+const getViewport = () => {
+  const viewport = document.querySelector<HTMLElement>(`.${VIEWPORT_MARKER}`);
+  assert(viewport, 'Expected scroll viewport');
+  return viewport;
+};
 const getContent = (viewport: HTMLElement) => viewport.firstElementChild as HTMLElement;
 
 const renderArea = (props: Partial<React.ComponentProps<typeof ScrollArea>> = {}) =>

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.test.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.test.tsx
@@ -10,7 +10,12 @@ afterEach(() => {
 
 const VIEWPORT_MARKER = 'test-viewport-marker';
 
-const getViewport = () => document.querySelector<HTMLElement>(`.${VIEWPORT_MARKER}`)!;
+const getViewport = () => {
+  const viewport = document.querySelector<HTMLElement>(`.${VIEWPORT_MARKER}`);
+  expect(viewport).not.toBeNull();
+  if (!viewport) throw new Error('Expected scroll viewport');
+  return viewport;
+};
 const getContent = (viewport: HTMLElement) => viewport.firstElementChild as HTMLElement;
 
 const renderArea = (props: Partial<React.ComponentProps<typeof ScrollArea>> = {}) =>

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.test.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, describe, expect, it, vi } from 'vitest';
 
 import { ScrollArea } from './scroll-area';
 

--- a/packages/playground-ui/src/ds/components/ThreadList/thread-list.test.tsx
+++ b/packages/playground-ui/src/ds/components/ThreadList/thread-list.test.tsx
@@ -6,6 +6,12 @@ import { ThreadList, ThreadListItem } from './thread-list';
 
 afterEach(cleanup);
 
+function getParent(element: HTMLElement): HTMLElement {
+  expect(element.parentElement).not.toBeNull();
+  if (!element.parentElement) throw new Error('Expected parent element');
+  return element.parentElement;
+}
+
 describe('ThreadList', () => {
   it('renders standalone block chrome by default', () => {
     render(
@@ -18,7 +24,7 @@ describe('ThreadList', () => {
     expect(nav.className).toContain('bg-surface3');
     expect(nav.className).toContain('rounded-studio-panel');
     expect(nav.className).toContain('border-border1/50');
-    expect(nav.parentElement!.className).toContain('pl-2');
+    expect(getParent(nav).className).toContain('pl-2');
   });
 
   it('drops block chrome and inset when embedded', () => {
@@ -32,7 +38,7 @@ describe('ThreadList', () => {
     expect(nav.className).not.toContain('bg-surface3');
     expect(nav.className).not.toContain('rounded-studio-panel');
     expect(nav.className).not.toContain('border-border1/50');
-    expect(nav.parentElement!.className).not.toContain('pl-2');
+    expect(getParent(nav).className).not.toContain('pl-2');
     expect(nav.className).toContain('overflow-y-auto');
   });
 });
@@ -52,7 +58,8 @@ describe('ThreadListItem', () => {
 
     const contentBoundary = link.querySelector('span');
     expect(contentBoundary).not.toBeNull();
-    expect(contentBoundary!.className).toContain('min-w-0');
-    expect(contentBoundary!.className).toContain('flex-1');
+    if (!contentBoundary) throw new Error('Expected content boundary');
+    expect(contentBoundary.className).toContain('min-w-0');
+    expect(contentBoundary.className).toContain('flex-1');
   });
 });

--- a/packages/playground-ui/src/ds/components/ThreadList/thread-list.test.tsx
+++ b/packages/playground-ui/src/ds/components/ThreadList/thread-list.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
 import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, describe, expect, it, vi } from 'vitest';
 
 import { ThreadList, ThreadListItem } from './thread-list';
 

--- a/packages/playground-ui/src/ds/components/ThreadList/thread-list.test.tsx
+++ b/packages/playground-ui/src/ds/components/ThreadList/thread-list.test.tsx
@@ -1,14 +1,17 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ThreadList, ThreadListItem } from './thread-list';
-import { assertDefined } from '@/test-utils/assert';
 
 afterEach(cleanup);
 
 function getParent(element: HTMLElement): HTMLElement {
-  return assertDefined(element.parentElement, 'Expected parent element');
+  const parent = element.parentElement;
+  assert(parent, 'Expected parent element');
+  return parent;
 }
 
 describe('ThreadList', () => {
@@ -55,7 +58,8 @@ describe('ThreadListItem', () => {
     expect(link.className).toContain('text-left');
     expect(link.className).toContain('pr-9');
 
-    const contentBoundary = assertDefined(link.querySelector('span'), 'Expected content boundary');
+    const contentBoundary = link.querySelector('span');
+    assert(contentBoundary, 'Expected content boundary');
     expect(contentBoundary.className).toContain('min-w-0');
     expect(contentBoundary.className).toContain('flex-1');
   });

--- a/packages/playground-ui/src/ds/components/ThreadList/thread-list.test.tsx
+++ b/packages/playground-ui/src/ds/components/ThreadList/thread-list.test.tsx
@@ -3,13 +3,12 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ThreadList, ThreadListItem } from './thread-list';
+import { assertDefined } from '@/test-utils/assert';
 
 afterEach(cleanup);
 
 function getParent(element: HTMLElement): HTMLElement {
-  expect(element.parentElement).not.toBeNull();
-  if (!element.parentElement) throw new Error('Expected parent element');
-  return element.parentElement;
+  return assertDefined(element.parentElement, 'Expected parent element');
 }
 
 describe('ThreadList', () => {
@@ -56,9 +55,7 @@ describe('ThreadListItem', () => {
     expect(link.className).toContain('text-left');
     expect(link.className).toContain('pr-9');
 
-    const contentBoundary = link.querySelector('span');
-    expect(contentBoundary).not.toBeNull();
-    if (!contentBoundary) throw new Error('Expected content boundary');
+    const contentBoundary = assertDefined(link.querySelector('span'), 'Expected content boundary');
     expect(contentBoundary.className).toContain('min-w-0');
     expect(contentBoundary.className).toContain('flex-1');
   });

--- a/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { downloadJson } from '../downloadJson';
+import { assertDefined } from '@/test-utils/assert';
 
 // jsdom's Blob exposes no `.text()`, and the global `Response` doesn't recognize it.
 // Read it the way the rest of this package does — via FileReader.
@@ -27,10 +28,7 @@ describe('downloadJson', () => {
     downloadJson('trace-abc.json', data);
 
     expect(createObjectURL).toHaveBeenCalledTimes(1);
-    const firstCall = createObjectURL.mock.calls[0];
-    expect(firstCall).toBeDefined();
-    if (!firstCall) throw new Error('Expected createObjectURL call');
-    const [blob] = firstCall as [Blob];
+    const [blob] = assertDefined(createObjectURL.mock.calls[0], 'Expected createObjectURL call') as [Blob];
     expect(blob.type).toBe('application/json');
     await expect(readBlobText(blob)).resolves.toBe(JSON.stringify(data, null, 2));
 

--- a/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
+import assert from 'node:assert';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { downloadJson } from '../downloadJson';
-import { assertDefined } from '@/test-utils/assert';
 
 // jsdom's Blob exposes no `.text()`, and the global `Response` doesn't recognize it.
 // Read it the way the rest of this package does — via FileReader.
@@ -28,7 +29,9 @@ describe('downloadJson', () => {
     downloadJson('trace-abc.json', data);
 
     expect(createObjectURL).toHaveBeenCalledTimes(1);
-    const [blob] = assertDefined(createObjectURL.mock.calls[0], 'Expected createObjectURL call') as [Blob];
+    const firstCall = createObjectURL.mock.calls[0];
+    assert(firstCall, 'Expected createObjectURL call');
+    const [blob] = firstCall as [Blob];
     expect(blob.type).toBe('application/json');
     await expect(readBlobText(blob)).resolves.toBe(JSON.stringify(data, null, 2));
 

--- a/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
@@ -27,7 +27,10 @@ describe('downloadJson', () => {
     downloadJson('trace-abc.json', data);
 
     expect(createObjectURL).toHaveBeenCalledTimes(1);
-    const blob = createObjectURL.mock.calls[0]![0] as Blob;
+    const firstCall = createObjectURL.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    if (!firstCall) throw new Error('Expected createObjectURL call');
+    const [blob] = firstCall as [Blob];
     expect(blob.type).toBe('application/json');
     await expect(readBlobText(blob)).resolves.toBe(JSON.stringify(data, null, 2));
 

--- a/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/downloadJson.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
-import assert from 'node:assert';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, describe, expect, it, vi } from 'vitest';
 import { downloadJson } from '../downloadJson';
 
 // jsdom's Blob exposes no `.text()`, and the global `Response` doesn't recognize it.

--- a/packages/playground-ui/src/lib/file/__tests__/schemes.parity.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/schemes.parity.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,7 +13,6 @@ import {
   isNonFetchableRemoteUrl,
   isRemoteUrl,
 } from '../schemes';
-import { assertDefined } from '@/test-utils/assert';
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -43,7 +43,9 @@ const readCoreSupportedProtocols = (): string[] => {
 
   const protocols = new Set<string>();
   for (const match of scanRegion.matchAll(/case '([a-z0-9]+):'/g)) {
-    protocols.add(assertDefined(match[1], 'Expected a protocol capture group in the core switch case'));
+    const protocol = match[1];
+    assert(protocol !== undefined, 'Expected a protocol capture group in the core switch case');
+    protocols.add(protocol);
   }
   return [...protocols].sort();
 };

--- a/packages/playground-ui/src/lib/file/__tests__/schemes.parity.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/schemes.parity.test.ts
@@ -1,9 +1,8 @@
-import assert from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 
 import {
   BROWSER_FETCHABLE_SCHEMES,

--- a/packages/playground-ui/src/lib/file/__tests__/schemes.parity.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/schemes.parity.test.ts
@@ -42,7 +42,8 @@ const readCoreSupportedProtocols = (): string[] => {
 
   const protocols = new Set<string>();
   for (const match of scanRegion.matchAll(/case '([a-z0-9]+):'/g)) {
-    protocols.add(match[1]!);
+    const [, protocol] = match;
+    if (protocol) protocols.add(protocol);
   }
   return [...protocols].sort();
 };

--- a/packages/playground-ui/src/lib/file/__tests__/schemes.parity.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/schemes.parity.test.ts
@@ -12,6 +12,7 @@ import {
   isNonFetchableRemoteUrl,
   isRemoteUrl,
 } from '../schemes';
+import { assertDefined } from '@/test-utils/assert';
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -42,8 +43,7 @@ const readCoreSupportedProtocols = (): string[] => {
 
   const protocols = new Set<string>();
   for (const match of scanRegion.matchAll(/case '([a-z0-9]+):'/g)) {
-    const [, protocol] = match;
-    if (protocol) protocols.add(protocol);
+    protocols.add(assertDefined(match[1], 'Expected a protocol capture group in the core switch case'));
   }
   return [...protocols].sort();
 };

--- a/packages/playground-ui/src/lib/map.test.ts
+++ b/packages/playground-ui/src/lib/map.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getOrCreate } from './map';
+
+describe('getOrCreate', () => {
+  it('creates and stores a value on a miss', () => {
+    const map = new Map<string, { count: number }>();
+    const value = getOrCreate(map, 'a', () => ({ count: 1 }));
+
+    expect(value).toEqual({ count: 1 });
+    expect(map.get('a')).toBe(value);
+  });
+
+  it('returns the existing value on a hit', () => {
+    const map = new Map<string, { count: number }>();
+    const first = getOrCreate(map, 'a', () => ({ count: 1 }));
+    const second = getOrCreate(map, 'a', () => ({ count: 2 }));
+
+    expect(second).toBe(first);
+    expect(second.count).toBe(1);
+    expect(map.size).toBe(1);
+  });
+
+  it('does not call the factory on a hit', () => {
+    const map = new Map<string, number>();
+    map.set('a', 42);
+
+    const create = vi.fn(() => 99);
+    const value = getOrCreate(map, 'a', create);
+
+    expect(value).toBe(42);
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/playground-ui/src/lib/map.ts
+++ b/packages/playground-ui/src/lib/map.ts
@@ -1,0 +1,7 @@
+export function getOrCreate<K, V>(map: Map<K, V>, key: K, create: () => V): V {
+  const existing = map.get(key);
+  if (existing !== undefined) return existing;
+  const value = create();
+  map.set(key, value);
+  return value;
+}

--- a/packages/playground-ui/src/lib/map.ts
+++ b/packages/playground-ui/src/lib/map.ts
@@ -1,0 +1,9 @@
+export function getOrCreateMapValue<K, V>(map: Map<K, V>, key: K, createValue: () => V): V {
+  if (map.has(key)) {
+    return map.get(key) as V;
+  }
+
+  const value = createValue();
+  map.set(key, value);
+  return value;
+}

--- a/packages/playground-ui/src/lib/map.ts
+++ b/packages/playground-ui/src/lib/map.ts
@@ -1,9 +1,0 @@
-export function getOrCreateMapValue<K, V>(map: Map<K, V>, key: K, createValue: () => V): V {
-  if (map.has(key)) {
-    return map.get(key) as V;
-  }
-
-  const value = createValue();
-  map.set(key, value);
-  return value;
-}

--- a/packages/playground-ui/src/test-utils/assert.ts
+++ b/packages/playground-ui/src/test-utils/assert.ts
@@ -1,4 +1,0 @@
-export function assertDefined<T>(value: T, message = 'Expected value to be defined'): NonNullable<T> {
-  if (value == null) throw new Error(message);
-  return value;
-}

--- a/packages/playground-ui/src/test-utils/assert.ts
+++ b/packages/playground-ui/src/test-utils/assert.ts
@@ -1,0 +1,4 @@
+export function assertDefined<T>(value: T, message = 'Expected value to be defined'): NonNullable<T> {
+  if (value == null) throw new Error(message);
+  return value;
+}


### PR DESCRIPTION
Removes the remaining non-null assertions from `packages/playground-ui`, replaces them with explicit guards and `skipToken`-gated queries, then enables the package-local `@typescript-eslint/no-non-null-assertion` rule to keep them from coming back.

This keeps the package behavior the same while making the nullability assumptions visible to TypeScript and tests. No changeset because this is an internal type-safety and lint cleanup.

Validation:
- `pnpm build:playground-ui`
- `pnpm --filter ./packages/playground-ui typecheck`
- `pnpm --filter ./packages/playground-ui test -- --run`
- `pnpm --filter ./packages/playground-ui lint` (0 errors, 37 existing warnings)
- Prettier check on changed TS/TSX files
- AST scan: 0 `TSNonNullExpression` in `packages/playground-ui`

CodeRabbit local review could not run in this non-interactive environment because the CLI requires `--api-key` authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the playground UI safer by removing “I promise this exists” shortcuts in the code. It adds checks for missing values, uses query skipping when required IDs aren’t present, and teaches the linter to block new non-null assertions.

## What changed
- Removed remaining non-null assertions across `packages/playground-ui`
- Replaced them with:
  - explicit guards
  - `assert` checks in tests
  - `skipToken`-gated React Query hooks
  - safer optional chaining / fallback logic
- Added a package-local ESLint rule to forbid `@typescript-eslint/no-non-null-assertion`
- Introduced and tested a shared `getOrCreate` Map helper to simplify repeated map-initialization code
- Added/updated tests for memory hooks, charts, tracing utilities, and UI components to match the safer handling

## Notes
- Runtime behavior is intended to stay the same
- No changeset was included
- Validation covered build, typecheck, tests, lint, Prettier, and an AST scan confirming no `TSNonNullExpression` remains in `packages/playground-ui`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->