### PR TITLE
fix(core): skip guaranteed-miss storage read in createRun for transient runs

### DIFF
--- a/.changeset/fair-boxes-tan.md
+++ b/.changeset/fair-boxes-tan.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed slow agent streaming with remote storage: output processors run an internal workflow once per streamed chunk, and each run performed a storage read that could never hit (the run id is freshly generated and these transient workflows never persist a snapshot). On high-latency databases this throttled token delivery to roughly one storage round-trip per token. The guaranteed-miss read is now skipped for freshly-created transient runs. (#19015)

--- a/packages/core/src/agent/__tests__/processor-workflow-storage-noise.test.ts
+++ b/packages/core/src/agent/__tests__/processor-workflow-storage-noise.test.ts
@@ -77,11 +77,13 @@ function buildAgentWithProcessor() {
 }
 
 describe('agent processor-workflow storage noise (issue #17137 follow-up to #17344)', () => {
-  it('gives the internal processor workflow access to storage (no "storage is not initialized" branch)', async () => {
-    // The buggy processor workflow used its own un-registered logger, so spying on the Mastra
-    // logger does not see the noise. Instead, assert the root cause directly: when
-    // getWorkflowRunById runs for the processor workflow it now has storage, so the
-    // no-storage debug branch is unreachable.
+  it('does not read storage (getWorkflowRunById) for the internal processor workflow on generate', async () => {
+    // #19015 short-circuits createRun's storage existence read for transient workflows
+    // (shouldPersistSnapshot: () => false) that mint a fresh runId. The internal
+    // processor workflow is exactly that, so its createRun no longer calls
+    // getWorkflowRunById at all. This strictly subsumes the original #17137/#17344
+    // no-noise goal: a lookup that never runs can never hit the "storage is not
+    // initialized" branch.
     const seen: Array<{ id: string; hasStorage: boolean }> = [];
     const original = (Workflow.prototype as unknown as { getWorkflowRunById: (...a: unknown[]) => unknown })
       .getWorkflowRunById;
@@ -100,8 +102,7 @@ describe('agent processor-workflow storage noise (issue #17137 follow-up to #173
     }
 
     const processorLookups = seen.filter(s => s.id === PROCESSOR_WORKFLOW_ID);
-    expect(processorLookups.length).toBeGreaterThan(0);
-    expect(processorLookups.every(s => s.hasStorage)).toBe(true);
+    expect(processorLookups).toEqual([]);
   });
 
   it('does not persist a snapshot for the internal processor workflow on generate', async () => {

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1663,9 +1663,13 @@ export class EventedWorkflow<
       stepResults: {},
     });
 
-    const existingRun = await this.getWorkflowRunById(runIdToUse, {
-      withNestedWorkflows: false,
-    });
+    // A freshly-minted run for a workflow that never persists a snapshot cannot have
+    // a stored row, so this existence read would be a guaranteed miss. Skipping it
+    // avoids a storage round trip on every createRun for transient workflows (#19015).
+    const existingRun =
+      shouldPersistSnapshot || options?.runId
+        ? await this.getWorkflowRunById(runIdToUse, { withNestedWorkflows: false })
+        : undefined;
 
     // Check if run exists in persistent storage (not just in-memory)
     const existsInStorage = existingRun && !existingRun.isFromInMemory;

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1076,3 +1076,78 @@ describe('Workflow (Default Engine Specifics)', () => {
     });
   });
 });
+
+describe('createRun storage existence read (issue #19015)', () => {
+  const ioSchema = z.object({ value: z.string() });
+  const buildStep = () =>
+    createStep({
+      id: 'passthrough',
+      inputSchema: ioSchema,
+      outputSchema: ioSchema,
+      execute: async ({ inputData }) => inputData,
+    });
+
+  it('skips the storage read for a transient (non-persisting) workflow with a freshly minted runId', async () => {
+    const storage = new MockStore();
+    const workflow = createWorkflow({
+      id: 'transient-createrun-wf',
+      inputSchema: ioSchema,
+      outputSchema: ioSchema,
+      options: { shouldPersistSnapshot: () => false },
+    })
+      .then(buildStep())
+      .commit();
+    new Mastra({ logger: false, storage, workflows: { 'transient-createrun-wf': workflow } });
+
+    const workflowsStore = await storage.getStore('workflows');
+    const readSpy = vi.spyOn(workflowsStore!, 'getWorkflowRunById');
+    const persistSpy = vi.spyOn(workflowsStore!, 'persistWorkflowSnapshot');
+
+    await workflow.createRun();
+
+    // The run id was just generated and the workflow never persists a snapshot, so
+    // the existence read would be a guaranteed miss — it must be short-circuited.
+    expect(readSpy).not.toHaveBeenCalled();
+    expect(persistSpy).not.toHaveBeenCalled();
+  });
+
+  it('still reads storage for a default (persisting) workflow', async () => {
+    const storage = new MockStore();
+    const workflow = createWorkflow({
+      id: 'persisting-createrun-wf',
+      inputSchema: ioSchema,
+      outputSchema: ioSchema,
+    })
+      .then(buildStep())
+      .commit();
+    new Mastra({ logger: false, storage, workflows: { 'persisting-createrun-wf': workflow } });
+
+    const workflowsStore = await storage.getStore('workflows');
+    const readSpy = vi.spyOn(workflowsStore!, 'getWorkflowRunById');
+
+    await workflow.createRun();
+
+    expect(readSpy).toHaveBeenCalled();
+  });
+
+  it('still reads storage for a transient workflow when an explicit runId is provided', async () => {
+    const storage = new MockStore();
+    const workflow = createWorkflow({
+      id: 'transient-explicit-createrun-wf',
+      inputSchema: ioSchema,
+      outputSchema: ioSchema,
+      options: { shouldPersistSnapshot: () => false },
+    })
+      .then(buildStep())
+      .commit();
+    new Mastra({ logger: false, storage, workflows: { 'transient-explicit-createrun-wf': workflow } });
+
+    const workflowsStore = await storage.getStore('workflows');
+    const readSpy = vi.spyOn(workflowsStore!, 'getWorkflowRunById');
+
+    // An explicit runId may reference an existing (resumable) run, so the read must run.
+    await workflow.createRun({ runId: 'explicit-run-id' });
+
+    expect(readSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2361,9 +2361,14 @@ export class Workflow<
       stepResults: {},
     });
 
-    const existingRun = await this.getWorkflowRunById(runIdToUse, {
-      withNestedWorkflows: false,
-    });
+    // A freshly-minted run for a workflow that never persists a snapshot (e.g. the
+    // transient processor workflows from #17344) cannot have a stored row, so this
+    // existence read would be a guaranteed miss. Skipping it removes one storage
+    // round trip per streamed chunk on the agent output-processor hot path (#19015).
+    const existingRun =
+      shouldPersistSnapshot || options?.runId
+        ? await this.getWorkflowRunById(runIdToUse, { withNestedWorkflows: false })
+        : undefined;
 
     // Check if run exists in persistent storage (not just in-memory)
     const existsInStorage = existingRun && !existingRun.isFromInMemory;


### PR DESCRIPTION
## Description

Agents run their output processors as an internal `${agentId}-output-processor` workflow, and that workflow is executed once per streamed chunk. Every one of those runs called `Workflow.createRun`, which did an unconditional `getWorkflowRunById` storage read to check whether the run already exists. But the run id is freshly generated on that same call, and these processor workflows hard-code `shouldPersistSnapshot: () => false`, so they never write a snapshot row — the read can never return anything. On a high-latency storage adapter this turned into one storage round-trip per streamed token (the issue reports token delivery dropping to ~4.7 tok/s, ~212ms between chunks, on a ~210ms-RTT Postgres).

The fix skips that existence read when the run id was just generated *and* the workflow never persists a snapshot. Persisting workflows, and any call that passes an explicit `runId` (resume), still read exactly as before, so behavior is unchanged for them.

Before:

```ts
// createRun, on every streamed chunk of an agent with output processors / memory:
const existingRun = await this.getWorkflowRunById(runIdToUse, { withNestedWorkflows: false });
// guaranteed miss — fresh runId, and the workflow never persists — but still a storage round-trip
```

After:

```ts
const existingRun =
  shouldPersistSnapshot || options?.runId
    ? await this.getWorkflowRunById(runIdToUse, { withNestedWorkflows: false })
    : undefined;
```

The same guard is applied to the evented engine's `createRun` for consistency.

## Related issue(s)

Fixes #19015

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

_Disclosure: I used AI assistance (Claude Code) to investigate and prepare this change._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops the app from doing a pointless “go look for something that can’t be there” storage check for temporary streaming workflows. That makes streamed agent responses faster, while keeping the old behavior for runs that are meant to be saved or resumed later.

## Summary
- Skips the `getWorkflowRunById` storage read in `Workflow.createRun()` when a run is freshly created and the workflow does not persist snapshots.
- Preserves storage lookup behavior when snapshots are persisted or when an explicit `runId` is provided for resume behavior.
- Applies the same guard in the evented workflow engine’s `createRun()`.
- Updates tests to cover the non-persisting transient workflow path, the persisting path, and explicit `runId` behavior.
- Adds a changeset documenting the `@mastra/core` patch and the streaming/storage performance fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->