### PR TITLE
paul/deved-356-bulletin-browser-recording 

### DIFF
--- a/docs/src/content/en/docs/browser/recording.mdx
+++ b/docs/src/content/en/docs/browser/recording.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Browser recording (alpha)"
+title: "Browser recording (beta)"
 description: "Record browser sessions as Motion-JPEG AVI videos with optional agent captions."
 packages:
   - "@mastra/core"
@@ -7,13 +7,15 @@ packages:
   - "@mastra/stagehand"
 ---
 
-# Browser recording (alpha)
+# Browser recording (beta)
+
+**Added in:** `@mastra/core@1.43.0`
 
 Browser recording adds two opt-in tools that let an agent save a browser session as a Motion-JPEG AVI video. The agent can also add short captions while it works.
 
-:::caution
+:::experimental
 
-Browser recording is an alpha feature. The API and output format may change.
+This feature is in beta. Breaking changes may occur without a major version bump until the API is stable.
 
 :::
 
@@ -34,7 +36,7 @@ Pass `recording.outputDir` to `AgentBrowser` or `StagehandBrowser`. The browser 
 
 The following example enables recording for `AgentBrowser`:
 
-```typescript title="src/mastra/browsers.ts"
+```typescript title="src/mastra/browsers/agent-browser.ts"
 import { join } from 'node:path'
 import { AgentBrowser } from '@mastra/agent-browser'
 
@@ -48,7 +50,7 @@ export const browser = new AgentBrowser({
 
 The same option works with `StagehandBrowser`:
 
-```typescript title="src/mastra/browsers.ts"
+```typescript title="src/mastra/browsers/stagehand-browser.ts"
 import { join } from 'node:path'
 import { StagehandBrowser } from '@mastra/stagehand'
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -474,6 +474,9 @@ const sidebars = {
           type: 'doc',
           id: 'browser/recording',
           label: 'Recording',
+          customProps: {
+            tags: ['beta'],
+          },
         },
         {
           type: 'doc',


### PR DESCRIPTION
## Description

docs: update browser recording admonition and sidebar nav item

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR updates the browser recording docs to say the feature is in beta now, which is a more accurate way to show that it’s still being tested and may change. It also updates the sidebar so the page is labeled as beta there too.

### Changes
- Updated the browser recording documentation to switch wording from **alpha** to **beta**.
- Changed the warning/admonition text to an **experimental beta** notice.
- Added an **“Added in”** note for `@mastra/core@1.43.0`.
- Updated example code block titles to use more specific file paths.
- Marked the browser recording sidebar entry with a `beta` tag.

### Notes
- Documentation-only change.
- No linked issue was provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->