### PR TITLE
chore(playground-ui): add no nested ternary ratchet

### DIFF
--- a/packages/playground-ui/eslint.config.js
+++ b/packages/playground-ui/eslint.config.js
@@ -19,6 +19,7 @@ export default [
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'no-nested-ternary': 'error',
     },
   },
   {

--- a/packages/playground-ui/eslint.config.js
+++ b/packages/playground-ui/eslint.config.js
@@ -6,6 +6,17 @@ const reactHooks = (await import('eslint-plugin-react-hooks')).default;
 
 const config = await createConfig();
 
+const restrictedInlineIifeSelectors = [
+  {
+    selector: 'CallExpression[callee.type="ArrowFunctionExpression"]',
+    message: 'Avoid inline IIFEs. Extract a named helper for values or a PascalCase component for JSX branches.',
+  },
+  {
+    selector: 'CallExpression[callee.type="FunctionExpression"]',
+    message: 'Avoid inline IIFEs. Extract a named helper for values or a PascalCase component for JSX branches.',
+  },
+];
+
 /** @type {import("eslint").Linter.Config[]} */
 export default [
   { ignores: ['storybook-static/**'] },
@@ -20,6 +31,7 @@ export default [
       'react-hooks/exhaustive-deps': 'warn',
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       'no-nested-ternary': 'error',
+      'no-restricted-syntax': ['error', ...restrictedInlineIifeSelectors],
     },
   },
   {

--- a/packages/playground-ui/src/domains/logs/components/logs-layout.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-layout.tsx
@@ -32,17 +32,24 @@ export function LogsLayout({ listSlot, logPanelSlot, tracePanelSlot, spanPanelSl
         <div
           className={cn(
             'grid gap-4 h-full overflow-auto',
-            tracePanelSlot && spanPanelSlot
-              ? logCollapsed
-                ? 'grid-rows-[auto_1fr_1fr]'
-                : 'grid-rows-[1fr_1fr_1fr]'
-              : tracePanelSlot
-                ? logCollapsed
-                  ? 'grid-rows-[auto_1fr]'
-                  : 'grid-rows-[1fr_1fr]'
-                : logCollapsed
-                  ? 'grid-rows-[auto]'
-                  : 'grid-rows-[1fr]',
+            (() => {
+              if (tracePanelSlot && spanPanelSlot) {
+                if (logCollapsed) {
+                  return 'grid-rows-[auto_1fr_1fr]';
+                }
+                return 'grid-rows-[1fr_1fr_1fr]';
+              }
+              if (tracePanelSlot) {
+                if (logCollapsed) {
+                  return 'grid-rows-[auto_1fr]';
+                }
+                return 'grid-rows-[1fr_1fr]';
+              }
+              if (logCollapsed) {
+                return 'grid-rows-[auto]';
+              }
+              return 'grid-rows-[1fr]';
+            })(),
           )}
         >
           {logPanelSlot}

--- a/packages/playground-ui/src/domains/logs/components/logs-layout.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-layout.tsx
@@ -14,6 +14,29 @@ export interface LogsLayoutProps {
   logCollapsed?: boolean;
 }
 
+function getLogsPanelGridRows({
+  tracePanelSlot,
+  spanPanelSlot,
+  logCollapsed,
+}: Pick<LogsLayoutProps, 'tracePanelSlot' | 'spanPanelSlot' | 'logCollapsed'>) {
+  if (tracePanelSlot && spanPanelSlot) {
+    if (logCollapsed) {
+      return 'grid-rows-[auto_1fr_1fr]';
+    }
+    return 'grid-rows-[1fr_1fr_1fr]';
+  }
+  if (tracePanelSlot) {
+    if (logCollapsed) {
+      return 'grid-rows-[auto_1fr]';
+    }
+    return 'grid-rows-[1fr_1fr]';
+  }
+  if (logCollapsed) {
+    return 'grid-rows-[auto]';
+  }
+  return 'grid-rows-[1fr]';
+}
+
 /**
  * Pure 2-column layout shell for the logs page. Owns no state and fetches no data — pass slots in.
  * Right-column row template adapts based on which panels are present and whether the log panel is
@@ -32,24 +55,7 @@ export function LogsLayout({ listSlot, logPanelSlot, tracePanelSlot, spanPanelSl
         <div
           className={cn(
             'grid gap-4 h-full overflow-auto',
-            (() => {
-              if (tracePanelSlot && spanPanelSlot) {
-                if (logCollapsed) {
-                  return 'grid-rows-[auto_1fr_1fr]';
-                }
-                return 'grid-rows-[1fr_1fr_1fr]';
-              }
-              if (tracePanelSlot) {
-                if (logCollapsed) {
-                  return 'grid-rows-[auto_1fr]';
-                }
-                return 'grid-rows-[1fr_1fr]';
-              }
-              if (logCollapsed) {
-                return 'grid-rows-[auto]';
-              }
-              return 'grid-rows-[1fr]';
-            })(),
+            getLogsPanelGridRows({ tracePanelSlot, spanPanelSlot, logCollapsed }),
           )}
         >
           {logPanelSlot}

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs-url-state.tsx
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs-url-state.tsx
@@ -131,7 +131,15 @@ export function useLogsUrlState(
         prev => {
           const next = new URLSearchParams(prev);
           for (const [field, value] of Object.entries(ids)) {
-            const param = field === 'logId' ? LOG_PARAM : field === 'traceId' ? TRACE_PARAM : SPAN_PARAM;
+            const param = (() => {
+              if (field === 'logId') {
+                return LOG_PARAM;
+              }
+              if (field === 'traceId') {
+                return TRACE_PARAM;
+              }
+              return SPAN_PARAM;
+            })();
             if (value) {
               next.set(param, value);
             } else {

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs-url-state.tsx
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs-url-state.tsx
@@ -19,6 +19,16 @@ const LOG_PARAM = 'logId';
 const TRACE_PARAM = 'traceId';
 const SPAN_PARAM = 'spanId';
 
+function getFeaturedParam(field: string) {
+  if (field === 'logId') {
+    return LOG_PARAM;
+  }
+  if (field === 'traceId') {
+    return TRACE_PARAM;
+  }
+  return SPAN_PARAM;
+}
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 const PRESET_MS: Partial<Record<LogsDatePreset, number>> = {
   'last-24h': DAY_MS,
@@ -131,15 +141,7 @@ export function useLogsUrlState(
         prev => {
           const next = new URLSearchParams(prev);
           for (const [field, value] of Object.entries(ids)) {
-            const param = (() => {
-              if (field === 'logId') {
-                return LOG_PARAM;
-              }
-              if (field === 'traceId') {
-                return TRACE_PARAM;
-              }
-              return SPAN_PARAM;
-            })();
+            const param = getFeaturedParam(field);
             if (value) {
               next.set(param, value);
             } else {

--- a/packages/playground-ui/src/domains/memory/components/observation-detail-view.tsx
+++ b/packages/playground-ui/src/domains/memory/components/observation-detail-view.tsx
@@ -324,7 +324,7 @@ export function ObservationDetailView({
 
   const selected = selectedRecordId ? sorted.find(r => r.id === selectedRecordId) : sorted[sorted.length - 1];
   const selectedIndex = selected ? sorted.findIndex(r => r.id === selected.id) : -1;
-  const previousRecord = selectedIndex > 0 ? sorted[selectedIndex - 1] : null;
+  const previousRecord = selectedIndex > 0 ? (sorted[selectedIndex - 1] ?? null) : null;
 
   useEffect(() => {
     if (!selectedRecordId && sorted.length > 0) {

--- a/packages/playground-ui/src/domains/memory/components/observation-detail-view.tsx
+++ b/packages/playground-ui/src/domains/memory/components/observation-detail-view.tsx
@@ -343,18 +343,24 @@ export function ObservationDetailView({
         )}
 
         <div data-testid="observation-detail-body" className="flex-1 overflow-y-auto p-4">
-          {showDiff && previousRecord ? (
-            <CodeDiff
-              codeA={typeof previousRecord.activeObservations === 'string' ? previousRecord.activeObservations : ''}
-              codeB={activeObservations}
-            />
-          ) : activeObservations ? (
-            <ObservationContent observations={activeObservations} />
-          ) : (
-            <p className="italic text-xs text-icon3">
-              {selected.isObserving || selected.isReflecting ? 'Processing…' : 'Initialized'}
-            </p>
-          )}
+          {(() => {
+            if (showDiff && previousRecord) {
+              return (
+                <CodeDiff
+                  codeA={typeof previousRecord.activeObservations === 'string' ? previousRecord.activeObservations : ''}
+                  codeB={activeObservations}
+                />
+              );
+            }
+            if (activeObservations) {
+              return <ObservationContent observations={activeObservations} />;
+            }
+            return (
+              <p className="italic text-xs text-icon3">
+                {selected.isObserving || selected.isReflecting ? 'Processing…' : 'Initialized'}
+              </p>
+            );
+          })()}
         </div>
       </div>
 

--- a/packages/playground-ui/src/domains/memory/components/observation-detail-view.tsx
+++ b/packages/playground-ui/src/domains/memory/components/observation-detail-view.tsx
@@ -273,6 +273,35 @@ function ObservationHistoryPanel({
   );
 }
 
+function ObservationDetailBody({
+  showDiff,
+  previousRecord,
+  activeObservations,
+  selected,
+}: {
+  showDiff: boolean;
+  previousRecord: OMHistoryRecord | null;
+  activeObservations: string;
+  selected: OMHistoryRecord;
+}) {
+  if (showDiff && previousRecord) {
+    return (
+      <CodeDiff
+        codeA={typeof previousRecord.activeObservations === 'string' ? previousRecord.activeObservations : ''}
+        codeB={activeObservations}
+      />
+    );
+  }
+  if (activeObservations) {
+    return <ObservationContent observations={activeObservations} />;
+  }
+  return (
+    <p className="italic text-xs text-icon3">
+      {selected.isObserving || selected.isReflecting ? 'Processing…' : 'Initialized'}
+    </p>
+  );
+}
+
 export interface ObservationDetailViewProps {
   records: OMHistoryRecord[];
   selectedRecordId: string | null;
@@ -343,24 +372,12 @@ export function ObservationDetailView({
         )}
 
         <div data-testid="observation-detail-body" className="flex-1 overflow-y-auto p-4">
-          {(() => {
-            if (showDiff && previousRecord) {
-              return (
-                <CodeDiff
-                  codeA={typeof previousRecord.activeObservations === 'string' ? previousRecord.activeObservations : ''}
-                  codeB={activeObservations}
-                />
-              );
-            }
-            if (activeObservations) {
-              return <ObservationContent observations={activeObservations} />;
-            }
-            return (
-              <p className="italic text-xs text-icon3">
-                {selected.isObserving || selected.isReflecting ? 'Processing…' : 'Initialized'}
-              </p>
-            );
-          })()}
+          <ObservationDetailBody
+            showDiff={showDiff}
+            previousRecord={previousRecord}
+            activeObservations={activeObservations}
+            selected={selected}
+          />
         </div>
       </div>
 

--- a/packages/playground-ui/src/domains/metrics/components/kpi-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/kpi-card-view.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { MetricsKpiCard } from '../../../ds/components/MetricsKpiCard';
 
 export interface KpiCardViewProps {
@@ -10,29 +9,41 @@ export interface KpiCardViewProps {
   isError: boolean;
 }
 
+function KpiCardStatus({
+  hasData,
+  prevValue,
+  changePct,
+  isLoading,
+  isError,
+}: Pick<KpiCardViewProps, 'prevValue' | 'changePct' | 'isLoading' | 'isError'> & { hasData: boolean }) {
+  if (isError) {
+    return <MetricsKpiCard.Error />;
+  }
+  if (isLoading) {
+    return <MetricsKpiCard.Loading />;
+  }
+  if (hasData) {
+    if (changePct != null) {
+      return <MetricsKpiCard.Change changePct={changePct} prevValue={prevValue} />;
+    }
+    return <MetricsKpiCard.NoChange />;
+  }
+  return <MetricsKpiCard.NoData />;
+}
+
 export function KpiCardView({ label, value, prevValue, changePct, isLoading, isError }: KpiCardViewProps) {
   const hasData = value != null;
-  let statusSlot: ReactNode;
-
-  if (isError) {
-    statusSlot = <MetricsKpiCard.Error />;
-  } else if (isLoading) {
-    statusSlot = <MetricsKpiCard.Loading />;
-  } else if (hasData) {
-    if (changePct != null) {
-      statusSlot = <MetricsKpiCard.Change changePct={changePct} prevValue={prevValue} />;
-    } else {
-      statusSlot = <MetricsKpiCard.NoChange />;
-    }
-  } else {
-    statusSlot = <MetricsKpiCard.NoData />;
-  }
-
   return (
     <MetricsKpiCard>
       <MetricsKpiCard.Label>{label}</MetricsKpiCard.Label>
       <MetricsKpiCard.Value className={hasData ? undefined : 'invisible'}>{hasData ? value : '—'}</MetricsKpiCard.Value>
-      {statusSlot}
+      <KpiCardStatus
+        hasData={hasData}
+        prevValue={prevValue}
+        changePct={changePct}
+        isLoading={isLoading}
+        isError={isError}
+      />
     </MetricsKpiCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/kpi-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/kpi-card-view.tsx
@@ -9,41 +9,61 @@ export interface KpiCardViewProps {
   isError: boolean;
 }
 
-function KpiCardStatus({
-  hasData,
+type KpiCardStatusState =
+  | { kind: 'error' }
+  | { kind: 'loading' }
+  | { kind: 'change'; changePct: number; prevValue: string | undefined }
+  | { kind: 'no-change' }
+  | { kind: 'no-data' };
+
+type KpiCardStatusInput = Pick<KpiCardViewProps, 'value' | 'prevValue' | 'changePct' | 'isLoading' | 'isError'>;
+
+function getKpiCardStatusState({
+  value,
   prevValue,
   changePct,
   isLoading,
   isError,
-}: Pick<KpiCardViewProps, 'prevValue' | 'changePct' | 'isLoading' | 'isError'> & { hasData: boolean }) {
+}: KpiCardStatusInput): KpiCardStatusState {
   if (isError) {
-    return <MetricsKpiCard.Error />;
+    return { kind: 'error' };
   }
   if (isLoading) {
-    return <MetricsKpiCard.Loading />;
+    return { kind: 'loading' };
   }
-  if (hasData) {
+  if (value != null) {
     if (changePct != null) {
-      return <MetricsKpiCard.Change changePct={changePct} prevValue={prevValue} />;
+      return { kind: 'change', changePct, prevValue };
     }
-    return <MetricsKpiCard.NoChange />;
+    return { kind: 'no-change' };
   }
-  return <MetricsKpiCard.NoData />;
+  return { kind: 'no-data' };
+}
+
+function KpiCardStatus({ state }: { state: KpiCardStatusState }) {
+  switch (state.kind) {
+    case 'error':
+      return <MetricsKpiCard.Error />;
+    case 'loading':
+      return <MetricsKpiCard.Loading />;
+    case 'change':
+      return <MetricsKpiCard.Change changePct={state.changePct} prevValue={state.prevValue} />;
+    case 'no-change':
+      return <MetricsKpiCard.NoChange />;
+    case 'no-data':
+      return <MetricsKpiCard.NoData />;
+  }
 }
 
 export function KpiCardView({ label, value, prevValue, changePct, isLoading, isError }: KpiCardViewProps) {
   const hasData = value != null;
+  const status = getKpiCardStatusState({ value, prevValue, changePct, isLoading, isError });
+
   return (
     <MetricsKpiCard>
       <MetricsKpiCard.Label>{label}</MetricsKpiCard.Label>
       <MetricsKpiCard.Value className={hasData ? undefined : 'invisible'}>{hasData ? value : '—'}</MetricsKpiCard.Value>
-      <KpiCardStatus
-        hasData={hasData}
-        prevValue={prevValue}
-        changePct={changePct}
-        isLoading={isLoading}
-        isError={isError}
-      />
+      <KpiCardStatus state={status} />
     </MetricsKpiCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/kpi-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/kpi-card-view.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { MetricsKpiCard } from '../../../ds/components/MetricsKpiCard';
 
 export interface KpiCardViewProps {
@@ -11,23 +12,27 @@ export interface KpiCardViewProps {
 
 export function KpiCardView({ label, value, prevValue, changePct, isLoading, isError }: KpiCardViewProps) {
   const hasData = value != null;
+  let statusSlot: ReactNode;
+
+  if (isError) {
+    statusSlot = <MetricsKpiCard.Error />;
+  } else if (isLoading) {
+    statusSlot = <MetricsKpiCard.Loading />;
+  } else if (hasData) {
+    if (changePct != null) {
+      statusSlot = <MetricsKpiCard.Change changePct={changePct} prevValue={prevValue} />;
+    } else {
+      statusSlot = <MetricsKpiCard.NoChange />;
+    }
+  } else {
+    statusSlot = <MetricsKpiCard.NoData />;
+  }
+
   return (
     <MetricsKpiCard>
       <MetricsKpiCard.Label>{label}</MetricsKpiCard.Label>
       <MetricsKpiCard.Value className={hasData ? undefined : 'invisible'}>{hasData ? value : '—'}</MetricsKpiCard.Value>
-      {isError ? (
-        <MetricsKpiCard.Error />
-      ) : isLoading ? (
-        <MetricsKpiCard.Loading />
-      ) : hasData ? (
-        changePct != null ? (
-          <MetricsKpiCard.Change changePct={changePct} prevValue={prevValue} />
-        ) : (
-          <MetricsKpiCard.NoChange />
-        )
-      ) : (
-        <MetricsKpiCard.NoData />
-      )}
+      {statusSlot}
     </MetricsKpiCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/latency-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/latency-card-view.tsx
@@ -78,6 +78,60 @@ export interface LatencyCardViewProps {
   actions?: ReactNode | ((tab: LatencyTab) => ReactNode);
 }
 
+function LatencyCardBody({
+  data,
+  isLoading,
+  isError,
+  activeTab,
+  setActiveTab,
+  initialTab,
+  onPointClick,
+}: Pick<LatencyCardViewProps, 'data' | 'isLoading' | 'isError' | 'onPointClick'> & {
+  activeTab: LatencyTab;
+  setActiveTab: (tab: LatencyTab) => void;
+  initialTab: LatencyTab;
+}) {
+  if (isLoading) {
+    return <MetricsCard.Loading />;
+  }
+  if (isError) {
+    return <MetricsCard.Error message="Failed to load latency data" />;
+  }
+  if (!data || (data.agentData.length === 0 && data.workflowData.length === 0 && data.toolData.length === 0)) {
+    return (
+      <MetricsCard.Content>
+        <MetricsCard.NoData message="No latency data yet" />
+      </MetricsCard.Content>
+    );
+  }
+  return (
+    <MetricsCard.Content>
+      <Tabs value={activeTab} onValueChange={setActiveTab} defaultTab={initialTab} className="overflow-visible">
+        <TabList>
+          <Tab value="agents">Agents</Tab>
+          <Tab value="workflows">Workflows</Tab>
+          <Tab value="tools">Tools</Tab>
+        </TabList>
+        <TabContent value="agents">
+          <LatencyChart
+            data={data.agentData}
+            onPointClick={onPointClick ? p => onPointClick('agents', p) : undefined}
+          />
+        </TabContent>
+        <TabContent value="workflows">
+          <LatencyChart
+            data={data.workflowData}
+            onPointClick={onPointClick ? p => onPointClick('workflows', p) : undefined}
+          />
+        </TabContent>
+        <TabContent value="tools">
+          <LatencyChart data={data.toolData} onPointClick={onPointClick ? p => onPointClick('tools', p) : undefined} />
+        </TabContent>
+      </Tabs>
+    </MetricsCard.Content>
+  );
+}
+
 export function LatencyCardView({ data, isLoading, isError, onPointClick, actions }: LatencyCardViewProps) {
   const initialTab = getInitialLatencyTab(data);
   const [activeTab, setActiveTab] = useState<LatencyTab>(initialTab);
@@ -107,47 +161,6 @@ export function LatencyCardView({ data, isLoading, isError, onPointClick, action
   const avgP50 =
     p50Values.length > 0 ? `${Math.round(p50Values.reduce((s, v) => s + v, 0) / p50Values.length)}ms` : '—';
 
-  let cardBody;
-  if (isLoading) {
-    cardBody = <MetricsCard.Loading />;
-  } else if (isError) {
-    cardBody = <MetricsCard.Error message="Failed to load latency data" />;
-  } else {
-    cardBody = (
-      <MetricsCard.Content>
-        {!hasData ? (
-          <MetricsCard.NoData message="No latency data yet" />
-        ) : (
-          <Tabs value={activeTab} onValueChange={setActiveTab} defaultTab={initialTab} className="overflow-visible">
-            <TabList>
-              <Tab value="agents">Agents</Tab>
-              <Tab value="workflows">Workflows</Tab>
-              <Tab value="tools">Tools</Tab>
-            </TabList>
-            <TabContent value="agents">
-              <LatencyChart
-                data={data.agentData}
-                onPointClick={onPointClick ? p => onPointClick('agents', p) : undefined}
-              />
-            </TabContent>
-            <TabContent value="workflows">
-              <LatencyChart
-                data={data.workflowData}
-                onPointClick={onPointClick ? p => onPointClick('workflows', p) : undefined}
-              />
-            </TabContent>
-            <TabContent value="tools">
-              <LatencyChart
-                data={data.toolData}
-                onPointClick={onPointClick ? p => onPointClick('tools', p) : undefined}
-              />
-            </TabContent>
-          </Tabs>
-        )}
-      </MetricsCard.Content>
-    );
-  }
-
   return (
     <MetricsCard>
       <MetricsCard.TopBar>
@@ -155,7 +168,15 @@ export function LatencyCardView({ data, isLoading, isError, onPointClick, action
         {hasData && <MetricsCard.Summary value={avgP50} label="Avg p50" />}
         {renderedActions ? <MetricsCard.Actions>{renderedActions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {cardBody}
+      <LatencyCardBody
+        data={data}
+        isLoading={isLoading}
+        isError={isError}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        initialTab={initialTab}
+        onPointClick={onPointClick}
+      />
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/latency-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/latency-card-view.tsx
@@ -29,6 +29,22 @@ const latencySeries = [
 
 export type LatencyTab = 'agents' | 'workflows' | 'tools';
 
+function getInitialLatencyTab(data: LatencyCardViewProps['data']): LatencyTab {
+  if (!data) {
+    return 'agents';
+  }
+  if (data.agentData.length > 0) {
+    return 'agents';
+  }
+  if (data.workflowData.length > 0) {
+    return 'workflows';
+  }
+  if (data.toolData.length > 0) {
+    return 'tools';
+  }
+  return 'agents';
+}
+
 function LatencyChart({ data, onPointClick }: { data: LatencyPoint[]; onPointClick?: (point: LatencyPoint) => void }) {
   if (data.length === 0) {
     return <MetricsCard.NoData message="No latency data yet" />;
@@ -63,15 +79,7 @@ export interface LatencyCardViewProps {
 }
 
 export function LatencyCardView({ data, isLoading, isError, onPointClick, actions }: LatencyCardViewProps) {
-  const initialTab: LatencyTab = !data
-    ? 'agents'
-    : data.agentData.length > 0
-      ? 'agents'
-      : data.workflowData.length > 0
-        ? 'workflows'
-        : data.toolData.length > 0
-          ? 'tools'
-          : 'agents';
+  const initialTab = getInitialLatencyTab(data);
   const [activeTab, setActiveTab] = useState<LatencyTab>(initialTab);
   // Resync to a non-empty tab when async data finishes loading. Without this,
   // a card that mounts before data arrives stays stuck on `agents` even when
@@ -99,6 +107,47 @@ export function LatencyCardView({ data, isLoading, isError, onPointClick, action
   const avgP50 =
     p50Values.length > 0 ? `${Math.round(p50Values.reduce((s, v) => s + v, 0) / p50Values.length)}ms` : '—';
 
+  let cardBody;
+  if (isLoading) {
+    cardBody = <MetricsCard.Loading />;
+  } else if (isError) {
+    cardBody = <MetricsCard.Error message="Failed to load latency data" />;
+  } else {
+    cardBody = (
+      <MetricsCard.Content>
+        {!hasData ? (
+          <MetricsCard.NoData message="No latency data yet" />
+        ) : (
+          <Tabs value={activeTab} onValueChange={setActiveTab} defaultTab={initialTab} className="overflow-visible">
+            <TabList>
+              <Tab value="agents">Agents</Tab>
+              <Tab value="workflows">Workflows</Tab>
+              <Tab value="tools">Tools</Tab>
+            </TabList>
+            <TabContent value="agents">
+              <LatencyChart
+                data={data.agentData}
+                onPointClick={onPointClick ? p => onPointClick('agents', p) : undefined}
+              />
+            </TabContent>
+            <TabContent value="workflows">
+              <LatencyChart
+                data={data.workflowData}
+                onPointClick={onPointClick ? p => onPointClick('workflows', p) : undefined}
+              />
+            </TabContent>
+            <TabContent value="tools">
+              <LatencyChart
+                data={data.toolData}
+                onPointClick={onPointClick ? p => onPointClick('tools', p) : undefined}
+              />
+            </TabContent>
+          </Tabs>
+        )}
+      </MetricsCard.Content>
+    );
+  }
+
   return (
     <MetricsCard>
       <MetricsCard.TopBar>
@@ -106,43 +155,7 @@ export function LatencyCardView({ data, isLoading, isError, onPointClick, action
         {hasData && <MetricsCard.Summary value={avgP50} label="Avg p50" />}
         {renderedActions ? <MetricsCard.Actions>{renderedActions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {isLoading ? (
-        <MetricsCard.Loading />
-      ) : isError ? (
-        <MetricsCard.Error message="Failed to load latency data" />
-      ) : (
-        <MetricsCard.Content>
-          {!hasData ? (
-            <MetricsCard.NoData message="No latency data yet" />
-          ) : (
-            <Tabs value={activeTab} onValueChange={setActiveTab} defaultTab={initialTab} className="overflow-visible">
-              <TabList>
-                <Tab value="agents">Agents</Tab>
-                <Tab value="workflows">Workflows</Tab>
-                <Tab value="tools">Tools</Tab>
-              </TabList>
-              <TabContent value="agents">
-                <LatencyChart
-                  data={data.agentData}
-                  onPointClick={onPointClick ? p => onPointClick('agents', p) : undefined}
-                />
-              </TabContent>
-              <TabContent value="workflows">
-                <LatencyChart
-                  data={data.workflowData}
-                  onPointClick={onPointClick ? p => onPointClick('workflows', p) : undefined}
-                />
-              </TabContent>
-              <TabContent value="tools">
-                <LatencyChart
-                  data={data.toolData}
-                  onPointClick={onPointClick ? p => onPointClick('tools', p) : undefined}
-                />
-              </TabContent>
-            </Tabs>
-          )}
-        </MetricsCard.Content>
-      )}
+      {cardBody}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/latency-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/latency-card-view.tsx
@@ -78,57 +78,41 @@ export interface LatencyCardViewProps {
   actions?: ReactNode | ((tab: LatencyTab) => ReactNode);
 }
 
-function LatencyCardBody({
+type LatencyData = NonNullable<LatencyCardViewProps['data']>;
+
+function LatencyCardContent({
   data,
-  isLoading,
-  isError,
   activeTab,
-  setActiveTab,
+  onTabChange,
   initialTab,
   onPointClick,
-}: Pick<LatencyCardViewProps, 'data' | 'isLoading' | 'isError' | 'onPointClick'> & {
+}: {
+  data: LatencyData;
   activeTab: LatencyTab;
-  setActiveTab: (tab: LatencyTab) => void;
+  onTabChange: (tab: LatencyTab) => void;
   initialTab: LatencyTab;
+  onPointClick: LatencyCardViewProps['onPointClick'];
 }) {
-  if (isLoading) {
-    return <MetricsCard.Loading />;
-  }
-  if (isError) {
-    return <MetricsCard.Error message="Failed to load latency data" />;
-  }
-  if (!data || (data.agentData.length === 0 && data.workflowData.length === 0 && data.toolData.length === 0)) {
-    return (
-      <MetricsCard.Content>
-        <MetricsCard.NoData message="No latency data yet" />
-      </MetricsCard.Content>
-    );
-  }
   return (
-    <MetricsCard.Content>
-      <Tabs value={activeTab} onValueChange={setActiveTab} defaultTab={initialTab} className="overflow-visible">
-        <TabList>
-          <Tab value="agents">Agents</Tab>
-          <Tab value="workflows">Workflows</Tab>
-          <Tab value="tools">Tools</Tab>
-        </TabList>
-        <TabContent value="agents">
-          <LatencyChart
-            data={data.agentData}
-            onPointClick={onPointClick ? p => onPointClick('agents', p) : undefined}
-          />
-        </TabContent>
-        <TabContent value="workflows">
-          <LatencyChart
-            data={data.workflowData}
-            onPointClick={onPointClick ? p => onPointClick('workflows', p) : undefined}
-          />
-        </TabContent>
-        <TabContent value="tools">
-          <LatencyChart data={data.toolData} onPointClick={onPointClick ? p => onPointClick('tools', p) : undefined} />
-        </TabContent>
-      </Tabs>
-    </MetricsCard.Content>
+    <Tabs value={activeTab} onValueChange={onTabChange} defaultTab={initialTab} className="overflow-visible">
+      <TabList>
+        <Tab value="agents">Agents</Tab>
+        <Tab value="workflows">Workflows</Tab>
+        <Tab value="tools">Tools</Tab>
+      </TabList>
+      <TabContent value="agents">
+        <LatencyChart data={data.agentData} onPointClick={onPointClick ? p => onPointClick('agents', p) : undefined} />
+      </TabContent>
+      <TabContent value="workflows">
+        <LatencyChart
+          data={data.workflowData}
+          onPointClick={onPointClick ? p => onPointClick('workflows', p) : undefined}
+        />
+      </TabContent>
+      <TabContent value="tools">
+        <LatencyChart data={data.toolData} onPointClick={onPointClick ? p => onPointClick('tools', p) : undefined} />
+      </TabContent>
+    </Tabs>
   );
 }
 
@@ -168,15 +152,26 @@ export function LatencyCardView({ data, isLoading, isError, onPointClick, action
         {hasData && <MetricsCard.Summary value={avgP50} label="Avg p50" />}
         {renderedActions ? <MetricsCard.Actions>{renderedActions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      <LatencyCardBody
-        data={data}
-        isLoading={isLoading}
-        isError={isError}
-        activeTab={activeTab}
-        setActiveTab={setActiveTab}
-        initialTab={initialTab}
-        onPointClick={onPointClick}
-      />
+      {isLoading && <MetricsCard.Loading />}
+      {!isLoading && isError && <MetricsCard.Error message="Failed to load latency data" />}
+      {!isLoading &&
+        !isError &&
+        (!data || (data.agentData.length === 0 && data.workflowData.length === 0 && data.toolData.length === 0)) && (
+          <MetricsCard.Content>
+            <MetricsCard.NoData message="No latency data yet" />
+          </MetricsCard.Content>
+        )}
+      {!isLoading && !isError && data && hasData && (
+        <MetricsCard.Content>
+          <LatencyCardContent
+            data={data}
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            initialTab={initialTab}
+            onPointClick={onPointClick}
+          />
+        </MetricsCard.Content>
+      )}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/memory-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/memory-card-view.tsx
@@ -48,6 +48,130 @@ function shortId(id: string): string {
 type ThreadTableRow = ActiveThreadRow & { key: string };
 type ResourceTableRow = ResourceThreadsRow & { key: string };
 
+function MemoryCardBody({
+  activeStatus,
+  activeTab,
+  setActiveTab,
+  threadRows,
+  resourceRows,
+  hasThreadData,
+  hasResourceData,
+  getThreadRowHref,
+  getResourceRowHref,
+  LinkComponent,
+}: {
+  activeStatus: Pick<MemoryTabState<ActiveThreadRow>, 'isLoading' | 'isError'>;
+  activeTab: MemoryTab;
+  setActiveTab: (tab: MemoryTab) => void;
+  threadRows: ThreadTableRow[];
+  resourceRows: ResourceTableRow[];
+  hasThreadData: boolean;
+  hasResourceData: boolean;
+  getThreadRowHref: MemoryCardViewProps['getThreadRowHref'];
+  getResourceRowHref: MemoryCardViewProps['getResourceRowHref'];
+  LinkComponent: MemoryCardViewProps['LinkComponent'];
+}) {
+  if (activeStatus.isLoading) {
+    return <MetricsCard.Loading />;
+  }
+  if (activeStatus.isError) {
+    return <MetricsCard.Error message="Failed to load memory data" />;
+  }
+  return (
+    <MetricsCard.Content>
+      <Tabs
+        defaultTab="threads"
+        value={activeTab}
+        onValueChange={v => {
+          if (isMemoryTab(v)) setActiveTab(v);
+        }}
+        className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
+      >
+        <TabList>
+          <Tab value="threads">Threads</Tab>
+          <Tab value="resources">Resources</Tab>
+        </TabList>
+        <TabContent value="threads">
+          {hasThreadData ? (
+            <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+              <DataList.Top>
+                <DataList.TopCell sticky="start">Thread ID</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Resource ID</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Runs</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
+              </DataList.Top>
+              {threadRows.map(row => {
+                const href = getThreadRowHref?.(row);
+                const rowCells = (
+                  <>
+                    <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                      {shortId(row.threadId)}
+                    </DataList.RowHeaderCell>
+                    <DataList.NumberCell>{row.resourceId ? shortId(row.resourceId) : '—'}</DataList.NumberCell>
+                    <DataList.NumberCell highlight>{row.runs.toLocaleString()}</DataList.NumberCell>
+                    <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
+                    <DataList.NumberCell>
+                      {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
+                    </DataList.NumberCell>
+                  </>
+                );
+
+                return href ? (
+                  <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
+                    {rowCells}
+                  </DataList.RowLink>
+                ) : (
+                  <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
+                );
+              })}
+            </DataList>
+          ) : (
+            <MetricsCard.NoData message="No thread activity yet" />
+          )}
+        </TabContent>
+        <TabContent value="resources">
+          {hasResourceData ? (
+            <DataList columns="auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+              <DataList.Top>
+                <DataList.TopCell sticky="start">Resource ID</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Threads</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
+              </DataList.Top>
+              {resourceRows.map(row => {
+                const href = getResourceRowHref?.(row);
+                const rowCells = (
+                  <>
+                    <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                      {shortId(row.resourceId)}
+                    </DataList.RowHeaderCell>
+                    <DataList.NumberCell highlight>{row.threadCount.toLocaleString()}</DataList.NumberCell>
+                    <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
+                    <DataList.NumberCell>
+                      {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
+                    </DataList.NumberCell>
+                  </>
+                );
+
+                return href ? (
+                  <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
+                    {rowCells}
+                  </DataList.RowLink>
+                ) : (
+                  <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
+                );
+              })}
+            </DataList>
+          ) : (
+            <MetricsCard.NoData message="No resource activity yet" />
+          )}
+        </TabContent>
+      </Tabs>
+    </MetricsCard.Content>
+  );
+}
+
 export function MemoryCardView({
   threads,
   resources,
@@ -69,107 +193,6 @@ export function MemoryCardView({
 
   const active = activeTab === 'threads' ? threads : resources;
   const renderedActions = typeof actions === 'function' ? actions(activeTab) : actions;
-  let cardBody: ReactNode;
-
-  if (active.isLoading) {
-    cardBody = <MetricsCard.Loading />;
-  } else if (active.isError) {
-    cardBody = <MetricsCard.Error message="Failed to load memory data" />;
-  } else {
-    cardBody = (
-      <MetricsCard.Content>
-        <Tabs
-          defaultTab="threads"
-          value={activeTab}
-          onValueChange={v => {
-            if (isMemoryTab(v)) setActiveTab(v);
-          }}
-          className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
-        >
-          <TabList>
-            <Tab value="threads">Threads</Tab>
-            <Tab value="resources">Resources</Tab>
-          </TabList>
-          <TabContent value="threads">
-            {hasThreadData ? (
-              <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-                <DataList.Top>
-                  <DataList.TopCell sticky="start">Thread ID</DataList.TopCell>
-                  <DataList.TopCell className="justify-end text-right">Resource ID</DataList.TopCell>
-                  <DataList.TopCell className="justify-end text-right">Runs</DataList.TopCell>
-                  <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
-                  <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
-                </DataList.Top>
-                {threadRows.map(row => {
-                  const href = getThreadRowHref?.(row);
-                  const rowCells = (
-                    <>
-                      <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                        {shortId(row.threadId)}
-                      </DataList.RowHeaderCell>
-                      <DataList.NumberCell>{row.resourceId ? shortId(row.resourceId) : '—'}</DataList.NumberCell>
-                      <DataList.NumberCell highlight>{row.runs.toLocaleString()}</DataList.NumberCell>
-                      <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
-                      <DataList.NumberCell>
-                        {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
-                      </DataList.NumberCell>
-                    </>
-                  );
-
-                  return href ? (
-                    <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
-                      {rowCells}
-                    </DataList.RowLink>
-                  ) : (
-                    <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
-                  );
-                })}
-              </DataList>
-            ) : (
-              <MetricsCard.NoData message="No thread activity yet" />
-            )}
-          </TabContent>
-          <TabContent value="resources">
-            {hasResourceData ? (
-              <DataList columns="auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-                <DataList.Top>
-                  <DataList.TopCell sticky="start">Resource ID</DataList.TopCell>
-                  <DataList.TopCell className="justify-end text-right">Threads</DataList.TopCell>
-                  <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
-                  <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
-                </DataList.Top>
-                {resourceRows.map(row => {
-                  const href = getResourceRowHref?.(row);
-                  const rowCells = (
-                    <>
-                      <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                        {shortId(row.resourceId)}
-                      </DataList.RowHeaderCell>
-                      <DataList.NumberCell highlight>{row.threadCount.toLocaleString()}</DataList.NumberCell>
-                      <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
-                      <DataList.NumberCell>
-                        {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
-                      </DataList.NumberCell>
-                    </>
-                  );
-
-                  return href ? (
-                    <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
-                      {rowCells}
-                    </DataList.RowLink>
-                  ) : (
-                    <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
-                  );
-                })}
-              </DataList>
-            ) : (
-              <MetricsCard.NoData message="No resource activity yet" />
-            )}
-          </TabContent>
-        </Tabs>
-      </MetricsCard.Content>
-    );
-  }
 
   return (
     <MetricsCard>
@@ -183,7 +206,18 @@ export function MemoryCardView({
         )}
         {renderedActions ? <MetricsCard.Actions>{renderedActions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {cardBody}
+      <MemoryCardBody
+        activeStatus={active}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        threadRows={threadRows}
+        resourceRows={resourceRows}
+        hasThreadData={hasThreadData}
+        hasResourceData={hasResourceData}
+        getThreadRowHref={getThreadRowHref}
+        getResourceRowHref={getResourceRowHref}
+        LinkComponent={LinkComponent}
+      />
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/memory-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/memory-card-view.tsx
@@ -48,127 +48,122 @@ function shortId(id: string): string {
 type ThreadTableRow = ActiveThreadRow & { key: string };
 type ResourceTableRow = ResourceThreadsRow & { key: string };
 
-function MemoryCardBody({
-  activeStatus,
-  activeTab,
-  setActiveTab,
-  threadRows,
-  resourceRows,
-  hasThreadData,
-  hasResourceData,
-  getThreadRowHref,
-  getResourceRowHref,
-  LinkComponent,
-}: {
-  activeStatus: Pick<MemoryTabState<ActiveThreadRow>, 'isLoading' | 'isError'>;
-  activeTab: MemoryTab;
-  setActiveTab: (tab: MemoryTab) => void;
-  threadRows: ThreadTableRow[];
-  resourceRows: ResourceTableRow[];
-  hasThreadData: boolean;
-  hasResourceData: boolean;
-  getThreadRowHref: MemoryCardViewProps['getThreadRowHref'];
-  getResourceRowHref: MemoryCardViewProps['getResourceRowHref'];
-  LinkComponent: MemoryCardViewProps['LinkComponent'];
-}) {
-  if (activeStatus.isLoading) {
-    return <MetricsCard.Loading />;
+type MemoryRows = {
+  threads: ThreadTableRow[];
+  resources: ResourceTableRow[];
+};
+
+type MemoryLinks = Pick<MemoryCardViewProps, 'getThreadRowHref' | 'getResourceRowHref' | 'LinkComponent'>;
+
+function MemoryThreadRows({ rows, links }: { rows: ThreadTableRow[]; links: MemoryLinks }) {
+  if (rows.length === 0) {
+    return <MetricsCard.NoData message="No thread activity yet" />;
   }
-  if (activeStatus.isError) {
-    return <MetricsCard.Error message="Failed to load memory data" />;
-  }
+
   return (
-    <MetricsCard.Content>
-      <Tabs
-        defaultTab="threads"
-        value={activeTab}
-        onValueChange={v => {
-          if (isMemoryTab(v)) setActiveTab(v);
-        }}
-        className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
-      >
-        <TabList>
-          <Tab value="threads">Threads</Tab>
-          <Tab value="resources">Resources</Tab>
-        </TabList>
-        <TabContent value="threads">
-          {hasThreadData ? (
-            <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-              <DataList.Top>
-                <DataList.TopCell sticky="start">Thread ID</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Resource ID</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Runs</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
-              </DataList.Top>
-              {threadRows.map(row => {
-                const href = getThreadRowHref?.(row);
-                const rowCells = (
-                  <>
-                    <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                      {shortId(row.threadId)}
-                    </DataList.RowHeaderCell>
-                    <DataList.NumberCell>{row.resourceId ? shortId(row.resourceId) : '—'}</DataList.NumberCell>
-                    <DataList.NumberCell highlight>{row.runs.toLocaleString()}</DataList.NumberCell>
-                    <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
-                    <DataList.NumberCell>
-                      {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
-                    </DataList.NumberCell>
-                  </>
-                );
+    <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+      <DataList.Top>
+        <DataList.TopCell sticky="start">Thread ID</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Resource ID</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Runs</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
+      </DataList.Top>
+      {rows.map(row => {
+        const href = links.getThreadRowHref?.(row);
+        const rowCells = (
+          <>
+            <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+              {shortId(row.threadId)}
+            </DataList.RowHeaderCell>
+            <DataList.NumberCell>{row.resourceId ? shortId(row.resourceId) : '—'}</DataList.NumberCell>
+            <DataList.NumberCell highlight>{row.runs.toLocaleString()}</DataList.NumberCell>
+            <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
+            <DataList.NumberCell>{row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}</DataList.NumberCell>
+          </>
+        );
 
-                return href ? (
-                  <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
-                    {rowCells}
-                  </DataList.RowLink>
-                ) : (
-                  <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
-                );
-              })}
-            </DataList>
-          ) : (
-            <MetricsCard.NoData message="No thread activity yet" />
-          )}
-        </TabContent>
-        <TabContent value="resources">
-          {hasResourceData ? (
-            <DataList columns="auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-              <DataList.Top>
-                <DataList.TopCell sticky="start">Resource ID</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Threads</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
-              </DataList.Top>
-              {resourceRows.map(row => {
-                const href = getResourceRowHref?.(row);
-                const rowCells = (
-                  <>
-                    <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                      {shortId(row.resourceId)}
-                    </DataList.RowHeaderCell>
-                    <DataList.NumberCell highlight>{row.threadCount.toLocaleString()}</DataList.NumberCell>
-                    <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
-                    <DataList.NumberCell>
-                      {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
-                    </DataList.NumberCell>
-                  </>
-                );
+        return href ? (
+          <DataList.RowLink key={row.key} to={href} LinkComponent={links.LinkComponent}>
+            {rowCells}
+          </DataList.RowLink>
+        ) : (
+          <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
+        );
+      })}
+    </DataList>
+  );
+}
 
-                return href ? (
-                  <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
-                    {rowCells}
-                  </DataList.RowLink>
-                ) : (
-                  <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
-                );
-              })}
-            </DataList>
-          ) : (
-            <MetricsCard.NoData message="No resource activity yet" />
-          )}
-        </TabContent>
-      </Tabs>
-    </MetricsCard.Content>
+function MemoryResourceRows({ rows, links }: { rows: ResourceTableRow[]; links: MemoryLinks }) {
+  if (rows.length === 0) {
+    return <MetricsCard.NoData message="No resource activity yet" />;
+  }
+
+  return (
+    <DataList columns="auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+      <DataList.Top>
+        <DataList.TopCell sticky="start">Resource ID</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Threads</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
+      </DataList.Top>
+      {rows.map(row => {
+        const href = links.getResourceRowHref?.(row);
+        const rowCells = (
+          <>
+            <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+              {shortId(row.resourceId)}
+            </DataList.RowHeaderCell>
+            <DataList.NumberCell highlight>{row.threadCount.toLocaleString()}</DataList.NumberCell>
+            <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
+            <DataList.NumberCell>{row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}</DataList.NumberCell>
+          </>
+        );
+
+        return href ? (
+          <DataList.RowLink key={row.key} to={href} LinkComponent={links.LinkComponent}>
+            {rowCells}
+          </DataList.RowLink>
+        ) : (
+          <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
+        );
+      })}
+    </DataList>
+  );
+}
+
+function MemoryCardContent({
+  rows,
+  activeTab,
+  onTabChange,
+  links,
+}: {
+  rows: MemoryRows;
+  activeTab: MemoryTab;
+  onTabChange: (tab: MemoryTab) => void;
+  links: MemoryLinks;
+}) {
+  return (
+    <Tabs
+      defaultTab="threads"
+      value={activeTab}
+      onValueChange={v => {
+        if (isMemoryTab(v)) onTabChange(v);
+      }}
+      className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
+    >
+      <TabList>
+        <Tab value="threads">Threads</Tab>
+        <Tab value="resources">Resources</Tab>
+      </TabList>
+      <TabContent value="threads">
+        <MemoryThreadRows rows={rows.threads} links={links} />
+      </TabContent>
+      <TabContent value="resources">
+        <MemoryResourceRows rows={rows.resources} links={links} />
+      </TabContent>
+    </Tabs>
   );
 }
 
@@ -206,18 +201,18 @@ export function MemoryCardView({
         )}
         {renderedActions ? <MetricsCard.Actions>{renderedActions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      <MemoryCardBody
-        activeStatus={active}
-        activeTab={activeTab}
-        setActiveTab={setActiveTab}
-        threadRows={threadRows}
-        resourceRows={resourceRows}
-        hasThreadData={hasThreadData}
-        hasResourceData={hasResourceData}
-        getThreadRowHref={getThreadRowHref}
-        getResourceRowHref={getResourceRowHref}
-        LinkComponent={LinkComponent}
-      />
+      {active.isLoading && <MetricsCard.Loading />}
+      {!active.isLoading && active.isError && <MetricsCard.Error message="Failed to load memory data" />}
+      {!active.isLoading && !active.isError && (
+        <MetricsCard.Content>
+          <MemoryCardContent
+            rows={{ threads: threadRows, resources: resourceRows }}
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            links={{ getThreadRowHref, getResourceRowHref, LinkComponent }}
+          />
+        </MetricsCard.Content>
+      )}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/memory-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/memory-card-view.tsx
@@ -69,6 +69,107 @@ export function MemoryCardView({
 
   const active = activeTab === 'threads' ? threads : resources;
   const renderedActions = typeof actions === 'function' ? actions(activeTab) : actions;
+  let cardBody: ReactNode;
+
+  if (active.isLoading) {
+    cardBody = <MetricsCard.Loading />;
+  } else if (active.isError) {
+    cardBody = <MetricsCard.Error message="Failed to load memory data" />;
+  } else {
+    cardBody = (
+      <MetricsCard.Content>
+        <Tabs
+          defaultTab="threads"
+          value={activeTab}
+          onValueChange={v => {
+            if (isMemoryTab(v)) setActiveTab(v);
+          }}
+          className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
+        >
+          <TabList>
+            <Tab value="threads">Threads</Tab>
+            <Tab value="resources">Resources</Tab>
+          </TabList>
+          <TabContent value="threads">
+            {hasThreadData ? (
+              <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+                <DataList.Top>
+                  <DataList.TopCell sticky="start">Thread ID</DataList.TopCell>
+                  <DataList.TopCell className="justify-end text-right">Resource ID</DataList.TopCell>
+                  <DataList.TopCell className="justify-end text-right">Runs</DataList.TopCell>
+                  <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
+                  <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
+                </DataList.Top>
+                {threadRows.map(row => {
+                  const href = getThreadRowHref?.(row);
+                  const rowCells = (
+                    <>
+                      <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                        {shortId(row.threadId)}
+                      </DataList.RowHeaderCell>
+                      <DataList.NumberCell>{row.resourceId ? shortId(row.resourceId) : '—'}</DataList.NumberCell>
+                      <DataList.NumberCell highlight>{row.runs.toLocaleString()}</DataList.NumberCell>
+                      <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
+                      <DataList.NumberCell>
+                        {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
+                      </DataList.NumberCell>
+                    </>
+                  );
+
+                  return href ? (
+                    <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
+                      {rowCells}
+                    </DataList.RowLink>
+                  ) : (
+                    <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
+                  );
+                })}
+              </DataList>
+            ) : (
+              <MetricsCard.NoData message="No thread activity yet" />
+            )}
+          </TabContent>
+          <TabContent value="resources">
+            {hasResourceData ? (
+              <DataList columns="auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+                <DataList.Top>
+                  <DataList.TopCell sticky="start">Resource ID</DataList.TopCell>
+                  <DataList.TopCell className="justify-end text-right">Threads</DataList.TopCell>
+                  <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
+                  <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
+                </DataList.Top>
+                {resourceRows.map(row => {
+                  const href = getResourceRowHref?.(row);
+                  const rowCells = (
+                    <>
+                      <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                        {shortId(row.resourceId)}
+                      </DataList.RowHeaderCell>
+                      <DataList.NumberCell highlight>{row.threadCount.toLocaleString()}</DataList.NumberCell>
+                      <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
+                      <DataList.NumberCell>
+                        {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
+                      </DataList.NumberCell>
+                    </>
+                  );
+
+                  return href ? (
+                    <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
+                      {rowCells}
+                    </DataList.RowLink>
+                  ) : (
+                    <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
+                  );
+                })}
+              </DataList>
+            ) : (
+              <MetricsCard.NoData message="No resource activity yet" />
+            )}
+          </TabContent>
+        </Tabs>
+      </MetricsCard.Content>
+    );
+  }
 
   return (
     <MetricsCard>
@@ -82,103 +183,7 @@ export function MemoryCardView({
         )}
         {renderedActions ? <MetricsCard.Actions>{renderedActions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {active.isLoading ? (
-        <MetricsCard.Loading />
-      ) : active.isError ? (
-        <MetricsCard.Error message="Failed to load memory data" />
-      ) : (
-        <MetricsCard.Content>
-          <Tabs
-            defaultTab="threads"
-            value={activeTab}
-            onValueChange={v => {
-              if (isMemoryTab(v)) setActiveTab(v);
-            }}
-            className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
-          >
-            <TabList>
-              <Tab value="threads">Threads</Tab>
-              <Tab value="resources">Resources</Tab>
-            </TabList>
-            <TabContent value="threads">
-              {hasThreadData ? (
-                <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-                  <DataList.Top>
-                    <DataList.TopCell sticky="start">Thread ID</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Resource ID</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Runs</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
-                  </DataList.Top>
-                  {threadRows.map(row => {
-                    const href = getThreadRowHref?.(row);
-                    const rowCells = (
-                      <>
-                        <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                          {shortId(row.threadId)}
-                        </DataList.RowHeaderCell>
-                        <DataList.NumberCell>{row.resourceId ? shortId(row.resourceId) : '—'}</DataList.NumberCell>
-                        <DataList.NumberCell highlight>{row.runs.toLocaleString()}</DataList.NumberCell>
-                        <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
-                        <DataList.NumberCell>
-                          {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
-                        </DataList.NumberCell>
-                      </>
-                    );
-
-                    return href ? (
-                      <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
-                        {rowCells}
-                      </DataList.RowLink>
-                    ) : (
-                      <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
-                    );
-                  })}
-                </DataList>
-              ) : (
-                <MetricsCard.NoData message="No thread activity yet" />
-              )}
-            </TabContent>
-            <TabContent value="resources">
-              {hasResourceData ? (
-                <DataList columns="auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-                  <DataList.Top>
-                    <DataList.TopCell sticky="start">Resource ID</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Threads</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Tokens</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
-                  </DataList.Top>
-                  {resourceRows.map(row => {
-                    const href = getResourceRowHref?.(row);
-                    const rowCells = (
-                      <>
-                        <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                          {shortId(row.resourceId)}
-                        </DataList.RowHeaderCell>
-                        <DataList.NumberCell highlight>{row.threadCount.toLocaleString()}</DataList.NumberCell>
-                        <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
-                        <DataList.NumberCell>
-                          {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
-                        </DataList.NumberCell>
-                      </>
-                    );
-
-                    return href ? (
-                      <DataList.RowLink key={row.key} to={href} LinkComponent={LinkComponent}>
-                        {rowCells}
-                      </DataList.RowLink>
-                    ) : (
-                      <DataList.RowStatic key={row.key}>{rowCells}</DataList.RowStatic>
-                    );
-                  })}
-                </DataList>
-              ) : (
-                <MetricsCard.NoData message="No resource activity yet" />
-              )}
-            </TabContent>
-          </Tabs>
-        </MetricsCard.Content>
-      )}
+      {cardBody}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/model-usage-cost-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/model-usage-cost-card-view.tsx
@@ -34,6 +34,67 @@ export interface ModelUsageCostCardViewProps {
   LinkComponent?: LinkComponent;
 }
 
+function ModelUsageCostCardBody({
+  rows,
+  isLoading,
+  isError,
+  getRowHref,
+  LinkComponent,
+}: Pick<ModelUsageCostCardViewProps, 'rows' | 'isLoading' | 'isError' | 'getRowHref' | 'LinkComponent'>) {
+  if (isLoading) {
+    return <MetricsCard.Loading />;
+  }
+  if (isError) {
+    return <MetricsCard.Error message="Failed to load model usage data" />;
+  }
+  if (!rows || rows.length === 0) {
+    return (
+      <MetricsCard.Content>
+        <MetricsCard.NoData message="No model usage data yet" />
+      </MetricsCard.Content>
+    );
+  }
+  return (
+    <MetricsCard.Content>
+      <DataList columns="auto auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+        <DataList.Top>
+          <DataList.TopCell sticky="start">Model</DataList.TopCell>
+          <DataList.TopCell className="justify-end text-right">Input</DataList.TopCell>
+          <DataList.TopCell className="justify-end text-right">Output</DataList.TopCell>
+          <DataList.TopCell className="justify-end text-right">Cache Read</DataList.TopCell>
+          <DataList.TopCell className="justify-end text-right">Cache Write</DataList.TopCell>
+          <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
+        </DataList.Top>
+        {rows.map(row => {
+          const href = getRowHref?.(row);
+          const rowCells = (
+            <>
+              <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                {row.model}
+              </DataList.RowHeaderCell>
+              <DataList.NumberCell>{row.input}</DataList.NumberCell>
+              <DataList.NumberCell>{row.output}</DataList.NumberCell>
+              <DataList.NumberCell>{row.cacheRead}</DataList.NumberCell>
+              <DataList.NumberCell>{row.cacheWrite}</DataList.NumberCell>
+              <DataList.NumberCell highlight>
+                {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
+              </DataList.NumberCell>
+            </>
+          );
+
+          return href ? (
+            <DataList.RowLink key={row.model} to={href} LinkComponent={LinkComponent}>
+              {rowCells}
+            </DataList.RowLink>
+          ) : (
+            <DataList.RowStatic key={row.model}>{rowCells}</DataList.RowStatic>
+          );
+        })}
+      </DataList>
+    </MetricsCard.Content>
+  );
+}
+
 export function ModelUsageCostCardView({
   rows,
   isLoading,
@@ -42,59 +103,7 @@ export function ModelUsageCostCardView({
   actions,
   LinkComponent,
 }: ModelUsageCostCardViewProps) {
-  const hasData = !!rows && rows.length > 0;
   const totalCostSummary = rows && rows.length > 0 ? getTotalCostSummaryValue(rows) : undefined;
-
-  let cardBody;
-  if (isLoading) {
-    cardBody = <MetricsCard.Loading />;
-  } else if (isError) {
-    cardBody = <MetricsCard.Error message="Failed to load model usage data" />;
-  } else {
-    cardBody = (
-      <MetricsCard.Content>
-        {!hasData ? (
-          <MetricsCard.NoData message="No model usage data yet" />
-        ) : (
-          <DataList columns="auto auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-            <DataList.Top>
-              <DataList.TopCell sticky="start">Model</DataList.TopCell>
-              <DataList.TopCell className="justify-end text-right">Input</DataList.TopCell>
-              <DataList.TopCell className="justify-end text-right">Output</DataList.TopCell>
-              <DataList.TopCell className="justify-end text-right">Cache Read</DataList.TopCell>
-              <DataList.TopCell className="justify-end text-right">Cache Write</DataList.TopCell>
-              <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
-            </DataList.Top>
-            {rows.map(row => {
-              const href = getRowHref?.(row);
-              const rowCells = (
-                <>
-                  <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                    {row.model}
-                  </DataList.RowHeaderCell>
-                  <DataList.NumberCell>{row.input}</DataList.NumberCell>
-                  <DataList.NumberCell>{row.output}</DataList.NumberCell>
-                  <DataList.NumberCell>{row.cacheRead}</DataList.NumberCell>
-                  <DataList.NumberCell>{row.cacheWrite}</DataList.NumberCell>
-                  <DataList.NumberCell highlight>
-                    {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
-                  </DataList.NumberCell>
-                </>
-              );
-
-              return href ? (
-                <DataList.RowLink key={row.model} to={href} LinkComponent={LinkComponent}>
-                  {rowCells}
-                </DataList.RowLink>
-              ) : (
-                <DataList.RowStatic key={row.model}>{rowCells}</DataList.RowStatic>
-              );
-            })}
-          </DataList>
-        )}
-      </MetricsCard.Content>
-    );
-  }
 
   return (
     <MetricsCard>
@@ -103,7 +112,13 @@ export function ModelUsageCostCardView({
         {totalCostSummary !== undefined && <MetricsCard.Summary value={totalCostSummary} label="Total cost" />}
         {actions ? <MetricsCard.Actions>{actions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {cardBody}
+      <ModelUsageCostCardBody
+        rows={rows}
+        isLoading={isLoading}
+        isError={isError}
+        getRowHref={getRowHref}
+        LinkComponent={LinkComponent}
+      />
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/model-usage-cost-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/model-usage-cost-card-view.tsx
@@ -34,64 +34,51 @@ export interface ModelUsageCostCardViewProps {
   LinkComponent?: LinkComponent;
 }
 
-function ModelUsageCostCardBody({
+function ModelUsageCostTable({
   rows,
-  isLoading,
-  isError,
   getRowHref,
   LinkComponent,
-}: Pick<ModelUsageCostCardViewProps, 'rows' | 'isLoading' | 'isError' | 'getRowHref' | 'LinkComponent'>) {
-  if (isLoading) {
-    return <MetricsCard.Loading />;
-  }
-  if (isError) {
-    return <MetricsCard.Error message="Failed to load model usage data" />;
-  }
-  if (!rows || rows.length === 0) {
-    return (
-      <MetricsCard.Content>
-        <MetricsCard.NoData message="No model usage data yet" />
-      </MetricsCard.Content>
-    );
-  }
+}: {
+  rows: ModelUsageRow[];
+  getRowHref: ModelUsageCostCardViewProps['getRowHref'];
+  LinkComponent: ModelUsageCostCardViewProps['LinkComponent'];
+}) {
   return (
-    <MetricsCard.Content>
-      <DataList columns="auto auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-        <DataList.Top>
-          <DataList.TopCell sticky="start">Model</DataList.TopCell>
-          <DataList.TopCell className="justify-end text-right">Input</DataList.TopCell>
-          <DataList.TopCell className="justify-end text-right">Output</DataList.TopCell>
-          <DataList.TopCell className="justify-end text-right">Cache Read</DataList.TopCell>
-          <DataList.TopCell className="justify-end text-right">Cache Write</DataList.TopCell>
-          <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
-        </DataList.Top>
-        {rows.map(row => {
-          const href = getRowHref?.(row);
-          const rowCells = (
-            <>
-              <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                {row.model}
-              </DataList.RowHeaderCell>
-              <DataList.NumberCell>{row.input}</DataList.NumberCell>
-              <DataList.NumberCell>{row.output}</DataList.NumberCell>
-              <DataList.NumberCell>{row.cacheRead}</DataList.NumberCell>
-              <DataList.NumberCell>{row.cacheWrite}</DataList.NumberCell>
-              <DataList.NumberCell highlight>
-                {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
-              </DataList.NumberCell>
-            </>
-          );
+    <DataList columns="auto auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+      <DataList.Top>
+        <DataList.TopCell sticky="start">Model</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Input</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Output</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Cache Read</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Cache Write</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
+      </DataList.Top>
+      {rows.map(row => {
+        const href = getRowHref?.(row);
+        const rowCells = (
+          <>
+            <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+              {row.model}
+            </DataList.RowHeaderCell>
+            <DataList.NumberCell>{row.input}</DataList.NumberCell>
+            <DataList.NumberCell>{row.output}</DataList.NumberCell>
+            <DataList.NumberCell>{row.cacheRead}</DataList.NumberCell>
+            <DataList.NumberCell>{row.cacheWrite}</DataList.NumberCell>
+            <DataList.NumberCell highlight>
+              {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
+            </DataList.NumberCell>
+          </>
+        );
 
-          return href ? (
-            <DataList.RowLink key={row.model} to={href} LinkComponent={LinkComponent}>
-              {rowCells}
-            </DataList.RowLink>
-          ) : (
-            <DataList.RowStatic key={row.model}>{rowCells}</DataList.RowStatic>
-          );
-        })}
-      </DataList>
-    </MetricsCard.Content>
+        return href ? (
+          <DataList.RowLink key={row.model} to={href} LinkComponent={LinkComponent}>
+            {rowCells}
+          </DataList.RowLink>
+        ) : (
+          <DataList.RowStatic key={row.model}>{rowCells}</DataList.RowStatic>
+        );
+      })}
+    </DataList>
   );
 }
 
@@ -112,13 +99,17 @@ export function ModelUsageCostCardView({
         {totalCostSummary !== undefined && <MetricsCard.Summary value={totalCostSummary} label="Total cost" />}
         {actions ? <MetricsCard.Actions>{actions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      <ModelUsageCostCardBody
-        rows={rows}
-        isLoading={isLoading}
-        isError={isError}
-        getRowHref={getRowHref}
-        LinkComponent={LinkComponent}
-      />
+      {isLoading && <MetricsCard.Loading />}
+      {!isLoading && isError && <MetricsCard.Error message="Failed to load model usage data" />}
+      {!isLoading && !isError && (
+        <MetricsCard.Content>
+          {!rows || rows.length === 0 ? (
+            <MetricsCard.NoData message="No model usage data yet" />
+          ) : (
+            <ModelUsageCostTable rows={rows} getRowHref={getRowHref} LinkComponent={LinkComponent} />
+          )}
+        </MetricsCard.Content>
+      )}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/model-usage-cost-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/model-usage-cost-card-view.tsx
@@ -5,6 +5,23 @@ import type { LinkComponent } from '../../../ds/types/link-component';
 import type { ModelUsageRow } from '../hooks/use-model-usage-cost-metrics';
 import { formatCost, METRICS_DATA_LIST_PROPS } from './metrics-utils';
 
+function getTotalCostSummaryValue(rows: ModelUsageRow[]) {
+  const totalCost = rows.reduce((sum, r) => sum + (r.cost ?? 0), 0);
+  const units = new Set<string>();
+  for (const row of rows) {
+    if (row.cost != null && row.costUnit) {
+      units.add(row.costUnit);
+    }
+  }
+  if (units.size === 0) {
+    return totalCost > 0 ? formatCost(totalCost) : '—';
+  }
+  if (units.size === 1) {
+    return totalCost > 0 ? formatCost(totalCost, [...units][0]) : '—';
+  }
+  return 'Mixed';
+}
+
 export interface ModelUsageCostCardViewProps {
   rows: ModelUsageRow[] | undefined;
   isLoading: boolean;
@@ -26,79 +43,67 @@ export function ModelUsageCostCardView({
   LinkComponent,
 }: ModelUsageCostCardViewProps) {
   const hasData = !!rows && rows.length > 0;
+  const totalCostSummary = rows && rows.length > 0 ? getTotalCostSummaryValue(rows) : undefined;
+
+  let cardBody;
+  if (isLoading) {
+    cardBody = <MetricsCard.Loading />;
+  } else if (isError) {
+    cardBody = <MetricsCard.Error message="Failed to load model usage data" />;
+  } else {
+    cardBody = (
+      <MetricsCard.Content>
+        {!hasData ? (
+          <MetricsCard.NoData message="No model usage data yet" />
+        ) : (
+          <DataList columns="auto auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+            <DataList.Top>
+              <DataList.TopCell sticky="start">Model</DataList.TopCell>
+              <DataList.TopCell className="justify-end text-right">Input</DataList.TopCell>
+              <DataList.TopCell className="justify-end text-right">Output</DataList.TopCell>
+              <DataList.TopCell className="justify-end text-right">Cache Read</DataList.TopCell>
+              <DataList.TopCell className="justify-end text-right">Cache Write</DataList.TopCell>
+              <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
+            </DataList.Top>
+            {rows.map(row => {
+              const href = getRowHref?.(row);
+              const rowCells = (
+                <>
+                  <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                    {row.model}
+                  </DataList.RowHeaderCell>
+                  <DataList.NumberCell>{row.input}</DataList.NumberCell>
+                  <DataList.NumberCell>{row.output}</DataList.NumberCell>
+                  <DataList.NumberCell>{row.cacheRead}</DataList.NumberCell>
+                  <DataList.NumberCell>{row.cacheWrite}</DataList.NumberCell>
+                  <DataList.NumberCell highlight>
+                    {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
+                  </DataList.NumberCell>
+                </>
+              );
+
+              return href ? (
+                <DataList.RowLink key={row.model} to={href} LinkComponent={LinkComponent}>
+                  {rowCells}
+                </DataList.RowLink>
+              ) : (
+                <DataList.RowStatic key={row.model}>{rowCells}</DataList.RowStatic>
+              );
+            })}
+          </DataList>
+        )}
+      </MetricsCard.Content>
+    );
+  }
 
   return (
     <MetricsCard>
       <MetricsCard.TopBar>
         <MetricsCard.TitleAndDescription title="Model Usage & Cost" description="Token consumption by model." />
-        {hasData &&
-          (() => {
-            const totalCost = rows.reduce((sum, r) => sum + (r.cost ?? 0), 0);
-            const units = new Set<string>();
-            for (const row of rows) {
-              if (row.cost != null && row.costUnit) {
-                units.add(row.costUnit);
-              }
-            }
-            let value: string;
-            if (units.size === 0) {
-              value = totalCost > 0 ? formatCost(totalCost) : '—';
-            } else if (units.size === 1) {
-              value = totalCost > 0 ? formatCost(totalCost, [...units][0]) : '—';
-            } else {
-              value = 'Mixed';
-            }
-            return <MetricsCard.Summary value={value} label="Total cost" />;
-          })()}
+        {totalCostSummary !== undefined && <MetricsCard.Summary value={totalCostSummary} label="Total cost" />}
         {actions ? <MetricsCard.Actions>{actions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {isLoading ? (
-        <MetricsCard.Loading />
-      ) : isError ? (
-        <MetricsCard.Error message="Failed to load model usage data" />
-      ) : (
-        <MetricsCard.Content>
-          {!hasData ? (
-            <MetricsCard.NoData message="No model usage data yet" />
-          ) : (
-            <DataList columns="auto auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-              <DataList.Top>
-                <DataList.TopCell sticky="start">Model</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Input</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Output</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Cache Read</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Cache Write</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Cost</DataList.TopCell>
-              </DataList.Top>
-              {rows.map(row => {
-                const href = getRowHref?.(row);
-                const rowCells = (
-                  <>
-                    <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                      {row.model}
-                    </DataList.RowHeaderCell>
-                    <DataList.NumberCell>{row.input}</DataList.NumberCell>
-                    <DataList.NumberCell>{row.output}</DataList.NumberCell>
-                    <DataList.NumberCell>{row.cacheRead}</DataList.NumberCell>
-                    <DataList.NumberCell>{row.cacheWrite}</DataList.NumberCell>
-                    <DataList.NumberCell highlight>
-                      {row.cost != null ? formatCost(row.cost, row.costUnit) : '—'}
-                    </DataList.NumberCell>
-                  </>
-                );
-
-                return href ? (
-                  <DataList.RowLink key={row.model} to={href} LinkComponent={LinkComponent}>
-                    {rowCells}
-                  </DataList.RowLink>
-                ) : (
-                  <DataList.RowStatic key={row.model}>{rowCells}</DataList.RowStatic>
-                );
-              })}
-            </DataList>
-          )}
-        </MetricsCard.Content>
-      )}
+      {cardBody}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/scores-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/scores-card-view.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { ReactNode } from 'react';
+import type { ComponentProps } from 'react';
 import { DataList } from '../../../ds/components/DataList/data-list';
 import { MetricsCard } from '../../../ds/components/MetricsCard/metrics-card';
 import { MetricsLineChart } from '../../../ds/components/MetricsLineChart/metrics-line-chart';
@@ -19,6 +19,8 @@ const SERIES_COLORS = [
   CHART_COLORS.yellow,
 ];
 
+type MetricsLineChartSeries = ComponentProps<typeof MetricsLineChart>['series'];
+
 export interface ScoresCardViewProps {
   data:
     | {
@@ -32,9 +34,67 @@ export interface ScoresCardViewProps {
   isError: boolean;
 }
 
-export function ScoresCardView({ data, isLoading, isError }: ScoresCardViewProps) {
-  const hasData = !!data && (data.summaryData.length > 0 || data.overTimeData.length > 0);
+function ScoresCardBody({
+  data,
+  isLoading,
+  isError,
+  series,
+}: ScoresCardViewProps & { series: MetricsLineChartSeries }) {
+  if (isLoading) {
+    return <MetricsCard.Loading />;
+  }
+  if (isError) {
+    return <MetricsCard.Error message="Failed to load scores data" />;
+  }
+  if (!data || (data.summaryData.length === 0 && data.overTimeData.length === 0)) {
+    return (
+      <MetricsCard.Content>
+        <MetricsCard.NoData message="No scores data yet" />
+      </MetricsCard.Content>
+    );
+  }
+  return (
+    <MetricsCard.Content>
+      <Tabs defaultTab="over-time" className="overflow-visible">
+        <TabList>
+          <Tab value="over-time">Over Time</Tab>
+          <Tab value="summary">Summary</Tab>
+        </TabList>
+        <TabContent value="over-time" className="pb-0">
+          {data.overTimeData.length > 0 ? (
+            <MetricsLineChart data={data.overTimeData} series={series} yDomain={[0, 1]} />
+          ) : (
+            <MetricsCard.NoData message="No time series data yet" />
+          )}
+        </TabContent>
+        <TabContent value="summary">
+          <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+            <DataList.Top>
+              <DataList.TopCell sticky="start">Scorer</DataList.TopCell>
+              <DataList.TopCell className="justify-end text-right">Avg</DataList.TopCell>
+              <DataList.TopCell className="justify-end text-right">Min</DataList.TopCell>
+              <DataList.TopCell className="justify-end text-right">Max</DataList.TopCell>
+              <DataList.TopCell className="justify-end text-right">Count</DataList.TopCell>
+            </DataList.Top>
+            {data.summaryData.map(row => (
+              <DataList.RowStatic key={row.scorer}>
+                <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                  {row.scorer}
+                </DataList.RowHeaderCell>
+                <DataList.NumberCell highlight>{row.avg.toFixed(2)}</DataList.NumberCell>
+                <DataList.NumberCell>{row.min.toFixed(2)}</DataList.NumberCell>
+                <DataList.NumberCell>{row.max.toFixed(2)}</DataList.NumberCell>
+                <DataList.NumberCell>{row.count.toLocaleString()}</DataList.NumberCell>
+              </DataList.RowStatic>
+            ))}
+          </DataList>
+        </TabContent>
+      </Tabs>
+    </MetricsCard.Content>
+  );
+}
 
+export function ScoresCardView({ data, isLoading, isError }: ScoresCardViewProps) {
   const series = useMemo(() => {
     if (!data?.scorerNames) return [];
     return data.scorerNames.map((name, i) => ({
@@ -51,66 +111,12 @@ export function ScoresCardView({ data, isLoading, isError }: ScoresCardViewProps
     }));
   }, [data?.scorerNames]);
 
-  let cardBody: ReactNode;
-
-  if (isLoading) {
-    cardBody = <MetricsCard.Loading />;
-  } else if (isError) {
-    cardBody = <MetricsCard.Error message="Failed to load scores data" />;
-  } else if (!data || !hasData) {
-    cardBody = (
-      <MetricsCard.Content>
-        <MetricsCard.NoData message="No scores data yet" />
-      </MetricsCard.Content>
-    );
-  } else {
-    cardBody = (
-      <MetricsCard.Content>
-        <Tabs defaultTab="over-time" className="overflow-visible">
-          <TabList>
-            <Tab value="over-time">Over Time</Tab>
-            <Tab value="summary">Summary</Tab>
-          </TabList>
-          <TabContent value="over-time" className="pb-0">
-            {data.overTimeData.length > 0 ? (
-              <MetricsLineChart data={data.overTimeData} series={series} yDomain={[0, 1]} />
-            ) : (
-              <MetricsCard.NoData message="No time series data yet" />
-            )}
-          </TabContent>
-          <TabContent value="summary">
-            <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-              <DataList.Top>
-                <DataList.TopCell sticky="start">Scorer</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Avg</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Min</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Max</DataList.TopCell>
-                <DataList.TopCell className="justify-end text-right">Count</DataList.TopCell>
-              </DataList.Top>
-              {data.summaryData.map(row => (
-                <DataList.RowStatic key={row.scorer}>
-                  <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                    {row.scorer}
-                  </DataList.RowHeaderCell>
-                  <DataList.NumberCell highlight>{row.avg.toFixed(2)}</DataList.NumberCell>
-                  <DataList.NumberCell>{row.min.toFixed(2)}</DataList.NumberCell>
-                  <DataList.NumberCell>{row.max.toFixed(2)}</DataList.NumberCell>
-                  <DataList.NumberCell>{row.count.toLocaleString()}</DataList.NumberCell>
-                </DataList.RowStatic>
-              ))}
-            </DataList>
-          </TabContent>
-        </Tabs>
-      </MetricsCard.Content>
-    );
-  }
-
   return (
     <MetricsCard>
       <MetricsCard.TopBar>
         <MetricsCard.TitleAndDescription title="Scores" description="Evaluation scorer performance." />
       </MetricsCard.TopBar>
-      {cardBody}
+      <ScoresCardBody data={data} isLoading={isLoading} isError={isError} series={series} />
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/scores-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/scores-card-view.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import type { ReactNode } from 'react';
 import { DataList } from '../../../ds/components/DataList/data-list';
 import { MetricsCard } from '../../../ds/components/MetricsCard/metrics-card';
 import { MetricsLineChart } from '../../../ds/components/MetricsLineChart/metrics-line-chart';
@@ -50,58 +51,66 @@ export function ScoresCardView({ data, isLoading, isError }: ScoresCardViewProps
     }));
   }, [data?.scorerNames]);
 
+  let cardBody: ReactNode;
+
+  if (isLoading) {
+    cardBody = <MetricsCard.Loading />;
+  } else if (isError) {
+    cardBody = <MetricsCard.Error message="Failed to load scores data" />;
+  } else if (!data || !hasData) {
+    cardBody = (
+      <MetricsCard.Content>
+        <MetricsCard.NoData message="No scores data yet" />
+      </MetricsCard.Content>
+    );
+  } else {
+    cardBody = (
+      <MetricsCard.Content>
+        <Tabs defaultTab="over-time" className="overflow-visible">
+          <TabList>
+            <Tab value="over-time">Over Time</Tab>
+            <Tab value="summary">Summary</Tab>
+          </TabList>
+          <TabContent value="over-time" className="pb-0">
+            {data.overTimeData.length > 0 ? (
+              <MetricsLineChart data={data.overTimeData} series={series} yDomain={[0, 1]} />
+            ) : (
+              <MetricsCard.NoData message="No time series data yet" />
+            )}
+          </TabContent>
+          <TabContent value="summary">
+            <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+              <DataList.Top>
+                <DataList.TopCell sticky="start">Scorer</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Avg</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Min</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Max</DataList.TopCell>
+                <DataList.TopCell className="justify-end text-right">Count</DataList.TopCell>
+              </DataList.Top>
+              {data.summaryData.map(row => (
+                <DataList.RowStatic key={row.scorer}>
+                  <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                    {row.scorer}
+                  </DataList.RowHeaderCell>
+                  <DataList.NumberCell highlight>{row.avg.toFixed(2)}</DataList.NumberCell>
+                  <DataList.NumberCell>{row.min.toFixed(2)}</DataList.NumberCell>
+                  <DataList.NumberCell>{row.max.toFixed(2)}</DataList.NumberCell>
+                  <DataList.NumberCell>{row.count.toLocaleString()}</DataList.NumberCell>
+                </DataList.RowStatic>
+              ))}
+            </DataList>
+          </TabContent>
+        </Tabs>
+      </MetricsCard.Content>
+    );
+  }
+
   return (
     <MetricsCard>
       <MetricsCard.TopBar>
         <MetricsCard.TitleAndDescription title="Scores" description="Evaluation scorer performance." />
       </MetricsCard.TopBar>
-      {isLoading ? (
-        <MetricsCard.Loading />
-      ) : isError ? (
-        <MetricsCard.Error message="Failed to load scores data" />
-      ) : (
-        <MetricsCard.Content>
-          {!hasData ? (
-            <MetricsCard.NoData message="No scores data yet" />
-          ) : (
-            <Tabs defaultTab="over-time" className="overflow-visible">
-              <TabList>
-                <Tab value="over-time">Over Time</Tab>
-                <Tab value="summary">Summary</Tab>
-              </TabList>
-              <TabContent value="over-time" className="pb-0">
-                {data.overTimeData.length > 0 ? (
-                  <MetricsLineChart data={data.overTimeData} series={series} yDomain={[0, 1]} />
-                ) : (
-                  <MetricsCard.NoData message="No time series data yet" />
-                )}
-              </TabContent>
-              <TabContent value="summary">
-                <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-                  <DataList.Top>
-                    <DataList.TopCell sticky="start">Scorer</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Avg</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Min</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Max</DataList.TopCell>
-                    <DataList.TopCell className="justify-end text-right">Count</DataList.TopCell>
-                  </DataList.Top>
-                  {data.summaryData.map(row => (
-                    <DataList.RowStatic key={row.scorer}>
-                      <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                        {row.scorer}
-                      </DataList.RowHeaderCell>
-                      <DataList.NumberCell highlight>{row.avg.toFixed(2)}</DataList.NumberCell>
-                      <DataList.NumberCell>{row.min.toFixed(2)}</DataList.NumberCell>
-                      <DataList.NumberCell>{row.max.toFixed(2)}</DataList.NumberCell>
-                      <DataList.NumberCell>{row.count.toLocaleString()}</DataList.NumberCell>
-                    </DataList.RowStatic>
-                  ))}
-                </DataList>
-              </TabContent>
-            </Tabs>
-          )}
-        </MetricsCard.Content>
-      )}
+      {cardBody}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/scores-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/scores-card-view.tsx
@@ -20,6 +20,7 @@ const SERIES_COLORS = [
 ];
 
 type MetricsLineChartSeries = ComponentProps<typeof MetricsLineChart>['series'];
+type ScoresCardData = NonNullable<ScoresCardViewProps['data']>;
 
 export interface ScoresCardViewProps {
   data:
@@ -34,67 +35,48 @@ export interface ScoresCardViewProps {
   isError: boolean;
 }
 
-function ScoresCardBody({
-  data,
-  isLoading,
-  isError,
-  series,
-}: ScoresCardViewProps & { series: MetricsLineChartSeries }) {
-  if (isLoading) {
-    return <MetricsCard.Loading />;
-  }
-  if (isError) {
-    return <MetricsCard.Error message="Failed to load scores data" />;
-  }
-  if (!data || (data.summaryData.length === 0 && data.overTimeData.length === 0)) {
-    return (
-      <MetricsCard.Content>
-        <MetricsCard.NoData message="No scores data yet" />
-      </MetricsCard.Content>
-    );
-  }
+function ScoresCardContent({ data, series }: { data: ScoresCardData; series: MetricsLineChartSeries }) {
   return (
-    <MetricsCard.Content>
-      <Tabs defaultTab="over-time" className="overflow-visible">
-        <TabList>
-          <Tab value="over-time">Over Time</Tab>
-          <Tab value="summary">Summary</Tab>
-        </TabList>
-        <TabContent value="over-time" className="pb-0">
-          {data.overTimeData.length > 0 ? (
-            <MetricsLineChart data={data.overTimeData} series={series} yDomain={[0, 1]} />
-          ) : (
-            <MetricsCard.NoData message="No time series data yet" />
-          )}
-        </TabContent>
-        <TabContent value="summary">
-          <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
-            <DataList.Top>
-              <DataList.TopCell sticky="start">Scorer</DataList.TopCell>
-              <DataList.TopCell className="justify-end text-right">Avg</DataList.TopCell>
-              <DataList.TopCell className="justify-end text-right">Min</DataList.TopCell>
-              <DataList.TopCell className="justify-end text-right">Max</DataList.TopCell>
-              <DataList.TopCell className="justify-end text-right">Count</DataList.TopCell>
-            </DataList.Top>
-            {data.summaryData.map(row => (
-              <DataList.RowStatic key={row.scorer}>
-                <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                  {row.scorer}
-                </DataList.RowHeaderCell>
-                <DataList.NumberCell highlight>{row.avg.toFixed(2)}</DataList.NumberCell>
-                <DataList.NumberCell>{row.min.toFixed(2)}</DataList.NumberCell>
-                <DataList.NumberCell>{row.max.toFixed(2)}</DataList.NumberCell>
-                <DataList.NumberCell>{row.count.toLocaleString()}</DataList.NumberCell>
-              </DataList.RowStatic>
-            ))}
-          </DataList>
-        </TabContent>
-      </Tabs>
-    </MetricsCard.Content>
+    <Tabs defaultTab="over-time" className="overflow-visible">
+      <TabList>
+        <Tab value="over-time">Over Time</Tab>
+        <Tab value="summary">Summary</Tab>
+      </TabList>
+      <TabContent value="over-time" className="pb-0">
+        {data.overTimeData.length > 0 ? (
+          <MetricsLineChart data={data.overTimeData} series={series} yDomain={[0, 1]} />
+        ) : (
+          <MetricsCard.NoData message="No time series data yet" />
+        )}
+      </TabContent>
+      <TabContent value="summary">
+        <DataList columns="auto auto auto auto auto" {...METRICS_DATA_LIST_PROPS}>
+          <DataList.Top>
+            <DataList.TopCell sticky="start">Scorer</DataList.TopCell>
+            <DataList.TopCell className="justify-end text-right">Avg</DataList.TopCell>
+            <DataList.TopCell className="justify-end text-right">Min</DataList.TopCell>
+            <DataList.TopCell className="justify-end text-right">Max</DataList.TopCell>
+            <DataList.TopCell className="justify-end text-right">Count</DataList.TopCell>
+          </DataList.Top>
+          {data.summaryData.map(row => (
+            <DataList.RowStatic key={row.scorer}>
+              <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                {row.scorer}
+              </DataList.RowHeaderCell>
+              <DataList.NumberCell highlight>{row.avg.toFixed(2)}</DataList.NumberCell>
+              <DataList.NumberCell>{row.min.toFixed(2)}</DataList.NumberCell>
+              <DataList.NumberCell>{row.max.toFixed(2)}</DataList.NumberCell>
+              <DataList.NumberCell>{row.count.toLocaleString()}</DataList.NumberCell>
+            </DataList.RowStatic>
+          ))}
+        </DataList>
+      </TabContent>
+    </Tabs>
   );
 }
 
 export function ScoresCardView({ data, isLoading, isError }: ScoresCardViewProps) {
+  const hasData = !!data && (data.summaryData.length > 0 || data.overTimeData.length > 0);
   const series = useMemo(() => {
     if (!data?.scorerNames) return [];
     return data.scorerNames.map((name, i) => ({
@@ -116,7 +98,17 @@ export function ScoresCardView({ data, isLoading, isError }: ScoresCardViewProps
       <MetricsCard.TopBar>
         <MetricsCard.TitleAndDescription title="Scores" description="Evaluation scorer performance." />
       </MetricsCard.TopBar>
-      <ScoresCardBody data={data} isLoading={isLoading} isError={isError} series={series} />
+      {isLoading && <MetricsCard.Loading />}
+      {!isLoading && isError && <MetricsCard.Error message="Failed to load scores data" />}
+      {!isLoading && !isError && (
+        <MetricsCard.Content>
+          {hasData && data ? (
+            <ScoresCardContent data={data} series={series} />
+          ) : (
+            <MetricsCard.NoData message="No scores data yet" />
+          )}
+        </MetricsCard.Content>
+      )}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/token-usage-by-agent-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/token-usage-by-agent-card-view.tsx
@@ -28,87 +28,80 @@ function isTokenUsageTab(value: string): value is TokenUsageTab {
   return value === 'tokens' || value === 'cost';
 }
 
-function TokenUsageByAgentCardBody({
+type TokenUsageTabs = {
+  activeTab: TokenUsageTab;
+  onTabChange: (tab: TokenUsageTab) => void;
+};
+
+type TokenUsageLinks = {
+  getRowHref: TokenUsageByAgentCardViewProps['getRowHref'];
+  LinkComponent: TokenUsageByAgentCardViewProps['LinkComponent'];
+};
+
+function getCostRows(rows: TokenUsageByAgentRow[]) {
+  return rows.filter((d): d is TokenUsageByAgentRow & { cost: number } => d.cost != null && d.cost > 0);
+}
+
+function TokenUsageByAgentContent({
   rows,
-  isLoading,
-  isError,
-  activeTab,
-  setActiveTab,
-  costRows,
-  hasCostData,
+  tabs,
+  links,
   costUnit,
-  getRowHref,
-  LinkComponent,
 }: {
   rows: TokenUsageByAgentRow[];
-  isLoading: boolean;
-  isError: boolean;
-  activeTab: TokenUsageTab;
-  setActiveTab: (tab: TokenUsageTab) => void;
-  costRows: (TokenUsageByAgentRow & { cost: number })[];
-  hasCostData: boolean;
+  tabs: TokenUsageTabs;
+  links: TokenUsageLinks;
   costUnit: string | null;
-  getRowHref?: (row: TokenUsageByAgentRow) => string | undefined;
-  LinkComponent?: LinkComponent;
 }) {
-  if (isLoading) {
-    return <MetricsCard.Loading />;
-  }
-  if (isError) {
-    return <MetricsCard.Error message="Failed to load token usage data" />;
-  }
+  const costRows = getCostRows(rows);
+  const hasCostData = costUnit != null && costRows.length > 0;
+
   return (
-    <MetricsCard.Content>
-      {rows.length === 0 ? (
-        <MetricsCard.NoData message="No token usage data yet" />
-      ) : (
-        <Tabs
-          defaultTab="tokens"
-          value={activeTab}
-          onValueChange={v => {
-            if (isTokenUsageTab(v)) setActiveTab(v);
-          }}
-          className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
-        >
-          <TabList>
-            <Tab value="tokens">Tokens</Tab>
-            <Tab value="cost">Cost</Tab>
-          </TabList>
-          <TabContent value="tokens">
-            <HorizontalBars
-              LinkComponent={LinkComponent}
-              data={rows.map(d => ({
-                name: d.name,
-                values: [d.input, d.output],
-                href: getRowHref?.(d),
-              }))}
-              segments={[
-                { label: 'Input', color: CHART_COLORS.blueDark },
-                { label: 'Output', color: CHART_COLORS.blue },
-              ]}
-              maxVal={Math.max(...rows.map(d => d.input + d.output))}
-              fmt={formatCompact}
-            />
-          </TabContent>
-          <TabContent value="cost">
-            {hasCostData ? (
-              <HorizontalBars
-                LinkComponent={LinkComponent}
-                data={costRows
-                  .slice()
-                  .sort((a, b) => (b.cost ?? 0) - (a.cost ?? 0))
-                  .map(d => ({ name: d.name, values: [d.cost], href: getRowHref?.(d) }))}
-                segments={[{ label: 'Cost', color: CHART_COLORS.purple }]}
-                maxVal={Math.max(...costRows.map(d => d.cost ?? 0))}
-                fmt={v => formatCost(v, costUnit)}
-              />
-            ) : (
-              <MetricsCard.NoData message="No cost data yet" />
-            )}
-          </TabContent>
-        </Tabs>
-      )}
-    </MetricsCard.Content>
+    <Tabs
+      defaultTab="tokens"
+      value={tabs.activeTab}
+      onValueChange={v => {
+        if (isTokenUsageTab(v)) tabs.onTabChange(v);
+      }}
+      className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
+    >
+      <TabList>
+        <Tab value="tokens">Tokens</Tab>
+        <Tab value="cost">Cost</Tab>
+      </TabList>
+      <TabContent value="tokens">
+        <HorizontalBars
+          LinkComponent={links.LinkComponent}
+          data={rows.map(d => ({
+            name: d.name,
+            values: [d.input, d.output],
+            href: links.getRowHref?.(d),
+          }))}
+          segments={[
+            { label: 'Input', color: CHART_COLORS.blueDark },
+            { label: 'Output', color: CHART_COLORS.blue },
+          ]}
+          maxVal={Math.max(...rows.map(d => d.input + d.output))}
+          fmt={formatCompact}
+        />
+      </TabContent>
+      <TabContent value="cost">
+        {hasCostData ? (
+          <HorizontalBars
+            LinkComponent={links.LinkComponent}
+            data={costRows
+              .slice()
+              .sort((a, b) => b.cost - a.cost)
+              .map(d => ({ name: d.name, values: [d.cost], href: links.getRowHref?.(d) }))}
+            segments={[{ label: 'Cost', color: CHART_COLORS.purple }]}
+            maxVal={Math.max(...costRows.map(d => d.cost))}
+            fmt={v => formatCost(v, costUnit)}
+          />
+        ) : (
+          <MetricsCard.NoData message="No cost data yet" />
+        )}
+      </TabContent>
+    </Tabs>
   );
 }
 
@@ -125,11 +118,11 @@ export function TokenUsageByAgentCardView({
   const rows = data ?? [];
   const hasData = rows.length > 0;
   const totalTokens = rows.reduce((s, d) => s + d.total, 0);
-  const costRows = rows.filter((d): d is TokenUsageByAgentRow & { cost: number } => d.cost != null && d.cost > 0);
+  const costRows = getCostRows(rows);
   const uniqueCostUnits = new Set(costRows.map(d => d.costUnit ?? 'usd'));
   const hasSingleCostUnit = uniqueCostUnits.size <= 1;
   const costUnit = hasSingleCostUnit ? ([...uniqueCostUnits][0] ?? 'usd') : null;
-  const totalCost = hasSingleCostUnit ? costRows.reduce((s, d) => s + (d.cost ?? 0), 0) : 0;
+  const totalCost = hasSingleCostUnit ? costRows.reduce((s, d) => s + d.cost, 0) : 0;
   const hasCostData = hasSingleCostUnit && totalCost > 0;
 
   return (
@@ -147,18 +140,22 @@ export function TokenUsageByAgentCardView({
           ))}
         {hasData && actions ? <MetricsCard.Actions>{actions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      <TokenUsageByAgentCardBody
-        rows={rows}
-        isLoading={isLoading}
-        isError={isError}
-        activeTab={activeTab}
-        setActiveTab={setActiveTab}
-        costRows={costRows}
-        hasCostData={hasCostData}
-        costUnit={costUnit}
-        getRowHref={getRowHref}
-        LinkComponent={LinkComponent}
-      />
+      {isLoading && <MetricsCard.Loading />}
+      {!isLoading && isError && <MetricsCard.Error message="Failed to load token usage data" />}
+      {!isLoading && !isError && (
+        <MetricsCard.Content>
+          {rows.length === 0 ? (
+            <MetricsCard.NoData message="No token usage data yet" />
+          ) : (
+            <TokenUsageByAgentContent
+              rows={rows}
+              tabs={{ activeTab, onTabChange: setActiveTab }}
+              links={{ getRowHref, LinkComponent }}
+              costUnit={costUnit}
+            />
+          )}
+        </MetricsCard.Content>
+      )}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/token-usage-by-agent-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/token-usage-by-agent-card-view.tsx
@@ -28,6 +28,90 @@ function isTokenUsageTab(value: string): value is TokenUsageTab {
   return value === 'tokens' || value === 'cost';
 }
 
+function TokenUsageByAgentCardBody({
+  rows,
+  isLoading,
+  isError,
+  activeTab,
+  setActiveTab,
+  costRows,
+  hasCostData,
+  costUnit,
+  getRowHref,
+  LinkComponent,
+}: {
+  rows: TokenUsageByAgentRow[];
+  isLoading: boolean;
+  isError: boolean;
+  activeTab: TokenUsageTab;
+  setActiveTab: (tab: TokenUsageTab) => void;
+  costRows: (TokenUsageByAgentRow & { cost: number })[];
+  hasCostData: boolean;
+  costUnit: string | null;
+  getRowHref?: (row: TokenUsageByAgentRow) => string | undefined;
+  LinkComponent?: LinkComponent;
+}) {
+  if (isLoading) {
+    return <MetricsCard.Loading />;
+  }
+  if (isError) {
+    return <MetricsCard.Error message="Failed to load token usage data" />;
+  }
+  return (
+    <MetricsCard.Content>
+      {rows.length === 0 ? (
+        <MetricsCard.NoData message="No token usage data yet" />
+      ) : (
+        <Tabs
+          defaultTab="tokens"
+          value={activeTab}
+          onValueChange={v => {
+            if (isTokenUsageTab(v)) setActiveTab(v);
+          }}
+          className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
+        >
+          <TabList>
+            <Tab value="tokens">Tokens</Tab>
+            <Tab value="cost">Cost</Tab>
+          </TabList>
+          <TabContent value="tokens">
+            <HorizontalBars
+              LinkComponent={LinkComponent}
+              data={rows.map(d => ({
+                name: d.name,
+                values: [d.input, d.output],
+                href: getRowHref?.(d),
+              }))}
+              segments={[
+                { label: 'Input', color: CHART_COLORS.blueDark },
+                { label: 'Output', color: CHART_COLORS.blue },
+              ]}
+              maxVal={Math.max(...rows.map(d => d.input + d.output))}
+              fmt={formatCompact}
+            />
+          </TabContent>
+          <TabContent value="cost">
+            {hasCostData ? (
+              <HorizontalBars
+                LinkComponent={LinkComponent}
+                data={costRows
+                  .slice()
+                  .sort((a, b) => (b.cost ?? 0) - (a.cost ?? 0))
+                  .map(d => ({ name: d.name, values: [d.cost], href: getRowHref?.(d) }))}
+                segments={[{ label: 'Cost', color: CHART_COLORS.purple }]}
+                maxVal={Math.max(...costRows.map(d => d.cost ?? 0))}
+                fmt={v => formatCost(v, costUnit)}
+              />
+            ) : (
+              <MetricsCard.NoData message="No cost data yet" />
+            )}
+          </TabContent>
+        </Tabs>
+      )}
+    </MetricsCard.Content>
+  );
+}
+
 export function TokenUsageByAgentCardView({
   data,
   isLoading,
@@ -47,67 +131,6 @@ export function TokenUsageByAgentCardView({
   const costUnit = hasSingleCostUnit ? ([...uniqueCostUnits][0] ?? 'usd') : null;
   const totalCost = hasSingleCostUnit ? costRows.reduce((s, d) => s + (d.cost ?? 0), 0) : 0;
   const hasCostData = hasSingleCostUnit && totalCost > 0;
-  let cardBody: ReactNode;
-
-  if (isLoading) {
-    cardBody = <MetricsCard.Loading />;
-  } else if (isError) {
-    cardBody = <MetricsCard.Error message="Failed to load token usage data" />;
-  } else {
-    cardBody = (
-      <MetricsCard.Content>
-        {!hasData ? (
-          <MetricsCard.NoData message="No token usage data yet" />
-        ) : (
-          <Tabs
-            defaultTab="tokens"
-            value={activeTab}
-            onValueChange={v => {
-              if (isTokenUsageTab(v)) setActiveTab(v);
-            }}
-            className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
-          >
-            <TabList>
-              <Tab value="tokens">Tokens</Tab>
-              <Tab value="cost">Cost</Tab>
-            </TabList>
-            <TabContent value="tokens">
-              <HorizontalBars
-                LinkComponent={LinkComponent}
-                data={rows.map(d => ({
-                  name: d.name,
-                  values: [d.input, d.output],
-                  href: getRowHref?.(d),
-                }))}
-                segments={[
-                  { label: 'Input', color: CHART_COLORS.blueDark },
-                  { label: 'Output', color: CHART_COLORS.blue },
-                ]}
-                maxVal={Math.max(...rows.map(d => d.input + d.output))}
-                fmt={formatCompact}
-              />
-            </TabContent>
-            <TabContent value="cost">
-              {hasCostData ? (
-                <HorizontalBars
-                  LinkComponent={LinkComponent}
-                  data={costRows
-                    .slice()
-                    .sort((a, b) => (b.cost ?? 0) - (a.cost ?? 0))
-                    .map(d => ({ name: d.name, values: [d.cost], href: getRowHref?.(d) }))}
-                  segments={[{ label: 'Cost', color: CHART_COLORS.purple }]}
-                  maxVal={Math.max(...costRows.map(d => d.cost ?? 0))}
-                  fmt={v => formatCost(v, costUnit)}
-                />
-              ) : (
-                <MetricsCard.NoData message="No cost data yet" />
-              )}
-            </TabContent>
-          </Tabs>
-        )}
-      </MetricsCard.Content>
-    );
-  }
 
   return (
     <MetricsCard>
@@ -124,7 +147,18 @@ export function TokenUsageByAgentCardView({
           ))}
         {hasData && actions ? <MetricsCard.Actions>{actions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {cardBody}
+      <TokenUsageByAgentCardBody
+        rows={rows}
+        isLoading={isLoading}
+        isError={isError}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        costRows={costRows}
+        hasCostData={hasCostData}
+        costUnit={costUnit}
+        getRowHref={getRowHref}
+        LinkComponent={LinkComponent}
+      />
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/token-usage-by-agent-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/token-usage-by-agent-card-view.tsx
@@ -47,6 +47,67 @@ export function TokenUsageByAgentCardView({
   const costUnit = hasSingleCostUnit ? ([...uniqueCostUnits][0] ?? 'usd') : null;
   const totalCost = hasSingleCostUnit ? costRows.reduce((s, d) => s + (d.cost ?? 0), 0) : 0;
   const hasCostData = hasSingleCostUnit && totalCost > 0;
+  let cardBody: ReactNode;
+
+  if (isLoading) {
+    cardBody = <MetricsCard.Loading />;
+  } else if (isError) {
+    cardBody = <MetricsCard.Error message="Failed to load token usage data" />;
+  } else {
+    cardBody = (
+      <MetricsCard.Content>
+        {!hasData ? (
+          <MetricsCard.NoData message="No token usage data yet" />
+        ) : (
+          <Tabs
+            defaultTab="tokens"
+            value={activeTab}
+            onValueChange={v => {
+              if (isTokenUsageTab(v)) setActiveTab(v);
+            }}
+            className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
+          >
+            <TabList>
+              <Tab value="tokens">Tokens</Tab>
+              <Tab value="cost">Cost</Tab>
+            </TabList>
+            <TabContent value="tokens">
+              <HorizontalBars
+                LinkComponent={LinkComponent}
+                data={rows.map(d => ({
+                  name: d.name,
+                  values: [d.input, d.output],
+                  href: getRowHref?.(d),
+                }))}
+                segments={[
+                  { label: 'Input', color: CHART_COLORS.blueDark },
+                  { label: 'Output', color: CHART_COLORS.blue },
+                ]}
+                maxVal={Math.max(...rows.map(d => d.input + d.output))}
+                fmt={formatCompact}
+              />
+            </TabContent>
+            <TabContent value="cost">
+              {hasCostData ? (
+                <HorizontalBars
+                  LinkComponent={LinkComponent}
+                  data={costRows
+                    .slice()
+                    .sort((a, b) => (b.cost ?? 0) - (a.cost ?? 0))
+                    .map(d => ({ name: d.name, values: [d.cost], href: getRowHref?.(d) }))}
+                  segments={[{ label: 'Cost', color: CHART_COLORS.purple }]}
+                  maxVal={Math.max(...costRows.map(d => d.cost ?? 0))}
+                  fmt={v => formatCost(v, costUnit)}
+                />
+              ) : (
+                <MetricsCard.NoData message="No cost data yet" />
+              )}
+            </TabContent>
+          </Tabs>
+        )}
+      </MetricsCard.Content>
+    );
+  }
 
   return (
     <MetricsCard>
@@ -63,63 +124,7 @@ export function TokenUsageByAgentCardView({
           ))}
         {hasData && actions ? <MetricsCard.Actions>{actions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {isLoading ? (
-        <MetricsCard.Loading />
-      ) : isError ? (
-        <MetricsCard.Error message="Failed to load token usage data" />
-      ) : (
-        <MetricsCard.Content>
-          {!hasData ? (
-            <MetricsCard.NoData message="No token usage data yet" />
-          ) : (
-            <Tabs
-              defaultTab="tokens"
-              value={activeTab}
-              onValueChange={v => {
-                if (isTokenUsageTab(v)) setActiveTab(v);
-              }}
-              className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
-            >
-              <TabList>
-                <Tab value="tokens">Tokens</Tab>
-                <Tab value="cost">Cost</Tab>
-              </TabList>
-              <TabContent value="tokens">
-                <HorizontalBars
-                  LinkComponent={LinkComponent}
-                  data={rows.map(d => ({
-                    name: d.name,
-                    values: [d.input, d.output],
-                    href: getRowHref?.(d),
-                  }))}
-                  segments={[
-                    { label: 'Input', color: CHART_COLORS.blueDark },
-                    { label: 'Output', color: CHART_COLORS.blue },
-                  ]}
-                  maxVal={Math.max(...rows.map(d => d.input + d.output))}
-                  fmt={formatCompact}
-                />
-              </TabContent>
-              <TabContent value="cost">
-                {hasCostData ? (
-                  <HorizontalBars
-                    LinkComponent={LinkComponent}
-                    data={costRows
-                      .slice()
-                      .sort((a, b) => (b.cost ?? 0) - (a.cost ?? 0))
-                      .map(d => ({ name: d.name, values: [d.cost], href: getRowHref?.(d) }))}
-                    segments={[{ label: 'Cost', color: CHART_COLORS.purple }]}
-                    maxVal={Math.max(...costRows.map(d => d.cost ?? 0))}
-                    fmt={v => formatCost(v, costUnit)}
-                  />
-                ) : (
-                  <MetricsCard.NoData message="No cost data yet" />
-                )}
-              </TabContent>
-            </Tabs>
-          )}
-        </MetricsCard.Content>
-      )}
+      {cardBody}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/token-usage-timeline-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/token-usage-timeline-card-view.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import { MetricsCard } from '../../../ds/components/MetricsCard';
 import { MetricsLineChart } from '../../../ds/components/MetricsLineChart';
 import { Tab, TabContent, TabList, Tabs } from '../../../ds/components/Tabs';
@@ -7,6 +7,7 @@ import type { TokenTimelinePoint, TokenUsageTimeSeriesInterval } from '../hooks/
 import { CHART_COLORS, formatCompact, formatCost } from './metrics-utils';
 
 type TokenUsageTimelineTab = 'tokens' | 'cost';
+type TokenUsageTimelineStatus = 'loading' | 'error' | 'empty' | 'ready';
 
 function sumMetric(dataKey: 'input' | 'output' | 'cost', formatter: (value: number) => string = formatCompact) {
   return (data: Record<string, unknown>[]) => ({
@@ -29,8 +30,28 @@ const tokenSeries = [
   },
 ];
 
+type MetricsLineChartSeries = ComponentProps<typeof MetricsLineChart>['series'];
+type MetricsLineChartData = ComponentProps<typeof MetricsLineChart>['data'];
+
 function isTokenUsageTimelineTab(value: string): value is TokenUsageTimelineTab {
   return value === 'tokens' || value === 'cost';
+}
+
+function getTokenUsageTimelineStatus({
+  isLoading,
+  isError,
+  hasData,
+}: Pick<TokenUsageTimelineCardViewProps, 'isLoading' | 'isError'> & { hasData: boolean }): TokenUsageTimelineStatus {
+  if (isLoading) {
+    return 'loading';
+  }
+  if (isError) {
+    return 'error';
+  }
+  if (!hasData) {
+    return 'empty';
+  }
+  return 'ready';
 }
 
 export interface TokenUsageTimelineCardViewProps {
@@ -39,6 +60,65 @@ export interface TokenUsageTimelineCardViewProps {
   isLoading: boolean;
   isError: boolean;
   actions?: ReactNode;
+}
+
+function TokenUsageTimelineCardBody({
+  status,
+  activeTab,
+  setActiveTab,
+  chartPoints,
+  costChartPoints,
+  costSeries,
+  hasCostData,
+}: {
+  status: TokenUsageTimelineStatus;
+  activeTab: TokenUsageTimelineTab;
+  setActiveTab: (tab: TokenUsageTimelineTab) => void;
+  chartPoints: MetricsLineChartData;
+  costChartPoints: MetricsLineChartData;
+  costSeries: MetricsLineChartSeries;
+  hasCostData: boolean;
+}) {
+  if (status === 'loading') {
+    return <MetricsCard.Loading />;
+  }
+  if (status === 'error') {
+    return <MetricsCard.Error message="Failed to load token usage timeline" />;
+  }
+  if (status === 'empty') {
+    return (
+      <MetricsCard.Content>
+        <MetricsCard.NoData message="No token usage data yet" />
+      </MetricsCard.Content>
+    );
+  }
+  return (
+    <MetricsCard.Content>
+      <Tabs
+        defaultTab="tokens"
+        value={activeTab}
+        onValueChange={value => {
+          if (isTokenUsageTimelineTab(value)) setActiveTab(value);
+        }}
+        className="overflow-visible"
+      >
+        <TabList>
+          <Tab value="tokens">Tokens</Tab>
+          <Tab value="cost">Cost</Tab>
+        </TabList>
+        <TabContent value="tokens">
+          <MetricsLineChart data={chartPoints} series={tokenSeries} />
+        </TabContent>
+        <TabContent value="cost">
+          {hasCostData ? (
+            <MetricsLineChart data={costChartPoints} series={costSeries} />
+          ) : (
+            <MetricsCard.NoData message="No cost data yet" />
+          )}
+        </TabContent>
+      </Tabs>
+    </MetricsCard.Content>
+  );
 }
 
 export function TokenUsageTimelineCardView({
@@ -51,17 +131,18 @@ export function TokenUsageTimelineCardView({
   const [activeTab, setActiveTab] = useState<TokenUsageTimelineTab>('tokens');
 
   const points = data ?? [];
-  const chartPoints = points.map(point => ({ ...point }));
+  const chartPoints: MetricsLineChartData = points.map(point => ({ ...point }));
   const hasData = points.length > 0;
   const totalTokens = points.reduce((sum, point) => sum + point.total, 0);
   const costPoints = points.filter(point => point.cost != null && point.cost > 0);
-  const costChartPoints = costPoints.map(point => ({ ...point }));
+  const costChartPoints: MetricsLineChartData = costPoints.map(point => ({ ...point }));
   const uniqueCostUnits = new Set(costPoints.map(point => point.costUnit).filter((unit): unit is string => !!unit));
   const hasSingleCostUnit = uniqueCostUnits.size === 1 && costPoints.every(point => point.costUnit != null);
   const costUnit = hasSingleCostUnit ? ([...uniqueCostUnits][0] ?? null) : null;
   const totalCost = hasSingleCostUnit ? costPoints.reduce((sum, point) => sum + (point.cost ?? 0), 0) : 0;
   const hasCostData = hasSingleCostUnit && totalCost > 0;
   const description = interval === '1h' ? 'Input and output tokens per hour.' : 'Input and output tokens per day.';
+  const status = getTokenUsageTimelineStatus({ isLoading, isError, hasData });
 
   const costSeries = [
     {
@@ -84,45 +165,15 @@ export function TokenUsageTimelineCardView({
           ))}
         {hasData && actions ? <MetricsCard.Actions>{actions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {(() => {
-        if (isLoading) {
-          return <MetricsCard.Loading />;
-        }
-        if (isError) {
-          return <MetricsCard.Error message="Failed to load token usage timeline" />;
-        }
-        return (
-          <MetricsCard.Content>
-            {!hasData ? (
-              <MetricsCard.NoData message="No token usage data yet" />
-            ) : (
-              <Tabs
-                defaultTab="tokens"
-                value={activeTab}
-                onValueChange={value => {
-                  if (isTokenUsageTimelineTab(value)) setActiveTab(value);
-                }}
-                className="overflow-visible"
-              >
-                <TabList>
-                  <Tab value="tokens">Tokens</Tab>
-                  <Tab value="cost">Cost</Tab>
-                </TabList>
-                <TabContent value="tokens">
-                  <MetricsLineChart data={chartPoints} series={tokenSeries} />
-                </TabContent>
-                <TabContent value="cost">
-                  {hasCostData ? (
-                    <MetricsLineChart data={costChartPoints} series={costSeries} />
-                  ) : (
-                    <MetricsCard.NoData message="No cost data yet" />
-                  )}
-                </TabContent>
-              </Tabs>
-            )}
-          </MetricsCard.Content>
-        );
-      })()}
+      <TokenUsageTimelineCardBody
+        status={status}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        chartPoints={chartPoints}
+        costChartPoints={costChartPoints}
+        costSeries={costSeries}
+        hasCostData={hasCostData}
+      />
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/token-usage-timeline-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/token-usage-timeline-card-view.tsx
@@ -84,41 +84,45 @@ export function TokenUsageTimelineCardView({
           ))}
         {hasData && actions ? <MetricsCard.Actions>{actions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {isLoading ? (
-        <MetricsCard.Loading />
-      ) : isError ? (
-        <MetricsCard.Error message="Failed to load token usage timeline" />
-      ) : (
-        <MetricsCard.Content>
-          {!hasData ? (
-            <MetricsCard.NoData message="No token usage data yet" />
-          ) : (
-            <Tabs
-              defaultTab="tokens"
-              value={activeTab}
-              onValueChange={value => {
-                if (isTokenUsageTimelineTab(value)) setActiveTab(value);
-              }}
-              className="overflow-visible"
-            >
-              <TabList>
-                <Tab value="tokens">Tokens</Tab>
-                <Tab value="cost">Cost</Tab>
-              </TabList>
-              <TabContent value="tokens">
-                <MetricsLineChart data={chartPoints} series={tokenSeries} />
-              </TabContent>
-              <TabContent value="cost">
-                {hasCostData ? (
-                  <MetricsLineChart data={costChartPoints} series={costSeries} />
-                ) : (
-                  <MetricsCard.NoData message="No cost data yet" />
-                )}
-              </TabContent>
-            </Tabs>
-          )}
-        </MetricsCard.Content>
-      )}
+      {(() => {
+        if (isLoading) {
+          return <MetricsCard.Loading />;
+        }
+        if (isError) {
+          return <MetricsCard.Error message="Failed to load token usage timeline" />;
+        }
+        return (
+          <MetricsCard.Content>
+            {!hasData ? (
+              <MetricsCard.NoData message="No token usage data yet" />
+            ) : (
+              <Tabs
+                defaultTab="tokens"
+                value={activeTab}
+                onValueChange={value => {
+                  if (isTokenUsageTimelineTab(value)) setActiveTab(value);
+                }}
+                className="overflow-visible"
+              >
+                <TabList>
+                  <Tab value="tokens">Tokens</Tab>
+                  <Tab value="cost">Cost</Tab>
+                </TabList>
+                <TabContent value="tokens">
+                  <MetricsLineChart data={chartPoints} series={tokenSeries} />
+                </TabContent>
+                <TabContent value="cost">
+                  {hasCostData ? (
+                    <MetricsLineChart data={costChartPoints} series={costSeries} />
+                  ) : (
+                    <MetricsCard.NoData message="No cost data yet" />
+                  )}
+                </TabContent>
+              </Tabs>
+            )}
+          </MetricsCard.Content>
+        );
+      })()}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/token-usage-timeline-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/token-usage-timeline-card-view.tsx
@@ -7,7 +7,6 @@ import type { TokenTimelinePoint, TokenUsageTimeSeriesInterval } from '../hooks/
 import { CHART_COLORS, formatCompact, formatCost } from './metrics-utils';
 
 type TokenUsageTimelineTab = 'tokens' | 'cost';
-type TokenUsageTimelineStatus = 'loading' | 'error' | 'empty' | 'ready';
 
 function sumMetric(dataKey: 'input' | 'output' | 'cost', formatter: (value: number) => string = formatCompact) {
   return (data: Record<string, unknown>[]) => ({
@@ -37,23 +36,6 @@ function isTokenUsageTimelineTab(value: string): value is TokenUsageTimelineTab 
   return value === 'tokens' || value === 'cost';
 }
 
-function getTokenUsageTimelineStatus({
-  isLoading,
-  isError,
-  hasData,
-}: Pick<TokenUsageTimelineCardViewProps, 'isLoading' | 'isError'> & { hasData: boolean }): TokenUsageTimelineStatus {
-  if (isLoading) {
-    return 'loading';
-  }
-  if (isError) {
-    return 'error';
-  }
-  if (!hasData) {
-    return 'empty';
-  }
-  return 'ready';
-}
-
 export interface TokenUsageTimelineCardViewProps {
   data: TokenTimelinePoint[] | undefined;
   interval: TokenUsageTimeSeriesInterval | undefined;
@@ -62,62 +44,43 @@ export interface TokenUsageTimelineCardViewProps {
   actions?: ReactNode;
 }
 
-function TokenUsageTimelineCardBody({
-  status,
+function TokenUsageTimelineContent({
   activeTab,
-  setActiveTab,
+  onTabChange,
   chartPoints,
   costChartPoints,
   costSeries,
-  hasCostData,
 }: {
-  status: TokenUsageTimelineStatus;
   activeTab: TokenUsageTimelineTab;
-  setActiveTab: (tab: TokenUsageTimelineTab) => void;
+  onTabChange: (tab: TokenUsageTimelineTab) => void;
   chartPoints: MetricsLineChartData;
   costChartPoints: MetricsLineChartData;
   costSeries: MetricsLineChartSeries;
-  hasCostData: boolean;
 }) {
-  if (status === 'loading') {
-    return <MetricsCard.Loading />;
-  }
-  if (status === 'error') {
-    return <MetricsCard.Error message="Failed to load token usage timeline" />;
-  }
-  if (status === 'empty') {
-    return (
-      <MetricsCard.Content>
-        <MetricsCard.NoData message="No token usage data yet" />
-      </MetricsCard.Content>
-    );
-  }
   return (
-    <MetricsCard.Content>
-      <Tabs
-        defaultTab="tokens"
-        value={activeTab}
-        onValueChange={value => {
-          if (isTokenUsageTimelineTab(value)) setActiveTab(value);
-        }}
-        className="overflow-visible"
-      >
-        <TabList>
-          <Tab value="tokens">Tokens</Tab>
-          <Tab value="cost">Cost</Tab>
-        </TabList>
-        <TabContent value="tokens">
-          <MetricsLineChart data={chartPoints} series={tokenSeries} />
-        </TabContent>
-        <TabContent value="cost">
-          {hasCostData ? (
-            <MetricsLineChart data={costChartPoints} series={costSeries} />
-          ) : (
-            <MetricsCard.NoData message="No cost data yet" />
-          )}
-        </TabContent>
-      </Tabs>
-    </MetricsCard.Content>
+    <Tabs
+      defaultTab="tokens"
+      value={activeTab}
+      onValueChange={value => {
+        if (isTokenUsageTimelineTab(value)) onTabChange(value);
+      }}
+      className="overflow-visible"
+    >
+      <TabList>
+        <Tab value="tokens">Tokens</Tab>
+        <Tab value="cost">Cost</Tab>
+      </TabList>
+      <TabContent value="tokens">
+        <MetricsLineChart data={chartPoints} series={tokenSeries} />
+      </TabContent>
+      <TabContent value="cost">
+        {costChartPoints.length > 0 ? (
+          <MetricsLineChart data={costChartPoints} series={costSeries} />
+        ) : (
+          <MetricsCard.NoData message="No cost data yet" />
+        )}
+      </TabContent>
+    </Tabs>
   );
 }
 
@@ -135,14 +98,13 @@ export function TokenUsageTimelineCardView({
   const hasData = points.length > 0;
   const totalTokens = points.reduce((sum, point) => sum + point.total, 0);
   const costPoints = points.filter(point => point.cost != null && point.cost > 0);
-  const costChartPoints: MetricsLineChartData = costPoints.map(point => ({ ...point }));
   const uniqueCostUnits = new Set(costPoints.map(point => point.costUnit).filter((unit): unit is string => !!unit));
   const hasSingleCostUnit = uniqueCostUnits.size === 1 && costPoints.every(point => point.costUnit != null);
   const costUnit = hasSingleCostUnit ? ([...uniqueCostUnits][0] ?? null) : null;
   const totalCost = hasSingleCostUnit ? costPoints.reduce((sum, point) => sum + (point.cost ?? 0), 0) : 0;
   const hasCostData = hasSingleCostUnit && totalCost > 0;
+  const costChartPoints: MetricsLineChartData = hasCostData ? costPoints.map(point => ({ ...point })) : [];
   const description = interval === '1h' ? 'Input and output tokens per hour.' : 'Input and output tokens per day.';
-  const status = getTokenUsageTimelineStatus({ isLoading, isError, hasData });
 
   const costSeries = [
     {
@@ -165,15 +127,24 @@ export function TokenUsageTimelineCardView({
           ))}
         {hasData && actions ? <MetricsCard.Actions>{actions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      <TokenUsageTimelineCardBody
-        status={status}
-        activeTab={activeTab}
-        setActiveTab={setActiveTab}
-        chartPoints={chartPoints}
-        costChartPoints={costChartPoints}
-        costSeries={costSeries}
-        hasCostData={hasCostData}
-      />
+      {isLoading && <MetricsCard.Loading />}
+      {!isLoading && isError && <MetricsCard.Error message="Failed to load token usage timeline" />}
+      {!isLoading && !isError && !hasData && (
+        <MetricsCard.Content>
+          <MetricsCard.NoData message="No token usage data yet" />
+        </MetricsCard.Content>
+      )}
+      {!isLoading && !isError && hasData && (
+        <MetricsCard.Content>
+          <TokenUsageTimelineContent
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            chartPoints={chartPoints}
+            costChartPoints={costChartPoints}
+            costSeries={costSeries}
+          />
+        </MetricsCard.Content>
+      )}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/traces-volume-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/traces-volume-card-view.tsx
@@ -94,6 +94,70 @@ export function TracesVolumeCardView({
   const tabErrorHrefs = (tab: VolumeTab) =>
     getErrorSegmentHref ? (row: VolumeRow) => getErrorSegmentHref(tab, row) : undefined;
 
+  let cardBody;
+  if (isLoading) {
+    cardBody = <MetricsCard.Loading />;
+  } else if (isError) {
+    cardBody = <MetricsCard.Error message="Failed to load trace volume data" />;
+  } else {
+    cardBody = (
+      <MetricsCard.Content>
+        {!hasData ? (
+          <MetricsCard.NoData message="No trace volume data yet" />
+        ) : (
+          <Tabs
+            value={activeTab}
+            onValueChange={setActiveTab}
+            defaultTab="agents"
+            className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
+          >
+            <TabList>
+              <Tab value="agents">Agents</Tab>
+              <Tab value="workflows">Workflows</Tab>
+              <Tab value="tools">Tools</Tab>
+            </TabList>
+            <TabContent value="agents">
+              {data.agentData.length > 0 ? (
+                <VolumeBars
+                  data={data.agentData}
+                  rowHrefs={tabRowHrefs('agents')}
+                  errorHrefs={tabErrorHrefs('agents')}
+                  LinkComponent={LinkComponent}
+                />
+              ) : (
+                <MetricsCard.NoData message="No agent data yet" />
+              )}
+            </TabContent>
+            <TabContent value="workflows">
+              {data.workflowData.length > 0 ? (
+                <VolumeBars
+                  data={data.workflowData}
+                  rowHrefs={tabRowHrefs('workflows')}
+                  errorHrefs={tabErrorHrefs('workflows')}
+                  LinkComponent={LinkComponent}
+                />
+              ) : (
+                <MetricsCard.NoData message="No workflow data yet" />
+              )}
+            </TabContent>
+            <TabContent value="tools">
+              {data.toolData.length > 0 ? (
+                <VolumeBars
+                  data={data.toolData}
+                  rowHrefs={tabRowHrefs('tools')}
+                  errorHrefs={tabErrorHrefs('tools')}
+                  LinkComponent={LinkComponent}
+                />
+              ) : (
+                <MetricsCard.NoData message="No tool data yet" />
+              )}
+            </TabContent>
+          </Tabs>
+        )}
+      </MetricsCard.Content>
+    );
+  }
+
   return (
     <MetricsCard>
       <MetricsCard.TopBar>
@@ -101,66 +165,7 @@ export function TracesVolumeCardView({
         {hasData && <MetricsCard.Summary value={formatCompact(total)} label="Total runs" />}
         {renderedActions ? <MetricsCard.Actions>{renderedActions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {isLoading ? (
-        <MetricsCard.Loading />
-      ) : isError ? (
-        <MetricsCard.Error message="Failed to load trace volume data" />
-      ) : (
-        <MetricsCard.Content>
-          {!hasData ? (
-            <MetricsCard.NoData message="No trace volume data yet" />
-          ) : (
-            <Tabs
-              value={activeTab}
-              onValueChange={setActiveTab}
-              defaultTab="agents"
-              className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
-            >
-              <TabList>
-                <Tab value="agents">Agents</Tab>
-                <Tab value="workflows">Workflows</Tab>
-                <Tab value="tools">Tools</Tab>
-              </TabList>
-              <TabContent value="agents">
-                {data.agentData.length > 0 ? (
-                  <VolumeBars
-                    data={data.agentData}
-                    rowHrefs={tabRowHrefs('agents')}
-                    errorHrefs={tabErrorHrefs('agents')}
-                    LinkComponent={LinkComponent}
-                  />
-                ) : (
-                  <MetricsCard.NoData message="No agent data yet" />
-                )}
-              </TabContent>
-              <TabContent value="workflows">
-                {data.workflowData.length > 0 ? (
-                  <VolumeBars
-                    data={data.workflowData}
-                    rowHrefs={tabRowHrefs('workflows')}
-                    errorHrefs={tabErrorHrefs('workflows')}
-                    LinkComponent={LinkComponent}
-                  />
-                ) : (
-                  <MetricsCard.NoData message="No workflow data yet" />
-                )}
-              </TabContent>
-              <TabContent value="tools">
-                {data.toolData.length > 0 ? (
-                  <VolumeBars
-                    data={data.toolData}
-                    rowHrefs={tabRowHrefs('tools')}
-                    errorHrefs={tabErrorHrefs('tools')}
-                    LinkComponent={LinkComponent}
-                  />
-                ) : (
-                  <MetricsCard.NoData message="No tool data yet" />
-                )}
-              </TabContent>
-            </Tabs>
-          )}
-        </MetricsCard.Content>
-      )}
+      {cardBody}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/traces-volume-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/traces-volume-card-view.tsx
@@ -74,6 +74,102 @@ export interface TracesVolumeCardViewProps {
   LinkComponent?: LinkComponent;
 }
 
+function getVolumeRowHrefs(tab: VolumeTab, getRowHref: TracesVolumeCardViewProps['getRowHref']) {
+  if (!getRowHref) {
+    return undefined;
+  }
+  return (row: VolumeRow) => getRowHref(tab, row);
+}
+
+function getVolumeErrorHrefs(tab: VolumeTab, getErrorSegmentHref: TracesVolumeCardViewProps['getErrorSegmentHref']) {
+  if (!getErrorSegmentHref) {
+    return undefined;
+  }
+  return (row: VolumeRow) => getErrorSegmentHref(tab, row);
+}
+
+function TracesVolumeCardBody({
+  data,
+  isLoading,
+  isError,
+  hasData,
+  activeTab,
+  setActiveTab,
+  getRowHref,
+  getErrorSegmentHref,
+  LinkComponent,
+}: Pick<
+  TracesVolumeCardViewProps,
+  'data' | 'isLoading' | 'isError' | 'getRowHref' | 'getErrorSegmentHref' | 'LinkComponent'
+> & {
+  hasData: boolean;
+  activeTab: VolumeTab;
+  setActiveTab: (tab: VolumeTab) => void;
+}) {
+  if (isLoading) {
+    return <MetricsCard.Loading />;
+  }
+  if (isError) {
+    return <MetricsCard.Error message="Failed to load trace volume data" />;
+  }
+  return (
+    <MetricsCard.Content>
+      {!hasData || !data ? (
+        <MetricsCard.NoData message="No trace volume data yet" />
+      ) : (
+        <Tabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          defaultTab="agents"
+          className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
+        >
+          <TabList>
+            <Tab value="agents">Agents</Tab>
+            <Tab value="workflows">Workflows</Tab>
+            <Tab value="tools">Tools</Tab>
+          </TabList>
+          <TabContent value="agents">
+            {data.agentData.length > 0 ? (
+              <VolumeBars
+                data={data.agentData}
+                rowHrefs={getVolumeRowHrefs('agents', getRowHref)}
+                errorHrefs={getVolumeErrorHrefs('agents', getErrorSegmentHref)}
+                LinkComponent={LinkComponent}
+              />
+            ) : (
+              <MetricsCard.NoData message="No agent data yet" />
+            )}
+          </TabContent>
+          <TabContent value="workflows">
+            {data.workflowData.length > 0 ? (
+              <VolumeBars
+                data={data.workflowData}
+                rowHrefs={getVolumeRowHrefs('workflows', getRowHref)}
+                errorHrefs={getVolumeErrorHrefs('workflows', getErrorSegmentHref)}
+                LinkComponent={LinkComponent}
+              />
+            ) : (
+              <MetricsCard.NoData message="No workflow data yet" />
+            )}
+          </TabContent>
+          <TabContent value="tools">
+            {data.toolData.length > 0 ? (
+              <VolumeBars
+                data={data.toolData}
+                rowHrefs={getVolumeRowHrefs('tools', getRowHref)}
+                errorHrefs={getVolumeErrorHrefs('tools', getErrorSegmentHref)}
+                LinkComponent={LinkComponent}
+              />
+            ) : (
+              <MetricsCard.NoData message="No tool data yet" />
+            )}
+          </TabContent>
+        </Tabs>
+      )}
+    </MetricsCard.Content>
+  );
+}
+
 export function TracesVolumeCardView({
   data,
   isLoading,
@@ -90,74 +186,6 @@ export function TracesVolumeCardView({
     ? [...data.agentData, ...data.workflowData, ...data.toolData].reduce((s, d) => s + d.completed + d.errors, 0)
     : 0;
 
-  const tabRowHrefs = (tab: VolumeTab) => (getRowHref ? (row: VolumeRow) => getRowHref(tab, row) : undefined);
-  const tabErrorHrefs = (tab: VolumeTab) =>
-    getErrorSegmentHref ? (row: VolumeRow) => getErrorSegmentHref(tab, row) : undefined;
-
-  let cardBody;
-  if (isLoading) {
-    cardBody = <MetricsCard.Loading />;
-  } else if (isError) {
-    cardBody = <MetricsCard.Error message="Failed to load trace volume data" />;
-  } else {
-    cardBody = (
-      <MetricsCard.Content>
-        {!hasData ? (
-          <MetricsCard.NoData message="No trace volume data yet" />
-        ) : (
-          <Tabs
-            value={activeTab}
-            onValueChange={setActiveTab}
-            defaultTab="agents"
-            className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
-          >
-            <TabList>
-              <Tab value="agents">Agents</Tab>
-              <Tab value="workflows">Workflows</Tab>
-              <Tab value="tools">Tools</Tab>
-            </TabList>
-            <TabContent value="agents">
-              {data.agentData.length > 0 ? (
-                <VolumeBars
-                  data={data.agentData}
-                  rowHrefs={tabRowHrefs('agents')}
-                  errorHrefs={tabErrorHrefs('agents')}
-                  LinkComponent={LinkComponent}
-                />
-              ) : (
-                <MetricsCard.NoData message="No agent data yet" />
-              )}
-            </TabContent>
-            <TabContent value="workflows">
-              {data.workflowData.length > 0 ? (
-                <VolumeBars
-                  data={data.workflowData}
-                  rowHrefs={tabRowHrefs('workflows')}
-                  errorHrefs={tabErrorHrefs('workflows')}
-                  LinkComponent={LinkComponent}
-                />
-              ) : (
-                <MetricsCard.NoData message="No workflow data yet" />
-              )}
-            </TabContent>
-            <TabContent value="tools">
-              {data.toolData.length > 0 ? (
-                <VolumeBars
-                  data={data.toolData}
-                  rowHrefs={tabRowHrefs('tools')}
-                  errorHrefs={tabErrorHrefs('tools')}
-                  LinkComponent={LinkComponent}
-                />
-              ) : (
-                <MetricsCard.NoData message="No tool data yet" />
-              )}
-            </TabContent>
-          </Tabs>
-        )}
-      </MetricsCard.Content>
-    );
-  }
-
   return (
     <MetricsCard>
       <MetricsCard.TopBar>
@@ -165,7 +193,17 @@ export function TracesVolumeCardView({
         {hasData && <MetricsCard.Summary value={formatCompact(total)} label="Total runs" />}
         {renderedActions ? <MetricsCard.Actions>{renderedActions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      {cardBody}
+      <TracesVolumeCardBody
+        data={data}
+        isLoading={isLoading}
+        isError={isError}
+        hasData={hasData}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        getRowHref={getRowHref}
+        getErrorSegmentHref={getErrorSegmentHref}
+        LinkComponent={LinkComponent}
+      />
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/metrics/components/traces-volume-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/traces-volume-card-view.tsx
@@ -74,6 +74,9 @@ export interface TracesVolumeCardViewProps {
   LinkComponent?: LinkComponent;
 }
 
+type TracesVolumeData = NonNullable<TracesVolumeCardViewProps['data']>;
+type TracesVolumeLinks = Pick<TracesVolumeCardViewProps, 'getRowHref' | 'getErrorSegmentHref' | 'LinkComponent'>;
+
 function getVolumeRowHrefs(tab: VolumeTab, getRowHref: TracesVolumeCardViewProps['getRowHref']) {
   if (!getRowHref) {
     return undefined;
@@ -88,85 +91,66 @@ function getVolumeErrorHrefs(tab: VolumeTab, getErrorSegmentHref: TracesVolumeCa
   return (row: VolumeRow) => getErrorSegmentHref(tab, row);
 }
 
-function TracesVolumeCardBody({
+function TracesVolumeContent({
   data,
-  isLoading,
-  isError,
-  hasData,
   activeTab,
-  setActiveTab,
-  getRowHref,
-  getErrorSegmentHref,
-  LinkComponent,
-}: Pick<
-  TracesVolumeCardViewProps,
-  'data' | 'isLoading' | 'isError' | 'getRowHref' | 'getErrorSegmentHref' | 'LinkComponent'
-> & {
-  hasData: boolean;
+  onTabChange,
+  links,
+}: {
+  data: TracesVolumeData;
   activeTab: VolumeTab;
-  setActiveTab: (tab: VolumeTab) => void;
+  onTabChange: (tab: VolumeTab) => void;
+  links: TracesVolumeLinks;
 }) {
-  if (isLoading) {
-    return <MetricsCard.Loading />;
-  }
-  if (isError) {
-    return <MetricsCard.Error message="Failed to load trace volume data" />;
-  }
   return (
-    <MetricsCard.Content>
-      {!hasData || !data ? (
-        <MetricsCard.NoData message="No trace volume data yet" />
-      ) : (
-        <Tabs
-          value={activeTab}
-          onValueChange={setActiveTab}
-          defaultTab="agents"
-          className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
-        >
-          <TabList>
-            <Tab value="agents">Agents</Tab>
-            <Tab value="workflows">Workflows</Tab>
-            <Tab value="tools">Tools</Tab>
-          </TabList>
-          <TabContent value="agents">
-            {data.agentData.length > 0 ? (
-              <VolumeBars
-                data={data.agentData}
-                rowHrefs={getVolumeRowHrefs('agents', getRowHref)}
-                errorHrefs={getVolumeErrorHrefs('agents', getErrorSegmentHref)}
-                LinkComponent={LinkComponent}
-              />
-            ) : (
-              <MetricsCard.NoData message="No agent data yet" />
-            )}
-          </TabContent>
-          <TabContent value="workflows">
-            {data.workflowData.length > 0 ? (
-              <VolumeBars
-                data={data.workflowData}
-                rowHrefs={getVolumeRowHrefs('workflows', getRowHref)}
-                errorHrefs={getVolumeErrorHrefs('workflows', getErrorSegmentHref)}
-                LinkComponent={LinkComponent}
-              />
-            ) : (
-              <MetricsCard.NoData message="No workflow data yet" />
-            )}
-          </TabContent>
-          <TabContent value="tools">
-            {data.toolData.length > 0 ? (
-              <VolumeBars
-                data={data.toolData}
-                rowHrefs={getVolumeRowHrefs('tools', getRowHref)}
-                errorHrefs={getVolumeErrorHrefs('tools', getErrorSegmentHref)}
-                LinkComponent={LinkComponent}
-              />
-            ) : (
-              <MetricsCard.NoData message="No tool data yet" />
-            )}
-          </TabContent>
-        </Tabs>
-      )}
-    </MetricsCard.Content>
+    <Tabs
+      value={activeTab}
+      onValueChange={onTabChange}
+      defaultTab="agents"
+      className="grid grid-rows-[auto_1fr] overflow-y-auto h-full"
+    >
+      <TabList>
+        <Tab value="agents">Agents</Tab>
+        <Tab value="workflows">Workflows</Tab>
+        <Tab value="tools">Tools</Tab>
+      </TabList>
+      <TabContent value="agents">
+        {data.agentData.length > 0 ? (
+          <VolumeBars
+            data={data.agentData}
+            rowHrefs={getVolumeRowHrefs('agents', links.getRowHref)}
+            errorHrefs={getVolumeErrorHrefs('agents', links.getErrorSegmentHref)}
+            LinkComponent={links.LinkComponent}
+          />
+        ) : (
+          <MetricsCard.NoData message="No agent data yet" />
+        )}
+      </TabContent>
+      <TabContent value="workflows">
+        {data.workflowData.length > 0 ? (
+          <VolumeBars
+            data={data.workflowData}
+            rowHrefs={getVolumeRowHrefs('workflows', links.getRowHref)}
+            errorHrefs={getVolumeErrorHrefs('workflows', links.getErrorSegmentHref)}
+            LinkComponent={links.LinkComponent}
+          />
+        ) : (
+          <MetricsCard.NoData message="No workflow data yet" />
+        )}
+      </TabContent>
+      <TabContent value="tools">
+        {data.toolData.length > 0 ? (
+          <VolumeBars
+            data={data.toolData}
+            rowHrefs={getVolumeRowHrefs('tools', links.getRowHref)}
+            errorHrefs={getVolumeErrorHrefs('tools', links.getErrorSegmentHref)}
+            LinkComponent={links.LinkComponent}
+          />
+        ) : (
+          <MetricsCard.NoData message="No tool data yet" />
+        )}
+      </TabContent>
+    </Tabs>
   );
 }
 
@@ -193,17 +177,22 @@ export function TracesVolumeCardView({
         {hasData && <MetricsCard.Summary value={formatCompact(total)} label="Total runs" />}
         {renderedActions ? <MetricsCard.Actions>{renderedActions}</MetricsCard.Actions> : null}
       </MetricsCard.TopBar>
-      <TracesVolumeCardBody
-        data={data}
-        isLoading={isLoading}
-        isError={isError}
-        hasData={hasData}
-        activeTab={activeTab}
-        setActiveTab={setActiveTab}
-        getRowHref={getRowHref}
-        getErrorSegmentHref={getErrorSegmentHref}
-        LinkComponent={LinkComponent}
-      />
+      {isLoading && <MetricsCard.Loading />}
+      {!isLoading && isError && <MetricsCard.Error message="Failed to load trace volume data" />}
+      {!isLoading && !isError && (
+        <MetricsCard.Content>
+          {!hasData || !data ? (
+            <MetricsCard.NoData message="No trace volume data yet" />
+          ) : (
+            <TracesVolumeContent
+              data={data}
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+              links={{ getRowHref, getErrorSegmentHref, LinkComponent }}
+            />
+          )}
+        </MetricsCard.Content>
+      )}
     </MetricsCard>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
@@ -94,24 +94,28 @@ export function SpanDataPanelView({
         </ButtonsGroup>
       </DataPanel.Header>
 
-      {isLoading ? (
-        <DataPanel.LoadingData>Loading span details...</DataPanel.LoadingData>
-      ) : !span ? (
-        <DataPanel.NoData>Span not found.</DataPanel.NoData>
-      ) : (
-        <SpanDataPanelContent
-          span={span}
-          traceId={traceId}
-          spanId={spanId}
-          activeTab={activeTab}
-          onTabChange={onTabChange}
-          scoringTabSlot={scoringTabSlot}
-          scoringTabBadge={scoringTabBadge}
-          feedbackTabSlot={feedbackTabSlot}
-          feedbackTabBadge={feedbackTabBadge}
-          isAnchor={isAnchor}
-        />
-      )}
+      {(() => {
+        if (isLoading) {
+          return <DataPanel.LoadingData>Loading span details...</DataPanel.LoadingData>;
+        }
+        if (!span) {
+          return <DataPanel.NoData>Span not found.</DataPanel.NoData>;
+        }
+        return (
+          <SpanDataPanelContent
+            span={span}
+            traceId={traceId}
+            spanId={spanId}
+            activeTab={activeTab}
+            onTabChange={onTabChange}
+            scoringTabSlot={scoringTabSlot}
+            scoringTabBadge={scoringTabBadge}
+            feedbackTabSlot={feedbackTabSlot}
+            feedbackTabBadge={feedbackTabBadge}
+            isAnchor={isAnchor}
+          />
+        );
+      })()}
     </DataPanel>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
@@ -61,6 +61,41 @@ export interface SpanDataPanelViewProps {
   isAnchor?: boolean;
 }
 
+function SpanDataPanelBody({
+  span,
+  isLoading,
+  traceId,
+  spanId,
+  activeTab,
+  onTabChange,
+  scoringTabSlot,
+  scoringTabBadge,
+  feedbackTabSlot,
+  feedbackTabBadge,
+  isAnchor,
+}: Omit<SpanDataPanelViewProps, 'onClose' | 'onPrevious' | 'onNext'>) {
+  if (isLoading) {
+    return <DataPanel.LoadingData>Loading span details...</DataPanel.LoadingData>;
+  }
+  if (!span) {
+    return <DataPanel.NoData>Span not found.</DataPanel.NoData>;
+  }
+  return (
+    <SpanDataPanelContent
+      span={span}
+      traceId={traceId}
+      spanId={spanId}
+      activeTab={activeTab}
+      onTabChange={onTabChange}
+      scoringTabSlot={scoringTabSlot}
+      scoringTabBadge={scoringTabBadge}
+      feedbackTabSlot={feedbackTabSlot}
+      feedbackTabBadge={feedbackTabBadge}
+      isAnchor={isAnchor}
+    />
+  );
+}
+
 export function SpanDataPanelView({
   traceId,
   spanId,
@@ -94,28 +129,19 @@ export function SpanDataPanelView({
         </ButtonsGroup>
       </DataPanel.Header>
 
-      {(() => {
-        if (isLoading) {
-          return <DataPanel.LoadingData>Loading span details...</DataPanel.LoadingData>;
-        }
-        if (!span) {
-          return <DataPanel.NoData>Span not found.</DataPanel.NoData>;
-        }
-        return (
-          <SpanDataPanelContent
-            span={span}
-            traceId={traceId}
-            spanId={spanId}
-            activeTab={activeTab}
-            onTabChange={onTabChange}
-            scoringTabSlot={scoringTabSlot}
-            scoringTabBadge={scoringTabBadge}
-            feedbackTabSlot={feedbackTabSlot}
-            feedbackTabBadge={feedbackTabBadge}
-            isAnchor={isAnchor}
-          />
-        );
-      })()}
+      <SpanDataPanelBody
+        span={span}
+        isLoading={isLoading}
+        traceId={traceId}
+        spanId={spanId}
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        scoringTabSlot={scoringTabSlot}
+        scoringTabBadge={scoringTabBadge}
+        feedbackTabSlot={feedbackTabSlot}
+        feedbackTabBadge={feedbackTabBadge}
+        isAnchor={isAnchor}
+      />
     </DataPanel>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
@@ -61,40 +61,10 @@ export interface SpanDataPanelViewProps {
   isAnchor?: boolean;
 }
 
-function SpanDataPanelBody({
-  span,
-  isLoading,
-  traceId,
-  spanId,
-  activeTab,
-  onTabChange,
-  scoringTabSlot,
-  scoringTabBadge,
-  feedbackTabSlot,
-  feedbackTabBadge,
-  isAnchor,
-}: Omit<SpanDataPanelViewProps, 'onClose' | 'onPrevious' | 'onNext'>) {
-  if (isLoading) {
-    return <DataPanel.LoadingData>Loading span details...</DataPanel.LoadingData>;
-  }
-  if (!span) {
-    return <DataPanel.NoData>Span not found.</DataPanel.NoData>;
-  }
-  return (
-    <SpanDataPanelContent
-      span={span}
-      traceId={traceId}
-      spanId={spanId}
-      activeTab={activeTab}
-      onTabChange={onTabChange}
-      scoringTabSlot={scoringTabSlot}
-      scoringTabBadge={scoringTabBadge}
-      feedbackTabSlot={feedbackTabSlot}
-      feedbackTabBadge={feedbackTabBadge}
-      isAnchor={isAnchor}
-    />
-  );
-}
+type SpanDataPanelTabSlots = Pick<
+  SpanDataPanelViewProps,
+  'activeTab' | 'onTabChange' | 'scoringTabSlot' | 'scoringTabBadge' | 'feedbackTabSlot' | 'feedbackTabBadge'
+>;
 
 export function SpanDataPanelView({
   traceId,
@@ -112,6 +82,15 @@ export function SpanDataPanelView({
   feedbackTabBadge,
   isAnchor,
 }: SpanDataPanelViewProps) {
+  const tabSlots = {
+    activeTab,
+    onTabChange,
+    scoringTabSlot,
+    scoringTabBadge,
+    feedbackTabSlot,
+    feedbackTabBadge,
+  };
+
   return (
     <DataPanel>
       <DataPanel.Header>
@@ -129,19 +108,11 @@ export function SpanDataPanelView({
         </ButtonsGroup>
       </DataPanel.Header>
 
-      <SpanDataPanelBody
-        span={span}
-        isLoading={isLoading}
-        traceId={traceId}
-        spanId={spanId}
-        activeTab={activeTab}
-        onTabChange={onTabChange}
-        scoringTabSlot={scoringTabSlot}
-        scoringTabBadge={scoringTabBadge}
-        feedbackTabSlot={feedbackTabSlot}
-        feedbackTabBadge={feedbackTabBadge}
-        isAnchor={isAnchor}
-      />
+      {isLoading && <DataPanel.LoadingData>Loading span details...</DataPanel.LoadingData>}
+      {!isLoading && !span && <DataPanel.NoData>Span not found.</DataPanel.NoData>}
+      {!isLoading && span && (
+        <SpanDataPanelContent span={span} traceId={traceId} spanId={spanId} tabSlots={tabSlots} isAnchor={isAnchor} />
+      )}
     </DataPanel>
   );
 }
@@ -150,25 +121,16 @@ function SpanDataPanelContent({
   span,
   traceId,
   spanId,
-  activeTab,
-  onTabChange,
-  scoringTabSlot,
-  scoringTabBadge,
-  feedbackTabSlot,
-  feedbackTabBadge,
+  tabSlots,
   isAnchor,
 }: {
   span: SpanRecord;
   traceId: string;
   spanId: string;
-  activeTab?: string;
-  onTabChange?: (tab: string) => void;
-  scoringTabSlot?: (args: { span: SpanRecord; traceId: string; spanId: string }) => ReactNode;
-  scoringTabBadge?: ReactNode;
-  feedbackTabSlot?: (args: { span: SpanRecord; traceId: string; spanId: string }) => ReactNode;
-  feedbackTabBadge?: ReactNode;
+  tabSlots: SpanDataPanelTabSlots;
   isAnchor?: boolean;
 }) {
+  const { activeTab, onTabChange, scoringTabSlot, scoringTabBadge, feedbackTabSlot, feedbackTabBadge } = tabSlots;
   const durationMs =
     span.startedAt && span.endedAt ? new Date(span.endedAt).getTime() - new Date(span.startedAt).getTime() : null;
   const usage = span.attributes?.usage as TokenUsage | undefined;

--- a/packages/playground-ui/src/domains/traces/components/span-details-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-details-view.tsx
@@ -31,63 +31,67 @@ export function SpanDetailsView({ spanId, span, isLoading, onClose }: SpanDetail
         <DataDetailsPanel.CloseButton onClick={onClose} />
       </DataDetailsPanel.Header>
 
-      {isLoading ? (
-        <DataDetailsPanel.LoadingData>Loading span...</DataDetailsPanel.LoadingData>
-      ) : !span ? (
-        <DataDetailsPanel.NoData>Span not found.</DataDetailsPanel.NoData>
-      ) : (
-        <DataDetailsPanel.Content>
-          <KV>
-            {span.spanType && (
-              <>
-                <KV.Key>Type</KV.Key>
-                <KV.Value>{span.spanType}</KV.Value>
-              </>
-            )}
-            {span.startedAt && (
-              <>
-                <KV.Key>Started</KV.Key>
-                <KV.Value>{format(new Date(span.startedAt), 'MMM dd, HH:mm:ss.SSS')}</KV.Value>
-              </>
-            )}
-            {span.endedAt && (
-              <>
-                <KV.Key>Ended</KV.Key>
-                <KV.Value>{format(new Date(span.endedAt), 'MMM dd, HH:mm:ss.SSS')}</KV.Value>
-              </>
-            )}
-            {durationMs != null && (
-              <>
-                <KV.Key>Duration</KV.Key>
-                <KV.Value>{durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(2)}s`}</KV.Value>
-              </>
-            )}
-          </KV>
+      {(() => {
+        if (isLoading) {
+          return <DataDetailsPanel.LoadingData>Loading span...</DataDetailsPanel.LoadingData>;
+        }
+        if (!span) {
+          return <DataDetailsPanel.NoData>Span not found.</DataDetailsPanel.NoData>;
+        }
+        return (
+          <DataDetailsPanel.Content>
+            <KV>
+              {span.spanType && (
+                <>
+                  <KV.Key>Type</KV.Key>
+                  <KV.Value>{span.spanType}</KV.Value>
+                </>
+              )}
+              {span.startedAt && (
+                <>
+                  <KV.Key>Started</KV.Key>
+                  <KV.Value>{format(new Date(span.startedAt), 'MMM dd, HH:mm:ss.SSS')}</KV.Value>
+                </>
+              )}
+              {span.endedAt && (
+                <>
+                  <KV.Key>Ended</KV.Key>
+                  <KV.Value>{format(new Date(span.endedAt), 'MMM dd, HH:mm:ss.SSS')}</KV.Value>
+                </>
+              )}
+              {durationMs != null && (
+                <>
+                  <KV.Key>Duration</KV.Key>
+                  <KV.Value>{durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(2)}s`}</KV.Value>
+                </>
+              )}
+            </KV>
 
-          <br />
+            <br />
 
-          <DataDetailsPanel.CodeSection
-            title="Input"
-            icon={<FileInputIcon />}
-            codeStr={JSON.stringify(span.input ?? null, null, 2)}
-          />
-          <DataDetailsPanel.CodeSection
-            title="Output"
-            icon={<FileOutputIcon />}
-            codeStr={JSON.stringify(span.output ?? null, null, 2)}
-          />
-          <DataDetailsPanel.CodeSection
-            title="Metadata"
-            icon={<BracesIcon />}
-            codeStr={JSON.stringify(span.metadata ?? null, null, 2)}
-          />
-          <DataDetailsPanel.CodeSection
-            title="Attributes"
-            icon={<BracesIcon />}
-            codeStr={JSON.stringify(span.attributes ?? null, null, 2)}
-          />
-        </DataDetailsPanel.Content>
-      )}
+            <DataDetailsPanel.CodeSection
+              title="Input"
+              icon={<FileInputIcon />}
+              codeStr={JSON.stringify(span.input ?? null, null, 2)}
+            />
+            <DataDetailsPanel.CodeSection
+              title="Output"
+              icon={<FileOutputIcon />}
+              codeStr={JSON.stringify(span.output ?? null, null, 2)}
+            />
+            <DataDetailsPanel.CodeSection
+              title="Metadata"
+              icon={<BracesIcon />}
+              codeStr={JSON.stringify(span.metadata ?? null, null, 2)}
+            />
+            <DataDetailsPanel.CodeSection
+              title="Attributes"
+              icon={<BracesIcon />}
+              codeStr={JSON.stringify(span.attributes ?? null, null, 2)}
+            />
+          </DataDetailsPanel.Content>
+        );
+      })()}
     </DataDetailsPanel>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/span-details-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-details-view.tsx
@@ -13,6 +13,76 @@ export interface SpanDetailsViewProps {
   onClose: () => void;
 }
 
+function SpanDetailsContent({
+  span,
+  isLoading,
+  durationMs,
+}: {
+  span: SpanRecord | undefined;
+  isLoading?: boolean;
+  durationMs: number | null;
+}) {
+  if (isLoading) {
+    return <DataDetailsPanel.LoadingData>Loading span...</DataDetailsPanel.LoadingData>;
+  }
+  if (!span) {
+    return <DataDetailsPanel.NoData>Span not found.</DataDetailsPanel.NoData>;
+  }
+  return (
+    <DataDetailsPanel.Content>
+      <KV>
+        {span.spanType && (
+          <>
+            <KV.Key>Type</KV.Key>
+            <KV.Value>{span.spanType}</KV.Value>
+          </>
+        )}
+        {span.startedAt && (
+          <>
+            <KV.Key>Started</KV.Key>
+            <KV.Value>{format(new Date(span.startedAt), 'MMM dd, HH:mm:ss.SSS')}</KV.Value>
+          </>
+        )}
+        {span.endedAt && (
+          <>
+            <KV.Key>Ended</KV.Key>
+            <KV.Value>{format(new Date(span.endedAt), 'MMM dd, HH:mm:ss.SSS')}</KV.Value>
+          </>
+        )}
+        {durationMs != null && (
+          <>
+            <KV.Key>Duration</KV.Key>
+            <KV.Value>{durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(2)}s`}</KV.Value>
+          </>
+        )}
+      </KV>
+
+      <br />
+
+      <DataDetailsPanel.CodeSection
+        title="Input"
+        icon={<FileInputIcon />}
+        codeStr={JSON.stringify(span.input ?? null, null, 2)}
+      />
+      <DataDetailsPanel.CodeSection
+        title="Output"
+        icon={<FileOutputIcon />}
+        codeStr={JSON.stringify(span.output ?? null, null, 2)}
+      />
+      <DataDetailsPanel.CodeSection
+        title="Metadata"
+        icon={<BracesIcon />}
+        codeStr={JSON.stringify(span.metadata ?? null, null, 2)}
+      />
+      <DataDetailsPanel.CodeSection
+        title="Attributes"
+        icon={<BracesIcon />}
+        codeStr={JSON.stringify(span.attributes ?? null, null, 2)}
+      />
+    </DataDetailsPanel.Content>
+  );
+}
+
 /**
  * Compact span panel using `DataDetailsPanel` (popover-style). Shows basic span metadata +
  * input/output/metadata/attributes code sections. Use this for inline span inspection; for the
@@ -31,67 +101,7 @@ export function SpanDetailsView({ spanId, span, isLoading, onClose }: SpanDetail
         <DataDetailsPanel.CloseButton onClick={onClose} />
       </DataDetailsPanel.Header>
 
-      {(() => {
-        if (isLoading) {
-          return <DataDetailsPanel.LoadingData>Loading span...</DataDetailsPanel.LoadingData>;
-        }
-        if (!span) {
-          return <DataDetailsPanel.NoData>Span not found.</DataDetailsPanel.NoData>;
-        }
-        return (
-          <DataDetailsPanel.Content>
-            <KV>
-              {span.spanType && (
-                <>
-                  <KV.Key>Type</KV.Key>
-                  <KV.Value>{span.spanType}</KV.Value>
-                </>
-              )}
-              {span.startedAt && (
-                <>
-                  <KV.Key>Started</KV.Key>
-                  <KV.Value>{format(new Date(span.startedAt), 'MMM dd, HH:mm:ss.SSS')}</KV.Value>
-                </>
-              )}
-              {span.endedAt && (
-                <>
-                  <KV.Key>Ended</KV.Key>
-                  <KV.Value>{format(new Date(span.endedAt), 'MMM dd, HH:mm:ss.SSS')}</KV.Value>
-                </>
-              )}
-              {durationMs != null && (
-                <>
-                  <KV.Key>Duration</KV.Key>
-                  <KV.Value>{durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(2)}s`}</KV.Value>
-                </>
-              )}
-            </KV>
-
-            <br />
-
-            <DataDetailsPanel.CodeSection
-              title="Input"
-              icon={<FileInputIcon />}
-              codeStr={JSON.stringify(span.input ?? null, null, 2)}
-            />
-            <DataDetailsPanel.CodeSection
-              title="Output"
-              icon={<FileOutputIcon />}
-              codeStr={JSON.stringify(span.output ?? null, null, 2)}
-            />
-            <DataDetailsPanel.CodeSection
-              title="Metadata"
-              icon={<BracesIcon />}
-              codeStr={JSON.stringify(span.metadata ?? null, null, 2)}
-            />
-            <DataDetailsPanel.CodeSection
-              title="Attributes"
-              icon={<BracesIcon />}
-              codeStr={JSON.stringify(span.attributes ?? null, null, 2)}
-            />
-          </DataDetailsPanel.Content>
-        );
-      })()}
+      <SpanDetailsContent span={span} isLoading={isLoading} durationMs={durationMs} />
     </DataDetailsPanel>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -66,55 +66,48 @@ export interface TraceDataPanelViewProps {
 
 type HierarchicalSpans = ReturnType<typeof formatHierarchicalSpans>;
 
-function TraceDataPanelBody({
-  collapsed,
-  isLoading,
-  hierarchicalSpans,
-  contentRef,
-  isOnTracePage,
-  rootSpan,
-  onEvaluateTrace,
-  onSaveAsDatasetItem,
-  onAddTraceMocksToItem,
-  showUnavailableFeaturesMsg,
-  traceId,
-  onSpanClick,
-  selectedSpanId,
-  expandedSpanIds,
-  setExpandedSpanIds,
-  timelineChartWidth,
-}: {
-  collapsed: boolean;
-  isLoading: TraceDataPanelViewProps['isLoading'];
-  hierarchicalSpans: HierarchicalSpans;
-  contentRef: RefObject<HTMLDivElement | null>;
-  isOnTracePage: boolean;
-  rootSpan: LightSpanRecord | undefined;
-  onEvaluateTrace: TraceDataPanelViewProps['onEvaluateTrace'];
-  onSaveAsDatasetItem: TraceDataPanelViewProps['onSaveAsDatasetItem'];
-  onAddTraceMocksToItem: TraceDataPanelViewProps['onAddTraceMocksToItem'];
-  showUnavailableFeaturesMsg: boolean;
+type TraceDataPanelContentContext = {
   traceId: string;
+  rootSpan: LightSpanRecord | undefined;
+  isOnTracePage: boolean;
+};
+
+type TraceDataPanelActions = Pick<
+  TraceDataPanelViewProps,
+  'onEvaluateTrace' | 'onSaveAsDatasetItem' | 'onAddTraceMocksToItem' | 'showUnavailableFeaturesMsg'
+>;
+
+type TraceDataPanelTimelineState = {
+  hierarchicalSpans: HierarchicalSpans;
   onSpanClick: (id: string) => void;
   selectedSpanId: string | undefined;
   expandedSpanIds: string[];
   setExpandedSpanIds: Dispatch<SetStateAction<string[]>>;
-  timelineChartWidth: TraceDataPanelViewProps['timelineChartWidth'];
+  chartWidth: TraceDataPanelViewProps['timelineChartWidth'];
+};
+
+function TraceDataPanelContent({
+  contentRef,
+  context,
+  actions,
+  timeline,
+}: {
+  contentRef: RefObject<HTMLDivElement | null>;
+  context: TraceDataPanelContentContext;
+  actions: TraceDataPanelActions;
+  timeline: TraceDataPanelTimelineState;
 }) {
-  if (collapsed) {
-    return null;
-  }
-  if (isLoading) {
-    return <DataPanel.LoadingData>Loading trace...</DataPanel.LoadingData>;
-  }
-  if (hierarchicalSpans.length === 0) {
-    return <DataPanel.NoData>No spans found for this trace.</DataPanel.NoData>;
-  }
+  const { traceId, rootSpan, isOnTracePage } = context;
+  const { onEvaluateTrace, onSaveAsDatasetItem, onAddTraceMocksToItem, showUnavailableFeaturesMsg } = actions;
+  const showTraceActions = !isOnTracePage && (onEvaluateTrace || onSaveAsDatasetItem || onAddTraceMocksToItem);
+  const showUnavailableFeaturesNotice =
+    !isOnTracePage && !onEvaluateTrace && !onSaveAsDatasetItem && !onAddTraceMocksToItem && showUnavailableFeaturesMsg;
+
   return (
     <DataPanel.Content ref={contentRef}>
       {!isOnTracePage && rootSpan && <TraceKeysAndValues rootSpan={rootSpan} className="mb-6" />}
 
-      {!isOnTracePage && (onEvaluateTrace || onSaveAsDatasetItem || onAddTraceMocksToItem) && (
+      {showTraceActions && (
         <div className="mb-6 flex flex-wrap justify-between items-center gap-4">
           {onEvaluateTrace && (
             <Button size="sm" onClick={onEvaluateTrace}>
@@ -143,25 +136,21 @@ function TraceDataPanelBody({
         </div>
       )}
 
-      {!isOnTracePage &&
-        !onEvaluateTrace &&
-        !onSaveAsDatasetItem &&
-        !onAddTraceMocksToItem &&
-        showUnavailableFeaturesMsg && (
-          <Notice variant="info" className="mb-6">
-            <Notice.Message>
-              Evaluating traces and saving them as dataset items is available in Mastra Studio (local or deployed).
-            </Notice.Message>
-          </Notice>
-        )}
+      {showUnavailableFeaturesNotice && (
+        <Notice variant="info" className="mb-6">
+          <Notice.Message>
+            Evaluating traces and saving them as dataset items is available in Mastra Studio (local or deployed).
+          </Notice.Message>
+        </Notice>
+      )}
 
       <TraceTimeline
-        hierarchicalSpans={hierarchicalSpans}
-        onSpanClick={onSpanClick}
-        selectedSpanId={selectedSpanId}
-        expandedSpanIds={expandedSpanIds}
-        setExpandedSpanIds={setExpandedSpanIds}
-        chartWidth={timelineChartWidth}
+        hierarchicalSpans={timeline.hierarchicalSpans}
+        onSpanClick={timeline.onSpanClick}
+        selectedSpanId={timeline.selectedSpanId}
+        expandedSpanIds={timeline.expandedSpanIds}
+        setExpandedSpanIds={timeline.setExpandedSpanIds}
+        chartWidth={timeline.chartWidth}
       />
     </DataPanel.Content>
   );
@@ -264,6 +253,8 @@ export function TraceDataPanelView({
       {isDownloadingTrace ? <Loader2Icon className="animate-spin" /> : <DownloadIcon />}
     </Button>
   );
+  const collapsedButtonTooltip = collapsed ? 'Expand panel' : 'Collapse panel';
+  const collapsedButtonIcon = collapsed ? <ChevronsUpDownIcon /> : <ChevronsDownUpIcon />;
 
   return (
     <DataPanel collapsed={collapsed}>
@@ -280,12 +271,8 @@ export function TraceDataPanelView({
             </DataPanel.Heading>
             <ButtonsGroup className="ml-auto shrink-0">
               {onCollapsedChange && (
-                <Button
-                  size="md"
-                  tooltip={collapsed ? 'Expand panel' : 'Collapse panel'}
-                  onClick={() => setCollapsed(!collapsed)}
-                >
-                  {collapsed ? <ChevronsUpDownIcon /> : <ChevronsDownUpIcon />}
+                <Button size="md" tooltip={collapsedButtonTooltip} onClick={() => setCollapsed(!collapsed)}>
+                  {collapsedButtonIcon}
                 </Button>
               )}
               {(onPrevious || onNext) && (
@@ -314,24 +301,25 @@ export function TraceDataPanelView({
         )}
       </DataPanel.Header>
 
-      <TraceDataPanelBody
-        collapsed={collapsed}
-        isLoading={isLoading}
-        hierarchicalSpans={hierarchicalSpans}
-        contentRef={contentRef}
-        isOnTracePage={isOnTracePage}
-        rootSpan={rootSpan}
-        onEvaluateTrace={onEvaluateTrace}
-        onSaveAsDatasetItem={onSaveAsDatasetItem}
-        onAddTraceMocksToItem={onAddTraceMocksToItem}
-        showUnavailableFeaturesMsg={showUnavailableFeaturesMsg}
-        traceId={traceId}
-        onSpanClick={handleSpanClick}
-        selectedSpanId={selectedSpanId}
-        expandedSpanIds={expandedSpanIds}
-        setExpandedSpanIds={setExpandedSpanIds}
-        timelineChartWidth={timelineChartWidth}
-      />
+      {!collapsed && isLoading && <DataPanel.LoadingData>Loading trace...</DataPanel.LoadingData>}
+      {!collapsed && !isLoading && hierarchicalSpans.length === 0 && (
+        <DataPanel.NoData>No spans found for this trace.</DataPanel.NoData>
+      )}
+      {!collapsed && !isLoading && hierarchicalSpans.length > 0 && (
+        <TraceDataPanelContent
+          contentRef={contentRef}
+          context={{ traceId, rootSpan, isOnTracePage }}
+          actions={{ onEvaluateTrace, onSaveAsDatasetItem, onAddTraceMocksToItem, showUnavailableFeaturesMsg }}
+          timeline={{
+            hierarchicalSpans,
+            onSpanClick: handleSpanClick,
+            selectedSpanId,
+            expandedSpanIds,
+            setExpandedSpanIds,
+            chartWidth: timelineChartWidth,
+          }}
+        />
+      )}
     </DataPanel>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -10,7 +10,7 @@ import {
   WrenchIcon,
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ReactNode } from 'react';
+import type { Dispatch, RefObject, SetStateAction } from 'react';
 import { getAllSpanIds } from '../hooks/get-all-span-ids';
 import { useDownloadTraceJson } from '../hooks/use-download-trace-json';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
@@ -62,6 +62,109 @@ export interface TraceDataPanelViewProps {
    * handlers (e.g. inline below an experiment result).
    */
   showUnavailableFeaturesMsg?: boolean;
+}
+
+type HierarchicalSpans = ReturnType<typeof formatHierarchicalSpans>;
+
+function TraceDataPanelBody({
+  collapsed,
+  isLoading,
+  hierarchicalSpans,
+  contentRef,
+  isOnTracePage,
+  rootSpan,
+  onEvaluateTrace,
+  onSaveAsDatasetItem,
+  onAddTraceMocksToItem,
+  showUnavailableFeaturesMsg,
+  traceId,
+  onSpanClick,
+  selectedSpanId,
+  expandedSpanIds,
+  setExpandedSpanIds,
+  timelineChartWidth,
+}: {
+  collapsed: boolean;
+  isLoading: TraceDataPanelViewProps['isLoading'];
+  hierarchicalSpans: HierarchicalSpans;
+  contentRef: RefObject<HTMLDivElement | null>;
+  isOnTracePage: boolean;
+  rootSpan: LightSpanRecord | undefined;
+  onEvaluateTrace: TraceDataPanelViewProps['onEvaluateTrace'];
+  onSaveAsDatasetItem: TraceDataPanelViewProps['onSaveAsDatasetItem'];
+  onAddTraceMocksToItem: TraceDataPanelViewProps['onAddTraceMocksToItem'];
+  showUnavailableFeaturesMsg: boolean;
+  traceId: string;
+  onSpanClick: (id: string) => void;
+  selectedSpanId: string | undefined;
+  expandedSpanIds: string[];
+  setExpandedSpanIds: Dispatch<SetStateAction<string[]>>;
+  timelineChartWidth: TraceDataPanelViewProps['timelineChartWidth'];
+}) {
+  if (collapsed) {
+    return null;
+  }
+  if (isLoading) {
+    return <DataPanel.LoadingData>Loading trace...</DataPanel.LoadingData>;
+  }
+  if (hierarchicalSpans.length === 0) {
+    return <DataPanel.NoData>No spans found for this trace.</DataPanel.NoData>;
+  }
+  return (
+    <DataPanel.Content ref={contentRef}>
+      {!isOnTracePage && rootSpan && <TraceKeysAndValues rootSpan={rootSpan} className="mb-6" />}
+
+      {!isOnTracePage && (onEvaluateTrace || onSaveAsDatasetItem || onAddTraceMocksToItem) && (
+        <div className="mb-6 flex flex-wrap justify-between items-center gap-4">
+          {onEvaluateTrace && (
+            <Button size="sm" onClick={onEvaluateTrace}>
+              <Icon>
+                <CircleGaugeIcon />
+              </Icon>
+              Evaluate Trace
+            </Button>
+          )}
+          {onSaveAsDatasetItem && (
+            <Button size="sm" onClick={() => onSaveAsDatasetItem({ traceId, rootSpanId: rootSpan?.spanId })}>
+              <Icon>
+                <SaveIcon />
+              </Icon>
+              Save as Dataset Item
+            </Button>
+          )}
+          {onAddTraceMocksToItem && (
+            <Button size="sm" onClick={() => onAddTraceMocksToItem({ traceId })}>
+              <Icon>
+                <WrenchIcon />
+              </Icon>
+              Add tool mocks to item
+            </Button>
+          )}
+        </div>
+      )}
+
+      {!isOnTracePage &&
+        !onEvaluateTrace &&
+        !onSaveAsDatasetItem &&
+        !onAddTraceMocksToItem &&
+        showUnavailableFeaturesMsg && (
+          <Notice variant="info" className="mb-6">
+            <Notice.Message>
+              Evaluating traces and saving them as dataset items is available in Mastra Studio (local or deployed).
+            </Notice.Message>
+          </Notice>
+        )}
+
+      <TraceTimeline
+        hierarchicalSpans={hierarchicalSpans}
+        onSpanClick={onSpanClick}
+        selectedSpanId={selectedSpanId}
+        expandedSpanIds={expandedSpanIds}
+        setExpandedSpanIds={setExpandedSpanIds}
+        chartWidth={timelineChartWidth}
+      />
+    </DataPanel.Content>
+  );
 }
 
 export function TraceDataPanelView({
@@ -162,71 +265,6 @@ export function TraceDataPanelView({
     </Button>
   );
 
-  let panelBody: ReactNode = null;
-  if (!collapsed) {
-    if (isLoading) {
-      panelBody = <DataPanel.LoadingData>Loading trace...</DataPanel.LoadingData>;
-    } else if (hierarchicalSpans.length === 0) {
-      panelBody = <DataPanel.NoData>No spans found for this trace.</DataPanel.NoData>;
-    } else {
-      panelBody = (
-        <DataPanel.Content ref={contentRef}>
-          {!isOnTracePage && rootSpan && <TraceKeysAndValues rootSpan={rootSpan} className="mb-6" />}
-
-          {!isOnTracePage && (onEvaluateTrace || onSaveAsDatasetItem || onAddTraceMocksToItem) && (
-            <div className="mb-6 flex flex-wrap justify-between items-center gap-4">
-              {onEvaluateTrace && (
-                <Button size="sm" onClick={onEvaluateTrace}>
-                  <Icon>
-                    <CircleGaugeIcon />
-                  </Icon>
-                  Evaluate Trace
-                </Button>
-              )}
-              {onSaveAsDatasetItem && (
-                <Button size="sm" onClick={() => onSaveAsDatasetItem({ traceId, rootSpanId: rootSpan?.spanId })}>
-                  <Icon>
-                    <SaveIcon />
-                  </Icon>
-                  Save as Dataset Item
-                </Button>
-              )}
-              {onAddTraceMocksToItem && (
-                <Button size="sm" onClick={() => onAddTraceMocksToItem({ traceId })}>
-                  <Icon>
-                    <WrenchIcon />
-                  </Icon>
-                  Add tool mocks to item
-                </Button>
-              )}
-            </div>
-          )}
-
-          {!isOnTracePage &&
-            !onEvaluateTrace &&
-            !onSaveAsDatasetItem &&
-            !onAddTraceMocksToItem &&
-            showUnavailableFeaturesMsg && (
-              <Notice variant="info" className="mb-6">
-                <Notice.Message>
-                  Evaluating traces and saving them as dataset items is available in Mastra Studio (local or deployed).
-                </Notice.Message>
-              </Notice>
-            )}
-
-          <TraceTimeline
-            hierarchicalSpans={hierarchicalSpans}
-            onSpanClick={handleSpanClick}
-            selectedSpanId={selectedSpanId}
-            expandedSpanIds={expandedSpanIds}
-            setExpandedSpanIds={setExpandedSpanIds}
-            chartWidth={timelineChartWidth}
-          />
-        </DataPanel.Content>
-      );
-    }
-  }
-
   return (
     <DataPanel collapsed={collapsed}>
       <DataPanel.Header>
@@ -276,7 +314,24 @@ export function TraceDataPanelView({
         )}
       </DataPanel.Header>
 
-      {panelBody}
+      <TraceDataPanelBody
+        collapsed={collapsed}
+        isLoading={isLoading}
+        hierarchicalSpans={hierarchicalSpans}
+        contentRef={contentRef}
+        isOnTracePage={isOnTracePage}
+        rootSpan={rootSpan}
+        onEvaluateTrace={onEvaluateTrace}
+        onSaveAsDatasetItem={onSaveAsDatasetItem}
+        onAddTraceMocksToItem={onAddTraceMocksToItem}
+        showUnavailableFeaturesMsg={showUnavailableFeaturesMsg}
+        traceId={traceId}
+        onSpanClick={handleSpanClick}
+        selectedSpanId={selectedSpanId}
+        expandedSpanIds={expandedSpanIds}
+        setExpandedSpanIds={setExpandedSpanIds}
+        timelineChartWidth={timelineChartWidth}
+      />
     </DataPanel>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -10,6 +10,7 @@ import {
   WrenchIcon,
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 import { getAllSpanIds } from '../hooks/get-all-span-ids';
 import { useDownloadTraceJson } from '../hooks/use-download-trace-json';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
@@ -161,6 +162,71 @@ export function TraceDataPanelView({
     </Button>
   );
 
+  let panelBody: ReactNode = null;
+  if (!collapsed) {
+    if (isLoading) {
+      panelBody = <DataPanel.LoadingData>Loading trace...</DataPanel.LoadingData>;
+    } else if (hierarchicalSpans.length === 0) {
+      panelBody = <DataPanel.NoData>No spans found for this trace.</DataPanel.NoData>;
+    } else {
+      panelBody = (
+        <DataPanel.Content ref={contentRef}>
+          {!isOnTracePage && rootSpan && <TraceKeysAndValues rootSpan={rootSpan} className="mb-6" />}
+
+          {!isOnTracePage && (onEvaluateTrace || onSaveAsDatasetItem || onAddTraceMocksToItem) && (
+            <div className="mb-6 flex flex-wrap justify-between items-center gap-4">
+              {onEvaluateTrace && (
+                <Button size="sm" onClick={onEvaluateTrace}>
+                  <Icon>
+                    <CircleGaugeIcon />
+                  </Icon>
+                  Evaluate Trace
+                </Button>
+              )}
+              {onSaveAsDatasetItem && (
+                <Button size="sm" onClick={() => onSaveAsDatasetItem({ traceId, rootSpanId: rootSpan?.spanId })}>
+                  <Icon>
+                    <SaveIcon />
+                  </Icon>
+                  Save as Dataset Item
+                </Button>
+              )}
+              {onAddTraceMocksToItem && (
+                <Button size="sm" onClick={() => onAddTraceMocksToItem({ traceId })}>
+                  <Icon>
+                    <WrenchIcon />
+                  </Icon>
+                  Add tool mocks to item
+                </Button>
+              )}
+            </div>
+          )}
+
+          {!isOnTracePage &&
+            !onEvaluateTrace &&
+            !onSaveAsDatasetItem &&
+            !onAddTraceMocksToItem &&
+            showUnavailableFeaturesMsg && (
+              <Notice variant="info" className="mb-6">
+                <Notice.Message>
+                  Evaluating traces and saving them as dataset items is available in Mastra Studio (local or deployed).
+                </Notice.Message>
+              </Notice>
+            )}
+
+          <TraceTimeline
+            hierarchicalSpans={hierarchicalSpans}
+            onSpanClick={handleSpanClick}
+            selectedSpanId={selectedSpanId}
+            expandedSpanIds={expandedSpanIds}
+            setExpandedSpanIds={setExpandedSpanIds}
+            chartWidth={timelineChartWidth}
+          />
+        </DataPanel.Content>
+      );
+    }
+  }
+
   return (
     <DataPanel collapsed={collapsed}>
       <DataPanel.Header>
@@ -210,67 +276,7 @@ export function TraceDataPanelView({
         )}
       </DataPanel.Header>
 
-      {!collapsed &&
-        (isLoading ? (
-          <DataPanel.LoadingData>Loading trace...</DataPanel.LoadingData>
-        ) : hierarchicalSpans.length === 0 ? (
-          <DataPanel.NoData>No spans found for this trace.</DataPanel.NoData>
-        ) : (
-          <DataPanel.Content ref={contentRef}>
-            {!isOnTracePage && rootSpan && <TraceKeysAndValues rootSpan={rootSpan} className="mb-6" />}
-
-            {!isOnTracePage && (onEvaluateTrace || onSaveAsDatasetItem || onAddTraceMocksToItem) && (
-              <div className="mb-6 flex flex-wrap justify-between items-center gap-4">
-                {onEvaluateTrace && (
-                  <Button size="sm" onClick={onEvaluateTrace}>
-                    <Icon>
-                      <CircleGaugeIcon />
-                    </Icon>
-                    Evaluate Trace
-                  </Button>
-                )}
-                {onSaveAsDatasetItem && (
-                  <Button size="sm" onClick={() => onSaveAsDatasetItem({ traceId, rootSpanId: rootSpan?.spanId })}>
-                    <Icon>
-                      <SaveIcon />
-                    </Icon>
-                    Save as Dataset Item
-                  </Button>
-                )}
-                {onAddTraceMocksToItem && (
-                  <Button size="sm" onClick={() => onAddTraceMocksToItem({ traceId })}>
-                    <Icon>
-                      <WrenchIcon />
-                    </Icon>
-                    Add tool mocks to item
-                  </Button>
-                )}
-              </div>
-            )}
-
-            {!isOnTracePage &&
-              !onEvaluateTrace &&
-              !onSaveAsDatasetItem &&
-              !onAddTraceMocksToItem &&
-              showUnavailableFeaturesMsg && (
-                <Notice variant="info" className="mb-6">
-                  <Notice.Message>
-                    Evaluating traces and saving them as dataset items is available in Mastra Studio (local or
-                    deployed).
-                  </Notice.Message>
-                </Notice>
-              )}
-
-            <TraceTimeline
-              hierarchicalSpans={hierarchicalSpans}
-              onSpanClick={handleSpanClick}
-              selectedSpanId={selectedSpanId}
-              expandedSpanIds={expandedSpanIds}
-              setExpandedSpanIds={setExpandedSpanIds}
-              chartWidth={timelineChartWidth}
-            />
-          </DataPanel.Content>
-        ))}
+      {panelBody}
     </DataPanel>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/trace-details-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-details-view.tsx
@@ -1,9 +1,12 @@
 import type { LightSpanRecord } from '@mastra/core/storage';
 import { useEffect, useMemo, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { getAllSpanIds } from '../hooks/get-all-span-ids';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
 import { TraceTimeline } from './trace-timeline';
 import { DataDetailsPanel } from '@/ds/components/DataDetailsPanel';
+
+type HierarchicalSpans = ReturnType<typeof formatHierarchicalSpans>;
 
 export interface TraceDetailsViewProps {
   traceId: string;
@@ -15,6 +18,40 @@ export interface TraceDetailsViewProps {
   onSpanSelect?: (spanId: string | undefined) => void;
   /** Fully controlled selection — the span to highlight. Pass whatever the parent's source of truth is. */
   selectedSpanId?: string | null;
+}
+
+function TraceDetailsContent({
+  isLoading,
+  hierarchicalSpans,
+  onSpanClick,
+  selectedSpanId,
+  expandedSpanIds,
+  setExpandedSpanIds,
+}: {
+  isLoading?: boolean;
+  hierarchicalSpans: HierarchicalSpans;
+  onSpanClick: (id: string) => void;
+  selectedSpanId?: string | null;
+  expandedSpanIds: string[];
+  setExpandedSpanIds: Dispatch<SetStateAction<string[]>>;
+}) {
+  if (isLoading) {
+    return <DataDetailsPanel.LoadingData>Loading trace...</DataDetailsPanel.LoadingData>;
+  }
+  if (hierarchicalSpans.length === 0) {
+    return <DataDetailsPanel.NoData>No spans found for this trace.</DataDetailsPanel.NoData>;
+  }
+  return (
+    <DataDetailsPanel.Content>
+      <TraceTimeline
+        hierarchicalSpans={hierarchicalSpans}
+        onSpanClick={onSpanClick}
+        selectedSpanId={selectedSpanId ?? undefined}
+        expandedSpanIds={expandedSpanIds}
+        setExpandedSpanIds={setExpandedSpanIds}
+      />
+    </DataDetailsPanel.Content>
+  );
 }
 
 /**
@@ -53,25 +90,14 @@ export function TraceDetailsView({
         <DataDetailsPanel.CloseButton onClick={onClose} />
       </DataDetailsPanel.Header>
 
-      {(() => {
-        if (isLoading) {
-          return <DataDetailsPanel.LoadingData>Loading trace...</DataDetailsPanel.LoadingData>;
-        }
-        if (hierarchicalSpans.length === 0) {
-          return <DataDetailsPanel.NoData>No spans found for this trace.</DataDetailsPanel.NoData>;
-        }
-        return (
-          <DataDetailsPanel.Content>
-            <TraceTimeline
-              hierarchicalSpans={hierarchicalSpans}
-              onSpanClick={handleSpanClick}
-              selectedSpanId={selectedSpanId ?? undefined}
-              expandedSpanIds={expandedSpanIds}
-              setExpandedSpanIds={setExpandedSpanIds}
-            />
-          </DataDetailsPanel.Content>
-        );
-      })()}
+      <TraceDetailsContent
+        isLoading={isLoading}
+        hierarchicalSpans={hierarchicalSpans}
+        onSpanClick={handleSpanClick}
+        selectedSpanId={selectedSpanId}
+        expandedSpanIds={expandedSpanIds}
+        setExpandedSpanIds={setExpandedSpanIds}
+      />
     </DataDetailsPanel>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/trace-details-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-details-view.tsx
@@ -53,21 +53,25 @@ export function TraceDetailsView({
         <DataDetailsPanel.CloseButton onClick={onClose} />
       </DataDetailsPanel.Header>
 
-      {isLoading ? (
-        <DataDetailsPanel.LoadingData>Loading trace...</DataDetailsPanel.LoadingData>
-      ) : hierarchicalSpans.length === 0 ? (
-        <DataDetailsPanel.NoData>No spans found for this trace.</DataDetailsPanel.NoData>
-      ) : (
-        <DataDetailsPanel.Content>
-          <TraceTimeline
-            hierarchicalSpans={hierarchicalSpans}
-            onSpanClick={handleSpanClick}
-            selectedSpanId={selectedSpanId ?? undefined}
-            expandedSpanIds={expandedSpanIds}
-            setExpandedSpanIds={setExpandedSpanIds}
-          />
-        </DataDetailsPanel.Content>
-      )}
+      {(() => {
+        if (isLoading) {
+          return <DataDetailsPanel.LoadingData>Loading trace...</DataDetailsPanel.LoadingData>;
+        }
+        if (hierarchicalSpans.length === 0) {
+          return <DataDetailsPanel.NoData>No spans found for this trace.</DataDetailsPanel.NoData>;
+        }
+        return (
+          <DataDetailsPanel.Content>
+            <TraceTimeline
+              hierarchicalSpans={hierarchicalSpans}
+              onSpanClick={handleSpanClick}
+              selectedSpanId={selectedSpanId ?? undefined}
+              expandedSpanIds={expandedSpanIds}
+              setExpandedSpanIds={setExpandedSpanIds}
+            />
+          </DataDetailsPanel.Content>
+        );
+      })()}
     </DataDetailsPanel>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/trace-keys-and-values.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-keys-and-values.tsx
@@ -13,6 +13,16 @@ function computeTraceStatus(span: { error?: unknown; endedAt?: Date | string | n
   return TraceStatus.SUCCESS;
 }
 
+function getTraceStatusLabel(status: TraceStatus) {
+  if (status === TraceStatus.ERROR) {
+    return 'ERROR';
+  }
+  if (status === TraceStatus.RUNNING) {
+    return 'RUNNING';
+  }
+  return 'SUCCESS';
+}
+
 /** Lightweight root-span fields available from `useTraceLightSpans`. */
 type RootSpanSummary = {
   entityId?: string | null;
@@ -33,15 +43,7 @@ export function TraceKeysAndValues({ rootSpan, numOfCol = 2, className }: TraceK
   const startedAt = rootSpan.startedAt ? new Date(rootSpan.startedAt) : null;
   const endedAt = rootSpan.endedAt ? new Date(rootSpan.endedAt) : null;
   const status = computeTraceStatus(rootSpan);
-  const statusLabel = (() => {
-    if (status === TraceStatus.ERROR) {
-      return 'ERROR';
-    }
-    if (status === TraceStatus.RUNNING) {
-      return 'RUNNING';
-    }
-    return 'SUCCESS';
-  })();
+  const statusLabel = getTraceStatusLabel(status);
 
   return (
     <DataKeysAndValues numOfCol={numOfCol} className={className}>

--- a/packages/playground-ui/src/domains/traces/components/trace-keys-and-values.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-keys-and-values.tsx
@@ -33,7 +33,15 @@ export function TraceKeysAndValues({ rootSpan, numOfCol = 2, className }: TraceK
   const startedAt = rootSpan.startedAt ? new Date(rootSpan.startedAt) : null;
   const endedAt = rootSpan.endedAt ? new Date(rootSpan.endedAt) : null;
   const status = computeTraceStatus(rootSpan);
-  const statusLabel = status === TraceStatus.ERROR ? 'ERROR' : status === TraceStatus.RUNNING ? 'RUNNING' : 'SUCCESS';
+  const statusLabel = (() => {
+    if (status === TraceStatus.ERROR) {
+      return 'ERROR';
+    }
+    if (status === TraceStatus.RUNNING) {
+      return 'RUNNING';
+    }
+    return 'SUCCESS';
+  })();
 
   return (
     <DataKeysAndValues numOfCol={numOfCol} className={className}>

--- a/packages/playground-ui/src/domains/traces/components/traces-layout.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-layout.tsx
@@ -14,6 +14,29 @@ export interface TracesLayoutProps {
   traceCollapsed?: boolean;
 }
 
+function getTracesPanelGridRows({
+  spanPanelSlot,
+  scorePanelSlot,
+  traceCollapsed,
+}: Pick<TracesLayoutProps, 'spanPanelSlot' | 'scorePanelSlot' | 'traceCollapsed'>) {
+  if (scorePanelSlot) {
+    if (traceCollapsed) {
+      return 'grid-rows-[auto_3fr_3fr]';
+    }
+    return 'grid-rows-[2fr_3fr_3fr]';
+  }
+  if (spanPanelSlot) {
+    if (traceCollapsed) {
+      return 'grid-rows-[auto_3fr]';
+    }
+    return 'grid-rows-[2fr_3fr]';
+  }
+  if (traceCollapsed) {
+    return 'grid-rows-[auto]';
+  }
+  return 'grid-rows-[1fr]';
+}
+
 /**
  * Pure 2-column layout shell for the traces page. Owns no state and fetches no data — pass slots in.
  * Right-column row template adapts based on which panels are present.
@@ -40,24 +63,7 @@ export function TracesLayout({
         <div
           className={cn(
             'grid gap-4 max-h-full overflow-auto',
-            (() => {
-              if (scorePanelSlot) {
-                if (traceCollapsed) {
-                  return 'grid-rows-[auto_3fr_3fr]';
-                }
-                return 'grid-rows-[2fr_3fr_3fr]';
-              }
-              if (spanPanelSlot) {
-                if (traceCollapsed) {
-                  return 'grid-rows-[auto_3fr]';
-                }
-                return 'grid-rows-[2fr_3fr]';
-              }
-              if (traceCollapsed) {
-                return 'grid-rows-[auto]';
-              }
-              return 'grid-rows-[1fr]';
-            })(),
+            getTracesPanelGridRows({ spanPanelSlot, scorePanelSlot, traceCollapsed }),
           )}
         >
           {tracePanelSlot}

--- a/packages/playground-ui/src/domains/traces/components/traces-layout.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-layout.tsx
@@ -40,17 +40,24 @@ export function TracesLayout({
         <div
           className={cn(
             'grid gap-4 max-h-full overflow-auto',
-            scorePanelSlot
-              ? traceCollapsed
-                ? 'grid-rows-[auto_3fr_3fr]'
-                : 'grid-rows-[2fr_3fr_3fr]'
-              : spanPanelSlot
-                ? traceCollapsed
-                  ? 'grid-rows-[auto_3fr]'
-                  : 'grid-rows-[2fr_3fr]'
-                : traceCollapsed
-                  ? 'grid-rows-[auto]'
-                  : 'grid-rows-[1fr]',
+            (() => {
+              if (scorePanelSlot) {
+                if (traceCollapsed) {
+                  return 'grid-rows-[auto_3fr_3fr]';
+                }
+                return 'grid-rows-[2fr_3fr_3fr]';
+              }
+              if (spanPanelSlot) {
+                if (traceCollapsed) {
+                  return 'grid-rows-[auto_3fr]';
+                }
+                return 'grid-rows-[2fr_3fr]';
+              }
+              if (traceCollapsed) {
+                return 'grid-rows-[auto]';
+              }
+              return 'grid-rows-[1fr]';
+            })(),
           )}
         >
           {tracePanelSlot}

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-url-state.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-url-state.tsx
@@ -167,14 +167,18 @@ export function useTraceUrlState(
    *  while the user navigates between spans inside the panel (which only changes spanIdParam). */
   const anchorSpanIdParam = searchParams.get(TRACE_ANCHOR_SPAN_ID_PARAM) || undefined;
   const tabParam = searchParams.get(TAB_PARAM);
-  const spanTabParam: SpanTab | undefined =
-    tabParam === 'scoring'
-      ? 'scoring'
-      : tabParam === 'feedback'
-        ? 'feedback'
-        : tabParam === 'details'
-          ? 'details'
-          : undefined;
+  const spanTabParam: SpanTab | undefined = (() => {
+    if (tabParam === 'scoring') {
+      return 'scoring';
+    }
+    if (tabParam === 'feedback') {
+      return 'feedback';
+    }
+    if (tabParam === 'details') {
+      return 'details';
+    }
+    return undefined;
+  })();
   const scoreIdParam = searchParams.get(SCORE_ID_PARAM) || undefined;
 
   const listMode = useMemo<TraceListMode>(() => {

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-url-state.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-url-state.tsx
@@ -34,6 +34,19 @@ const PRESET_MS: Partial<Record<TraceDatePreset, number>> = {
   'last-30d': 30 * DAY_MS,
 };
 
+function parseSpanTab(tabParam: string | null): SpanTab | undefined {
+  if (tabParam === 'scoring') {
+    return 'scoring';
+  }
+  if (tabParam === 'feedback') {
+    return 'feedback';
+  }
+  if (tabParam === 'details') {
+    return 'details';
+  }
+  return undefined;
+}
+
 /** Mutates `params` in place to drop the featured trace/span/tab/score selection.
  *  Used whenever a filter changes — selection no longer makes sense in the new result set. */
 function clearSelectionParams(params: URLSearchParams) {
@@ -167,18 +180,7 @@ export function useTraceUrlState(
    *  while the user navigates between spans inside the panel (which only changes spanIdParam). */
   const anchorSpanIdParam = searchParams.get(TRACE_ANCHOR_SPAN_ID_PARAM) || undefined;
   const tabParam = searchParams.get(TAB_PARAM);
-  const spanTabParam: SpanTab | undefined = (() => {
-    if (tabParam === 'scoring') {
-      return 'scoring';
-    }
-    if (tabParam === 'feedback') {
-      return 'feedback';
-    }
-    if (tabParam === 'details') {
-      return 'details';
-    }
-    return undefined;
-  })();
+  const spanTabParam = parseSpanTab(tabParam);
   const scoreIdParam = searchParams.get(SCORE_ID_PARAM) || undefined;
 
   const listMode = useMemo<TraceListMode>(() => {

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -151,12 +151,15 @@ export function refreshPage0Rows(
   if (!old || old.pages.length === 0) return old;
   const [firstPage, ...rest] = old.pages;
 
-  const refreshedRows =
-    listMode === 'branches' && 'branches' in refreshed
-      ? (refreshed.branches ?? [])
-      : 'spans' in refreshed
-        ? (refreshed.spans ?? [])
-        : [];
+  const refreshedRows = (() => {
+    if (listMode === 'branches' && 'branches' in refreshed) {
+      return refreshed.branches ?? [];
+    }
+    if ('spans' in refreshed) {
+      return refreshed.spans ?? [];
+    }
+    return [];
+  })();
 
   if (refreshedRows.length === 0) return old;
 
@@ -369,12 +372,15 @@ export const useTraces: (args: UseTracesArgs) => UseTracesReturn = ({
       mergeDeltaIntoPage0(old, result, listMode),
     );
 
-    const newRows =
-      listMode === 'branches' && 'branches' in result
-        ? (result.branches ?? [])
-        : 'spans' in result
-          ? (result.spans ?? [])
-          : [];
+    const newRows = (() => {
+      if (listMode === 'branches' && 'branches' in result) {
+        return result.branches ?? [];
+      }
+      if ('spans' in result) {
+        return result.spans ?? [];
+      }
+      return [];
+    })();
     if (newRows.length === 0) return;
     const keys = newRows.map(r => `${r.traceId}:${r.spanId ?? ''}`);
     setRecentlyAddedKeys(prev => {

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -119,6 +119,16 @@ function getPageSpans(page: TracesPageResponse) {
   return page.spans ?? [];
 }
 
+function getRowsFromListResponse(response: ListTracesResponse | ListBranchesResponse, listMode: TraceListMode) {
+  if (listMode === 'branches' && 'branches' in response) {
+    return response.branches ?? [];
+  }
+  if ('spans' in response) {
+    return response.spans ?? [];
+  }
+  return [];
+}
+
 /** Deduplicates trace/branch rows by traceId + spanId across all loaded pages.
  *  Also surfaces page 0's deltaCursor so the live-tail query can read it reactively. */
 export function selectUniqueTraces(data: { pages: TracesPageResponse[] }): {
@@ -151,15 +161,7 @@ export function refreshPage0Rows(
   if (!old || old.pages.length === 0) return old;
   const [firstPage, ...rest] = old.pages;
 
-  const refreshedRows = (() => {
-    if (listMode === 'branches' && 'branches' in refreshed) {
-      return refreshed.branches ?? [];
-    }
-    if ('spans' in refreshed) {
-      return refreshed.spans ?? [];
-    }
-    return [];
-  })();
+  const refreshedRows = getRowsFromListResponse(refreshed, listMode);
 
   if (refreshedRows.length === 0) return old;
 
@@ -372,15 +374,7 @@ export const useTraces: (args: UseTracesArgs) => UseTracesReturn = ({
       mergeDeltaIntoPage0(old, result, listMode),
     );
 
-    const newRows = (() => {
-      if (listMode === 'branches' && 'branches' in result) {
-        return result.branches ?? [];
-      }
-      if ('spans' in result) {
-        return result.spans ?? [];
-      }
-      return [];
-    })();
+    const newRows = getRowsFromListResponse(result, listMode);
     if (newRows.length === 0) return;
     const keys = newRows.map(r => `${r.traceId}:${r.spanId ?? ''}`);
     setRecentlyAddedKeys(prev => {

--- a/packages/playground-ui/src/domains/traces/utils/span-utils.ts
+++ b/packages/playground-ui/src/domains/traces/utils/span-utils.ts
@@ -11,11 +11,15 @@ export function getInputPreview(input: unknown, maxLength = 100): string {
   if (input == null) return '';
 
   // Unwrap legacy { messages: [...] } wrapper from agent_run spans
-  const messageArray = Array.isArray(input)
-    ? input
-    : input && typeof input === 'object' && !Array.isArray(input) && Array.isArray((input as any).messages)
-      ? (input as any).messages
-      : null;
+  const messageArray = (() => {
+    if (Array.isArray(input)) {
+      return input;
+    }
+    if (input && typeof input === 'object' && !Array.isArray(input) && Array.isArray((input as any).messages)) {
+      return (input as any).messages;
+    }
+    return null;
+  })();
 
   if (messageArray) {
     const messages = messageArray as MessageLike[];

--- a/packages/playground-ui/src/domains/traces/utils/span-utils.ts
+++ b/packages/playground-ui/src/domains/traces/utils/span-utils.ts
@@ -2,6 +2,16 @@ import type { SpanRecord } from '@mastra/core/storage';
 
 type MessageLike = { role?: string; content?: unknown };
 
+function getMessageArray(input: unknown) {
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (input && typeof input === 'object' && !Array.isArray(input) && Array.isArray((input as any).messages)) {
+    return (input as any).messages;
+  }
+  return null;
+}
+
 /**
  * Extract a truncated text preview from a span's input field.
  * Agent traces store `input` as an array of message objects.
@@ -11,15 +21,7 @@ export function getInputPreview(input: unknown, maxLength = 100): string {
   if (input == null) return '';
 
   // Unwrap legacy { messages: [...] } wrapper from agent_run spans
-  const messageArray = (() => {
-    if (Array.isArray(input)) {
-      return input;
-    }
-    if (input && typeof input === 'object' && !Array.isArray(input) && Array.isArray((input as any).messages)) {
-      return (input as any).messages;
-    }
-    return null;
-  })();
+  const messageArray = getMessageArray(input);
 
   if (messageArray) {
     const messages = messageArray as MessageLike[];

--- a/packages/playground-ui/src/ds/components/CodeEditor/highlight.ts
+++ b/packages/playground-ui/src/ds/components/CodeEditor/highlight.ts
@@ -32,29 +32,31 @@ const langAliases: Record<string, string> = {
 
 let highlighterPromise: Promise<HighlighterCore> | null = null;
 
+async function createHighlighter() {
+  const [{ createHighlighterCore }, { createJavaScriptRegexEngine }] = await Promise.all([
+    import('shiki/core'),
+    import('shiki/engine/javascript'),
+  ]);
+
+  return createHighlighterCore({
+    themes: [import('shiki/themes/github-light.mjs'), import('shiki/themes/github-dark.mjs')],
+    langs: [
+      import('shiki/langs/javascript.mjs'),
+      import('shiki/langs/typescript.mjs'),
+      import('shiki/langs/tsx.mjs'),
+      import('shiki/langs/jsx.mjs'),
+      import('shiki/langs/json.mjs'),
+      import('shiki/langs/bash.mjs'),
+      import('shiki/langs/markdown.mjs'),
+      import('shiki/langs/python.mjs'),
+    ],
+    engine: createJavaScriptRegexEngine(),
+  });
+}
+
 function getHighlighter(): Promise<HighlighterCore> {
   if (!highlighterPromise) {
-    highlighterPromise = (async () => {
-      const [{ createHighlighterCore }, { createJavaScriptRegexEngine }] = await Promise.all([
-        import('shiki/core'),
-        import('shiki/engine/javascript'),
-      ]);
-
-      return createHighlighterCore({
-        themes: [import('shiki/themes/github-light.mjs'), import('shiki/themes/github-dark.mjs')],
-        langs: [
-          import('shiki/langs/javascript.mjs'),
-          import('shiki/langs/typescript.mjs'),
-          import('shiki/langs/tsx.mjs'),
-          import('shiki/langs/jsx.mjs'),
-          import('shiki/langs/json.mjs'),
-          import('shiki/langs/bash.mjs'),
-          import('shiki/langs/markdown.mjs'),
-          import('shiki/langs/python.mjs'),
-        ],
-        engine: createJavaScriptRegexEngine(),
-      });
-    })();
+    highlighterPromise = createHighlighter();
   }
 
   return highlighterPromise;

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
@@ -23,6 +23,16 @@ const meta: Meta<typeof DataCodeSection> = {
 export default meta;
 type Story = StoryObj<typeof DataCodeSection>;
 
+function getMockStepType(index: number) {
+  if (index % 3 === 0) {
+    return 'transform';
+  }
+  if (index % 3 === 1) {
+    return 'validate';
+  }
+  return 'output';
+}
+
 const sampleJson = JSON.stringify(
   {
     model: 'gpt-4-turbo',
@@ -84,15 +94,7 @@ export const LargeContent: Story = {
           name: 'Data Processing Pipeline',
           steps: Array.from({ length: 20 }, (_, i) => ({
             id: `step-${i + 1}`,
-            type: (() => {
-              if (i % 3 === 0) {
-                return 'transform';
-              }
-              if (i % 3 === 1) {
-                return 'validate';
-              }
-              return 'output';
-            })(),
+            type: getMockStepType(i),
             config: { timeout: 5000, retries: 3 },
           })),
           metadata: {

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
@@ -84,7 +84,15 @@ export const LargeContent: Story = {
           name: 'Data Processing Pipeline',
           steps: Array.from({ length: 20 }, (_, i) => ({
             id: `step-${i + 1}`,
-            type: i % 3 === 0 ? 'transform' : i % 3 === 1 ? 'validate' : 'output',
+            type: (() => {
+              if (i % 3 === 0) {
+                return 'transform';
+              }
+              if (i % 3 === 1) {
+                return 'validate';
+              }
+              return 'output';
+            })(),
             config: { timeout: 5000, retries: 3 },
           })),
           metadata: {

--- a/packages/playground-ui/src/ds/components/DataList/ScoresDataList/scores-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/ScoresDataList/scores-data-list-cells.tsx
@@ -10,6 +10,26 @@ function toDate(value: Date | string): Date | null {
   return isNaN(date.getTime()) ? null : date;
 }
 
+function formatScoreDateCellLabel(date: Date | null) {
+  if (!date) {
+    return '-';
+  }
+  if (isToday(date)) {
+    return 'Today';
+  }
+  return format(date, 'MMM dd');
+}
+
+function formatScoreCellValue(score: unknown) {
+  if (score == null) {
+    return '-';
+  }
+  if (typeof score === 'object') {
+    return JSON.stringify(score);
+  }
+  return String(score);
+}
+
 // ---------------------------------------------------------------------------
 // DateCell
 // ---------------------------------------------------------------------------
@@ -22,15 +42,7 @@ export function ScoresDataListDateCell({ timestamp }: ScoresDataListDateCellProp
   const date = toDate(timestamp);
   return (
     <DataListCell height="compact" className="text-ui-smd text-neutral2">
-      {(() => {
-        if (date) {
-          if (isToday(date)) {
-            return 'Today';
-          }
-          return format(date, 'MMM dd');
-        }
-        return '-';
-      })()}
+      {formatScoreDateCellLabel(date)}
     </DataListCell>
   );
 }
@@ -95,15 +107,7 @@ export interface ScoresDataListScoreCellProps {
 }
 
 export function ScoresDataListScoreCell({ score }: ScoresDataListScoreCellProps) {
-  const display = (() => {
-    if (score == null) {
-      return '-';
-    }
-    if (typeof score === 'object') {
-      return JSON.stringify(score);
-    }
-    return String(score);
-  })();
+  const display = formatScoreCellValue(score);
   return (
     <DataListCell height="compact" className="text-ui-smd font-mono text-neutral3">
       {display}

--- a/packages/playground-ui/src/ds/components/DataList/ScoresDataList/scores-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/ScoresDataList/scores-data-list-cells.tsx
@@ -22,7 +22,15 @@ export function ScoresDataListDateCell({ timestamp }: ScoresDataListDateCellProp
   const date = toDate(timestamp);
   return (
     <DataListCell height="compact" className="text-ui-smd text-neutral2">
-      {date ? (isToday(date) ? 'Today' : format(date, 'MMM dd')) : '-'}
+      {(() => {
+        if (date) {
+          if (isToday(date)) {
+            return 'Today';
+          }
+          return format(date, 'MMM dd');
+        }
+        return '-';
+      })()}
     </DataListCell>
   );
 }
@@ -87,7 +95,15 @@ export interface ScoresDataListScoreCellProps {
 }
 
 export function ScoresDataListScoreCell({ score }: ScoresDataListScoreCellProps) {
-  const display = score == null ? '-' : typeof score === 'object' ? JSON.stringify(score) : String(score);
+  const display = (() => {
+    if (score == null) {
+      return '-';
+    }
+    if (typeof score === 'object') {
+      return JSON.stringify(score);
+    }
+    return String(score);
+  })();
   return (
     <DataListCell height="compact" className="text-ui-smd font-mono text-neutral3">
       {display}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -245,7 +245,15 @@ export function DataListDateCell({ timestamp }: DataListDateCellProps) {
   const date = toDate(timestamp);
   return (
     <DataListCell height="compact" className="text-ui-smd text-neutral2">
-      {date ? (isToday(date) ? 'Today' : format(date, 'MMM dd')) : null}
+      {(() => {
+        if (date) {
+          if (isToday(date)) {
+            return 'Today';
+          }
+          return format(date, 'MMM dd');
+        }
+        return null;
+      })()}
     </DataListCell>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -236,6 +236,16 @@ function toDate(value: Date | string): Date | null {
   return isNaN(date.getTime()) ? null : date;
 }
 
+function formatDateCellLabel(date: Date | null) {
+  if (!date) {
+    return null;
+  }
+  if (isToday(date)) {
+    return 'Today';
+  }
+  return format(date, 'MMM dd');
+}
+
 export interface DataListDateCellProps {
   timestamp: Date | string;
 }
@@ -245,15 +255,7 @@ export function DataListDateCell({ timestamp }: DataListDateCellProps) {
   const date = toDate(timestamp);
   return (
     <DataListCell height="compact" className="text-ui-smd text-neutral2">
-      {(() => {
-        if (date) {
-          if (isToday(date)) {
-            return 'Today';
-          }
-          return format(date, 'MMM dd');
-        }
-        return null;
-      })()}
+      {formatDateCellLabel(date)}
     </DataListCell>
   );
 }

--- a/packages/playground-ui/src/ds/components/ItemList/item-list-date-cell.tsx
+++ b/packages/playground-ui/src/ds/components/ItemList/item-list-date-cell.tsx
@@ -9,18 +9,20 @@ export type ItemListDateCellProps = {
   withTime?: boolean;
 };
 
+function getDisplayDayAndMonth(date: Date | string | null) {
+  if (!date) {
+    return '';
+  }
+  if (isToday(new Date(date))) {
+    return 'Today';
+  }
+  return format(new Date(date), 'MMM dd');
+}
+
 export function ItemListDateCell({ date, className, withTime = false }: ItemListDateCellProps) {
   const isThisYearDate = date ? isThisYear(new Date(date)) : false;
 
-  const displayDayAndMonth = (() => {
-    if (date) {
-      if (isToday(new Date(date))) {
-        return 'Today';
-      }
-      return format(new Date(date), 'MMM dd');
-    }
-    return '';
-  })();
+  const displayDayAndMonth = getDisplayDayAndMonth(date);
   const displayYear = date && !isThisYearDate ? format(new Date(date), 'yyyy') : '';
   const displayTime = date && withTime ? `${format(new Date(date), "'at' h:mm aaa")}` : '';
 

--- a/packages/playground-ui/src/ds/components/ItemList/item-list-date-cell.tsx
+++ b/packages/playground-ui/src/ds/components/ItemList/item-list-date-cell.tsx
@@ -12,7 +12,15 @@ export type ItemListDateCellProps = {
 export function ItemListDateCell({ date, className, withTime = false }: ItemListDateCellProps) {
   const isThisYearDate = date ? isThisYear(new Date(date)) : false;
 
-  const displayDayAndMonth = date ? (isToday(new Date(date)) ? 'Today' : format(new Date(date), 'MMM dd')) : '';
+  const displayDayAndMonth = (() => {
+    if (date) {
+      if (isToday(new Date(date))) {
+        return 'Today';
+      }
+      return format(new Date(date), 'MMM dd');
+    }
+    return '';
+  })();
   const displayYear = date && !isThisYearDate ? format(new Date(date), 'yyyy') : '';
   const displayTime = date && withTime ? `${format(new Date(date), "'at' h:mm aaa")}` : '';
 

--- a/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form-nested-fields.tsx
+++ b/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form-nested-fields.tsx
@@ -3,11 +3,22 @@ import { useJSONSchemaForm } from './json-schema-form-context';
 import { useJSONSchemaFormField } from './json-schema-form-field-context';
 import { JSONSchemaFormNestedProvider } from './json-schema-form-nested-context';
 import { createField } from './types';
+import type { SchemaField } from './types';
 import { cn } from '@/lib/utils';
 
 export interface JSONSchemaFormNestedFieldsProps {
   className?: string;
   children?: React.ReactNode;
+}
+
+function getNestedFields(field: SchemaField) {
+  if (field.type === 'object') {
+    return field.properties || [];
+  }
+  if (field.type === 'array' && field.items) {
+    return field.items.properties || [];
+  }
+  return [];
 }
 
 export function NestedFields({ className, children }: JSONSchemaFormNestedFieldsProps) {
@@ -37,15 +48,7 @@ export function NestedFields({ className, children }: JSONSchemaFormNestedFields
 
   // For objects, show properties directly
   // For arrays, show the items schema's properties (items is always an object)
-  const nestedFields = (() => {
-    if (field.type === 'object') {
-      return field.properties || [];
-    }
-    if (field.type === 'array' && field.items) {
-      return field.items.properties || [];
-    }
-    return [];
-  })();
+  const nestedFields = getNestedFields(field);
 
   return (
     <JSONSchemaFormNestedProvider value={{ parentPath: nestedPath, depth: nestedDepth, fields: nestedFields }}>

--- a/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form-nested-fields.tsx
+++ b/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form-nested-fields.tsx
@@ -37,12 +37,15 @@ export function NestedFields({ className, children }: JSONSchemaFormNestedFields
 
   // For objects, show properties directly
   // For arrays, show the items schema's properties (items is always an object)
-  const nestedFields =
-    field.type === 'object'
-      ? field.properties || []
-      : field.type === 'array' && field.items
-        ? field.items.properties || []
-        : [];
+  const nestedFields = (() => {
+    if (field.type === 'object') {
+      return field.properties || [];
+    }
+    if (field.type === 'array' && field.items) {
+      return field.items.properties || [];
+    }
+    return [];
+  })();
 
   return (
     <JSONSchemaFormNestedProvider value={{ parentPath: nestedPath, depth: nestedDepth, fields: nestedFields }}>

--- a/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
+++ b/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
@@ -71,38 +71,42 @@ export function KeyValueList({ data, className, labelsAreHidden, isLoading, Link
                 '[&>a>svg]:w-[1em] [&>a>svg]:h-[1em] [&>a>svg]:text-neutral3 [&>a>svg]:ml-[-0.5em]',
               )}
             >
-              {isLoading ? (
-                <span
-                  className={cn('bg-surface4 rounded-e-lg w-full')}
-                  style={{ width: `${Math.floor(Math.random() * (90 - 30 + 1)) + 50}%` }}
-                >
-                  &nbsp;
-                </span>
-              ) : isValueItemArray ? (
-                value?.map(item => {
-                  if (item.path && Link) {
-                    return (
-                      <RelationWrapper description={item.description} key={item.id}>
-                        <Link href={item.path}>
-                          {item?.name} <ChevronRightIcon />
-                        </Link>
-                      </RelationWrapper>
-                    );
-                  }
-                  if (item.path) {
-                    return (
-                      <RelationWrapper description={item.description} key={item.id}>
-                        <a href={item.path}>
-                          {item?.name} <ChevronRightIcon />
-                        </a>
-                      </RelationWrapper>
-                    );
-                  }
-                  return <span key={item.id}>{item?.name}</span>;
-                })
-              ) : (
-                <>{value ? value : <span className="text-neutral3 text-ui-sm">n/a</span>}</>
-              )}
+              {(() => {
+                if (isLoading) {
+                  return (
+                    <span
+                      className={cn('bg-surface4 rounded-e-lg w-full')}
+                      style={{ width: `${Math.floor(Math.random() * (90 - 30 + 1)) + 50}%` }}
+                    >
+                      &nbsp;
+                    </span>
+                  );
+                }
+                if (isValueItemArray) {
+                  return value?.map(item => {
+                    if (item.path && Link) {
+                      return (
+                        <RelationWrapper description={item.description} key={item.id}>
+                          <Link href={item.path}>
+                            {item?.name} <ChevronRightIcon />
+                          </Link>
+                        </RelationWrapper>
+                      );
+                    }
+                    if (item.path) {
+                      return (
+                        <RelationWrapper description={item.description} key={item.id}>
+                          <a href={item.path}>
+                            {item?.name} <ChevronRightIcon />
+                          </a>
+                        </RelationWrapper>
+                      );
+                    }
+                    return <span key={item.id}>{item?.name}</span>;
+                  });
+                }
+                return <>{value ? value : <span className="text-neutral3 text-ui-sm">n/a</span>}</>;
+              })()}
             </dd>
           </React.Fragment>
         );

--- a/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
+++ b/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
@@ -29,11 +29,59 @@ export type KeyValueListProps = {
   LinkComponent?: LinkComponent;
 };
 
-export function KeyValueList({ data, className, labelsAreHidden, isLoading, LinkComponent: Link }: KeyValueListProps) {
-  const LabelWrapper = ({ children }: { children: React.ReactNode }) => {
-    return labelsAreHidden ? <VisuallyHidden>{children}</VisuallyHidden> : children;
-  };
+function KeyValueLabel({ hidden, children }: { hidden?: boolean; children: React.ReactNode }) {
+  return hidden ? <VisuallyHidden>{children}</VisuallyHidden> : children;
+}
 
+function getLoadingValueWidth(index: number) {
+  return `${50 + ((index * 17) % 41)}%`;
+}
+
+function KeyValueValue({
+  value,
+  isLoading,
+  Link,
+  index,
+}: {
+  value: Value;
+  isLoading?: boolean;
+  Link?: LinkComponent;
+  index: number;
+}) {
+  if (isLoading) {
+    return (
+      <span className={cn('bg-surface4 rounded-e-lg w-full')} style={{ width: getLoadingValueWidth(index) }}>
+        &nbsp;
+      </span>
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => {
+      if (item.path && Link) {
+        return (
+          <RelationWrapper description={item.description} key={item.id}>
+            <Link href={item.path}>
+              {item?.name} <ChevronRightIcon />
+            </Link>
+          </RelationWrapper>
+        );
+      }
+      if (item.path) {
+        return (
+          <RelationWrapper description={item.description} key={item.id}>
+            <a href={item.path}>
+              {item?.name} <ChevronRightIcon />
+            </a>
+          </RelationWrapper>
+        );
+      }
+      return <span key={item.id}>{item?.name}</span>;
+    });
+  }
+  return <>{value ? value : <span className="text-neutral3 text-ui-sm">n/a</span>}</>;
+}
+
+export function KeyValueList({ data, className, labelsAreHidden, isLoading, LinkComponent: Link }: KeyValueListProps) {
   if (!data || data.length === 0) {
     return null;
   }
@@ -41,8 +89,6 @@ export function KeyValueList({ data, className, labelsAreHidden, isLoading, Link
   return (
     <dl className={cn('grid grid-cols-[auto_1fr] gap-x-4 items-start content-start', className)}>
       {data.map(({ label, value, icon, separator }, index) => {
-        const isValueItemArray = Array.isArray(value);
-
         return (
           <React.Fragment key={label + index}>
             <dt className={cn('text-neutral3 text-ui-md flex items-center gap-8 justify-between min-h-9')}>
@@ -55,7 +101,7 @@ export function KeyValueList({ data, className, labelsAreHidden, isLoading, Link
                   },
                 )}
               >
-                {icon} <LabelWrapper>{label}</LabelWrapper>
+                {icon} <KeyValueLabel hidden={labelsAreHidden}>{label}</KeyValueLabel>
               </span>
               {!labelsAreHidden && (
                 <span className={cn('text-neutral3', '[&>svg]:w-[1em] [&>svg]:h-[1em] [&>svg]:text-neutral3')}>
@@ -71,42 +117,7 @@ export function KeyValueList({ data, className, labelsAreHidden, isLoading, Link
                 '[&>a>svg]:w-[1em] [&>a>svg]:h-[1em] [&>a>svg]:text-neutral3 [&>a>svg]:ml-[-0.5em]',
               )}
             >
-              {(() => {
-                if (isLoading) {
-                  return (
-                    <span
-                      className={cn('bg-surface4 rounded-e-lg w-full')}
-                      style={{ width: `${Math.floor(Math.random() * (90 - 30 + 1)) + 50}%` }}
-                    >
-                      &nbsp;
-                    </span>
-                  );
-                }
-                if (isValueItemArray) {
-                  return value?.map(item => {
-                    if (item.path && Link) {
-                      return (
-                        <RelationWrapper description={item.description} key={item.id}>
-                          <Link href={item.path}>
-                            {item?.name} <ChevronRightIcon />
-                          </Link>
-                        </RelationWrapper>
-                      );
-                    }
-                    if (item.path) {
-                      return (
-                        <RelationWrapper description={item.description} key={item.id}>
-                          <a href={item.path}>
-                            {item?.name} <ChevronRightIcon />
-                          </a>
-                        </RelationWrapper>
-                      );
-                    }
-                    return <span key={item.id}>{item?.name}</span>;
-                  });
-                }
-                return <>{value ? value : <span className="text-neutral3 text-ui-sm">n/a</span>}</>;
-              })()}
+              <KeyValueValue value={value} isLoading={isLoading} Link={Link} index={index} />
             </dd>
           </React.Fragment>
         );

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -47,6 +47,56 @@ type SlottedNavChildProps = {
   className?: string;
 };
 
+function getTooltipContent(link: NavLink, isCollapsed: boolean) {
+  if (link.tooltipMsg) {
+    if (isCollapsed) {
+      return `${link.name} | ${link.tooltipMsg}`;
+    }
+    return link.tooltipMsg;
+  }
+  return link.name;
+}
+
+function createInteractiveElement({
+  asChild,
+  children,
+  itemClassName,
+  link,
+  Link,
+  linkParams,
+  state,
+}: {
+  asChild: boolean;
+  children: React.ReactNode;
+  itemClassName: string;
+  link?: NavLink;
+  Link: LinkComponent;
+  linkParams: { target?: string; rel?: string };
+  state: SidebarState;
+}) {
+  if (asChild) {
+    if (!React.isValidElement<SlottedNavChildProps>(children)) {
+      throw new Error(
+        'MainSidebarNavLink requires a valid React element child when `asChild` is true so it can apply `SlottedNavChildProps` and merge `itemClassName`.',
+      );
+    }
+
+    return React.cloneElement(children, {
+      className: cn(itemClassName, children.props.className),
+    });
+  }
+  if (link) {
+    return (
+      <Link href={link.url} {...linkParams} className={itemClassName}>
+        {link.icon}
+        <MainSidebarNavLabel state={state}>{link.name}</MainSidebarNavLabel>
+        {children}
+      </Link>
+    );
+  }
+  return null;
+}
+
 export function MainSidebarNavLink({
   link,
   state: stateProp,
@@ -77,27 +127,7 @@ export function MainSidebarNavLink({
     level,
   });
 
-  let interactiveEl: React.ReactNode = null;
-
-  if (asChild) {
-    if (!React.isValidElement<SlottedNavChildProps>(children)) {
-      throw new Error(
-        'MainSidebarNavLink requires a valid React element child when `asChild` is true so it can apply `SlottedNavChildProps` and merge `itemClassName`.',
-      );
-    }
-
-    interactiveEl = React.cloneElement(children, {
-      className: cn(itemClassName, children.props.className),
-    });
-  } else if (link) {
-    interactiveEl = (
-      <Link href={link.url} {...linkParams} className={itemClassName}>
-        {link.icon}
-        <MainSidebarNavLabel state={state}>{link.name}</MainSidebarNavLabel>
-        {children}
-      </Link>
-    );
-  }
+  const interactiveEl = createInteractiveElement({ asChild, children, itemClassName, link, Link, linkParams, state });
 
   return (
     <li {...props} className={cn('flex flex-col relative min-w-0', className)}>
@@ -105,15 +135,7 @@ export function MainSidebarNavLink({
         <Tooltip>
           <TooltipTrigger render={interactiveEl} />
           <TooltipContent side="right" align="center" sideOffset={16}>
-            {(() => {
-              if (link.tooltipMsg) {
-                if (isCollapsed) {
-                  return `${link.name} | ${link.tooltipMsg}`;
-                }
-                return link.tooltipMsg;
-              }
-              return link.name;
-            })()}
+            {getTooltipContent(link, isCollapsed)}
           </TooltipContent>
         </Tooltip>
       ) : (

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -105,7 +105,15 @@ export function MainSidebarNavLink({
         <Tooltip>
           <TooltipTrigger render={interactiveEl} />
           <TooltipContent side="right" align="center" sideOffset={16}>
-            {link.tooltipMsg ? (isCollapsed ? `${link.name} | ${link.tooltipMsg}` : link.tooltipMsg) : link.name}
+            {(() => {
+              if (link.tooltipMsg) {
+                if (isCollapsed) {
+                  return `${link.name} | ${link.tooltipMsg}`;
+                }
+                return link.tooltipMsg;
+              }
+              return link.name;
+            })()}
           </TooltipContent>
         </Tooltip>
       ) : (

--- a/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import type { PropertyFilterField, PropertyFilterToken } from './types';
 import { Checkbox } from '@/ds/components/Checkbox';
 import { Input } from '@/ds/components/Input';
@@ -31,13 +32,96 @@ export function PickMultiPanel({ field, tokens, onChange }: PickMultiPanelProps)
   const token = useMemo(() => tokens.find(t => t.fieldId === field.id), [tokens, field.id]);
   // Fall back to `defaultValue` when no token exists — lets view-toggle fields (e.g. List mode)
   // show their default option pre-selected before the user explicitly picks one.
-  const selectedValue = typeof token?.value === 'string' ? token.value : !field.multi ? field.defaultValue : undefined;
+  let selectedValue: string | undefined;
+  if (typeof token?.value === 'string') {
+    selectedValue = token.value;
+  } else if (!field.multi) {
+    selectedValue = field.defaultValue;
+  }
   const selectedValues = useMemo<string[]>(() => {
     const value = token?.value;
     if (Array.isArray(value)) return value;
     if (typeof value === 'string') return [value];
     return [];
   }, [token]);
+
+  let optionsContent: ReactNode;
+  if (field.isLoading) {
+    optionsContent = (
+      <div className="flex items-center gap-2 px-2 py-1.5 text-ui-sm text-neutral3">
+        <Spinner size="sm" className="size-3 text-neutral3" />
+        Loading options…
+      </div>
+    );
+  } else if (filteredOptions.length === 0) {
+    optionsContent = (
+      <div className="px-2 py-1.5 text-ui-sm text-neutral3">{field.emptyText ?? 'No option found.'}</div>
+    );
+  } else if (field.multi) {
+    optionsContent = (
+      <div className="max-h-[80dvh] overflow-auto">
+        {filteredOptions.map(option => {
+          const checked = selectedValues.includes(option.value);
+          return (
+            <label
+              key={option.value}
+              title={option.label}
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
+            >
+              <Checkbox
+                data-pick-multi-item=""
+                checked={checked}
+                onCheckedChange={next => {
+                  const isChecked = next === true;
+                  let nextValues: string[];
+                  if (isChecked) {
+                    if (selectedValues.includes(option.value)) {
+                      nextValues = selectedValues;
+                    } else {
+                      nextValues = [...selectedValues, option.value];
+                    }
+                  } else {
+                    nextValues = selectedValues.filter(v => v !== option.value);
+                  }
+                  onChange(field.id, nextValues);
+                }}
+                className="shrink-0"
+              />
+              <span className="truncate min-w-0 flex-1">{option.label}</span>
+            </label>
+          );
+        })}
+      </div>
+    );
+  } else {
+    optionsContent = (
+      <RadioGroup
+        value={selectedValue ?? ''}
+        onValueChange={value => onChange(field.id, value)}
+        className="max-h-[80dvh] gap-0 overflow-auto"
+      >
+        {filteredOptions.map(option => (
+          <label
+            key={option.value}
+            title={option.label}
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
+          >
+            <RadioGroupItem data-pick-multi-item="" value={option.value} className="shrink-0" />
+            <span className="truncate min-w-0 flex-1">{option.label}</span>
+          </label>
+        ))}
+        {!field.omitAnyOption && (
+          <label
+            title="Any"
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
+          >
+            <RadioGroupItem data-pick-multi-item="" value="Any" className="shrink-0" />
+            <span className="truncate min-w-0 flex-1">Any</span>
+          </label>
+        )}
+      </RadioGroup>
+    );
+  }
 
   return (
     <>
@@ -60,69 +144,7 @@ export function PickMultiPanel({ field, tokens, onChange }: PickMultiPanelProps)
         />
       )}
 
-      {field.isLoading ? (
-        <div className="flex items-center gap-2 px-2 py-1.5 text-ui-sm text-neutral3">
-          <Spinner size="sm" className="size-3 text-neutral3" />
-          Loading options…
-        </div>
-      ) : filteredOptions.length === 0 ? (
-        <div className="px-2 py-1.5 text-ui-sm text-neutral3">{field.emptyText ?? 'No option found.'}</div>
-      ) : field.multi ? (
-        <div className="max-h-[80dvh] overflow-auto">
-          {filteredOptions.map(option => {
-            const checked = selectedValues.includes(option.value);
-            return (
-              <label
-                key={option.value}
-                title={option.label}
-                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
-              >
-                <Checkbox
-                  data-pick-multi-item=""
-                  checked={checked}
-                  onCheckedChange={next => {
-                    const isChecked = next === true;
-                    const nextValues = isChecked
-                      ? selectedValues.includes(option.value)
-                        ? selectedValues
-                        : [...selectedValues, option.value]
-                      : selectedValues.filter(v => v !== option.value);
-                    onChange(field.id, nextValues);
-                  }}
-                  className="shrink-0"
-                />
-                <span className="truncate min-w-0 flex-1">{option.label}</span>
-              </label>
-            );
-          })}
-        </div>
-      ) : (
-        <RadioGroup
-          value={selectedValue ?? ''}
-          onValueChange={value => onChange(field.id, value)}
-          className="max-h-[80dvh] gap-0 overflow-auto"
-        >
-          {filteredOptions.map(option => (
-            <label
-              key={option.value}
-              title={option.label}
-              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
-            >
-              <RadioGroupItem data-pick-multi-item="" value={option.value} className="shrink-0" />
-              <span className="truncate min-w-0 flex-1">{option.label}</span>
-            </label>
-          ))}
-          {!field.omitAnyOption && (
-            <label
-              title="Any"
-              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
-            >
-              <RadioGroupItem data-pick-multi-item="" value="Any" className="shrink-0" />
-              <span className="truncate min-w-0 flex-1">Any</span>
-            </label>
-          )}
-        </RadioGroup>
-      )}
+      {optionsContent}
     </>
   );
 }

--- a/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react';
-import type { ReactNode } from 'react';
 import type { PropertyFilterField, PropertyFilterToken } from './types';
 import { Checkbox } from '@/ds/components/Checkbox';
 import { Input } from '@/ds/components/Input';
@@ -13,6 +12,148 @@ export type PickMultiPanelProps = {
   tokens: PropertyFilterToken[];
   onChange: (fieldId: string, value: string | string[] | undefined) => void;
 };
+
+type PickMultiOption = PickMultiField['options'][number];
+
+function getSelectedValue(token: PropertyFilterToken | undefined, field: PickMultiField) {
+  if (typeof token?.value === 'string') {
+    return token.value;
+  }
+  if (!field.multi) {
+    return field.defaultValue;
+  }
+  return undefined;
+}
+
+function getNextSelectedValues(selectedValues: string[], optionValue: string, isChecked: boolean) {
+  if (!isChecked) {
+    return selectedValues.filter(v => v !== optionValue);
+  }
+  if (selectedValues.includes(optionValue)) {
+    return selectedValues;
+  }
+  return [...selectedValues, optionValue];
+}
+
+function getPickMultiOptionLabelId(fieldId: string, optionValue: string) {
+  return `pick-multi-option-${fieldId}-${optionValue}`.replace(/[^A-Za-z0-9_-]/g, '_');
+}
+
+function isEventTargetInPickMultiControl(target: EventTarget | null) {
+  return target instanceof Element && target.closest('[data-pick-multi-control]') != null;
+}
+
+function PickMultiOptions({
+  field,
+  filteredOptions,
+  selectedValue,
+  selectedValues,
+  onChange,
+}: {
+  field: PickMultiField;
+  filteredOptions: PickMultiOption[];
+  selectedValue: string | undefined;
+  selectedValues: string[];
+  onChange: PickMultiPanelProps['onChange'];
+}) {
+  if (field.isLoading) {
+    return (
+      <div className="flex items-center gap-2 px-2 py-1.5 text-ui-sm text-neutral3">
+        <Spinner size="sm" className="size-3 text-neutral3" />
+        Loading options…
+      </div>
+    );
+  }
+  if (filteredOptions.length === 0) {
+    return <div className="px-2 py-1.5 text-ui-sm text-neutral3">{field.emptyText ?? 'No option found.'}</div>;
+  }
+  if (field.multi) {
+    return (
+      <div className="max-h-[80dvh] overflow-auto">
+        {filteredOptions.map(option => {
+          const checked = selectedValues.includes(option.value);
+          const labelId = getPickMultiOptionLabelId(field.id, option.value);
+          return (
+            <div
+              key={option.value}
+              title={option.label}
+              onPointerUp={event => {
+                if (isEventTargetInPickMultiControl(event.target)) return;
+                onChange(field.id, getNextSelectedValues(selectedValues, option.value, !checked));
+              }}
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
+            >
+              <Checkbox
+                data-pick-multi-item=""
+                data-pick-multi-control=""
+                checked={checked}
+                aria-labelledby={labelId}
+                onCheckedChange={next =>
+                  onChange(field.id, getNextSelectedValues(selectedValues, option.value, next === true))
+                }
+                className="shrink-0"
+              />
+              <span id={labelId} className="truncate min-w-0 flex-1">
+                {option.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+  return (
+    <RadioGroup
+      value={selectedValue ?? ''}
+      onValueChange={value => onChange(field.id, value)}
+      className="max-h-[80dvh] gap-0 overflow-auto"
+    >
+      {filteredOptions.map(option => (
+        <div
+          key={option.value}
+          title={option.label}
+          onPointerUp={event => {
+            if (isEventTargetInPickMultiControl(event.target)) return;
+            onChange(field.id, option.value);
+          }}
+          className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
+        >
+          <RadioGroupItem
+            data-pick-multi-item=""
+            data-pick-multi-control=""
+            value={option.value}
+            aria-labelledby={getPickMultiOptionLabelId(field.id, option.value)}
+            className="shrink-0"
+          />
+          <span id={getPickMultiOptionLabelId(field.id, option.value)} className="truncate min-w-0 flex-1">
+            {option.label}
+          </span>
+        </div>
+      ))}
+      {!field.omitAnyOption && (
+        <div
+          title="Any"
+          onPointerUp={event => {
+            if (isEventTargetInPickMultiControl(event.target)) return;
+            onChange(field.id, 'Any');
+          }}
+          className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
+        >
+          <RadioGroupItem
+            data-pick-multi-item=""
+            data-pick-multi-control=""
+            value="Any"
+            aria-labelledby={getPickMultiOptionLabelId(field.id, 'Any')}
+            className="shrink-0"
+          />
+          <span id={getPickMultiOptionLabelId(field.id, 'Any')} className="truncate min-w-0 flex-1">
+            Any
+          </span>
+        </div>
+      )}
+    </RadioGroup>
+  );
+}
 
 /**
  * Reusable body for a pick-multi side popover: optional search input plus a
@@ -32,96 +173,13 @@ export function PickMultiPanel({ field, tokens, onChange }: PickMultiPanelProps)
   const token = useMemo(() => tokens.find(t => t.fieldId === field.id), [tokens, field.id]);
   // Fall back to `defaultValue` when no token exists — lets view-toggle fields (e.g. List mode)
   // show their default option pre-selected before the user explicitly picks one.
-  let selectedValue: string | undefined;
-  if (typeof token?.value === 'string') {
-    selectedValue = token.value;
-  } else if (!field.multi) {
-    selectedValue = field.defaultValue;
-  }
+  const selectedValue = getSelectedValue(token, field);
   const selectedValues = useMemo<string[]>(() => {
     const value = token?.value;
     if (Array.isArray(value)) return value;
     if (typeof value === 'string') return [value];
     return [];
   }, [token]);
-
-  let optionsContent: ReactNode;
-  if (field.isLoading) {
-    optionsContent = (
-      <div className="flex items-center gap-2 px-2 py-1.5 text-ui-sm text-neutral3">
-        <Spinner size="sm" className="size-3 text-neutral3" />
-        Loading options…
-      </div>
-    );
-  } else if (filteredOptions.length === 0) {
-    optionsContent = (
-      <div className="px-2 py-1.5 text-ui-sm text-neutral3">{field.emptyText ?? 'No option found.'}</div>
-    );
-  } else if (field.multi) {
-    optionsContent = (
-      <div className="max-h-[80dvh] overflow-auto">
-        {filteredOptions.map(option => {
-          const checked = selectedValues.includes(option.value);
-          return (
-            <label
-              key={option.value}
-              title={option.label}
-              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
-            >
-              <Checkbox
-                data-pick-multi-item=""
-                checked={checked}
-                onCheckedChange={next => {
-                  const isChecked = next === true;
-                  let nextValues: string[];
-                  if (isChecked) {
-                    if (selectedValues.includes(option.value)) {
-                      nextValues = selectedValues;
-                    } else {
-                      nextValues = [...selectedValues, option.value];
-                    }
-                  } else {
-                    nextValues = selectedValues.filter(v => v !== option.value);
-                  }
-                  onChange(field.id, nextValues);
-                }}
-                className="shrink-0"
-              />
-              <span className="truncate min-w-0 flex-1">{option.label}</span>
-            </label>
-          );
-        })}
-      </div>
-    );
-  } else {
-    optionsContent = (
-      <RadioGroup
-        value={selectedValue ?? ''}
-        onValueChange={value => onChange(field.id, value)}
-        className="max-h-[80dvh] gap-0 overflow-auto"
-      >
-        {filteredOptions.map(option => (
-          <label
-            key={option.value}
-            title={option.label}
-            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
-          >
-            <RadioGroupItem data-pick-multi-item="" value={option.value} className="shrink-0" />
-            <span className="truncate min-w-0 flex-1">{option.label}</span>
-          </label>
-        ))}
-        {!field.omitAnyOption && (
-          <label
-            title="Any"
-            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
-          >
-            <RadioGroupItem data-pick-multi-item="" value="Any" className="shrink-0" />
-            <span className="truncate min-w-0 flex-1">Any</span>
-          </label>
-        )}
-      </RadioGroup>
-    );
-  }
 
   return (
     <>
@@ -144,7 +202,13 @@ export function PickMultiPanel({ field, tokens, onChange }: PickMultiPanelProps)
         />
       )}
 
-      {optionsContent}
+      <PickMultiOptions
+        field={field}
+        filteredOptions={filteredOptions}
+        selectedValue={selectedValue}
+        selectedValues={selectedValues}
+        onChange={onChange}
+      />
     </>
   );
 }

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
@@ -102,6 +102,16 @@ function clampScrollButtonNumber(value: number | undefined, fallback: number, mi
   return Number.isFinite(resolvedValue) ? Math.max(min, resolvedValue) : Math.max(min, fallback);
 }
 
+function getContentStyle(orientation: Orientation): React.CSSProperties | undefined {
+  if (orientation === 'vertical') {
+    return { minWidth: '0px' };
+  }
+  if (orientation === 'horizontal') {
+    return { minHeight: '0px' };
+  }
+  return undefined;
+}
+
 type ScrollButtonProps = {
   direction: ScrollButtonDirection;
   label: string;
@@ -268,15 +278,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
     // content can grow wider than the viewport (required for horizontal scroll
     // measurement). For vertical-only scroll we override it so children shrink
     // to the viewport width instead of forcing horizontal scroll.
-    const contentStyle: React.CSSProperties | undefined = (() => {
-      if (orientation === 'vertical') {
-        return { minWidth: '0px' };
-      }
-      if (orientation === 'horizontal') {
-        return { minHeight: '0px' };
-      }
-      return undefined;
-    })();
+    const contentStyle = getContentStyle(orientation);
 
     return (
       <ScrollAreaPrimitive.Root

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
@@ -268,12 +268,15 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
     // content can grow wider than the viewport (required for horizontal scroll
     // measurement). For vertical-only scroll we override it so children shrink
     // to the viewport width instead of forcing horizontal scroll.
-    const contentStyle: React.CSSProperties | undefined =
-      orientation === 'vertical'
-        ? { minWidth: '0px' }
-        : orientation === 'horizontal'
-          ? { minHeight: '0px' }
-          : undefined;
+    const contentStyle: React.CSSProperties | undefined = (() => {
+      if (orientation === 'vertical') {
+        return { minWidth: '0px' };
+      }
+      if (orientation === 'horizontal') {
+        return { minHeight: '0px' };
+      }
+      return undefined;
+    })();
 
     return (
       <ScrollAreaPrimitive.Root

--- a/packages/playground-ui/src/ds/components/Slider/slider.tsx
+++ b/packages/playground-ui/src/ds/components/Slider/slider.tsx
@@ -14,6 +14,16 @@ function toArray(value: number | readonly number[]): number[] {
   return [...value];
 }
 
+function getSliderValues(value: SliderProps['value'], defaultValue: SliderProps['defaultValue'], min: number) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (Array.isArray(defaultValue)) {
+    return defaultValue;
+  }
+  return [min];
+}
+
 const Slider = ({
   className,
   defaultValue,
@@ -24,15 +34,7 @@ const Slider = ({
   onValueCommitted,
   ...props
 }: SliderProps) => {
-  const values = (() => {
-    if (Array.isArray(value)) {
-      return value;
-    }
-    if (Array.isArray(defaultValue)) {
-      return defaultValue;
-    }
-    return [min];
-  })();
+  const values = getSliderValues(value, defaultValue, min);
 
   return (
     <SliderPrimitive.Root

--- a/packages/playground-ui/src/ds/components/Slider/slider.tsx
+++ b/packages/playground-ui/src/ds/components/Slider/slider.tsx
@@ -24,7 +24,15 @@ const Slider = ({
   onValueCommitted,
   ...props
 }: SliderProps) => {
-  const values = Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min];
+  const values = (() => {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (Array.isArray(defaultValue)) {
+      return defaultValue;
+    }
+    return [min];
+  })();
 
   return (
     <SliderPrimitive.Root

--- a/packages/playground-ui/src/ee/signals/components/signal-details-page.tsx
+++ b/packages/playground-ui/src/ee/signals/components/signal-details-page.tsx
@@ -198,12 +198,14 @@ export function SignalTraceListTab({
           </DataList.TopCells>
         </DataList.Top>
 
-        {loading ? (
-          <SignalTraceListSkeleton />
-        ) : visible.length === 0 ? (
-          <DataList.NoMatch message="No traces match this subtopic." />
-        ) : (
-          visible.map(example => (
+        {(() => {
+          if (loading) {
+            return <SignalTraceListSkeleton />;
+          }
+          if (visible.length === 0) {
+            return <DataList.NoMatch message="No traces match this subtopic." />;
+          }
+          return visible.map(example => (
             <DataList.RowButton
               key={example.exampleId}
               featured={selectedTraceId === example.traceId}
@@ -212,8 +214,8 @@ export function SignalTraceListTab({
             >
               <DataList.TextCell>{example.signalText}</DataList.TextCell>
             </DataList.RowButton>
-          ))
-        )}
+          ));
+        })()}
       </DataList>
 
       {hasMore && !loading ? (

--- a/packages/playground-ui/src/ee/signals/components/signal-details-page.tsx
+++ b/packages/playground-ui/src/ee/signals/components/signal-details-page.tsx
@@ -106,6 +106,35 @@ function SignalTraceListSkeleton({ rows = 8 }: { rows?: number }) {
   );
 }
 
+function SignalTraceListRows({
+  loading,
+  visible,
+  selectedTraceId,
+  onTraceSelect,
+}: {
+  loading: boolean;
+  visible: EntityLearningTopicExample[];
+  selectedTraceId: string | null;
+  onTraceSelect: (traceId: string) => void;
+}) {
+  if (loading) {
+    return <SignalTraceListSkeleton />;
+  }
+  if (visible.length === 0) {
+    return <DataList.NoMatch message="No traces match this subtopic." />;
+  }
+  return visible.map(example => (
+    <DataList.RowButton
+      key={example.exampleId}
+      featured={selectedTraceId === example.traceId}
+      onClick={() => onTraceSelect(example.traceId)}
+      aria-pressed={selectedTraceId === example.traceId}
+    >
+      <DataList.TextCell>{example.signalText}</DataList.TextCell>
+    </DataList.RowButton>
+  ));
+}
+
 function SignalClusterSidebarSkeleton({ rows = 5 }: { rows?: number }) {
   return (
     <aside className="min-h-0 w-72 shrink-0 overflow-y-auto border-r border-border1/60 pr-4 py-4" aria-hidden="true">
@@ -198,24 +227,12 @@ export function SignalTraceListTab({
           </DataList.TopCells>
         </DataList.Top>
 
-        {(() => {
-          if (loading) {
-            return <SignalTraceListSkeleton />;
-          }
-          if (visible.length === 0) {
-            return <DataList.NoMatch message="No traces match this subtopic." />;
-          }
-          return visible.map(example => (
-            <DataList.RowButton
-              key={example.exampleId}
-              featured={selectedTraceId === example.traceId}
-              onClick={() => onTraceSelect(example.traceId)}
-              aria-pressed={selectedTraceId === example.traceId}
-            >
-              <DataList.TextCell>{example.signalText}</DataList.TextCell>
-            </DataList.RowButton>
-          ));
-        })()}
+        <SignalTraceListRows
+          loading={loading}
+          visible={visible}
+          selectedTraceId={selectedTraceId}
+          onTraceSelect={onTraceSelect}
+        />
       </DataList>
 
       {hasMore && !loading ? (

--- a/packages/playground-ui/src/ee/signals/components/signals-overview-page.tsx
+++ b/packages/playground-ui/src/ee/signals/components/signals-overview-page.tsx
@@ -130,6 +130,63 @@ interface SignalSectionProps {
   onSelectCluster: (signalName: string, topicId: string) => void;
 }
 
+function SignalClusterCountBadge({
+  isLoading,
+  isError,
+  topicCount,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  topicCount: number;
+}) {
+  if (isLoading) {
+    return <Skeleton className="h-badge-default w-20 rounded-full" aria-hidden="true" />;
+  }
+  if (isError) {
+    return null;
+  }
+  return (
+    <Badge variant="default">
+      {topicCount} {topicCount === 1 ? 'cluster' : 'clusters'}
+    </Badge>
+  );
+}
+
+function SignalSectionBody({
+  isLoading,
+  isError,
+  topics,
+  signalName,
+  onSelectCluster,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  topics: EntityLearningTopic[];
+  signalName: string;
+  onSelectCluster: (signalName: string, topicId: string) => void;
+}) {
+  if (isLoading) {
+    return <SignalSectionSkeleton />;
+  }
+  if (isError) {
+    return <p className="px-1 text-ui-md text-accent2">Failed to load clusters for this signal.</p>;
+  }
+  if (topics.length === 0) {
+    return <p className="px-1 text-ui-md text-neutral3">No clusters found for this signal yet.</p>;
+  }
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      {topics.map(topic => (
+        <SignalClusterCard
+          key={topic.topicId}
+          topic={topic}
+          onSelect={topicId => onSelectCluster(signalName, topicId)}
+        />
+      ))}
+    </div>
+  );
+}
+
 export function SignalSection({ entity, catalog, signalName, onSeeDetails, onSelectCluster }: SignalSectionProps) {
   // No runId: the API resolves the latest run per signal. `entity.latestRunId`
   // is entity-wide and belongs to a single signal, so reusing it here would
@@ -137,45 +194,13 @@ export function SignalSection({ entity, catalog, signalName, onSeeDetails, onSel
   const { data, isLoading, isError } = useEntityTopics(entity.entityId, signalName);
   const topics = data?.topics ?? [];
 
-  let clusterCountBadge = null;
-  if (isLoading) {
-    clusterCountBadge = <Skeleton className="h-badge-default w-20 rounded-full" aria-hidden="true" />;
-  } else if (!isError) {
-    clusterCountBadge = (
-      <Badge variant="default">
-        {topics.length} {topics.length === 1 ? 'cluster' : 'clusters'}
-      </Badge>
-    );
-  }
-
-  let sectionBody;
-  if (isLoading) {
-    sectionBody = <SignalSectionSkeleton />;
-  } else if (isError) {
-    sectionBody = <p className="px-1 text-ui-md text-accent2">Failed to load clusters for this signal.</p>;
-  } else if (topics.length === 0) {
-    sectionBody = <p className="px-1 text-ui-md text-neutral3">No clusters found for this signal yet.</p>;
-  } else {
-    sectionBody = (
-      <div className="grid gap-6 md:grid-cols-2">
-        {topics.map(topic => (
-          <SignalClusterCard
-            key={topic.topicId}
-            topic={topic}
-            onSelect={topicId => onSelectCluster(signalName, topicId)}
-          />
-        ))}
-      </div>
-    );
-  }
-
   return (
     <section className="space-y-4">
       <header className="flex items-start justify-between gap-6 px-1">
         <div className="min-w-0">
           <div className="flex items-center gap-3">
             <h2 className="text-ui-2xl font-semibold text-neutral6">{catalog.name}</h2>
-            {clusterCountBadge}
+            <SignalClusterCountBadge isLoading={isLoading} isError={isError} topicCount={topics.length} />
           </div>
           {catalog.description ? <p className="text-ui-lg text-neutral3">{catalog.description}</p> : null}
         </div>
@@ -192,7 +217,13 @@ export function SignalSection({ entity, catalog, signalName, onSeeDetails, onSel
         </Button>
       </header>
 
-      {sectionBody}
+      <SignalSectionBody
+        isLoading={isLoading}
+        isError={isError}
+        topics={topics}
+        signalName={signalName}
+        onSelectCluster={onSelectCluster}
+      />
     </section>
   );
 }
@@ -201,6 +232,91 @@ export interface SignalsOverviewPageProps {
   selectedEntity: SelectedEntity | null;
   onEntityChange: (selected: SelectedEntity | null) => void;
   onSignalSelect: (signalName: string, topicId?: string) => void;
+}
+
+function SignalsOverviewContent({
+  isLoading,
+  isError,
+  entities,
+  entity,
+  selectedEntity,
+  onEntityChange,
+  onSignalSelect,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  entities: EntityLearningEntitySummary[];
+  entity: EntityLearningEntitySummary | undefined;
+  selectedEntity: SelectedEntity | null;
+  onEntityChange: (selected: SelectedEntity | null) => void;
+  onSignalSelect: (signalName: string, topicId?: string) => void;
+}) {
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState iconSlot={<Spinner />} titleSlot="Loading entities…" />
+      </div>
+    );
+  }
+  if (isError) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<CircleSlashIcon />}
+          titleSlot="Failed to load entities"
+          descriptionSlot="Failed to load entities from the observability endpoint."
+        />
+      </div>
+    );
+  }
+  if (entities.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<InboxIcon />}
+          titleSlot="No entities available"
+          descriptionSlot="No entities are available on the server yet."
+        />
+      </div>
+    );
+  }
+  if (!entity) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<MousePointerClickIcon />}
+          titleSlot="No entity selected"
+          descriptionSlot="Select an entity to inspect its signals and clusters."
+          actionSlot={<SignalsEntityFilter entities={entities} selected={selectedEntity} onChange={onEntityChange} />}
+        />
+      </div>
+    );
+  }
+  if (entity.availableSignals.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<InboxIcon />}
+          titleSlot="No signals yet"
+          descriptionSlot="This entity has no signals yet."
+        />
+      </div>
+    );
+  }
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-12">
+      {entity.availableSignals.map(signalName => (
+        <SignalSection
+          key={signalName}
+          entity={entity}
+          signalName={signalName}
+          catalog={getSignalCatalogEntry(signalName)}
+          onSeeDetails={onSignalSelect}
+          onSelectCluster={onSignalSelect}
+        />
+      ))}
+    </div>
+  );
 }
 
 export function SignalsOverviewPage({ selectedEntity, onEntityChange, onSignalSelect }: SignalsOverviewPageProps) {
@@ -214,71 +330,6 @@ export function SignalsOverviewPage({ selectedEntity, onEntityChange, onSignalSe
   // shows the top bar with an empty agent dropdown.
   const showFilterBar = Boolean(entity);
 
-  let content;
-  if (isLoading) {
-    content = (
-      <div className="flex h-full items-center justify-center">
-        <EmptyState iconSlot={<Spinner />} titleSlot="Loading entities…" />
-      </div>
-    );
-  } else if (isError) {
-    content = (
-      <div className="flex h-full items-center justify-center">
-        <EmptyState
-          iconSlot={<CircleSlashIcon />}
-          titleSlot="Failed to load entities"
-          descriptionSlot="Failed to load entities from the observability endpoint."
-        />
-      </div>
-    );
-  } else if (entities.length === 0) {
-    content = (
-      <div className="flex h-full items-center justify-center">
-        <EmptyState
-          iconSlot={<InboxIcon />}
-          titleSlot="No entities available"
-          descriptionSlot="No entities are available on the server yet."
-        />
-      </div>
-    );
-  } else if (!entity) {
-    content = (
-      <div className="flex h-full items-center justify-center">
-        <EmptyState
-          iconSlot={<MousePointerClickIcon />}
-          titleSlot="No entity selected"
-          descriptionSlot="Select an entity to inspect its signals and clusters."
-          actionSlot={<SignalsEntityFilter entities={entities} selected={selectedEntity} onChange={onEntityChange} />}
-        />
-      </div>
-    );
-  } else if (entity.availableSignals.length === 0) {
-    content = (
-      <div className="flex h-full items-center justify-center">
-        <EmptyState
-          iconSlot={<InboxIcon />}
-          titleSlot="No signals yet"
-          descriptionSlot="This entity has no signals yet."
-        />
-      </div>
-    );
-  } else {
-    content = (
-      <div className="mx-auto flex max-w-6xl flex-col gap-12">
-        {entity.availableSignals.map(signalName => (
-          <SignalSection
-            key={signalName}
-            entity={entity}
-            signalName={signalName}
-            catalog={getSignalCatalogEntry(signalName)}
-            onSeeDetails={onSignalSelect}
-            onSelectCluster={onSignalSelect}
-          />
-        ))}
-      </div>
-    );
-  }
-
   return (
     <TopicsLayout sidebar={null} contentPadding={false}>
       <div className="flex h-full min-w-0 flex-col" aria-label="Signals">
@@ -288,7 +339,17 @@ export function SignalsOverviewPage({ selectedEntity, onEntityChange, onSignalSe
           </div>
         )}
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-6">{content}</div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-6">
+          <SignalsOverviewContent
+            isLoading={isLoading}
+            isError={isError}
+            entities={entities}
+            entity={entity}
+            selectedEntity={selectedEntity}
+            onEntityChange={onEntityChange}
+            onSignalSelect={onSignalSelect}
+          />
+        </div>
       </div>
     </TopicsLayout>
   );

--- a/packages/playground-ui/src/ee/signals/components/signals-overview-page.tsx
+++ b/packages/playground-ui/src/ee/signals/components/signals-overview-page.tsx
@@ -137,19 +137,45 @@ export function SignalSection({ entity, catalog, signalName, onSeeDetails, onSel
   const { data, isLoading, isError } = useEntityTopics(entity.entityId, signalName);
   const topics = data?.topics ?? [];
 
+  let clusterCountBadge = null;
+  if (isLoading) {
+    clusterCountBadge = <Skeleton className="h-badge-default w-20 rounded-full" aria-hidden="true" />;
+  } else if (!isError) {
+    clusterCountBadge = (
+      <Badge variant="default">
+        {topics.length} {topics.length === 1 ? 'cluster' : 'clusters'}
+      </Badge>
+    );
+  }
+
+  let sectionBody;
+  if (isLoading) {
+    sectionBody = <SignalSectionSkeleton />;
+  } else if (isError) {
+    sectionBody = <p className="px-1 text-ui-md text-accent2">Failed to load clusters for this signal.</p>;
+  } else if (topics.length === 0) {
+    sectionBody = <p className="px-1 text-ui-md text-neutral3">No clusters found for this signal yet.</p>;
+  } else {
+    sectionBody = (
+      <div className="grid gap-6 md:grid-cols-2">
+        {topics.map(topic => (
+          <SignalClusterCard
+            key={topic.topicId}
+            topic={topic}
+            onSelect={topicId => onSelectCluster(signalName, topicId)}
+          />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <section className="space-y-4">
       <header className="flex items-start justify-between gap-6 px-1">
         <div className="min-w-0">
           <div className="flex items-center gap-3">
             <h2 className="text-ui-2xl font-semibold text-neutral6">{catalog.name}</h2>
-            {isLoading ? (
-              <Skeleton className="h-badge-default w-20 rounded-full" aria-hidden="true" />
-            ) : !isError ? (
-              <Badge variant="default">
-                {topics.length} {topics.length === 1 ? 'cluster' : 'clusters'}
-              </Badge>
-            ) : null}
+            {clusterCountBadge}
           </div>
           {catalog.description ? <p className="text-ui-lg text-neutral3">{catalog.description}</p> : null}
         </div>
@@ -166,23 +192,7 @@ export function SignalSection({ entity, catalog, signalName, onSeeDetails, onSel
         </Button>
       </header>
 
-      {isLoading ? (
-        <SignalSectionSkeleton />
-      ) : isError ? (
-        <p className="px-1 text-ui-md text-accent2">Failed to load clusters for this signal.</p>
-      ) : topics.length === 0 ? (
-        <p className="px-1 text-ui-md text-neutral3">No clusters found for this signal yet.</p>
-      ) : (
-        <div className="grid gap-6 md:grid-cols-2">
-          {topics.map(topic => (
-            <SignalClusterCard
-              key={topic.topicId}
-              topic={topic}
-              onSelect={topicId => onSelectCluster(signalName, topicId)}
-            />
-          ))}
-        </div>
-      )}
+      {sectionBody}
     </section>
   );
 }
@@ -204,6 +214,71 @@ export function SignalsOverviewPage({ selectedEntity, onEntityChange, onSignalSe
   // shows the top bar with an empty agent dropdown.
   const showFilterBar = Boolean(entity);
 
+  let content;
+  if (isLoading) {
+    content = (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState iconSlot={<Spinner />} titleSlot="Loading entities…" />
+      </div>
+    );
+  } else if (isError) {
+    content = (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<CircleSlashIcon />}
+          titleSlot="Failed to load entities"
+          descriptionSlot="Failed to load entities from the observability endpoint."
+        />
+      </div>
+    );
+  } else if (entities.length === 0) {
+    content = (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<InboxIcon />}
+          titleSlot="No entities available"
+          descriptionSlot="No entities are available on the server yet."
+        />
+      </div>
+    );
+  } else if (!entity) {
+    content = (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<MousePointerClickIcon />}
+          titleSlot="No entity selected"
+          descriptionSlot="Select an entity to inspect its signals and clusters."
+          actionSlot={<SignalsEntityFilter entities={entities} selected={selectedEntity} onChange={onEntityChange} />}
+        />
+      </div>
+    );
+  } else if (entity.availableSignals.length === 0) {
+    content = (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<InboxIcon />}
+          titleSlot="No signals yet"
+          descriptionSlot="This entity has no signals yet."
+        />
+      </div>
+    );
+  } else {
+    content = (
+      <div className="mx-auto flex max-w-6xl flex-col gap-12">
+        {entity.availableSignals.map(signalName => (
+          <SignalSection
+            key={signalName}
+            entity={entity}
+            signalName={signalName}
+            catalog={getSignalCatalogEntry(signalName)}
+            onSeeDetails={onSignalSelect}
+            onSelectCluster={onSignalSelect}
+          />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <TopicsLayout sidebar={null} contentPadding={false}>
       <div className="flex h-full min-w-0 flex-col" aria-label="Signals">
@@ -213,61 +288,7 @@ export function SignalsOverviewPage({ selectedEntity, onEntityChange, onSignalSe
           </div>
         )}
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-6">
-          {isLoading ? (
-            <div className="flex h-full items-center justify-center">
-              <EmptyState iconSlot={<Spinner />} titleSlot="Loading entities…" />
-            </div>
-          ) : isError ? (
-            <div className="flex h-full items-center justify-center">
-              <EmptyState
-                iconSlot={<CircleSlashIcon />}
-                titleSlot="Failed to load entities"
-                descriptionSlot="Failed to load entities from the observability endpoint."
-              />
-            </div>
-          ) : entities.length === 0 ? (
-            <div className="flex h-full items-center justify-center">
-              <EmptyState
-                iconSlot={<InboxIcon />}
-                titleSlot="No entities available"
-                descriptionSlot="No entities are available on the server yet."
-              />
-            </div>
-          ) : !entity ? (
-            <div className="flex h-full items-center justify-center">
-              <EmptyState
-                iconSlot={<MousePointerClickIcon />}
-                titleSlot="No entity selected"
-                descriptionSlot="Select an entity to inspect its signals and clusters."
-                actionSlot={
-                  <SignalsEntityFilter entities={entities} selected={selectedEntity} onChange={onEntityChange} />
-                }
-              />
-            </div>
-          ) : entity.availableSignals.length === 0 ? (
-            <div className="flex h-full items-center justify-center">
-              <EmptyState
-                iconSlot={<InboxIcon />}
-                titleSlot="No signals yet"
-                descriptionSlot="This entity has no signals yet."
-              />
-            </div>
-          ) : (
-            <div className="mx-auto flex max-w-6xl flex-col gap-12">
-              {entity.availableSignals.map(signalName => (
-                <SignalSection
-                  key={signalName}
-                  entity={entity}
-                  signalName={signalName}
-                  catalog={getSignalCatalogEntry(signalName)}
-                  onSeeDetails={onSignalSelect}
-                  onSelectCluster={onSignalSelect}
-                />
-              ))}
-            </div>
-          )}
-        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-6">{content}</div>
       </div>
     </TopicsLayout>
   );

--- a/packages/playground-ui/src/lib/resize/collapsible-panel.tsx
+++ b/packages/playground-ui/src/lib/resize/collapsible-panel.tsx
@@ -213,7 +213,15 @@ export const CollapsiblePanel = ({
         style={{
           minWidth: 'var(--panel-min-w)',
           opacity: collapsed ? 0 : undefined,
-          translate: collapsed ? (direction === 'left' ? '-100% 0' : '100% 0') : undefined,
+          translate: (() => {
+            if (collapsed) {
+              if (direction === 'left') {
+                return '-100% 0';
+              }
+              return '100% 0';
+            }
+            return undefined;
+          })(),
         }}
         className={cn(
           'absolute inset-y-0 w-full overflow-hidden',

--- a/packages/playground-ui/src/lib/resize/collapsible-panel.tsx
+++ b/packages/playground-ui/src/lib/resize/collapsible-panel.tsx
@@ -19,6 +19,16 @@ const PILL_EDGE_MARGIN = 22;
 
 type PanelElementRef = RefObject<HTMLDivElement | null>;
 
+function getPanelContentTranslate(collapsed: boolean, direction: CollapsiblePanelProps['direction']) {
+  if (!collapsed) {
+    return undefined;
+  }
+  if (direction === 'left') {
+    return '-100% 0';
+  }
+  return '100% 0';
+}
+
 const usePanelSizeTransitions = (elementRef: PanelElementRef) => {
   const [booted, setBooted] = useState(false);
   const bootedRef = useRef(false);
@@ -213,15 +223,7 @@ export const CollapsiblePanel = ({
         style={{
           minWidth: 'var(--panel-min-w)',
           opacity: collapsed ? 0 : undefined,
-          translate: (() => {
-            if (collapsed) {
-              if (direction === 'left') {
-                return '-100% 0';
-              }
-              return '100% 0';
-            }
-            return undefined;
-          })(),
+          translate: getPanelContentTranslate(collapsed, direction),
         }}
         className={cn(
           'absolute inset-y-0 w-full overflow-hidden',


### PR DESCRIPTION
## Summary
- refactor `packages/playground-ui` nested ternary sites into named locals, helpers, or explicit branches
- enable the package-local `no-nested-ternary` ESLint ratchet for `playground-ui`
- intentionally leave `packages/playground` for a follow-up PR so the review stays scoped

## Validation
- staged `packages/playground-ui` AST scan: 0 nested ternary sites
- `pnpm --filter ./packages/playground-ui lint`
- `pnpm --filter ./packages/playground-ui typecheck`
- `pnpm --filter ./packages/playground-ui test --run`
- `pnpm build:playground-ui`
- `git diff --check`
- Prettier check on touched files

No changeset: internal lint ratchet/refactor only, with no public API change.