### PR TITLE
fix(cli): report zero duration analytics

### DIFF
--- a/.changeset/fine-cloths-tell.md
+++ b/.changeset/fine-cloths-tell.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed CLI analytics so zero millisecond command durations are reported.

--- a/packages/cli/src/analytics/__tests__/index.test.ts
+++ b/packages/cli/src/analytics/__tests__/index.test.ts
@@ -18,6 +18,7 @@ vi.mock('posthog-node', () => ({
   }),
 }));
 
+import { PostHog } from 'posthog-node';
 import { PosthogAnalytics } from '../index.js';
 
 afterEach(() => {
@@ -85,6 +86,34 @@ describe('PosthogAnalytics distinct ids', () => {
       expect(config.distinctId).toBe(distinctId);
       expect(config.sessionId).toMatch(/^[0-9a-f-]{36}$/);
       expect((analytics as unknown as { sessionId: string }).sessionId).toBe(config.sessionId);
+    });
+  });
+});
+
+describe('PosthogAnalytics command tracking', () => {
+  it('includes zero duration command events', () => {
+    withTempAnalyticsConfig(() => {
+      const analytics = new PosthogAnalytics({
+        version: 'test-version',
+        apiKey: 'test-key',
+        host: 'https://posthog.test',
+      });
+      const client = vi.mocked(PostHog).mock.results.at(-1)?.value as { capture: ReturnType<typeof vi.fn> };
+
+      analytics.trackCommand({
+        command: 'test-command',
+        durationMs: 0,
+      });
+
+      expect(client.capture).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          event: 'cli_command',
+          properties: expect.objectContaining({
+            command: 'test-command',
+            durationMs: 0,
+          }),
+        }),
+      );
     });
   });
 });

--- a/packages/cli/src/analytics/index.ts
+++ b/packages/cli/src/analytics/index.ts
@@ -206,7 +206,7 @@ export class PosthogAnalytics {
         commandData.args = options.args;
       }
 
-      if (options.durationMs) {
+      if (options.durationMs !== undefined) {
         commandData.durationMs = options.durationMs;
       }
 


### PR DESCRIPTION
This preserves durationMs: 0 in CLI command analytics payloads instead of dropping the field through a truthiness check.

Tested with:

pnpm --filter ./packages/cli test src/analytics/__tests__/index.test.ts
