### PR TITLE
fix(loggers): send upstash trim as pipeline command

### DIFF
--- a/.changeset/plain-carpets-thank.md
+++ b/.changeset/plain-carpets-thank.md
@@ -1,0 +1,5 @@
+---
+'@mastra/loggers': patch
+---
+
+Fixed Upstash log trimming so log retention runs as a separate pipeline command.

--- a/packages/loggers/src/upstash/index.test.ts
+++ b/packages/loggers/src/upstash/index.test.ts
@@ -91,6 +91,26 @@ describe('UpstashTransport', () => {
     });
   });
 
+  it('should trim logs as a separate pipeline command', async () => {
+    const logger = new PinoLogger({
+      name: 'test-logger',
+      level: LogLevel.INFO,
+      transports: {
+        upstash: transport,
+      },
+    });
+
+    logger.info('message to trim');
+    await transport._flush();
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+    expect(body).toHaveLength(2);
+    expect(body[0][0]).toBe('LPUSH');
+    expect(body[0]).not.toContain('LTRIM');
+    expect(body[1]).toEqual(['LTRIM', defaultOptions.listName, 0, defaultOptions.maxListLength - 1]);
+  });
+
   it('should properly clean up resources on destroy', () => {
     const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
     const flushSpy = vi.spyOn(transport, '_flush').mockImplementation(() => Promise.resolve());

--- a/packages/loggers/src/upstash/index.ts
+++ b/packages/loggers/src/upstash/index.ts
@@ -44,14 +44,14 @@ export class UpstashTransport extends LoggerTransport {
     }, this.flushInterval);
   }
 
-  private async executeUpstashCommand(command: any[]): Promise<any> {
+  private async executeUpstashCommands(commands: any[][]): Promise<any> {
     const response = await fetch(`${this.upstashUrl}/pipeline`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${this.upstashToken}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify([command]),
+      body: JSON.stringify(commands),
     });
 
     if (!response.ok) {
@@ -59,6 +59,10 @@ export class UpstashTransport extends LoggerTransport {
     }
 
     return response.json();
+  }
+
+  private async executeUpstashCommand(command: any[]): Promise<any> {
+    return this.executeUpstashCommands([command]);
   }
 
   async _flush() {
@@ -71,15 +75,15 @@ export class UpstashTransport extends LoggerTransport {
 
     try {
       // Prepare the Upstash Redis command
-      const command = ['LPUSH', this.listName, ...logs.map(log => JSON.stringify(log))];
+      const commands: any[][] = [['LPUSH', this.listName, ...logs.map(log => JSON.stringify(log))]];
 
       // Trim the list if it exceeds maxListLength
       if (this.maxListLength > 0) {
-        command.push('LTRIM', this.listName, 0 as any, (this.maxListLength - 1) as any);
+        commands.push(['LTRIM', this.listName, 0, this.maxListLength - 1]);
       }
 
       // Send logs to Upstash Redis
-      await this.executeUpstashCommand(command);
+      await this.executeUpstashCommands(commands);
       this.lastFlush = now;
     } catch (error) {
       // On error, put logs back in the buffer


### PR DESCRIPTION
## Description

Send Upstash trim through the same pipeline command flow as log writes.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
