### PR TITLE
fix: resolve source-built mastracode plugin links

### DIFF
--- a/.changeset/salty-garlics-try.md
+++ b/.changeset/salty-garlics-try.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed GitHub plugin setup when running Mastra Code from a source-built bundle and installing plugins that require a different pnpm version.

--- a/mastracode/e2e/tui/plugins.ts
+++ b/mastracode/e2e/tui/plugins.ts
@@ -213,6 +213,7 @@ function writeGithubInstallPluginSource(pluginDir: string): void {
     JSON.stringify(
       {
         type: 'module',
+        packageManager: 'pnpm@11.8.0',
         dependencies: {
           'e2e-plugin-installed-dependency': 'file:./fixtures/dependency',
         },
@@ -529,6 +530,7 @@ export const pluginsScaffoldInstallToolScenario: McE2eScenario = {
     await runtime.waitForScreenText(/Install new plugin/i, terminal, 8_000);
     terminal.write('\r');
     await runtime.waitForScreenText(/Install plugin from:/i, terminal, 8_000);
+    terminal.write('\x1b[B');
     terminal.write('\r');
     await runtime.waitForScreenText(/Local plugin path or discovered plugin:/i, terminal, 8_000);
     terminal.write('\r');
@@ -611,6 +613,14 @@ export const pluginsGithubInstallGhCliScenario: McE2eScenario = {
   },
   async inProcessApp({ homeDir, projectDir, startMastraCodeApp }) {
     if (!githubInstallGhPath) throw new Error('GitHub install gh fixture was not prepared');
+    githubInstallCheckoutDir = join(
+      homeDir,
+      '.mastracode',
+      'plugins',
+      'sources',
+      'github',
+      'acme-github-install-plugin',
+    );
     const { PluginManager } = await import('../../src/plugins/manager.js');
     return startMastraCodeApp({
       config: {
@@ -631,7 +641,6 @@ export const pluginsGithubInstallGhCliScenario: McE2eScenario = {
     await runtime.waitForScreenText(/Install new plugin/i, terminal, 8_000);
     terminal.write('\r');
     await runtime.waitForScreenText(/Install plugin from:/i, terminal, 8_000);
-    terminal.write('\x1b[B');
     terminal.write('\r');
     await runtime.waitForScreenText(/GitHub URL:/i, terminal, 8_000);
     await typeTextSlowly(terminal, 'https://github.com/acme/github-install-plugin');
@@ -714,7 +723,6 @@ export const pluginsGithubInstallMissingPackageManagerScenario: McE2eScenario = 
     await runtime.waitForScreenText(/Install new plugin/i, terminal, 8_000);
     terminal.write('\r');
     await runtime.waitForScreenText(/Install plugin from:/i, terminal, 8_000);
-    terminal.write('\x1b[B');
     terminal.write('\r');
     await runtime.waitForScreenText(/GitHub URL:/i, terminal, 8_000);
     await typeTextSlowly(terminal, 'https://github.com/acme/github-install-plugin');

--- a/mastracode/src/plugins/__tests__/dependencies.test.ts
+++ b/mastracode/src/plugins/__tests__/dependencies.test.ts
@@ -39,7 +39,7 @@ describe('installPluginDependencies', () => {
     expect(execaMock).not.toHaveBeenCalled();
   });
 
-  it('uses pnpm when packageManager declares pnpm', async () => {
+  it('uses pnpm with version mismatch checks disabled when packageManager declares pnpm', async () => {
     const pluginRoot = makePluginRoot();
     writePackageJson(pluginRoot, { packageManager: 'pnpm@10.0.0' });
 
@@ -47,7 +47,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--ignore-scripts'],
+      ['install', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: pluginRoot }),
     );
   });
@@ -61,7 +61,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--frozen-lockfile', '--ignore-scripts'],
+      ['install', '--frozen-lockfile', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: pluginRoot }),
     );
   });
@@ -164,7 +164,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--ignore-scripts'],
+      ['install', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: pluginRoot }),
     );
   });
@@ -210,7 +210,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--ignore-scripts'],
+      ['install', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: nestedRoot }),
     );
   });
