### PR TITLE
fix(daytona): default cwd to first mount path when omitted

### DIFF
--- a/.changeset/clear-adults-knock.md
+++ b/.changeset/clear-adults-knock.md
@@ -1,0 +1,5 @@
+---
+'@mastra/daytona': patch
+---
+
+Fixed relative paths in executeCommand missing FUSE mounts when cwd is omitted. Commands now default to the first mount path, so relative-path writes land in cloud storage instead of silently going to /home/daytona.

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -617,6 +617,55 @@ describe('DaytonaSandbox', () => {
     });
   });
 
+  describe('Default cwd from mounts', () => {
+    it('no mounts and no cwd — command has no cd prefix', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+      await sandbox.executeCommand('echo', ['hello']);
+
+      const cmd: string = mockSandbox.process.executeSessionCommand.mock.calls[0]![1].command;
+      expect(cmd).not.toContain('cd ');
+      expect(cmd).toContain('(echo hello)');
+    });
+
+    it('mount exists and no cwd — command cds to mount path', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+      sandbox.mounts.entries.set('/data/gcs-mount', { state: 'mounted' });
+
+      await sandbox.executeCommand('echo', ['hello']);
+
+      const cmd: string = mockSandbox.process.executeSessionCommand.mock.calls[0]![1].command;
+      expect(cmd).toContain('cd /data/gcs-mount');
+      expect(cmd).toContain('(echo hello)');
+    });
+
+    it('mount exists but explicit cwd overrides', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+      sandbox.mounts.entries.set('/data/gcs-mount', { state: 'mounted' });
+
+      await sandbox.executeCommand('echo', ['hello'], { cwd: '/tmp' });
+
+      const cmd: string = mockSandbox.process.executeSessionCommand.mock.calls[0]![1].command;
+      expect(cmd).toContain('cd /tmp');
+      expect(cmd).not.toContain('gcs-mount');
+    });
+
+    it('multiple mounts — defaults to first mount path', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+      sandbox.mounts.entries.set('/data/first-mount', { state: 'mounted' });
+      sandbox.mounts.entries.set('/data/second-mount', { state: 'mounted' });
+
+      await sandbox.executeCommand('echo', ['hello']);
+
+      const cmd: string = mockSandbox.process.executeSessionCommand.mock.calls[0]![1].command;
+      expect(cmd).toContain('cd /data/first-mount');
+      expect(cmd).not.toContain('second-mount');
+    });
+  });
+
   describe('Mount Configuration', () => {
     it('S3 prefix mount uses bucket:/prefix syntax in mount command', async () => {
       mockSandbox.process.executeCommand.mockImplementation(async (command: string) => {

--- a/workspaces/daytona/src/sandbox/process-manager.ts
+++ b/workspaces/daytona/src/sandbox/process-manager.ts
@@ -186,10 +186,12 @@ export class DaytonaProcessManager extends SandboxProcessManager<DaytonaSandbox>
   }
 
   async spawn(command: string, options: SpawnProcessOptions = {}): Promise<ProcessHandle> {
-    // Apply default timeout if the caller didn't specify one
+    // Apply default timeout and default cwd to the first mount path so that
+    // relative paths resolve inside the FUSE mount instead of /home/daytona.
     const effectiveOptions = {
       ...options,
       timeout: options.timeout ?? this._defaultTimeout,
+      cwd: options.cwd ?? this.sandbox.mounts?.entries?.keys().next().value,
     };
 
     // Merge default env with per-spawn env


### PR DESCRIPTION
## Description

When `executeCommand()` is called without an explicit `cwd`, Daytona runs commands from `/home/daytona` instead of the FUSE mount path. This causes relative-path writes to silently miss cloud storage mounts (S3/GCS/Azure) — the file lands on the local home dir and never reaches the bucket.

- Default `cwd` in `DaytonaProcessManager.spawn()` to the first mount path from `this.sandbox.mounts.entries`
- When no mounts exist, `cwd` remains `undefined` — preserving existing behavior
- Explicit `cwd` overrides still take priority

## Related Issue(s)

Fixes #18975

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When the code runs a command without telling it *where to start*, it used to start in the wrong folder (so files could end up in `/home/daytona` instead of the mounted storage). This update makes those commands start in the first mounted folder by default, so relative file paths read/write to the cloud mount. If you set `cwd` explicitly, that choice still wins.

## Summary
- Updated `DaytonaProcessManager.spawn()` to default `cwd` to the first sandbox mount path when `cwd` is omitted (so relative paths resolve inside the FUSE mount instead of `/home/daytona`).
- Kept existing behavior when there are no mounts (no default `cd` prefix is added).
- Preserved existing default timeout handling.
- Added tests covering `executeCommand`’s generated command behavior for: no mounts, mounts without `cwd`, explicit `cwd` overriding mounts, and multiple mounts selecting the first.
- Added a changeset documenting the fix for relative paths when `cwd` is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->