### PR TITLE
fix(core): preserve batched non-text stream parts

### DIFF
--- a/.changeset/modern-dogs-relate.md
+++ b/.changeset/modern-dogs-relate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed batch parts processing so non-text stream parts are preserved when mixed batches are flushed.

--- a/packages/core/src/processors/processors/batch-parts.test.ts
+++ b/packages/core/src/processors/processors/batch-parts.test.ts
@@ -268,6 +268,65 @@ describe('BatchPartsProcessor', () => {
       expect(result).toBeNull();
     });
 
+    it('preserves non-text parts when flushing mixed batches with emitOnNonText false', async () => {
+      processor = new BatchPartsProcessor({ batchSize: 10, emitOnNonText: false });
+
+      const textChunk1: ChunkType = {
+        type: 'text-delta',
+        payload: { text: 'Hello', id: 'text-1' },
+        runId: '1',
+        from: ChunkFrom.AGENT,
+      };
+      const objectChunk: ChunkType = { type: 'object', object: { key: 'value' }, runId: '1', from: ChunkFrom.AGENT };
+      const textChunk2: ChunkType = {
+        type: 'text-delta',
+        payload: { text: ' world', id: 'text-1' },
+        runId: '1',
+        from: ChunkFrom.AGENT,
+      };
+      const state: BatchPartsState = { batch: [], timeoutId: undefined, timeoutTriggered: false };
+
+      await processor.processOutputStream({
+        part: textChunk1,
+        streamParts: [textChunk1],
+        state,
+        abort: () => {
+          throw new Error('abort');
+        },
+      });
+      await processor.processOutputStream({
+        part: objectChunk,
+        streamParts: [textChunk1, objectChunk],
+        state,
+        abort: () => {
+          throw new Error('abort');
+        },
+      });
+      await processor.processOutputStream({
+        part: textChunk2,
+        streamParts: [textChunk1, objectChunk, textChunk2],
+        state,
+        abort: () => {
+          throw new Error('abort');
+        },
+      });
+
+      expect(processor.flush(state)).toEqual({
+        type: 'text-delta',
+        runId: '1',
+        from: ChunkFrom.AGENT,
+        payload: { text: 'Hello', id: 'text-1' },
+      });
+      expect(processor.flush(state)).toEqual(objectChunk);
+      expect(processor.flush(state)).toEqual({
+        type: 'text-delta',
+        runId: '1',
+        from: ChunkFrom.AGENT,
+        payload: { text: ' world', id: 'text-1' },
+      });
+      expect(processor.flush(state)).toBeNull();
+    });
+
     it('should handle mixed text and non-text chunks correctly', async () => {
       processor = new BatchPartsProcessor({ batchSize: 3 });
 

--- a/packages/core/src/processors/processors/batch-parts.ts
+++ b/packages/core/src/processors/processors/batch-parts.ts
@@ -145,33 +145,35 @@ export class BatchPartsProcessor implements Processor<'batch-parts'> {
       return part || null;
     }
 
-    // Combine multiple text chunks into a single text part
-    const textChunks = state.batch.filter((part: ChunkType) => part.type === 'text-delta') as ChunkType[];
-
-    if (textChunks.length > 0) {
-      // Combine all text deltas
-      const combinedText = textChunks.map(part => (part.type === 'text-delta' ? part.payload.text : '')).join('');
-
-      // Create a new combined text part, preserving id and runId from the first chunk
-      const firstChunk = textChunks[0] as ChunkType & { type: 'text-delta' };
-      const combinedChunk: ChunkType = {
-        type: 'text-delta',
-        payload: { text: combinedText, id: firstChunk.payload.id },
-        runId: firstChunk.runId,
-        from: ChunkFrom.AGENT,
-      };
-
-      // Clear the batch completely - non-text chunks should be handled by the main logic
-      // when they arrive, not accumulated here
-      state.batch = [];
-
-      return combinedChunk;
-    } else {
-      // If no text chunks, return the first non-text part
-      const part = state.batch[0];
+    const firstPart = state.batch[0];
+    if (firstPart?.type !== 'text-delta') {
       state.batch = state.batch.slice(1);
-      return part || null;
+      return firstPart;
     }
+
+    const textChunks: Extract<ChunkType, { type: 'text-delta' }>[] = [];
+    for (const part of state.batch) {
+      if (part.type !== 'text-delta') {
+        break;
+      }
+      textChunks.push(part);
+    }
+
+    const combinedText = textChunks.map(part => part.payload.text).join('');
+    const firstChunk = textChunks[0];
+    if (!firstChunk) {
+      return null;
+    }
+
+    const combinedChunk: ChunkType = {
+      type: 'text-delta',
+      payload: { text: combinedText, id: firstChunk.payload.id },
+      runId: firstChunk.runId,
+      from: ChunkFrom.AGENT,
+    };
+
+    state.batch = state.batch.slice(textChunks.length);
+    return combinedChunk;
   }
 
   /**


### PR DESCRIPTION
Fixes #18560.

This keeps BatchPartsProcessor from dropping non-text parts when emitOnNonText is false and a mixed batch is flushed. The flush path now emits leading text deltas as one chunk, then leaves later non-text and text parts queued for the next flush.

Tested with:

pnpm --filter ./packages/core test src/processors/processors/batch-parts.test.ts
