### PR TITLE
fix(pg): import the observational memory schema statically so the ESM build creates its table

### DIFF
--- a/.changeset/pg-esm-om-schema.md
+++ b/.changeset/pg-esm-om-schema.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed the ESM build never creating the `mastra_observational_memory` table. The OM schema was loaded through a dynamic `require` that esbuild rewrites to a throwing shim in the ESM output, and the silent catch skipped the table's creation, so `deleteThread()` crashed with Postgres error 42P01 on databases initialized from ESM processes (plain node ESM, tsx, vitest). The schema is now imported statically, which the `@mastra/core` peer dependency range guarantees is available.

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { createRequire } from 'node:module';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -8,6 +7,7 @@ import {
   MemoryStorage,
   normalizePerPage,
   calculatePagination,
+  OBSERVATIONAL_MEMORY_TABLE_SCHEMA,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
@@ -54,18 +54,14 @@ export const OM_MIGRATION_COLUMNS: string[] = [
 ];
 
 /**
- * Try to import the OM schema statically. On older @mastra/core versions that
- * don't export OBSERVATIONAL_MEMORY_TABLE_SCHEMA this will be undefined,
- * and getExportDDL / init() will simply skip the OM table.
+ * The OM schema is imported statically above: the peer dependency range
+ * (`@mastra/core >= 1.49.0`) guarantees the export exists. This used to be a
+ * dynamic `require` guarded by `typeof require === 'function'` for older core
+ * versions, but esbuild rewrites the bare `require` identifier in the ESM
+ * bundle to a shim that always throws, and the silent catch meant the
+ * published ESM build skipped creating the OM table entirely (#18954).
  */
-let _omTableSchema: Record<string, Record<string, any>> | undefined;
-try {
-  const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
-  const storage = __require('@mastra/core/storage');
-  _omTableSchema = storage.OBSERVATIONAL_MEMORY_TABLE_SCHEMA;
-} catch {
-  // OM not available in this version of core
-}
+const _omTableSchema: Record<string, Record<string, any>> = OBSERVATIONAL_MEMORY_TABLE_SCHEMA;
 import type {
   StorageResourceType,
   StorageListMessagesInput,
@@ -196,11 +192,11 @@ export class MemoryPG extends MemoryStorage {
     await this.#db.createTable({ tableName: TABLE_MESSAGES, schema: TABLE_SCHEMAS[TABLE_MESSAGES] });
     await this.#db.createTable({ tableName: TABLE_RESOURCES, schema: TABLE_SCHEMAS[TABLE_RESOURCES] });
 
-    // Reuse the module-level `_omTableSchema` set via the top-of-file
-    // `createRequire` shim. `await import('@mastra/core/storage')` here used
-    // to deadlock `mastra build` output: bundlers rewrite the dynamic import
-    // to point at the entry chunk that statically depends on this file, so
-    // the cycle never resolves when storage initializes during module
+    // Reuse the module-level `_omTableSchema` (static import). Don't switch
+    // this to `await import('@mastra/core/storage')`: that used to deadlock
+    // `mastra build` output, because bundlers rewrite the dynamic import to
+    // point at the entry chunk that statically depends on this file, so the
+    // cycle never resolves when storage initializes during module
     // evaluation (#18298).
     const omSchema = _omTableSchema?.[OM_TABLE];
 

--- a/stores/pg/src/storage/domains/memory/om-dist-schema.test.ts
+++ b/stores/pg/src/storage/domains/memory/om-dist-schema.test.ts
@@ -1,0 +1,45 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The observational memory schema used to be loaded through a dynamic
+ * `require` guarded by `typeof require === 'function'`. esbuild rewrites the
+ * bare `require` identifier in the ESM bundle to its dynamic-require shim,
+ * which is always a function and always throws in ESM; the surrounding
+ * `catch {}` swallowed that, so the published ESM build silently skipped
+ * creating `mastra_observational_memory` while the CJS build created it
+ * (#18954). Because the failure only exists in the bundled output, these
+ * tests run `exportSchemas()` from the built artifacts in child processes.
+ * CI builds the package before running tests, so dist/ is always present
+ * there; locally the suite is skipped until `pnpm build:lib` has run.
+ */
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const distEsm = join(pkgRoot, 'dist/index.js');
+const distCjs = join(pkgRoot, 'dist/index.cjs');
+
+function exportSchemasFromEsm(): string {
+  const script = `import(${JSON.stringify(pathToFileURL(distEsm).href)}).then(m => process.stdout.write(m.exportSchemas()));`;
+  return execFileSync(process.execPath, ['--input-type=module', '-e', script], { encoding: 'utf8' });
+}
+
+function exportSchemasFromCjs(): string {
+  const script = `process.stdout.write(require(${JSON.stringify(distCjs)}).exportSchemas());`;
+  return execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+}
+
+describe.skipIf(!existsSync(distEsm) || !existsSync(distCjs))('observational memory schema in built output', () => {
+  it('ESM build includes the observational memory table', () => {
+    const ddl = exportSchemasFromEsm();
+    expect(ddl).toContain('mastra_observational_memory');
+    expect(ddl).toContain('idx_om_lookup_key');
+  }, 30000);
+
+  it('CJS build includes the observational memory table', () => {
+    const ddl = exportSchemasFromCjs();
+    expect(ddl).toContain('mastra_observational_memory');
+    expect(ddl).toContain('idx_om_lookup_key');
+  }, 30000);
+});


### PR DESCRIPTION
## Description

`@mastra/pg`'s ESM build silently skips creating the `mastra_observational_memory` table. Since #16628 made `Memory.deleteThread()` unconditionally call `clearObservationalMemory()`, every `deleteThread()` against a database initialized from an ESM process (plain node ESM, tsx, vitest) crashes with Postgres error 42P01. CJS-bundled runtimes are unaffected, which makes it look flaky in mixed setups: a Next.js server creates the table, standalone workers and tests crash until it happens to exist.

Root cause: the OM schema was loaded through a dynamic `require` guarded by `typeof require === 'function'`, kept around for older `@mastra/core` versions that didn't export `OBSERVATIONAL_MEMORY_TABLE_SCHEMA`. esbuild rewrites the bare `require` identifier in the ESM bundle to its dynamic-require shim, which is always a function and always throws in ESM. The bare `catch {}` swallowed that, `_omTableSchema` stayed undefined, and `init()` / `exportSchemas()` skipped the whole OM table block. You can see the divergence directly on the built artifacts from current main: `exportSchemas()` from `dist/index.cjs` includes `mastra_observational_memory`, from `dist/index.js` it doesn't.

The fix imports the schema statically. The compat guard is obsolete: the peer dependency range is `@mastra/core >=1.49.0-0` and the export has existed since well before that, so every core version the range admits has it. A static import also sidesteps the `await import()` route, which is not an option here because bundlers rewrite it into a cycle with the entry chunk and deadlock during module evaluation (#18298). The comment in `init()` keeps that warning.

## Related issue(s)

Fixes #18954

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Since the failure only exists in the bundled output (the source works fine under vitest's transform), the new test runs `exportSchemas()` from the built `dist/index.js` and `dist/index.cjs` in child node processes and asserts both contain the OM table DDL. The ESM case fails on current main and passes with this change; CI builds the package before running store tests, so the test always runs there (it skips locally until `pnpm build:lib` has run). The full pg storage suites (1230 tests) plus the memory domain tests pass against the docker Postgres, and tsc, eslint, and prettier are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a problem where one version of the PostgreSQL package forgot to create a needed table for memory data. It does this by loading the table definition in a simpler, more reliable way and adds a test to make sure both built versions create it.

## Summary
- Switched the Observational Memory schema loading in `@mastra/pg` from a guarded dynamic `require` to a static import, ensuring the `mastra_observational_memory` table is created in ESM builds.
- Removed the obsolete fallback logic and updated comments to reflect the ESM/bundler behavior.
- Added a test that checks the built `dist/index.js` and `dist/index.cjs` outputs both include the OM table DDL via `exportSchemas()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->