### PR TITLE
fix(playground): keep system prompt editor editable

### DIFF
--- a/packages/playground/src/domains/agents/components/__tests__/agent-playground-config.test.tsx
+++ b/packages/playground/src/domains/agents/components/__tests__/agent-playground-config.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -55,6 +55,16 @@ describe('AgentPlaygroundConfig', () => {
       expect(screen.getByRole('tab', { name: 'Variables' })).not.toBeNull();
       expect(screen.getByRole('tab', { name: 'System Prompt' })).not.toBeNull();
       expect(screen.getByRole('tab', { name: 'Tools 2' })).not.toBeNull();
+    });
+
+    it('keeps the system prompt in edit mode without a preview toggle', () => {
+      render(<AgentPlaygroundConfigHarness />);
+
+      fireEvent.click(screen.getByRole('tab', { name: 'System Prompt' }));
+
+      expect(screen.getByText('Instruction blocks editor')).not.toBeNull();
+      expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
     });
   });
 });

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
@@ -8,8 +8,8 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import type { JsonSchema, JsonSchemaProperty } from '@mastra/playground-ui/utils/json-schema';
-import { Braces, Wrench, Cpu, Eye, Pencil } from 'lucide-react';
-import { useState, useMemo } from 'react';
+import { Braces, Wrench, Cpu } from 'lucide-react';
+import { useMemo } from 'react';
 
 import { useAgentEditFormContext } from '../../context/agent-edit-form-context';
 import { useCompareAgentVersions } from '../../hooks/use-agent-versions';
@@ -669,7 +669,6 @@ export function AgentPlaygroundConfig({ agentId, selectedVersionId, latestVersio
   const instructionBlocks = form.watch('instructionBlocks');
   const variables = form.watch('variables') as JsonSchema | undefined;
   const toolCount = tools ? Object.keys(tools).length : 0;
-  const [showPreview, setShowPreview] = useState(false);
 
   const variableEntries = useMemo(() => Object.entries(variables?.properties ?? {}), [variables]);
 
@@ -743,26 +742,9 @@ export function AgentPlaygroundConfig({ agentId, selectedVersionId, latestVersio
                     </PopoverContent>
                   </HoverPopover>
                 </Txt>
-
-                {!readOnly && (
-                  <div className="flex items-center justify-between">
-                    <button
-                      type="button"
-                      onClick={() => setShowPreview(prev => !prev)}
-                      className="flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors text-neutral3 hover:text-neutral5 hover:bg-surface3"
-                    >
-                      <Icon size="sm">{showPreview ? <Pencil /> : <Eye />}</Icon>
-                      {showPreview ? 'Edit' : 'Preview'}
-                    </button>
-                  </div>
-                )}
               </div>
 
-              {readOnly || showPreview ? (
-                <ReadOnlyInstructions blocks={instructionBlocks} />
-              ) : (
-                <InstructionBlocksPage />
-              )}
+              {readOnly ? <ReadOnlyInstructions blocks={instructionBlocks} /> : <InstructionBlocksPage />}
             </TabContent>
 
             <TabContent value="tools" className="px-4 py-0 pb-4">


### PR DESCRIPTION
Removes the Preview/Edit toggle from the writable agent system prompt tab. Writable agents now keep instruction blocks in edit mode, while read-only and version comparison states still use the read-only rendering.

The toggle only swapped to a compact read-only view of the same blocks, so it added an extra mode switch without previewing a fully resolved prompt.

Validated with `pnpm --filter ./packages/playground test:run src/domains/agents/components/__tests__/agent-playground-config.test.tsx`, `pnpm --filter ./packages/playground typecheck`, `pnpm --filter ./packages/playground lint`, `pnpm exec prettier --check packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx packages/playground/src/domains/agents/components/__tests__/agent-playground-config.test.tsx`, `git diff --check`, and `npx -y react-doctor@latest . --verbose --scope changed`. Playground lint passes with existing warnings outside this change. The changeset CLI reported 0 changed packages, so no changeset file was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change keeps the system prompt editor open and editable instead of switching it into a preview view. If you can edit an agent, you now keep editing the instruction blocks directly; only read-only and comparison views stay locked.

## Summary
- Removed the Preview/Edit toggle from the writable agent system prompt tab.
- Made writable agents always render the editable instruction blocks view.
- Kept read-only rendering for read-only and version comparison states.
- Added a test to verify the System Prompt tab shows instruction blocks in edit mode and no Preview/Edit buttons.

## Validation
- Component tests
- Typecheck
- Lint
- Prettier
- `git diff --check`
- `react-doctor`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->