### PR TITLE
fix: resolve CodeQL sanitization and error-exposure alerts

### DIFF
--- a/.changeset/lucky-doors-shine.md
+++ b/.changeset/lucky-doors-shine.md
@@ -1,0 +1,6 @@
+---
+'@mastra/mcp': patch
+'mastracode': patch
+---
+
+Security hardening from CodeQL review: MCP serverless 500 responses no longer echo internal error messages to clients (details are still logged server-side), and macOS system notifications now escape backslashes and run osascript without a shell so notification text can't inject commands.

--- a/mastracode/src/tui/notify.ts
+++ b/mastracode/src/tui/notify.ts
@@ -3,7 +3,7 @@
  * Sends a terminal bell and optionally a native OS notification.
  */
 
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import type { HookManager } from '../hooks/manager.js';
 
 export type NotificationMode = 'bell' | 'system' | 'both' | 'off';
@@ -50,8 +50,15 @@ function sendSystemNotification(reason: NotificationReason, message?: string): v
   if (process.platform === 'darwin') {
     const title = 'Mastra Code';
     const body = message || reasonToMessage(reason);
-    const escaped = body.replace(/"/g, '\\"');
-    exec(`osascript -e 'display notification "${escaped}" with title "${title}"'`);
+    // The message can contain arbitrary text (including model output), so:
+    // - escape backslashes before quotes for the AppleScript string literal
+    // - pass the script via execFile args so no shell is involved
+    // (CodeQL js/incomplete-sanitization)
+    const escaped = body.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const script = `display notification "${escaped}" with title "${title}"`;
+    execFile('osascript', ['-e', script], () => {
+      // Best-effort: ignore notification failures
+    });
   }
   // Linux/Windows: could add notify-send / powershell in the future
 }

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1794,13 +1794,14 @@ export class MCPServer extends MCPServerBase {
       // If headers haven't been sent, send an error response
       if (!res.headersSent) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
+        // Error details are logged above; don't echo them to the client
+        // (CodeQL js/stack-trace-exposure)
         res.end(
           JSON.stringify({
             jsonrpc: '2.0',
             error: {
               code: -32603,
               message: 'Internal server error',
-              data: error instanceof Error ? error.message : String(error),
             },
             id: null,
           }),

--- a/scripts/commonjs-tsc-fixer.js
+++ b/scripts/commonjs-tsc-fixer.js
@@ -37,7 +37,9 @@ async function writeDtsFiles() {
           const dir = dirname(file);
           const distRoot = join(rootPath, 'dist');
           const subPath = slash(relative(distRoot, dir));
-          const filename = key.replace('*', subPath);
+          // split/join replaces every '*' and doesn't interpret '$' patterns
+          // in the replacement (CodeQL js/incomplete-sanitization)
+          const filename = key.split('*').join(subPath);
 
           const targetPath = join(rootPath, filename) + '.d.ts';
           await mkdir(dirname(targetPath), { recursive: true });


### PR DESCRIPTION
## Summary

Resolves 3 CodeQL alerts: `js/incomplete-sanitization` #652 and #690, `js/stack-trace-exposure` #394.

**mastracode macOS notifications (#652)** — the real find of the batch: notification text (which can include model/agent-derived content) was interpolated into `exec(`osascript -e '… "${escaped}" …'`)` with only `"` escaped. A single quote in the message broke out of the shell quoting entirely → command injection. Now backslashes and quotes are escaped for the AppleScript string literal and osascript runs via `execFile` with an args array — no shell involved, so shell metacharacters are inert.

**@mastra/mcp serverless error responses (#394)** — 500 responses included the internal error message in the JSON-RPC `error.data` field, exposing internals to clients. The message is dropped from the response; full details are still logged server-side via `trackException` and `logger.error`.

**scripts/commonjs-tsc-fixer (#690)** — `key.replace('*', subPath)` only replaced the first `*` and would interpret `$` patterns in the replacement. Switched to `split('*').join(subPath)`. Build-script hygiene, not exploitable.

## Test plan

- `tsc --noEmit` clean in `packages/mcp` and `mastracode`
- MCP server suite: 85/85 passing
- `node --check` on the build script
- Hostile-input probe for the notification escaping (quotes, backslashes, `$(…)`, backticks) confirms the AppleScript literal stays well-formed
