### PR TITLE
fix(loggers): search all file logs by run id

### DIFF
--- a/.changeset/clear-peas-yell.md
+++ b/.changeset/clear-peas-yell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/loggers': patch
+---
+
+Fixed file logger run ID lookups so they search all matching logs before applying pagination.

--- a/packages/loggers/src/file/index.test.ts
+++ b/packages/loggers/src/file/index.test.ts
@@ -136,5 +136,23 @@ describe('FileTransport', () => {
       logs = await fileLogger.listLogsByRunId({ runId: 'test-run-id' });
       expect(logs.total).toBe(1);
     });
+
+    it('should find logs by runId beyond the first listLogs page', async () => {
+      const logLines = Array.from({ length: 120 }, (_, index) =>
+        JSON.stringify({
+          level: LogLevel.INFO,
+          msg: `message-${index}`,
+          runId: index >= 110 ? 'target-run-id' : 'other-run-id',
+          time: Date.now() + index,
+        }),
+      );
+      fs.writeFileSync(testPath, `${logLines.join('\n')}\n`);
+
+      const logs = await fileLogger.listLogsByRunId({ runId: 'target-run-id' });
+
+      expect(logs.total).toBe(10);
+      expect(logs.logs).toHaveLength(10);
+      expect(logs.logs.every(log => log.runId === 'target-run-id')).toBe(true);
+    });
   });
 });

--- a/packages/loggers/src/file/index.ts
+++ b/packages/loggers/src/file/index.ts
@@ -171,7 +171,7 @@ export class FileTransport extends LoggerTransport {
     try {
       const page = pageInput === 0 ? 1 : (pageInput ?? 1);
       const perPage = perPageInput ?? 100;
-      const allLogs = await this.listLogs({ fromDate, toDate, logLevel, filters });
+      const allLogs = await this.listLogs({ fromDate, toDate, logLevel, filters, returnPaginationResults: false });
       const logs = (allLogs?.logs?.filter(log => log?.runId === runId) || []) as BaseLogMessage[];
       const total = logs.length;
       const resolvedPerPage = perPage || 100;


### PR DESCRIPTION
## Description

Search paginated file logger results when filtering by run id.

## Related issue(s)

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
