### PR TITLE
fix(duckdb): forward listTracesLight through the lazy observability facade

### DIFF
--- a/.changeset/duckdb-list-traces-light.md
+++ b/.changeset/duckdb-list-traces-light.md
@@ -1,0 +1,5 @@
+---
+'@mastra/duckdb': patch
+---
+
+Fixed listing lightweight traces on DuckDB storage. Calling `listTracesLight` on a DuckDB observability store previously threw "This storage provider does not support listing lightweight traces" because the lazy-loading store facade was missing the forwarding method, even though DuckDB fully supports the operation. The call now returns lightweight traces as expected. Fixes #18942.

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -430,6 +430,48 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(traces.spans.length).toBeGreaterThanOrEqual(1);
     });
 
+    it('listTracesLight returns seeded traces via the facade', async () => {
+      await storage.batchCreateSpans({
+        records: [
+          {
+            traceId: 'trace-light-1',
+            spanId: 'root-light',
+            parentSpanId: null,
+            name: 'workflow-run',
+            spanType: SpanType.WORKFLOW_RUN,
+            isEvent: false,
+            entityType: EntityType.WORKFLOW_RUN,
+            entityId: 'wf-light',
+            entityName: 'myWorkflow',
+            userId: null,
+            organizationId: null,
+            resourceId: null,
+            runId: null,
+            sessionId: null,
+            threadId: null,
+            requestId: null,
+            environment: 'production',
+            source: null,
+            serviceName: 'svc',
+            scope: null,
+            attributes: null,
+            metadata: null,
+            tags: ['v1'],
+            links: null,
+            input: null,
+            output: null,
+            error: null,
+            startedAt: new Date('2026-01-03T00:00:00Z'),
+            endedAt: new Date('2026-01-03T00:00:01Z'),
+          },
+        ],
+      });
+
+      // On base the facade falls through to the base-class throw; after the fix it resolves.
+      const result = await storage.listTracesLight({});
+      expect(result.spans.map(s => s.traceId)).toContain('trace-light-1');
+    });
+
     it('listTraces applies scalar prefilter and tag post-filter correctly', async () => {
       await storage.batchCreateSpans({
         records: [

--- a/stores/duckdb/src/storage/index.ts
+++ b/stores/duckdb/src/storage/index.ts
@@ -202,6 +202,13 @@ export class ObservabilityStorageDuckDB extends CoreObservabilityStorage {
     return delegate.listTraces(...args);
   }
 
+  async listTracesLight(
+    ...args: Parameters<ObservabilityStoreImpl['listTracesLight']>
+  ): ReturnType<ObservabilityStoreImpl['listTracesLight']> {
+    const delegate = await this.requireDelegate();
+    return delegate.listTracesLight(...args);
+  }
+
   async listBranches(
     ...args: Parameters<ObservabilityStoreImpl['listBranches']>
   ): ReturnType<ObservabilityStoreImpl['listBranches']> {


### PR DESCRIPTION
## What
Adds the missing `listTracesLight` forwarding method to `@mastra/duckdb`'s lazy-loading observability store facade.

## Why
`mastra api trace list` (the default lightweight trace-listing path) returns a 500, `"This storage provider does not support listing lightweight traces"`, for any project using a DuckDB-backed observability store, even though DuckDB fully supports the operation. `--verbose` (the full `listTraces` path) works, which makes it look inconsistent.

Reported in #18942 with a confirmed repro.

## How
The DuckDB observability domain (`stores/duckdb/src/storage/index.ts`) is a lazy-loading facade that hand-forwards each method to a dynamically-imported delegate via `requireDelegate()`. Every observability method has a wrapper, except `listTracesLight`, which was missed (the originating PR #16608 added `listTracesLight` + `--verbose` to the real implementation but not this facade wrapper). So calls fell through to the base class `ObservabilityStorage.listTracesLight`, which throws by default.

The real implementation (`stores/duckdb/src/storage/domains/observability/index.ts`) already implements `listTracesLight` correctly. I this just adds the one missing wrapper, matching the surrounding `listTraces` / `listBranches` pattern verbatim.

## Testing
Added a regression test in `stores/duckdb/src/storage/domains/observability/index.test.ts` that seeds a root span and calls `listTracesLight({})` on the facade (`store.observability`).

- On `main` (without the fix): the test **fails** with `"This storage provider does not support listing lightweight traces"`.
- With the fix: it **passes**, returning the seeded trace.

Ran the full DuckDB observability suite locally: **151 passed**. `tsc --noEmit` clean.

Fixes #18942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
DuckDB was missing a tiny forwarding step, so one trace-listing request was getting lost and causing an error. This change connects that request to the real DuckDB trace code, so lightweight trace lists work again.

### Summary
- Added `listTracesLight` forwarding to the DuckDB lazy-loading observability facade.
- Added a regression test to verify `store.listTracesLight({})` returns seeded lightweight traces.
- Added a changeset documenting the DuckDB patch fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->