### PR TITLE
feat(mastracode): /slack command to connect Slack and use Slack tools from the agent

### DIFF
--- a/.changeset/calm-ravens-bake.md
+++ b/.changeset/calm-ravens-bake.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added a `/slack` command to connect your Slack account and use Slack tools (search, read, send messages, canvases, users) from the agent. The integration is off by default and fully managed from `/slack`: run `/slack connect` to authorize with a read-only, read-write, or full permission level (this also turns it on), `/slack level <level>` to change scopes, and `/slack disconnect` to turn it off and clear the token. It uses Slack's official MCP server with OAuth 2.0 + PKCE, so no client secret is stored and tokens refresh automatically.

--- a/mastracode/slack-app-manifest.README.md
+++ b/mastracode/slack-app-manifest.README.md
@@ -1,0 +1,56 @@
+# Mastra Code — Slack app manifest
+
+`slack-app-manifest.json` is the checked-in source of truth for the
+**Mastra-published Slack app** ("Mastra Code") that powers the `/slack`
+integration. mastracode never asks users to create their own app; it ships the
+resulting public `client_id` and drives an OAuth 2.0 + PKCE loopback flow
+against this app.
+
+## What this app must be
+
+- **Public client (PKCE)** — `oauth_config.pkce_enabled: true`. This lets
+  desktop/CLI clients authenticate **without a client secret**. mastracode ships
+  no secret. ⚠️ Enabling this is a **one-way** change on the Slack app; it cannot
+  be reverted without Slack support. (It can also be toggled in the dashboard
+  under OAuth & Permissions → Advanced options → Proof Key for Code Exchange.)
+- **MCP enabled** — `settings.is_mcp_enabled: true`, so the app can be used with
+  Slack's remote MCP server at `https://mcp.slack.com/mcp`.
+- **Bot user** — `features.bot_user` plus a `bot` scope (`users:read`). Slack's
+  user-token authorize endpoint requires the app to declare a bot user even
+  though the MCP server only uses the resulting user token.
+- **Token rotation** — `settings.token_rotation_enabled: true`. PKCE forces
+  refresh tokens to **expire in 30 days**; mastracode refreshes silently via
+  `AuthStorage` (`getApiKey` auto-refreshes on expiry).
+- **Loopback redirects** — `oauth_config.redirect_urls` lists the localhost
+  ports mastracode's loopback callback server binds to. These **must** match the
+  ports in `src/slack/oauth.ts`. Changing them requires a manifest update **and**
+  re-publishing the app.
+
+## Scopes are a superset
+
+`oauth_config.scopes.user` is the **full superset** of user-token scopes the app
+can grant. mastracode's permission-level presets in `src/slack/scopes.ts` request
+a subset of these depending on the level the user picked (`read-only`,
+`read-write`, `full`). The `SLACK_MANIFEST_USER_SCOPES` constant in that file
+mirrors this list, and a unit test asserts every preset scope appears here. **If
+you add a scope to a preset, add it here and re-publish the app first.**
+
+## Publishing / updating
+
+1. Create or update the app from this manifest in the Slack app dashboard
+   (Settings → "App Manifest"), or via the Slack CLI.
+2. Confirm PKCE and MCP are enabled (set by `oauth_config.pkce_enabled` and
+   `settings.is_mcp_enabled` in the manifest; verify on the OAuth & Permissions
+   page).
+3. Distribute the app so workspace admins can approve it — **Slack MCP requires
+   workspace-admin approval** before members can connect.
+4. Copy the app's **Client ID** into `src/slack/client-id.ts`
+   (`MASTRA_SLACK_CLIENT_ID`) or provide it at runtime via the
+   `MASTRACODE_SLACK_CLIENT_ID` env var. There is **no client secret**.
+
+## BYO app
+
+Restricted orgs that cannot use the shared app can point mastracode at their own
+PKCE public app with the identical flow via `SlackSettings.clientId` or
+`/slack connect --byo <client_id>`. Their app must mirror this manifest
+(public client + MCP + matching redirect URLs).

--- a/mastracode/slack-app-manifest.json
+++ b/mastracode/slack-app-manifest.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "Source-of-truth manifest for the Mastra-published Slack app ('Mastra Code'). See slack-app-manifest.README.md. The user scopes here are the SUPERSET that mastracode's permission-level presets (src/slack/scopes.ts SLACK_MANIFEST_USER_SCOPES) must be a subset of. redirect_urls MUST match the loopback ports in src/slack/oauth.ts. oauth_config.pkce_enabled=true makes this a public client (required for the no-secret PKCE token exchange); enabling PKCE is a one-way, irreversible change on the app.",
+  "display_information": {
+    "name": "Mastra Code",
+    "description": "Connect your Slack account to the Mastra Code CLI agent to search, read, and send messages.",
+    "background_color": "#1a1a2e"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "mastra-code",
+      "always_online": false
+    }
+  },
+  "oauth_config": {
+    "redirect_urls": [
+      "http://localhost:41927/callback",
+      "http://localhost:41928/callback",
+      "http://localhost:41929/callback"
+    ],
+    "scopes": {
+      "bot": ["users:read"],
+      "user": [
+        "search:read.public",
+        "search:read.private",
+        "channels:history",
+        "groups:history",
+        "im:history",
+        "mpim:history",
+        "users:read",
+        "users:read.email",
+        "canvases:read",
+        "chat:write",
+        "reactions:write",
+        "canvases:write",
+        "channels:read",
+        "groups:read",
+        "channels:write",
+        "groups:write"
+      ]
+    },
+    "pkce_enabled": true
+  },
+  "settings": {
+    "token_rotation_enabled": true,
+    "is_mcp_enabled": true,
+    "org_deploy_enabled": true
+  }
+}

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -59,6 +59,21 @@ const controllerSetStateMock = vi.fn();
 const controllerSetThreadSettingMock = vi.fn();
 const createMcpManagerMock = vi.fn();
 const hookManagerConstructorMock = vi.fn();
+
+// The third arg to createMcpManager is an async resolver that merges the caller's
+// programmatic mcpServers with the (off-by-default) Slack MCP server. This helper
+// asserts the first two args and resolves the resolver to compare the merged map.
+async function expectMcpManagerCalledWith(
+  projectPath: string,
+  configDir: string,
+  expectedServers: Record<string, unknown> | undefined,
+): Promise<void> {
+  expect(createMcpManagerMock).toHaveBeenCalledWith(projectPath, configDir, expect.any(Function));
+  const call = createMcpManagerMock.mock.calls.find(([p, c]) => p === projectPath && c === configDir);
+  expect(call).toBeDefined();
+  const resolver = call![2] as () => Promise<Record<string, unknown>>;
+  await expect(resolver()).resolves.toEqual(expectedServers ?? {});
+}
 const getStorageConfigMock = vi.fn(() => ({ type: 'memory' }));
 const getResourceIdOverrideMock = vi.fn(() => undefined);
 const getDynamicWorkspaceMock = vi.fn();
@@ -472,7 +487,7 @@ describe('createMastraCode', () => {
     expect(agentControllerConfig?.initialState?.configDir).toBe('.acme-code');
     expect(getDynamicMemoryMock).not.toHaveBeenCalled();
     expect(getStorageConfigMock).toHaveBeenCalledWith(projectPath, expect.anything(), '.acme-code');
-    expect(createMcpManagerMock).toHaveBeenCalledWith(projectPath, '.acme-code', undefined);
+    await expectMcpManagerCalledWith(projectPath, '.acme-code', undefined);
     expect(hookManagerConstructorMock).toHaveBeenCalledWith(projectPath, 'session-init', '.acme-code', undefined);
   });
 
