### PR TITLE
fix(deps): override uuid and tar transitives stuck on old majors (Category C)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,8 @@ overrides:
   '@opentelemetry/sdk-node@<0.217.0': 0.217.0
   '@opentelemetry/exporter-prometheus@<0.217.0': 0.217.0
   uuid@>=13.0.0 <13.0.1: 13.0.1
+  uuid@<11.1.1: 11.1.1
+  tar@<7.5.16: 7.5.16
   http-proxy-middleware@>=0.16.0 <2.0.10: 2.0.10
   launch-editor@<2.14.1: 2.14.1
   mdast-util-to-hast@>=13.0.0 <13.2.1: 13.2.1
@@ -4608,7 +4610,7 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       tar:
-        specifier: ^7.5.15
+        specifier: 7.5.16
         version: 7.5.16
     devDependencies:
       '@internal/ai-sdk-v4':
@@ -24573,10 +24575,6 @@ packages:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
 
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -27773,11 +27771,6 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   tar@7.5.16:
     resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
@@ -28492,27 +28485,12 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuid@13.0.1:
     resolution: {integrity: sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==}
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuidv7@0.6.3:
@@ -29291,7 +29269,7 @@ snapshots:
 
   '@a2a-js/sdk@0.3.13(@grpc/grpc-js@1.14.4)(express@5.2.1)':
     dependencies:
-      uuid: 11.1.0
+      uuid: 11.1.1
     optionalDependencies:
       '@grpc/grpc-js': 1.14.4
       express: 5.2.1
@@ -31193,7 +31171,7 @@ snapshots:
     dependencies:
       '@azure/msal-common': 15.13.0
       jsonwebtoken: 9.0.3
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   '@azure/storage-blob@12.31.0':
     dependencies:
@@ -32223,7 +32201,7 @@ snapshots:
       form-data: 4.0.6
       jwt-decode: 4.0.0
       toml: 3.0.0
-      uuid: 11.1.0
+      uuid: 11.1.1
       ws: 8.21.0(bufferutil@4.1.0)
       yaml: 2.9.0
       zod: 3.25.76
@@ -32266,7 +32244,7 @@ snapshots:
       openai: 4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0))(zod@4.4.3)
       pino: 9.14.0
       pino-pretty: 13.1.3
-      uuid: 11.1.0
+      uuid: 11.1.1
       ws: 8.21.0(bufferutil@4.1.0)
       zod: 4.4.3
       zod-to-json-schema: 3.25.1(zod@4.4.3)
@@ -32791,7 +32769,7 @@ snapshots:
       '@segment/analytics-node': 2.3.0(encoding@0.1.13)
       chalk: 4.1.2
       graphql: 16.14.0
-      uuid: 10.0.0
+      uuid: 11.1.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
@@ -33207,7 +33185,7 @@ snapshots:
       safe-buffer: '@socketregistry/safe-buffer@1.0.9'
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   '@dagrejs/dagre@1.1.8':
     dependencies:
@@ -35061,7 +35039,7 @@ snapshots:
       stream-events: 1.0.5
       teeny-request: 10.1.0
       through2: 4.0.2
-      uuid: 11.1.0
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -35073,7 +35051,7 @@ snapshots:
       google-gax: 4.6.1(encoding@0.1.13)
       pumpify: 2.0.1
       stream-events: 1.0.5
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -35094,7 +35072,7 @@ snapshots:
       p-limit: 3.1.0
       retry-request: 7.0.2(encoding@0.1.13)
       teeny-request: 9.0.0(encoding@0.1.13)
-      uuid: 8.3.2
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -35800,7 +35778,7 @@ snapshots:
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
-      uuid: 10.0.0
+      uuid: 11.1.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
@@ -36662,7 +36640,7 @@ snapshots:
       rasha: 1.2.5
       safe-flat: 2.1.0
       url-parse: 1.5.10
