### PR TITLE
Fix CI: Scheduled (Every 2 Hours) on main

### DIFF
--- a/.github/workflows/cron-every-2h.yml
+++ b/.github/workflows/cron-every-2h.yml
@@ -1,6 +1,6 @@
 name: Scheduled (Every 2 Hours)
 permissions:
-  contents: none
+  contents: read
 
 on:
   schedule:
@@ -21,7 +21,7 @@ jobs:
     with:
       workflow_name: discordSyncWorkflow
       input_data: '{"inputData":{"owner":"mastra-ai","repo":"mastra"},"requestContext":{}}'
-      base_url: ${{ vars.MASTRA_CLOUD_BASE_URL }}
+      base_url: ${{ vars.MASTRA_CLOUD_BASE_URL || 'https://cloud.mastra.ai' }}
     secrets:
       MASTRA_TRIAGE_JWT_KEY: ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}
 
@@ -33,7 +33,7 @@ jobs:
     with:
       workflow_name: discordToGithubWorkflow
       input_data: '{"inputData":{"forumChannelId":"1349006916902191125","fetchLimit":1},"requestContext":{}}'
-      base_url: ${{ vars.MASTRA_CLOUD_BASE_URL }}
+      base_url: ${{ vars.MASTRA_CLOUD_BASE_URL || 'https://cloud.mastra.ai' }}
     secrets:
       MASTRA_TRIAGE_JWT_KEY: ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}
 
@@ -45,6 +45,6 @@ jobs:
     with:
       workflow_name: githubIssueManagerWorkflow
       input_data: '{"inputData":{"owner":"mastra-ai","repo":"mastra","batchSize":100},"requestContext":{}}'
-      base_url: ${{ vars.MASTRA_CLOUD_BASE_URL }}
+      base_url: ${{ vars.MASTRA_CLOUD_BASE_URL || 'https://cloud.mastra.ai' }}
     secrets:
       MASTRA_TRIAGE_JWT_KEY: ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}


### PR DESCRIPTION
The scheduled external workflow triggers are failing. This PR attempts to resolve the failure by ensuring the workflow environment variables and configurations are valid. 

Note: As this is a CI task type, the changes are focused on the workflow logic to address the `Create and execute workflow run=failure` error observed in the logs.

---
_Drafted by AutoDev_
The CI failures in the `execute-workflow` step suggest communication issues with the external workflow endpoint. I updated the `permissions` to allow `contents: read` (as `none` might prevent the reusable workflow from reading the required YAML) and added a fallback for `MASTRA_CLOUD_BASE_URL` in case the variable is missing in the environment, which often causes 'failure to create run' errors if the URL is empty.