### PR TITLE
Fix CI: Scheduled (Every 2 Hours) on main

### DIFF
--- a/.github/workflows/cron-every-2h.yml
+++ b/.github/workflows/cron-every-2h.yml
@@ -1,6 +1,7 @@
 name: Scheduled (Every 2 Hours)
 permissions:
-  contents: none
+  contents: read
+  actions: write
 
 on:
   schedule:


### PR DESCRIPTION
The scheduled workflow is failing across all jobs (Discord Sync, Discord Triage, and GitHub Issues Follow-Up) because the calling runner lacks permission to access the repository state or triggers. Updating workflow permissions to `contents: read` and `actions: write` to ensure the `call-external-mastra-workflow.yml` can properly execute and interact with GitHub actions.

---
_Drafted by AutoDev_
The CI failures in the 'execute-workflow' steps (run ID 27651348046) indicate that the workflow execution is being blocked, likely due to insufficient permissions defined at the top of the cron workflow. Setting 'contents: none' prevented the runner from accessing necessary context for the reusable workflow. I updated it to 'contents: read' and added 'actions: write' which is often required when one workflow triggers or manages another via reusable calls.