### PR TITLE
Fix memory API cross-resource thread enumeration (GHSA-cw45-899f-pvrr)

### DIFF
--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -1816,7 +1816,7 @@ describe('Memory Handlers', () => {
         );
       });
 
-      it('should list all threads when no MASTRA_RESOURCE_ID_KEY is set', async () => {
+      it('should list all threads when no MASTRA_RESOURCE_ID_KEY is set and auth is not configured', async () => {
         const mastra = new Mastra({
           logger: false,
           agents: { 'test-agent': mockAgent },
@@ -1825,16 +1825,42 @@ describe('Memory Handlers', () => {
         await mockMemory.createThread({ resourceId: 'user-a' });
         await mockMemory.createThread({ resourceId: 'user-b' });
 
-        // Without reserved key, client-provided value is used
+        // Without reserved key and without auth, no filter is applied
         const result = await LIST_THREADS_ROUTE.handler({
           ...createTestServerContext({ mastra }),
           agentId: 'test-agent',
-          resourceId: undefined, // No filter
+          resourceId: undefined,
           page: 0,
           perPage: 10,
         });
 
         expect(result.threads).toHaveLength(2);
+      });
+
+      it('should throw 400 when auth is configured but no resourceId is available (prevents cross-user enumeration)', async () => {
+        const mastra = new Mastra({
+          logger: false,
+          agents: { 'test-agent': mockAgent },
+          server: {
+            auth: {
+              authenticateToken: async () => ({ id: 'user-bob' }),
+            },
+          },
+        });
+
+        await mockMemory.createThread({ resourceId: 'user-a' });
+        await mockMemory.createThread({ resourceId: 'user-b' });
+
+        // Auth is configured but mapUserToResourceId is absent, so effectiveResourceId is undefined
+        await expect(
+          LIST_THREADS_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            resourceId: undefined, // No filter, no identity
+            page: 0,
+            perPage: 10,
+          }),
+        ).rejects.toThrow(HTTPException);
       });
 
       it('should filter listed threads through FGA before returning them', async () => {

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -838,6 +838,14 @@ export const LIST_THREADS_ROUTE = createRoute({
       // Use effective resourceId (context key takes precedence over client-provided value)
       const effectiveResourceId = getEffectiveResourceId(requestContext, resourceId);
 
+      // When authentication is configured but no resourceId can be resolved,
+      // refuse to enumerate all threads — the caller has no proven identity to scope by.
+      // This prevents cross-user thread enumeration when mapUserToResourceId is omitted.
+      const authConfig = mastra.getServer?.()?.auth;
+      if (authConfig && typeof authConfig.authenticateToken === 'function' && !effectiveResourceId) {
+        throw new HTTPException(400, { message: 'resourceId is required when authentication is configured' });
+      }
+
       // Gateway proxy: list threads from gateway API
       const agent = await getAgentFromContext({ mastra, agentId, requestContext });
       const isGateway = agent ? await isGatewayAgentAsync(agent) : false;

--- a/packages/server/src/server/handlers/utils.ts
+++ b/packages/server/src/server/handlers/utils.ts
@@ -92,15 +92,20 @@ export function getEffectiveThreadId(
 
 /**
  * Validates that a thread belongs to the specified resourceId.
- * Throws 403 if the thread exists but belongs to a different resource.
+ * Throws 403 if the thread exists but belongs to a different resource,
+ * or if the thread has an owner but the caller's identity is unknown.
  * Threads with no resourceId are accessible to all (shared threads).
  */
 export async function validateThreadOwnership(
   thread: { resourceId?: string | null } | null | undefined,
   effectiveResourceId: string | undefined,
 ): Promise<void> {
-  if (thread && effectiveResourceId && thread.resourceId && thread.resourceId !== effectiveResourceId) {
-    throw new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' });
+  if (thread && thread.resourceId) {
+    // Thread has an explicit owner. Deny access when the caller has no identity
+    // (effectiveResourceId undefined) or their identity differs.
+    if (!effectiveResourceId || thread.resourceId !== effectiveResourceId) {
+      throw new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' });
+    }
   }
 }
 


### PR DESCRIPTION
validateThreadOwnership only enforced ownership when effectiveResourceId was truthy — so any authenticated caller with no resolved identity could read or enumerate threads belonging to other users.

Two changes:

1. packages/server/src/server/handlers/utils.ts validateThreadOwnership: when a thread has a resourceId, deny access (403) if the caller's effectiveResourceId is absent OR mismatches. Previously the guard was a single four-way AND that silently passed when effectiveResourceId was undefined.

2. packages/server/src/server/handlers/memory.ts (LIST_THREADS_ROUTE) When authentication is configured (authenticateToken present) but no effectiveResourceId can be resolved, return 400 instead of dumping every thread in the store. This closes the enumeration hole that appears when mapUserToResourceId is omitted from the auth config.

Fixes #18911 / GHSA-cw45-899f-pvrr

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
