### PR TITLE
Deduplicate message payloads in memory storage

### DIFF
--- a/.changeset/fifty-moles-give.md
+++ b/.changeset/fifty-moles-give.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Deduplicated message payloads when saving to memory storage. Tool-result payloads duplicated inside providerMetadata.mastra.modelOutput are replaced with internal references at write time and restored transparently on read, cutting stored message size roughly in half for tools that return large payloads (like screenshots). Fully backward compatible with existing rows.

--- a/.changeset/silver-buckets-cheat.md
+++ b/.changeset/silver-buckets-cheat.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Reduced message storage size by removing duplicated payloads at rest. Large tool-result payloads that also appear in a tool's toModelOutput mapping are now stored once and rehydrated on read, and file attachments are no longer stored twice (once as file parts and once as experimental_attachments). Existing stored messages are read back unchanged — no migration needed.

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -179,6 +179,10 @@ const thread = await memory.getThreadById({ threadId: 'thread-123' })
 
 Once you have a thread, use [`recall()`](/reference/memory/recall) to retrieve its messages. It supports pagination, date filtering, and [semantic search](/docs/memory/semantic-recall).
 
+:::note
+Large tool-result payloads that also appear in a tool's `toModelOutput()` mapping are stored once at rest and rehydrated transparently on read. Messages returned by `recall()` always contain the full payloads.
+:::
+
 Basic recall returns all messages from a thread:
 
 ```typescript

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -138,9 +138,6 @@ const sidebars = {
                   type: 'doc',
                   id: 'agents/sdk-agents',
                   label: 'SDK Agents',
-                  customProps: {
-                    tags: ['new'],
-                  },
                 },
                 {
                   type: 'category',

--- a/packages/core/src/agent/__tests__/message-payload-dedupe.test.ts
+++ b/packages/core/src/agent/__tests__/message-payload-dedupe.test.ts
@@ -1,0 +1,243 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { MockMemory } from '../../memory/mock';
+import { createTool } from '../../tools';
+import { Agent } from '../agent';
+import { MessageList } from '../message-list';
+
+/**
+ * Baseline repro tests for message payload duplication at rest (storage dedupe).
+ *
+ * Root cause 1: when a tool defines `toModelOutput()`, the mapped output is persisted at
+ * `providerMetadata.mastra.modelOutput` alongside the raw `toolInvocation.result`. For
+ * screenshot-style tools the same large payload string is stored twice in one part.
+ *
+ * Root cause 2: `AIV5Adapter.toDB` derives `experimental_attachments` from `file` parts and
+ * persists both, so every attachment's bytes are stored twice in the same row.
+ *
+ * These tests measure the at-rest shape (raw store rows) and the in-process shape (what
+ * consumers see after read), pinning that dedupe is invisible to consumers.
+ */
+
+const BIG_PAYLOAD = `iVBORw0KGgoAAAANSUhEUg${'A'.repeat(4096)}==`;
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe('message payload dedupe at rest', () => {
+  it('stores a large toModelOutput payload once when it is embedded in the raw tool result', async () => {
+    let doStreamCallCount = 0;
+    const toolCallModel = new MockLanguageModelV2({
+      doStream: async () => {
+        doStreamCallCount++;
+        if (doStreamCallCount === 1) {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-screenshot-1',
+                toolName: 'screenshot-tool',
+                input: '{}',
+                providerExecuted: false,
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'I looked at the screenshot' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    // Screenshot-shaped tool: raw result embeds the big base64 string, and toModelOutput
+    // wraps the exact same string in a model-facing shape (same bytes, different wrapper).
+    const rawResult = {
+      content: [{ type: 'image', data: BIG_PAYLOAD, mimeType: 'image/png' }],
+    };
+    const expectedModelOutput = {
+      type: 'content',
+      value: [{ type: 'media', data: BIG_PAYLOAD, mediaType: 'image/png' }],
+    };
+
+    const screenshotTool = createTool({
+      id: 'screenshot-tool',
+      description: 'Takes a screenshot',
+      inputSchema: z.object({}),
+      execute: async () => rawResult,
+      toModelOutput: () => expectedModelOutput as any,
+    });
+
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'payload-dedupe-agent',
+      name: 'Payload Dedupe Test',
+      instructions: 'Take a screenshot, then describe it.',
+      model: toolCallModel,
+      memory: mockMemory,
+      tools: { 'screenshot-tool': screenshotTool },
+    });
+
+    const threadId = 'thread-payload-dedupe';
+    const resourceId = 'resource-payload-dedupe';
+
+    const result = await agent.stream('take a screenshot', {
+      memory: { thread: threadId, resource: resourceId },
+    });
+    await result.consumeStream();
+
+    // --- At-rest shape: read raw rows straight from the store (below Memory) ---
+    const memoryStore = await mockMemory.storage.getStore('memory');
+    const { messages: rawRows } = await memoryStore!.listMessages({ threadId, perPage: false });
+    const atRest = JSON.stringify(rawRows);
+
+    // The raw result must be stored in full.
+    expect(atRest).toContain(BIG_PAYLOAD);
+    // The payload must be stored exactly once — modelOutput must reference it, not copy it.
+    expect(countOccurrences(atRest, BIG_PAYLOAD)).toBe(1);
+
+    // --- In-process shape: reads through Memory must see the exact original shapes ---
+    const recalled = await mockMemory.recall({ threadId, resourceId });
+    const toolResultPart = recalled.messages
+      .flatMap(message => message.content.parts ?? [])
+      .find(
+        part =>
+          part.type === 'tool-invocation' &&
+          (part as any).toolInvocation?.toolCallId === 'call-screenshot-1' &&
+          (part as any).toolInvocation?.state === 'result',
+      ) as any;
+
+    expect(toolResultPart).toBeDefined();
+    expect(toolResultPart.toolInvocation.result).toEqual(rawResult);
+    expect(toolResultPart.providerMetadata?.mastra?.modelOutput).toEqual(expectedModelOutput);
+  });
+
+  it('rehydrates stored payload refs when messages re-enter a MessageList from memory', async () => {
+    // Simulates any consumer that reads rows straight from a store (bypassing Memory)
+    // and feeds them into a MessageList: markers must be resolved back to full strings.
+    const dbMessage = {
+      id: 'msg-marker-1',
+      role: 'assistant' as const,
+      createdAt: new Date(),
+      threadId: 'thread-marker',
+      resourceId: 'resource-marker',
+      content: {
+        format: 2 as const,
+        parts: [
+          {
+            type: 'tool-invocation' as const,
+            toolInvocation: {
+              toolCallId: 'call-1',
+              toolName: 'screenshot-tool',
+              args: {},
+              state: 'result' as const,
+              result: { content: [{ type: 'image', data: BIG_PAYLOAD, mimeType: 'image/png' }] },
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'media',
+                      data: { $mastra_tool_result_ref: ['content', 0, 'data'] },
+                      mediaType: 'image/png',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const list = new MessageList({ threadId: 'thread-marker', resourceId: 'resource-marker' });
+    list.add(dbMessage as any, 'memory');
+
+    const [assistant] = list.get.all.db();
+    const part = (assistant?.content.parts ?? []).find(p => p.type === 'tool-invocation') as any;
+    expect(part).toBeDefined();
+    expect(part.providerMetadata?.mastra?.modelOutput).toEqual({
+      type: 'content',
+      value: [{ type: 'media', data: BIG_PAYLOAD, mediaType: 'image/png' }],
+    });
+  });
+});
+
+describe('attachment payload dedupe at rest', () => {
+  it('stores file attachment bytes once (no experimental_attachments duplicate of file parts)', async () => {
+    const dataUri = `data:image/png;base64,${BIG_PAYLOAD}`;
+
+    // AIV5 UI message with a file part → AIV5Adapter.toDB
+    const list = new MessageList({ threadId: 'thread-attach', resourceId: 'resource-attach' });
+    list.add(
+      {
+        id: 'attach-msg-1',
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'What is in this image?' },
+          { type: 'file', url: dataUri, mediaType: 'image/png' },
+        ],
+      } as any,
+      'user',
+    );
+
+    const dbMessages = list.get.all.db();
+    const atRest = JSON.stringify(dbMessages);
+
+    expect(atRest).toContain(BIG_PAYLOAD);
+    expect(countOccurrences(atRest, BIG_PAYLOAD)).toBe(1);
+
+    // The file part must retain the data.
+    const fileParts = dbMessages.flatMap(m => m.content.parts ?? []).filter(p => p.type === 'file') as any[];
+    expect(fileParts).toHaveLength(1);
+    expect(fileParts[0].data).toBe(dataUri);
+  });
+
+  it('still persists experimental_attachments for true V4 input without file parts', async () => {
+    const dataUri = `data:image/png;base64,${BIG_PAYLOAD}`;
+
+    const list = new MessageList({ threadId: 'thread-attach-v4', resourceId: 'resource-attach-v4' });
+    list.add(
+      {
+        id: 'attach-msg-v4',
+        role: 'user',
+        content: 'What is in this image?',
+        parts: [{ type: 'text', text: 'What is in this image?' }],
+        experimental_attachments: [{ url: dataUri, contentType: 'image/png', name: 'img.png' }],
+      } as any,
+      'user',
+    );
+
+    const dbMessages = list.get.all.db();
+    const atRest = JSON.stringify(dbMessages);
+
+    // The attachment data must survive, stored exactly once.
+    expect(atRest).toContain(BIG_PAYLOAD);
+    expect(countOccurrences(atRest, BIG_PAYLOAD)).toBe(1);
+  });
+});

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,5 +1,12 @@
 export { TripWire } from './trip-wire';
-export { MessageList, convertMessages, aiV5ModelMessageToV2PromptMessage, TypeDetector } from './message-list';
+export {
+  MessageList,
+  convertMessages,
+  aiV5ModelMessageToV2PromptMessage,
+  TypeDetector,
+  dedupeMessagePayloadRefs,
+  rehydrateMessagePayloadRefs,
+} from './message-list';
 export type { OutputFormat } from './message-list';
 export * from './types';
 export * from './signals';

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -583,7 +583,6 @@ export class AIV5Adapter {
     // Process parts to build V2 content
     const toolInvocationParts = parts.filter(p => AIV5.isToolUIPart(p));
     const reasoningParts = parts.filter(p => p.type === 'reasoning');
-    const fileParts = parts.filter(p => p.type === 'file');
     const textParts = parts.filter(p => p.type === 'text');
 
     // Build tool invocations array
@@ -618,14 +617,11 @@ export class AIV5Adapter {
       reasoning = reasoningParts.map(p => p.text).join('\n');
     }
 
-    // Build experimental_attachments from file parts
-    let experimental_attachments: MastraDBMessage['content']['experimental_attachments'] = undefined;
-    if (fileParts.length > 0) {
-      experimental_attachments = fileParts.map(p => ({
-        url: p.url || '',
-        contentType: p.mediaType,
-      }));
-    }
+    // Note: we deliberately do NOT derive `experimental_attachments` from file parts here.
+    // The file parts are retained in the V2 parts array below, so persisting attachments too
+    // would store every attachment's bytes twice in the same row. Read paths derive
+    // attachments from file parts when needed (AIV4Adapter.toUIMessage), and the V5 read
+    // path already prefers file parts over attachments.
 
     // Build content from text parts (AIV4 content is a string)
     let content: MastraDBMessage['content']['content'] = undefined;
@@ -754,7 +750,6 @@ export class AIV5Adapter {
         parts: filteredV2Parts as MastraMessageContentV2['parts'],
         toolInvocations,
         reasoning,
-        experimental_attachments,
         content,
         metadata: Object.keys(cleanMetadata).length > 0 ? cleanMetadata : undefined,
       },

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -72,6 +72,14 @@ export { MessageStateManager } from './state';
 // Detection exports
 export { TypeDetector } from './detection';
 
+// Payload ref exports (storage-level dedupe of modelOutput payloads)
+export {
+  dedupeMessagePayloadRefs,
+  rehydrateMessagePayloadRefs,
+  PAYLOAD_REF_KEY,
+  PAYLOAD_REF_MIN_LENGTH,
+} from './payload-refs';
+
 // Cache exports
 export { CacheKeyGenerator } from './cache';
 

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -26,6 +26,7 @@ import {
 } from './conversion';
 import { TypeDetector } from './detection/TypeDetector';
 import { MessageMerger } from './merge';
+import { rehydrateMessagePayloadRefs } from './payload-refs';
 import { convertImageFilePart } from './prompt/convert-file';
 import { convertToV1Messages } from './prompt/convert-to-mastra-v1';
 import { downloadAssetsFromMessages } from './prompt/download-assets';
@@ -1503,7 +1504,12 @@ export class MessageList {
       });
     }
 
-    const messageV2 = convertInputToMastraDBMessage(message, messageSource, this.createAdapterContext());
+    let messageV2 = convertInputToMastraDBMessage(message, messageSource, this.createAdapterContext());
+    if (messageSource === 'memory') {
+      // Messages read from storage may carry at-rest payload-ref markers (deduped
+      // providerMetadata.mastra.modelOutput). Restore the full in-process shape.
+      messageV2 = rehydrateMessagePayloadRefs([messageV2])[0]!;
+    }
     const signalMetadata =
       messageV2.role === 'signal'
         ? (messageV2.content.metadata?.signal as { acceptedAt?: string; createdAt?: string } | undefined)

--- a/packages/core/src/agent/message-list/payload-refs.test.ts
+++ b/packages/core/src/agent/message-list/payload-refs.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PAYLOAD_REF_KEY,
+  PAYLOAD_REF_MIN_LENGTH,
+  dedupeMessagePayloadRefs,
+  rehydrateMessagePayloadRefs,
+} from './payload-refs';
+import type { MastraDBMessage } from './state/types';
+
+const BIG_A = `A${'a'.repeat(PAYLOAD_REF_MIN_LENGTH)}`;
+const BIG_B = `B${'b'.repeat(PAYLOAD_REF_MIN_LENGTH)}`;
+const SMALL = 'small-string';
+
+function makeMessage({
+  result,
+  modelOutput,
+  state = 'result',
+}: {
+  result?: unknown;
+  modelOutput?: unknown;
+  state?: string;
+}): MastraDBMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    createdAt: new Date('2026-01-01'),
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    content: {
+      format: 2,
+      parts: [
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            toolCallId: 'call-1',
+            toolName: 'test-tool',
+            args: {},
+            state,
+            ...(result !== undefined ? { result } : {}),
+          },
+          ...(modelOutput !== undefined ? { providerMetadata: { mastra: { modelOutput } } } : {}),
+        } as any,
+      ],
+    },
+  };
+}
+
+function getModelOutput(message: MastraDBMessage): unknown {
+  const part = message.content.parts[0] as any;
+  return part?.providerMetadata?.mastra?.modelOutput;
+}
+
+describe('dedupeMessagePayloadRefs', () => {
+  it('replaces a large string in modelOutput that matches a string in result with a ref marker', () => {
+    const input = [
+      makeMessage({
+        result: { content: [{ type: 'image', data: BIG_A }] },
+        modelOutput: { type: 'content', value: [{ type: 'media', data: BIG_A, mediaType: 'image/png' }] },
+      }),
+    ];
+    const [deduped] = dedupeMessagePayloadRefs(input);
+    expect(getModelOutput(deduped!)).toEqual({
+      type: 'content',
+      value: [{ type: 'media', data: { [PAYLOAD_REF_KEY]: ['content', 0, 'data'] }, mediaType: 'image/png' }],
+    });
+    // Raw result untouched.
+    expect((deduped!.content.parts[0] as any).toolInvocation.result).toEqual({
+      content: [{ type: 'image', data: BIG_A }],
+    });
+  });
+
+  it('leaves strings below the threshold alone', () => {
+    const input = [
+      makeMessage({
+        result: { data: SMALL },
+        modelOutput: { type: 'text', value: SMALL },
+      }),
+    ];
+    const output = dedupeMessagePayloadRefs(input);
+    expect(output).toBe(input); // unchanged by reference
+  });
+
+  it('leaves large modelOutput strings that do not appear in result alone', () => {
+    const input = [
+      makeMessage({
+        result: { data: BIG_A },
+        modelOutput: { type: 'text', value: BIG_B },
+      }),
+    ];
+    const output = dedupeMessagePayloadRefs(input);
+    expect(output).toBe(input);
+  });
+
+  it('handles multiple and nested payloads across arrays and objects', () => {
+    const input = [
+      makeMessage({
+        result: { images: [{ data: BIG_A }, { data: BIG_B }], meta: { note: SMALL } },
+        modelOutput: {
+          type: 'content',
+          value: [
+            { type: 'media', data: BIG_A },
+            { type: 'media', data: BIG_B },
+            { type: 'text', text: SMALL },
+          ],
+        },
+      }),
+    ];
+    const [deduped] = dedupeMessagePayloadRefs(input);
+    expect(getModelOutput(deduped!)).toEqual({
+      type: 'content',
+      value: [
+        { type: 'media', data: { [PAYLOAD_REF_KEY]: ['images', 0, 'data'] } },
+        { type: 'media', data: { [PAYLOAD_REF_KEY]: ['images', 1, 'data'] } },
+        { type: 'text', text: SMALL },
+      ],
+    });
+  });
+
+  it('uses the first result path deterministically when the same string appears at several paths', () => {
+    const input = [
+      makeMessage({
+        result: { first: BIG_A, second: BIG_A },
+        modelOutput: { value: BIG_A },
+      }),
+    ];
+    const [deduped] = dedupeMessagePayloadRefs(input);
+    expect(getModelOutput(deduped!)).toEqual({ value: { [PAYLOAD_REF_KEY]: ['first'] } });
+  });
+
+  it('dedupes a modelOutput that is itself a bare large string', () => {
+    const input = [
+      makeMessage({
+        result: { data: BIG_A },
+        modelOutput: BIG_A,
+      }),
+    ];
+    const [deduped] = dedupeMessagePayloadRefs(input);
+    expect(getModelOutput(deduped!)).toEqual({ [PAYLOAD_REF_KEY]: ['data'] });
+  });
+
+  it('is idempotent (running dedupe twice equals running it once)', () => {
+    const input = [
+      makeMessage({
+        result: { data: BIG_A },
+        modelOutput: { value: BIG_A },
+      }),
+    ];
+    const once = dedupeMessagePayloadRefs(input);
+    const twice = dedupeMessagePayloadRefs(once);
+    expect(twice).toBe(once);
+  });
+
+  it('skips parts without modelOutput, without result state, or with no result', () => {
+    const noModelOutput = [makeMessage({ result: { data: BIG_A } })];
+    expect(dedupeMessagePayloadRefs(noModelOutput)).toBe(noModelOutput);
+
+    const callState = [makeMessage({ modelOutput: { value: BIG_A }, state: 'call' })];
+    expect(dedupeMessagePayloadRefs(callState)).toBe(callState);
+  });
+
+  it('does not mutate its input', () => {
+    const input = [
+      makeMessage({
+        result: { data: BIG_A },
+        modelOutput: { value: BIG_A },
+      }),
+    ];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    dedupeMessagePayloadRefs(input);
+    expect(JSON.parse(JSON.stringify(input))).toEqual(snapshot);
+  });
+});
+
+describe('rehydrateMessagePayloadRefs', () => {
+  it('resolves ref markers back to the original strings (roundtrip identity)', () => {
+    const original = [
+      makeMessage({
+        result: { images: [{ data: BIG_A }, { data: BIG_B }] },
+        modelOutput: {
+          type: 'content',
+          value: [
+            { type: 'media', data: BIG_A },
+            { type: 'media', data: BIG_B },
+          ],
+        },
+      }),
+    ];
+    const roundtripped = rehydrateMessagePayloadRefs(dedupeMessagePayloadRefs(original));
+    expect(JSON.parse(JSON.stringify(roundtripped))).toEqual(JSON.parse(JSON.stringify(original)));
+  });
+
+  it('passes old rows (no markers) through untouched by reference', () => {
+    const input = [
+      makeMessage({
+        result: { data: BIG_A },
+        modelOutput: { type: 'text', value: 'plain output' },
+      }),
+    ];
+    expect(rehydrateMessagePayloadRefs(input)).toBe(input);
+  });
+
+  it('leaves markers whose path does not resolve to a string untouched', () => {
+    const input = [
+      makeMessage({
+        result: { data: { nested: true } },
+        modelOutput: { value: { [PAYLOAD_REF_KEY]: ['missing', 'path'] } },
+      }),
+    ];
+    const output = rehydrateMessagePayloadRefs(input);
+    expect(output).toBe(input);
+    expect(getModelOutput(output[0]!)).toEqual({ value: { [PAYLOAD_REF_KEY]: ['missing', 'path'] } });
+  });
+
+  it('leaves marker-shaped objects with extra keys alone (user-data collision safety)', () => {
+    const input = [
+      makeMessage({
+        result: { data: BIG_A },
+        modelOutput: { value: { [PAYLOAD_REF_KEY]: ['data'], extra: 1 } },
+      }),
+    ];
+    const output = rehydrateMessagePayloadRefs(input);
+    expect(output).toBe(input);
+  });
+
+  it('rehydrates a modelOutput that is itself a bare marker', () => {
+    const input = [
+      makeMessage({
+        result: { data: BIG_A },
+        modelOutput: { [PAYLOAD_REF_KEY]: ['data'] },
+      }),
+    ];
+    const [rehydrated] = rehydrateMessagePayloadRefs(input);
+    expect(getModelOutput(rehydrated!)).toBe(BIG_A);
+  });
+
+  it('does not mutate its input', () => {
+    const input = [
+      makeMessage({
+        result: { data: BIG_A },
+        modelOutput: { value: { [PAYLOAD_REF_KEY]: ['data'] } },
+      }),
+    ];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    rehydrateMessagePayloadRefs(input);
+    expect(JSON.parse(JSON.stringify(input))).toEqual(snapshot);
+  });
+});

--- a/packages/core/src/agent/message-list/payload-refs.ts
+++ b/packages/core/src/agent/message-list/payload-refs.ts
@@ -1,0 +1,239 @@
+import type { MastraDBMessage, MastraMessagePart, MastraToolInvocationPart } from './state/types';
+
+/**
+ * Payload refs: storage-level dedupe of `providerMetadata.mastra.modelOutput`.
+ *
+ * When a tool defines `toModelOutput()`, the mapped model-facing output is persisted at
+ * `providerMetadata.mastra.modelOutput` alongside the raw `toolInvocation.result`. For
+ * media-heavy tools (screenshots, file reads) the exact same large string payload ends up
+ * stored twice in the same part — once inside `result`, once inside `modelOutput`.
+ *
+ * `dedupeMessagePayloadRefs` (write path) replaces string values inside `modelOutput` that
+ * are byte-identical to a string inside the sibling `result` with a namespaced marker
+ * pointing at the result's JSON path. `rehydrateMessagePayloadRefs` (read path) resolves
+ * markers back into the full strings, so in-process consumers always see today's shape.
+ *
+ * - Scope is a single tool-invocation part: markers only ever point into the sibling result.
+ * - Only strings >= PAYLOAD_REF_MIN_LENGTH chars are deduped (small strings aren't worth a marker).
+ * - Both functions are pure: inputs are never mutated; unchanged messages/parts are returned
+ *   by reference.
+ * - Rows written before this existed contain no markers and pass through rehydrate untouched,
+ *   so no migration is needed.
+ */
+
+/** Namespaced marker key. A marker is `{ [PAYLOAD_REF_KEY]: <path into sibling result> }`. */
+export const PAYLOAD_REF_KEY = '$mastra_tool_result_ref';
+
+/** Minimum string length (in UTF-16 code units) for a value to be replaced with a ref. */
+export const PAYLOAD_REF_MIN_LENGTH = 1024;
+
+type PathSegment = string | number;
+
+function isPlainObjectOrArray(value: unknown): value is Record<string, unknown> | unknown[] {
+  return typeof value === 'object' && value !== null;
+}
+
+function isPayloadRefMarker(value: unknown): value is { [PAYLOAD_REF_KEY]: PathSegment[] } {
+  if (!isPlainObjectOrArray(value) || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || keys[0] !== PAYLOAD_REF_KEY) return false;
+  const path = (value as Record<string, unknown>)[PAYLOAD_REF_KEY];
+  return Array.isArray(path) && path.every(seg => typeof seg === 'string' || typeof seg === 'number');
+}
+
+/**
+ * Collect all string values >= PAYLOAD_REF_MIN_LENGTH inside `result`, keyed by string value.
+ * First path encountered (depth-first, key order) wins, making dedupe deterministic.
+ */
+function indexLargeStrings(result: unknown): Map<string, PathSegment[]> | undefined {
+  let index: Map<string, PathSegment[]> | undefined;
+  const seen = new Set<object>();
+
+  const walk = (value: unknown, path: PathSegment[]): void => {
+    if (typeof value === 'string') {
+      if (value.length >= PAYLOAD_REF_MIN_LENGTH) {
+        index ??= new Map();
+        if (!index.has(value)) index.set(value, path);
+      }
+      return;
+    }
+    if (!isPlainObjectOrArray(value)) return;
+    if (seen.has(value)) return;
+    seen.add(value);
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) walk(value[i], [...path, i]);
+    } else {
+      for (const key of Object.keys(value)) walk((value as Record<string, unknown>)[key], [...path, key]);
+    }
+  };
+
+  walk(result, []);
+  return index;
+}
+
+/**
+ * Walk `value`, replacing string values found in `index` with ref markers.
+ * Returns the original reference when nothing changed.
+ */
+function replaceStringsWithRefs(
+  value: unknown,
+  index: Map<string, PathSegment[]>,
+): { value: unknown; changed: boolean } {
+  if (typeof value === 'string') {
+    const path = index.get(value);
+    if (path) return { value: { [PAYLOAD_REF_KEY]: path }, changed: true };
+    return { value, changed: false };
+  }
+  if (!isPlainObjectOrArray(value)) return { value, changed: false };
+  // Leave anything already marker-shaped alone (idempotency + user-data safety).
+  if (isPayloadRefMarker(value)) return { value, changed: false };
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map(item => {
+      const res = replaceStringsWithRefs(item, index);
+      if (res.changed) changed = true;
+      return res.value;
+    });
+    return changed ? { value: next, changed } : { value, changed: false };
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    const res = replaceStringsWithRefs((value as Record<string, unknown>)[key], index);
+    if (res.changed) changed = true;
+    next[key] = res.value;
+  }
+  return changed ? { value: next, changed } : { value, changed: false };
+}
+
+/** Resolve a marker path inside `result`. Returns the string, or undefined if it doesn't resolve. */
+function resolvePayloadRef(result: unknown, path: PathSegment[]): string | undefined {
+  let current: unknown = result;
+  for (const seg of path) {
+    if (!isPlainObjectOrArray(current)) return undefined;
+    current = Array.isArray(current) ? current[seg as number] : (current as Record<string, unknown>)[seg as string];
+  }
+  return typeof current === 'string' ? current : undefined;
+}
+
+/**
+ * Walk `value`, resolving ref markers against `result`.
+ * Markers that don't resolve to a string are left byte-identical (no throw).
+ * Returns the original reference when nothing changed.
+ */
+function resolveRefsWithResult(value: unknown, result: unknown): { value: unknown; changed: boolean } {
+  if (!isPlainObjectOrArray(value)) return { value, changed: false };
+
+  if (isPayloadRefMarker(value)) {
+    const resolved = resolvePayloadRef(result, (value as Record<string, unknown>)[PAYLOAD_REF_KEY] as PathSegment[]);
+    if (resolved !== undefined) return { value: resolved, changed: true };
+    return { value, changed: false };
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map(item => {
+      const res = resolveRefsWithResult(item, result);
+      if (res.changed) changed = true;
+      return res.value;
+    });
+    return changed ? { value: next, changed } : { value, changed: false };
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    const res = resolveRefsWithResult((value as Record<string, unknown>)[key], result);
+    if (res.changed) changed = true;
+    next[key] = res.value;
+  }
+  return changed ? { value: next, changed } : { value, changed: false };
+}
+
+function getModelOutput(part: MastraToolInvocationPart): unknown {
+  const mastra = part.providerMetadata?.mastra;
+  if (!mastra || typeof mastra !== 'object') return undefined;
+  if (!('modelOutput' in mastra)) return undefined;
+  return (mastra as Record<string, unknown>).modelOutput;
+}
+
+function withModelOutput(part: MastraToolInvocationPart, modelOutput: unknown): MastraToolInvocationPart {
+  const mastra = {
+    ...(part.providerMetadata?.mastra as Record<string, unknown>),
+    modelOutput,
+  } as NonNullable<MastraToolInvocationPart['providerMetadata']>[string];
+  return {
+    ...part,
+    providerMetadata: {
+      ...part.providerMetadata,
+      mastra,
+    },
+  };
+}
+
+function isDedupableToolInvocationPart(part: MastraMessagePart): part is MastraToolInvocationPart {
+  return (
+    part.type === 'tool-invocation' &&
+    (part as MastraToolInvocationPart).toolInvocation?.state === 'result' &&
+    'result' in (part as MastraToolInvocationPart).toolInvocation
+  );
+}
+
+function transformMessages(
+  messages: MastraDBMessage[],
+  transformPart: (part: MastraToolInvocationPart) => MastraToolInvocationPart | undefined,
+): MastraDBMessage[] {
+  let anyMessageChanged = false;
+  const nextMessages = messages.map(message => {
+    const parts = message.content?.parts;
+    if (!Array.isArray(parts) || parts.length === 0) return message;
+
+    let messageChanged = false;
+    const nextParts = parts.map(part => {
+      if (!isDedupableToolInvocationPart(part)) return part;
+      const nextPart = transformPart(part);
+      if (nextPart === undefined) return part;
+      messageChanged = true;
+      return nextPart;
+    });
+
+    if (!messageChanged) return message;
+    anyMessageChanged = true;
+    return { ...message, content: { ...message.content, parts: nextParts } };
+  });
+  return anyMessageChanged ? nextMessages : messages;
+}
+
+/**
+ * Write-path transform: replace large strings inside `providerMetadata.mastra.modelOutput`
+ * that are byte-identical to strings inside the sibling `toolInvocation.result` with ref
+ * markers. Pure; returns the input array by reference when nothing changed.
+ */
+export function dedupeMessagePayloadRefs(messages: MastraDBMessage[]): MastraDBMessage[] {
+  return transformMessages(messages, part => {
+    const modelOutput = getModelOutput(part);
+    if (modelOutput === undefined) return undefined;
+    const index = indexLargeStrings(part.toolInvocation.result);
+    if (!index) return undefined;
+    const { value, changed } = replaceStringsWithRefs(modelOutput, index);
+    if (!changed) return undefined;
+    return withModelOutput(part, value);
+  });
+}
+
+/**
+ * Read-path transform: resolve ref markers inside `providerMetadata.mastra.modelOutput`
+ * against the sibling `toolInvocation.result`. Markers that don't resolve are left as-is.
+ * Pure; returns the input array by reference when nothing changed.
+ */
+export function rehydrateMessagePayloadRefs(messages: MastraDBMessage[]): MastraDBMessage[] {
+  return transformMessages(messages, part => {
+    const modelOutput = getModelOutput(part);
+    if (modelOutput === undefined) return undefined;
+    const { value, changed } = resolveRefsWithResult(modelOutput, part.toolInvocation.result);
+    if (!changed) return undefined;
+    return withModelOutput(part, value);
+  });
+}

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -1,6 +1,7 @@
 import type { JSONSchema7 } from 'json-schema';
 import { z } from 'zod/v4';
 import type { MastraDBMessage } from '../agent/message-list';
+import { dedupeMessagePayloadRefs, rehydrateMessagePayloadRefs } from '../agent/message-list/payload-refs';
 import { ErrorCategory, ErrorDomain, MastraError } from '../error';
 import { toStandardSchema, standardSchemaToJSONSchema } from '../schema';
 import type {
@@ -139,7 +140,10 @@ export class MockMemory extends MastraMemory {
     memoryConfig?: MemoryConfigInternal;
   }): Promise<{ messages: MastraDBMessage[] }> {
     const memoryStorage = await this.getMemoryStore();
-    return memoryStorage.saveMessages({ messages: messages.filter(message => message.role !== 'system') });
+    const result = await memoryStorage.saveMessages({
+      messages: dedupeMessagePayloadRefs(messages.filter(message => message.role !== 'system')),
+    });
+    return { ...result, messages: rehydrateMessagePayloadRefs(result.messages) };
   }
 
   async listThreads(args: StorageListThreadsInput): Promise<StorageListThreadsOutput> {
@@ -174,7 +178,7 @@ export class MockMemory extends MastraMemory {
     return {
       ...result,
       messages: filterSystemReminderMessages(
-        result.messages.filter(message => message.role !== 'system'),
+        rehydrateMessagePayloadRefs(result.messages.filter(message => message.role !== 'system')),
         includeSystemReminders,
       ),
     };

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -1,5 +1,6 @@
 import type { Processor } from '..';
 import type { MastraDBMessage, MessageList } from '../../agent';
+import { dedupeMessagePayloadRefs } from '../../agent/message-list/payload-refs';
 import { parseMemoryRequestContext } from '../../memory';
 import { removeWorkingMemoryTags } from '../../memory/working-memory-utils';
 import { SpanType, EntityType } from '../../observability';
@@ -317,7 +318,8 @@ export class MessageHistory implements Processor {
       });
     }
 
-    // Persist messages after thread is guaranteed to exist
-    await this.storage.saveMessages({ messages: filtered });
+    // Persist messages after thread is guaranteed to exist.
+    // Dedupe redundant modelOutput payloads at rest (rehydrated on read).
+    await this.storage.saveMessages({ messages: dedupeMessagePayloadRefs(filtered) });
   }
 }

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -2,7 +2,7 @@ import { embedMany } from '@internal/ai-sdk-v4';
 import type { TextPart } from '@internal/ai-sdk-v4';
 import { embedMany as embedManyV5 } from '@internal/ai-sdk-v5';
 import { embedMany as embedManyV6 } from '@internal/ai-v6';
-import { MessageList } from '@mastra/core/agent';
+import { MessageList, dedupeMessagePayloadRefs, rehydrateMessagePayloadRefs } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent';
 
 import { coreFeatures } from '@mastra/core/features';
@@ -366,7 +366,8 @@ export class Memory extends MastraMemory {
     }>;
   }): Promise<{ messages: MastraDBMessage[]; total: number; page: number; perPage: number | false; hasMore: boolean }> {
     const memoryStore = await this.getMemoryStore();
-    return memoryStore.listMessagesByResourceId(args);
+    const result = await memoryStore.listMessagesByResourceId(args);
+    return { ...result, messages: rehydrateMessagePayloadRefs(result.messages) };
   }
 
   protected async validateThreadIsOwnedByResource(threadId: string, resourceId: string, config: MemoryConfigInternal) {
@@ -597,7 +598,9 @@ export class Memory extends MastraMemory {
           : {}),
       });
       // Reverse to restore chronological order if we queried DESC to get newest messages
-      const rawMessages = shouldGetNewestAndReverse ? paginatedResult.messages.reverse() : paginatedResult.messages;
+      const rawMessages = rehydrateMessagePayloadRefs(
+        shouldGetNewestAndReverse ? paginatedResult.messages.reverse() : paginatedResult.messages,
+      );
 
       const list = new MessageList({ threadId, resourceId }).add(rawMessages, 'memory');
 
@@ -1156,8 +1159,10 @@ ${workingMemory}`;
         .get.all.db();
 
       const memoryStore = await this.getMemoryStore();
