### PR TITLE
fix(core,observability): preserve tracingOptions.metadata across resume

### DIFF
--- a/.changeset/shy-snails-invite.md
+++ b/.changeset/shy-snails-invite.md
@@ -1,5 +1,4 @@
 ---
-'@mastra/observability': patch
 '@mastra/core': patch
 ---
 

--- a/.changeset/shy-snails-invite.md
+++ b/.changeset/shy-snails-invite.md
@@ -1,0 +1,6 @@
+---
+'@mastra/observability': patch
+'@mastra/core': patch
+---
+
+Fixed tracingOptions.metadata (sessionId, userId) being silently dropped on agent resume. Metadata and tags are now persisted in the workflow snapshot during suspend and restored into tracingOptions when the agent resumes, ensuring Langfuse traces retain their sessionId across pick/input-form continuations.

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -200,8 +200,8 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       traceState = this.computeTraceState(tracingOptions);
     }
 
-    // Merge tracingOptions.metadata with span metadata (tracingOptions.metadata takes precedence)
-    const tracingMetadata = tracingOptions?.metadata;
+    // Merge tracingOptions.metadata with span metadata (tracingOptions.metadata takes precedence for root spans)
+    const tracingMetadata = !options.parent ? tracingOptions?.metadata : undefined;
     const mergedMetadata = metadata || tracingMetadata ? { ...metadata, ...tracingMetadata } : undefined;
 
     // Extract metadata from RequestContext
@@ -221,7 +221,8 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
         ? { ...(enrichedMetadata ?? {}), environment: this.#mastraEnvironment }
         : enrichedMetadata;
 
-    const tags = tracingOptions?.tags;
+    // Tags are only passed for root spans (no parent)
+    const tags = !options.parent ? tracingOptions?.tags : undefined;
 
     // Extract traceId and parentSpanId from tracingOptions for root spans (no parent)
     // These allow nested workflows to join the parent workflow's trace

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -200,8 +200,8 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       traceState = this.computeTraceState(tracingOptions);
     }
 
-    // Merge tracingOptions.metadata with span metadata (tracingOptions.metadata takes precedence for root spans)
-    const tracingMetadata = !options.parent ? tracingOptions?.metadata : undefined;
+    // Merge tracingOptions.metadata with span metadata (tracingOptions.metadata takes precedence)
+    const tracingMetadata = tracingOptions?.metadata;
     const mergedMetadata = metadata || tracingMetadata ? { ...metadata, ...tracingMetadata } : undefined;
 
     // Extract metadata from RequestContext
@@ -221,8 +221,7 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
         ? { ...(enrichedMetadata ?? {}), environment: this.#mastraEnvironment }
         : enrichedMetadata;
 
-    // Tags are only passed for root spans (no parent)
-    const tags = !options.parent ? tracingOptions?.tags : undefined;
+    const tags = tracingOptions?.tags;
 
     // Extract traceId and parentSpanId from tracingOptions for root spans (no parent)
     // These allow nested workflows to join the parent workflow's trace

--- a/packages/core/src/agent/__tests__/resume-span-tracing.test.ts
+++ b/packages/core/src/agent/__tests__/resume-span-tracing.test.ts
@@ -600,4 +600,128 @@ describe('resumed AGENT_RUN span input and trace continuity', () => {
       spy.mockRestore();
     }
   }, 30000);
