### PR TITLE
fix(evals): preserve zero hallucination scale

### DIFF
--- a/.changeset/shaggy-mice-beam.md
+++ b/.changeset/shaggy-mice-beam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed hallucination scorer scaling so scale 0 is preserved.

--- a/packages/evals/src/scorers/llm/hallucination/index.test.ts
+++ b/packages/evals/src/scorers/llm/hallucination/index.test.ts
@@ -474,5 +474,26 @@ describe('HallucinationMetric', () => {
       // With empty context, factual claims are considered hallucinations
       expect(result.score).toBe(testCase.expectedResult.score);
     });
+
+    it('should preserve scale 0 when generating scores', () => {
+      const zeroScaleScorer = createHallucinationScorer({ model, options: { context: ['Supported fact'], scale: 0 } });
+      const generateScoreStep = zeroScaleScorer['steps'].find(step => step.name === 'generateScore');
+
+      const score = generateScoreStep?.definition?.({
+        results: {
+          analyzeStepResult: {
+            verdicts: [
+              {
+                statement: 'Unsupported claim',
+                verdict: 'yes',
+                reason: 'Contradicted by context',
+              },
+            ],
+          },
+        },
+      } as any);
+
+      expect(score).toBe(0);
+    });
   });
 });

--- a/packages/evals/src/scorers/llm/hallucination/index.ts
+++ b/packages/evals/src/scorers/llm/hallucination/index.ts
@@ -95,7 +95,7 @@ export function createHallucinationScorer({
         return 0;
       }
 
-      const score = (contradictedStatements / totalStatements) * (options?.scale || 1);
+      const score = (contradictedStatements / totalStatements) * (options?.scale ?? 1);
 
       return roundToTwoDecimals(score);
     })
@@ -114,7 +114,7 @@ export function createHallucinationScorer({
           output: getAssistantMessageFromRunOutput(run.output) ?? '',
           context,
           score,
-          scale: options?.scale || 1,
+          scale: options?.scale ?? 1,
           verdicts: results.analyzeStepResult?.verdicts || [],
         });
         return prompt;


### PR DESCRIPTION
## Description

Preserve an explicitly configured zero scale in hallucination scoring.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
