### PR TITLE
fix(core): isolate tool request contexts

### DIFF
--- a/.changeset/dull-peaches-dance.md
+++ b/.changeset/dull-peaches-dance.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed request context mutations leaking between tool calls.

--- a/packages/core/src/storage/utils.test.ts
+++ b/packages/core/src/storage/utils.test.ts
@@ -12,8 +12,6 @@ import {
   filterByDateRange,
   jsonValueEquals,
 } from './utils';
-import type { StoreName } from './utils';
-
 describe('safelyParseJSON', () => {
   const sampleObject = {
     foo: 'bar',

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -57,14 +57,18 @@ import { validateToolInput, validateToolOutput, validateToolSuspendData } from '
  * closure on top — keys that survived serialisation are preserved while
  * non-serializable keys from the closure (like `controller`) are restored.
  */
+function cloneRequestContext(requestContext: RequestContext | undefined): RequestContext {
+  return requestContext instanceof RequestContext ? new RequestContext(requestContext.entries()) : new RequestContext();
+}
+
 function mergeRequestContexts(
   closureRC: RequestContext | undefined,
   execRC: RequestContext | undefined,
 ): RequestContext {
-  if (closureRC && closureRC === execRC) return closureRC;
+  if (closureRC && closureRC === execRC) return cloneRequestContext(closureRC);
   if (!closureRC && !execRC) return new RequestContext();
-  if (!closureRC) return execRC instanceof RequestContext ? execRC : new RequestContext();
-  if (!execRC || !(execRC instanceof RequestContext) || execRC.size() === 0) return closureRC;
+  if (!closureRC) return cloneRequestContext(execRC);
+  if (!execRC || !(execRC instanceof RequestContext) || execRC.size() === 0) return cloneRequestContext(closureRC);
 
   const merged = new RequestContext();
   // Start with the evented engine's serialised snapshot


### PR DESCRIPTION
## Summary
- Remove the unused `StoreName` import that caused `@mastra/core#lint` to fail on `main`.
- Clone request contexts for tool execution so mutations inside one tool call do not leak into later tool calls.
- Add a patch changeset for `@mastra/core`.

## What broke
- The lint failure came from an unused type import in `packages/core/src/storage/utils.test.ts`.
- The request-context regression came from passing the same mutable `RequestContext` instance through tool execution when the closure-time and execution-time contexts were the same object. That allowed one tool call to mutate context seen by later tool calls.

## Why this fix
- Cloning the `RequestContext` preserves the request-scoped values tools need while isolating tool-local mutations.
- The change stays inside the existing request-context merge path used by tool execution, so it avoids broader loop/runtime refactors.

## Test plan
- `pnpm --filter ./packages/core lint`
- `pnpm --filter ./packages/core exec vitest run src/loop/test-utils/aimock/scenarios/request-context-mutation.scenario.test.ts src/storage/utils.test.ts`
- `pnpm build:core`
- `pnpm --filter ./packages/core check`
