### PR TITLE
fix(core): handle leading step-start as prefix in StepContentExtractor

### DIFF
--- a/.changeset/step-content-off-by-one.md
+++ b/.changeset/step-content-off-by-one.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix StepContentExtractor to handle leading step-start markers as step prefixes instead of separators

--- a/packages/core/src/agent/message-list/conversion/step-content.ts
+++ b/packages/core/src/agent/message-list/conversion/step-content.ts
@@ -85,7 +85,7 @@ export class StepContentExtractor {
     }
 
     // Count total steps (1 + number of step-start markers)
-    const totalSteps = stepBoundaries.length + 1;
+    const totalSteps = stepBoundaries.length;
 
     // Get the content for the last step using the regular step logic
     if (totalSteps === 1 && !hasStepStart) {
@@ -115,13 +115,15 @@ export class StepContentExtractor {
     stepBoundaries: number[],
     stepContentFn: (message?: AIV5Type.ModelMessage) => AIV5Type.StepResult<any>['content'],
   ): AIV5Type.StepResult<any>['content'] {
-    const firstStepStart = stepBoundaries[0] ?? uiMessagesParts.length;
-    if (firstStepStart === 0) {
-      // No content before first step-start
-      return [];
+    if (stepBoundaries.length === 0) {
+      return StepContentExtractor.convertPartsToContent(uiMessagesParts, 'step-1', stepContentFn);
     }
 
-    const stepParts = uiMessagesParts.slice(0, firstStepStart);
+    // step-start is a step prefix, not a separator.
+    // Step 1 content is everything after the first marker up to the next boundary.
+    const firstStepStart = stepBoundaries[0];
+    const secondStepStart = stepBoundaries[1];
+    const stepParts = uiMessagesParts.slice(firstStepStart + 1, secondStepStart ?? uiMessagesParts.length);
     return StepContentExtractor.convertPartsToContent(stepParts, 'step-1', stepContentFn);
   }
 
@@ -134,12 +136,13 @@ export class StepContentExtractor {
     stepNumber: number,
     stepContentFn: (message?: AIV5Type.ModelMessage) => AIV5Type.StepResult<any>['content'],
   ): AIV5Type.StepResult<any>['content'] {
-    const stepIndex = stepNumber - 2; // -2 because step 2 is at index 0 in boundaries
+    // step-start is a prefix, so step N content is between boundary[N-1] and boundary[N]
+    const stepIndex = stepNumber - 1;
     if (stepIndex < 0 || stepIndex >= stepBoundaries.length) {
       return [];
     }
 
-    const startIndex = (stepBoundaries[stepIndex] ?? 0) + 1; // Start after the step-start marker
+    const startIndex = stepBoundaries[stepIndex] + 1; // Start after the step-start marker
     const endIndex = stepBoundaries[stepIndex + 1] ?? uiMessagesParts.length;
 
     if (startIndex >= endIndex) {

--- a/packages/core/src/agent/message-list/conversion/step-content.ts
+++ b/packages/core/src/agent/message-list/conversion/step-content.ts
@@ -84,12 +84,13 @@ export class StepContentExtractor {
       return StepContentExtractor.convertPartsToContent(stepParts, 'last-step', stepContentFn);
     }
 
-    // Count total steps (1 + number of step-start markers)
+    // A leading step-start marker is a prefix for step 1, not a separate step,
+    // so the total step count equals the number of markers (not markers + 1).
     const totalSteps = stepBoundaries.length;
 
     // Get the content for the last step using the regular step logic
-    if (totalSteps === 1 && !hasStepStart) {
-      // Only one step, return all content
+    if (totalSteps === 0) {
+      // No step-start markers: return all content as the single (last) step
       return StepContentExtractor.convertPartsToContent(uiMessagesParts, 'last-step', stepContentFn);
     }
 
@@ -116,14 +117,22 @@ export class StepContentExtractor {
     stepContentFn: (message?: AIV5Type.ModelMessage) => AIV5Type.StepResult<any>['content'],
   ): AIV5Type.StepResult<any>['content'] {
     if (stepBoundaries.length === 0) {
+      // No step-start markers: all content belongs to step 1
       return StepContentExtractor.convertPartsToContent(uiMessagesParts, 'step-1', stepContentFn);
     }
 
-    // step-start is a step prefix, not a separator.
-    // Step 1 content is everything after the first marker up to the next boundary.
-    const firstStepStart = stepBoundaries[0];
-    const secondStepStart = stepBoundaries[1];
-    const stepParts = uiMessagesParts.slice(firstStepStart + 1, secondStepStart ?? uiMessagesParts.length);
+    const firstBoundary = stepBoundaries[0];
+
+    if (firstBoundary === 0) {
+      // Prefix layout: a leading step-start marker begins step 1.
+      // Step 1 content is everything after the leading marker up to the next marker.
+      const secondBoundary = stepBoundaries[1];
+      const stepParts = uiMessagesParts.slice(1, secondBoundary ?? uiMessagesParts.length);
+      return StepContentExtractor.convertPartsToContent(stepParts, 'step-1', stepContentFn);
+    }
+
+    // Separator layout: no leading marker, so step 1 is the content before the first marker.
+    const stepParts = uiMessagesParts.slice(0, firstBoundary);
     return StepContentExtractor.convertPartsToContent(stepParts, 'step-1', stepContentFn);
   }
 
@@ -136,8 +145,11 @@ export class StepContentExtractor {
     stepNumber: number,
     stepContentFn: (message?: AIV5Type.ModelMessage) => AIV5Type.StepResult<any>['content'],
   ): AIV5Type.StepResult<any>['content'] {
-    // step-start is a prefix, so step N content is between boundary[N-1] and boundary[N]
-    const stepIndex = stepNumber - 1;
+    // Indexing depends on layout. A leading step-start marker (prefix layout) begins
+    // step 1, so step N maps to boundary[N-1]. Without a leading marker (separator
+    // layout), markers separate steps, so step N maps to boundary[N-2].
+    const hasLeadingMarker = stepBoundaries.length > 0 && stepBoundaries[0] === 0;
+    const stepIndex = hasLeadingMarker ? stepNumber - 1 : stepNumber - 2;
     if (stepIndex < 0 || stepIndex >= stepBoundaries.length) {
       return [];
     }


### PR DESCRIPTION
## Problem

`StepContentExtractor.extractStepContent` treats a leading `step-start` marker inconsistently. Assistant steps are stored beginning with a `step-start` marker, which is a **prefix** that begins a step, not a separator between steps. The extractor records every `step-start` as a boundary, which makes step 1 read as empty and shifts every later step number by one.

### Reproduction

For stored assistant message parts `["step-start", "STEP1", "step-start", "STEP2"]`:
- `modelContent(1)` returns `[]` (STEP1 content is dropped)
- `modelContent(2)` returns STEP1 content (off by one)
- `modelContent(-1)` returns STEP2 content (correct)

The invariant `modelContent(1) === modelContent(-1)` for a single-step message is violated.

## Root Cause

- `extractFirstStep` returns `[]` when `firstStepStart === 0`, treating the leading marker as an empty step
- `extractMiddleStep` uses `stepNumber - 2` indexing, treating markers as separators
- `extractLastStep` correctly uses `slice(lastStepStart + 1)`, proving `step-start` is a prefix

## Fix

- `extractFirstStep`: When the first marker is at index 0, return content after it (up to the next boundary), not `[]`
- `extractMiddleStep`: Use `stepNumber - 1` as the boundary index (step N is between boundary[N-1] and boundary[N])
- `extractLastStep`: Adjust `totalSteps` to equal the number of boundaries

Fixes #18774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This fixes how Mastra splits an assistant’s reply into “steps” when the reply starts with a `step-start` marker. Previously, that first marker could be treated like an empty boundary (making step 1 empty and shifting later steps); now it’s treated as the start of step 1, so `modelContent(1)`, `modelContent(2)`, and `modelContent(-1)` line up correctly.

### What changed
- Updated `StepContentExtractor.extractStepContent` so a leading `step-start` at index `0` is treated as the **prefix for step 1** (not a separator that creates an empty first step).
- Fixed first-step extraction: with a leading marker, `modelContent(1)` now returns content **after** the first `step-start` up to the next marker.
- Fixed middle-step extraction indexing so step-number slices no longer shift by one when the layout is prefix-style (leading marker).
- Fixed last-step extraction counting/slicing: total step computation and last-step extraction now stay consistent with the prefix-style layout.
- Preserved the invariant for a single-step message: `modelContent(1) === modelContent(-1)`.
- Kept separator-style messages unchanged (when there is no leading `step-start` marker at index `0`).

### Tests
- Added unit tests covering the reported `step-start`-at-index-0 off-by-one cases, including `modelContent(1)`, `modelContent(2)`, and the single-step invariant (`modelContent(1) === modelContent(-1)`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->