### PR TITLE
fix(core): preserve empty scrubber placeholder

### DIFF
--- a/.changeset/busy-experts-scream.md
+++ b/.changeset/busy-experts-scream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the system prompt scrubber so empty placeholder text is preserved.

--- a/packages/core/src/processors/processors/system-prompt-scrubber.test.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.test.ts
@@ -422,6 +422,15 @@ describe('SystemPromptScrubber', () => {
       expect(processor['placeholderText']).toBe('[CUSTOM_PLACEHOLDER]');
     });
 
+    it('should preserve empty placeholder text', async () => {
+      processor = new SystemPromptScrubber({
+        model: mockModel,
+        placeholderText: '',
+      });
+
+      expect(processor['placeholderText']).toBe('');
+    });
+
     it('should use custom instructions', async () => {
       const customInstructions = 'Custom detection instructions';
       processor = new SystemPromptScrubber({

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -86,7 +86,7 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
     this.customPatterns = options.customPatterns || [];
     this.includeDetections = options.includeDetections || false;
     this.redactionMethod = options.redactionMethod || 'mask';
-    this.placeholderText = options.placeholderText || '[SYSTEM_PROMPT]';
+    this.placeholderText = options.placeholderText ?? '[SYSTEM_PROMPT]';
     this.lastMessageOnly = options.lastMessageOnly ?? false;
     this.structuredOutputOptions = options.structuredOutputOptions;
 


### PR DESCRIPTION
## Description

Preserve an explicitly empty system prompt scrubber placeholder.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
