### PR TITLE
fix(cli): Update clack / adjust prompt wording

### DIFF
--- a/packages/_changeset-cli/package.json
+++ b/packages/_changeset-cli/package.json
@@ -21,7 +21,7 @@
     "@changesets/read": "^0.6.7",
     "@changesets/types": "^6.1.0",
     "@changesets/write": "^0.4.0",
-    "@clack/prompts": "^1.1.0",
+    "@clack/prompts": "^1.7.0",
     "@inquirer/editor": "^4.2.23",
     "@manypkg/get-packages": "^3.1.0",
     "@manypkg/tools": "^2.1.1",

--- a/packages/_changeset-cli/src/changeset/getVersionBumps.ts
+++ b/packages/_changeset-cli/src/changeset/getVersionBumps.ts
@@ -25,7 +25,7 @@ async function promptForVersionBumps({
     {
       packages: () => {
         return p.autocompleteMultiselect({
-          message: `Which packages would you like to include? ${color.dim('(use arrow keys / space bar)')}`,
+          message: `Which packages would you like to include?`,
           options: [
             ...changedPackages.map(pkg => ({ value: pkg, label: pkg, hint: 'changed' })),
             ...unchangedPackages.map(pkg => ({ value: pkg.packageJson.name, label: pkg.packageJson.name })),
@@ -39,10 +39,11 @@ async function promptForVersionBumps({
       major: ({ results }): Promise<string[]> => {
         const packages = (results.packages ?? []) as string[];
         return p.multiselect({
-          message: `Which packages should have a ${color.red('major')} bump? ${color.dim('(use arrow keys / space bar)')}`,
+          message: `Which packages should have a ${color.red('major')} bump?`,
           options: packages.map((value: string) => ({ value })),
           initialValues: preSelectedPackages.major.filter(pkg => packages.includes(pkg)),
           required: false,
+          showInstructions: true,
         }) as Promise<string[]>;
       },
       minor: ({ results }): Promise<string[]> => {
@@ -54,10 +55,11 @@ async function promptForVersionBumps({
         }
 
         return p.multiselect({
-          message: `Which packages should have a ${color.yellow('minor')} bump? ${color.dim('(use arrow keys / space bar)')}`,
+          message: `Which packages should have a ${color.yellow('minor')} bump?`,
           options: possiblePackages.map(value => ({ value })),
           initialValues: preSelectedPackages.minor.filter(pkg => packages.includes(pkg)),
           required: false,
+          showInstructions: true,
         }) as Promise<string[]>;
       },
       patch: async ({ results }): Promise<string[]> => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@babel/parser": "^7.29.7",
     "@babel/types": "^7.29.7",
-    "@clack/prompts": "^1.1.0",
+    "@clack/prompts": "^1.7.0",
     "@expo/devcert": "^1.2.1",
     "@mastra/deployer": "workspace:^",
     "@mastra/loggers": "workspace:^",

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -57,6 +57,7 @@ export async function promptForObservability(
         { value: 'no', label: 'No' },
       ],
       initialValue: 'yes',
+      showInstructions: false,
     });
 
     if (p.isCancel(choice)) return {};
@@ -792,8 +793,9 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
         skip?.llmProvider
           ? undefined
           : p.select({
-              message: 'Select a default provider:',
+              message: 'Select a default model provider:',
               options: LLM_PROVIDERS,
+              showInstructions: false,
             }),
       llmApiKey: async ({ results: { llmProvider } }) => {
         if (skip?.llmApiKey) return undefined;
@@ -806,6 +808,7 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
             { value: 'enter', label: 'Enter API key' },
           ],
           initialValue: 'skip',
+          showInstructions: false,
         });
 
         if (keyChoice === 'enter') {
@@ -828,12 +831,13 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
         if (skip?.skills && skip?.mcpServer) return { skills: undefined, mcpServer: undefined };
 
         const choice = await p.select({
-          message: `Configure Mastra tooling for agents?`,
+          message: `Select tooling for your coding assistant:`,
           options: [
             { value: 'skills', label: 'Skills', hint: 'recommended' },
             { value: 'mcp', label: 'MCP Docs Server' },
           ],
           initialValue: 'skills',
+          showInstructions: false,
         });
 
         if (p.isCancel(choice)) {
@@ -884,7 +888,7 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
 
           // Show popular agents first with "Show all" option
           const initialSelection = await p.select({
-            message: `Select your agent:`,
+            message: `Select your coding assistant:`,
             options: [...POPULAR_AGENTS, { value: '__show_all__', label: '+ Show all agents' }],
             initialValue: 'universal',
           });
@@ -898,7 +902,7 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
           // If user selected "Show all", show full list
           if (initialSelection === '__show_all__') {
             const followUpSelection = await p.select({
-              message: `Select your agent:`,
+              message: `Select your coding assistant:`,
               options: ALL_AGENTS,
             });
 
@@ -920,7 +924,7 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
         // If MCP selected, show editor sub-selection
         if (choice === 'mcp') {
           const editor = await p.select({
-            message: `Which editor?`,
+            message: `Select your coding assistant:`,
             options: [
               {
                 value: 'cursor',

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -27,7 +27,7 @@
     "codemod"
   ],
   "dependencies": {
-    "@clack/prompts": "^1.1.0",
+    "@clack/prompts": "^1.7.0",
     "commander": "^14.0.3",
     "debug": "^4.4.3",
     "jscodeshift": "^17.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1894,16 +1894,16 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: ^2.0.62
-        version: 2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^2.0.99
-        version: 2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: ^2.0.1
         version: 2.0.3
       '@ai-sdk/provider-utils':
         specifier: ^3.0.22
-        version: 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+        version: 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       '@huggingface/hub':
         specifier: ^0.15.2
         version: 0.15.2
@@ -1976,7 +1976,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   integrations/brightdata:
     devDependencies:
@@ -3013,8 +3013,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@clack/prompts':
-        specifier: ^1.1.0
-        version: 1.3.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@inquirer/editor':
         specifier: ^4.2.23
         version: 4.2.23(@types/node@22.19.15)
@@ -3778,8 +3778,8 @@ importers:
         specifier: ^7.29.7
         version: 7.29.7
       '@clack/prompts':
-        specifier: ^1.1.0
-        version: 1.3.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@expo/devcert':
         specifier: ^1.2.1
         version: 1.2.1
@@ -3911,8 +3911,8 @@ importers:
   packages/codemod:
     dependencies:
       '@clack/prompts':
-        specifier: ^1.1.0
-        version: 1.3.0
+        specifier: ^1.7.0
+        version: 1.7.0
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -11116,12 +11116,12 @@ packages:
     resolution: {integrity: sha512-s2DXAwkTpmiIKSATXgrO879s1pqFwS70Y0JPd+TRGRzDeh6nfqt5dnKt5Bug0P1zwkB6DoPurhnYS9nqhSmD/w==}
     engines: {node: '>=20'}
 
-  '@clack/core@1.3.0':
-    resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==}
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@1.3.0':
-    resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==}
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
   '@clerk/backend@1.34.0':
@@ -29562,10 +29562,10 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+  '@ai-sdk/google@2.0.72(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -29721,6 +29721,26 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
+
+  '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@types/node'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - typescript
+      - vite
 
   '@ai-sdk/openai@2.0.106(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(zod@3.25.76)':
     dependencies:
@@ -32410,14 +32430,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@clack/core@1.3.0':
+  '@clack/core@1.4.3':
     dependencies:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.3.0':
+  '@clack/prompts@1.7.0':
     dependencies:
-      '@clack/core': 1.3.0
+      '@clack/core': 1.4.3
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
@@ -41553,7 +41573,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8)':
     dependencies:
@@ -41646,7 +41666,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Description

Update `@clack/prompts` so that keyboard hints are shown by default, see https://github.com/bombshell-dev/clack/releases/tag/%40clack%2Fprompts%401.7.0.

Adjust wording of `create-mastra` CLI slightly so it's clearer what you configure

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/18960

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the command-line setup easier to understand and less noisy. It also upgrades the prompt library so the built-in keyboard help shows up automatically, and clarifies the wording when you’re choosing what kind of assistant or setup you want.

### What changed
- Updated `@clack/prompts` to `1.7.0` in:
  - `packages/_changeset-cli/package.json`
  - `packages/cli/package.json`
  - `packages/codemod/package.json`
- Adjusted `_changeset-cli` version-bump prompts:
  - removed custom arrow/spacebar hint text from messages
  - enabled `showInstructions` for major/minor multiselect prompts
- Updated `create-mastra` init prompts:
  - hid instruction text on several selects with `showInstructions: false`
  - replaced “agent” with “coding assistant” in skills/MCP prompt wording
  - clarified the configuration prompt to better explain the `.agents` vs `.claude` choice

<!-- end of auto-generated comment: release notes by coderabbit.ai -->