### PR TITLE
fix(core): backfill resource id on hydrated messages

### DIFF
--- a/.changeset/tired-dancers-begin.md
+++ b/.changeset/tired-dancers-begin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed message hydration to backfill resource IDs when thread IDs are already present.

--- a/packages/core/src/agent/message-list/conversion/input-converter.test.ts
+++ b/packages/core/src/agent/message-list/conversion/input-converter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { InputConversionContext } from './input-converter';
+import { hydrateMastraDBMessageFields } from './input-converter';
+import type { MastraDBMessage } from '../state/types';
+
+describe('hydrateMastraDBMessageFields', () => {
+  it('backfills resourceId when the message already has a threadId', () => {
+    const message = {
+      id: 'msg-1',
+      role: 'user',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      threadId: 'thread-1',
+      content: {
+        format: 2,
+        parts: [],
+      },
+    } satisfies MastraDBMessage;
+    const context = {
+      memoryInfo: {
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+      },
+      newMessageId: vi.fn(() => 'generated-id'),
+      generateCreatedAt: vi.fn(() => new Date('2026-01-02T00:00:00.000Z')),
+      dbMessages: [],
+    } satisfies InputConversionContext;
+
+    const result = hydrateMastraDBMessageFields(message, context, 'memory');
+
+    expect(result.threadId).toBe('thread-1');
+    expect(result.resourceId).toBe('resource-1');
+    expect(context.newMessageId).not.toHaveBeenCalled();
+    expect(context.generateCreatedAt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agent/message-list/conversion/input-converter.test.ts
+++ b/packages/core/src/agent/message-list/conversion/input-converter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { MastraDBMessage } from '../state/types';
 import type { InputConversionContext } from './input-converter';
 import { hydrateMastraDBMessageFields } from './input-converter';
-import type { MastraDBMessage } from '../state/types';
 
 describe('hydrateMastraDBMessageFields', () => {
   it('backfills resourceId when the message already has a threadId', () => {

--- a/packages/core/src/agent/message-list/conversion/input-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/input-converter.ts
@@ -220,10 +220,10 @@ export function hydrateMastraDBMessageFields(
 
   if (!message.threadId && context.memoryInfo?.threadId) {
     message.threadId = context.memoryInfo.threadId;
+  }
 
-    if (!message.resourceId && context.memoryInfo?.resourceId) {
-      message.resourceId = context.memoryInfo.resourceId;
-    }
+  if (!message.resourceId && context.memoryInfo?.resourceId) {
+    message.resourceId = context.memoryInfo.resourceId;
   }
 
   return message;


### PR DESCRIPTION
Fixes #18559.

This updates MastraDB message hydration so `resourceId` is filled from `memoryInfo` independently from `threadId`. Previously, messages that already had a `threadId` skipped the `resourceId` backfill.

I added a focused regression test for a restored message that already has `threadId` but is missing `resourceId`.

Checks run:
- pnpm --filter ./packages/core test src/agent/message-list/conversion/input-converter.test.ts
- pnpm --filter ./packages/core test src/agent/message-list/conversion/input-converter.test.ts src/agent/message-list/tests/message-list.test.ts
- pnpm --filter ./packages/core check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When MastraDB restores a saved message, it should be able to remember which “resource box” it belongs to. This PR fixes hydration so that even if the message already has its “thread/conversation ID,” it will still fill in the missing “resource ID” from `memoryInfo`.

## What changed
- Fixed `hydrateMastraDBMessageFields` so `resourceId` is backfilled independently of whether `threadId` is missing.
- Kept any existing `threadId` intact while hydrating missing `resourceId` from `context.memoryInfo?.resourceId`.
- Added a regression test for a restored message that already has `threadId` but lacks `resourceId`, asserting that `resourceId` is restored and that unnecessary ID/createdAt generation is not triggered.
- Added a changeset entry for a patch release to `@mastra/core`.

## Notes
- This targets restored DB message conversion so resource-scoped memory/history association is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->