### PR TITLE
feat: add @mastra/keenable integration package

### DIFF
--- a/.changeset/keenable-integration.md
+++ b/.changeset/keenable-integration.md
@@ -1,0 +1,5 @@
+---
+'@mastra/keenable': patch
+---
+
+Add `@mastra/keenable`, Keenable web search and page-fetch tools for Mastra agents. Exposes `createKeenableSearchTool`, `createKeenableFetchTool`, and `createKeenableTools`, each returning `createTool`-compatible tools with full Zod schemas. Keyless by default (no API key required); an optional `KEENABLE_API_KEY` lifts the rate limit. No provider SDK dependency; talks to the Keenable HTTP API directly.

--- a/.changeset/keenable-integration.md
+++ b/.changeset/keenable-integration.md
@@ -3,3 +3,10 @@
 ---
 
 Add `@mastra/keenable`, Keenable web search and page-fetch tools for Mastra agents. Exposes `createKeenableSearchTool`, `createKeenableFetchTool`, and `createKeenableTools`, each returning `createTool`-compatible tools with full Zod schemas. Keyless by default (no API key required); an optional `KEENABLE_API_KEY` lifts the rate limit. No provider SDK dependency; talks to the Keenable HTTP API directly.
+
+```ts
+import { createKeenableTools } from '@mastra/keenable';
+
+const tools = createKeenableTools();
+// Keyless by default; or pass a key: createKeenableTools({ apiKey: 'keen_...' })
+```

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -667,6 +667,7 @@ const sidebars = {
         { type: 'doc', id: 'tools/vector-query-tool', label: 'createVectorQueryTool()' },
         { type: 'doc', id: 'tools/mcp-client', label: 'MCPClient' },
         { type: 'doc', id: 'tools/mcp-server', label: 'MCPServer' },
+        { type: 'doc', id: 'tools/keenable', label: 'Keenable Tools' },
         { type: 'doc', id: 'tools/perplexity', label: 'Perplexity Tools' },
         { type: 'doc', id: 'tools/tavily', label: 'Tavily Tools' },
       ],