@@ -603,7 +618,7 @@ describe('createMastraCode', () => {
 
     expect(getResourceIdOverrideMock).toHaveBeenCalledWith(projectPath, '.acme-code');
     expect(getStorageConfigMock).toHaveBeenCalledWith(projectPath, expect.anything(), '.acme-code');
-    expect(createMcpManagerMock).toHaveBeenCalledWith(projectPath, '.acme-code', undefined);
+    await expectMcpManagerCalledWith(projectPath, '.acme-code', undefined);
     expect(hookManagerConstructorMock).toHaveBeenCalledWith(projectPath, 'session-init', '.acme-code', undefined);
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
       | { initialState?: Record<string, unknown> }
@@ -636,7 +651,7 @@ describe('createMastraCode', () => {
 
     await createMastraCode({ cwd, configDir: '.acme-code', mcpServers });
 
-    expect(createMcpManagerMock).toHaveBeenCalledWith(projectPath, '.acme-code', mcpServers);
+    await expectMcpManagerCalledWith(projectPath, '.acme-code', mcpServers);
   });
 
   it('rejects cross-process PubSub mode without a PubSub instance', async () => {

--- a/mastracode/src/auth/storage.ts
+++ b/mastracode/src/auth/storage.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { slackOAuthProvider } from '../slack/oauth.js';
 import { getAppDataDir } from '../utils/project.js';
 import { anthropicOAuthProvider } from './providers/anthropic.js';
 import { githubCopilotOAuthProvider } from './providers/github-copilot.js';
@@ -35,6 +36,10 @@ const oauthProviderRegistry = new Map<string, OAuthProviderInterface>([
   [anthropicOAuthProvider.id, anthropicOAuthProvider],
   [openaiCodexOAuthProvider.id, openaiCodexOAuthProvider],
   [githubCopilotOAuthProvider.id, githubCopilotOAuthProvider],
+  // Slack is not a model provider — it has no PROVIDER_DEFAULT_MODELS entry.
+  // It's registered here so AuthStorage.getApiKey('slack') auto-refreshes the
+  // PKCE user token used as a bearer header for Slack's remote MCP server.
+  [slackOAuthProvider.id, slackOAuthProvider],
 ]);
 
 /**

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -81,6 +81,7 @@ import { setAuthStorage as setOpenAIAuthStorage } from './providers/openai-codex
 
 import { stateSchema } from './schema.js';
 import type { MastraCodeState } from './schema.js';
+import { buildSlackMcpServers } from './slack/config.js';
 
 import { mastra } from './tui/theme.js';
 import { syncGateways } from './utils/gateway-sync.js';
@@ -467,8 +468,20 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
 
   const memory = config?.memory === false ? undefined : (config?.memory ?? getDynamicMemory(storage, vectorStore));
 
-  // MCP
-  const mcpManager = config?.disableMcp ? undefined : createMcpManager(project.rootPath, configDir, config?.mcpServers);
+  // MCP. The Slack MCP server (if enabled + connected) is injected via an async
+  // resolver so its bearer token is refreshed on every init/reload. Its token is
+  // never written to mcp.json. The `slack` settings are re-read from disk here
+  // (not the startup `globalSettings` snapshot) so enabling Slack + connecting
+  // mid-session is picked up on the next `reload()`.
+  const staticMcpServers = config?.mcpServers;
+  const mcpExtraServers = async (): Promise<Record<string, McpServerConfig>> => {
+    const slackSettings = loadSettings(config?.settingsPath).slack;
+    return {
+      ...staticMcpServers,
+      ...(await buildSlackMcpServers(authStorage, slackSettings)),
+    };
+  };
+  const mcpManager = config?.disableMcp ? undefined : createMcpManager(project.rootPath, configDir, mcpExtraServers);
 
   // Hooks
   const hookManager = config?.disableHooks

--- a/mastracode/src/mcp/__tests__/config.test.ts
+++ b/mastracode/src/mcp/__tests__/config.test.ts
@@ -374,13 +374,23 @@ describe('expandEnvVars', () => {
 
 describe('loadMcpConfig', () => {
   let projectDir: string;
+  let homeDir: string;
+  let previousHome: string | undefined;
 
   beforeEach(() => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-config-'));
+    // Isolate the global config layer (~/.mastracode/mcp.json) from the developer's
+    // real home so tests never read machine-specific MCP servers.
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-home-'));
+    previousHome = process.env.HOME;
+    process.env.HOME = homeDir;
   });
 
   afterEach(() => {
     fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
   });
 
   function writeJson(filePath: string, data: unknown): void {
@@ -427,25 +437,16 @@ describe('loadMcpConfig', () => {
   });
 
   it('lets a root .mcp.json override the global ~/.mastracode/mcp.json by server name', () => {
-    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-home-'));
-    const previousHome = process.env.HOME;
-    process.env.HOME = homeDir;
-    try {
-      writeJson(path.join(homeDir, '.mastracode', 'mcp.json'), {
-        mcpServers: { shared: { command: 'global-cmd' } },
-      });
-      writeJson(path.join(projectDir, '.mcp.json'), {
-        mcpServers: { shared: { command: 'root-cmd' } },
-      });
+    writeJson(path.join(homeDir, '.mastracode', 'mcp.json'), {
+      mcpServers: { shared: { command: 'global-cmd' } },
+    });
+    writeJson(path.join(projectDir, '.mcp.json'), {
+      mcpServers: { shared: { command: 'root-cmd' } },
+    });
 
-      const config = loadMcpConfig(projectDir);
+    const config = loadMcpConfig(projectDir);
 
-      expect(config.mcpServers!['shared']).toEqual({ command: 'root-cmd', args: undefined, env: undefined });
-    } finally {
-      if (previousHome === undefined) delete process.env.HOME;
-      else process.env.HOME = previousHome;
-      fs.rmSync(homeDir, { recursive: true, force: true });
-    }
+    expect(config.mcpServers!['shared']).toEqual({ command: 'root-cmd', args: undefined, env: undefined });
   });
 
   it('lets a root .mcp.json override .claude/settings.local.json by server name', () => {

--- a/mastracode/src/mcp/__tests__/manager.test.ts
+++ b/mastracode/src/mcp/__tests__/manager.test.ts
@@ -65,6 +65,15 @@ describe('createMcpManager', () => {
       const manager = createMcpManager('/tmp/test');
       expect(manager.hasServers()).toBe(true);
     });
+
+    it('returns true when a dynamic extra-server resolver is present and config is empty', () => {
+      // The Slack MCP server is injected via an async resolver at init/reload
+      // time. hasServers() must report true so the caller runs init() and the
+      // resolver gets a chance to inject the server on a fresh session load.
+      setupConfig({});
+      const manager = createMcpManager('/tmp/test', undefined, async () => ({}));
+      expect(manager.hasServers()).toBe(true);
+    });
   });
 
   describe('getSkippedServers', () => {

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -118,18 +118,45 @@ function getStorageKeyFingerprint(value: string): string {
  * Create an MCP manager that wraps MCPClient with config-file discovery
  * and per-server status tracking.
  */
+/**
+ * Programmatic MCP servers merged in at highest priority. Either a static map
+ * of server configs, or an async resolver that is re-invoked on every
+ * init/reload so entries whose auth (e.g. a bearer token) must be re-fetched
+ * — such as the Slack MCP server — always connect with fresh headers.
+ */
+export type ExtraServers = Record<string, McpServerConfig> | (() => Promise<Record<string, McpServerConfig>>);
+
 export function createMcpManager(
   projectDir: string,
   configDirName = DEFAULT_CONFIG_DIR,
-  extraServers?: Record<string, McpServerConfig>,
+  extraServers?: ExtraServers,
 ): McpManager {
-  /** Merge programmatic servers into a base config (highest priority). */
-  const applyExtraServers = (base: McpConfig): McpConfig => {
-    if (!extraServers || Object.keys(extraServers).length === 0) return base;
+  /** Merge static programmatic servers into a base config (highest priority). */
+  const applyStaticExtraServers = (base: McpConfig): McpConfig => {
+    if (!extraServers || typeof extraServers === 'function' || Object.keys(extraServers).length === 0) {
+      return base;
+    }
     return { ...base, mcpServers: { ...base.mcpServers, ...extraServers } };
   };
 
-  let config = applyExtraServers(loadMcpConfig(projectDir, configDirName));
+  /**
+   * Resolve async extra servers (if the resolver form was provided) and merge
+   * them into the current config. Called right before every connect so tokens
+   * are refreshed. Static extra servers are already merged into `config`.
+   */
+  const resolveDynamicExtraServers = async (): Promise<void> => {
+    if (typeof extraServers !== 'function') return;
+    let resolved: Record<string, McpServerConfig> = {};
+    try {
+      resolved = await extraServers();
+    } catch {
+      resolved = {};
+    }
+    if (Object.keys(resolved).length === 0) return;
+    config = { ...config, mcpServers: { ...config.mcpServers, ...resolved } };
+  };
+
+  let config = applyStaticExtraServers(loadMcpConfig(projectDir, configDirName));
   let client: MCPClient | null = null;
   let tools: Record<string, any> = {};
   let serverStatuses = new Map<string, McpServerStatus>();
@@ -309,6 +336,7 @@ export function createMcpManager(
   return {
     async init() {
       if (initialized) return;
+      await resolveDynamicExtraServers();
       await connectAndCollectTools();
       initialized = true;
     },
@@ -328,11 +356,12 @@ export function createMcpManager(
 
     async reload() {
       await disconnect();
-      config = applyExtraServers(loadMcpConfig(projectDir, configDirName));
+      config = applyStaticExtraServers(loadMcpConfig(projectDir, configDirName));
       tools = {};
       serverStatuses = new Map();
       stderrLogs = new Map();
       initialized = false;
+      await resolveDynamicExtraServers();
       await connectAndCollectTools();
       initialized = true;
     },
@@ -455,7 +484,12 @@ export function createMcpManager(
     hasServers() {
       const hasConfigured = config.mcpServers !== undefined && Object.keys(config.mcpServers).length > 0;
       const hasSkipped = config.skippedServers !== undefined && config.skippedServers.length > 0;
-      return hasConfigured || hasSkipped;
+      // A dynamic resolver (e.g. the Slack MCP server) may inject servers at
+      // init/reload time that aren't in the static config yet. Report true so
+      // the caller runs init(), which resolves and connects them. init() is a
+      // no-op when the resolver yields nothing, so this is safe.
+      const hasDynamicResolver = typeof extraServers === 'function';
+      return hasConfigured || hasSkipped || hasDynamicResolver;
     },
 
     getServerStatuses() {

--- a/mastracode/src/onboarding/__tests__/settings.test.ts
+++ b/mastracode/src/onboarding/__tests__/settings.test.ts
@@ -68,6 +68,7 @@ function createSettings(overrides?: Partial<GlobalSettings>): GlobalSettings {
     },
     shellPassthrough: { mode: 'default' },
     voice: { enabled: false, engine: 'cloud', provider: 'openai', model: 'whisper-1' },
+    slack: { enabled: false, permissionLevel: 'read-only' },
     signals: { unixSocketPubSub: false, experimentalGithubSignals: false },
     observability: { resources: {}, localTracing: false },
     ...overrides,
@@ -162,6 +163,59 @@ describe('voice settings parsing', () => {
       const { voice } = loadSettings(filePath);
 
       expect(voice.engine).toMatch(/^(macos-native|cloud)$/);
+    });
+  });
+});
+
+describe('slack settings parsing', () => {
+  it('defaults to disabled + read-only when missing from the file', () => {
+    withTempSettingsFile(filePath => {
+      writeFileSync(filePath, JSON.stringify({}), 'utf-8');
+
+      const { slack } = loadSettings(filePath);
+
+      expect(slack.enabled).toBe(false);
+      expect(slack.permissionLevel).toBe('read-only');
+      expect(slack.clientId).toBeUndefined();
+    });
+  });
+
+  it('round-trips a valid enabled + read-write config', () => {
+    withTempSettingsFile(filePath => {
+      writeFileSync(
+        filePath,
+        JSON.stringify({ slack: { enabled: true, permissionLevel: 'read-write', clientId: 'client-abc' } }),
+        'utf-8',
+      );
+
+      const { slack } = loadSettings(filePath);
+
+      expect(slack.enabled).toBe(true);
+      expect(slack.permissionLevel).toBe('read-write');
+      expect(slack.clientId).toBe('client-abc');
+    });
+  });
+
+  it('falls back to read-only for an invalid permission level', () => {
+    withTempSettingsFile(filePath => {
+      writeFileSync(filePath, JSON.stringify({ slack: { enabled: true, permissionLevel: 'root' } }), 'utf-8');
+
+      const { slack } = loadSettings(filePath);
+
+      expect(slack.enabled).toBe(true);
+      expect(slack.permissionLevel).toBe('read-only');
+    });
+  });
+
+  it('does not persist a Slack token into settings', () => {
+    withTempSettingsFile(filePath => {
+      const settings = loadSettings(filePath);
+      settings.slack.enabled = true;
+      saveSettings(settings, filePath);
+
+      const raw = readFileSync(filePath, 'utf-8');
+      expect(raw).not.toMatch(/xoxp-/);
+      expect(raw).not.toMatch(/access[_"]/i);
     });
   });
 });

--- a/mastracode/src/onboarding/settings.ts
+++ b/mastracode/src/onboarding/settings.ts
@@ -10,6 +10,8 @@ import type { MastraBrowser } from '@mastra/core/browser';
 import type { LSPConfig } from '@mastra/core/workspace';
 import { AuthStorage } from '../auth/storage.js';
 import { buildCodexStagehandFetch, createCodexMiddleware } from '../providers/openai-codex.js';
+import { DEFAULT_SLACK_PERMISSION_LEVEL, isSlackPermissionLevel } from '../slack/scopes.js';
+import type { SlackPermissionLevel } from '../slack/scopes.js';
 import { DEFAULT_STT_PROVIDER, resolveSTTModel } from '../tui/voice/stt-registry.js';
 import { getAppDataDir } from '../utils/project.js';
 
@@ -142,6 +144,20 @@ export interface BrowserSettings {
   agentBrowser?: AgentBrowserSettings;
 }
 
+/** Slack MCP integration configuration persisted in global settings. */
+export interface SlackSettings {
+  /** Whether the Slack MCP integration is enabled. Off by default. */
+  enabled: boolean;
+  /** Permission level → scope preset requested during OAuth. */
+  permissionLevel: SlackPermissionLevel;
+  /**
+   * Optional BYO public client_id for restricted orgs. Falls back to Mastra's
+   * published app when unset. The Slack token itself is NOT stored here — it
+   * lives in auth.json under the `slack` provider.
+   */
+  clientId?: string;
+}
+
 export interface GlobalSettings {
   // Onboarding tracking
   onboarding: {
@@ -238,6 +254,8 @@ export interface GlobalSettings {
   lsp?: LSPConfig;
   // Browser automation configuration
   browser: BrowserSettings;
+  // Slack MCP integration configuration (off by default)
+  slack: SlackSettings;
   // Direct TUI `!` shell passthrough configuration
   shellPassthrough: ShellPassthroughSettings;
   // Hold-space voice input configuration
@@ -328,6 +346,7 @@ const DEFAULTS: GlobalSettings = {
     viewport: { width: 1280, height: 720 },
     stagehand: { env: 'LOCAL' },
   },
+  slack: { enabled: false, permissionLevel: DEFAULT_SLACK_PERMISSION_LEVEL },
   shellPassthrough: { mode: 'default' },
   voice: { enabled: false, engine: defaultVoiceEngine(), provider: DEFAULT_STT_PROVIDER },
   signals: { unixSocketPubSub: false, experimentalGithubSignals: false },
@@ -564,6 +583,16 @@ function parseVoiceSettings(rawVoice: unknown): VoiceSettings {
   };
 }
 
+function parseSlackSettings(rawSlack: unknown): SlackSettings {
+  const raw = rawSlack && typeof rawSlack === 'object' ? (rawSlack as Record<string, unknown>) : {};
+  const enabled = typeof raw.enabled === 'boolean' ? raw.enabled : DEFAULTS.slack.enabled;
+  const permissionLevel = isSlackPermissionLevel(raw.permissionLevel)
+    ? raw.permissionLevel
+    : DEFAULTS.slack.permissionLevel;
+  const clientId = typeof raw.clientId === 'string' && raw.clientId.trim() ? raw.clientId.trim() : undefined;
+  return { enabled, permissionLevel, clientId };
+}
+
 const VALID_PROJECT_ID = /^[a-zA-Z0-9_-]+$/;
 
 function parseObservabilitySettings(raw: unknown): ObservabilitySettings {
@@ -629,6 +658,7 @@ function migrateFromAuth(settingsPath: string): boolean {
         memoryGateway: raw.memoryGateway && typeof raw.memoryGateway === 'object' ? raw.memoryGateway : {},
         lsp: raw.lsp && typeof raw.lsp === 'object' ? (raw.lsp as LSPConfig) : undefined,
         browser: parseBrowserSettings(raw.browser),
+        slack: parseSlackSettings(raw.slack),
         shellPassthrough: parseShellPassthroughSettings(raw.shellPassthrough),
         voice: parseVoiceSettings(raw.voice),
         signals: parseSignalSettings(raw.signals),
@@ -752,6 +782,7 @@ export function loadSettings(filePath: string = getSettingsPath()): GlobalSettin
       memoryGateway: raw.memoryGateway && typeof raw.memoryGateway === 'object' ? raw.memoryGateway : {},
       lsp: raw.lsp && typeof raw.lsp === 'object' ? (raw.lsp as LSPConfig) : undefined,
       browser: parseBrowserSettings(raw.browser),
+      slack: parseSlackSettings(raw.slack),
       shellPassthrough: parseShellPassthroughSettings(raw.shellPassthrough),
       voice: parseVoiceSettings(raw.voice),
       signals: parseSignalSettings(raw.signals),

--- a/mastracode/src/slack/__tests__/config.test.ts
+++ b/mastracode/src/slack/__tests__/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AuthStorage } from '../../auth/storage.js';
+import type { SlackSettings } from '../../onboarding/settings.js';
+import { buildSlackMcpServers, hasSlackToken, SLACK_MCP_SERVER_NAME, SLACK_MCP_URL } from '../config.js';
+
+function makeAuthStorage(overrides: Partial<AuthStorage> = {}): AuthStorage {
+  return {
+    getApiKey: vi.fn(async () => undefined),
+    get: vi.fn(() => undefined),
+    ...overrides,
+  } as unknown as AuthStorage;
+}
+
+const enabled: SlackSettings = { enabled: true, permissionLevel: 'read-only' };
+const disabled: SlackSettings = { enabled: false, permissionLevel: 'read-only' };
+
+describe('buildSlackMcpServers', () => {
+  it('returns no entry when slack is disabled', async () => {
+    const authStorage = makeAuthStorage({ getApiKey: vi.fn(async () => 'xoxp-1') });
+    const servers = await buildSlackMcpServers(authStorage, disabled);
+    expect(servers).toEqual({});
+    // Must not even ask for a token when disabled.
+    expect(authStorage.getApiKey).not.toHaveBeenCalled();
+  });
+
+  it('returns no entry when settings are undefined', async () => {
+    const servers = await buildSlackMcpServers(makeAuthStorage(), undefined);
+    expect(servers).toEqual({});
+  });
+
+  it('returns no entry when enabled but no token is stored', async () => {
+    const authStorage = makeAuthStorage({ getApiKey: vi.fn(async () => undefined) });
+    const servers = await buildSlackMcpServers(authStorage, enabled);
+    expect(servers).toEqual({});
+    expect(authStorage.getApiKey).toHaveBeenCalledWith('slack');
+  });
+
+  it('injects a bearer header sourced from AuthStorage when enabled + connected', async () => {
+    const authStorage = makeAuthStorage({ getApiKey: vi.fn(async () => 'xoxp-secret') });
+    const servers = await buildSlackMcpServers(authStorage, enabled);
+
+    expect(Object.keys(servers)).toEqual([SLACK_MCP_SERVER_NAME]);
+    const entry = servers[SLACK_MCP_SERVER_NAME] as { url: string; headers: Record<string, string> };
+    expect(entry.url).toBe(SLACK_MCP_URL);
+    expect(entry.headers).toEqual({ Authorization: 'Bearer xoxp-secret' });
+    // The raw token only lives in the in-memory header, sourced via getApiKey.
+    expect(authStorage.getApiKey).toHaveBeenCalledWith('slack');
+  });
+});
+
+describe('hasSlackToken', () => {
+  it('is true only when an oauth credential is stored', () => {
+    expect(hasSlackToken(makeAuthStorage({ get: vi.fn(() => undefined) }))).toBe(false);
+    expect(hasSlackToken(makeAuthStorage({ get: vi.fn(() => ({ type: 'api', key: 'x' }) as any) }))).toBe(false);
+    expect(
+      hasSlackToken(
+        makeAuthStorage({ get: vi.fn(() => ({ type: 'oauth', access: 'a', refresh: 'r', expires: 1 }) as any) }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/mastracode/src/slack/__tests__/manifest.test.ts
+++ b/mastracode/src/slack/__tests__/manifest.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { SLACK_CALLBACK_PORTS } from '../oauth.js';
+import { SLACK_MANIFEST_USER_SCOPES } from '../scopes.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// src/slack/__tests__ -> mastracode root
+const manifestPath = join(here, '..', '..', '..', 'slack-app-manifest.json');
+
+type Manifest = {
+  oauth_config: {
+    redirect_urls: string[];
+    scopes: { user: string[] };
+    pkce_enabled?: boolean;
+  };
+  settings: Record<string, unknown>;
+};
+
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Manifest;
+
+describe('slack app manifest', () => {
+  it('declares exactly the manifest user-scope superset from scopes.ts', () => {
+    expect([...manifest.oauth_config.scopes.user].sort()).toEqual([...SLACK_MANIFEST_USER_SCOPES].sort());
+  });
+
+  it('lists a redirect URL for every loopback callback port', () => {
+    for (const port of SLACK_CALLBACK_PORTS) {
+      expect(manifest.oauth_config.redirect_urls).toContain(`http://localhost:${port}/callback`);
+    }
+    expect(manifest.oauth_config.redirect_urls).toHaveLength(SLACK_CALLBACK_PORTS.length);
+  });
+
+  it('enables the public (PKCE) client and MCP', () => {
+    expect(manifest.oauth_config.pkce_enabled).toBe(true);
+    expect(manifest.settings.is_mcp_enabled).toBe(true);
+  });
+});

--- a/mastracode/src/slack/__tests__/oauth.test.ts
+++ b/mastracode/src/slack/__tests__/oauth.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OAuthCredentials } from '../../auth/types.js';
+import {
+  __testing,
+  buildAuthorizeUrl,
+  exchangeAuthorizationCode,
+  refreshSlackToken,
+  slackOAuthProvider,
+} from '../oauth.js';
+
+describe('buildAuthorizeUrl', () => {
+  it('builds a PKCE authorize URL with user_scope and S256', () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        clientId: 'client-123',
+        redirectUri: 'http://localhost:41927/callback',
+        scopes: ['search:read.public', 'chat:write'],
+        challenge: 'the-challenge',
+        state: 'the-state',
+      }),
+    );
+    expect(url.origin + url.pathname).toBe('https://slack.com/oauth/v2/authorize');
+    expect(url.searchParams.get('client_id')).toBe('client-123');
+    // Slack requests user-token scopes via user_scope (not scope).
+    expect(url.searchParams.get('user_scope')).toBe('search:read.public,chat:write');
+    expect(url.searchParams.get('scope')).toBeNull();
+    expect(url.searchParams.get('redirect_uri')).toBe('http://localhost:41927/callback');
+    expect(url.searchParams.get('code_challenge')).toBe('the-challenge');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('state')).toBe('the-state');
+  });
+});
+
+describe('parseAuthorizationInput', () => {
+  const parse = __testing.parseAuthorizationInput;
+
+  it('extracts code and state from a redirect URL', () => {
+    expect(parse('http://localhost:41927/callback?code=abc&state=xyz')).toEqual({ code: 'abc', state: 'xyz' });
+  });
+
+  it('extracts code and state from a query string', () => {
+    expect(parse('code=abc&state=xyz')).toEqual({ code: 'abc', state: 'xyz' });
+  });
+
+  it('treats a bare value as a raw code', () => {
+    expect(parse('  raw-code  ')).toEqual({ code: 'raw-code' });
+  });
+
+  it('returns empty for blank input', () => {
+    expect(parse('   ')).toEqual({});
+  });
+});
+
+describe('tokenResponseToCredentials', () => {
+  const map = __testing.tokenResponseToCredentials;
+
+  it('maps the authed_user token and team into credentials', () => {
+    const before = Date.now();
+    const cred = map(
+      {
+        ok: true,
+        team: { id: 'T1', name: 'Acme' },
+        authed_user: { id: 'U1', access_token: 'xoxp-1', refresh_token: 'ref-1', expires_in: 3600 },
+      },
+      'client-123',
+    );
+    expect(cred.access).toBe('xoxp-1');
+    expect(cred.refresh).toBe('ref-1');
+    expect(cred.clientId).toBe('client-123');
+    expect(cred.teamId).toBe('T1');
+    expect(cred.teamName).toBe('Acme');
+    expect(cred.userId).toBe('U1');
+    expect(cred.expires).toBeGreaterThanOrEqual(before + 3600 * 1000);
+  });
+
+  it('keeps the previous refresh token when Slack omits one', () => {
+    const cred = map({ ok: true, authed_user: { access_token: 'xoxp-2' } }, 'client-123', {
+      refresh: 'old-refresh',
+      teamId: 'T9',
+      teamName: 'Old',
+    });
+    expect(cred.refresh).toBe('old-refresh');
+    expect(cred.teamId).toBe('T9');
+    expect(cred.teamName).toBe('Old');
+  });
+
+  it('throws when ok is false', () => {
+    expect(() => map({ ok: false, error: 'invalid_grant' }, 'c')).toThrow(/invalid_grant/);
+  });
+
+  it('throws when the user token is missing', () => {
+    expect(() => map({ ok: true, authed_user: {} }, 'c')).toThrow(/missing user access token/);
+  });
+});
+
+describe('exchangeAuthorizationCode', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs a PKCE authorization_code grant with NO client_secret', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, authed_user: { access_token: 'xoxp-9', expires_in: 3600 } }),
+    });
+
+    await exchangeAuthorizationCode({
+      code: 'the-code',
+      verifier: 'the-verifier',
+      redirectUri: 'http://localhost:41927/callback',
+      clientId: 'client-123',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://slack.com/api/oauth.v2.access');
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('code')).toBe('the-code');
+    expect(body.get('code_verifier')).toBe('the-verifier');
+    expect(body.get('client_id')).toBe('client-123');
+    expect(body.get('redirect_uri')).toBe('http://localhost:41927/callback');
+    // Public client: never sends a secret.
+    expect(body.has('client_secret')).toBe(false);
+  });
+
+  it('throws on a non-2xx response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, text: async () => 'boom' });
+    await expect(
+      exchangeAuthorizationCode({ code: 'c', verifier: 'v', redirectUri: 'r', clientId: 'id' }),
+    ).rejects.toThrow(/HTTP 500/);
+  });
+});
+
+describe('refreshSlackToken', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs a refresh_token grant with the stored client_id and NO secret', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        authed_user: { access_token: 'xoxp-new', refresh_token: 'ref-new', expires_in: 3600 },
+      }),
+    });
+
+    const cred: OAuthCredentials = {
+      access: 'xoxp-old',
+      refresh: 'ref-old',
+      expires: 1,
+      clientId: 'client-abc',
+    };
+    const next = await refreshSlackToken(cred);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('ref-old');
+    expect(body.get('client_id')).toBe('client-abc');
+    expect(body.has('client_secret')).toBe(false);
+    expect(next.access).toBe('xoxp-new');
+    expect(next.refresh).toBe('ref-new');
+  });
+
+  it('throws when there is no refresh token stored', async () => {
+    await expect(refreshSlackToken({ access: 'a', refresh: '', expires: 1, clientId: 'client-abc' })).rejects.toThrow(
+      /no refresh token/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when no client_id can be resolved', async () => {
+    await expect(refreshSlackToken({ access: 'a', refresh: 'r', expires: 1 })).rejects.toThrow(/no client_id/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('slackOAuthProvider', () => {
+  it('is a callback-server provider that returns the access token as the api key', () => {
+    expect(slackOAuthProvider.id).toBe('slack');
+    expect(slackOAuthProvider.usesCallbackServer).toBe(true);
+    expect(slackOAuthProvider.getApiKey({ access: 'xoxp-key', refresh: 'r', expires: 1 })).toBe('xoxp-key');
+  });
+});

--- a/mastracode/src/slack/__tests__/scopes.test.ts
+++ b/mastracode/src/slack/__tests__/scopes.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SLACK_PERMISSION_LEVEL,
+  isSlackPermissionLevel,
+  scopesForLevel,
+  SLACK_MANIFEST_USER_SCOPES,
+  SLACK_PERMISSION_LEVELS,
+} from '../scopes.js';
+import type { SlackPermissionLevel } from '../scopes.js';
+
+describe('slack scopes', () => {
+  it('exposes the three permission levels in order of privilege', () => {
+    expect(SLACK_PERMISSION_LEVELS).toEqual(['read-only', 'read-write', 'full']);
+  });
+
+  it('defaults to read-only', () => {
+    expect(DEFAULT_SLACK_PERMISSION_LEVEL).toBe('read-only');
+  });
+
+  it('returns a fresh array each call (no shared mutable preset)', () => {
+    const a = scopesForLevel('read-only');
+    const b = scopesForLevel('read-only');
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+    a.push('mutated');
+    expect(scopesForLevel('read-only')).not.toContain('mutated');
+  });
+
+  it('nests presets: read-only ⊆ read-write ⊆ full', () => {
+    const readOnly = scopesForLevel('read-only');
+    const readWrite = scopesForLevel('read-write');
+    const full = scopesForLevel('full');
+
+    for (const scope of readOnly) expect(readWrite).toContain(scope);
+    for (const scope of readWrite) expect(full).toContain(scope);
+    expect(readWrite.length).toBeGreaterThan(readOnly.length);
+    expect(full.length).toBeGreaterThan(readWrite.length);
+  });
+
+  it('adds write scopes only at read-write and above', () => {
+    expect(scopesForLevel('read-only')).not.toContain('chat:write');
+    expect(scopesForLevel('read-write')).toContain('chat:write');
+    expect(scopesForLevel('full')).toContain('chat:write');
+  });
+
+  it('keeps every preset scope a subset of the manifest superset', () => {
+    for (const level of SLACK_PERMISSION_LEVELS) {
+      for (const scope of scopesForLevel(level)) {
+        expect(SLACK_MANIFEST_USER_SCOPES).toContain(scope);
+      }
+    }
+  });
+
+  it('validates permission level strings', () => {
+    for (const level of SLACK_PERMISSION_LEVELS) {
+      expect(isSlackPermissionLevel(level)).toBe(true);
+    }
+    expect(isSlackPermissionLevel('write')).toBe(false);
+    expect(isSlackPermissionLevel('')).toBe(false);
+    expect(isSlackPermissionLevel(undefined)).toBe(false);
+    expect(isSlackPermissionLevel(3)).toBe(false);
+  });
+
+  it('narrows the type via the guard', () => {
+    const value: unknown = 'full';
+    if (isSlackPermissionLevel(value)) {
+      const level: SlackPermissionLevel = value;
+      expect(scopesForLevel(level).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/mastracode/src/slack/client-id.ts
+++ b/mastracode/src/slack/client-id.ts
@@ -1,0 +1,27 @@
+/**
+ * Public OAuth client_id for the Mastra-published Slack app ("Mastra Code").
+ *
+ * The app is a PKCE public client, so there is NO client secret — this id is
+ * safe to ship in the binary. Restricted orgs can override it with their own
+ * BYO app via `SlackSettings.clientId` or `/slack connect --byo <client_id>`.
+ *
+ * NOTE: Until the Mastra Slack app is published, this is a placeholder. The
+ * `SLACK_APP_PUBLISHED` flag gates the one-click flow; when false, users must
+ * supply a BYO client_id.
+ */
+
+/** The published public client_id, or undefined until the app ships. */
+export const MASTRA_SLACK_CLIENT_ID: string | undefined = process.env.MASTRACODE_SLACK_CLIENT_ID || undefined;
+
+/** Whether Mastra's published Slack app is available for one-click connect. */
+export const SLACK_APP_PUBLISHED = Boolean(MASTRA_SLACK_CLIENT_ID);
+
+/**
+ * Resolve the client_id to use: an explicit BYO id wins, otherwise Mastra's
+ * published id. Returns undefined when neither is available (BYO required).
+ */
+export function resolveSlackClientId(byoClientId?: string): string | undefined {
+  const byo = byoClientId?.trim();
+  if (byo) return byo;
+  return MASTRA_SLACK_CLIENT_ID;
+}

--- a/mastracode/src/slack/config.ts
+++ b/mastracode/src/slack/config.ts
@@ -1,0 +1,52 @@
+/**
+ * Wiring for Slack's remote MCP server (`mcp.slack.com`).
+ *
+ * The Slack user token is NEVER written to mcp.json. Instead we register the
+ * server programmatically via `createMcpManager`'s async `extraServers`
+ * resolver, injecting `Authorization: Bearer <token>` at connect/reload time.
+ * The token is sourced from `AuthStorage.getApiKey('slack')`, which silently
+ * refreshes the PKCE token when it has expired.
+ *
+ * When Slack is disabled in settings, or no token is stored, the resolver
+ * returns an empty map so no MCP entry, tools, or network calls exist.
+ */
+
+import type { AuthStorage } from '../auth/storage.js';
+import type { McpServerConfig } from '../mcp/types.js';
+import type { SlackSettings } from '../onboarding/settings.js';
+import { SLACK_AUTH_PROVIDER_ID } from './oauth.js';
+
+/** The config key / display name used for the Slack MCP server entry. */
+export const SLACK_MCP_SERVER_NAME = 'slack';
+
+/** Slack's official remote MCP endpoint (Streamable HTTP). */
+export const SLACK_MCP_URL = 'https://mcp.slack.com/mcp';
+
+/**
+ * Build the programmatic MCP server map for Slack. Returns an empty object
+ * (no entry) when the feature is disabled or no valid token is available.
+ *
+ * This is the async resolver passed to `createMcpManager` so the bearer token
+ * is re-fetched (and refreshed if needed) on every init/reload.
+ */
+export async function buildSlackMcpServers(
+  authStorage: AuthStorage,
+  slackSettings: SlackSettings | undefined,
+): Promise<Record<string, McpServerConfig>> {
+  if (!slackSettings?.enabled) return {};
+
+  const token = await authStorage.getApiKey(SLACK_AUTH_PROVIDER_ID);
+  if (!token) return {};
+
+  return {
+    [SLACK_MCP_SERVER_NAME]: {
+      url: SLACK_MCP_URL,
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  };
+}
+
+/** Whether a Slack user token is currently stored (regardless of validity). */
+export function hasSlackToken(authStorage: AuthStorage): boolean {
+  return authStorage.get(SLACK_AUTH_PROVIDER_ID)?.type === 'oauth';
+}

--- a/mastracode/src/slack/oauth.ts
+++ b/mastracode/src/slack/oauth.ts
@@ -1,0 +1,440 @@
+/**
+ * Slack user-token OAuth 2.0 + PKCE flow for the `/slack` integration.
+ *
+ * mastracode drives this flow itself (out-of-band) against the Mastra-published
+ * Slack app, then passes the resulting user token to Slack's remote MCP server
+ * as a bearer header. This does NOT go through `@mastra/mcp`'s OAuth provider
+ * (which assumes Dynamic Client Registration that Slack rejects).
+ *
+ * PKCE means the app is a public client: the token exchange sends `code` +
+ * `code_verifier` and NO client_secret. PKCE also makes refresh tokens expire
+ * (~30 days), so `AuthStorage.getApiKey` refreshes silently on expiry.
+ *
+ * NOTE: This module uses Node.js crypto/http for the loopback callback. It is
+ * only intended for CLI use, not browser environments.
+ */
+
+// NEVER convert to top-level imports - breaks browser/Vite builds (web-ui)
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+let _cryptoPromise: Promise<typeof import('node:crypto')> | null = null;
+let _randomBytes: ((size: number) => Buffer) | null = null;
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+let _httpPromise: Promise<typeof import('node:http')> | null = null;
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+let _http: typeof import('node:http') | null = null;
+
+type HttpServer = {
+  off: (event: 'error' | 'listening', listener: (...args: any[]) => void) => HttpServer;
+  once: (event: 'error' | 'listening', listener: (...args: any[]) => void) => HttpServer;
+  listen: (port: number, hostname: string) => HttpServer;
+  close: () => void;
+};
+
+if (typeof process !== 'undefined' && (process.versions?.node || process.versions?.bun)) {
+  _cryptoPromise = import('node:crypto').then(m => {
+    _randomBytes = m.randomBytes;
+    return m;
+  });
+  _httpPromise = import('node:http').then(m => {
+    _http = m;
+    return m;
+  });
+}
+
+import { generatePKCE } from '../auth/pkce.js';
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from '../auth/types.js';
+import { resolveSlackClientId } from './client-id.js';
+import { DEFAULT_SLACK_PERMISSION_LEVEL, scopesForLevel } from './scopes.js';
+import type { SlackPermissionLevel } from './scopes.js';
+
+/** Auth provider id under which the Slack user token is stored in auth.json. */
+export const SLACK_AUTH_PROVIDER_ID = 'slack';
+
+const AUTHORIZE_URL = 'https://slack.com/oauth/v2/authorize';
+const TOKEN_URL = 'https://slack.com/api/oauth.v2.access';
+
+/**
+ * Loopback ports mastracode binds to for the OAuth callback. These MUST match
+ * `oauth_config.redirect_urls` in slack-app-manifest.json.
+ */
+export const SLACK_CALLBACK_PORTS: readonly number[] = [41927, 41928, 41929];
+
+const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 12 * 60 * 60;
+
+const SUCCESS_HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Slack connected</title>
+</head>
+<body>
+  <p>Slack connected. Return to your terminal to continue.</p>
+</body>
+</html>`;
+
+/**
+ * Extra login context that the `/slack connect` command sets on the provider
+ * right before calling `AuthStorage.login('slack', ...)`, since the generic
+ * `OAuthProviderInterface.login` signature can't carry it.
+ */
+export interface SlackLoginContext {
+  permissionLevel: SlackPermissionLevel;
+  clientId?: string;
+}
+
+let pendingLoginContext: SlackLoginContext | null = null;
+
+/** Set the scopes/client_id to use for the next `login()` call. */
+export function setSlackLoginContext(ctx: SlackLoginContext): void {
+  pendingLoginContext = ctx;
+}
+
+async function getRandomBytes(): Promise<(size: number) => Buffer> {
+  if (!_randomBytes && _cryptoPromise) {
+    _randomBytes = (await _cryptoPromise).randomBytes;
+  }
+  if (!_randomBytes) {
+    throw new Error('Slack OAuth is only available in Node.js environments');
+  }
+  return _randomBytes;
+}
+
+async function getHttpModule() {
+  if (!_http && _httpPromise) {
+    _http = await _httpPromise;
+  }
+  if (!_http) {
+    throw new Error('Slack OAuth is only available in Node.js environments');
+  }
+  return _http;
+}
+
+async function createState(): Promise<string> {
+  const randomBytes = await getRandomBytes();
+  return randomBytes(16).toString('hex');
+}
+
+/** Build the Slack authorize URL for the PKCE flow (user-token scopes). */
+export function buildAuthorizeUrl(params: {
+  clientId: string;
+  redirectUri: string;
+  scopes: string[];
+  challenge: string;
+  state: string;
+}): string {
+  const url = new URL(AUTHORIZE_URL);
+  // Slack requests user-token scopes via `user_scope` (not `scope`).
+  url.searchParams.set('client_id', params.clientId);
+  url.searchParams.set('user_scope', params.scopes.join(','));
+  url.searchParams.set('redirect_uri', params.redirectUri);
+  url.searchParams.set('code_challenge', params.challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', params.state);
+  return url.toString();
+}
+
+type SlackTokenResponse = {
+  ok?: boolean;
+  error?: string;
+  team?: { id?: string; name?: string };
+  authed_user?: {
+    id?: string;
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    token_type?: string;
+  };
+};
+
+function tokenResponseToCredentials(
+  json: SlackTokenResponse,
+  clientId: string,
+  previous?: Partial<OAuthCredentials>,
+): OAuthCredentials {
+  if (!json.ok) {
+    throw new Error(`Slack OAuth failed: ${json.error ?? 'unknown_error'}`);
+  }
+  const user = json.authed_user;
+  if (!user?.access_token) {
+    throw new Error('Slack OAuth response missing user access token');
+  }
+  return {
+    access: user.access_token,
+    // Slack omits refresh_token when token rotation is off; keep the old one.
+    refresh: user.refresh_token ?? (previous?.refresh as string) ?? '',
+    expires: Date.now() + (user.expires_in ?? DEFAULT_TOKEN_EXPIRES_IN_SECONDS) * 1000,
+    clientId,
+    teamId: json.team?.id ?? previous?.teamId,
+    teamName: json.team?.name ?? previous?.teamName,
+    userId: user.id ?? previous?.userId,
+  };
+}
+
+/** Exchange an authorization code for Slack user-token credentials (no secret). */
+export async function exchangeAuthorizationCode(params: {
+  code: string;
+  verifier: string;
+  redirectUri: string;
+  clientId: string;
+}): Promise<OAuthCredentials> {
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: params.clientId,
+      code: params.code,
+      code_verifier: params.verifier,
+      redirect_uri: params.redirectUri,
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Slack token exchange HTTP ${response.status}: ${text}`);
+  }
+  return tokenResponseToCredentials((await response.json()) as SlackTokenResponse, params.clientId);
+}
+
+/** Refresh Slack user-token credentials using the refresh token (no secret). */
+export async function refreshSlackToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+  const clientId = resolveSlackClientId(credentials.clientId as string | undefined);
+  if (!clientId) {
+    throw new Error('Cannot refresh Slack token: no client_id available');
+  }
+  if (!credentials.refresh) {
+    throw new Error('Cannot refresh Slack token: no refresh token stored');
+  }
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: clientId,
+      refresh_token: credentials.refresh,
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Slack token refresh HTTP ${response.status}: ${text}`);
+  }
+  const json = (await response.json()) as SlackTokenResponse;
+  // A refresh response returns the rotated token under authed_user as well.
+  return tokenResponseToCredentials(json, clientId, credentials);
+}
+
+type OAuthServerInfo = {
+  redirectUri: string;
+  warning?: string;
+  close: () => void;
+  cancelWait: () => void;
+  waitForCode: () => Promise<{ code: string } | null>;
+};
+
+function listen(server: HttpServer, port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const onError = () => {
+      server.off('listening', onListening);
+      resolve(false);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve(true);
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+async function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
+  const http = await getHttpModule();
+  let lastCode: string | null = null;
+  let cancelled = false;
+  const server = http.createServer((req, res) => {
+    try {
+      const url = new URL(req.url || '', 'http://localhost');
+      if (url.pathname !== '/callback') {
+        res.statusCode = 404;
+        res.end('Not found');
+        return;
+      }
+      if (url.searchParams.get('state') !== state) {
+        res.statusCode = 400;
+        res.end('State mismatch');
+        return;
+      }
+      const code = url.searchParams.get('code');
+      if (!code) {
+        res.statusCode = 400;
+        res.end('Missing authorization code');
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.end(SUCCESS_HTML);
+      lastCode = code;
+    } catch {
+      res.statusCode = 500;
+      res.end('Internal error');
+    }
+  });
+
+  let boundPort: number | null = null;
+  for (const port of SLACK_CALLBACK_PORTS) {
+    if (await listen(server, port)) {
+      boundPort = port;
+      break;
+    }
+  }
+
+  if (boundPort === null) {
+    return {
+      redirectUri: `http://localhost:${SLACK_CALLBACK_PORTS[0]}/callback`,
+      warning: `Slack OAuth requires one of localhost ports ${SLACK_CALLBACK_PORTS.join(', ')}, but all are in use. Free one and retry.`,
+      close: () => {
+        try {
+          server.close();
+        } catch {
+          // ignore
+        }
+      },
+      cancelWait: () => {},
+      waitForCode: async () => null,
+    };
+  }
+
+  return {
+    redirectUri: `http://localhost:${boundPort}/callback`,
+    close: () => server.close(),
+    cancelWait: () => {
+      cancelled = true;
+    },
+    waitForCode: async () => {
+      const sleep = () => new Promise(r => setTimeout(r, 100));
+      for (let i = 0; i < 1800; i += 1) {
+        if (lastCode) return { code: lastCode };
+        if (cancelled) return null;
+        await sleep();
+      }
+      return null;
+    },
+  };
+}
+
+function parseAuthorizationInput(input: string): { code?: string; state?: string } {
+  const value = input.trim();
+  if (!value) return {};
+  try {
+    const url = new URL(value);
+    return {
+      code: url.searchParams.get('code') ?? undefined,
+      state: url.searchParams.get('state') ?? undefined,
+    };
+  } catch {
+    // not a URL; treat as raw code
+  }
+  if (value.includes('code=')) {
+    const params = new URLSearchParams(value);
+    return { code: params.get('code') ?? undefined, state: params.get('state') ?? undefined };
+  }
+  return { code: value };
+}
+
+/** Run the full PKCE loopback login flow and return user-token credentials. */
+export async function loginSlack(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+  const ctx = pendingLoginContext ?? { permissionLevel: DEFAULT_SLACK_PERMISSION_LEVEL };
+  pendingLoginContext = null;
+
+  const clientId = resolveSlackClientId(ctx.clientId);
+  if (!clientId) {
+    throw new Error(
+      'No Slack client_id available. Mastra\u2019s Slack app is not published yet; connect with `/slack connect --byo <client_id>`.',
+    );
+  }
+
+  const scopes = scopesForLevel(ctx.permissionLevel);
+  const state = await createState();
+  const { verifier, challenge } = await generatePKCE();
+  const server = await startLocalOAuthServer(state);
+  if (server.warning) {
+    throw new Error(server.warning);
+  }
+
+  const url = buildAuthorizeUrl({
+    clientId,
+    redirectUri: server.redirectUri,
+    scopes,
+    challenge,
+    state,
+  });
+
+  callbacks.onAuth({
+    url,
+    instructions: 'A browser window should open. Approve the Slack permissions to finish.',
+  });
+
+  try {
+    let code: string | undefined;
+    const result = await server.waitForCode();
+    if (result?.code) {
+      code = result.code;
+    } else if (callbacks.onManualCodeInput) {
+      const input = await callbacks.onManualCodeInput();
+      const parsed = parseAuthorizationInput(input);
+      if (parsed.state && parsed.state !== state) {
+        throw new Error('State mismatch');
+      }
+      code = parsed.code;
+    }
+
+    if (!code) {
+      const input = await callbacks.onPrompt({
+        message: 'Paste the authorization code (or full redirect URL):',
+      });
+      const parsed = parseAuthorizationInput(input);
+      if (parsed.state && parsed.state !== state) {
+        throw new Error('State mismatch');
+      }
+      code = parsed.code;
+    }
+
+    if (!code) {
+      throw new Error('Missing authorization code');
+    }
+
+    return await exchangeAuthorizationCode({
+      code,
+      verifier,
+      redirectUri: server.redirectUri,
+      clientId,
+    });
+  } finally {
+    server.close();
+  }
+}
+
+export const __testing = {
+  buildAuthorizeUrl,
+  parseAuthorizationInput,
+  startLocalOAuthServer,
+  tokenResponseToCredentials,
+};
+
+export const slackOAuthProvider: OAuthProviderInterface = {
+  id: SLACK_AUTH_PROVIDER_ID,
+  name: 'Slack',
+  usesCallbackServer: true,
+
+  async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+    return loginSlack(callbacks);
+  },
+
+  async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+    return refreshSlackToken(credentials);
+  },
+
+  getApiKey(credentials: OAuthCredentials): string {
+    return credentials.access;
+  },
+};

--- a/mastracode/src/slack/scopes.ts
+++ b/mastracode/src/slack/scopes.ts
@@ -1,0 +1,61 @@
+/**
+ * Slack permission levels and their user-token scope presets.
+ *
+ * These presets are the scopes mastracode requests when running the PKCE
+ * OAuth flow against the Mastra-published Slack app. Every scope listed here
+ * MUST also be declared in `slack-app-manifest.json` (the app's granted
+ * superset) — `SLACK_MANIFEST_USER_SCOPES` below mirrors that manifest and a
+ * unit test asserts each preset is a subset of it.
+ */
+
+/** Permission level chosen by the user; controls which scopes are requested. */
+export type SlackPermissionLevel = 'read-only' | 'read-write' | 'full';
+
+/** All permission levels, ordered from least to most privileged. */
+export const SLACK_PERMISSION_LEVELS: readonly SlackPermissionLevel[] = ['read-only', 'read-write', 'full'] as const;
+
+/** The default permission level for a fresh connection. */
+export const DEFAULT_SLACK_PERMISSION_LEVEL: SlackPermissionLevel = 'read-only';
+
+const READ_ONLY_SCOPES = [
+  'search:read.public',
+  'search:read.private',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'mpim:history',
+  'users:read',
+  'users:read.email',
+  'canvases:read',
+] as const;
+
+const READ_WRITE_EXTRA_SCOPES = ['chat:write', 'reactions:write', 'canvases:write'] as const;
+
+const FULL_EXTRA_SCOPES = ['channels:read', 'groups:read', 'channels:write', 'groups:write'] as const;
+
+const READ_WRITE_SCOPES = [...READ_ONLY_SCOPES, ...READ_WRITE_EXTRA_SCOPES] as const;
+
+const FULL_SCOPES = [...READ_WRITE_SCOPES, ...FULL_EXTRA_SCOPES] as const;
+
+/** Map from permission level to the exact set of user-token scopes to request. */
+const SCOPE_PRESETS: Record<SlackPermissionLevel, readonly string[]> = {
+  'read-only': READ_ONLY_SCOPES,
+  'read-write': READ_WRITE_SCOPES,
+  full: FULL_SCOPES,
+};
+
+/**
+ * Superset of user-token scopes declared in the Slack app manifest. Kept in
+ * sync with `slack-app-manifest.json`. Every preset scope must appear here.
+ */
+export const SLACK_MANIFEST_USER_SCOPES: readonly string[] = [...FULL_SCOPES] as const;
+
+/** Return the user-token scopes to request for a given permission level. */
+export function scopesForLevel(level: SlackPermissionLevel): string[] {
+  return [...SCOPE_PRESETS[level]];
+}
+
+/** Type guard for a valid permission level string. */
+export function isSlackPermissionLevel(value: unknown): value is SlackPermissionLevel {
+  return typeof value === 'string' && (SLACK_PERMISSION_LEVELS as readonly string[]).includes(value);
+}

--- a/mastracode/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/src/tui/__tests__/command-dispatch.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   handleSkillCommand: vi.fn().mockResolvedValue(undefined),
   handleJudgeCommand: vi.fn().mockResolvedValue(undefined),
   handleGithubCommand: vi.fn().mockResolvedValue(undefined),
+  handleSlackCommand: vi.fn().mockResolvedValue(undefined),
   handleReportIssueCommand: vi.fn().mockResolvedValue(undefined),
   handleMcpCommand: vi.fn().mockResolvedValue(undefined),
   handlePluginsCommand: vi.fn().mockResolvedValue(undefined),
@@ -57,6 +58,7 @@ vi.mock('../commands/index.js', () => ({
   handleFeedbackCommand: vi.fn(),
   handleObservabilityCommand: vi.fn(),
   handleGithubCommand: mocks.handleGithubCommand,
+  handleSlackCommand: mocks.handleSlackCommand,
   handleGoalCommand: mocks.handleGoalCommand,
   handleJudgeCommand: mocks.handleJudgeCommand,
 }));
@@ -88,6 +90,7 @@ describe('dispatchSlashCommand models routing', () => {
     mocks.handleSkillCommand.mockClear();
     mocks.handleJudgeCommand.mockClear();
     mocks.handleGithubCommand.mockClear();
+    mocks.handleSlackCommand.mockClear();
     mocks.handleReportIssueCommand.mockClear();
     mocks.handleMcpCommand.mockClear();
     mocks.handlePluginsCommand.mockClear();
@@ -176,6 +179,17 @@ describe('dispatchSlashCommand models routing', () => {
     expect(handled).toBe(true);
     expect(mocks.handleGithubCommand).toHaveBeenCalledTimes(1);
     expect(mocks.handleGithubCommand).toHaveBeenCalledWith(ctx, ['mastra-ai/mastra#17447']);
+  });
+
+  it('routes /slack to handleSlackCommand', async () => {
+    const state = { customSlashCommands: [] } as any;
+    const ctx = {} as any;
+
+    const handled = await dispatchSlashCommand('/slack connect read-write', state, () => ctx);
+
+    expect(handled).toBe(true);
+    expect(mocks.handleSlackCommand).toHaveBeenCalledTimes(1);
+    expect(mocks.handleSlackCommand).toHaveBeenCalledWith(ctx, ['connect', 'read-write']);
   });
 
   it('routes /plugins to handlePluginsCommand', async () => {

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -45,6 +45,7 @@ import {
   handleObservabilityCommand,
   handleGithubCommand,
   handleGoalCommand,
+  handleSlackCommand,
 } from './commands/index.js';
 import { isCurrentThreadActive, sendSlashCommandMessage } from './commands/send-slash-command-message.js';
 import type { SlashCommandContext } from './commands/types.js';
@@ -256,6 +257,9 @@ export async function dispatchSlashCommand(
       return true;
     case 'github':
       await handleGithubCommand(buildCtx(), args);
+      return true;
+    case 'slack':
+      await handleSlackCommand(buildCtx(), args);
       return true;
     case 'goal':
       await handleGoalCommand(buildCtx(), args);

--- a/mastracode/src/tui/commands/__tests__/slack.test.ts
+++ b/mastracode/src/tui/commands/__tests__/slack.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { handleSlackCommand } from '../slack.js';
+import type { SlashCommandContext } from '../types.js';
+
+const loadSettingsMock = vi.fn();
+const saveSettingsMock = vi.fn();
+const setSlackLoginContextMock = vi.fn();
+const hasSlackTokenMock = vi.fn();
+const resolveSlackClientIdMock = vi.fn();
+
+vi.mock('../../../onboarding/settings.js', () => ({
+  loadSettings: () => loadSettingsMock(),
+  saveSettings: (value: unknown) => saveSettingsMock(value),
+}));
+
+vi.mock('../../../slack/oauth.js', () => ({
+  SLACK_AUTH_PROVIDER_ID: 'slack',
+  setSlackLoginContext: (ctx: unknown) => setSlackLoginContextMock(ctx),
+}));
+
+vi.mock('../../../slack/config.js', () => ({
+  SLACK_MCP_SERVER_NAME: 'slack',
+  hasSlackToken: (...args: unknown[]) => hasSlackTokenMock(...args),
+}));
+
+vi.mock('../../../slack/client-id.js', () => ({
+  resolveSlackClientId: (...args: unknown[]) => resolveSlackClientIdMock(...args),
+}));
+
+// Login dialog + overlay are UI-only; connect flow is exercised via login mock.
+vi.mock('../../components/login-dialog.js', () => ({
+  LoginDialogComponent: class {
+    focused = false;
+    signal = undefined;
+    constructor(
+      public ui: unknown,
+      public providerId: string,
+      public onComplete: () => void,
+    ) {}
+    showAuth() {}
+    showPrompt() {
+      return Promise.resolve('');
+    }
+    showProgress() {}
+  },
+}));
+
+vi.mock('../../overlay.js', () => ({
+  showModalOverlay: vi.fn(),
+}));
+
+function createContext(overrides: { login?: ReturnType<typeof vi.fn>; logout?: ReturnType<typeof vi.fn> } = {}) {
+  const login = overrides.login ?? vi.fn(async () => undefined);
+  const logout = overrides.logout ?? vi.fn();
+  const reload = vi.fn(async () => undefined);
+  const getServerStatuses = vi.fn(() => [] as Array<{ name: string; connected: boolean; toolCount: number }>);
+  const authStorage = {
+    login,
+    logout,
+    get: vi.fn(() => undefined),
+  };
+  const ctx = {
+    authStorage,
+    mcpManager: { reload, getServerStatuses },
+    state: { ui: { hideOverlay: vi.fn() } },
+    showInfo: vi.fn(),
+    showError: vi.fn(),
+  } as unknown as SlashCommandContext;
+  return { ctx, login, logout, reload, getServerStatuses, authStorage };
+}
+
+describe('handleSlackCommand', () => {
+  beforeEach(() => {
+    loadSettingsMock.mockReset();
+    saveSettingsMock.mockReset();
+    setSlackLoginContextMock.mockReset();
+    hasSlackTokenMock.mockReset();
+    resolveSlackClientIdMock.mockReset();
+
+    loadSettingsMock.mockReturnValue({ slack: { enabled: true, permissionLevel: 'read-only' } });
+    hasSlackTokenMock.mockReturnValue(false);
+    resolveSlackClientIdMock.mockReturnValue('client-123');
+  });
+
+  it('shows disabled status with no args when off', async () => {
+    loadSettingsMock.mockReturnValue({ slack: { enabled: false, permissionLevel: 'read-only' } });
+    const { ctx } = createContext();
+    await handleSlackCommand(ctx, []);
+    const message = (ctx.showInfo as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(message).toContain('Slack integration: disabled');
+    expect(message).toContain('Connected: no');
+  });
+
+  it('shows status with no args', async () => {
+    const { ctx } = createContext();
+    await handleSlackCommand(ctx, []);
+    const message = (ctx.showInfo as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(message).toContain('Slack integration: enabled');
+    expect(message).toContain('Connected: no');
+    expect(message).toContain('Permission level: read-only');
+  });
+
+  it('rejects an unknown permission level on connect', async () => {
+    const { ctx, login } = createContext();
+    await handleSlackCommand(ctx, ['connect', 'bogus']);
+    expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining("Unknown permission level 'bogus'"));
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it('runs the login flow on connect and reloads the MCP manager', async () => {
+    const { ctx, login, reload } = createContext();
+    await handleSlackCommand(ctx, ['connect', 'read-write']);
+    expect(setSlackLoginContextMock).toHaveBeenCalledWith(expect.objectContaining({ permissionLevel: 'read-write' }));
+    expect(login).toHaveBeenCalledWith('slack', expect.any(Object));
+    expect(reload).toHaveBeenCalled();
+    // Connecting turns the integration on.
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ slack: expect.objectContaining({ enabled: true }) }),
+    );
+  });
+
+  it('errors on connect when no client_id can be resolved', async () => {
+    resolveSlackClientIdMock.mockReturnValue(undefined);
+    const { ctx, login } = createContext();
+    await handleSlackCommand(ctx, ['connect']);
+    expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining('No Slack client_id'));
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it('changes the permission level and persists it', async () => {
+    const { ctx } = createContext();
+    await handleSlackCommand(ctx, ['level', 'full']);
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ slack: expect.objectContaining({ permissionLevel: 'full' }) }),
+    );
+    expect(ctx.showInfo).toHaveBeenCalledWith(expect.stringContaining('re-authorize'));
+  });
+
+  it('rejects an unknown permission level on level', async () => {
+    const { ctx } = createContext();
+    await handleSlackCommand(ctx, ['level', 'nope']);
+    expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining("Unknown permission level 'nope'"));
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('reports not-connected on disconnect when no token exists and disabled', async () => {
+    loadSettingsMock.mockReturnValue({ slack: { enabled: false, permissionLevel: 'read-only' } });
+    hasSlackTokenMock.mockReturnValue(false);
+    const { ctx, logout } = createContext();
+    await handleSlackCommand(ctx, ['disconnect']);
+    expect(ctx.showInfo).toHaveBeenCalledWith('Slack is not connected.');
+    expect(logout).not.toHaveBeenCalled();
+  });
+
+  it('logs out, disables, and reloads on disconnect when connected', async () => {
+    hasSlackTokenMock.mockReturnValue(true);
+    const { ctx, logout, reload } = createContext();
+    await handleSlackCommand(ctx, ['disconnect']);
+    expect(logout).toHaveBeenCalledWith('slack');
+    expect(reload).toHaveBeenCalled();
+    // Disconnecting turns the integration off.
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ slack: expect.objectContaining({ enabled: false }) }),
+    );
+    expect(ctx.showInfo).toHaveBeenCalledWith('Disconnected from Slack.');
+  });
+
+  it('shows usage on an unrecognized action', async () => {
+    const { ctx } = createContext();
+    await handleSlackCommand(ctx, ['frobnicate']);
+    expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining('Usage: /slack'));
+  });
+});

--- a/mastracode/src/tui/commands/index.ts
+++ b/mastracode/src/tui/commands/index.ts
@@ -38,4 +38,5 @@ export { handlePluginsCommand } from './plugins.js';
 export { handleFeedbackCommand } from './feedback.js';
 export { handleObservabilityCommand } from './observability.js';
 export { handleGithubCommand } from './github.js';
+export { handleSlackCommand } from './slack.js';
 export { handleGoalCommand, handleJudgeCommand } from './goal.js';

--- a/mastracode/src/tui/commands/slack.ts
+++ b/mastracode/src/tui/commands/slack.ts
@@ -1,0 +1,210 @@
+/**
+ * `/slack` command — manage the opt-in Slack MCP integration.
+ *
+ * Surface:
+ *   /slack                     status (connected team, level, tools)
+ *   /slack connect [level]     run PKCE login, store token, enable + reload MCP
+ *   /slack connect --byo <id>  same, using a BYO public client_id
+ *   /slack level <level>       change the requested permission level
+ *   /slack disconnect          clear the token, disable + remove the MCP entry
+ *
+ * The feature is off by default. There is no separate enable toggle: `connect`
+ * turns it on (`slack.enabled = true`) and `disconnect` turns it off. The
+ * `slack.enabled` flag is internal derived state the MCP resolver reads; it is
+ * never surfaced in /settings.
+ */
+
+import { loadSettings, saveSettings } from '../../onboarding/settings.js';
+import { resolveSlackClientId } from '../../slack/client-id.js';
+import { hasSlackToken, SLACK_MCP_SERVER_NAME } from '../../slack/config.js';
+import { SLACK_AUTH_PROVIDER_ID, setSlackLoginContext } from '../../slack/oauth.js';
+import {
+  DEFAULT_SLACK_PERMISSION_LEVEL,
+  isSlackPermissionLevel,
+  scopesForLevel,
+  SLACK_PERMISSION_LEVELS,
+} from '../../slack/scopes.js';
+import type { SlackPermissionLevel } from '../../slack/scopes.js';
+import { LoginDialogComponent } from '../components/login-dialog.js';
+import { showModalOverlay } from '../overlay.js';
+import type { SlashCommandContext } from './types.js';
+
+function permissionLevelList(): string {
+  return SLACK_PERMISSION_LEVELS.join(', ');
+}
+
+/** Extract a `--byo <client_id>` pair from args, returning the id and the rest. */
+function extractByoClientId(args: string[]): { clientId?: string; rest: string[] } {
+  const index = args.indexOf('--byo');
+  if (index === -1) return { rest: args };
+  const clientId = args[index + 1];
+  const rest = [...args.slice(0, index), ...args.slice(index + 2)];
+  return { clientId, rest };
+}
+
+function describeSlackStatus(ctx: SlashCommandContext, level: SlackPermissionLevel, enabled: boolean): string {
+  const authStorage = ctx.authStorage;
+  const connected = authStorage ? hasSlackToken(authStorage) : false;
+  const cred = authStorage?.get(SLACK_AUTH_PROVIDER_ID);
+  const lines: string[] = [`Slack integration: ${enabled ? 'enabled' : 'disabled'}`];
+
+  if (connected && cred?.type === 'oauth') {
+    const team = typeof cred.teamName === 'string' ? cred.teamName : undefined;
+    const teamId = typeof cred.teamId === 'string' ? cred.teamId : undefined;
+    lines.push(`Connected: ${team ?? teamId ?? 'yes'}`);
+    if (typeof cred.expires === 'number') {
+      const expired = Date.now() >= cred.expires;
+      lines.push(`Token: ${expired ? 'expired (auto-refreshes on next use)' : 'valid'}`);
+    }
+  } else {
+    lines.push('Connected: no — run /slack connect');
+  }
+
+  lines.push(`Permission level: ${level} (${scopesForLevel(level).length} scopes)`);
+
+  const slackStatus = ctx.mcpManager?.getServerStatuses().find(s => s.name === SLACK_MCP_SERVER_NAME);
+  if (slackStatus) {
+    lines.push(
+      `MCP server: ${slackStatus.connected ? 'connected' : 'not connected'}, ${slackStatus.toolCount} tool${slackStatus.toolCount === 1 ? '' : 's'}`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+async function connectSlack(
+  ctx: SlashCommandContext,
+  level: SlackPermissionLevel,
+  clientId: string | undefined,
+): Promise<void> {
+  if (!ctx.authStorage) {
+    ctx.showError('Auth storage not configured');
+    return;
+  }
+
+  if (!resolveSlackClientId(clientId)) {
+    ctx.showError(
+      'No Slack client_id available. Mastra\u2019s Slack app is not published yet; connect with `/slack connect --byo <client_id>`.',
+    );
+    return;
+  }
+
+  setSlackLoginContext({ permissionLevel: level, clientId });
+
+  await new Promise<void>(resolve => {
+    const dialog = new LoginDialogComponent(ctx.state.ui, SLACK_AUTH_PROVIDER_ID, () => {
+      ctx.state.ui.hideOverlay();
+      resolve();
+    });
+
+    showModalOverlay(ctx.state.ui, dialog, { widthPercent: 0.8, maxHeight: '60%' });
+    dialog.focused = true;
+
+    ctx
+      .authStorage!.login(SLACK_AUTH_PROVIDER_ID, {
+        onAuth: (info: { url: string; instructions?: string }) => {
+          dialog.showAuth(info.url, info.instructions);
+        },
+        onPrompt: async (prompt: { message: string; placeholder?: string }) => {
+          return dialog.showPrompt(prompt.message, prompt.placeholder);
+        },
+        onProgress: (message: string) => {
+          dialog.showProgress(message);
+        },
+        signal: dialog.signal,
+      })
+      .then(async () => {
+        ctx.state.ui.hideOverlay();
+        // Connecting turns the integration on. `enabled` is internal derived
+        // state the MCP resolver reads; persist the chosen level + BYO id too.
+        const current = loadSettings();
+        current.slack.enabled = true;
+        current.slack.permissionLevel = level;
+        if (clientId) current.slack.clientId = clientId;
+        saveSettings(current);
+        await ctx.mcpManager?.reload();
+        const status = ctx.mcpManager?.getServerStatuses().find(s => s.name === SLACK_MCP_SERVER_NAME);
+        if (status?.connected) {
+          ctx.showInfo(`Connected to Slack — ${status.toolCount} tool${status.toolCount === 1 ? '' : 's'} available.`);
+        } else {
+          ctx.showInfo('Connected to Slack. Run /mcp to see available tools.');
+        }
+        resolve();
+      })
+      .catch((error: Error) => {
+        ctx.state.ui.hideOverlay();
+        if (error.message !== 'Login cancelled') {
+          ctx.showError(`Failed to connect Slack: ${error.message}`);
+        }
+        resolve();
+      });
+  });
+}
+
+async function disconnectSlack(ctx: SlashCommandContext): Promise<void> {
+  if (!ctx.authStorage) {
+    ctx.showError('Auth storage not configured');
+    return;
+  }
+  const settings = loadSettings();
+  if (!hasSlackToken(ctx.authStorage) && !settings.slack.enabled) {
+    ctx.showInfo('Slack is not connected.');
+    return;
+  }
+  ctx.authStorage.logout(SLACK_AUTH_PROVIDER_ID);
+  // Disconnecting turns the integration off so the MCP resolver drops the entry.
+  settings.slack.enabled = false;
+  saveSettings(settings);
+  await ctx.mcpManager?.reload();
+  ctx.showInfo('Disconnected from Slack.');
+}
+
+export async function handleSlackCommand(ctx: SlashCommandContext, args: string[] = []): Promise<void> {
+  const settings = loadSettings();
+  const level = settings.slack.permissionLevel;
+
+  const [action, ...rest] = args;
+
+  if (!action || action === 'status') {
+    ctx.showInfo(describeSlackStatus(ctx, level, settings.slack.enabled));
+    return;
+  }
+
+  if (action === 'connect') {
+    const { clientId, rest: connectArgs } = extractByoClientId(rest);
+    const requestedLevel = connectArgs[0];
+    if (requestedLevel && !isSlackPermissionLevel(requestedLevel)) {
+      ctx.showError(`Unknown permission level '${requestedLevel}'. Choose one of: ${permissionLevelList()}.`);
+      return;
+    }
+    const connectLevel: SlackPermissionLevel = isSlackPermissionLevel(requestedLevel)
+      ? requestedLevel
+      : (level ?? DEFAULT_SLACK_PERMISSION_LEVEL);
+    await connectSlack(ctx, connectLevel, clientId ?? settings.slack.clientId);
+    return;
+  }
+
+  if (action === 'level' || action === 'scopes') {
+    const requested = rest[0];
+    if (!requested) {
+      ctx.showInfo(`Current permission level: ${level}. Choose one of: ${permissionLevelList()}.`);
+      return;
+    }
+    if (!isSlackPermissionLevel(requested)) {
+      ctx.showError(`Unknown permission level '${requested}'. Choose one of: ${permissionLevelList()}.`);
+      return;
+    }
+    const current = loadSettings();
+    current.slack.permissionLevel = requested;
+    saveSettings(current);
+    ctx.showInfo(`Slack permission level set to ${requested}. Run /slack connect to re-authorize with the new scopes.`);
+    return;
+  }
+
+  if (action === 'disconnect') {
+    await disconnectSlack(ctx);
+    return;
+  }
+
+  ctx.showError('Usage: /slack, /slack connect [level] [--byo <client_id>], /slack level <level>, /slack disconnect');
+}

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -385,6 +385,17 @@ export function setupAutocomplete(state: TUIState): void {
         ].filter(command => command.value.startsWith(argumentPrefix.toLowerCase())),
     },
     {
+      name: 'slack',
+      description: 'Manage the Slack integration (connect, level, disconnect)',
+      getArgumentCompletions: (argumentPrefix: string) =>
+        [
+          { value: 'connect', label: 'connect', description: 'Connect a Slack account (OAuth)' },
+          { value: 'level', label: 'level', description: 'Set the requested permission level' },
+          { value: 'disconnect', label: 'disconnect', description: 'Disconnect the Slack account' },
+          { value: 'status', label: 'status', description: 'Show Slack connection status' },
+        ].filter(command => command.value.startsWith(argumentPrefix.toLowerCase())),
+    },
+    {
       name: 'goal',
       description: 'Set/manage persistent goal (Ralph loop)',
       getArgumentCompletions: (argumentPrefix: string) =>


### PR DESCRIPTION
## What this ships

A `/slack` integration for mastracode: connect your own Slack account and get Slack tools (search, read, send messages, canvases, users) available to the agent — no copy/pasting Slack context into a session, and no hand-rolling a Slack app or managing tokens.

It's **off by default** and managed entirely from `/slack`:

- `/slack connect [level] [--byo <client_id>]` — authorize + enable it
- `/slack level <read-only|read-write|full>` — change requested scopes
- `/slack disconnect` — disable + clear the token
- `/slack` — status (team, permission level, token validity, tool count)

## How it works

- **Slack's official remote MCP server** provides the tools, so there are no new per-tool deps to maintain here.
- **OAuth 2.0 + PKCE** against a published "Mastra Code" Slack app (no client secret), via a localhost loopback callback. `--byo <client_id>` lets restricted orgs use their own PKCE app.
- The user token lands in `auth.json` (`0o600`) under the `slack` provider and rides the **same `AuthStorage` OAuth pipeline** as the Anthropic/Codex logins — so it **auto-refreshes** on expiry (PKCE tokens expire in ~30 days). The raw token is **never written to `mcp.json`**.
- The Slack MCP server is injected via an **async `extraServers` resolver** that builds the `Authorization: Bearer` header from `AuthStorage` on each init/reload, so the token stays fresh and the entry only exists when Slack is enabled + connected.

## Open design questions (want input before this lands)

1. **Reuse `SlackProvider` instead of the custom PKCE pipeline?** We already have a `SlackProvider` that handles auth / encrypted credential storage / token rotation. This branch rolls its own PKCE + `AuthStorage` flow. Worth evaluating whether we can reuse `SlackProvider` for the auth/rotation side.
2. **MC web support.** The current flow is localhost-loopback PKCE, which is CLI/desktop-specific and won't translate to MC web as-is. If web parity matters, the callback strategy needs rethinking.
3. **MCP vs `createChatTools()`.** We went with Slack's MCP server for zero new deps. If we're already registering Slack endpoints / handling incoming events elsewhere, the `chat/channels` dep would be present anyway and `createChatTools()` is cross-platform.

## Test plan

- Unit (colocated, all passing): scope preset ↔ level mapping (presets ⊆ manifest scopes), PKCE authorize-URL + code-exchange shape (asserts **no client_secret**), refresh path + `AuthStorage.getApiKey('slack')` auto-refresh, MCP entry register/remove + bearer header (token never in `mcp.json`), `parseSlackSettings` defaults/round-trip, `/slack` dispatch + status/connect/disconnect.
- Also fixes a session-load bug: on a fresh session the Slack tools didn't appear unless you reconnected, because `hasServers()` gated `init()` before the async resolver ran. `hasServers()` now accounts for a dynamic resolver. New test covers it.
- Narrowest checks only: `pnpm --filter ./mastracode test` + `tsc --noEmit` (both green). No repo-wide builds.

## Notes / caveats

- Requires the "Mastra Code" Slack app to be published + admin-approved per workspace (Slack MCP requirement). Until it's published, use `--byo <client_id>` with your own PKCE app (a manifest is checked in).
- PKCE marks the app a public client permanently (one-way) and forces ~30-day refresh tokens — handled by `AuthStorage` auto-refresh.

🤖 Draft for review — see open design questions above.