+      // Dedupe redundant payload copies (e.g. providerMetadata.mastra.modelOutput strings that
+      // byte-match the sibling tool result) at rest. Read paths rehydrate the original shape.
       const result = await memoryStore.saveMessages({
-        messages: dbMessages,
+        messages: dedupeMessagePayloadRefs(dbMessages),
       });
 
       let totalTokens = 0;
@@ -1281,7 +1286,12 @@ ${workingMemory}`;
         }
       }
 
-      const saveResult = { ...result, usage: totalTokens > 0 ? { tokens: totalTokens } : undefined };
+      // Callers must see the full in-process shape, not the at-rest deduped one.
+      const saveResult = {
+        ...result,
+        messages: rehydrateMessagePayloadRefs(result.messages),
+        usage: totalTokens > 0 ? { tokens: totalTokens } : undefined,
+      };
 
       span?.end({
         output: { success: true },
@@ -1602,7 +1612,7 @@ ${workingMemory}`;
           perPage: false,
           filter: dateFilter,
         });
-        messages = result.messages;
+        messages = rehydrateMessagePayloadRefs(result.messages);
       } else {
         const result = await memoryStore.listMessages({
           threadId,
@@ -1610,7 +1620,7 @@ ${workingMemory}`;
           perPage: false,
           filter: dateFilter,
         });
-        messages = result.messages;
+        messages = rehydrateMessagePayloadRefs(result.messages);
       }
     } else {
       // No OM: load recent messages
@@ -1624,7 +1634,7 @@ ${workingMemory}`;
           orderBy: { field: 'createdAt', direction: 'DESC' },
           perPage: typeof lastMessages === 'number' ? lastMessages : undefined,
         });
-        messages = result.messages.reverse(); // DESC → chronological order
+        messages = rehydrateMessagePayloadRefs(result.messages.reverse()); // DESC → chronological order
       }
     }
 
