### PR TITLE
Improve MastraCode project picker

### DIFF
--- a/.changeset/fuzzy-experts-sin.md
+++ b/.changeset/fuzzy-experts-sin.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved MastraCode web project opening so the folder picker appears as a full-page inline flow on the landing page.

--- a/mastracode/src/shared/hooks/use-fs.ts
+++ b/mastracode/src/shared/hooks/use-fs.ts
@@ -19,5 +19,7 @@ export function useDirectoryListing(path: string | undefined) {
       const qs = path ? `?path=${encodeURIComponent(path)}` : '';
       return client.get<DirectoryListing>(`/api/web/fs/list${qs}`);
     },
+    placeholderData: previous => previous,
+    staleTime: 60_000,
   });
 }

--- a/mastracode/src/web/ui/App.tsx
+++ b/mastracode/src/web/ui/App.tsx
@@ -11,7 +11,6 @@ import { useActiveProject } from './useActiveProject';
 import { useAgentControllerSession } from './useAgentControllerSession';
 import { useDensityPreference } from './useDensityPreference';
 import { useGlobalShortcuts } from './useGlobalShortcuts';
-import { useProjectModalAutoOpen } from './useProjectModalAutoOpen';
 import { useProjectSessionSync } from './useProjectSessionSync';
 import { useTranscriptScroll } from './useTranscriptScroll';
 
@@ -69,7 +68,6 @@ export default function App() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [composerCommandName, setComposerCommandName] = useState<string | null>(null);
 