--- a/docs/src/content/en/reference/tools/keenable.mdx
+++ b/docs/src/content/en/reference/tools/keenable.mdx
@@ -1,0 +1,152 @@
+---
+title: "Reference: Keenable tools | Tools and MCP"
+description: "API reference for @mastra/keenable, which provides keyless-by-default web search and page-fetch tools for Mastra agents."
+packages:
+  - "@mastra/keenable"
+---
+
+# Keenable tools
+
+The `@mastra/keenable` package wraps the [Keenable](https://keenable.ai) web search API as Mastra-compatible tools. It exposes factory functions for search and fetch, each returning a tool created with [`createTool()`](./create-tool) that includes full Zod input/output schemas.
+
+Keenable is **keyless by default**: the tools work with no account or key against the public endpoints (rate-limited). An optional `KEENABLE_API_KEY` lifts the hourly cap; it is never required. No provider SDK is needed; the package calls the Keenable HTTP API directly.
+
+## Installation
+
+```sh npm2yarn
+npm install @mastra/keenable zod
+```
+
+## Quick start
+
+Use `createKeenableTools()` to get both tools with shared configuration:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createKeenableTools } from '@mastra/keenable'
+
+const tools = createKeenableTools()
+// Keyless by default. To lift the rate limit, pass an explicit key:
+// const tools = createKeenableTools({ apiKey: 'keen_...' })
+```
+
+Each tool can also be created individually:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createKeenableSearchTool, createKeenableFetchTool } from '@mastra/keenable'
+
+const searchTool = createKeenableSearchTool()
+const fetchTool = createKeenableFetchTool({ apiKey: 'keen_...' })
+```
+
+By default the tools read `KEENABLE_API_KEY` from the environment when present; with no key they use the keyless public endpoints. Set `KEENABLE_API_URL` to override the base URL.
+
+## `createKeenableSearchTool()`
+
+Returns a tool (id `keenable-search`) that queries the Keenable web index.
+
+### Input
+
+<PropertiesTable
+  content={[
+  { name: 'query', type: 'string', required: true, description: 'The search query.' },
+  {
+    name: 'site',
+    type: 'string',
+    isOptional: true,
+    description: "Restrict results to a single domain, e.g. 'techcrunch.com'.",
+  },
+  {
+    name: 'publishedAfter',
+    type: 'string',
+    isOptional: true,
+    description: 'Only pages published on or after this date (YYYY-MM-DD).',
+  },
+  {
+    name: 'publishedBefore',
+    type: 'string',
+    isOptional: true,
+    description: 'Only pages published on or before this date (YYYY-MM-DD).',
+  },
+  {
+    name: 'acquiredAfter',
+    type: 'string',
+    isOptional: true,
+    description: 'Only pages indexed on or after this date (YYYY-MM-DD).',
+  },
+  {
+    name: 'acquiredBefore',
+    type: 'string',
+    isOptional: true,
+    description: 'Only pages indexed on or before this date (YYYY-MM-DD).',
+  },
+  { name: 'maxResults', type: 'number', isOptional: true, description: 'Maximum number of results to return (1-20).' },
+]}
+/>
+
+### Output
+
+<PropertiesTable
+  content={[
+  { name: 'query', type: 'string', description: 'The query that was run.' },
+  {
+    name: 'results',
+    type: 'Array<{ title, url, description?, publishedAt?, acquiredAt? }>',
+    description: 'The search results.',
+  },
+]}
+/>
+
+## `createKeenableFetchTool()`
+
+Returns a tool (id `keenable-fetch`) that fetches a single URL and returns its main content as markdown.
+
+### Input
+
+<PropertiesTable
+  content={[
+  { name: 'url', type: 'string', required: true, description: 'The URL of the page to fetch and extract as markdown.' },
+]}
+/>
+
+### Output
+
+<PropertiesTable
+  content={[
+  { name: 'url', type: 'string', description: 'The fetched URL.' },
+  { name: 'title', type: 'string', isOptional: true, description: 'Page title.' },
+  { name: 'content', type: 'string', isOptional: true, description: 'Main content as markdown.' },
+  { name: 'description', type: 'string', isOptional: true, description: 'Page description, when available.' },
+  { name: 'author', type: 'string', isOptional: true, description: 'Author, when available.' },
+  { name: 'publishedAt', type: 'string', isOptional: true, description: 'Publication date, when available.' },
+]}
+/>
+
+## Configuration
+
+All factory functions accept an optional config object:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'apiKey',
+    type: 'string',
+    isOptional: true,
+    description:
+      'Keenable API key. Keyless by default; falls back to KEENABLE_API_KEY. A key lifts the hourly rate limit.',
+  },
+  {
+    name: 'baseUrl',
+    type: 'string',
+    isOptional: true,
+    description: 'API base URL. Falls back to KEENABLE_API_URL, then https://api.keenable.ai.',
+  },
+  {
+    name: 'clientSource',
+    type: 'string',
+    isOptional: true,
+    description: "Attribution tag Keenable segments integration traffic by. Defaults to 'Mastra'.",
+  },
+]}
+/>
+
+Create a key at [keenable.ai/console](https://keenable.ai/console).

--- a/integrations/keenable/CHANGELOG.md
+++ b/integrations/keenable/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @mastra/keenable

--- a/integrations/keenable/README.md
+++ b/integrations/keenable/README.md
@@ -1,0 +1,82 @@
+# @mastra/keenable
+
+[Keenable](https://keenable.ai) web search and page-fetch tools for [Mastra](https://mastra.ai) agents.
+
+**Keyless by default.** The tools work with no account or API key against Keenable's public endpoints (rate-limited). An optional `KEENABLE_API_KEY` lifts the hourly cap; it is never a prerequisite.
+
+## Installation
+
+```bash
+npm install @mastra/keenable zod
+```
+
+No provider SDK is required; the package talks to the Keenable HTTP API directly.
+
+## Quick Start
+
+Use `createKeenableTools()` to get both tools with a shared configuration:
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { createKeenableTools } from '@mastra/keenable';
+
+const tools = createKeenableTools();
+// Keyless by default. To lift the rate limit, set KEENABLE_API_KEY
+// or pass an explicit key:
+// const tools = createKeenableTools({ apiKey: 'keen_...' });
+
+const agent = new Agent({
+  id: 'web-research-agent',
+  name: 'Web Research Agent',
+  instructions: 'You research topics on the web: search for sources, then read the most relevant pages.',
+  model: 'anthropic/claude-sonnet-4-6',
+  tools,
+});
+```
+
+By default the tools read `KEENABLE_API_KEY` from the environment when present; with no key they call the keyless public endpoints. Set `KEENABLE_API_URL` to point at a different base URL.
+
+## Individual Tools
+
+Each tool can be created independently:
+
+```typescript
+import { createKeenableSearchTool, createKeenableFetchTool } from '@mastra/keenable';
+
+const searchTool = createKeenableSearchTool(); // keyless
+const fetchTool = createKeenableFetchTool({ apiKey: 'keen_...' });
+```
+
+### Search
+
+Queries the Keenable web index. Accepts:
+
+- `query` (required)
+- `site`: restrict to a single domain, e.g. `'techcrunch.com'`
+- `publishedAfter` / `publishedBefore`: filter by publication date (YYYY-MM-DD)
+- `acquiredAfter` / `acquiredBefore`: filter by index date (YYYY-MM-DD)
+- `maxResults`: cap results (1-20)
+
+Returns `{ query, results: [{ title, url, description?, publishedAt?, acquiredAt? }] }`.
+
+### Fetch
+
+Fetches a single URL and returns its main content as markdown:
+
+- `url` (required)
+
+Returns `{ url, title?, content?, description?, author?, publishedAt? }`.
+
+## Configuration
+
+`createKeenable*Tool` and `createKeenableTools` accept:
+
+- `apiKey`: optional, falls back to `KEENABLE_API_KEY`. Keyless when unset.
+- `baseUrl`: optional, falls back to `KEENABLE_API_URL`, then `https://api.keenable.ai`.
+- `clientSource`: attribution tag Keenable segments integration traffic by (defaults to `'Mastra'`).
+
+Get a key at [keenable.ai/console](https://keenable.ai/console).
+
+## License
+
+Apache-2.0

--- a/integrations/keenable/eslint.config.js
+++ b/integrations/keenable/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/integrations/keenable/lint-staged.config.js
+++ b/integrations/keenable/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/integrations/keenable/package.json
+++ b/integrations/keenable/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@mastra/keenable",
+  "version": "1.0.0",
+  "description": "Keenable web search and fetch tools for Mastra agents (keyless by default)",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "mastra",
+    "keenable",
+    "web-search",
+    "tools",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "integrations/keenable"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "homepage": "https://mastra.ai",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "zod": ">=3.0.0 || >=4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/integrations/keenable/src/__tests__/client.test.ts
+++ b/integrations/keenable/src/__tests__/client.test.ts
@@ -100,4 +100,20 @@ describe('getKeenableClient', () => {
     mockFetch.mockResolvedValue(jsonResponse({ message: 'rate limited' }, false, 429));
     await expect(getKeenableClient().search('x')).rejects.toThrow(/Keenable search failed \(429\): rate limited/);
   });
+
+  it('surfaces a non-JSON error body verbatim (body read once)', async () => {
+    // Real Response bodies can only be read once; readError must not call
+    // json() and then text(). Here json() would throw and text() is plain text.
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => {
+        throw new Error('Unexpected token S in JSON');
+      },
+      text: async () => 'Service Unavailable',
+    } as unknown as Response);
+    await expect(getKeenableClient().search('x')).rejects.toThrow(
+      /Keenable search failed \(503\): Service Unavailable/,
+    );
+  });
 });

