### PR TITLE
fix: Root cause: `createHonoServer()` (used directly by the Vercel/Cloud

### DIFF
--- a/packages/core/src/events/event-emitter/index.ts
+++ b/packages/core/src/events/event-emitter/index.ts
@@ -207,6 +207,18 @@ export class EventEmitterPubSub extends PubSub implements LeaseProvider {
     }
   }
 
+  /**
+   * True when at least one listener is registered for `topic`, across both
+   * fan-out subscribers and worker groups (group and batched subscribers all
+   * end up registered on `this.emitter`, so a single `listenerCount` check
+   * covers every `subscribe()` path). Since this pubsub is strictly
+   * in-process, a `false` here means a `publish()` for that topic can never
+   * be observed by anyone.
+   */
+  hasSubscribers(topic: string): boolean {
+    return this.emitter.listenerCount(topic) > 0;
+  }
+
   async flush(): Promise<void> {
     // A batched cb can nack mid-delivery, which schedules a redelivery via
     // setTimeout(0). The redelivered event lands back in `batchBuffers`

--- a/packages/core/src/workflows/evented/execution-engine-no-consumer.test.ts
+++ b/packages/core/src/workflows/evented/execution-engine-no-consumer.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { MastraError } from '../../error';
+import { EventEmitterPubSub } from '../../events/event-emitter';
+import { Mastra } from '../../mastra';
+import { MockStore } from '../../storage/mock';
+import { createStep, createWorkflow } from '.';
+
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/18807.
+ *
+ * Declaring `schedule` on a workflow promotes it to the evented execution
+ * engine for *every* run, not just scheduler-fired ones. The evented engine
+ * only makes progress once something consumes the `workflows` pubsub topic
+ * (wired up by `mastra.startWorkers()`). On serverless deployers that never
+ * call `startWorkers()`, a plain `createRun()` + `run.start()` call (e.g.
+ * from a custom HTTP route) used to hang forever instead of failing.
+ */
+describe('EventedExecutionEngine — no event consumer', () => {
+  const buildScheduledWorkflow = () => {
+    const step = createStep({
+      id: 'noop',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      execute: async () => ({}),
+    });
+
+    return createWorkflow({
+      id: 'scheduled-wf',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      schedule: { cron: '*/15 * * * *' },
+    })
+      .then(step)
+      .commit();
+  };
+
+  it('fails fast instead of hanging when startWorkers() was never called', async () => {
+    const workflow = buildScheduledWorkflow();
+    // eslint-disable-next-line no-new -- registers `workflow` with this Mastra instance as a side effect
+    new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { [workflow.id]: workflow },
+      pubsub: new EventEmitterPubSub(),
+    });
+    // Intentionally do NOT call `mastra.startWorkers()` — this mirrors a
+    // serverless request handler (e.g. @mastra/deployer-vercel) that never
+    // wires up the workflow event processor before a route calls
+    // `run.start()`.
+
+    const run = await workflow.createRun();
+
+    await expect(run.start({ inputData: {} })).rejects.toThrow(/no event consumer is running/i);
+  });
+
+  it('throws a MastraError with the EVENTED_WORKFLOW_NO_EVENT_CONSUMER id', async () => {
+    const workflow = buildScheduledWorkflow();
+    // eslint-disable-next-line no-new -- registers `workflow` with this Mastra instance as a side effect
+    new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { [workflow.id]: workflow },
+      pubsub: new EventEmitterPubSub(),
+    });
+
+    const run = await workflow.createRun();
+
+    await expect(run.start({ inputData: {} })).rejects.toMatchObject({
+      id: 'EVENTED_WORKFLOW_NO_EVENT_CONSUMER',
+    } satisfies Partial<MastraError>);
+  });
+
+  it('runs normally once startWorkers() has wired up a consumer', async () => {
+    const workflow = buildScheduledWorkflow();
+    const mastra = new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { [workflow.id]: workflow },
+      pubsub: new EventEmitterPubSub(),
+    });
+    await mastra.startWorkers();
+
+    try {
+      const run = await workflow.createRun();
+      const result = await run.start({ inputData: {} });
+      expect(result.status).toBe('success');
+    } finally {
+      await mastra.stopWorkers();
+    }
+  });
+});

