### PR TITLE
fix(memory): add transient flag to data-om-status part

### DIFF
--- a/.changeset/data-om-status-transient.md
+++ b/.changeset/data-om-status-transient.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Mark data-om-status parts as transient so they are not persisted as standalone assistant messages

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -2629,7 +2629,7 @@ ${formattedMessages}
       omDebug(
         `[OM:status] step=${stepNumber} msgs=${pendingTokens}/${threshold} obs=${currentObservationTokens}/${effectiveObservationTokensThreshold} gen=${record.generationCount}`,
       );
-      await writer.custom(statusPart).catch(() => {});
+      await writer.custom({ ...statusPart, transient: true }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Problem

The `data-om-status` Observational Memory data part is emitted without the `transient: true` flag that every other OM lifecycle marker carries. As a result, Mastra's `OutputWriter` treats each `data-om-status` snapshot as a standalone assistant message and persists it to `mastra_messages`, polluting message history and crowding out real conversation messages from paginated history reads.

## Root Cause

In `observational-memory.ts`, the status part is emitted via:
```ts
await writer.custom(statusPart).catch(() => {});
```

While every other OM marker uses `transient: true`:
```ts
void writer.custom({ ...startMarker, transient: true }).catch(() => {});
```

## Fix

Spread `statusPart` and add `transient: true` to the custom call, matching the pattern used by all other OM lifecycle markers.

Fixes #18869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes `data-om-status` behave like a “temporary status ping,” not a real chat message. So the system won’t save these progress snapshots into message history where they can clutter or push real conversation turns out of paginated reads.

## Summary
- Mark `data-om-status` as `transient: true` when emitting it during `emitProgress` for Observational Memory (when streaming via `ProcessorStreamWriter`).
- Prevents `OutputWriter` from persisting `data-om-status` snapshots as standalone assistant messages.
- Adds a Changesets entry to bump `@mastra/memory` with the documented fix (aligning `data-om-status` with other Observational Memory transient lifecycle markers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->