### PR TITLE
fix: extract goal judge user message text

### DIFF
--- a/.changeset/tame-goals-breathe.md
+++ b/.changeset/tame-goals-breathe.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Extract text from DB-shaped user messages in goal judge prompts instead of stringifying them as `[object Object]`.
+Extract text from DB-shaped user messages in goal judge prompts instead of stringifying them as `[object Object]`. Goal judge prompts now also skip malformed, empty, or synthetic reminder messages when selecting the latest user context.

--- a/.changeset/tame-goals-breathe.md
+++ b/.changeset/tame-goals-breathe.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Extract text from DB-shaped user messages in goal judge prompts instead of stringifying them as `[object Object]`.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -378,6 +378,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -378,7 +378,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
       - name: Checkout repo

--- a/packages/core/src/agent/goal/scorer.test.ts
+++ b/packages/core/src/agent/goal/scorer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import { createMockModel } from '../../test-utils/llm-mock';
 import { createTool } from '../../tools';
+import type { MastraDBMessage, MastraMessageContentV2 } from '../message-list';
 import { DEFAULT_GOAL_JUDGE_PROMPT, GOAL_SCORE_WAITING } from './objective';
 import { createGoalScorer } from './scorer';
 
@@ -25,7 +26,26 @@ const viewTool = createTool({
   execute: async () => ({ content: '' }),
 });
 
