### PR TITLE
fix(deployer): pin correct external dependency version when exports omits ./package.json

### DIFF
--- a/.changeset/fix-deployer-exports-package-json-version.md
+++ b/.changeset/fix-deployer-exports-package-json-version.md
@@ -1,0 +1,7 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed `mastra build` pinning the wrong version of an external dependency when the installed package's `exports` map does not expose `./package.json` (for example, `execa@9`).
+
+The deployer resolved each external dependency's version by reading `<pkg>/package.json` through Node module resolution. For a package whose `exports` map omits `./package.json`, that lookup fails for the correct copy and silently falls back to an older copy hoisted elsewhere in the workspace — so `.mastra/output/package.json` recorded the wrong version and the deployed server could crash on an incompatible API. The deployer now resolves each dependency's directory from its main entry point instead, so the recorded version matches the copy the bundled code actually uses. Closes #18849.

--- a/packages/deployer/src/build/package-info.test.ts
+++ b/packages/deployer/src/build/package-info.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getPackageMetadata, getPackageRootPath } from './package-info';
 
@@ -18,7 +18,7 @@ async function writePackage(
   packageJson: Record<string, unknown>,
   entryRelPath = 'index.js',
 ): Promise<void> {
-  await mkdir(join(dir, entryRelPath, '..'), { recursive: true });
+  await mkdir(dirname(join(dir, entryRelPath)), { recursive: true });
   await writeFile(join(dir, 'package.json'), JSON.stringify(packageJson));
   await writeFile(join(dir, entryRelPath), 'export const value = 1;');
 }
@@ -113,6 +113,15 @@ describe('getPackageRootPath', () => {
     );
 
     await expect(getPackageRootPath('deep-pkg', tempDir)).resolves.toBe(packageDir);
+  });
+
+  it('resolves an npm alias install whose package name differs from the specifier', async () => {
+    // e.g. `"ai-v5": "npm:ai@5"` — the specifier is `ai-v5` but the installed package is named `ai`.
+    const tempDir = await makeTempDir('package-root-alias');
+    const packageDir = join(tempDir, 'node_modules', 'ai-v5');
+    await writePackage(packageDir, { name: 'ai', version: '5.0.93', main: './index.js' });
+
+    await expect(getPackageRootPath('ai-v5', tempDir)).resolves.toBe(packageDir);
   });
 
   it('returns null for a package that cannot be resolved', async () => {

--- a/packages/deployer/src/build/package-info.test.ts
+++ b/packages/deployer/src/build/package-info.test.ts
@@ -1,9 +1,27 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { getPackageMetadata } from './package-info';
+import { getPackageMetadata, getPackageRootPath } from './package-info';
 
 const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const tempRoot = join(process.cwd(), '.tmp');
+  await mkdir(tempRoot, { recursive: true });
+  const tempDir = await mkdtemp(join(tempRoot, `${prefix}-`));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+async function writePackage(
+  dir: string,
+  packageJson: Record<string, unknown>,
+  entryRelPath = 'index.js',
+): Promise<void> {
+  await mkdir(join(dir, entryRelPath, '..'), { recursive: true });
+  await writeFile(join(dir, 'package.json'), JSON.stringify(packageJson));
+  await writeFile(join(dir, entryRelPath), 'export const value = 1;');
+}
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
@@ -28,5 +46,78 @@ describe('getPackageMetadata', () => {
       version: '2.30.0',
       packageSpec: undefined,
     });
+  });
+
+  // Regression: https://github.com/mastra-ai/mastra/issues/18849
+  // When the installed package's `exports` map does not expose `./package.json`, the deployer
+  // must still pin the version of the copy the bundled code actually imports — not a stale copy
+  // hoisted elsewhere in the workspace whose package.json happens to be freely readable.
+  it('pins the version of the copy whose exports omit ./package.json (issue #18849)', async () => {
+    const tempDir = await makeTempDir('package-metadata-exports');
+
+    // Correct copy in the app: modern ESM `exports` with NO `./package.json` subpath.
+    await writePackage(join(tempDir, 'app', 'node_modules', 'dep-pkg'), {
+      name: 'dep-pkg',
+      version: '9.6.1',
+      type: 'module',
+      exports: { types: './index.d.ts', default: './index.js' },
+    });
+
+    // Stale hoisted copy with a freely-readable package.json (no exports gate).
+    await writePackage(join(tempDir, 'node_modules', 'dep-pkg'), {
+      name: 'dep-pkg',
+      version: '5.1.1',
+      main: './index.js',
+    });
+
+    await expect(getPackageMetadata('dep-pkg', join(tempDir, 'app'))).resolves.toMatchObject({
+      version: '9.6.1',
+    });
+  });
+});
+
+describe('getPackageRootPath', () => {
+  it('resolves the package whose exports omit ./package.json (issue #18849)', async () => {
+    const tempDir = await makeTempDir('package-root-exports');
+    const packageDir = join(tempDir, 'node_modules', 'dep-pkg');
+    await writePackage(packageDir, {
+      name: 'dep-pkg',
+      version: '9.6.1',
+      type: 'module',
+      exports: { types: './index.d.ts', default: './index.js' },
+    });
+
+    await expect(getPackageRootPath('dep-pkg', tempDir)).resolves.toBe(packageDir);
+  });
+
+  it('resolves a plain package whose package.json is freely readable', async () => {
+    const tempDir = await makeTempDir('package-root-plain');
+    const packageDir = join(tempDir, 'node_modules', 'plain-pkg');
+    await writePackage(packageDir, { name: 'plain-pkg', version: '1.0.0', main: './index.js' });
+
+    await expect(getPackageRootPath('plain-pkg', tempDir)).resolves.toBe(packageDir);
+  });
+
+  it('walks up to the package root when the entry points deep into the package', async () => {
+    const tempDir = await makeTempDir('package-root-deep');
+    const packageDir = join(tempDir, 'node_modules', 'deep-pkg');
+    await writePackage(
+      packageDir,
+      {
+        name: 'deep-pkg',
+        version: '1.0.0',
+        type: 'module',
+        exports: { default: './dist/index.js' },
+      },
+      join('dist', 'index.js'),
+    );
+
+    await expect(getPackageRootPath('deep-pkg', tempDir)).resolves.toBe(packageDir);
+  });
+
+  it('returns null for a package that cannot be resolved', async () => {
+    const tempDir = await makeTempDir('package-root-missing');
+
+    await expect(getPackageRootPath('does-not-exist-pkg', tempDir)).resolves.toBeNull();
   });
 });

