### PR TITLE
fix(core): decouple workflow schedules from the evented execution engine

### DIFF
--- a/.changeset/tame-dolls-rest.md
+++ b/.changeset/tame-dolls-rest.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow schedule engine promotion. Manual executions of scheduled workflows now run on the default in-process engine rather than evented engine, preventing hangs on serverless environments.

--- a/packages/core/src/workflows/create.ts
+++ b/packages/core/src/workflows/create.ts
@@ -31,18 +31,6 @@ export function createWorkflow<
   TSteps extends Step<string, any, any, any, any, any, DefaultEngineType>[] = Step[],
   TRequestContextSchema extends PublicSchema<any> | undefined = undefined,
 >(params: CreateWorkflowParams<TWorkflowId, TStateSchema, TInputSchema, TOutputSchema, TSteps, TRequestContextSchema>) {
-  if (params.schedule) {
-    return createEventedWorkflowImpl(params as any) as unknown as Workflow<
-      DefaultEngineType,
-      TSteps,
-      TWorkflowId,
-      InferSchemaOutput<TStateSchema>,
-      InferPublicSchema<TInputSchema>,
-      InferPublicSchema<TOutputSchema>,
-      InferPublicSchema<TInputSchema>,
-      InferSchemaOutput<TRequestContextSchema>
-    >;
-  }
   return new Workflow<
     DefaultEngineType,
     TSteps,

--- a/packages/core/src/workflows/schedule-promotion.test.ts
+++ b/packages/core/src/workflows/schedule-promotion.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { createWorkflow as createDefaultWorkflow, createStep } from './index';
 
-describe('createWorkflow (default) — schedule promotion to evented', () => {
-  it('returns an evented workflow when a schedule is declared', () => {
+describe('createWorkflow (default) — schedules', () => {
+  it('retains default engine when a schedule is declared but exposes configs', () => {
     const step = createStep({
       id: 'noop',
       inputSchema: z.object({}),
@@ -20,13 +20,13 @@ describe('createWorkflow (default) — schedule promotion to evented', () => {
       .then(step)
       .commit();
 
-    expect(wf.engineType).toBe('evented');
+    expect(wf.engineType).toBe('default');
     // Sanity: the evented surface is reachable.
     expect(typeof (wf as any).getScheduleConfigs).toBe('function');
     expect((wf as any).getScheduleConfigs()).toHaveLength(1);
   });
 
-  it('preserves the default engine when no schedule is declared', () => {
+  it('preserves the default engine and returns empty schedule configs when no schedule is declared', () => {
     const step = createStep({
       id: 'noop',
       inputSchema: z.object({}),
@@ -42,11 +42,8 @@ describe('createWorkflow (default) — schedule promotion to evented', () => {
       .then(step)
       .commit();
 
-    // The default engineType is the empty-string default. The important assertion
-    // is that it is *not* 'evented'.
-    expect(wf.engineType).not.toBe('evented');
-    // Default workflows do not expose getScheduleConfigs.
-    expect((wf as any).getScheduleConfigs).toBeUndefined();
+    expect(wf.engineType).toBe('default');
+    expect(wf.getScheduleConfigs()).toEqual([]);
   });
 
   it('validates cron at construction time on the default factory', () => {
@@ -71,7 +68,34 @@ describe('createWorkflow (default) — schedule promotion to evented', () => {
       ],
     });
 
-    expect(wf.engineType).toBe('evented');
-    expect((wf as any).getScheduleConfigs()).toHaveLength(2);
+    expect(wf.engineType).toBe('default');
+    expect(wf.getScheduleConfigs()).toHaveLength(2);
+  });
+
+  it('executes in-process via DefaultExecutionEngine when started manually even with a schedule declared', async () => {
+    const step = createStep({
+      id: 'step1',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async () => ({ value: 'hello' }),
+    });
+
+    const wf = createDefaultWorkflow({
+      id: 'run-wf',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+      schedule: { cron: '*/5 * * * *' },
+    })
+      .then(step)
+      .commit();
+
+    expect(wf.engineType).toBe('default');
+
+    const run = await wf.createRun();
+    const result = await run.start({ inputData: {} });
+    expect(result.status).toBe('success');
+    if (result.status === 'success') {
+      expect(result.result).toEqual({ value: 'hello' });
+    }
   });
 });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -56,6 +56,8 @@ import type { DynamicArgument } from '../types';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from './constants';
 import { DefaultExecutionEngine } from './default';
 import type { ExecutionEngine, ExecutionGraph } from './execution-engine';
+import { validateCron } from './scheduler/cron';
+import type { WorkflowScheduleConfig } from './scheduler/types';
 import type {
   ConditionFunction,
   ExecuteFunction,
@@ -1589,6 +1591,7 @@ export class Workflow<
   #mastra?: Mastra;
 
   #runs: Map<string, Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>> = new Map();
+  #schedules: WorkflowScheduleConfig[] = [];
 
   constructor({
     mastra,
@@ -1604,6 +1607,7 @@ export class Workflow<
     steps,
     options = {},
     type,
+    schedule,
   }: WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps, TRequestContext>) {
     super({ name: id, component: RegisteredLogger.WORKFLOW });
     this.id = id;
@@ -1643,10 +1647,38 @@ export class Workflow<
     this.engineType = 'default';
 
     this.#runs = new Map();
+
+    if (schedule) {
+      const schedules = Array.isArray(schedule) ? schedule : [schedule];
+      if (Array.isArray(schedule)) {
+        const seenIds = new Set<string>();
+        for (const entry of schedules) {
+          if (!entry.id) {
+            throw new Error(
+              `Workflow "${id}" declares an array of schedules but one entry is missing the required \`id\` field. Every entry in a schedule array must have a unique stable id.`,
+            );
+          }
+          if (seenIds.has(entry.id)) {
+            throw new Error(`Workflow "${id}" declares duplicate schedule id "${entry.id}".`);
+          }
+          seenIds.add(entry.id);
+        }
+      }
+      for (const entry of schedules) {
+        validateCron(entry.cron, entry.timezone);
+      }
+      this.#schedules = schedules.map(cfg => ({ ...cfg })) as any;
+    } else {
+      this.#schedules = [];
+    }
   }
 
   get runs() {
     return this.#runs;
+  }
+
+  getScheduleConfigs(): WorkflowScheduleConfig[] {
+    return this.#schedules.map(cfg => ({ ...cfg }));
   }
 
   get mastra() {


### PR DESCRIPTION
## Description

Previously, declaring a schedule on a workflow conditionally promoted it to an `EventedWorkflow` running on the `EventedExecutionEngine`. This forced all executions—including manual runs triggered via `run.start()` or HTTP endpoints—to use the evented engine. The evented engine relies on a pubsub queue and background event workers, which causes hangs and timeouts in serverless environments (such as Vercel) where long-running background workers do not exist.

This PR decouples scheduling configurations from the execution engine:
- `createWorkflow()` now always returns the standard `Workflow` class running on the in-process `DefaultExecutionEngine`.
- Schedule normalization, cron syntax checks, and duplicate ID validation have been moved to the base `Workflow` class constructor.
- Exposes schedule metadata via `.getScheduleConfigs()` on the base `Workflow` class so that the scheduler worker can still discover, register, and trigger workflow runs asynchronously via the pubsub queue.
- Added a regression test to verify that manual runs for scheduled workflows execute synchronously in-process via the `DefaultExecutionEngine`.

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/18807

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Before, just adding a schedule to a workflow could accidentally make it run in a different way. Now, scheduled workflows keep using the normal in-process runner, while the scheduler can still see the schedule and trigger it when needed.

## Summary
- Stopped `createWorkflow()` from auto-promoting scheduled workflows to the evented engine.
- Moved schedule parsing, cron validation, and duplicate/missing schedule ID checks into the base `Workflow` constructor.
- Added `getScheduleConfigs()` so schedule metadata is available to the scheduler worker.
- Updated tests to verify scheduled workflows still use the default engine for manual runs and expose schedule configs correctly.
- Added a changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->