### PR TITLE
fix(core): accept AI SDK v7 messages in Agent message input

### DIFF
--- a/.changeset/tame-chicken-grin.md
+++ b/.changeset/tame-chicken-grin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `agent.generate()` and `agent.stream()` rejecting AI SDK v7 messages under strict TypeScript. AI SDK v7 `ModelMessage` and `UIMessage` inputs are now accepted, matching the existing v4-v6 support. (#18956)

--- a/e2e-tests/type-check/template/core/agent-message-input.test-d.ts
+++ b/e2e-tests/type-check/template/core/agent-message-input.test-d.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/18956
+ *
+ * `Agent#generate`/`#stream` accept `MessageListInput`, whose `MessageInput`
+ * union listed AI SDK v4/v5/v6 message types but not v7. Under
+ * `exactOptionalPropertyTypes: true`, an AI SDK v7 `ModelMessage` is not
+ * assignable to the v5 branch (v7 `providerOptions?: JSONValue | undefined`
+ * vs v5 `providerOptions?: JSONValue`), so `agent.generate(v7Messages)` failed
+ * to compile (TS2769) in userland. These tests run against packed artifacts
+ * installed from the local registry — exactly what users consume — under
+ * `exactOptionalPropertyTypes: true` (see tsconfig.exact-optional.json), the
+ * strict flag that surfaces the bug.
+ */
+import { describe, it } from 'vitest';
+import { Agent } from '@mastra/core/agent';
+import type { ModelMessage, UIMessage } from 'ai-v7';
+
+const agent = new Agent({
+  id: 'v7-input-agent',
+  name: 'v7 Input Agent',
+  instructions: 'You are a helpful assistant',
+  model: 'openai/gpt-4o',
+});
+
+declare const modelMessages: ModelMessage[];
+declare const uiMessages: UIMessage[];
+
+describe('Agent message input accepts AI SDK v7 messages (#18956)', () => {
+  it('accepts v7 ModelMessage[] in generate()', async () => {
+    await agent.generate(modelMessages);
+  });
+
+  it('accepts v7 UIMessage[] in generate()', async () => {
+    await agent.generate(uiMessages);
+  });
+});

--- a/e2e-tests/type-check/template/package.json
+++ b/e2e-tests/type-check/template/package.json
@@ -25,7 +25,8 @@
     "zod-v3": "npm:zod@^3.25.76",
     "zod-v4": "npm:zod@^4.3.6",
     "openai-v4": "npm:@ai-sdk/openai@^1.3.24",
-    "openai-v5": "npm:@ai-sdk/openai@^2.0.89"
+    "openai-v5": "npm:@ai-sdk/openai@^2.0.89",
+    "ai-v7": "npm:ai@^7.0.0"
   },
   "devDependencies": {
     "vitest": "4.1.5",

--- a/e2e-tests/type-check/template/tsconfig.exact-optional.json
+++ b/e2e-tests/type-check/template/tsconfig.exact-optional.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "exactOptionalPropertyTypes": true
   },
-  "include": ["./core/auth.test-d.ts"]
+  "include": ["./core/auth.test-d.ts", "./core/agent-message-input.test-d.ts"]
 }

--- a/e2e-tests/type-check/template/vitest.config.ts
+++ b/e2e-tests/type-check/template/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
           typecheck: {
             enabled: true,
             include: ['./**/*.test-d.ts'],
-            exclude: ['**/node_modules/**', './core/auth.test-d.ts'],
+            exclude: ['**/node_modules/**', './core/auth.test-d.ts', './core/agent-message-input.test-d.ts'],
           },
         },
       },
