### PR TITLE
skill: discourage className-only test assertions

### DIFF
--- a/.claude/skills/playground-msw-tests/SKILL.md
+++ b/.claude/skills/playground-msw-tests/SKILL.md
@@ -48,6 +48,10 @@ contract.
 - ❌ Implementation-mirror tests — do not duplicate source class strings,
   branch logic, generated shapes, or calculations without asserting a real
   behavior or regression.
+- ❌ Class-name-only visual tests — `expect(node.className).toContain(...)`
+  usually just tests that the implementation string exists. Prefer no test over
+  a className duplication test; use computed style, user-visible behavior, or a
+  browser/Storybook check unless the class string itself is the public API.
 - ❌ Inline TypeScript types in tests (`type AgentLite = { id: string }`) —
   these drift silently from the real SDK.
 - ❌ `as any` / `as unknown as ListAgentsResponse` on fixture data, MSW

--- a/.claude/skills/react-best-practices/SKILL.md
+++ b/.claude/skills/react-best-practices/SKILL.md
@@ -7,7 +7,7 @@ description: React performance optimization guidelines from Mastra Engineering. 
 
 ## Overview
 
-Routing and priority guide for React performance and quality, containing 21 rules across 9 categories. Rule files hold the detailed explanations, examples, review smells, and impact metrics.
+Routing and priority guide for React performance and quality, containing 22 rules across 9 categories. Rule files hold the detailed explanations, examples, review smells, and impact metrics.
 
 ## When to Apply
 
@@ -74,6 +74,7 @@ Rules are prioritized by impact:
 **Testing:**
 
 - BDD tests that drive the real `@mastra/client-js` + React Query stack and mock only the network; never `vi.mock` our own hooks/services/auth gating or the SDK (`testing-bdd-no-mocks`)
+- Avoid class-name assertions for visual behavior; prefer computed styles, user-visible behavior, or browser validation, and prefer no test over a className-only implementation mirror (`testing-no-classname-assertions`)
 
 **Type Safety:**
 
@@ -117,4 +118,4 @@ grep -l "Tanstack" references/rules/
 - `js-*` - JavaScript micro-optimizations (3 rules)
 - `types-*` - Type-safety / no-`as`-cast rules (1 rule)
 - `structure-*` - Component/hook structure (6 rules)
-- `testing-*` - BDD tests + mock-only-the-network policy (1 rule)
+- `testing-*` - BDD tests + mock-only-the-network policy + no className implementation-mirror assertions (2 rules)

--- a/.claude/skills/react-best-practices/references/react-best-practices-reference.md
+++ b/.claude/skills/react-best-practices/references/react-best-practices-reference.md
@@ -4,7 +4,7 @@
 Mastra Engineering
 January 2026
 
-This catalog is an index for React performance and quality guidance used by agents and LLMs. It contains 21 rules across 9 categories, prioritized by impact. The canonical guidance — detailed explanations, incorrect vs. correct examples, review smells, and impact metrics — lives in `references/rules/*.md`.
+This catalog is an index for React performance and quality guidance used by agents and LLMs. It contains 22 rules across 9 categories, prioritized by impact. The canonical guidance — detailed explanations, incorrect vs. correct examples, review smells, and impact metrics — lives in `references/rules/*.md`.
 
 ## How to Use This Catalog
 
@@ -23,7 +23,7 @@ This catalog is an index for React performance and quality guidance used by agen
 | 5        | Rendering Performance     | MEDIUM                        | 2          |
 | 6        | JavaScript Performance    | LOW-MEDIUM                    | 3          |
 | 7        | Component Structure       | MEDIUM-HIGH (maintainability) | 6          |
-| 8        | Testing                   | MEDIUM-HIGH (correctness)     | 1          |
+| 8        | Testing                   | MEDIUM-HIGH (correctness)     | 2          |
 | 9        | Type Safety               | HIGH                          | 1          |
 
 ## Category Focus
@@ -37,7 +37,7 @@ This catalog is an index for React performance and quality guidance used by agen
 | Rendering Performance     | Optimizing the rendering process reduces the work the browser needs to do.                                                                                                                     |
 | JavaScript Performance    | Micro-optimizations for hot paths can add up to meaningful improvements.                                                                                                                       |
 | Component Structure       | Bloated components are hard to test, review, and reuse, and unrelated state changes re-render everything.                                                                                      |
-| Testing                   | Drive the real client + React Query stack and mock only the network, so a green test proves production behavior, not the mock.                                                                 |
+| Testing                   | Drive the real client + React Query stack and mock only the network; assert behavior or computed styles instead of implementation class strings.                                               |
 | Type Safety               | Never cast with `as`; let production boundary types flow through and narrow with real type guards, query generics, typed factories, or `implements` so the compiler still catches shape drift. |
 
 ## Rules