@@ -227,7 +227,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--frozen-lockfile', '--ignore-scripts'],
+      ['install', '--frozen-lockfile', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: nestedRoot }),
     );
   });

--- a/mastracode/src/plugins/__tests__/dependencies.test.ts
+++ b/mastracode/src/plugins/__tests__/dependencies.test.ts
@@ -47,7 +47,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--pm-on-fail=ignore', '--ignore-scripts'],
+      ['install', '--ignore-workspace', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: pluginRoot }),
     );
   });
@@ -61,7 +61,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--frozen-lockfile', '--pm-on-fail=ignore', '--ignore-scripts'],
+      ['install', '--ignore-workspace', '--frozen-lockfile', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: pluginRoot }),
     );
   });
@@ -164,7 +164,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--pm-on-fail=ignore', '--ignore-scripts'],
+      ['install', '--ignore-workspace', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: pluginRoot }),
     );
   });
@@ -210,7 +210,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--pm-on-fail=ignore', '--ignore-scripts'],
+      ['install', '--ignore-workspace', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: nestedRoot }),
     );
   });
@@ -227,7 +227,7 @@ describe('installPluginDependencies', () => {
 
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--frozen-lockfile', '--pm-on-fail=ignore', '--ignore-scripts'],
+      ['install', '--ignore-workspace', '--frozen-lockfile', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: nestedRoot }),
     );
   });

