### PR TITLE
fix(editor): support Composio 0.10.1 auth flow

### DIFF
--- a/.changeset/calm-papayas-burn.md
+++ b/.changeset/calm-papayas-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Improved Composio provider compatibility with Composio 0.10.1.

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -81,8 +81,8 @@
   },
   "dependencies": {
     "@arcadeai/arcadejs": "^2.4.1",
-    "@composio/core": "^0.6.5",
-    "@composio/mastra": "^0.6.5",
+    "@composio/core": "0.11.0",
+    "@composio/mastra": "0.10.1",
     "@mastra/memory": "workspace:*",
     "@mastra/schema-compat": "workspace:*"
   },

--- a/packages/editor/src/providers/composio.test.ts
+++ b/packages/editor/src/providers/composio.test.ts
@@ -13,6 +13,7 @@ const { composioInstances, makeFakeComposio } = vi.hoisted(() => {
     toolkits: { get: ReturnType<typeof vi.fn>; getConnectedAccountInitiationFields: ReturnType<typeof vi.fn> };
     tools: { get: ReturnType<typeof vi.fn>; getRawComposioTools: ReturnType<typeof vi.fn> };
     connectedAccounts: {
+      link: ReturnType<typeof vi.fn>;
       initiate: ReturnType<typeof vi.fn>;
       get: ReturnType<typeof vi.fn>;
       list: ReturnType<typeof vi.fn>;
@@ -29,7 +30,7 @@ const { composioInstances, makeFakeComposio } = vi.hoisted(() => {
       hasProvider: Boolean(opts.provider),
       toolkits: { get: vi.fn(), getConnectedAccountInitiationFields: vi.fn() },
       tools: { get: vi.fn(), getRawComposioTools: vi.fn() },
-      connectedAccounts: { initiate: vi.fn(), get: vi.fn(), list: vi.fn(), delete: vi.fn() },
+      connectedAccounts: { link: vi.fn(), initiate: vi.fn(), get: vi.fn(), list: vi.fn(), delete: vi.fn() },
       authConfigs: { list: vi.fn() },
     };
     instances.push(inst);
@@ -305,16 +306,17 @@ describe('ComposioToolProvider — authorize', () => {
 
     raw.authConfigs.list.mockResolvedValue({
       items: [
-        { id: 'ac_1', status: 'ENABLED' },
-        { id: 'ac_2', status: 'DISABLED' },
+        { id: 'ac_1', status: 'ENABLED', authScheme: 'OAUTH2' },
+        { id: 'ac_2', status: 'DISABLED', authScheme: 'OAUTH2' },
       ],
     });
-    raw.connectedAccounts.initiate.mockResolvedValue({ id: 'ca_new', redirectUrl: 'https://oauth' });
+    raw.connectedAccounts.link.mockResolvedValue({ id: 'ca_new', redirectUrl: 'https://oauth' });
 
     const result = await integration.authorize({ toolkit: 'gmail', connectionId: 'author_1' });
 
     expect(raw.authConfigs.list).toHaveBeenCalledWith({ toolkit: 'gmail' });
-    expect(raw.connectedAccounts.initiate).toHaveBeenCalledWith('author_1', 'ac_1', { allowMultiple: true });
+    expect(raw.connectedAccounts.link).toHaveBeenCalledWith('author_1', 'ac_1', { allowMultiple: true });
+    expect(raw.connectedAccounts.initiate).not.toHaveBeenCalled();
     expect(result).toEqual({ url: 'https://oauth', authId: 'ca_new' });
   });
 
@@ -345,7 +347,7 @@ describe('ComposioToolProvider — authorize', () => {
     );
   });
 
-  it('forwards config to connectedAccounts.initiate as { authScheme, val }', async () => {
+  it('falls back to connectedAccounts.initiate when config must be forwarded', async () => {
     const integration = new ComposioToolProvider({ apiKey: 'k' });
     await integration.authorize({ toolkit: 'confluence', connectionId: 'a' }).catch(() => undefined);
     const raw = getRawInstance();
@@ -361,9 +363,28 @@ describe('ComposioToolProvider — authorize', () => {
       config: { subdomain: 'acme' },
     });
 
+    expect(raw.connectedAccounts.link).not.toHaveBeenCalled();
     expect(raw.connectedAccounts.initiate).toHaveBeenCalledWith('author_1', 'ac_1', {
       allowMultiple: true,
       config: { authScheme: 'OAUTH2', val: { subdomain: 'acme' } },
+    });
+  });
+
+  it('falls back to connectedAccounts.initiate for non-OAuth auth schemes', async () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+    await integration.authorize({ toolkit: 'notion', connectionId: 'a' }).catch(() => undefined);
+    const raw = getRawInstance();
+
+    raw.authConfigs.list.mockResolvedValue({
+      items: [{ id: 'ac_1', status: 'ENABLED', authScheme: 'API_KEY' }],
+    });
+    raw.connectedAccounts.initiate.mockResolvedValue({ id: 'ca_new', redirectUrl: 'https://oauth' });
+
+    await integration.authorize({ toolkit: 'notion', connectionId: 'author_1' });
+
+    expect(raw.connectedAccounts.link).not.toHaveBeenCalled();
+    expect(raw.connectedAccounts.initiate).toHaveBeenCalledWith('author_1', 'ac_1', {
+      allowMultiple: true,
     });
   });
 
@@ -375,11 +396,12 @@ describe('ComposioToolProvider — authorize', () => {
     raw.authConfigs.list.mockResolvedValue({
       items: [{ id: 'ac_1', status: 'ENABLED', authScheme: 'OAUTH2' }],
     });
-    raw.connectedAccounts.initiate.mockResolvedValue({ id: 'ca_new', redirectUrl: 'https://oauth' });
+    raw.connectedAccounts.link.mockResolvedValue({ id: 'ca_new', redirectUrl: 'https://oauth' });
 
     await integration.authorize({ toolkit: 'gmail', connectionId: 'a', config: {} });
 
-    expect(raw.connectedAccounts.initiate).toHaveBeenCalledWith('a', 'ac_1', { allowMultiple: true });
+    expect(raw.connectedAccounts.link).toHaveBeenCalledWith('a', 'ac_1', { allowMultiple: true });
+    expect(raw.connectedAccounts.initiate).not.toHaveBeenCalled();
   });
 });
 
@@ -587,7 +609,7 @@ describe('ComposioToolProvider — listConnections', () => {
           status: 'ACTIVE',
           isDisabled: false,
           createdAt: '2026-01-01T00:00:00Z',
-          user_id: 'user_42',
+          wordId: 'user_42',
         },
       ],
       nextCursor: 'next_page',

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -230,14 +230,20 @@ export class ComposioToolProvider extends BaseToolProvider {
     // for authorize we treat it as the Composio `userId` so the new connected
     // account lands under the same bucket as the agent's resolved identity.
     const internalUserId = opts.connectionId || DEFAULT_INTERNAL_USER_ID;
+    const hasConfig = Boolean(opts.config && Object.keys(opts.config).length > 0);
+    const useLink = shouldUseConnectedAccountLink(authScheme, hasConfig);
+
     // `allowMultiple: true` — we explicitly support N connected accounts per
     // (user, auth config) and disambiguate at runtime via per-connection labels.
     // `config` carries provider-specific user-supplied fields (e.g. Confluence
-    // subdomain) collected by the picker via `listConnectionFields`. Composio
-    // expects a discriminated `{ authScheme, val }` shape; we cast through
-    // `unknown` because our generic interface keeps it Record-shaped.
+    // subdomain) collected by the picker via `listConnectionFields`.
+    // `connectedAccounts.link()` is the supported 0.10.x replacement for
+    // redirectable OAuth flows, but Composio does not expose a config-capable
+    // replacement yet and the higher-level authorize helpers still route through
+    // `initiate()` internally. Until that changes, config-bearing and non-OAuth
+    // flows must keep using `initiate()`.
     const initiateConfig =
-      opts.config && Object.keys(opts.config).length > 0 && authScheme
+      hasConfig && authScheme
         ? ({ authScheme, val: opts.config } as unknown as Parameters<
             typeof composio.connectedAccounts.initiate
           >[2] extends infer O
@@ -246,13 +252,18 @@ export class ComposioToolProvider extends BaseToolProvider {
               : never
             : never)
         : undefined;
-    const request = await composio.connectedAccounts.initiate(internalUserId, authConfigId, {
-      allowMultiple: true,
-      ...(initiateConfig ? { config: initiateConfig } : {}),
-    });
+    const linkOptions = { allowMultiple: true } as unknown as Parameters<typeof composio.connectedAccounts.link>[2];
+    const request = useLink
+      ? await composio.connectedAccounts.link(internalUserId, authConfigId, linkOptions)
+      : await composio.connectedAccounts.initiate(internalUserId, authConfigId, {
+          allowMultiple: true,
+          ...(initiateConfig ? { config: initiateConfig } : {}),
+        });
 
     if (!request.redirectUrl) {
-      throw new Error(`[composio] initiate did not return a redirectUrl for toolkit "${opts.toolkit}"`);
+      throw new Error(
+        `[composio] ${useLink ? 'link' : 'initiate'} did not return a redirectUrl for toolkit "${opts.toolkit}"`,
+      );
     }
 
     return { url: request.redirectUrl, authId: request.id };
@@ -352,9 +363,8 @@ export class ComposioToolProvider extends BaseToolProvider {
       connectionId: account.id,
       status: mapComposioStatus(account.status, account.isDisabled),
       createdAt: account.createdAt,
-      // `user_id` is preserved by the Composio SDK transform via spread but
-      // isn't on the typed shape. Read it via a narrow cast.
-      authorId: (account as unknown as { user_id?: string }).user_id,
+      // Composio 0.10.x surfaces the external user bucket as `wordId`.
+      authorId: account.wordId ?? undefined,
     }));
 
     const nextCursor = (list as { nextCursor?: string | null }).nextCursor ?? null;
@@ -428,6 +438,18 @@ export class ComposioToolProvider extends BaseToolProvider {
 type ComposioAuthScheme = NonNullable<
   Awaited<ReturnType<Composio['authConfigs']['list']>>['items'][number]['authScheme']
 >;
+
+/**
+ * Composio 0.10.x deprecates `connectedAccounts.initiate()` for redirectable
+ * OAuth flows in favor of `connectedAccounts.link()`. We can only use `link()`
+ * when no extra connection config is required because 0.10.1 does not expose a
+ * config-capable replacement for those flows, and `toolkits.authorize()` still
+ * delegates to `initiate()` internally.
+ */
+function shouldUseConnectedAccountLink(authScheme: ComposioAuthScheme | undefined, hasConfig: boolean): boolean {
+  if (hasConfig) return false;
+  return authScheme === 'OAUTH1' || authScheme === 'OAUTH2' || authScheme === 'DCR_OAUTH';
+}
 
 /**
  * Best-effort 404 detection across the various error shapes the Composio

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1858,16 +1858,16 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: ^2.0.62
-        version: 2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^2.0.99
-        version: 2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: ^2.0.1
         version: 2.0.3
       '@ai-sdk/provider-utils':
         specifier: ^3.0.22
-        version: 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@huggingface/hub':
         specifier: ^0.15.2
         version: 0.15.2
@@ -1940,7 +1940,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   integrations/brightdata:
     devDependencies:
@@ -4410,11 +4410,11 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       '@composio/core':
-        specifier: ^0.6.5
-        version: 0.6.11(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
+        specifier: 0.11.0
+        version: 0.11.0(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
       '@composio/mastra':
-        specifier: ^0.6.5
-        version: 0.6.11(@composio/core@0.6.11(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76))(@mastra/core@packages+core)(zod@3.25.76)
+        specifier: 0.10.1
+        version: 0.10.1(@composio/core@0.11.0(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76))(@mastra/core@packages+core)(zod@3.25.76)
       '@mastra/memory':
         specifier: workspace:*
         version: link:../memory
@@ -11210,11 +11210,11 @@ packages:
     peerDependencies:
       commander: ~14.0.0
 
-  '@composio/client@0.1.0-alpha.66':
-    resolution: {integrity: sha512-SDHcTWzz2dgdYAew/gQsRpjHpEzHKm6sW7KM4wCoJWNJuuMuey9Ahje91ZucNjfaqpI8CFW+pXY4nWkZf5LD7Q==}
+  '@composio/client@0.1.0-alpha.72':
+    resolution: {integrity: sha512-2WYXgdlMvhoaJCsaSfyMAYGQ2tS5l2Fqdh2cMRqNi8NybIoOkFZy2ApBJJOoQwqfpUr41VymMW6FtiNQm7JavQ==}
 
-  '@composio/core@0.6.11':
-    resolution: {integrity: sha512-0uNA1DhHF0l3d51GVRw4CA8oYgqsps+aGMW6J4jA6Ut53HfBHwHJ4JAa9HU/2Psho8tCoprM6NR5DxWGD50H+A==}
+  '@composio/core@0.11.0':
+    resolution: {integrity: sha512-KjDGw7ig70xHBQuNyN+HQamF52ZueguM40uiPgQu24T7csqYlQ1GxBo7sw5u+2UzqjbHv7+yDFvX0b/qwlcwpQ==}
     peerDependencies:
       zod: ^3.25 || ^4
 
@@ -11223,11 +11223,11 @@ packages:
     peerDependencies:
       zod: '>=3.25.76 <5'
 
-  '@composio/mastra@0.6.11':
-    resolution: {integrity: sha512-lN9JOf4o+oO7ff8yUKcPCJWqLaII6zlW2ZWZiuimHilPjEKwjRenK6gc+soCoMU5s26cziY39I3S2eh1vII3Aw==}
+  '@composio/mastra@0.10.1':
+    resolution: {integrity: sha512-aVj4hYcVQ1WgeMvfaku7QK3qf7cEoKYWyG1hsNzg/AACeimIoMBL264hlX+nKC+CEIU8uABILDGlWA53mfybiQ==}
     peerDependencies:
-      '@composio/core': 0.6.11
-      '@mastra/core': ^1.0.4
+      '@composio/core': '>=0.10.0 <1.0.0'
+      '@mastra/core': ^1.46.0
       zod: ^3.25 || ^4
 
   '@connectrpc/connect-node@1.7.0':
@@ -14086,8 +14086,8 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@mastra/schema-compat@1.1.0':
-    resolution: {integrity: sha512-2v8nTaAC/279jHs0ux2Emp+lNgBFq3QeNbZCGSHFeeBhbqqM5aWJCPY2Xgw8Z/dY3mTpFxBbmXQz3oRyYStnqg==}
+  '@mastra/schema-compat@1.3.2':
+    resolution: {integrity: sha512-ArzpkHL/otVuMjjZn2tm6jNVikZvY5UTIGDhdMz1nI3zlN4TRfiOj2N86xcWwwEvL64dAhZ98Ce7Cp8SvZejWA==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -29742,10 +29742,10 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -29901,26 +29901,6 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
-
-  '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@opentelemetry/api'
-      - '@types/node'
-      - '@vitest/browser-playwright'
-      - '@vitest/browser-preview'
-      - '@vitest/browser-webdriverio'
-      - '@vitest/coverage-istanbul'
-      - '@vitest/coverage-v8'
-      - '@vitest/ui'
-      - happy-dom
-      - jsdom
-      - typescript
-      - vite
 
   '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
@@ -32740,11 +32720,11 @@ snapshots:
     dependencies:
       commander: 14.0.3
 
-  '@composio/client@0.1.0-alpha.66': {}
+  '@composio/client@0.1.0-alpha.72': {}
 
-  '@composio/core@0.6.11(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)':
+  '@composio/core@0.11.0(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)':
     dependencies:
-      '@composio/client': 0.1.0-alpha.66
+      '@composio/client': 0.1.0-alpha.72
       '@composio/json-schema-to-zod': 0.1.20(zod@3.25.76)
       '@types/json-schema': 7.0.15
       chalk: 4.1.2
@@ -32760,11 +32740,11 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@composio/mastra@0.6.11(@composio/core@0.6.11(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76))(@mastra/core@packages+core)(zod@3.25.76)':
+  '@composio/mastra@0.10.1(@composio/core@0.11.0(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76))(@mastra/core@packages+core)(zod@3.25.76)':
     dependencies:
-      '@composio/core': 0.6.11(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
+      '@composio/core': 0.11.0(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
       '@mastra/core': link:packages/core
-      '@mastra/schema-compat': 1.1.0(zod@3.25.76)
+      '@mastra/schema-compat': 1.3.2(zod@3.25.76)
       zod: 3.25.76
 
   '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
@@ -32788,7 +32768,7 @@ snapshots:
 
   '@copilotkit/aimock@1.29.0(vitest@4.1.8)':
     optionalDependencies:
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@copilotkit/react-core@1.8.10(@types/react@19.2.14)(encoding@0.1.13)(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -36031,7 +36011,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mastra/schema-compat@1.1.0(zod@3.25.76)':
+  '@mastra/schema-compat@1.3.2(zod@3.25.76)':
     dependencies:
       json-schema-to-zod: 2.7.0
       zod: 3.25.76

--- a/templates/template-google-sheets/package.json
+++ b/templates/template-google-sheets/package.json
@@ -16,8 +16,8 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@composio/core": "^0.6.3",
-    "@composio/mastra": "^0.6.3",
+    "@composio/core": "0.11.0",
+    "@composio/mastra": "0.10.1",
     "@mastra/core": "latest",
     "@mastra/fastembed": "latest",
     "@mastra/libsql": "latest",


### PR DESCRIPTION
Composio 0.10.1 in @composio/mastra expects core exports that are missing from @composio/core 0.10.0, so the editor could fail at runtime with a missing normalizeToolArguments export. This bumps @composio/core to 0.11.0, updates the editor provider to use connectedAccounts.link() for redirectable OAuth flows, and keeps the initiate() fallback for config-bearing and non-OAuth connections that still require it. It also updates the template dependency pair and keeps the existing provider contract intact.

Before: importing @composio/mastra could throw at startup and builder connection creation always used the deprecated path. After: the runtime import succeeds, redirectable OAuth uses the supported link flow, and the editor tests and build still pass.