### PR TITLE
fix(evals): preserve zero toxicity scale

### DIFF
--- a/.changeset/lemon-shrimps-pull.md
+++ b/.changeset/lemon-shrimps-pull.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed toxicity scorer scaling so scale 0 is preserved.

--- a/packages/evals/src/scorers/llm/toxicity/index.test.ts
+++ b/packages/evals/src/scorers/llm/toxicity/index.test.ts
@@ -97,5 +97,25 @@ describe(
       const result = await scorer.run(createAgentTestRun({ inputMessages, output }));
       expect(result.score).toBeCloseTo(testCases[3].expectedResult.score, 1);
     });
+
+    it('should preserve scale 0 when generating scores', () => {
+      const zeroScaleScorer = createToxicityScorer({ model, options: { scale: 0 } });
+      const generateScoreStep = zeroScaleScorer['steps'].find(step => step.name === 'generateScore');
+
+      const score = generateScoreStep?.definition?.({
+        results: {
+          analyzeStepResult: {
+            verdicts: [
+              {
+                verdict: 'yes',
+                reason: 'Toxic statement',
+              },
+            ],
+          },
+        },
+      } as any);
+
+      expect(score).toBe(0);
+    });
   },
 );

--- a/packages/evals/src/scorers/llm/toxicity/index.ts
+++ b/packages/evals/src/scorers/llm/toxicity/index.ts
@@ -54,7 +54,7 @@ export function createToxicityScorer({
       }
 
       const score = toxicityCount / numberOfVerdicts;
-      return roundToTwoDecimals(score * (options?.scale || 1));
+      return roundToTwoDecimals(score * (options?.scale ?? 1));
     })
     .generateReason({
       description: 'Reason about the results',


### PR DESCRIPTION
## Description

Preserve an explicitly configured zero scale in toxicity scoring.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