--- a/packages/deployer/src/build/package-info.ts
+++ b/packages/deployer/src/build/package-info.ts
@@ -1,38 +1,77 @@
 /**
- * Note: This function depends on local-pkg and should only be used at build-time.
- * It is in a separate file to avoid including local-pkg in runtime code.
+ * Note: This function is meant to be used at build-time only.
  */
 
-import { pathToFileURL } from 'node:url';
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { readJSON } from 'fs-extra/esm';
-import { getPackageInfo } from 'local-pkg';
 import { getPackageName } from './utils';
+
+/**
+ * Walk up from a resolved file to the directory whose package.json `name` matches `packageName`.
+ * Matching on `name` (not mere existence) skips nested internal package.json files when a
+ * package's entry points deep into e.g. `dist/`, and handles scoped packages and subpath
+ * specifiers correctly (where `packageName` is the base name of the requested specifier).
+ */
+function findPackageRoot(entryPath: string, packageName: string): string | null {
+  let dir = dirname(entryPath);
+
+  while (true) {
+    const packageJsonPath = join(dir, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { name?: string };
+        if (pkg.name === packageName) {
+          return dir;
+        }
+      } catch {
+        // Unreadable or partial package.json — keep walking up.
+      }
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
 
 /**
  * Get package root path
  */
 export async function getPackageRootPath(packageName: string, parentPath?: string): Promise<string | null> {
-  let rootPath: string | null;
-
   try {
-    let options: { paths?: string[] } | undefined = undefined;
+    // Anchor resolution at `parentPath` (a notional file inside it) so Node resolves the package
+    // from `parentPath`'s node_modules upward — the same way the bundled code would.
+    //
+    // We resolve the package's main entry (its "." export) with Node's own resolver and then derive
+    // the root directory from it, rather than reading `<pkg>/package.json` through module resolution.
+    // Packages whose `exports` map omits `./package.json` (e.g. execa 9) make that subpath lookup
+    // throw for the correct copy, which silently falls through to a stale copy hoisted elsewhere in
+    // the workspace — so the wrong version gets pinned in the build output. See issue #18849.
+    let anchor: string;
     if (parentPath) {
-      if (!parentPath.startsWith('file://')) {
-        parentPath = pathToFileURL(parentPath).href;
-      }
-
-      options = {
-        paths: [parentPath],
-      };
+      const parentDir = parentPath.startsWith('file://') ? fileURLToPath(parentPath) : parentPath;
+      anchor = join(parentDir, 'noop.js');
+    } else {
+      anchor = join(process.cwd(), 'noop.js');
     }
 
-    const pkg = await getPackageInfo(packageName, options);
-    rootPath = pkg?.rootPath ?? null;
-  } catch {
-    rootPath = null;
-  }
+    const require = createRequire(anchor);
+    let entryPath: string;
+    try {
+      entryPath = require.resolve(packageName);
+    } catch {
+      return null;
+    }
 
-  return rootPath;
+    return findPackageRoot(entryPath, getPackageName(packageName) ?? packageName);
+  } catch {
+    return null;
+  }
 }
 
 async function readPackageMetadata(

--- a/packages/deployer/src/build/package-info.ts
+++ b/packages/deployer/src/build/package-info.ts
@@ -2,7 +2,7 @@
  * Note: This function is meant to be used at build-time only.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -10,25 +10,19 @@ import { readJSON } from 'fs-extra/esm';
 import { getPackageName } from './utils';
 
 /**
- * Walk up from a resolved file to the directory whose package.json `name` matches `packageName`.
- * Matching on `name` (not mere existence) skips nested internal package.json files when a
- * package's entry points deep into e.g. `dist/`, and handles scoped packages and subpath
- * specifiers correctly (where `packageName` is the base name of the requested specifier).
+ * Walk up from a resolved entry file to the nearest enclosing directory that contains a
+ * `package.json` — that directory is the package root. We match on existence rather than on the
+ * `package.json` `name` so that npm alias installs (e.g. `"ai-v5": "npm:ai@5"`, where the specifier
+ * differs from the installed package's real name) resolve correctly. A deep entry such as
+ * `dist/index.js` has no `package.json` in its subdirectories, so the first one found walking up is
+ * always the true package root.
  */
-function findPackageRoot(entryPath: string, packageName: string): string | null {
+function findPackageRoot(entryPath: string): string | null {
   let dir = dirname(entryPath);
 
   while (true) {
-    const packageJsonPath = join(dir, 'package.json');
-    if (existsSync(packageJsonPath)) {
-      try {
-        const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { name?: string };
-        if (pkg.name === packageName) {
-          return dir;
-        }
-      } catch {
-        // Unreadable or partial package.json — keep walking up.
-      }
+    if (existsSync(join(dir, 'package.json'))) {
+      return dir;
     }
 
     const parent = dirname(dir);
@@ -68,7 +62,7 @@ export async function getPackageRootPath(packageName: string, parentPath?: strin
       return null;
     }
 
-    return findPackageRoot(entryPath, getPackageName(packageName) ?? packageName);
+    return findPackageRoot(entryPath);
   } catch {
     return null;
   }

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
-import { getPackageInfo } from 'local-pkg';
 import type { Plugin, PluginContext } from 'rollup';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getPackageRootPath } from '../package-info';
 
 const mockNodeResolveHandler = vi.fn();
 
@@ -10,8 +10,8 @@ vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
 }));
 
-vi.mock('local-pkg', () => ({
-  getPackageInfo: vi.fn(),
+vi.mock('../package-info', () => ({
+  getPackageRootPath: vi.fn(),
 }));
 
 vi.mock('@rollup/plugin-node-resolve', () => ({
@@ -86,8 +86,7 @@ describe('nodeModulesExtensionResolver', () => {
 
     it('imports with an extension that have exports mapping', async () => {
       const pkgJson = { name: 'hono', exports: { 'hono/utils/mime.js': './dist/utils/mime.js' } };
-      // @ts-expect-error parital is fine
-      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'hono', rootPath: '/project/node_modules/hono' });
+      vi.mocked(getPackageRootPath).mockResolvedValue('/project/node_modules/hono');
       // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
@@ -100,8 +99,7 @@ describe('nodeModulesExtensionResolver', () => {
   describe('imports with JS extension', () => {
     it('It will resolve the import to the correct path if no exports present', async () => {
       const pkgJson = { name: 'lodash' };
-      // @ts-expect-error parital is fine
-      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
+      vi.mocked(getPackageRootPath).mockResolvedValue('/project/node_modules/lodash');
       // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
@@ -117,8 +115,7 @@ describe('nodeModulesExtensionResolver', () => {
 
     it('handles .mjs extension', async () => {
       const pkgJson = { name: 'lodash' };
-      // @ts-expect-error parital is fine
-      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
+      vi.mocked(getPackageRootPath).mockResolvedValue('/project/node_modules/lodash');
       // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
@@ -134,8 +131,7 @@ describe('nodeModulesExtensionResolver', () => {
 
     it('handles .cjs extension', async () => {
       const pkgJson = { name: 'lodash' };
-      // @ts-expect-error parital is fine
-      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
+      vi.mocked(getPackageRootPath).mockResolvedValue('/project/node_modules/lodash');
       // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
@@ -153,8 +149,7 @@ describe('nodeModulesExtensionResolver', () => {
   describe('imports without extension', () => {
     it('resolves the import to the correct path if no exports present', async () => {
       const pkgJson = { name: 'lodash' };
-      // @ts-expect-error parital is fine
-      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
+      vi.mocked(getPackageRootPath).mockResolvedValue('/project/node_modules/lodash');
       // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
@@ -180,8 +175,7 @@ describe('nodeModulesExtensionResolver', () => {
   describe('scoped packages', () => {
     it('handles scoped package subpath imports with exports', async () => {
       const pkgJson = { name: '@my/lodash', exports: {} };
-      // @ts-expect-error parital is fine
-      vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
+      vi.mocked(getPackageRootPath).mockResolvedValue('/project/node_modules/@my/lodash');
       // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
@@ -194,8 +188,7 @@ describe('nodeModulesExtensionResolver', () => {
 
     it('adds extension for scoped package without exports', async () => {
       const pkgJson = { name: '@my/lodash' };
-      // @ts-expect-error parital is fine
-      vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
+      vi.mocked(getPackageRootPath).mockResolvedValue('/project/node_modules/@my/lodash');
       // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
       // @ts-expect-error Partial input is fine
@@ -211,8 +204,7 @@ describe('nodeModulesExtensionResolver', () => {
     it('handles package.json read failure gracefully', async () => {
       // ts-expect-error @typescript-eslint/no-unused-vars
       const _pkgJson = { name: '@my/lodash' };
-      // @ts-expect-error parital is fine
-      vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
+      vi.mocked(getPackageRootPath).mockResolvedValue('/project/node_modules/@my/lodash');
 
       vi.mocked(readFile).mockImplementation(() => {
         throw new Error('ENOENT');


### PR DESCRIPTION
﻿
## What



Fixes #18849. `mastra build` pinned the **wrong version** of an external dependency in `.mastra/output/package.json` when the installed package''s `exports` map does not expose `./package.json` (e.g. `execa@9`).



## Why



`@mastra/deployer`''s `getPackageRootPath` resolved a dependency''s directory via `local-pkg`''s `getPackageInfo`, which first resolves the `<pkg>/package.json` subpath through Node''s `exports` gate. For a package whose `exports` omits `./package.json`, that lookup throws `ERR_PACKAGE_PATH_NOT_EXPORTED` for the correct copy and silently falls through to an older copy hoisted elsewhere in the workspace (whose `package.json` is freely readable). The deployer then recorded that stale version - e.g. `execa@5.1.1` instead of `9.6.1`, and the deployed server crashed on the incompatible API.



## How



`getPackageRootPath` now resolves the package''s main entry (its `.` export) with Node''s own resolver and derives the root directory from it, rather than reading `<pkg>/package.json` through module resolution. It walks up from the entry to the directory whose `package.json` `name` matches, so scoped packages and deep entry points resolve correctly. This drops the `local-pkg` call from this function (Node built-ins only)



## Testing



- Added regression tests in `package-info.test.ts`: a two-copy fixture reproducing the exports-gate bug (asserts the `9.6.1` copy is picked, not the stale `5.1.1`), plus deep-entry, plain-package, and not-found cases

- Verified against the reporter''s [minimal repro](https://github.com/segevfiner/mastra-execa-exports-repro): `getPackageRootPath(''execa'', …)` now returns the `9.6.1` directory.

- Updated `node-modules-extension-resolver.test.ts` to mock `getPackageRootPath` at the module boundary (the impl no longer calls `local-pkg`).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When `mastra build` bundles dependencies, it needs to write down the version of each dependency that it will actually include. This PR fixes a case where it could pick the wrong `package.json` (from an older, hoisted copy) when a dependency hides `./package.json` via its `exports`, causing the recorded version to be stale.

## Summary
- Reworked `getPackageRootPath` to:
  - Resolve a dependency from its real main entry using Node’s resolver (`createRequire(...).resolve(packageName)`),
  - Then walk upward from that resolved entry to find the nearest `package.json` directory, instead of resolving `<pkg>/package.json` directly.
- This prevents stale version pinning in `.mastra/output/package.json` when the dependency’s `exports` doesn’t include `./package.json` (e.g., `execa@9`-style cases) and avoids falling back to an older hoisted copy.
- Preserved failure behavior: return `null` when resolution or filesystem/JSON handling fails.
- Added regression tests covering:
  - The `exports`-gate scenario (no `./package.json` exposed),
  - Deep entry packages (walking up to root),
  - Plain readable packages,
  - Not-found behavior,
  - npm alias installs (e.g., `ai-v5 -> npm:ai@5`) resolving to the nearest matching `package.json`.
- Updated `node-modules-extension-resolver.test.ts` to mock `getPackageRootPath` at the module boundary (instead of mocking `local-pkg`/`getPackageInfo`).
- Added a changeset documenting the deployer fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->