### PR TITLE
fix(core): remove unused StoreName import in storage utils test

### DIFF
--- a/packages/core/src/storage/utils.test.ts
+++ b/packages/core/src/storage/utils.test.ts
@@ -12,7 +12,6 @@ import {
   filterByDateRange,
   jsonValueEquals,
 } from './utils';
-import type { StoreName } from './utils';
 
 describe('safelyParseJSON', () => {
   const sampleObject = {


### PR DESCRIPTION
Removes an unused `import type { StoreName }` in `packages/core/src/storage/utils.test.ts` that fails `@typescript-eslint/no-unused-vars` and reddens `@mastra/core#lint` on main.

```
15:15  error  'StoreName' is defined but never used  @typescript-eslint/no-unused-vars
```

Verified: `pnpm --filter ./packages/core exec eslint src/storage/utils.test.ts` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change removes an extra import from a test file that wasn’t being used. It helps the code pass lint checks again without changing how the tests work.

## Summary
- Removed the unused `StoreName` type import from `packages/core/src/storage/utils.test.ts`
- No test behavior or assertions changed
- Fixes the `@typescript-eslint/no-unused-vars` lint failure in `@mastra/core`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->