### PR TITLE
fix(core): preserve empty structured instructions

### DIFF
--- a/.changeset/empty-foxes-mix.md
+++ b/.changeset/empty-foxes-mix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed structured output processors so empty custom instructions are preserved.

--- a/packages/core/src/processors/processors/structured-output.test.ts
+++ b/packages/core/src/processors/processors/structured-output.test.ts
@@ -938,6 +938,17 @@ describe('StructuredOutputProcessor', () => {
       // The custom instructions should be used instead of generated ones
       expect(await agent.getInstructions()).toBe(customInstructions);
     });
+
+    it('should preserve empty custom instructions', async () => {
+      const customProcessor = new StructuredOutputProcessor({
+        schema: testSchema,
+        model: mockModel,
+        instructions: '',
+      });
+
+      const agent = (customProcessor as unknown as { structuringAgent: Agent }).structuringAgent;
+      expect(await agent.getInstructions()).toBe('');
+    });
   });
 
   describe('integration scenarios', () => {

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -75,7 +75,7 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
     this.jsonPromptInjection = options.jsonPromptInjection;
     this.providerOptions = options.providerOptions;
     this.logger = options.logger;
-    this.structuringInstructions = options.instructions || this.generateInstructions();
+    this.structuringInstructions = options.instructions ?? this.generateInstructions();
     // Create internal structuring agent as fallback (used when no explicit agent is set)
     this.structuringAgent = new Agent({
       id: 'structured-output-structurer',


### PR DESCRIPTION
## Summary
- Preserve explicitly empty structured output processor instructions
- Add a regression test for custom instruction handling

## Testing
- pnpm exec vitest run src/processors/processors/structured-output.test.ts
- pnpm --filter ./packages/core exec eslint src/processors/processors/structured-output.ts src/processors/processors/structured-output.test.ts
- pnpm --filter ./packages/core check
- pnpm --filter ./packages/core build:lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the code respect when someone explicitly sets instructions to an empty string instead of ignoring it and making up new ones. It also adds a test to make sure that special case keeps working.

## Summary
- Fixed `StructuredOutputProcessor` to use nullish coalescing so empty `instructions` are preserved.
- Added a regression test covering empty custom instructions.
- Included a changeset entry to publish a patch for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->