### PR TITLE
fix(cli): make local env file optional for `mastra deploy`

### DIFF
--- a/.changeset/deploy-optional-env-file.md
+++ b/.changeset/deploy-optional-env-file.md
@@ -1,0 +1,7 @@
+---
+'mastra': patch
+---
+
+`mastra deploy` no longer requires a local `.env` or `.env.<name>` file when the target environment already has env vars stored on Mastra Cloud. Previously the command errored with "No env file found for deploy" even when Cloud held the canonical env vars for that environment.
+
+If an explicit `--env-file` is passed, or a `.env*` file exists in the project, behavior is unchanged: those vars are read and layered on top of the environment's stored env vars for that deploy (Cloud is the base, local values win). If neither is present, the deploy proceeds with an empty local payload and Cloud's stored env vars are used as-is. `mastra studio deploy` and `mastra server deploy` are unchanged.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -29,7 +29,7 @@ import { getToken, getCurrentOrgId } from '../auth/credentials.js';
 import { preflightBuildOutput, printPreflightIssues } from '../deploy-preflight.js';
 import { fetchEnvironments, fetchProjects, createEnvironment } from '../env/platform-api.js';
 import type { Environment } from '../env/platform-api.js';
-import { loadDeployEnvFromDotenv, readEnvVars, getMastraVersion } from '../studio/deploy.js';
+import { getDeployEnvFiles, loadDeployEnvFromDotenv, readEnvVars, getMastraVersion } from '../studio/deploy.js';
 import { createProject } from '../studio/platform-api.js';
 import { getProjectConfigToSave, loadProjectConfig, saveProjectConfig } from '../studio/project-config.js';
 
@@ -749,12 +749,23 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
     }
   }
 
-  const envVars = await readEnvVars(targetDir, { autoAccept, envFile });
+  // If the user didn't pass --env-file and no ambient .env* file exists,
+  // skip the local env-var upload entirely and let the platform use the
+  // env vars stored on the target environment. The server-side deploy
+  // handler merges request envVars over environment.envVars, so an empty
+  // (absent) envVars payload cleanly falls back to what's already stored.
+  let envVars: Record<string, string> = {};
+  const hasAmbientEnvFile = envFile ? true : (await getDeployEnvFiles(targetDir)).length > 0;
+  if (hasAmbientEnvFile) {
+    envVars = await readEnvVars(targetDir, { autoAccept, envFile });
+  }
   const envCount = Object.keys(envVars).length;
   if (envCount > 0) {
     p.log.step(`Found ${envCount} env var(s)`);
-  } else {
+  } else if (hasAmbientEnvFile) {
     p.log.step('No env vars found in selected env file');
+  } else {
+    p.log.step('No local env file — using env vars stored on the environment');
   }
 
   // Pre-upload validation

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -479,6 +479,31 @@ describe('readEnvVars', () => {
   });
 });
 
+describe('getDeployEnvFiles', () => {
+  it('returns an empty list when no .env* files exist (unified deploy uses this to fall back to environment-stored env vars)', async () => {
+    const { readdir } = await import('node:fs/promises');
+    vi.mocked(readdir).mockResolvedValue([] as Awaited<ReturnType<typeof readdir>>);
+
+    const { getDeployEnvFiles } = await import('./deploy.js');
+
+    await expect(getDeployEnvFiles('/project')).resolves.toEqual([]);
+  });
+
+  it('returns sorted deploy env files, excluding .example files', async () => {
+    const { readdir } = await import('node:fs/promises');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
+      { name: '.env.example', isFile: () => true, isSymbolicLink: () => false },
+      { name: '.env', isFile: () => true, isSymbolicLink: () => false },
+      { name: 'package.json', isFile: () => true, isSymbolicLink: () => false },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+
+    const { getDeployEnvFiles } = await import('./deploy.js');
+
+    await expect(getDeployEnvFiles('/project')).resolves.toEqual(['.env', '.env.production']);
+  });
+});
+
 describe('deployAction', () => {
   it('passes disablePlatformObservability to uploadDeploy and preserves it when saving config', async () => {
     const { access, readdir, readFile, stat } = await import('node:fs/promises');

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -115,7 +115,7 @@ export function loadDeployEnvFromDotenv(projectDir: string): void {
   });
 }
 
-async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
+export async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
   const entries = await readdir(projectDir, { withFileTypes: true });
 
   return entries


### PR DESCRIPTION
## Summary

`mastra deploy` currently fails with `"No env file found for deploy. Add a .env or .env.* file before deploying."` when no local `.env` or `.env.<name>` file exists, even when the target environment already has env vars stored on Mastra Cloud. This makes the "Cloud is my source of truth for env vars" workflow feel broken — users have to keep placeholder empty `.env` files around just to satisfy a client-side check.

The platform already does the right thing: `POST /v1/projects/:projectId/environments/:envId/deploy` merges the request's `envVars` over the environment's stored `envVars` (see `mastra-ai/platform` `servers/api/src/routes/environments.ts`), so an empty local payload cleanly falls back to what's on Cloud.

## Change

Only the unified `mastra deploy` command is affected. `mastra studio deploy` and `mastra server deploy` are unchanged (they still throw when no env file is found, preserving stable CLI behavior).

| Scenario | Before | After |
|---|---|---|
| `--env-file` passed, file missing | Error: `Env file not found` | **Unchanged** — same error |
| Ambient `.env*` present, no flag | Reads it, uploads vars | **Unchanged** |
| No flag, no ambient `.env*` | **Errors out** | Deploys with empty local payload; Cloud vars used as-is |

New user-facing log line when the fallback triggers: `No local env file — using env vars stored on the environment`.

## Implementation notes

- Exported `getDeployEnvFiles` from `studio/deploy.ts` so the unified deploy can pre-check for ambient env files instead of catching and pattern-matching on a thrown error message string.
- Added unit tests for `getDeployEnvFiles` covering the empty-directory case (the exact branch the new fallback pivots on) and the sorted/`.example`-excluding case.

## Testing

- `pnpm --filter ./packages/cli typecheck` — 0 errors
- `npx eslint` on touched files — 0 errors
- `npx vitest run` in `packages/cli` — 549/549 tests pass (2 new)
- `npx prettier --check` on touched files — clean

## Follow-up

Once this lands and gets patched into `mastra`, the `mastra deploy` reference section (added in #18752) should get a note that the env file is optional. Happy to fold that into this PR if preferred, or do it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
`mastra deploy` got easier to use: if your cloud environment already has the needed settings, you no longer need a local `.env` file just to deploy. It will now keep going without one and use the settings already saved in the cloud.

## Summary
- Updated unified `mastra deploy` to allow deployment when no local `.env` or `.env.<name>` file is present.
- When no local env file is found, deploy now uses an empty local env payload and relies on env vars stored on Mastra Cloud.
- Added a new log message for the fallback path: `No local env file — using env vars stored on the environment`.
- Kept existing behavior unchanged for:
  - `--env-file` provided but missing
  - `mastra studio deploy`
  - `mastra server deploy`
- Exported `getDeployEnvFiles` from `studio/deploy.ts` so unified deploy can inspect ambient env files directly.
- Added tests for:
  - empty-directory fallback
  - env-file sorting
  - excluding `.env.example`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->