### PR TITLE
fix(playground-ui): call Agent Learning via session-authenticated /api/learning routes

### DIFF
--- a/.changeset/signals-api-learning-contract.md
+++ b/.changeset/signals-api-learning-contract.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fix the Signals (Agent Learning) client to call the platform query service's session-authenticated `/api/learning/*` routes instead of the internal `/entity-learning/*` output-service contract. The client now derives the query-service origin from the injected observability endpoint, sends the WorkOS session cookie via `credentials: 'include'`, and scopes reads with the `X-Mastra-Project-Id` header — matching the existing `/api/observability/*` auth pattern. Previously the Signals UI called an internal-only endpoint with no credentials, which 404'd on every hosted and local deployment.

--- a/packages/playground-ui/src/ee/signals/components/__tests__/signal-details-page.test.tsx
+++ b/packages/playground-ui/src/ee/signals/components/__tests__/signal-details-page.test.tsx
@@ -19,7 +19,7 @@ import { SignalDetailsPage } from '../signal-details-page';
 
 const BASE_URL = 'http://localhost:4111';
 const OBSERVABILITY_ENDPOINT = 'https://observability.test';
-const ROOT = `${OBSERVABILITY_ENDPOINT}/entity-learning`;
+const ROOT = `${OBSERVABILITY_ENDPOINT}/api/learning`;
 
 const server = setupServer();
 

--- a/packages/playground-ui/src/ee/signals/components/__tests__/signals-overview-page.test.tsx
+++ b/packages/playground-ui/src/ee/signals/components/__tests__/signals-overview-page.test.tsx
@@ -16,7 +16,7 @@ import type { SelectedEntity } from '../../types';
 import { SignalsOverviewPage } from '../signals-overview-page';
 
 const BASE_URL = 'https://observability.test';
-const ROOT = `${BASE_URL}/entity-learning`;
+const ROOT = `${BASE_URL}/api/learning`;
 
 const server = setupServer();
 

--- a/packages/playground-ui/src/ee/signals/hooks/__tests__/use-entity-learning.test.tsx
+++ b/packages/playground-ui/src/ee/signals/hooks/__tests__/use-entity-learning.test.tsx
@@ -10,7 +10,7 @@ import { entitiesResponse, pointsResponse, topicsResponse } from '../../services
 import { useEntities, useEntityPoints, useEntityTopics } from '../use-entity-learning';
 
 const BASE_URL = 'https://observability.test';
-const ROOT = `${BASE_URL}/entity-learning`;
+const ROOT = `${BASE_URL}/api/learning`;
 
 const server = setupServer();
 
