### PR TITLE
fix(memory): honor per-call observationalMemory:false when OM is enabled on the instance

### DIFF
--- a/.changeset/fix-om-per-call-disable.md
+++ b/.changeset/fix-om-per-call-disable.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed disabling Observational Memory for a single call. Previously, passing `observationalMemory: false` for one request had no effect when Observational Memory was already enabled on the Memory instance — it stayed active. This per-request override is now respected correctly.

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -2768,4 +2768,31 @@ describe('Memory', () => {
       expect(childSpan.error).not.toHaveBeenCalled();
     });
   });
+
+  describe('per-call observationalMemory override (#18943)', () => {
+    const withOMEnabled = () =>
+      new Memory({
+        storage: new InMemoryStore(),
+        options: { observationalMemory: { enabled: true } },
+      });
+
+    it('adds the observational-memory input processor when OM is enabled on the instance', async () => {
+      const memory = withOMEnabled();
+      const processors = await memory.getInputProcessors([], new RequestContext());
+      expect(processors.find(p => p.id === 'observational-memory')).toBeDefined();
+    });
+
+    it('honors a per-call observationalMemory:false and does not add the OM processor', async () => {
+      const memory = withOMEnabled();
+      const requestContext = new RequestContext();
+      // Per-call disable, even though OM is enabled on the instance. Before the
+      // fix this was silently ignored (the override normalizes to undefined, so
+      // the code fell back to the instance config) and the processor was still
+      // added.
+      requestContext.set('MastraMemory', { memoryConfig: { observationalMemory: false } });
+
+      const processors = await memory.getInputProcessors([], requestContext);
+      expect(processors.find(p => p.id === 'observational-memory')).toBeUndefined();
+    });
+  });
 });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -2999,14 +2999,16 @@ Notes:
     if (hasObservationalMemory) return null;
 
     const runtimeMemory = context?.get('MastraMemory') as { memoryConfig?: RuntimeMemoryConfig } | undefined;
-    const runtimeObservationalMemory = normalizeObservationalMemoryConfig(
-      runtimeMemory?.memoryConfig?.observationalMemory,
-    );
-    const threadConfig = runtimeObservationalMemory
-      ? this.getMergedThreadConfig({
-          ...runtimeMemory?.memoryConfig,
-          observationalMemory: runtimeObservationalMemory,
-        } as MemoryConfigInternal)
+    // Merge in the per-call config whenever it explicitly carries an
+    // `observationalMemory` override, keyed on presence rather than truthiness.
+    // A per-call `observationalMemory: false` normalizes to `undefined`, so
+    // branching on the normalized value would drop the override and fall back
+    // to the instance config — silently ignoring an explicit per-call disable
+    // when OM is enabled on the instance (#18943).
+    const runtimeMemoryConfig = runtimeMemory?.memoryConfig;
+    const hasRuntimeOMOverride = !!runtimeMemoryConfig && 'observationalMemory' in runtimeMemoryConfig;
+    const threadConfig = hasRuntimeOMOverride
+      ? this.getMergedThreadConfig(runtimeMemoryConfig as MemoryConfigInternal)
       : this.threadConfig;
 
     const effectiveConfig = normalizeObservationalMemoryConfig(threadConfig.observationalMemory);


### PR DESCRIPTION
Fixes #18943.

> **Scope note (please read before merge):** #18943 has two parts. This PR fixes only part (2), the per-call disable bug. Part (1), the branch-aware recall selector, is a larger feature and is **intentionally out of scope** here. If maintainers want that feature tracked separately, it should move to a fresh follow-up issue before this merges, since `Fixes #18943` will auto-close the original on merge. Happy to open that follow-up issue on request.

## The two parts of #18943

1. A branch-aware recall selector (a larger feature) — **not addressed in this PR.**
2. A bug where a per-call `observationalMemory: false` is silently ignored when Observational Memory is enabled on the Memory instance — **this is what this PR fixes.**

## Problem

`Memory.getInputProcessors` injects the Observational Memory input processor via `createOMProcessor`. It decided whether a per-call runtime override applied by branching on the *normalized* override:

```ts
const runtimeObservationalMemory = normalizeObservationalMemoryConfig(runtimeMemory?.memoryConfig?.observationalMemory);
const threadConfig = runtimeObservationalMemory ? this.getMergedThreadConfig({ ... }) : this.threadConfig;
```

But `normalizeObservationalMemoryConfig(false)` returns `undefined`, so an explicit per-call `observationalMemory: false` was indistinguishable from "no override provided" — the code fell back to `this.threadConfig` (instance config, OM enabled) and the OM processor was still added. The per-call disable was accepted by the API and silently dropped.

## Fix

Apply the per-call config whenever it carries an `observationalMemory` key (keyed on presence, not truthiness):

```ts
const hasRuntimeOMOverride = !!runtimeMemoryConfig && 'observationalMemory' in runtimeMemoryConfig;
const threadConfig = hasRuntimeOMOverride ? this.getMergedThreadConfig(runtimeMemoryConfig) : this.threadConfig;
```

`getMergedThreadConfig` deep-merges the per-call `false` over the enabled instance value; the merged `observationalMemory: false` then normalizes to `undefined` and `createOMProcessor` returns `null`, so the processor is not added. Callers that pass no override are unchanged.

`createOMProcessor` is the single OM injection point used by both the default engine (`prepare-stream` -> `getInputProcessors`) and the durable engine, so one change covers both.

## Test

Adds a regression describe block in `packages/memory/src/index.test.ts`: with OM enabled on the instance, `getInputProcessors` includes the `observational-memory` processor by default, and a per-call `RequestContext` carrying `{ memoryConfig: { observationalMemory: false } }` now correctly omits it. Fails on `main`, passes with the fix.

## Verification

- New regression test fails on `main`, passes with the fix.
- `@mastra/memory` suite stays green (index + clone-thread-om, 107 tests).
- `pnpm --filter @mastra/memory build` OK; prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a case where turning a feature off just for one request didn’t actually turn it off. Now, if a request says `observationalMemory: false`, it really stays off even when it’s enabled on the Memory instance.

## Summary
- Fixed per-call `observationalMemory: false` overrides in `@mastra/memory`
- Updated merge logic to detect the `observationalMemory` setting by key presence, not truthiness
- Kept instance-level behavior unchanged when no per-call override is provided
- Added regression tests covering:
  - default behavior when Observational Memory is enabled on the instance
  - per-request disable behavior via `RequestContext`
- Added a changeset for a patch release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->