--- a/integrations/keenable/src/__tests__/client.test.ts
+++ b/integrations/keenable/src/__tests__/client.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { getKeenableClient } from '../client.js';
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe('getKeenableClient', () => {
+  const originalKey = process.env.KEENABLE_API_KEY;
+  const originalUrl = process.env.KEENABLE_API_URL;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    delete process.env.KEENABLE_API_KEY;
+    delete process.env.KEENABLE_API_URL;
+    mockFetch = vi.fn().mockResolvedValue(jsonResponse({ query: 'q', results: [] }));
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalKey !== undefined) process.env.KEENABLE_API_KEY = originalKey;
+    else delete process.env.KEENABLE_API_KEY;
+    if (originalUrl !== undefined) process.env.KEENABLE_API_URL = originalUrl;
+    else delete process.env.KEENABLE_API_URL;
+  });
+
+  it('uses the keyless public endpoint and attribution header when no key is set', async () => {
+    await getKeenableClient().search('hello');
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://api.keenable.ai/v1/search/public');
+    expect(init.method).toBe('POST');
+    expect(init.headers['X-Keenable-Title']).toBe('Mastra');
+    expect(init.headers['X-API-Key']).toBeUndefined();
+    expect(JSON.parse(init.body)).toMatchObject({ query: 'hello', mode: 'pro' });
+  });
+
+  it('switches to the keyed endpoint and sends X-API-Key when a key is set', async () => {
+    await getKeenableClient({ apiKey: 'keen_test' }).search('hello');
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://api.keenable.ai/v1/search');
+    expect(init.headers['X-API-Key']).toBe('keen_test');
+  });
+
+  it('falls back to KEENABLE_API_KEY env var', async () => {
+    process.env.KEENABLE_API_KEY = 'keen_env';
+    await getKeenableClient().search('hi');
+    expect(mockFetch.mock.calls[0][1].headers['X-API-Key']).toBe('keen_env');
+  });
+
+  it('honors a custom baseUrl and clientSource', async () => {
+    await getKeenableClient({ baseUrl: 'https://api.example.com/', clientSource: 'custom-app' }).search('hi');
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://api.example.com/v1/search/public');
+    expect(init.headers['X-Keenable-Title']).toBe('custom-app');
+  });
+
+  it('maps search results and trims to maxResults', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        query: 'ts',
+        results: [
+          {
+            title: 'A',
+            url: 'https://a.com',
+            description: 'da',
+            published_at: '2026-01-01',
+            acquired_at: '2026-01-02',
+          },
+          { title: 'B', url: 'https://b.com' },
+          { title: 'C', url: 'https://c.com' },
+        ],
+      }),
+    );
+    const res = await getKeenableClient().search('ts', { maxResults: 2 });
+    expect(res.results).toHaveLength(2);
+    expect(res.results[0]).toEqual({
+      title: 'A',
+      url: 'https://a.com',
+      description: 'da',
+      publishedAt: '2026-01-01',
+      acquiredAt: '2026-01-02',
+    });
+  });
+
+  it('fetches a page from the keyless endpoint with the url query param', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ url: 'https://x.com', title: 'X', content: '# X' }));
+    const page = await getKeenableClient().fetch('https://x.com/a b');
+    expect(mockFetch.mock.calls[0][0]).toBe('https://api.keenable.ai/v1/fetch/public?url=https%3A%2F%2Fx.com%2Fa%20b');
+    expect(page).toMatchObject({ url: 'https://x.com', title: 'X', content: '# X' });
+  });
+
+  it('throws a helpful error on a non-2xx response', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'rate limited' }, false, 429));
+    await expect(getKeenableClient().search('x')).rejects.toThrow(/Keenable search failed \(429\): rate limited/);
+  });
+});

