### PR TITLE
fix(core): type provider-registry.json import to fix main build

### DIFF
--- a/.changeset/wet-points-chew.md
+++ b/.changeset/wet-points-chew.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a TypeScript build error caused by the regenerated provider registry adding per-model shape overrides

--- a/packages/core/src/llm/model/provider-registry.ts
+++ b/packages/core/src/llm/model/provider-registry.ts
@@ -12,7 +12,7 @@ import { getGatewayId, shouldEnableGateway } from './gateways/gateway-helpers.js
 import { MastraGateway } from './gateways/mastra.js';
 import { ModelsDevGateway } from './gateways/models-dev.js';
 import { NetlifyGateway } from './gateways/netlify.js';
-import staticRegistry from './provider-registry.json';
+import staticRegistryJson from './provider-registry.json';
 import type { Provider, ModelForProvider, ModelRouterModelId, ProviderModels } from './provider-types.generated.js';
 
 // Re-export types for convenience
@@ -24,6 +24,10 @@ interface RegistryData {
   models: Record<string, string[]>;
   version: string;
 }
+
+// JSON imports widen string literals to `string`, so fields like
+// `modelOverrides[*].shape` don't match their literal-union types.
+const staticRegistry = staticRegistryJson as RegistryData;
 
 /**
  * Check if running in offline/air-gapped mode.


### PR DESCRIPTION
## Summary

The auto-regenerate bot commit 9f169f00ec (`chore: regenerate providers and docs [skip ci]`) added `modelOverrides` entries with `shape` fields to `provider-registry.json` for the first time (Sakana AI provider). Because it was pushed with `[skip ci]`, main's build never ran and is currently broken:

- TypeScript widens JSON string literals to `string`, so the imported registry no longer satisfies `shape?: 'responses' | 'completions'` in `ModelProviderOverride`
- `@mastra/core#build:lib` fails with 3x TS2345 in `src/llm/model/provider-registry.ts` (lines 249, 300, 314)
- Every PR's "Changed Test Gate" job also fails, since it builds main's source

This casts the JSON import to `RegistryData` at the import boundary, which also protects against future regenerations introducing literal-union fields.

## Test plan

- `tsc --noEmit -p tsconfig.build.json` in packages/core — clean on main + this fix
- `vitest run src/llm/model/provider-registry.test.ts` — 33/33 pass
- eslint clean