### PR TITLE
fix(cli): preserve zero studio ports

### DIFF
--- a/.changeset/fine-geckos-talk.md
+++ b/.changeset/fine-geckos-talk.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Studio port configuration so explicit zero values are preserved.

--- a/packages/cli/src/commands/studio/studio.test.ts
+++ b/packages/cli/src/commands/studio/studio.test.ts
@@ -28,6 +28,7 @@ function createStudioFixture() {
       window.MASTRA_ORGANIZATION_ID = '%%MASTRA_ORGANIZATION_ID%%';
       window.MASTRA_PLATFORM_PROJECT_ID = '%%MASTRA_PLATFORM_PROJECT_ID%%';
       window.MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT = '%%MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT%%';
+      window.MASTRA_SERVER_PORT = '%%MASTRA_SERVER_PORT%%';
     </script>
   </head>
   <body>studio</body>
@@ -110,6 +111,25 @@ describe('studio base path support', () => {
 
       expect(htmlResponse.status).toBe(200);
       expect(htmlResponse.body).toContain("window.MASTRA_TEMPLATES = 'true'");
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('preserves explicit zero server port configuration', async () => {
+    process.env.MASTRA_STUDIO_BASE_PATH = '/agents';
+    const studioDir = createStudioFixture();
+    const server = createServer(studioDir, { serverPort: 0 }, '');
+
+    await new Promise<void>(resolve => server.listen(0, resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    try {
+      const htmlResponse = await request(`http://127.0.0.1:${port}/agents`);
+
+      expect(htmlResponse.status).toBe(200);
+      expect(htmlResponse.body).toContain("window.MASTRA_SERVER_PORT = '0'");
     } finally {
       await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
     }

--- a/packages/cli/src/commands/studio/studio.ts
+++ b/packages/cli/src/commands/studio/studio.ts
@@ -68,7 +68,7 @@ export async function studio(
       process.exit(1);
     }
 
-    const port = options.port || 3000;
+    const port = options.port ?? 3000;
 
     // Start the server using the installed serve binary
     // Start the server using node
@@ -111,7 +111,7 @@ export const createServer = (builtStudioPath: string, options: StudioOptions, re
   let html = readFileSync(indexHtmlPath, 'utf8')
     .replaceAll('%%MASTRA_STUDIO_BASE_PATH%%', basePath)
     .replaceAll('%%MASTRA_SERVER_HOST%%', options.serverHost || 'localhost')
-    .replaceAll('%%MASTRA_SERVER_PORT%%', String(options.serverPort || 4111))
+    .replaceAll('%%MASTRA_SERVER_PORT%%', String(options.serverPort ?? 4111))
     .replaceAll('%%MASTRA_SERVER_PROTOCOL%%', options.serverProtocol || 'http')
     .replaceAll('%%MASTRA_API_PREFIX%%', options.serverApiPrefix || '/api')
     .replaceAll('%%MASTRA_EXPERIMENTAL_FEATURES%%', experimentalFeatures)


### PR DESCRIPTION
## Description

Preserve explicit zero values for Studio port options.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