-  useProjectModalAutoOpen(projects.length, setProjectsOpen);
   useGlobalShortcuts({
     busy,
     projectsOpen,

--- a/mastracode/src/web/ui/AppLayout.tsx
+++ b/mastracode/src/web/ui/AppLayout.tsx
@@ -8,6 +8,7 @@ import { CommandPalette } from './CommandPalette';
 import type { SlashCommand } from './commands';
 import { GoalPanel, StatusLine, Transcript } from './components';
 import { Composer } from './Composer';
+import { ProjectDirectoryPicker } from './ProjectDirectoryPicker';
 import type { Project } from './projects';
 import { ProjectsModal } from './ProjectsModal';
 import { SettingsPanel } from './SettingsPanel';
@@ -100,16 +101,18 @@ export function AppLayout({
   onComposerCommandApplied,
   runPaletteCommand,
 }: AppLayoutProps) {
+  const openProjectManagement = () => {
+    closeSidebar();
+    if (activeProject) setProjectsOpen(true);
+  };
+
   return (
     <div className="relative z-1 flex h-screen">
       <Sidebar
         open={sidebarOpen}
         projects={projects}
         activeProjectId={activeProjectId}
-        onManageProjects={() => {
-          setProjectsOpen(true);
-          closeSidebar();
-        }}
+        onManageProjects={openProjectManagement}
         onOpenSettings={() => {
           setSettingsOpen(true);
           closeSidebar();
@@ -155,18 +158,11 @@ export function AppLayout({
         </header>
 
         {!activeProject ? (
-          <div className="m-auto flex max-w-md flex-col items-center gap-3 px-6 text-center">
-            <Txt as="h2" variant="header-md" className="text-icon6">
-              Welcome to MastraCode
-            </Txt>
-            <Txt as="p" variant="ui-md" className="max-w-sm text-icon3">
-              Open a project folder to start a coding session. Each project keeps its own threads, memory, and workspace
-              — shared with the terminal.
-            </Txt>
-            <Button variant="primary" className="mt-2" onClick={() => setProjectsOpen(true)}>
-              Open a project
-            </Button>
-          </div>
+          <ProjectDirectoryPicker
+            onSelectProject={project => selectProject(project)}
+            onProjectsChange={setProjects}
+            variant="page"
+          />
         ) : (
           <>
             {transcript.goal && (

--- a/mastracode/src/web/ui/DirectoryPicker.tsx
+++ b/mastracode/src/web/ui/DirectoryPicker.tsx
@@ -1,5 +1,5 @@
 import { Breadcrumb, Button, Crumb, Txt } from '@mastra/playground-ui';
-import { Folder } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Folder } from 'lucide-react';
 import { useState } from 'react';
 
 import { useDirectoryListing } from '../../shared/hooks/use-fs';
@@ -10,19 +10,19 @@ import { useDirectoryListing } from '../../shared/hooks/use-fs';
  * (confined to the server's configured root). The user drills into folders and
  * picks one — yielding a real absolute path with no typing.
  *
- * This is a *body* component with no backdrop of its own: it's embedded inside
- * a host modal (see ProjectsModal) so project selection is a first-class,
- * centered flow rather than a sidebar popover.
+ * This is a *body* component with no backdrop of its own: it can be embedded
+ * inline on the landing page or inside a host dialog.
  */
 
 interface DirectoryBrowserProps {
   /** Called with the chosen absolute path and its basename. */
   onPick: (path: string, name: string) => void;
-  onCancel: () => void;
+  onCancel?: () => void;
   /** True while the chosen folder is being resolved (server round-trip). */
   busy?: boolean;
   /** Error from resolving the chosen folder, if any. */
   error?: string | null;
+  layout?: 'dialog' | 'page';
 }
 
 function basename(path: string): string {
@@ -44,94 +44,207 @@ function crumbs(path: string): { label: string; path: string }[] {
 
 const ENTRY_CLASS =
   'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-ui-md text-icon5 transition-colors hover:bg-surface4 focus-visible:outline-hidden focus-visible:bg-surface4 disabled:opacity-50';
+const PAGE_ENTRY_CLASS =
+  'flex min-h-10 w-full items-center gap-2 rounded-md border border-transparent px-3 py-2 text-left text-ui-md text-icon5 transition-colors hover:bg-surface3 focus-visible:border-border1 focus-visible:bg-surface3 focus-visible:outline-hidden disabled:opacity-50';
 
-export function DirectoryBrowser({ onPick, onCancel, busy = false, error: pickError = null }: DirectoryBrowserProps) {
+export function DirectoryBrowser({
+  onPick,
+  onCancel,
+  busy = false,
+  error: pickError = null,
+  layout = 'dialog',
+}: DirectoryBrowserProps) {
   // `undefined` lists the server root; explicit paths drill into subfolders.
-  // React Query owns the fetch + per-path cache, so navigation is just state.
-  const [path, setPath] = useState<string | undefined>(undefined);
+  // React Query owns the fetch + per-path cache, while local history gives
+  // the picker lightweight browser-style back/forward movement.
+  const [history, setHistory] = useState<Array<string | undefined>>([undefined]);
+  const [historyIndex, setHistoryIndex] = useState(0);
+  const path = history[historyIndex];
   const listingQuery = useDirectoryListing(path);
 
   const listing = listingQuery.data ?? null;
   const loading = listingQuery.isPending;
+  const transitioning = listingQuery.isPlaceholderData;
+  const fetching = listingQuery.isFetching && !loading;
   const error = listingQuery.error instanceof Error ? listingQuery.error.message : null;
+  const canGoBack = historyIndex > 0;
+  const canGoForward = historyIndex < history.length - 1;
 
-  const browse = (next?: string) => setPath(next);
+  const browse = (next?: string) => {
+    if (next === path) return;
+    setHistory(current => [...current.slice(0, historyIndex + 1), next]);
+    setHistoryIndex(historyIndex + 1);
+  };
+  const goBack = () => setHistoryIndex(current => Math.max(0, current - 1));
+  const goForward = () => setHistoryIndex(current => Math.min(history.length - 1, current + 1));
+  const pageLayout = layout === 'page';
+
+  const navigationButtons = (
+    <div className="flex shrink-0 items-center gap-0.5">
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        type="button"
+        aria-label="Go back"
+        tooltip="Go back"
+        disabled={!canGoBack}
+        onClick={goBack}
+      >
+        <ChevronLeft size={16} />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        type="button"
+        aria-label="Go forward"
+        tooltip="Go forward"
+        disabled={!canGoForward}
+        onClick={goForward}
+      >
+        <ChevronRight size={16} />
+      </Button>
+    </div>
+  );
+
+  const breadcrumb = listing ? (
+    <Breadcrumb label="Path" className="min-w-0 flex-1 overflow-hidden" listClassName="min-w-0 overflow-hidden">
+      {crumbs(listing.path).map((c, i, arr) => {
+        const isCurrent = i === arr.length - 1;
+        return isCurrent ? (
+          <Crumb key={c.path} as="span" isCurrent title={c.path}>
+            {c.label}
+          </Crumb>
+        ) : (
+          <Crumb
+            key={c.path}
+            as="button"
+            isCurrent={false}
+            type="button"
+            title={c.path}
+            onClick={() => void browse(c.path)}
+          >
+            {c.label}
+          </Crumb>
+        );
+      })}
+    </Breadcrumb>
+  ) : (
+    <Txt as="div" variant="ui-sm" className="text-icon3">
+      Loading path…
+    </Txt>
+  );
+  const pathControls = (
+    <div className="flex min-w-0 items-center gap-1.5">
+      {navigationButtons}
+      {breadcrumb}
+      {fetching && (
+        <Txt as="span" variant="ui-xs" className="hidden shrink-0 text-icon3 sm:inline">
+          Loading…
+        </Txt>
+      )}
+    </div>
+  );
+
+  const pickButton = (
+    <Button
+      variant="primary"
+      size="sm"
+      disabled={!listing || busy || transitioning}
+      onClick={() => listing && onPick(listing.path, basename(listing.path))}
+    >
+      {busy ? 'Adding…' : 'Use this folder'}
+    </Button>
+  );
+
+  const listContent = (
+    <>
+      {loading && (
+        <Txt as="div" variant="ui-sm" className="px-2 py-1.5 text-icon3">
+          Loading…
+        </Txt>
+      )}
+      {error && (
+        <Txt as="div" variant="ui-sm" className="px-2 py-1.5 text-notice-destructive-fg">
+          {error}
+        </Txt>
+      )}
+      {!loading && !error && listing && (
+        <>
+          {listing.entries.length === 0 && (
+            <Txt as="div" variant="ui-sm" className="px-2 py-1.5 text-icon3">
+              No subfolders here
+            </Txt>
+          )}
+          {listing.entries.map(entry => (
+            <button
+              key={entry.path}
+              type="button"
+              className={pageLayout ? PAGE_ENTRY_CLASS : ENTRY_CLASS}
+              disabled={transitioning}
+              onClick={() => void browse(entry.path)}
+              title={`Open ${entry.name}`}
+            >
+              <Folder size={15} className="shrink-0 text-accent1" />
+              <span className="truncate">{entry.name}</span>
+            </button>
+          ))}
+        </>
+      )}
+    </>
+  );
+
+  const pickErrorElement = pickError ? (
+    <Txt as="div" variant="ui-sm" className="text-notice-destructive-fg">
+      {pickError}
+    </Txt>
+  ) : null;
+
+  if (pageLayout) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="sticky top-0 z-10 border-b border-border1 bg-surface1/95 py-3 backdrop-blur">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0 overflow-hidden">{pathControls}</div>
+            <div className="flex shrink-0 items-center justify-end gap-2">
+              {onCancel && (
+                <Button variant="ghost" size="sm" onClick={onCancel} disabled={busy}>
+                  Cancel
+                </Button>
+              )}
+              {pickButton}
+            </div>
+          </div>
+          {pickErrorElement && <div className="pt-2">{pickErrorElement}</div>}
+        </div>
+
+        <div className="flex flex-col gap-0.5 py-2" aria-busy={loading || transitioning}>
+          {listContent}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-3">
-      {listing && (
-        <Breadcrumb label="Path">
-          {crumbs(listing.path).map((c, i, arr) => {
-            const isCurrent = i === arr.length - 1;
-            return (
-              <Crumb
-                key={c.path}
-                as={isCurrent ? 'span' : 'button'}
-                isCurrent={isCurrent}
-                {...(isCurrent
-                  ? { title: c.path }
-                  : { type: 'button', title: c.path, onClick: () => void browse(c.path) })}
-              >
-                {c.label}
-              </Crumb>
-            );
-          })}
-        </Breadcrumb>
-      )}
+      {pathControls}
 
-      <div className="flex max-h-72 min-h-40 flex-col gap-0.5 overflow-y-auto rounded-lg border border-border1 bg-surface-overlay-soft p-1.5">
-        {loading && (
-          <Txt as="div" variant="ui-sm" className="px-2 py-1.5 text-icon3">
-            Loading…
-          </Txt>
-        )}
-        {error && (
-          <Txt as="div" variant="ui-sm" className="px-2 py-1.5 text-notice-destructive-fg">
-            {error}
-          </Txt>
-        )}
-        {!loading && !error && listing && (
-          <>
-            {listing.entries.length === 0 && (
-              <Txt as="div" variant="ui-sm" className="px-2 py-1.5 text-icon3">
-                No subfolders here
-              </Txt>
-            )}
-            {listing.entries.map(entry => (
-              <button
-                key={entry.path}
-                type="button"
-                className={ENTRY_CLASS}
-                onClick={() => void browse(entry.path)}
-                title={`Open ${entry.name}`}
-              >
-                <Folder size={15} className="text-accent1" />
-                <span className="truncate">{entry.name}</span>
-              </button>
-            ))}
-          </>
-        )}
+      <div
+        className="flex max-h-72 min-h-40 flex-col gap-0.5 overflow-y-auto rounded-lg border border-border1 bg-surface-overlay-soft p-1.5"
+        aria-busy={loading || transitioning}
+      >
+        {listContent}
       </div>
 
-      {pickError && (
-        <Txt as="div" variant="ui-sm" className="text-notice-destructive-fg">
-          {pickError}
-        </Txt>
-      )}
+      {pickErrorElement}
 
       <div className="flex items-center justify-end gap-3">
         <div className="flex items-center gap-2">
-          <Button variant="ghost" size="sm" onClick={onCancel} disabled={busy}>
-            Cancel
-          </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            disabled={!listing || busy}
-            onClick={() => listing && onPick(listing.path, basename(listing.path))}
-          >
-            {busy ? 'Adding…' : 'Use this folder'}
-          </Button>
+          {onCancel && (
+            <Button variant="ghost" size="sm" onClick={onCancel} disabled={busy}>
+              Cancel
+            </Button>
+          )}
+          {pickButton}
         </div>
       </div>
     </div>

--- a/mastracode/src/web/ui/ProjectDirectoryPicker.tsx
+++ b/mastracode/src/web/ui/ProjectDirectoryPicker.tsx
@@ -1,0 +1,80 @@
+import { Txt } from '@mastra/playground-ui';
+import { useState } from 'react';
+
+import { DirectoryBrowser } from './DirectoryPicker';
+import type { Project } from './projects';
+import { addProject, loadProjects } from './projects';
+
+interface ProjectDirectoryPickerProps {
+  onSelectProject: (project: Project) => void | Promise<void>;
+  onProjectsChange: (projects: Project[]) => void;
+  onClose?: () => void;
+  onCancel?: () => void;
+  variant?: 'dialog' | 'page';
+}
+
+export function ProjectDirectoryPicker({
+  onSelectProject,
+  onProjectsChange,
+  onClose,
+  onCancel,
+  variant = 'dialog',
+}: ProjectDirectoryPickerProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePick = async (path: string, name: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const project = await addProject(name || path, path);
+      onProjectsChange(loadProjects());
+      await onSelectProject(project);
+      onClose?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const description =
+    'Choose a local folder. Threads, memory, and workspace stay scoped to that directory and are shared with the terminal.';
+  const browser = (
+    <DirectoryBrowser
+      onPick={(path, name) => void handlePick(path, name)}
+      onCancel={onCancel}
+      busy={busy}
+      error={error}
+      layout={variant === 'page' ? 'page' : 'dialog'}
+    />
+  );
+
+  if (variant === 'page') {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <header className="border-b border-border1 px-4 py-5 md:px-8">
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-1.5">
+            <Txt as="h1" variant="header-md" className="text-icon6">
+              Open a project
+            </Txt>
+            <Txt as="p" variant="ui-sm" className="max-w-[68ch] text-icon3">
+              {description}
+            </Txt>
+          </div>
+        </header>
+
+        <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 md:px-8">{browser}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Txt as="p" variant="ui-sm" className="text-icon3">
+        {description}
+      </Txt>
+      {browser}
+    </div>
+  );
+}

--- a/mastracode/src/web/ui/ProjectsModal.tsx
+++ b/mastracode/src/web/ui/ProjectsModal.tsx
@@ -2,9 +2,9 @@ import { Button, Dialog, DialogContent, DialogHeader, DialogTitle, Txt } from '@
 import { Folder, Plus, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
-import { DirectoryBrowser } from './DirectoryPicker';
+import { ProjectDirectoryPicker } from './ProjectDirectoryPicker';
 import type { Project } from './projects';
-import { addProject, loadProjects, removeProject } from './projects';
+import { removeProject } from './projects';
 
 interface ProjectsModalProps {
   projects: Project[];
@@ -31,8 +31,6 @@ export function ProjectsModal({
 }: ProjectsModalProps) {
   const empty = projects.length === 0;
   const [adding, setAdding] = useState(empty);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   // Escape backs out of the add view to the list first (when projects exist);
   // the DS Dialog otherwise owns close-on-Escape for the list view.
@@ -46,23 +44,6 @@ export function ProjectsModal({
     window.addEventListener('keydown', onKey, true);
     return () => window.removeEventListener('keydown', onKey, true);
   }, [adding, empty]);
-
-  const handlePick = async (path: string, name: string) => {
-    setBusy(true);
-    setError(null);
-    try {
-      // addProject resolves the server-side (TUI-matching) resourceId, then
-      // persists to localStorage. Reload so we don't double-append.
-      const project = await addProject(name || path, path);
-      onProjectsChange(loadProjects());
-      onSelectProject(project);
-      onClose();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
-  };
 
   const handleRemove = (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
@@ -79,18 +60,12 @@ export function ProjectsModal({
 
         <div className="flex flex-col gap-3 px-5 pb-5">
           {adding ? (
-            <>
-              <Txt as="p" variant="ui-sm" className="text-icon3">
-                Choose a folder on this machine. Its threads, memory, and workspace stay scoped to that directory — and
-                are shared with the terminal.
-              </Txt>
-              <DirectoryBrowser
-                onPick={(p, n) => void handlePick(p, n)}
-                onCancel={() => (empty ? onClose() : setAdding(false))}
-                busy={busy}
-                error={error}
-              />
-            </>
+            <ProjectDirectoryPicker
+              onSelectProject={onSelectProject}
+              onProjectsChange={onProjectsChange}
+              onClose={onClose}
+              onCancel={() => (empty ? onClose() : setAdding(false))}
+            />
           ) : (
             <>
               <div className="flex flex-col gap-1.5">

--- a/mastracode/src/web/ui/useProjectModalAutoOpen.ts
+++ b/mastracode/src/web/ui/useProjectModalAutoOpen.ts
@@ -1,7 +1,0 @@
-import { useEffect } from 'react';
-
-export function useProjectModalAutoOpen(projectCount: number, setProjectsOpen: (open: boolean) => void) {
-  useEffect(() => {
-    if (projectCount === 0) setProjectsOpen(true);
-  }, [projectCount, setProjectsOpen]);
-}


### PR DESCRIPTION
<img width="1682" height="2024" alt="CleanShot 2026-07-02 at 14 20 30@2x" src="https://github.com/user-attachments/assets/fca59ea1-954f-4fbe-8513-08027394a546" />

## Summary

- Replace the first-run MastraCode empty state with an inline full-page project picker instead of auto-opening a dialog.
- Share the project directory picker between the full-page flow and the existing project management dialog.
- Add cached directory navigation with previous data retained during folder changes, plus back/forward ghost icon buttons before the playground-ui breadcrumb.

## Validation

- Browser verified on `http://localhost:5173/`: inline picker renders without a dialog, desktop/mobile layout wraps cleanly, and folder history buttons enable/disable as expected.
- `git diff --check`
- `pnpm --filter ./mastracode check:ui` currently fails because the local `@mastra/playground-ui` build is missing declaration output, which cascades into existing implicit-any errors across the UI.