-      uuid: 11.1.0
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -40388,7 +40366,7 @@ snapshots:
       '@temporalio/proto': 1.17.2
       abort-controller: 3.0.0
       long: 5.3.2
-      uuid: 11.1.0
+      uuid: 11.1.1
 
   '@temporalio/common@1.17.2':
     dependencies:
@@ -42853,7 +42831,7 @@ snapshots:
       simple-git: 3.36.0
       source-map: 0.7.6
       termi-link: 1.1.0
-      uuid: 9.0.1
+      uuid: 11.1.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
@@ -42961,7 +42939,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 14.0.0
-      tar: 6.2.1
+      tar: 7.5.16
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -43149,7 +43127,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
-  chownr@2.0.0: {}
+  chownr@2.0.0:
+    optional: true
 
   chownr@3.0.0: {}
 
@@ -44178,7 +44157,7 @@ snapshots:
       docker-modem: 5.0.7
       protobufjs: 7.6.3
       tar-fs: 2.1.4
-      uuid: 10.0.0
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -45372,7 +45351,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       node-forge: 1.4.0
-      uuid: 11.1.0
+      uuid: 11.1.1
     optionalDependencies:
       '@google-cloud/firestore': 7.11.6
       '@google-cloud/storage': 7.19.0(encoding@0.1.13)
@@ -45492,6 +45471,7 @@ snapshots:
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
+    optional: true
 
   fs-monkey@1.1.0: {}
 
@@ -45522,7 +45502,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -45737,7 +45717,7 @@ snapshots:
       proto3-json-serializer: 2.0.2
       protobufjs: 7.6.3
       retry-request: 7.0.2(encoding@0.1.13)
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -48308,7 +48288,7 @@ snapshots:
       agent-base: 6.0.2
       bent: 7.3.12
       https-proxy-agent: 4.0.0