@@ -24,7 +24,7 @@ export default defineConfig({
           include: [],
           typecheck: {
             enabled: true,
-            include: ['./core/auth.test-d.ts'],
+            include: ['./core/auth.test-d.ts', './core/agent-message-input.test-d.ts'],
             exclude: ['**/node_modules/**'],
             tsconfig: './tsconfig.exact-optional.json',
           },

--- a/packages/core/src/agent/message-list/detection/TypeDetector.ts
+++ b/packages/core/src/agent/message-list/detection/TypeDetector.ts
@@ -1,12 +1,14 @@
 import type { Message as AIV4Message, UIMessage as UIMessageV4 } from '@internal/ai-sdk-v4';
 
 import type { MastraDBMessage, MastraMessageV1 } from '../state/types';
-import type { AIV5Type, AIV6Type, CoreMessageV4 } from '../types';
+import type { AIV5Type, AIV6Type, AIV7Type, CoreMessageV4 } from '../types';
 
 /**
  * Type representing all possible message input formats
  */
 export type MessageInput =
+  | AIV7Type.UIMessage
+  | AIV7Type.ModelMessage
   | AIV6Type.UIMessage
   | AIV6Type.ModelMessage
   | AIV5Type.UIMessage
@@ -81,7 +83,7 @@ export class TypeDetector {
       !TypeDetector.isAIV4CoreMessage(msg) &&
       'parts' in msg &&
       TypeDetector.hasAIV6UIMessageCharacteristics(
-        msg as AIV6Type.UIMessage | AIV5Type.UIMessage | UIMessageV4 | AIV4Message,
+        msg as AIV7Type.UIMessage | AIV6Type.UIMessage | AIV5Type.UIMessage | UIMessageV4 | AIV4Message,
       )
     );
   }
@@ -122,7 +124,7 @@ export class TypeDetector {
       !('parts' in msg) &&
       'content' in msg &&
       TypeDetector.hasAIV6CoreMessageCharacteristics(
-        msg as CoreMessageV4 | AIV5Type.ModelMessage | AIV6Type.ModelMessage | AIV4Message,
+        msg as CoreMessageV4 | AIV5Type.ModelMessage | AIV6Type.ModelMessage | AIV7Type.ModelMessage | AIV4Message,
       )
     );
   }
