### PR TITLE
docs: clarify Mastra Code agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ vitest tests are colocated with source
 When adding a model name or ID to changesets or comments, use a literal value from docs/src/plugins/remark-model-tokens/models.ts (do not use placeholder tokens, remark does not replace them in changesets/comments)
 
 Prefer narrowest package build/test/lint/typecheck; start with unit/integration before E2E
-Use specific root scripts like pnpm build:core, pnpm --filter ./packages/name script, or pnpm turbo build --filter ./packages/<name>
-Avoid pnpm setup/build/build:packages unless package-local options are insufficient
+Use specific root scripts like pnpm build:core, pnpm --filter ./packages/name script, or pnpm turbo build --filter ./packages/<name>; these build that package's dependency graph
+Avoid pnpm setup/build/build:packages unless package-local options are insufficient whole monorepo builds are slow and usually unneeded
 Fresh clone: pnpm install, then build relevant packages
 Unresolvable internal/workspace imports means deps aren't built
 some integration tests need pnpm i --ignore-workspace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,14 +7,11 @@ packages use strict TypeScript
 vitest tests are colocated with source
 When adding a model name or ID to changesets or comments, use a literal value from docs/src/plugins/remark-model-tokens/models.ts (do not use placeholder tokens, remark does not replace them in changesets/comments)
 
