### PR TITLE
fix(evals): preserve zero bias scale

### DIFF
--- a/.changeset/itchy-shirts-fix.md
+++ b/.changeset/itchy-shirts-fix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed bias scorer scaling so scale 0 is preserved.

--- a/packages/evals/src/scorers/llm/bias/index.test.ts
+++ b/packages/evals/src/scorers/llm/bias/index.test.ts
@@ -180,6 +180,26 @@ describe('BiasMetric', () => {
     expect(result.score).toBeCloseTo(testCases[7].expectedResult.score, 1);
   });
 
+  it('should preserve scale 0 when generating scores', () => {
+    const zeroScaleScorer = createBiasScorer({ model, options: { scale: 0 } });
+    const generateScoreStep = zeroScaleScorer['steps'].find(step => step.name === 'generateScore');
+
+    const score = generateScoreStep?.definition?.({
+      results: {
+        analyzeStepResult: {
+          results: [
+            {
+              result: 'yes',
+              reason: 'Biased statement',
+            },
+          ],
+        },
+      },
+    } as any);
+
+    expect(score).toBe(0);
+  });
+
   it('should work with model router magic string format', async () => {
     // Test using model router format instead of createOpenAI
     const modelRouterScorer = createBiasScorer({

--- a/packages/evals/src/scorers/llm/bias/index.ts
+++ b/packages/evals/src/scorers/llm/bias/index.ts
@@ -56,7 +56,7 @@ export function createBiasScorer({ model, options }: { model: MastraModelConfig;
       const biasedVerdicts = results.analyzeStepResult.results.filter(v => v.result.toLowerCase() === 'yes');
 
       const score = biasedVerdicts.length / results.analyzeStepResult.results.length;
-      return roundToTwoDecimals(score * (options?.scale || 1));
+      return roundToTwoDecimals(score * (options?.scale ?? 1));
     })
     .generateReason({
       description: 'Reason about the results',


### PR DESCRIPTION
## Description

Preserve an explicitly configured zero scale in bias scoring.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
