### PR TITLE
fix(server): preserve zero search context ranges

### DIFF
--- a/.changeset/nine-bobcats-like.md
+++ b/.changeset/nine-bobcats-like.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed memory search so zero semantic recall context ranges do not include neighboring messages.

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -1131,6 +1131,80 @@ describe('Memory Handlers', () => {
   });
 
   describe('searchMemoryHandler', () => {
+    it('should preserve zero semantic recall context ranges', async () => {
+      const threadId = 'test-thread';
+      const resourceId = 'test-resource';
+      await mockMemory.createThread({ threadId, resourceId, title: 'Test Thread' });
+      await mockMemory.saveMessages({
+        messages: [
+          {
+            id: 'before-msg',
+            content: 'before content',
+            role: 'user',
+            type: 'text',
+            createdAt: new Date('2025-01-01T00:00:00Z'),
+            threadId,
+            resourceId,
+          },
+          {
+            id: 'match-msg',
+            content: 'needle content',
+            role: 'assistant',
+            type: 'text',
+            createdAt: new Date('2025-01-01T00:01:00Z'),
+            threadId,
+            resourceId,
+          },
+          {
+            id: 'after-msg',
+            content: 'after content',
+            role: 'user',
+            type: 'text',
+            createdAt: new Date('2025-01-01T00:02:00Z'),
+            threadId,
+            resourceId,
+          },
+        ] as MastraDBMessage[],
+        memoryConfig: {},
+      });
+
+      const mastra = new Mastra({
+        logger: false,
+        agents: {
+          'test-agent': mockAgent,
+        },
+        storage,
+      });
+
+      const result = await SEARCH_MEMORY_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        agentId: 'test-agent',
+        resourceId,
+        threadId,
+        searchQuery: 'needle',
+        memoryConfig: {
+          semanticRecall: {
+            topK: 1,
+            scope: 'thread',
+            messageRange: {
+              before: 0,
+              after: 0,
+            },
+          },
+        },
+        limit: 20,
+      });
+
+      const matchResult = result.results.find(result => result.id === 'match-msg');
+      expect(matchResult).toMatchObject({
+        id: 'match-msg',
+        context: {
+          before: [],
+          after: [],
+        },
+      });
+    });
+
     it('should filter resource-scoped search results to FGA-accessible threads', async () => {
       await mockMemory.createThread({ threadId: 'allowed-thread', resourceId: 'test-resource', title: 'Allowed' });
       await mockMemory.createThread({ threadId: 'blocked-thread', resourceId: 'test-resource', title: 'Blocked' });

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -1924,13 +1924,13 @@ export const SEARCH_MEMORY_ROUTE = createRoute({
           ? 2
           : typeof config.semanticRecall?.messageRange === `number`
             ? config.semanticRecall.messageRange
-            : config.semanticRecall?.messageRange.before || 2;
+            : config.semanticRecall?.messageRange.before ?? 2;
       const afterRange =
         typeof config.semanticRecall === `boolean`
           ? 2
           : typeof config.semanticRecall?.messageRange === `number`
             ? config.semanticRecall.messageRange
-            : config.semanticRecall?.messageRange.after || 2;
+            : config.semanticRecall?.messageRange.after ?? 2;
 
       if (resourceScope && config.semanticRecall) {
         config.semanticRecall =


### PR DESCRIPTION
## Description

Preserve explicit zero context range values in server search handling.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
