### PR TITLE
fix(core): scope channel threads per agent and ignore bot messages by default

### DIFF
--- a/.changeset/per-agent-channel-threads.md
+++ b/.changeset/per-agent-channel-threads.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+---
+
+Scoped channel threads per agent so multiple agents sharing one storage instance no longer bleed conversation history and subscription state into each other's threads. Each agent now maps a platform thread (Slack, Discord, Telegram) to its own Mastra thread via a `channel_agentId` metadata key; threads created before this change are claimed by the first agent that touches them, keeping existing history. Fixes thread subscription state bleeding across agents.
+
+Added a `respondToBots` option to the channels config (default `false`). Agents now ignore messages authored by other bots in the default handlers, preventing bot-to-bot reply loops when multiple bots share a channel or thread. This is a behavior change: previously another bot's message in a subscribed thread would wake the agent. Opt back in with `respondToBots: true`:
+
+```typescript
+export const agent = new Agent({
+  id: 'agent',
+  channels: {
+    adapters: {
+      slack: createSlackAdapter(),
+    },
+    respondToBots: true,
+  },
+})
+```

--- a/docs/src/content/en/docs/agents/channels.mdx
+++ b/docs/src/content/en/docs/agents/channels.mdx
@@ -132,6 +132,28 @@ In group conversations, Mastra automatically prefixes each message with the send
 [Bob (@U456DEF)]: I have a question too.
 ```
 
+## Multiple agents on one platform
+
+Channel threads are scoped per agent. When two agents (for example, a support bot and a triage bot) are both active in the same Slack or Discord thread, each agent gets its own Mastra thread with independent conversation history and subscription state. One agent subscribing to a platform thread doesn't affect the other.
+
+Threads created before per-agent scoping have no owning agent recorded. The first agent to touch such a thread claims it and keeps its history; other agents get fresh threads.
+
+By default, agents ignore messages authored by other bots. This prevents two subscribed bots from replying to each other in a loop. Set `respondToBots: true` to opt in:
+
+```typescript
+export const agent = new Agent({
+  id: 'agent',
+  channels: {
+    adapters: {
+      slack: createSlackAdapter(),
+    },
+    respondToBots: true,
+  },
+})
+```
+
+The guard applies to the built-in handlers, so custom `handlers` that call `defaultHandler` inherit it. Handlers that do their own routing bypass it.
+
 ## Multimodal content
 
 Models like Gemini can natively process images, video, and audio. Combine `inlineMedia` and `inlineLinks` to let users share rich content with your agent across platforms:

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -52,6 +52,14 @@ The `channels` property accepts a `ChannelConfig` object with the following fiel
     description: 'Override default message handlers for DMs, mentions, and subscribed threads.',
   },
   {
+    name: 'respondToBots',
+    type: 'boolean',
+    isOptional: true,
+    defaultValue: 'false',
+    description:
+      "Whether messages authored by other bots wake the agent. By default the built-in handlers ignore bot-authored messages, preventing reply loops when multiple bots share a channel or thread. Messages the adapter can't classify pass through. The guard lives in the default handler, so custom `handlers` that call `defaultHandler` inherit it.",
+  },
+  {
     name: 'inlineMedia',
     type: 'string[] | ((mimeType: string) => boolean)',
     isOptional: true,

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -685,6 +685,231 @@ describe('AgentChannels', () => {
       );
     });
   });
+
+  describe('per-agent thread scoping', () => {
+    function makeMastra() {
+      const db = new InMemoryDB();
+      const memoryStore = new InMemoryMemory({ db });
+      return {
+        getStorage: () => ({ getStore: () => memoryStore }),
+        getServer: () => null,
+      } as any;
+    }
+
+    function makeChatThread(adapter: any) {
+      return {
+        id: 'channel-1:thread-1',
+        channelId: 'channel-1',
+        isDM: false,
+        adapter,
+        isSubscribed: vi.fn().mockResolvedValue(true),
+        subscribe: vi.fn().mockResolvedValue(undefined),
+        mentionUser: vi.fn((userId: string) => `<@${userId}>`),
+        messages: (async function* () {})(),
+      } as any;
+    }
+
+    const message = {
+      id: 'message-1',
+      text: 'hi',
+      author: { userId: 'user-1', userName: 'tyler', fullName: 'Tyler Barnes' },
+      attachments: [],
+    } as any;
+
+    function makeChannels(agentId: string) {
+      const channels = new AgentChannels({ adapters: { discord: createMockAdapter('discord') } });
+      channels.__setAgent(createMockAgent(agentId));
+      return channels;
+    }
+
+    async function listChannelThreads(mockMastra: any) {
+      const memoryStore = await mockMastra.getStorage().getStore('memory');
+      const { threads } = await memoryStore.listThreads({
+        filter: { metadata: { channel_externalThreadId: 'channel-1:thread-1' } },
+        perPage: 100,
+      });
+      return threads;
+    }
+
+    it('two agents on the same external thread get distinct Mastra threads', async () => {
+      const mockMastra = makeMastra();
+      const channelsA = makeChannels('agent-a');
+      const channelsB = makeChannels('agent-b');
+      await channelsA.initialize(mockMastra);
+      await channelsB.initialize(mockMastra);
+
+      await (channelsA as any).processChatMessage(makeChatThread(channelsA.adapters.discord), message, mockMastra);
+      await (channelsB as any).processChatMessage(makeChatThread(channelsB.adapters.discord), message, mockMastra);
+
+      const threads = await listChannelThreads(mockMastra);
+      expect(threads).toHaveLength(2);
+      const agentIds = threads.map((t: any) => t.metadata?.channel_agentId).sort();
+      expect(agentIds).toEqual(['agent-a', 'agent-b']);
+      // Both threads point at the same pure platform thread ID
+      for (const thread of threads) {
+        expect(thread.metadata?.channel_externalThreadId).toBe('channel-1:thread-1');
+      }
+    });
+
+    it('reuses the agent-scoped thread on subsequent messages', async () => {
+      const mockMastra = makeMastra();
+      const channels = makeChannels('agent-a');
+      await channels.initialize(mockMastra);
+
+      await (channels as any).processChatMessage(makeChatThread(channels.adapters.discord), message, mockMastra);
+      await (channels as any).processChatMessage(makeChatThread(channels.adapters.discord), message, mockMastra);
+
+      const threads = await listChannelThreads(mockMastra);
+      expect(threads).toHaveLength(1);
+    });
+
+    it('claims a legacy thread (no channel_agentId) and stamps this agent ID', async () => {
+      const mockMastra = makeMastra();
+      const channels = makeChannels('agent-a');
+      await channels.initialize(mockMastra);
+
+      const memoryStore = await mockMastra.getStorage().getStore('memory');
+      await memoryStore.saveThread({
+        thread: {
+          id: 'legacy-thread',
+          title: 'discord conversation',
+          resourceId: 'original-owner',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: {
+            channel_platform: 'discord',
+            channel_externalThreadId: 'channel-1:thread-1',
+            channel_externalChannelId: 'channel-1',
+          },
+        },
+      });
+
+      await (channels as any).processChatMessage(makeChatThread(channels.adapters.discord), message, mockMastra);
+
+      const threads = await listChannelThreads(mockMastra);
+      expect(threads).toHaveLength(1);
+      expect(threads[0].id).toBe('legacy-thread');
+      expect(threads[0].metadata?.channel_agentId).toBe('agent-a');
+      expect(threads[0].resourceId).toBe('original-owner');
+    });
+
+    it('does not steal a thread already claimed by another agent', async () => {
+      const mockMastra = makeMastra();
+      const channels = makeChannels('agent-b');
+      await channels.initialize(mockMastra);
+
+      const memoryStore = await mockMastra.getStorage().getStore('memory');
+      await memoryStore.saveThread({
+        thread: {
+          id: 'claimed-thread',
+          title: 'discord conversation',
+          resourceId: 'agent-a-owner',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: {
+            channel_platform: 'discord',
+            channel_externalThreadId: 'channel-1:thread-1',
+            channel_externalChannelId: 'channel-1',
+            channel_agentId: 'agent-a',
+          },
+        },
+      });
+
+      await (channels as any).processChatMessage(makeChatThread(channels.adapters.discord), message, mockMastra);
+
+      const threads = await listChannelThreads(mockMastra);
+      expect(threads).toHaveLength(2);
+      const claimed = threads.find((t: any) => t.id === 'claimed-thread');
+      expect(claimed?.metadata?.channel_agentId).toBe('agent-a');
+      const fresh = threads.find((t: any) => t.id !== 'claimed-thread');
+      expect(fresh?.metadata?.channel_agentId).toBe('agent-b');
+    });
+  });
+
+  describe('bot-wake guard (respondToBots)', () => {
+    function makeMastra() {
+      const db = new InMemoryDB();
+      const memoryStore = new InMemoryMemory({ db });
+      return {
+        getStorage: () => ({ getStore: () => memoryStore }),
+        getServer: () => null,
+      } as any;
+    }
+
+    function makeChatThread(adapter: any) {
+      return {
+        id: 'channel-1:thread-1',
+        channelId: 'channel-1',
+        isDM: false,
+        adapter,
+        isSubscribed: vi.fn().mockResolvedValue(true),
+        subscribe: vi.fn().mockResolvedValue(undefined),
+        mentionUser: vi.fn((userId: string) => `<@${userId}>`),
+        messages: (async function* () {})(),
+        post: vi.fn().mockResolvedValue(undefined),
+      } as any;
+    }
+
+    function makeMessage(isBot: unknown) {
+      return {
+        id: 'message-1',
+        text: 'hi',
+        author: { userId: 'user-1', userName: 'other-bot', fullName: 'Other Bot', isBot },
+        attachments: [],
+      } as any;
+    }
+
+    it('ignores bot-authored messages by default', async () => {
+      const agent = createMockAgent();
+      const channels = new AgentChannels({ adapters: { discord: createMockAdapter('discord') } });
+      channels.__setAgent(agent);
+      const mockMastra = makeMastra();
+      await channels.initialize(mockMastra);
+
+      await (channels as any).handleChatMessage(
+        makeChatThread(channels.adapters.discord),
+        makeMessage(true),
+        mockMastra,
+      );
+
+      expect(agent.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('wakes on bot messages when respondToBots is true', async () => {
+      const agent = createMockAgent();
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        respondToBots: true,
+      });
+      channels.__setAgent(agent);
+      const mockMastra = makeMastra();
+      await channels.initialize(mockMastra);
+
+      await (channels as any).handleChatMessage(
+        makeChatThread(channels.adapters.discord),
+        makeMessage(true),
+        mockMastra,
+      );
+
+      expect(agent.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([false, 'unknown', undefined])('passes through when isBot is %s', async isBot => {
+      const agent = createMockAgent();
+      const channels = new AgentChannels({ adapters: { discord: createMockAdapter('discord') } });
+      channels.__setAgent(agent);
+      const mockMastra = makeMastra();
+      await channels.initialize(mockMastra);
+
+      await (channels as any).handleChatMessage(
+        makeChatThread(channels.adapters.discord),
+        makeMessage(isBot),
+        mockMastra,
+      );
+
+      expect(agent.sendMessage).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('matchesDomain', () => {

--- a/packages/core/src/channels/__tests__/state-adapter.test.ts
+++ b/packages/core/src/channels/__tests__/state-adapter.test.ts
@@ -262,4 +262,84 @@ describe('MastraStateAdapter', () => {
       expect(entry2?.message.text).toBe('b');
     });
   });
+
+  describe('per-agent subscription scoping', () => {
+    const externalThreadId = 'slack:C1:171234.5678';
+
+    async function seedThread(id: string, agentId?: string) {
+      await memoryStore.saveThread({
+        thread: {
+          id,
+          title: 'Test thread',
+          resourceId: 'slack:user1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: {
+            channel_platform: 'slack',
+            channel_externalThreadId: externalThreadId,
+            channel_externalChannelId: 'slack:C1',
+            ...(agentId ? { channel_agentId: agentId } : {}),
+          },
+        },
+      });
+    }
+
+    it('isolates subscriptions between agents on the same external thread', async () => {
+      await seedThread('thread-agent-a', 'agent-a');
+      await seedThread('thread-agent-b', 'agent-b');
+
+      const adapterA = new MastraStateAdapter(memoryStore, 'agent-a');
+      const adapterB = new MastraStateAdapter(memoryStore, 'agent-b');
+      await adapterA.connect();
+      await adapterB.connect();
+
+      await adapterA.subscribe(externalThreadId);
+
+      expect(await adapterA.isSubscribed(externalThreadId)).toBe(true);
+      expect(await adapterB.isSubscribed(externalThreadId)).toBe(false);
+
+      // Flag landed on agent A's thread only
+      const threadA = await memoryStore.getThreadById({ threadId: 'thread-agent-a' });
+      const threadB = await memoryStore.getThreadById({ threadId: 'thread-agent-b' });
+      expect((threadA?.metadata as Record<string, unknown>)?.channel_subscribed).toBe('true');
+      expect((threadB?.metadata as Record<string, unknown>)?.channel_subscribed).toBeUndefined();
+    });
+
+    it('falls back to an unclaimed legacy thread (no channel_agentId)', async () => {
+      await seedThread('legacy-thread');
+
+      const scoped = new MastraStateAdapter(memoryStore, 'agent-a');
+      await scoped.connect();
+
+      await scoped.subscribe(externalThreadId);
+      expect(await scoped.isSubscribed(externalThreadId)).toBe(true);
+
+      const thread = await memoryStore.getThreadById({ threadId: 'legacy-thread' });
+      expect((thread?.metadata as Record<string, unknown>)?.channel_subscribed).toBe('true');
+    });
+
+    it('does not use a thread claimed by another agent', async () => {
+      await seedThread('claimed-thread', 'agent-a');
+
+      const adapterB = new MastraStateAdapter(memoryStore, 'agent-b');
+      await adapterB.connect();
+
+      // No thread for agent B and no unclaimed legacy thread — subscribe is a no-op
+      await adapterB.subscribe(externalThreadId);
+      expect(await adapterB.isSubscribed(externalThreadId)).toBe(false);
+
+      const thread = await memoryStore.getThreadById({ threadId: 'claimed-thread' });
+      expect((thread?.metadata as Record<string, unknown>)?.channel_subscribed).toBeUndefined();
+    });
+
+    it('unscoped adapter (no agentId) keeps pre-scoping behavior', async () => {
+      await seedThread('any-thread', 'agent-a');
+
+      const unscoped = new MastraStateAdapter(memoryStore);
+      await unscoped.connect();
+
+      await unscoped.subscribe(externalThreadId);
+      expect(await unscoped.isSubscribed(externalThreadId)).toBe(true);
+    });
+  });
 });

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -74,6 +74,8 @@ export class AgentChannels {
   private adapterConfigs: Record<string, ChannelAdapterConfig>;
   /** Handler overrides from config. */
   private handlerOverrides: ChannelHandlers;
+  /** Whether messages authored by other bots wake the agent. */
+  private respondToBots: boolean;
   /** Additional Chat SDK options. */
   private chatOptions: Omit<ChatConfig, 'adapters' | 'state' | 'userName'>;
   /** Thread context config for fetching prior messages. */
@@ -142,6 +144,7 @@ export class AgentChannels {
     this.adapters = adapters;
     this.adapterConfigs = adapterConfigs;
     this.handlerOverrides = config.handlers ?? {};
+    this.respondToBots = config.respondToBots ?? false;
     this.customState = config.state;
     this.userName = config.userName ?? 'Mastra';
     this.chatOptions = config.chatOptions ?? {};
@@ -241,7 +244,7 @@ export class AgentChannels {
             'Channels require storage to be configured on the Mastra instance. Configure a storage provider like LibSQLStore.',
           );
         }
-        this.stateAdapter = new MastraStateAdapter(memoryStore);
+        this.stateAdapter = new MastraStateAdapter(memoryStore, this.agent.id);
         this.log('info', 'Using MastraStateAdapter (subscriptions persist across restarts)');
       }
 
@@ -811,6 +814,18 @@ export class AgentChannels {
    * updates the channel message in real-time via edits.
    */
   private async handleChatMessage(chatThread: Thread, message: Message, mastra: Mastra): Promise<void> {
+    // Don't wake the agent for messages authored by other bots (the Chat SDK
+    // already filters this bot's own messages). Prevents bot-to-bot reply
+    // loops when multiple bots share a thread. `isBot: 'unknown'` passes
+    // through so adapters that can't classify authors don't block humans.
+    // Opt back in with `channels: { respondToBots: true }`.
+    if (message.author?.isBot === true && !this.respondToBots) {
+      this.log('debug', `[${chatThread.adapter.name}] Ignoring bot message (respondToBots is disabled)`, {
+        messageId: message.id,
+        authorId: message.author?.userId,
+      });
+      return;
+    }
     try {
       await this.processChatMessage(chatThread, message, mastra);
     } catch (err) {
@@ -1325,10 +1340,14 @@ export class AgentChannels {
       );
     }
 
-    const metadata = {
+    const baseMetadata = {
       channel_platform: platform,
       channel_externalThreadId: externalThreadId,
       channel_externalChannelId: channelId,
+    };
+    const metadata = {
+      ...baseMetadata,
+      channel_agentId: this.agent.id,
     };
 
     const { threads } = await memoryStore.listThreads({
@@ -1338,6 +1357,24 @@ export class AgentChannels {
 
     if (threads.length > 0) {
       return threads[0]!;
+    }
+
+    // Legacy fallback: threads created before per-agent scoping have no
+    // channel_agentId. Claim an unclaimed one by stamping this agent's ID so
+    // existing conversations keep their history. Threads already claimed by
+    // another agent are never reused. A concurrent claim by two agents is
+    // last-writer-wins — a rare one-shot race during migration.
+    const { threads: legacyThreads } = await memoryStore.listThreads({
+      filter: { metadata: baseMetadata },
+      perPage: 10,
+    });
+    const legacyThread = legacyThreads.find(thread => thread.metadata?.channel_agentId === undefined);
+    if (legacyThread) {
+      return memoryStore.updateThread({
+        id: legacyThread.id,
+        title: legacyThread.title ?? `${platform} conversation`,
+        metadata: { ...legacyThread.metadata, channel_agentId: this.agent.id },
+      });
     }
 
     const resolvedResourceId = typeof resourceId === 'function' ? await resourceId() : resourceId;

--- a/packages/core/src/channels/state-adapter.ts
+++ b/packages/core/src/channels/state-adapter.ts
@@ -18,6 +18,7 @@ interface CachedValue<T = unknown> {
  */
 export class MastraStateAdapter implements StateAdapter {
   private memoryStore: MemoryStorage;
+  private agentId?: string;
   private connected = false;
   private connectPromise: Promise<void> | null = null;
 
@@ -27,8 +28,15 @@ export class MastraStateAdapter implements StateAdapter {
   private readonly lists = new Map<string, { values: unknown[]; expiresAt: number | null }>();
   private readonly queues = new Map<string, QueueEntry[]>();
 
-  constructor(memoryStore: MemoryStorage) {
+  /**
+   * @param memoryStore Mastra memory storage domain used to persist subscriptions.
+   * @param agentId Scopes thread lookups to threads owned by this agent
+   *   (`channel_agentId` metadata). When omitted, lookups are unscoped —
+   *   matching the pre-scoping behavior for custom constructions.
+   */
+  constructor(memoryStore: MemoryStorage, agentId?: string) {
     this.memoryStore = memoryStore;
+    this.agentId = agentId;
   }
 
   async connect(): Promise<void> {
@@ -231,14 +239,32 @@ export class MastraStateAdapter implements StateAdapter {
   }
 
   /**
-   * Find a Mastra thread by its external (SDK) thread ID.
-   * External thread IDs are stored in `channel_externalThreadId` metadata.
+   * Find a Mastra thread by its external (SDK) thread ID, scoped to this agent.
+   * External thread IDs are stored in `channel_externalThreadId` metadata and
+   * agent scoping in `channel_agentId`.
    */
   private async findThreadByExternalId(externalThreadId: string) {
+    if (!this.agentId) {
+      const { threads } = await this.memoryStore.listThreads({
+        filter: { metadata: { channel_externalThreadId: externalThreadId } },
+        perPage: 1,
+      });
+      return threads[0] ?? null;
+    }
+
     const { threads } = await this.memoryStore.listThreads({
-      filter: { metadata: { channel_externalThreadId: externalThreadId } },
+      filter: { metadata: { channel_externalThreadId: externalThreadId, channel_agentId: this.agentId } },
       perPage: 1,
     });
-    return threads[0] ?? null;
+    if (threads[0]) return threads[0];
+
+    // Legacy fallback: threads created before per-agent scoping have no
+    // channel_agentId. Accept one that no agent has claimed yet; never reuse a
+    // thread claimed by another agent.
+    const { threads: legacyThreads } = await this.memoryStore.listThreads({
+      filter: { metadata: { channel_externalThreadId: externalThreadId } },
+      perPage: 10,
+    });
+    return legacyThreads.find(thread => thread.metadata?.channel_agentId === undefined) ?? null;
   }
 }

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -373,6 +373,23 @@ export interface ChannelConfig {
   handlers?: ChannelHandlers;
 
   /**
+   * Whether messages authored by other bots wake the agent.
+   *
+   * Defaults to `false`: the default handlers ignore messages whose author is
+   * a bot (`isBot === true`), preventing bot-to-bot reply loops when multiple
+   * bots share a channel or thread. Messages with `isBot: false` or
+   * `isBot: 'unknown'` always pass through.
+   *
+   * Set to `true` to let bot-authored messages trigger the agent. The guard
+   * lives in the default handler, so custom {@link handlers} that call
+   * `defaultHandler` inherit it, while handlers that do their own routing
+   * bypass it.
+   *
+   * @default false
+   */
+  respondToBots?: boolean;
+
+  /**
    * Which media types to send inline to the model (as file parts).
    * Everything else is described as text metadata so the agent knows about the
    * file without crashing models that reject unsupported types.


### PR DESCRIPTION
Fixes #17037

## Problem

When two or more agents (bots) share one Mastra storage instance and receive messages on the same platform thread (Slack thread, Telegram chat, Discord channel), they all map it to a **single** Mastra thread. `getOrCreateThread()` and `MastraStateAdapter.findThreadByExternalId()` filter only on `{ channel_platform, channel_externalThreadId, channel_externalChannelId }` — no agent scoping. Consequences:

- Shared conversation history and a `resourceId` race between agents
- The `channel_subscribed` flag is one boolean on that shared thread, so one bot subscribing makes **every** bot reply to subsequent messages (the bug in #17037)
- Broadcast/schedule delivery cross-contaminates between agents

Separately: `handleChatMessage` has no bot-author guard. The Chat SDK only filters a bot's *own* messages (`isMe`), so another bot's message in a subscribed thread wakes the agent. With per-agent threads, two subscribed bots replying to each other is a real infinite-loop risk.

## Fix

**Part 1 — per-agent thread identity.** Thread identity becomes `(platform, externalThreadId, channelId, agentId)` via a new `channel_agentId` metadata key:

- `getOrCreateThread()` stamps `channel_agentId` on new threads and includes it in lookups
- `MastraStateAdapter` takes an optional `agentId` ctor param and scopes `findThreadByExternalId()` the same way; subscription isolation follows for free since `channel_subscribed` now lives on a per-agent thread
- **Legacy migration:** on a scoped miss, an unclaimed legacy thread (no `channel_agentId`) is claimed and stamped by the first agent that touches it — single-agent deployments keep their history seamlessly. Threads already claimed by another agent are never stolen.
- `channel_externalThreadId` stays **pure** (the real platform thread ID), so `buildRenderContextForThread()` and the schedule/broadcast path keep working unchanged

**Part 2 — bot-wake guard.** New `ChannelConfig` option `respondToBots?: boolean` (default `false`). `handleChatMessage` returns early for `author.isBot === true` unless opted in. `isBot: 'unknown'`/`false` pass through so humans on adapters that can't classify are never blocked.

> ⚠️ **Behavior change:** agents no longer auto-reply to other bots' messages by default. Bot-to-bot replies are now opt-in via `respondToBots: true`.

## Relationship to #17049

#17049 addresses the same issue by mangling the stored external ID to `${agentId}:${externalThreadId}`. That breaks the self-sufficient broadcast path (`buildRenderContextForThread()` would materialize a nonexistent platform thread), orphans all existing channel threads on upgrade (no legacy fallback), and changes the meaning of `channel_externalThreadId` for everything else that reads it. This PR keeps the external ID pure and scopes identity with a separate metadata key instead.

## Test plan

- 12 new tests: cross-agent thread isolation, legacy claim + stamp, no-steal of claimed threads, subscription isolation at the state-adapter level, and the full `respondToBots` matrix (`true`/`false`/`'unknown'`/default)
- Red/green proof: copying the new test files onto a clean `origin/main` checkout yields **6 failed / 75 passed** — each failure matches the bug (shared thread, cross-agent subscription bleed, bot message waking the agent). On this branch, all 252 channels tests pass.
- `pnpm --filter ./packages/core check` clean
- Docs updated (guide + reference) with per-agent scoping, migration note, and `respondToBots`

## Out of scope

#18877 (duplicate replies on multi-instance deployments) is a different bug in the same area — the in-memory dedupe cache needs a storage-backed atomic primitive. The `agentId` handle added to `MastraStateAdapter` here is the scoping hook that follow-up will need for agent-scoped dedupe keys.