@@ -144,7 +146,7 @@ export class TypeDetector {
    * Check if a message has AIV6-only UI characteristics.
    */
   static hasAIV6UIMessageCharacteristics(
-    msg: AIV6Type.UIMessage | AIV5Type.UIMessage | UIMessageV4 | AIV4Message,
+    msg: AIV7Type.UIMessage | AIV6Type.UIMessage | AIV5Type.UIMessage | UIMessageV4 | AIV4Message,
   ): msg is AIV6Type.UIMessage {
     if (!('parts' in msg) || !msg.parts) return false;
 
@@ -170,7 +172,7 @@ export class TypeDetector {
    * V5 UIMessages have specific part types and field names that differ from V4.
    */
   static hasAIV5UIMessageCharacteristics(
-    msg: AIV6Type.UIMessage | AIV5Type.UIMessage | UIMessageV4 | AIV4Message,
+    msg: AIV7Type.UIMessage | AIV6Type.UIMessage | AIV5Type.UIMessage | UIMessageV4 | AIV4Message,
   ): msg is AIV5Type.UIMessage {
     // AI SDK v4 has separate arrays of tool invocations, reasoning, and
     // attachments that do not preserve overall part ordering, so their
@@ -214,7 +216,7 @@ export class TypeDetector {
    * Check if a message has AIV6-only core characteristics.
    */
   static hasAIV6CoreMessageCharacteristics(
-    msg: CoreMessageV4 | AIV5Type.ModelMessage | AIV6Type.ModelMessage | AIV4Message,
+    msg: CoreMessageV4 | AIV5Type.ModelMessage | AIV6Type.ModelMessage | AIV7Type.ModelMessage | AIV4Message,
   ): msg is AIV6Type.ModelMessage {
     if ('parts' in msg || typeof msg.content === 'string') return false;
 
@@ -233,6 +235,7 @@ export class TypeDetector {
       | CoreMessageV4
       | AIV6Type.ModelMessage
       | AIV5Type.ModelMessage
+      | AIV7Type.ModelMessage
       // This is here because the AIV4 Message type can omit parts entirely.
       | AIV4Message,
   ): msg is AIV5Type.ModelMessage {

--- a/packages/core/src/agent/message-list/types.ts
+++ b/packages/core/src/agent/message-list/types.ts
@@ -1,6 +1,7 @@
 import type { CoreMessage, Message } from '@internal/ai-sdk-v4';
 import type * as AIV5 from '@internal/ai-sdk-v5';
 import type * as AIV6 from '@internal/ai-v6';
+import type * as AIV7 from '@internal/ai-v7';
 
 import type { CreatedAgentSignal } from '../signals';
 import type { MastraDBMessage, MastraMessageV1, UIMessageWithMetadata } from './state/types';
@@ -10,6 +11,7 @@ export type { CoreMessage as CoreMessageV4, UIMessage as UIMessageV4 } from '@in
 export type * as AIV4Type from '@internal/ai-sdk-v4';
 export type * as AIV5Type from '@internal/ai-sdk-v5';
 export type * as AIV6Type from '@internal/ai-v6';
+export type * as AIV7Type from '@internal/ai-v7';
 
 // Re-export all message types from state/types for convenience
 export type {
@@ -28,6 +30,8 @@ export type AIV5ResponseMessage = AIV5.AssistantModelMessage | AIV5.ToolModelMes
 export type AIV6ResponseMessage = AIV6.AssistantModelMessage | AIV6.ToolModelMessage;
 
 export type MessageInput =
+  | AIV7.UIMessage
+  | AIV7.ModelMessage
   | AIV6.UIMessage
   | AIV6.ModelMessage
   | AIV5.UIMessage

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -98,6 +98,7 @@ export default defineConfig({
         '@internal/ai-sdk-v4',
         '@internal/ai-sdk-v5',
         '@internal/ai-v6',
+        '@internal/ai-v7',
         '@internal/external-types',
         '@internal/core',
         '@internal/voice',


### PR DESCRIPTION
## Description

`agent.generate()` / `agent.stream()` accept `MessageListInput`, whose `MessageInput` union listed AI SDK v4/v5/v6 messages but not v7. In a project compiled with `exactOptionalPropertyTypes: true`, passing AI SDK v7 `ModelMessage`/`UIMessage` failed to type-check (`TS2769`, bottoming out on `providerOptions`).

Before:

```ts
import type { ModelMessage } from 'ai'; // AI SDK v7
const messages: ModelMessage[] = [{ role: 'user', content: 'hi' }];
await agent.generate(messages); // ✗ TS2769
```

After: the same call type-checks.

This adds the v7 branch to the public `MessageInput` union and keeps the internal `TypeDetector` union and helper signatures in sync, so v7 messages are accepted and routed through the existing v5/v6 detection paths. It's type-only — no runtime changes. `@internal/ai-v7` is allowlisted in the core type bundle so the published `.d.ts` can reference it. A userland type-check regression test exercises `agent.generate()` with v7 messages under `exactOptionalPropertyTypes`.

## Related issue(s)

Fixes #18956

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

_Disclosure: I used AI assistance (Claude Code) to investigate and prepare this change._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change teaches `agent.generate()` and `agent.stream()` to understand a newer kind of message from AI SDK v7, so TypeScript stops complaining when people use it. It also updates the tests and build setup so the new message type is recognized everywhere it needs to be.

## Summary
- Added AI SDK v7 `ModelMessage` and `UIMessage` to the core `MessageInput` union.
- Kept message type detection/conversion helpers aligned with the new v7 inputs.
- Allowed `@internal/ai-v7` in generated core type bundles so the published `.d.ts` can reference it.
- Added a type-check regression test covering `agent.generate()` with v7 messages under `exactOptionalPropertyTypes: true`.
- Updated the type-check test template and Vitest config to include the new fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->