### PR TITLE
fix(stores): raise @mastra/core peer floor to >=1.49.0-0 for tenancy exports

### DIFF
--- a/.changeset/stores-tenancy-peer-floor.md
+++ b/.changeset/stores-tenancy-peer-floor.md
@@ -1,0 +1,26 @@
+---
+'@mastra/libsql': patch
+'@mastra/pg': patch
+'@mastra/mysql': patch
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+---
+
+Raise `@mastra/core` peer floor to `>=1.49.0-0` on all storage adapters
+
+The tenancy work in MASTRA-4438 and MASTRA-4445 added new named imports from
+`@mastra/core/storage` into the store adapters — `DatasetTenancyFilters`,
+`ExperimentTenancyFilters`, and `DeleteDatasetItemInput` — but did not bump the
+adapters' peer floor for `@mastra/core`. Those symbols first ship in
+`@mastra/core@1.49.0`, so a consumer pinning an older core (e.g. `1.42.1`) with
+a newer store patch would fail at load time with a `SyntaxError: Named export
+'DatasetTenancyFilters' not found`.
+
+This raises the peer floor to `>=1.49.0-0` on all five adapters (`@mastra/libsql`,
+`@mastra/pg`, `@mastra/mysql`, `@mastra/mongodb`, `@mastra/spanner`) so npm/pnpm
+will refuse the mismatched install rather than break at runtime.
+
+`@mastra/spanner` had been sitting at `>=1.0.0-0` since inception; this bump also
+closes that long-standing gap.
+
+No behavior change. Consumers already on a compatible core version are unaffected.

--- a/.changeset/stores-tenancy-peer-floor.md
+++ b/.changeset/stores-tenancy-peer-floor.md
@@ -6,21 +6,4 @@
 '@mastra/spanner': patch
 ---
 
-Raise `@mastra/core` peer floor to `>=1.49.0-0` on all storage adapters
-
-The tenancy work in MASTRA-4438 and MASTRA-4445 added new named imports from
-`@mastra/core/storage` into the store adapters — `DatasetTenancyFilters`,
-`ExperimentTenancyFilters`, and `DeleteDatasetItemInput` — but did not bump the
-adapters' peer floor for `@mastra/core`. Those symbols first ship in
-`@mastra/core@1.49.0`, so a consumer pinning an older core (e.g. `1.42.1`) with
-a newer store patch would fail at load time with a `SyntaxError: Named export
-'DatasetTenancyFilters' not found`.
-
-This raises the peer floor to `>=1.49.0-0` on all five adapters (`@mastra/libsql`,
-`@mastra/pg`, `@mastra/mysql`, `@mastra/mongodb`, `@mastra/spanner`) so npm/pnpm
-will refuse the mismatched install rather than break at runtime.
-
-`@mastra/spanner` had been sitting at `>=1.0.0-0` since inception; this bump also
-closes that long-standing gap.
-
-No behavior change. Consumers already on a compatible core version are unaffected.
+Raise `@mastra/core` peer floor to `>=1.49.0-0` on all storage adapters so the tenancy-related named exports the adapters now consume are guaranteed to exist at install time.

--- a/stores/libsql/package.json
+++ b/stores/libsql/package.json
@@ -44,7 +44,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.42.1-0 <2.0.0-0"
+    "@mastra/core": ">=1.49.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/mongodb/package.json
+++ b/stores/mongodb/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.42.1-0 <2.0.0-0"
+    "@mastra/core": ">=1.49.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/mysql/package.json
+++ b/stores/mysql/package.json
@@ -48,7 +48,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.42.1-0 <2.0.0-0"
+    "@mastra/core": ">=1.49.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -63,7 +63,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.42.1-0 <2.0.0-0"
+    "@mastra/core": ">=1.49.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/spanner/package.json
+++ b/stores/spanner/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.49.0-0 <2.0.0-0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

Raise the `@mastra/core` peer floor on all storage adapters to `>=1.49.0-0` so the tenancy-related named exports introduced in recent OSS work are guaranteed to exist at install time.

## Background

MASTRA-4438 (datasets tenancy) and MASTRA-4445 (experiments tenancy) added new named imports from `@mastra/core/storage` into all five store adapters:

- `DatasetTenancyFilters` — first shipped in `@mastra/core@1.46.0`
- `ExperimentTenancyFilters` — first shipped in `@mastra/core@1.46.0`
- `DeleteDatasetItemInput` — will first ship in `@mastra/core@1.49.0`

Neither PR bumped the store adapters' peer floor for `@mastra/core`. It has been sitting at:

- `@mastra/libsql`, `@mastra/pg`, `@mastra/mysql`, `@mastra/mongodb`: `>=1.42.1-0`
- `@mastra/spanner`: `>=1.0.0-0` (never bumped)

The precedent for handling this class of change is #16811, which explicitly bumped the peer floor in the same commit that added a new named import.

## The gap

A consumer who pins `@mastra/core@1.42.1` and takes a newer store patch (e.g. `@mastra/pg` after MASTRA-4438 landed) would fail at module load with:

```
SyntaxError: Named export 'DatasetTenancyFilters' not found.
The requested module '@mastra/core/storage' is a CommonJS module...
```

Because pnpm workspaces / lockfiles typically install matching versions together, no breakage has been reported. But the gap is real for consumers who pin core independently.

## Fix

Bump the peer floor on all five stores to `>=1.49.0-0`, the first release that contains all three symbols. `@mastra/spanner`'s long-standing `>=1.0.0-0` floor is closed as a side effect.

No behavior change. No code changes. Just package.json.

## Files

- `stores/libsql/package.json`
- `stores/pg/package.json`
- `stores/mysql/package.json`
- `stores/mongodb/package.json`
- `stores/spanner/package.json`
- `.changeset/stores-tenancy-peer-floor.md`

## Verification

Symbols verified against tagged core releases:

| Symbol | First tagged in |
|---|---|
| `DatasetTenancyFilters` | `@mastra/core@1.46.0` |
| `ExperimentTenancyFilters` | `@mastra/core@1.46.0` |
| `DeleteDatasetItemInput` | `@mastra/core@1.49.0` (this release cycle) |

`>=1.49.0-0` is the minimum floor that covers all three.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This update makes sure all storage adapters only work with a newer enough `@mastra/core` package, so they won’t try to use features that older versions don’t have. It helps prevent install-time or load-time errors without changing how the adapters behave.

### What changed
- Raised the `@mastra/core` peer dependency floor to `>=1.49.0-0` for:
  - `@mastra/libsql`
  - `@mastra/pg`
  - `@mastra/mysql`
  - `@mastra/mongodb`
  - `@mastra/spanner`
- Added the related changeset entry.

### Why
This ensures tenancy-related exports used by the adapters are always available, including `DatasetTenancyFilters`, `ExperimentTenancyFilters`, and `DeleteDatasetItemInput`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->