### PR TITLE
fix(core): handle leading step start in model content

### DIFF
--- a/.changeset/orange-moles-reply.md
+++ b/.changeset/orange-moles-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed step-specific model content so leading step-start markers do not shift numbered steps.

--- a/packages/core/src/agent/message-list/conversion/step-content.test.ts
+++ b/packages/core/src/agent/message-list/conversion/step-content.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { StepContentExtractor } from './step-content';
+
+describe('StepContentExtractor', () => {
+  const stepContentFn = (message?: { content?: unknown }) =>
+    Array.isArray(message?.content) ? message.content : message?.content ? [message.content] : [];
+
+  it('returns first step content when the message starts with a step-start marker', () => {
+    const uiMessages = [
+      {
+        id: 'msg-1',
+        role: 'assistant' as const,
+        parts: [{ type: 'step-start' as const }, { type: 'text' as const, text: 'Only step' }],
+      },
+    ];
+
+    expect(StepContentExtractor.extractStepContent(uiMessages, 1, stepContentFn)).toEqual([
+      { type: 'text', text: 'Only step' },
+    ]);
+    expect(StepContentExtractor.extractStepContent(uiMessages, 1, stepContentFn)).toEqual(
+      StepContentExtractor.extractStepContent(uiMessages, -1, stepContentFn),
+    );
+  });
+
+  it('does not shift numbered steps when the first part is step-start', () => {
+    const uiMessages = [
+      {
+        id: 'msg-1',
+        role: 'assistant' as const,
+        parts: [
+          { type: 'step-start' as const },
+          { type: 'text' as const, text: 'Step one' },
+          { type: 'step-start' as const },
+          { type: 'text' as const, text: 'Step two' },
+        ],
+      },
+    ];
+
+    expect(StepContentExtractor.extractStepContent(uiMessages, 1, stepContentFn)).toEqual([
+      { type: 'text', text: 'Step one' },
+    ]);
+    expect(StepContentExtractor.extractStepContent(uiMessages, 2, stepContentFn)).toEqual([
+      { type: 'text', text: 'Step two' },
+    ]);
+    expect(StepContentExtractor.extractStepContent(uiMessages, -1, stepContentFn)).toEqual([
+      { type: 'text', text: 'Step two' },
+    ]);
+  });
+});

--- a/packages/core/src/agent/message-list/conversion/step-content.ts
+++ b/packages/core/src/agent/message-list/conversion/step-content.ts
@@ -39,6 +39,9 @@ export class StepContentExtractor {
         stepBoundaries.push(index);
       }
     });
+    if (stepBoundaries[0] === 0) {
+      stepBoundaries.shift();
+    }
 
     // Handle -1 to get the last step (the current/most recent step)
     if (stepNumber === -1) {


### PR DESCRIPTION
Fixes #18774.

This treats a leading step-start marker as the prefix for step 1 instead of a separator before step 1, so modelContent(1) and later numbered steps are no longer shifted.

Tested with:

pnpm --filter ./packages/core test src/agent/message-list/conversion/step-content.test.ts