--- a/mastracode/src/plugins/__tests__/install.test.ts
+++ b/mastracode/src/plugins/__tests__/install.test.ts
@@ -224,7 +224,7 @@ describe('installGithubPlugin', () => {
     expect(execaMock).toHaveBeenNthCalledWith(
       4,
       'pnpm',
-      ['install', '--frozen-lockfile', '--ignore-scripts'],
+      ['install', '--frozen-lockfile', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: checkoutDir }),
     );
     expect(

--- a/mastracode/src/plugins/__tests__/install.test.ts
+++ b/mastracode/src/plugins/__tests__/install.test.ts
@@ -224,7 +224,7 @@ describe('installGithubPlugin', () => {
     expect(execaMock).toHaveBeenNthCalledWith(
       4,
       'pnpm',
-      ['install', '--frozen-lockfile', '--pm-on-fail=ignore', '--ignore-scripts'],
+      ['install', '--ignore-workspace', '--frozen-lockfile', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: checkoutDir }),
     );
     expect(

--- a/mastracode/src/plugins/__tests__/manager.test.ts
+++ b/mastracode/src/plugins/__tests__/manager.test.ts
@@ -211,7 +211,7 @@ describe('PluginManager', () => {
     );
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--pm-on-fail=ignore', '--ignore-scripts'],
+      ['install', '--ignore-workspace', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: checkoutDir, env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }) }),
     );
     expect(fs.realpathSync(path.join(checkoutDir, 'node_modules', 'mastracode'))).toBe(

--- a/mastracode/src/plugins/__tests__/manager.test.ts
+++ b/mastracode/src/plugins/__tests__/manager.test.ts
@@ -211,7 +211,7 @@ describe('PluginManager', () => {
     );
     expect(execaMock).toHaveBeenCalledWith(
       'pnpm',
-      ['install', '--ignore-scripts'],
+      ['install', '--pm-on-fail=ignore', '--ignore-scripts'],
       expect.objectContaining({ cwd: checkoutDir, env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }) }),
     );
     expect(fs.realpathSync(path.join(checkoutDir, 'node_modules', 'mastracode'))).toBe(

--- a/mastracode/src/plugins/__tests__/package-link.test.ts
+++ b/mastracode/src/plugins/__tests__/package-link.test.ts
@@ -4,9 +4,9 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { ensureMastraCodePackageLink } from '../package-link.js';
+import { ensureMastraCodePackageLink, findMastraCodePackageRoot } from '../package-link.js';
 
-const mastracodePackageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const mastracodePackageRoot = findMastraCodePackageRoot(path.dirname(fileURLToPath(import.meta.url)));
 
 let tempDir: string | undefined;
 
@@ -22,6 +22,13 @@ function makePluginRoot(): string {
   tempDir = pluginRoot;
   return pluginRoot;
 }
+
+describe('findMastraCodePackageRoot', () => {
+  it('finds the mastracode package root from source and bundled dist paths', () => {
+    expect(findMastraCodePackageRoot(path.join(mastracodePackageRoot, 'src', 'plugins'))).toBe(mastracodePackageRoot);
+    expect(findMastraCodePackageRoot(path.join(mastracodePackageRoot, 'dist'))).toBe(mastracodePackageRoot);
+  });
+});
 
 describe('ensureMastraCodePackageLink', () => {
   it('links mastracode when it is not declared as an installable dependency', () => {

--- a/mastracode/src/plugins/dependencies.ts
+++ b/mastracode/src/plugins/dependencies.ts
@@ -113,8 +113,8 @@ function getInstallCommand(
 
   if (manager?.startsWith('pnpm@')) {
     return hasFile(pluginRoot, 'pnpm-lock.yaml')
-      ? installCommand('pnpm', ['install', '--frozen-lockfile'])
-      : installCommand('pnpm', ['install']);
+      ? installCommand('pnpm', ['install', '--frozen-lockfile', '--pm-on-fail=ignore'])
+      : installCommand('pnpm', ['install', '--pm-on-fail=ignore']);
   }
 
   if (manager?.startsWith('npm@')) {
@@ -138,11 +138,11 @@ function getInstallCommand(
   }
 
   if (hasFile(pluginRoot, 'pnpm-lock.yaml')) {
-    return installCommand('pnpm', ['install', '--frozen-lockfile']);
+    return installCommand('pnpm', ['install', '--frozen-lockfile', '--pm-on-fail=ignore']);
   }
 
   if (hasFile(commandRoot, 'pnpm-lock.yaml')) {
-    return installCommand('pnpm', ['install']);
+    return installCommand('pnpm', ['install', '--pm-on-fail=ignore']);
   }
 
   if (hasNpmLockfile(pluginRoot)) {

--- a/mastracode/src/plugins/dependencies.ts
+++ b/mastracode/src/plugins/dependencies.ts
@@ -113,8 +113,8 @@ function getInstallCommand(
 
   if (manager?.startsWith('pnpm@')) {
     return hasFile(pluginRoot, 'pnpm-lock.yaml')
-      ? installCommand('pnpm', ['install', '--frozen-lockfile', '--pm-on-fail=ignore'])
-      : installCommand('pnpm', ['install', '--pm-on-fail=ignore']);
+      ? installCommand('pnpm', ['install', '--ignore-workspace', '--frozen-lockfile', '--pm-on-fail=ignore'])
+      : installCommand('pnpm', ['install', '--ignore-workspace', '--pm-on-fail=ignore']);
   }
 
   if (manager?.startsWith('npm@')) {
@@ -138,11 +138,11 @@ function getInstallCommand(
   }
 
   if (hasFile(pluginRoot, 'pnpm-lock.yaml')) {
-    return installCommand('pnpm', ['install', '--frozen-lockfile', '--pm-on-fail=ignore']);
+    return installCommand('pnpm', ['install', '--ignore-workspace', '--frozen-lockfile', '--pm-on-fail=ignore']);
   }
 
   if (hasFile(commandRoot, 'pnpm-lock.yaml')) {
-    return installCommand('pnpm', ['install', '--pm-on-fail=ignore']);
+    return installCommand('pnpm', ['install', '--ignore-workspace', '--pm-on-fail=ignore']);
   }
 
   if (hasNpmLockfile(pluginRoot)) {

--- a/mastracode/src/plugins/package-link.ts
+++ b/mastracode/src/plugins/package-link.ts
@@ -2,7 +2,27 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const MASTRACODE_PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const MASTRACODE_PACKAGE_ROOT = findMastraCodePackageRoot(path.dirname(fileURLToPath(import.meta.url)));
+
+export function findMastraCodePackageRoot(startDir: string): string {
+  let currentDir = path.resolve(startDir);
+
+  while (true) {
+    const packageJsonPath = path.join(currentDir, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { name?: string };
+      if (packageJson.name === 'mastracode') {
+        return currentDir;
+      }
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      throw new Error(`Could not find mastracode package root from ${startDir}`);
+    }
+    currentDir = parentDir;
+  }
+}
 
 export function ensureMastraCodePackageLink(pluginDir: string): void {
   if (declaresInstallableMastraCodeDependency(pluginDir)) {

--- a/mastracode/src/tui/commands/__tests__/plugins.test.ts
+++ b/mastracode/src/tui/commands/__tests__/plugins.test.ts
@@ -451,6 +451,14 @@ describe('handlePluginsCommand', () => {
     list.onSelect({ value: '__install__' });
     await waitForOverlayCalls(2);
 
+    expect(modal.askModalQuestion).toHaveBeenNthCalledWith(1, ctx.state.ui, {
+      question: 'Install plugin from:',
+      options: [{ label: 'GitHub URL' }, { label: 'Local path' }],
+    });
+    expect(modal.askModalQuestion).toHaveBeenNthCalledWith(3, ctx.state.ui, {
+      question: 'Install scope:',
+      options: [{ label: 'global' }, { label: 'project' }],
+    });
     const progress = overlay.showModalOverlay.mock.calls[1]?.[1] as any;
     expect(progress.children.map((child: any) => child.text).join('\n')).toContain('Installing GitHub plugin');
     expect(progress.children.map((child: any) => child.text).join('\n')).toContain('Press Esc or Ctrl-C to cancel.');

--- a/mastracode/src/tui/commands/plugins.ts
+++ b/mastracode/src/tui/commands/plugins.ts
@@ -386,7 +386,7 @@ async function installPluginFlow(ctx: SlashCommandContext): Promise<void> {
   if (!ctx.pluginManager) return;
   const source = await askModalQuestion(ctx.state.ui, {
     question: 'Install plugin from:',
-    options: [{ label: 'Local path' }, { label: 'GitHub URL' }],
+    options: [{ label: 'GitHub URL' }, { label: 'Local path' }],
   });
   if (!source) return;
 
@@ -401,7 +401,7 @@ async function installPluginFlow(ctx: SlashCommandContext): Promise<void> {
 
   const scopeAnswer = await askModalQuestion(ctx.state.ui, {
     question: 'Install scope:',
-    options: [{ label: 'project' }, { label: 'global' }],
+    options: [{ label: 'global' }, { label: 'project' }],
   });
   if (scopeAnswer !== 'project' && scopeAnswer !== 'global') return;
 


### PR DESCRIPTION
This fixes a couple of GitHub plugin setup issues we saw while testing source-built Mastra Code.

When MC is run from a built `dist` file inside the monorepo, the plugin linker was resolving the package root by assuming a fixed source path depth. That could point `node_modules/mastracode` at the monorepo root instead of the `mastracode` package.

Before:
```txt
plugin/node_modules/mastracode -> /path/to/mastra
```

After:
```txt
plugin/node_modules/mastracode -> /path/to/mastra/mastracode
```

It also makes pnpm plugin installs tolerate version pin mismatches from plugin repos, so a plugin pinned to a different pnpm version does not fail before install starts.

Also included: the plugin install picker now shows GitHub before local and global before project, matching the default flow we usually want.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Mastra Code has to point each plugin at the correct “home folder” inside the monorepo, and install plugin dependencies with pnpm in a way that doesn’t crash when the plugin expects a different pnpm version. This PR fixes the folder detection for the symlink setup, makes pnpm installs more tolerant, and adjusts a couple of UI choice orders.

## Summary
- Fixed plugin package-root resolution by adding `findMastraCodePackageRoot(startDir)` and using it to compute `MASTRACODE_PACKAGE_ROOT`, so the created symlink targets the `mastracode` package directory (instead of relying on a hardcoded source-path depth).
- Updated pnpm plugin dependency installation commands to be more resilient to pnpm version pin mismatches by adding `--pm-on-fail=ignore` (and adjusting related install flags like `--ignore-workspace` / `--frozen-lockfile` in the appropriate pnpm scenarios).
- Reordered plugin install TUI prompts:
  - “Install plugin from” now shows **GitHub URL** before **Local path**
  - “Install scope” now shows **global** before **project**
- Updated unit/e2e tests and fixtures to match the new package-root lookup, pnpm command arguments, and prompt ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->