### PR TITLE
fix(docs): Indent on mobile sidebar

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -339,7 +339,7 @@ span[class*='categoryLinkLabel'] {
 }
 
 .theme-doc-sidebar-item-link-level-2 .menu__link {
-  padding-inline-start: 0.25rem;
+  padding-inline-start: 0;
 }
 
 .menu__caret {
@@ -803,9 +803,18 @@ article p {
   border-bottom: 0.5px solid var(--border) !important;
 }
 
+.theme-doc-sidebar-item-link-level-2 {
+  padding-inline-start: 0.75rem;
+  margin-block-end: calc(0.25rem * 1.5);
+}
+
 @media (min-width: 62.25rem) {
   #doc-item-container {
     gap: 2rem;
+  }
+
+  .theme-doc-sidebar-item-link-level-2 .menu__link {
+    padding-inline-start: 0.25rem;
   }
 
   [class*='docSidebarContainer'] {
@@ -1335,11 +1344,6 @@ article p {
 
   .menu__list-item-collapsible {
     margin-inline-start: -0.25rem;
-  }
-
-  .theme-doc-sidebar-item-link-level-2 {
-    padding-inline-start: 0.65rem;
-    margin-block-end: calc(0.25rem * 1.5);
   }
 
   .theme-doc-sidebar-item-link-level-3 > a,


### PR DESCRIPTION
## Description

Fix indendation CSS issue in sidebar on mobile views

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes the sidebar on small screens so the nested items line up better and don’t look oddly indented. It does this by adjusting the sidebar’s spacing rules in the docs CSS.

### What changed
- Updated `docs/custom.css` to tweak level-2 sidebar link indentation and spacing.
- Moved some spacing behavior to the parent sidebar item rule.
- Added a mobile-specific adjustment so the sidebar looks right on larger screens too.

### Impact
- Improves the appearance of the documentation sidebar on mobile.
- No public API or exported code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->