+
+  it('restores persisted tracingOptions.metadata and tags on resume when caller does not re-supply them', async () => {
+    const { spy, agentRunCalls } = await spyOnAgentRunSpans();
+
+    try {
+      const findUserTool = createFindUserTool();
+      const userAgent = new Agent({
+        id: 'user-agent',
+        name: 'User Agent',
+        instructions: 'Find users.',
+        model: createMockModel(),
+        tools: { findUserTool },
+      });
+      const storage = new InMemoryStore();
+      const mastra = new Mastra({ agents: { userAgent }, logger: false, storage });
+      const agent = mastra.getAgent('userAgent');
+
+      // Initial stream to create a suspended run
+      const stream = await agent.stream('Find Dero Israel', { requireToolApproval: true });
+      await drainFullStream(stream);
+
+      // Seed the snapshot with tracingMetadata and tracingTags (simulating what
+      // the workflow span save does in production, where the span inherits
+      // parent metadata via BaseSpan constructor)
+      const workflowsStore = await storage.getStore('workflows');
+      const snapshot = await workflowsStore?.loadWorkflowSnapshot({
+        workflowName: 'agentic-loop',
+        runId: stream.runId,
+      });
+      if (snapshot) {
+        await workflowsStore?.persistWorkflowSnapshot({
+          workflowName: 'agentic-loop',
+          runId: stream.runId,
+          snapshot: {
+            ...snapshot,
+            tracingContext: {
+              ...(snapshot.tracingContext ?? {}),
+              tracingMetadata: { sessionId: 'session-abc', userId: 'user-xyz', custom: 'value' },
+              tracingTags: ['production', 'experiment-v2'],
+            },
+          },
+        });
+      }
+
+      // Resume WITHOUT re-supplying tracingOptions
+      const resumeStream = await agent.resumeStream({ approved: true }, { runId: stream.runId });
+      await drainFullStream(resumeStream);
+
+      expect(agentRunCalls.length).toBe(2);
+      const resumedCall = agentRunCalls[1];
+      expect(resumedCall.tracingOptions?.metadata).toMatchObject({
+        sessionId: 'session-abc',
+        userId: 'user-xyz',
+        custom: 'value',
+      });
+      expect(resumedCall.tracingOptions?.tags).toEqual(['production', 'experiment-v2']);
+    } finally {
+      spy.mockRestore();
+    }
+  }, 30000);
+
+  it('caller-provided tracingOptions.metadata on resume overrides persisted values', async () => {
+    const { spy, agentRunCalls } = await spyOnAgentRunSpans();
+
+    try {
+      const findUserTool = createFindUserTool();
+      const userAgent = new Agent({
+        id: 'user-agent',
+        name: 'User Agent',
+        instructions: 'Find users.',
+        model: createMockModel(),
+        tools: { findUserTool },
+      });
+      const storage = new InMemoryStore();
+      const mastra = new Mastra({ agents: { userAgent }, logger: false, storage });
+      const agent = mastra.getAgent('userAgent');
+
+      const stream = await agent.stream('Find Dero Israel', { requireToolApproval: true });
+      await drainFullStream(stream);
+
+      // Seed snapshot with persisted metadata
+      const workflowsStore = await storage.getStore('workflows');
+      const snapshot = await workflowsStore?.loadWorkflowSnapshot({
+        workflowName: 'agentic-loop',
+        runId: stream.runId,
+      });
+      if (snapshot) {
+        await workflowsStore?.persistWorkflowSnapshot({
+          workflowName: 'agentic-loop',
+          runId: stream.runId,
+          snapshot: {
+            ...snapshot,
+            tracingContext: {
+              ...(snapshot.tracingContext ?? {}),
+              tracingMetadata: { sessionId: 'original-session', userId: 'original-user' },
+              tracingTags: ['original-tag'],
+            },
+          },
+        });
+      }
+
+      // Resume WITH new tracingOptions — caller values should override persisted
+      const resumeStream = await agent.resumeStream(
+        { approved: true },
+        {
+          runId: stream.runId,
+          tracingOptions: {
+            metadata: { sessionId: 'overridden-session' },
+            tags: ['overridden-tag'],
+          },
+        },
+      );
+      await drainFullStream(resumeStream);
+
+      expect(agentRunCalls.length).toBe(2);
+      const resumedCall = agentRunCalls[1];
+      // Caller-provided sessionId overrides persisted; persisted userId preserved
+      expect(resumedCall.tracingOptions?.metadata?.sessionId).toBe('overridden-session');
+      expect(resumedCall.tracingOptions?.metadata?.userId).toBe('original-user');
+      expect(resumedCall.tracingOptions?.tags).toEqual(['overridden-tag']);
+    } finally {
+      spy.mockRestore();
+    }
+  }, 30000);
 });

