### PR TITLE
fix(docs): Active sidebar indicator

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1332,7 +1332,7 @@ article p {
   .menu__link--active:not(.menu__link--sublist)::before {
     content: '';
     position: absolute;
-    left: calc(0.25rem * -2.5);
+    left: calc(0.25rem * -3);
     top: calc(0.25rem * 1);
     bottom: 0;
     width: 1.5px;


### PR DESCRIPTION
## Description

Fix the misalignment

<img width="184" height="69" alt="image" src="https://github.com/user-attachments/assets/cad2dedb-6b15-4db9-9538-81a8bcf4ef01" />


## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change nudges the little green bar for the selected sidebar item a bit farther left so it lines up better with the rest of the page. It’s a small visual fix to make the docs sidebar look cleaner and more accurate.

## Summary
- Updated `docs/custom.css` to move the active sidebar indicator slightly left.
- Adjusted `.menu__link--active:not(.menu__link--sublist)::before` from `calc(0.25rem * -2.5)` to `calc(0.25rem * -3)`.

## Impact
- Improves alignment of the active navigation marker in the docs sidebar.
- No public API or exported entity changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->