### PR TITLE
chore(docs): Improve ref docs of createTool & getAgentById

### DIFF
--- a/docs/src/content/en/reference/core/getAgentById.mdx
+++ b/docs/src/content/en/reference/core/getAgentById.mdx
@@ -7,12 +7,34 @@ packages:
 
 # Mastra.getAgentById()
 
-The `.getAgentById()` method is used to retrieve an agent by its ID. The method accepts a single `string` parameter for the agent's ID.
+The `.getAgentById()` method retrieves a registered agent by its `id`. It first searches registered agents by `agent.id`. If no agent matches, it falls back to [`Mastra.getAgent()`](/reference/core/getAgent) and treats the provided value as the agent registry key.
+
+Use `mastra.getAgentById(id)` to retrieve the code-defined agent. Use `await mastra.getAgentById(id, version)` to retrieve a versioned agent.
 
 ## Usage example
 
-```typescript
-mastra.getAgentById('test-agent-123')
+The following example registers an agent, retrieves it by ID, and uses the returned agent.
+
+```typescript title="src/mastra/index.ts"
+import { Agent } from '@mastra/core/agent'
+import { Mastra } from '@mastra/core/mastra'
+
+const supportAgent = new Agent({
+  id: 'support-agent-id',
+  name: 'Support Agent',
+  instructions: 'Answer support questions clearly and concisely.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+})
+
+export const mastra = new Mastra({
+  agents: {
+    supportAgent,
+  },
+})
+
+const agent = mastra.getAgentById('support-agent-id')
+
+const response = await agent.generate('How can I reset my password?')
 ```
 
 ## Parameters
@@ -21,9 +43,34 @@ mastra.getAgentById('test-agent-123')
   content={[
   {
     name: 'id',
-    type: 'string',
+    type: "TAgents[TAgentName]['id']",
     description:
-      'The ID of the agent to retrieve. The method will first search for an agent with this ID, and if not found, will attempt to use it as a name to call getAgent().',
+      'The ID of the agent to retrieve. Mastra first searches registered agents by `agent.id`. If none match, it uses this value as the agent registry key and calls `getAgent()`.',
+  },
+  {
+    name: 'version',
+    type: "{ versionId: string } | { status?: 'draft' | 'published' }",
+    description:
+      'Optional version selector for retrieving a versioned agent. When provided, the method returns a promise.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'VersionSelector',
+        parameters: [
+          {
+            name: 'versionId',
+            type: 'string',
+            description: 'The ID of a specific agent version to retrieve.',
+          },
+          {
+            name: 'status',
+            type: "'draft' | 'published'",
+            description: 'Select the latest agent version with this publication status.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
   },
 ]}
 />
@@ -34,12 +81,20 @@ mastra.getAgentById('test-agent-123')
   content={[
   {
     name: 'agent',
-    type: 'Agent',
-    description: 'The agent instance with the specified ID. Throws an error if the agent is not found.',
+    type: 'TAgents[TAgentName]',
+    description: 'The agent instance with the specified ID when `version` is omitted.',
+  },
+  {
+    name: 'agent',
+    type: 'Promise<TAgents[TAgentName]>',
+    description: 'A promise that resolves to the versioned agent instance when `version` is provided.',
   },
 ]}
 />
 
+Throws a `MastraError` when no agent is found by ID or registry key.
+
 ## Related
 
+- [Mastra.getAgent()](/reference/core/getAgent)
 - [Agents overview](/docs/agents/overview)

--- a/docs/src/content/en/reference/core/getAgentById.mdx
+++ b/docs/src/content/en/reference/core/getAgentById.mdx
@@ -43,7 +43,7 @@ const response = await agent.generate('How can I reset my password?')
   content={[
   {
     name: 'id',
-    type: "string",
+    type: 'string',
     description:
       'The ID of the agent to retrieve. Mastra first searches registered agents by `agent.id`. If none match, it uses this value as the agent registry key and calls `getAgent()`.',
   },

--- a/docs/src/content/en/reference/core/getAgentById.mdx
+++ b/docs/src/content/en/reference/core/getAgentById.mdx
@@ -43,7 +43,7 @@ const response = await agent.generate('How can I reset my password?')
   content={[
   {
     name: 'id',
-    type: "TAgents[TAgentName]['id']",
+    type: "string",
     description:
       'The ID of the agent to retrieve. Mastra first searches registered agents by `agent.id`. If none match, it uses this value as the agent registry key and calls `getAgent()`.',
   },

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -122,11 +122,31 @@ export const tool = createTool({
     isOptional: true,
   },
   {
+    name: 'providerOptions',
+    type: 'Record<string, Record<string, unknown>>',
+    description:
+      'Provider-specific options passed to the model when this tool is used. Keys are provider names, such as `anthropic` or `openai`, and values are provider-specific configuration objects.',
+    isOptional: true,
+  },
+  {
+    name: 'inputExamples',
+    type: 'Array<{ input: Record<string, unknown> }>',
+    description: 'Examples of valid tool inputs that supported model providers can use as input examples.',
+    isOptional: true,
+  },
+  {
+    name: 'background',
+    type: 'ToolBackgroundConfig',
+    description:
+      'Background task configuration for this tool. When enabled, the tool can execute in the background while the agent conversation continues.',
+    isOptional: true,
+  },
+  {
     name: 'execute',
     type: 'function',
     description:
-      "The function that contains the tool's logic. It receives two parameters: the validated input data based on inputSchema (first parameter) and an optional execution context object (second parameter) containing `requestContext`, `tracingContext`, `abortSignal`, and other execution metadata.",
-    isOptional: false,
+      "The function that contains the tool's logic. Ordinary custom tools usually provide `execute`, but the type allows omission for tool definitions that are executed or adapted elsewhere. It receives two parameters: the validated input data based on inputSchema (first parameter) and an execution context object (second parameter) containing `requestContext`, `abortSignal`, and other execution metadata.",
+    isOptional: true,
     properties: [
       {
         parameters: [
@@ -153,12 +173,6 @@ export const tool = createTool({
                     type: 'RequestContext',
                     isOptional: true,
                     description: 'Request Context for accessing shared state and dependencies',
-                  },
-                  {
-                    name: 'tracingContext',
-                    type: 'TracingContext',
-                    isOptional: true,
-                    description: 'Tracing context for creating child spans and adding metadata',
                   },
                   {
                     name: 'abortSignal',
@@ -263,32 +277,34 @@ export const tool = createTool({
     name: 'onInputStart',
     type: 'function',
     description:
-      'Optional callback invoked when the tool call input streaming begins. Receives `toolCallId`, `messages`, and `abortSignal`.',
+      'Optional callback invoked when the tool call input streaming begins. Signature: `(options: ToolCallOptions) => void | PromiseLike<void>`.',
     isOptional: true,
   },
   {
     name: 'onInputDelta',
     type: 'function',
     description:
-      'Optional callback invoked for each incremental chunk of input text as it streams in. Receives `inputTextDelta`, `toolCallId`, `messages`, and `abortSignal`.',
+      'Optional callback invoked for each incremental chunk of input text as it streams in. Signature: `({ inputTextDelta, ...options }: { inputTextDelta: string } & ToolCallOptions) => void | PromiseLike<void>`.',
     isOptional: true,
   },
   {
     name: 'onInputAvailable',
     type: 'function',
     description:
-      'Optional callback invoked when the complete tool input is available and parsed. Receives the validated `input` object, `toolCallId`, `messages`, and `abortSignal`.',
+      'Optional callback invoked when the complete tool input is available and parsed. Signature: `({ input, ...options }: { input: TSchemaIn } & ToolCallOptions) => void | PromiseLike<void>`.',
     isOptional: true,
   },
   {
     name: 'onOutput',
     type: 'function',
     description:
-      "Optional callback invoked after the tool has successfully executed and returned output. Receives the tool's `output`, `toolCallId`, `messages`, and `abortSignal`.",
+      "Optional callback invoked after the tool has successfully executed and returned output. Signature: `({ output, toolName, ...options }: { output: TSchemaOut; toolName: string } & Omit<ToolCallOptions, 'messages'>) => void | PromiseLike<void>`.",
     isOptional: true,
   },
 ]}
 />
+
+Runtime-populated fields such as `mastra` and `mcpMetadata` appear in source types but are set by Mastra or MCP adapters. You do not need to configure them for ordinary `createTool()` usage.
 
 ## Returns
 
@@ -527,8 +543,9 @@ export const weatherTool = createTool({
     },
   },
   execute: async inputData => {
-    const weather = await fetchWeather(inputData.location)
-    return { weather }
+    return {
+      weather: `Current weather for ${inputData.location}: sunny`,
+    }
   },
 })
 ```
@@ -537,7 +554,44 @@ export const weatherTool = createTool({
 
 Tools support lifecycle hooks that allow you to monitor and react to different stages of tool execution. These hooks are particularly useful for logging, analytics, validation, and real-time updates during streaming.
 
-### Available Hooks
+The following example demonstrates a tool with all lifecycle hooks configured:
+
+```typescript title="src/mastra/tools/weather-tool.ts"
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+export const weatherTool = createTool({
+  id: 'get-weather',
+  description: 'Get weather for a city',
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  outputSchema: z.object({
+    city: z.string(),
+    forecast: z.string(),
+  }),
+  execute: async ({ city }) => {
+    return {
+      city,
+      forecast: 'sunny',
+    }
+  },
+  onInputStart: ({ toolCallId }) => {
+    console.log(`Tool call ${toolCallId} input started`)
+  },
+  onInputDelta: ({ inputTextDelta, toolCallId }) => {
+    console.log(`Tool call ${toolCallId} received input chunk: ${inputTextDelta}`)
+  },
+  onInputAvailable: ({ input, toolCallId }) => {
+    console.log(`Tool call ${toolCallId} received city: ${input.city}`)
+  },
+  onOutput: ({ output, toolCallId, toolName }) => {
+    console.log(`Tool ${toolName} call ${toolCallId} returned forecast: ${output.forecast}`)
+  },
+})
+```
+
+### Available hooks
 
 #### `onInputStart`
 
@@ -606,7 +660,7 @@ export const tool = createTool({
 })
 ```
 
-### Hook Execution Order
+### Hook execution order
 
 For a typical streaming tool call, the hooks are invoked in this order:
 
@@ -616,19 +670,14 @@ For a typical streaming tool call, the hooks are invoked in this order:
 1. Tool's **execute** function runs
 1. **onOutput**: Tool has completed successfully
 
-### Hook Parameters
+### Hook parameters
 
-All hooks receive a parameter object with these common properties:
+Hook callbacks receive these source-backed parameter shapes:
 
-- `toolCallId` (string): Unique identifier for this specific tool call
-- `abortSignal` (AbortSignal): Signal for detecting if the operation should be cancelled
-
-Additionally:
-
-- `onInputStart`, `onInputDelta`, and `onInputAvailable` receive `messages` (array): The conversation messages at the time of the tool call
-- `onInputDelta` receives `inputTextDelta` (string): The incremental text chunk
-- `onInputAvailable` receives `input`: The validated input data (typed according to `inputSchema`)
-- `onOutput` receives `output`: The tool's return value (typed according to `outputSchema`) and `toolName` (string): The name of the tool
+- `onInputStart`: Receives `ToolCallOptions`, including fields such as `toolCallId`, `messages`, and `abortSignal`.
+- `onInputDelta`: Receives `{ inputTextDelta: string } & ToolCallOptions`.
+- `onInputAvailable`: Receives `{ input: TSchemaIn } & ToolCallOptions`, where `input` is typed from `inputSchema`.
+- `onOutput`: Receives `{ output: TSchemaOut; toolName: string } & Omit<ToolCallOptions, 'messages'>`, where `output` is typed from `outputSchema`. This hook does not receive `messages`.
 
 ### Error handling
 
@@ -647,7 +696,7 @@ mcp: {
 }
 ```
 
-### `ToolAnnotations` Properties
+### `ToolAnnotations` properties
 
 <PropertiesTable
   content={[


### PR DESCRIPTION
## Description

Improve reference docs for createTool and getAgentById.

Changes were made with https://github.com/mastra-ai/mastra/pull/18810

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR updates two documentation pages so they explain the “how it finds things” and “what you can configure” parts more clearly. It’s just documentation—no code behavior changes.

## Summary
- Updated `getAgentById` reference docs to clarify the ID lookup flow:
  - tries matching `agent.id` first
  - if not found, treats the input as a registry key and falls back to `Mastra.getAgent()`
- Expanded/clarified `getAgentById` parameter documentation:
  - refined `id` to describe the two-step lookup behavior while keeping type `string`
  - expanded `version` into a typed selector union (with detailed `VersionSelector` structure)
- Revised `getAgentById` return documentation:
  - distinguishes return types when `version` is omitted vs provided
  - notes that a `MastraError` is thrown if no agent is found
  - updates related links to point to `Mastra.getAgent()`
- Updated `createTool` reference docs:
  - added documentation for `providerOptions`, `inputExamples`, and `background`
  - clarified `execute` documentation/optionality
  - removed `tracingContext` from the documented `ToolExecutionContext` shape
- Reworked tool lifecycle hook documentation:
  - provided more explicit callback signatures for hooks (e.g., `onInputStart`, `onInputDelta`, `onInputAvailable`, `onOutput`)
  - documented that `mastra`/`mcpMetadata` are runtime-populated
  - rewrote hook parameter descriptions (including that `onOutput` omits `messages`)
  - updated MCP-related headings and the MCP tool example’s `execute` return behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->