### PR TITLE
fix: harden child-process calls against shell injection (CodeQL)

### DIFF
--- a/.changeset/eight-clouds-march.md
+++ b/.changeset/eight-clouds-march.md
@@ -1,0 +1,8 @@
+---
+'mastra': patch
+'@mastra/codemod': patch
+'@mastra/deployer': patch
+'mastracode': patch
+---
+
+Hardened child-process invocations against shell command injection. Package installs and codemod runs now pass arguments as arrays instead of interpolating them into shell strings, the deployer's shared child-process logger rejects arguments containing shell metacharacters, and the login dialog validates auth URLs and opens the browser without a shell. As a side effect, `mastra codemod` now works on project paths containing spaces.

--- a/mastracode/src/tui/components/login-dialog.ts
+++ b/mastracode/src/tui/components/login-dialog.ts
@@ -2,12 +2,41 @@
  * Login dialog component - handles OAuth login flow UI
  */
 
-import { exec } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { Box, Container, getKeybindings, Spacer, Text } from '@earendil-works/pi-tui';
 import type { Focusable, TUI } from '@earendil-works/pi-tui';
 import { getOAuthProviders } from '../../auth/index.js';
 import { theme } from '../theme.js';
 import { MaskedInput } from './masked-input.js';
+
+/**
+ * Open a URL in the default browser without going through a shell.
+ * Only well-formed http(s) URLs are opened; anything else is ignored
+ * (the URL is still displayed for the user to open manually).
+ */
+function openUrlInBrowser(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return;
+  }
+
+  const [cmd, args]: [string, string[]] =
+    process.platform === 'darwin'
+      ? ['open', [url]]
+      : process.platform === 'win32'
+        ? ['rundll32', ['url.dll,FileProtocolHandler', url]]
+        : ['xdg-open', [url]];
+
+  const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+  // Opening the browser is best-effort — the URL is shown in the dialog.
+  child.on('error', () => {});
+  child.unref();
+}
 
 export class LoginDialogComponent extends Box implements Focusable {
   private contentContainer: Container;
@@ -94,9 +123,11 @@ export class LoginDialogComponent extends Box implements Focusable {
       this.contentContainer.addChild(new Text(theme.fg('warning', instructions)));
     }
 
-    // Try to open browser
-    const openCmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
-    exec(`${openCmd} "${url}"`);
+    // Try to open browser. The URL comes from the auth provider, so treat it
+    // as untrusted: only open well-formed http(s) URLs, and spawn without a
+    // shell so it can't be used for command injection (CodeQL
+    // js/shell-command-constructed-from-input).
+    openUrlInBrowser(url);
 
     this.tui.requestRender();
   }

