### PR TITLE
test(core): add unit tests for durable iteration-state helpers

### DIFF
--- a/.changeset/iteration-state-tests.md
+++ b/.changeset/iteration-state-tests.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-Add unit tests for iteration-state helpers

--- a/.changeset/iteration-state-tests.md
+++ b/.changeset/iteration-state-tests.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add unit tests for iteration-state helpers

--- a/packages/core/src/agent/durable/workflows/shared/iteration-state.test.ts
+++ b/packages/core/src/agent/durable/workflows/shared/iteration-state.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateAccumulatedUsage,
+  buildStepRecord,
+  createBaseIterationStateUpdate,
+} from './iteration-state';
+import type { BaseIterationState } from './schemas';
+import type { DurableAgenticExecutionOutput } from '../../types';
+
+describe('calculateAccumulatedUsage', () => {
+  const base = { inputTokens: 10, outputTokens: 20, totalTokens: 30 };
+
+  it('sums token counts when execution usage is provided', () => {
+    const result = calculateAccumulatedUsage(base, { inputTokens: 5, outputTokens: 7, totalTokens: 12 });
+    expect(result).toEqual({ inputTokens: 15, outputTokens: 27, totalTokens: 42 });
+  });
+
+  it('returns current usage unchanged when execution usage is undefined', () => {
+    const result = calculateAccumulatedUsage(base);
+    expect(result).toEqual(base);
+  });
+
+  it('treats missing token fields as zero', () => {
+    const result = calculateAccumulatedUsage(base, { inputTokens: 3 });
+    expect(result).toEqual({ inputTokens: 13, outputTokens: 20, totalTokens: 30 });
+  });
+
+  it('handles zero-value current usage', () => {
+    const zero = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    const result = calculateAccumulatedUsage(zero, { inputTokens: 1, outputTokens: 2, totalTokens: 3 });
+    expect(result).toEqual({ inputTokens: 1, outputTokens: 2, totalTokens: 3 });
+  });
+});
+
+describe('buildStepRecord', () => {
+  const makeOutput = (overrides: Partial<DurableAgenticExecutionOutput> = {}): DurableAgenticExecutionOutput => ({
+    output: {
+      text: 'hello',
+      toolCalls: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 't', input: {} }],
+      toolResults: [{ type: 'tool-result', toolCallId: 'tc1', toolName: 't', output: {} }],
+      usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+    },
+    toolResults: [{ type: 'tool-result', toolCallId: 'tc1', toolName: 't', output: {} }],
+    stepResult: { reason: 'stop' },
+    messageListState: {},
+    state: {},
+    messageId: 'm1',
+    backgroundTaskPending: false,
+    delegationBailed: false,
+    ...overrides,
+  } as unknown as DurableAgenticExecutionOutput);
+
+  it('maps execution output fields onto a StepRecord', () => {
+    const record = buildStepRecord(makeOutput());
+    expect(record.text).toBe('hello');
+    expect(record.toolCalls).toHaveLength(1);
+    expect(record.toolResults).toHaveLength(1);
+    expect(record.usage).toEqual({ inputTokens: 1, outputTokens: 2, totalTokens: 3 });
+    expect(record.finishReason).toBe('stop');
+  });
+
+  it('preserves undefined text when missing', () => {
+    const out = makeOutput({ output: { text: undefined } } as any);
+    expect(buildStepRecord(out).text).toBeUndefined();
+  });
+});
+
+describe('createBaseIterationStateUpdate', () => {
+  const baseState: BaseIterationState = {
+    runId: 'run-1',
+    agentId: 'agent-1',
+    agentName: 'Agent',
+    messageListState: {},
+    toolsMetadata: [],
+    modelConfig: {} as any,
+    options: {} as any,
+    state: {},
+    messageId: 'm0',
+    iterationCount: 0,
+    accumulatedSteps: [],
+    accumulatedUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    lastStepResult: {} as any,
+    backgroundTaskPending: false,
+    delegationBailed: false,
+    pendingFeedbackStop: false,
+    agentSpanData: {} as any,
+    modelSpanData: {} as any,
+  } as unknown as BaseIterationState;
+
+  const execOutput = {
+    output: { text: 'step-1', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+    toolResults: [],
+    stepResult: { reason: 'stop' },
+    messageListState: { updated: true },
+    state: { phase: 'running' },
+    messageId: 'm1',
+    backgroundTaskPending: true,
+    delegationBailed: false,
+  } as unknown as DurableAgenticExecutionOutput;
+
+  it('increments iteration count and accumulates usage', () => {
+    const next = createBaseIterationStateUpdate({ currentState: baseState, executionOutput: execOutput });
+    expect(next.iterationCount).toBe(1);
+    expect(next.accumulatedUsage).toEqual({ inputTokens: 10, outputTokens: 5, totalTokens: 15 });
+    expect(next.accumulatedSteps).toHaveLength(1);
+  });
+
+  it('carries forward identity and config fields unchanged', () => {
+    const next = createBaseIterationStateUpdate({ currentState: baseState, executionOutput: execOutput });
+    expect(next.runId).toBe('run-1');
+    expect(next.agentId).toBe('agent-1');
+    expect(next.agentName).toBe('Agent');
+    expect(next.toolsMetadata).toBe(baseState.toolsMetadata);
+    expect(next.modelConfig).toBe(baseState.modelConfig);
+    expect(next.options).toBe(baseState.options);
+  });
+
+  it('propagates execution output state fields', () => {
+    const next = createBaseIterationStateUpdate({ currentState: baseState, executionOutput: execOutput });
+    expect(next.messageListState).toEqual({ updated: true });
+    expect(next.state).toEqual({ phase: 'running' });
+    expect(next.messageId).toBe('m1');
+    expect(next.backgroundTaskPending).toBe(true);
+    expect(next.delegationBailed).toBe(false);
+    expect(next.lastStepResult).toEqual({ reason: 'stop' });
+  });
+
+  it('preserves pendingFeedbackStop and span identity across iterations', () => {
+    const stateWithFlags = { ...baseState, pendingFeedbackStop: true };
+    const next = createBaseIterationStateUpdate({ currentState: stateWithFlags, executionOutput: execOutput });
+    expect(next.pendingFeedbackStop).toBe(true);
+    expect(next.agentSpanData).toBe(baseState.agentSpanData);
+    expect(next.modelSpanData).toBe(baseState.modelSpanData);
+  });
+
+  it('accumulates steps across multiple iterations', () => {
+    const first = createBaseIterationStateUpdate({ currentState: baseState, executionOutput: execOutput });
+    const second = createBaseIterationStateUpdate({ currentState: first, executionOutput: execOutput });
+    expect(second.iterationCount).toBe(2);
+    expect(second.accumulatedSteps).toHaveLength(2);
+    expect(second.accumulatedUsage).toEqual({ inputTokens: 20, outputTokens: 10, totalTokens: 30 });
+  });
+});

--- a/packages/core/src/agent/durable/workflows/shared/iteration-state.ts
+++ b/packages/core/src/agent/durable/workflows/shared/iteration-state.ts
@@ -95,5 +95,9 @@ export function createBaseIterationStateUpdate(input: IterationStateUpdateInput)
     accumulatedUsage: newUsage,
     lastStepResult: executionOutput.stepResult,
     backgroundTaskPending: executionOutput.backgroundTaskPending,
+    delegationBailed: executionOutput.delegationBailed,
+    pendingFeedbackStop: currentState.pendingFeedbackStop,
+    agentSpanData: currentState.agentSpanData,
+    modelSpanData: currentState.modelSpanData,
   };
 }


