### PR TITLE
chore(playground-ui): deprecate asChild props

### DIFF
--- a/.changeset/clear-cups-pay.md
+++ b/.changeset/clear-cups-pay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Deprecated legacy `asChild` props in Playground UI. Use Base UI's native `render` prop for typed composition.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,6 @@ For work in packages read package local packages/<name>/AGENTS.md first
 
 turborepo pnpm workspace
 packages use strict TypeScript
-Do not add new `asChild` usage; prefer Base UI's native `render` prop for stronger type safety.
 vitest tests are colocated with source
 When adding a model name or ID to changesets or comments, use a literal value from docs/src/plugins/remark-model-tokens/models.ts (do not use placeholder tokens, remark does not replace them in changesets/comments)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ For work in packages read package local packages/<name>/AGENTS.md first
 
 turborepo pnpm workspace
 packages use strict TypeScript
+Do not add new `asChild` usage; prefer Base UI's native `render` prop for stronger type safety.
 vitest tests are colocated with source
 When adding a model name or ID to changesets or comments, use a literal value from docs/src/plugins/remark-model-tokens/models.ts (do not use placeholder tokens, remark does not replace them in changesets/comments)
 

--- a/packages/playground-ui/AGENTS.md
+++ b/packages/playground-ui/AGENTS.md
@@ -28,3 +28,4 @@ applicable.
 
 This package needs both component validation and realistic UI validation.
 Preserve design-system consistency and existing component APIs where possible.
+Do not add new `asChild` usage; prefer Base UI's native `render` prop for stronger type safety.

--- a/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
+++ b/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
@@ -26,7 +26,7 @@ function AlertDialog({
 }
 
 type AlertDialogTriggerProps = AlertDialogPrimitive.Trigger.Props & {
-  /** @deprecated Use Base UI's `render` prop instead, e.g. `render={<Button />}`. */
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
 };
 

--- a/packages/playground-ui/src/ds/components/Collapsible/collapsible.tsx
+++ b/packages/playground-ui/src/ds/components/Collapsible/collapsible.tsx
@@ -7,6 +7,7 @@ const Collapsible = CollapsiblePrimitive.Root;
 
 type CollapsibleTriggerProps = Omit<CollapsiblePrimitive.Trigger.Props, 'className'> & {
   className?: string;
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
 };
 

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -11,7 +11,7 @@ import './dialog.css';
 const Dialog = DialogPrimitive.Root;
 
 type DialogTriggerProps = DialogPrimitive.Trigger.Props & {
-  /** @deprecated Use Base UI's `render` prop instead, e.g. `render={<Button />}`. */
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
 };
 
@@ -29,7 +29,7 @@ DialogTrigger.displayName = 'DialogTrigger';
 const DialogPortal = DialogPrimitive.Portal;
 
 type DialogCloseProps = DialogPrimitive.Close.Props & {
-  /** @deprecated Use Base UI's `render` prop instead, e.g. `render={<Button />}`. */
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
 };
 

--- a/packages/playground-ui/src/ds/components/Drawer/drawer.tsx
+++ b/packages/playground-ui/src/ds/components/Drawer/drawer.tsx
@@ -231,6 +231,7 @@ Drawer.displayName = 'Drawer';
 
 // Generic (not `forwardRef`) so `handle` / `payload` stay type-safe on detached triggers.
 type DrawerTriggerProps<Payload = unknown> = DrawerPrimitive.Trigger.Props<Payload> & {
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
 };
 
@@ -246,6 +247,7 @@ function DrawerTrigger<Payload = unknown>({ asChild, children, ...props }: Drawe
 DrawerTrigger.displayName = 'DrawerTrigger';
 
 type DrawerCloseProps = DrawerPrimitive.Close.Props & {
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
 };
 

--- a/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
+++ b/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
@@ -28,7 +28,7 @@ const popupClass = cn(
 );
 
 type DropdownMenuTriggerProps = MenuPrimitive.Trigger.Props & {
-  /** @deprecated Use Base UI's `render` prop instead, e.g. `render={<Button />}`. */
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
 };
 

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -36,6 +36,9 @@ export type MainSidebarNavLinkProps = Omit<ComponentPropsWithoutRef<'li'>, 'chil
    * Use for `<button>` items or custom router Links. Item classes are forwarded
    * to the slotted element. `link.url` and `LinkComponent` are ignored; other
    * `link` presentation fields still apply when supplied.
+   *
+   * @deprecated Prefer typed render composition for new APIs; this legacy
+   * slotted prop will be migrated separately.
    */
   asChild?: boolean;
 };

--- a/packages/playground-ui/src/ds/components/Popover/popover.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils';
 const Popover = PopoverPrimitive.Root;
 
 type PopoverTriggerProps = PopoverPrimitive.Trigger.Props & {
-  /** @deprecated Use Base UI's `render` prop instead, e.g. `render={<Button />}`. */
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
 };
 

--- a/packages/playground-ui/src/ds/components/Switch/switch.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.tsx
@@ -6,6 +6,7 @@ import './switch.css';
 
 type SwitchProps = Omit<SwitchPrimitive.Root.Props, 'className'> & {
   className?: string;
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
   icon?: React.ReactNode;
   checkedIcon?: React.ReactNode;

--- a/packages/playground-ui/src/ds/components/Tooltip/tooltip.tsx
+++ b/packages/playground-ui/src/ds/components/Tooltip/tooltip.tsx
@@ -30,7 +30,7 @@ function TooltipProvider({ delay, delayDuration, timeout, skipDelayDuration, ...
 const Tooltip = TooltipPrimitive.Root;
 
 type TooltipTriggerProps = TooltipPrimitive.Trigger.Props & {
-  /** Radix-style alias for Base UI's native `render` prop. */
+  /** @deprecated Use Base UI's native `render` prop instead for stronger composition typing. */
   asChild?: boolean;
 };
 


### PR DESCRIPTION
This marks the Playground UI `asChild` compatibility props as deprecated and points new composition toward Base UI's native `render` prop for stronger typing.

It intentionally does not migrate existing call sites yet. The diff only adds the repo guidance, TypeScript-visible `@deprecated` annotations, and a patch changeset.

Validated with `pnpm --filter ./packages/playground-ui typecheck`, `pnpm --filter ./packages/playground-ui lint`, `pnpm build:playground-ui`, and `git diff --check`. CodeRabbit local review was skipped because the CLI is installed but not authenticated (`coderabbit doctor` reports not signed in).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change tells developers not to use some older “attach this child” patterns in Playground UI anymore. Instead, it points them to Base UI’s newer `render` prop, which is better typed and clearer to use.

### Summary
- Added guidance in `packages/playground-ui/AGENTS.md` to avoid new `asChild` usage.
- Marked legacy `asChild`/similar composition props as deprecated in Playground UI component docs and types.
- Updated deprecation messages across several components to recommend Base UI’s native `render` prop.
- Added a changeset for `@mastra/playground-ui` documenting the patch release and deprecation guidance.

### Validation
- `pnpm --filter ./packages/playground-ui typecheck`
- `pnpm --filter ./packages/playground-ui lint`
- `pnpm build:playground-ui`
- `git diff --check`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->