### PR TITLE
fix(core): store workflow references by id in map serialization

### DIFF
--- a/.changeset/big-otters-kiss.md
+++ b/.changeset/big-otters-kiss.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a heap out-of-memory crash at startup when using mapVariable to map init data (or a workflow-typed step) into a step. The serialized workflow graph now stores a reference to the workflow by id instead of inlining the entire live workflow instance (including its logger and nested steps), which could balloon to ~1GB and crash the process during workflow setup. (#19018)

--- a/packages/core/src/workflows/map-initdata-serialization.test.ts
+++ b/packages/core/src/workflows/map-initdata-serialization.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/19018.
+ *
+ * `workflow.map({ field: mapVariable({ initData: <workflow>, path }) })` used to keep
+ * the live `Workflow` instance on the serialized map config. Because `Workflow` extends
+ * `MastraBase` (whose `logger`/`component` are enumerable own fields), `JSON.stringify`
+ * of that config in `.map()` deep-walked the logger and the entire — possibly
+ * self-referential — step graph, ballooning `mapConfig` to ~1GB and OOMing at
+ * `.commit()`/module load, before the length-truncation guard could run.
+ *
+ * The serialized config must store only a lightweight reference (the workflow id), not
+ * the instance. The runtime map iterates the original config and reads `initData` for
+ * truthiness only (via `getInitData()`), so behavior is unchanged.
+ */
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+import { createWorkflow } from './create';
+import { createStep, mapVariable } from './workflow';
+
+const inputSchema = z.object({ cool: z.string() });
+const outputSchema = z.object({ mapped: z.string() });
+
+function buildInitDataMapWorkflow(id: string) {
+  const step1 = createStep({
+    id: `${id}-step1`,
+    inputSchema,
+    outputSchema: z.object({ done: z.boolean() }),
+    execute: async () => ({ done: true }),
+  });
+
+  const workflow = createWorkflow({ id, inputSchema, outputSchema });
+
+  // Self-reference on initData is the real-world OOM trigger: the workflow is fed as
+  // init-data into its own map step.
+  workflow
+    .then(step1)
+    .map(
+      {
+        mapped: mapVariable({ initData: workflow, path: 'cool' }) as any,
+      },
+      { id: 'init-map-step' },
+    )
+    .commit();
+
+  return workflow;
+}
+
+describe('map() initData serialization (issue #19018)', () => {
+  it('stores only a reference to the init-data workflow, not the live instance', () => {
+    const workflow = buildInitDataMapWorkflow('init-oom-wf');
+
+    const entry = workflow.serializedStepGraph.find(
+      (e: any) => e.type === 'step' && e.step?.id === 'init-map-step',
+    ) as any;
+    expect(entry).toBeDefined();
+
+    const mapConfig: string = entry.step.mapConfig;
+
+    // The whole point: the serialized workflow instance (logger + graph) must not leak in.
+    expect(mapConfig).not.toContain('logger');
+    expect(mapConfig).not.toContain('"component"');
+    // Only a reference (the workflow id) is kept.
+    expect(mapConfig).toContain('"initData"');
+    expect(mapConfig).toContain('init-oom-wf');
+  });
+
+  it('still resolves the mapped field from init data at runtime', async () => {
+    const workflow = buildInitDataMapWorkflow('init-runtime-wf');
+    new Mastra({ logger: false, storage: new MockStore(), workflows: { 'init-runtime-wf': workflow } });
+
+    const run = await workflow.createRun();
+    const result = await run.start({ inputData: { cool: 'hello-from-init' } });
+
+    expect(result.status).toBe('success');
+    if (result.status === 'success') {
+      expect(result.result).toEqual({ mapped: 'hello-from-init' });
+    }
+  });
+});

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1894,6 +1894,26 @@ export class Workflow<
             requestContextPath: m.requestContextPath,
             schema: m.schema,
           };
+        } else if (m.initData) {
+          // Store only a reference to the init-data workflow, never the live instance.
+          // A Workflow extends MastraBase, whose `logger`/`component` are enumerable own
+          // fields, so JSON.stringify-ing it below deep-walks the logger and the entire
+          // (possibly self-referential) step graph — ballooning mapConfig and OOMing at
+          // .commit()/module load (#19018). The runtime map iterates the original
+          // mappingConfig, not this serialized copy, and only checks `m.initData` for
+          // truthiness, so a reference is behavior-preserving.
+          a[key] = {
+            initData: m.initData?.id ?? true,
+            path: m.path,
+            schema: m.schema,
+          };
+        } else if (m.step) {
+          // Same reasoning for step references (a step may itself be a workflow, #11124).
+          a[key] = {
+            step: Array.isArray(m.step) ? m.step.map((s: any) => s?.id) : m.step?.id,
+            path: m.path,
+            schema: m.schema,
+          };
         } else {
           a[key] = m;
         }


### PR DESCRIPTION
## Description

`workflow.map({ field: mapVariable({ initData: someWorkflow, path }) })` was keeping the live `Workflow` instance on the serialized map config. Since `Workflow` extends `MastraBase` (whose `logger` and `component` are enumerable own fields), the `JSON.stringify` that `.map()` does to build `mapConfig` deep-walked the logger and the whole — often self-referential — step graph. For a deeply nested workflow that string balloons to ~1GB and the process dies with a heap OOM at `.commit()`/module load, before the existing length-truncation guard can even run. The same reducer branch also kept the live instance for the `mapVariable({ step })` form.

The fix stores just a reference (the workflow/step id) in the serialized config instead of the live instance. The runtime map iterates the original config and only checks `initData` for truthiness (then calls `getInitData()`), so it never reads the reference — behavior is unchanged.

Before:

```ts
// object-form .map() reducer — initData/step entries fell through to:
a[key] = m; // keeps the live Workflow instance, then JSON.stringify walks all of it
```

After:

```ts
} else if (m.initData) {
  a[key] = { initData: m.initData?.id ?? true, path: m.path, schema: m.schema };
} else if (m.step) {
  a[key] = {
    step: Array.isArray(m.step) ? m.step.map(s => s?.id) : m.step?.id,
    path: m.path,
    schema: m.schema,
  };
} else {
  a[key] = m;
}
```

## Related issue(s)

Fixes #19018

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

_Disclosure: I used AI assistance (Claude Code) to investigate and prepare this change._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops the app from copying a whole workflow object into saved map settings, which could make files huge and even crash from running out of memory. Instead, it saves a small ID reference and still works the same when the workflow runs.

## Summary
- Fixed `Workflow.map()` serialization so `mapVariable({ initData })` no longer embeds a live `Workflow` instance.
- Updated `mapVariable({ step })` serialization to store step ID references instead of full step objects.
- Kept runtime behavior unchanged; execution still resolves `initData` and mapped steps as before.
- Added regression tests covering both the serialization size fix and runtime behavior.
- Documented the fix in the changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->