### PR TITLE
chore(docs): Update cloneThread ref

### DIFF
--- a/docs/src/content/en/reference/memory/cloneThread.mdx
+++ b/docs/src/content/en/reference/memory/cloneThread.mdx
@@ -11,7 +11,16 @@ The `.cloneThread()` method creates a copy of an existing conversation thread, i
 
 ## Usage example
 
+The following example creates a `Memory` instance and clones an existing thread.
+
 ```typescript
+import { Memory } from '@mastra/memory'
+import { LibSQLStore } from '@mastra/libsql'
+
+const memory = new Memory({
+  storage: new LibSQLStore({ id: 'memory-store', url: 'file:./memory.db' }),
+})
+
 const { thread, clonedMessages } = await memory.cloneThread({
   sourceThreadId: 'original-thread-123',
 })
@@ -42,7 +51,8 @@ const { thread, clonedMessages } = await memory.cloneThread({
   {
     name: 'title',
     type: 'string',
-    description: "Optional title for the cloned thread. Defaults to '[source title] (Copy)'.",
+    description:
+      'Optional title for the cloned thread. If omitted, the clone uses `Clone of ${sourceThread.title}` when the source thread has a title. Otherwise, the title is empty.',
     isOptional: true,
   },
   {
@@ -127,7 +137,7 @@ const { thread, clonedMessages } = await memory.cloneThread({
 ]}
 />
 
-### Clone Metadata
+### Clone metadata
 
 The cloned thread's metadata includes a `clone` property with:
 
@@ -191,8 +201,18 @@ const { thread: dateFilteredClone } = await memory.cloneThread({
   },
 })
 
+// Clone specific messages
+const { thread: selectedMessagesClone } = await memory.cloneThread({
+  sourceThreadId: 'original-thread-123',
+  options: {
+    messageFilter: {
+      messageIds: ['message-1', 'message-2'],
+    },
+  },
+})
+
 // Continue conversation on the cloned thread
-const response = await agent.generate("Let's try a different approach", {
+const response = await agent.generate('Try a different approach', {
   memory: {
     thread: fullClone.id,
     resource: fullClone.resourceId,
@@ -200,9 +220,13 @@ const response = await agent.generate("Let's try a different approach", {
 })
 ```
 
+Pass the cloned `thread.id` and `thread.resourceId` to `agent.generate()` to continue the conversation from the cloned thread.
+
 ## Vector embeddings
 
-When the Memory instance has semantic recall enabled (with a vector store and embedder configured), `cloneThread()` automatically creates vector embeddings for all cloned messages. This ensures that semantic search works correctly on the cloned thread.
+When the Memory instance has semantic recall enabled with a vector store and embedder configured, `cloneThread()` automatically creates vector embeddings for all cloned messages. This ensures that semantic search works correctly on the cloned thread.
+
+In this example, `embeddingModel` is the embedding model configured for the project.
 
 ```typescript
 import { Memory } from '@mastra/memory'
@@ -228,6 +252,14 @@ const results = await memory.recall({
   vectorSearchString: 'search query',
 })
 ```
+
+## Working memory
+
+When working memory is enabled, `cloneThread()` copies or shares working memory based on the working-memory scope and the clone's `resourceId`:
+
+- **Thread-scoped working memory**: The working memory is copied to the cloned thread.
+- **Resource-scoped working memory with the same `resourceId`**: The working memory is shared because the source and cloned threads belong to the same resource.
+- **Resource-scoped working memory with a different `resourceId`**: The working memory is copied to the cloned thread's resource.
 
 ## Observational Memory
 


### PR DESCRIPTION
## Description

Small cloneThread improvement made with https://github.com/mastra-ai/mastra/pull/18810

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the `cloneThread()` docs clearer and more helpful. It updates the examples and wording so people can better understand how to clone a thread, what happens to its title and messages, and how memory is handled.

### Documentation updates
- Refreshed the `Memory.cloneThread()` reference example to show creating `Memory` with a `LibSQLStore` first.
- Clarified the `title` parameter behavior when the source thread has no title.
- Tweaked the “Clone metadata” heading capitalization.
- Expanded the cloning example to include cloning selected messages with `messageIds`.
- Updated the follow-up `agent.generate()` example to use the cloned thread’s `id` and `resourceId`.
- Reworked the “Vector embeddings” section into a shorter narrative flow.
- Added a new “Working memory” section explaining how working memory is copied or shared depending on scope and `resourceId`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->