### PR TITLE
fix(react): retry aborted thread subscription so Studio chat doesn't hang (#18768)

### DIFF
--- a/.changeset/huge-bugs-watch.md
+++ b/.changeset/huge-bugs-watch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Fixed Studio agent chat hanging on the first message when thread signals are enabled. When the thread subscription was aborted during mount, `useChat` cached the failed attempt and never retried it, so the assistant reply never arrived until a full page reload. The subscription is now retried on the next send, and a failed subscription no longer leaves the chat stuck in a pending state.

--- a/.changeset/huge-bugs-watch.md
+++ b/.changeset/huge-bugs-watch.md
@@ -2,4 +2,4 @@
 '@mastra/react': patch
 ---
 
-Fixed Studio agent chat hanging on the first message when thread signals are enabled. When the thread subscription was aborted during mount, `useChat` cached the failed attempt and never retried it, so the assistant reply never arrived until a full page reload. The subscription is now retried on the next send, and a failed subscription no longer leaves the chat stuck in a pending state.
+Fixed Studio agent chat hanging on the first message when thread signals are enabled. When the thread subscription was aborted during mount, `useChat` cached the failed attempt and never retried it, so the assistant reply never arrived until a full page reload. The subscription is now retried on the next send. Also, when a send fails for any reason (subscription setup, request, or stream), `useChat` now resets its running state instead of leaving the chat spinner stuck until reload.

--- a/client-sdks/react/src/agent/hooks.test.ts
+++ b/client-sdks/react/src/agent/hooks.test.ts
@@ -819,6 +819,61 @@ describe('useChat forwards clientTools', () => {
     expect(threadSubscriptionUnsubscribeMock).toHaveBeenCalledTimes(1);
   });
 
