### PR TITLE
chore: strip internal Linear ticket references from pending changesets

### DIFF
--- a/.changeset/chatty-areas-grab.md
+++ b/.changeset/chatty-areas-grab.md
@@ -26,5 +26,3 @@ await client.getDataset('abc123', { organizationId: 'org_a', projectId: 'proj_1'
 await client.deleteDataset('abc123', { organizationId: 'org_a' });
 await client.updateDataset({ id: 'abc123', name: 'renamed', organizationId: 'org_a' });
 ```
-
-Related: [MASTRA-4438](https://linear.app/kepler-crm/issue/MASTRA-4438)

--- a/.changeset/pink-mails-attend.md
+++ b/.changeset/pink-mails-attend.md
@@ -36,5 +36,3 @@ await mastra.datasets.delete({ id });
 const ds = await mastra.datasets.get({ id, organizationId, projectId });
 await mastra.datasets.delete({ id, organizationId, projectId });
 ```
-
-Related: [MASTRA-4438](https://linear.app/kepler-crm/issue/MASTRA-4438)

--- a/.changeset/spanner-datasets-target-fields-alter.md
+++ b/.changeset/spanner-datasets-target-fields-alter.md
@@ -2,6 +2,6 @@
 '@mastra/spanner': patch
 ---
 
-Widened `SpannerStore` dataset initialization to backfill `targetType`, `targetIds`, and `scorerIds` on pre-existing `mastra_datasets` tables. The `createDataset` / `updateDataset` write paths and the new `listDatasets` `targetType` / `targetIds` filters (MASTRA-4433) reference these columns; deployments that upgraded in place before these columns were declared would otherwise hit column-not-found errors on both writes and the new filter path.
+Widened `SpannerStore` dataset initialization to backfill `targetType`, `targetIds`, and `scorerIds` on pre-existing `mastra_datasets` tables. The `createDataset` / `updateDataset` write paths and the new `listDatasets` `targetType` / `targetIds` filters reference these columns; deployments that upgraded in place before these columns were declared would otherwise hit column-not-found errors on both writes and the new filter path.
 
 Fresh databases were already unaffected because `createTable` reads the full `DATASETS_SCHEMA`.

--- a/.changeset/swift-things-push.md
+++ b/.changeset/swift-things-push.md
@@ -12,5 +12,3 @@
 Scoped `getDatasetById` and `deleteDataset` to tenancy filters when the caller passes `organizationId` / `projectId`.
 
 The adapters now push the tenancy predicate into the SQL/query when the new optional `filters` argument is present. Legacy calls that omit tenancy are unchanged. On mismatch, `getDatasetById` returns `null` and `deleteDataset` is a silent no-op — the cascade delete (dataset items and versions) is gated by a scoped parent pre-check, so cross-tenant data is never touched.
-
-Related: [MASTRA-4438](https://linear.app/kepler-crm/issue/MASTRA-4438)

--- a/.changeset/tired-donuts-fly.md
+++ b/.changeset/tired-donuts-fly.md
@@ -19,5 +19,3 @@ Added optional `organizationId` and `projectId` query parameters to the dataset 
 GET /datasets/abc123?organizationId=org_a&projectId=proj_1
 DELETE /datasets/abc123?organizationId=org_a
 ```
-
-Related: [MASTRA-4438](https://linear.app/kepler-crm/issue/MASTRA-4438)


### PR DESCRIPTION
## Summary

Removes `MASTRA-XXXX` Linear ticket references from the five pending dataset-tenancy changesets so they don't ship to `CHANGELOG.md` files on npm.

## What changed

- `.changeset/chatty-areas-grab.md` — dropped trailing `Related: [MASTRA-4438](...)` line
- `.changeset/pink-mails-attend.md` — dropped trailing `Related: [MASTRA-4438](...)` line
- `.changeset/swift-things-push.md` — dropped trailing `Related: [MASTRA-4438](...)` line
- `.changeset/tired-donuts-fly.md` — dropped trailing `Related: [MASTRA-4438](...)` line
- `.changeset/spanner-datasets-target-fields-alter.md` — dropped bare `(MASTRA-4433)` inline parenthetical

## Why

The four `Related:` links pointed at `linear.app/kepler-crm/...`, a private Linear workspace. External users clicking those from a published npm changelog get a 404/login screen. The spanner changeset embedded a bare `MASTRA-4433` mid-sentence with no link at all — pure noise to anyone reading the changelog.

## Scope

- Only touches unpublished changesets. Historical `[MASTRA-*]` entries in already-published `CHANGELOG.md` files are left alone.
- No source, test, or doc changes.

## Test plan

- `grep -rE "MASTRA-[0-9]+" .changeset/` returns nothing.
- Changeset frontmatter is untouched, so the version bumps published from these entries are unaffected.
