### PR TITLE
fix(core,observability): add flush() to ObservabilityEntrypoint and fix serverless docs

### DIFF
--- a/.changeset/fix-observability-flush-docs.md
+++ b/.changeset/fix-observability-flush-docs.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': patch
+'@mastra/observability': minor
+---
+
+Added `flush()` to `ObservabilityEntrypoint` so `mastra.observability.flush()` works directly in serverless environments.
+
+Previously, `flush()` only existed on individual `ObservabilityInstance` objects, requiring users to call `mastra.observability.getDefaultInstance()?.flush()`. The entrypoint-level `flush()` delegates to all registered instances, matching the existing `shutdown()` pattern.
+
+```ts
+// Before (broken — getObservability() didn't exist, flush() wasn't on the entrypoint)
+const observability = mastra.getObservability()
+await observability.flush()
+
+// After
+await mastra.observability.flush()
+```
+
+Fixed the serverless flush docs in the observability config guide and Vercel deployment guide to use the correct API.

--- a/docs/src/content/en/docs/observability/config.mdx
+++ b/docs/src/content/en/docs/observability/config.mdx
@@ -101,8 +101,7 @@ export const observability = new Observability({
 In serverless environments, flush observability exporters before the runtime pauses or exits:
 
 ```ts
-const observability = mastra.getObservability()
-await observability.flush()
+await mastra.observability.flush()
 ```
 
 Use external storage in serverless environments instead of local file storage. For storage selection and routing, see [Storage](/docs/observability/storage).

--- a/docs/src/content/en/guides/deployment/vercel.mdx
+++ b/docs/src/content/en/guides/deployment/vercel.mdx
@@ -116,8 +116,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const agent = mastra.getAgent('myAgent')
   const result = await agent.generate([{ role: 'user', content: message }])
 
-  const observability = mastra.getObservability()
-  await observability?.flush()
+  await mastra.observability.flush()
 
   return res.json(result)
 }

--- a/observability/mastra/src/default.ts
+++ b/observability/mastra/src/default.ts
@@ -407,6 +407,11 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
     this.#registry.clear();
   }
 
+  /** Flush all registered instances without shutting down. */
+  async flush(): Promise<void> {
+    await this.#registry.flush();
+  }
+
   /** Shut down all registered instances, flushing any pending data. */
   async shutdown(): Promise<void> {
     await this.#registry.shutdown();

--- a/observability/mastra/src/registry.test.ts
+++ b/observability/mastra/src/registry.test.ts
@@ -352,6 +352,40 @@ describe('Observability Registry', () => {
       expect(customTracing?.getConfig().serviceName).toBe('custom-service');
     });
 
+    it('should flush all registered instances without shutting down', async () => {
+      let flushCalled = false;
+
+      class TestInstance extends BaseObservabilityInstance {
+        protected createSpan<TType extends SpanType>(_options: CreateSpanOptions<TType>): Span<TType> {
+          return {} as Span<TType>;
+        }
+
+        async flush(): Promise<void> {
+          flushCalled = true;
+          await super.flush();
+        }
+      }
+
+      const testInstance = new TestInstance({
+        serviceName: 'test-service',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [new TestExporter()],
+      });
+
+      observability = new Observability({
+        configs: {
+          test: testInstance,
+        },
+      });
+
+      await observability.flush();
+
+      expect(flushCalled).toBe(true);
+      // Instances should still be registered after flush (unlike shutdown)
+      expect(observability.getInstance('test')).toBe(testInstance);
+    });
+
     it('should handle registry shutdown during Mastra shutdown', async () => {
       let shutdownCalled = false;
 

--- a/observability/mastra/src/registry.ts
+++ b/observability/mastra/src/registry.ts
@@ -87,6 +87,14 @@ export class ObservabilityRegistry {
   }
 
   /**
+   * Flush all registered instances without shutting down.
+   */
+  async flush(): Promise<void> {
+    const flushPromises = Array.from(this.#instances.values()).map(instance => instance.flush());
+    await Promise.allSettled(flushPromises);
+  }
+
+  /**
    * Shutdown all instances and clear the registry
    */
   async shutdown(): Promise<void> {

--- a/packages/core/src/observability/no-op.ts
+++ b/packages/core/src/observability/no-op.ts
@@ -153,6 +153,10 @@ export class NoOpObservability implements ObservabilityEntrypoint {
     return;
   }
 
+  async flush(): Promise<void> {
+    return;
+  }
+
   async shutdown(): Promise<void> {
     return;
   }

--- a/packages/core/src/observability/types/core.ts
+++ b/packages/core/src/observability/types/core.ts
@@ -309,6 +309,8 @@ export interface ObservabilityInstance {
 // ============================================================================
 
 export interface ObservabilityEntrypoint {
+  flush(): Promise<void>;
+
   shutdown(): Promise<void>;
 
   setMastraContext(options: { mastra: Mastra }): void;


### PR DESCRIPTION
## Description

The docs for flushing observability in serverless environments used a non-existent `mastra.getObservability()` method and called `flush()` on `ObservabilityEntrypoint`, which didn't have that method. This PR adds `flush()` to the entrypoint (matching the existing `shutdown()` pattern) and fixes the docs to use the correct `mastra.observability.flush()` API.

- Added `flush()` to `ObservabilityEntrypoint` interface in `@mastra/core`
- Implemented `flush()` in `NoOpObservability`, `ObservabilityRegistry`, and `Observability` class — delegates to all registered instances
- Fixed serverless flush code examples in observability config docs and Vercel deployment guide
- Added test verifying flush calls through to instances without clearing the registry

## Related Issue(s)

Fixes #18867

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change adds a “finish sending my data now” button for observability, so serverless apps can safely flush pending telemetry before they exit. It also fixes the docs to show the real API to use.

## Summary
- Added `flush()` to the observability entrypoint contract in `@mastra/core`.
- Implemented `flush()` in `NoOpObservability`, `ObservabilityRegistry`, and `Observability`, with registry flushes forwarded to all registered instances without clearing them.
- Added a test to verify `flush()` is forwarded and does not unregister instances.
- Updated serverless observability docs to use `mastra.observability.flush()` instead of the nonexistent `mastra.getObservability()` pattern.
- Adjusted the observability config docs and Vercel deployment guide to reflect the correct serverless usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->