--- a/integrations/keenable/src/__tests__/fetch.test.ts
+++ b/integrations/keenable/src/__tests__/fetch.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { createKeenableFetchTool } from '../fetch.js';
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe('createKeenableFetchTool', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    delete process.env.KEENABLE_API_KEY;
+    mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        url: 'https://example.com/article',
+        title: 'Article',
+        content: '# Article\n\nBody',
+        author: 'Jane',
+        published_at: '2026-02-03',
+      }),
+    );
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('creates a tool with the correct id and schemas', () => {
+    const tool = createKeenableFetchTool();
+    expect(tool.id).toBe('keenable-fetch');
+    expect(tool.description!.length).toBeGreaterThan(0);
+    expect(tool.inputSchema).toBeDefined();
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  it('fetches a URL and maps the page fields', async () => {
+    const tool = createKeenableFetchTool();
+    const page = await tool.execute!({ url: 'https://example.com/article' }, {} as any);
+
+    expect(mockFetch.mock.calls[0][0]).toContain('/v1/fetch/public?url=');
+    expect(page).toEqual({
+      url: 'https://example.com/article',
+      title: 'Article',
+      content: '# Article\n\nBody',
+      description: undefined,
+      author: 'Jane',
+      publishedAt: '2026-02-03',
+    });
+  });
+});