### PR DESCRIPTION
Adds unit tests for `packages/core/src/agent/durable/workflows/shared/iteration-state.ts`, covering:

- `calculateAccumulatedUsage`: token summation, undefined/missing fields, zero values
- `buildStepRecord`: field mapping from execution output, missing text
- `createBaseIterationStateUpdate`: iteration count increment, usage accumulation, identity/config carry-forward, execution state propagation, `pendingFeedbackStop`/span identity preservation, multi-iteration step accumulation

Fixes #18950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This change adds tests to make sure the agent’s “memory” of what happened in each loop is counted and copied correctly. It also makes sure a few important flags and IDs keep getting carried forward so the agent doesn’t lose track of itself between steps.

### What changed
- Added a new Vitest suite for `packages/core/src/agent/durable/workflows/shared/iteration-state.ts`.
- Covered `calculateAccumulatedUsage` for:
  - normal token summation
  - missing/undefined usage data
  - zero-valued fields
- Covered `buildStepRecord` for:
  - mapping execution output into a `StepRecord`
  - preserving `undefined` text when missing
- Covered `createBaseIterationStateUpdate` for:
  - iteration count increments
  - accumulated usage and step accumulation
  - identity/config carry-forward
  - execution-state propagation
  - preserving `pendingFeedbackStop`
  - preserving span identity data across iterations
  - multi-iteration accumulation behavior

### Code change
- `createBaseIterationStateUpdate` now also carries forward:
  - `delegationBailed`
  - `pendingFeedbackStop`
  - `agentSpanData`
  - `modelSpanData`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->