### PR TITLE
fix(ci): check out local action from main in privileged major-version-check workflow

### DIFF
--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -61,10 +61,8 @@ jobs:
             ).data;
 
             const headSha = pr.head.sha;
-            // Output SHAs for downstream steps
+            // Output head SHA for downstream steps
             core.setOutput('head_sha', headSha);
-            // Output base SHA for checkout step (to prevent malicious PR from modifying local action)
-            core.setOutput('base_sha', pr.base.sha);
 
             // Regex to check for major in frontmatter
             const majorRegex = /:\s*["']?major["']?/;
@@ -94,8 +92,10 @@ jobs:
         if: steps.check_major.outputs.has_major_changeset == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          # Pin to PR base SHA to prevent malicious PRs from modifying the local action
-          ref: ${{ steps.check_major.outputs.base_sha }}
+          # Always check out the local action from the trusted default branch.
+          # Never use PR-derived refs here: this privileged workflow (issue_comment)
+          # runs the checked-out action with access to app secrets.
+          ref: main
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 


### PR DESCRIPTION
## Summary

Resolves the **critical** CodeQL alert #788 (`actions/untrusted-checkout/critical`) in `major-version-check.yml`.

The workflow runs on `issue_comment` — a privileged trigger with secret access — and checks out the repo to execute the local `.github/actions/app-auth` action, which mints a GitHub App token from `DANE_APP_PRIVATE_KEY` and writes it to `.netrc`.

The checkout was pinned to the PR's **base SHA**, which already blocks the classic attack (fork PR modifies the local action). But PR authors choose the base *branch*, so the action code could still be sourced from any branch in the repo — and the PR-payload-derived ref is what CodeQL flags.

**Fix:** pin the checkout to `main`. The privileged workflow now only ever executes the trusted default-branch version of the action, regardless of PR base. This removes the event-payload → checkout-ref data flow entirely, so the alert closes on its own rather than needing a dismissal. The now-unused `base_sha` step output is removed.

No behavior change for the check itself: the sparse checkout of `.github/actions` from `main` serves the same purpose as before.

## Test plan

- [x] YAML validates
- [x] No remaining references to `base_sha` in this workflow
- [x] `head_sha` output (still used for check-run reporting) untouched
- [ ] CodeQL alert #788 auto-closes after merge
