### PR TITLE
fix(core): exclude internal workflows from scheduler-enable heuristic

### DIFF
--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1445,8 +1445,15 @@ export class Mastra<
 
     if (this.#notificationDispatchConfig?.enabled !== false) {
       const workflow = createNotificationDispatchWorkflow(this.#notificationDispatchConfig);
-      this.addWorkflow(workflow, workflow.id);
+      // Mark as hidden BEFORE addWorkflow so the scheduler-enable heuristic
+      // (#hasScheduledWorkflow) skips internal schedules. Without this,
+      // addWorkflow sets #hasScheduledWorkflow = true for the dispatcher's
+      // cron, which makes #shouldEnableScheduler() return true for every app
+      // even when the user declared no scheduled workflows — causing the
+      // scheduler to poll storage every 10 s and prevent serverless containers
+      // from ever sleeping (see #18864).
       this.#hiddenWorkflowKeys.add(workflow.id);
+      this.addWorkflow(workflow, workflow.id);
     }
 
     if (config?.workflows) {
@@ -3960,8 +3967,10 @@ export class Mastra<
     this.registerStaticWorkflowScorers(workflow);
 
     // If a schedule is declared, mark the flag and register into the
-    // running scheduler worker (if already started).
-    if (hasSchedule) {
+    // running scheduler worker (if already started). Skip hidden/internal
+    // workflows so their schedules don't auto-enable the scheduler — the
+    // scheduler should only start when the *user* declares a scheduled workflow.
+    if (hasSchedule && !this.#hiddenWorkflowKeys.has(workflowKey)) {
       this.#hasScheduledWorkflow = true;
       const worker = this.#findSchedulerWorker();
       if (worker?.scheduler) {


### PR DESCRIPTION
Since 1.39.0, the notification dispatcher workflow is auto-registered with a */1 * * * * cron. addWorkflow() set #hasScheduledWorkflow = true for it, making #shouldEnableScheduler() return true on every Mastra instance — even when the user declared no scheduled workflows. This causes the WorkflowScheduler tick loop to poll storage every 10 s indefinitely, preventing serverless containers from ever sleeping and generating constant background traffic to remote storage (e.g. Turso, Neon) on otherwise-idle apps.

Fix: mark the notification dispatcher workflow as hidden before addWorkflow(), and skip the #hasScheduledWorkflow = true assignment inside addWorkflow() when the workflow is already in #hiddenWorkflowKeys. The scheduler now only starts automatically when the user declares a scheduled workflow, matching the behaviour before 1.39.0.

The notification dispatcher's schedule is still registered in the database and executed when the scheduler runs (explicitly or due to user-declared schedules); only the auto-enable side effect is removed.

Fixes #18864

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
