### PR TITLE
fix(deployer): false-positive LOCAL_STORAGE_PATH preflight error from bundler intermediates

### DIFF
--- a/.changeset/modern-items-study.md
+++ b/.changeset/modern-items-study.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed a false-positive LOCAL_STORAGE_PATH preflight error that flagged storage paths like `file:./data.db` that don't exist in your project. The deploy bundler's local-storage detector now excludes everything under `.mastra/.build/` (deployer-generated intermediate chunks), not just `@mastra__*` shim files. Those chunks can carry JSDoc examples from library code (for example `LibSQLStore({ url: 'file:./data.db' })` from `@mastra/core`), which previously blocked `mastra server deploy` and forced `--skip-preflight` even though the user's code had no local storage paths. Local storage paths in your own source files are still detected.

--- a/packages/deployer/src/build/plugins/local-storage-detector.test.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.test.ts
@@ -64,17 +64,20 @@ describe('localStorageDetector', () => {
     expect(detections).toHaveLength(0);
   });
 
-  it('ignores deployer .mastra/.build shim files for @mastra/* packages', () => {
+  it('ignores all deployer .mastra/.build shim files', () => {
     // Reproduces the false positive triggered when a user sets a `bundler:` field
     // in `new Mastra({...})`, which causes the optimizer to pre-bundle
-    // `@mastra/core` into `.mastra/.build/@mastra__core__*.mjs` shims. These
-    // shims preserve JSDoc examples like `url: 'file:./data.db'`.
+    // dependencies into `.mastra/.build/*.mjs` shims. These shims preserve
+    // JSDoc examples like `url: 'file:./data.db'`. Non-@mastra shims (e.g.
+    // `@ag-ui__mastra.mjs`) can carry the same JSDoc, so the whole directory
+    // must be excluded.
     const plugin = getPlugin();
     plugin.transform(
       `const example = "storage: new LibSQLStore({ url: 'file:./data.db' })";`,
       '/project/.mastra/.build/@mastra__core__mastra.mjs',
     );
     plugin.transform(`const example = "url: 'file:./data.db'";`, '/project/.mastra/.build/@mastra__core.mjs');
+    plugin.transform(`const example = "url: 'file:./data.db'";`, '/project/.mastra/.build/@ag-ui__mastra.mjs');
 
     const emitted: Array<{ fileName: string; source: string }> = [];
     const ctx = {
@@ -91,6 +94,7 @@ describe('localStorageDetector', () => {
           modules: {
             '/project/.mastra/.build/@mastra__core__mastra.mjs': { renderedLength: 5000 },
             '/project/.mastra/.build/@mastra__core.mjs': { renderedLength: 5000 },
+            '/project/.mastra/.build/@ag-ui__mastra.mjs': { renderedLength: 5000 },
           },
         },
       },

--- a/packages/deployer/src/build/plugins/local-storage-detector.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.ts
@@ -27,19 +27,21 @@ export interface LocalStorageDetection {
 
 /**
  * Matches the deployer's own intermediate dependency shims emitted under
- * `.mastra/.build/` (e.g. `@mastra__core.mjs`, `@mastra__core__mastra.mjs`).
+ * `.mastra/.build/` (e.g. `@mastra__core.mjs`, `@ag-ui__mastra.mjs`).
  * These pre-bundled chunks preserve JSDoc examples from the original library
  * source (e.g. `LibSQLStore({ url: 'file:./data.db' })`) which would otherwise
- * trip the host-local detector even though they're not user code.
+ * trip the host-local detector even though they're not user code. Everything
+ * in this directory is deployer-generated dependency output, never user
+ * source, so the whole directory is excluded.
  */
-const MASTRA_SHIM_PATH = /[\\/]\.mastra[\\/]\.build[\\/]@mastra__/;
+const MASTRA_BUILD_DIR = /[\\/]\.mastra[\\/]\.build[\\/]/;
 
 /**
  * Rollup plugin that detects host-local storage URLs (e.g. `file:./mastra.db`,
  * `postgres://localhost`) in **user source modules** during bundling.
  *
  * Only modules outside `node_modules` (and the deployer's own
- * `.mastra/.build/@mastra__*` shim files) are inspected, so library code
+ * `.mastra/.build/` shim files) are inspected, so library code
  * (like Agent Builder prompt templates or JSDoc examples in `@mastra/core`)
  * is naturally excluded.  Tree-shaken modules are excluded via
  * `generateBundle` — only modules that actually contribute rendered code to
@@ -56,7 +58,7 @@ export function localStorageDetector(): Plugin {
 
     transform(_code, id) {
       if (id.includes('node_modules')) return null;
-      if (MASTRA_SHIM_PATH.test(id)) return null;
+      if (MASTRA_BUILD_DIR.test(id)) return null;
 
       const matches: Array<{ value: string; hint: string }> = [];
       for (const { pattern, hint } of LOCAL_HOST_PATTERNS) {


### PR DESCRIPTION
The deploy preflight check could flag local storage paths like `file:./data.db` even when they don't exist anywhere in the user's project, blocking `mastra server deploy` and forcing `--skip-preflight`.

The local-storage detector excluded only `@mastra__*` shim files under `.mastra/.build/`, but the bundler writes other intermediate modules there too — including generic `chunk-*.mjs` files that preserve JSDoc examples from `@mastra/core`:

```ts
// inside .mastra/.build/chunk-JGDMZZAO.mjs (bundled @mastra/core JSDoc)
 * const mastra = new Mastra({
 *   storage: new LibSQLStore({ id: 'mastra-storage', url: 'file:./data.db' })
 * });
```

The detector now excludes everything under `.mastra/.build/`, since nothing in that directory is user source. Local storage paths in your own files are still detected.

Verified end-to-end against a real affected project: reproduced the false positive with the published deployer, confirmed the flagged module was a generated chunk, and confirmed the fix clears it while still flagging a real `file:./data.db` added to user source. Unit tests extended to cover non-`@mastra__` build intermediates (11 passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops the deploy checker from blaming your app for paths that only exist in temporary build files. It now ignores the whole `.mastra/.build/` folder, so only real local-storage paths in your source code still cause warnings.

## Summary
- Fixed a false-positive `LOCAL_STORAGE_PATH` preflight error during `mastra server deploy`.
- Updated the detector to ignore all generated files under `.mastra/.build/`, not just `@mastra__*` shims.
- Kept detection active for user-authored source files that באמת contain local-storage paths.
- Expanded tests to cover additional generated build intermediates, including non-`@mastra__` shim files.
- Verified the issue against a real affected project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->