--- a/packages/core/src/agent/__tests__/resume-span-tracing.test.ts
+++ b/packages/core/src/agent/__tests__/resume-span-tracing.test.ts
@@ -601,11 +601,10 @@ describe('resumed AGENT_RUN span input and trace continuity', () => {
     }
   }, 30000);
 
-  async function createSuspendedRunWithSeededTracing(
-    spy: ReturnType<typeof vi.spyOn>,
-    agentRunCalls: any[],
-    seed: { tracingMetadata: Record<string, any>; tracingTags: string[] },
-  ) {
+  async function createSuspendedRunWithSeededTracing(seed: {
+    tracingMetadata: Record<string, any>;
+    tracingTags: string[];
+  }) {
     const findUserTool = createFindUserTool();
     const userAgent = new Agent({
       id: 'user-agent',
@@ -641,14 +640,14 @@ describe('resumed AGENT_RUN span input and trace continuity', () => {
       },
     });
 
-    return { agent, stream, agentRunCalls };
+    return { agent, stream };
   }
 
   it('restores persisted tracingOptions.metadata and tags on resume when caller does not re-supply them', async () => {
     const { spy, agentRunCalls } = await spyOnAgentRunSpans();
 
     try {
-      const { agent, stream } = await createSuspendedRunWithSeededTracing(spy, agentRunCalls, {
+      const { agent, stream } = await createSuspendedRunWithSeededTracing({
         tracingMetadata: { sessionId: 'session-abc', userId: 'user-xyz', custom: 'value' },
         tracingTags: ['production', 'experiment-v2'],
       });
@@ -673,7 +672,7 @@ describe('resumed AGENT_RUN span input and trace continuity', () => {
     const { spy, agentRunCalls } = await spyOnAgentRunSpans();
 
     try {
-      const { agent, stream } = await createSuspendedRunWithSeededTracing(spy, agentRunCalls, {
+      const { agent, stream } = await createSuspendedRunWithSeededTracing({
         tracingMetadata: { sessionId: 'original-session', userId: 'original-user' },
         tracingTags: ['original-tag'],
       });

--- a/packages/core/src/agent/__tests__/resume-span-tracing.test.ts
+++ b/packages/core/src/agent/__tests__/resume-span-tracing.test.ts
@@ -601,50 +601,58 @@ describe('resumed AGENT_RUN span input and trace continuity', () => {
     }
   }, 30000);
 
+  async function createSuspendedRunWithSeededTracing(
+    spy: ReturnType<typeof vi.spyOn>,
+    agentRunCalls: any[],
+    seed: { tracingMetadata: Record<string, any>; tracingTags: string[] },
+  ) {
+    const findUserTool = createFindUserTool();
+    const userAgent = new Agent({
+      id: 'user-agent',
+      name: 'User Agent',
+      instructions: 'Find users.',
+      model: createMockModel(),
+      tools: { findUserTool },
+    });
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({ agents: { userAgent }, logger: false, storage });
+    const agent = mastra.getAgent('userAgent');
+
+    const stream = await agent.stream('Find Dero Israel', { requireToolApproval: true });
+    await drainFullStream(stream);
+
+    const workflowsStore = await storage.getStore('workflows');
+    const snapshot = await workflowsStore?.loadWorkflowSnapshot({
+      workflowName: 'agentic-loop',
+      runId: stream.runId,
+    });
+    expect(snapshot).toBeTruthy();
+
+    await workflowsStore!.persistWorkflowSnapshot({
+      workflowName: 'agentic-loop',
+      runId: stream.runId,
+      snapshot: {
+        ...snapshot!,
+        tracingContext: {
+          ...(snapshot!.tracingContext ?? {}),
+          tracingMetadata: seed.tracingMetadata,
+          tracingTags: seed.tracingTags,
+        },
+      },
+    });
+
+    return { agent, stream, agentRunCalls };
+  }
+
   it('restores persisted tracingOptions.metadata and tags on resume when caller does not re-supply them', async () => {
     const { spy, agentRunCalls } = await spyOnAgentRunSpans();
 
     try {
-      const findUserTool = createFindUserTool();
-      const userAgent = new Agent({
-        id: 'user-agent',
-        name: 'User Agent',
-        instructions: 'Find users.',
-        model: createMockModel(),
-        tools: { findUserTool },
+      const { agent, stream } = await createSuspendedRunWithSeededTracing(spy, agentRunCalls, {
+        tracingMetadata: { sessionId: 'session-abc', userId: 'user-xyz', custom: 'value' },
+        tracingTags: ['production', 'experiment-v2'],
       });
-      const storage = new InMemoryStore();
-      const mastra = new Mastra({ agents: { userAgent }, logger: false, storage });
-      const agent = mastra.getAgent('userAgent');
 
-      // Initial stream to create a suspended run
-      const stream = await agent.stream('Find Dero Israel', { requireToolApproval: true });
-      await drainFullStream(stream);
-
-      // Seed the snapshot with tracingMetadata and tracingTags (simulating what
-      // the workflow span save does in production, where the span inherits
-      // parent metadata via BaseSpan constructor)
-      const workflowsStore = await storage.getStore('workflows');
-      const snapshot = await workflowsStore?.loadWorkflowSnapshot({
-        workflowName: 'agentic-loop',
-        runId: stream.runId,
-      });
-      if (snapshot) {
-        await workflowsStore?.persistWorkflowSnapshot({
-          workflowName: 'agentic-loop',
-          runId: stream.runId,
-          snapshot: {
-            ...snapshot,
-            tracingContext: {
-              ...(snapshot.tracingContext ?? {}),
-              tracingMetadata: { sessionId: 'session-abc', userId: 'user-xyz', custom: 'value' },
-              tracingTags: ['production', 'experiment-v2'],
-            },
-          },
-        });
-      }
-
-      // Resume WITHOUT re-supplying tracingOptions
       const resumeStream = await agent.resumeStream({ approved: true }, { runId: stream.runId });
       await drainFullStream(resumeStream);
 
@@ -665,43 +673,11 @@ describe('resumed AGENT_RUN span input and trace continuity', () => {
     const { spy, agentRunCalls } = await spyOnAgentRunSpans();
 
     try {
-      const findUserTool = createFindUserTool();
-      const userAgent = new Agent({
-        id: 'user-agent',
-        name: 'User Agent',
-        instructions: 'Find users.',
-        model: createMockModel(),
-        tools: { findUserTool },
+      const { agent, stream } = await createSuspendedRunWithSeededTracing(spy, agentRunCalls, {
+        tracingMetadata: { sessionId: 'original-session', userId: 'original-user' },
+        tracingTags: ['original-tag'],
       });
-      const storage = new InMemoryStore();
-      const mastra = new Mastra({ agents: { userAgent }, logger: false, storage });
-      const agent = mastra.getAgent('userAgent');
 
-      const stream = await agent.stream('Find Dero Israel', { requireToolApproval: true });
-      await drainFullStream(stream);
-
-      // Seed snapshot with persisted metadata
-      const workflowsStore = await storage.getStore('workflows');
-      const snapshot = await workflowsStore?.loadWorkflowSnapshot({
-        workflowName: 'agentic-loop',
-        runId: stream.runId,
-      });
-      if (snapshot) {
-        await workflowsStore?.persistWorkflowSnapshot({
-          workflowName: 'agentic-loop',
-          runId: stream.runId,
-          snapshot: {
-            ...snapshot,
-            tracingContext: {
-              ...(snapshot.tracingContext ?? {}),
-              tracingMetadata: { sessionId: 'original-session', userId: 'original-user' },
-              tracingTags: ['original-tag'],
-            },
-          },
-        });
-      }
-
-      // Resume WITH new tracingOptions — caller values should override persisted
       const resumeStream = await agent.resumeStream(
         { approved: true },
         {
@@ -716,7 +692,6 @@ describe('resumed AGENT_RUN span input and trace continuity', () => {
 
       expect(agentRunCalls.length).toBe(2);
       const resumedCall = agentRunCalls[1];
-      // Caller-provided sessionId overrides persisted; persisted userId preserved
       expect(resumedCall.tracingOptions?.metadata?.sessionId).toBe('overridden-session');
       expect(resumedCall.tracingOptions?.metadata?.userId).toBe('original-user');
       expect(resumedCall.tracingOptions?.tags).toEqual(['overridden-tag']);

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6739,7 +6739,13 @@ export class Agent<
       : undefined;
     const persistedTracingContext = isResume
       ? (resumeContext?.snapshot?.tracingContext as
-          | { traceId?: string; spanId?: string; parentSpanId?: string }
+          | {
+              traceId?: string;
+              spanId?: string;
+              parentSpanId?: string;
+              tracingMetadata?: Record<string, any>;
+              tracingTags?: string[];
+            }
           | undefined)
       : undefined;
 
@@ -6756,6 +6762,8 @@ export class Agent<
       isResume && persistedTracingContext?.traceId
         ? {
             ...options.tracingOptions,
+            metadata: { ...persistedTracingContext?.tracingMetadata, ...options.tracingOptions?.metadata },
+            tags: options.tracingOptions?.tags ?? persistedTracingContext?.tracingTags,
             traceId: effectiveTraceId,
             parentSpanId: shouldUsePersistedParentSpan ? persistedTracingContext?.spanId : userProvidedParentSpanId,
           }

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -1387,7 +1387,11 @@ export class DurableAgent<
             ...(resolvedVersionId ? { entityVersionId: resolvedVersionId } : {}),
           },
           tracingPolicy: agentTracingPolicy,
-          tracingOptions: { traceId: origTraceId },
+          tracingOptions: {
+            traceId: origTraceId,
+            metadata: entry.agentSpan?.metadata,
+            tags: entry.agentSpan?.tags,
+          },
           requestContext,
           mastra: this.#mastra,
         });

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -1389,8 +1389,8 @@ export class DurableAgent<
           tracingPolicy: agentTracingPolicy,
           tracingOptions: {
             traceId: origTraceId,
-            metadata: entry.agentSpan?.metadata,
-            tags: entry.agentSpan?.tags,
+            metadata: { ...entry.agentSpan?.metadata, ...options?.tracingOptions?.metadata },
+            tags: options?.tracingOptions?.tags ?? entry.agentSpan?.tags,
           },
           requestContext,
           mastra: this.#mastra,

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -876,6 +876,8 @@ export class DefaultExecutionEngine extends ExecutionEngine {
                 traceId: workflowSpan.traceId,
                 spanId: workflowSpan.id,
                 parentSpanId: workflowSpan.getParentSpanId(),
+                ...(workflowSpan.metadata ? { tracingMetadata: workflowSpan.metadata } : {}),
+                ...(workflowSpan.tags?.length ? { tracingTags: workflowSpan.tags } : {}),
               }
             : {};
 

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -287,12 +287,32 @@ export class WorkflowEventProcessor extends EventProcessor {
    */
   private resolveSuspendTracingContext(
     runId: string,
-  ): { traceId?: string; spanId?: string; parentSpanId?: string } | undefined {
+  ):
+    | {
+        traceId?: string;
+        spanId?: string;
+        parentSpanId?: string;
+        tracingMetadata?: Record<string, any>;
+        tracingTags?: string[];
+      }
+    | undefined {
     const span = this.resolveRunTracingContext(runId)?.currentSpan as
-      | { id?: string; traceId?: string; getParentSpanId?: () => string | undefined }
+      | {
+          id?: string;
+          traceId?: string;
+          getParentSpanId?: () => string | undefined;
+          metadata?: Record<string, any>;
+          tags?: string[];
+        }
       | undefined;
     if (!span) return undefined;
-    return { traceId: span.traceId, spanId: span.id, parentSpanId: span.getParentSpanId?.() };
+    return {
+      traceId: span.traceId,
+      spanId: span.id,
+      parentSpanId: span.getParentSpanId?.(),
+      ...(span.metadata ? { tracingMetadata: span.metadata } : {}),
+      ...(span.tags?.length ? { tracingTags: span.tags } : {}),
+    };
   }
 
   /**

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -285,9 +285,7 @@ export class WorkflowEventProcessor extends EventProcessor {
    * `default.ts`'s `persistTracingContext`; the evented engine holds the live span on
    * Mastra (since it can't ride pubsub events), so we resolve it via runId here.
    */
-  private resolveSuspendTracingContext(
-    runId: string,
-  ):
+  private resolveSuspendTracingContext(runId: string):
     | {
         traceId?: string;
         spanId?: string;

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -14,6 +14,7 @@ import type {
   StepSuccess,
   TimeTravelExecutionParams,
   WorkflowRunState,
+  WorkflowStateTracingContext,
 } from '../../../workflows/types';
 import type { Workflow } from '../../../workflows/workflow';
 import { createRestartExecutionParams, createTimeTravelExecutionParams, validateStepResumeData } from '../../utils';
@@ -285,15 +286,7 @@ export class WorkflowEventProcessor extends EventProcessor {
    * `default.ts`'s `persistTracingContext`; the evented engine holds the live span on
    * Mastra (since it can't ride pubsub events), so we resolve it via runId here.
    */
-  private resolveSuspendTracingContext(runId: string):
-    | {
-        traceId?: string;
-        spanId?: string;
-        parentSpanId?: string;
-        tracingMetadata?: Record<string, any>;
-        tracingTags?: string[];
-      }
-    | undefined {
+  private resolveSuspendTracingContext(runId: string): WorkflowStateTracingContext | undefined {
     const span = this.resolveRunTracingContext(runId)?.currentSpan as
       | {
           id?: string;

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -317,6 +317,8 @@ export type WorkflowStateTracingContext = {
   traceId?: string;
   spanId?: string;
   parentSpanId?: string;
+  tracingMetadata?: Record<string, any>;
+  tracingTags?: string[];
 };
 
 /**

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -4116,6 +4116,8 @@ export class Run<
 
     const resumeTracingOptions = {
       ...params.tracingOptions,
+      metadata: { ...persistedTracingContext?.tracingMetadata, ...params.tracingOptions?.metadata },
+      tags: params.tracingOptions?.tags ?? persistedTracingContext?.tracingTags,
       traceId: effectiveTraceId,
       parentSpanId: shouldUsePersistedParentSpan
         ? persistedTracingContext?.spanId


### PR DESCRIPTION
## Description

Fixes `tracingOptions.metadata` (`sessionId`, `userId`) being silently dropped when an agent resumes after a pick/input-form suspension, causing orphaned Langfuse traces with no `sessionId`.

- Extend `WorkflowStateTracingContext` with `tracingMetadata` and `tracingTags` fields
- Persist span metadata and tags into the workflow snapshot at both default and evented engine suspend points
- Restore persisted metadata/tags into `resumeTracingOptions` on agent resume, workflow resume, and durable agent resume paths (caller-provided values override persisted)

**Scoped to `@mastra/core` only** — no observability or exporter changes needed. The `!options.parent` guard in `startSpan` does not affect resumed spans (they have no live parent object), so the fix is entirely about persisting and restoring metadata across the suspend/resume boundary.

## Related Issue(s)

Fixes #18875

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an agent pauses to wait for user input and then continues, some “tracking info” (like sessionId and userId) was getting lost, so the next trace didn’t connect to the earlier one. This PR saves that tracking info when pausing and restores it when resuming, so tools like Langfuse can still group everything correctly.

## What changed

- Persist tracing metadata and tags in workflow snapshots at suspension points.
- Restore persisted metadata and tags when resuming agents, workflows, and durable agents.
- Preserve caller-provided tracing values, while filling unspecified fields from persisted values.
- Extend `WorkflowStateTracingContext` with optional tracing metadata and tags.
- Add regression tests covering restoration and caller-overrides.
- Include a patch changeset for `@mastra/core`.

## Testing

- Focused regression tests passed: 11/11.
- Broader `@mastra/core` tests still contain unrelated existing failures and type errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->