### PR TITLE
fix(daytona): pass --implicit-dirs to gcsfuse so externally-written objects are visible

### DIFF
--- a/.changeset/daytona-gcs-implicit-dirs.md
+++ b/.changeset/daytona-gcs-implicit-dirs.md
@@ -1,0 +1,5 @@
+---
+'@mastra/daytona': patch
+---
+
+Pass `--implicit-dirs` to gcsfuse in Daytona GCS mounts. Without it, objects written directly to the bucket via the GCS API (no placeholder "directory" object) are unreachable in the mount — not listed and not readable by full path. This is common when the mount reads bucket contents produced by another process (SDK uploads, other services, gsutil).

--- a/workspaces/daytona/src/sandbox/mounts/gcs.ts
+++ b/workspaces/daytona/src/sandbox/mounts/gcs.ts
@@ -173,6 +173,14 @@ export async function mountGCS(mountPath: string, config: DaytonaGCSMountConfig,
   }
 
   const hasCredentials = !!config.serviceAccountKey;
+  // Infer directories from object prefixes. GCS has no real directories — a
+  // "folder" only exists implicitly as a shared prefix of object names. Without
+  // --implicit-dirs, an object written to the bucket via the GCS API without a
+  // placeholder "directory" object (e.g. an SDK/gsutil upload of foo/bar.txt
+  // with no foo/ marker) is unreachable in the mount: it isn't listed, and it
+  // can't be read by full path. Common when the mount reads bucket contents
+  // produced by another process. See gcsfuse docs "implicit directories".
+  const implicitDirsFlag = '--implicit-dirs';
   // Run gcsfuse as the sandbox user (not root) so the FUSE connection is registered
   // in the container's user namespace — allowing fusermount -u to unmount it later.
   let mountCmd: string;
@@ -185,10 +193,10 @@ export async function mountGCS(mountPath: string, config: DaytonaGCSMountConfig,
     await writeFile(keyPath, config.serviceAccountKey!);
     await run(`chmod 600 ${shellQuote(keyPath)}`, 30_000);
 
-    mountCmd = `gcsfuse --key-file=${shellQuote(keyPath)} ${onlyDirFlag}-o allow_other ${uidGidFlags} ${shellQuote(config.bucket)} ${quotedMountPath}`;
+    mountCmd = `gcsfuse --key-file=${shellQuote(keyPath)} ${implicitDirsFlag} ${onlyDirFlag}-o allow_other ${uidGidFlags} ${shellQuote(config.bucket)} ${quotedMountPath}`;
   } else {
     logger.debug(`${LOG_PREFIX} No credentials provided, mounting GCS as public bucket (read-only)`);
-    mountCmd = `gcsfuse --anonymous-access ${onlyDirFlag}-o allow_other ${uidGidFlags} ${shellQuote(config.bucket)} ${quotedMountPath}`;
+    mountCmd = `gcsfuse --anonymous-access ${implicitDirsFlag} ${onlyDirFlag}-o allow_other ${uidGidFlags} ${shellQuote(config.bucket)} ${quotedMountPath}`;
   }
 
   logger.debug(`${LOG_PREFIX} Mounting GCS:`, mountCmd);


### PR DESCRIPTION
# Description

Daytona GCS mounts are missing `--implicit-dirs`, so any object created directly in the bucket via the GCS API — without a placeholder "directory" object — is **completely unreachable** in the sandbox: not listed by `ls`, and not even readable by full path.

## Why this fix is needed

GCS has no real directories. A "folder" only exists implicitly as a shared prefix of object names. When a process writes `gs://bucket/<prefix>/assets/audio.wav` through the GCS SDK (or `gsutil`, or any non-mount path) it does **not** create an `assets/` placeholder object. By default gcsfuse does not infer that implicit directory, so inside the sandbox:

```
$ ls /gcs-data/assets
ls: cannot access '/gcs-data/assets': No such file or directory
$ cat /gcs-data/assets/audio.wav
cat: /gcs-data/assets/audio.wav: No such file or directory   # invisible even by full path
```

From the gcsfuse docs: *"Directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists."* `--implicit-dirs` makes gcsfuse infer directories from object prefixes (at the cost of one extra `Objects.list` per name lookup).

This matters whenever the mount is a **reader** of bucket contents produced elsewhere — SDK uploads from an asset pipeline, another service, or `gsutil`. Those objects silently never appear in the mount.

## Change

Add `--implicit-dirs` to the gcsfuse command in `workspaces/daytona/src/sandbox/mounts/gcs.ts`, in both the credentialed and `--anonymous-access` commands. Same splice pattern as the existing `--only-dir` flag.

```ts
// Before: object at gs://my-bucket/a/b/threadA/assets/audio.wav is invisible in the mount
// After:  it is listed and readable at /gcs-data/assets/audio.wav
```

## Verification

Confirmed end-to-end against a real Daytona sandbox (gcsfuse 3.10.0): with the flag as the only difference, an object written to the bucket externally under an implicit directory goes from unreachable (no listing, no full-path read) to listed and readable.

## Related

- Follow-up candidate (not in this PR — a consistency-vs-perf policy call): gcsfuse 3.x defaults the metadata cache TTL to infinite on high-performance machines, so externally-written objects don't refresh in a live mount. `--metadata-cache-ttl-secs=0` / `--kernel-list-cache-ttl-secs=0` would address that; happy to open a separate PR or fold it in if maintainers prefer.

Fixes #19001


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Daytona mounts Google Cloud Storage using `gcsfuse`. This change tells `gcsfuse` to treat “folders” as implied by object names, so files uploaded from outside the mount (no special folder marker needed) show up and can be read inside the sandbox.

## Summary
- Added `--implicit-dirs` to the `gcsfuse` command in `workspaces/daytona/src/sandbox/mounts/gcs.ts`.
- Applied the flag for both mount modes:
  - authenticated mounts (with `--key-file`)
  - anonymous/public mounts (with `--anonymous-access`)
- Updated `.changeset/daytona-gcs-implicit-dirs.md` to document a patch release for `@mastra/daytona`.

## Impact
- Objects written directly to a GCS bucket (e.g., via the GCS API/SDK or `gsutil`) are now discoverable in directory listings and readable by their full path inside the mounted sandbox, even when no placeholder “directory” object exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->