--- a/integrations/keenable/src/__tests__/search.test.ts
+++ b/integrations/keenable/src/__tests__/search.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { createKeenableSearchTool } from '../search.js';
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe('createKeenableSearchTool', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    delete process.env.KEENABLE_API_KEY;
+    mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        query: 'test query',
+        results: [{ title: 'Result 1', url: 'https://example.com', description: 'Snippet' }],
+      }),
+    );
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('creates a tool with the correct id and schemas', () => {
+    const tool = createKeenableSearchTool();
+    expect(tool.id).toBe('keenable-search');
+    expect(tool.description!.length).toBeGreaterThan(0);
+    expect(tool.inputSchema).toBeDefined();
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  it('maps filter params into the request body and returns mapped results', async () => {
+    const tool = createKeenableSearchTool();
+    const result = await tool.execute!(
+      { query: 'test query', site: 'github.com', publishedAfter: '2026-01-01', maxResults: 5 },
+      {} as any,
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toMatchObject({ query: 'test query', mode: 'pro', site: 'github.com', published_after: '2026-01-01' });
+    expect(result.results[0]).toEqual({ title: 'Result 1', url: 'https://example.com', description: 'Snippet' });
+  });
+});

--- a/integrations/keenable/src/client.ts
+++ b/integrations/keenable/src/client.ts
@@ -52,19 +52,24 @@ export interface KeenableClient {
 }
 
 async function readError(res: Response): Promise<string> {
+  // Read the body exactly once: a Response stream can only be consumed a single
+  // time, so we cannot call json() and then fall back to text(). Read text and
+  // opportunistically parse it as JSON.
+  let raw = '';
   try {
-    const body: any = await res.json();
+    raw = await res.text();
+  } catch {
+    return '';
+  }
+  try {
+    const body: any = JSON.parse(raw);
     if (body && typeof body === 'object') {
       return String(body.message || body.error || body.detail || '');
     }
   } catch {
-    try {
-      return (await res.text()).trim();
-    } catch {
-      /* ignore */
-    }
+    // Not JSON; fall through to the raw text.
   }
-  return '';
+  return raw.trim();
 }
 
 /**

--- a/integrations/keenable/src/client.ts
+++ b/integrations/keenable/src/client.ts
@@ -1,0 +1,143 @@
+const DEFAULT_BASE_URL = 'https://api.keenable.ai';
+
+export interface KeenableClientOptions {
+  /** Keenable API key. Keyless by default (rate-limited); a key lifts the hourly cap. Falls back to `KEENABLE_API_KEY`. */
+  apiKey?: string;
+  /** API base URL. Falls back to `KEENABLE_API_URL`, then `https://api.keenable.ai`. */
+  baseUrl?: string;
+  /** Attribution tag Keenable segments integration traffic by. Defaults to `'Mastra'`. */
+  clientSource?: string;
+}
+
+export interface KeenableSearchOptions {
+  /** Restrict results to a single domain, e.g. `'techcrunch.com'`. */
+  site?: string;
+  /** Only pages published on or after this date (YYYY-MM-DD). */
+  publishedAfter?: string;
+  /** Only pages published on or before this date (YYYY-MM-DD). */
+  publishedBefore?: string;
+  /** Only pages indexed on or after this date (YYYY-MM-DD). */
+  acquiredAfter?: string;
+  /** Only pages indexed on or before this date (YYYY-MM-DD). */
+  acquiredBefore?: string;
+  /** Cap the number of results returned (the API returns a fixed-size set; extras are trimmed client-side). */
+  maxResults?: number;
+}
+
+export interface KeenableSearchResult {
+  title: string;
+  url: string;
+  description?: string;
+  publishedAt?: string;
+  acquiredAt?: string;
+}
+
+export interface KeenableSearchResponse {
+  query: string;
+  results: KeenableSearchResult[];
+}
+
+export interface KeenablePage {
+  url: string;
+  title?: string;
+  content?: string;
+  description?: string;
+  author?: string;
+  publishedAt?: string;
+}
+
+export interface KeenableClient {
+  search(query: string, options?: KeenableSearchOptions): Promise<KeenableSearchResponse>;
+  fetch(url: string): Promise<KeenablePage>;
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body: any = await res.json();
+    if (body && typeof body === 'object') {
+      return String(body.message || body.error || body.detail || '');
+    }
+  } catch {
+    try {
+      return (await res.text()).trim();
+    } catch {
+      /* ignore */
+    }
+  }
+  return '';
+}
+
+/**
+ * Build a Keenable API client. Keyless by default: with no key it calls the
+ * public endpoints (rate-limited); a key switches to the authenticated
+ * endpoints and lifts the cap. No third-party SDK, just a thin `fetch` wrapper.
+ */
+export function getKeenableClient(config?: KeenableClientOptions): KeenableClient {
+  const apiKey = (config?.apiKey ?? process.env.KEENABLE_API_KEY)?.trim() || undefined;
+  const baseUrl = (config?.baseUrl ?? process.env.KEENABLE_API_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const clientSource = config?.clientSource ?? 'Mastra';
+
+  function headers(json: boolean): Record<string, string> {
+    const h: Record<string, string> = {
+      Accept: 'application/json',
+      'User-Agent': 'keenable-mastra',
+      'X-Keenable-Title': clientSource,
+    };
+    if (json) h['Content-Type'] = 'application/json';
+    if (apiKey) h['X-API-Key'] = apiKey;
+    return h;
+  }
+
+  return {
+    async search(query, options = {}) {
+      const payload: Record<string, unknown> = { query, mode: 'pro' };
+      if (options.site) payload.site = options.site;
+      if (options.publishedAfter) payload.published_after = options.publishedAfter;
+      if (options.publishedBefore) payload.published_before = options.publishedBefore;
+      if (options.acquiredAfter) payload.acquired_after = options.acquiredAfter;
+      if (options.acquiredBefore) payload.acquired_before = options.acquiredBefore;
+
+      const path = apiKey ? '/v1/search' : '/v1/search/public';
+      const res = await fetch(`${baseUrl}${path}`, {
+        method: 'POST',
+        headers: headers(true),
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        throw new Error(`Keenable search failed (${res.status}): ${await readError(res)}`.trim());
+      }
+      const data: any = await res.json();
+      let results: KeenableSearchResult[] = (data?.results ?? []).map((r: any) => ({
+        title: r.title,
+        url: r.url,
+        description: r.description || undefined,
+        publishedAt: r.published_at || undefined,
+        acquiredAt: r.acquired_at || undefined,
+      }));
+      if (typeof options.maxResults === 'number') {
+        results = results.slice(0, options.maxResults);
+      }
+      return { query: data?.query ?? query, results };
+    },
+
+    async fetch(url) {
+      const path = apiKey ? '/v1/fetch' : '/v1/fetch/public';
+      const res = await fetch(`${baseUrl}${path}?url=${encodeURIComponent(url)}`, {
+        method: 'GET',
+        headers: headers(false),
+      });
+      if (!res.ok) {
+        throw new Error(`Keenable fetch failed (${res.status}): ${await readError(res)}`.trim());
+      }
+      const data: any = await res.json();
+      return {
+        url: data?.url ?? url,
+        title: data?.title || undefined,
+        content: data?.content || undefined,
+        description: data?.description || undefined,
+        author: data?.author || undefined,
+        publishedAt: data?.published_at || undefined,
+      };
+    },
+  };
+}

--- a/integrations/keenable/src/fetch.ts
+++ b/integrations/keenable/src/fetch.ts
@@ -1,0 +1,40 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getKeenableClient } from './client.js';
+import type { KeenableClient, KeenableClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  url: z.string().url().describe('The URL of the page to fetch and extract as markdown'),
+});
+
+const outputSchema = z.object({
+  url: z.string(),
+  title: z.string().optional(),
+  content: z.string().optional(),
+  description: z.string().optional(),
+  author: z.string().optional(),
+  publishedAt: z.string().optional(),
+});
+
+export function createKeenableFetchTool(config?: KeenableClientOptions) {
+  let client: KeenableClient | null = null;
+
+  function getClient(): KeenableClient {
+    if (!client) {
+      client = getKeenableClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'keenable-fetch',
+    description:
+      'Fetch a web page via Keenable and return its main content as markdown, along with title, description, author, and publication date. Use this to read a page found via search. Keyless by default.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      return getClient().fetch(input.url);
+    },
+  });
+}