-async function captureJudgePromptForMessages(messages: Array<Record<string, unknown>>) {
+function createUserMessage(content: MastraMessageContentV2): MastraDBMessage {
+  return {
+    id: 'msg-user',
+    role: 'user',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    content,
+  };
+}
+
+function createSignalMessage(content: MastraMessageContentV2, id = 'msg-signal'): MastraDBMessage {
+  return {
+    id,
+    role: 'signal',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    type: 'user',
+    content,
+  };
+}
+
+async function captureJudgePromptForMessages(messages: MastraDBMessage[]) {
   let prompt = '';
   const scorer = createGoalScorer({
     judgeModel: createMockModel({
@@ -51,10 +71,7 @@ async function captureJudgePromptForMessages(messages: Array<Record<string, unkn
 describe('createGoalScorer latest user message text extraction', () => {
   it('includes text from DB-shaped latest user content instead of stringifying the object', async () => {
     const prompt = await captureJudgePromptForMessages([
-      {
-        role: 'user',
-        content: { format: 2, parts: [{ type: 'text', text: 'actual user text' }] },
-      },
+      createUserMessage({ format: 2, parts: [{ type: 'text', text: 'actual user text' }] }),
     ]);
 
     expect(prompt).toContain('Latest user message');
@@ -64,20 +81,54 @@ describe('createGoalScorer latest user message text extraction', () => {
 
   it('joins all DB-shaped text parts from the latest user content with newlines', async () => {
     const prompt = await captureJudgePromptForMessages([
-      {
-        role: 'user',
-        content: {
-          format: 2,
-          parts: [
-            { type: 'text', text: 'first text part' },
-            { type: 'text', text: 'second text part' },
-          ],
-        },
-      },
+      createUserMessage({
+        format: 2,
+        parts: [
+          { type: 'text', text: 'first text part' },
+          { type: 'text', text: 'second text part' },
+        ],
+      }),
     ]);
 
     expect(prompt).toContain('first text part\\nsecond text part');
     expect(prompt).not.toContain('[object Object]');
+  });
+
+  it('uses user signal rows as latest user content for signal-delivered messages', async () => {
+    const prompt = await captureJudgePromptForMessages([
+      createUserMessage({ format: 2, parts: [{ type: 'text', text: 'previous user text' }] }),
+      createSignalMessage({
+        format: 2,
+        parts: [{ type: 'text', text: 'received your message user' }],
+        metadata: { signal: { type: 'user', tagName: 'user' } },
+      }),
+    ]);
+
+    expect(prompt).toContain('received your message user');
+    expect(prompt).not.toContain('previous user text');
+    expect(prompt).not.toContain('[object Object]');
+  });
+
+  it('skips synthetic system reminders when selecting the latest user content', async () => {
+    const prompt = await captureJudgePromptForMessages([
+      createUserMessage({ format: 2, parts: [{ type: 'text', text: 'actual human message' }] }),
+      createUserMessage({
+        format: 2,
+        parts: [{ type: 'text', text: '<system-reminder>Please continue naturally</system-reminder>' }],
+      }),
+    ]);
+
+    expect(prompt).toContain('actual human message');
+    expect(prompt).not.toContain('<system-reminder>Please continue naturally</system-reminder>');
+  });
+
+  it('skips empty user rows when selecting the latest user content', async () => {
+    const prompt = await captureJudgePromptForMessages([
+      createUserMessage({ format: 2, parts: [{ type: 'text', text: 'actual human message' }] }),
+      createUserMessage({ format: 2, parts: [{ type: 'text', text: '' }] }),
+    ]);
+
+    expect(prompt).toContain('actual human message');
   });
 });
 

--- a/packages/core/src/agent/goal/scorer.test.ts
+++ b/packages/core/src/agent/goal/scorer.test.ts
@@ -25,6 +25,62 @@ const viewTool = createTool({
   execute: async () => ({ content: '' }),
 });
 
+async function captureJudgePromptForMessages(messages: Array<Record<string, unknown>>) {
+  let prompt = '';
+  const scorer = createGoalScorer({
+    judgeModel: createMockModel({
+      objectGenerationMode: 'json',
+      mockText: { decision: 'continue', reason: 'keep going' },
+      spyGenerate: props => {
+        prompt = JSON.stringify(props.prompt);
+      },
+      spyStream: props => {
+        prompt = JSON.stringify(props.prompt);
+      },
+    }) as any,
+  });
+
+  await scorer.run({
+    input: { originalTask: 'do the thing', currentText: 'still working', messages },
+    output: 'still working',
+  } as any);
+
+  return prompt;
+}
+
+describe('createGoalScorer latest user message text extraction', () => {
+  it('includes text from DB-shaped latest user content instead of stringifying the object', async () => {
+    const prompt = await captureJudgePromptForMessages([
+      {
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'actual user text' }] },
+      },
+    ]);
+
+    expect(prompt).toContain('Latest user message');
+    expect(prompt).toContain('actual user text');
+    expect(prompt).not.toContain('[object Object]');
+  });
+
+  it('joins all DB-shaped text parts from the latest user content with newlines', async () => {
+    const prompt = await captureJudgePromptForMessages([
+      {
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [
+            { type: 'text', text: 'first text part' },
+            { type: 'text', text: 'second text part' },
+          ],
+        },
+      },
+    ]);
+
+    expect(prompt).toContain('first text part\\nsecond text part');
+    expect(prompt).not.toContain('[object Object]');
+  });
+});
+
 describe('createGoalScorer tool support', () => {
   it('omits tools from the judge config by default (portable, text-only)', () => {
     const scorer = createGoalScorer({ judgeModel });

--- a/packages/core/src/agent/goal/scorer.ts
+++ b/packages/core/src/agent/goal/scorer.ts
@@ -61,6 +61,9 @@ function extractTextContent(content: unknown): string {
       .filter((text: string | null): text is string => Boolean(text))
       .join('\n');
   }
+  if (content && typeof content === 'object' && Array.isArray((content as any).parts)) {
+    return extractTextContent((content as any).parts);
+  }
   return String(content ?? '');
 }
 

--- a/packages/core/src/agent/goal/scorer.ts
+++ b/packages/core/src/agent/goal/scorer.ts
@@ -4,9 +4,11 @@ import type { AgentMemoryOption, ToolsInput } from '../../agent/types';
 import { createScorer } from '../../evals';
 import type { ScorerJudgeConfig } from '../../evals';
 import type { MastraModelConfig } from '../../llm';
+import type { StreamCompletionContext } from '../../loop/network/validation';
 import type { Mastra } from '../../mastra';
 import type { MastraMemory } from '../../memory';
 import type { RequestContext } from '../../request-context';
+import type { MastraDBMessage, MastraMessageContentV2, MastraMessagePart } from '../message-list';
 import { DEFAULT_GOAL_JUDGE_PROMPT, GOAL_SCORE_WAITING, GOAL_SCORER_ID } from './objective';
 
 // The goal scorer is an LLM-as-judge that grades the agent's latest output
@@ -30,62 +32,78 @@ const analyzeOutputSchema = z.object({
 
 type GoalAnalysis = z.infer<typeof analyzeOutputSchema>;
 
-function getOutputText(run: { input?: unknown; output?: unknown }): string {
+type GoalScorerInput = Partial<Pick<StreamCompletionContext, 'currentText' | 'originalTask' | 'messages'>>;
+
+type GoalScorerRun = {
+  input?: GoalScorerInput;
+  output?: string;
+};
+
+type TextMessagePart = Extract<MastraMessagePart, { type: 'text' }>;
+
+function getOutputText(run: GoalScorerRun): string {
   // The goal step passes the in-progress text on `run.input.currentText`
   // (via StreamCompletionContext), mirroring isTaskComplete.
-  const input = run.input as Record<string, unknown> | undefined;
-  if (input && typeof input.currentText === 'string') return input.currentText;
-  return typeof run.output === 'string' ? run.output : '';
+  return run.input?.currentText ?? run.output ?? '';
 }
 
-function getObjectiveText(run: { input?: unknown }): string {
-  const input = run.input as Record<string, unknown> | undefined;
-  if (input && typeof input.originalTask === 'string') return input.originalTask;
-  return '';
+function getObjectiveText(run: GoalScorerRun): string {
+  return run.input?.originalTask ?? '';
 }
 
 function truncateForJudge(value: string): string {
   return value.length > 4000 ? `${value.slice(0, 4000)}\n...[truncated]` : value;
 }
 
-function extractTextContent(content: unknown): string {
-  if (typeof content === 'string') return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((part: any) => {
-        if (typeof part === 'string') return part;
-        if (typeof part?.text === 'string') return part.text;
-        if (typeof part?.content === 'string') return part.content;
-        return null;
-      })
-      .filter((text: string | null): text is string => Boolean(text))
-      .join('\n');
-  }
-  if (content && typeof content === 'object' && Array.isArray((content as any).parts)) {
-    return extractTextContent((content as any).parts);
-  }
-  return String(content ?? '');
+function isTextPart(part: MastraMessagePart): part is TextMessagePart {
+  return part.type === 'text';
 }
 
-function getLatestUserContext(run: { input?: unknown }): {
+function extractTextContent(content: MastraMessageContentV2): string {
+  return (content.parts ?? [])
+    .filter(isTextPart)
+    .map(part => part.text)
+    .filter(Boolean)
+    .join('\n');
+}
+
+function hasUserSignalMetadata(signal: unknown): signal is { type: 'user' } {
+  return (
+    signal !== null &&
+    typeof signal === 'object' &&
+    !Array.isArray(signal) &&
+    'type' in signal &&
+    signal.type === 'user'
+  );
+}
+
+function isUserMessageForGoal(message: MastraDBMessage): boolean {
+  return (
+    message.role === 'user' || (message.role === 'signal' && hasUserSignalMetadata(message.content.metadata?.signal))
+  );
+}
+
+function isSyntheticReminderContent(content: string): boolean {
+  const trimmed = content.trimStart();
+  return trimmed.startsWith('<system-reminder') || trimmed.startsWith('<current-objective');
+}
+
+function isLatestUserCandidateForGoal(message: MastraDBMessage): boolean {
+  if (!isUserMessageForGoal(message)) return false;
+  const textContent = extractTextContent(message.content);
+  return textContent.trim() !== '' && !isSyntheticReminderContent(textContent);
+}
+
+function getLatestUserContext(run: GoalScorerRun): {
   lastUserContent: string | null;
   assistantStepsSinceLastUser: number;
 } {
-  const input = run.input as Record<string, unknown> | undefined;
-  const messages = Array.isArray(input?.messages) ? input.messages : [];
-  let lastUserIndex = -1;
+  const messages = run.input?.messages ?? [];
+  const lastUserIndex = messages.findLastIndex(isLatestUserCandidateForGoal);
 
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i] as any;
-    if (msg?.role === 'user') {
-      lastUserIndex = i;
-      break;
-    }
-  }
-
-  const lastUserContent = lastUserIndex >= 0 ? extractTextContent((messages[lastUserIndex] as any)?.content) : null;
+  const lastUserContent = lastUserIndex >= 0 ? extractTextContent(messages[lastUserIndex]!.content) : null;
   const assistantStepsSinceLastUser =
-    lastUserIndex >= 0 ? messages.slice(lastUserIndex + 1).filter((msg: any) => msg?.role === 'assistant').length : 0;
+    lastUserIndex >= 0 ? messages.slice(lastUserIndex + 1).filter(msg => msg.role === 'assistant').length : 0;
 
   return { lastUserContent, assistantStepsSinceLastUser };
 }

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
@@ -180,11 +180,11 @@ describe('goal step waiting semantics', () => {
         dbMessages: [
           {
             role: 'user',
-            content: [{ type: 'text', text: 'Please continue after answering this.' }],
+            content: { format: 2, parts: [{ type: 'text', text: 'Please continue after answering this.' }] },
           },
           {
             role: 'assistant',
-            content: [{ type: 'text', text: 'Answered the user and kept working.' }],
+            content: { format: 2, parts: [{ type: 'text', text: 'Answered the user and kept working.' }] },
           },
         ],
       });


### PR DESCRIPTION
Fixes goal judge prompts when the latest user input comes from stored DB message content or a user signal.

Before, DB-shaped content could stringify as `[object Object]`, and synthetic reminder messages could be picked as the latest user message:

```txt
Latest user message:
[object Object]
```

or:

```txt
Latest user message:
<system-reminder>Please continue naturally ...</system-reminder>
```

After, the scorer extracts text from `content.parts`, treats `signal.type === "user"` rows as user messages, and skips synthetic reminder/objective content when choosing the latest user context:

```txt
Latest user message:
received your message user
```

Added focused scorer coverage for DB-shaped content, multi-part text joining, user signal rows, and skipping synthetic reminders. Also included a patch changeset for `@mastra/core`.

Verified with:

```sh
pnpm --filter ./packages/core exec vitest run src/agent/goal/scorer.test.ts --reporter=dot --bail 1
pnpm --filter ./packages/core check
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The “goal judge” builds a prompt using the latest real user message. This PR teaches it how to correctly read user text stored in DB “message objects” (even when the text is split into parts), instead of accidentally turning them into `[object Object]`, and it avoids fake/synthetic reminder/objective messages.

## Summary
- Fixed goal-scorer “latest user context” extraction for DB-shaped message content by reading `content.parts ?? []`, joining only text parts (`type === 'text'`) with newlines, and handling malformed/empty candidates safely.
- Treats `signal.type === "user"` rows as user messages when selecting the latest user context.
- Filters out synthetic reminder/objective content when selecting the latest eligible user message (skipping candidates whose trimmed text starts with `<system-reminder` or `<current-objective`), and falls back to earlier valid user context when the latest candidate is empty/malformed.
- Added focused test coverage in `packages/core/src/agent/goal/scorer.test.ts` for:
  - DB-shaped content extraction (V2 `{ format: 2, parts: [...] }`)
  - multi-part text joining with newlines
  - using user-signal rows as the latest user input
  - skipping synthetic reminder/objective messages and empty/malformed latest-user candidates
- Updated `packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts` test fixture(s) to use Mastra “format 2” `{ format: 2, parts: [...] }` content shape.
- Expanded changeset for `@mastra/core` documenting the goal-judge prompt fix and the latest-user selection behavior (including notes about fallback behavior).
- Updated the `e2e-tests.yml` workflow to provide `OPENAI_API_KEY` to the `e2e-client-js` job via secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->