@@ -98,9 +98,10 @@ This catalog is an index for React performance and quality guidance used by agen
 
 ### 8. Testing
 
-| Rule                   | Title                                | Impact      | Summary                                                                                                                 | Canonical file                             |
-| ---------------------- | ------------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `testing-bdd-no-mocks` | BDD Tests That Mock Only the Network | MEDIUM-HIGH | Drive the real `@mastra/client-js` + React Query stack and mock only the network; write tests BDD-style. Lint-enforced. | `references/rules/testing-bdd-no-mocks.md` |
+| Rule                              | Title                                          | Impact      | Summary                                                                                                                   | Canonical file                                        |
+| --------------------------------- | ---------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `testing-bdd-no-mocks`            | BDD Tests That Mock Only the Network           | MEDIUM-HIGH | Drive the real `@mastra/client-js` + React Query stack and mock only the network; write tests BDD-style. Lint-enforced.   | `references/rules/testing-bdd-no-mocks.md`            |
+| `testing-no-classname-assertions` | Avoid ClassName Assertions for Visual Behavior | MEDIUM-HIGH | Prefer computed styles, behavior, or browser validation over class-name assertions that duplicate implementation strings. | `references/rules/testing-no-classname-assertions.md` |
 
 ### 9. Type Safety
 

--- a/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
+++ b/.claude/skills/react-best-practices/references/rules/testing-bdd-no-mocks.md
@@ -86,6 +86,7 @@ describe('AgentEditPage', () => {
 - **Inner `describe('when <context>')`** = one precondition: an input shape, an RBAC capability, a feature flag, or a loading/error/empty/success state — each set up with a **real MSW fixture**, never a mocked hook.
 - **`it('<outcome>')`** = one Then. Split multi-assert cases into separate `it`s so a failure names the exact broken outcome.
 - Avoid implementation-mirror tests: do not duplicate source class strings, branch logic, generated shapes, or calculations unless the assertion protects a real behavior or regression.
+- For class-name assertions specifically, use `testing-no-classname-assertions`: prefer computed style, user-visible behavior, or browser validation over duplicating visual implementation tokens.
 - Keep single-context units **flat** — don't nest `when` blocks for their own sake.
 
 Fixtures live in a nearby `__tests__/fixtures/` folder, typed with response types re-exported from `@mastra/client-js`. No bespoke inline types that drift from the SDK.

--- a/.claude/skills/react-best-practices/references/rules/testing-no-classname-assertions.md
+++ b/.claude/skills/react-best-practices/references/rules/testing-no-classname-assertions.md
@@ -56,15 +56,17 @@ the rendered border, or that another class does not override it.
 ### Correct
 
 ```tsx
-it('removes the focused editor outline', () => {
+it('removes the focused editor outline', async () => {
+  const user = userEvent.setup();
   const { container } = render(<CodeEditor value="content" />);
+  const textbox = screen.getByRole('textbox');
   const editor = container.querySelector<HTMLElement>('.cm-editor');
 
   if (!editor) {
     throw new Error('Expected CodeMirror editor');
   }
 
-  editor.classList.add('cm-focused');
+  await user.click(textbox);
 
   expect(getComputedStyle(editor).outline).toBe('none');
 });

--- a/.claude/skills/react-best-practices/references/rules/testing-no-classname-assertions.md
+++ b/.claude/skills/react-best-practices/references/rules/testing-no-classname-assertions.md
@@ -1,0 +1,93 @@
+---
+title: Avoid ClassName Assertions for Visual Behavior
+impact: MEDIUM-HIGH
+impactDescription: className assertions usually duplicate implementation strings without proving user-visible behavior, so they create brittle false confidence
+tags: testing, classname, computed-style, jsdom, visual-regression
+---
+
+## Avoid ClassName Assertions for Visual Behavior
+
+Do not assert generated `className` strings to prove visual behavior. A test like
+`expect(node.className).toContain('border-border2')` usually only proves that
+the source string was copied into the test. It does not prove the browser
+receives the intended style, the selector wins, focus/hover state works, or the
+user-visible behavior exists.
+
+Prefer **no test** over a class-name-only test that just duplicates the
+implementation. Add the test when it can fail for a real product regression.
+
+### Preferred assertions
+
+- User-visible behavior: text, roles, ARIA state, disabled state, keyboard flow,
+  selected/current state, validation messages, navigation, or submitted data.
+- Computed style in jsdom when the behavior is CSS: `getComputedStyle(element)`
+  for `outline`, `borderColor`, `display`, `visibility`, `overflow`,
+  `textOverflow`, `whiteSpace`, `pointerEvents`, etc.
+- Actual DOM measurements when the regression is layout/overflow:
+  `scrollWidth > clientWidth`, stable dimensions, or rendered height/width.
+- Playwright or Storybook/browser validation when jsdom cannot model the real
+  behavior: pseudo-elements, media queries, hover/focus rendering, layout engine
+  differences, screenshots, or canvas/animation state.
+
+### Good exceptions
+
+Class assertions are acceptable when the class string is the public contract:
+
+- A component explicitly promises to forward a caller-provided `className`.
+- A class builder, CVA recipe, or Tailwind merge utility is the unit under test.
+- A public slot/classNames API documents specific slot keys or passthrough
+  behavior.
+
+Even then, test the public contract, not incidental design-system tokens.
+
+### Incorrect
+
+```tsx
+it('shows a focused border', () => {
+  render(<InputGroup />);
+
+  expect(screen.getByTestId('input-group').className).toContain('focus-within:border-neutral5/50');
+});
+```
+
+This duplicates the implementation. It does not prove the focused state changes
+the rendered border, or that another class does not override it.
+
+### Correct
+
+```tsx
+it('removes the focused editor outline', () => {
+  const { container } = render(<CodeEditor value="content" />);
+  const editor = container.querySelector<HTMLElement>('.cm-editor');
+
+  if (!editor) {
+    throw new Error('Expected CodeMirror editor');
+  }
+
+  editor.classList.add('cm-focused');
+
+  expect(getComputedStyle(editor).outline).toBe('none');
+});
+```
+
+### Correct when layout is the behavior
+
+```tsx
+it('truncates long labels instead of expanding the row', () => {
+  render(<StatusBadge label="A very long status label that must truncate" />);
+  const label = screen.getByText(/very long status/);
+
+  expect(getComputedStyle(label).overflowX).toBe('hidden');
+  expect(getComputedStyle(label).textOverflow).toBe('ellipsis');
+  expect(label.scrollWidth).toBeGreaterThan(label.clientWidth);
+});
+```
+
+### Review smells
+
+- `expect(element.className).toContain(...)` for a visual result.
+- Tests that grep for Tailwind tokens (`bg-*`, `border-*`, `outline-*`,
+  `rounded-*`, `text-*`) instead of proving rendered behavior.
+- Snapshot tests whose only meaningful assertion is a class list.
+- Tests that pass because a variant returned the expected class but would still
+  pass if Tailwind stopped generating the utility or another selector won.


### PR DESCRIPTION
Adds a React best-practices testing rule for avoiding className-only assertions when the test is meant to prove visual behavior.

The rule calls out the main smell: these tests usually duplicate the implementation string and can pass without proving rendered behavior. It recommends computed styles, user-visible behavior, DOM measurements, or browser/Storybook validation instead, and explicitly says no test is usually better than a className-only implementation mirror.

It still leaves room for the good exceptions: className forwarding, class builder/CVA utilities, Tailwind merge helpers, and documented slot/classNames APIs where the class string is the public contract.

Also adds a short pointer in `playground-msw-tests` and cross-links from the existing BDD testing rule.

Validated with Prettier, skill quick validation for `react-best-practices` and `playground-msw-tests`, a rule-count check showing 22 total React rules and 2 testing rules, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR helps you write better UI tests by discouraging tests that only check a component’s `className` string when you actually care whether it looks/behaves correctly. Instead, it points you to checks that reflect what users experience (styles, layout, accessibility/interaction states, or real browser validation).

### What changed
- Added a new React best-practices testing rule: **disallow `className`-only (class-name-only) assertions for visual behavior**, and explained that these often just mirror implementation tokens instead of proving rendered behavior.
- Documented better alternatives, including:
  - asserting **computed styles**
  - asserting **user-visible / accessibility states** (including interaction like focus)
  - using **DOM/layout measurements** for things like overflow/truncation
  - validating in a **real browser / Storybook** when jsdom can’t render CSS accurately
- Allowed narrowly scoped exceptions where class strings are part of the **public contract**, such as:
  - className forwarding
  - documented class builder/CVA/recipe utilities
  - Tailwind merge helpers
  - documented slot/pass-through classNames APIs
- Updated related documentation and rule catalog:
  - React best-practices docs + rule catalog now reflect the expanded Testing rule set (22 total rules).
  - Cross-linked the new guidance from the existing BDD testing rule.
  - Added a short pointer in `playground-msw-tests`.
- Documentation includes “incorrect vs correct” examples and a “review smells” checklist for token-grep/class-list assertions.
- Validation steps mentioned: Prettier, quick validation for `react-best-practices` and `playground-msw-tests`, a rule-count check, and `git diff --check`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->