--- a/packages/cli/src/services/service.deps.ts
+++ b/packages/cli/src/services/service.deps.ts
@@ -47,10 +47,10 @@ export class DepsService {
     const pm = this.packageManager;
     const installCommand = getPackageManagerAddCommand(pm);
 
-    const packageList = packages.join(' ');
-    return execa(`${pm} ${installCommand} ${packageList}`, {
+    // Pass arguments as an array (no shell) so package names can't be used
+    // for command injection (CodeQL js/shell-command-constructed-from-input).
+    return execa(pm, [...installCommand.split(' '), ...packages], {
       all: true,
-      shell: true,
       stdio: 'pipe',
     });
   }

--- a/packages/codemod/src/lib/transform.ts
+++ b/packages/codemod/src/lib/transform.ts
@@ -1,11 +1,11 @@
 import child_process from 'node:child_process';
-import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import util from 'node:util';
 import debug from 'debug';
 
-const exec = util.promisify(child_process.exec);
+const execFile = util.promisify(child_process.execFile);
 
 interface TransformOptions {
   dry?: boolean;
@@ -19,40 +19,48 @@ const error = debug('codemod:transform:error');
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-function getJscodeshift(): string {
-  const localJscodeshift = path.resolve(__dirname, '../node_modules/.bin/jscodeshift');
-  return fs.existsSync(localJscodeshift) ? localJscodeshift : 'jscodeshift';
+function getJscodeshiftBin(): string {
+  // jscodeshift is a direct dependency, so resolve its bin script and run it
+  // with the current Node executable. This avoids both shell resolution and
+  // platform-specific .bin shims.
+  const require = createRequire(import.meta.url);
+  return require.resolve('jscodeshift/bin/jscodeshift.js');
 }
 
-function buildCommand(codemodPath: string, targetPath: string, jscodeshift: string, options: TransformOptions): string {
+function buildArgs(codemodPath: string, targetPath: string, options: TransformOptions): string[] {
   // Ignoring everything under `.*/` covers `.mastra/` along with any other
   // framework build related or otherwise intended-to-be-hidden directories.
-  let command = `${jscodeshift} -t ${codemodPath} ${targetPath} \
-    --parser tsx \
-    --ignore-pattern="**/node_modules/**" \
-    --ignore-pattern="**/.*/**" \
-    --ignore-pattern="**/dist/**" \
-    --ignore-pattern="**/build/**" \
-    --ignore-pattern="**/*.min.js" \
-    --ignore-pattern="**/*.bundle.js"`;
+  const args = [
+    '-t',
+    codemodPath,
+    targetPath,
+    '--parser',
+    'tsx',
+    '--ignore-pattern=**/node_modules/**',
+    '--ignore-pattern=**/.*/**',
+    '--ignore-pattern=**/dist/**',
+    '--ignore-pattern=**/build/**',
+    '--ignore-pattern=**/*.min.js',
+    '--ignore-pattern=**/*.bundle.js',
+  ];
 
   if (options.dry) {
-    command += ' --dry';
+    args.push('--dry');
   }
 
   if (options.print) {
-    command += ' --print';
+    args.push('--print');
   }
 
   if (options.verbose) {
-    command += ' --verbose';
+    args.push('--verbose');
   }
 
   if (options.jscodeshift) {
-    command += ` ${options.jscodeshift}`;
+    args.push(...options.jscodeshift.split(' ').filter(Boolean));
   }
 
-  return command;
+  return args;
 }
 
 export type TransformErrors = {
@@ -104,9 +112,10 @@ export async function transform(
   }
   const codemodPath = path.resolve(__dirname, `./codemods/${codemod}.js`);
   const targetPath = path.resolve(source);
-  const jscodeshift = getJscodeshift();
-  const command = buildCommand(codemodPath, targetPath, jscodeshift, transformOptions);
-  const { stdout } = await exec(command, { encoding: 'utf8' });
+  const args = buildArgs(codemodPath, targetPath, transformOptions);
+  // execFile with an args array (no shell) so paths can't be used for
+  // command injection (CodeQL js/shell-command-injection-from-environment).
+  const { stdout } = await execFile(process.execPath, [getJscodeshiftBin(), ...args], { encoding: 'utf8' });
   const errors = parseErrors(codemod, stdout);
   const notImplementedErrors = parseNotImplementedErrors(codemod, stdout);
   if (options.logStatus) {

--- a/packages/deployer/src/deploy/log.ts
+++ b/packages/deployer/src/deploy/log.ts
@@ -19,10 +19,23 @@ export const createPinoStream = (logger: IMastraLogger) => {
   });
 };
 
+/**
+ * Args are joined into a shell command (`shell: true` is required for package
+ * manager shims on Windows), so only allow characters that appear in package
+ * specifiers and CLI flags — never shell metacharacters (CodeQL
+ * js/shell-command-constructed-from-input).
+ */
+const SAFE_SHELL_ARG = /^[\w@%+=:,./^~-]*$/;
+
 export function createChildProcessLogger({ logger, root }: { logger: IMastraLogger; root: string }) {
   const pinoStream = createPinoStream(logger);
   return async ({ cmd, args, env }: { cmd: string; args: string[]; env: Record<string, string> }) => {
     try {
+      for (const arg of args) {
+        if (!SAFE_SHELL_ARG.test(arg)) {
+          throw new Error(`Refusing to pass unsafe argument to shell command: ${JSON.stringify(arg)}`);
+        }
+      }
       const subprocess = spawn(cmd, args, {
         cwd: root,
         shell: true,


### PR DESCRIPTION
## Summary

Resolves all 5 open CodeQL shell-command alerts (medium severity): `js/shell-command-constructed-from-input` #323, #571, #655, #714 and `js/shell-command-injection-from-environment` #399.

Each flagged path interpolated externally-influenced strings into a shell command. Fixes, by risk:

**mastracode login dialog (#655)** — the most meaningful one: the OAuth URL comes from the auth provider over the network and was interpolated into `exec(`open "${url}"`)`. A compromised/MITM'd auth endpoint could have injected shell commands. Now the URL is validated as well-formed http(s) and the browser is opened via `spawn` with an args array (`open` / `rundll32 url.dll,FileProtocolHandler` / `xdg-open`) — no shell at all. Best-effort as before; the URL is still displayed for manual opening.

**packages/codemod (#399)** — `mastra codemod` built a jscodeshift invocation as one string and ran it through `exec`. Now it resolves `jscodeshift/bin/jscodeshift.js` via `createRequire` and runs it with `execFile(process.execPath, [bin, ...args])` — no shell, no `.bin` shim lookup. Side benefit: codemods now work on project paths containing spaces (previously broken).

**packages/cli `DepsService.installPackages` (#571)** — switched `execa` from a single interpolated string + `shell: true` to the `execa(pm, args)` array form. execa's cross-spawn still resolves `pnpm.cmd`-style shims on Windows, so no shell is needed.

**packages/deployer `createChildProcessLogger` (#714) + `getNpmArgs` flow (#323)** — this sink genuinely needs `shell: true` for package-manager shims on Windows, so instead args are validated against an allowlist (`/^[\w@%+=:,./^~-]*$/` — package specifier and CLI flag characters) and the call throws on anything containing shell metacharacters. All current callers pass `pkg@version` specs and `--cpu=/--os=/--libc=` flags, which pass validation.

## Test plan

- `tsc --noEmit` clean in all 4 packages (cli, codemod, deployer, mastracode)
- Tests: codemod 79/79, deployer services 4/4, cli services 11/11
- Manual end-to-end: built `@mastra/codemod` and ran `v1/mastra-core-imports` against a directory with spaces in its path — transform applied correctly
