### PR TITLE
chore(playground-ui): deprecate line tabs fallback

### DIFF
--- a/.changeset/bumpy-cats-happen.md
+++ b/.changeset/bumpy-cats-happen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Deprecated the legacy line TabList fallback for new tabs while keeping existing tabs compatible.

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -1,6 +1,5 @@
 import { Tabs as BaseTabs } from '@base-ui/react/tabs';
 import { cva } from 'class-variance-authority';
-import type { VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const tabListVariants = cva('flex items-center relative text-ui-lg', {
@@ -16,17 +15,32 @@ const tabListVariants = cva('flex items-center relative text-ui-lg', {
   },
 });
 
+/**
+ * @deprecated `line` remains the omitted fallback for backward compatibility.
+ * Pass `variant="pill"` or `variant="pill-ghost"` for new tabs.
+ */
+export type DeprecatedLineTabListVariant = 'line';
+
+export type TabListVariant = DeprecatedLineTabListVariant | 'pill' | 'pill-ghost';
+
 export type TabListProps = {
   children: React.ReactNode;
   className?: string;
   sticky?: boolean;
+  /**
+   * Visual treatment for the tab list.
+   *
+   * Defaults to `line` only for backward compatibility. New tabs should pass
+   * `variant="pill"` or `variant="pill-ghost"` explicitly.
+   */
+  variant?: TabListVariant;
   /**
    * Optional inline styles applied to the underlying tab list element.
    * To override the active tab indicator color, set the `--tab-indicator-color`
    * CSS variable, e.g. `style={{ '--tab-indicator-color': 'var(--accent5)' } as React.CSSProperties}`.
    */
   style?: React.CSSProperties;
-} & VariantProps<typeof tabListVariants>;
+};
 
 export const TabList = ({ children, className, variant, sticky, style }: TabListProps) => {
   const resolvedVariant = variant ?? 'line';

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -1,5 +1,6 @@
 import { Tabs as BaseTabs } from '@base-ui/react/tabs';
 import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const tabListVariants = cva('flex items-center relative text-ui-lg', {
@@ -15,15 +16,18 @@ const tabListVariants = cva('flex items-center relative text-ui-lg', {
   },
 });
 
+type TabListVariantsProps = VariantProps<typeof tabListVariants>;
+type TabListVariantValue = NonNullable<TabListVariantsProps['variant']>;
+
 /**
  * @deprecated `line` remains the omitted fallback for backward compatibility.
  * Pass `variant="pill"` or `variant="pill-ghost"` for new tabs.
  */
-export type DeprecatedLineTabListVariant = 'line';
+export type DeprecatedLineTabListVariant = Extract<TabListVariantValue, 'line'>;
 
-export type TabListVariant = DeprecatedLineTabListVariant | 'pill' | 'pill-ghost';
+export type TabListVariant = DeprecatedLineTabListVariant | Exclude<TabListVariantValue, DeprecatedLineTabListVariant>;
 
-export type TabListProps = {
+export type TabListProps = Omit<TabListVariantsProps, 'variant'> & {
   children: React.ReactNode;
   className?: string;
   sticky?: boolean;
@@ -33,7 +37,7 @@ export type TabListProps = {
    * Defaults to `line` only for backward compatibility. New tabs should pass
    * `variant="pill"` or `variant="pill-ghost"` explicitly.
    */
-  variant?: TabListVariant;
+  variant?: TabListVariant | null;
   /**
    * Optional inline styles applied to the underlying tab list element.
    * To override the active tab indicator color, set the `--tab-indicator-color`

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
@@ -25,7 +25,7 @@ export const Tab = ({ children, value, onClick, onClose, disabled, className }: 
         'hover:text-neutral4',
         'data-[active]:text-neutral5',
         'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:hover:text-neutral3',
-        // Line variant (default) — active state drawn by <Tabs.Indicator> in TabList
+        // Line variant legacy fallback — active state drawn by <Tabs.Indicator> in TabList
         'group-data-[variant=line]/tabs-list:py-2 group-data-[variant=line]/tabs-list:px-5',
         'group-data-[variant=line]/tabs-list:border-b-2 group-data-[variant=line]/tabs-list:border-transparent',
         // Pill variant
@@ -43,6 +43,7 @@ export const Tab = ({ children, value, onClick, onClose, disabled, className }: 
       {children}
       {onClose && (
         <button
+          type="button"
           onClick={e => {
             e.stopPropagation();
             onClose();

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
@@ -15,7 +15,28 @@ const meta: Meta<typeof Tabs> = {
 export default meta;
 type Story = StoryObj<typeof Tabs>;
 
-export const Default: Story = {
+export const Recommended: Story = {
+  render: () => (
+    <Tabs defaultTab="tab1" className="w-[400px]">
+      <TabList variant="pill">
+        <Tab value="tab1">Overview</Tab>
+        <Tab value="tab2">Details</Tab>
+        <Tab value="tab3">Settings</Tab>
+      </TabList>
+      <TabContent value="tab1">
+        <div className="p-4 text-neutral5">Overview content goes here</div>
+      </TabContent>
+      <TabContent value="tab2">
+        <div className="p-4 text-neutral5">Details content goes here</div>
+      </TabContent>
+      <TabContent value="tab3">
+        <div className="p-4 text-neutral5">Settings content goes here</div>
+      </TabContent>
+    </Tabs>
+  ),
+};
+
+export const LegacyLineFallback: Story = {
   render: () => (
     <Tabs defaultTab="tab1" className="w-[400px]">
       <TabList>
@@ -24,7 +45,7 @@ export const Default: Story = {
         <Tab value="tab3">Settings</Tab>
       </TabList>
       <TabContent value="tab1">
-        <div className="p-4 text-neutral5">Overview content goes here</div>
+        <div className="p-4 text-neutral5">Line fallback content goes here</div>
       </TabContent>
       <TabContent value="tab2">
         <div className="p-4 text-neutral5">Details content goes here</div>


### PR DESCRIPTION
Keeps the existing `TabList` omitted-variant behavior on the line treatment, but marks that fallback as legacy in the public type comments so new implementations prefer `variant="pill"` or `variant="pill-ghost"`.

Also moves the first Storybook example to the recommended pill variant, keeps a dedicated legacy line fallback story, and adds `type="button"` to closable tabs so they cannot submit surrounding forms.

Checks run:
- `pnpm --filter ./packages/playground-ui lint`
- `pnpm exec prettier --check .changeset/bumpy-cats-happen.md packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx`
- `pnpm --filter ./packages/playground-ui typecheck`
- `pnpm build:playground-ui`
- `npx -y react-doctor@latest packages/playground-ui/src/ds/components/Tabs --verbose --scope changed`

CodeRabbit CLI is installed, but `coderabbit doctor` reports it is not signed in, so I did not run a local CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change tells developers to use the newer pill-style tabs instead of relying on an old line-style fallback. It keeps the old behavior working for now, but marks it as legacy, updates the examples to show the preferred version, and fixes tab close buttons so they don’t accidentally submit forms.

### Summary
- Marked the legacy `TabList` line fallback as deprecated in public types while preserving runtime compatibility.
- Refined the tab variant typings so new usage is guided toward `pill` and `pill-ghost`.
- Updated Tabs stories so the main example uses `variant="pill"` and added a separate legacy fallback example.
- Set closable tab buttons to `type="button"` to prevent unintended form submission.
- Adjusted comments to describe the line treatment as a legacy fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->