### PR TITLE
docs: standardize sidebar title conjunctions

### DIFF
--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -185,7 +185,7 @@ const sidebars = {
             {
               type: 'doc',
               id: 'workflows/agents-and-tools',
-              label: 'Agents & Tools',
+              label: 'Agents and Tools',
             },
             {
               type: 'doc',
@@ -195,7 +195,7 @@ const sidebars = {
             {
               type: 'doc',
               id: 'workflows/suspend-and-resume',
-              label: 'Suspend & Resume',
+              label: 'Suspend and Resume',
             },
             {
               type: 'doc',

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -875,5 +875,5 @@ export const testWorkflow = createWorkflow({...})
 
 ## Related
 
-- [Suspend & Resume](/docs/workflows/suspend-and-resume)
+- [Suspend and Resume](/docs/workflows/suspend-and-resume)
 - [Human-in-the-loop](/docs/workflows/human-in-the-loop)

--- a/docs/src/content/en/docs/workflows/error-handling.mdx
+++ b/docs/src/content/en/docs/workflows/error-handling.mdx
@@ -362,6 +362,6 @@ for await (const chunk of stream.stream) {
 ## Related
 
 - [Control Flow](/docs/workflows/control-flow)
-- [Suspend & Resume](/docs/workflows/suspend-and-resume)
+- [Suspend and Resume](/docs/workflows/suspend-and-resume)
 - [Time Travel](/docs/workflows/time-travel)
 - [Human-in-the-loop](/docs/workflows/human-in-the-loop)

--- a/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
+++ b/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
@@ -219,4 +219,4 @@ const handleDelete = async () => {
 ## Related
 
 - [Control Flow](/docs/workflows/control-flow)
-- [Suspend & Resume](/docs/workflows/suspend-and-resume)
+- [Suspend and Resume](/docs/workflows/suspend-and-resume)

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -589,5 +589,5 @@ For a closer look at workflows, see our [Workflow Guide](/guides/guide/ai-recrui
 
 - [Workflow State](/docs/workflows/workflow-state)
 - [Control Flow](/docs/workflows/control-flow)
-- [Suspend & Resume](/docs/workflows/suspend-and-resume)
+- [Suspend and Resume](/docs/workflows/suspend-and-resume)
 - [Error Handling](/docs/workflows/error-handling)

--- a/docs/src/content/en/docs/workflows/snapshots.mdx
+++ b/docs/src/content/en/docs/workflows/snapshots.mdx
@@ -241,6 +241,6 @@ if (result.status === 'suspended') {
 ## Related
 
 - [Control Flow](/docs/workflows/control-flow)
-- [Suspend & Resume](/docs/workflows/suspend-and-resume)
+- [Suspend and Resume](/docs/workflows/suspend-and-resume)
 - [Time Travel](/docs/workflows/time-travel)
 - [Human-in-the-loop](/docs/workflows/human-in-the-loop)

--- a/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
+++ b/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Suspend & resume | Workflows"
+title: "Suspend and resume | Workflows"
 description: "Suspend and resume in Mastra workflows allows you to pause execution while waiting for external input or resources."
 packages:
   - "@mastra/core"
 ---
 
-# Suspend & resume
+# Suspend and resume
 
 Workflows can be paused at any step to collect additional data, wait for API callbacks, throttle costly operations, or request [human-in-the-loop](/docs/workflows/human-in-the-loop) input. When a workflow is suspended, its current execution state is saved as a snapshot. You can later resume the workflow from a [specific step ID](/docs/workflows/snapshots#retrieving-snapshots), restoring the exact state captured in that snapshot. [Snapshots](/docs/workflows/snapshots) are stored in your configured storage provider and persist across deployments and application restarts.
 

--- a/docs/src/content/en/docs/workflows/time-travel.mdx
+++ b/docs/src/content/en/docs/workflows/time-travel.mdx
@@ -312,6 +312,6 @@ const result = await run.timeTravel({
 ## Related
 
 - [Snapshots](/docs/workflows/snapshots)
-- [Suspend & Resume](/docs/workflows/suspend-and-resume)
+- [Suspend and Resume](/docs/workflows/suspend-and-resume)
 - [Error Handling](/docs/workflows/error-handling)
 - [Control Flow](/docs/workflows/control-flow)

--- a/docs/src/content/en/docs/workflows/workflow-state.mdx
+++ b/docs/src/content/en/docs/workflows/workflow-state.mdx
@@ -183,6 +183,6 @@ const parentWorkflow = createWorkflow({
 ## Related
 
 - [Workflows overview](/docs/workflows/overview)
-- [Suspend & Resume](/docs/workflows/suspend-and-resume)
+- [Suspend and Resume](/docs/workflows/suspend-and-resume)
 - [Step Class](/reference/workflows/step)
 - [Workflow Class](/reference/workflows/workflow)

--- a/docs/src/content/en/reference/auth/google.mdx
+++ b/docs/src/content/en/reference/auth/google.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Reference: MastraAuthGoogle & MastraRBACGoogle | Auth"
+title: "Reference: MastraAuthGoogle and MastraRBACGoogle | Auth"
 description: API reference for the MastraAuthGoogle and MastraRBACGoogle classes, which authenticate and authorize Mastra applications using Google Workspace.
 packages:
   - "@mastra/auth-google"
   - "@mastra/core"
 ---
 
-# MastraAuthGoogle & MastraRBACGoogle class
+# MastraAuthGoogle and MastraRBACGoogle class
 
 ## MastraAuthGoogle class
 

--- a/docs/src/content/en/reference/auth/okta.mdx
+++ b/docs/src/content/en/reference/auth/okta.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Reference: MastraAuthOkta & MastraRBACOkta | Auth"
+title: "Reference: MastraAuthOkta and MastraRBACOkta | Auth"
 description: "API reference for the MastraAuthOkta and MastraRBACOkta classes, which authenticate and authorize Mastra applications using Okta."
 packages:
   - "@mastra/auth-okta"
   - "@mastra/core"
 ---
 
-# MastraAuthOkta & MastraRBACOkta class
+# MastraAuthOkta and MastraRBACOkta class
 
 ## MastraAuthOkta class
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -651,7 +651,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Tools & MCP',
+      label: 'Tools and MCP',
       collapsed: true,
       items: [
         { type: 'doc', id: 'tools/brightdata', label: 'Bright Data Tools' },

--- a/docs/src/content/en/reference/tools/brightdata.mdx
+++ b/docs/src/content/en/reference/tools/brightdata.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Bright Data tools | Tools & MCP"
+title: "Reference: Bright Data tools | Tools and MCP"
 description: "API reference for @mastra/brightdata, which provides web search and fetch tools backed by Bright Data's SERP API and Web Unlocker."
 packages:
   - "@mastra/brightdata"

--- a/docs/src/content/en/reference/tools/create-code-mode.mdx
+++ b/docs/src/content/en/reference/tools/create-code-mode.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createCodeMode() | Tools & MCP"
+title: "Reference: createCodeMode() | Tools and MCP"
 description: "API reference for createCodeMode(), used to run multi-tool computations in a sandbox."
 packages:
   - "@mastra/core"

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createTool() | Tools & MCP"
+title: "Reference: createTool() | Tools and MCP"
 description: Documentation for the `createTool()` function in Mastra, used to define custom tools for agents.
 packages:
   - "@mastra/core"

--- a/docs/src/content/en/reference/tools/document-chunker-tool.mdx
+++ b/docs/src/content/en/reference/tools/document-chunker-tool.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createDocumentChunkerTool() | Tools & MCP"
+title: "Reference: createDocumentChunkerTool() | Tools and MCP"
 description: Documentation for the Document Chunker Tool in Mastra, which splits documents into smaller chunks for efficient processing and retrieval.
 packages:
   - "@mastra/rag"

--- a/docs/src/content/en/reference/tools/graph-rag-tool.mdx
+++ b/docs/src/content/en/reference/tools/graph-rag-tool.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createGraphRAGTool() | Tools & MCP"
+title: "Reference: createGraphRAGTool() | Tools and MCP"
 description: Documentation for the GraphRAG Tool in Mastra, which enhances RAG by building a graph of semantic relationships between documents.
 packages:
   - "@mastra/core"

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MCPClient | Tools & MCP"
+title: "Reference: MCPClient | Tools and MCP"
 description: API Reference for MCPClient - A class for managing multiple Model Context Protocol servers and their tools.
 packages:
   - "@mastra/core"

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MCPServer | Tools & MCP"
+title: "Reference: MCPServer | Tools and MCP"
 description: API Reference for MCPServer - A class for exposing Mastra tools and capabilities as a Model Context Protocol server.
 packages:
   - "@mastra/core"

--- a/docs/src/content/en/reference/tools/perplexity.mdx
+++ b/docs/src/content/en/reference/tools/perplexity.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Perplexity tools | Tools & MCP"
+title: "Reference: Perplexity tools | Tools and MCP"
 description: "API reference for @mastra/perplexity, which provides a Perplexity Search tool for Mastra agents."
 packages:
   - "@mastra/perplexity"

--- a/docs/src/content/en/reference/tools/tavily.mdx
+++ b/docs/src/content/en/reference/tools/tavily.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Tavily tools | Tools & MCP"
+title: "Reference: Tavily tools | Tools and MCP"
 description: "API reference for @mastra/tavily, which provides web search, extract, crawl, and map tools for Mastra agents."
 packages:
   - "@mastra/tavily"

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createVectorQueryTool() | Tools & MCP"
+title: "Reference: createVectorQueryTool() | Tools and MCP"
 description: Documentation for the Vector Query Tool in Mastra, which facilitates semantic search over vector stores with filtering and reranking capabilities.
 packages:
   - "@mastra/core"

--- a/docs/src/content/en/reference/workflows/run-methods/timeTravel.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/timeTravel.mdx
@@ -311,4 +311,4 @@ const result = await run.timeTravel({
 - [Workflows overview](/docs/workflows/overview#running-workflows)
 - [Workflow.createRun()](../workflow-methods/create-run)
 - [Snapshots](/docs/workflows/snapshots)
-- [Suspend & Resume](/docs/workflows/suspend-and-resume)
+- [Suspend and Resume](/docs/workflows/suspend-and-resume)


### PR DESCRIPTION
## Summary
- Replaces non-brand ampersands with "and" in docs sidebar labels.
- Updates matching docs and reference page titles/headings/link text for consistency.
- Leaves brand terms like "Weights & Biases" unchanged.

## Testing
- pnpm run validate: fails because of an unrelated stale sidebar "new" tag for SDK Agents in docs/src/content/en/docs/sidebars.js:142. Frontmatter, sidebar links, and reference sidebar sorting passed before that failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR makes the docs use “and” instead of “&” in sidebar labels, page titles, headings, and related links, so everything looks more consistent. It keeps real brand names that use “&” unchanged.

## Summary
- Standardized docs sidebar category labels by replacing non-brand ampersands with “and”
- Updated related workflow docs link text and headings to match the new wording
- Renamed several reference page titles under the tools and auth docs for consistency
- Left brand names with ampersands, such as “Weights & Biases,” unchanged

## Testing
- `validate` script was missing (`ERR_PNPM_NO_SCRIPT`)
- An unrelated stale sidebar “new” tag failure was noted after other checks had already passed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->