--- a/integrations/keenable/src/fetch.ts
+++ b/integrations/keenable/src/fetch.ts
@@ -5,7 +5,7 @@ import { getKeenableClient } from './client.js';
 import type { KeenableClient, KeenableClientOptions } from './client.js';
 
 const inputSchema = z.object({
-  url: z.string().url().describe('The URL of the page to fetch and extract as markdown'),
+  url: z.url().describe('The URL of the page to fetch and extract as markdown'),
 });
 
 const outputSchema = z.object({

--- a/integrations/keenable/src/index.ts
+++ b/integrations/keenable/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  getKeenableClient,
+  type KeenableClientOptions,
+  type KeenableClient,
+  type KeenableSearchOptions,
+  type KeenableSearchResult,
+  type KeenableSearchResponse,
+  type KeenablePage,
+} from './client.js';
+export { createKeenableSearchTool } from './search.js';
+export { createKeenableFetchTool } from './fetch.js';
+export { createKeenableTools } from './tools.js';

--- a/integrations/keenable/src/search.ts
+++ b/integrations/keenable/src/search.ts
@@ -1,0 +1,57 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getKeenableClient } from './client.js';
+import type { KeenableClient, KeenableClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  query: z.string().describe('The search query'),
+  site: z.string().optional().describe("Restrict results to a single domain, e.g. 'techcrunch.com'"),
+  publishedAfter: z.string().optional().describe('Only pages published on or after this date (YYYY-MM-DD)'),
+  publishedBefore: z.string().optional().describe('Only pages published on or before this date (YYYY-MM-DD)'),
+  acquiredAfter: z.string().optional().describe('Only pages indexed on or after this date (YYYY-MM-DD)'),
+  acquiredBefore: z.string().optional().describe('Only pages indexed on or before this date (YYYY-MM-DD)'),
+  maxResults: z.number().min(1).max(20).optional().describe('Maximum number of results to return (1-20)'),
+});
+
+const outputSchema = z.object({
+  query: z.string(),
+  results: z.array(
+    z.object({
+      title: z.string(),
+      url: z.string(),
+      description: z.string().optional(),
+      publishedAt: z.string().optional(),
+      acquiredAt: z.string().optional(),
+    }),
+  ),
+});
+
+export function createKeenableSearchTool(config?: KeenableClientOptions) {
+  let client: KeenableClient | null = null;
+
+  function getClient(): KeenableClient {
+    if (!client) {
+      client = getKeenableClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'keenable-search',
+    description:
+      'Search the web using Keenable, a search index built for AI agents. Returns relevant results with title, URL, and snippet. Supports filtering by site and publication/index date. Keyless by default.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      return getClient().search(input.query, {
+        site: input.site,
+        publishedAfter: input.publishedAfter,
+        publishedBefore: input.publishedBefore,
+        acquiredAfter: input.acquiredAfter,
+        acquiredBefore: input.acquiredBefore,
+        maxResults: input.maxResults,
+      });
+    },
+  });
+}

