### PR TITLE
feat(mcp-registry-registry): add remote openclaw to the registry list

### DIFF
--- a/.changeset/lucky-plums-arrive.md
+++ b/.changeset/lucky-plums-arrive.md
@@ -3,3 +3,10 @@
 ---
 
 Add Remote OpenClaw to the registry list
+
+```ts
+import { getRegistryListings } from '@mastra/mcp-registry-registry';
+
+const result = await getRegistryListings({ id: 'remoteopenclaw' }, { detailed: true });
+console.log(result.registries[0].url); // https://www.remoteopenclaw.com/
+```

--- a/.changeset/lucky-plums-arrive.md
+++ b/.changeset/lucky-plums-arrive.md
@@ -5,8 +5,8 @@
 Add Remote OpenClaw to the registry list
 
 ```ts
-import { getRegistryListings } from '@mastra/mcp-registry-registry';
+import { registryData } from '@mastra/mcp-registry-registry';
 
-const result = await getRegistryListings({ id: 'remoteopenclaw' }, { detailed: true });
-console.log(result.registries[0].url); // https://www.remoteopenclaw.com/
+const remoteOpenClaw = registryData.registries.find(r => r.id === 'remoteopenclaw');
+console.log(remoteOpenClaw?.url); // https://www.remoteopenclaw.com/
 ```

--- a/.changeset/lucky-plums-arrive.md
+++ b/.changeset/lucky-plums-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp-registry-registry': patch
+---
+
+Add Remote OpenClaw to the registry list

--- a/packages/mcp-registry-registry/src/registry/registry.ts
+++ b/packages/mcp-registry-registry/src/registry/registry.ts
@@ -212,6 +212,13 @@ export const registryData: RegistryFile = {
       postProcessServers: processPulseMcpServers,
     },
     {
+      id: 'remoteopenclaw',
+      name: 'Remote OpenClaw',
+      description: 'Free searchable directory of MCP servers, agent skills, and plugins for coding agents.',
+      url: 'https://www.remoteopenclaw.com/',
+      count: 13870,
+    },
+    {
       id: 'smithery',
       name: 'Smithery',
       description: 'Extend your agent with 4,274 capabilities via Model Context Protocol servers.',


### PR DESCRIPTION
## Description

adds [remoteopenclaw.com](https://www.remoteopenclaw.com) to the registry list in `@mastra/mcp-registry-registry`, alongside the 28 existing registries.

it is a free searchable directory of 13,870+ MCP servers plus agent skills and plugins for Claude Code, Codex, OpenCode, and OpenClaw. it also has a public search API at `/api/search` (no key) and an MIT-licensed CLI/MCP server ([aidevelopers2/remoteopenclaw-mcp](https://github.com/aidevelopers2/remoteopenclaw-mcp)) listed in the official MCP registry.

the entry follows the existing shape (id, name, description, url, count) and is placed alphabetically between Pulse MCP and Smithery. no custom processor needed. included a patch changeset.

Closes #18899

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds Remote OpenClaw to the Mastra “registry of registries” list, so people can discover its MCP servers without having to know where to look. It also adds a small release note so the update can be published.

### Summary
- Added a new `remoteopenclaw` entry to `packages/mcp-registry-registry/src/registry/registry.ts`, using the standard registry fields: `id`, `name`, `description`, `url`, and `count` (no custom processor).
- Inserted the entry alphabetically between Pulse MCP and Smithery.
- Added a patch-level changeset for `@mastra/mcp-registry-registry` to publish the update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->