### PR TITLE
test(core): add unit tests for fetchWithRetry

### DIFF
--- a/.changeset/fetch-with-retry-tests.md
+++ b/.changeset/fetch-with-retry-tests.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-Add unit tests for fetchWithRetry

--- a/.changeset/fetch-with-retry-tests.md
+++ b/.changeset/fetch-with-retry-tests.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add unit tests for fetchWithRetry

--- a/packages/core/src/utils/fetchWithRetry.test.ts
+++ b/packages/core/src/utils/fetchWithRetry.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchWithRetry } from './fetchWithRetry';
+
+describe('fetchWithRetry', () => {
+  const realSetTimeout = setTimeout;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const flush = async () => {
+    // Run scheduled timers + pending microtasks until the queue settles.
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve();
+      if (vi.getTimerCount() > 0) {
+        vi.advanceTimersByTime(20000);
+      }
+      await Promise.resolve();
+    }
+  };
+
+  it('returns the response immediately when fetch succeeds', async () => {
+    const ok = new Response('ok', { status: 200 });
+    mockFetch.mockResolvedValue(ok);
+
+    const result = fetchWithRetry('https://example.com');
+    const res = await result;
+    expect(res).toBe(ok);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on network failure up to maxRetries then throws', async () => {
+    const networkError = new TypeError('Failed to fetch');
+    mockFetch
+      .mockRejectedValueOnce(networkError)
+      .mockRejectedValueOnce(networkError)
+      .mockRejectedValueOnce(networkError);
+
+    const promise = fetchWithRetry('https://example.com', {}, 3);
+    await flush();
+    await expect(promise).rejects.toThrow('Failed to fetch');
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries on non-OK response status then succeeds', async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response('', { status: 500, statusText: 'Internal Server Error' }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const promise = fetchWithRetry('https://example.com', {}, 3);
+    await flush();
+    const res = await promise;
+    expect(res.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws immediately when shouldRetryResponse returns false', async () => {
+    const notOk = new Response('', { status: 400, statusText: 'Bad Request' });
+    mockFetch.mockResolvedValue(notOk);
+
+    const promise = fetchWithRetry('https://example.com', {}, 3, {
+      shouldRetryResponse: () => false,
+    });
+    await flush();
+    await expect(promise).rejects.toThrow('Request failed with status: 400');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws after exhausting retries on persistent non-OK status', async () => {
+    mockFetch.mockResolvedValue(new Response('', { status: 503, statusText: 'Service Unavailable' }));
+
+    const promise = fetchWithRetry('https://example.com', {}, 2);
+    await flush();
+    await expect(promise).rejects.toThrow('Request failed with status: 503');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('wraps non-Error thrown values as Errors', async () => {
+    mockFetch.mockRejectedValueOnce('string error');
+
+    const promise = fetchWithRetry('https://example.com', {}, 1);
+    await flush();
+    await expect(promise).rejects.toBeInstanceOf(Error);
+  });
+
+  it('passes url and options through to fetch', async () => {
+    const ok = new Response('ok', { status: 200 });
+    mockFetch.mockResolvedValue(ok);
+
+    const opts: RequestInit = { method: 'POST', headers: { 'x-test': '1' } };
+    await fetchWithRetry('https://example.com', opts);
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com', opts);
+  });
+});


### PR DESCRIPTION
Adds unit tests for `packages/core/src/utils/fetchWithRetry.ts`, covering:

- Immediate return on success
- Network failure retries up to `maxRetries`
- Non-OK response retries then success
- Immediate throw when `shouldRetryResponse` returns false
- Persistent non-OK status exhausting retries
- Non-Error throwables wrapped as Error
- Pass-through of url and options to `fetch`

Tests use fake timers to keep retry/backoff deterministic.

Fixes #18949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds tests that make sure `fetchWithRetry` behaves the right way when requests work, fail, or need to try again. It helps prevent future bugs by checking that retries, delays, and error handling stay consistent.

### What changed
- Added a new Vitest suite for `packages/core/src/utils/fetchWithRetry.ts`.
- Covered:
  - immediate success
  - retrying network failures up to `maxRetries`
  - retrying non-OK responses until success
  - stopping retries when `shouldRetryResponse` returns false
  - failing after retries are exhausted
  - wrapping non-`Error` throwables as `Error`
  - passing `url` and `options` through to `fetch`
- Used fake timers and a flush helper to make retry/backoff behavior deterministic.
- Added a Changesets metadata file for a patch release note about the new tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->