### PR TITLE
feat(clickhouse): add legacy-to-VNext span migration

### DIFF
--- a/.changeset/legacy-span-migration.md
+++ b/.changeset/legacy-span-migration.md
@@ -1,0 +1,5 @@
+---
+'@mastra/clickhouse': minor
+---
+
+Added legacy-to-VNext span migration for ClickHouse observability storage. Customers using `ObservabilityStorageClickhouse` (legacy) can now run `npx mastra migrate` to copy historical spans from `mastra_ai_spans` to the VNext `mastra_span_events` schema. The migration handles column mapping, batches by day for memory safety, deduplicates legacy rows, converts empty-string parentSpanId to NULL for correct root span detection, and supports both old (`Nullable(String)` JSON) and new (`Array(String)`) tags schemas. The legacy table is preserved as a backup after migration.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -754,6 +754,7 @@ Runs database migrations to update your storage schema. This command is useful w
 The command bundles your project, connects to your configured storage backend, and executes any pending migrations. Currently supports:
 
 - **Duplicate spans migration**: Removes duplicate `(traceId, spanId)` entries and adds a unique constraint to ensure data integrity.
+- **ClickHouse legacy-to-vNext span migration**: Copies historical spans from the legacy `mastra_ai_spans` table to the vNext `mastra_span_events` schema. Runs in batches to stay within memory limits. See the [ClickHouse storage reference](/reference/storage/clickhouse#migrating-from-legacy-to-vnext) for details.
 
 ```bash
 mastra migrate

--- a/docs/src/content/en/reference/storage/clickhouse.mdx
+++ b/docs/src/content/en/reference/storage/clickhouse.mdx
@@ -87,6 +87,20 @@ const observabilityStore = new ObservabilityStorageClickhouse({
 
 New projects should use `ObservabilityStorageClickhouseVNext` instead.
 
+### Migrating from legacy to vNext
+
+To migrate historical spans from the legacy `mastra_ai_spans` table to the vNext schema, run:
+
+```bash npm2yarn
+npx mastra migrate
+```
+
+The migration copies span data from `mastra_ai_spans` into `mastra_span_events` in day-sized batches. It handles column mapping, deduplicates legacy rows, and preserves the original table as a backup. After migration, traces appear in Studio through the vNext adapter.
+
+:::note
+The legacy table is not deleted. Drop it manually after verifying the migration.
+:::
+
 ### ClickHouse for every domain
 
 `ClickhouseStoreVNext` backs the `memory`, `workflows`, and `observability` domains with ClickHouse and uses the vNext observability adapter automatically. Use it when you want ClickHouse to back the entire application without wiring a composite store manually.

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
@@ -127,7 +127,13 @@ import * as discoveryOps from './discovery';
 import * as feedbackOps from './feedback';
 import * as logsOps from './logs';
 import * as metricsOps from './metrics';
-import { checkSignalTablesMigrationStatus, isReplacingMergeTreeEngine, migrateSignalTables } from './migration';
+import {
+  checkLegacySpanMigrationStatus,
+  checkSignalTablesMigrationStatus,
+  isReplacingMergeTreeEngine,
+  migrateLegacySpans,
+  migrateSignalTables,
+} from './migration';
 import type { ClickHouseDeltaCursorStrategy } from './polling';
 import { deltaPollingSupported } from './polling';
 import * as scoresOps from './scores';
@@ -440,6 +446,19 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
       });
     }
 
+    // Non-blocking: detect legacy span table and suggest migration
+    try {
+      const legacyStatus = await checkLegacySpanMigrationStatus(this.#client);
+      if (legacyStatus.needsMigration) {
+        this.logger?.warn?.(
+          `Legacy span table 'mastra_ai_spans' detected. ` +
+            `Run 'npx mastra migrate' to migrate historical spans to the v-next schema.`,
+        );
+      }
+    } catch {
+      // Ignore — non-critical detection
+    }
+
     try {
       await assertExistingTablesCompatibleWithReplication(this.#client, this.#replication);
       const existingStrategy = await detectExistingDeltaCursorStrategy(this.#client);
@@ -559,9 +578,9 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
   }
 
   /**
-   * Manually migrate legacy signal tables to the signal-ID ReplacingMergeTree schema.
-   * The public method name is historical; the CLI still calls `migrateSpans()`
-   * for observability migrations even though this now also migrates signal tables.
+   * Manually migrate legacy tables to the v-next schema.
+   * Handles both signal table migrations (MergeTree → ReplacingMergeTree)
+   * and legacy span migration (mastra_ai_spans → mastra_span_events).
    */
   async migrateSpans(): Promise<{
     success: boolean;
@@ -569,35 +588,47 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
     duplicatesRemoved: number;
     message: string;
   }> {
-    const migrationStatus = await checkSignalTablesMigrationStatus(this.#client);
+    const messages: string[] = [];
 
-    if (!migrationStatus.needsMigration) {
-      return {
-        success: true,
-        alreadyMigrated: true,
-        duplicatesRemoved: 0,
-        message: 'Migration already complete. Signal tables already use signal-ID dedupe keys.',
-      };
+    // Signal table migration
+    const signalStatus = await checkSignalTablesMigrationStatus(this.#client);
+    if (signalStatus.needsMigration) {
+      if (isReplicationConfigured(this.#replication)) {
+        throw new MastraError({
+          id: createStorageErrorId('CLICKHOUSE', 'REPLICATION', 'SIGNAL_TABLES_MIGRATION_UNSUPPORTED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text:
+            'ClickHouse replication is enabled, so Mastra will not run copy-and-swap signal table migrations automatically. ' +
+            'Migrate existing local signal tables manually before enabling replication.',
+        });
+      }
+      await migrateSignalTables(this.#client, this.logger);
+      messages.push(`Migrated signal tables: ${signalStatus.tables.map(t => t.table).join(', ')}.`);
     }
 
-    if (isReplicationConfigured(this.#replication)) {
-      throw new MastraError({
-        id: createStorageErrorId('CLICKHOUSE', 'REPLICATION', 'SIGNAL_TABLES_MIGRATION_UNSUPPORTED'),
-        domain: ErrorDomain.STORAGE,
-        category: ErrorCategory.USER,
-        text:
-          'ClickHouse replication is enabled, so Mastra will not run copy-and-swap signal table migrations automatically. ' +
-          'Migrate existing local signal tables manually before enabling replication.',
-      });
+    // Legacy span migration
+    const legacyStatus = await checkLegacySpanMigrationStatus(this.#client);
+    if (legacyStatus.needsMigration) {
+      if (isReplicationConfigured(this.#replication)) {
+        throw new MastraError({
+          id: createStorageErrorId('CLICKHOUSE', 'REPLICATION', 'LEGACY_SPAN_MIGRATION_UNSUPPORTED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: 'ClickHouse replication is enabled. Migrate legacy mastra_ai_spans manually before enabling replication.',
+        });
+      }
+      const result = await migrateLegacySpans(this.#client, this.logger);
+      messages.push(`Migrated ${result.migratedRows} legacy spans in ${result.batches} batches.`);
     }
 
-    await migrateSignalTables(this.#client, this.logger);
+    const alreadyMigrated = !signalStatus.needsMigration && !legacyStatus.needsMigration;
 
     return {
       success: true,
-      alreadyMigrated: false,
+      alreadyMigrated,
       duplicatesRemoved: 0,
-      message: `Migration complete. Migrated signal tables: ${migrationStatus.tables.map(t => t.table).join(', ')}.`,
+      message: alreadyMigrated ? 'Migration already complete.' : `Migration complete. ${messages.join(' ')}`,
     };
   }
 

--- a/stores/clickhouse/src/storage/domains/observability/v-next/migration.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/migration.test.ts
@@ -16,8 +16,15 @@ import {
   MV_TRACE_ROOTS_DELTA,
   TABLE_LOG_EVENTS,
   TABLE_METRIC_EVENTS,
+  TABLE_SPAN_EVENTS,
+  TABLE_TRACE_ROOTS,
 } from './ddl';
-import { isReplacingMergeTreeEngine, migrateSignalTables } from './migration';
+import {
+  checkLegacySpanMigrationStatus,
+  isReplacingMergeTreeEngine,
+  migrateLegacySpans,
+  migrateSignalTables,
+} from './migration';
 import { ObservabilityStorageClickhouseVNext } from '.';
 
 describe('isReplacingMergeTreeEngine', () => {
@@ -108,6 +115,9 @@ async function dropAll(client: ClickHouseClient): Promise<void> {
   for (const table of ALL_TABLE_NAMES) {
     await client.command({ query: `DROP TABLE IF EXISTS ${table}` });
   }
+  // Drop legacy span migration tables
+  await client.command({ query: `DROP TABLE IF EXISTS mastra_ai_spans` });
+  await client.command({ query: `DROP TABLE IF EXISTS mastra_legacy_span_migration_done` });
   const leftovers = await client.query({
     query: `SELECT name FROM system.tables WHERE database = currentDatabase() AND name LIKE '%_migrating_%'`,
     format: 'JSONEachRow',
@@ -347,5 +357,605 @@ describe('migrateSignalTables (ClickHouse v-next)', () => {
       })
     ).json()) as unknown[];
     expect(leftovers).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy span migration: mastra_ai_spans → mastra_span_events
+// ---------------------------------------------------------------------------
+
+/** Minimal legacy schema — only the columns from OLD_SPAN_SCHEMA (pre-entity-hierarchy). */
+const LEGACY_SPANS_MINIMAL_DDL = `
+CREATE TABLE mastra_ai_spans (
+  "traceId" String,
+  "spanId" String,
+  "parentSpanId" Nullable(String),
+  "name" String,
+  "spanType" String,
+  "isEvent" Bool DEFAULT false,
+  "startedAt" DateTime64(3, 'UTC'),
+  "endedAt" Nullable(DateTime64(3, 'UTC')),
+  "createdAt" DateTime64(3, 'UTC'),
+  "updatedAt" DateTime64(3, 'UTC'),
+  "scope" Nullable(String),
+  "attributes" Nullable(String),
+  "metadata" Nullable(String),
+  "links" Nullable(String),
+  "input" Nullable(String),
+  "output" Nullable(String),
+  "error" Nullable(String)
+)
+ENGINE = ReplacingMergeTree(updatedAt)
+ORDER BY ("traceId", "spanId")
+SETTINGS index_granularity = 8192
+`;
+
+/** Full legacy schema — includes all columns added over time via alterTable. */
+const LEGACY_SPANS_FULL_DDL = `
+CREATE TABLE mastra_ai_spans (
+  "traceId" String,
+  "spanId" String,
+  "parentSpanId" Nullable(String),
+  "name" String,
+  "spanType" String,
+  "isEvent" Bool DEFAULT false,
+  "startedAt" DateTime64(3, 'UTC'),
+  "endedAt" Nullable(DateTime64(3, 'UTC')),
+  "createdAt" DateTime64(3, 'UTC'),
+  "updatedAt" DateTime64(3, 'UTC'),
+  "scope" Nullable(String),
+  "attributes" Nullable(String),
+  "metadata" Nullable(String),
+  "links" Nullable(String),
+  "input" Nullable(String),
+  "output" Nullable(String),
+  "error" Nullable(String),
+  "requestContext" Nullable(String),
+  "source" Nullable(String),
+  "tags" Array(String) DEFAULT [],
+  "entityType" Nullable(String),
+  "entityId" Nullable(String),
+  "entityName" Nullable(String),
+  "entityVersionId" Nullable(String),
+  "parentEntityType" Nullable(String),
+  "parentEntityId" Nullable(String),
+  "parentEntityName" Nullable(String),
+  "parentEntityVersionId" Nullable(String),
+  "rootEntityType" Nullable(String),
+  "rootEntityId" Nullable(String),
+  "rootEntityName" Nullable(String),
+  "rootEntityVersionId" Nullable(String),
+  "userId" Nullable(String),
+  "organizationId" Nullable(String),
+  "resourceId" Nullable(String),
+  "runId" Nullable(String),
+  "sessionId" Nullable(String),
+  "threadId" Nullable(String),
+  "requestId" Nullable(String),
+  "environment" Nullable(String),
+  "serviceName" Nullable(String),
+  "experimentId" Nullable(String)
+)
+ENGINE = ReplacingMergeTree(updatedAt)
+ORDER BY ("traceId", "spanId")
+SETTINGS index_granularity = 8192
+`;
+
+describe('migrateLegacySpans (mastra_ai_spans → mastra_span_events)', () => {
+  let client: ClickHouseClient;
+
+  beforeAll(() => {
+    client = createClient({
+      url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+      username: process.env.CLICKHOUSE_USERNAME || 'default',
+      password: process.env.CLICKHOUSE_PASSWORD || 'password',
+    });
+  });
+
+  beforeEach(async () => {
+    await dropAll(client);
+  });
+
+  afterAll(async () => {
+    await dropAll(client);
+    await client.close();
+  });
+
+  it('is a no-op when legacy table does not exist', async () => {
+    const result = await migrateLegacySpans(client);
+    expect(result).toEqual({ migratedRows: 0, batches: 0 });
+  });
+
+  it('returns needsMigration=false when legacy table does not exist', async () => {
+    const status = await checkLegacySpanMigrationStatus(client);
+    expect(status.needsMigration).toBe(false);
+  });
+
+  it('returns needsMigration=false when legacy table is empty', async () => {
+    await client.command({ query: LEGACY_SPANS_MINIMAL_DDL });
+    const status = await checkLegacySpanMigrationStatus(client);
+    expect(status.needsMigration).toBe(false);
+  });
+
+  it('is a no-op when legacy table exists but is empty', async () => {
+    await client.command({ query: LEGACY_SPANS_MINIMAL_DDL });
+    const result = await migrateLegacySpans(client);
+    expect(result).toEqual({ migratedRows: 0, batches: 0 });
+  });
+
+  it('migrates minimal legacy schema with missing newer columns', async () => {
+    await client.command({ query: LEGACY_SPANS_MINIMAL_DDL });
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          parentSpanId: null,
+          name: 'agent-run',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-01-15 10:00:00.000',
+          endedAt: '2026-01-15 10:00:01.000',
+          createdAt: '2026-01-15 10:00:00.000',
+          updatedAt: '2026-01-15 10:00:01.000',
+          metadata: '{"customKey":"val"}',
+        },
+        {
+          traceId: 'trace-2',
+          spanId: 'span-2',
+          parentSpanId: 'span-1',
+          name: 'tool-call',
+          spanType: 'tool_call',
+          isEvent: false,
+          startedAt: '2026-01-16 12:00:00.000',
+          endedAt: null, // NULL endedAt — should be coalesced
+          createdAt: '2026-01-16 12:00:00.000',
+          updatedAt: '2026-01-16 12:00:00.000',
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    const result = await migrateLegacySpans(client);
+    expect(result.migratedRows).toBe(2);
+    expect(result.batches).toBe(2); // Two different days
+
+    const rows = (await (
+      await client.query({
+        query: `SELECT * FROM ${TABLE_SPAN_EVENTS} ORDER BY startedAt`,
+        format: 'JSONEachRow',
+        clickhouse_settings: { date_time_output_format: 'iso' },
+      })
+    ).json()) as Array<Record<string, unknown>>;
+
+    expect(rows).toHaveLength(2);
+
+    // dedupeKey is traceId:spanId
+    expect(rows[0]!.dedupeKey).toBe('trace-1:span-1');
+    expect(rows[1]!.dedupeKey).toBe('trace-2:span-2');
+
+    // Missing columns are NULL
+    expect(rows[0]!.entityType).toBeNull();
+    expect(rows[0]!.executionSource).toBeNull();
+
+    // NULL endedAt coalesced from startedAt
+    expect(rows[1]!.endedAt).toBe(rows[1]!.startedAt);
+  });
+
+  it('migrates full legacy schema with column renames and metadata transform', async () => {
+    await client.command({ query: LEGACY_SPANS_FULL_DDL });
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          parentSpanId: null,
+          name: 'agent-run',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-03-01 08:00:00.000',
+          endedAt: '2026-03-01 08:00:05.000',
+          createdAt: '2026-03-01 08:00:00.000',
+          updatedAt: '2026-03-01 08:00:05.000',
+          source: 'cloud',
+          tags: ['prod', 'v2'],
+          entityType: 'agent',
+          entityId: 'my-agent',
+          entityName: 'My Agent',
+          metadata: '{"customKey":"val","entityType":"agent","nested":{"deep":true}}',
+          environment: 'production',
+          serviceName: 'my-service',
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    await migrateLegacySpans(client);
+
+    const rows = (await (
+      await client.query({
+        query: `SELECT * FROM ${TABLE_SPAN_EVENTS}`,
+        format: 'JSONEachRow',
+        clickhouse_settings: { date_time_output_format: 'iso' },
+      })
+    ).json()) as Array<Record<string, unknown>>;
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+
+    // source → executionSource rename
+    expect(row.executionSource).toBe('cloud');
+
+    // tags preserved
+    expect(row.tags).toEqual(['prod', 'v2']);
+
+    // entity fields preserved
+    expect(row.entityType).toBe('agent');
+    expect(row.entityId).toBe('my-agent');
+    expect(row.entityName).toBe('My Agent');
+
+    // metadata → metadataRaw rename
+    expect(JSON.parse(row.metadataRaw as string)).toEqual({
+      customKey: 'val',
+      entityType: 'agent',
+      nested: { deep: true },
+    });
+
+    // metadataSearch: only flat string values excluding promoted keys
+    // "entityType" is a promoted key → excluded
+    // "nested" is an object → excluded by JSONExtractKeysAndValues with 'String' type
+    // Only "customKey":"val" should remain
+    const metadataSearch = row.metadataSearch as Record<string, string>;
+    expect(metadataSearch).toHaveProperty('customKey', 'val');
+    expect(metadataSearch).not.toHaveProperty('entityType');
+
+    expect(row.environment).toBe('production');
+    expect(row.serviceName).toBe('my-service');
+  });
+
+  it('deduplicates legacy rows, keeping the latest updatedAt', async () => {
+    await client.command({ query: LEGACY_SPANS_MINIMAL_DDL });
+
+    // Insert two rows with the same (traceId, spanId) but different updatedAt
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-dup',
+          spanId: 'span-dup',
+          name: 'old-version',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-02-01 10:00:00.000',
+          endedAt: '2026-02-01 10:00:01.000',
+          createdAt: '2026-02-01 10:00:00.000',
+          updatedAt: '2026-02-01 10:00:01.000',
+        },
+        {
+          traceId: 'trace-dup',
+          spanId: 'span-dup',
+          name: 'new-version',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-02-01 10:00:00.000',
+          endedAt: '2026-02-01 10:00:02.000',
+          createdAt: '2026-02-01 10:00:00.000',
+          updatedAt: '2026-02-01 10:00:05.000',
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    await migrateLegacySpans(client);
+    await client.command({ query: `OPTIMIZE TABLE ${TABLE_SPAN_EVENTS} FINAL` });
+
+    const rows = (await (
+      await client.query({
+        query: `SELECT name FROM ${TABLE_SPAN_EVENTS}`,
+        format: 'JSONEachRow',
+      })
+    ).json()) as Array<{ name: string }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe('new-version');
+  });
+
+  it('is idempotent: second run does not create extra rows', async () => {
+    await client.command({ query: LEGACY_SPANS_MINIMAL_DDL });
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-idem',
+          spanId: 'span-idem',
+          name: 'test',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-04-01 10:00:00.000',
+          endedAt: '2026-04-01 10:00:01.000',
+          createdAt: '2026-04-01 10:00:00.000',
+          updatedAt: '2026-04-01 10:00:01.000',
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    await migrateLegacySpans(client);
+    await migrateLegacySpans(client);
+    await client.command({ query: `OPTIMIZE TABLE ${TABLE_SPAN_EVENTS} FINAL` });
+
+    const rows = (await (
+      await client.query({
+        query: `SELECT * FROM ${TABLE_SPAN_EVENTS}`,
+        format: 'JSONEachRow',
+      })
+    ).json()) as unknown[];
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it('migrates through migrateSpans() and reports legacy span count', async () => {
+    await client.command({ query: LEGACY_SPANS_MINIMAL_DDL });
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-int',
+          spanId: 'span-int',
+          name: 'integration-test',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-07-01 10:00:00.000',
+          endedAt: '2026-07-01 10:00:01.000',
+          createdAt: '2026-07-01 10:00:00.000',
+          updatedAt: '2026-07-01 10:00:01.000',
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    const store = new ObservabilityStorageClickhouseVNext({ client });
+    const result = await store.migrateSpans();
+
+    expect(result.success).toBe(true);
+    expect(result.alreadyMigrated).toBe(false);
+    expect(result.message).toMatch(/Migrated 1 legacy spans in 1 batches/);
+  });
+
+  it('reports alreadyMigrated when no migrations are needed', async () => {
+    // No legacy table, no signal tables needing migration
+    const store = new ObservabilityStorageClickhouseVNext({ client });
+    const result = await store.migrateSpans();
+
+    expect(result.success).toBe(true);
+    expect(result.alreadyMigrated).toBe(true);
+  });
+
+  it('populates materialized views even without prior init()', async () => {
+    // Migration creates MVs itself — no need for store.init() first.
+    await client.command({ query: LEGACY_SPANS_FULL_DDL });
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-mv',
+          spanId: 'span-root',
+          parentSpanId: null,
+          name: 'root-agent',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-08-01 10:00:00.000',
+          endedAt: '2026-08-01 10:00:05.000',
+          createdAt: '2026-08-01 10:00:00.000',
+          updatedAt: '2026-08-01 10:00:05.000',
+          entityType: 'agent',
+        },
+        {
+          traceId: 'trace-mv',
+          spanId: 'span-child',
+          parentSpanId: 'span-root',
+          name: 'child-tool',
+          spanType: 'tool_call',
+          isEvent: false,
+          startedAt: '2026-08-01 10:00:01.000',
+          endedAt: '2026-08-01 10:00:02.000',
+          createdAt: '2026-08-01 10:00:01.000',
+          updatedAt: '2026-08-01 10:00:02.000',
+          entityType: 'tool',
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    await migrateLegacySpans(client);
+
+    const rootRows = (await (
+      await client.query({
+        query: `SELECT "traceId", "spanId", "name" FROM ${TABLE_TRACE_ROOTS}`,
+        format: 'JSONEachRow',
+      })
+    ).json()) as Array<{ traceId: string; spanId: string; name: string }>;
+
+    expect(rootRows).toHaveLength(1);
+    expect(rootRows[0]!.spanId).toBe('span-root');
+    expect(rootRows[0]!.name).toBe('root-agent');
+  });
+
+  it('converts parentSpanId empty string to NULL so root spans appear in trace_roots', async () => {
+    await client.command({ query: LEGACY_SPANS_MINIMAL_DDL });
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-empty-parent',
+          spanId: 'span-root-empty',
+          parentSpanId: '', // Legacy stores empty string for root spans
+          name: 'root-with-empty-parent',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-09-01 10:00:00.000',
+          endedAt: '2026-09-01 10:00:01.000',
+          createdAt: '2026-09-01 10:00:00.000',
+          updatedAt: '2026-09-01 10:00:01.000',
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    await migrateLegacySpans(client);
+
+    // parentSpanId should be NULL in VNext, not ''
+    const rows = (await (
+      await client.query({
+        query: `SELECT "parentSpanId" FROM ${TABLE_SPAN_EVENTS}`,
+        format: 'JSONEachRow',
+      })
+    ).json()) as Array<{ parentSpanId: string | null }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.parentSpanId).toBeNull();
+
+    // And it should appear in trace_roots MV
+    const rootRows = (await (
+      await client.query({
+        query: `SELECT "spanId" FROM ${TABLE_TRACE_ROOTS}`,
+        format: 'JSONEachRow',
+      })
+    ).json()) as Array<{ spanId: string }>;
+    expect(rootRows).toHaveLength(1);
+    expect(rootRows[0]!.spanId).toBe('span-root-empty');
+  });
+
+  it('handles legacy tags stored as Nullable(String) JSON text', async () => {
+    // Very old schemas store tags as Nullable(String) containing JSON arrays
+    await client.command({
+      query: `
+      CREATE TABLE mastra_ai_spans (
+        "traceId" String,
+        "spanId" String,
+        "parentSpanId" Nullable(String),
+        "name" String,
+        "spanType" String,
+        "isEvent" Bool DEFAULT false,
+        "startedAt" DateTime64(3, 'UTC'),
+        "endedAt" Nullable(DateTime64(3, 'UTC')),
+        "createdAt" DateTime64(3, 'UTC'),
+        "updatedAt" DateTime64(3, 'UTC'),
+        "tags" Nullable(String)
+      )
+      ENGINE = ReplacingMergeTree(updatedAt)
+      ORDER BY ("traceId", "spanId")
+      `,
+    });
+
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-json-tags',
+          spanId: 'span-json-tags',
+          name: 'test',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-10-01 10:00:00.000',
+          endedAt: '2026-10-01 10:00:01.000',
+          createdAt: '2026-10-01 10:00:00.000',
+          updatedAt: '2026-10-01 10:00:01.000',
+          tags: '["prod", "v2", "prod"]', // JSON text with duplicate
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    await migrateLegacySpans(client);
+
+    const rows = (await (
+      await client.query({
+        query: `SELECT "tags" FROM ${TABLE_SPAN_EVENTS}`,
+        format: 'JSONEachRow',
+      })
+    ).json()) as Array<{ tags: string[] }>;
+    expect(rows).toHaveLength(1);
+    // Should be parsed from JSON, deduplicated
+    expect(rows[0]!.tags).toContain('prod');
+    expect(rows[0]!.tags).toContain('v2');
+    expect(rows[0]!.tags.filter(t => t === 'prod')).toHaveLength(1); // deduplicated
+  });
+
+  it('is truly idempotent via marker table — second run skips migration', async () => {
+    await client.command({ query: LEGACY_SPANS_MINIMAL_DDL });
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-marker',
+          spanId: 'span-marker',
+          name: 'test',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-11-01 10:00:00.000',
+          endedAt: '2026-11-01 10:00:01.000',
+          createdAt: '2026-11-01 10:00:00.000',
+          updatedAt: '2026-11-01 10:00:01.000',
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    const first = await migrateLegacySpans(client);
+    expect(first.migratedRows).toBe(1);
+
+    // Second run should detect marker and skip entirely
+    const second = await migrateLegacySpans(client);
+    expect(second.migratedRows).toBe(0);
+    expect(second.batches).toBe(0);
+
+    // Status check should also report no migration needed
+    const status = await checkLegacySpanMigrationStatus(client);
+    expect(status.needsMigration).toBe(false);
+  });
+
+  it('does not skip migration when marker table exists but has no rows (crash recovery)', async () => {
+    // Simulate a crash: marker table was created but INSERT never happened
+    await client.command({
+      query: `CREATE TABLE mastra_legacy_span_migration_done (completedAt DateTime64(3, 'UTC')) ENGINE = MergeTree ORDER BY completedAt`,
+    });
+
+    await client.command({ query: LEGACY_SPANS_MINIMAL_DDL });
+    await client.insert({
+      table: 'mastra_ai_spans',
+      values: [
+        {
+          traceId: 'trace-crash',
+          spanId: 'span-crash',
+          name: 'test',
+          spanType: 'agent_run',
+          isEvent: false,
+          startedAt: '2026-12-01 10:00:00.000',
+          endedAt: '2026-12-01 10:00:01.000',
+          createdAt: '2026-12-01 10:00:00.000',
+          updatedAt: '2026-12-01 10:00:01.000',
+        },
+      ],
+      format: 'JSONEachRow',
+      clickhouse_settings: { date_time_input_format: 'best_effort' },
+    });
+
+    // Empty marker table should NOT suppress migration
+    const status = await checkLegacySpanMigrationStatus(client);
+    expect(status.needsMigration).toBe(true);
+
+    const result = await migrateLegacySpans(client);
+    expect(result.migratedRows).toBe(1);
   });
 });

--- a/stores/clickhouse/src/storage/domains/observability/v-next/migration.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/migration.ts
@@ -8,10 +8,16 @@ import {
   TABLE_LOG_EVENTS,
   TABLE_SCORE_EVENTS,
   TABLE_FEEDBACK_EVENTS,
+  TABLE_SPAN_EVENTS,
   METRIC_EVENTS_DDL,
   LOG_EVENTS_DDL,
   SCORE_EVENTS_DDL,
   FEEDBACK_EVENTS_DDL,
+  SPAN_EVENTS_DDL,
+  TRACE_ROOTS_DDL,
+  TRACE_ROOTS_MV_DDL,
+  TRACE_BRANCHES_DDL,
+  TRACE_BRANCHES_MV_DDL,
 } from './ddl';
 
 interface SignalMigration {
@@ -61,6 +67,12 @@ async function getTableColumns(client: ClickHouseClient, table: string): Promise
   return rows.map(r => r.name);
 }
 
+async function getTableColumnTypes(client: ClickHouseClient, table: string): Promise<Map<string, string>> {
+  const result = await client.query({ query: `DESCRIBE TABLE ${table}`, format: 'JSONEachRow' });
+  const rows = (await result.json()) as Array<{ name: string; type: string }>;
+  return new Map(rows.map(r => [r.name, r.type]));
+}
+
 function buildTemporaryTableDDL(createDDL: string, table: string, tempTable: string): string {
   return createDDL.replace(`CREATE TABLE IF NOT EXISTS ${table}`, `CREATE TABLE ${tempTable}`);
 }
@@ -107,6 +119,288 @@ export async function checkSignalTablesMigrationStatus(client: ClickHouseClient)
  * → drop old data. EXCHANGE swaps the two table names atomically, so concurrent
  * writers never observe a missing table.
  */
+const TABLE_LEGACY_SPANS = 'mastra_ai_spans';
+
+// Keys that have dedicated columns in the VNext schema and should be excluded from metadataSearch.
+// Must stay in sync with PROMOTED_KEYS in helpers.ts.
+const PROMOTED_METADATA_KEYS = [
+  'experimentId',
+  'entityType',
+  'entityId',
+  'entityName',
+  'entityVersionId',
+  'parentEntityVersionId',
+  'rootEntityVersionId',
+  'userId',
+  'organizationId',
+  'resourceId',
+  'runId',
+  'sessionId',
+  'threadId',
+  'requestId',
+  'environment',
+  'executionSource',
+  'serviceName',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Legacy span migration: mastra_ai_spans → mastra_span_events
+// ---------------------------------------------------------------------------
+
+export interface LegacySpanMigrationStatus {
+  needsMigration: boolean;
+}
+
+const TABLE_LEGACY_MIGRATION_DONE = 'mastra_legacy_span_migration_done';
+
+async function hasMarkerRow(client: ClickHouseClient): Promise<boolean> {
+  const engine = await getTableEngine(client, TABLE_LEGACY_MIGRATION_DONE);
+  if (!engine) return false;
+  const result = await client.query({
+    query: `SELECT count() as cnt FROM ${TABLE_LEGACY_MIGRATION_DONE}`,
+    format: 'JSONEachRow',
+  });
+  const rows = (await result.json()) as Array<{ cnt: string | number }>;
+  return Number(rows[0]?.cnt ?? 0) > 0;
+}
+
+export async function checkLegacySpanMigrationStatus(client: ClickHouseClient): Promise<LegacySpanMigrationStatus> {
+  if (await hasMarkerRow(client)) {
+    return { needsMigration: false };
+  }
+
+  const engine = await getTableEngine(client, TABLE_LEGACY_SPANS);
+  if (!engine) {
+    return { needsMigration: false };
+  }
+
+  const countResult = await client.query({
+    query: `SELECT count() as cnt FROM ${TABLE_LEGACY_SPANS}`,
+    format: 'JSONEachRow',
+  });
+  const countRows = (await countResult.json()) as Array<{ cnt: string | number }>;
+  const legacyRowCount = Number(countRows[0]?.cnt ?? 0);
+
+  if (legacyRowCount === 0) {
+    return { needsMigration: false };
+  }
+
+  return { needsMigration: true };
+}
+
+// VNext target columns in DDL order, used for INSERT column list.
+const VNEXT_SPAN_COLUMNS = [
+  'dedupeKey',
+  'traceId',
+  'spanId',
+  'parentSpanId',
+  'experimentId',
+  'entityType',
+  'entityId',
+  'entityName',
+  'entityVersionId',
+  'parentEntityVersionId',
+  'parentEntityType',
+  'parentEntityId',
+  'parentEntityName',
+  'rootEntityVersionId',
+  'rootEntityType',
+  'rootEntityId',
+  'rootEntityName',
+  'userId',
+  'organizationId',
+  'resourceId',
+  'runId',
+  'sessionId',
+  'threadId',
+  'requestId',
+  'environment',
+  'executionSource',
+  'serviceName',
+  'name',
+  'spanType',
+  'isEvent',
+  'startedAt',
+  'endedAt',
+  'tags',
+  'metadataSearch',
+  'attributes',
+  'scope',
+  'links',
+  'input',
+  'output',
+  'error',
+  'metadataRaw',
+  'requestContext',
+] as const;
+
+/**
+ * Build SELECT expressions that map legacy mastra_ai_spans columns to VNext mastra_span_events columns.
+ * Handles missing columns (older schemas) by emitting NULL or default values.
+ */
+function buildLegacySpanSelectExprs(legacyColumnTypes: Map<string, string>): string {
+  const has = (col: string) => legacyColumnTypes.has(col);
+  const colOrNull = (legacy: string) => (has(legacy) ? `"${legacy}"` : 'NULL');
+
+  const promotedIn = PROMOTED_METADATA_KEYS.map(k => `'${k}'`).join(', ');
+
+  const metadataSearchExpr = has('metadata')
+    ? `CAST(arrayFilter(x -> x.1 NOT IN (${promotedIn}) AND trim(BOTH ' ' FROM x.2) != '', arrayMap(x -> (x.1, trim(BOTH ' ' FROM x.2)), JSONExtractKeysAndValues(COALESCE("metadata", '{}'), 'String'))), 'Map(String, String)')`
+    : `CAST(map(), 'Map(String, String)')`;
+
+  // Legacy tables may store tags as Nullable(String) JSON or Array(String).
+  let tagsExpr = '[]';
+  if (has('tags')) {
+    const tagsType = legacyColumnTypes.get('tags')!;
+    if (tagsType.includes('Array')) {
+      // Array(String) — trim, dedup, drop empty
+      tagsExpr = `arrayFilter(x -> x != '', arrayDistinct(arrayMap(x -> trim(BOTH ' ' FROM x), "tags")))`;
+    } else {
+      // Nullable(String) JSON text — parse then trim, dedup, drop empty
+      tagsExpr = `arrayFilter(x -> x != '', arrayDistinct(arrayMap(x -> trim(BOTH ' ' FROM x), JSONExtract(COALESCE("tags", '[]'), 'Array(String)'))))`;
+    }
+  }
+
+  const exprs: Record<(typeof VNEXT_SPAN_COLUMNS)[number], string> = {
+    dedupeKey: `concat("traceId", ':', "spanId")`,
+    traceId: `"traceId"`,
+    spanId: `"spanId"`,
+    // Legacy stores '' for root spans; VNext MV filters on IS NULL.
+    parentSpanId: has('parentSpanId') ? `nullIf("parentSpanId", '')` : 'NULL',
+    experimentId: colOrNull('experimentId'),
+    entityType: colOrNull('entityType'),
+    entityId: colOrNull('entityId'),
+    entityName: colOrNull('entityName'),
+    entityVersionId: colOrNull('entityVersionId'),
+    parentEntityVersionId: colOrNull('parentEntityVersionId'),
+    parentEntityType: colOrNull('parentEntityType'),
+    parentEntityId: colOrNull('parentEntityId'),
+    parentEntityName: colOrNull('parentEntityName'),
+    rootEntityVersionId: colOrNull('rootEntityVersionId'),
+    rootEntityType: colOrNull('rootEntityType'),
+    rootEntityId: colOrNull('rootEntityId'),
+    rootEntityName: colOrNull('rootEntityName'),
+    userId: colOrNull('userId'),
+    organizationId: colOrNull('organizationId'),
+    resourceId: colOrNull('resourceId'),
+    runId: colOrNull('runId'),
+    sessionId: colOrNull('sessionId'),
+    threadId: colOrNull('threadId'),
+    requestId: colOrNull('requestId'),
+    environment: colOrNull('environment'),
+    executionSource: has('source') ? `"source"` : 'NULL',
+    serviceName: colOrNull('serviceName'),
+    name: `"name"`,
+    spanType: `"spanType"`,
+    isEvent: `"isEvent"`,
+    startedAt: `"startedAt"`,
+    // VNext requires non-null endedAt; events always use startedAt.
+    endedAt: `if("isEvent", "startedAt", COALESCE("endedAt", "startedAt"))`,
+    tags: tagsExpr,
+    metadataSearch: metadataSearchExpr,
+    attributes: colOrNull('attributes'),
+    scope: colOrNull('scope'),
+    links: colOrNull('links'),
+    input: colOrNull('input'),
+    output: colOrNull('output'),
+    error: colOrNull('error'),
+    metadataRaw: has('metadata') ? `"metadata"` : 'NULL',
+    requestContext: colOrNull('requestContext'),
+  };
+
+  return VNEXT_SPAN_COLUMNS.map(c => `${exprs[c]} AS "${c}"`).join(',\n    ');
+}
+
+export interface LegacySpanMigrationResult {
+  migratedRows: number;
+  batches: number;
+}
+
+/**
+ * Migrate span data from legacy mastra_ai_spans to VNext mastra_span_events.
+ * Runs entirely server-side inside ClickHouse using batched INSERT...SELECT by day.
+ * Does NOT drop the legacy table — the user should drop it manually after verification.
+ */
+export async function migrateLegacySpans(
+  client: ClickHouseClient,
+  logger?: IMastraLogger,
+): Promise<LegacySpanMigrationResult> {
+  if (await hasMarkerRow(client)) {
+    return { migratedRows: 0, batches: 0 };
+  }
+
+  const engine = await getTableEngine(client, TABLE_LEGACY_SPANS);
+  if (!engine) {
+    return { migratedRows: 0, batches: 0 };
+  }
+
+  const legacyColumnTypes = await getTableColumnTypes(client, TABLE_LEGACY_SPANS);
+  const hasUpdatedAt = legacyColumnTypes.has('updatedAt');
+
+  // Create base tables and MVs so inserted rows flow into trace_roots/trace_branches.
+  await client.command({ query: SPAN_EVENTS_DDL });
+  await client.command({ query: TRACE_ROOTS_DDL });
+  await client.command({ query: TRACE_BRANCHES_DDL });
+  await client.command({ query: TRACE_ROOTS_MV_DDL });
+  await client.command({ query: TRACE_BRANCHES_MV_DDL });
+
+  const selectExprs = buildLegacySpanSelectExprs(legacyColumnTypes);
+  const columnList = VNEXT_SPAN_COLUMNS.map(c => `"${c}"`).join(', ');
+
+  // Dedup ORDER BY: pick the most recent version of each (traceId, spanId)
+  const dedupOrder = hasUpdatedAt
+    ? `ORDER BY "traceId", "spanId", COALESCE("updatedAt", "createdAt") DESC`
+    : `ORDER BY "traceId", "spanId", "createdAt" DESC`;
+
+  // Query all populated days at once to avoid scanning empty days.
+  const daysResult = await client.query({
+    query: `SELECT
+      toString(toDate(COALESCE(endedAt, startedAt))) as day,
+      count() as cnt
+    FROM ${TABLE_LEGACY_SPANS}
+    GROUP BY day
+    ORDER BY day`,
+    format: 'JSONEachRow',
+  });
+  const days = (await daysResult.json()) as Array<{ day: string; cnt: string | number }>;
+
+  let migratedRows = 0;
+  let batches = 0;
+
+  for (const { day, cnt } of days) {
+    const dayCount = Number(cnt);
+
+    await client.command({
+      query: `INSERT INTO ${TABLE_SPAN_EVENTS} (${columnList})
+        SELECT ${selectExprs}
+        FROM ${TABLE_LEGACY_SPANS}
+        WHERE toDate(COALESCE(endedAt, startedAt)) = {batchDate:Date}
+        ${dedupOrder}
+        LIMIT 1 BY "traceId", "spanId"`,
+      query_params: { batchDate: day },
+    });
+
+    migratedRows += dayCount;
+    batches++;
+    logger?.info?.(`Migrated batch ${day}: ${dayCount} rows`);
+  }
+
+  // Write marker so subsequent runs skip.
+  await client.command({
+    query: `CREATE TABLE IF NOT EXISTS ${TABLE_LEGACY_MIGRATION_DONE} (completedAt DateTime64(3, 'UTC')) ENGINE = MergeTree ORDER BY completedAt`,
+  });
+  await client.command({
+    query: `INSERT INTO ${TABLE_LEGACY_MIGRATION_DONE} VALUES (now64(3))`,
+  });
+
+  logger?.info?.(
+    `Legacy span migration complete: ${migratedRows} rows in ${batches} batches. ` +
+      `The legacy table '${TABLE_LEGACY_SPANS}' has been preserved. Drop it manually after verifying the migration.`,
+  );
+
+  return { migratedRows, batches };
+}
+
 export async function migrateSignalTables(client: ClickHouseClient, logger?: IMastraLogger): Promise<void> {
   for (const { table, createDDL, idColumn } of SIGNAL_MIGRATIONS) {
     const engine = await getTableEngine(client, table);


### PR DESCRIPTION
## Description

Add automated migration of historical span data from legacy `mastra_ai_spans` to VNext `mastra_span_events` schema, triggered by `npx mastra migrate`. This unblocks customers with millions of legacy spans who switch to `ObservabilityStorageClickhouseVNext` and find their historical traces invisible in Studio.

- Batched day-by-day `INSERT INTO ... SELECT` runs entirely server-side in ClickHouse for memory safety at scale
- Column mapping handles renames (`source` → `executionSource`, `metadata` → `metadataRaw` + `metadataSearch`), missing columns in old schemas (NULL fill), and `endedAt` coalescing
- Converts empty-string `parentSpanId` to NULL so root spans flow into `trace_roots` MV correctly
- Detects legacy `tags` column type (`Nullable(String)` JSON vs `Array(String)`) and handles both
- Creates VNext base tables and MVs before inserting so rows populate `trace_roots`/`trace_branches` during migration
- Marker table prevents re-runs; checks for actual rows to handle crash recovery
- Non-blocking warning in `init()` when legacy table is detected
- Legacy table preserved as backup after migration

## Related Issue(s)

Fixes #18496

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
ClickHouse used to store trace “spans” in an old table, but Studio now looks at a new table. This PR adds a one-time migration (`npx mastra migrate`) that copies the old spans into the new schema so your historical traces show up again.

## Summary
- Added a legacy-to-VNext ClickHouse span migration for `mastra_ai_spans` → VNext `mastra_span_events`, intended to run via `npx mastra migrate`.
- On `init()`, performs a best-effort detection of the legacy spans table and logs a non-blocking warning telling operators to run `npx mastra migrate` (detection failures are swallowed so startup continues).
- Rerun safety + crash recovery:
  - `checkLegacySpanMigrationStatus()` uses a marker table (`mastra_legacy_span_migration_done`) to skip reruns when completed (but an empty marker table won’t block re-migration after a simulated crash).
  - `migrateLegacySpans()` is idempotent and re-uses the marker/table state to avoid duplicate work.
- Migration approach:
  - Runs server-side in ClickHouse in day-by-day batches over populated legacy days (based on `toDate(COALESCE(endedAt, startedAt))`) to scale to large datasets.
  - Creates the required VNext destination tables and trace-related materialized views (trace roots/branches) before inserting migrated rows.
- Data mapping details:
  - Normalizes root spans by converting legacy `parentSpanId = ''` to `NULL` so roots are detected correctly.
  - Coalesces/derives time fields (e.g., `endedAt` falls back to `startedAt` when needed, and event vs non-event handling is preserved).
  - Handles renamed/missing columns by tolerating absent legacy fields and emitting `NULL`/defaults as appropriate (e.g., `source` → `executionSource`, `metadata` → `metadataRaw`, and deriving `metadataSearch` by filtering promoted keys and non-string values).
  - Supports legacy `tags` stored in either:
    - `Array(String)` form, or
    - older `Nullable(String)` JSON-text form (parsing, trimming, and de-duping repeated tag values).
- Deduplication:
  - Deduplicates by `(traceId, spanId)` using `ORDER BY` (preferring the latest row when `updatedAt` exists) and `LIMIT 1 BY traceId, spanId`.
- Preserves the legacy table as a backup after migration (no automatic deletion).
- Wired into `ObservabilityStorageClickhouseVNext.migrateSpans()` alongside existing signal-table migration so legacy spans migration is triggered as part of the normal migration flow.
- Added documentation:
  - CLI `mastra migrate` reference entry for the legacy span migration.
  - ClickHouse storage docs section explaining how/why the migration works and that the legacy table is kept.
- Added/expanded test coverage for detection/no-op cases, schema variation handling, column derivations, tags parsing for both legacy formats, root normalization, dedup + `updatedAt` preference, idempotency, marker semantics/crash recovery, and integration checks that `migrateSpans()` triggers legacy migration and populates trace roots without needing `store.init()`.
- Included a Changeset for `@mastra/clickhouse` documenting the minor version bump and the new migration capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->