--- a/packages/core/src/workflows/evented/execution-engine.ts
+++ b/packages/core/src/workflows/evented/execution-engine.ts
@@ -1,4 +1,6 @@
 import type { RequestContext } from '../../di';
+import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
+import { EventEmitterPubSub } from '../../events/event-emitter';
 import type { PubSub } from '../../events/pubsub';
 import type { Event } from '../../events/types';
 import type { Mastra } from '../../mastra';
@@ -91,6 +93,28 @@ export class EventedExecutionEngine extends ExecutionEngine {
     const pubsub = this.mastra?.pubsub;
     if (!pubsub) {
       throw new Error('No Pubsub adapter configured on the Mastra instance');
+    }
+
+    // The evented engine only makes progress when something is consuming
+    // `workflow.start`/`workflow.resume` events on the `workflows` topic —
+    // either the OrchestrationWorker or the push subscription wired up by
+    // `mastra.startWorkers()`. The default pubsub is strictly in-process, so
+    // if nothing has subscribed yet, no process anywhere can ever pick this
+    // run up: publishing would hang forever instead of failing loudly (e.g.
+    // a serverless route that never calls `startWorkers()`). Fail fast here
+    // instead. Adapters that support out-of-process consumers (Redis, etc.)
+    // are intentionally not checked, since their consumer may simply not
+    // have started yet in this process.
+    if (pubsub instanceof EventEmitterPubSub && !pubsub.hasSubscribers('workflows')) {
+      throw new MastraError({
+        id: 'EVENTED_WORKFLOW_NO_EVENT_CONSUMER',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text:
+          `Workflow "${params.workflowId}" runs on the evented execution engine (enabled by declaring \`schedule\`), but no event consumer is running to process run "${params.runId}". ` +
+          `Call \`await mastra.startWorkers()\` during startup so the workflow event processor is wired up, or remove the \`schedule\` field from this workflow's definition to use the default in-process engine.`,
+        details: { workflowId: params.workflowId, runId: params.runId },
+      });
     }
 
     // Set up promise that will resolve when workflow finishes


### PR DESCRIPTION
Fixes #18807

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

---

Root cause: `createHonoServer()` (used directly by the Vercel/Cloudflare/Netlify serverless deployer entrypoints) never calls `mastra.startWorkers()`, unlike `createNodeServer()` (used by `mastra dev`/`mastra start`), so the evented engine's `workflows` pubsub topic has zero subscribers and `EventedExecutionEngine.execute()` awaits `workflows-finish` forever. Added a `hasSubscribers(topic)` check on `EventEmitterPubSub` (events/event-emitter/index.ts) and a guard in `EventedExecutionEngine.execute()` that throws a clear `EVENTED_WORKFLOW_NO_EVENT_CONSUMER` MastraError instead of hanging when the default in-process pubsub has no listener on `workflows`, plus a regression test file covering the failing/fixed/happy-path cases.

**How this was tested:** `pnpm run setup pnpm build pnpm build:packages or repo wide test runs when package local is enough`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops certain workflows from getting “stuck forever” when they need a background worker but none is running. Instead of waiting endlessly, the app now quickly tells you to start workers or remove the schedule so the workflow can run normally.

## Summary
- Added `hasSubscribers(topic)` to `EventEmitterPubSub` so the in-process pubsub can detect whether anything is listening for workflow events.
- Updated `EventedExecutionEngine.execute()` to fail fast with `EVENTED_WORKFLOW_NO_EVENT_CONSUMER` when the `workflows` topic has no consumer, instead of hanging on `workflows-finish`.
- Added a regression test covering the no-consumer failure case, the emitted error shape, and the successful path after `mastra.startWorkers()` is called.

## Impact
- Prevents silent hangs for scheduled workflows in serverless/manual run scenarios.
- Provides a clear error message and actionable guidance when the evented engine is used without an active event processor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->