### PR TITLE
fix(loggers): allow disabling upstash trim

### DIFF
--- a/.changeset/brave-yaks-work.md
+++ b/.changeset/brave-yaks-work.md
@@ -1,0 +1,5 @@
+---
+'@mastra/loggers': patch
+---
+
+Fixed Upstash logger maxListLength so setting it to 0 disables log trimming.

--- a/packages/loggers/src/upstash/index.test.ts
+++ b/packages/loggers/src/upstash/index.test.ts
@@ -91,6 +91,29 @@ describe('UpstashTransport', () => {
     });
   });
 
+  it('should allow disabling log trimming with maxListLength 0', async () => {
+    const noTrimTransport = new UpstashTransport({
+      ...defaultOptions,
+      maxListLength: 0,
+    });
+    const logger = new PinoLogger({
+      name: 'test-logger',
+      level: LogLevel.INFO,
+      transports: {
+        upstash: noTrimTransport,
+      },
+    });
+
+    logger.info('message without trim');
+    await noTrimTransport._flush();
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(noTrimTransport.maxListLength).toBe(0);
+    expect(body[0]).not.toContain('LTRIM');
+
+    noTrimTransport._destroy(new Error('test'), () => {});
+  });
+
   it('should properly clean up resources on destroy', () => {
     const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
     const flushSpy = vi.spyOn(transport, '_flush').mockImplementation(() => Promise.resolve());

--- a/packages/loggers/src/upstash/index.ts
+++ b/packages/loggers/src/upstash/index.ts
@@ -29,7 +29,7 @@ export class UpstashTransport extends LoggerTransport {
     this.upstashUrl = opts.upstashUrl;
     this.upstashToken = opts.upstashToken;
     this.listName = opts.listName || 'application-logs';
-    this.maxListLength = opts.maxListLength || 10000;
+    this.maxListLength = opts.maxListLength ?? 10000;
     this.batchSize = opts.batchSize || 100;
     this.flushInterval = opts.flushInterval || 10000;
 


### PR DESCRIPTION
## Description

Allow Upstash log trimming to be explicitly disabled.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
