### PR TITLE
fix(core): stream array json incrementally

### DIFF
--- a/.changeset/brown-moles-speak.md
+++ b/.changeset/brown-moles-speak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed array text streams so progressive object chunks always produce valid JSON.

--- a/packages/core/src/stream/base/output-format-handlers.test.ts
+++ b/packages/core/src/stream/base/output-format-handlers.test.ts
@@ -6,7 +6,11 @@ import { z } from 'zod/v4';
 import type { PublicSchema } from '../../schema';
 import type { ChunkType } from '../types';
 import { ChunkFrom } from '../types';
-import { createObjectStreamTransformer, escapeUnescapedControlCharsInJsonStrings } from './output-format-handlers';
+import {
+  createJsonTextStreamTransformer,
+  createObjectStreamTransformer,
+  escapeUnescapedControlCharsInJsonStrings,
+} from './output-format-handlers';
 
 describe('escapeUnescapedControlCharsInJsonStrings', () => {
   it('should escape newlines inside JSON strings', () => {
@@ -92,6 +96,61 @@ continued", "item2"]}`;
 });
 
 describe('output-format-handlers', () => {
+  describe('createJsonTextStreamTransformer', () => {
+    const schema = z.array(z.object({ id: z.number() }));
+
+    async function readJsonText(chunks: ChunkType<typeof schema>[]) {
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream(chunks).pipeThrough(createJsonTextStreamTransformer(schema));
+      return (await convertAsyncIterableToArray(stream)).join('');
+    }
+
+    it('emits valid JSON when the first array object chunk already contains elements', async () => {
+      const output = await readJsonText([
+        { type: 'object', object: [{ id: 1 }], runId: 'test-run', from: ChunkFrom.AGENT },
+        {
+          type: 'object',
+          object: [{ id: 1 }, { id: 2 }],
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+        },
+        {
+          type: 'object',
+          object: [{ id: 1 }, { id: 2 }, { id: 3 }],
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+        },
+      ]);
+
+      expect(output).toBe('[{"id":1},{"id":2},{"id":3}]');
+      expect(JSON.parse(output)).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    });
+
+    it('emits valid JSON when the first array object chunk is empty', async () => {
+      const output = await readJsonText([
+        { type: 'object', object: [], runId: 'test-run', from: ChunkFrom.AGENT },
+        { type: 'object', object: [{ id: 1 }], runId: 'test-run', from: ChunkFrom.AGENT },
+      ]);
+
+      expect(output).toBe('[{"id":1}]');
+      expect(JSON.parse(output)).toEqual([{ id: 1 }]);
+    });
+
+    it('emits valid JSON for a single array object chunk', async () => {
+      const output = await readJsonText([
+        {
+          type: 'object',
+          object: [{ id: 1 }, { id: 2 }],
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+        },
+      ]);
+
+      expect(output).toBe('[{"id":1},{"id":2}]');
+      expect(JSON.parse(output)).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+  });
+
   describe('schema validation', () => {
     it('should validate against zod schema and provide detailed error messages', async () => {
       const schema = z.object({

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -718,19 +718,6 @@ export function createJsonTextStreamTransformer<OUTPUT = undefined>(schema?: Sta
       if (outputSchema?.outputFormat === 'array' && Array.isArray(chunk.object)) {
         chunkCount++;
 
-        // If this is the first chunk, decide between complete vs incremental streaming
-        if (chunkCount === 1) {
-          // If the first chunk already has multiple elements or is complete,
-          // emit as single JSON string
-          if (chunk.object.length > 0) {
-            controller.enqueue(JSON.stringify(chunk.object));
-            previousArrayLength = chunk.object.length;
-            hasStartedArray = true;
-            return;
-          }
-        }
-
-        // Incremental streaming mode (multiple chunks)
         if (!hasStartedArray) {
           controller.enqueue('[');
           hasStartedArray = true;
@@ -753,7 +740,7 @@ export function createJsonTextStreamTransformer<OUTPUT = undefined>(schema?: Sta
     },
     flush(controller) {
       // Close the array when the stream ends (only for incremental streaming)
-      if (hasStartedArray && outputSchema?.outputFormat === 'array' && chunkCount > 1) {
+      if (hasStartedArray && outputSchema?.outputFormat === 'array') {
         controller.enqueue(']');
       }
     },


### PR DESCRIPTION
Fixes #18758.

This removes the first-chunk fast path for array JSON text streams so progressive object chunks always emit one valid JSON array. It covers non-empty first chunks, empty first chunks, and single-chunk arrays.

Tested with:

pnpm --filter ./packages/core test src/stream/base/output-format-handlers.test.ts
