### PR TITLE
docs(skills-agent-approval): fixed syntax in skills docs and added code snippet example for runtime suspension of tools

### DIFF
--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -125,6 +125,29 @@ A tool can also pause _during_ its `execute` function by calling `suspend()`. Th
 
 The stream emits a `tool-call-suspended` chunk with a custom payload defined by the tool's `suspendSchema`. You resume by calling `resumeStream()` with data matching the tool's `resumeSchema`.
 
+```typescript
+const weatherTool = createTool({
+  id: 'get-weather',
+  inputSchema: z.object({
+    location: z.string().optional(),
+  }),
+  suspendSchema: z.object({
+    question: z.string(),
+  }),
+  resumeSchema: z.object({
+    location: z.string(),
+  }),
+  execute: async ({ location }, context) => {
+    if (!location) {
+      return await context?.agent?.suspend({
+        question: 'Which city would you like the weather for?',
+      });
+    }
+    return await fetchWeather(location);
+  },
+});
+```
+
 :::note
 
 `suspend()` doesn't throw — return immediately after calling it (e.g. `return await suspend({ ... })`). Code after `await suspend(...)` still runs before the tool pauses.

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -141,11 +141,11 @@ const weatherTool = createTool({
     if (!location) {
       return await context?.agent?.suspend({
         question: 'Which city would you like the weather for?',
-      });
+      })
     }
-    return await fetchWeather(location);
+    return await fetchWeather(location)
   },
-});
+})
 ```
 
 :::note

--- a/docs/src/content/en/docs/agents/skills.mdx
+++ b/docs/src/content/en/docs/agents/skills.mdx
@@ -139,6 +139,8 @@ export const agent = new Agent({
 
 The resolver function receives `{ requestContext }` and returns a `SkillInput[]` array or a `Promise<SkillInput[]>`.
 
+See [Request Context](/docs/server/request-context) for more on using request context with agents and workflows.
+
 ## Merging with workspace skills
 
 When an agent has both `skills` and a workspace with skills configured, they merge. Agent-level skills take precedence on name conflicts:
@@ -159,7 +161,7 @@ const customReview = createSkill({
   instructions: '...',
 })
 
-export const agent = new Agent({
+export const reviewer = new Agent({
   id: 'reviewer',
   model: '__GATEWAY_OPENAI_MODEL__',
   workspace,


### PR DESCRIPTION
## Description

Improved documentation in two places for `skill` and `agent-approval` pages.

### Skills Page

- Just a very minor syntax correction, the agent is exposed as `agent`. But imported in the next example as `reviewer`. 

<img width="758" height="989" alt="Screenshot 2026-07-07 at 5 23 23 PM" src="https://github.com/user-attachments/assets/60d0f859-764f-46b9-9e00-2f451b7c394e" />

- Next, added a link section to `Request Context` section. When talking about dynamic skill. In the flow of things, `Request context` that is being shared across agents and workflows is not introduced till the later part of the docs. While reading the connection was missing about what does `requestContext` thats passed to skils mean.

<img width="771" height="839" alt="Screenshot 2026-07-07 at 5 27 34 PM" src="https://github.com/user-attachments/assets/4c888c57-59ed-452f-8c05-fee85d64cf7a" />


- Added a example for how a execute can be suspended when the docs is discussing about the suspension and how it doesn't throw etc.

### Current

<img width="719" height="391" alt="Screenshot 2026-07-07 at 5 37 51 PM" src="https://github.com/user-attachments/assets/9bbb965b-7059-497a-b8d6-394f8b9c9921" />

### Updated

<img width="717" height="848" alt="Screenshot 2026-07-07 at 5 37 46 PM" src="https://github.com/user-attachments/assets/8bd557de-2edb-4d1b-87d8-6dd8425ae190" />




## Related issue(s)

Haven't created any, as it's a document update.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR updates the docs so examples match up correctly, explains what “request context” means, and shows how a tool can pause to ask for missing info—without error—and continue later.

## Summary
- Fixed a confusing skills/agent example by renaming the exported agent variable from `agent` to `reviewer` for consistency.
- Added a **Request Context** cross-reference in the **Dynamic skills** section to clarify how `requestContext` is used.
- Expanded the docs with a **runtime suspension** example for `suspend()` showing a tool that pauses when input is missing (using `suspendSchema`/`resumeSchema`) and resumes later, including the note that `suspend()` does not throw and you should return immediately after calling it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->