### PR TITLE
fix(rag): preserve zeroentropy option values

### DIFF
--- a/.changeset/free-stamps-trade.md
+++ b/.changeset/free-stamps-trade.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Fixed ZeroEntropy reranker options so explicit empty values are preserved.

--- a/packages/rag/src/rerank/relevance/zeroentropy/index.test.ts
+++ b/packages/rag/src/rerank/relevance/zeroentropy/index.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ZeroEntropy from 'zeroentropy';
+import { ZeroEntropyRelevanceScorer } from './';
+
+vi.mock('zeroentropy', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      models: {
+        rerank: vi.fn().mockResolvedValue({ results: [{ relevance_score: 0.7 }] }),
+      },
+    };
+  }),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.ZEROENTROPY_API_KEY;
+});
+
+describe('ZeroEntropyRelevanceScorer', () => {
+  it('uses environment API key and default model when options are omitted', async () => {
+    process.env.ZEROENTROPY_API_KEY = 'env-key';
+
+    const scorer = new ZeroEntropyRelevanceScorer();
+    await scorer.getRelevanceScore('query', 'document');
+
+    expect(ZeroEntropy).toHaveBeenCalledWith({ apiKey: 'env-key' });
+    expect(getRerankMock()).toHaveBeenCalledWith({
+      query: 'query',
+      documents: ['document'],
+      model: 'zerank-1',
+      top_n: 1,
+    });
+  });
+
+  it('preserves explicitly empty API key and model options', async () => {
+    process.env.ZEROENTROPY_API_KEY = 'env-key';
+
+    const scorer = new ZeroEntropyRelevanceScorer('', '');
+    await scorer.getRelevanceScore('query', 'document');
+
+    expect(ZeroEntropy).toHaveBeenCalledWith({ apiKey: '' });
+    expect(getRerankMock()).toHaveBeenCalledWith({
+      query: 'query',
+      documents: ['document'],
+      model: '',
+      top_n: 1,
+    });
+  });
+});
+
+function getRerankMock() {
+  return vi.mocked(ZeroEntropy).mock.results.at(-1)?.value.models.rerank;
+}

--- a/packages/rag/src/rerank/relevance/zeroentropy/index.ts
+++ b/packages/rag/src/rerank/relevance/zeroentropy/index.ts
@@ -8,9 +8,9 @@ export class ZeroEntropyRelevanceScorer implements RelevanceScoreProvider {
 
   constructor(model?: string, apiKey?: string) {
     this.client = new ZeroEntropy({
-      apiKey: apiKey || process.env.ZEROENTROPY_API_KEY || '',
+      apiKey: apiKey ?? process.env.ZEROENTROPY_API_KEY ?? '',
     });
-    this.model = model || 'zerank-1';
+    this.model = model ?? 'zerank-1';
   }
 
   async getRelevanceScore(query: string, text: string): Promise<number> {


### PR DESCRIPTION
This switches the ZeroEntropy reranker constructor to nullish defaults so explicit empty model or API key values are passed through instead of being replaced by environment/default values.

Tested with:

pnpm --filter ./packages/rag test src/rerank/relevance/zeroentropy/index.test.ts
