### PR TITLE
fix(deployer): fail early when flat skill is missing required description

### DIFF
--- a/.changeset/fix-flat-skill-description.md
+++ b/.changeset/fix-flat-skill-description.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed flat markdown skills crashing at runtime when missing a description in frontmatter. Discovery now fails early with a clear error pointing to the file and the Agent Skills spec.

--- a/packages/deployer/src/build/fs-routing/discover.ts
+++ b/packages/deployer/src/build/fs-routing/discover.ts
@@ -194,7 +194,7 @@ async function parsePackagedSkill(
   const parsed = matter(raw);
   const frontmatter = parsed.data as { name?: string; description?: string };
   const name = frontmatter.name ?? fallbackName;
-  const description = frontmatter.description ?? '';
+  const description = frontmatter.description;
 
   if (!description) {
     throw new Error(

--- a/packages/deployer/src/build/fs-routing/discover.ts
+++ b/packages/deployer/src/build/fs-routing/discover.ts
@@ -195,6 +195,15 @@ async function parsePackagedSkill(
   const frontmatter = parsed.data as { name?: string; description?: string };
   const name = frontmatter.name ?? fallbackName;
   const description = frontmatter.description ?? '';
+
+  if (!description) {
+    throw new Error(
+      `Skill "${name}" in ${skillMdPath} is missing a required "description". ` +
+        `Add a YAML frontmatter block with a "description:" field. ` +
+        `See https://agentskills.io/specification for the SKILL.md format.`,
+    );
+  }
+
   const instructions = parsed.content.trim();
   return { kind: 'packaged', name, description, instructions, references };
 }

--- a/packages/deployer/src/build/fs-routing/fs-routing.test.ts
+++ b/packages/deployer/src/build/fs-routing/fs-routing.test.ts
@@ -270,11 +270,21 @@ describe('discoverFsAgents', () => {
     await writeAgent('weather', {
       config: `export default { model: 'openai/gpt-4o' };`,
       instructions: 'hi',
-      skills: { 'faq.md': `# FAQ\nAnswer questions.` },
+      skills: { 'faq.md': `---\ndescription: Answer common questions.\n---\n\n# FAQ\nAnswer questions.` },
     });
 
     const skill = (await discoverFsAgents(dir))[0]!.skills[0]!;
-    expect(skill).toMatchObject({ kind: 'packaged', name: 'faq' });
+    expect(skill).toMatchObject({ kind: 'packaged', name: 'faq', description: 'Answer common questions.' });
+  });
+
+  it('throws when a flat markdown skill is missing a description', async () => {
+    await writeAgent('weather', {
+      config: `export default { model: 'openai/gpt-4o' };`,
+      instructions: 'hi',
+      skills: { 'faq.md': `# FAQ\nAnswer questions.` },
+    });
+
+    await expect(discoverFsAgents(dir)).rejects.toThrow(/missing a required "description"/);
   });
 
   it('discovers a createSkill module as a module skill', async () => {


### PR DESCRIPTION
## Description

Flat `.md` skills without a `description` in frontmatter crash at runtime with `"Skill description cannot be empty"` because `parsePackagedSkill()` defaults description to `''`, which passes through codegen into `createSkill()` where validation rejects it. This adds an early check at discovery time with a clear error message pointing to the file and the Agent Skills spec.

- Validate description is non-empty in `parsePackagedSkill()` at discovery time, matching the workspace skills validation pattern in `workspace-skills.ts`
- Update the existing flat skill test to include frontmatter with a description
- Add a new test asserting that a flat skill without a description throws a clear error

## Related Issue(s)

Fixes #18933

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes sure “flat” `.md` skills have a required `description` when they’re discovered. Instead of letting bad metadata slip through and crash later at runtime, discovery now stops early with a clear, file-specific error.

## Summary
- Added early validation in `parsePackagedSkill()` to require a non-empty `description` in flat skill frontmatter (`SKILL.md`), throwing during discovery (not runtime).
- Improved the thrown error message to point to the specific file and the Agent Skills spec for the required `description:` field.
- Updated the existing flat markdown skill discovery test to include/assert `description` from frontmatter.
- Added a new test ensuring flat markdown skill discovery fails when `description` is missing.
- Added a changeset for a `@mastra/deployer` patch release documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->