### PR TITLE
fix(cli): preserve empty studio api prefix

### DIFF
--- a/.changeset/itchy-wombats-enjoy.md
+++ b/.changeset/itchy-wombats-enjoy.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Studio configuration so an empty API prefix is preserved.

--- a/packages/cli/src/commands/studio/studio.test.ts
+++ b/packages/cli/src/commands/studio/studio.test.ts
@@ -28,6 +28,7 @@ function createStudioFixture() {
       window.MASTRA_ORGANIZATION_ID = '%%MASTRA_ORGANIZATION_ID%%';
       window.MASTRA_PLATFORM_PROJECT_ID = '%%MASTRA_PLATFORM_PROJECT_ID%%';
       window.MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT = '%%MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT%%';
+      window.MASTRA_API_PREFIX = '%%MASTRA_API_PREFIX%%';
     </script>
   </head>
   <body>studio</body>
@@ -110,6 +111,25 @@ describe('studio base path support', () => {
 
       expect(htmlResponse.status).toBe(200);
       expect(htmlResponse.body).toContain("window.MASTRA_TEMPLATES = 'true'");
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('preserves explicit empty API prefix configuration', async () => {
+    process.env.MASTRA_STUDIO_BASE_PATH = '/agents';
+    const studioDir = createStudioFixture();
+    const server = createServer(studioDir, { serverApiPrefix: '' }, '');
+
+    await new Promise<void>(resolve => server.listen(0, resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    try {
+      const htmlResponse = await request(`http://127.0.0.1:${port}/agents`);
+
+      expect(htmlResponse.status).toBe(200);
+      expect(htmlResponse.body).toContain("window.MASTRA_API_PREFIX = ''");
     } finally {
       await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
     }

--- a/packages/cli/src/commands/studio/studio.ts
+++ b/packages/cli/src/commands/studio/studio.ts
@@ -113,7 +113,7 @@ export const createServer = (builtStudioPath: string, options: StudioOptions, re
     .replaceAll('%%MASTRA_SERVER_HOST%%', options.serverHost || 'localhost')
     .replaceAll('%%MASTRA_SERVER_PORT%%', String(options.serverPort || 4111))
     .replaceAll('%%MASTRA_SERVER_PROTOCOL%%', options.serverProtocol || 'http')
-    .replaceAll('%%MASTRA_API_PREFIX%%', options.serverApiPrefix || '/api')
+    .replaceAll('%%MASTRA_API_PREFIX%%', options.serverApiPrefix ?? '/api')
     .replaceAll('%%MASTRA_EXPERIMENTAL_FEATURES%%', experimentalFeatures)
     .replaceAll('%%MASTRA_TEMPLATES%%', templatesEnabled)
     .replaceAll('%%MASTRA_CLOUD_API_ENDPOINT%%', '')


### PR DESCRIPTION
## Description

Preserve an explicitly empty Studio API prefix option.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
