### PR TITLE
fix(evals): preserve zero prompt alignment scale

### DIFF
--- a/.changeset/nine-cities-double.md
+++ b/.changeset/nine-cities-double.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed prompt alignment scorer scaling so scale 0 is preserved.

--- a/packages/evals/src/scorers/llm/prompt-alignment/index.test.ts
+++ b/packages/evals/src/scorers/llm/prompt-alignment/index.test.ts
@@ -114,6 +114,45 @@ describe('Prompt Alignment Scorer', () => {
       // The scale is applied internally in the generateScore function
     });
 
+    it('should preserve scale 0 when generating scores', () => {
+      const scorer = createPromptAlignmentScorerLLM({
+        model: mockModel,
+        options: { scale: 0 },
+      });
+      const generateScoreStep = scorer['steps'].find(step => step.name === 'generateScore');
+
+      const score = generateScoreStep?.definition?.({
+        results: {
+          analyzeStepResult: {
+            intentAlignment: {
+              score: 1,
+              primaryIntent: 'Answer the question',
+              isAddressed: true,
+              reasoning: 'Fully addressed',
+            },
+            requirementsFulfillment: {
+              requirements: [],
+              overallScore: 1,
+            },
+            completeness: {
+              score: 1,
+              missingElements: [],
+              reasoning: 'Complete',
+            },
+            responseAppropriateness: {
+              score: 1,
+              formatAlignment: true,
+              toneAlignment: true,
+              reasoning: 'Appropriate',
+            },
+            overallAssessment: 'Fully aligned',
+          },
+        },
+      } as any);
+
+      expect(score).toBe(0);
+    });
+
     it('should work with default scale', () => {
       const scorer = createPromptAlignmentScorerLLM({
         model: mockModel,

--- a/packages/evals/src/scorers/llm/prompt-alignment/index.ts
+++ b/packages/evals/src/scorers/llm/prompt-alignment/index.ts
@@ -78,7 +78,7 @@ export function createPromptAlignmentScorerLLM({
   model: MastraModelConfig;
   options?: PromptAlignmentOptions;
 }) {
-  const scale = options?.scale || 1;
+  const scale = options?.scale ?? 1;
   const evaluationMode = options?.evaluationMode || 'both';
 
   return createScorer<ScorerRunInputForLLMJudge, ScorerRunOutputForLLMJudge>({


### PR DESCRIPTION
## Description

Preserve an explicitly configured zero scale in prompt alignment scoring.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