-Prefer narrowest build test lint typecheck for packages
-when package splits unit integration or E2E coverage run narrowest suite first
-From root prefer specific scripts like pnpm build:core or pnpm --filter ./packages/name script
-Do not pnpm run setup pnpm build pnpm build:packages or repo wide test runs when package local is enough
-Don't run pnpm build directly (slow, builds everything); build individual packages from root like pnpm build:core or pnpm build:memory, or generically pnpm turbo build --filter ./packages/<name> — turbo builds only the workspace dependency graph that package needs
-Fresh worktree/clone: pnpm install, then build the packages you'll work in (command above)
-Unresolvable @internal/* or workspace package imports in tests mean deps aren't built — build them (command above); never restructure tests to tolerate an unbuilt environment
-Before pushing commits or opening PRs run the narrowest relevant local checks; if CodeRabbit CLI is installed and configured, run a local CodeRabbit review too
+Prefer narrowest package build/test/lint/typecheck; start with unit/integration before E2E
+Use specific root scripts like pnpm build:core, pnpm --filter ./packages/name script, or pnpm turbo build --filter ./packages/<name>
+Avoid pnpm setup/build/build:packages unless package-local options are insufficient
+Fresh clone: pnpm install, then build relevant packages
+Unresolvable internal/workspace imports means deps aren't built
 some integration tests need pnpm i --ignore-workspace
 
 features and new packages need related docs updates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@ Prefer narrowest build test lint typecheck for packages
 when package splits unit integration or E2E coverage run narrowest suite first
 From root prefer specific scripts like pnpm build:core or pnpm --filter ./packages/name script
 Do not pnpm run setup pnpm build pnpm build:packages or repo wide test runs when package local is enough
-Building whole monorepo is slow and should be last resort
+Don't run pnpm build directly (slow, builds everything); build individual packages from root like pnpm build:core or pnpm build:memory, or generically pnpm turbo build --filter ./packages/<name> — turbo builds only the workspace dependency graph that package needs
+Fresh worktree/clone: pnpm install, then build the packages you'll work in (command above)
+Unresolvable @internal/* or workspace package imports in tests mean deps aren't built — build them (command above); never restructure tests to tolerate an unbuilt environment
 Before pushing commits or opening PRs run the narrowest relevant local checks; if CodeRabbit CLI is installed and configured, run a local CodeRabbit review too
 some integration tests need pnpm i --ignore-workspace
 

--- a/mastracode/AGENTS.md
+++ b/mastracode/AGENTS.md
@@ -1,0 +1,23 @@
+Build from root: pnpm build:mastracode
+Test from root: pnpm test:mastracode
+Typecheck from root: pnpm --filter ./mastracode check
+Lint from root: pnpm --filter ./mastracode lint
+
+Run pnpm build:mastracode before broad Mastra Code test audits so workspace dependency dist artifacts are available.
+For focused tests, prefer pnpm --filter ./mastracode exec vitest run <test-file> --reporter=dot --bail 1 before the full package suite.
+
+Most unit tests live under mastracode/src/ and are colocated with the code they cover.
+Run focused agent, model, headless, TUI, command, MCP, plugin, or processor tests before broader validation when those areas change.
+
+Mastra Code TUI/e2e scenarios live under mastracode/e2e/tui/ with fixtures in mastracode/e2e/fixtures/.
+List scenarios with pnpm --filter ./mastracode run e2e:list.
+Run smoke scenarios with pnpm --filter ./mastracode run e2e:smoke.
+For focused scenario development, use MC_E2E_VITEST_SCENARIOS=<scenario> pnpm --filter ./mastracode exec vitest run --config e2e/vitest.config.ts --reporter=dot.
+Run pnpm --filter ./mastracode run e2e:test -- --reporter=dot before shipping runner changes.
+
+For Mastra Code TUI work, use the testing-mastracode-tui skill for interactive/manual testing guidance, but prefer mastracode/e2e/README.md as the source of truth for runner commands.
+
+TUI-visible or TUI-triggered behavior should have checked-in TUI e2e coverage; lower-level tests are supporting shields, not substitutes.
+If realistic long conversation or OM fixture data is needed, read the local Mastra Code Application Support database only via read-only operations, sanitize it, and transform it into deterministic AIMock-compatible fixtures.
+
+Keep changes here surgical; Mastra Code exercises core harness, storage, memory, tools, MCP, browser, plugins, signals, and TUI integration paths.


### PR DESCRIPTION
Adds package-local agent instructions for Mastra Code and tightens the root build guidance so agents avoid slow repo-wide builds.

The main intent is to make the preferred path clearer:

```sh
pnpm build:mastracode
pnpm --filter ./mastracode exec vitest run <test-file> --reporter=dot --bail 1
MC_E2E_VITEST_SCENARIOS=<scenario> pnpm --filter ./mastracode exec vitest run --config e2e/vitest.config.ts --reporter=dot
```

Also calls out the common workspace dependency issue: if tests cannot resolve workspace package artifacts, build the relevant package graph instead of changing tests to tolerate an unbuilt repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR updates the docs so AI coding agents know the fastest, safest commands to build and test just the `mastracode` package (not the whole monorepo). It also explains what to do when tests can’t find workspace-built artifacts: build the needed package dependency graph first.

## Summary
- Added package-local agent instructions in `mastracode/AGENTS.md`, including:
  - Root commands: `pnpm build:mastracode`, `pnpm test:mastracode`, `pnpm --filter ./mastracode check`, `pnpm --filter ./mastracode lint`
  - Build-before-audits guidance: run `pnpm build:mastracode` before broader Mastra Code test audits so workspace dist artifacts exist
  - Focused Vitest guidance: prefer `pnpm --filter ./mastracode exec vitest run <test-file> --reporter=dot --bail 1` before the full suite
  - E2E/TUI scenario guidance and example commands, including `MC_E2E_VITEST_SCENARIOS=<scenario> pnpm --filter ./mastracode exec vitest run --config e2e/vitest.config.ts --reporter=dot`
  - Where unit vs TUI/e2e tests and fixtures live, plus fixture handling and “keep edits surgical” conventions
- Tightened root `AGENTS.md` to discourage slow whole-repo builds by emphasizing:
  - “Prefer narrowest package build/test/lint/typecheck; start with unit/integration before E2E”
  - Targeted dependency-graph builds via package-specific root scripts and `pnpm --filter ./packages/<name> ...` / `pnpm turbo build --filter ./packages/<name>`
  - Fresh-clone workflow: `pnpm install`, then build relevant packages
  - Troubleshooting rule: “Unresolvable internal/workspace imports means deps aren’t built” (and notes about some integration tests needing `pnpm i --ignore-workspace`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->