@@ -30,7 +30,9 @@ function wrapper({ children }: { children: ReactNode }) {
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 
 beforeEach(() => {
-  w.MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT = BASE_URL;
+  // The injected endpoint is the trace-ingest URL; the client must derive
+  // the query-service origin from it and call /api/learning on that origin.
+  w.MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT = `${BASE_URL}/v1/traces`;
   w.MASTRA_ORGANIZATION_ID = 'org-1';
   w.MASTRA_PLATFORM_PROJECT_ID = 'proj-1';
 });
@@ -134,11 +136,13 @@ describe('entity-learning hooks', () => {
   });
 
   describe('useEntityPoints', () => {
-    it('forwards includeOutliers to the request', async () => {
+    it('forwards includeOutliers to the request and scopes via the project header', async () => {
       let capturedUrl: URL | undefined;
+      let capturedProjectHeader: string | null = null;
       server.use(
         http.get(`${ROOT}/entities/:entityId/points`, ({ request }) => {
           capturedUrl = new URL(request.url);
+          capturedProjectHeader = request.headers.get('X-Mastra-Project-Id');
           return HttpResponse.json(pointsResponse);
         }),
       );
@@ -150,7 +154,10 @@ describe('entity-learning hooks', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(capturedUrl?.searchParams.get('includeOutliers')).toBe('true');
-      expect(capturedUrl?.searchParams.get('organizationId')).toBe('org-1');
+      // Scope comes from the session server-side; the client only narrows by
+      // project via the header, never query params.
+      expect(capturedUrl?.searchParams.has('organizationId')).toBe(false);
+      expect(capturedProjectHeader).toBe('proj-1');
     });
   });
 });

--- a/packages/playground-ui/src/ee/signals/hooks/use-entity-learning-config.ts
+++ b/packages/playground-ui/src/ee/signals/hooks/use-entity-learning-config.ts
@@ -18,20 +18,36 @@ export type EntityLearningConfig = {
 };
 
 /**
+ * The injected observability endpoint is the trace-ingest URL (e.g.
+ * `https://observability.mastra.ai/v1/traces`). Agent Learning lives on the
+ * same origin under `/api/learning`, so strip the path down to the origin.
+ * Falls back to the raw value when it isn't an absolute URL (e.g. tests or
+ * proxy-relative setups).
+ */
+function toQueryServiceOrigin(endpoint: string): string {
+  try {
+    return new URL(endpoint).origin;
+  } catch {
+    return endpoint;
+  }
+}
+
+/**
  * Reads the server-injected platform observability config from `window` and
  * memoizes a configured Entity-Learning service. Returns `service: null` when
  * the observability endpoint is not configured, so callers can gate queries.
  */
 export function useEntityLearningConfig(): EntityLearningConfig {
   const w = typeof window === 'undefined' ? undefined : (window as EntityLearningWindow);
-  const baseUrl = w?.MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT || undefined;
+  const observabilityEndpoint = w?.MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT || undefined;
+  const baseUrl = observabilityEndpoint ? toQueryServiceOrigin(observabilityEndpoint) : undefined;
   const organizationId = w?.MASTRA_ORGANIZATION_ID || undefined;
   const projectId = w?.MASTRA_PLATFORM_PROJECT_ID || undefined;
 
   const service = useMemo(() => {
     if (!baseUrl) return null;
-    return createEntityLearningService({ baseUrl, organizationId, projectId });
-  }, [baseUrl, organizationId, projectId]);
+    return createEntityLearningService({ baseUrl, projectId });
+  }, [baseUrl, projectId]);
 
   return {
     baseUrl,

--- a/packages/playground-ui/src/ee/signals/services/__tests__/entity-learning-service.test.ts
+++ b/packages/playground-ui/src/ee/signals/services/__tests__/entity-learning-service.test.ts
@@ -16,7 +16,7 @@ import {
 } from './fixtures/entity-learning';
 
 const BASE_URL = 'https://observability.test';
-const ROOT = `${BASE_URL}/entity-learning`;
+const ROOT = `${BASE_URL}/api/learning`;
 
 const server = setupServer();
 
@@ -25,10 +25,10 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('createEntityLearningService', () => {
-  describe('when no org/project scoping is configured', () => {
+  describe('when no project scoping is configured', () => {
     const service = createEntityLearningService({ baseUrl: BASE_URL });
 
-    it('fetches typed entities from /entities', async () => {
+    it('fetches typed entities from /api/learning/entities', async () => {
       server.use(http.get(`${ROOT}/entities`, () => HttpResponse.json(entitiesResponse)));
 
       const result = await service.getEntities();
@@ -36,11 +36,13 @@ describe('createEntityLearningService', () => {
       expect(result).toEqual(entitiesResponse);
     });
 
-    it('does not append organizationId or projectId query params', async () => {
+    it('does not send scope query params or a project header', async () => {
       let capturedUrl: URL | undefined;
+      let capturedProjectHeader: string | null = null;
       server.use(
         http.get(`${ROOT}/entities`, ({ request }) => {
           capturedUrl = new URL(request.url);
+          capturedProjectHeader = request.headers.get('X-Mastra-Project-Id');
           return HttpResponse.json(entitiesResponse);
         }),
       );
@@ -49,31 +51,39 @@ describe('createEntityLearningService', () => {
 
       expect(capturedUrl?.searchParams.has('organizationId')).toBe(false);
       expect(capturedUrl?.searchParams.has('projectId')).toBe(false);
+      expect(capturedProjectHeader).toBeNull();
     });
   });
 
-  describe('when org and project scoping is configured', () => {
+  describe('when project scoping is configured', () => {
     const service = createEntityLearningService({
       baseUrl: `${BASE_URL}/`,
-      organizationId: 'org-1',
       projectId: 'proj-1',
     });
 
-    it('trims the trailing slash and scopes every request with org and project ids', async () => {
+    it('trims the trailing slash, sends the project header, and sends the session credentials', async () => {
       let capturedUrl: URL | undefined;
+      let capturedProjectHeader: string | null = null;
+      let capturedCredentials: RequestCredentials | undefined;
       server.use(
         http.get(`${ROOT}/entities`, ({ request }) => {
           capturedUrl = new URL(request.url);
+          capturedProjectHeader = request.headers.get('X-Mastra-Project-Id');
+          capturedCredentials = request.credentials;
           return HttpResponse.json(entitiesResponse);
         }),
       );
 
       await service.getEntities();
 
-      expect(capturedUrl?.pathname).toBe('/entity-learning/entities');
+      expect(capturedUrl?.pathname).toBe('/api/learning/entities');
       expect(capturedUrl?.origin).toBe(BASE_URL);
-      expect(capturedUrl?.searchParams.get('organizationId')).toBe('org-1');
-      expect(capturedUrl?.searchParams.get('projectId')).toBe('proj-1');
+      // Scope is resolved server-side from the session; only the project
+      // header narrows it. Query params must not carry scope.
+      expect(capturedUrl?.searchParams.has('organizationId')).toBe(false);
+      expect(capturedUrl?.searchParams.has('projectId')).toBe(false);
+      expect(capturedProjectHeader).toBe('proj-1');
+      expect(capturedCredentials).toBe('include');
     });
 
     it('passes signalName to /runs', async () => {
@@ -103,7 +113,7 @@ describe('createEntityLearningService', () => {
       const result = await service.getEntityRun('entity_support', '32', 'sentiment');
 
       expect(result).toEqual(runResponse);
-      expect(capturedUrl?.pathname).toBe('/entity-learning/entities/entity_support/runs/32');
+      expect(capturedUrl?.pathname).toBe('/api/learning/entities/entity_support/runs/32');
       expect(capturedUrl?.searchParams.get('signalName')).toBe('sentiment');
     });
 
@@ -178,7 +188,7 @@ describe('createEntityLearningService', () => {
       const result = await service.getEntityTopic('entity_support', '89', 'sentiment', '32');
 
       expect(result).toEqual(topicResponse);
-      expect(capturedUrl?.pathname).toBe('/entity-learning/entities/entity_support/topics/89');
+      expect(capturedUrl?.pathname).toBe('/api/learning/entities/entity_support/topics/89');
     });
 
     it('passes limit to topic examples', async () => {
@@ -242,7 +252,7 @@ describe('createEntityLearningService', () => {
       });
 
       expect(result).toEqual(topicExamplesResponse);
-      expect(capturedUrl?.pathname).toBe('/entity-learning/entities/entity_support/outliers/examples');
+      expect(capturedUrl?.pathname).toBe('/api/learning/entities/entity_support/outliers/examples');
     });
   });
 

--- a/packages/playground-ui/src/ee/signals/services/entity-learning-service.ts
+++ b/packages/playground-ui/src/ee/signals/services/entity-learning-service.ts
@@ -11,9 +11,13 @@ import type {
 } from './entity-learning-types';
 
 export type EntityLearningServiceConfig = {
-  /** Platform observability endpoint, e.g. `https://observability.mastra.ai`. */
+  /**
+   * Platform observability query-service origin (mobs-query), e.g.
+   * `https://observability.mastra.ai`. Agent Learning routes are served
+   * session-authenticated under `/api/learning` on this origin — the same
+   * origin and auth model as the `/api/observability/*` routes.
+   */
   baseUrl: string;
-  organizationId?: string;
   projectId?: string;
 };
 
@@ -41,20 +45,20 @@ export type EntityLearningService = ReturnType<typeof createEntityLearningServic
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 
 /**
- * Network layer for the platform Entity-Learning API. The base URL is the
- * observability endpoint; every route is scoped under `/entity-learning`.
+ * Network layer for the platform Agent Learning API served by the
+ * observability query service (mobs-query) under `/api/learning`.
+ *
+ * Auth follows the observability pattern: the WorkOS session cookie is sent
+ * via `credentials: 'include'`, and the org/project scope is resolved
+ * server-side from the session. `projectId` is passed as the
+ * `X-Mastra-Project-Id` header so the server scopes reads to that project;
+ * caller-supplied scope can never widen access beyond the session.
  */
 export function createEntityLearningService(config: EntityLearningServiceConfig) {
-  const root = `${trimTrailingSlash(config.baseUrl)}/entity-learning`;
+  const root = `${trimTrailingSlash(config.baseUrl)}/api/learning`;
 
   const buildUrl = (path: string, params?: Record<string, string | number | boolean | undefined>) => {
     const url = new URL(`${root}${path}`);
-    if (config.organizationId) {
-      url.searchParams.set('organizationId', config.organizationId);
-    }
-    if (config.projectId) {
-      url.searchParams.set('projectId', config.projectId);
-    }
     if (params) {
       for (const [key, value] of Object.entries(params)) {
         if (value !== undefined) {
@@ -66,7 +70,10 @@ export function createEntityLearningService(config: EntityLearningServiceConfig)
   };
 
   async function getJson<T>(url: string): Promise<T> {
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      credentials: 'include',
+      headers: config.projectId ? { 'X-Mastra-Project-Id': config.projectId } : undefined,
+    });
     if (!res.ok) {
       throw new Error(`Entity-Learning request failed (${res.status}): ${url}`);
     }

--- a/packages/playground/src/ee/signals/__tests__/index.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/index.test.tsx
@@ -13,7 +13,7 @@ import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';
 const OBSERVABILITY_ENDPOINT = 'https://observability.test';
-const ENTITY_LEARNING_ROOT = `${OBSERVABILITY_ENDPOINT}/entity-learning`;
+const ENTITY_LEARNING_ROOT = `${OBSERVABILITY_ENDPOINT}/api/learning`;
 
 type EntityLearningWindow = typeof globalThis & {
   MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT?: string;


### PR DESCRIPTION
## Summary

The Signals (Agent Learning) page in Studio could never load data on hosted or local deployments. Its entity-learning client called `${MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT}/entity-learning/*` with a bare `fetch` (no credentials, no headers). That URL contract only exists on the **internal** entity-signals output-service (GKE ClusterIP, intentionally not exposed publicly), so every request 404'd.

This migrates the client to the documented platform pattern (`platform/docs/entity-learning-local-oss-setup.md`) — the same auth model as the existing `/api/observability/*` calls:

- Derive the observability **query-service origin** from the injected `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` (which is the trace-ingest URL, e.g. `https://observability.mastra.ai/v1/traces` → origin `https://observability.mastra.ai`).
- Call `/api/learning/*` on that origin — mobs-query serves these routes session-authenticated with full path parity for every route the UI uses.
- Send `credentials: 'include'` so the WorkOS session cookie flows.
- Scope reads with the `X-Mastra-Project-Id` header. Org/project scope is resolved **server-side** from the session (caller-supplied scope params are overwritten by mobs-query), so the client no longer sends `organizationId`/`projectId` query params.

## Test plan

- `pnpm --filter ./packages/playground-ui exec vitest run src/ee/signals` — 41 tests pass (MSW handlers moved to the `/api/learning` contract; new assertions cover the project header, `credentials: 'include'`, and origin derivation from a `/v1/traces` endpoint).
- `pnpm --filter ./packages/playground exec vitest run src/ee/signals` — 9 tests pass.
- `pnpm --filter ./packages/playground-ui typecheck` + `pnpm --filter ./packages/playground typecheck` — clean.
- Verified against staging: `GET https://observability.staging.mastra.ai/api/learning/entities` with a valid session/Bearer passes auth and proxies to the output-service (platform-side wiring for the staging upstream is being fixed separately in the platform repo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change teaches the Signals UI to talk to the proper “logged-in” learning API instead of a private internal one. It also makes sure your session is sent along and that requests are tied to the right project.

### Summary
- Switched Signals Agent Learning requests from `/entity-learning/*` to the session-authenticated `/api/learning/*` routes on the observability query-service.
- Derived the query-service origin from `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT`.
- Added `credentials: 'include'` so the WorkOS session cookie is sent.
- Scoped learning reads with `X-Mastra-Project-Id` instead of client-sent `organizationId`/`projectId` query params.
- Updated `useEntityLearningConfig` and `createEntityLearningService` to match the new routing/scoping model.
- Adjusted playground-ui and playground tests to expect the new endpoints and request behavior.
- Added a changeset note for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->