### PR TITLE
fix(evals): preserve zero context precision scale

### DIFF
--- a/.changeset/green-candles-mix.md
+++ b/.changeset/green-candles-mix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed context precision scorer scaling so scale 0 is preserved.

--- a/packages/evals/src/scorers/llm/context-precision/index.test.ts
+++ b/packages/evals/src/scorers/llm/context-precision/index.test.ts
@@ -266,6 +266,33 @@ describe('createContextPrecisionScorer', () => {
     expect(result.score).toBe(10.0); // Perfect score with scale 10
   });
 
+  it('should preserve scale 0 when generating scores', () => {
+    const scorer = createContextPrecisionScorer({
+      model: mockModel,
+      options: {
+        context: ['Photosynthesis converts sunlight to energy.'],
+        scale: 0,
+      },
+    });
+    const generateScoreStep = scorer['steps'].find(step => step.name === 'generateScore');
+
+    const score = generateScoreStep?.definition?.({
+      results: {
+        analyzeStepResult: {
+          verdicts: [
+            {
+              context_index: 0,
+              verdict: 'yes',
+              reason: 'Relevant',
+            },
+          ],
+        },
+      },
+    } as any);
+
+    expect(score).toBe(0);
+  });
+
   it('should handle empty analyze results', async () => {
     const scorer = createContextPrecisionScorer({
       model: mockModel,

--- a/packages/evals/src/scorers/llm/context-precision/index.ts
+++ b/packages/evals/src/scorers/llm/context-precision/index.ts
@@ -130,7 +130,7 @@ export function createContextPrecisionScorer({
 
       // Mean Average Precision = sum_of_precisions / total_relevant_items
       const map = sumPrecision / relevantCount;
-      const score = map * (options.scale || 1);
+      const score = map * (options.scale ?? 1);
 
       return roundToTwoDecimals(score);
     })
@@ -148,7 +148,7 @@ export function createContextPrecisionScorer({
           output,
           context,
           score,
-          scale: options.scale || 1,
+          scale: options.scale ?? 1,
           verdicts: (results.analyzeStepResult?.verdicts || []) as {
             context_index: number;
             verdict: string;


### PR DESCRIPTION
## Description

Preserve an explicitly configured zero scale in context precision scoring.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
