### PR TITLE
fix(playground): remove cms block editor focus outline

### DIFF
--- a/.changeset/fluffy-coins-wish.md
+++ b/.changeset/fluffy-coins-wish.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Added an embedded CodeEditor variant for borderless editor surfaces.
+Added an embedded CodeEditor variant for borderless editor surfaces and aligned CodeEditor focus styling to use the container border instead of CodeMirror's internal outline.

--- a/.changeset/fluffy-coins-wish.md
+++ b/.changeset/fluffy-coins-wish.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added an embedded CodeEditor variant for borderless editor surfaces.

--- a/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor-styles.test.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor-styles.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { CodeEditor } from '../code-editor';
@@ -9,29 +9,38 @@ afterEach(() => {
 });
 
 describe('CodeEditor styles', () => {
-  it('removes the focused editor outline from the default surface', () => {
-    const { container } = render(<CodeEditor value="default content" showCopyButton={false} />);
+  const renderFocusedEditor = async (variant: 'default' | 'embedded') => {
+    const { container } = render(<CodeEditor value={`${variant} content`} showCopyButton={false} variant={variant} />);
     const editor = container.querySelector<HTMLElement>('.cm-editor');
+    const textbox = container.querySelector<HTMLElement>('[role="textbox"]');
 
     if (!editor) {
       throw new Error('Expected CodeMirror editor to render.');
     }
 
-    editor.classList.add('cm-focused');
+    if (!textbox) {
+      throw new Error('Expected CodeMirror textbox to render.');
+    }
 
-    expect(getComputedStyle(editor).outline).toBe('none');
+    textbox.focus();
+
+    expect(document.activeElement).toBe(textbox);
+
+    await waitFor(() => {
+      const editorStyle = getComputedStyle(editor);
+      expect(editorStyle.outline).toBe('none');
+      expect(editorStyle.outlineStyle).not.toMatch(/dashed|dotted/);
+    });
+
+    const textboxStyle = getComputedStyle(textbox);
+    expect(textboxStyle.outlineStyle).not.toMatch(/dashed|dotted/);
+  };
+
+  it('removes the focused editor outline from the default surface', async () => {
+    await renderFocusedEditor('default');
   });
 
-  it('removes the focused editor outline from the embedded surface', () => {
-    const { container } = render(<CodeEditor value="embedded content" showCopyButton={false} variant="embedded" />);
-    const editor = container.querySelector<HTMLElement>('.cm-editor');
-
-    if (!editor) {
-      throw new Error('Expected CodeMirror editor to render.');
-    }
-
-    editor.classList.add('cm-focused');
-
-    expect(getComputedStyle(editor).outline).toBe('none');
+  it('removes the focused editor outline from the embedded surface', async () => {
+    await renderFocusedEditor('embedded');
   });
 });

--- a/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor-styles.test.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor-styles.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { CodeEditor } from '../code-editor';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('CodeEditor styles', () => {
+  it('removes the focused editor outline from the embedded surface', () => {
+    const { container } = render(<CodeEditor value="embedded content" showCopyButton={false} variant="embedded" />);
+    const editor = container.querySelector<HTMLElement>('.cm-editor');
+
+    if (!editor) {
+      throw new Error('Expected CodeMirror editor to render.');
+    }
+
+    editor.classList.add('cm-focused');
+
+    expect(getComputedStyle(editor).outline).toBe('none');
+  });
+});

--- a/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor-styles.test.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor-styles.test.tsx
@@ -9,6 +9,19 @@ afterEach(() => {
 });
 
 describe('CodeEditor styles', () => {
+  it('removes the focused editor outline from the default surface', () => {
+    const { container } = render(<CodeEditor value="default content" showCopyButton={false} />);
+    const editor = container.querySelector<HTMLElement>('.cm-editor');
+
+    if (!editor) {
+      throw new Error('Expected CodeMirror editor to render.');
+    }
+
+    editor.classList.add('cm-focused');
+
+    expect(getComputedStyle(editor).outline).toBe('none');
+  });
+
   it('removes the focused editor outline from the embedded surface', () => {
     const { container } = render(<CodeEditor value="embedded content" showCopyButton={false} variant="embedded" />);
     const editor = container.querySelector<HTMLElement>('.cm-editor');

--- a/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor.test.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor.test.tsx
@@ -31,4 +31,14 @@ describe('CodeEditor', () => {
 
     expect(codeMirrorProps.at(-1)?.extensions).not.toContain(EditorView.lineWrapping);
   });
+
+  it('can render as an embedded borderless editor surface', () => {
+    const { container } = render(<CodeEditor value="embedded content" showCopyButton={false} variant="embedded" />);
+
+    const editorRoot = container.firstElementChild;
+
+    expect(editorRoot?.className).toContain('bg-transparent');
+    expect(editorRoot?.className).toContain('border-none');
+    expect(editorRoot?.className).toContain('[&_.cm-editor.cm-focused]:outline-hidden');
+  });
 });

--- a/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor.test.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor.test.tsx
@@ -31,14 +31,4 @@ describe('CodeEditor', () => {
 
     expect(codeMirrorProps.at(-1)?.extensions).not.toContain(EditorView.lineWrapping);
   });
-
-  it('can render as an embedded borderless editor surface', () => {
-    const { container } = render(<CodeEditor value="embedded content" showCopyButton={false} variant="embedded" />);
-
-    const editorRoot = container.firstElementChild;
-
-    expect(editorRoot?.className).toContain('bg-transparent');
-    expect(editorRoot?.className).toContain('border-none');
-    expect(editorRoot?.className).toContain('[&_.cm-editor.cm-focused]:outline-hidden');
-  });
 });

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -30,6 +30,10 @@ const meta: Meta<typeof CodeEditor> = {
     lineWrapping: {
       control: { type: 'boolean' },
     },
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'embedded'],
+    },
   },
 };
 
@@ -90,6 +94,43 @@ export const ArrayData: Story = {
       { id: 3, name: 'Agent 3', status: 'active' },
     ],
     className: 'w-[400px]',
+  },
+};
+
+export const FocusedDefault: Story = {
+  args: {
+    data: [
+      { id: 1, name: 'Agent 1', status: 'active' },
+      { id: 2, name: 'Agent 2', status: 'inactive' },
+      { id: 3, name: 'Agent 3', status: 'active' },
+    ],
+    className: 'w-150',
+  },
+  play: async ({ canvasElement }) => {
+    canvasElement.querySelector<HTMLElement>('[role="textbox"]')?.focus();
+  },
+};
+
+export const FocusedEmbedded: Story = {
+  args: {
+    value: `Use the agent instructions below.
+
+- Keep answers concise
+- Ask before taking destructive actions
+- Prefer tool-backed evidence over assumptions`,
+    variant: 'embedded',
+    language: 'markdown',
+    lineNumbers: false,
+    showCopyButton: false,
+    className: 'min-h-24 w-150',
+  },
+  render: args => (
+    <div className="w-150 rounded-md bg-surface3 p-3">
+      <CodeEditor {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    canvasElement.querySelector<HTMLElement>('[role="textbox"]')?.focus();
   },
 };
 

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -124,11 +124,6 @@ export const FocusedEmbedded: Story = {
     showCopyButton: false,
     className: 'min-h-24 w-150',
   },
-  render: args => (
-    <div className="w-150 rounded-md bg-surface3 p-3">
-      <CodeEditor {...args} />
-    </div>
-  ),
   play: async ({ canvasElement }) => {
     canvasElement.querySelector<HTMLElement>('[role="textbox"]')?.focus();
   },

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -148,7 +148,7 @@ export const FocusedEmbeddedInBlock: Story = {
     className: 'min-h-24',
   },
   render: args => (
-    <div className="w-150 rounded-md border border-border1 bg-surface3 p-3 transition-colors focus-within:border-neutral5/50">
+    <div className="w-150 rounded-md border border-border1 bg-surface3 p-3 transition-colors focus-within:border-border2">
       <CodeEditor {...args} />
     </div>
   ),

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -134,6 +134,29 @@ export const FocusedEmbedded: Story = {
   },
 };
 
