### PR TITLE
Change default maxDepth value to 8

### DIFF
--- a/packages/core/src/observability/types/core.ts
+++ b/packages/core/src/observability/types/core.ts
@@ -427,7 +427,7 @@ export interface SerializationOptions {
   maxStringLength?: number;
   /**
    * Maximum depth for nested objects
-   * @default 6
+   * @default 8
    */
   maxDepth?: number;
   /**


### PR DESCRIPTION

## Description

Docs say it is 6 but it is 8 in the reality

https://github.com/mastra-ai/mastra/blob/21b504c0524897d1fe5a08b5e94ceaf9c9f9faf1/observability/mastra/src/spans/serialization.ts#L53


## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change updates the note for a setting that controls how deep data gets copied when saved. The code was already using 8, so the docs now match what the system actually does.

### Summary
- Updated the `SerializationOptions.maxDepth` JSDoc `@default` value from `6` to `8`.
- No type or API shape changes were made.

### Public API impact
- None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->