### PR TITLE
fix(loggers): preserve http retry options

### DIFF
--- a/.changeset/ready-planets-see.md
+++ b/.changeset/ready-planets-see.md
@@ -1,0 +1,5 @@
+---
+'@mastra/loggers': patch
+---
+
+Fixed HTTP logger retry options so explicit zero retries, zero delay, and disabled backoff are preserved.

--- a/packages/loggers/src/http/index.test.ts
+++ b/packages/loggers/src/http/index.test.ts
@@ -60,6 +60,23 @@ describe('HttpTransport', () => {
       expect(minimalTransport['flushInterval']).toBe(10000);
       expect(minimalTransport['timeout']).toBe(30000);
     });
+
+    it('should preserve explicit retry option falsy values', () => {
+      const noRetryTransport = new HttpTransport({
+        url: 'https://example.com',
+        retryOptions: {
+          maxRetries: 0,
+          retryDelay: 0,
+          exponentialBackoff: false,
+        },
+      });
+
+      expect(noRetryTransport['retryOptions']).toEqual({
+        maxRetries: 0,
+        retryDelay: 0,
+        exponentialBackoff: false,
+      });
+    });
   });
 
   describe('logging functionality', () => {

--- a/packages/loggers/src/http/index.ts
+++ b/packages/loggers/src/http/index.ts
@@ -46,9 +46,9 @@ export class HttpTransport extends LoggerTransport {
     this.flushInterval = options.flushInterval || 10000;
     this.timeout = options.timeout || 30000;
     this.retryOptions = {
-      maxRetries: options.retryOptions?.maxRetries || 3,
-      retryDelay: options.retryOptions?.retryDelay || 1000,
-      exponentialBackoff: options.retryOptions?.exponentialBackoff || true,
+      maxRetries: options.retryOptions?.maxRetries ?? 3,
+      retryDelay: options.retryOptions?.retryDelay ?? 1000,
+      exponentialBackoff: options.retryOptions?.exponentialBackoff ?? true,
     };
 
     this.logBuffer = [];


### PR DESCRIPTION
## Description

Preserve explicit retry option values in the HTTP transport.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