-      uuid: 9.0.1
+      uuid: 11.1.1
       ws: 8.21.0(bufferutil@4.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -48433,8 +48413,7 @@ snapshots:
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
-
-  minipass@5.0.0: {}
+    optional: true
 
   minipass@7.1.3: {}
 
@@ -48442,6 +48421,7 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+    optional: true
 
   minizlib@3.1.0:
     dependencies:
@@ -48471,7 +48451,7 @@ snapshots:
       nice-grpc: 2.1.16
       protobufjs: 7.6.3
       smol-toml: 1.6.1
-      uuid: 11.1.0
+      uuid: 11.1.1
 
   modern-tar@0.7.6: {}
 
@@ -48663,7 +48643,7 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
       ecdsa-sig-formatter: 1.0.11
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   no-case@3.0.4:
     dependencies:
@@ -48738,7 +48718,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.8.4
-      tar: 6.2.1
+      tar: 7.5.16
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -48764,7 +48744,7 @@ snapshots:
       node-forge: 1.4.0
       pako: 2.1.0
       process: 0.11.10
-      uuid: 9.0.1
+      uuid: 11.1.1
 
   node-liblzma@2.2.0:
     dependencies:
@@ -48784,7 +48764,7 @@ snapshots:
       semver: 7.8.4
       source-map-support: 0.5.21
       teen_process: 2.3.3
-      uuid: 11.1.0
+      uuid: 11.1.1
       which: 5.0.0
 
   node-source-walk@7.0.2:
@@ -51874,7 +51854,7 @@ snapshots:
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
-      uuid: 8.3.2
+      uuid: 11.1.1
       websocket-driver: 0.7.4
 
   socks-proxy-agent@6.2.1:
@@ -52012,7 +51992,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 6.2.1
+      tar: 7.5.16
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -52427,15 +52407,6 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-
   tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -52483,7 +52454,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -53254,15 +53225,9 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@10.0.0: {}
-
-  uuid@11.1.0: {}
+  uuid@11.1.1: {}
 
   uuid@13.0.1: {}
-
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
 
   uuidv7@0.6.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -169,6 +169,11 @@ overrides:
   '@opentelemetry/sdk-node@<0.217.0': 0.217.0
   '@opentelemetry/exporter-prometheus@<0.217.0': 0.217.0
   uuid@>=13.0.0 <13.0.1: 13.0.1
+  # uuid <11.1.1 and tar <7.5.16 are pinned by transitive parents on old
+  # majors (msal-node/google-gax/etc. declare uuid ^8-^10; the sqlite3
+  # install chain declares tar ^6). Both keep the APIs those parents use.
+  uuid@<11.1.1: 11.1.1
+  tar@<7.5.16: 7.5.16
   http-proxy-middleware@>=0.16.0 <2.0.10: 2.0.10
   launch-editor@<2.14.1: 2.14.1
   mdast-util-to-hast@>=13.0.0 <13.2.1: 13.2.1


### PR DESCRIPTION
## Summary

Stacked on #18793 (Category B). Final tranche of the Dependabot cleanup: overrides for the two remaining patchable packages, where transitive parents pin old majors with no in-range fix.

**New override floors in `pnpm-workspace.yaml`**

| Package | Floor | Alerts | Why it's safe |
|---|---|---|---|
| uuid | `<11.1.1` → 11.1.1 | #2017 (medium) | Was pulled at 8.3.2/9.0.1/10.0.0 by `@azure/msal-node`, `google-gax`, `@google-cloud/speech`, `@langchain/core`, `dockerode`, `sockjs`, `njwt`, etc. All use the stable `v1/v4/v5/validate` API unchanged since v8; uuid 11 still ships CJS (verified by requiring it directly). |
| tar | `<7.5.16` → 7.5.16 | 7 alerts (high) | 6.2.1 was pulled only by the `sqlite3` install chain (`cacache@15`, `node-gyp@8`), exercised solely on source builds. tar 7 keeps the `extract/x/t/list/create` API (verified). |

**Deliberately not overridden** (dismissal candidates, tracked separately):
- `esbuild@0.18.20` / `0.27.3–0.27.7` (#30 medium, #2103 low): vite@7 declares `^0.27.0` and wrangler pins `0.27.3` exactly. Forcing the entire build toolchain (vite/tsup/wrangler/storybook) across a breaking esbuild minor to fix a dev-only `serve()` advisory that nothing in this repo uses is a bad trade.
- `@opentelemetry/core@1.30.1` (#2195): no patched 1.x exists; consumers are the otel 1.x suite via `@google-cloud/pubsub` (runtime dep of `pubsub/google-cloud-pubsub`). Forcing core 2.x against resources/sdk-metrics 1.x would break.
- `@ai-sdk/provider-utils` ×5: NO_PATCH (vendored ai_v4/ai_v5).

No changesets: only `pnpm-workspace.yaml` overrides + lockfile changed; no published-package manifest is affected.

## Test plan

- `pnpm install` clean; `--frozen-lockfile` passes
- `uuid@8.3.2/9.0.1/10.0.0/11.1.0` and `tar@6.2.1` confirmed gone from `pnpm-lock.yaml` (only 11.1.1/13.0.1 and 7.5.16 remain)
- `pnpm peers check` identical before/after (diff of sorted output empty)
- Runtime smoke: `require('uuid')` → 11.1.1, `v4`/`validate`/`v5`/`v1` all work via CJS; `tar@7.5.16` exports `extract/x/t/list/create`
- `turbo build` for the most-exposed packages (`@mastra/voice-azure`, `@mastra/voice-google`, `@mastra/auth-clerk`, `@mastra/fastembed`): 13/13 tasks pass
- `@mastra/auth-clerk` tests (exercises the njwt→uuid chain): 48/48 pass
- voice/azure, voice/google, fastembed test failures are environmental (live-API timeouts, missing local model cache) and pre-existing; fastembed already resolved tar 7.5.16 before this change