--- a/integrations/keenable/src/tools.ts
+++ b/integrations/keenable/src/tools.ts
@@ -1,0 +1,10 @@
+import type { KeenableClientOptions } from './client.js';
+import { createKeenableFetchTool } from './fetch.js';
+import { createKeenableSearchTool } from './search.js';
+
+export function createKeenableTools(config?: KeenableClientOptions) {
+  return {
+    keenableSearch: createKeenableSearchTool(config),
+    keenableFetch: createKeenableFetchTool(config),
+  };
+}

--- a/integrations/keenable/tsconfig.build.json
+++ b/integrations/keenable/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/keenable/tsconfig.json
+++ b/integrations/keenable/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/keenable/tsup.config.ts
+++ b/integrations/keenable/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/integrations/keenable/turbo.json
+++ b/integrations/keenable/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://v2-9-16.turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/integrations/keenable/vitest.config.ts
+++ b/integrations/keenable/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:integrations/keenable',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1894,16 +1894,16 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: ^2.0.62
-        version: 2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^2.0.99
-        version: 2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: ^2.0.1
         version: 2.0.3
       '@ai-sdk/provider-utils':
         specifier: ^3.0.22
-        version: 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@huggingface/hub':
         specifier: ^0.15.2
         version: 0.15.2
@@ -1976,9 +1976,33 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   integrations/brightdata:
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.9(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+
+  integrations/keenable:
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -11152,6 +11176,7 @@ packages:
 
   '@clickhouse/client-common@1.20.0':
     resolution: {integrity: sha512-s0oDSwxQyJO/Xwne6sNE7xTAlms72Hq2AHzHAB9oSOBfiaXTzQOyHQrhufJ9ldPJTwr4L47/RxG1i6I0I8Xy9A==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.20.0':
     resolution: {integrity: sha512-LfHZ9bZZhc7KrNFVa9v73JMqwsP+m/5SgwdKMmxze4Urcw6pE0F7RNog3Lzx3GKRnJr3Hd15uDlIbqaDa9BbgA==}
@@ -29562,10 +29587,10 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -29721,6 +29746,26 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
+
+  '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@types/node'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - typescript
+      - vite
 
   '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
@@ -41553,7 +41598,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8)':
     dependencies:
@@ -41646,7 +41691,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
Closes #18987

## Description

Adds `@mastra/keenable`, a new integration package that exposes [Keenable](https://keenable.ai) web search and page fetch as first-class Mastra tools, following the structure of `@mastra/tavily`.

- `createKeenableSearchTool`, `createKeenableFetchTool`, and a convenience `createKeenableTools()`, each returning `createTool`-compatible tools with full Zod input/output schemas.
- **Keyless by default**: works with no account or API key against Keenable's public endpoints (rate-limited). An optional `KEENABLE_API_KEY` lifts the hourly cap and switches to the authenticated endpoints; it is never a prerequisite. This is the main difference from key-required providers.
- **No provider SDK dependency**: a thin `fetch` wrapper over the Keenable HTTP API (zero runtime deps), so the package stays light.
- Tools lazily instantiate the client and default `clientSource` to `'Mastra'` for attribution.
- Unit tests (11) for the client and both tools, a `README`, a `docs/reference` page + sidebar entry, and a changeset.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- `pnpm --filter @mastra/keenable build:lib` — passes (types generated)
- `pnpm --filter @mastra/keenable test` — 11 passed
- `pnpm --filter @mastra/keenable lint` — clean

Usage:

```typescript
import { createKeenableTools } from '@mastra/keenable';

const tools = createKeenableTools(); // keyless; or { apiKey: 'keen_...' }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a new Keenable package for Mastra that lets agents search the web and fetch web pages as plug-and-play tools. It works even without an API key by using Keenable’s public endpoints, but can also use `KEENABLE_API_KEY` for higher limits.

### Summary
- Added new `@mastra/keenable` integration package with Mastra-compatible tools:
  - `createKeenableSearchTool` (id: `keenable-search`)
  - `createKeenableFetchTool` (id: `keenable-fetch`)
  - `createKeenableTools()` to create both with shared config
- Implemented a thin, `fetch`-based Keenable HTTP client (`getKeenableClient`) with:
  - keyless-by-default behavior (public search/fetch endpoints)
  - optional `KEENABLE_API_KEY` / `{ apiKey }` for authenticated access and higher limits
  - optional `KEENABLE_API_URL` / `{ baseUrl }` override
  - lazy client instantiation and default `clientSource: "Mastra"`
  - improved error handling by reading/parsing the response body once (supports non-JSON error bodies)
  - Zod URL validation via `z.url()`
- Added full Zod input/output schemas for tool compatibility with Mastra’s `createTool`
- Added/updated unit tests for client/search/fetch behavior (including non-JSON error-body handling)
- Added documentation and site wiring:
  - `integrations/keenable/README.md`
  - `docs/src/content/en/reference/tools/keenable.mdx`
  - `docs/src/content/en/reference/sidebars.js` sidebar entry
- Added build/test/lint/package configuration plus a changeset for publishing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->