### PR TITLE
ci: standardize app auth step ids

### DIFF
--- a/.github/workflows/changed-test-gate-labeler.yml
+++ b/.github/workflows/changed-test-gate-labeler.yml
@@ -26,7 +26,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Generate GitHub App token
-        id: app_token
+        id: app-auth
         uses: ./.github/actions/app-auth
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
@@ -51,7 +51,7 @@ jobs:
         working-directory: scripts/pr-test-gate
         env:
           PHASE: label
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/issue-pending-release.yml
+++ b/.github/workflows/issue-pending-release.yml
@@ -26,7 +26,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Generate GitHub App token
-        id: app_token
+        id: app-auth
         uses: ./.github/actions/app-auth
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
@@ -51,7 +51,7 @@ jobs:
         working-directory: scripts/release-issue-notification
         env:
           MODE: pending-release
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Generate GitHub App token
         if: steps.check_major.outputs.has_major_changeset == 'true'
-        id: app_token
+        id: app-auth
         uses: ./.github/actions/app-auth
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
@@ -116,7 +116,7 @@ jobs:
         id: check_approval
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
-          github-token: ${{ steps.app_token.outputs.token }}
+          github-token: ${{ steps.app-auth.outputs.token }}
           script: |
             const prNumber = context.payload?.pull_request?.number || context.payload?.issue?.number;
             const { owner, repo } = context.repo;

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -37,7 +37,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Generate GitHub App token
-        id: app_token
+        id: app-auth
         uses: ./.github/actions/app-auth
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
@@ -64,7 +64,7 @@ jobs:
         working-directory: scripts/pr-issue-link
         env:
           MODE: nudge
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -88,7 +88,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Generate GitHub App token
-        id: app_token
+        id: app-auth
         uses: ./.github/actions/app-auth
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
@@ -113,7 +113,7 @@ jobs:
         run: npx tsx index.ts
         working-directory: scripts/pr-complexity
         env:
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -137,7 +137,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Generate GitHub App token
-        id: app_token
+        id: app-auth
         uses: ./.github/actions/app-auth
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
@@ -161,7 +161,7 @@ jobs:
         run: npx tsx index.ts
         working-directory: scripts/pr-automation-comment
         env:
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -183,7 +183,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Generate GitHub App token
-        id: app_token
+        id: app-auth
         uses: ./.github/actions/app-auth
         with:
           client-id: ${{ vars.DANE_CLIENT_ID }}
@@ -209,7 +209,7 @@ jobs:
         working-directory: scripts/pr-issue-link
         env:
           MODE: close-stale
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           STALE_DAYS: ${{ vars.PR_NEEDS_ISSUE_STALE_DAYS || '1' }}


### PR DESCRIPTION
## Summary

This standardizes GitHub App auth step IDs in workflows that use the shared `.github/actions/app-auth` action.

Before this change, some workflows used `app_token` while others used `app-auth`, even though they all call the same action and consume the same token output. After this change, the step ID and token references consistently use `app-auth`.

## Test plan

- Verified all updated workflow token references point to `steps.app-auth.outputs.token`.
- Verified workflow YAML parses successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change gives the GitHub App token step the same name everywhere in the workflows, so the next steps can always find the token in the same place. It helps avoid confusion and makes the automation easier to keep working.

## Summary
- Standardized GitHub App auth step IDs from `app_token` to `app-auth` in shared workflow usage.
- Updated all affected token references to use `steps.app-auth.outputs.token`.
- Applied the rename in:
  - `.github/workflows/changed-test-gate-labeler.yml`
  - `.github/workflows/issue-pending-release.yml`
  - `.github/workflows/major-version-check.yml`
  - `.github/workflows/pr-triage.yml`

## Validation
- Verified the updated workflow token references point to `steps.app-auth.outputs.token`.
- Confirmed the workflow YAML parses successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->