### PR TITLE
fix(playground): remove agent version clock icon

### DIFF
--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
@@ -19,7 +19,7 @@ import { HoverPopover, PopoverTrigger, PopoverContent } from '@mastra/playground
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
-import { Check, ChevronDown, Clock, Download, GitPullRequest, Info, MessageSquare, Save } from 'lucide-react';
+import { Check, ChevronDown, Download, GitPullRequest, Info, MessageSquare, Save } from 'lucide-react';
 import { useMemo, useState, useCallback } from 'react';
 
 import { useAgentVersions } from '../../hooks/use-agent-versions';
@@ -131,10 +131,6 @@ export function AgentPlaygroundVersionBar({
   return {
     versionSelector: (
       <div className="flex items-center gap-2 px-4 py-3 border-b border-border1 bg-surface3">
-        <Icon size="sm" className="text-neutral3 shrink-0">
-          <Clock />
-        </Icon>
-
         {versions.length > 0 ? (
           <Combobox
             options={versionOptions}


### PR DESCRIPTION
Removes the leading clock icon from the agent editor version selector so the control starts directly with the selected version.

Validated with targeted Prettier, targeted ESLint, `git diff --check`, and the pre-commit `lint-staged` hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

ELI5: This change removes a little clock picture from the agent version picker so the dropdown starts right away with the selected version. It makes the control look cleaner and less cluttered.

### Summary
- Removed the `Clock` icon import from `agent-playground-version-bar.tsx`.
- Deleted the clock icon from the agent version selector UI, so the selected version now appears without the leading icon.
- No exported or public APIs were changed.

### Validation
- Targeted Prettier
- Targeted ESLint
- `git diff --check`
- Pre-commit `lint-staged` hook

<!-- end of auto-generated comment: release notes by coderabbit.ai -->