### PR TITLE
fix(core): preserve empty scrubber instructions

### DIFF
--- a/.changeset/tame-worlds-strive.md
+++ b/.changeset/tame-worlds-strive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the system prompt scrubber so empty custom instructions are preserved.

--- a/packages/core/src/processors/processors/system-prompt-scrubber.test.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.test.ts
@@ -432,6 +432,15 @@ describe('SystemPromptScrubber', () => {
       expect(processor['instructions']).toBe(customInstructions);
     });
 
+    it('should preserve empty custom instructions', async () => {
+      processor = new SystemPromptScrubber({
+        model: mockModel,
+        instructions: '',
+      });
+
+      expect(processor['instructions']).toBe('');
+    });
+
     it('should require model in constructor', () => {
       expect(() => {
         new SystemPromptScrubber({} as any);

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -91,7 +91,7 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
     this.structuredOutputOptions = options.structuredOutputOptions;
 
     // Initialize instructions after customPatterns is set
-    this.instructions = options.instructions || this.getDefaultInstructions();
+    this.instructions = options.instructions ?? this.getDefaultInstructions();
 
     // Store the model for lazy initialization
     this.model = options.model;


### PR DESCRIPTION
## Summary
- Preserve explicitly empty system prompt scrubber instructions
- Add a regression test for custom instruction handling

## Testing
- pnpm exec vitest run src/processors/processors/system-prompt-scrubber.test.ts
- pnpm --filter ./packages/core exec eslint src/processors/processors/system-prompt-scrubber.ts src/processors/processors/system-prompt-scrubber.test.ts
- pnpm --filter ./packages/core check
- pnpm --filter ./packages/core build:lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the system prompt scrubber respect an empty instruction string instead of silently swapping in a default one. In other words, if someone intentionally sets the instructions to be empty, the code now keeps it that way.

## Summary
- Updated `SystemPromptScrubber` to use nullish coalescing so `''` is preserved while `null`/`undefined` still fall back to default instructions.
- Added a regression test to confirm `instructions: ''` remains unchanged.
- Included a changeset noting the patch release and behavior fix for empty custom instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->