+  // Regression test for https://github.com/mastra-ai/mastra/issues/18768.
+  //
+  // Two compounding bugs in ensureThreadSubscription (hooks.ts):
+  //
+  // 1. Its .catch() only clears _threadSubscription{Key,Abort,Promise}Ref
+  //    when isThreadSignalUnsupportedError(error) is true. For an AbortError
+  //    (or any other error) the refs are left pointing at the dead, rejected
+  //    promise/key, so every later call with the same key just re-awaits
+  //    that stale rejection instead of retrying the subscribe fetch. This is
+  //    the "retry never completes" behavior from the issue's HAR: no new
+  //    POST /threads/subscribe is even attempted.
+  // 2. `await ensureThreadSubscription(...)` in stream() (hooks.ts:739) sits
+  //    above the try/catch that wraps sendMessage/sendSignal (:766), so the
+  //    error escapes stream() -> sendMessage() uncaught. setIsRunning(true)
+  //    from the top of stream() is never undone, so the chat is stuck
+  //    "pending" until a full reload.
+  it('retries an aborted thread subscription on send and never leaves isRunning stuck', async () => {
+    const abortError = Object.assign(new Error('signal is aborted without reason'), { name: 'AbortError' });
+    // Reject both the mount-time subscribe AND the send-time retry so we
+    // exercise the retry (bug 1) and the isRunning cleanup on failure (bug 2).
+    subscribeToThreadMock.mockRejectedValueOnce(abortError).mockRejectedValueOnce(abortError);
+
+    const { result } = renderHook(
+      () =>
+        useChat({
+          agentId: 'test-agent',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+          enableThreadSignals: true,
+        }),
+      { wrapper },
+    );
+
+    // Mount-time subscription attempt fails and is swallowed (isAbortError).
+    await waitFor(() => expect(subscribeToThreadMock).toHaveBeenCalledTimes(1));
+    expect(result.current.isRunning).toBe(false);
+
+    let sendError: unknown;
+    await act(async () => {
+      try {
+        await result.current.sendMessage({ mode: 'stream', message: 'hello', threadId: 'thread-1' });
+      } catch (error) {
+        sendError = error;
+      }
+    });
+
+    // Bug 1 fixed: the send path releases the dead cached rejection and retries
+    // the subscribe fetch instead of re-awaiting the stale promise.
+    expect(subscribeToThreadMock).toHaveBeenCalledTimes(2);
+    expect((sendError as Error | undefined)?.name).toBe('AbortError');
+    // Bug 2 fixed: isRunning was flipped true when stream() started; the aborted
+    // ensureThreadSubscription no longer escapes uncaught, so it is reset.
+    expect(result.current.isRunning).toBe(false);
+  });
+
   it('uses the legacy stream path when thread signals are explicitly disabled', async () => {
     const { result } = renderHook(
       () =>

--- a/client-sdks/react/src/agent/hooks.test.ts
+++ b/client-sdks/react/src/agent/hooks.test.ts
@@ -819,26 +819,14 @@ describe('useChat forwards clientTools', () => {
     expect(threadSubscriptionUnsubscribeMock).toHaveBeenCalledTimes(1);
   });
 
-  // Regression test for https://github.com/mastra-ai/mastra/issues/18768.
-  //
-  // Two compounding bugs in ensureThreadSubscription (hooks.ts):
-  //
-  // 1. Its .catch() only clears _threadSubscription{Key,Abort,Promise}Ref
-  //    when isThreadSignalUnsupportedError(error) is true. For an AbortError
-  //    (or any other error) the refs are left pointing at the dead, rejected
-  //    promise/key, so every later call with the same key just re-awaits
-  //    that stale rejection instead of retrying the subscribe fetch. This is
-  //    the "retry never completes" behavior from the issue's HAR: no new
-  //    POST /threads/subscribe is even attempted.
-  // 2. `await ensureThreadSubscription(...)` in stream() (hooks.ts:739) sits
-  //    above the try/catch that wraps sendMessage/sendSignal (:766), so the
-  //    error escapes stream() -> sendMessage() uncaught. setIsRunning(true)
-  //    from the top of stream() is never undone, so the chat is stuck
-  //    "pending" until a full reload.
+  // Regression test for https://github.com/mastra-ai/mastra/issues/18768:
+  // an aborted mount-time subscribe used to stay cached (so no send ever
+  // retried the subscribe fetch) and the rejection escaped stream() uncaught,
+  // leaving isRunning stuck true until a full reload.
   it('retries an aborted thread subscription on send and never leaves isRunning stuck', async () => {
     const abortError = Object.assign(new Error('signal is aborted without reason'), { name: 'AbortError' });
     // Reject both the mount-time subscribe AND the send-time retry so we
-    // exercise the retry (bug 1) and the isRunning cleanup on failure (bug 2).
+    // exercise the retry and the isRunning cleanup on failure.
     subscribeToThreadMock.mockRejectedValueOnce(abortError).mockRejectedValueOnce(abortError);
 
     const { result } = renderHook(
@@ -865,12 +853,39 @@ describe('useChat forwards clientTools', () => {
       }
     });
 
-    // Bug 1 fixed: the send path releases the dead cached rejection and retries
-    // the subscribe fetch instead of re-awaiting the stale promise.
+    // The send path released the dead cached rejection and retried the
+    // subscribe fetch instead of re-awaiting the stale promise.
     expect(subscribeToThreadMock).toHaveBeenCalledTimes(2);
     expect((sendError as Error | undefined)?.name).toBe('AbortError');
-    // Bug 2 fixed: isRunning was flipped true when stream() started; the aborted
-    // ensureThreadSubscription no longer escapes uncaught, so it is reset.
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('resets isRunning when the signal send request itself fails', async () => {
+    sendMessageMock.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(
+      () =>
+        useChat({
+          agentId: 'test-agent',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+          enableThreadSignals: true,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(subscribeToThreadMock).toHaveBeenCalledTimes(1));
+
+    let sendError: unknown;
+    await act(async () => {
+      try {
+        await result.current.sendMessage({ mode: 'stream', message: 'hello', threadId: 'thread-1' });
+      } catch (error) {
+        sendError = error;
+      }
+    });
+
+    expect((sendError as Error | undefined)?.message).toBe('network down');
     expect(result.current.isRunning).toBe(false);
   });
 

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -498,20 +498,27 @@ export const useChat = ({
             });
         })
         .catch(error => {
-          if (isThreadSignalUnsupportedError(error)) {
+          const unsupported = isThreadSignalUnsupportedError(error);
+          if (unsupported) {
             markThreadSignalsUnsupported();
-            if (_threadSubscriptionAbortRef.current === subscriptionAbort) {
-              _threadSubscriptionRef.current = null;
-              _threadSubscriptionAbortRef.current = null;
-              _threadSubscriptionKeyRef.current = undefined;
-              _threadSubscriptionPromiseRef.current = null;
-            }
-            return;
-          }
-
-          if (!isAbortError(error)) {
+          } else if (!isAbortError(error)) {
             console.error('[useChat] Thread subscription failed', error);
             setIsRunning(false);
+          }
+
+          // Always release the cached subscription state so the next call
+          // retries with a fresh fetch instead of re-awaiting this rejected
+          // promise. Without this, an aborted mount-time subscribe strands the
+          // channel and the reply never arrives until reload (issue #18768).
+          if (_threadSubscriptionAbortRef.current === subscriptionAbort) {
+            _threadSubscriptionRef.current = null;
+            _threadSubscriptionAbortRef.current = null;
+            _threadSubscriptionKeyRef.current = undefined;
+            _threadSubscriptionPromiseRef.current = null;
+          }
+
+          if (unsupported) {
+            return;
           }
           throw error;
         });
@@ -736,7 +743,15 @@ export const useChat = ({
 
     _onChunk.current = onChunk;
 
-    await ensureThreadSubscription({ threadId, resourceId: resourceId || agentId });
+    try {
+      await ensureThreadSubscription({ threadId, resourceId: resourceId || agentId });
+    } catch (error) {
+      // Establishing the subscription failed (e.g. an aborted retry). Clear the
+      // running flag so the chat is not stranded in a "pending" state until a
+      // reload (issue #18768) before surfacing the error.
+      setIsRunning(false);
+      throw error;
+    }
 
     if (_threadSignalsUnsupportedRef.current) {
       await streamWithLegacyRoute();

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -460,6 +460,16 @@ export const useChat = ({
       _threadSubscriptionAbortRef.current = subscriptionAbort;
       _threadSubscriptionKeyRef.current = subscriptionKey;
 
+      // Release the cached subscription state, but only while this attempt
+      // still owns it — a newer attempt cleans up after itself.
+      const releaseSubscriptionRefs = () => {
+        if (_threadSubscriptionAbortRef.current !== subscriptionAbort) return;
+        _threadSubscriptionRef.current = null;
+        _threadSubscriptionAbortRef.current = null;
+        _threadSubscriptionKeyRef.current = undefined;
+        _threadSubscriptionPromiseRef.current = null;
+      };
+
       const clientWithAbort = new MastraClient({
         ...baseClient!.options,
         abortSignal: subscriptionAbort.signal,
@@ -490,35 +500,23 @@ export const useChat = ({
               if (_threadSubscriptionRef.current === subscription) {
                 _threadSubscriptionRef.current = null;
               }
-              if (_threadSubscriptionAbortRef.current === subscriptionAbort) {
-                _threadSubscriptionAbortRef.current = null;
-                _threadSubscriptionKeyRef.current = undefined;
-                _threadSubscriptionPromiseRef.current = null;
-              }
+              releaseSubscriptionRefs();
             });
         })
         .catch(error => {
-          const unsupported = isThreadSignalUnsupportedError(error);
-          if (unsupported) {
+          // Release on every failure so the next call retries with a fresh
+          // fetch instead of re-awaiting this rejected promise. Without this,
+          // an aborted mount-time subscribe strands the channel and the reply
+          // never arrives until reload (issue #18768).
+          releaseSubscriptionRefs();
+
+          if (isThreadSignalUnsupportedError(error)) {
             markThreadSignalsUnsupported();
-          } else if (!isAbortError(error)) {
+            return;
+          }
+          if (!isAbortError(error)) {
             console.error('[useChat] Thread subscription failed', error);
             setIsRunning(false);
-          }
-
-          // Always release the cached subscription state so the next call
-          // retries with a fresh fetch instead of re-awaiting this rejected
-          // promise. Without this, an aborted mount-time subscribe strands the
-          // channel and the reply never arrives until reload (issue #18768).
-          if (_threadSubscriptionAbortRef.current === subscriptionAbort) {
-            _threadSubscriptionRef.current = null;
-            _threadSubscriptionAbortRef.current = null;
-            _threadSubscriptionKeyRef.current = undefined;
-            _threadSubscriptionPromiseRef.current = null;
-          }
-
-          if (unsupported) {
-            return;
           }
           throw error;
         });
@@ -743,15 +741,7 @@ export const useChat = ({
 
     _onChunk.current = onChunk;
 
-    try {
-      await ensureThreadSubscription({ threadId, resourceId: resourceId || agentId });
-    } catch (error) {
-      // Establishing the subscription failed (e.g. an aborted retry). Clear the
-      // running flag so the chat is not stranded in a "pending" state until a
-      // reload (issue #18768) before surfacing the error.
-      setIsRunning(false);
-      throw error;
-    }
+    await ensureThreadSubscription({ threadId, resourceId: resourceId || agentId });
 
     if (_threadSignalsUnsupportedRef.current) {
       await streamWithLegacyRoute();
@@ -1165,12 +1155,19 @@ export const useChat = ({
       setMessages(s => [...s, dbUserMessage]);
     }
 
-    if (mode === 'generate') {
-      await generate({ ...args, coreUserMessages });
-    } else if (mode === 'stream') {
-      await stream({ ...args, coreUserMessages, signalId, clientMessageId });
-    } else if (mode === 'network') {
-      await network({ ...args, coreUserMessages });
+    try {
+      if (mode === 'generate') {
+        await generate({ ...args, coreUserMessages });
+      } else if (mode === 'stream') {
+        await stream({ ...args, coreUserMessages, signalId, clientMessageId });
+      } else if (mode === 'network') {
+        await network({ ...args, coreUserMessages });
+      }
+    } catch (error) {
+      // A failed send (subscription setup, request, or stream) must not leave
+      // the chat stranded in a "running" state until reload (issue #18768).
+      setIsRunning(false);
+      throw error;
     }
   };
 


### PR DESCRIPTION
Fixes #18768.

With thread signals enabled, the first message after a fresh load could hang on the pending spinner and only show the reply after a full page reload.

The mount-time `subscribeToThread` can get aborted mid-flight (an unrelated re-render tears the subscription down, since the provider rebuilds its client on every render). `ensureThreadSubscription` cached that rejected promise forever, so every later send re-awaited the dead rejection instead of re-subscribing — and the rejection escaped `stream()` uncaught, leaving `isRunning` stuck on `true`.

### Changes

- `ensureThreadSubscription` releases its cached refs on **every** failure (shared `releaseSubscriptionRefs` helper, also reused by the stream-teardown path), so the next send re-subscribes with a fresh request. The send path re-subscribes *before* starting the run, so the fresh subscription is live in time to receive the reply.
- `sendMessage` now wraps the whole send dispatch: a failure anywhere (subscription setup, request, or stream — in `stream`, `generate`, and `network` modes) resets `isRunning` instead of stranding the chat in a pending state.

### Verification

Reproduced against @gregorskii's [mastra-thread-subscription-repro](https://github.com/gregorskii/mastra-thread-subscription-repro) driving the real `useChat` in a browser, with the mount-time subscribe aborted (the HAR condition from the issue). Same run both times — the only difference is the library.

Before, on shipped `@mastra/react@1.2.2` — `isRunning: true`, no reply, stuck until reload:

![before](https://raw.githubusercontent.com/mastra-ai/mastra/pr-18903-repro-shots/buggy-after-send.png)

After, with this fix — re-subscribes, delivers `"pong"`, `isRunning: false`:

![after](https://raw.githubusercontent.com/mastra-ai/mastra/pr-18903-repro-shots/fixed-after-send.png)

Regression tests in `hooks.test.ts` (red before the fix): aborted mount subscribe → retried on send, `isRunning` reset; failed send request → `isRunning` reset.

### Follow-ups (out of scope)

- The optimistic user bubble keeps `status: 'pending'` when the retry also fails — needs an error affordance (product decision).
- Root trigger: `MastraClientProvider` builds its client in the render body without `useMemo`; memoizing it would remove the mount-abort churn entirely.
- A send racing the still-in-flight mount subscribe awaits the shared promise and fails without retrying (narrow window; the next send recovers).
- Storage reconciliation for a subscription that drops mid-run, as the repro's README also suggests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This fix stops Studio chat from getting “stuck thinking” it’s still sending a message when a thread subscription fails or gets canceled early. If the first try doesn’t work, `useChat` now cleans up and tries again later, so the assistant can reply normally instead of hanging.

## Summary
- Releases cached thread-subscription refs after failures so aborted mount-time subscriptions can be retried on the next send.
- Makes send flow start only after subscription setup is ready.
- Resets `isRunning` on failures during subscription setup, request, or streaming so the UI doesn’t stay stuck pending.
- Adds regression tests for aborted subscription retry and failed send cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->