@@ -1649,7 +1659,7 @@ ${workingMemory}`;
     if (persistableMessages.length === 0) return;
 
     const memoryStore = await this.getMemoryStore();
-    await memoryStore.saveMessages({ messages: persistableMessages });
+    await memoryStore.saveMessages({ messages: dedupeMessagePayloadRefs(persistableMessages) });
   }
 
   /**
@@ -2242,7 +2252,9 @@ Notes:
         const existingMessagesResult = await memoryStore.listMessagesById({
           messageIds: messagesWithContent.map(m => m.id),
         });
-        const existingMessagesMap = new Map(existingMessagesResult.messages.map(m => [m.id, m]));
+        const existingMessagesMap = new Map(
+          rehydrateMessagePayloadRefs(existingMessagesResult.messages).map(m => [m.id, m]),
+        );
 
         // Collect embeddings for messages with new text content
         const embeddingData: Array<{
@@ -2380,7 +2392,8 @@ Notes:
       }
     }
 
-    return memoryStore.updateMessages({ messages });
+    const updated = await memoryStore.updateMessages({ messages });
+    return rehydrateMessagePayloadRefs(updated);
   }
 
   /**


### PR DESCRIPTION
## Summary

Assistant messages were storing large tool-result payloads twice per message. When a tool defines `toModelOutput()`, the mapped model-facing output is persisted at `providerMetadata.mastra.modelOutput` alongside the raw `toolInvocation.result` — and for tools like screenshots, that means the same multi-hundred-KB base64 payload lands in the same row twice. Measured on a real 30GB production database, this redundancy accounted for ~43% of the 6.4GB messages table. File attachments were additionally stored twice: once as `file` parts and once as the derived `experimental_attachments` field (worst observed row: 15.6MB, of which half was a duplicate 7.8MB file).

This PR stores each payload once at rest and rehydrates transparently on read. No migration is needed — old rows read back unchanged, and nothing observable changes in-process for processors, prompt building, or the playground.

## How it works

**Payload refs** (`packages/core/src/agent/message-list/payload-refs.ts`)
- At write time, string values ≥ 1KB inside `modelOutput` that exactly match a value in the sibling `toolInvocation.result` are replaced with a namespaced path marker (`$mastra_tool_result_ref`).
- At read time, markers are resolved back from the sibling `result`. Markers are only interpreted when the path resolves to a string; anything else is left byte-identical, so user data shaped like a marker is safe and unresolved markers degrade gracefully (never a crash).
- Helpers are pure and non-mutating; unchanged messages are returned by reference.

**Wiring**
- Dedupe at every memory write boundary: `Memory.saveMessages`, `Memory.persistMessages`, `MockMemory.saveMessages`, and the `MessageHistory` processor's direct storage write.
- Rehydrate at every read boundary: `Memory` read paths (recall, listMessagesByResourceId, updateMessages merge-read, system-message reads), `MockMemory`, and defensively at `MessageList` DB-format intake for any consumer reading a store directly.

**Attachments**
- `AIV5Adapter` stops persisting `experimental_attachments` when the same data is retained as `file` parts (it was derived data). V4 consumers see the same `toUIMessage` shape as before, derived from file parts at read time.

## Test plan

- New baseline integration test (`message-payload-dedupe.test.ts`): asserts a large `toModelOutput` payload is stored **once** at rest (failed before this change: stored twice), attachment bytes stored once, refs rehydrated when messages re-enter a `MessageList` from memory, and dedupe→rehydrate roundtrip is identity.
- New unit tests for the payload-ref helpers (roundtrip identity, threshold behavior, nested/array paths, marker-shaped user data left alone, missing sibling result preserved untouched, non-mutation).
- Focused suites green: message-list + adapters (563 tests), save-and-errors + loop suites, tool-call-filter with `preserveModelOutput`, base64-images-with-threads, attachment adapter tests.
- Memory package: unit suite (1198 tests) and storage-backed integration tests (libsql, message ordering, vector metadata, streaming, duplicate IDs) all green.
- Typecheck clean for core and memory. Docs validation passes.

Note: `request-context-mutation.scenario.test.ts` failures are pre-existing on main (verified by stashing this change and re-running on the base commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes memory storage smarter about repeating the same big message data twice. Instead of saving the same large tool output or attachment bytes in two places, it saves them once and puts a small pointer in the other place, then restores the full data when reading it back.

## Summary
- Deduplicates large tool-result payloads at rest by replacing repeated `providerMetadata.mastra.modelOutput` strings with internal payload references.
- Rehydrates those references on read so in-memory message shapes stay the same for consumers.
- Applies the same storage savings to file attachments, avoiding duplicate persistence when `file` parts already contain the bytes.
- Wires the dedupe/rehydrate flow through memory write/read paths, including `Memory`, `MockMemory`, `MessageHistory`, and `MessageList`.
- Adds a payload-reference helper module plus tests covering roundtrip behavior, non-mutation, marker handling, and storage-size reduction.
- Updates docs to note that `recall()` returns fully restored messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->