+export const FocusedEmbeddedInBlock: Story = {
+  args: {
+    value: `Use the agent instructions below.
+
+- Keep answers concise
+- Ask before taking destructive actions
+- Prefer tool-backed evidence over assumptions`,
+    variant: 'embedded',
+    language: 'markdown',
+    lineNumbers: false,
+    showCopyButton: false,
+    className: 'min-h-24',
+  },
+  render: args => (
+    <div className="w-150 rounded-md border border-border1 bg-surface3 p-3 transition-colors focus-within:border-neutral5/50">
+      <CodeEditor {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    canvasElement.querySelector<HTMLElement>('[role="textbox"]')?.focus();
+  },
+};
+
 export const WithoutCopyButton: Story = {
   args: {
     data: { message: 'Hello, World!' },

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -143,7 +143,7 @@ export const FocusedEmbeddedInBlock: Story = {
     className: 'min-h-24',
   },
   render: args => (
-    <div className="w-150 rounded-md border border-border1 bg-surface3 p-3 transition-colors focus-within:border-border2">
+    <div className="w-150 rounded-md border border-border1 bg-surface3 p-3 transition-colors focus-within:border-neutral6/10">
       <CodeEditor {...args} />
     </div>
   ),

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -143,7 +143,7 @@ export const FocusedEmbeddedInBlock: Story = {
     className: 'min-h-24',
   },
   render: args => (
-    <div className="w-150 rounded-md border border-border1 bg-surface3 p-3 transition-colors focus-within:border-neutral6/10">
+    <div className="w-150 rounded-md border border-border1 bg-surface3 p-3 transition-colors focus-within:border-neutral6/20">
       <CodeEditor {...args} />
     </div>
   ),

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -228,12 +228,16 @@ const codeEditorVariants = cva('p-1 font-mono relative overflow-hidden', {
   variants: {
     variant: {
       default: 'rounded-md bg-surface3 border border-border1',
-      embedded: 'rounded-none border-none bg-transparent [&_.cm-editor.cm-focused]:outline-hidden',
+      embedded: 'rounded-none border-none bg-transparent',
     },
   },
   defaultVariants: {
     variant: 'default',
   },
+});
+
+const embeddedEditorAttributes = EditorView.editorAttributes.of({
+  style: 'outline: none',
 });
 
 export type CodeEditorProps = {
@@ -288,6 +292,10 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
         exts.push(EditorView.lineWrapping);
       }
 
+      if (variant === 'embedded') {
+        exts.push(embeddedEditorAttributes);
+      }
+
       if (language === 'json') {
         exts.push(jsonLanguage);
       } else if (language === 'markdown') {
@@ -307,7 +315,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
       }
 
       return exts;
-    }, [language, highlightVariables, schema, editable, lineWrapping]);
+    }, [language, highlightVariables, schema, editable, lineWrapping, variant]);
 
     return (
       <div className={cn(codeEditorVariants({ variant }), className)} {...props}>

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -232,7 +232,7 @@ const codeEditorVariants = cva(
   {
     variants: {
       variant: {
-        default: 'rounded-md bg-surface3 border border-border1 p-1 focus-within:border-border2',
+        default: 'rounded-md bg-surface3 border border-border1 p-1 focus-within:border-neutral6/10',
         embedded: 'rounded-none border-none bg-transparent p-0',
       },
     },

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -8,6 +8,8 @@ import { tags as t } from '@lezer/highlight';
 import { draculaInit } from '@uiw/codemirror-theme-dracula';
 import CodeMirror from '@uiw/react-codemirror';
 import type { ReactCodeMirrorRef } from '@uiw/react-codemirror';
+import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 import { forwardRef, useMemo } from 'react';
 import type { HTMLAttributes } from 'react';
 import { codeLanguages } from './code-languages';
@@ -222,6 +224,18 @@ export const useCodemirrorTheme = (): Extension => {
   return useMemo(() => (isDark ? buildDarkTheme() : buildLightTheme()), [isDark]);
 };
 
+const codeEditorVariants = cva('p-1 font-mono relative overflow-hidden', {
+  variants: {
+    variant: {
+      default: 'rounded-md bg-surface3 border border-border1',
+      embedded: 'rounded-none border-none bg-transparent [&_.cm-editor.cm-focused]:outline-hidden',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
 export type CodeEditorProps = {
   data?: Record<string, unknown> | Array<Record<string, unknown>>;
   value?: string;
@@ -240,7 +254,8 @@ export type CodeEditorProps = {
   lineWrapping?: boolean;
   /** When false, makes the editor read-only */
   editable?: boolean;
-} & Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>;
+} & VariantProps<typeof codeEditorVariants> &
+  Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>;
 
 export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
   (
@@ -258,6 +273,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
       lineNumbers = true,
       lineWrapping = true,
       editable,
+      variant,
       ...props
     },
     ref,
@@ -294,10 +310,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
     }, [language, highlightVariables, schema, editable, lineWrapping]);
 
     return (
-      <div
-        className={cn('rounded-md bg-surface3 p-1 font-mono relative border border-border1 overflow-hidden', className)}
-        {...props}
-      >
+      <div className={cn(codeEditorVariants({ variant }), className)} {...props}>
         {showCopyButton && <CopyButton content={formattedCode} className="absolute top-2 right-2 z-20" />}
         <CodeMirror
           ref={ref}

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -232,7 +232,7 @@ const codeEditorVariants = cva(
   {
     variants: {
       variant: {
-        default: 'rounded-md bg-surface3 border border-border1 p-1 focus-within:border-neutral6/10',
+        default: 'rounded-md bg-surface3 border border-border1 p-1 focus-within:border-neutral6/20',
         embedded: 'rounded-none border-none bg-transparent p-0',
       },
     },

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -17,7 +17,6 @@ import { createVariableAutocomplete } from './variable-autocomplete-extension';
 import { variableHighlight } from './variable-highlight-extension';
 import { CopyButton } from '@/ds/components/CopyButton';
 import { useTheme } from '@/ds/components/ThemeProvider';
-import { inputFocusBorderWithin } from '@/ds/primitives/form-element';
 import type { JsonSchema } from '@/lib/json-schema';
 import { cn } from '@/lib/utils';
 
@@ -233,7 +232,7 @@ const codeEditorVariants = cva(
   {
     variants: {
       variant: {
-        default: cn('rounded-md bg-surface3 border border-border1', inputFocusBorderWithin),
+        default: 'rounded-md bg-surface3 border border-border1 focus-within:border-border2',
         embedded: 'rounded-none border-none bg-transparent',
       },
     },

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -226,14 +226,14 @@ export const useCodemirrorTheme = (): Extension => {
 
 const codeEditorVariants = cva(
   cn(
-    'p-1 font-mono relative overflow-hidden outline-hidden focus:outline-hidden focus-within:outline-hidden',
+    'font-mono relative overflow-hidden outline-hidden focus:outline-hidden focus-within:outline-hidden',
     'transition-colors duration-normal ease-out-custom',
   ),
   {
     variants: {
       variant: {
-        default: 'rounded-md bg-surface3 border border-border1 focus-within:border-border2',
-        embedded: 'rounded-none border-none bg-transparent',
+        default: 'rounded-md bg-surface3 border border-border1 p-1 focus-within:border-border2',
+        embedded: 'rounded-none border-none bg-transparent p-0',
       },
     },
     defaultVariants: {

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -1,7 +1,7 @@
 import { jsonLanguage } from '@codemirror/lang-json';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
-import { EditorState } from '@codemirror/state';
+import { EditorState, Prec } from '@codemirror/state';
 import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { tags as t } from '@lezer/highlight';
@@ -226,7 +226,10 @@ export const useCodemirrorTheme = (): Extension => {
 };
 
 const codeEditorVariants = cva(
-  cn('p-1 font-mono relative overflow-hidden', 'transition-colors duration-normal ease-out-custom'),
+  cn(
+    'p-1 font-mono relative overflow-hidden outline-hidden focus:outline-hidden focus-within:outline-hidden',
+    'transition-colors duration-normal ease-out-custom',
+  ),
   {
     variants: {
       variant: {
@@ -240,9 +243,33 @@ const codeEditorVariants = cva(
   },
 );
 
-const editorFocusAttributes = EditorView.editorAttributes.of({
-  style: 'outline: none',
-});
+const editorFocusAttributes = Prec.highest(
+  EditorView.editorAttributes.of({
+    style: 'outline: none',
+  }),
+);
+
+const editorFocusTheme = Prec.highest(
+  EditorView.theme({
+    '&': {
+      outline: 'none',
+    },
+    '&.cm-focused': {
+      outline: 'none',
+    },
+    '.cm-scroller': {
+      outline: 'none',
+    },
+    '.cm-content': {
+      outline: 'none',
+    },
+    '.cm-content:focus': {
+      outline: 'none',
+    },
+  }),
+);
+
+const editorFocusExtensions: Extension[] = [editorFocusAttributes, editorFocusTheme];
 
 export type CodeEditorProps = {
   data?: Record<string, unknown> | Array<Record<string, unknown>>;
@@ -290,7 +317,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
     const formattedCode = data ? JSON.stringify(data, null, 2) : (value ?? '');
 
     const extensions = useMemo(() => {
-      const exts: Extension[] = [editorFocusAttributes];
+      const exts: Extension[] = [...editorFocusExtensions];
 
       if (lineWrapping) {
         exts.push(EditorView.lineWrapping);

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -17,6 +17,7 @@ import { createVariableAutocomplete } from './variable-autocomplete-extension';
 import { variableHighlight } from './variable-highlight-extension';
 import { CopyButton } from '@/ds/components/CopyButton';
 import { useTheme } from '@/ds/components/ThemeProvider';
+import { inputFocusBorderWithin } from '@/ds/primitives/form-element';
 import type { JsonSchema } from '@/lib/json-schema';
 import { cn } from '@/lib/utils';
 
@@ -224,19 +225,22 @@ export const useCodemirrorTheme = (): Extension => {
   return useMemo(() => (isDark ? buildDarkTheme() : buildLightTheme()), [isDark]);
 };
 
-const codeEditorVariants = cva('p-1 font-mono relative overflow-hidden', {
-  variants: {
-    variant: {
-      default: 'rounded-md bg-surface3 border border-border1',
-      embedded: 'rounded-none border-none bg-transparent',
+const codeEditorVariants = cva(
+  cn('p-1 font-mono relative overflow-hidden', 'transition-colors duration-normal ease-out-custom'),
+  {
+    variants: {
+      variant: {
+        default: cn('rounded-md bg-surface3 border border-border1', inputFocusBorderWithin),
+        embedded: 'rounded-none border-none bg-transparent',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
     },
   },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
+);
 
-const embeddedEditorAttributes = EditorView.editorAttributes.of({
+const editorFocusAttributes = EditorView.editorAttributes.of({
   style: 'outline: none',
 });
 
@@ -286,14 +290,10 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
     const formattedCode = data ? JSON.stringify(data, null, 2) : (value ?? '');
 
     const extensions = useMemo(() => {
-      const exts: Extension[] = [];
+      const exts: Extension[] = [editorFocusAttributes];
 
       if (lineWrapping) {
         exts.push(EditorView.lineWrapping);
-      }
-
-      if (variant === 'embedded') {
-        exts.push(embeddedEditorAttributes);
       }
 
       if (language === 'json') {
@@ -315,7 +315,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(
       }
 
       return exts;
-    }, [language, highlightVariables, schema, editable, lineWrapping, variant]);
+    }, [language, highlightVariables, schema, editable, lineWrapping]);
 
     return (
       <div className={cn(codeEditorVariants({ variant }), className)} {...props}>

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
@@ -251,7 +251,8 @@ const InlineBlockContent = ({
           value={block.content}
           onChange={handleContentChange}
           placeholder={placeholder}
-          className="border-none rounded-none bg-transparent min-h-12 [&_.cm-editor.cm-focused]:outline-hidden"
+          variant="embedded"
+          className="min-h-12"
           language="markdown"
           highlightVariables
           showCopyButton={false}

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
@@ -251,7 +251,7 @@ const InlineBlockContent = ({
           value={block.content}
           onChange={handleContentChange}
           placeholder={placeholder}
-          className="border-none rounded-none bg-transparent min-h-12"
+          className="border-none rounded-none bg-transparent min-h-12 [&_.cm-editor.cm-focused]:outline-hidden"
           language="markdown"
           highlightVariables
           showCopyButton={false}

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
@@ -213,7 +213,7 @@ const RefBlockContent = ({
               value={localContent}
               onChange={handleContentChange}
               placeholder="Referenced block is empty..."
-              className="border-none rounded-none bg-transparent min-h-12"
+              className="border-none rounded-none bg-transparent min-h-12 [&_.cm-editor.cm-focused]:outline-hidden"
               language="markdown"
               highlightVariables
               showCopyButton={false}

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
@@ -213,7 +213,8 @@ const RefBlockContent = ({
               value={localContent}
               onChange={handleContentChange}
               placeholder="Referenced block is empty..."
-              className="border-none rounded-none bg-transparent min-h-12 [&_.cm-editor.cm-focused]:outline-hidden"
+              variant="embedded"
+              className="min-h-12"
               language="markdown"
               highlightVariables
               showCopyButton={false}


### PR DESCRIPTION
Fixes the unwanted dashed focus outline that appears when focusing CodeMirror-backed `CodeEditor` surfaces, including the embedded CMS instruction block editors and the normal bordered editor shown in Storybook. The root cause is CodeMirror's focused editor outline rendering inside the component chrome.

The fix lives component-wise in `@mastra/playground-ui`: `CodeEditor` now suppresses CodeMirror's internal focused outline for all variants, the default bordered variant uses the same subtle `focus-within` container border treatment as the input family, and `variant="embedded"` remains available for borderless editor surfaces. The CMS inline/ref block editors use that embedded variant with only layout sizing kept locally.

Storybook now includes `Composite/CodeEditor` stories for `Focused Default` and `Focused Embedded`, and the built Storybook index includes `composite-codeeditor--focused-default` and `composite-codeeditor--focused-embedded`. The regression asserts the rendered `.cm-editor` computed outline in jsdom for both default and embedded variants instead of checking class tokens. A patch changeset is included for `@mastra/playground-ui`.

Validated with `pnpm exec prettier --check .changeset/fluffy-coins-wish.md packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor.test.tsx packages/playground-ui/src/ds/components/CodeEditor/__tests__/code-editor-styles.test.tsx packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx`, `pnpm --filter ./packages/playground-ui test -- src/ds/components/CodeEditor/__tests__/code-editor.test.tsx src/ds/components/CodeEditor/__tests__/code-editor-styles.test.tsx --runInBand`, `pnpm --filter ./packages/playground-ui typecheck`, `pnpm --filter ./packages/playground-ui build`, `pnpm --filter ./packages/playground-ui lint`, `pnpm --filter ./packages/playground-ui build-storybook`, `pnpm --filter ./packages/playground typecheck`, `pnpm --filter ./packages/playground lint`, `git diff --check`, and `npx -y react-doctor@latest . --verbose --scope changed --base origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When you click into the code editor, CodeMirror was showing a distracting dashed outline. This PR removes that internal outline and instead uses a more subtle “border shows when focused” look—plus it adds an `embedded` mode for borderless editors used inside CMS blocks.

## Summary
- Removed CodeMirror’s internal dashed focus outline from `CodeEditor` by adding high-precedence focus styling extensions in `@mastra/playground-ui`.
- Introduced a `variant` prop for `CodeEditor`:
  - `default`: keeps the bordered editor look, using a subtle outer `focus-within` container border treatment for focus styling.
  - `embedded`: borderless/better blended inline mode for embedded editor surfaces.
- Updated CMS instruction/ref block editors to use `variant="embedded"` (and simplified styling to rely on local sizing like `min-h-12`).
- Added Storybook stories for focused states: `FocusedDefault`, `FocusedEmbedded`, and a wrapped `FocusedEmbeddedInBlock`; updated the Storybook index accordingly.
- Updated the regression test to assert the rendered `.cm-editor` computed outline in jsdom for both `default` and `embedded` variants.
- Added a patch changeset for `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->