### PR TITLE
feat(mcp): add coerceSchemasTo option for edge runtimes

### DIFF
--- a/.changeset/fiery-mice-tell.md
+++ b/.changeset/fiery-mice-tell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': minor
+---
+
+Added `coerceSchemasTo` option to MCPClient. Set to `'zod'` to convert MCP tool input schemas from JSON Schema to Zod at load time. This fixes MCP tool calls crashing on Cloudflare Workers and other edge runtimes that block runtime code generation (`new Function()`).

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -19,6 +19,7 @@ constructor({
   id?: string;
   servers: Record<string, MastraMCPServerDefinition>;
   timeout?: number;
+  coerceSchemasTo?: 'json-schema' | 'zod';
 }: MCPClientOptions)
 ```
 
@@ -48,8 +49,49 @@ constructor({
     defaultValue: '60000',
     description: 'Global timeout value in milliseconds for all servers unless overridden in individual server configs.',
   },
+  {
+    name: 'coerceSchemasTo',
+    type: "'json-schema' | 'zod'",
+    isOptional: true,
+    defaultValue: "'json-schema'",
+    description:
+      'Controls how MCP tool input schemas are exposed to Mastra tools. Set to `zod` in edge runtimes like Cloudflare Workers to avoid AJV code generation during tool input validation.',
+  },
 ]}
 />
+
+## Edge runtime schema validation
+
+MCP servers publish tool input schemas as JSON Schema. By default, Mastra validates them through AJV, which uses runtime code generation (`new Function()`).
+
+Edge runtimes like Cloudflare Workers block runtime code generation. Set `coerceSchemasTo` to `'zod'` to convert MCP tool input schemas to Zod when toolsets are loaded:
+
+```typescript
+const mcp = new MCPClient({
+  coerceSchemasTo: 'zod',
+  servers: {
+    deepwiki: {
+      url: new URL('https://mcp.deepwiki.com/mcp'),
+    },
+  },
+})
+```
+
+`coerceSchemasTo` only changes how Mastra validates MCP tool _input_ schemas. MCP tool _output_ schemas are validated by the MCP SDK during `Client.callTool()` using the server's `jsonSchemaValidator`. In Cloudflare Workers or other V8 isolates, pass a Worker-safe validator for servers that advertise `outputSchema`:
+
+```typescript
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker'
+
+const mcp = new MCPClient({
+  coerceSchemasTo: 'zod',
+  servers: {
+    deepwiki: {
+      url: new URL('https://mcp.deepwiki.com/mcp'),
+      jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+    },
+  },
+})
+```
 
 ### `MastraMCPServerDefinition`
 

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -93,6 +93,12 @@ const mcp = new MCPClient({
 })
 ```
 
+:::note
+
+The underlying converter (`zod-from-json-schema`) does not support `$ref`, `$defs`, or `anyOf`/`oneOf` in JSON Schema. Tools with these constructs accept any input when `coerceSchemasTo` is `'zod'`. The MCP server still validates inputs on its side, so invalid arguments are caught before execution.
+
+:::
+
 ### `MastraMCPServerDefinition`
 
 Each server in the `servers` map is configured using the `MastraMCPServerDefinition` type. The transport type is detected based on the provided parameters:

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,7 +39,8 @@
     "@modelcontextprotocol/ext-apps": "^1.7.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "exit-hook": "^5.1.0",
-    "fast-deep-equal": "^3.1.3"
+    "fast-deep-equal": "^3.1.3",
+    "zod-from-json-schema": "^0.1.0"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.0.0-0 <2.0.0-0"

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -281,6 +281,71 @@ describe('InternalMastraMCPClient - jsonSchemaValidator pass-through', () => {
   });
 });
 
