### PR TITLE
Revert "fix(deployer): resolve metadata for exported packages"

### DIFF
--- a/packages/deployer/src/build/package-info.test.ts
+++ b/packages/deployer/src/build/package-info.test.ts
@@ -10,34 +10,6 @@ afterEach(async () => {
 });
 
 describe('getPackageMetadata', () => {
-  it('reads metadata for packages that do not export package.json', async () => {
-    const tempRoot = join(process.cwd(), '.tmp');
-    await mkdir(tempRoot, { recursive: true });
-    const tempDir = await mkdtemp(join(tempRoot, 'package-metadata-'));
-    tempDirs.push(tempDir);
-
-    const packageDir = join(tempDir, 'node_modules', 'hidden-package-json');
-    await mkdir(packageDir, { recursive: true });
-    await writeFile(
-      join(packageDir, 'package.json'),
-      JSON.stringify({
-        name: 'hidden-package-json',
-        version: '9.6.1',
-        type: 'module',
-        exports: {
-          '.': './index.js',
-        },
-      }),
-    );
-    await writeFile(join(packageDir, 'index.js'), `export const value = true;`);
-
-    await expect(getPackageMetadata('hidden-package-json', tempDir)).resolves.toMatchObject({
-      rootPath: packageDir,
-      version: '9.6.1',
-      packageSpec: undefined,
-    });
-  });
-
   it('falls back from a package subpath to the package root metadata', async () => {
     const tempRoot = join(process.cwd(), '.tmp');
     await mkdir(tempRoot, { recursive: true });

--- a/packages/deployer/src/build/package-info.ts
+++ b/packages/deployer/src/build/package-info.ts
@@ -3,72 +3,16 @@
  * It is in a separate file to avoid including local-pkg in runtime code.
  */
 
-import { existsSync, statSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 import { readJSON } from 'fs-extra/esm';
 import { getPackageInfo } from 'local-pkg';
 import { getPackageName } from './utils';
-
-const moduleRequire = createRequire(import.meta.url);
-
-async function findPackageRootPath(resolvedPath: string, packageName: string): Promise<string | null> {
-  let currentDir = dirname(resolvedPath);
-
-  while (currentDir !== dirname(currentDir)) {
-    try {
-      const pkgJson = await readJSON(join(currentDir, 'package.json'));
-      if (!packageName || pkgJson.name === packageName) {
-        return currentDir;
-      }
-    } catch {
-      // Keep walking up until we find the package boundary.
-    }
-
-    currentDir = dirname(currentDir);
-  }
-
-  return null;
-}
-
-async function resolvePackageRootPath(packageName: string, parentPath?: string): Promise<string | null> {
-  try {
-    const requestedPackageName = getPackageName(packageName);
-    const resolveBasePath = parentPath ? getResolveBasePath(parentPath) : null;
-    if (resolveBasePath && !existsSync(resolveBasePath)) {
-      return null;
-    }
-
-    const resolver = resolveBasePath
-      ? createRequire(pathToFileURL(join(resolveBasePath, '__mastra_resolve__.js')))
-      : moduleRequire;
-    const resolvedPath = resolver.resolve(packageName);
-
-    return findPackageRootPath(resolvedPath, requestedPackageName ?? packageName);
-  } catch {
-    return null;
-  }
-}
-
-function getResolveBasePath(parentPath: string): string {
-  const filePath = parentPath.startsWith('file://') ? fileURLToPath(parentPath) : parentPath;
-
-  try {
-    return statSync(filePath).isDirectory() ? filePath : dirname(filePath);
-  } catch {
-    return dirname(filePath);
-  }
-}
 
 /**
  * Get package root path
  */
 export async function getPackageRootPath(packageName: string, parentPath?: string): Promise<string | null> {
-  let rootPath = await resolvePackageRootPath(packageName, parentPath);
-  if (rootPath) {
-    return rootPath;
-  }
+  let rootPath: string | null;
 
   try {
     let options: { paths?: string[] } | undefined = undefined;


### PR DESCRIPTION
Reverts mastra-ai/mastra#18930

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change undoes a previous fix that tried to better find metadata for packages that were exported in a special way. In simple terms, it takes the deployer back to the older behavior for locating package info and removes the related test coverage.

### What changed
- Reverted the package root/metadata lookup logic in `packages/deployer/src/build/package-info.ts` back from the newer `local-pkg`-based approach.
- Removed the test that covered metadata resolution for packages that do not export `package.json`.
- Kept the remaining fallback behavior test for resolving subpaths to package-root metadata.

### Impact
- Restores the prior deployer metadata resolution behavior.
- Narrows test coverage to match the reverted implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->