+describe('InternalMastraMCPClient - MCP schema coercion', () => {
+  let testServer: Awaited<ReturnType<typeof setupTestServer>>;
+  let client: InternalMastraMCPClient;
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    testServer?.httpServer.close();
+  });
+
+  it("coerces MCP JSON Schema input schemas to Zod when coerceSchemasTo is 'zod'", async () => {
+    testServer = await setupTestServer(false);
+    client = new InternalMastraMCPClient({
+      name: 'zod-coercion-client',
+      server: { url: testServer.baseUrl },
+      coerceSchemasTo: 'zod',
+    });
+    await client.connect();
+
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+
+    expect(greetTool?.inputSchema).toBeDefined();
+    expect(typeof (greetTool?.inputSchema as any).safeParse).toBe('function');
+  });
+
+  it("does not invoke Function during MCP input schema validation when coerceSchemasTo is 'zod'", async () => {
+    testServer = await setupTestServer(false);
+    client = new InternalMastraMCPClient({
+      name: 'zod-no-codegen-client',
+      server: { url: testServer.baseUrl },
+      coerceSchemasTo: 'zod',
+    });
+    await client.connect();
+
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'greet',
+          description: 'A simple greeting tool',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              name: { type: 'string' as const, description: 'Name to greet', default: 'World' },
+            },
+          },
+        },
+      ],
+    } as Awaited<ReturnType<Client['listTools']>>);
+
+    const functionSpy = vi.spyOn(globalThis, 'Function');
+
+    try {
+      const tools = await client.tools();
+      const greetTool = tools.greet;
+      const result = await greetTool?.inputSchema?.['~standard'].validate({ name: 'Ada' });
+
+      expect(result).toEqual({ value: { name: 'Ada' } });
+      expect(functionSpy).not.toHaveBeenCalled();
+    } finally {
+      functionSpy.mockRestore();
+    }
+  });
+});
+
 describe('MastraMCPClient with Streamable HTTP', () => {
   let testServer: {
     httpServer: HttpServer;

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -795,7 +795,10 @@ export class InternalMastraMCPClient extends MastraBase {
     const jsonSchema = ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
 
     if (this.coerceSchemasTo === 'zod') {
-      return convertJsonSchemaToZod(jsonSchema as Record<string, unknown>);
+      // Double assertion: zod/v4's ZodTypeAny (any, any) is structurally compatible with
+      // PublicSchema's z4.ZodType (unknown, unknown) but TS can't prove it due to
+      // recursive generic depth (TS2589) across module boundaries.
+      return convertJsonSchemaToZod(jsonSchema as Record<string, unknown>) as unknown as PublicSchema;
     }
 
     return jsonSchema;

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -7,7 +7,7 @@ import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { createTool } from '@mastra/core/tools';
 import type { NeedsApprovalFn, Tool } from '@mastra/core/tools';
 import { toStandardSchema } from '@mastra/schema-compat';
-import type { JSONSchema7, StandardSchemaWithJSON } from '@mastra/schema-compat';
+import type { JSONSchema7, PublicSchema, StandardSchemaWithJSON } from '@mastra/schema-compat';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -41,6 +41,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { asyncExitHook, gracefulExit } from 'exit-hook';
+import { convertJsonSchemaToZod } from 'zod-from-json-schema';
 import { getMastraToolStrictMeta } from '../shared/mastra-tool-meta';
 import { ElicitationClientActions } from './actions/elicitation';
 import { ProgressClientActions } from './actions/progress';
@@ -223,6 +224,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private _roots: Root[];
   private readonly requireToolApproval: RequireToolApproval | undefined;
   private readonly onToolError: 'throw' | 'return';
+  private readonly coerceSchemasTo: InternalMastraMCPClientOptions['coerceSchemasTo'];
 
   /** Provides access to resource operations (list, read, subscribe, etc.) */
   public readonly resources: ResourceClientActions;
@@ -242,6 +244,7 @@ export class InternalMastraMCPClient extends MastraBase {
     server,
     capabilities = {},
     timeout = DEFAULT_REQUEST_TIMEOUT_MSEC,
+    coerceSchemasTo,
   }: InternalMastraMCPClientOptions) {
     super({ name: 'MastraMCPClient' });
     this.name = name;
@@ -252,6 +255,7 @@ export class InternalMastraMCPClient extends MastraBase {
     this.enableProgressTracking = !!server.enableProgressTracking;
     this.requireToolApproval = server.requireToolApproval;
     this.onToolError = server.onToolError ?? 'throw';
+    this.coerceSchemasTo = coerceSchemasTo ?? 'json-schema';
 
     // Initialize roots from server config
     this._roots = server.roots ?? [];
@@ -787,8 +791,14 @@ export class InternalMastraMCPClient extends MastraBase {
 
   private async convertInputSchema(
     inputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['inputSchema'],
-  ): Promise<JSONSchema7> {
-    return ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
+  ): Promise<PublicSchema> {
+    const jsonSchema = ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
+
+    if (this.coerceSchemasTo === 'zod') {
+      return convertJsonSchemaToZod(jsonSchema as Record<string, unknown>);
+    }
+
+    return jsonSchema;
   }
 
   /**

--- a/packages/mcp/src/client/configuration.test.ts
+++ b/packages/mcp/src/client/configuration.test.ts
@@ -233,6 +233,27 @@ describe('MCPClient tool discovery retries', () => {
     expect(capabilities).toMatchObject(customCapabilities);
   });
 
+  it('forwards coerceSchemasTo into InternalMastraMCPClient', async () => {
+    const connectSpy = vi.spyOn(InternalMastraMCPClient.prototype, 'connect').mockResolvedValue(true);
+
+    const client = new MCPClient({
+      id: `configuration-test-${++clientId}`,
+      coerceSchemasTo: 'zod',
+      servers: {
+        weather: {
+          url: new URL('http://localhost:1234/sse'),
+        },
+      },
+    });
+
+    clients.push(client);
+
+    const internalClient = await (client as any).getConnectedClientForServer('weather');
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect((internalClient as any).coerceSchemasTo).toBe('zod');
+  });
+
   it('returns cached server instructions for configured servers', async () => {
     vi.spyOn(InternalMastraMCPClient.prototype, 'connect').mockImplementation(async function (this: any) {
       this.serverInstructions = this.name === 'db' ? 'Validate schema before migrating.' : undefined;

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -32,6 +32,8 @@ export interface MCPClientOptions {
   servers: Record<string, MastraMCPServerDefinition>;
   /** Optional global timeout in milliseconds for all servers (default: 60000ms) */
   timeout?: number;
+  /** Schema representation for MCP tool inputs. Set to 'zod' in edge runtimes to avoid AJV code generation (default: 'json-schema') */
+  coerceSchemasTo?: 'json-schema' | 'zod';
 }
 
 /**
@@ -72,6 +74,7 @@ export class MCPClient extends MastraBase {
   private serverConfigs: Record<string, MastraMCPServerDefinition> = {};
   private id: string;
   private defaultTimeout: number;
+  private coerceSchemasTo: MCPClientOptions['coerceSchemasTo'];
   private mcpClientsById = new Map<string, InternalMastraMCPClient>();
   private disconnectPromise: Promise<void> | null = null;
 
@@ -107,13 +110,14 @@ export class MCPClient extends MastraBase {
     super({ name: 'MCPClient' });
     this.defaultTimeout = args.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC;
     this.serverConfigs = args.servers;
+    this.coerceSchemasTo = args.coerceSchemasTo;
     this.id = args.id ?? this.makeId();
 
     if (args.id) {
       this.id = args.id;
       const cached = mcpClientInstances.get(this.id);
 
-      if (cached && !equal(cached.serverConfigs, args.servers)) {
+      if (cached && !equal(cached.getInstanceIdentity(), this.getInstanceIdentity())) {
         const existingInstance = mcpClientInstances.get(this.id);
         if (existingInstance) {
           void existingInstance.disconnect();
@@ -668,8 +672,15 @@ To fix this you have three different options:
   }
 
   private makeId() {
-    const text = JSON.stringify(this.serverConfigs).normalize('NFKC');
+    const text = JSON.stringify(this.getInstanceIdentity()).normalize('NFKC');
     return createHash('sha256').update('MCPClient').update(text).digest('hex');
+  }
+
+  private getInstanceIdentity() {
+    return {
+      serverConfigs: this.serverConfigs,
+      coerceSchemasTo: this.coerceSchemasTo ?? 'json-schema',
+    };
   }
 
   /**
@@ -1009,6 +1020,7 @@ To fix this you have three different options:
       server: config,
       timeout: config.timeout ?? this.defaultTimeout,
       capabilities: config.capabilities,
+      coerceSchemasTo: this.coerceSchemasTo,
     });
 
     mcpClient.__setLogger(this.logger);

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -88,6 +88,7 @@ export class MCPClient extends MastraBase {
    * @param args.id - Optional unique identifier to allow multiple instances with same config
    * @param args.servers - Map of server names to server configurations
    * @param args.timeout - Optional global timeout in milliseconds (default: 60000)
+   * @param args.coerceSchemasTo - Schema representation for MCP tool inputs: 'json-schema' (default) or 'zod' for edge runtimes
    *
    * @throws {Error} If multiple instances with identical config are created without an ID
    *

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -455,4 +455,6 @@ export type InternalMastraMCPClientOptions = {
   version?: string;
   /** Optional timeout in milliseconds */
   timeout?: number;
+  /** Optional MCP schema coercion target */
+  coerceSchemasTo?: 'json-schema' | 'zod';
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1894,16 +1894,16 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: ^2.0.62
-        version: 2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^2.0.99
-        version: 2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: ^2.0.1
         version: 2.0.3
       '@ai-sdk/provider-utils':
         specifier: ^3.0.22
-        version: 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@huggingface/hub':
         specifier: ^0.15.2
         version: 0.15.2
@@ -1976,7 +1976,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   integrations/brightdata:
     devDependencies:
@@ -4716,6 +4716,9 @@ importers:
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
+      zod-from-json-schema:
+        specifier: ^0.1.0
+        version: 0.1.0
     devDependencies:
       '@hono/node-server':
         specifier: ^1.19.11
@@ -29159,6 +29162,9 @@ packages:
   zod-from-json-schema@0.0.5:
     resolution: {integrity: sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ==}
 
+  zod-from-json-schema@0.1.0:
+    resolution: {integrity: sha512-yPcDmFziXePHO8iK4WXl4WcqlKolohQKEdhbJadCzZ/+/ayr1IELxWrVQ/NSUKiuIweNiDlZoi6dgle4Bd1baw==}
+
   zod-from-json-schema@0.5.2:
     resolution: {integrity: sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g==}
 
@@ -29559,10 +29565,10 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -29718,6 +29724,26 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
+
+  '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@types/node'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - typescript
+      - vite
 
   '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
@@ -41550,7 +41576,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8)':
     dependencies:
@@ -41643,7 +41669,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -54103,6 +54129,10 @@ snapshots:
       readable-stream: 4.7.0
 
   zod-from-json-schema@0.0.5:
+    dependencies:
+      zod: 3.25.76
+
+  zod-from-json-schema@0.1.0:
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## Description

Adds a `coerceSchemasTo` option to `MCPClient` that converts MCP tool input schemas from JSON Schema to Zod at load time. This fixes MCP tool calls crashing on Cloudflare Workers and other edge runtimes that block runtime code generation (`new Function()`).

- Added `coerceSchemasTo?: 'json-schema' | 'zod'` to `MCPClientOptions` and `InternalMastraMCPClientOptions`
- Modified `convertInputSchema()` to conditionally convert JSON Schema to Zod via `zod-from-json-schema`
- Included `coerceSchemasTo` in cache identity so different coercion modes produce distinct client instances
- Added `zod-from-json-schema` as a dependency of `@mastra/mcp`
- Updated MCP client reference docs with new property and edge runtime usage section

## Related Issue(s)

Fixes #15926

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR lets the MCP client convert a tool’s **input JSON schema** into **Zod** when the tool is loaded. That way, edge runtimes (like Cloudflare Workers) that don’t allow runtime code generation (e.g., `new Function`) won’t crash when validating inputs.

## Summary
- Added `coerceSchemasTo?: 'json-schema' | 'zod'` to `MCPClient` options and `InternalMastraMCPClientOptions` (default: `'json-schema'`).
- Updated MCP input schema handling to optionally coerce JSON Schema → Zod at load time via `zod-from-json-schema` (leaving the existing Ajv/json-schema path unchanged by default).
- Adjusted client instance identity/caching so different `coerceSchemasTo` values create distinct client instances.
- Added `zod-from-json-schema` as a dependency of `@mastra/mcp`.
- Updated docs with the new option, including edge-runtime-safe guidance and notes about the converter’s limitations (e.g., `$ref/$defs`, `anyOf/oneOf`).
- Added/updated tests to verify:
  - coercion produces Zod-compatible schemas (e.g., `safeParse`),
  - validation doesn’t trigger the global `Function` constructor in the `'zod'` mode,
  - `MCPClient` forwards `coerceSchemasTo` into the internal client.
- Added a changeset for a minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->